### PR TITLE
docs: add Claude Code workflow guide, path-scoped rules, and /component skill

### DIFF
--- a/.claude/commands/component.md
+++ b/.claude/commands/component.md
@@ -1,0 +1,130 @@
+---
+description: "Scaffold a new shared UI component following all project patterns"
+argument-hint: "<ComponentName>"
+allowed-tools: Read, Write, Edit, Grep, Glob
+---
+
+# Create a New Shared UI Component
+
+Create a new shared UI component named `$ARGUMENTS` in `apps/web/src/shared/ui/`.
+
+## Before You Start
+
+1. Read `apps/web/src/index.css` to understand existing design tokens and CSS patterns
+2. Read `docs/frontend-ui-style-guide.md` for visual and interaction standards
+3. Check existing components in `apps/web/src/shared/ui/` — reuse or extend before creating new
+4. Read `.claude/rules/ui-components.md` for all component conventions
+
+## Component File: `apps/web/src/shared/ui/{kebab-case-name}.tsx`
+
+Follow this exact pattern:
+
+```tsx
+import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+
+// 1. Props interface extending native element
+interface {ComponentName}Props extends ComponentPropsWithoutRef<'{native-element}'> {
+  // Custom props here (use `tone`, `invalid`, `compact` naming)
+}
+
+// 2. Component with forwardRef + named function
+export const {ComponentName} = forwardRef<HTML{Element}Element, {ComponentName}Props>(
+  function {ComponentName}({ className = '', /* custom props */, ...props }, ref) {
+    // 3. Class string construction
+    const classes = ['{base-class}', /* conditionals */, className]
+      .filter(Boolean)
+      .join(' ');
+
+    // 4. Return native element with ref + spread
+    return <{element} ref={ref} className={classes} {...props} />;
+  },
+);
+```
+
+### Rules
+
+- **Always `forwardRef`** with a named function (not arrow function)
+- **Extend native element props** via `ComponentPropsWithoutRef<'element'>`
+- **Accept and merge `className`** — never override consumer's classes
+- **Spread `...props`** on the root element
+- **No external dependencies** — no clsx, no CVA, no UI library imports
+- **Use design tokens** for all colors, spacing, typography in CSS
+
+## CSS Styles: Add to `apps/web/src/index.css`
+
+Add styles in the appropriate section of `index.css` following existing patterns:
+
+```css
+/* Component: {ComponentName} */
+.{component-name} {
+  /* Use design tokens */
+  color: var(--text-primary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.625rem;
+  padding: 0.75rem 1rem;
+}
+
+.{component-name}--{modifier} {
+  /* Variant styles */
+}
+```
+
+### CSS Rules
+
+- Use BEM-like naming: `.component-name`, `.component-name--modifier`, `.component-name__child`
+- All values from CSS custom properties (tokens) — no hardcoded colors
+- Spacing on 4px grid: `0.25rem`, `0.5rem`, `0.75rem`, `1rem`, `1.5rem`, `2rem`
+- Border radius: `0.625rem` (controls), `0.75rem` (cards/dialogs), `999px` (pills)
+- Include focus styles: `outline: 2px solid var(--accent-focus); outline-offset: 2px;`
+- Include disabled state: `opacity: 0.7; cursor: not-allowed;`
+
+## Test File: `apps/web/src/shared/ui/{kebab-case-name}.test.tsx`
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { {ComponentName} } from './{kebab-case-name}';
+
+describe('{ComponentName}', () => {
+  it('should render with default props', () => {
+    render(<{ComponentName}>Content</{ComponentName}>);
+    // Assert renders correctly
+  });
+
+  it('should forward ref to native element', () => {
+    const ref = { current: null as HTML{Element}Element | null };
+    render(<{ComponentName} ref={ref}>Test</{ComponentName}>);
+    expect(ref.current).toBeInstanceOf(HTML{Element}Element);
+  });
+
+  it('should merge custom className', () => {
+    render(<{ComponentName} className="custom">Test</{ComponentName}>);
+    // Assert both internal and custom classes present
+  });
+
+  // Add tone/variant tests if applicable
+  // Add accessibility tests (aria attributes, roles)
+});
+```
+
+## Accessibility Checklist
+
+Before marking complete, verify:
+
+- [ ] Uses semantic HTML element (not `<div>` with role)
+- [ ] Keyboard accessible (Tab, Enter, Escape where appropriate)
+- [ ] Focus outline visible (`var(--accent-focus)`)
+- [ ] `aria-invalid` supported if it's a form control
+- [ ] Decorative elements have `aria-hidden="true"`
+- [ ] Color is never the only signal — always pair with text
+- [ ] Screen reader announces meaningful content
+
+## Quality Gate
+
+After creating the component:
+
+```bash
+pnpm test
+pnpm type-check
+pnpm lint
+```

--- a/.claude/rules/fe-pages.md
+++ b/.claude/rules/fe-pages.md
@@ -1,0 +1,266 @@
+---
+paths:
+  - "apps/web/src/pages/**"
+  - "apps/web/src/features/**"
+---
+
+# Page & Feature Composition Rules
+
+These rules apply when building pages and feature modules in the OpenLinker frontend.
+
+## Page Structure
+
+Every page follows this layout using `PageLayout`:
+
+```tsx
+<PageLayout
+  eyebrow="Section"
+  title="Page Title"
+  description="Optional subtitle"
+  actions={<Link className="button button--primary" to="/new">Create</Link>}
+>
+  {/* Page content */}
+</PageLayout>
+```
+
+## Data Fetching Pattern
+
+### Query Hook → Loading → Error → Empty → Data
+
+Every page or feature component that fetches data must handle all four states explicitly:
+
+```tsx
+function ConnectionsListPage() {
+  const connectionsQuery = useConnectionsQuery();
+
+  if (connectionsQuery.isLoading) {
+    return <LoadingState title="Loading connections" message="Fetching connection data..." />;
+  }
+
+  if (connectionsQuery.error) {
+    return (
+      <ErrorState
+        title="Unable to load connections"
+        message={connectionsQuery.error.message}
+        action={<Button onClick={() => void connectionsQuery.refetch()}>Retry</Button>}
+      />
+    );
+  }
+
+  const connections = connectionsQuery.data ?? [];
+  if (connections.length === 0) {
+    return (
+      <EmptyState
+        title="No connections yet"
+        message="Create your first integration connection to get started."
+        action={<Link className="button button--primary" to="/connections/new">Add connection</Link>}
+      />
+    );
+  }
+
+  return <DataTable rows={connections} columns={columns} rowKey={(c) => c.id} />;
+}
+```
+
+### Rules
+
+- **Never skip states** — loading, error, and empty must always be handled
+- **Use feedback components** — `LoadingState`, `ErrorState`, `EmptyState` from `shared/ui/feedback-state`
+- **Provide retry on errors** — `action` prop with `refetch()` call
+- **Provide CTA on empty** — guide the user toward the next action
+- **Default to empty array** — `const data = query.data ?? []` before length check
+
+## Query & Mutation Hooks
+
+### Query Hooks (in `features/{domain}/hooks/`)
+
+```tsx
+// use-connections-query.ts
+export function useConnectionsQuery(filters?: ConnectionFilters): UseQueryResult<Connection[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: connectionsQueryKeys.list(filters),
+    queryFn: () => apiClient.connections.list(filters),
+  });
+}
+```
+
+### Query Key Factory (in `features/{domain}/api/`)
+
+```tsx
+// connections.query-keys.ts
+export const connectionsQueryKeys = {
+  all: ['connections'] as const,
+  list: (filters?: ConnectionFilters) =>
+    ['connections', 'list', filters?.platformType ?? 'all', filters?.status ?? 'all'] as const,
+  detail: (connectionId: string) => ['connections', 'detail', connectionId] as const,
+};
+```
+
+### Mutation Hooks
+
+```tsx
+// use-create-connection-mutation.ts
+export function useCreateConnectionMutation(): UseMutationResult<Connection, Error, CreateConnectionInput> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input) => apiClient.connections.create(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: connectionsQueryKeys.all });
+    },
+  });
+}
+```
+
+### Rules
+
+- **One hook per file** — `use-{action}-query.ts` or `use-{action}-mutation.ts`
+- **Always invalidate on mutation success** — use the `all` key to invalidate the entire domain
+- **Return the full `UseQueryResult` / `UseMutationResult`** — let the consumer destructure
+- **Use `useApiClient()`** — never import the API client directly
+
+## Form Patterns
+
+### Schema → Form → Mutation → Toast
+
+```tsx
+// 1. Zod schema (colocated in *.schema.ts)
+const schema = z.object({
+  name: z.string().trim().min(1, 'Name is required'),
+  email: z.string().email('Invalid email'),
+});
+type FormValues = z.input<typeof schema>;
+type FormSubmission = z.output<typeof schema>;
+
+// 2. Form setup
+const form = useForm<FormValues, undefined, FormSubmission>({
+  defaultValues: { name: '', email: '' },
+  resolver: zodResolver(schema),
+});
+
+// 3. Mutation
+const mutation = useSomeMutation();
+const { showToast } = useToast();
+
+// 4. Submit handler
+const onSubmit = form.handleSubmit(async (values) => {
+  try {
+    await mutation.mutateAsync(values);
+    form.reset();
+    showToast({ tone: 'success', title: 'Created', description: 'Item was created.' });
+  } catch {
+    // API error displayed via mutation.error below
+  }
+});
+```
+
+### Form Layout
+
+```tsx
+<form onSubmit={onSubmit} noValidate>
+  {/* API errors at top */}
+  {mutation.error && <Alert tone="error">{mutation.error.message}</Alert>}
+
+  {/* Validation summary after first submit */}
+  {form.formState.submitCount > 0 && validationMessages.length > 0 && (
+    <FormErrorSummary errors={validationMessages} />
+  )}
+
+  {/* Fields */}
+  <FormField label="Name" name="name" error={form.formState.errors.name?.message}>
+    <Input {...form.register('name')} />
+  </FormField>
+
+  {/* Submit with pending state */}
+  <Button type="submit" disabled={mutation.isPending}>
+    {mutation.isPending ? 'Creating...' : 'Create'}
+  </Button>
+</form>
+```
+
+### Rules
+
+- **Zod schemas in `*.schema.ts`** — colocated with the form component
+- **Export types** — `FormValues` (input), `FormSubmission` (output), and a `toApiInput()` mapper if shapes differ
+- **Show validation summary only after first submit** — `submitCount > 0`
+- **Show API errors in `Alert`** — at the top of the form, separate from validation
+- **Disable submit during mutation** — show loading text in the button
+- **Reset form on success** — `form.reset()` after successful mutation
+- **Toast on success** — always confirm the action to the user
+- **`noValidate` on `<form>`** — let Zod handle validation, not the browser
+
+## Toast Usage
+
+```tsx
+const { showToast } = useToast();
+
+// Success
+showToast({ tone: 'success', title: 'Saved', description: 'Connection updated.' });
+
+// Error (manual, when not using mutation.error)
+showToast({ tone: 'error', description: 'Something went wrong.' });
+```
+
+- Default auto-dismiss: 4 seconds
+- Use for transient feedback (success confirmations, background task completions)
+- Do NOT use for errors that need user action — use `Alert` or `ErrorState` instead
+
+## Feature Module Structure
+
+```
+features/{domain}/
+├── api/
+│   ├── {domain}.api.ts           # API functions
+│   ├── {domain}.types.ts         # Request/response types
+│   └── {domain}.query-keys.ts    # Query key factory
+├── hooks/
+│   ├── use-{domain}-query.ts     # Query hooks
+│   └── use-{action}-mutation.ts  # Mutation hooks
+└── components/
+    ├── {Component}.tsx           # Feature components
+    ├── {Component}.test.tsx      # Component tests
+    └── {component}.schema.ts     # Zod form schemas
+```
+
+## Testing Feature Components
+
+Use `renderWithProviders()` from `test/test-utils.tsx`:
+
+```tsx
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+
+it('should show connections table when data loads', async () => {
+  const mockApi = createMockApiClient({
+    connections: {
+      list: vi.fn().mockResolvedValue([{ id: '1', name: 'Store' }]),
+    },
+  });
+
+  renderWithProviders(<ConnectionsListPage />, { apiClient: mockApi });
+
+  expect(await screen.findByText('Store')).toBeInTheDocument();
+});
+
+it('should show error state when fetch fails', async () => {
+  const mockApi = createMockApiClient({
+    connections: {
+      list: vi.fn().mockRejectedValue(new Error('Network error')),
+    },
+  });
+
+  renderWithProviders(<ConnectionsListPage />, { apiClient: mockApi });
+
+  expect(await screen.findByText('Unable to load connections')).toBeInTheDocument();
+});
+```
+
+### Testing Priorities
+
+1. **Happy path** — data loads and renders correctly
+2. **Loading state** — spinner/skeleton appears
+3. **Error state** — error message and retry button
+4. **Empty state** — empty message and CTA
+5. **Form submission** — validation, success toast, API error display
+6. **User interactions** — clicks, navigation, dialog confirm/cancel

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -22,22 +22,63 @@ paths:
 ## Naming
 
 - Components: `PascalCase.tsx`
-- Hooks: `use-*.ts`
+- Hooks: `use-*.ts` (kebab-case)
 - Route modules: `*.route.tsx`
-- Tests: `*.test.tsx`
+- Tests: `*.test.tsx` (colocated with source)
 - API modules: `*.api.ts`
 - Query keys: `*.query-keys.ts`
+- Types: `*.types.ts`
+- Zod schemas: `*.schema.ts`
 
-## Patterns
+## Styling
 
-- API calls go through `shared/api/api-client.ts` — no raw `fetch()` in components
-- Query hooks live in `features/{domain}/hooks/use-*-query.ts`
-- Mutation hooks live in `features/{domain}/hooks/use-*-mutation.ts`
-- Zod schemas live alongside forms in `*.schema.ts`
+- **No Tailwind, no CSS-in-JS** — pure vanilla CSS with design tokens in `index.css`
+- All colors, spacing, typography via CSS custom properties (`var(--token-name)`)
+- Spacing on 4px grid: `0.25rem`, `0.5rem`, `0.75rem`, `1rem`, `1.5rem`, `2rem`
+- CSS class naming: `.component-name`, `.component-name--modifier`, `.component-name__child`
+- New styles go in `apps/web/src/index.css` in the appropriate section
+
+## Component Patterns
+
+- All shared UI components use `forwardRef` (required for React Hook Form)
+- Extend native element props via `ComponentPropsWithoutRef<'element'>`
+- Accept and merge `className` — never override
+- No external UI library (no shadcn, Radix, MUI) — thin wrappers over native HTML
+- Use `tone` for variant props (not `variant` or `color`)
+- Class construction: `['base', condition ? 'modifier' : '', className].filter(Boolean).join(' ')`
+
+## Data Fetching
+
+- Use `useApiClient()` hook — never import API client directly
+- Query hooks return full `UseQueryResult` — let consumer destructure
+- Mutation hooks invalidate queries on success via `queryClient.invalidateQueries()`
+- Always handle all states: loading → error → empty → data
+
+## Form Patterns
+
+- Zod schema in `*.schema.ts` colocated with form component
+- Export `FormValues` (input type) and `FormSubmission` (output type)
+- Show `FormErrorSummary` only after first submit (`submitCount > 0`)
+- Show API errors in `Alert` at top of form (separate from validation)
+- Disable submit button during mutation, show loading text
+- Toast on success, `form.reset()` after successful mutation
+- Add `noValidate` on `<form>` — Zod handles validation, not the browser
+
+## Accessibility
+
+- Semantic HTML first — `<button>`, `<input>`, `<dialog>`, `<table>`, not `<div>` with roles
+- Labels on all form controls via `<label htmlFor>` or `aria-label`
+- Use `FormField` for automatic `aria-invalid`, `aria-describedby` wiring
+- `role="alert"` for errors, `aria-live="polite"` for loading/status
+- `aria-hidden="true"` on decorative elements
+- Visible focus outlines — never remove (`2px solid var(--accent-focus)`)
+- Color is never the only signal — always pair with text
 
 ## Testing
 
-- Unit tests with Vitest + Testing Library
+- Use `renderWithProviders()` from `test/test-utils.tsx`
+- Use `createMockApiClient()` to mock API responses
+- Test priorities: happy path → loading → error → empty → form submission → interactions
 - Mock API responses, not implementation details
 - Test user interactions, not internal state
 - Run: `pnpm test`
@@ -45,5 +86,7 @@ paths:
 ## UI Style
 
 - Follow `docs/frontend-ui-style-guide.md` for layout, spacing, and component patterns
-- Use shared UI components from `shared/ui/`
+- Use shared UI components from `shared/ui/` — check existing inventory before creating new
 - Status-first, dense-but-readable operator cockpit style
+- Shopify admin clarity + Linear polish — no glassmorphism, heavy gradients, or glow effects
+- Monospace (`.mono-text`) for identifiers, payload fields, system references

--- a/.claude/rules/ui-components.md
+++ b/.claude/rules/ui-components.md
@@ -1,0 +1,194 @@
+---
+paths:
+  - "apps/web/src/shared/ui/**"
+---
+
+# UI Component Rules
+
+These rules apply when creating or modifying shared UI components in `apps/web/src/shared/ui/`.
+
+## Design System Foundation
+
+This project uses **no external UI library** — components are thin wrappers over native HTML elements, styled with vanilla CSS and design tokens (`index.css`). The goal is Shopify admin clarity, Linear polish, and operations console efficiency.
+
+## Component Structure
+
+Every shared UI component must follow this pattern:
+
+```tsx
+import { forwardRef, type ComponentPropsWithoutRef } from 'react';
+
+interface InputProps extends ComponentPropsWithoutRef<'input'> {
+  invalid?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  function Input({ className = '', invalid = false, ...props }, ref) {
+    const classes = ['control', invalid ? 'control--invalid' : '', className]
+      .filter(Boolean)
+      .join(' ');
+    return <input ref={ref} className={classes} {...props} />;
+  },
+);
+```
+
+### Required Patterns
+
+1. **Always use `forwardRef`** — required for React Hook Form `register()` integration
+2. **Named function inside forwardRef** — `forwardRef<El, Props>(function Name(...) {})` for DevTools clarity
+3. **Extend native element props** — use `ComponentPropsWithoutRef<'element'>` as base
+4. **Accept `className` prop** — merge with internal classes, never override
+5. **Spread remaining props** — `{...props}` on the root element to preserve native behavior
+6. **Export the component and its props type** — consumers may need the type
+
+### Class String Construction
+
+No utility libraries (no `cn()`, no `clsx`, no CVA). Use manual concatenation:
+
+```tsx
+const classes = ['base-class', condition ? 'modifier' : '', className]
+  .filter(Boolean)
+  .join(' ');
+```
+
+### Prop Naming
+
+- Boolean toggles: `invalid`, `compact`, `withDot` — not `isInvalid`, `isCompact`
+- Variant selectors: `tone` (not `variant`, `color`, or `type`)
+- Standard tones: `'primary' | 'secondary' | 'danger' | 'ghost'` for actions
+- Status tones: `'success' | 'warning' | 'error' | 'info' | 'review' | 'neutral'`
+
+## Styling
+
+### Use CSS Custom Properties (Design Tokens)
+
+Never hardcode colors, spacing, or typography. Always reference tokens from `index.css`:
+
+```css
+/* Good */
+color: var(--text-primary);
+background: var(--bg-surface);
+border: 1px solid var(--border-subtle);
+border-radius: 0.625rem;
+
+/* Bad */
+color: #16202b;
+background: white;
+border: 1px solid #e5eaf0;
+```
+
+### Key Token Categories
+
+- **Backgrounds:** `--bg-canvas`, `--bg-shell`, `--bg-surface`, `--bg-surface-elevated`, `--bg-muted`
+- **Borders:** `--border-subtle`, `--border-default`, `--border-strong`
+- **Text:** `--text-primary`, `--text-secondary`, `--text-muted`, `--text-disabled`, `--text-on-primary`
+- **Accent:** `--accent-primary`, `--accent-primary-hover`, `--accent-primary-soft`, `--accent-focus`
+- **Status:** `--status-{tone}`, `--status-{tone}-soft`, `--status-{tone}-border`, `--status-{tone}-fg`
+
+### Spacing Scale (4px Increments)
+
+Use rem values on the 4px grid: `0.25rem`, `0.5rem`, `0.75rem`, `1rem`, `1.5rem`, `2rem`.
+
+### Border Radius
+
+- Form controls, buttons: `0.625rem` (10px)
+- Dialogs, toasts, cards: `0.75rem` (12px)
+- Pills, badges: `999px`
+
+### CSS Class Naming
+
+Use BEM-like flat convention matching existing patterns:
+
+```css
+.component-name { }
+.component-name--modifier { }
+.component-name__child { }
+```
+
+Add new styles in `apps/web/src/index.css` in the appropriate section.
+
+## Accessibility
+
+### Non-Negotiable Requirements
+
+1. **Semantic HTML first** — use `<button>`, `<input>`, `<dialog>`, `<table>`, not `<div>` with roles
+2. **Labels on all form controls** — via `<label htmlFor>` or `aria-label`
+3. **`aria-invalid` on invalid controls** — wired through `invalid` prop or `FormField`
+4. **`aria-describedby` for descriptions and errors** — `FormField` handles this automatically
+5. **`role="alert"` for errors** — immediate screen reader announcement
+6. **`aria-live="polite"` for loading/status** — non-intrusive updates
+7. **`aria-hidden="true"` on decorative elements** — dots, icons, chevrons
+8. **Visible focus outlines** — `2px solid var(--accent-focus)` with `2px` offset. Never remove.
+9. **Color is never the only signal** — always pair with text, icon, or dot
+
+### Dialog Pattern
+
+Use native `<dialog>` with `.showModal()` / `.close()`:
+
+```tsx
+<dialog ref={dialogRef} aria-labelledby={titleId} aria-describedby={descId}>
+```
+
+### Table Pattern
+
+Always include a `<caption>` (use `.sr-only` if visually hidden):
+
+```tsx
+<table className="data-table">
+  <caption className="sr-only">{caption}</caption>
+  <thead>
+    <tr>{columns.map(col => <th key={col.id} scope="col">...)}</tr>
+  </thead>
+</table>
+```
+
+## Testing
+
+Every shared UI component gets a colocated `*.test.tsx`:
+
+```tsx
+// button.test.tsx
+import { render, screen } from '@testing-library/react';
+import { Button } from './button';
+
+describe('Button', () => {
+  it('should render with primary tone by default', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole('button', { name: 'Click me' })).toHaveClass('button--primary');
+  });
+
+  it('should forward ref to native button element', () => {
+    const ref = { current: null as HTMLButtonElement | null };
+    render(<Button ref={ref}>Test</Button>);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it('should merge custom className with internal classes', () => {
+    render(<Button className="custom">Test</Button>);
+    expect(screen.getByRole('button')).toHaveClass('button', 'custom');
+  });
+});
+```
+
+### Testing Priorities
+
+1. **Renders correctly** with default and custom props
+2. **Forwards ref** to the native element
+3. **Merges className** without overriding internal classes
+4. **Accessibility attributes** are correct (aria-invalid, aria-describedby, roles)
+5. **Keyboard interaction** works (focus, Enter, Escape for dialogs)
+6. **Tone/variant modifiers** apply correct CSS classes
+
+## Existing Component Inventory
+
+Before creating a new component, check if one already exists in `shared/ui/`:
+
+- **Form controls:** `Button`, `Input`, `Select`, `Textarea`
+- **Form layout:** `FormField`, `FieldError`, `FormErrorSummary`
+- **Status:** `StatusBadge`, `Alert`, `EnvironmentBadge`
+- **Feedback:** `LoadingState`, `EmptyState`, `ErrorState` (in `feedback-state.tsx`)
+- **Data:** `DataTable` (generic, typed columns)
+- **Overlays:** `ConfirmDialog`, `ToastProvider` / `useToast()`
+- **Layout:** `AppShell`, `PageLayout`
+
+Reuse and extend before creating new components.


### PR DESCRIPTION
## Summary

- Add `docs/claude-code-workflow-guide.md` — comprehensive guide for using Claude Code in this project (worktrees, context management, skills, hooks)
- Add `.claude/rules/` path-scoped rules for backend, frontend, pages, and UI components — Claude auto-loads the relevant rule set based on file being edited
- Add `.claude/commands/component.md` — the `/component` skill for scaffolding new shared UI components following all project patterns
- Add `.claude/settings.json` — worktree config and hook wiring
- Add `.worktreeinclude` — specifies files to copy into isolated worktrees
- Update `CLAUDE.md` to reference the new workflow guide
- Update `.gitignore` for Claude-related paths

## Test plan

- [ ] Verify `.claude/rules/` files are picked up by Claude Code when editing files in the corresponding paths
- [ ] Run `/component` skill and confirm it scaffolds a component correctly
- [ ] Confirm `docs/claude-code-workflow-guide.md` is referenced from `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)