### PR TITLE
feat(auth): add minimal authorization model

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -8,6 +8,7 @@
  */
 import { Controller, Get, Inject } from '@nestjs/common';
 import { AppService } from './app.service';
+import { Public } from './auth/decorators/public.decorator';
 import { IDevStackHealthService } from './health/dev-stack-health.service.interface';
 import {
   InternalHealthResponse,
@@ -15,6 +16,7 @@ import {
 } from './health/dev-stack-health.types';
 import { DEV_STACK_HEALTH_SERVICE_TOKEN } from './health/health.module';
 
+@Public()
 @Controller()
 export class AppController {
   constructor(

--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -15,7 +15,7 @@ import { LoginResponseDto } from './dto/login-response.dto';
 import { User } from '@openlinker/core/users';
 
 const makeUser = (): User =>
-  new User('user-uuid-123', 'admin', null, '$2a$10$hash', new Date(), new Date());
+  new User('user-uuid-123', 'admin', null, '$2a$10$hash', 'admin', new Date(), new Date());
 
 const makeLoginResponse = (): LoginResponseDto => {
   const dto = new LoginResponseDto();
@@ -71,16 +71,19 @@ describe('AuthController', () => {
   });
 
   describe('GET /auth/me', () => {
-    it('should return UserResponseDto for the authenticated user', async () => {
+    it('should return UserResponseDto with role and permissions for the authenticated user', async () => {
       const user = makeUser();
       authService.getMe.mockResolvedValue(user);
 
-      const req = { user: { id: user.id, username: user.username } } as never;
-      const result = await controller.getMe(req);
+      const authenticatedUser = { id: user.id, username: user.username, role: 'admin' as const };
+      const result = await controller.getMe(authenticatedUser);
 
       expect(authService.getMe).toHaveBeenCalledWith(user.id);
       expect(result.id).toBe(user.id);
       expect(result.username).toBe(user.username);
+      expect(result.role).toBe('admin');
+      expect(result.permissions).toBeDefined();
+      expect(result.permissions.length).toBeGreaterThan(0);
     });
   });
 });

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -3,7 +3,7 @@
  *
  * HTTP REST API endpoints for authentication. Provides login (POST /auth/login)
  * and current-user (GET /auth/me) endpoints. The login endpoint is public;
- * /auth/me requires a valid JWT bearer token.
+ * /auth/me requires a valid JWT bearer token (enforced by global guard).
  *
  * @module apps/api/src/auth
  */
@@ -14,11 +14,8 @@ import {
   HttpCode,
   HttpStatus,
   Post,
-  Req,
   UnauthorizedException,
-  UseGuards,
 } from '@nestjs/common';
-import type { Request as ExpressRequest } from 'express';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -26,21 +23,19 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
-import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { Public } from './decorators/public.decorator';
+import { CurrentUser } from './decorators/current-user.decorator';
 import { LoginDto } from './dto/login.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { UserResponseDto } from './dto/user-response.dto';
-import { AuthenticatedUser } from './strategies/jwt.strategy';
-
-interface RequestWithUser extends ExpressRequest {
-  user: AuthenticatedUser;
-}
+import { AuthenticatedUser } from './auth.types';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Login with username and password, returns JWT' })
@@ -56,13 +51,12 @@ export class AuthController {
   }
 
   @Get('me')
-  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get the currently authenticated user' })
   @ApiResponse({ status: 200, description: 'Current user', type: UserResponseDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async getMe(@Req() req: RequestWithUser): Promise<UserResponseDto> {
-    const user = await this.authService.getMe(req.user.id);
-    return UserResponseDto.fromDomain(user);
+  async getMe(@CurrentUser() user: AuthenticatedUser): Promise<UserResponseDto> {
+    const fullUser = await this.authService.getMe(user.id);
+    return UserResponseDto.fromDomain(fullUser);
   }
 }

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,13 +1,15 @@
 /**
- * Authentication Module
+ * Authentication & Authorization Module
  *
- * Provides JWT-based authentication for the OpenLinker API. Imports UsersModule
- * for user lookup and configures Passport with the JWT strategy. Exports
- * AuthService for use in other modules if needed.
+ * Provides JWT-based authentication and role-based authorization for the
+ * OpenLinker API. Registers JwtAuthGuard and RolesGuard as global APP_GUARDs
+ * so all routes are protected by default. Use @Public() to opt out of auth
+ * and @Roles() to restrict by role.
  *
  * @module apps/api/src/auth
  */
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -15,6 +17,8 @@ import { UsersModule } from '@openlinker/core/users';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RolesGuard } from './guards/roles.guard';
 
 @Module({
   imports: [
@@ -32,7 +36,12 @@ import { AuthController } from './auth.controller';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    { provide: APP_GUARD, useClass: JwtAuthGuard },
+    { provide: APP_GUARD, useClass: RolesGuard },
+  ],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -19,6 +19,7 @@ const makeUser = (overrides: Partial<User> = {}): User =>
     overrides.username ?? 'admin',
     overrides.email ?? null,
     overrides.passwordHash ?? '$2a$10$hashedpassword',
+    overrides.role ?? 'admin',
     overrides.createdAt ?? new Date(),
     overrides.updatedAt ?? new Date(),
   );
@@ -83,7 +84,7 @@ describe('AuthService', () => {
   });
 
   describe('login', () => {
-    it('should return LoginResponseDto with access_token', () => {
+    it('should return LoginResponseDto with access_token containing role', () => {
       const user = makeUser();
 
       const result = service.login(user);
@@ -91,6 +92,7 @@ describe('AuthService', () => {
       expect(jwtService.sign).toHaveBeenCalledWith({
         sub: user.id,
         username: user.username,
+        role: user.role,
       });
       expect(result.access_token).toBe('signed-jwt-token');
     });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -37,7 +37,7 @@ export class AuthService {
   }
 
   login(user: User): LoginResponseDto {
-    const payload = { sub: user.id, username: user.username };
+    const payload = { sub: user.id, username: user.username, role: user.role };
     const dto = new LoginResponseDto();
     dto.access_token = this.jwtService.sign(payload);
     return dto;

--- a/apps/api/src/auth/auth.types.ts
+++ b/apps/api/src/auth/auth.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Authentication & Authorization Types
+ *
+ * Shared type definitions for the auth module. Includes JWT payload shape
+ * and the authenticated user object attached to requests by the JWT strategy.
+ *
+ * @module apps/api/src/auth
+ */
+import { UserRole } from '@openlinker/core/users';
+
+/**
+ * Shape of the JWT token payload after signing/verification.
+ */
+export interface JwtPayload {
+  sub: string;
+  username: string;
+  role: UserRole;
+}
+
+/**
+ * Authenticated user object attached to req.user by the JWT strategy.
+ * Available in controllers via @CurrentUser() decorator.
+ */
+export interface AuthenticatedUser {
+  id: string;
+  username: string;
+  role: UserRole;
+}

--- a/apps/api/src/auth/decorators/current-user.decorator.ts
+++ b/apps/api/src/auth/decorators/current-user.decorator.ts
@@ -1,0 +1,21 @@
+/**
+ * Current User Param Decorator
+ *
+ * Extracts the authenticated user from the request object. Use instead of
+ * `@Req() req` for cleaner controller signatures.
+ *
+ * @example
+ *   @Get('me')
+ *   getMe(@CurrentUser() user: AuthenticatedUser): Promise<...>
+ *
+ * @module apps/api/src/auth/decorators
+ */
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { AuthenticatedUser } from '../auth.types';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuthenticatedUser => {
+    const request = ctx.switchToHttp().getRequest<{ user: AuthenticatedUser }>();
+    return request.user;
+  },
+);

--- a/apps/api/src/auth/decorators/public.decorator.ts
+++ b/apps/api/src/auth/decorators/public.decorator.ts
@@ -1,0 +1,12 @@
+/**
+ * Public Route Decorator
+ *
+ * Marks a controller method or class as publicly accessible, bypassing
+ * JWT authentication enforced by the global JwtAuthGuard.
+ *
+ * @module apps/api/src/auth/decorators
+ */
+import { CustomDecorator, SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = (): CustomDecorator<string> => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/api/src/auth/decorators/roles.decorator.ts
+++ b/apps/api/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,14 @@
+/**
+ * Roles Decorator
+ *
+ * Marks a controller method or class as requiring one of the specified roles.
+ * Used by RolesGuard to enforce role-based access control. If no @Roles()
+ * decorator is present, any authenticated user is allowed.
+ *
+ * @module apps/api/src/auth/decorators
+ */
+import { CustomDecorator, SetMetadata } from '@nestjs/common';
+import { UserRole } from '@openlinker/core/users';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]): CustomDecorator<string> => SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/auth/dto/user-response.dto.spec.ts
+++ b/apps/api/src/auth/dto/user-response.dto.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * UserResponseDto Unit Tests
+ *
+ * Tests the fromDomain() factory method including role and permissions
+ * derivation from the User domain entity.
+ *
+ * @module apps/api/src/auth/dto
+ */
+import { User, ROLE_PERMISSIONS, PermissionValues } from '@openlinker/core/users';
+import { UserResponseDto } from './user-response.dto';
+
+describe('UserResponseDto', () => {
+  describe('fromDomain', () => {
+    it('should map basic user fields correctly', () => {
+      const user = new User('id-1', 'testuser', 'test@example.com', 'hash', 'admin', new Date(), new Date());
+
+      const dto = UserResponseDto.fromDomain(user);
+
+      expect(dto.id).toBe('id-1');
+      expect(dto.username).toBe('testuser');
+      expect(dto.email).toBe('test@example.com');
+    });
+
+    it('should include role in the response', () => {
+      const user = new User('id-1', 'testuser', null, 'hash', 'viewer', new Date(), new Date());
+
+      const dto = UserResponseDto.fromDomain(user);
+
+      expect(dto.role).toBe('viewer');
+    });
+
+    it('should derive admin permissions correctly', () => {
+      const user = new User('id-1', 'admin', null, 'hash', 'admin', new Date(), new Date());
+
+      const dto = UserResponseDto.fromDomain(user);
+
+      expect(dto.permissions).toEqual([...PermissionValues]);
+      expect(dto.permissions).toEqual([...ROLE_PERMISSIONS['admin']]);
+    });
+
+    it('should derive viewer permissions correctly', () => {
+      const user = new User('id-1', 'viewer', null, 'hash', 'viewer', new Date(), new Date());
+
+      const dto = UserResponseDto.fromDomain(user);
+
+      expect(dto.permissions).toEqual([...ROLE_PERMISSIONS['viewer']]);
+      expect(dto.permissions).toContain('connections:read');
+      expect(dto.permissions).not.toContain('connections:write');
+    });
+
+    it('should not expose passwordHash', () => {
+      const user = new User('id-1', 'testuser', null, 'secret-hash', 'admin', new Date(), new Date());
+
+      const dto = UserResponseDto.fromDomain(user);
+
+      expect(dto).not.toHaveProperty('passwordHash');
+    });
+  });
+});

--- a/apps/api/src/auth/dto/user-response.dto.ts
+++ b/apps/api/src/auth/dto/user-response.dto.ts
@@ -2,12 +2,19 @@
  * User Response DTO
  *
  * Response body for GET /auth/me. Exposes safe user fields only — never
- * returns passwordHash or internal infrastructure details.
+ * returns passwordHash or internal infrastructure details. Includes role
+ * and derived permissions for frontend authorization decisions.
  *
  * @module apps/api/src/auth/dto
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { User } from '@openlinker/core/users';
+import {
+  User,
+  UserRoleValues,
+  PermissionValues,
+  ROLE_PERMISSIONS,
+} from '@openlinker/core/users';
+import type { UserRole, Permission } from '@openlinker/core/users';
 
 export class UserResponseDto {
   @ApiProperty({ description: 'Internal user ID (UUID)' })
@@ -19,11 +26,23 @@ export class UserResponseDto {
   @ApiPropertyOptional({ description: 'Email address', nullable: true })
   email!: string | null;
 
+  @ApiProperty({ description: 'User role', enum: UserRoleValues })
+  role!: UserRole;
+
+  @ApiProperty({
+    description: 'Permissions derived from role',
+    enum: PermissionValues,
+    isArray: true,
+  })
+  permissions!: Permission[];
+
   static fromDomain(user: User): UserResponseDto {
     const dto = new UserResponseDto();
     dto.id = user.id;
     dto.username = user.username;
     dto.email = user.email;
+    dto.role = user.role;
+    dto.permissions = [...ROLE_PERMISSIONS[user.role]];
     return dto;
   }
 }

--- a/apps/api/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/apps/api/src/auth/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * JwtAuthGuard Unit Tests
+ *
+ * Tests the @Public() bypass logic in the global JWT authentication guard.
+ *
+ * @module apps/api/src/auth/guards
+ */
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtAuthGuard } from './jwt-auth.guard';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+describe('JwtAuthGuard', () => {
+  let guard: JwtAuthGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new JwtAuthGuard(reflector);
+  });
+
+  function createMockContext(): ExecutionContext {
+    return {
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => ({}),
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  it('should bypass authentication when @Public() is set', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+    const context = createMockContext();
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('should delegate to parent AuthGuard when @Public() is not set', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+    const context = createMockContext();
+
+    // The parent AuthGuard('jwt').canActivate() would throw or return
+    // an Observable in a real scenario. We just verify it doesn't
+    // short-circuit to true.
+    const parentCanActivate = jest.spyOn(
+      Object.getPrototypeOf(Object.getPrototypeOf(guard)),
+      'canActivate',
+    );
+    parentCanActivate.mockReturnValue(true);
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(parentCanActivate).toHaveBeenCalledWith(context);
+  });
+
+  it('should read metadata from both handler and class', async () => {
+    const spy = jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
+    const context = createMockContext();
+
+    await guard.canActivate(context);
+
+    expect(spy).toHaveBeenCalledWith(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+  });
+});

--- a/apps/api/src/auth/guards/jwt-auth.guard.ts
+++ b/apps/api/src/auth/guards/jwt-auth.guard.ts
@@ -1,14 +1,30 @@
 /**
  * JWT Authentication Guard
  *
- * Route guard that protects endpoints requiring JWT authentication.
- * Uses the JWT strategy to validate tokens and ensure authenticated access.
+ * Global route guard that protects all endpoints by default. Routes decorated
+ * with @Public() bypass JWT validation. Registered as APP_GUARD in AuthModule.
  *
  * @module apps/api/src/auth/guards
  */
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { Observable } from 'rxjs';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) return true;
+    return super.canActivate(context);
+  }
+}
 

--- a/apps/api/src/auth/guards/roles.guard.spec.ts
+++ b/apps/api/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * RolesGuard Unit Tests
+ *
+ * Tests role-based access control enforcement. Verifies that the guard
+ * allows/denies access based on @Roles() decorator metadata and user role.
+ *
+ * @module apps/api/src/auth/guards
+ */
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { UserRole } from '@openlinker/core/users';
+
+function createMockExecutionContext(user?: { role: UserRole }): ExecutionContext {
+  return {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  it('should allow access when no @Roles() decorator is present', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+    const context = createMockExecutionContext({ role: 'viewer' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should allow access when @Roles() has empty array', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([]);
+    const context = createMockExecutionContext({ role: 'viewer' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should allow access when user role matches required role', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['admin']);
+    const context = createMockExecutionContext({ role: 'admin' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should throw ForbiddenException when user role does not match required role', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['admin']);
+    const context = createMockExecutionContext({ role: 'viewer' });
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+
+  it('should allow access when user has one of multiple required roles', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['admin', 'viewer']);
+    const context = createMockExecutionContext({ role: 'viewer' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should throw ForbiddenException when req.user is undefined', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['admin']);
+    const context = createMockExecutionContext(undefined);
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+
+  it('should read metadata from both handler and class', () => {
+    const spy = jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+    const context = createMockExecutionContext({ role: 'admin' });
+
+    guard.canActivate(context);
+
+    expect(spy).toHaveBeenCalledWith(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+  });
+});

--- a/apps/api/src/auth/guards/roles.guard.ts
+++ b/apps/api/src/auth/guards/roles.guard.ts
@@ -1,0 +1,39 @@
+/**
+ * Roles Guard
+ *
+ * Enforces role-based access control on routes decorated with @Roles().
+ * If no @Roles() decorator is present, any authenticated user is allowed.
+ * Throws 403 Forbidden when the user's role is not in the required set.
+ *
+ * Registered as APP_GUARD in AuthModule (runs after JwtAuthGuard).
+ *
+ * @module apps/api/src/auth/guards
+ */
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from '@openlinker/core/users';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { AuthenticatedUser } from '../auth.types';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles || requiredRoles.length === 0) return true;
+
+    const { user } = context.switchToHttp().getRequest<{ user?: AuthenticatedUser }>();
+    if (!user) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
+
+    if (!requiredRoles.includes(user.role)) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
+    return true;
+  }
+}

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -14,16 +14,7 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
-
-export interface JwtPayload {
-  sub: string;
-  username: string;
-}
-
-export interface AuthenticatedUser {
-  id: string;
-  username: string;
-}
+import { JwtPayload, AuthenticatedUser } from '../auth.types';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -37,6 +28,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   validate(payload: JwtPayload): AuthenticatedUser {
-    return { id: payload.sub, username: payload.username };
+    return { id: payload.sub, username: payload.username, role: payload.role };
   }
 }

--- a/apps/api/src/integrations/http/adapter.controller.ts
+++ b/apps/api/src/integrations/http/adapter.controller.ts
@@ -7,13 +7,11 @@
  *
  * @module apps/api/src/integrations/http
  */
-import { Controller, Get } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { AdapterRegistryPort } from '@openlinker/core/integrations';
-import { ADAPTER_REGISTRY_TOKEN } from '@openlinker/core/integrations';
-import { Inject } from '@nestjs/common';
-import { AdapterMetadata } from '@openlinker/core/integrations';
+import { Controller, Get, Inject } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { AdapterRegistryPort, ADAPTER_REGISTRY_TOKEN, AdapterMetadata } from '@openlinker/core/integrations';
 
+@ApiBearerAuth()
 @ApiTags('adapters')
 @Controller('adapters')
 export class AdapterController {

--- a/apps/api/src/integrations/http/allegro.controller.ts
+++ b/apps/api/src/integrations/http/allegro.controller.ts
@@ -18,8 +18,11 @@ import {
   HttpStatus,
   BadRequestException,
   NotFoundException,
+  Inject,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { Public } from '../../auth/decorators/public.decorator';
+import { Roles } from '../../auth/decorators/roles.decorator';
 import { AllegroOAuthService } from '../application/services/allegro-oauth.service';
 import { AllegroOAuthConnectDto } from './dto/allegro-oauth-connect.dto';
 import { AllegroOAuthCallbackQueryDto } from './dto/allegro-oauth-callback-query.dto';
@@ -31,7 +34,6 @@ import {
 } from '@openlinker/integrations-allegro';
 import { AllegroQuantityCommandResponseDto } from './dto/allegro-quantity-command-response.dto';
 import { AllegroCommandsQueryDto } from './dto/allegro-commands-query.dto';
-import { Inject } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
 
 @ApiTags('allegro')
@@ -47,6 +49,8 @@ export class AllegroController {
     private readonly commandRepository: AllegroQuantityCommandRepositoryPort,
   ) {}
 
+  @Roles('admin')
+  @ApiBearerAuth()
   @Post('oauth/connect')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Initiate Allegro OAuth flow' })
@@ -68,6 +72,7 @@ export class AllegroController {
     },
   })
   @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async connect(@Body() dto: AllegroOAuthConnectDto): Promise<{
     authorizationUrl: string;
     state: string;
@@ -88,6 +93,7 @@ export class AllegroController {
     return result;
   }
 
+  @Public()
   @Get('oauth/callback')
   @ApiOperation({ summary: 'Handle Allegro OAuth callback' })
   @ApiQuery({ name: 'code', description: 'OAuth authorization code', required: true })
@@ -151,6 +157,7 @@ export class AllegroController {
     }
   }
 
+  @ApiBearerAuth()
   @Get('connections/:id/validate')
   @ApiOperation({ summary: 'Validate Allegro connection configuration' })
   @ApiParam({ name: 'id', description: 'Connection ID (UUID)', example: '123e4567-e89b-12d3-a456-426614174000' })
@@ -181,6 +188,7 @@ export class AllegroController {
     return this.oauthService.validateConnection(connectionId);
   }
 
+  @ApiBearerAuth()
   @Get('connections/:id/cursors')
   @ApiOperation({ summary: 'Get all cursors for an Allegro connection' })
   @ApiParam({ name: 'id', description: 'Connection ID (UUID)' })
@@ -242,6 +250,7 @@ export class AllegroController {
     return { cursors: [] };
   }
 
+  @ApiBearerAuth()
   @Get('connections/:id/commands')
   @ApiOperation({ summary: 'Get quantity commands for an Allegro connection' })
   @ApiParam({ name: 'id', description: 'Connection ID (UUID)' })
@@ -266,6 +275,7 @@ export class AllegroController {
     return commands.map((command: AllegroQuantityCommand) => AllegroQuantityCommandResponseDto.fromDomain(command));
   }
 
+  @ApiBearerAuth()
   @Get('connections/:id/commands/failed')
   @ApiOperation({ summary: 'Get failed quantity commands for an Allegro connection' })
   @ApiParam({ name: 'id', description: 'Connection ID (UUID)' })
@@ -290,6 +300,7 @@ export class AllegroController {
     return commands.map((command: AllegroQuantityCommand) => AllegroQuantityCommandResponseDto.fromDomain(command));
   }
 
+  @ApiBearerAuth()
   @Get('connections/:id/commands/:commandId')
   @ApiOperation({ summary: 'Get quantity command by commandId for a connection' })
   @ApiParam({ name: 'id', description: 'Connection ID (UUID)' })

--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -17,7 +17,8 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
 import { CreateConnectionDto } from './dto/create-connection.dto';
 import { UpdateConnectionDto } from './dto/update-connection.dto';
 import { ConnectionFiltersDto } from './dto/connection-filters.dto';
@@ -25,6 +26,7 @@ import { ConnectionResponseDto } from './dto/connection-response.dto';
 import { ConnectionService } from '../application/services/connection.service';
 import { ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier-mapping';
 
+@ApiBearerAuth()
 @ApiTags('connections')
 @Controller('connections')
 export class ConnectionController {
@@ -32,6 +34,7 @@ export class ConnectionController {
     private readonly connectionService: ConnectionService,
   ) {}
 
+  @Roles('admin')
   @Post()
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Create a new connection' })
@@ -41,6 +44,7 @@ export class ConnectionController {
     type: ConnectionResponseDto,
   })
   @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async create(
     @Body() dto: CreateConnectionDto,
   ): Promise<ConnectionResponseDto> {
@@ -81,6 +85,7 @@ export class ConnectionController {
     return ConnectionResponseDto.fromDomain(connection);
   }
 
+  @Roles('admin')
   @Patch(':id')
   @ApiOperation({ summary: 'Update an existing connection' })
   @ApiResponse({
@@ -88,6 +93,7 @@ export class ConnectionController {
     description: 'Connection updated successfully',
     type: ConnectionResponseDto,
   })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @ApiResponse({ status: 404, description: 'Connection not found' })
   async update(
     @Param('id') id: string,
@@ -103,6 +109,7 @@ export class ConnectionController {
     return ConnectionResponseDto.fromDomain(connection);
   }
 
+  @Roles('admin')
   @Patch(':id/disable')
   @ApiOperation({ summary: 'Disable a connection' })
   @ApiResponse({
@@ -110,6 +117,7 @@ export class ConnectionController {
     description: 'Connection disabled successfully',
     type: ConnectionResponseDto,
   })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @ApiResponse({ status: 404, description: 'Connection not found' })
   async disable(@Param('id') id: string): Promise<ConnectionResponseDto> {
     const connection = await this.connectionService.disable(id);

--- a/apps/api/src/migrations/1776000000000-add-role-to-users.ts
+++ b/apps/api/src/migrations/1776000000000-add-role-to-users.ts
@@ -1,0 +1,27 @@
+/**
+ * Migration: Add role column to users table
+ *
+ * Adds a `role` column to the `users` table for role-based access control.
+ * Existing users are backfilled with `admin` role. New users default to `admin`.
+ *
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRoleToUsers1776000000000 implements MigrationInterface {
+  name = 'AddRoleToUsers1776000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+        ADD COLUMN "role" character varying(50) NOT NULL DEFAULT 'admin'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+        DROP COLUMN "role"
+    `);
+  }
+}

--- a/apps/api/src/sync/http/sync.controller.ts
+++ b/apps/api/src/sync/http/sync.controller.ts
@@ -15,12 +15,15 @@ import {
   BadRequestException,
   Inject,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
 import { JobEnqueuePort, JOB_ENQUEUE_TOKEN, SyncJobRequest } from '@openlinker/core/sync';
 import { EnqueueSyncJobDto } from './dto/enqueue-sync-job.dto';
 import { EnqueueSyncJobResponseDto } from './dto/enqueue-sync-job-response.dto';
 import { Logger } from '@openlinker/shared/logging';
 
+@Roles('admin')
+@ApiBearerAuth()
 @ApiTags('sync')
 @Controller('sync')
 export class SyncController {
@@ -47,6 +50,7 @@ export class SyncController {
     status: 400,
     description: 'Invalid request (validation failed)',
   })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async enqueueJob(@Body() dto: EnqueueSyncJobDto): Promise<EnqueueSyncJobResponseDto> {
     this.logger.log(
       `Enqueuing sync job: ${dto.jobType} for connection ${dto.connectionId} (idempotencyKey: ${dto.idempotencyKey})`,

--- a/apps/api/src/webhooks/http/webhook.controller.ts
+++ b/apps/api/src/webhooks/http/webhook.controller.ts
@@ -22,6 +22,7 @@ import {
   PayloadTooLargeException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiHeader } from '@nestjs/swagger';
+import { Public } from '../../auth/decorators/public.decorator';
 import { WebhookRequestDto } from './dto/webhook-request.dto';
 import { WebhookService } from '../application/services/webhook.service';
 import { RequestWithRawBody } from './middleware/raw-body.middleware';
@@ -29,6 +30,7 @@ import { WebhookAuthenticationException } from '../application/errors/webhook-au
 import { WebhookReplayException } from '../application/errors/webhook-replay.exception';
 import { Logger } from '@openlinker/shared/logging';
 
+@Public()
 @ApiTags('webhooks')
 @Controller('webhooks')
 export class WebhookController {

--- a/apps/web/src/shared/auth/session.types.ts
+++ b/apps/web/src/shared/auth/session.types.ts
@@ -1,7 +1,9 @@
 export interface SessionUser {
   id: string;
-  email: string;
-  roles: string[];
+  username: string;
+  email: string | null;
+  role: string;
+  permissions: string[];
 }
 
 export interface Session {

--- a/apps/worker/jest.config.js
+++ b/apps/worker/jest.config.js
@@ -16,6 +16,8 @@ module.exports = {
     '^@openlinker/core/(.*)$': path.resolve(__dirname, '../../libs/core/src/$1'),
     '^@openlinker/shared/(.*)$': path.resolve(__dirname, '../../libs/shared/src/$1'),
     '^@openlinker/integrations-prestashop/(.*)$': path.resolve(__dirname, '../../libs/integrations/prestashop/src/$1'),
+    '^@openlinker/integrations-allegro$': path.resolve(__dirname, '../../libs/integrations/allegro/src/index.ts'),
+    '^@openlinker/integrations-allegro/(.*)$': path.resolve(__dirname, '../../libs/integrations/allegro/src/$1'),
   },
 };
 

--- a/docs/plans/implementation-plan-minimal-authorization.md
+++ b/docs/plans/implementation-plan-minimal-authorization.md
@@ -1,0 +1,552 @@
+# Implementation Plan: Minimal Authorization Model
+
+**Date**: 2026-03-28
+**Issue**: [#58 — Add minimal authorization model](https://github.com/SilkSoftwareHouse/openlinker/issues/58)
+**Status**: Ready for Review
+**Estimated Effort**: 1.5–2 days
+
+---
+
+## 1. Task Summary
+
+**Objective**: Add a minimal role-based authorization model that protects operational endpoints, returns `403 Forbidden` for unauthorized access, and exposes current-user capabilities to the frontend.
+
+**Context**: The backend has JWT authentication (login, token generation, `JwtAuthGuard`), but **zero authorization**. Only `GET /auth/me` is guarded — every other endpoint (connections, sync, integrations, adapters) is publicly accessible. The frontend `SessionUser` type already has a `roles: string[]` field but it's never populated.
+
+**Classification**: Infrastructure / Interface (cross-cutting concern — touches auth guards, controllers, user entity, and migration)
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- Add a `role` field to the User entity (domain + ORM + migration)
+- Define role types (`admin`, `viewer`)
+- Embed role in JWT payload so authorization is stateless
+- Create `@Public()` decorator to exempt endpoints from authentication
+- Create `@Roles()` decorator for role-based route protection
+- Create `RolesGuard` that enforces `@Roles()` metadata
+- Apply `JwtAuthGuard` **globally** (via `APP_GUARD`) so all routes are protected by default
+- Mark public endpoints (`/health`, `/auth/login`, webhooks, OAuth callback) with `@Public()`
+- Create `@CurrentUser()` param decorator for cleaner controller signatures
+- Return `403 Forbidden` when an authenticated user lacks the required role
+- Expose role and derived permissions in `GET /auth/me` response
+- Update frontend `SessionUser` population path (contract only — no UI gating)
+- Unit tests for guard, decorator, and service changes
+- Database migration for the `role` column
+
+### Out of Scope
+- Granular per-resource permissions (future)
+- Role management API (CRUD for roles) — admin seeds roles via migration/env
+- Frontend UI gating based on roles (separate issue)
+- Multi-tenancy or organization-scoped permissions
+- Refresh token flow
+- Audit logging of authorization decisions
+
+### Constraints
+- Must not break existing login flow
+- Must be backward-compatible: existing users get a default role (`admin` for MVP seed user)
+- JWT payload size must stay small (role string, not full permission list)
+- `as const` union types preferred over enums (engineering standards)
+- Migration required — `synchronize: true` is forbidden
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layers**:
+- **CORE** (`libs/core/src/users/`) — role types, User domain entity update, repository port update
+- **Infrastructure** (`libs/core/src/users/infrastructure/`) — ORM entity, migration, repository mapping
+- **Interface / App** (`apps/api/src/auth/`) — guards, decorators, controller updates
+
+**Capabilities Involved**:
+- No new ports. This extends the existing Identity bounded context.
+
+**Existing Services Reused**:
+- `AuthService` — extended to include role in JWT
+- `UserRepositoryPort` / `UserRepository` — mapping updated for `role` field
+- `JwtAuthGuard` — used as global guard with `@Public()` bypass
+- `UsersModule` — re-exports updated user types
+
+**New Components Required**:
+| Component | Location | Layer |
+|---|---|---|
+| Role types (`role.types.ts`) | `libs/core/src/users/domain/types/` | CORE / Domain |
+| `@Public()` decorator | `apps/api/src/auth/decorators/public.decorator.ts` | Interface |
+| `@Roles()` decorator | `apps/api/src/auth/decorators/roles.decorator.ts` | Interface |
+| `@CurrentUser()` decorator | `apps/api/src/auth/decorators/current-user.decorator.ts` | Interface |
+| `RolesGuard` | `apps/api/src/auth/guards/roles.guard.ts` | Interface |
+| Migration | `apps/api/src/migrations/{ts}-add-role-to-users.ts` | Infrastructure |
+
+**Core vs Integration Justification**:
+Roles are part of the Identity bounded context. They define who can do what — this is core domain logic that doesn't belong in any integration. The role type definition lives in CORE; the enforcement (guards, decorators) lives in the app/interface layer.
+
+**Reference**: [Architecture Overview - Hexagonal Architecture Structure](./architecture-overview.md#hexagonal-architecture-structure)
+
+---
+
+## 4. Internal Patterns Research
+
+### Similar Implementations Found
+- **`JwtAuthGuard`** (`apps/api/src/auth/guards/jwt-auth.guard.ts`) — extends `AuthGuard('jwt')`, minimal implementation. `RolesGuard` will follow the same style.
+- **`RequestWithUser`** (`apps/api/src/auth/auth.controller.ts`) — typed `req.user` interface. Will be replaced by `@CurrentUser()` decorator.
+- **`UserResponseDto.fromDomain()`** — static factory pattern for safe response mapping. Will be extended to include `role` and `permissions`.
+- **`USER_REPOSITORY_TOKEN`** (`Symbol('UserRepositoryPort')`) — DI token pattern for repository injection.
+- **`as const` pattern** — used throughout the codebase (e.g., `ConnectionStatusValues`). Role types will follow the same pattern.
+
+### NestJS Global Guard Pattern
+NestJS supports `APP_GUARD` for global guards. Combined with a `@Public()` decorator using `SetMetadata`, this is the standard pattern for "auth-by-default with opt-out":
+
+```typescript
+// Global guard registration
+{ provide: APP_GUARD, useClass: JwtAuthGuard }
+{ provide: APP_GUARD, useClass: RolesGuard }
+```
+
+The `JwtAuthGuard` must check for `@Public()` metadata and skip validation when present.
+
+---
+
+## 5. Questions & Assumptions
+
+### Assumptions
+1. **Two roles for MVP**: `admin` (full access) and `viewer` (read-only). This is the minimum viable permission model.
+2. **Default role for existing users**: `admin` — the existing seed user should retain full access after migration.
+3. **Default role for new users**: `admin` — since there's no user registration API and users are created via seed/migration, defaulting to `admin` is safe for MVP.
+4. **Stateless authorization**: Role is embedded in JWT payload. No per-request DB lookup. This means role changes require re-login (acceptable for MVP).
+5. **Viewer can read, admin can write**: `viewer` role can access GET endpoints; `admin` role can access all endpoints.
+6. **Webhook endpoints stay public**: They use signature verification, not JWT auth.
+7. **Health endpoints stay public**: No auth required for health checks.
+8. **OAuth callback stays public**: The Allegro OAuth callback endpoint must be accessible without JWT.
+9. **Permissions are derived, not stored**: The `GET /auth/me` response will include a `permissions` array derived from the role at response time — not stored in the database.
+
+### Open Questions
+1. **Should `viewer` role exist at MVP?** — Safe default: yes, define it now even if only `admin` is assigned initially. The guard logic and types are trivial to add.
+2. **Should role changes require token refresh?** — Safe default: yes (stateless JWT). Acceptable for MVP with small user count.
+
+### Documentation Gaps
+- The architecture overview mentions "Authentication & Authorization" in the Identity bounded context but doesn't define an authorization model. This plan fills that gap.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: Domain — Role Types and Entity Update
+**Goal**: Define role types and add `role` to the User domain entity.
+
+**Step 1.1: Create role types**
+- **File**: `libs/core/src/users/domain/types/role.types.ts` (new)
+- **Action**: Define `UserRoleValues` as const array and `UserRole` union type. Define `PermissionValues` and `Permission` type. Add `ROLE_PERMISSIONS` mapping (role → permissions).
+- **Acceptance**: Types compile, are importable from `@openlinker/core/users`.
+- **Dependencies**: None
+
+```typescript
+// role.types.ts
+export const UserRoleValues = ['admin', 'viewer'] as const;
+export type UserRole = (typeof UserRoleValues)[number];
+
+export const PermissionValues = [
+  'connections:read',
+  'connections:write',
+  'sync:read',
+  'sync:write',
+  'integrations:read',
+  'integrations:write',
+  'adapters:read',
+] as const;
+export type Permission = (typeof PermissionValues)[number];
+
+export const ROLE_PERMISSIONS: Record<UserRole, readonly Permission[]> = {
+  admin: PermissionValues, // all permissions
+  viewer: [
+    'connections:read',
+    'sync:read',
+    'integrations:read',
+    'adapters:read',
+  ],
+} as const;
+```
+
+**Step 1.2: Update User domain entity**
+- **File**: `libs/core/src/users/domain/entities/user.entity.ts`
+- **Action**: Add `role: UserRole` field to the `User` class. Import from `role.types.ts`.
+- **Acceptance**: `User` entity has `role` property typed as `UserRole`.
+- **Dependencies**: Step 1.1
+
+**Step 1.3: Export new types from users index**
+- **File**: `libs/core/src/users/index.ts`
+- **Action**: Re-export `UserRole`, `UserRoleValues`, `Permission`, `PermissionValues`, `ROLE_PERMISSIONS` from the new types file.
+- **Acceptance**: Types importable via `@openlinker/core/users`.
+- **Dependencies**: Step 1.1
+
+---
+
+### Phase 2: Infrastructure — ORM Entity, Migration, Repository
+**Goal**: Persist the role field and migrate existing data.
+
+**Step 2.1: Update User ORM entity**
+- **File**: `libs/core/src/users/infrastructure/persistence/entities/user.orm-entity.ts`
+- **Action**: Add `@Column({ type: 'varchar', length: 50, default: 'admin' }) role: string` column.
+- **Acceptance**: ORM entity has `role` column.
+- **Dependencies**: Step 1.2
+
+**Step 2.2: Generate database migration**
+- **File**: `apps/api/src/migrations/{timestamp}-add-role-to-users.ts` (new, generated)
+- **Action**: Generate migration via `pnpm --filter @openlinker/api migration:generate -- src/migrations/AddRoleToUsers`. Review generated SQL — should add `role varchar(50) DEFAULT 'admin'` to `users` table and backfill existing rows.
+- **Acceptance**: `migration:show` confirms pending migration. Running `migration:run` succeeds. Existing users have `role = 'admin'`.
+- **Dependencies**: Step 2.1, running dev database
+
+**Step 2.3: Update User repository mapping**
+- **File**: `libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts`
+- **Action**: Update `toDomain()` to map `entity.role` → `user.role` (cast to `UserRole`). Update `toOrm()` to map `user.role` → `entity.role`.
+- **Acceptance**: Round-trip mapping preserves `role` field.
+- **Dependencies**: Step 2.1, Step 1.2
+
+---
+
+### Phase 3: Auth — Decorators, Guards, JWT Payload
+**Goal**: Build the authorization infrastructure.
+
+**Step 3.1: Create `@Public()` decorator**
+- **File**: `apps/api/src/auth/decorators/public.decorator.ts` (new)
+- **Action**: Create decorator using `SetMetadata(IS_PUBLIC_KEY, true)`. Export `IS_PUBLIC_KEY` constant.
+- **Acceptance**: Decorator compiles, can be applied to controller methods.
+- **Dependencies**: None
+
+```typescript
+import { SetMetadata } from '@nestjs/common';
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);
+```
+
+**Step 3.2: Create `@Roles()` decorator**
+- **File**: `apps/api/src/auth/decorators/roles.decorator.ts` (new)
+- **Action**: Create decorator using `SetMetadata(ROLES_KEY, roles)`. Accepts `UserRole[]`.
+- **Acceptance**: Decorator compiles, can be applied to controller methods.
+- **Dependencies**: Step 1.1 (role types)
+
+```typescript
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '@openlinker/core/users';
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);
+```
+
+**Step 3.3: Create `@CurrentUser()` param decorator**
+- **File**: `apps/api/src/auth/decorators/current-user.decorator.ts` (new)
+- **Action**: Create `createParamDecorator` that extracts `req.user` from the execution context.
+- **Acceptance**: Can be used as `@CurrentUser() user: AuthenticatedUser` in controller methods.
+- **Dependencies**: None
+
+**Step 3.4: Update `JwtAuthGuard` to support `@Public()`**
+- **File**: `apps/api/src/auth/guards/jwt-auth.guard.ts`
+- **Action**: Override `canActivate()` to check for `IS_PUBLIC_KEY` metadata via `Reflector`. If `@Public()` is set, return `true` without validating JWT.
+- **Acceptance**: Routes marked `@Public()` bypass JWT validation. Undecorated routes require valid JWT.
+- **Dependencies**: Step 3.1
+
+```typescript
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) { super(); }
+
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) return true;
+    return super.canActivate(context);
+  }
+}
+```
+
+**Step 3.5: Create `RolesGuard`**
+- **File**: `apps/api/src/auth/guards/roles.guard.ts` (new)
+- **Action**: Create `CanActivate` guard that reads `ROLES_KEY` metadata via `Reflector`. If no `@Roles()` decorator is present, allow access (authenticated is sufficient). If `@Roles()` is present, check `req.user.role` against the required roles. Throw `ForbiddenException` if role doesn't match.
+- **Acceptance**: Routes with `@Roles('admin')` reject `viewer` users with 403.
+- **Dependencies**: Step 3.2
+
+```typescript
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles || requiredRoles.length === 0) return true;
+
+    const { user } = context.switchToHttp().getRequest();
+    if (!user) return false; // defensive: @Public() routes have no req.user
+    return requiredRoles.includes(user.role);
+  }
+}
+```
+
+**Step 3.6: Add role to JWT payload and strategy**
+- **File**: `apps/api/src/auth/auth.service.ts`
+- **Action**: Include `role` in JWT payload: `{ sub: user.id, username: user.username, role: user.role }`.
+- **File**: `apps/api/src/auth/strategies/jwt.strategy.ts`
+- **Action**: Extract `role` from payload and include in `AuthenticatedUser` return value.
+- **File**: `apps/api/src/auth/auth.types.ts` (new or update existing type)
+- **Action**: Add `role: UserRole` to `AuthenticatedUser` interface. Add `JwtPayload` interface.
+- **Acceptance**: After login, decoded JWT contains `role`. `req.user` includes `role`.
+- **Dependencies**: Step 1.1, Step 2.3
+
+**Step 3.7: Register guards globally in `AuthModule`**
+- **File**: `apps/api/src/auth/auth.module.ts`
+- **Action**: Add `APP_GUARD` providers for `JwtAuthGuard` and `RolesGuard` (in that order — auth first, then roles).
+- **Acceptance**: All routes require JWT by default. `@Public()` bypasses auth. `@Roles()` enforces role check.
+- **Dependencies**: Steps 3.4, 3.5
+
+```typescript
+providers: [
+  AuthService,
+  JwtStrategy,
+  { provide: APP_GUARD, useClass: JwtAuthGuard },
+  { provide: APP_GUARD, useClass: RolesGuard },
+],
+```
+
+---
+
+### Phase 4: Controllers — Apply Decorators
+**Goal**: Protect all endpoints appropriately.
+
+**Step 4.1: Mark public endpoints with `@Public()`**
+- **Files**:
+  - `apps/api/src/app.controller.ts` — `@Public()` on class (health endpoints)
+  - `apps/api/src/auth/auth.controller.ts` — `@Public()` on `login()` method
+  - `apps/api/src/webhooks/webhook.controller.ts` — `@Public()` on class (signature-verified)
+  - `apps/api/src/integrations/allegro/allegro.controller.ts` — `@Public()` on OAuth callback method only
+- **Action**: Import and apply `@Public()` decorator.
+- **Acceptance**: Public endpoints remain accessible without JWT. All other endpoints return `401` without token.
+- **Dependencies**: Step 3.7
+
+**Step 4.1b: Add `@ApiBearerAuth()` Swagger decorator to guarded controllers**
+- **Files**:
+  - `apps/api/src/integrations/http/connection.controller.ts` — `@ApiBearerAuth()` on class
+  - `apps/api/src/integrations/allegro/allegro.controller.ts` — `@ApiBearerAuth()` on class
+  - `apps/api/src/sync/sync.controller.ts` — `@ApiBearerAuth()` on class
+  - `apps/api/src/auth/auth.controller.ts` — `@ApiBearerAuth()` on `getMe()` method
+  - `apps/api/src/integrations/http/adapter.controller.ts` — `@ApiBearerAuth()` on class
+- **Action**: Import `@ApiBearerAuth()` from `@nestjs/swagger` and apply to controllers/methods that require JWT. This ensures the Swagger UI "Authorize" button sends the Bearer token for these endpoints.
+- **Acceptance**: Swagger UI shows lock icon on guarded endpoints; clicking "Try it out" sends the `Authorization: Bearer` header.
+- **Dependencies**: Step 4.1
+
+**Step 4.2: Apply `@Roles()` to write endpoints**
+- **Files**:
+  - `apps/api/src/integrations/http/connection.controller.ts` — `@Roles('admin')` on POST/PATCH methods; GET methods accessible to any authenticated user
+  - `apps/api/src/integrations/allegro/allegro.controller.ts` — `@Roles('admin')` on `connect()` (OAuth initiation) and diagnostic/command endpoints
+  - `apps/api/src/sync/sync.controller.ts` — `@Roles('admin')` on POST (trigger sync)
+- **Action**: Import and apply `@Roles()` decorator to write/mutate endpoints.
+- **Acceptance**: `viewer` users get `403` on write endpoints, `200` on read endpoints.
+- **Dependencies**: Step 3.7
+
+**Step 4.3: Update `AuthController` to use `@CurrentUser()` and return role/permissions**
+- **File**: `apps/api/src/auth/auth.controller.ts`
+- **Action**: Replace `@Req() req: RequestWithUser` with `@CurrentUser() user: AuthenticatedUser` in `getMe()`. Update `getMe()` to include `role` and `permissions` in response.
+- **File**: `apps/api/src/auth/dto/user-response.dto.ts`
+- **Action**: Add `role: string` and `permissions: string[]` fields. Update `fromDomain()` to populate them using `ROLE_PERMISSIONS` mapping.
+- **Acceptance**: `GET /auth/me` returns `{ id, username, email, role, permissions: [...] }`.
+- **Dependencies**: Steps 1.1, 3.3, 3.6
+
+---
+
+### Phase 5: Testing
+**Goal**: Verify guards, decorators, and authorization behavior.
+
+**Step 5.1: Unit test — `RolesGuard`**
+- **File**: `apps/api/src/auth/guards/roles.guard.spec.ts` (new)
+- **Tests**:
+  - `should allow access when no @Roles() decorator is present`
+  - `should allow access when user role matches required role`
+  - `should deny access when user role does not match required role`
+  - `should allow access when user has one of multiple required roles`
+  - `should deny access when req.user is undefined (defensive @Public() + @Roles() edge case)`
+- **Dependencies**: Step 3.5
+
+**Step 5.2: Unit test — `JwtAuthGuard` with `@Public()`**
+- **File**: `apps/api/src/auth/guards/jwt-auth.guard.spec.ts` (new)
+- **Tests**:
+  - `should bypass authentication when @Public() is set`
+  - `should require authentication when @Public() is not set`
+- **Dependencies**: Step 3.4
+
+**Step 5.3: Unit test — `AuthService` JWT payload**
+- **File**: `apps/api/src/auth/auth.service.spec.ts` (update existing or create)
+- **Tests**:
+  - `should include role in JWT payload on login`
+  - `should return user with role from getMe()`
+- **Dependencies**: Step 3.6
+
+**Step 5.4: Unit test — `UserResponseDto`**
+- **File**: `apps/api/src/auth/dto/user-response.dto.spec.ts` (new)
+- **Tests**:
+  - `should include role and permissions in response`
+  - `should derive admin permissions correctly`
+  - `should derive viewer permissions correctly`
+- **Dependencies**: Step 4.3
+
+**Step 5.5: Run quality gate**
+- **Action**: Run `pnpm lint && pnpm type-check && pnpm test` — all must pass.
+- **Dependencies**: All previous steps
+
+---
+
+### Phase 6: Frontend Contract Update
+**Goal**: Ensure frontend can consume the new role/permissions data.
+
+**Step 6.1: Update frontend auth API types**
+- **File**: `apps/web/src/shared/auth/session.types.ts` (or feature-level auth API types)
+- **Action**: Verify `SessionUser.roles` is populated from the `GET /auth/me` response. The field already exists. If there's an auth API module or mapper, update it to read `role` and `permissions` from the response and map `role` → `roles: [role]`.
+- **Acceptance**: After login, `useSession()` returns a `SessionUser` with populated `roles` array.
+- **Dependencies**: Step 4.3
+
+---
+
+### Implementation Details
+
+**New Components**:
+| Layer | Component | File |
+|---|---|---|
+| Domain | `role.types.ts` | `libs/core/src/users/domain/types/role.types.ts` |
+| Domain | Updated `User` entity | `libs/core/src/users/domain/entities/user.entity.ts` |
+| Infrastructure | Updated `UserOrmEntity` | `libs/core/src/users/infrastructure/persistence/entities/user.orm-entity.ts` |
+| Infrastructure | Migration | `apps/api/src/migrations/{ts}-add-role-to-users.ts` |
+| Interface | `@Public()` decorator | `apps/api/src/auth/decorators/public.decorator.ts` |
+| Interface | `@Roles()` decorator | `apps/api/src/auth/decorators/roles.decorator.ts` |
+| Interface | `@CurrentUser()` decorator | `apps/api/src/auth/decorators/current-user.decorator.ts` |
+| Interface | `RolesGuard` | `apps/api/src/auth/guards/roles.guard.ts` |
+| Interface | Auth types | `apps/api/src/auth/auth.types.ts` |
+
+**Configuration Changes**:
+- None. No new environment variables required.
+
+**Database Migrations**:
+- `AddRoleToUsers` — adds `role VARCHAR(50) DEFAULT 'admin' NOT NULL` to `users` table. Backfills existing rows with `'admin'`.
+
+**Error Handling**:
+- `401 Unauthorized` — returned by `JwtAuthGuard` when JWT is missing/invalid (existing behavior, now global)
+- `403 Forbidden` — returned by `RolesGuard` when authenticated user lacks the required role (new)
+
+**Reference**: [Engineering Standards - Project Structure](./engineering-standards.md#project-structure)
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Granular Permission Model (PBAC)
+- **Description**: Store individual permissions in a `user_permissions` join table. Each user has a set of fine-grained permissions.
+- **Why Rejected**: Over-engineered for MVP with 1–2 users. Adds migration complexity, join queries, and permission management UI. Can evolve to this later by deriving permissions from roles (which this plan already does via `ROLE_PERMISSIONS`).
+- **Trade-offs**: More flexible but more complex to manage, test, and maintain.
+
+### Alternative 2: Per-Request DB Role Lookup
+- **Description**: Don't embed role in JWT. Fetch role from DB on every request.
+- **Why Rejected**: Adds a DB query to every authenticated request. Unnecessary for MVP with infrequent role changes. Stateless JWT is simpler and faster.
+- **Trade-offs**: Would allow instant role changes without re-login, but at a per-request performance cost.
+
+### Alternative 3: CASL-based Authorization
+- **Description**: Use the CASL library for attribute-based access control.
+- **Why Rejected**: Heavy dependency for a two-role system. CASL shines for complex per-resource rules — not needed here.
+- **Trade-offs**: More powerful but harder to understand and debug for simple role checks.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Domain types in `libs/core/src/users/domain/types/` — no framework dependency
+- ✅ Guards and decorators in `apps/api/src/auth/` — interface/app layer
+- ✅ ORM entity in infrastructure layer, separate from domain entity
+- ✅ Repository mapping updated in infrastructure layer
+- ✅ `as const` union types for roles and permissions
+- **Reference**: [Architecture Overview](./architecture-overview.md)
+
+### Naming Conventions
+- ✅ `role.types.ts` — follows `*.types.ts` pattern
+- ✅ `public.decorator.ts`, `roles.decorator.ts` — descriptive decorator files
+- ✅ `roles.guard.ts` — follows `*.guard.ts` NestJS convention
+- ✅ `RolesGuard` — PascalCase class
+- ✅ `UserRole`, `Permission` — PascalCase types
+- ✅ `ROLES_KEY`, `IS_PUBLIC_KEY` — UPPER_SNAKE_CASE constants
+- **Reference**: [Engineering Standards - Naming Conventions](./engineering-standards.md#naming-conventions)
+
+### Risks
+- **Stale JWT after role change**: If a user's role is changed in the database, their existing JWT still carries the old role until expiry. **Mitigation**: Acceptable for MVP (1-day token expiry, tiny user base). Document that role changes require re-login.
+- **Global guard breaks existing tests**: Adding `APP_GUARD` globally means any existing controller tests that don't mock the guard will fail. **Mitigation**: Update existing controller tests to either provide mock guards or use `@Public()` where appropriate.
+- **Webhook endpoints must stay public**: Webhooks use HMAC signature verification, not JWT. Must ensure `@Public()` is applied. **Mitigation**: Explicitly tested.
+
+### Edge Cases
+- **Unauthenticated request to guarded endpoint**: Returns `401` (handled by `JwtAuthGuard`).
+- **Authenticated request with insufficient role**: Returns `403` (handled by `RolesGuard`).
+- **Expired JWT**: Returns `401` (handled by Passport JWT strategy).
+- **New user created without explicit role**: Gets `admin` default from DB column default and ORM entity default.
+- **`@Public()` + `@Roles()`**: `@Public()` bypasses auth entirely, so `req.user` is undefined. `RolesGuard` defensively returns `false` if `req.user` is missing and `@Roles()` is set — but in practice this combination should not be used. A public endpoint shouldn't check roles.
+
+### Backward Compatibility
+- ✅ Existing login flow unchanged — just adds `role` to JWT payload
+- ✅ Existing `GET /auth/me` response extended (additive, not breaking)
+- ✅ Existing users get `admin` role via migration default
+- ✅ Frontend `SessionUser.roles` field already exists — just needs population
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+| Test File | What's Tested |
+|---|---|
+| `roles.guard.spec.ts` | Role enforcement: allow, deny, no-decorator passthrough |
+| `jwt-auth.guard.spec.ts` | `@Public()` bypass, standard auth enforcement |
+| `auth.service.spec.ts` | JWT payload includes role, `getMe()` returns role |
+| `user-response.dto.spec.ts` | Response includes role and derived permissions |
+
+### Mocking Strategy
+- Mock `Reflector` for guard tests (to simulate decorator metadata)
+- Mock `ExecutionContext` for guard tests
+- Mock `UserRepositoryPort` for service tests
+- Mock `JwtService` for auth service tests
+
+### Acceptance Criteria
+- [ ] `POST /auth/login` returns JWT containing `role` claim
+- [ ] `GET /auth/me` returns `{ id, username, email, role, permissions: [...] }`
+- [ ] Unauthenticated requests to guarded endpoints return `401`
+- [ ] `viewer` role on a `@Roles('admin')` endpoint returns `403`
+- [ ] `admin` role on a `@Roles('admin')` endpoint returns success
+- [ ] Health, login, webhook, and OAuth callback endpoints remain accessible without JWT
+- [ ] Swagger UI shows lock icon on guarded endpoints and sends Bearer token
+- [ ] All existing tests pass after changes
+- [ ] `pnpm lint && pnpm type-check && pnpm test` passes
+- [ ] Migration runs cleanly on existing database
+- [ ] Existing users have `role = 'admin'` after migration
+
+**Reference**: [Testing Guide](./testing-guide.md)
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture
+- [x] Respects CORE vs Integration boundaries
+- [x] Uses existing patterns (no unnecessary abstractions)
+- [x] Idempotency considered (migration is idempotent via TypeORM tracking)
+- [x] Event-driven patterns — N/A (no events for role changes in MVP)
+- [x] Rate limits & retries — N/A (no external API calls)
+- [x] Error handling comprehensive (401 + 403 covered)
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](./architecture-overview.md)
+- [Engineering Standards](./engineering-standards.md)
+- [Testing Guide](./testing-guide.md)
+- [Code Review Guide](./code-review-guide.md)
+- [Migrations Guide](./migrations.md)

--- a/libs/core/src/users/domain/entities/user.entity.ts
+++ b/libs/core/src/users/domain/entities/user.entity.ts
@@ -8,12 +8,15 @@
  * @module libs/core/src/users/domain/entities
  */
 
+import { UserRole } from '../types/role.types';
+
 export class User {
   constructor(
     public readonly id: string,
     public readonly username: string,
     public readonly email: string | null,
     public readonly passwordHash: string,
+    public readonly role: UserRole,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
   ) {}

--- a/libs/core/src/users/domain/ports/user-repository.port.ts
+++ b/libs/core/src/users/domain/ports/user-repository.port.ts
@@ -11,5 +11,5 @@ import { User } from '../entities/user.entity';
 export interface UserRepositoryPort {
   findByUsername(username: string): Promise<User | null>;
   findById(id: string): Promise<User | null>;
-  save(user: Pick<User, 'username' | 'email' | 'passwordHash'>): Promise<User>;
+  save(user: Pick<User, 'username' | 'email' | 'passwordHash' | 'role'>): Promise<User>;
 }

--- a/libs/core/src/users/domain/types/role.types.ts
+++ b/libs/core/src/users/domain/types/role.types.ts
@@ -1,0 +1,49 @@
+/**
+ * Role and Permission Type Definitions
+ *
+ * Defines the role-based access control types for OpenLinker. Roles are
+ * assigned to users and map to a set of permissions. Permissions follow
+ * the `resource:action` convention (e.g., `connections:read`).
+ *
+ * @module libs/core/src/users/domain/types
+ */
+
+/**
+ * Valid user role values.
+ *
+ * - `admin`: Full access to all endpoints
+ * - `viewer`: Read-only access to operational data
+ */
+export const UserRoleValues = ['admin', 'viewer'] as const;
+
+/**
+ * Union type derived from UserRoleValues.
+ */
+export type UserRole = (typeof UserRoleValues)[number];
+
+/**
+ * Valid permission values following `resource:action` convention.
+ */
+export const PermissionValues = [
+  'connections:read',
+  'connections:write',
+  'sync:read',
+  'sync:write',
+  'integrations:read',
+  'integrations:write',
+  'adapters:read',
+] as const;
+
+/**
+ * Union type derived from PermissionValues.
+ */
+export type Permission = (typeof PermissionValues)[number];
+
+/**
+ * Maps each role to its granted permissions.
+ * Permissions are derived at response time, not stored in the database.
+ */
+export const ROLE_PERMISSIONS: Record<UserRole, readonly Permission[]> = {
+  admin: PermissionValues,
+  viewer: ['connections:read', 'sync:read', 'integrations:read', 'adapters:read'],
+} as const;

--- a/libs/core/src/users/index.ts
+++ b/libs/core/src/users/index.ts
@@ -1,8 +1,8 @@
 /**
  * Users Module Public API
  *
- * Exports domain entities, ports, exceptions, and the NestJS module for the
- * users bounded context.
+ * Exports domain entities, ports, exceptions, types, and the NestJS module
+ * for the users bounded context.
  *
  * @module libs/core/src/users
  */
@@ -10,6 +10,12 @@ export { User } from './domain/entities/user.entity';
 export type { UserRepositoryPort } from './domain/ports/user-repository.port';
 export { UserNotFoundException } from './domain/exceptions/user-not-found.exception';
 export { UsersModule, USER_REPOSITORY_TOKEN } from './users.module';
+export {
+  UserRoleValues,
+  PermissionValues,
+  ROLE_PERMISSIONS,
+} from './domain/types/role.types';
+export type { UserRole, Permission } from './domain/types/role.types';
 
 // ORM entity exported for testing and TypeORM CLI usage
 export { UserOrmEntity } from './infrastructure/persistence/entities/user.orm-entity';

--- a/libs/core/src/users/infrastructure/persistence/entities/user.orm-entity.ts
+++ b/libs/core/src/users/infrastructure/persistence/entities/user.orm-entity.ts
@@ -29,6 +29,9 @@ export class UserOrmEntity {
   @Column({ name: 'password_hash' })
   passwordHash!: string;
 
+  @Column({ type: 'varchar', length: 50, default: 'admin' })
+  role!: string;
+
   @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
   createdAt!: Date;
 

--- a/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
@@ -13,6 +13,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../../../domain/entities/user.entity';
 import { UserRepositoryPort } from '../../../domain/ports/user-repository.port';
+import { UserRole, UserRoleValues } from '../../../domain/types/role.types';
 import { UserOrmEntity } from '../entities/user.orm-entity';
 
 @Injectable()
@@ -32,22 +33,28 @@ export class UserRepository implements UserRepositoryPort {
     return entity ? this.toDomain(entity) : null;
   }
 
-  async save(user: Pick<User, 'username' | 'email' | 'passwordHash'>): Promise<User> {
+  async save(user: Pick<User, 'username' | 'email' | 'passwordHash' | 'role'>): Promise<User> {
     const entity = this.ormRepository.create({
       username: user.username,
       email: user.email,
       passwordHash: user.passwordHash,
+      role: user.role,
     });
     const saved = await this.ormRepository.save(entity);
     return this.toDomain(saved);
   }
 
   private toDomain(entity: UserOrmEntity): User {
+    const role = UserRoleValues.includes(entity.role as UserRole)
+      ? (entity.role as UserRole)
+      : 'viewer';
+
     return new User(
       entity.id,
       entity.username,
       entity.email,
       entity.passwordHash,
+      role,
       entity.createdAt,
       entity.updatedAt,
     );


### PR DESCRIPTION
## Summary
- Add role-based access control (RBAC) with two roles (`admin`, `viewer`) to protect all operational endpoints
- All routes are protected by default via global `APP_GUARD`; public endpoints opt out with `@Public()`
- Write endpoints require `@Roles('admin')`; read endpoints allow any authenticated user
- `GET /auth/me` now returns `role` and derived `permissions` for frontend authorization decisions

## What changed

### Domain (libs/core)
- New `UserRole` and `Permission` types using `as const` pattern in `role.types.ts`
- `ROLE_PERMISSIONS` map derives permissions from roles at runtime
- `User` entity and ORM entity extended with `role` field
- `UserRepositoryPort.save()` updated to accept `role`
- Runtime validation on role mapping in repository

### Auth infrastructure (apps/api)
- `@Public()` decorator — exempts routes from JWT auth
- `@Roles()` decorator — enforces role-based access
- `@CurrentUser()` decorator — cleaner param extraction replacing `@Req()`
- `RolesGuard` — throws `403 Forbidden` on insufficient role
- `JwtAuthGuard` — updated to support `@Public()` bypass as global guard
- `JwtPayload` and `AuthenticatedUser` extracted to `auth.types.ts`
- Role included in JWT payload (stateless authorization)
- `APP_GUARD` registration: `JwtAuthGuard` → `RolesGuard` (in order)

### Controllers
- `@Public()` applied to: health, login, webhooks, OAuth callback
- `@Roles('admin')` applied to: connection writes, sync jobs, OAuth connect
- `@ApiBearerAuth()` on all guarded endpoints; `@ApiResponse(403)` documented
- Swagger lock icon correctly absent on public endpoints

### Frontend
- `SessionUser` updated with `role`, `permissions`, `username`, nullable `email`

### Migration
- `AddRoleToUsers` — adds `role VARCHAR(50) NOT NULL DEFAULT 'admin'` to `users` table

### Bonus fix
- Fixed pre-existing worker test failure: added missing `@openlinker/integrations-allegro` mapping to `apps/worker/jest.config.js`

## Route protection matrix

| Endpoint | Auth | Role |
|---|---|---|
| `GET /`, `/health/**` | Public | — |
| `POST /auth/login` | Public | — |
| `POST /webhooks/**` | Public (HMAC) | — |
| `GET /allegro/oauth/callback` | Public | — |
| `GET /auth/me` | JWT | any |
| `GET /connections`, `GET /adapters` | JWT | any |
| `POST /connections`, `PATCH /connections/**` | JWT | admin |
| `POST /allegro/oauth/connect` | JWT | admin |
| `GET /allegro/connections/**` | JWT | any |
| `POST /sync/jobs` | JWT | admin |

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes — 85 worker + 106 API + 167 core + 23 web tests
- [x] Pre-commit hook passes (all packages green)
- [x] Run `pnpm --filter @openlinker/api migration:run` against dev database
- [x] Verify `POST /auth/login` returns JWT with `role` claim
- [x] Verify `GET /auth/me` returns `role` + `permissions`
- [x] Verify unauthenticated request to `GET /connections` returns 401
- [x] Verify `viewer` role on `POST /connections` returns 403
- [x] Verify health/webhook/login endpoints remain accessible without JWT

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)