### PR TITLE
refactor(identifier-mapping): apply tech-review suggestions

### DIFF
--- a/apps/web/src/shared/auth/jwt-bearer-session-adapter.test.ts
+++ b/apps/web/src/shared/auth/jwt-bearer-session-adapter.test.ts
@@ -69,7 +69,7 @@ describe('JwtBearerSessionAdapter', () => {
           username: 'admin',
           email: 'admin@example.com',
           role: 'admin',
-          permissions: ['read:products', 'connections:read'],
+          permissions: ['connections:read', 'read:products'],
         },
       });
       expect(fetchFn).toHaveBeenCalledWith('http://localhost:3000/auth/me', {

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
@@ -51,66 +51,14 @@ export class IdentifierMappingService implements IIdentifierMappingService {
     connectionId: string,
     context?: MappingContext,
   ): Promise<string> {
-    // Step 1: Resolve Connection and derive platformType
     const connection = await this.connectionPort.get(connectionId);
-    const platformType = connection.platformType;
-
-    // Step 2: Check if mapping already exists
-    const existing = await this.repository.findByExternalKey(
+    return this.getOrCreateInternalIdWithPlatform(
       entityType,
-      platformType,
-      connectionId,
       externalId,
-    );
-    if (existing) {
-      this.logger.debug(
-        `Found existing mapping for ${entityType}:${externalId}@${connectionId} -> ${existing.internalId}`,
-      );
-      return existing.internalId;
-    }
-
-    // Step 3: Generate new internal ID and create mapping
-    const internalId = this.generateInternalId(entityType);
-    const mapping = new IdentifierMapping(
-      randomUUID(),
-      entityType,
-      internalId,
-      externalId,
-      platformType,
       connectionId,
-      context ?? null,
-      new Date(),
-      new Date(),
+      connection.platformType,
+      context,
     );
-
-    try {
-      await this.repository.insertMapping(mapping);
-      this.logger.log(
-        `Created new mapping for ${entityType}:${externalId}@${connectionId} -> ${internalId}`,
-      );
-      return internalId;
-    } catch (error) {
-      // Concurrent insert: another worker created the same mapping first.
-      // Read the winner and return its internalId (idempotent result).
-      if (error instanceof DuplicateIdentifierMappingError) {
-        const winner = await this.repository.findByExternalKey(
-          entityType,
-          platformType,
-          connectionId,
-          externalId,
-        );
-        if (winner) {
-          this.logger.debug(
-            `Concurrent insert detected for ${entityType}:${externalId}@${connectionId}, returning existing mapping -> ${winner.internalId}`,
-          );
-          return winner.internalId;
-        }
-        // Winner not found — should not happen; re-throw original error
-        throw error;
-      }
-
-      throw error;
-    }
   }
 
   async getInternalId(
@@ -210,7 +158,10 @@ export class IdentifierMappingService implements IIdentifierMappingService {
     );
     const connectionMap = new Map(connections.map((c) => [c.id, c]));
 
-    // Process items with resolved platformType (avoid redundant connection lookups)
+    // Process items with resolved platformType (avoid redundant connection lookups).
+    // Note: all requests are issued concurrently. This is intentional for the current
+    // use case where batch sizes are small (typically < 50 items per job). If batch
+    // sizes grow significantly, consider chunking to limit DB concurrency.
     await Promise.all(
       requests.map(async (request) => {
         const connection = connectionMap.get(request.connectionId);
@@ -350,7 +301,11 @@ export class IdentifierMappingService implements IIdentifierMappingService {
       );
     }
 
-    // Create mapping (createMapping already checks for duplicates and throws if exists)
+    // Create mapping (createMapping already checks for duplicates and throws if exists).
+    // TODO: this path is not concurrency-safe — concurrent calls can race between the
+    // findByExternalKey check above and repository.create() below, producing a raw
+    // QueryFailedError instead of a domain error. Fix if concurrent createMapping calls
+    // become a realistic scenario.
     await this.createMapping(entityType, externalId, connectionId, internalId, context);
     this.logger.debug(
       `Created mapping: ${entityType}:${externalId}@${connectionId} -> ${internalId}`,

--- a/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
@@ -6,14 +6,17 @@
  *
  * @module libs/core/src/identifier-mapping/domain/types
  */
-export type EntityType =
-  | 'Product'
-  | 'ProductVariant'
-  | 'Sku'
-  | 'Order'
-  | 'Offer'
-  | 'Inventory'
-  | 'Customer';
+export const EntityTypeValues = [
+  'Product',
+  'ProductVariant',
+  'Sku',
+  'Order',
+  'Offer',
+  'Inventory',
+  'Customer',
+] as const;
+
+export type EntityType = (typeof EntityTypeValues)[number];
 
 export interface MappingContext {
   parentEntityType?: string;

--- a/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts
+++ b/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts
@@ -23,6 +23,7 @@ import { IdentifierMapping } from '../../../domain/entities/identifier-mapping.e
 import { DuplicateIdentifierMappingError } from '../../../domain/exceptions/duplicate-identifier-mapping.error';
 import {
   EntityType,
+  EntityTypeValues,
   MappingContext,
 } from '@openlinker/core/identifier-mapping/domain/types/identifier-mapping.types';
 
@@ -98,9 +99,11 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
       const saved = await this.repository.save(entity);
       return this.toDomain(saved);
     } catch (error) {
+      // PostgreSQL error code 23505 = unique_violation. Using the code rather than
+      // message string to avoid locale/version sensitivity.
       if (
         error instanceof QueryFailedError &&
-        error.message.includes('duplicate key value')
+        (error as QueryFailedError & { code?: string }).code === '23505'
       ) {
         throw new DuplicateIdentifierMappingError(
           mapping.entityType,
@@ -128,6 +131,9 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
   }
 
   private toDomain(entity: IdentifierMappingOrmEntity): IdentifierMapping {
+    if (!(EntityTypeValues as readonly string[]).includes(entity.entityType)) {
+      throw new Error(`Invalid entityType in database: ${entity.entityType}`);
+    }
     return new IdentifierMapping(
       entity.id,
       entity.entityType as EntityType,


### PR DESCRIPTION
- Deduplicate getOrCreateInternalId: delegate to private helper instead of duplicating the concurrency retry body
- Replace PostgreSQL message string with error code 23505 (unique_violation) for more reliable duplicate-key detection
- Add EntityTypeValues as const array; validate entityType in toDomain to guard against invalid values from the database
- Document batch concurrency assumption (small batches < ~50 items)
- Add TODO comment on getOrCreateExactMapping noting it is not concurrency-safe
- Fix pre-existing test: align permissions array order with mock response