### PR TITLE
feat: connection diagnostics API and health dashboard (#65, #74)

### DIFF
--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -35,20 +35,20 @@ describe('ConnectionController', () => {
 
   const makeSyncJob = (overrides: Partial<SyncJob> = {}): SyncJob =>
     new SyncJob(
-      overrides.id ?? 'job-1',
-      overrides.jobType ?? 'marketplace.orders.poll',
-      'connection-123',
-      {},
-      overrides.status ?? 'succeeded',
-      overrides.idempotencyKey ?? 'key-1',
-      overrides.attempts ?? 1,
-      10,
-      new Date('2025-01-01T10:00:00Z'),
-      null,
-      null,
-      overrides.lastError ?? null,
-      overrides.createdAt ?? new Date('2025-01-01T10:00:00Z'),
-      overrides.updatedAt ?? new Date('2025-01-01T10:01:00Z'),
+      /* id           */ overrides.id ?? 'job-1',
+      /* jobType      */ overrides.jobType ?? 'marketplace.orders.poll',
+      /* connectionId */ 'connection-123',
+      /* payload      */ {},
+      /* status       */ overrides.status ?? 'succeeded',
+      /* idempotencyKey */ overrides.idempotencyKey ?? 'key-1',
+      /* attempts     */ overrides.attempts ?? 1,
+      /* maxAttempts  */ 10,
+      /* nextRunAt    */ new Date('2025-01-01T10:00:00Z'),
+      /* lockedAt     */ null,
+      /* lockedBy     */ null,
+      /* lastError    */ overrides.lastError ?? null,
+      /* createdAt    */ overrides.createdAt ?? new Date('2025-01-01T10:00:00Z'),
+      /* updatedAt    */ overrides.updatedAt ?? new Date('2025-01-01T10:01:00Z'),
     );
 
   beforeEach(async () => {
@@ -227,14 +227,16 @@ describe('ConnectionController', () => {
       await expect(controller.getDiagnostics('unknown-id')).rejects.toBeInstanceOf(NotFoundException);
     });
 
-    it('should derive lastFailedAt from most recent failed job', async () => {
-      const failedJob = makeSyncJob({
-        status: 'failed',
+    it('should derive lastFailedAt from retrying job with lastError (markFailed sets status queued)', async () => {
+      // markFailed() re-queues jobs as 'queued', so 'failed' status never appears.
+      // The filter uses lastError !== null to capture retrying failures.
+      const retryingJob = makeSyncJob({
+        status: 'queued',
         lastError: 'Timeout',
         updatedAt: new Date('2025-01-01T11:00:00Z'),
       });
       service.get.mockResolvedValue(mockConnection);
-      syncJobRepository.findRecentByConnectionId.mockResolvedValue([failedJob]);
+      syncJobRepository.findRecentByConnectionId.mockResolvedValue([retryingJob]);
 
       const result = await controller.getDiagnostics('connection-123');
 

--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -6,15 +6,21 @@
  *
  * @module apps/api/src/integrations/http
  */
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConnectionController } from './connection.controller';
 import { ConnectionService } from '../application/services/connection.service';
 import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';
 import { ConnectionResponseDto } from './dto/connection-response.dto';
+import { ConnectionDiagnosticsResponseDto } from './dto/connection-diagnostics-response.dto';
+import { SYNC_JOB_REPOSITORY_TOKEN } from '@openlinker/core/sync';
+import type { SyncJobRepositoryPort } from '@openlinker/core/sync/domain/ports/sync-job-repository.port';
+import { SyncJob } from '@openlinker/core/sync/domain/entities/sync-job.entity';
 
 describe('ConnectionController', () => {
   let controller: ConnectionController;
   let service: jest.Mocked<ConnectionService>;
+  let syncJobRepository: jest.Mocked<SyncJobRepositoryPort>;
 
   const mockConnection = new Connection(
     'connection-123',
@@ -27,6 +33,24 @@ describe('ConnectionController', () => {
     new Date('2025-01-01'),
   );
 
+  const makeSyncJob = (overrides: Partial<SyncJob> = {}): SyncJob =>
+    new SyncJob(
+      overrides.id ?? 'job-1',
+      overrides.jobType ?? 'marketplace.orders.poll',
+      'connection-123',
+      {},
+      overrides.status ?? 'succeeded',
+      overrides.idempotencyKey ?? 'key-1',
+      overrides.attempts ?? 1,
+      10,
+      new Date('2025-01-01T10:00:00Z'),
+      null,
+      null,
+      overrides.lastError ?? null,
+      overrides.createdAt ?? new Date('2025-01-01T10:00:00Z'),
+      overrides.updatedAt ?? new Date('2025-01-01T10:01:00Z'),
+    );
+
   beforeEach(async () => {
     const mockService = {
       create: jest.fn(),
@@ -36,6 +60,16 @@ describe('ConnectionController', () => {
       disable: jest.fn(),
     } as unknown as jest.Mocked<ConnectionService>;
 
+    const mockSyncJobRepository: jest.Mocked<SyncJobRepositoryPort> = {
+      createIfNotExistsByIdempotencyKey: jest.fn(),
+      findAndLockDueJobs: jest.fn(),
+      markSucceeded: jest.fn(),
+      markFailed: jest.fn(),
+      markDead: jest.fn(),
+      requeueStuckJobs: jest.fn(),
+      findRecentByConnectionId: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ConnectionController],
       providers: [
@@ -43,11 +77,16 @@ describe('ConnectionController', () => {
           provide: ConnectionService,
           useValue: mockService,
         },
+        {
+          provide: SYNC_JOB_REPOSITORY_TOKEN,
+          useValue: mockSyncJobRepository,
+        },
       ],
     }).compile();
 
     controller = module.get<ConnectionController>(ConnectionController);
     service = module.get(ConnectionService);
+    syncJobRepository = module.get(SYNC_JOB_REPOSITORY_TOKEN);
   });
 
   describe('create', () => {
@@ -163,10 +202,57 @@ describe('ConnectionController', () => {
       expect(service.disable).toHaveBeenCalledWith('connection-123');
     });
   });
+
+  describe('getDiagnostics', () => {
+    it('should return diagnostics DTO for existing connection', async () => {
+      const succeededJob = makeSyncJob({ status: 'succeeded', updatedAt: new Date('2025-01-01T10:01:00Z') });
+      service.get.mockResolvedValue(mockConnection);
+      syncJobRepository.findRecentByConnectionId.mockResolvedValue([succeededJob]);
+
+      const result = await controller.getDiagnostics('connection-123');
+
+      expect(result).toBeInstanceOf(ConnectionDiagnosticsResponseDto);
+      expect(result.connectionId).toBe('connection-123');
+      expect(result.connectionName).toBe('Test Connection');
+      expect(result.connectionStatus).toBe('active');
+      expect(result.lastSucceededAt).toBe('2025-01-01T10:01:00.000Z');
+      expect(result.lastFailedAt).toBeNull();
+      expect(result.recentJobs).toHaveLength(1);
+      expect(syncJobRepository.findRecentByConnectionId).toHaveBeenCalledWith('connection-123', 10);
+    });
+
+    it('should throw NotFoundException for unknown connection', async () => {
+      service.get.mockRejectedValue(new NotFoundException('Connection not found'));
+
+      await expect(controller.getDiagnostics('unknown-id')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should derive lastFailedAt from most recent failed job', async () => {
+      const failedJob = makeSyncJob({
+        status: 'failed',
+        lastError: 'Timeout',
+        updatedAt: new Date('2025-01-01T11:00:00Z'),
+      });
+      service.get.mockResolvedValue(mockConnection);
+      syncJobRepository.findRecentByConnectionId.mockResolvedValue([failedJob]);
+
+      const result = await controller.getDiagnostics('connection-123');
+
+      expect(result.lastFailedAt).toBe('2025-01-01T11:00:00.000Z');
+      expect(result.lastSucceededAt).toBeNull();
+      expect(result.recentErrors).toEqual(['Timeout']);
+    });
+
+    it('should return empty diagnostics when no jobs exist', async () => {
+      service.get.mockResolvedValue(mockConnection);
+      syncJobRepository.findRecentByConnectionId.mockResolvedValue([]);
+
+      const result = await controller.getDiagnostics('connection-123');
+
+      expect(result.recentJobs).toHaveLength(0);
+      expect(result.lastSucceededAt).toBeNull();
+      expect(result.lastFailedAt).toBeNull();
+      expect(result.recentErrors).toHaveLength(0);
+    });
+  });
 });
-
-
-
-
-
-

--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -16,6 +16,7 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  Inject,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
@@ -23,8 +24,11 @@ import { CreateConnectionDto } from './dto/create-connection.dto';
 import { UpdateConnectionDto } from './dto/update-connection.dto';
 import { ConnectionFiltersDto } from './dto/connection-filters.dto';
 import { ConnectionResponseDto } from './dto/connection-response.dto';
+import { ConnectionDiagnosticsResponseDto } from './dto/connection-diagnostics-response.dto';
 import { ConnectionService } from '../application/services/connection.service';
 import { ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier-mapping';
+import { SyncJobRepositoryPort } from '@openlinker/core/sync/domain/ports/sync-job-repository.port';
+import { SYNC_JOB_REPOSITORY_TOKEN } from '@openlinker/core/sync';
 
 @ApiBearerAuth()
 @ApiTags('connections')
@@ -32,6 +36,8 @@ import { ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier
 export class ConnectionController {
   constructor(
     private readonly connectionService: ConnectionService,
+    @Inject(SYNC_JOB_REPOSITORY_TOKEN)
+    private readonly syncJobRepository: SyncJobRepositoryPort,
   ) {}
 
   @Roles('admin')
@@ -107,6 +113,20 @@ export class ConnectionController {
     };
     const connection = await this.connectionService.update(id, patch);
     return ConnectionResponseDto.fromDomain(connection);
+  }
+
+  @Get(':id/diagnostics')
+  @ApiOperation({ summary: 'Get connection diagnostics and activity summary' })
+  @ApiResponse({
+    status: 200,
+    description: 'Connection diagnostics with recent sync job activity',
+    type: ConnectionDiagnosticsResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
+  async getDiagnostics(@Param('id') id: string): Promise<ConnectionDiagnosticsResponseDto> {
+    const connection = await this.connectionService.get(id);
+    const recentJobs = await this.syncJobRepository.findRecentByConnectionId(id, 10);
+    return ConnectionDiagnosticsResponseDto.fromDomain(connection, recentJobs);
   }
 
   @Roles('admin')

--- a/apps/api/src/integrations/http/dto/connection-diagnostics-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/connection-diagnostics-response.dto.ts
@@ -47,7 +47,7 @@ export class ConnectionDiagnosticsResponseDto {
   @ApiProperty({ description: 'Timestamp of last succeeded job (ISO 8601), or null if none', nullable: true })
   lastSucceededAt!: string | null;
 
-  @ApiProperty({ description: 'Timestamp of last failed or dead job (ISO 8601), or null if none', nullable: true })
+  @ApiProperty({ description: 'Timestamp of last failed, dead, or retrying job with a recorded error (ISO 8601), or null if none', nullable: true })
   lastFailedAt!: string | null;
 
   @ApiProperty({ description: 'Error messages from recent failed jobs', type: [String] })

--- a/apps/api/src/integrations/http/dto/connection-diagnostics-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/connection-diagnostics-response.dto.ts
@@ -1,0 +1,97 @@
+/**
+ * Connection Diagnostics Response DTO
+ *
+ * Aggregated operational summary for a single connection. Combines connection
+ * status with recent sync job activity to give the FE a single read endpoint
+ * for per-connection diagnostics.
+ *
+ * @module apps/api/src/integrations/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import type { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';
+import type { SyncJob } from '@openlinker/core/sync/domain/entities/sync-job.entity';
+
+export class RecentJobSummaryDto {
+  @ApiProperty({ description: 'Job UUID' })
+  id!: string;
+
+  @ApiProperty({ description: 'Job type identifier' })
+  jobType!: string;
+
+  @ApiProperty({ description: 'Job status', example: 'succeeded' })
+  status!: string;
+
+  @ApiProperty({ description: 'Number of execution attempts' })
+  attempts!: number;
+
+  @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Last update timestamp (ISO 8601)' })
+  updatedAt!: string;
+
+  @ApiProperty({ description: 'Last error message, if any', nullable: true })
+  lastError!: string | null;
+}
+
+export class ConnectionDiagnosticsResponseDto {
+  @ApiProperty({ description: 'Connection UUID' })
+  connectionId!: string;
+
+  @ApiProperty({ description: 'Human-readable connection name' })
+  connectionName!: string;
+
+  @ApiProperty({ description: 'Connection status', example: 'active' })
+  connectionStatus!: string;
+
+  @ApiProperty({ description: 'Timestamp of last succeeded job (ISO 8601), or null if none', nullable: true })
+  lastSucceededAt!: string | null;
+
+  @ApiProperty({ description: 'Timestamp of last failed or dead job (ISO 8601), or null if none', nullable: true })
+  lastFailedAt!: string | null;
+
+  @ApiProperty({ description: 'Error messages from recent failed jobs', type: [String] })
+  recentErrors!: string[];
+
+  @ApiProperty({ description: 'Last 10 sync jobs for this connection, newest first', type: [RecentJobSummaryDto] })
+  recentJobs!: RecentJobSummaryDto[];
+
+  static fromDomain(
+    connection: Connection,
+    recentJobs: SyncJob[],
+  ): ConnectionDiagnosticsResponseDto {
+    const dto = new ConnectionDiagnosticsResponseDto();
+    dto.connectionId = connection.id;
+    dto.connectionName = connection.name;
+    dto.connectionStatus = connection.status;
+
+    const succeededJobs = recentJobs.filter((j) => j.status === 'succeeded');
+    const failedJobs = recentJobs.filter((j) => j.status === 'failed' || j.status === 'dead');
+
+    dto.lastSucceededAt = succeededJobs.length > 0
+      ? new Date(succeededJobs[0].updatedAt).toISOString()
+      : null;
+
+    dto.lastFailedAt = failedJobs.length > 0
+      ? new Date(failedJobs[0].updatedAt).toISOString()
+      : null;
+
+    dto.recentErrors = failedJobs
+      .map((j) => j.lastError)
+      .filter((e): e is string => e !== null && e !== undefined);
+
+    dto.recentJobs = recentJobs.map((j) => {
+      const jobDto = new RecentJobSummaryDto();
+      jobDto.id = j.id;
+      jobDto.jobType = j.jobType;
+      jobDto.status = j.status;
+      jobDto.attempts = j.attempts;
+      jobDto.createdAt = new Date(j.createdAt).toISOString();
+      jobDto.updatedAt = new Date(j.updatedAt).toISOString();
+      jobDto.lastError = j.lastError ?? null;
+      return jobDto;
+    });
+
+    return dto;
+  }
+}

--- a/apps/api/src/integrations/http/dto/connection-diagnostics-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/connection-diagnostics-response.dto.ts
@@ -66,7 +66,9 @@ export class ConnectionDiagnosticsResponseDto {
     dto.connectionStatus = connection.status;
 
     const succeededJobs = recentJobs.filter((j) => j.status === 'succeeded');
-    const failedJobs = recentJobs.filter((j) => j.status === 'failed' || j.status === 'dead');
+    // 'failed' status is never written — markFailed() re-queues jobs as 'queued'.
+    // Capture dead jobs and any retrying job that has a recorded lastError.
+    const failedJobs = recentJobs.filter((j) => j.status === 'dead' || j.lastError !== null);
 
     dto.lastSucceededAt = succeededJobs.length > 0
       ? new Date(succeededJobs[0].updatedAt).toISOString()

--- a/apps/api/src/migrations/1777000000000-add-sync-jobs-connection-id-created-at-index.ts
+++ b/apps/api/src/migrations/1777000000000-add-sync-jobs-connection-id-created-at-index.ts
@@ -3,7 +3,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class AddSyncJobsConnectionIdCreatedAtIndex1777000000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE INDEX "IDX_sync_jobs_connectionId_createdAt" ON "sync_jobs" ("connectionId", "createdAt" DESC)`,
+      `CREATE INDEX "IDX_sync_jobs_connectionId_createdAt" ON "sync_jobs" ("connectionId", "createdAt")`,
     );
   }
 

--- a/apps/api/src/migrations/1777000000000-add-sync-jobs-connection-id-created-at-index.ts
+++ b/apps/api/src/migrations/1777000000000-add-sync-jobs-connection-id-created-at-index.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSyncJobsConnectionIdCreatedAtIndex1777000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_sync_jobs_connectionId_createdAt" ON "sync_jobs" ("connectionId", "createdAt" DESC)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "IDX_sync_jobs_connectionId_createdAt"`,
+    );
+  }
+}

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -2,6 +2,7 @@ import { createAdaptersApi, type AdaptersApi } from '../../features/adapters/api
 import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/allegro.api';
 import { createAuthApi, type AuthApi } from '../../features/auth/api/auth.api';
 import { createConnectionsApi, type ConnectionsApi } from '../../features/connections/api/connections.api';
+import { createHealthApi, type HealthApi } from '../../features/health/api/health.api';
 import { createSyncJobsApi, type SyncJobsApi } from '../../features/sync-jobs/api/sync.api';
 import { ApiError } from '../../shared/api/api-error';
 import type { SessionAdapter } from '../../shared/auth/session-adapter';
@@ -20,6 +21,7 @@ export interface ApiClient {
   allegro: AllegroApi;
   auth: AuthApi;
   connections: ConnectionsApi;
+  health: HealthApi;
   request: <T>(path: string, init?: RequestInit) => Promise<T>;
   syncJobs: SyncJobsApi;
 }
@@ -105,6 +107,7 @@ export function createApiClient({
     allegro: createAllegroApi(request),
     auth: createAuthApi(request),
     connections: createConnectionsApi(request),
+    health: createHealthApi(request),
     request,
     syncJobs: createSyncJobsApi(request),
   };

--- a/apps/web/src/features/connections/api/connections.api.ts
+++ b/apps/web/src/features/connections/api/connections.api.ts
@@ -1,7 +1,14 @@
-import type { Connection, ConnectionFilters, CreateConnectionInput, UpdateConnectionInput } from './connections.types';
+import type {
+  Connection,
+  ConnectionDiagnostics,
+  ConnectionFilters,
+  CreateConnectionInput,
+  UpdateConnectionInput,
+} from './connections.types';
 
 export interface ConnectionsApi {
   create: (input: CreateConnectionInput) => Promise<Connection>;
+  getDiagnostics: (connectionId: string) => Promise<ConnectionDiagnostics>;
   getById: (connectionId: string) => Promise<Connection>;
   list: (filters?: ConnectionFilters) => Promise<Connection[]>;
   update: (connectionId: string, input: UpdateConnectionInput) => Promise<Connection>;
@@ -33,6 +40,9 @@ export function createConnectionsApi(request: ApiRequest): ConnectionsApi {
         method: 'POST',
         body: JSON.stringify(input),
       });
+    },
+    getDiagnostics(connectionId): Promise<ConnectionDiagnostics> {
+      return request<ConnectionDiagnostics>(`/connections/${connectionId}/diagnostics`);
     },
     getById(connectionId): Promise<Connection> {
       return request<Connection>(`/connections/${connectionId}`);

--- a/apps/web/src/features/connections/api/connections.query-keys.ts
+++ b/apps/web/src/features/connections/api/connections.query-keys.ts
@@ -5,4 +5,5 @@ export const connectionsQueryKeys = {
   list: (filters?: ConnectionFilters) =>
     ['connections', 'list', filters?.platformType ?? 'all', filters?.status ?? 'all'] as const,
   detail: (connectionId: string) => ['connections', 'detail', connectionId] as const,
+  diagnostics: (connectionId: string) => ['connections', 'diagnostics', connectionId] as const,
 };

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -35,3 +35,23 @@ export interface UpdateConnectionInput {
   config?: Record<string, unknown>;
   adapterKey?: string;
 }
+
+export interface RecentJobSummary {
+  id: string;
+  jobType: string;
+  status: string;
+  attempts: number;
+  createdAt: string;
+  updatedAt: string;
+  lastError: string | null;
+}
+
+export interface ConnectionDiagnostics {
+  connectionId: string;
+  connectionName: string;
+  connectionStatus: string;
+  lastSucceededAt: string | null;
+  lastFailedAt: string | null;
+  recentErrors: string[];
+  recentJobs: RecentJobSummary[];
+}

--- a/apps/web/src/features/connections/hooks/use-connection-diagnostics-query.ts
+++ b/apps/web/src/features/connections/hooks/use-connection-diagnostics-query.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { connectionsQueryKeys } from '../api/connections.query-keys';
+import type { ConnectionDiagnostics } from '../api/connections.types';
+
+export function useConnectionDiagnosticsQuery(
+  connectionId: string | undefined,
+): UseQueryResult<ConnectionDiagnostics> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: connectionsQueryKeys.diagnostics(connectionId ?? ''),
+    queryFn: () => apiClient.connections.getDiagnostics(connectionId!),
+    enabled: connectionId !== undefined && connectionId.length > 0,
+    retry: false,
+  });
+}

--- a/apps/web/src/features/health/api/health.api.ts
+++ b/apps/web/src/features/health/api/health.api.ts
@@ -1,0 +1,15 @@
+import type { DevStackHealth } from './health.types';
+
+export interface HealthApi {
+  getDevStackHealth: () => Promise<DevStackHealth>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+export function createHealthApi(request: ApiRequest): HealthApi {
+  return {
+    getDevStackHealth: () => request<DevStackHealth>('/health/dev-stack'),
+  };
+}

--- a/apps/web/src/features/health/api/health.query-keys.ts
+++ b/apps/web/src/features/health/api/health.query-keys.ts
@@ -1,0 +1,4 @@
+export const healthQueryKeys = {
+  all: ['health'] as const,
+  devStack: () => ['health', 'dev-stack'] as const,
+};

--- a/apps/web/src/features/health/api/health.types.ts
+++ b/apps/web/src/features/health/api/health.types.ts
@@ -1,0 +1,17 @@
+export type ServiceStatus = 'ok' | 'error';
+export type OverallStatus = 'ok' | 'degraded' | 'error';
+
+export interface ServiceHealth {
+  status: ServiceStatus;
+  message?: string;
+}
+
+export interface DevStackHealth {
+  status: OverallStatus;
+  services: {
+    postgres: ServiceHealth;
+    redis: ServiceHealth;
+    prestashop: ServiceHealth;
+  };
+  timestamp: string;
+}

--- a/apps/web/src/features/health/hooks/use-dev-stack-health-query.ts
+++ b/apps/web/src/features/health/hooks/use-dev-stack-health-query.ts
@@ -1,0 +1,14 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { healthQueryKeys } from '../api/health.query-keys';
+import type { DevStackHealth } from '../api/health.types';
+
+export function useDevStackHealthQuery(): UseQueryResult<DevStackHealth> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: healthQueryKeys.devStack(),
+    queryFn: () => apiClient.health.getDevStackHealth(),
+    retry: false,
+  });
+}

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -1,11 +1,82 @@
-import { screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-import { renderWithProviders } from '../../test/test-utils';
+import { screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
 import { DashboardPage } from './dashboard-page';
 
 describe('DashboardPage', () => {
   it('renders the operations overview heading', () => {
     renderWithProviders(<DashboardPage />);
     expect(screen.getByRole('heading', { name: 'Operations overview' })).toBeInTheDocument();
+  });
+
+  it('shows real connection count from API', async () => {
+    const apiClient = createMockApiClient({
+      connections: {
+        list: vi.fn().mockResolvedValue([
+          { id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop', config: {}, credentialsRef: 'ref', createdAt: '', updatedAt: '' },
+          { id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro', config: {}, credentialsRef: 'ref', createdAt: '', updatedAt: '' },
+        ]),
+      },
+    });
+    renderWithProviders(<DashboardPage />, { apiClient });
+
+    expect(await screen.findByText('1 / 2')).toBeInTheDocument();
+    expect(screen.getByText('Store A')).toBeInTheDocument();
+    expect(screen.getByText('Store B')).toBeInTheDocument();
+  });
+
+  it('shows system health services from API', async () => {
+    const { container } = renderWithProviders(<DashboardPage />);
+
+    expect(await within(container).findByText('PostgreSQL')).toBeInTheDocument();
+    expect(within(container).getByText('Redis')).toBeInTheDocument();
+    expect(within(container).getByText('PrestaShop')).toBeInTheDocument();
+  });
+
+  it('shows error message when a service is degraded', async () => {
+    const apiClient = createMockApiClient({
+      health: {
+        getDevStackHealth: vi.fn().mockResolvedValue({
+          status: 'degraded',
+          services: {
+            postgres: { status: 'ok' },
+            redis: { status: 'ok' },
+            prestashop: { status: 'error', message: 'Connection refused' },
+          },
+          timestamp: '2026-04-06T00:00:00.000Z',
+        }),
+      },
+    });
+    renderWithProviders(<DashboardPage />, { apiClient });
+
+    expect(await screen.findByText('Connection refused')).toBeInTheDocument();
+  });
+
+  it('shows loading state while connections are fetching', () => {
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+    renderWithProviders(<DashboardPage />, { apiClient });
+
+    expect(screen.getByRole('heading', { name: 'Loading connections' })).toBeInTheDocument();
+  });
+
+  it('shows error state when health check fails', async () => {
+    const apiClient = createMockApiClient({
+      health: {
+        getDevStackHealth: vi.fn().mockRejectedValue(new Error('Health endpoint unreachable')),
+      },
+    });
+    renderWithProviders(<DashboardPage />, { apiClient });
+
+    expect(await screen.findByRole('heading', { name: 'Health check failed' })).toBeInTheDocument();
+  });
+
+  it('shows placeholder panels for sync jobs sections', () => {
+    renderWithProviders(<DashboardPage />);
+
+    const headings = screen.getAllByRole('heading').map((h) => h.textContent);
+    expect(headings).toContain('Recent sync events');
+    expect(headings).toContain('Retry and incident queue');
   });
 });

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -1,8 +1,8 @@
-import type { ReactElement } from 'react';
+import { useCallback, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { useDevStackHealthQuery } from '../../features/health/hooks/use-dev-stack-health-query';
-import type { OverallStatus, ServiceHealth } from '../../features/health/api/health.types';
+import type { OverallStatus, ServiceHealth } from '../../features/health/api/health.types'; // ServiceHealth used in ServiceHealthRow prop type
 import type { Connection } from '../../features/connections/api/connections.types';
 import { Button } from '../../shared/ui/button';
 import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
@@ -15,7 +15,7 @@ function toStatusTone(status: string): StatusBadgeTone {
   return 'neutral';
 }
 
-function toHealthTone(status: OverallStatus | 'ok' | 'error'): StatusBadgeTone {
+function toHealthTone(status: OverallStatus): StatusBadgeTone {
   if (status === 'ok') return 'success';
   if (status === 'degraded') return 'warning';
   return 'error';
@@ -64,10 +64,10 @@ export function DashboardPage(): ReactElement {
   const activeCount = connections.filter((c) => c.status === 'active').length;
   const errorCount = connections.filter((c) => c.status === 'error').length;
 
-  function handleRefresh(): void {
+  const handleRefresh = useCallback((): void => {
     void connectionsQuery.refetch();
     void healthQuery.refetch();
-  }
+  }, [connectionsQuery.refetch, healthQuery.refetch]);
 
   return (
     <PageLayout
@@ -111,13 +111,13 @@ export function DashboardPage(): ReactElement {
         <article className="metric-card">
           <span className="metric-card__label">Jobs needing attention</span>
           <strong className="metric-card__value">—</strong>
-          <p className="muted-text">Available when #70 ships</p>
+          <p className="muted-text">Visible once sync job monitoring is enabled</p>
         </article>
 
         <article className="metric-card">
           <span className="metric-card__label">Manual reviews</span>
           <strong className="metric-card__value">—</strong>
-          <p className="muted-text">Available when #70 ships</p>
+          <p className="muted-text">Visible once sync job monitoring is enabled</p>
         </article>
       </section>
 
@@ -194,7 +194,7 @@ export function DashboardPage(): ReactElement {
             <span className="toolbar-chip">Coming soon</span>
           </div>
           <p className="muted-text panel-copy">
-            Sync job activity timeline will be visible here once the jobs read API (#70) ships.
+            Sync job activity timeline will be visible here once the sync job monitoring feature ships.
           </p>
         </article>
 
@@ -207,7 +207,7 @@ export function DashboardPage(): ReactElement {
             <span className="toolbar-chip">Coming soon</span>
           </div>
           <p className="muted-text panel-copy">
-            Failed and retrying sync jobs will appear here once the jobs read API (#70) ships.
+            Failed and retrying sync jobs will appear here once the sync job monitoring feature ships.
           </p>
         </article>
       </div>

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -2,7 +2,7 @@ import { useCallback, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { useDevStackHealthQuery } from '../../features/health/hooks/use-dev-stack-health-query';
-import type { OverallStatus, ServiceHealth } from '../../features/health/api/health.types'; // ServiceHealth used in ServiceHealthRow prop type
+import type { OverallStatus, ServiceHealth } from '../../features/health/api/health.types';
 import type { Connection } from '../../features/connections/api/connections.types';
 import { Button } from '../../shared/ui/button';
 import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -1,152 +1,201 @@
 import type { ReactElement } from 'react';
-import { StatusBadge } from '../../shared/ui/status-badge';
 import { Link } from 'react-router-dom';
+import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
+import { useDevStackHealthQuery } from '../../features/health/hooks/use-dev-stack-health-query';
+import type { OverallStatus, ServiceHealth } from '../../features/health/api/health.types';
+import type { Connection } from '../../features/connections/api/connections.types';
+import { Button } from '../../shared/ui/button';
+import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
 import { PageLayout } from '../../shared/ui/page-layout';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+
+function toStatusTone(status: string): StatusBadgeTone {
+  if (status === 'active') return 'success';
+  if (status === 'error') return 'error';
+  return 'neutral';
+}
+
+function toHealthTone(status: OverallStatus | 'ok' | 'error'): StatusBadgeTone {
+  if (status === 'ok') return 'success';
+  if (status === 'degraded') return 'warning';
+  return 'error';
+}
+
+function ServiceHealthRow({ name, health }: { name: string; health: ServiceHealth }): ReactElement {
+  return (
+    <li>
+      <strong>{name}</strong>
+      <StatusBadge tone={toHealthTone(health.status)}>
+        {health.status}
+      </StatusBadge>
+      {health.message ? <span className="muted-text">{health.message}</span> : null}
+    </li>
+  );
+}
+
+function ConnectionHealthList({ connections }: { connections: Connection[] }): ReactElement {
+  if (connections.length === 0) {
+    return (
+      <p className="muted-text">
+        No connections configured.{' '}
+        <Link to="/connections/new">Add the first connection.</Link>
+      </p>
+    );
+  }
+  return (
+    <ul className="check-list">
+      {connections.map((c) => (
+        <li key={c.id}>
+          <strong>{c.name}</strong>
+          <StatusBadge tone={toStatusTone(c.status)} withDot>
+            {c.status}
+          </StatusBadge>
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 export function DashboardPage(): ReactElement {
+  const connectionsQuery = useConnectionsQuery();
+  const healthQuery = useDevStackHealthQuery();
+
+  const connections = connectionsQuery.data ?? [];
+  const activeCount = connections.filter((c) => c.status === 'active').length;
+  const errorCount = connections.filter((c) => c.status === 'error').length;
+
+  function handleRefresh(): void {
+    void connectionsQuery.refetch();
+    void healthQuery.refetch();
+  }
+
   return (
     <PageLayout
       eyebrow="Overview"
       title="Operations overview"
-      description="Monitor failures, retry pressure, integration health, and manual-review workload from one command surface."
+      description="Monitor integration health, dependency status, and connection activity from one command surface."
       actions={
-        <Link className="button" to="/connections">
-          Review integrations
-        </Link>
+        <Button onClick={handleRefresh} disabled={connectionsQuery.isFetching || healthQuery.isFetching}>
+          {connectionsQuery.isFetching || healthQuery.isFetching ? 'Refreshing…' : 'Refresh'}
+        </Button>
       }
     >
+      {/* ── Metric strip ─────────────────────────────────────────── */}
       <section className="status-strip">
-        <article className="metric-card">
+        <article className={errorCount > 0 ? 'metric-card metric-card--warning' : 'metric-card'}>
           <span className="metric-card__label">Integration health</span>
-          <strong className="metric-card__value">3 / 3</strong>
-          <p>All channels connected</p>
+          {connectionsQuery.isLoading ? (
+            <strong className="metric-card__value">—</strong>
+          ) : (
+            <strong className="metric-card__value">{activeCount} / {connections.length}</strong>
+          )}
+          <p>{errorCount > 0 ? `${errorCount} connection${errorCount > 1 ? 's' : ''} in error` : 'All channels active'}</p>
         </article>
-        <article className="metric-card metric-card--warning">
-          <span className="metric-card__label">Jobs needing attention</span>
-          <strong className="metric-card__value">2</strong>
-          <p>1 failed, 1 retrying</p>
-        </article>
+
         <article className="metric-card">
-          <span className="metric-card__label">Inventory conflicts</span>
-          <strong className="metric-card__value">0</strong>
-          <p>No blocked syncs</p>
+          <span className="metric-card__label">System health</span>
+          {healthQuery.isLoading ? (
+            <strong className="metric-card__value">—</strong>
+          ) : healthQuery.error ? (
+            <strong className="metric-card__value">!</strong>
+          ) : (
+            <strong className="metric-card__value">
+              <StatusBadge tone={toHealthTone(healthQuery.data?.status ?? 'error')}>
+                {healthQuery.data?.status ?? 'unknown'}
+              </StatusBadge>
+            </strong>
+          )}
+          <p>Postgres · Redis · PrestaShop</p>
         </article>
-        <article className="metric-card metric-card--review">
+
+        <article className="metric-card">
+          <span className="metric-card__label">Jobs needing attention</span>
+          <strong className="metric-card__value">—</strong>
+          <p className="muted-text">Available when #70 ships</p>
+        </article>
+
+        <article className="metric-card">
           <span className="metric-card__label">Manual reviews</span>
-          <strong className="metric-card__value">1</strong>
-          <p>1 operator checkpoint</p>
+          <strong className="metric-card__value">—</strong>
+          <p className="muted-text">Available when #70 ships</p>
         </article>
       </section>
 
       <div className="workspace-grid workspace-grid--primary">
+        {/* ── Integration health ───────────────────────────────────── */}
         <article className="panel panel--dense">
           <div className="panel__header">
             <div>
-              <p className="eyebrow">Triage</p>
-              <h3 className="section-title">Attention queue</h3>
+              <p className="eyebrow">Integrations</p>
+              <h3 className="section-title">Connection health</h3>
             </div>
-            <span className="panel__meta">Action now</span>
+            <span className="panel__meta">
+              {connectionsQuery.isLoading ? '…' : `${connections.length} configured`}
+            </span>
           </div>
 
-          <table className="data-table">
-            <thead>
-              <tr>
-                <th>Status</th>
-                <th>Entity</th>
-                <th>Issue</th>
-                <th>Source</th>
-                <th>Since</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><StatusBadge tone="error">Failed</StatusBadge></td>
-                <td>Connection</td>
-                <td>Allegro auth validation failed</td>
-                <td className="mono-text">allegro.main</td>
-                <td>12m</td>
-                <td>Reconnect</td>
-              </tr>
-              <tr>
-                <td><StatusBadge tone="warning">Retrying</StatusBadge></td>
-                <td>Sync job</td>
-                <td>Connection validation backoff in progress</td>
-                <td className="mono-text">job_sync_1842</td>
-                <td>4m</td>
-                <td>Inspect</td>
-              </tr>
-              <tr>
-                <td><StatusBadge tone="review">Review</StatusBadge></td>
-                <td>Integration</td>
-                <td>New setup waiting for credentials approval</td>
-                <td className="mono-text">prestashop.draft</td>
-                <td>21m</td>
-                <td>Open</td>
-              </tr>
-            </tbody>
-          </table>
+          {connectionsQuery.isLoading && (
+            <LoadingState title="Loading connections" message="Fetching connection status…" liveRegion="off" />
+          )}
+          {connectionsQuery.error && (
+            <ErrorState
+              title="Unable to load connections"
+              message={connectionsQuery.error.message}
+              action={<Button onClick={() => void connectionsQuery.refetch()}>Retry</Button>}
+            />
+          )}
+          {!connectionsQuery.isLoading && !connectionsQuery.error && (
+            <ConnectionHealthList connections={connections} />
+          )}
         </article>
 
+        {/* ── System health ─────────────────────────────────────────── */}
         <article className="panel panel--dense">
           <div className="panel__header">
             <div>
-              <p className="eyebrow">Health</p>
-              <h3 className="section-title">Integration health</h3>
+              <p className="eyebrow">Infrastructure</p>
+              <h3 className="section-title">System health</h3>
             </div>
-            <span className="panel__meta">Last sync</span>
+            {healthQuery.data && (
+              <StatusBadge tone={toHealthTone(healthQuery.data.status)}>
+                {healthQuery.data.status}
+              </StatusBadge>
+            )}
           </div>
 
-          <ul className="check-list">
-            <li>
-              <strong>Allegro sandbox</strong>
-              <span className="muted-text">Healthy · synced 2m ago</span>
-            </li>
-            <li>
-              <strong>PrestaShop staging</strong>
-              <span className="muted-text">Needs review · auth warning</span>
-            </li>
-            <li>
-              <strong>Webhook intake</strong>
-              <span className="muted-text">Healthy · 0 replay errors</span>
-            </li>
-          </ul>
+          {healthQuery.isLoading && (
+            <LoadingState title="Checking system health" message="Pinging dependencies…" liveRegion="off" />
+          )}
+          {healthQuery.error && (
+            <ErrorState
+              title="Health check failed"
+              message={healthQuery.error.message}
+              action={<Button onClick={() => void healthQuery.refetch()}>Retry</Button>}
+            />
+          )}
+          {healthQuery.data && (
+            <ul className="check-list">
+              <ServiceHealthRow name="PostgreSQL" health={healthQuery.data.services.postgres} />
+              <ServiceHealthRow name="Redis" health={healthQuery.data.services.redis} />
+              <ServiceHealthRow name="PrestaShop" health={healthQuery.data.services.prestashop} />
+            </ul>
+          )}
         </article>
       </div>
 
+      {/* ── Placeholder panels ───────────────────────────────────────── */}
       <div className="workspace-grid">
         <article className="panel panel--dense">
           <div className="panel__header">
             <div>
               <p className="eyebrow">Activity</p>
-              <h3 className="section-title">Recent events</h3>
+              <h3 className="section-title">Recent sync events</h3>
             </div>
-            <span className="panel__meta">Timeline</span>
+            <span className="toolbar-chip">Coming soon</span>
           </div>
-
-          <ul className="timeline-list">
-            <li>
-              <span className="timeline-list__time">23:41</span>
-              <div>
-                <strong>Connection validated</strong>
-                <p className="timeline-list__description">Allegro sandbox credentials accepted and connection kept active.</p>
-              </div>
-            </li>
-            <li>
-              <span className="timeline-list__time">23:35</span>
-              <div>
-                <strong>Retry scheduled</strong>
-                <p className="timeline-list__description">Validation job entered retry backoff after transient upstream failure.</p>
-              </div>
-            </li>
-            <li>
-              <span className="timeline-list__time">23:18</span>
-              <div>
-                <strong>Manual review opened</strong>
-                <p className="timeline-list__description">A new integration draft is waiting for operator confirmation.</p>
-              </div>
-            </li>
-          </ul>
+          <p className="muted-text panel-copy">
+            Sync job activity timeline will be visible here once the jobs read API (#70) ships.
+          </p>
         </article>
 
         <article className="panel panel--dense">
@@ -155,23 +204,11 @@ export function DashboardPage(): ReactElement {
               <p className="eyebrow">Failures</p>
               <h3 className="section-title">Retry and incident queue</h3>
             </div>
-            <span className="panel__meta">Ops bridge</span>
+            <span className="toolbar-chip">Coming soon</span>
           </div>
-
-          <ul className="check-list">
-            <li>
-              <strong>Retry backlog</strong>
-              <span className="muted-text">1 validation retry scheduled in the next 5 minutes</span>
-            </li>
-            <li>
-              <strong>Manual review queue</strong>
-              <span className="muted-text">1 connection setup blocked on credentials confirmation</span>
-            </li>
-            <li>
-              <strong>Dead-letter queue</strong>
-              <span className="muted-text">No failed events requiring replay</span>
-            </li>
-          </ul>
+          <p className="muted-text panel-copy">
+            Failed and retrying sync jobs will appear here once the jobs read API (#70) ships.
+          </p>
         </article>
       </div>
     </PageLayout>

--- a/apps/web/src/shared/auth/jwt-bearer-session-adapter.test.ts
+++ b/apps/web/src/shared/auth/jwt-bearer-session-adapter.test.ts
@@ -69,7 +69,7 @@ describe('JwtBearerSessionAdapter', () => {
           username: 'admin',
           email: 'admin@example.com',
           role: 'admin',
-          permissions: ['read:products', 'connections:read'],
+          permissions: ['connections:read', 'read:products'],
         },
       });
       expect(fetchFn).toHaveBeenCalledWith('http://localhost:3000/auth/me', {

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -38,6 +38,7 @@ type DeepPartialApiClient = {
   allegro?: Partial<ApiClient['allegro']>;
   auth?: Partial<ApiClient['auth']>;
   connections?: Partial<ApiClient['connections']>;
+  health?: Partial<ApiClient['health']>;
   syncJobs?: Partial<ApiClient['syncJobs']>;
 };
 
@@ -66,11 +67,32 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
     } as ApiClient['auth'],
     connections: {
       create: vi.fn().mockResolvedValue(sampleConnection),
+      getDiagnostics: vi.fn().mockResolvedValue({
+        connectionId: 'conn_1',
+        connectionName: 'Main PrestaShop Store',
+        connectionStatus: 'active',
+        lastSucceededAt: null,
+        lastFailedAt: null,
+        recentErrors: [],
+        recentJobs: [],
+      }),
       getById: vi.fn().mockResolvedValue(sampleConnection),
       list: vi.fn().mockResolvedValue([sampleConnection]),
       update: vi.fn().mockResolvedValue(sampleConnection),
       ...overrides.connections,
     } as ApiClient['connections'],
+    health: {
+      getDevStackHealth: vi.fn().mockResolvedValue({
+        status: 'ok',
+        services: {
+          postgres: { status: 'ok' },
+          redis: { status: 'ok' },
+          prestashop: { status: 'ok' },
+        },
+        timestamp: '2026-04-06T00:00:00.000Z',
+      }),
+      ...overrides.health,
+    } as ApiClient['health'],
     syncJobs: {
       enqueue: vi.fn().mockResolvedValue({
         jobId: 'job_1',

--- a/docs/plans/implementation-plan-diagnostics-and-health-dashboard.md
+++ b/docs/plans/implementation-plan-diagnostics-and-health-dashboard.md
@@ -1,0 +1,546 @@
+# Implementation Plan: Connection Diagnostics API + Health Dashboard
+
+**Date**: 2026-04-06
+**Status**: Ready for Review
+**Estimated Effort**: 5–7 hours
+**Issues**:
+- [#65 — BE: Add connection diagnostics and activity API](https://github.com/SilkSoftwareHouse/openlinker/issues/65)
+- [#74 — FE: Build health and environment dashboard](https://github.com/SilkSoftwareHouse/openlinker/issues/74)
+**Branch**: `65-74-diagnostics-and-health-dashboard`
+
+---
+
+## 1. Task Summary
+
+**Objective**: Deliver two connected slices in a single branch:
+
+1. **#65 (BE)** — Add `GET /connections/:id/diagnostics` to the backend. The endpoint aggregates data from the `connections` and `sync_jobs` tables to give the FE a single, per-connection operational summary: status, last success/failure timestamps, recent job list, and recent error messages.
+
+2. **#74 (FE)** — Replace the entirely static mock dashboard with real data. Wire the system health section to `GET /health/dev-stack`, the connection health panel to `GET /connections`, and the per-connection diagnostic card to the new `GET /connections/:id/diagnostics` endpoint. Add a manual refresh control. Keep the sync-jobs activity timeline as a placeholder — that data source (`GET /sync/jobs`) is being built in parallel in issue #70 and must not be blocked on.
+
+**Context**: The backend has health endpoints and a fully persisted sync_jobs table, but no read API surfacing job data. The frontend dashboard has production-quality UI but is wired to hardcoded mock data. This plan delivers the last-mile connection between the two.
+
+**Classification**: Backend / Interface (connection controller + diagnostics DTO) + Frontend / Feature (health feature module + dashboard wiring)
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+
+**Backend (#65):**
+- `findRecentByConnectionId(connectionId, limit)` — new method on `SyncJobRepositoryPort` and `SyncJobRepository`
+- `GET /connections/:id/diagnostics` — new endpoint on `ConnectionController`
+- `ConnectionDiagnosticsResponseDto` — response DTO
+
+**Frontend (#74):**
+- `features/health/` — new feature module: API types, `health.api.ts`, query-keys, `use-dev-stack-health-query.ts`
+- `features/connections/api/connections.api.ts` — add `getDiagnostics(connectionId)` method
+- `features/connections/api/connections.types.ts` — add `ConnectionDiagnostics` type
+- `api-client.ts` — add `health` module
+- `test-utils.tsx` — add health mock
+- Dashboard page — replace static metric card, connection health list, and system health section with real data; keep sync-jobs sections as explicit placeholders; add refresh button
+- Tests for the new hooks and the updated dashboard component
+
+### Out of Scope
+
+- `GET /sync/jobs` read API — being built in issue #70. The dashboard's "Recent events" and "Retry queue" sections stay as placeholder panels until #70 lands.
+- Connection activity event log / audit trail — not yet a domain concept.
+- Real-time WebSocket updates — refresh is manual (polling future enhancement).
+- Allegro-specific validation state — the diagnostics endpoint uses connection status from the connections table, not the Allegro validation endpoint.
+- Database migrations — no schema changes needed; `sync_jobs` table already exists.
+
+### Constraints
+
+- `SyncJobRepositoryPort` is a CORE domain port — any new method must be read-only and non-destructive.
+- The diagnostics endpoint is read-only, no auth scope beyond the existing JWT guard.
+- FE must not import `sync.api.ts` job-listing methods that do not yet exist — use only what the API client already exposes.
+
+---
+
+## 3. Architecture Mapping
+
+### Backend
+
+**Target Layer**: Interface (controller) + Infrastructure (repository method)
+
+**Affected files by layer:**
+
+| Layer | File | Change |
+|---|---|---|
+| Domain / Port | `libs/core/src/sync/domain/ports/sync-job-repository.port.ts` | Add `findRecentByConnectionId` |
+| Infrastructure | `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts` | Implement new method |
+| Interface / DTO | `apps/api/src/integrations/http/dto/connection-diagnostics-response.dto.ts` | New DTO |
+| Interface / Controller | `apps/api/src/integrations/http/connection.controller.ts` | New `GET :id/diagnostics` endpoint |
+
+**Ports involved:**
+- `SyncJobRepositoryPort` (extended, in CORE)
+- `SYNC_JOB_REPOSITORY_TOKEN` already exported from `SyncModule` — inject into `ConnectionController` via the existing token
+
+**Core vs Integration justification**: The `SyncJobRepositoryPort` lives in CORE (`libs/core/src/sync/`) — this is correct. The new `findRecentByConnectionId` method is a pure read query that returns domain entities. The controller (`apps/api/src/integrations/http/`) is the Interface layer that assembles the diagnostics view model from two data sources (connection service + sync job repository), which is appropriate for a thin aggregation controller.
+
+### Frontend
+
+**Target Layer**: `features/health/` (new) + `features/connections/` (extended) + `pages/dashboard/` (replaced)
+
+**Dependency direction**: `pages/dashboard` → `features/health` + `features/connections` → `shared` ✅
+
+---
+
+## 4. Internal Patterns Research
+
+### Backend patterns followed
+
+- **Port extension**: `SyncJobRepositoryPort` follows the same pattern as `ConnectionCursorRepositoryPort` — pure interface in domain, TypeORM implementation in infrastructure.
+- **Controller injection**: `AllegroController` already injects `ALLEGRO_QUANTITY_COMMAND_REPOSITORY_TOKEN` directly — same pattern for injecting `SYNC_JOB_REPOSITORY_TOKEN` into `ConnectionController`.
+- **DTO static factory**: `ConnectionResponseDto.fromDomain(connection)` — same pattern for `ConnectionDiagnosticsResponseDto`.
+
+### Frontend patterns followed
+
+- **Feature API module**: `features/allegro/api/allegro.api.ts` + `allegro.query-keys.ts` → same structure for `features/health/api/`
+- **Query hook**: `use-start-allegro-oauth-mutation.ts` (hook per file, returns full `UseMutationResult`) → same for `use-dev-stack-health-query.ts`
+- **Connections extension**: add `getDiagnostics` to existing `ConnectionsApi` interface — same pattern as `handleCallback` was added to `AllegroApi`
+- **Dashboard data states**: all four states (loading/error/empty/data) per `fe-pages.md` rules
+
+---
+
+## 5. Questions & Assumptions
+
+### Assumptions
+
+- **Diagnostics aggregation in controller**: The controller directly assembles the diagnostics view model from `ConnectionService` and `SyncJobRepositoryPort`. A dedicated service is not needed for this single read query — the controller is the appropriate aggregation point for MVP (consistent with `AllegroController` pattern).
+- **Limit = 10**: The diagnostics endpoint returns the 10 most recent jobs, ordered by `createdAt DESC`. This is a fixed limit for MVP.
+- **lastSucceededAt / lastFailedAt**: Derived from the recent job list — the `updatedAt` of the most recent job with `status === 'succeeded'` or `status IN ('failed', 'dead')` respectively.
+- **`recentErrors`**: Array of non-null `lastError` strings from the recent job list, deduplicated, limited to 5.
+- **No per-connection diagnostics on the dashboard main panel**: The dashboard shows the connection list from `GET /connections`. Clicking into a connection takes you to the connection detail page (future work in #63). The `GET /connections/:id/diagnostics` endpoint is consumed by the connection detail page eventually; the dashboard uses it only to show the last-active timestamp on each connection row. For MVP, the dashboard does NOT call diagnostics for each connection — that would be N+1 requests. The dashboard uses only `GET /connections` (list) + `GET /health/dev-stack`.
+- **Refresh UX**: A single "Refresh" button in the dashboard `PageLayout` actions slot calls `refetch()` on all active queries.
+- **Dashboard metric cards after this PR**: "Integration health" card shows real count. "Jobs needing attention", "Inventory conflicts", "Manual reviews" stay as placeholder values until #70 + future issues land.
+
+### Open Questions
+
+- Should `GET /connections/:id/diagnostics` require admin role or any authenticated user? **Assumption**: Any authenticated user (same as `GET /connections/:id`) — operators need to see this.
+- Should `recentErrors` be deduplicated or ordered by recency? **Assumption**: Ordered by recency (same order as jobs), not deduplicated — keeps it simple and predictable.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Backend: extend the port and repository
+
+**Step 1.1 — Add `findRecentByConnectionId` to `SyncJobRepositoryPort`**
+
+- **File**: `libs/core/src/sync/domain/ports/sync-job-repository.port.ts`
+- **Action**: Add method signature:
+  ```typescript
+  findRecentByConnectionId(connectionId: string, limit: number): Promise<SyncJob[]>;
+  ```
+- **Acceptance**: TypeScript compiles; existing port consumers still compile.
+
+**Step 1.2 — Implement in `SyncJobRepository`**
+
+- **File**: `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts`
+- **Action**: Implement using TypeORM query builder:
+  ```typescript
+  async findRecentByConnectionId(connectionId: string, limit: number): Promise<SyncJob[]> {
+    const entities = await this.repository.find({
+      where: { connectionId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+    return entities.map((e) => this.toDomain(e));
+  }
+  ```
+- **Acceptance**: Unit test in `sync-job.repository.spec.ts` (if exists) or a targeted spec covering the new method; verifies correct ordering and limit.
+
+---
+
+### Phase 2 — Backend: diagnostics endpoint
+
+**Step 2.1 — Create `ConnectionDiagnosticsResponseDto`**
+
+- **File**: `apps/api/src/integrations/http/dto/connection-diagnostics-response.dto.ts`
+- **Shape**:
+  ```typescript
+  export class ConnectionDiagnosticsResponseDto {
+    connectionId: string;
+    connectionName: string;
+    connectionStatus: string;           // 'active' | 'disabled' | 'error'
+    lastSucceededAt: string | null;     // ISO timestamp of most recent succeeded job
+    lastFailedAt: string | null;        // ISO timestamp of most recent failed/dead job
+    recentErrors: string[];             // lastError from recent failed/dead jobs
+    recentJobs: RecentJobSummaryDto[];  // last N jobs
+  }
+
+  export class RecentJobSummaryDto {
+    id: string;
+    jobType: string;
+    status: string;
+    attempts: number;
+    createdAt: string;
+    updatedAt: string;
+    lastError: string | null;
+  }
+  ```
+- Add static `fromDomain(connection, recentJobs)` factory method.
+- **Acceptance**: TypeScript compiles; Swagger decorators present.
+
+**Step 2.2 — Add diagnostics endpoint to `ConnectionController`**
+
+- **File**: `apps/api/src/integrations/http/connection.controller.ts`
+- **Action**:
+  1. Inject `SYNC_JOB_REPOSITORY_TOKEN` in constructor (already exported from `SyncModule`).
+  2. Add `GET :id/diagnostics` handler:
+     - Call `this.connectionService.get(id)` to get connection (throws `NotFoundException` if missing — existing pattern).
+     - Call `this.syncJobRepository.findRecentByConnectionId(id, 10)`.
+     - Build and return `ConnectionDiagnosticsResponseDto.fromDomain(connection, recentJobs)`.
+  3. Add Swagger `@ApiOperation`, `@ApiResponse` decorators.
+- **Acceptance**: `GET /connections/:id/diagnostics` returns the DTO; 404 for unknown IDs; unit test covers happy path + 404.
+
+**Step 2.3 — Ensure `SyncModule` is imported in `IntegrationsModule`**
+
+- **File**: `apps/api/src/integrations/integrations.module.ts`
+- **Action**: Verify `SyncModule` is already imported (it likely is, as sync tokens are used elsewhere). If not, add it.
+- **Acceptance**: `pnpm type-check` passes; `SYNC_JOB_REPOSITORY_TOKEN` resolves in `ConnectionController`.
+
+---
+
+### Phase 3 — Frontend: health feature module
+
+**Step 3.1 — Create `features/health/api/health.types.ts`**
+
+- **File**: `apps/web/src/features/health/api/health.types.ts`
+- **Shape**:
+  ```typescript
+  export type ServiceStatus = 'ok' | 'degraded' | 'error';
+
+  export interface ServiceHealth {
+    status: 'ok' | 'error';
+    message?: string;
+  }
+
+  export interface DevStackHealth {
+    status: ServiceStatus;
+    services: {
+      postgres: ServiceHealth;
+      redis: ServiceHealth;
+      prestashop: ServiceHealth;
+    };
+    timestamp: string;
+  }
+  ```
+- **Acceptance**: Types compile; no `any`.
+
+**Step 3.2 — Create `features/health/api/health.query-keys.ts`**
+
+- **File**: `apps/web/src/features/health/api/health.query-keys.ts`
+- **Content**:
+  ```typescript
+  export const healthQueryKeys = {
+    all: ['health'] as const,
+    devStack: () => ['health', 'dev-stack'] as const,
+  };
+  ```
+
+**Step 3.3 — Create `features/health/api/health.api.ts`**
+
+- **File**: `apps/web/src/features/health/api/health.api.ts`
+- **Content**:
+  ```typescript
+  export interface HealthApi {
+    getDevStackHealth: () => Promise<DevStackHealth>;
+  }
+
+  export function createHealthApi(request: ApiRequest): HealthApi {
+    return {
+      getDevStackHealth: () => request<DevStackHealth>('/health/dev-stack'),
+    };
+  }
+  ```
+
+**Step 3.4 — Create `features/health/hooks/use-dev-stack-health-query.ts`**
+
+- **File**: `apps/web/src/features/health/hooks/use-dev-stack-health-query.ts`
+- **Content**: `useQuery` with `queryKey: healthQueryKeys.devStack()`, `queryFn: () => apiClient.health.getDevStackHealth()`, `retry: false` (health checks should fail fast).
+
+---
+
+### Phase 4 — Frontend: extend connections API with diagnostics
+
+**Step 4.1 — Add `ConnectionDiagnostics` to `connections.types.ts`**
+
+- **File**: `apps/web/src/features/connections/api/connections.types.ts`
+- **Add**:
+  ```typescript
+  export interface RecentJobSummary {
+    id: string;
+    jobType: string;
+    status: string;
+    attempts: number;
+    createdAt: string;
+    updatedAt: string;
+    lastError: string | null;
+  }
+
+  export interface ConnectionDiagnostics {
+    connectionId: string;
+    connectionName: string;
+    connectionStatus: string;
+    lastSucceededAt: string | null;
+    lastFailedAt: string | null;
+    recentErrors: string[];
+    recentJobs: RecentJobSummary[];
+  }
+  ```
+
+**Step 4.2 — Add `getDiagnostics` to `connections.api.ts`**
+
+- **File**: `apps/web/src/features/connections/api/connections.api.ts`
+- **Add** to `ConnectionsApi` interface and factory:
+  ```typescript
+  getDiagnostics: (connectionId: string) => Promise<ConnectionDiagnostics>;
+  ```
+  Implementation: `request<ConnectionDiagnostics>('/connections/${connectionId}/diagnostics')`
+
+**Step 4.3 — Add `use-connection-diagnostics-query.ts`**
+
+- **File**: `apps/web/src/features/connections/hooks/use-connection-diagnostics-query.ts`
+- **Content**: `useQuery` with `queryKey: connectionsQueryKeys.diagnostics(connectionId)`, enabled only when `connectionId` is defined.
+- Also extend `connections.query-keys.ts` with `diagnostics: (id: string) => ['connections', 'diagnostics', id] as const`.
+
+---
+
+### Phase 5 — Frontend: wire up api-client and test-utils
+
+**Step 5.1 — Add `health` to `api-client.ts`**
+
+- **File**: `apps/web/src/app/api/api-client.ts`
+- Add `health: HealthApi` to `ApiClient` interface.
+- Add `health: createHealthApi(request)` to the factory return.
+
+**Step 5.2 — Add health mock to `test-utils.tsx`**
+
+- **File**: `apps/web/src/test/test-utils.tsx`
+- Add to `createMockApiClient`:
+  ```typescript
+  health: {
+    getDevStackHealth: vi.fn().mockResolvedValue({
+      status: 'ok',
+      services: {
+        postgres: { status: 'ok' },
+        redis: { status: 'ok' },
+        prestashop: { status: 'ok' },
+      },
+      timestamp: '2026-04-06T00:00:00.000Z',
+    }),
+    ...overrides.health,
+  } as ApiClient['health'],
+  ```
+- Add `health?: Partial<ApiClient['health']>` to `DeepPartialApiClient`.
+
+---
+
+### Phase 6 — Frontend: replace dashboard static content
+
+**Step 6.1 — Rewrite `dashboard-page.tsx`**
+
+- **File**: `apps/web/src/pages/dashboard/dashboard-page.tsx`
+- **Action**:
+  1. Consume `useConnectionsQuery()` (already exists in `features/connections/hooks/`).
+  2. Consume `useDevStackHealthQuery()` (new).
+  3. **Metric strip** — "Integration health" card: show `{active}/{total}` connections from the query. Pending/failed count from connections with `status !== 'active'`. Keep "Jobs needing attention", "Inventory conflicts", "Manual reviews" as static placeholder cards with a "Coming soon" label.
+  4. **Integration health panel** — replace hardcoded list with real connections from the query; show `StatusBadge` per connection status; show `createdAt` as "Connected since".
+  5. **System health panel** — new panel showing Postgres / Redis / PrestaShop status from `useDevStackHealthQuery()` with `StatusBadge`.
+  6. **Activity and retry panels** — keep as explicit placeholder panels with "Coming soon" chip (consistent with `ModulePlaceholderPage` pattern used elsewhere).
+  7. **Refresh button** — in `PageLayout` `actions` slot; calls `connectionsQuery.refetch()` + `healthQuery.refetch()` on click.
+  8. Handle loading, error, and empty states for each data-driven section per `fe-pages.md` rules.
+- **Acceptance**: Dashboard shows real connection data and real health status; all states handled.
+
+---
+
+### Phase 7 — Tests
+
+**Step 7.1 — BE: `connection.controller.spec.ts`**
+
+- **File**: `apps/api/src/integrations/http/connection.controller.spec.ts`
+- **Tests** (add to existing spec):
+  - `should return diagnostics for existing connection`
+  - `should throw 404 for unknown connection`
+  - `should derive lastSucceededAt and lastFailedAt from recent jobs`
+
+**Step 7.2 — FE: `use-dev-stack-health-query.test.ts`**
+
+- **File**: `apps/web/src/features/health/hooks/use-dev-stack-health-query.test.ts`
+- Test: hook fetches `/health/dev-stack` and returns the health data.
+
+**Step 7.3 — FE: `dashboard-page.test.tsx`**
+
+- **File**: `apps/web/src/pages/dashboard/dashboard-page.test.tsx`
+- **Tests**:
+  - Shows real connection count from API
+  - Shows health status badges (ok/degraded/error)
+  - Shows loading state for connections section
+  - Shows error state for health section
+  - Refresh button calls refetch
+
+---
+
+### Implementation Details
+
+**DTO response shape for `GET /connections/:id/diagnostics`:**
+```json
+{
+  "connectionId": "uuid",
+  "connectionName": "Main PrestaShop Store",
+  "connectionStatus": "active",
+  "lastSucceededAt": "2026-04-06T10:00:00.000Z",
+  "lastFailedAt": null,
+  "recentErrors": [],
+  "recentJobs": [
+    {
+      "id": "uuid",
+      "jobType": "marketplace.orders.poll",
+      "status": "succeeded",
+      "attempts": 1,
+      "createdAt": "2026-04-06T10:00:00.000Z",
+      "updatedAt": "2026-04-06T10:01:00.000Z",
+      "lastError": null
+    }
+  ]
+}
+```
+
+**No database migration needed** — `sync_jobs` table exists; new query only reads from it.
+
+**No new CSS needed** — `StatusBadge`, existing panel/metric-card classes, `toolbar-chip` all exist.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Separate `ConnectionDiagnosticsService`
+
+**Description**: Create a dedicated application service combining connection + sync job data instead of doing it in the controller.
+
+**Why Rejected**: The diagnostics endpoint is a single read-only aggregation of two already-resolved data sources. A dedicated service would be a one-method wrapper with no domain logic. The controller pattern is already established in `AllegroController` for similar aggregations.
+
+---
+
+### Alternative 2: N+1 diagnostics calls on dashboard (one per connection)
+
+**Description**: The dashboard calls `GET /connections/:id/diagnostics` for each connection to show last-sync timestamps inline.
+
+**Why Rejected**: N+1 API calls from the dashboard would be a performance anti-pattern. The connection list from `GET /connections` is sufficient for the dashboard panel. Diagnostics are for detail views (`/connections/:id`).
+
+---
+
+### Alternative 3: Extend `GET /connections` list response to include diagnostic fields
+
+**Description**: Add `lastSucceededAt`, `lastFailedAt` to the connection list DTO directly.
+
+**Why Rejected**: Would require joining `sync_jobs` on every connections list call — expensive and adds complexity to a frequently-called endpoint. Keeping diagnostics as a separate endpoint follows the principle of progressive disclosure and keeps the list fast.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Port extended in CORE domain layer (not in infrastructure or application)
+- ✅ Repository implementation in infrastructure layer
+- ✅ Controller in interface layer, calls application service + injects repository directly (consistent with existing pattern)
+- ✅ FE dependency direction: `pages` → `features` → `shared`
+
+### Naming Conventions
+- ✅ `sync-job-repository.port.ts` — existing file, method name follows camelCase
+- ✅ `connection-diagnostics-response.dto.ts` — matches `*-response.dto.ts` pattern
+- ✅ `health.api.ts`, `health.types.ts`, `health.query-keys.ts` — matches established API module pattern
+- ✅ `use-dev-stack-health-query.ts` — matches `use-{resource}-query.ts` hook pattern
+- ✅ `use-connection-diagnostics-query.ts` — matches hook pattern
+
+### Risks
+
+- **`SyncModule` not imported in `IntegrationsModule`**: If `IntegrationsModule` doesn't already import `SyncModule`, `SYNC_JOB_REPOSITORY_TOKEN` won't resolve → controller will fail at startup. **Mitigation**: verify in Step 2.3; add import if missing.
+- **`sync_jobs` table empty in dev**: The dashboard's real connection list and health data will still render; only the diagnostics-driven fields will show empty arrays. Gracefully handled by `recentJobs: []`.
+- **`/health/dev-stack` PrestaShop check slow**: The dev-stack health endpoint calls PrestaShop synchronously. In environments where PrestaShop is down, this call might be slow. **Mitigation**: TanStack Query's `retry: false` and the `staleTime` setting prevent hammering a slow endpoint.
+- **`useConnectionsQuery` already used in ConnectionsOverview**: Dashboard reuses the same query key — TanStack Query will deduplicate the requests. No duplicate API calls.
+
+### Edge Cases
+- Connection with zero sync jobs: `recentJobs: []`, `lastSucceededAt: null`, `lastFailedAt: null`, `recentErrors: []`.
+- All jobs failed: `lastSucceededAt: null`, `lastFailedAt` = most recent `updatedAt`.
+- Dashboard with zero connections: show `EmptyState` in the connection health panel with a "Add connection" CTA.
+
+### Backward Compatibility
+- ✅ Existing `SyncJobRepositoryPort` consumers unaffected (new method added, existing methods unchanged)
+- ✅ Existing `GET /connections` endpoints unchanged
+- ✅ Existing `connections.api.ts` methods unchanged (additive extension)
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Backend Unit Tests
+
+**File**: `apps/api/src/integrations/http/connection.controller.spec.ts` (extend existing)
+- `GET /connections/:id/diagnostics` — happy path returns DTO
+- `GET /connections/:id/diagnostics` — 404 when connection not found
+- `lastSucceededAt` derived from most recent succeeded job's `updatedAt`
+- `lastFailedAt` derived from most recent failed/dead job's `updatedAt`
+
+**Mocking strategy**: Mock `ConnectionService` and `SyncJobRepositoryPort` (not concrete classes).
+
+### Frontend Tests
+
+**`use-dev-stack-health-query.test.ts`**: hook returns health data; handles error state.
+
+**`dashboard-page.test.tsx`** (extend or replace existing):
+| Test | Arrangement | Assertion |
+|---|---|---|
+| Shows real connection count | mock connections list | `2 connections` (or equivalent) visible |
+| Shows health status ok | mock health response `status: ok` | "ok" badge or equivalent visible |
+| Shows health status degraded | mock health response `status: degraded` | degraded state visible |
+| Shows loading for connections | never-resolving connection list | loading state visible |
+| Shows error for health | health query rejects | error state in health panel |
+| Refresh button calls refetch | render then click | both queries refetched |
+
+### Acceptance Criteria
+
+- [x] `GET /connections/:id/diagnostics` returns correct DTO structure
+- [x] Dashboard "Integration health" metric shows real connection count
+- [x] Dashboard "System health" panel shows Postgres / Redis / PrestaShop status from `/health/dev-stack`
+- [x] Dashboard connection list shows real connections with status badges
+- [x] All data-driven sections handle loading, error, and empty states
+- [x] Refresh button refetches all live data
+- [x] Sync-jobs sections are visible but clearly labelled as "Coming soon"
+
+### Quality Gate
+
+```bash
+pnpm lint        # zero errors
+pnpm type-check  # zero errors
+pnpm test        # all unit tests pass
+```
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture (port in domain, impl in infrastructure, aggregation in controller)
+- [x] Respects CORE vs Integration boundaries (SyncJobRepositoryPort extended in CORE)
+- [x] Uses existing patterns (no new abstractions beyond what the task requires)
+- [x] Idempotency considered (read-only endpoint, N/A for writes)
+- [x] Event-driven patterns used where applicable (N/A — synchronous read query)
+- [x] Rate limits & retries addressed (health query uses `retry: false`)
+- [x] Error handling comprehensive (404 for unknown connections; loading/error states in FE)
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Frontend Architecture](../frontend-architecture.md)
+- [Testing Guide](../testing-guide.md)

--- a/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
+++ b/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
@@ -77,5 +77,17 @@ export interface SyncJobRepositoryPort {
    * @returns Number of jobs requeued
    */
   requeueStuckJobs(lockTimeoutMinutes: number): Promise<number>;
+
+  /**
+   * Find recent jobs for a connection
+   *
+   * Returns the most recent sync jobs for the given connection, ordered by
+   * createdAt descending. Used for diagnostics and activity summary views.
+   *
+   * @param connectionId - Connection UUID
+   * @param limit - Maximum number of jobs to return
+   * @returns Array of sync job domain entities, newest first
+   */
+  findRecentByConnectionId(connectionId: string, limit: number): Promise<SyncJob[]>;
 }
 

--- a/libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts
+++ b/libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts
@@ -18,6 +18,7 @@ import {
 @Entity('sync_jobs')
 @Index(['status', 'nextRunAt'])
 @Index(['lockedAt'])
+@Index(['connectionId', 'createdAt']) // Supports findRecentByConnectionId diagnostics query
 export class SyncJobOrmEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;

--- a/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
@@ -212,6 +212,15 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
     return result.affected || 0;
   }
 
+  async findRecentByConnectionId(connectionId: string, limit: number): Promise<SyncJob[]> {
+    const entities = await this.repository.find({
+      where: { connectionId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+    return entities.map((e) => this.toDomain(e));
+  }
+
   /**
    * Map ORM entity to domain entity
    */


### PR DESCRIPTION
## Summary
- Adds `GET /connections/:id/diagnostics` — a single endpoint giving the FE per-connection operational health: status, last success/failure timestamps, recent errors, and the last 10 sync jobs
- Replaces the entirely static dashboard mock data with real data from `GET /connections` and `GET /health/dev-stack`; adds a Refresh button; sync-jobs panels stay as explicit placeholders until #70 lands

## Changes

**Backend (#65):**
- `SyncJobRepositoryPort` + `SyncJobRepository` — add `findRecentByConnectionId(connectionId, limit)` with index-backed query
- `ConnectionDiagnosticsResponseDto` — aggregates connection status + recent job activity; correctly captures retrying jobs via `lastError !== null` (since `markFailed()` re-queues as `'queued'`, never writing `status = 'failed'`)
- `ConnectionController` — new `GET :id/diagnostics` endpoint injecting existing `SYNC_JOB_REPOSITORY_TOKEN`
- Migration `1777000000000` — composite index on `(connectionId, createdAt)` for the diagnostics query

**Frontend (#74):**
- `features/health/` — new module: `health.api.ts`, `health.types.ts`, `health.query-keys.ts`, `use-dev-stack-health-query.ts`
- `features/connections/` — `getDiagnostics()` method, `ConnectionDiagnostics` type, `use-connection-diagnostics-query.ts` hook
- `api-client.ts` + `test-utils.tsx` — health module wired
- `dashboard-page.tsx` — metric cards, connection health list, and system health panel wired to real data; `useCallback` on refresh handler; placeholder panels with operator-friendly copy

## Test plan
- [x] Unit tests pass (`pnpm test`) — 305/305
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] `GET /connections/:id/diagnostics` returns correct DTO with `lastSucceededAt` / `lastFailedAt` / `recentErrors`
- [ ] `GET /connections/unknown/diagnostics` returns 404
- [ ] Dashboard shows real connection count and status badges
- [ ] Dashboard system health panel shows Postgres / Redis / PrestaShop status
- [ ] Refresh button refetches both queries
- [ ] Dashboard placeholder panels render with "Coming soon" chip

## Tech review
✅ **Approved** after three review rounds. Key fixes applied:
- `failedJobs` filter uses `lastError !== null` instead of `status === 'failed'` (which `markFailed()` never writes)
- Migration index direction aligned with `@Index` decorator (ASC, no DESC)
- `@ApiProperty` description updated to mention retrying jobs
- `useCallback` on `handleRefresh`; placeholder text cleaned of internal issue numbers

Closes #65
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)