### PR TITLE
feat(web): Allegro OAuth onboarding wizard (FE-011)

### DIFF
--- a/apps/web/src/app/routes/allegro-setup.route.tsx
+++ b/apps/web/src/app/routes/allegro-setup.route.tsx
@@ -1,0 +1,7 @@
+import type { RouteObject } from 'react-router-dom';
+import { AllegroSetupPage } from '../../pages/connections/allegro-setup-page';
+
+export const allegroSetupRoute: RouteObject = {
+  path: 'connections/new/allegro',
+  element: <AllegroSetupPage />,
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -1,6 +1,7 @@
 import type { RouteObject } from 'react-router-dom';
 import { AuthenticatedAppLayout } from '../layouts/authenticated-app-layout';
 import { allegroCallbackRoute } from './allegro-callback.route';
+import { allegroSetupRoute } from './allegro-setup.route';
 import { automationsRoute } from './automations.route';
 import { connectionDetailRoute } from './connection-detail.route';
 import { connectionsRoute } from './connections.route';
@@ -24,6 +25,7 @@ export const rootRoute: RouteObject = {
     inventoryRoute,
     connectionsRoute,
     newConnectionRoute,
+    allegroSetupRoute,
     connectionDetailRoute,
     allegroCallbackRoute,
     jobsLogsRoute,

--- a/apps/web/src/features/allegro/api/allegro.api.ts
+++ b/apps/web/src/features/allegro/api/allegro.api.ts
@@ -1,4 +1,6 @@
 export interface StartAllegroOAuthInput {
+  clientId: string;
+  clientSecret: string;
   redirectUri: string;
   environment?: 'sandbox' | 'production';
   connectionName?: string;
@@ -9,8 +11,15 @@ export interface StartAllegroOAuthResponse {
   state: string;
 }
 
+export interface AllegroCallbackResponse {
+  message: string;
+  connectionId: string;
+  connectionName: string;
+}
+
 export interface AllegroApi {
   startOAuth: (input: StartAllegroOAuthInput) => Promise<StartAllegroOAuthResponse>;
+  handleCallback: (code: string, state: string) => Promise<AllegroCallbackResponse>;
 }
 
 interface ApiRequest {
@@ -24,6 +33,11 @@ export function createAllegroApi(request: ApiRequest): AllegroApi {
         method: 'POST',
         body: JSON.stringify(input),
       });
+    },
+
+    handleCallback(code, state): Promise<AllegroCallbackResponse> {
+      const params = new URLSearchParams({ code, state });
+      return request<AllegroCallbackResponse>(`/integrations/allegro/oauth/callback?${params.toString()}`);
     },
   };
 }

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { AllegroSetupForm } from './AllegroSetupForm';
+
+function fillForm(
+  container: HTMLElement,
+  overrides: { name?: string; clientId?: string; clientSecret?: string } = {},
+): void {
+  const { name = 'Allegro sandbox', clientId = 'test-client-id', clientSecret = 'test-secret' } =
+    overrides;
+  const scope = within(container);
+
+  fireEvent.change(scope.getByLabelText(/connection name/i), { target: { value: name } });
+  fireEvent.change(scope.getByLabelText(/client id/i), { target: { value: clientId } });
+  fireEvent.change(scope.getByLabelText(/client secret/i), { target: { value: clientSecret } });
+}
+
+describe('AllegroSetupForm', () => {
+  it('renders all four form fields', () => {
+    const { container } = renderWithProviders(<AllegroSetupForm />);
+    const scope = within(container);
+
+    expect(scope.getByLabelText(/connection name/i)).toBeInTheDocument();
+    expect(scope.getByLabelText(/environment/i)).toBeInTheDocument();
+    expect(scope.getByLabelText(/client id/i)).toBeInTheDocument();
+    expect(scope.getByLabelText(/client secret/i)).toBeInTheDocument();
+  });
+
+  it('disables submit button while mutation is pending', async () => {
+    const apiClient = createMockApiClient({
+      allegro: { startOAuth: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+    const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
+
+    fillForm(container);
+    fireEvent.click(within(container).getByRole('button', { name: /connect with allegro/i }));
+
+    expect(
+      await within(container).findByRole('button', { name: /connecting/i }),
+    ).toBeDisabled();
+  });
+
+  it('shows API error when mutation fails', async () => {
+    const apiClient = createMockApiClient({
+      allegro: { startOAuth: vi.fn().mockRejectedValue(new Error('Invalid client credentials')) },
+    });
+    const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
+
+    fillForm(container);
+    fireEvent.click(within(container).getByRole('button', { name: /connect with allegro/i }));
+
+    expect(await screen.findByText('Invalid client credentials')).toBeInTheDocument();
+  });
+
+  it('calls startOAuth with correct input on valid submission', async () => {
+    const startOAuth = vi.fn().mockResolvedValue({
+      authorizationUrl: 'https://allegro.pl/auth',
+      state: 'abc123',
+    });
+    const apiClient = createMockApiClient({ allegro: { startOAuth } });
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { origin: 'http://localhost:5173', assign: vi.fn() },
+    });
+
+    const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
+    fillForm(container);
+    fireEvent.click(within(container).getByRole('button', { name: /connect with allegro/i }));
+
+    await waitFor(() => {
+      expect(startOAuth).toHaveBeenCalledWith({
+        clientId: 'test-client-id',
+        clientSecret: 'test-secret',
+        redirectUri: 'http://localhost:5173/integrations/allegro/connect/callback',
+        environment: 'sandbox',
+        connectionName: 'Allegro sandbox',
+      });
+    });
+  });
+
+  it('redirects to authorizationUrl on success', async () => {
+    const assignMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { origin: 'http://localhost:5173', assign: assignMock },
+    });
+    const apiClient = createMockApiClient({
+      allegro: {
+        startOAuth: vi.fn().mockResolvedValue({
+          authorizationUrl: 'https://allegro.pl/auth?state=y',
+          state: 'y',
+        }),
+      },
+    });
+
+    const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
+    fillForm(container);
+    fireEvent.click(within(container).getByRole('button', { name: /connect with allegro/i }));
+
+    await waitFor(() => {
+      expect(assignMock).toHaveBeenCalledWith('https://allegro.pl/auth?state=y');
+    });
+  });
+});

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
 import { AllegroSetupForm } from './AllegroSetupForm';
 
@@ -17,6 +17,10 @@ function fillForm(
 }
 
 describe('AllegroSetupForm', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('renders all four form fields', () => {
     const { container } = renderWithProviders(<AllegroSetupForm />);
     const scope = within(container);
@@ -59,10 +63,7 @@ describe('AllegroSetupForm', () => {
       state: 'abc123',
     });
     const apiClient = createMockApiClient({ allegro: { startOAuth } });
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { origin: 'http://localhost:5173', assign: vi.fn() },
-    });
+    vi.stubGlobal('location', { origin: 'http://localhost:5173', assign: vi.fn() });
 
     const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
     fillForm(container);
@@ -81,10 +82,7 @@ describe('AllegroSetupForm', () => {
 
   it('redirects to authorizationUrl on success', async () => {
     const assignMock = vi.fn();
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { origin: 'http://localhost:5173', assign: assignMock },
-    });
+    vi.stubGlobal('location', { origin: 'http://localhost:5173', assign: assignMock });
     const apiClient = createMockApiClient({
       allegro: {
         startOAuth: vi.fn().mockResolvedValue({

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
@@ -1,0 +1,128 @@
+import type { ReactElement } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useStartAllegroOAuthMutation } from '../hooks/use-start-allegro-oauth-mutation';
+import {
+  allegroSetupSchema,
+  ALLEGRO_SETUP_DEFAULT_VALUES,
+  toStartOAuthInput,
+  type AllegroSetupFormSubmission,
+  type AllegroSetupFormValues,
+} from './allegro-setup.schema';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
+
+export function AllegroSetupForm(): ReactElement {
+  const startOAuth = useStartAllegroOAuthMutation();
+  const form = useForm<AllegroSetupFormValues, undefined, AllegroSetupFormSubmission>({
+    defaultValues: ALLEGRO_SETUP_DEFAULT_VALUES,
+    resolver: zodResolver(allegroSetupSchema),
+  });
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      const redirectUri = `${window.location.origin}/integrations/allegro/connect/callback`;
+      const { authorizationUrl } = await startOAuth.mutateAsync(
+        toStartOAuthInput(values, redirectUri),
+      );
+      window.location.assign(authorizationUrl);
+    } catch {
+      return;
+    }
+  });
+
+  return (
+    <form className="form-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">OAuth 2.0</p>
+          <h3 className="section-title">Allegro app credentials</h3>
+        </div>
+        <span className="panel__meta">Entered once</span>
+      </div>
+
+      {form.formState.submitCount > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
+      {startOAuth.error ? (
+        <Alert tone="error" title="Failed to start authorization">
+          {startOAuth.error.message}
+        </Alert>
+      ) : null}
+
+      <div className="form-grid">
+        <FormField
+          label="Connection name"
+          name="name"
+          error={form.formState.errors.name?.message}
+          description="A label for this Allegro integration in OpenLinker."
+        >
+          <Input
+            {...form.register('name')}
+            placeholder="Allegro sandbox"
+            invalid={Boolean(form.formState.errors.name)}
+          />
+        </FormField>
+
+        <FormField
+          label="Environment"
+          name="environment"
+          error={form.formState.errors.environment?.message}
+        >
+          <Select {...form.register('environment')} invalid={Boolean(form.formState.errors.environment)}>
+            <option value="sandbox">Sandbox</option>
+            <option value="production">Production</option>
+          </Select>
+        </FormField>
+
+        <FormField
+          label="Client ID"
+          name="clientId"
+          error={form.formState.errors.clientId?.message}
+          description="OAuth client ID from your Allegro developer app."
+        >
+          <Input
+            {...form.register('clientId')}
+            placeholder="your-allegro-client-id"
+            invalid={Boolean(form.formState.errors.clientId)}
+            autoComplete="off"
+          />
+        </FormField>
+
+        <FormField
+          label="Client secret"
+          name="clientSecret"
+          error={form.formState.errors.clientSecret?.message}
+          description="OAuth client secret from your Allegro developer app."
+        >
+          <Input
+            {...form.register('clientSecret')}
+            type="password"
+            placeholder="your-allegro-client-secret"
+            invalid={Boolean(form.formState.errors.clientSecret)}
+            autoComplete="off"
+          />
+        </FormField>
+      </div>
+
+      <p className="muted-text panel-copy">
+        After submitting, you will be redirected to Allegro to authorize this connection. Make sure
+        your Allegro app has{' '}
+        <span className="mono-text">{typeof window !== 'undefined' ? `${window.location.origin}/integrations/allegro/connect/callback` : '/integrations/allegro/connect/callback'}</span>{' '}
+        registered as a redirect URI.
+      </p>
+
+      <div className="form-actions">
+        <Button type="submit" disabled={startOAuth.isPending}>
+          {startOAuth.isPending ? 'Connecting…' : 'Connect with Allegro'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
@@ -114,7 +114,7 @@ export function AllegroSetupForm(): ReactElement {
       <p className="muted-text panel-copy">
         After submitting, you will be redirected to Allegro to authorize this connection. Make sure
         your Allegro app has{' '}
-        <span className="mono-text">{typeof window !== 'undefined' ? `${window.location.origin}/integrations/allegro/connect/callback` : '/integrations/allegro/connect/callback'}</span>{' '}
+        <span className="mono-text">{`${window.location.origin}/integrations/allegro/connect/callback`}</span>{' '}
         registered as a redirect URI.
       </p>
 

--- a/apps/web/src/features/allegro/components/allegro-setup.schema.ts
+++ b/apps/web/src/features/allegro/components/allegro-setup.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import type { StartAllegroOAuthInput } from '../api/allegro.api';
+
+export const allegroSetupSchema = z.object({
+  name: z.string().trim().min(1, 'Connection name is required'),
+  environment: z.enum(['sandbox', 'production']),
+  clientId: z.string().trim().min(1, 'Client ID is required'),
+  clientSecret: z.string().trim().min(1, 'Client secret is required'),
+});
+
+export type AllegroSetupFormValues = z.input<typeof allegroSetupSchema>;
+export type AllegroSetupFormSubmission = z.output<typeof allegroSetupSchema>;
+
+export const ALLEGRO_SETUP_DEFAULT_VALUES: AllegroSetupFormValues = {
+  name: '',
+  environment: 'sandbox',
+  clientId: '',
+  clientSecret: '',
+};
+
+export function toStartOAuthInput(
+  values: AllegroSetupFormSubmission,
+  redirectUri: string,
+): StartAllegroOAuthInput {
+  return {
+    clientId: values.clientId,
+    clientSecret: values.clientSecret,
+    redirectUri,
+    environment: values.environment,
+    connectionName: values.name,
+  };
+}

--- a/apps/web/src/features/allegro/hooks/use-handle-allegro-callback-mutation.ts
+++ b/apps/web/src/features/allegro/hooks/use-handle-allegro-callback-mutation.ts
@@ -1,0 +1,21 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import type { AllegroCallbackResponse } from '../api/allegro.api';
+
+interface HandleCallbackInput {
+  code: string;
+  state: string;
+}
+
+export function useHandleAllegroCallbackMutation(): UseMutationResult<
+  AllegroCallbackResponse,
+  Error,
+  HandleCallbackInput
+> {
+  const apiClient = useApiClient();
+
+  return useMutation({
+    mutationFn: ({ code, state }: HandleCallbackInput) =>
+      apiClient.allegro.handleCallback(code, state),
+  });
+}

--- a/apps/web/src/features/connections/components/create-connection-form.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.tsx
@@ -52,6 +52,8 @@ export function CreateConnectionForm(): ReactElement {
   });
 
   const watchedPlatformType = form.watch('platformType');
+  // TODO: when a second OAuth platform is added, extract platform-specific
+  // form rendering into separate components rather than accumulating conditionals here.
   const isAllegroSelected = watchedPlatformType === 'allegro';
 
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
@@ -59,6 +61,10 @@ export function CreateConnectionForm(): ReactElement {
   );
 
   const onSubmit = form.handleSubmit(async (values) => {
+    // Guard against Enter-key form submission while a platform-specific wizard
+    // (e.g. Allegro) is selected: the schema still validates hidden fields, so
+    // submission would fail silently without visible feedback.
+    if (isAllegroSelected) return;
     try {
       await createConnection.mutateAsync(toCreateConnectionInput(values));
       form.reset(DEFAULT_VALUES);

--- a/apps/web/src/features/connections/components/create-connection-form.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { PLATFORM_TYPES } from '../api/connections.types';
 import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
@@ -49,6 +50,9 @@ export function CreateConnectionForm(): ReactElement {
     defaultValues: DEFAULT_VALUES,
     resolver: zodResolver(createConnectionSchema),
   });
+
+  const watchedPlatformType = form.watch('platformType');
+  const isAllegroSelected = watchedPlatformType === 'allegro';
 
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : [],
@@ -107,45 +111,59 @@ export function CreateConnectionForm(): ReactElement {
             </Select>
           </FormField>
 
-          <FormField label="Credentials reference" name="credentialsRef" error={form.formState.errors.credentialsRef?.message}>
-            <Input
-              {...form.register('credentialsRef')}
-              placeholder="db:cred_123"
-              invalid={Boolean(form.formState.errors.credentialsRef)}
-            />
-          </FormField>
+          {isAllegroSelected ? null : (
+            <FormField label="Credentials reference" name="credentialsRef" error={form.formState.errors.credentialsRef?.message}>
+              <Input
+                {...form.register('credentialsRef')}
+                placeholder="db:cred_123"
+                invalid={Boolean(form.formState.errors.credentialsRef)}
+              />
+            </FormField>
+          )}
 
+          {isAllegroSelected ? null : (
+            <FormField
+              label="Adapter key"
+              name="adapterKey"
+              error={form.formState.errors.adapterKey?.message}
+              description="Optional when the default adapter can be inferred from the selected platform."
+            >
+              <Input
+                {...form.register('adapterKey')}
+                placeholder="prestashop.webservice.v1"
+                invalid={Boolean(form.formState.errors.adapterKey)}
+              />
+            </FormField>
+          )}
+        </div>
+
+        {isAllegroSelected ? (
+          <Alert tone="info" title="Allegro uses OAuth">
+            Allegro connections require OAuth authorization.{' '}
+            <Link to="/connections/new/allegro">Use the Allegro setup wizard</Link> to connect your
+            account securely.
+          </Alert>
+        ) : (
           <FormField
-            label="Adapter key"
-            name="adapterKey"
-            error={form.formState.errors.adapterKey?.message}
-            description="Optional when the default adapter can be inferred from the selected platform."
+            label="Config JSON"
+            name="configText"
+            error={form.formState.errors.configText?.message}
+            description="Provide only safe connection configuration values. Secrets must remain outside the browser."
           >
-            <Input
-              {...form.register('adapterKey')}
-              placeholder="prestashop.webservice.v1"
-              invalid={Boolean(form.formState.errors.adapterKey)}
-            />
+            <Textarea {...form.register('configText')} rows={10} invalid={Boolean(form.formState.errors.configText)} />
           </FormField>
-        </div>
+        )}
 
-        <FormField
-          label="Config JSON"
-          name="configText"
-          error={form.formState.errors.configText?.message}
-          description="Provide only safe connection configuration values. Secrets must remain outside the browser."
-        >
-          <Textarea {...form.register('configText')} rows={10} invalid={Boolean(form.formState.errors.configText)} />
-        </FormField>
-
-        <div className="form-actions">
-          <Button type="submit" disabled={createConnection.isPending}>
-            {createConnection.isPending ? 'Creating...' : 'Create connection'}
-          </Button>
-          <Button tone="secondary" onClick={() => setIsResetDialogOpen(true)} disabled={createConnection.isPending}>
-            Reset draft
-          </Button>
-        </div>
+        {isAllegroSelected ? null : (
+          <div className="form-actions">
+            <Button type="submit" disabled={createConnection.isPending}>
+              {createConnection.isPending ? 'Creating...' : 'Create connection'}
+            </Button>
+            <Button tone="secondary" onClick={() => setIsResetDialogOpen(true)} disabled={createConnection.isPending}>
+              Reset draft
+            </Button>
+          </div>
+        )}
       </form>
 
       <ConfirmDialog

--- a/apps/web/src/pages/connections/allegro-setup-page.tsx
+++ b/apps/web/src/pages/connections/allegro-setup-page.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { AllegroSetupForm } from '../../features/allegro/components/AllegroSetupForm';
+import { PageLayout } from '../../shared/ui/page-layout';
+
+export function AllegroSetupPage(): ReactElement {
+  return (
+    <PageLayout
+      eyebrow="Integrations"
+      title="Connect Allegro"
+      description="Authorize OpenLinker to manage your Allegro offers, orders, and inventory via the Allegro API."
+      actions={
+        <Link className="button button--secondary" to="/connections/new">
+          Back
+        </Link>
+      }
+      summary={
+        <div className="toolbar__group">
+          <span className="toolbar-chip">OAuth 2.0</span>
+          <span className="toolbar-chip">Allegro API</span>
+        </div>
+      }
+    >
+      <AllegroSetupForm />
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/integrations/allegro-connect-callback-page.test.tsx
+++ b/apps/web/src/pages/integrations/allegro-connect-callback-page.test.tsx
@@ -1,0 +1,82 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
+import { AllegroConnectCallbackPage } from './allegro-connect-callback-page';
+
+const CALLBACK_ROUTE = '/integrations/allegro/connect/callback';
+
+describe('AllegroConnectCallbackPage', () => {
+  it('shows error state when Allegro returns ?error param', () => {
+    renderWithProviders(<AllegroConnectCallbackPage />, {
+      route: `${CALLBACK_ROUTE}?error=access_denied`,
+    });
+
+    expect(screen.getByRole('heading', { name: 'Authorization denied' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /start over/i })).toHaveAttribute(
+      'href',
+      '/connections/new/allegro',
+    );
+  });
+
+  it('shows error state when code or state params are missing', () => {
+    renderWithProviders(<AllegroConnectCallbackPage />, {
+      route: `${CALLBACK_ROUTE}?state=abc123`,
+    });
+
+    expect(screen.getByRole('heading', { name: 'Invalid callback' })).toBeInTheDocument();
+  });
+
+  it('shows loading state while mutation is pending', () => {
+    const apiClient = createMockApiClient({
+      allegro: { handleCallback: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+    renderWithProviders(<AllegroConnectCallbackPage />, {
+      apiClient,
+      route: `${CALLBACK_ROUTE}?code=auth_code&state=csrf_state`,
+    });
+
+    expect(screen.getByRole('heading', { name: 'Completing authorization' })).toBeInTheDocument();
+  });
+
+  it('shows success panel with connection details on mutation success', async () => {
+    const apiClient = createMockApiClient({
+      allegro: {
+        handleCallback: vi.fn().mockResolvedValue({
+          message: 'Connection created.',
+          connectionId: 'conn_allegro_1',
+          connectionName: 'Allegro sandbox',
+        }),
+      },
+    });
+    renderWithProviders(<AllegroConnectCallbackPage />, {
+      apiClient,
+      route: `${CALLBACK_ROUTE}?code=auth_code&state=csrf_state`,
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Connection created' })).toBeInTheDocument();
+    expect(screen.getByText('Allegro sandbox')).toBeInTheDocument();
+    expect(screen.getByText('conn_allegro_1')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go to connection/i })).toHaveAttribute(
+      'href',
+      '/connections/conn_allegro_1',
+    );
+  });
+
+  it('shows error state on mutation failure', async () => {
+    const apiClient = createMockApiClient({
+      allegro: {
+        handleCallback: vi.fn().mockRejectedValue(new Error('Invalid or expired OAuth state')),
+      },
+    });
+    renderWithProviders(<AllegroConnectCallbackPage />, {
+      apiClient,
+      route: `${CALLBACK_ROUTE}?code=auth_code&state=expired_state`,
+    });
+
+    expect(await screen.findByText('Invalid or expired OAuth state')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /try again/i })).toHaveAttribute(
+      'href',
+      '/connections/new/allegro',
+    );
+  });
+});

--- a/apps/web/src/pages/integrations/allegro-connect-callback-page.tsx
+++ b/apps/web/src/pages/integrations/allegro-connect-callback-page.tsx
@@ -1,30 +1,121 @@
 import type { ReactElement } from 'react';
-import { EmptyState } from '../../shared/ui/feedback-state';
+import { useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useHandleAllegroCallbackMutation } from '../../features/allegro/hooks/use-handle-allegro-callback-mutation';
+import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
 import { PageLayout } from '../../shared/ui/page-layout';
 
 export function AllegroConnectCallbackPage(): ReactElement {
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get('code');
+  const state = searchParams.get('state');
+  const oauthError = searchParams.get('error');
+
+  const callbackMutation = useHandleAllegroCallbackMutation();
+
+  useEffect(() => {
+    if (code && state) {
+      callbackMutation.mutate({ code, state });
+    }
+  // Intentionally run once on mount — OAuth callback is a one-shot operation.
+  }, []); // eslint-disable-line
+
+  function renderContent(): ReactElement {
+    if (oauthError) {
+      return (
+        <ErrorState
+          title="Authorization denied"
+          message="You did not authorize OpenLinker on Allegro. No connection was created."
+          action={
+            <Link className="button" to="/connections/new/allegro">
+              Start over
+            </Link>
+          }
+        />
+      );
+    }
+
+    if (!code || !state) {
+      return (
+        <ErrorState
+          title="Invalid callback"
+          message="The OAuth callback is missing required parameters. This may happen if you navigate here directly."
+          action={
+            <Link className="button" to="/connections/new/allegro">
+              Start setup
+            </Link>
+          }
+        />
+      );
+    }
+
+    if (callbackMutation.isPending) {
+      return <LoadingState title="Completing authorization" message="Exchanging authorization code with Allegro…" />;
+    }
+
+    if (callbackMutation.error) {
+      return (
+        <ErrorState
+          title="Authorization failed"
+          message={callbackMutation.error.message}
+          action={
+            <Link className="button" to="/connections/new/allegro">
+              Try again
+            </Link>
+          }
+        />
+      );
+    }
+
+    if (callbackMutation.data) {
+      const { connectionId, connectionName } = callbackMutation.data;
+      return (
+        <article className="panel panel--dense">
+          <div className="panel__header">
+            <div>
+              <p className="eyebrow">Success</p>
+              <h3 className="section-title">Connection created</h3>
+            </div>
+            <span className="panel__meta">Active</span>
+          </div>
+          <dl className="definition-list">
+            <div>
+              <dt>Name</dt>
+              <dd>{connectionName}</dd>
+            </div>
+            <div>
+              <dt>Connection ID</dt>
+              <dd className="mono-text">{connectionId}</dd>
+            </div>
+          </dl>
+          <div className="form-actions">
+            <Link className="button" to={`/connections/${connectionId}`}>
+              Go to connection
+            </Link>
+            <Link className="button button--secondary" to="/connections">
+              View all connections
+            </Link>
+          </div>
+        </article>
+      );
+    }
+
+    return <LoadingState title="Completing authorization" message="Exchanging authorization code with Allegro…" />;
+  }
+
   return (
     <PageLayout
       eyebrow="OAuth callback"
-      title="Allegro callback checkpoint"
-      description="This route reserves the browser return point for a future step-based integration onboarding flow."
+      title="Allegro authorization"
+      description="Processing the authorization response from Allegro."
       summary={
-        <>
-          <div className="toolbar__group">
-            <span className="toolbar-chip">Reserved route</span>
-            <span className="toolbar-chip">OAuth boundary</span>
-          </div>
-          <div className="toolbar__group">
-            <span className="muted-text">The callback exists now so the app shell does not need to change when OAuth is implemented.</span>
-          </div>
-        </>
+        <div className="toolbar__group">
+          <span className="toolbar-chip">OAuth 2.0</span>
+          <span className="toolbar-chip">Allegro API</span>
+        </div>
       }
     >
-      <EmptyState
-        eyebrow="Setup wizard"
-        title="Flow placeholder"
-        message="FE-001 defines the route boundary now so OAuth can be added later without changing the shell or page model."
-      />
+      {renderContent()}
     </PageLayout>
   );
 }

--- a/apps/web/src/pages/integrations/allegro-connect-callback-page.tsx
+++ b/apps/web/src/pages/integrations/allegro-connect-callback-page.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useHandleAllegroCallbackMutation } from '../../features/allegro/hooks/use-handle-allegro-callback-mutation';
 import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
@@ -12,13 +12,14 @@ export function AllegroConnectCallbackPage(): ReactElement {
   const oauthError = searchParams.get('error');
 
   const callbackMutation = useHandleAllegroCallbackMutation();
+  const hasCalledRef = useRef(false);
 
   useEffect(() => {
-    if (code && state) {
+    if (!hasCalledRef.current && code && state) {
+      hasCalledRef.current = true;
       callbackMutation.mutate({ code, state });
     }
-  // Intentionally run once on mount — OAuth callback is a one-shot operation.
-  }, []); // eslint-disable-line
+  }, [code, state, callbackMutation.mutate]);
 
   function renderContent(): ReactElement {
     if (oauthError) {

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -53,6 +53,11 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
         authorizationUrl: 'https://example.com/oauth',
         state: 'state',
       }),
+      handleCallback: vi.fn().mockResolvedValue({
+        message: 'OAuth callback processed successfully. Connection created.',
+        connectionId: 'conn_allegro_1',
+        connectionName: 'Allegro sandbox',
+      }),
       ...overrides.allegro,
     } as ApiClient['allegro'],
     auth: {

--- a/docs/plans/implementation-plan-allegro-onboarding-wizard.md
+++ b/docs/plans/implementation-plan-allegro-onboarding-wizard.md
@@ -1,0 +1,432 @@
+# Implementation Plan: Allegro Onboarding Wizard (FE-011)
+
+**Date**: 2026-04-06
+**Status**: Ready for Review
+**Estimated Effort**: 4–6 hours
+**Issue**: [#66 — FE: Build Allegro onboarding wizard](https://github.com/SilkSoftwareHouse/openlinker/issues/66)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Turn the fully-implemented Allegro OAuth backend into a usable operator workflow. The wizard collects Allegro app credentials and a connection name, initiates the OAuth flow, handles the browser callback, and shows a success/failure result screen.
+
+**Context**: The backend is complete — `POST /integrations/allegro/oauth/connect` and `GET /integrations/allegro/oauth/callback` both work. The FE has a placeholder callback page at `/integrations/allegro/connect/callback`, a registered route, and a wired `useStartAllegroOAuthMutation` hook. What's missing is the setup form, the callback handler, and the wiring between them.
+
+**Classification**: Frontend / Feature — `apps/web/src/`
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+
+- `AllegroSetupForm` — collects connection name, environment, client ID, client secret
+- Calling `POST /integrations/allegro/oauth/connect` and redirecting the browser to the returned `authorizationUrl`
+- `AllegroConnectCallbackPage` — reads `?code` and `?state` from the URL, calls the backend callback API, shows loading / success / error states
+- New route `/connections/new/allegro` for the wizard entry point
+- Redirect hint in the generic `CreateConnectionForm` when Allegro platform is selected
+- FE API contract fix: add `clientId`/`clientSecret` to `StartAllegroOAuthInput`, add `handleCallback` to `AllegroApi`
+- Tests for the setup form and callback page
+
+### Out of Scope
+
+- Any backend changes — all endpoints are already implemented
+- Connection validation step (exists at `GET /integrations/allegro/connections/:id/validate`, deferred to #63)
+- Redesigning the generic "New connection" page
+- Allegro token refresh or expiry handling
+- Support for multiple Allegro connections in the same wizard session
+
+### Constraints
+
+- No `clientId`/`clientSecret` may be embedded in FE code or env files — they are operator-entered at setup time
+- `redirectUri` must use `window.location.origin` at runtime — cannot be a static env var because the FE domain varies per deployment
+- The callback route `/integrations/allegro/connect/callback` already exists in the router and must not change
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: `apps/web` — `features/allegro/`, `pages/connections/`, `pages/integrations/`
+
+**Capabilities Involved**: None (no backend ports involved — purely FE orchestration of existing REST endpoints)
+
+**Existing Services Reused**:
+- `useStartAllegroOAuthMutation` hook (`features/allegro/hooks/`) — calls `POST /integrations/allegro/oauth/connect`
+- `AllegroApi` + `createAllegroApi` (`features/allegro/api/allegro.api.ts`) — needs two additions
+- `PageLayout`, `Alert`, `Button`, `FormField`, `Input`, `Select`, `LoadingState`, `ErrorState` from `shared/ui/`
+- `renderWithProviders` + `createMockApiClient` from `test/test-utils.tsx`
+
+**New Components Required**:
+| File | Purpose |
+|---|---|
+| `features/allegro/api/allegro.api.ts` | Add `clientId`/`clientSecret` to input type; add `handleCallback` |
+| `features/allegro/hooks/use-handle-allegro-callback-mutation.ts` | Mutation hook for the callback API call |
+| `features/allegro/components/allegro-setup.schema.ts` | Zod schema for the setup form |
+| `features/allegro/components/AllegroSetupForm.tsx` | Step 1 form component |
+| `features/allegro/components/AllegroSetupForm.test.tsx` | Unit tests for the form |
+| `pages/connections/allegro-setup-page.tsx` | Page wrapping the setup form |
+| `pages/integrations/allegro-connect-callback-page.tsx` | Replace stub — real callback handler |
+| `pages/integrations/allegro-connect-callback-page.test.tsx` | Tests for the callback page |
+| `app/routes/allegro-setup.route.tsx` | Route declaration for `/connections/new/allegro` |
+
+**Modified Files**:
+| File | Change |
+|---|---|
+| `app/routes/root.route.tsx` | Register `allegroSetupRoute` |
+| `features/connections/components/create-connection-form.tsx` | When Allegro selected, show redirect notice |
+
+**Core vs Integration Justification**: N/A — purely FE. The backend boundary is not crossed architecturally; the FE consumes existing REST endpoints.
+
+**Dependency direction**: `pages` → `features/allegro` → `shared` ✅
+
+---
+
+## 4. External / Domain Research
+
+### Allegro OAuth Flow (as implemented in backend)
+
+1. FE calls `POST /integrations/allegro/oauth/connect` with `{ clientId, clientSecret, redirectUri, environment, connectionName }`
+2. Backend generates a random state, stores `{ clientId, clientSecret, redirectUri, environment, connectionName }` in Redis with a 10-minute TTL
+3. Backend returns `{ authorizationUrl, state }` — the `authorizationUrl` already includes all required Allegro OAuth params
+4. FE redirects browser to `authorizationUrl`
+5. Operator authorizes on Allegro
+6. Allegro redirects browser to `redirectUri` with `?code=...&state=...`
+7. **`redirectUri` must be the FE callback URL** (`window.location.origin + "/integrations/allegro/connect/callback"`) — the FE receives the code and state, then calls the backend
+8. FE callback page calls `GET /integrations/allegro/oauth/callback?code=...&state=...`
+9. Backend validates state against Redis (one-time use), exchanges code for tokens, creates the connection, returns `{ message, connectionId, connectionName }`
+
+### Error cases to handle on the callback page:
+- `?error=access_denied` — operator denied authorization on Allegro (Allegro adds this param)
+- Missing `?code` or `?state` — malformed redirect
+- Backend returns 400 — invalid/expired state (operator took more than 10 minutes)
+- Backend returns 5xx — unexpected server error
+- Network failure
+
+### Internal Patterns
+- **Setup form**: follows `LoginForm.tsx` / `CreateConnectionForm.tsx` — Zod schema + React Hook Form + mutation
+- **Mutation hook**: follows `use-start-allegro-oauth-mutation.ts`
+- **Callback URL params**: use `useSearchParams()` from React Router (established in the router setup)
+- **All four states**: loading / error / empty / data per `fe-pages.md` rules
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+
+- Should the callback page auto-redirect to `/connections/{connectionId}` after a few seconds, or stay on the success screen? **Assumption**: stay on success screen with an explicit "Go to connection" link — less surprising than automatic redirect.
+- Should the `AllegroSetupForm` show/hide the `clientSecret` field (password masking)? **Assumption**: yes — use `type="password"` on the secret input since this is a sensitive credential.
+
+### Assumptions
+
+- `redirectUri = window.location.origin + "/integrations/allegro/connect/callback"` — constructed at form submit time in the browser. Operators must register this URL in their Allegro app settings.
+- The backend `GET /integrations/allegro/oauth/callback` is `@Public()` — no auth token needed for the callback call. This is confirmed in the controller.
+- The POST endpoint requires `@Roles('admin')` — the operator must be logged in as admin to initiate the flow. The `AuthenticatedAppLayout` already enforces authentication for all child routes.
+- We do NOT support the `?error` query param from Allegro in the existing `AllegroOAuthCallbackQueryDto` — handle it purely on the FE by checking for its presence before calling the backend.
+- `connectionName` is optional at setup time. If omitted, the backend generates a default name.
+
+### Documentation Gaps
+
+- The backend comment says "In production, this could redirect to a success page" — this design defers that to future work. The FE-mediated callback flow (FE receives code, FE calls backend) is the right MVP approach.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Fix the API contract
+
+**Goal**: Make the FE API match what the backend actually expects.
+
+**Step 1.1 — Update `allegro.api.ts`**
+
+- **File**: `apps/web/src/features/allegro/api/allegro.api.ts`
+- **Action**:
+  1. Add `clientId: string` and `clientSecret: string` to `StartAllegroOAuthInput` (required, because the backend DTO requires them)
+  2. Add `AllegroCallbackResponse` interface: `{ message: string; connectionId: string; connectionName: string }`
+  3. Add `handleCallback(code: string, state: string): Promise<AllegroCallbackResponse>` to `AllegroApi` interface
+  4. Implement `handleCallback` in `createAllegroApi` — calls `GET /integrations/allegro/oauth/callback?code=...&state=...`
+- **Acceptance**: TypeScript compiles; the updated `allegro` property in `createMockApiClient` in `test-utils.tsx` needs `handleCallback` added
+
+**Step 1.2 — Update `test-utils.tsx`**
+
+- **File**: `apps/web/src/test/test-utils.tsx`
+- **Action**: Add `handleCallback: vi.fn().mockResolvedValue({ message: 'OK', connectionId: 'conn_1', connectionName: 'Allegro sandbox' })` to the mock `allegro` object
+- **Acceptance**: `pnpm type-check` passes; existing tests still pass
+
+**Step 1.3 — Add `use-handle-allegro-callback-mutation.ts`**
+
+- **File**: `apps/web/src/features/allegro/hooks/use-handle-allegro-callback-mutation.ts`
+- **Action**: Create mutation hook that calls `apiClient.allegro.handleCallback(code, state)`
+- **Acceptance**: Hook exports `useHandleAllegroCallbackMutation`; follows `use-start-allegro-oauth-mutation.ts` pattern
+
+---
+
+### Phase 2 — Allegro setup form
+
+**Goal**: Collect operator credentials and initiate the OAuth redirect.
+
+**Step 2.1 — Create `allegro-setup.schema.ts`**
+
+- **File**: `apps/web/src/features/allegro/components/allegro-setup.schema.ts`
+- **Action**: Define Zod schema with fields:
+  - `name: z.string().trim().min(1)` — connection name
+  - `environment: z.enum(['sandbox', 'production'])` — default `'sandbox'`
+  - `clientId: z.string().trim().min(1)` — Allegro OAuth client ID
+  - `clientSecret: z.string().trim().min(1)` — Allegro OAuth client secret
+- **Acceptance**: Export `AllegroSetupFormValues`, `AllegroSetupFormSubmission`, and `toStartOAuthInput(values, redirectUri): StartAllegroOAuthInput`
+
+**Step 2.2 — Create `AllegroSetupForm.tsx`**
+
+- **File**: `apps/web/src/features/allegro/components/AllegroSetupForm.tsx`
+- **Action**:
+  1. React Hook Form with zodResolver
+  2. Fields: connection name (text), environment (select: sandbox / production), client ID (text), client secret (password)
+  3. On submit: call `useStartAllegroOAuthMutation`, compute `redirectUri = window.location.origin + "/integrations/allegro/connect/callback"`, then `window.location.href = authorizationUrl`
+  4. Show `Alert tone="error"` on mutation failure
+  5. Disable submit while pending; show `FormErrorSummary` after first submit attempt
+  6. Informational note: "You will be redirected to Allegro to authorize this connection."
+- **Acceptance**: Form renders; submitting calls `startOAuth`; on success `window.location.href` is set to `authorizationUrl`
+
+**Step 2.3 — Create `allegro-setup-page.tsx`**
+
+- **File**: `apps/web/src/pages/connections/allegro-setup-page.tsx`
+- **Action**: Wrap `AllegroSetupForm` in `PageLayout` with eyebrow "Integrations", title "Connect Allegro", description, summary toolbar chips ("OAuth 2.0", "Allegro API"), and a back link to `/connections/new`
+- **Acceptance**: Page renders correctly inside the shell
+
+**Step 2.4 — Create route and register**
+
+- **File**: `apps/web/src/app/routes/allegro-setup.route.tsx`
+- **Action**: `{ path: 'connections/new/allegro', element: <AllegroSetupPage /> }`
+- **File**: `apps/web/src/app/routes/root.route.tsx`
+- **Action**: Import and add `allegroSetupRoute` to the children array (before `allegroCallbackRoute`)
+- **Acceptance**: Navigating to `/connections/new/allegro` renders `AllegroSetupPage`
+
+**Step 2.5 — Add redirect hint in `CreateConnectionForm`**
+
+- **File**: `apps/web/src/features/connections/components/create-connection-form.tsx`
+- **Action**: When `platformType === 'allegro'` is selected, render an `Alert tone="info"` inside the form that reads: "Allegro uses OAuth — [use the Allegro setup wizard]" (link to `/connections/new/allegro`). The rest of the generic form fields stay hidden while this notice is shown to prevent the operator entering meaningless credentials.
+- **Acceptance**: Selecting Allegro in the generic form shows the info alert and hides the other fields
+
+---
+
+### Phase 3 — Callback handler
+
+**Goal**: Process the OAuth return, show success or a clear failure message.
+
+**Step 3.1 — Rewrite `allegro-connect-callback-page.tsx`**
+
+- **File**: `apps/web/src/pages/integrations/allegro-connect-callback-page.tsx`
+- **Action**:
+  1. Read `code`, `state`, and `error` from `useSearchParams()`
+  2. If `error` param present: show `ErrorState` with "Authorization denied" message and a "Try again" link to `/connections/new/allegro`
+  3. If `code` or `state` missing: show `ErrorState` with "Invalid callback — missing parameters"
+  4. Otherwise: call `useHandleAllegroCallbackMutation` on mount (via `useEffect` with the mutation `mutate` function) — show `LoadingState` while pending
+  5. On mutation success: show a success panel — connection name, connection ID in mono-text, "Go to connection" button linking to `/connections/{connectionId}`, "View all connections" secondary link
+  6. On mutation error: show `ErrorState` with the server error message, retry link to `/connections/new/allegro`
+- **Acceptance**: All four states render correctly; mutation is called once on mount when code+state are present
+
+---
+
+### Phase 4 — Tests
+
+**Step 4.1 — `AllegroSetupForm.test.tsx`**
+
+- **File**: `apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx`
+- **Tests**:
+  | Test | Arrangement | Assertion |
+  |---|---|---|
+  | Shows all four form fields | default render | name, environment, client ID, client secret inputs present |
+  | Disables submit while pending | mutation pending | submit button disabled |
+  | Shows API error on failure | mutation rejects | `Alert tone="error"` appears |
+  | Calls startOAuth with correct input | valid form submit | `apiClient.allegro.startOAuth` called with `clientId`, `clientSecret`, `redirectUri`, `environment`, `connectionName` |
+  | Redirects on success | mutation resolves | `window.location.href` set to `authorizationUrl` |
+
+**Step 4.2 — `allegro-connect-callback-page.test.tsx`**
+
+- **File**: `apps/web/src/pages/integrations/allegro-connect-callback-page.test.tsx`
+- **Tests**:
+  | Test | Arrangement | Assertion |
+  |---|---|---|
+  | Shows error when `?error=access_denied` present | route with `?error=access_denied` | "Authorization denied" error state |
+  | Shows error when code missing | route with `?state=abc` only | error state about missing parameters |
+  | Shows loading while mutation pending | route with `?code=x&state=y`, never-resolving mutation | loading state |
+  | Shows success with connection info | route with `?code=x&state=y`, mutation resolves | connection name and ID visible |
+  | Shows error on mutation failure | route with `?code=x&state=y`, mutation rejects | error state with retry link |
+
+---
+
+### Implementation Details
+
+**`allegro.api.ts` final shape:**
+```typescript
+export interface StartAllegroOAuthInput {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  environment?: 'sandbox' | 'production';
+  connectionName?: string;
+}
+
+export interface AllegroCallbackResponse {
+  message: string;
+  connectionId: string;
+  connectionName: string;
+}
+
+export interface AllegroApi {
+  startOAuth: (input: StartAllegroOAuthInput) => Promise<StartAllegroOAuthResponse>;
+  handleCallback: (code: string, state: string) => Promise<AllegroCallbackResponse>;
+}
+```
+
+**`handleCallback` implementation:**
+```typescript
+handleCallback(code, state): Promise<AllegroCallbackResponse> {
+  return request<AllegroCallbackResponse>(
+    `/integrations/allegro/oauth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`,
+  );
+}
+```
+
+Note: `GET` with no body — use query string.
+
+**`redirectUri` construction in `AllegroSetupForm`:**
+```typescript
+const redirectUri = `${window.location.origin}/integrations/allegro/connect/callback`;
+```
+
+This is computed at submit time so it works for any deployment (local, staging, production).
+
+**Callback page mutation trigger — key pattern:**
+```typescript
+const callbackMutation = useHandleAllegroCallbackMutation();
+
+useEffect(() => {
+  if (code && state) {
+    callbackMutation.mutate({ code, state });
+  }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, []); // Intentionally empty — run once on mount only
+```
+
+**No new CSS needed** — all required classes are already in `index.css`.
+
+**No backend changes needed** — `POST /integrations/allegro/oauth/connect` and `GET /integrations/allegro/oauth/callback` are complete.
+
+**No migration needed** — no schema changes.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Backend-mediated callback (redirectUri = API URL)
+
+The `redirectUri` points to the backend `GET /integrations/allegro/oauth/callback`. After processing, the backend 302-redirects to a FE success page.
+
+**Why Rejected**: Requires backend changes (adding redirect logic). The FE already has a reserved callback route. The FE-mediated approach (FE receives code, calls backend) requires zero backend changes and keeps the UI concerns in the FE layer.
+
+---
+
+### Alternative 2: Platform selection cards replacing the generic form
+
+Replace `/connections/new` entirely with a platform-selection card grid (Allegro card → OAuth wizard, PrestaShop card → generic form).
+
+**Why Rejected**: Scope creep beyond issue #66. The generic form remains useful for PrestaShop and future platforms. The redirect hint approach achieves the goal with minimal disruption to existing flows.
+
+---
+
+### Alternative 3: Inline wizard steps on the same page
+
+Single `/connections/new` page with step-based rendering (step 1: select platform, step 2: platform-specific form, step 3: callback result).
+
+**Why Rejected**: The OAuth flow requires a real browser navigation to Allegro and back. You cannot keep the user on the same page during OAuth. The `/connections/new/allegro` + `/integrations/allegro/connect/callback` two-page model maps naturally to the OAuth redirect dance.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ `pages` → `features` → `shared` dependency direction preserved
+- ✅ No API calls from page components — all through feature hooks
+- ✅ No global store introduced — mutation state is local to the component
+
+### Naming Conventions
+- ✅ `allegro-setup.schema.ts` — matches `*.schema.ts` form schema convention
+- ✅ `use-handle-allegro-callback-mutation.ts` — matches `use-{action}-mutation.ts` hook convention
+- ✅ `allegro-setup-page.tsx` — matches kebab-case page convention
+- ✅ `allegro-connect-callback-page.test.tsx` — matches kebab-case test convention
+
+### Risks
+
+- **`window.location.href` assignment in tests**: Assigning to `window.location.href` in JSDOM requires mocking. Use `vi.spyOn(window.location, 'assign')` or `Object.defineProperty(window, 'location', { writable: true, value: { href: '' } })` in form tests.
+- **`useEffect` + `useMutation` on mount**: The callback page fires the mutation once on mount. React Strict Mode double-invokes effects. This is fine here because `handleCallback` is idempotent server-side (Redis state is one-time use — the second invocation would return a 400 but the first already succeeded). In test, use a never-resolving mutation to test loading state.
+- **10-minute state TTL**: If the operator takes more than 10 minutes between starting and completing the OAuth, the backend returns 400. The callback page's error state handles this gracefully with a retry link.
+- **`credentialsRef` still shown in generic form when Allegro redirected**: The generic form hides its fields when Allegro is selected but the redirect hint is shown — no stale credentials can be entered.
+
+### Edge Cases
+- `?error=access_denied` from Allegro → show denial state (not a backend error)
+- Network failure during backend callback call → `ErrorState` with retry
+- User navigates directly to `/integrations/allegro/connect/callback` without params → show clear "Invalid callback" state (no blank page)
+- `authorizationUrl` opens as top-level navigation (not popup) — standard OAuth pattern, correct
+
+### Backward Compatibility
+- ✅ Generic `CreateConnectionForm` remains functional for PrestaShop
+- ✅ Existing `allegroCallbackRoute` path unchanged
+- ✅ `useStartAllegroOAuthMutation` type change is additive (new required fields) — no existing callers to break
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Component Tests (Vitest + Testing Library)
+
+**`AllegroSetupForm.test.tsx`** — 5 tests covering: field rendering, submit-disabled-when-pending, API error display, correct mutation call, redirect on success
+
+**`allegro-connect-callback-page.test.tsx`** — 5 tests covering: `?error` param, missing params, loading state, success state with connection info, mutation error state
+
+### Mocking Strategy
+- `apiClient.allegro.startOAuth` and `apiClient.allegro.handleCallback` — mocked via `createMockApiClient`
+- `window.location` — mocked in form test to capture redirect
+- URL search params — passed via `renderWithProviders({ route: '/integrations/allegro/connect/callback?code=x&state=y' })`
+
+### Acceptance Criteria (from issue #66)
+- [x] Setup form collects connection name, environment, client ID, client secret
+- [x] Calling the OAuth connect endpoint and receiving authorizationUrl
+- [x] Redirect flow — browser navigates to Allegro authorization page
+- [x] Callback success UX — shows connection name, ID, link to detail
+- [x] Callback failure UX — clear error message with retry path
+- [x] Validation result screen — success panel on the callback page
+
+### Quality Gate
+```bash
+pnpm lint        # zero errors
+pnpm type-check  # zero errors
+pnpm test        # all tests pass
+```
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture (FE dependency direction)
+- [x] Respects CORE vs Integration boundaries (no boundary crossing)
+- [x] Uses existing patterns (mutation hooks, schema files, `renderWithProviders`)
+- [x] Idempotency considered (callback mutation fires once on mount; backend state is one-time-use)
+- [x] Event-driven patterns used where applicable (N/A — synchronous user flow)
+- [x] Rate limits & retries addressed (N/A — OAuth callback is a one-shot flow; retry via "try again" link)
+- [x] Error handling comprehensive (5 distinct error cases covered)
+- [x] Testing strategy complete (10 tests covering all meaningful states)
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Frontend Architecture](../frontend-architecture.md)
+- [Frontend UI Style Guide](../frontend-ui-style-guide.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)


### PR DESCRIPTION
## Summary
- Implements the full Allegro OAuth onboarding flow in the frontend, turning the existing backend endpoints into a usable operator workflow
- Fixes a pre-existing API contract bug: `StartAllegroOAuthInput` was missing `clientId` and `clientSecret` which the backend DTO requires
- Adds an Enter-key submission guard and TODO comment to `CreateConnectionForm` for when Allegro is selected

## Changes
- `features/allegro/api/allegro.api.ts` — add `clientId`/`clientSecret` to input type; add `handleCallback` for the FE-mediated OAuth callback
- `features/allegro/hooks/use-handle-allegro-callback-mutation.ts` — new mutation hook
- `features/allegro/components/allegro-setup.schema.ts` — Zod schema with `toStartOAuthInput` mapper
- `features/allegro/components/AllegroSetupForm.tsx` — setup form: connection name, environment, client ID, client secret; redirects to Allegro on success
- `pages/connections/allegro-setup-page.tsx` — page at `/connections/new/allegro`
- `pages/integrations/allegro-connect-callback-page.tsx` — replaces placeholder; handles `?code`/`?state` from Allegro, calls backend callback API, shows loading / success / error states
- `app/routes/allegro-setup.route.tsx` + `root.route.tsx` — registers the new route
- `features/connections/components/create-connection-form.tsx` — shows redirect notice when Allegro is selected; guards Enter-key submission

## Test plan
- [x] Unit tests pass (`pnpm test`) — 58/58
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] Navigate to `/connections/new` → select Allegro → redirect notice appears with link to wizard
- [ ] Navigate to `/connections/new/allegro` → form renders with all four fields
- [ ] Submit wizard form → browser redirects to Allegro authorization URL
- [ ] Simulate callback with `?code=x&state=y` → loading → success panel with connection name and ID
- [ ] Simulate callback with `?error=access_denied` → denial error state with "Start over" link
- [ ] Navigate directly to `/integrations/allegro/connect/callback` (no params) → "Invalid callback" error state

## Tech review
✅ **Approved after fixes** — all IMPORTANT items resolved:
- Removed `typeof window !== 'undefined'` SSR guard (dead code producing incomplete redirect URI)
- Replaced blanket `eslint-disable-line` with ref-based `hasCalledRef` one-shot pattern
- Added `if (isAllegroSelected) return` guard in `onSubmit` to prevent silent validation failure on Enter-key submission
- Replaced `Object.defineProperty(window.location)` with `vi.stubGlobal` + `afterEach(vi.unstubAllGlobals)` in tests

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)