### PR TITLE
feat: enhance inventory propagation with inventoryUpdatedAt support

### DIFF
--- a/ISSUE_40.md
+++ b/ISSUE_40.md
@@ -1,0 +1,14 @@
+# Developer Task
+
+## Description
+Wire InventorySyncService so that inventory changes propagate to Allegro offers using the mapping from Listings domain.
+
+## Tasks
+- [x] On inventory update, resolve mapped Allegro offers per connection
+- [x] Enqueue/execute updateOfferQuantity jobs (idempotent)
+- [x] Ensure retries/backoff work with commandId idempotency
+
+## Acceptance Criteria
+- [x] Inventory update results in Allegro quantity command execution
+- [x] Retries do not duplicate effects
+- [x] Tests pass

--- a/apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts
@@ -48,7 +48,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
   });
 
   describe('execute', () => {
-    const createJob = (payload: { productId: string; variantId?: string | null }): SyncJob => ({
+    const createJob = (payload: { productId: string; variantId?: string | null; inventoryUpdatedAt?: string | null }): SyncJob => ({
       id: 'job-id',
       jobType: 'inventory.propagateToMarketplaces',
       connectionId: '', // Empty for inventory propagation jobs
@@ -213,6 +213,42 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
     });
 
     it('should generate idempotency key correctly', async () => {
+      const job = createJob({
+        productId: 'product-id',
+        inventoryUpdatedAt: '2026-01-01T12:00:00.000Z',
+      });
+      const inventory = new InventoryItemEntity(
+        'inventory-id',
+        'product-id',
+        null,
+        100,
+        0,
+        null,
+        new Date(),
+      );
+
+      inventoryService.getInventory.mockResolvedValue(inventory);
+      identifierMapping.getExternalIds.mockResolvedValue([
+        {
+          entityType: 'Offer',
+          platformType: 'allegro',
+          connectionId: 'connection-id',
+          externalId: 'offer-id',
+        },
+      ]);
+      jobEnqueue.enqueueJob.mockResolvedValue('enqueued-job-id');
+
+      await handler.execute(job);
+
+      expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idempotencyKey:
+            'inventory:connection-id:product-id:base:100:2026-01-01T12:00:00.000Z',
+        }),
+      );
+    });
+
+    it('should keep backward compatibility when inventoryUpdatedAt is missing', async () => {
       const job = createJob({ productId: 'product-id' });
       const inventory = new InventoryItemEntity(
         'inventory-id',
@@ -239,7 +275,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
 
       expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
         expect.objectContaining({
-          idempotencyKey: 'inventory:connection-id:product-id:base:100',
+          idempotencyKey: 'inventory:connection-id:product-id:base:100:legacy',
         }),
       );
     });

--- a/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
+++ b/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
@@ -32,6 +32,7 @@ import { Logger } from '@openlinker/shared/logging';
 interface InventoryPropagateToMarketplacesPayload {
   productId: string;
   variantId?: string | null;
+  inventoryUpdatedAt?: string | null;
 }
 
 /**
@@ -114,9 +115,10 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
         return;
       }
 
+      const writeEventToken = payload.inventoryUpdatedAt || 'legacy';
       const enqueuePromises = allegroMappings.map(async (mapping) => {
-        // Generate idempotency key: inventory:connectionId:productId:variantId:quantity
-        const idempotencyKey = `inventory:${mapping.connectionId}:${payload.productId}:${payload.variantId || 'base'}:${availableQuantity}`;
+        // Include write-event token to avoid suppressing legitimate quantity oscillations (e.g. 5->6->5).
+        const idempotencyKey = `inventory:${mapping.connectionId}:${payload.productId}:${payload.variantId || 'base'}:${availableQuantity}:${writeEventToken}`;
 
         const updatePayload = {
           schemaVersion: 1 as const,
@@ -174,6 +176,8 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
     return {
       productId: payload.productId,
       variantId: payload.variantId || null,
+      inventoryUpdatedAt:
+        typeof payload.inventoryUpdatedAt === 'string' ? payload.inventoryUpdatedAt : null,
     };
   }
 }

--- a/libs/core/src/inventory/application/services/__tests__/inventory.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory.service.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * Inventory Service Tests
+ *
+ * Unit tests for InventoryService. Focus on propagation enqueue behavior
+ * after canonical inventory writes.
+ *
+ * @module libs/core/src/inventory/application/services/__tests__
+ */
+
+import { InventoryService } from '../inventory.service';
+import { InventoryRepositoryPort } from '../../../domain/ports/inventory-repository.port';
+import { InventoryItem } from '../../../domain/entities/inventory-item.entity';
+import { SyncJobQueuePort } from '@openlinker/core/sync';
+
+describe('InventoryService', () => {
+  let service: InventoryService;
+  let inventoryRepository: jest.Mocked<InventoryRepositoryPort>;
+  let jobQueue: jest.Mocked<SyncJobQueuePort>;
+
+  const createItem = (overrides?: Partial<InventoryItem>): InventoryItem => {
+    const base = new InventoryItem(
+      'inventory-id',
+      'product-id',
+      null,
+      5,
+      0,
+      null,
+      new Date('2026-01-01T10:00:00.000Z'),
+    );
+
+    return new InventoryItem(
+      overrides?.id ?? base.id,
+      overrides?.productId ?? base.productId,
+      overrides?.productVariantId ?? base.productVariantId,
+      overrides?.availableQuantity ?? base.availableQuantity,
+      overrides?.reservedQuantity ?? base.reservedQuantity,
+      overrides?.locationId ?? base.locationId,
+      overrides?.updatedAt ?? base.updatedAt,
+    );
+  };
+
+  beforeEach(() => {
+    inventoryRepository = {
+      findByProductAndVariant: jest.fn(),
+      upsert: jest.fn(),
+    } as unknown as jest.Mocked<InventoryRepositoryPort>;
+
+    jobQueue = {
+      enqueue: jest.fn().mockResolvedValue('job-id'),
+      enqueueBulk: jest.fn(),
+    } as unknown as jest.Mocked<SyncJobQueuePort>;
+
+    service = new InventoryService(inventoryRepository, jobQueue);
+  });
+
+  it('enqueues inventory propagation when quantity changes', async () => {
+    const input = createItem({
+      availableQuantity: 7,
+      updatedAt: new Date('2026-01-01T12:00:00.000Z'),
+    });
+    const previous = createItem({
+      availableQuantity: 5,
+      updatedAt: new Date('2026-01-01T11:00:00.000Z'),
+    });
+
+    inventoryRepository.findByProductAndVariant.mockResolvedValue(previous);
+    inventoryRepository.upsert.mockResolvedValue(input);
+
+    await service.setInventory(input);
+
+    expect(jobQueue.enqueue).toHaveBeenCalledWith({
+      type: 'inventory.propagateToMarketplaces',
+      connectionId: '00000000-0000-0000-0000-000000000000',
+      payload: {
+        productId: 'product-id',
+        variantId: null,
+        inventoryUpdatedAt: '2026-01-01T12:00:00.000Z',
+      },
+      options: {
+        dedupeKey: 'inventory:propagate:product-id:base:2026-01-01T12:00:00.000Z',
+      },
+    });
+  });
+
+  it('skips enqueue when available quantity is unchanged', async () => {
+    const input = createItem({
+      availableQuantity: 5,
+      updatedAt: new Date('2026-01-01T12:00:00.000Z'),
+    });
+    const previous = createItem({
+      availableQuantity: 5,
+      updatedAt: new Date('2026-01-01T11:00:00.000Z'),
+    });
+
+    inventoryRepository.findByProductAndVariant.mockResolvedValue(previous);
+    inventoryRepository.upsert.mockResolvedValue(input);
+
+    await service.setInventory(input);
+
+    expect(jobQueue.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips enqueue for non-default location inventory', async () => {
+    const input = createItem({
+      locationId: 'warehouse-a',
+      availableQuantity: 7,
+    });
+
+    inventoryRepository.findByProductAndVariant.mockResolvedValue(null);
+    inventoryRepository.upsert.mockResolvedValue(input);
+
+    await service.setInventory(input);
+
+    expect(jobQueue.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('throws when enqueue fails after upsert', async () => {
+    const input = createItem({
+      availableQuantity: 7,
+      updatedAt: new Date('2026-01-01T12:00:00.000Z'),
+    });
+
+    inventoryRepository.findByProductAndVariant.mockResolvedValue(null);
+    inventoryRepository.upsert.mockResolvedValue(input);
+    jobQueue.enqueue.mockRejectedValue(new Error('queue unavailable'));
+
+    await expect(service.setInventory(input)).rejects.toThrow(
+      'Failed to enqueue inventory propagation job: queue unavailable',
+    );
+  });
+
+  it('does not enqueue when upsert fails', async () => {
+    const input = createItem({
+      availableQuantity: 7,
+    });
+
+    inventoryRepository.findByProductAndVariant.mockResolvedValue(null);
+    inventoryRepository.upsert.mockRejectedValue(new Error('db error'));
+
+    await expect(service.setInventory(input)).rejects.toThrow('db error');
+    expect(jobQueue.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('enqueues both updates for 5->6->5 transitions', async () => {
+    const first = createItem({
+      availableQuantity: 6,
+      updatedAt: new Date('2026-01-01T12:00:00.000Z'),
+    });
+    const second = createItem({
+      availableQuantity: 5,
+      updatedAt: new Date('2026-01-01T12:05:00.000Z'),
+    });
+
+    inventoryRepository.findByProductAndVariant
+      .mockResolvedValueOnce(createItem({ availableQuantity: 5 }))
+      .mockResolvedValueOnce(createItem({ availableQuantity: 6 }));
+    inventoryRepository.upsert
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+
+    await service.setInventory(first);
+    await service.setInventory(second);
+
+    expect(jobQueue.enqueue).toHaveBeenCalledTimes(2);
+    expect(jobQueue.enqueue).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        options: {
+          dedupeKey: 'inventory:propagate:product-id:base:2026-01-01T12:00:00.000Z',
+        },
+      }),
+    );
+    expect(jobQueue.enqueue).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        options: {
+          dedupeKey: 'inventory:propagate:product-id:base:2026-01-01T12:05:00.000Z',
+        },
+      }),
+    );
+  });
+
+  it('uses persisted updatedAt as write event token', async () => {
+    const input = createItem({
+      availableQuantity: 7,
+      updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+    });
+    const persisted = createItem({
+      availableQuantity: 7,
+      updatedAt: new Date('2026-01-01T12:00:00.000Z'),
+    });
+
+    inventoryRepository.findByProductAndVariant.mockResolvedValue(null);
+    inventoryRepository.upsert.mockResolvedValue(persisted);
+
+    await service.setInventory(input);
+
+    expect(jobQueue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          inventoryUpdatedAt: '2026-01-01T12:00:00.000Z',
+        }),
+        options: expect.objectContaining({
+          dedupeKey: 'inventory:propagate:product-id:base:2026-01-01T12:00:00.000Z',
+        }),
+      }),
+    );
+  });
+});
+

--- a/libs/core/src/inventory/application/services/inventory.service.ts
+++ b/libs/core/src/inventory/application/services/inventory.service.ts
@@ -16,22 +16,81 @@ import { InventoryRepositoryPort } from '../../domain/ports/inventory-repository
 import { InventoryItem } from '../../domain/entities/inventory-item.entity';
 import { Logger } from '@openlinker/shared/logging';
 import { INVENTORY_REPOSITORY_TOKEN } from '../../inventory.tokens';
+import {
+  SyncJobQueuePort,
+  SYNC_JOB_QUEUE_TOKEN,
+} from '@openlinker/core/sync';
 
 @Injectable()
 export class InventoryService implements IInventoryService {
   private readonly logger = new Logger(InventoryService.name);
+  // inventory.propagateToMarketplaces is global and not tied to one connection.
+  private readonly SYSTEM_CONNECTION_ID = '00000000-0000-0000-0000-000000000000';
 
   constructor(
     @Inject(INVENTORY_REPOSITORY_TOKEN)
     private readonly inventoryRepository: InventoryRepositoryPort,
+    @Inject(SYNC_JOB_QUEUE_TOKEN)
+    private readonly jobQueue: SyncJobQueuePort,
   ) {}
 
   async setInventory(item: InventoryItem): Promise<InventoryItem> {
     this.logger.debug(
       `Setting inventory for product: ${item.productId}, variant: ${item.productVariantId ?? 'base'}, location: ${item.locationId ?? 'default'}`,
     );
+
+    const previous = await this.inventoryRepository.findByProductAndVariant(
+      item.productId,
+      item.productVariantId,
+      item.locationId,
+    );
+
     const upserted = await this.inventoryRepository.upsert(item);
     this.logger.debug(`Inventory set: ${upserted.id}`);
+
+    // Marketplace propagation currently assumes canonical single-location inventory.
+    if (upserted.locationId !== null) {
+      this.logger.debug(
+        `inventory_write_propagation_skipped_non_default_location product=${upserted.productId} variant=${upserted.productVariantId ?? 'base'} location=${upserted.locationId}`,
+      );
+      return upserted;
+    }
+
+    if (previous && previous.availableQuantity === upserted.availableQuantity) {
+      this.logger.debug(
+        `inventory_write_propagation_skipped_no_change product=${upserted.productId} variant=${upserted.productVariantId ?? 'base'} quantity=${upserted.availableQuantity}`,
+      );
+      return upserted;
+    }
+
+    const writeEventToken = upserted.updatedAt.toISOString();
+    const dedupeKey = this.buildPropagationDedupeKey(upserted, writeEventToken);
+    try {
+      await this.jobQueue.enqueue({
+        type: 'inventory.propagateToMarketplaces',
+        connectionId: this.SYSTEM_CONNECTION_ID,
+        payload: {
+          productId: upserted.productId,
+          variantId: upserted.productVariantId,
+          inventoryUpdatedAt: writeEventToken,
+        },
+        options: {
+          dedupeKey,
+        },
+      });
+
+      this.logger.debug(
+        `inventory_write_propagation_enqueued product=${upserted.productId} variant=${upserted.productVariantId ?? 'base'} quantity=${upserted.availableQuantity} event=${writeEventToken}`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `inventory_write_propagation_enqueue_failed product=${upserted.productId} variant=${upserted.productVariantId ?? 'base'} event=${writeEventToken} reason=${message}`,
+      );
+      // Fail fast: callers should retry the operation to avoid silent propagation loss.
+      throw new Error(`Failed to enqueue inventory propagation job: ${message}`);
+    }
+
     return upserted;
   }
 
@@ -48,6 +107,15 @@ export class InventoryService implements IInventoryService {
       productVariantId,
       locationId,
     );
+  }
+
+  private buildPropagationDedupeKey(item: InventoryItem, writeEventToken: string): string {
+    return [
+      'inventory:propagate',
+      item.productId,
+      item.productVariantId ?? 'base',
+      writeEventToken,
+    ].join(':');
   }
 }
 

--- a/libs/core/src/inventory/inventory.module.ts
+++ b/libs/core/src/inventory/inventory.module.ts
@@ -23,6 +23,7 @@ import {
 import { ProductsModule } from '@openlinker/core/products';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
+import { SyncModule } from '@openlinker/core/sync';
 
 // Re-export tokens for convenience
 export {
@@ -38,6 +39,7 @@ export {
     ProductsModule, // Required for FK relationship to ProductOrmEntity
     IntegrationsModule, // Required for INTEGRATIONS_SERVICE_TOKEN (marketplace adapter resolution)
     IdentifierMappingModule, // Required for IDENTIFIER_MAPPING_SERVICE_TOKEN
+    SyncModule, // Required for SYNC_JOB_QUEUE_TOKEN (inventory propagation enqueue)
   ],
   providers: [
     // Provide classes directly first


### PR DESCRIPTION
- Added `inventoryUpdatedAt` field to the `InventoryPropagateToMarketplacesPayload` interface to track inventory update timestamps.
- Updated idempotency key generation in `InventoryPropagateToMarketplacesHandler` to include the `inventoryUpdatedAt` value, allowing for better handling of quantity oscillations.
- Modified tests to validate the correct generation of idempotency keys with the new timestamp feature and ensure backward compatibility when the field is absent.
- Integrated `SyncModule` into the inventory module for job queue management during inventory updates.

closes: #40 