### PR TITLE
feat: implement typed API client layer and add missing query hooks

### DIFF
--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -5,9 +5,12 @@ import { createSyncJobsApi, type SyncJobsApi } from '../../features/sync-jobs/ap
 import { ApiError } from '../../shared/api/api-error';
 import type { SessionAdapter } from '../../shared/auth/session-adapter';
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 interface ApiClientConfig {
   baseUrl: string;
   fetchFn?: typeof fetch;
+  requestTimeoutMs?: number;
   sessionAdapter: SessionAdapter;
 }
 
@@ -40,6 +43,7 @@ async function readResponseBody(response: Response): Promise<unknown> {
 export function createApiClient({
   baseUrl,
   fetchFn = fetch,
+  requestTimeoutMs = DEFAULT_TIMEOUT_MS,
   sessionAdapter,
 }: ApiClientConfig): ApiClient {
   const request = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
@@ -56,17 +60,39 @@ export function createApiClient({
       headers.set('Authorization', `Bearer ${accessToken}`);
     }
 
-    const response = await fetchFn(buildUrl(baseUrl, path), {
-      ...init,
-      headers,
-    });
-    const payload = await readResponseBody(response);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => { controller.abort(); }, requestTimeoutMs);
+    const signal = init.signal ?? controller.signal;
 
-    if (!response.ok) {
-      throw ApiError.fromResponse(response, payload);
+    try {
+      const response = await fetchFn(buildUrl(baseUrl, path), {
+        ...init,
+        headers,
+        signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      const payload = await readResponseBody(response);
+
+      if (!response.ok) {
+        throw ApiError.fromResponse(response, payload);
+      }
+
+      return payload as T;
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      if (error instanceof ApiError) {
+        throw error;
+      }
+
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw ApiError.fromTimeout(path);
+      }
+
+      throw ApiError.fromNetworkFailure(error);
     }
-
-    return payload as T;
   };
 
   return {

--- a/apps/web/src/features/adapters/api/adapters.query-keys.ts
+++ b/apps/web/src/features/adapters/api/adapters.query-keys.ts
@@ -1,0 +1,4 @@
+export const adaptersQueryKeys = {
+  all: ['adapters'] as const,
+  list: () => ['adapters', 'list'] as const,
+};

--- a/apps/web/src/features/adapters/hooks/use-adapters-query.ts
+++ b/apps/web/src/features/adapters/hooks/use-adapters-query.ts
@@ -1,0 +1,13 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import type { AdapterSummary } from '../api/adapters.api';
+import { adaptersQueryKeys } from '../api/adapters.query-keys';
+
+export function useAdaptersQuery(): UseQueryResult<AdapterSummary[]> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: adaptersQueryKeys.list(),
+    queryFn: () => apiClient.adapters.list(),
+  });
+}

--- a/apps/web/src/features/allegro/api/allegro.query-keys.ts
+++ b/apps/web/src/features/allegro/api/allegro.query-keys.ts
@@ -1,0 +1,3 @@
+export const allegroQueryKeys = {
+  all: ['allegro'] as const,
+};

--- a/apps/web/src/features/allegro/hooks/use-start-allegro-oauth-mutation.ts
+++ b/apps/web/src/features/allegro/hooks/use-start-allegro-oauth-mutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import type { StartAllegroOAuthInput, StartAllegroOAuthResponse } from '../api/allegro.api';
+
+export function useStartAllegroOAuthMutation(): UseMutationResult<
+  StartAllegroOAuthResponse,
+  Error,
+  StartAllegroOAuthInput
+> {
+  const apiClient = useApiClient();
+
+  return useMutation({
+    mutationFn: (input: StartAllegroOAuthInput) => apiClient.allegro.startOAuth(input),
+  });
+}

--- a/apps/web/src/features/sync-jobs/api/sync.query-keys.ts
+++ b/apps/web/src/features/sync-jobs/api/sync.query-keys.ts
@@ -1,0 +1,3 @@
+export const syncJobsQueryKeys = {
+  all: ['sync-jobs'] as const,
+};

--- a/apps/web/src/features/sync-jobs/hooks/use-enqueue-sync-job-mutation.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-enqueue-sync-job-mutation.ts
@@ -1,0 +1,11 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import type { EnqueueSyncJobInput, SyncJobResponse } from '../api/sync.api';
+
+export function useEnqueueSyncJobMutation(): UseMutationResult<SyncJobResponse, Error, EnqueueSyncJobInput> {
+  const apiClient = useApiClient();
+
+  return useMutation({
+    mutationFn: (input: EnqueueSyncJobInput) => apiClient.syncJobs.enqueue(input),
+  });
+}

--- a/apps/web/src/shared/api/api-error.ts
+++ b/apps/web/src/shared/api/api-error.ts
@@ -9,6 +9,26 @@ export class ApiError extends Error {
     this.details = details;
   }
 
+  isUnauthorized(): boolean {
+    return this.status === 401;
+  }
+
+  isForbidden(): boolean {
+    return this.status === 403;
+  }
+
+  isNotFound(): boolean {
+    return this.status === 404;
+  }
+
+  isServerError(): boolean {
+    return this.status >= 500;
+  }
+
+  isNetworkError(): boolean {
+    return this.status === 0;
+  }
+
   static fromResponse(response: Response, details: unknown): ApiError {
     if (typeof details === 'object' && details !== null && 'message' in details) {
       const message = Array.isArray(details.message) ? details.message.join(', ') : String(details.message);
@@ -20,5 +40,14 @@ export class ApiError extends Error {
     }
 
     return new ApiError(response.statusText || 'Request failed', response.status, details);
+  }
+
+  static fromNetworkFailure(cause: unknown): ApiError {
+    const message = cause instanceof Error ? cause.message : 'Network request failed';
+    return new ApiError(message, 0, cause);
+  }
+
+  static fromTimeout(path: string): ApiError {
+    return new ApiError(`Request timed out: ${path}`, 0, { timeout: true, path });
   }
 }


### PR DESCRIPTION
## Summary

- **API client** (`app/api/api-client.ts`): add `requestTimeoutMs` (default 30s via `AbortController`); all network failures, CORS errors, and timeouts now surface as typed `ApiError` instead of unhandled rejections
- **`ApiError`** (`shared/api/api-error.ts`): add status check helpers (`isUnauthorized`, `isForbidden`, `isNotFound`, `isServerError`, `isNetworkError`) and static factories (`fromNetworkFailure`, `fromTimeout`)
- **Query hooks** for three previously hook-less feature modules, following the `connections` pattern:
  - `features/adapters` → `use-adapters-query.ts` + `adapters.query-keys.ts`
  - `features/sync-jobs` → `use-enqueue-sync-job-mutation.ts` + `sync.query-keys.ts`
  - `features/allegro` → `use-start-allegro-oauth-mutation.ts` + `allegro.query-keys.ts`

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — passes
- [x] `pnpm --filter @openlinker/web lint` — passes
- [x] `pnpm --filter @openlinker/web test` — 17 tests across 7 suites, all pass

Closes #55
Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)