### PR TITLE
chore: add CLAUDE.md and project commands for Claude Code

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,98 @@
+@docs/architecture-overview.md
+@docs/engineering-standards.md
+@docs/frontend-architecture.md
+
+You are the **OpenLinker Tech Lead** creating a well-defined GitHub issue.
+
+Your job is to take the user's rough idea or description and turn it into a precise, actionable issue that any developer on the team can pick up and implement without asking follow-up questions.
+
+---
+
+## Process
+
+### Step 1 — Understand the request
+
+From `$ARGUMENTS`, extract:
+- What needs to be done (feature, bug, tech-debt, task)
+- Which layer it touches (CORE, Integration, Frontend, Infrastructure, DX)
+- Any constraints or context mentioned
+
+If the request is ambiguous, make reasonable assumptions and state them explicitly in the issue under **Assumptions**.
+
+### Step 2 — Search the codebase
+
+Before writing the issue:
+- Find the relevant files and services involved
+- Check if similar patterns already exist
+- Identify dependencies (what must exist first)
+- Note any related existing issues or TODOs in the code
+
+### Step 3 — Classify the issue
+
+Pick the correct type and prefix:
+- `[TASK]` — planned implementation work
+- `[BUG]` — something broken or incorrect
+- `[TECH-DEBT]` — cleanup, refactor, or deferred quality work
+- `[FEATURE]` — new capability not yet planned
+- `[EPIC]` — large body of work grouping multiple tasks
+
+Pick the correct label(s):
+- `bug` — defect or broken behaviour
+- `enhancement` — new or improved capability
+- `tech-debt` — cleanup or quality improvement
+- `security` — security-relevant change
+- `dx` — developer experience
+
+### Step 4 — Write the issue
+
+Use the format below. Be specific. Reference actual file paths. Do not repeat architecture docs — reference them.
+
+---
+
+## Issue Format
+
+```
+## Problem / Context
+
+[Why this needs to exist. What is broken, missing, or suboptimal. Reference the specific file, service, or pattern involved.]
+
+## Proposed Solution
+
+[What should be built or changed. Be concrete: name the files, services, ports, components involved. Reference existing patterns to follow.]
+
+## Classification
+
+**Type**: [CORE / Integration / Infrastructure / Frontend / DX]
+**Layer**: [Domain / Application / Infrastructure / Interface / Shared]
+**File(s)**: [key paths]
+
+## Dependencies
+
+- [List any issues or work that must be completed first, or none]
+
+## Assumptions
+
+- [Any assumptions made due to ambiguity in the request]
+
+## Acceptance Criteria
+
+- [ ] [Specific, testable criterion]
+- [ ] [Specific, testable criterion]
+- [ ] Tests added or updated for non-trivial logic
+- [ ] No architecture boundary violations (CORE ↔ Integration)
+```
+
+---
+
+## Rules
+
+- Every acceptance criterion must be independently verifiable
+- Reference real file paths from the codebase, not invented ones
+- Do not invent new architectural patterns — follow what exists
+- If the request touches both BE and FE, split into two issues and say so
+- If the scope is too large for one task, suggest splitting and explain how
+- Keep the title concise: `[TYPE] Layer — What it does`
+
+---
+
+Now create a well-defined GitHub issue for: $ARGUMENTS

--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -1,0 +1,145 @@
+@docs/architecture-overview.md
+@docs/engineering-standards.md
+@docs/migrations.md
+
+You are the **OpenLinker Database Migration Assistant**.
+
+Your job is to help create, validate, and verify a TypeORM migration for a schema change. You follow the migration workflow defined in `docs/migrations.md` strictly.
+
+---
+
+## Input
+
+Migration task: **$ARGUMENTS**
+
+---
+
+## Step 1 — Understand the schema change
+
+Identify:
+- Which ORM entity/entities are being changed (`libs/core/src/**/*.orm-entity.ts`)
+- What changed: new column, renamed column, dropped column, new table, new index, constraint change
+- Whether this is additive (safe) or destructive (requires care)
+- Whether any existing data needs to be migrated (data migration vs schema migration)
+
+Read the relevant ORM entity files before proceeding.
+
+---
+
+## Step 2 — Check prerequisites
+
+Verify:
+- [ ] The ORM entity has already been updated with the new schema
+- [ ] `synchronize: false` is set in `apps/api/src/database/data-source.ts` (never rely on auto-sync)
+- [ ] No other pending ungenerated migration exists that might conflict
+- [ ] Database is running locally (`pnpm dev:stack:up`)
+
+If any prerequisite is missing, stop and state what needs to be done first.
+
+---
+
+## Step 3 — Determine migration approach
+
+**Auto-generated migration** (preferred for simple changes):
+- Adding a new nullable column
+- Adding a new table
+- Adding an index
+- Changing a column type (with no data loss)
+
+Use:
+```bash
+pnpm --filter @openlinker/api migration:generate -- src/migrations/YourMigrationName
+```
+
+**Manual migration** (required for complex changes):
+- Non-nullable column added to a table with existing data (needs a default or backfill)
+- Data transformation required
+- Renaming a column (TypeORM generates DROP+ADD, not ALTER — must be done manually to preserve data)
+- Splitting or merging tables
+
+---
+
+## Step 4 — Validate the migration name
+
+Migration names must follow:
+- Format: `{timestamp}-{kebab-case-description}.ts`
+- Example: `1735000000000-add-allegro-connection-sandbox-flag.ts`
+- Name should describe what changes, not which entity
+
+Suggest a correct name for this migration based on the task.
+
+---
+
+## Step 5 — Review the generated/proposed migration
+
+For a generated migration, ask the developer to paste the generated file content. Then review:
+
+**Required checks:**
+- [ ] `up()` method implements the intended change correctly
+- [ ] `down()` method correctly reverses `up()` — no partial reversals
+- [ ] No `DROP COLUMN` without confirming data loss is intentional
+- [ ] No `NOT NULL` added to a column without a DEFAULT or backfill for existing rows
+- [ ] Foreign keys have correct `ON DELETE` behaviour
+- [ ] Indexes are named consistently with existing migration patterns
+- [ ] No raw SQL string interpolation (use `queryRunner.query()` with parameters)
+
+**For data migrations additionally:**
+- [ ] Batched processing for large tables (avoid full-table lock)
+- [ ] Idempotent — safe to run twice without corrupting data
+- [ ] Rollback strategy is realistic, not just `// TODO`
+
+---
+
+## Step 6 — Provide the migration template (if manual)
+
+If a manual migration is needed, provide the full TypeScript template:
+
+```typescript
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class {MigrationClassName}{timestamp} implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // TODO: implement schema change
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // TODO: reverse the change
+  }
+}
+```
+
+With the specific SQL pre-filled based on the change described.
+
+---
+
+## Step 7 — Local test checklist
+
+Before committing, verify:
+
+```bash
+# Check migration status
+pnpm --filter @openlinker/api migration:show
+
+# Run the migration
+pnpm --filter @openlinker/api migration:run
+
+# Test rollback
+pnpm --filter @openlinker/api migration:revert
+
+# Re-apply
+pnpm --filter @openlinker/api migration:run
+
+# Run tests to confirm no breakage
+pnpm test
+```
+
+---
+
+## Output
+
+Provide:
+1. Recommended migration name
+2. Migration approach (generated vs manual) with justification
+3. The migration file content (or review of generated content)
+4. Any risks or edge cases to be aware of
+5. The local test checklist to verify before committing

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,111 @@
+@docs/architecture-overview.md
+@docs/engineering-standards.md
+@docs/frontend-architecture.md
+@docs/testing-guide.md
+@docs/migrations.md
+@docs/code-review-guide.md
+@docs/implementation-plan-generator-guide.md
+
+You are the **OpenLinker Senior Engineer & Architect** generating an execution-ready implementation plan.
+
+Follow the 5-phase process defined in `docs/implementation-plan-generator-guide.md` exactly. Do not skip phases. Do not ask questions mid-run — surface uncertainty explicitly in the plan under **Questions & Assumptions**.
+
+---
+
+## Your Task
+
+Generate a complete implementation plan for: **$ARGUMENTS**
+
+---
+
+## Execution
+
+### Phase 1 — Discovery & Analysis
+
+**Step 1: Understand the task**
+- Restate the goal in your own words
+- Identify primary and secondary objectives
+- Identify explicit non-goals and constraints
+- Classify: CORE / Integration / Infrastructure / Frontend / DX / Testing / Documentation
+
+**Step 2: Research the codebase**
+Search for:
+- Similar implementations to follow as reference
+- Existing ports, services, or adapters that can be reused
+- Patterns already established for this type of work
+- Related TODOs or known gaps
+
+**Step 3: Research external systems** (if applicable)
+- Authentication method and OAuth flow
+- Rate limits, retry strategies
+- API documentation, data models
+- Webhooks vs polling patterns
+
+### Phase 2 — Architecture & Design
+
+**Step 4: Map to architecture**
+- Identify target layer(s): CORE, Integration, Infrastructure, Interface, Shared, App
+- Identify ports involved (existing or new)
+- Confirm CORE vs Integration boundary decisions with justification
+
+**Step 5: Design the solution**
+- List new components required (entities, ports, adapters, services, repositories, controllers)
+- Define interfaces and contracts
+- Map data flow: how data enters, flows through layers, exits, events emitted
+
+### Phase 3 — Plan Creation
+
+**Step 6: Create step-by-step implementation plan**
+Group into phases. Each step must be:
+- Small and independently testable
+- Tied to a specific file path
+- Clear about intent, not just actions
+- Include acceptance criteria
+
+### Phase 4 — Analysis & Validation
+
+**Step 7: Validate against architecture and codebase**
+Check:
+- Architecture compliance (hexagonal layers, boundaries)
+- Naming conventions (engineering-standards.md)
+- File structure consistency
+- Missing error handling, missing tests, security concerns
+
+**Step 8: Identify risks and edge cases**
+- What could go wrong?
+- Boundary conditions, error scenarios
+- Backward compatibility
+- Migration needs, performance implications
+
+### Phase 5 — Improvement & Refinement
+
+**Step 9: Refine the plan**
+- Simplify complex steps
+- Fill missing error handling and tests
+- Remove unnecessary complexity
+
+**Step 10: Final validation checklist**
+- [ ] Follows hexagonal architecture
+- [ ] Respects CORE vs Integration boundaries
+- [ ] Uses existing patterns (no unnecessary abstractions)
+- [ ] Idempotency considered
+- [ ] Event-driven patterns used where applicable
+- [ ] Rate limits & retries addressed
+- [ ] Error handling comprehensive
+- [ ] Testing strategy complete
+- [ ] Naming conventions followed
+- [ ] File structure matches standards
+- [ ] Plan is execution-ready
+
+---
+
+## Output
+
+Save the completed plan as a Markdown file at:
+```
+docs/plans/implementation-plan-{feature-name}.md
+```
+
+Use the required output format from `docs/implementation-plan-generator-guide.md`.
+
+The plan must be self-contained: understandable without additional context.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,113 @@
+@docs/architecture-overview.md
+@docs/engineering-standards.md
+@docs/frontend-architecture.md
+@docs/frontend-ui-style-guide.md
+@docs/testing-guide.md
+@docs/code-review-guide.md
+@docs/migrations.md
+
+You are the **OpenLinker Tech Lead** performing a systematic pull request review.
+
+Follow the 4-step workflow from `docs/code-review-guide.md`. Be direct. Ground every issue in a specific doc, file, or established pattern.
+
+---
+
+## Input
+
+PR or diff to review: **$ARGUMENTS**
+
+If a PR number is given, read the PR title, description, and diff before reviewing.
+If a file path or diff is given, review that directly.
+
+---
+
+## Step 1 — Understand Context
+
+Before reviewing any code:
+
+1. Read all changed files
+2. Understand what the PR is trying to accomplish
+3. Search for similar existing patterns in the codebase to establish the baseline
+4. Identify which architectural layers are touched (CORE, Integration, Infrastructure, Interface, Frontend)
+5. Read the PR description and linked issue (if any)
+
+---
+
+## Step 2 — Systematic Review
+
+Review each changed file against these dimensions:
+
+### Architecture & Boundaries
+- Hexagonal architecture compliance — correct layer placement
+- CORE ↔ Integration boundary — no bleeding of domain logic into integrations or vice versa
+- Frontend dependency direction — `app → pages → features → shared` only
+- Port/adapter pattern correctness
+
+### Naming & Structure
+- File naming matches `docs/engineering-standards.md` patterns (`*.port.ts`, `*-adapter.ts`, `*.service.ts`, etc.)
+- Class naming follows conventions
+- File is in the correct folder for its layer
+
+### Code Quality
+- TypeScript strict mode — no `any`, proper types
+- Explicit over implicit behavior
+- No hidden coupling or shared assumptions
+- Error handling — domain exceptions used correctly, errors not silently swallowed
+- Logging where observable behavior is expected
+- Idempotency for operations that may be retried
+
+### Tests
+- Unit test exists for non-trivial logic (`.spec.ts` colocated with source)
+- Integration test exists if a full vertical slice is introduced (`*.int-spec.ts`)
+- Tests follow Arrange-Act-Assert pattern
+- Tests cover edge cases, not just happy path
+
+### Security
+- No secrets or credentials in frontend code
+- No authorization logic duplicated in frontend
+- SQL/injection safety via TypeORM query builder (no raw string interpolation)
+
+### Frontend-specific (if applicable)
+- State ownership rules followed (server state → TanStack Query, form state → RHF, etc.)
+- No raw `fetch()` from pages or shared components
+- CSS uses tokens, not raw hex values
+- Accessibility: focus states, contrast, badges with text not just color
+
+### Database (if applicable)
+- New ORM entity changes have a corresponding migration
+- Migration has both `up()` and `down()` methods
+- Migration name follows `{timestamp}-{description}.ts` format
+
+---
+
+## Step 3 — Document Findings
+
+For each issue:
+
+**[BLOCKING | IMPORTANT | SUGGESTION]** — `path/to/file.ts` (line N if known)
+> What the problem is, why it violates a specific rule or pattern, and what to do instead. Reference the relevant doc section.
+
+Use:
+- **BLOCKING** — must be fixed before merge (architecture violation, security issue, missing migration, broken contract)
+- **IMPORTANT** — should be fixed (naming, missing test, wrong layer, unhandled error)
+- **SUGGESTION** — optional improvement (clarity, observability, future-proofing)
+
+Also note:
+- **Documentation gaps** — if the change introduces patterns not covered in docs
+- **Positive observations** — if non-obvious patterns are done correctly, say so
+
+---
+
+## Step 4 — Final Assessment
+
+### Summary
+One paragraph: what does this PR do, overall quality, and the most important concern.
+
+### Merge Readiness
+One of:
+- ✅ **Approve** — ready to merge as-is
+- 🔄 **Approve with changes** — merge after addressing IMPORTANT items
+- ❌ **Request changes** — has BLOCKING issues, must be revised before merge
+
+### Priority fixes (if any)
+Numbered list of what must be fixed, in priority order.

--- a/.claude/commands/tech-review.md
+++ b/.claude/commands/tech-review.md
@@ -1,0 +1,94 @@
+@docs/architecture-overview.md
+@docs/engineering-standards.md
+@docs/frontend-architecture.md
+@docs/frontend-ui-style-guide.md
+@docs/testing-guide.md
+@docs/code-review-guide.md
+@docs/migrations.md
+
+You are the **OpenLinker Tech Lead** performing a technical review.
+
+Your responsibility is to give honest, precise, senior-level feedback grounded strictly in OpenLinker's documented architecture, engineering standards, and established patterns.
+
+---
+
+## Review Scope
+
+Review the provided code, diff, file, or implementation plan for:
+
+### Architecture & Boundaries
+- CORE vs Integration boundary violations
+- Hexagonal architecture compliance (layers, port/adapter patterns)
+- Dependency direction violations (both backend and frontend)
+- Logic that belongs in CORE but lives in an integration, or vice versa
+
+### Engineering Standards
+- Naming conventions (files, classes, ports, adapters, DTOs, hooks, components)
+- File placement and project structure
+- TypeScript strict mode compliance
+- Explicit vs implicit behavior
+
+### Code Quality
+- Hidden coupling or shared assumptions
+- Premature abstraction or over-engineering
+- Missing or incorrect error handling
+- Idempotency and retry-safety where applicable
+- Observable behavior (logging, events) where expected
+
+### Frontend (if applicable)
+- State ownership rules (server state, URL state, form state, local state)
+- Dependency direction: `app` → `pages` → `features` → `shared`
+- No raw API calls from pages or presentational components
+- CSS token usage, component primitive reuse, accessibility
+
+### Testing
+- Missing tests for non-trivial logic
+- Incorrect mocking strategy
+- Test structure and naming compliance
+
+### Security
+- Secrets or credentials in frontend code
+- Authorization logic duplicated in the frontend
+- SQL injection, XSS, or other OWASP risks
+
+---
+
+## Review Format
+
+Structure your review as follows:
+
+### Summary
+One short paragraph: overall quality and the single most important concern.
+
+### Issues
+
+For each issue found:
+
+**[BLOCKING | IMPORTANT | SUGGESTION]** — `path/to/file.ts` (line N if known)
+> Brief description of the problem, why it violates a standard or principle, and what to do instead. Reference the relevant doc section when useful.
+
+Use:
+- **BLOCKING** — must be fixed before merge (architecture violation, security issue, broken contract)
+- **IMPORTANT** — should be fixed (naming, missing test, wrong layer)
+- **SUGGESTION** — optional improvement (clarity, future-proofing, style)
+
+### Verdict
+
+One of:
+- ✅ **Approve** — ready to merge
+- 🔄 **Approve with changes** — minor issues, can merge after fixing IMPORTANT items
+- ❌ **Request changes** — has BLOCKING issues, must be revised
+
+---
+
+## Behavior Rules
+
+- Be direct. Do not soften feedback beyond what is accurate.
+- Ground every BLOCKING or IMPORTANT issue in a specific doc, rule, or established pattern.
+- Do not invent new standards — only apply what is documented or clearly established in the codebase.
+- If something is ambiguous in the docs, flag it as a SUGGESTION or note the gap.
+- If nothing is wrong, say so clearly rather than manufacturing issues.
+
+---
+
+Now review the following: $ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,238 @@
+@docs/architecture-overview.md
+@docs/engineering-standards.md
+
+# OpenLinker – Claude Code Guide
+
+OpenLinker is an open-source, modular, API-first e-commerce orchestration platform built on **Hexagonal Architecture** (Ports and Adapters) in a pnpm monorepo.
+
+---
+
+## Reference Documentation
+
+Before writing or modifying code, read the relevant doc(s):
+
+| Topic | File |
+|---|---|
+| System architecture, layers, bounded contexts | `docs/architecture-overview.md` |
+| Coding standards, naming, file structure | `docs/engineering-standards.md` |
+| Testing standards and practices | `docs/testing-guide.md` |
+| Code review standards | `docs/code-review-guide.md` |
+| Database migration workflow | `docs/migrations.md` |
+| Frontend technical architecture and state rules | `docs/frontend-architecture.md` |
+| Frontend visual and interaction style | `docs/frontend-ui-style-guide.md` |
+| Implementation plan process | `docs/implementation-plan-generator-guide.md` |
+
+Architecture docs define **intent and direction**, not every implementation detail. You may infer missing layers or patterns if they clearly align — but always justify them explicitly.
+
+---
+
+## Architecture Rules
+
+### Backend
+
+The system follows Hexagonal Architecture organized by layer:
+
+- **CORE** (`libs/core/src/`) — domain logic, ports (interfaces), core services. Platform-agnostic.
+- **Integrations** (`libs/integrations/`) — adapters implementing CORE ports for external platforms (Allegro, PrestaShop, etc.)
+- **Infrastructure** — persistence (PostgreSQL via TypeORM), Redis, repositories
+- **Interface** — REST controllers, request/response DTOs, event handlers
+- **Shared** (`libs/shared/`) — cross-cutting utilities and types
+
+**CORE vs Integration boundary is strict:**
+- CORE defines capability ports (`ProductMasterPort`, `InventoryMasterPort`, `OrderProcessorManagerPort`, etc.)
+- Integrations implement those ports — they never bleed domain logic back into CORE
+- Do not blur this boundary for convenience
+
+### Frontend
+
+The frontend lives in `apps/web` and is a browser-first admin SPA. See `docs/frontend-architecture.md` for all conventions.
+
+Dependency direction is enforced:
+- `app` → `pages` → `features` → `shared`
+- `shared` must not import `features` or `pages`
+
+State ownership:
+- Server state → TanStack Query
+- URL state → route params / search params
+- Form state → React Hook Form
+- Session state → `SessionProvider`
+- Local UI state → component-local `useState` / `useReducer`
+- No general-purpose global store for FE-001
+
+---
+
+## Naming Conventions (Summary)
+
+See `docs/engineering-standards.md` for the full list. Key patterns:
+
+**Backend:**
+- Ports: `*.port.ts` → class `{Capability}Port`
+- Adapters: `*-adapter.ts` → class `{Platform}{Capability}Adapter`
+- Services: `*.service.ts` implementing `*.service.interface.ts`
+- Entities: `*.entity.ts`, ORM entities: `*.orm-entity.ts`
+- Mappers: `*.mapper.ts`, DTOs: `*.dto.ts`
+- Unit tests: `*.spec.ts`, integration tests: `*.int-spec.ts`
+
+**Frontend:**
+- Components: `PascalCase.tsx`
+- Hooks: `use-*.ts`
+- Route modules: `*.route.tsx`
+- Tests: `*.test.tsx`
+
+---
+
+## Behavior Rules
+
+- **Do not** redefine or reinterpret architecture — follow what the docs say
+- **Do not** duplicate architectural explanations in code or comments
+- **Do not** bypass CORE ↔ Integration boundaries
+- **Prefer** reusing existing abstractions over creating new ones
+- **Default** to MVP-appropriate solutions unless explicitly told otherwise
+- **Justify** any new pattern, abstraction, or component explicitly
+
+## Code Quality Rules
+
+### Never do these
+
+- No `any` in TypeScript — use proper types or `unknown` with narrowing
+- No `console.log` — use the shared `Logger` from `libs/shared/src/logging/`
+- No comments that explain *what* code does — comments explain *why*
+- No hardcoded secrets, tokens, or credentials anywhere in code
+- No `.env` files committed to git
+- No `synchronize: true` in TypeORM config — migrations are the source of truth
+- No force-push to `main`
+- No skipping hooks with `--no-verify`
+- No `// eslint-disable` without a specific reason in the same comment
+
+### Security baselines
+
+- Validate all user input at system boundaries (controllers, DTOs with class-validator)
+- Use TypeORM query builder — never interpolate user input into raw SQL
+- Never return secrets, tokens, or credentials in API responses
+- Never embed secrets in frontend code — only `VITE_*` public build-time vars in browser code
+- Use `@UseGuards(JwtAuthGuard)` on all non-public endpoints
+
+### TypeScript
+
+- Strict mode is on — no implicit `any`, no loose null checks
+- Prefer explicit return types on public methods and exported functions
+- Use `unknown` over `any` when type is genuinely unknown; narrow with type guards
+- Keep types close to where they are used — colocate with the module that owns them
+
+---
+
+## Working Process
+
+### For code tasks
+
+1. Read relevant documentation and find similar existing patterns in the codebase
+2. Propose what will be implemented now vs. what can be deferred
+3. Implement conservatively — only what is required, keep changes localized
+4. Add or update tests for non-trivial logic
+5. Run the quality gate before committing (see below)
+6. Commit on a dedicated branch named after the issue (e.g. `55-100-fe-api-client-and-query-layer`)
+7. Push and open a PR with `Closes #N` in the body — **never close an issue manually before the PR is merged**
+
+**Branch naming:** `{issue-number}-{short-kebab-description}` branched from `main`
+**Issue lifecycle:** open → PR in review → merged → auto-closed by GitHub via `Closes #N`
+
+### Quality gate (run before every commit)
+
+```bash
+pnpm lint        # must pass with zero errors
+pnpm type-check  # must pass with zero errors
+pnpm test        # all unit tests must pass
+```
+
+For backend schema changes: also run `pnpm --filter @openlinker/api migration:show` to confirm no pending migrations are missing.
+
+### For implementation plans
+
+Use `/plan <description or issue>`. Plans are saved to `docs/plans/implementation-plan-{feature-name}.md`.
+
+### For code review
+
+Use `/tech-review <file or diff>` for a quick pass or `/pr-review <PR number>` for a full systematic review.
+
+### For migrations
+
+A migration is required whenever an ORM entity in `libs/core/src/**/*.orm-entity.ts` changes schema.
+Use `/migrate <description>` to generate, validate, and verify the migration.
+See `docs/migrations.md` for the full workflow.
+
+---
+
+## Dev Commands
+
+```bash
+# Dev stack (Postgres, Redis, MySQL, PrestaShop)
+pnpm dev:stack:up
+pnpm dev:stack:down
+
+# Start apps
+pnpm start:dev:api       # NestJS API on :3000
+pnpm start:dev:worker    # Background job worker
+pnpm start:dev:web       # React frontend on :5173
+
+# Testing
+pnpm test                # Unit tests (fast, no Docker)
+pnpm test:watch          # Unit tests in watch mode
+pnpm test:cov            # Unit tests with coverage
+pnpm test:integration    # Integration tests (requires Docker)
+
+# Quality
+pnpm lint                # ESLint
+pnpm type-check          # TypeScript check (no emit)
+pnpm format              # Prettier
+
+# Build
+pnpm build               # Build all packages
+pnpm build:api           # Build API only
+
+# Migrations
+pnpm --filter @openlinker/api migration:generate -- src/migrations/MigrationName
+pnpm --filter @openlinker/api migration:run
+pnpm --filter @openlinker/api migration:revert
+pnpm --filter @openlinker/api migration:show
+```
+
+---
+
+## Testing Rules (Summary)
+
+See `docs/testing-guide.md` for the full guide.
+
+| | Unit tests | Integration tests |
+|---|---|---|
+| File pattern | `*.spec.ts` | `*.int-spec.ts` |
+| Location | Colocated with source in `src/` | `test/integration/` |
+| Command | `pnpm test` | `pnpm test:integration` |
+| Requires Docker | No | Yes (Testcontainers) |
+| Speed | Fast (~2–3s total) | Slow (~10–15s per suite) |
+
+**Key rules:**
+- Unit tests mock all external dependencies (DB, HTTP, Redis)
+- Integration tests use real Postgres + Redis via Testcontainers — never mock the database
+- Use `resetTestHarness()` between integration tests to clean state
+- Test names: `should [expected behaviour] when [condition]`
+- Aim for 80%+ unit test coverage; integration tests cover critical vertical slices only
+
+---
+
+## Tech Stack
+
+**Backend:** TypeScript (strict), NestJS, Node.js LTS, pnpm workspaces, PostgreSQL (TypeORM), Redis, RabbitMQ
+
+**Frontend:** React + TypeScript, Vite, React Router, TanStack Query, React Hook Form + Zod, Vitest + Testing Library
+
+---
+
+## Available Skills
+
+| Command | What it does |
+|---|---|
+| `/plan <task>` | Generate a full 5-phase implementation plan, saved to `docs/plans/` |
+| `/tech-review <file\|diff>` | Quick tech lead review with BLOCKING/IMPORTANT/SUGGESTION ratings |
+| `/pr-review <PR number\|diff>` | Full systematic PR review using `code-review-guide.md` workflow |
+| `/migrate <description>` | Guide through creating, validating, and verifying a TypeORM migration |
+| `/create-issue <description>` | Turn a rough idea into a well-defined GitHub issue |


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` at repo root — auto-loaded by Claude Code with architecture rules, dev commands cheatsheet, testing rules, working process with quality gate, and issue lifecycle enforcement (`Closes #N` in PR, never close manually)
- Add `.claude/commands/` with five project commands: `/tech-review`, `/create-issue`, `/plan`, `/pr-review`, `/migrate`
- Add `docs/plans/.gitkeep` to track the plans output directory in git

## Test plan

- [ ] Open a new Claude Code session in this repo and verify `CLAUDE.md` is auto-loaded (visible in context)
- [ ] Run `/tech-review`, `/create-issue`, `/plan`, `/pr-review`, `/migrate` slash commands and confirm they load correctly
- [ ] Confirm `docs/plans/` directory exists for plan file output

🤖 Generated with [Claude Code](https://claude.com/claude-code)