### PR TITLE
feat: implement real authentication API and FE quality baseline (#57, #56)

### DIFF
--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -62,7 +62,10 @@ export function createApiClient({
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => { controller.abort(); }, requestTimeoutMs);
-    const signal = init.signal ?? controller.signal;
+    // Combine the timeout signal with any caller-supplied signal so both can abort the request
+    const signal = init.signal
+      ? AbortSignal.any([controller.signal, init.signal])
+      : controller.signal;
 
     try {
       const response = await fetchFn(buildUrl(baseUrl, path), {

--- a/apps/web/src/features/connections/components/connections-overview.test.tsx
+++ b/apps/web/src/features/connections/components/connections-overview.test.tsx
@@ -1,19 +1,7 @@
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
 import { ConnectionsOverview } from './connections-overview';
-
-const sampleConnection = {
-  id: 'conn_1',
-  name: 'Main PrestaShop Store',
-  platformType: 'prestashop',
-  status: 'active',
-  config: { baseUrl: 'https://example.com' },
-  credentialsRef: 'db:cred_1',
-  adapterKey: 'prestashop.webservice.v1',
-  createdAt: '2026-01-01T00:00:00.000Z',
-  updatedAt: '2026-01-01T00:00:00.000Z',
-};
 
 describe('ConnectionsOverview', () => {
   it('shows loading state while fetching', () => {

--- a/apps/web/src/pages/connections/connections-list-page.test.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { ConnectionsListPage } from './connections-list-page';
 
 describe('ConnectionsListPage', () => {
@@ -11,23 +11,9 @@ describe('ConnectionsListPage', () => {
 
   it('displays connections returned by the API', async () => {
     const apiClient = createMockApiClient({
-      connections: {
-        list: vi.fn().mockResolvedValue([
-          {
-            id: 'conn_1',
-            name: 'Main PrestaShop Store',
-            platformType: 'prestashop',
-            status: 'active',
-            config: { baseUrl: 'https://example.com' },
-            credentialsRef: 'db:cred_1',
-            adapterKey: 'prestashop.webservice.v1',
-            createdAt: '2026-01-01T00:00:00.000Z',
-            updatedAt: '2026-01-01T00:00:00.000Z',
-          },
-        ]),
-      },
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
     });
     renderWithProviders(<ConnectionsListPage />, { apiClient });
-    expect(await screen.findByText('Main PrestaShop Store')).toBeInTheDocument();
+    expect(await screen.findByText(sampleConnection.name)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/shared/ui/confirm-dialog.test.tsx
+++ b/apps/web/src/shared/ui/confirm-dialog.test.tsx
@@ -22,7 +22,7 @@ describe('ConfirmDialog', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it('closes on cancel', () => {
+  it('calls onOpenChange(false) when the cancel button is clicked', () => {
     const onConfirm = vi.fn();
     const onOpenChange = vi.fn();
 
@@ -36,36 +36,15 @@ describe('ConfirmDialog', () => {
       />,
     );
 
-    fireEvent.click(within(within(view.container).getAllByRole('dialog', { name: 'Delete item?' })[0]).getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Cancel' }));
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('traps focus within the dialog actions', () => {
-    const view = render(
-      <ConfirmDialog
-        open
-        onConfirm={vi.fn()}
-        onOpenChange={vi.fn()}
-        title="Delete item?"
-        description="This action cannot be undone."
-      />,
-    );
+  // Focus trapping (Tab cycle) and Escape handling are provided natively by showModal() —
+  // they are browser behaviours not exercisable via fireEvent in jsdom.
 
-    const dialog = within(view.container).getAllByRole('dialog', { name: 'Delete item?' })[0];
-    const cancelButton = within(dialog).getByRole('button', { name: 'Cancel' });
-    const confirmButton = within(dialog).getByRole('button', { name: 'Confirm' });
-
-    expect(confirmButton).toHaveFocus();
-
-    fireEvent.keyDown(window, { key: 'Tab' });
-    expect(cancelButton).toHaveFocus();
-
-    fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
-    expect(confirmButton).toHaveFocus();
-  });
-
-  it('restores focus to the previously focused element after close', () => {
+  it('focuses the confirm button when opened and restores focus to the trigger when closed', () => {
     const onConfirm = vi.fn();
     const onOpenChange = vi.fn();
     const view = render(

--- a/apps/web/src/shared/ui/confirm-dialog.tsx
+++ b/apps/web/src/shared/ui/confirm-dialog.tsx
@@ -23,118 +23,76 @@ export function ConfirmDialog({
   open,
   title,
   tone = 'default',
-}: ConfirmDialogProps): ReactElement | null {
+}: ConfirmDialogProps): ReactElement {
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const baseId = useId();
   const titleId = `${baseId}-title`;
   const descriptionId = `${baseId}-description`;
 
+  // showModal/close handle focus trapping, Escape key, and focus restoration natively
   useEffect(() => {
-    if (!open) {
-      return undefined;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open) {
+      dialog.showModal();
+      confirmButtonRef.current?.focus();
+    } else if (dialog.open) {
+      dialog.close();
     }
+  }, [open]);
 
-    lastFocusedElementRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    confirmButtonRef.current?.focus();
+  // Intercept the native cancel event (fired on Escape) to keep controlled state in sync
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
 
-    const getFocusableElements = (): HTMLElement[] => {
-      if (!dialogRef.current) {
-        return [];
-      }
-
-      const focusableSelector = [
-        'button:not([disabled])',
-        '[href]',
-        'input:not([disabled])',
-        'select:not([disabled])',
-        'textarea:not([disabled])',
-        '[tabindex]:not([tabindex="-1"])',
-      ].join(',');
-
-      return Array.from(dialogRef.current.querySelectorAll<HTMLElement>(focusableSelector)).filter(
-        (element) => !element.hasAttribute('aria-hidden'),
-      );
+    const handleCancel = (event: Event): void => {
+      event.preventDefault();
+      onOpenChange(false);
     };
 
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape') {
-        onOpenChange(false);
-        return;
-      }
-
-      if (event.key !== 'Tab') {
-        return;
-      }
-
-      const focusableElements = getFocusableElements();
-      if (focusableElements.length === 0) {
-        event.preventDefault();
-        return;
-      }
-
-      const firstFocusableElement = focusableElements[0];
-      const lastFocusableElement = focusableElements[focusableElements.length - 1];
-
-      if (event.shiftKey && document.activeElement === firstFocusableElement) {
-        event.preventDefault();
-        lastFocusableElement.focus();
-        return;
-      }
-
-      if (!event.shiftKey && document.activeElement === lastFocusableElement) {
-        event.preventDefault();
-        firstFocusableElement.focus();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-
+    dialog.addEventListener('cancel', handleCancel);
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-      lastFocusedElementRef.current?.focus();
+      dialog.removeEventListener('cancel', handleCancel);
     };
-  }, [onOpenChange, open]);
-
-  if (!open) {
-    return null;
-  }
+  }, [onOpenChange]);
 
   return (
-    <div
-      className="dialog-backdrop"
+    <dialog
+      ref={dialogRef}
+      aria-describedby={descriptionId}
+      aria-labelledby={titleId}
+      className="dialog"
       onClick={(event) => {
+        // Close when clicking the backdrop (the dialog element itself, not its children)
         if (event.target === event.currentTarget) {
           onOpenChange(false);
         }
       }}
     >
-      <div
-        ref={dialogRef}
-        aria-describedby={descriptionId}
-        aria-labelledby={titleId}
-        aria-modal="true"
-        className="dialog"
-        role="dialog"
-      >
-        <div className="dialog__header">
-          <h2 id={titleId} className="dialog__title">
-            {title}
-          </h2>
-        </div>
-        <div id={descriptionId} className="dialog__body">
-          {description}
-        </div>
-        <div className="dialog__actions">
-          <Button tone="secondary" onClick={() => onOpenChange(false)}>
-            {cancelLabel}
-          </Button>
-          <Button ref={confirmButtonRef} tone={tone === 'danger' ? 'danger' : 'primary'} onClick={onConfirm} disabled={isConfirming}>
-            {confirmLabel}
-          </Button>
-        </div>
+      <div className="dialog__header">
+        <h2 id={titleId} className="dialog__title">
+          {title}
+        </h2>
       </div>
-    </div>
+      <div id={descriptionId} className="dialog__body">
+        {description}
+      </div>
+      <div className="dialog__actions">
+        <Button tone="secondary" onClick={() => onOpenChange(false)}>
+          {cancelLabel}
+        </Button>
+        <Button
+          ref={confirmButtonRef}
+          tone={tone === 'danger' ? 'danger' : 'primary'}
+          onClick={onConfirm}
+          disabled={isConfirming}
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+    </dialog>
   );
 }

--- a/apps/web/src/shared/ui/feedback-state.tsx
+++ b/apps/web/src/shared/ui/feedback-state.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement, ReactNode } from 'react';
 
+type AriaLive = 'assertive' | 'off' | 'polite';
+
 interface BaseStateProps {
   action?: ReactNode;
   eyebrow?: string;
@@ -7,13 +9,26 @@ interface BaseStateProps {
   title: ReactNode;
 }
 
+interface LoadingStateProps extends Omit<BaseStateProps, 'action'> {
+  // Defaults to "polite". Set to "off" when the loading state is rendered on initial page
+  // load (not as a transition from a prior loaded state) to avoid spurious announcements.
+  liveRegion?: AriaLive;
+}
+
+interface EmptyStateProps extends BaseStateProps {
+  // Defaults to "polite". Set to "off" when the empty state is rendered on initial page
+  // load (not as a transition from a prior loaded state) to avoid spurious announcements.
+  liveRegion?: AriaLive;
+}
+
 export function LoadingState({
   eyebrow = 'Loading',
+  liveRegion = 'polite',
   message,
   title,
-}: Omit<BaseStateProps, 'action'>): ReactElement {
+}: LoadingStateProps): ReactElement {
   return (
-    <div className="state-card state-card--loading" role="status" aria-live="polite">
+    <div className="state-card state-card--loading" role="status" aria-live={liveRegion}>
       <div className="state-card__header">
         <p className="eyebrow">{eyebrow}</p>
         <h2 className="state-card__title">{title}</h2>
@@ -23,9 +38,9 @@ export function LoadingState({
   );
 }
 
-export function EmptyState({ action, eyebrow = 'Empty state', message, title }: BaseStateProps): ReactElement {
+export function EmptyState({ action, eyebrow = 'Empty state', liveRegion = 'polite', message, title }: EmptyStateProps): ReactElement {
   return (
-    <div className="state-card empty-state" role="status">
+    <div className="state-card empty-state" role="status" aria-live={liveRegion}>
       <div className="state-card__header">
         <p className="eyebrow">{eyebrow}</p>
         <h2 className="state-card__title">{title}</h2>

--- a/apps/web/src/shared/ui/form-field.tsx
+++ b/apps/web/src/shared/ui/form-field.tsx
@@ -16,6 +16,9 @@ interface ControlProps {
 }
 
 interface FormFieldProps {
+  // children must be a form control (Input, Select, Textarea, or a wrapper component) that
+  // forwards id, aria-describedby, and aria-invalid to its underlying native element.
+  // Wrappers that do not forward these props will silently break the accessibility wiring.
   children: ReactElement<ControlProps>;
   description?: ReactNode;
   error?: string;

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,1 +1,20 @@
 import '@testing-library/jest-dom/vitest';
+
+// jsdom does not implement HTMLDialogElement.showModal / .close.
+// These stubs mirror the browser behaviours that our components rely on in tests:
+//   showModal — marks the dialog open and remembers the previously-focused element
+//   close     — closes the dialog and restores focus (matching native browser behaviour)
+const previouslyFocused = new WeakMap<HTMLDialogElement, HTMLElement | null>();
+
+HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement): void {
+  previouslyFocused.set(
+    this,
+    document.activeElement instanceof HTMLElement ? document.activeElement : null,
+  );
+  this.setAttribute('open', '');
+};
+
+HTMLDialogElement.prototype.close = function (this: HTMLDialogElement): void {
+  this.removeAttribute('open');
+  previouslyFocused.get(this)?.focus();
+};

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -15,7 +15,7 @@ interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
   route?: string;
 }
 
-const sampleConnection: Connection = {
+export const sampleConnection: Connection = {
   id: 'conn_1',
   name: 'Main PrestaShop Store',
   platformType: 'prestashop',


### PR DESCRIPTION
## Summary

- **Auth API (#57)**: Real JWT authentication with `/auth/login`, `/auth/logout`, `/auth/me` endpoints backed by a `users` table, bcrypt password hashing, and `JwtAuthGuard`-protected endpoints. Includes full unit and integration test coverage.
- **FE UI primitives (#54)**: Complete shared component library — Button, Input, Select, Textarea, StatusBadge, DataTable, Alert, ConfirmDialog, FormField, FieldError, FormErrorSummary, FeedbackState, ToastProvider, EnvironmentBadge, PageLayout. All components have co-located tests.
- **FE quality baseline (#56)**: Vitest configured with jsdom, `renderWithProviders` + `createMockApiClient` test utilities, component/page test baseline (10 test files, 23 tests), `type-check` and `lint` scripts wired into CI.
- **Tech-review fixes**: AbortController timeout composable with caller signal via `AbortSignal.any`; `ConfirmDialog` migrated to native `<dialog>` + `showModal()`/`close()`; shared test fixture exported; `FormField` contract documented; `liveRegion` prop added to `LoadingState`/`EmptyState`.

## Test plan

- [ ] `pnpm lint` — zero errors across all packages
- [ ] `pnpm type-check` — zero errors across all packages
- [ ] `pnpm test` — all unit tests pass (web: 10 files / 23 tests; core: full suite)
- [ ] `POST /auth/login` with valid credentials returns JWT + user payload
- [ ] `POST /auth/login` with invalid credentials returns 401
- [ ] `GET /auth/me` with valid Bearer token returns user; without token returns 401
- [ ] `POST /auth/logout` returns 200
- [ ] Frontend renders authenticated shell; unauthenticated state shows loading gate

Closes #57
Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)