### PR TITLE
feat(sync): sync jobs read API and dashboard (#70, #71)

### DIFF
--- a/apps/api/src/sync/application/services/scheduler.service.ts
+++ b/apps/api/src/sync/application/services/scheduler.service.ts
@@ -300,10 +300,10 @@ export class SchedulerService implements OnModuleInit {
     };
 
     // Enqueue job
-    const jobId = await this.jobEnqueue.enqueueJob(jobRequest);
+    const { jobId, isExisting } = await this.jobEnqueue.enqueueJob(jobRequest);
 
     this.logger.debug(
-      `Enqueued job for connection ${connection.id} (${connection.name}) in task ${task.taskId}: ${jobId}`,
+      `Enqueued job for connection ${connection.id} (${connection.name}) in task ${task.taskId}: ${jobId} (existing: ${String(isExisting)})`,
     );
 
     return jobId;

--- a/apps/api/src/sync/http/dto/list-sync-jobs-query.dto.ts
+++ b/apps/api/src/sync/http/dto/list-sync-jobs-query.dto.ts
@@ -1,0 +1,44 @@
+/**
+ * List Sync Jobs Query DTO
+ *
+ * Query parameters for GET /sync/jobs. All fields are optional.
+ *
+ * @module apps/api/src/sync/http/dto
+ */
+import { IsEnum, IsOptional, IsUUID, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { JobStatusValues, JobTypeValues } from '@openlinker/core/sync';
+import type { JobStatus, JobType } from '@openlinker/core/sync';
+
+export class ListSyncJobsQueryDto {
+  @ApiPropertyOptional({ enum: JobStatusValues, description: 'Filter by job status' })
+  @IsOptional()
+  @IsEnum(JobStatusValues)
+  status?: JobStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by connection ID (UUID)' })
+  @IsOptional()
+  @IsUUID()
+  connectionId?: string;
+
+  @ApiPropertyOptional({ enum: JobTypeValues, description: 'Filter by job type' })
+  @IsOptional()
+  @IsEnum(JobTypeValues)
+  jobType?: JobType;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/apps/api/src/sync/http/dto/paginated-sync-jobs-response.dto.ts
+++ b/apps/api/src/sync/http/dto/paginated-sync-jobs-response.dto.ts
@@ -1,0 +1,23 @@
+/**
+ * Paginated Sync Jobs Response DTO
+ *
+ * Response shape for GET /sync/jobs.
+ *
+ * @module apps/api/src/sync/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { SyncJobResponseDto } from './sync-job-response.dto';
+
+export class PaginatedSyncJobsResponseDto {
+  @ApiProperty({ type: [SyncJobResponseDto] })
+  items!: SyncJobResponseDto[];
+
+  @ApiProperty({ description: 'Total number of jobs matching the filters' })
+  total!: number;
+
+  @ApiProperty({ description: 'Page size used for this response' })
+  limit!: number;
+
+  @ApiProperty({ description: 'Offset used for this response' })
+  offset!: number;
+}

--- a/apps/api/src/sync/http/dto/sync-job-response.dto.ts
+++ b/apps/api/src/sync/http/dto/sync-job-response.dto.ts
@@ -8,19 +8,20 @@
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { JobStatusValues, JobTypeValues } from '@openlinker/core/sync';
+import type { JobStatus, JobType } from '@openlinker/core/sync';
 
 export class SyncJobResponseDto {
   @ApiProperty({ description: 'Job UUID' })
   id!: string;
 
   @ApiProperty({ enum: JobTypeValues, description: 'Job type identifier' })
-  jobType!: string;
+  jobType!: JobType;
 
   @ApiProperty({ description: 'Connection UUID this job belongs to' })
   connectionId!: string;
 
   @ApiProperty({ enum: JobStatusValues, description: 'Current job status' })
-  status!: string;
+  status!: JobStatus;
 
   @ApiProperty({ description: 'Number of execution attempts so far' })
   attempts!: number;

--- a/apps/api/src/sync/http/dto/sync-job-response.dto.ts
+++ b/apps/api/src/sync/http/dto/sync-job-response.dto.ts
@@ -1,0 +1,54 @@
+/**
+ * Sync Job Response DTO
+ *
+ * Response shape for a single sync job. Used in both list and detail responses.
+ * Dates are serialised as ISO 8601 strings.
+ *
+ * @module apps/api/src/sync/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { JobStatusValues, JobTypeValues } from '@openlinker/core/sync';
+
+export class SyncJobResponseDto {
+  @ApiProperty({ description: 'Job UUID' })
+  id!: string;
+
+  @ApiProperty({ enum: JobTypeValues, description: 'Job type identifier' })
+  jobType!: string;
+
+  @ApiProperty({ description: 'Connection UUID this job belongs to' })
+  connectionId!: string;
+
+  @ApiProperty({ enum: JobStatusValues, description: 'Current job status' })
+  status!: string;
+
+  @ApiProperty({ description: 'Number of execution attempts so far' })
+  attempts!: number;
+
+  @ApiProperty({ description: 'Maximum allowed attempts before marking dead' })
+  maxAttempts!: number;
+
+  @ApiProperty({ description: 'Timestamp when job is eligible to run (ISO 8601)' })
+  nextRunAt!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Last error message if job failed' })
+  lastError!: string | null;
+
+  @ApiProperty({ description: 'Job creation timestamp (ISO 8601)' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Job last-update timestamp (ISO 8601)' })
+  updatedAt!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Job payload (admin only)' })
+  payloadJson!: Record<string, unknown> | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Idempotency key used for deduplication' })
+  idempotencyKey!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Timestamp when worker locked the job' })
+  lockedAt!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Worker instance ID that locked the job' })
+  lockedBy!: string | null;
+}

--- a/apps/api/src/sync/http/sync.controller.spec.ts
+++ b/apps/api/src/sync/http/sync.controller.spec.ts
@@ -6,32 +6,69 @@
  * @module apps/api/src/sync/http
  */
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { SyncController } from './sync.controller';
-import { JobEnqueuePort, JOB_ENQUEUE_TOKEN, SyncJobRequest } from '@openlinker/core/sync';
+import {
+  JobEnqueuePort,
+  JOB_ENQUEUE_TOKEN,
+  SyncJobRequest,
+  SyncJobRepositoryPort,
+  SYNC_JOB_REPOSITORY_TOKEN,
+  SyncJobEntity,
+} from '@openlinker/core/sync';
 import { EnqueueSyncJobDto } from './dto/enqueue-sync-job.dto';
+
+function makeSyncJob(overrides: Partial<SyncJobEntity> = {}): SyncJobEntity {
+  return new SyncJobEntity(
+    overrides.id ?? 'job-1',
+    overrides.jobType ?? 'marketplace.orders.poll',
+    overrides.connectionId ?? 'conn-1',
+    overrides.payload ?? {},
+    overrides.status ?? 'queued',
+    overrides.idempotencyKey ?? 'key-1',
+    overrides.attempts ?? 0,
+    overrides.maxAttempts ?? 10,
+    overrides.nextRunAt ?? new Date('2026-01-01T00:00:00Z'),
+    overrides.lockedAt ?? null,
+    overrides.lockedBy ?? null,
+    overrides.lastError ?? null,
+    overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
+    overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
+  );
+}
 
 describe('SyncController', () => {
   let controller: SyncController;
   let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+  let syncJobRepository: jest.Mocked<SyncJobRepositoryPort>;
 
   const mockJobEnqueue: jest.Mocked<JobEnqueuePort> = {
     enqueueJob: jest.fn(),
+  };
+
+  const mockSyncJobRepository: jest.Mocked<SyncJobRepositoryPort> = {
+    createIfNotExistsByIdempotencyKey: jest.fn(),
+    findAndLockDueJobs: jest.fn(),
+    findById: jest.fn(),
+    findMany: jest.fn(),
+    markSucceeded: jest.fn(),
+    markFailed: jest.fn(),
+    markDead: jest.fn(),
+    requeueStuckJobs: jest.fn(),
   };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SyncController],
       providers: [
-        {
-          provide: JOB_ENQUEUE_TOKEN,
-          useValue: mockJobEnqueue,
-        },
+        { provide: JOB_ENQUEUE_TOKEN, useValue: mockJobEnqueue },
+        { provide: SYNC_JOB_REPOSITORY_TOKEN, useValue: mockSyncJobRepository },
       ],
     }).compile();
 
     controller = module.get<SyncController>(SyncController);
     jobEnqueue = module.get(JOB_ENQUEUE_TOKEN);
+    syncJobRepository = module.get(SYNC_JOB_REPOSITORY_TOKEN);
 
     jest.clearAllMocks();
   });
@@ -124,11 +161,66 @@ describe('SyncController', () => {
 
         expect(result.jobType).toBe(jobType);
         expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
-          expect.objectContaining({
-            jobType,
-          }),
+          expect.objectContaining({ jobType }),
         );
       }
+    });
+  });
+
+  describe('listJobs', () => {
+    it('should return paginated response', async () => {
+      syncJobRepository.findMany.mockResolvedValue({ items: [makeSyncJob()], total: 1 });
+
+      const result = await controller.listJobs({ limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+    });
+
+    it('should pass filters to repository', async () => {
+      syncJobRepository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listJobs({
+        status: 'dead',
+        connectionId: 'conn-abc',
+        jobType: 'marketplace.offers.sync',
+        limit: 5,
+        offset: 10,
+      });
+
+      expect(syncJobRepository.findMany).toHaveBeenCalledWith(
+        { status: 'dead', connectionId: 'conn-abc', jobType: 'marketplace.offers.sync' },
+        { limit: 5, offset: 10 },
+      );
+    });
+
+    it('should serialize Date fields to ISO strings', async () => {
+      syncJobRepository.findMany.mockResolvedValue({ items: [makeSyncJob()], total: 1 });
+
+      const result = await controller.listJobs({});
+
+      expect(result.items[0].createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(result.items[0].nextRunAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('getJob', () => {
+    it('should return job DTO when job exists', async () => {
+      syncJobRepository.findById.mockResolvedValue(makeSyncJob({ lastError: 'boom', attempts: 2 }));
+
+      const result = await controller.getJob('job-1');
+
+      expect(result.id).toBe('job-1');
+      expect(result.lastError).toBe('boom');
+      expect(result.attempts).toBe(2);
+    });
+
+    it('should throw NotFoundException when job does not exist', async () => {
+      syncJobRepository.findById.mockResolvedValue(null);
+
+      await expect(controller.getJob('missing-id')).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/api/src/sync/http/sync.controller.spec.ts
+++ b/apps/api/src/sync/http/sync.controller.spec.ts
@@ -87,7 +87,7 @@ describe('SyncController', () => {
 
     it('should enqueue a job successfully', async () => {
       const expectedJobId = '1704110400000-0';
-      jobEnqueue.enqueueJob.mockResolvedValue(expectedJobId);
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: expectedJobId, isExisting: false });
 
       const result = await controller.enqueueJob(validDto);
 
@@ -108,8 +108,8 @@ describe('SyncController', () => {
     });
 
     it('should detect existing job (idempotent)', async () => {
-      const existingJobId = 'existing:marketplace:123e4567-e89b-12d3-a456-426614174000:orders:poll-1';
-      jobEnqueue.enqueueJob.mockResolvedValue(existingJobId);
+      const existingJobId = 'marketplace:123e4567-e89b-12d3-a456-426614174000:orders:poll-1';
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: existingJobId, isExisting: true });
 
       const result = await controller.enqueueJob(validDto);
 
@@ -155,7 +155,7 @@ describe('SyncController', () => {
           idempotencyKey: `test:${jobType}:1`,
         };
 
-        jobEnqueue.enqueueJob.mockResolvedValue(`job-${jobType}`);
+        jobEnqueue.enqueueJob.mockResolvedValue({ jobId: `job-${jobType}`, isExisting: false });
 
         const result = await controller.enqueueJob(dto);
 

--- a/apps/api/src/sync/http/sync.controller.ts
+++ b/apps/api/src/sync/http/sync.controller.ts
@@ -82,11 +82,7 @@ export class SyncController {
         idempotencyKey: dto.idempotencyKey,
       };
 
-      // Enqueue job
-      const jobId = await this.jobEnqueue.enqueueJob(jobRequest);
-
-      // Check if this is an existing job (idempotent)
-      const isExisting = jobId.startsWith('existing:');
+      const { jobId, isExisting } = await this.jobEnqueue.enqueueJob(jobRequest);
 
       this.logger.log(
         `Job enqueued successfully: ${jobId} (type: ${dto.jobType}, connection: ${dto.connectionId})`,

--- a/apps/api/src/sync/http/sync.controller.ts
+++ b/apps/api/src/sync/http/sync.controller.ts
@@ -9,17 +9,32 @@
 import {
   Controller,
   Post,
+  Get,
   Body,
+  Query,
+  Param,
   HttpCode,
   HttpStatus,
   BadRequestException,
+  NotFoundException,
   Inject,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
-import { JobEnqueuePort, JOB_ENQUEUE_TOKEN, SyncJobRequest } from '@openlinker/core/sync';
+import {
+  JobEnqueuePort,
+  JOB_ENQUEUE_TOKEN,
+  SyncJobRequest,
+  SyncJobRepositoryPort,
+  SYNC_JOB_REPOSITORY_TOKEN,
+} from '@openlinker/core/sync';
+import type { SyncJob } from '@openlinker/core/sync';
 import { EnqueueSyncJobDto } from './dto/enqueue-sync-job.dto';
 import { EnqueueSyncJobResponseDto } from './dto/enqueue-sync-job-response.dto';
+import { ListSyncJobsQueryDto } from './dto/list-sync-jobs-query.dto';
+import { SyncJobResponseDto } from './dto/sync-job-response.dto';
+import { PaginatedSyncJobsResponseDto } from './dto/paginated-sync-jobs-response.dto';
 import { Logger } from '@openlinker/shared/logging';
 
 @Roles('admin')
@@ -32,6 +47,8 @@ export class SyncController {
   constructor(
     @Inject(JOB_ENQUEUE_TOKEN)
     private readonly jobEnqueue: JobEnqueuePort,
+    @Inject(SYNC_JOB_REPOSITORY_TOKEN)
+    private readonly syncJobRepository: SyncJobRepositoryPort,
   ) {}
 
   @Post('jobs')
@@ -93,6 +110,63 @@ export class SyncController {
 
       throw new BadRequestException('Failed to enqueue job: Unknown error');
     }
+  }
+
+  @Get('jobs')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List sync jobs',
+    description: 'Returns a paginated list of sync jobs. Supports filtering by status, connectionId, and jobType.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated job list', type: PaginatedSyncJobsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listJobs(@Query() query: ListSyncJobsQueryDto): Promise<PaginatedSyncJobsResponseDto> {
+    const { status, connectionId, jobType, limit = 20, offset = 0 } = query;
+
+    const { items, total } = await this.syncJobRepository.findMany(
+      { status, connectionId, jobType },
+      { limit, offset },
+    );
+
+    return {
+      items: items.map((j) => this.toDto(j)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  @Get('jobs/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get sync job by ID' })
+  @ApiResponse({ status: 200, description: 'Job detail', type: SyncJobResponseDto })
+  @ApiResponse({ status: 404, description: 'Job not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getJob(@Param('id', ParseUUIDPipe) id: string): Promise<SyncJobResponseDto> {
+    const job = await this.syncJobRepository.findById(id);
+    if (!job) {
+      throw new NotFoundException(`Sync job not found: ${id}`);
+    }
+    return this.toDto(job);
+  }
+
+  private toDto(job: SyncJob): SyncJobResponseDto {
+    return {
+      id: job.id,
+      jobType: job.jobType,
+      connectionId: job.connectionId,
+      status: job.status,
+      attempts: job.attempts,
+      maxAttempts: job.maxAttempts,
+      nextRunAt: job.nextRunAt instanceof Date ? job.nextRunAt.toISOString() : job.nextRunAt,
+      lastError: job.lastError ?? null,
+      createdAt: job.createdAt instanceof Date ? job.createdAt.toISOString() : job.createdAt,
+      updatedAt: job.updatedAt instanceof Date ? job.updatedAt.toISOString() : job.updatedAt,
+      payloadJson: job.payload ?? null,
+      idempotencyKey: job.idempotencyKey ?? null,
+      lockedAt: job.lockedAt instanceof Date ? job.lockedAt.toISOString() : (job.lockedAt ?? null),
+      lockedBy: job.lockedBy ?? null,
+    };
   }
 }
 

--- a/apps/web/src/app/routes/jobs-logs.route.tsx
+++ b/apps/web/src/app/routes/jobs-logs.route.tsx
@@ -1,14 +1,11 @@
 import type { RouteObject } from 'react-router-dom';
-import { ModulePlaceholderPage } from '../../pages/placeholders/module-placeholder-page';
+import { SyncJobsPage } from '../../pages/sync-jobs/sync-jobs-page';
+import { SyncJobDetailPage } from '../../pages/sync-jobs/sync-job-detail-page';
 
 export const jobsLogsRoute: RouteObject = {
   path: 'jobs-logs',
-  element: (
-    <ModulePlaceholderPage
-      eyebrow="Operations"
-      title="Jobs and logs workspace"
-      moduleName="Jobs & Logs"
-      description="Background execution visibility, retry triage, and diagnostic log drilldowns will be grouped in this module."
-    />
-  ),
+  children: [
+    { index: true, element: <SyncJobsPage /> },
+    { path: ':id', element: <SyncJobDetailPage /> },
+  ],
 };

--- a/apps/web/src/features/sync-jobs/api/sync-jobs.types.ts
+++ b/apps/web/src/features/sync-jobs/api/sync-jobs.types.ts
@@ -1,0 +1,48 @@
+export const JOB_STATUS_VALUES = ['queued', 'running', 'succeeded', 'failed', 'dead'] as const;
+export type JobStatus = (typeof JOB_STATUS_VALUES)[number];
+
+export const JOB_TYPE_VALUES = [
+  'marketplace.orders.poll',
+  'marketplace.order.sync',
+  'marketplace.offers.sync',
+  'marketplace.offerQuantity.update',
+  'master.product.syncByExternalId',
+  'master.inventory.syncByExternalId',
+  'inventory.propagateToMarketplaces',
+] as const;
+export type JobType = (typeof JOB_TYPE_VALUES)[number];
+
+export interface SyncJob {
+  id: string;
+  jobType: string;
+  connectionId: string;
+  status: JobStatus;
+  attempts: number;
+  maxAttempts: number;
+  nextRunAt: string;
+  lastError: string | null;
+  payloadJson: Record<string, unknown> | null;
+  idempotencyKey: string | null;
+  lockedAt: string | null;
+  lockedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SyncJobFilters {
+  status?: JobStatus;
+  connectionId?: string;
+  jobType?: JobType;
+}
+
+export interface SyncJobPagination {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedSyncJobs {
+  items: SyncJob[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/web/src/features/sync-jobs/api/sync-jobs.types.ts
+++ b/apps/web/src/features/sync-jobs/api/sync-jobs.types.ts
@@ -1,4 +1,13 @@
-export const JOB_STATUS_VALUES = ['queued', 'running', 'succeeded', 'failed', 'dead'] as const;
+/**
+ * Sync Jobs Feature Types
+ *
+ * Frontend transport types for the sync jobs API. Mirrors the backend
+ * SyncJobResponseDto contract. All date fields are ISO 8601 strings.
+ *
+ * @module apps/web/src/features/sync-jobs/api
+ */
+
+export const JOB_STATUS_VALUES = ['queued', 'running', 'succeeded', 'dead'] as const;
 export type JobStatus = (typeof JOB_STATUS_VALUES)[number];
 
 export const JOB_TYPE_VALUES = [

--- a/apps/web/src/features/sync-jobs/api/sync.api.ts
+++ b/apps/web/src/features/sync-jobs/api/sync.api.ts
@@ -1,3 +1,10 @@
+import type {
+  SyncJob,
+  SyncJobFilters,
+  SyncJobPagination,
+  PaginatedSyncJobs,
+} from './sync-jobs.types';
+
 export interface EnqueueSyncJobInput {
   connectionId: string;
   syncType: string;
@@ -11,10 +18,23 @@ export interface SyncJobResponse {
 
 export interface SyncJobsApi {
   enqueue: (input: EnqueueSyncJobInput) => Promise<SyncJobResponse>;
+  list: (filters?: SyncJobFilters, pagination?: SyncJobPagination) => Promise<PaginatedSyncJobs>;
+  getById: (id: string) => Promise<SyncJob>;
 }
 
 interface ApiRequest {
   <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+function buildQuery(filters?: SyncJobFilters, pagination?: SyncJobPagination): string {
+  const params = new URLSearchParams();
+  if (filters?.status) params.set('status', filters.status);
+  if (filters?.connectionId) params.set('connectionId', filters.connectionId);
+  if (filters?.jobType) params.set('jobType', filters.jobType);
+  if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
+  if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
 }
 
 export function createSyncJobsApi(request: ApiRequest): SyncJobsApi {
@@ -24,6 +44,12 @@ export function createSyncJobsApi(request: ApiRequest): SyncJobsApi {
         method: 'POST',
         body: JSON.stringify(input),
       });
+    },
+    list(filters, pagination): Promise<PaginatedSyncJobs> {
+      return request<PaginatedSyncJobs>(`/sync/jobs${buildQuery(filters, pagination)}`);
+    },
+    getById(id): Promise<SyncJob> {
+      return request<SyncJob>(`/sync/jobs/${id}`);
     },
   };
 }

--- a/apps/web/src/features/sync-jobs/api/sync.api.ts
+++ b/apps/web/src/features/sync-jobs/api/sync.api.ts
@@ -1,3 +1,11 @@
+/**
+ * Sync Jobs API Client
+ *
+ * Thin API module for the sync jobs feature. Provides typed methods for
+ * enqueueing, listing, and fetching individual sync jobs via the REST API.
+ *
+ * @module apps/web/src/features/sync-jobs/api
+ */
 import type {
   SyncJob,
   SyncJobFilters,
@@ -7,7 +15,7 @@ import type {
 
 export interface EnqueueSyncJobInput {
   connectionId: string;
-  syncType: string;
+  jobType: string;
   payload?: Record<string, unknown>;
 }
 

--- a/apps/web/src/features/sync-jobs/api/sync.query-keys.ts
+++ b/apps/web/src/features/sync-jobs/api/sync.query-keys.ts
@@ -1,3 +1,8 @@
+import type { SyncJobFilters, SyncJobPagination } from './sync-jobs.types';
+
 export const syncJobsQueryKeys = {
   all: ['sync-jobs'] as const,
+  list: (filters?: SyncJobFilters, pagination?: SyncJobPagination) =>
+    ['sync-jobs', 'list', filters ?? {}, pagination ?? {}] as const,
+  detail: (id: string) => ['sync-jobs', 'detail', id] as const,
 };

--- a/apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.tsx
+++ b/apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.tsx
@@ -1,3 +1,12 @@
+/**
+ * Sync Job Status Badge
+ *
+ * Renders a semantic status badge for a sync job status value.
+ * Tone mapping mirrors the job lifecycle: queued → info, running → review,
+ * succeeded → success, dead → error.
+ *
+ * @module apps/web/src/features/sync-jobs/components
+ */
 import type { ReactElement } from 'react';
 import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
 import type { JobStatus } from '../api/sync-jobs.types';
@@ -6,7 +15,6 @@ const STATUS_TONE: Record<JobStatus, StatusBadgeTone> = {
   queued: 'info',
   running: 'review',
   succeeded: 'success',
-  failed: 'warning',
   dead: 'error',
 };
 

--- a/apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.tsx
+++ b/apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from 'react';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import type { JobStatus } from '../api/sync-jobs.types';
+
+const STATUS_TONE: Record<JobStatus, StatusBadgeTone> = {
+  queued: 'info',
+  running: 'review',
+  succeeded: 'success',
+  failed: 'warning',
+  dead: 'error',
+};
+
+interface SyncJobStatusBadgeProps {
+  status: string;
+}
+
+export function SyncJobStatusBadge({ status }: SyncJobStatusBadgeProps): ReactElement {
+  const tone: StatusBadgeTone = STATUS_TONE[status as JobStatus] ?? 'neutral';
+  return (
+    <StatusBadge tone={tone} withDot>
+      {status}
+    </StatusBadge>
+  );
+}

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.test.tsx
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useSyncJobQuery } from './use-sync-job-query';
+import type { SyncJob } from '../api/sync-jobs.types';
+
+function createWrapper(
+  apiClient: ReturnType<typeof createMockApiClient>,
+): ({ children }: PropsWithChildren) => ReactElement {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: PropsWithChildren): ReactElement {
+    return (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  };
+}
+
+const mockJob: SyncJob = {
+  id: 'job-1',
+  jobType: 'marketplace.orders.poll',
+  connectionId: 'conn-1',
+  status: 'succeeded',
+  attempts: 1,
+  maxAttempts: 10,
+  nextRunAt: '2026-01-01T00:00:00.000Z',
+  lastError: null,
+  payloadJson: { key: 'value' },
+  idempotencyKey: 'key-1',
+  lockedAt: null,
+  lockedBy: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('useSyncJobQuery', () => {
+  it('should return job data on success', async () => {
+    const apiClient = createMockApiClient({
+      syncJobs: { getById: vi.fn().mockResolvedValue(mockJob) },
+    });
+
+    const { result } = renderHook(() => useSyncJobQuery('job-1'), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.id).toBe('job-1');
+    expect(result.current.data?.status).toBe('succeeded');
+    expect(apiClient.syncJobs.getById).toHaveBeenCalledWith('job-1');
+  });
+
+  it('should be disabled when id is empty', () => {
+    const apiClient = createMockApiClient({
+      syncJobs: { getById: vi.fn() },
+    });
+
+    const { result } = renderHook(() => useSyncJobQuery(''), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(apiClient.syncJobs.getById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.ts
@@ -10,5 +10,6 @@ export function useSyncJobQuery(id: string): UseQueryResult<SyncJob> {
     queryKey: syncJobsQueryKeys.detail(id),
     queryFn: () => apiClient.syncJobs.getById(id),
     enabled: Boolean(id),
+    retry: false,
   });
 }

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.ts
@@ -1,0 +1,14 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { syncJobsQueryKeys } from '../api/sync.query-keys';
+import type { SyncJob } from '../api/sync-jobs.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useSyncJobQuery(id: string): UseQueryResult<SyncJob> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: syncJobsQueryKeys.detail(id),
+    queryFn: () => apiClient.syncJobs.getById(id),
+    enabled: Boolean(id),
+  });
+}

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.test.tsx
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useSyncJobsQuery } from './use-sync-jobs-query';
+import type { PaginatedSyncJobs } from '../api/sync-jobs.types';
+
+function createWrapper(
+  apiClient: ReturnType<typeof createMockApiClient>,
+): ({ children }: PropsWithChildren) => ReactElement {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: PropsWithChildren): ReactElement {
+    return (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  };
+}
+
+const mockResult: PaginatedSyncJobs = {
+  items: [
+    {
+      id: 'job-1',
+      jobType: 'marketplace.orders.poll',
+      connectionId: 'conn-1',
+      status: 'queued',
+      attempts: 0,
+      maxAttempts: 10,
+      nextRunAt: '2026-01-01T00:00:00.000Z',
+      lastError: null,
+      payloadJson: null,
+      idempotencyKey: 'key-1',
+      lockedAt: null,
+      lockedBy: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+  ],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+describe('useSyncJobsQuery', () => {
+  it('should return paginated jobs on success', async () => {
+    const apiClient = createMockApiClient({
+      syncJobs: { list: vi.fn().mockResolvedValue(mockResult) },
+    });
+
+    const { result } = renderHook(() => useSyncJobsQuery(), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.items).toHaveLength(1);
+    expect(result.current.data?.total).toBe(1);
+    expect(apiClient.syncJobs.list).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it('should pass filters to the API client', async () => {
+    const apiClient = createMockApiClient({
+      syncJobs: {
+        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 10, offset: 20 }),
+      },
+    });
+
+    renderHook(() => useSyncJobsQuery({ status: 'dead' }, { limit: 10, offset: 20 }), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    await waitFor(() =>
+      expect(apiClient.syncJobs.list).toHaveBeenCalledWith(
+        { status: 'dead' },
+        { limit: 10, offset: 20 },
+      ),
+    );
+  });
+});

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts
@@ -1,0 +1,16 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { syncJobsQueryKeys } from '../api/sync.query-keys';
+import type { PaginatedSyncJobs, SyncJobFilters, SyncJobPagination } from '../api/sync-jobs.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useSyncJobsQuery(
+  filters?: SyncJobFilters,
+  pagination?: SyncJobPagination,
+): UseQueryResult<PaginatedSyncJobs> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: syncJobsQueryKeys.list(filters, pagination),
+    queryFn: () => apiClient.syncJobs.list(filters, pagination),
+  });
+}

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts
@@ -12,5 +12,6 @@ export function useSyncJobsQuery(
   return useQuery({
     queryKey: syncJobsQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.syncJobs.list(filters, pagination),
+    retry: false,
   });
 }

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -1,0 +1,118 @@
+import type { ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobStatusBadge';
+import { useSyncJobQuery } from '../../features/sync-jobs/hooks/use-sync-job-query';
+
+export function SyncJobDetailPage(): ReactElement {
+  const { id = '' } = useParams<{ id: string }>();
+  const query = useSyncJobQuery(id);
+
+  if (query.isLoading) {
+    return (
+      <PageLayout eyebrow="Sync Jobs" title="Job detail">
+        <LoadingState liveRegion="off" title="Loading job" message="Fetching job details…" />
+      </PageLayout>
+    );
+  }
+
+  if (query.error || !query.data) {
+    return (
+      <PageLayout eyebrow="Sync Jobs" title="Job detail">
+        <ErrorState
+          title="Unable to load job"
+          message={query.error?.message ?? 'Job not found'}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      </PageLayout>
+    );
+  }
+
+  const job = query.data;
+
+  return (
+    <PageLayout
+      eyebrow="Sync Jobs"
+      title={<span className="mono-text">{job.jobType}</span>}
+      actions={
+        <Link to=".." relative="path" className="button button--ghost">
+          ← Back to jobs
+        </Link>
+      }
+    >
+      {/* Status + metadata */}
+      <section className="detail-section">
+        <dl className="detail-list">
+          <div className="detail-list__row">
+            <dt>Status</dt>
+            <dd><SyncJobStatusBadge status={job.status} /></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Job ID</dt>
+            <dd><span className="mono-text">{job.id}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Connection</dt>
+            <dd><span className="mono-text">{job.connectionId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Attempts</dt>
+            <dd>{job.attempts} / {job.maxAttempts}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Next run at</dt>
+            <dd>{new Date(job.nextRunAt).toLocaleString()}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Created</dt>
+            <dd>{new Date(job.createdAt).toLocaleString()}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Updated</dt>
+            <dd>{new Date(job.updatedAt).toLocaleString()}</dd>
+          </div>
+          {job.idempotencyKey ? (
+            <div className="detail-list__row">
+              <dt>Idempotency key</dt>
+              <dd><span className="mono-text">{job.idempotencyKey}</span></dd>
+            </div>
+          ) : null}
+          {job.lockedAt ? (
+            <div className="detail-list__row">
+              <dt>Locked at</dt>
+              <dd>{new Date(job.lockedAt).toLocaleString()}</dd>
+            </div>
+          ) : null}
+          {job.lockedBy ? (
+            <div className="detail-list__row">
+              <dt>Locked by</dt>
+              <dd><span className="mono-text">{job.lockedBy}</span></dd>
+            </div>
+          ) : null}
+        </dl>
+      </section>
+
+      {/* Error section */}
+      {job.lastError ? (
+        <section className="detail-section">
+          <h3 className="detail-section__title">Last error</h3>
+          <pre className="mono-text detail-section__pre">{job.lastError}</pre>
+        </section>
+      ) : null}
+
+      {/* Payload section */}
+      {job.payloadJson ? (
+        <section className="detail-section">
+          <h3 className="detail-section__title">Payload</h3>
+          <pre className="mono-text detail-section__pre">
+            {JSON.stringify(job.payloadJson, null, 2)}
+          </pre>
+        </section>
+      ) : null}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
@@ -1,0 +1,206 @@
+import type { ReactElement } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobStatusBadge';
+import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
+import type { SyncJob, SyncJobFilters, JobStatus, JobType } from '../../features/sync-jobs/api/sync-jobs.types';
+import { JOB_STATUS_VALUES, JOB_TYPE_VALUES } from '../../features/sync-jobs/api/sync-jobs.types';
+
+const PAGE_SIZE = 20;
+
+const COLUMNS: DataTableColumn<SyncJob>[] = [
+  {
+    id: 'status',
+    header: 'Status',
+    cell: (job) => <SyncJobStatusBadge status={job.status} />,
+  },
+  {
+    id: 'jobType',
+    header: 'Job type',
+    cell: (job) => <span className="mono-text">{job.jobType}</span>,
+  },
+  {
+    id: 'connectionId',
+    header: 'Connection',
+    cell: (job) => <span className="mono-text">{job.connectionId}</span>,
+  },
+  {
+    id: 'attempts',
+    header: 'Attempts',
+    align: 'right',
+    cell: (job) => `${job.attempts} / ${job.maxAttempts}`,
+  },
+  {
+    id: 'lastError',
+    header: 'Last error',
+    cell: (job) =>
+      job.lastError ? (
+        <span className="mono-text" title={job.lastError}>
+          {job.lastError.length > 60 ? `${job.lastError.slice(0, 60)}…` : job.lastError}
+        </span>
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+  {
+    id: 'createdAt',
+    header: 'Created',
+    cell: (job) => new Date(job.createdAt).toLocaleString(),
+  },
+  {
+    id: 'detail',
+    header: '',
+    cell: (job) => (
+      <Link to={job.id} className="button button--ghost button--compact">
+        View
+      </Link>
+    ),
+  },
+];
+
+export function SyncJobsPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const status = (searchParams.get('status') as JobStatus | null) ?? undefined;
+  const jobType = (searchParams.get('jobType') as JobType | null) ?? undefined;
+  const connectionId = searchParams.get('connectionId') ?? undefined;
+  const offset = Number(searchParams.get('offset') ?? '0');
+
+  const filters: SyncJobFilters = { status, jobType, connectionId };
+  const pagination = { limit: PAGE_SIZE, offset };
+
+  const query = useSyncJobsQuery(filters, pagination);
+
+  function setFilter(key: string, value: string): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      next.delete('offset'); // reset pagination on filter change
+      return next;
+    });
+  }
+
+  function setOffset(next: number): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === 0) {
+        p.delete('offset');
+      } else {
+        p.set('offset', String(next));
+      }
+      return p;
+    });
+  }
+
+  const total = query.data?.total ?? 0;
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  return (
+    <PageLayout
+      eyebrow="Operations"
+      title="Sync Jobs"
+      description="Background processing visibility — filter by status, job type, or connection."
+    >
+      {/* Filter bar */}
+      <div className="toolbar">
+        <select
+          aria-label="Filter by status"
+          value={status ?? ''}
+          onChange={(e) => { setFilter('status', e.target.value); }}
+        >
+          <option value="">All statuses</option>
+          {JOB_STATUS_VALUES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+
+        <select
+          aria-label="Filter by job type"
+          value={jobType ?? ''}
+          onChange={(e) => { setFilter('jobType', e.target.value); }}
+        >
+          <option value="">All job types</option>
+          {JOB_TYPE_VALUES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+
+        <input
+          aria-label="Filter by connection ID"
+          placeholder="Connection ID"
+          value={connectionId ?? ''}
+          onChange={(e) => { setFilter('connectionId', e.target.value); }}
+        />
+      </div>
+
+      {/* Table */}
+      {query.isLoading ? (
+        <LoadingState
+          liveRegion="off"
+          title="Loading jobs"
+          message="Fetching sync job data…"
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load sync jobs"
+          message={query.error.message}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      ) : (query.data?.items.length ?? 0) === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No jobs found"
+          message={
+            status || jobType || connectionId
+              ? 'No jobs match the current filters. Try clearing some filters.'
+              : 'No sync jobs have been enqueued yet.'
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Sync jobs"
+            columns={COLUMNS}
+            rows={query.data?.items ?? []}
+            rowKey={(job) => job.id}
+          />
+
+          {/* Pagination */}
+          <div className="toolbar" style={{ justifyContent: 'space-between' }}>
+            <span className="text-muted">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <Button
+                disabled={!hasPrev}
+                onClick={() => { setOffset(offset - PAGE_SIZE); }}
+              >
+                Previous
+              </Button>
+              <Button
+                disabled={!hasNext}
+                onClick={() => { setOffset(offset + PAGE_SIZE); }}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/shared/auth/jwt-bearer-session-adapter.test.ts
+++ b/apps/web/src/shared/auth/jwt-bearer-session-adapter.test.ts
@@ -69,7 +69,7 @@ describe('JwtBearerSessionAdapter', () => {
           username: 'admin',
           email: 'admin@example.com',
           role: 'admin',
-          permissions: ['read:products', 'connections:read'],
+          permissions: ['connections:read', 'read:products'],
         },
       });
       expect(fetchFn).toHaveBeenCalledWith('http://localhost:3000/auth/me', {

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -76,6 +76,13 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
         jobId: 'job_1',
         status: 'queued',
       }),
+      list: vi.fn().mockResolvedValue({
+        items: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      }),
+      getById: vi.fn().mockResolvedValue(null),
       ...overrides.syncJobs,
     } as ApiClient['syncJobs'],
   };

--- a/apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts
@@ -86,7 +86,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
           externalId: 'offer-id',
         },
       ]);
-      jobEnqueue.enqueueJob.mockResolvedValue('enqueued-job-id');
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'enqueued-job-id', isExisting: false });
 
       await handler.execute(job);
 
@@ -161,7 +161,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
           externalId: 'offer-id',
         },
       ]);
-      jobEnqueue.enqueueJob.mockResolvedValue('enqueued-job-id');
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'enqueued-job-id', isExisting: false });
 
       await handler.execute(job);
 
@@ -197,7 +197,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
           externalId: 'offer-id',
         },
       ]);
-      jobEnqueue.enqueueJob.mockResolvedValue('enqueued-job-id');
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'enqueued-job-id', isExisting: false });
 
       await handler.execute(job);
 
@@ -236,7 +236,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
           externalId: 'offer-id',
         },
       ]);
-      jobEnqueue.enqueueJob.mockResolvedValue('enqueued-job-id');
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'enqueued-job-id', isExisting: false });
 
       await handler.execute(job);
 
@@ -269,7 +269,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
           externalId: 'offer-id',
         },
       ]);
-      jobEnqueue.enqueueJob.mockResolvedValue('enqueued-job-id');
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'enqueued-job-id', isExisting: false });
 
       await handler.execute(job);
 
@@ -321,7 +321,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
           externalId: 'offer-2',
         },
       ]);
-      jobEnqueue.enqueueJob.mockResolvedValue('enqueued-job-id');
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'enqueued-job-id', isExisting: false });
 
       await handler.execute(job);
 

--- a/docs/plans/implementation-plan-sync-jobs-read-api-and-dashboard.md
+++ b/docs/plans/implementation-plan-sync-jobs-read-api-and-dashboard.md
@@ -1,0 +1,718 @@
+# Implementation Plan: Sync Jobs Read API + Dashboard
+
+**Date**: 2026-04-06
+**Status**: Ready for Review
+**Estimated Effort**: 4–6 hours
+**Issues**: [#70](https://github.com/SilkSoftwareHouse/openlinker/issues/70) (BE) · [#71](https://github.com/SilkSoftwareHouse/openlinker/issues/71) (FE)
+**Branch**: `70-71-sync-jobs-read-api-and-dashboard`
+
+---
+
+## 1. Task Summary
+
+**Objective**: Add `GET /sync/jobs` and `GET /sync/jobs/:id` REST endpoints that expose sync job state to the frontend, then build the sync jobs dashboard page that consumes those endpoints.
+
+**Context**: The backend has a full sync job persistence layer (`sync_jobs` table, `SyncJobRepository`, `SyncJobRepositoryPort`) but exposes only `POST /sync/jobs` for enqueuing. Operators have no visibility into job status, failure reasons, or retry state. The frontend route (`/jobs-logs`) exists as a placeholder.
+
+**Classification**: CORE / Infrastructure (BE repository) · Interface (API controller + DTOs) · Frontend Feature
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- Two new repository port methods: `findMany` (filtered, paginated list) and `findById`
+- Two new controller endpoints: `GET /sync/jobs` and `GET /sync/jobs/:id`
+- Request/response DTOs with Swagger docs
+- Frontend types, API client methods, React Query hooks
+- Sync jobs list page at `/jobs-logs` with status/type/connection filters and pagination
+- Sync job detail page at `/jobs-logs/:id` with all fields and failure display
+- Unit tests for new repository methods and new controller endpoints
+- Unit tests for new FE hooks
+
+### Out of Scope
+- Retry/requeue actions from the UI (tracked in #72)
+- Real-time streaming / WebSocket updates
+- Adding a DB index on `connectionId` or `createdAt` (noted as follow-up performance item)
+- Cursor-based pagination (offset is sufficient for MVP scale)
+
+### Constraints
+- All new endpoints are `@Roles('admin')` — no new auth surface
+- `payloadJson` is included in the detail response (admin-only, useful for debugging)
+- `lockedBy` / `lockedAt` are included only in the detail response
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layers**:
+- `libs/core/src/sync/` — domain port extension + repository implementation (CORE / Infrastructure)
+- `apps/api/src/sync/` — controller + DTOs (Interface layer)
+- `apps/web/src/features/sync-jobs/` — API client, types, query keys, hooks (FE Feature)
+- `apps/web/src/pages/sync-jobs/` — page components (FE Pages)
+- `apps/web/src/app/routes/` — route wiring (FE App)
+
+**Existing Ports Reused**:
+- `SyncJobRepositoryPort` — extended with two read methods (no new port)
+- `SYNC_JOB_REPOSITORY_TOKEN` — already exported from `CoreSyncModule`, injected directly into controller (same pattern as `JOB_ENQUEUE_TOKEN`)
+
+**New Components**:
+- `SyncJobFilters` + `SyncJobPagination` types in domain types
+- `findMany` + `findById` on `SyncJobRepositoryPort` + `SyncJobRepository`
+- 3 new API DTOs
+- 2 new controller methods
+- FE: `sync-jobs.types.ts`, extended `sync.api.ts`, extended `sync.query-keys.ts`, 2 hooks, 2 pages, 2 components
+
+**Core vs Integration**: Change is entirely in CORE (persistence layer) and Interface (API). No integration adapters touched.
+
+---
+
+## 4. External / Domain Research
+
+No external systems involved.
+
+### Internal Patterns
+- **Repository read pattern**: `findMany` uses TypeORM `findAndCount` with dynamic `where`, `order: { createdAt: 'DESC' }`, `take`/`skip`. Returns `{ items: SyncJob[]; total: number }`.
+- **Controller injection**: `SyncController` already injects `JOB_ENQUEUE_TOKEN` — inject `SYNC_JOB_REPOSITORY_TOKEN` the same way for reads.
+- **FE API client**: `createConnectionsApi(request)` factory pattern — replicate exactly in `createSyncJobsApi`.
+- **FE Query hooks**: `useConnectionsQuery` pattern — `useQuery` with `apiClient.syncJobs.list(filters)`.
+- **FE types**: Separate `*.types.ts` file with `as const` arrays for status/type values.
+- **FE status badge**: `StatusBadge` from `shared/ui` — map job status to `StatusBadgeTone`.
+
+---
+
+## 5. Questions & Assumptions
+
+### Assumptions
+1. **Offset pagination** is sufficient at current `sync_jobs` table size. Cursor pagination not needed for MVP.
+2. **`payloadJson` included in detail only** — list response excludes it to keep payloads small; detail response includes it.
+3. **`lockedBy`/`lockedAt` detail-only** — not operator-relevant in list view.
+4. **Default sort**: `createdAt DESC` (most recent first) — operators want to see latest jobs.
+5. **Default page size**: 20 jobs, max 100.
+6. **`status: 'failed'`** in the API means `status = 'queued'` with `attempts > 0` and `lastError IS NOT NULL` in the DB (the repository uses `queued` to re-enqueue failed jobs). To avoid confusing operators, the API presents `queued` + `lastError` as `'failed'` visually on the FE. The backend `status` field is returned as-is; the FE derives the display state.
+
+   **Actually**: After reading the repository, `markFailed` re-sets status to `'queued'` for retry. So from the DB there is no persistent `'failed'` status for retryable jobs — `'failed'` and `'dead'` are both terminal states only (`markDead` sets `status = 'dead'`). A job actively retrying shows as `'queued'` with `attempts > 0`. The FE should show `attempts` to communicate retry context.
+
+7. **No new DB migration needed** — no schema changes.
+
+### Open Questions
+- None — all ambiguities resolved above.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Backend: Domain Types + Repository Port
+
+**Goal**: Extend the domain contract to support read queries.
+
+#### Step 1 — Add filter/pagination types to `sync-job.types.ts`
+
+**File**: `libs/core/src/sync/domain/types/sync-job.types.ts`
+
+Add at the end of the existing file:
+
+```typescript
+export interface SyncJobFilters {
+  status?: JobStatus;
+  connectionId?: string;
+  jobType?: JobType;
+}
+
+export interface SyncJobPagination {
+  limit: number;   // 1–100
+  offset: number;  // >= 0
+}
+
+export interface PaginatedSyncJobs {
+  items: SyncJob[];
+  total: number;
+}
+```
+
+**Acceptance**: Types compile, no `any`.
+
+---
+
+#### Step 2 — Extend `SyncJobRepositoryPort` with read methods
+
+**File**: `libs/core/src/sync/domain/ports/sync-job-repository.port.ts`
+
+Add two methods to the interface:
+
+```typescript
+/**
+ * Find jobs matching filters with pagination.
+ * Results ordered by createdAt DESC.
+ */
+findMany(
+  filters: SyncJobFilters,
+  pagination: SyncJobPagination,
+): Promise<PaginatedSyncJobs>;
+
+/**
+ * Find a single job by ID. Returns null if not found.
+ */
+findById(id: string): Promise<SyncJob | null>;
+```
+
+**Acceptance**: Interface compiles; `SyncJobRepository` will need to implement the new methods (next step).
+
+---
+
+### Phase 2 — Backend: Repository Implementation
+
+**Goal**: Implement the new port methods in the infrastructure repository.
+
+#### Step 3 — Implement `findMany` and `findById` in `SyncJobRepository`
+
+**File**: `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts`
+
+`findById`:
+```typescript
+async findById(id: string): Promise<SyncJob | null> {
+  const entity = await this.repository.findOne({ where: { id } });
+  return entity ? this.toDomain(entity) : null;
+}
+```
+
+`findMany`:
+```typescript
+async findMany(
+  filters: SyncJobFilters,
+  pagination: SyncJobPagination,
+): Promise<PaginatedSyncJobs> {
+  const where: Record<string, unknown> = {};
+  if (filters.status) where['status'] = filters.status;
+  if (filters.connectionId) where['connectionId'] = filters.connectionId;
+  if (filters.jobType) where['jobType'] = filters.jobType;
+
+  const [entities, total] = await this.repository.findAndCount({
+    where,
+    order: { createdAt: 'DESC' },
+    take: pagination.limit,
+    skip: pagination.offset,
+  });
+
+  return {
+    items: entities.map((e) => this.toDomain(e)),
+    total,
+  };
+}
+```
+
+**Acceptance**: Unit test (mock TypeORM `Repository`) passes for filtered list, empty list, and single-item results.
+
+---
+
+#### Step 4 — Unit test for repository read methods
+
+**File**: `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.spec.ts` (new)
+
+Test cases:
+- `findById` returns domain entity when found
+- `findById` returns null when not found
+- `findMany` returns paginated items and total
+- `findMany` applies status filter correctly
+- `findMany` returns empty items and `total: 0` when no match
+
+**Acceptance**: All tests green with `pnpm test`.
+
+---
+
+### Phase 3 — Backend: API Layer
+
+**Goal**: Expose the read queries as REST endpoints with Swagger docs.
+
+#### Step 5 — `ListSyncJobsQueryDto`
+
+**File**: `apps/api/src/sync/http/dto/list-sync-jobs-query.dto.ts` (new)
+
+```typescript
+import { IsEnum, IsOptional, IsUUID, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { JobStatusValues, JobStatus, JobTypeValues, JobType } from '@openlinker/core/sync';
+
+export class ListSyncJobsQueryDto {
+  @ApiPropertyOptional({ enum: JobStatusValues })
+  @IsOptional()
+  @IsEnum(JobStatusValues)
+  status?: JobStatus;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUUID()
+  connectionId?: string;
+
+  @ApiPropertyOptional({ enum: JobTypeValues })
+  @IsOptional()
+  @IsEnum(JobTypeValues)
+  jobType?: JobType;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}
+```
+
+**Acceptance**: DTO validates correctly; invalid enum values rejected.
+
+---
+
+#### Step 6 — `SyncJobResponseDto`
+
+**File**: `apps/api/src/sync/http/dto/sync-job-response.dto.ts` (new)
+
+```typescript
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { JobStatusValues, JobTypeValues } from '@openlinker/core/sync';
+
+export class SyncJobResponseDto {
+  @ApiProperty() id: string;
+  @ApiProperty({ enum: JobTypeValues }) jobType: string;
+  @ApiProperty() connectionId: string;
+  @ApiProperty({ enum: JobStatusValues }) status: string;
+  @ApiProperty() attempts: number;
+  @ApiProperty() maxAttempts: number;
+  @ApiProperty() nextRunAt: string;
+  @ApiPropertyOptional({ nullable: true }) lastError: string | null;
+  @ApiProperty() createdAt: string;
+  @ApiProperty() updatedAt: string;
+  // Detail-only fields (null in list responses)
+  @ApiPropertyOptional({ nullable: true }) payloadJson: Record<string, unknown> | null;
+  @ApiPropertyOptional({ nullable: true }) lockedAt: string | null;
+  @ApiPropertyOptional({ nullable: true }) lockedBy: string | null;
+  @ApiPropertyOptional({ nullable: true }) idempotencyKey: string | null;
+}
+```
+
+> **Note**: All fields are included in both list and detail responses for simplicity. The FE list view renders a subset; the detail view renders all.
+
+---
+
+#### Step 7 — `PaginatedSyncJobsResponseDto`
+
+**File**: `apps/api/src/sync/http/dto/paginated-sync-jobs-response.dto.ts` (new)
+
+```typescript
+import { ApiProperty } from '@nestjs/swagger';
+import { SyncJobResponseDto } from './sync-job-response.dto';
+
+export class PaginatedSyncJobsResponseDto {
+  @ApiProperty({ type: [SyncJobResponseDto] }) items: SyncJobResponseDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() limit: number;
+  @ApiProperty() offset: number;
+}
+```
+
+---
+
+#### Step 8 — Extend `SyncController` with GET endpoints
+
+**File**: `apps/api/src/sync/http/sync.controller.ts`
+
+Add `SYNC_JOB_REPOSITORY_TOKEN` injection and two new methods:
+
+```typescript
+// Add to constructor:
+@Inject(SYNC_JOB_REPOSITORY_TOKEN)
+private readonly syncJobRepository: SyncJobRepositoryPort,
+
+// New methods:
+@Get('jobs')
+@HttpCode(HttpStatus.OK)
+async listJobs(@Query() query: ListSyncJobsQueryDto): Promise<PaginatedSyncJobsResponseDto> { ... }
+
+@Get('jobs/:id')
+@HttpCode(HttpStatus.OK)
+async getJob(@Param('id', ParseUUIDPipe) id: string): Promise<SyncJobResponseDto> { ... }
+```
+
+`listJobs` maps `query` → `SyncJobFilters` + `SyncJobPagination`, calls `syncJobRepository.findMany(...)`, maps result to `PaginatedSyncJobsResponseDto`.
+
+`getJob` calls `syncJobRepository.findById(id)`, throws `NotFoundException` if null, maps to `SyncJobResponseDto`.
+
+**Mapper**: Private `toDto(job: SyncJob): SyncJobResponseDto` method on the controller — converts Dates to ISO strings, passes through all fields.
+
+**Acceptance**: `GET /sync/jobs` returns paginated list; filters work; `GET /sync/jobs/:id` returns detail; unknown ID returns 404.
+
+---
+
+#### Step 9 — Unit test for new controller methods
+
+**File**: `apps/api/src/sync/http/sync.controller.spec.ts` (new)
+
+Test cases:
+- `listJobs` returns paginated response from repository
+- `listJobs` passes filters through correctly
+- `getJob` returns job when found
+- `getJob` throws `NotFoundException` when not found
+
+Mock `SYNC_JOB_REPOSITORY_TOKEN` and `JOB_ENQUEUE_TOKEN`.
+
+**Acceptance**: All tests green.
+
+---
+
+### Phase 4 — Frontend: Types, API Client, Query Keys, Hooks
+
+**Goal**: FE data layer to consume the new endpoints.
+
+#### Step 10 — `sync-jobs.types.ts`
+
+**File**: `apps/web/src/features/sync-jobs/api/sync-jobs.types.ts` (new)
+
+```typescript
+export const JOB_STATUS_VALUES = ['queued', 'running', 'succeeded', 'failed', 'dead'] as const;
+export type JobStatus = (typeof JOB_STATUS_VALUES)[number];
+
+export const JOB_TYPE_VALUES = [
+  'marketplace.orders.poll',
+  'marketplace.order.sync',
+  'marketplace.offers.sync',
+  'marketplace.offerQuantity.update',
+  'master.product.syncByExternalId',
+  'master.inventory.syncByExternalId',
+  'inventory.propagateToMarketplaces',
+] as const;
+export type JobType = (typeof JOB_TYPE_VALUES)[number];
+
+export interface SyncJob {
+  id: string;
+  jobType: string;
+  connectionId: string;
+  status: JobStatus;
+  attempts: number;
+  maxAttempts: number;
+  nextRunAt: string;
+  lastError: string | null;
+  payloadJson: Record<string, unknown> | null;
+  lockedAt: string | null;
+  lockedBy: string | null;
+  idempotencyKey: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SyncJobFilters {
+  status?: JobStatus;
+  connectionId?: string;
+  jobType?: JobType;
+}
+
+export interface SyncJobPagination {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedSyncJobs {
+  items: SyncJob[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+```
+
+**Acceptance**: No `any`, all values typed.
+
+---
+
+#### Step 11 — Extend `sync.api.ts`
+
+**File**: `apps/web/src/features/sync-jobs/api/sync.api.ts`
+
+Add to `SyncJobsApi` interface and `createSyncJobsApi` factory:
+
+```typescript
+list: (filters?: SyncJobFilters, pagination?: SyncJobPagination) => Promise<PaginatedSyncJobs>;
+getById: (id: string) => Promise<SyncJob>;
+```
+
+`list` builds query string from filters + pagination params (limit, offset), calls `GET /sync/jobs?...`.
+`getById` calls `GET /sync/jobs/:id`.
+
+**Acceptance**: Methods typed, query string builder handles all optional params correctly.
+
+---
+
+#### Step 12 — Extend `sync.query-keys.ts`
+
+**File**: `apps/web/src/features/sync-jobs/api/sync.query-keys.ts`
+
+```typescript
+export const syncJobsQueryKeys = {
+  all: ['sync-jobs'] as const,
+  list: (filters?: SyncJobFilters, pagination?: SyncJobPagination) =>
+    ['sync-jobs', 'list', filters ?? {}, pagination ?? {}] as const,
+  detail: (id: string) => ['sync-jobs', 'detail', id] as const,
+};
+```
+
+---
+
+#### Step 13 — `use-sync-jobs-query.ts`
+
+**File**: `apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts` (new)
+
+```typescript
+export function useSyncJobsQuery(
+  filters?: SyncJobFilters,
+  pagination?: SyncJobPagination,
+): UseQueryResult<PaginatedSyncJobs> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: syncJobsQueryKeys.list(filters, pagination),
+    queryFn: () => apiClient.syncJobs.list(filters, pagination),
+  });
+}
+```
+
+---
+
+#### Step 14 — `use-sync-job-query.ts`
+
+**File**: `apps/web/src/features/sync-jobs/hooks/use-sync-job-query.ts` (new)
+
+```typescript
+export function useSyncJobQuery(id: string): UseQueryResult<SyncJob> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: syncJobsQueryKeys.detail(id),
+    queryFn: () => apiClient.syncJobs.getById(id),
+    enabled: Boolean(id),
+  });
+}
+```
+
+---
+
+### Phase 5 — Frontend: Components + Pages + Routes
+
+**Goal**: Operator-facing UI for sync job visibility.
+
+#### Step 15 — `SyncJobStatusBadge` component
+
+**File**: `apps/web/src/features/sync-jobs/components/sync-job-status-badge.tsx` (new)
+
+Maps `JobStatus` → `StatusBadgeTone`:
+
+| Status | Tone |
+|---|---|
+| `queued` | `info` |
+| `running` | `review` |
+| `succeeded` | `success` |
+| `failed` | `warning` |
+| `dead` | `error` |
+
+```typescript
+export function SyncJobStatusBadge({ status }: { status: string }): ReactElement {
+  const tone = STATUS_TONE_MAP[status as JobStatus] ?? 'neutral';
+  return <StatusBadge tone={tone} withDot>{status}</StatusBadge>;
+}
+```
+
+**Acceptance**: Renders correct tone for each status; unknown status falls back to `neutral`.
+
+---
+
+#### Step 16 — Sync jobs list page
+
+**File**: `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx` (new)
+
+Structure:
+```
+PageLayout (eyebrow="Operations", title="Sync Jobs")
+  ├── Filter bar (status Select, jobType Select, connectionId input)
+  ├── DataTable (columns: status, jobType, connectionId, attempts, lastError, createdAt)
+  │     rows link to /jobs-logs/:id
+  └── Pagination controls (Prev / Next buttons, "Showing X–Y of Z")
+```
+
+State:
+- Filters: URL search params (`?status=&jobType=&connectionId=`)
+- Pagination: URL search params (`?limit=20&offset=0`)
+- Server state: `useSyncJobsQuery(filters, pagination)`
+
+All states handled: loading skeleton → error state (`FeedbackState`) → empty state → data.
+
+**Acceptance**: Renders table; filter changes update URL + refetch; pagination works; error and empty states display.
+
+---
+
+#### Step 17 — Sync job detail page
+
+**File**: `apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx` (new)
+
+Structure:
+```
+PageLayout (eyebrow="Sync Jobs", title=jobType, back link)
+  ├── Status + metadata section (id, status badge, connectionId, attempts/maxAttempts, timestamps)
+  ├── Error section (if lastError) — monospace pre block with error text
+  └── Payload section (payloadJson) — monospace pre block, JSON.stringify(…, null, 2)
+```
+
+Uses `useSyncJobQuery(id)` from URL param.
+Loading → error (`FeedbackState`) → data.
+
+**Acceptance**: Renders all fields; error section only visible when `lastError` present.
+
+---
+
+#### Step 18 — Wire routes
+
+**File**: `apps/web/src/app/routes/jobs-logs.route.tsx`
+
+Replace the `ModulePlaceholderPage` stub with real pages:
+
+```typescript
+export const jobsLogsRoute: RouteObject = {
+  path: 'jobs-logs',
+  children: [
+    { index: true, element: <SyncJobsPage /> },
+    { path: ':id', element: <SyncJobDetailPage /> },
+  ],
+};
+```
+
+**Acceptance**: `/jobs-logs` renders list; `/jobs-logs/:id` renders detail; back navigation works.
+
+---
+
+### Phase 6 — Frontend: Tests
+
+#### Step 19 — Hook unit tests
+
+**Files**:
+- `apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.test.ts` (new)
+- `apps/web/src/features/sync-jobs/hooks/use-sync-job-query.test.ts` (new)
+
+Test with `renderWithProviders` + `createMockApiClient`:
+- `useSyncJobsQuery` returns paginated data on success
+- `useSyncJobsQuery` is in loading state initially
+- `useSyncJobQuery` returns job data on success
+- `useSyncJobQuery` is disabled when id is empty
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: New `SyncJobQueryService` application service
+**Description**: Wrap `findMany`/`findById` in a dedicated application service rather than injecting the repository directly into the controller.
+**Why Rejected**: The existing `SyncController` already injects `JobEnqueuePort` directly — a consistent pattern. A separate query service adds a file and an interface for zero architectural gain at this scope.
+
+### Alternative 2: Cursor-based pagination
+**Description**: Use `createdAt` as a cursor instead of offset.
+**Why Rejected**: Offset pagination is simpler to implement and consume for an admin tool where operators navigate by page. The `sync_jobs` table is unlikely to grow large enough for offset to be a problem at MVP stage.
+
+### Alternative 3: Separate list/detail DTOs
+**Description**: Return a slimmer `SyncJobSummaryDto` in the list (excluding `payloadJson`, `lockedBy`, etc.) and a full `SyncJobResponseDto` for detail.
+**Why Rejected**: Minimal bandwidth benefit since `payloadJson` is typically a small object. Single DTO keeps the mapping code simpler and avoids type proliferation.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Repository port extended in domain layer, implementation in infrastructure layer
+- ✅ Controller in interface layer, injects via Symbol token — no concrete class dependency
+- ✅ No TypeORM in application layer
+- ✅ FE: API client in `features/`, pages in `pages/`, components colocated with feature
+
+### Naming Conventions
+- ✅ `list-sync-jobs-query.dto.ts`, `sync-job-response.dto.ts` — follow `*.dto.ts` pattern
+- ✅ `use-sync-jobs-query.ts`, `use-sync-job-query.ts` — follow `use-*.ts` pattern
+- ✅ `sync-job-status-badge.tsx` — `PascalCase` component
+
+### Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `ORDER BY createdAt DESC` slow on large table | Low (MVP) | Add `@Index('createdAt')` if table grows; noted in plan |
+| `connectionId` filter full-scan | Low (MVP) | Add `@Index('connectionId')` when needed |
+| FE pagination offset drift (items inserted while browsing) | Low | Cosmetically acceptable for operator tool; no fix needed at MVP |
+| `toDomain` throws on unknown `jobType` in DB | Existing risk | Already guarded in existing `toDomain` method |
+
+### Edge Cases
+- `GET /sync/jobs/:id` with non-UUID → `ParseUUIDPipe` returns 400 automatically
+- `GET /sync/jobs` with `limit=0` → class-validator `@Min(1)` returns 400
+- `offset` greater than `total` → returns `items: [], total: N` (correct behaviour)
+- `findMany` with no filters → returns all jobs paginated (intended)
+
+### Backward Compatibility
+- ✅ Only additive changes — new repository methods, new endpoints, new FE files
+- ✅ Existing `POST /sync/jobs` unchanged
+- ✅ Existing `createSyncJobsApi` extended (not replaced); `enqueue` method preserved
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+
+| File | What's tested |
+|---|---|
+| `sync-job.repository.spec.ts` (new) | `findById` found/not found; `findMany` with filters, pagination, empty result |
+| `sync.controller.spec.ts` (new) | `listJobs` paginated response, filter passthrough; `getJob` found/not found (404) |
+| `use-sync-jobs-query.test.ts` (new) | Loading → success; filters passed to API client |
+| `use-sync-job-query.test.ts` (new) | Loading → success; disabled when id empty |
+
+### Integration Tests
+Not required for this slice. The repository's `findAndCount` is standard TypeORM — no raw SQL involved — making mocked unit tests reliable.
+
+### Manual Verification
+1. `pnpm start:dev:api` → `GET /sync/jobs` returns `{ items: [], total: 0, limit: 20, offset: 0 }`
+2. Enqueue a job via `POST /sync/jobs` → appears in `GET /sync/jobs`
+3. Filter by `status=queued` → returns only queued jobs
+4. `GET /sync/jobs/:id` with valid ID → full detail
+5. `GET /sync/jobs/not-a-uuid` → 400
+6. `GET /sync/jobs/00000000-0000-0000-0000-000000000000` → 404
+7. FE: `/jobs-logs` loads list; filters update URL; row click navigates to `/jobs-logs/:id`
+
+### Acceptance Criteria
+- [ ] `GET /sync/jobs` returns paginated list with optional status/connectionId/jobType filters
+- [ ] `GET /sync/jobs/:id` returns full job detail; unknown ID returns 404
+- [ ] All responses include ISO timestamps and failure reason
+- [ ] Frontend `/jobs-logs` renders list with all states (loading, empty, error, data)
+- [ ] Frontend `/jobs-logs/:id` renders detail with error/payload sections
+- [ ] Status filter, jobType filter, and pagination work end-to-end
+- [ ] `pnpm lint` passes
+- [ ] `pnpm type-check` passes
+- [ ] `pnpm test` passes (unit tests green)
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture (port in domain, impl in infrastructure, controller in interface)
+- [x] Respects CORE vs Integration boundaries — no integration adapters touched
+- [x] Uses existing patterns (`createConnectionsApi` factory, `useQuery` hooks, `DataTable` + `StatusBadge`)
+- [x] Idempotency considered — read-only endpoints, no side effects
+- [x] Event-driven patterns N/A for read API
+- [x] Rate limits N/A (internal admin API)
+- [x] Error handling comprehensive (`NotFoundException` for missing job, `ParseUUIDPipe` for bad ID, `FeedbackState` on FE)
+- [x] Testing strategy complete (unit tests for all new logic)
+- [x] Naming conventions followed (BE + FE)
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)
+- [Frontend Architecture](../frontend-architecture.md)

--- a/libs/core/src/sync/application/services/sync-job-queue.service.ts
+++ b/libs/core/src/sync/application/services/sync-job-queue.service.ts
@@ -47,7 +47,7 @@ export class SyncJobQueueService implements SyncJobQueuePort {
         idempotencyKey: req.options.dedupeKey,
       };
 
-      const jobId = await this.jobEnqueue.enqueueJob(jobRequest);
+      const { jobId } = await this.jobEnqueue.enqueueJob(jobRequest);
       jobIds.push(jobId);
     }
 

--- a/libs/core/src/sync/domain/exceptions/invalid-sync-job-state.error.ts
+++ b/libs/core/src/sync/domain/exceptions/invalid-sync-job-state.error.ts
@@ -1,0 +1,25 @@
+/**
+ * Invalid Sync Job State Error
+ *
+ * Domain exception thrown when a sync job record in the database contains a
+ * value that does not match the known JobType or JobStatus sets. This indicates
+ * a data-integrity issue (e.g. a stale record from a schema migration or a
+ * manual database edit).
+ *
+ * @module libs/core/src/sync/domain/exceptions
+ */
+export class InvalidSyncJobStateError extends Error {
+  constructor(
+    public readonly field: 'jobType' | 'status',
+    public readonly value: string,
+    public readonly jobId?: string,
+  ) {
+    super(
+      `Invalid sync job ${field} "${value}"${jobId ? ` for job ${jobId}` : ''}`,
+    );
+    this.name = 'InvalidSyncJobStateError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidSyncJobStateError);
+    }
+  }
+}

--- a/libs/core/src/sync/domain/ports/job-enqueue.port.ts
+++ b/libs/core/src/sync/domain/ports/job-enqueue.port.ts
@@ -9,7 +9,7 @@
  * @module libs/core/src/sync/domain/ports
  * @see {@link RedisStreamsJobEnqueueService} for the Redis Streams implementation
  */
-import { SyncJobRequest } from '../types/sync-job.types';
+import { EnqueueJobResult, SyncJobRequest } from '../types/sync-job.types';
 
 /**
  * Job Enqueue Port
@@ -27,10 +27,10 @@ export interface JobEnqueuePort {
    * job requests under handler retries, parallel consumers, and pending re-deliveries.
    *
    * @param job - The sync job request to enqueue
-   * @returns Promise resolving to the job ID assigned by the queue
+   * @returns Promise resolving to the enqueue result (job ID + idempotency flag)
    * @throws Error if enqueueing fails
    */
-  enqueueJob(job: SyncJobRequest): Promise<string>;
+  enqueueJob(job: SyncJobRequest): Promise<EnqueueJobResult>;
 }
 
 

--- a/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
+++ b/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
@@ -10,6 +10,7 @@
  * @see {@link SyncJobRepository} for the TypeORM implementation
  */
 import { SyncJob } from '../entities/sync-job.entity';
+import { SyncJobFilters, SyncJobPagination, PaginatedSyncJobs } from '../types/sync-job.types';
 
 /**
  * Sync Job Repository Port
@@ -66,6 +67,17 @@ export interface SyncJobRepositoryPort {
    * @param error - Final error message
    */
   markDead(id: string, error: string): Promise<void>;
+
+  /**
+   * Find jobs matching filters with offset pagination.
+   * Results are ordered by createdAt DESC.
+   */
+  findMany(filters: SyncJobFilters, pagination: SyncJobPagination): Promise<PaginatedSyncJobs>;
+
+  /**
+   * Find a single job by ID. Returns null if not found.
+   */
+  findById(id: string): Promise<SyncJob | null>;
 
   /**
    * Requeue stuck jobs (optional helper)

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -44,7 +44,6 @@ export const JobStatusValues = [
   'queued',
   'running',
   'succeeded',
-  'failed',
   'dead',
 ] as const;
 
@@ -55,6 +54,19 @@ export const JobStatusValues = [
  * without runtime overhead.
  */
 export type JobStatus = (typeof JobStatusValues)[number];
+
+/**
+ * Enqueue Job Result
+ *
+ * Returned by JobEnqueuePort.enqueueJob. Separates the job ID from the
+ * idempotency flag so callers do not need to parse string prefixes.
+ */
+export interface EnqueueJobResult {
+  /** Job ID assigned by the queue (stream message ID or existing job ID) */
+  jobId: string;
+  /** True when the idempotency key matched an already-enqueued job */
+  isExisting: boolean;
+}
 
 /**
  * Sync Job Request

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -87,6 +87,40 @@ export interface SyncJobRequest {
 }
 
 /**
+ * Sync Job Filters
+ *
+ * Criteria for querying sync jobs. All fields are optional — omitting a field
+ * means no filter is applied for that dimension.
+ */
+export interface SyncJobFilters {
+  status?: JobStatus;
+  connectionId?: string;
+  jobType?: JobType;
+}
+
+/**
+ * Sync Job Pagination
+ *
+ * Offset-based pagination parameters for sync job list queries.
+ */
+export interface SyncJobPagination {
+  /** Number of items to return (1–100) */
+  limit: number;
+  /** Number of items to skip */
+  offset: number;
+}
+
+/**
+ * Paginated Sync Jobs
+ *
+ * Result of a paginated sync job query.
+ */
+export interface PaginatedSyncJobs {
+  items: SyncJob[];
+  total: number;
+}
+
+/**
  * Sync Job (Persisted)
  *
  * Represents a persisted sync job in the database. Extends SyncJobRequest

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -19,7 +19,15 @@ export { SyncLockPort, SyncLockToken } from './application/ports/sync-lock.port'
 export { SyncJob as SyncJobEntity } from './domain/entities/sync-job.entity';
 
 // Types
-export type { SyncJob, SyncJobRequest, JobType, JobStatus } from './domain/types/sync-job.types';
+export type {
+  SyncJob,
+  SyncJobRequest,
+  JobType,
+  JobStatus,
+  SyncJobFilters,
+  SyncJobPagination,
+  PaginatedSyncJobs,
+} from './domain/types/sync-job.types';
 export { JobTypeValues, JobStatusValues } from './domain/types/sync-job.types';
 export {
   MarketplaceOrdersPollPayloadV1,

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -22,6 +22,7 @@ export { SyncJob as SyncJobEntity } from './domain/entities/sync-job.entity';
 export type {
   SyncJob,
   SyncJobRequest,
+  EnqueueJobResult,
   JobType,
   JobStatus,
   SyncJobFilters,
@@ -42,6 +43,7 @@ export {
 
 // Exceptions
 export { SyncJobExecutionError } from './domain/exceptions/sync-job-execution.error';
+export { InvalidSyncJobStateError } from './domain/exceptions/invalid-sync-job-state.error';
 
 // Infrastructure exports (for testing/mocking)
 export { RedisStreamsJobEnqueueService } from './infrastructure/adapters/redis-streams-job-enqueue.service';

--- a/libs/core/src/sync/infrastructure/adapters/__tests__/redis-streams-job-enqueue.service.spec.ts
+++ b/libs/core/src/sync/infrastructure/adapters/__tests__/redis-streams-job-enqueue.service.spec.ts
@@ -61,7 +61,7 @@ describe('RedisStreamsJobEnqueueService', () => {
 
       const result = await service.enqueueJob(jobRequest);
 
-      expect(result).toBe(messageId);
+      expect(result).toEqual({ jobId: messageId, isExisting: false });
       expect(redisClient.set).toHaveBeenCalledWith(
         idempotencyKey,
         'enqueued',
@@ -100,7 +100,7 @@ describe('RedisStreamsJobEnqueueService', () => {
 
       const result = await service.enqueueJob(jobRequest);
 
-      expect(result).toBe(`existing:${jobRequest.idempotencyKey}`);
+      expect(result).toEqual({ jobId: jobRequest.idempotencyKey, isExisting: true });
       expect(redisClient.set).toHaveBeenCalledWith(
         idempotencyKey,
         'enqueued',

--- a/libs/core/src/sync/infrastructure/adapters/redis-streams-job-enqueue.service.ts
+++ b/libs/core/src/sync/infrastructure/adapters/redis-streams-job-enqueue.service.ts
@@ -12,7 +12,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { RedisClientType } from 'redis';
 import { JobEnqueuePort } from '../../domain/ports/job-enqueue.port';
-import { SyncJobRequest } from '../../domain/types/sync-job.types';
+import { EnqueueJobResult, SyncJobRequest } from '../../domain/types/sync-job.types';
 import { Logger } from '@openlinker/shared/logging';
 
 @Injectable()
@@ -27,7 +27,7 @@ export class RedisStreamsJobEnqueueService implements JobEnqueuePort {
     private readonly redisClient: RedisClientType,
   ) {}
 
-  async enqueueJob(job: SyncJobRequest): Promise<string> {
+  async enqueueJob(job: SyncJobRequest): Promise<EnqueueJobResult> {
     const idempotencyKey = `${this.IDEMPOTENCY_KEY_PREFIX}${job.idempotencyKey}`;
 
     try {
@@ -38,15 +38,10 @@ export class RedisStreamsJobEnqueueService implements JobEnqueuePort {
       });
 
       if (idempotencyResult !== 'OK') {
-        // Job already enqueued - return existing job ID
-        // We store the job ID in the idempotency key value, but for MVP we'll
-        // return a deterministic ID based on the idempotency key
         this.logger.debug(
           `Job already enqueued (idempotent): ${job.jobType} for ${job.connectionId}`,
         );
-        // For MVP, we can't retrieve the original job ID, so we return a deterministic one
-        // In a full implementation, we might store jobId -> idempotencyKey mapping
-        return `existing:${job.idempotencyKey}`;
+        return { jobId: job.idempotencyKey, isExisting: true };
       }
 
       // Build field map for XADD command
@@ -68,7 +63,6 @@ export class RedisStreamsJobEnqueueService implements JobEnqueuePort {
         await this.redisClient.del(idempotencyKey).catch(() => {
           // Ignore cleanup errors
         });
-        // Throw consistent error message format
         throw new Error(`Failed to enqueue job to stream: ${this.STREAM_NAME}`);
       }
 
@@ -88,7 +82,7 @@ export class RedisStreamsJobEnqueueService implements JobEnqueuePort {
         `Enqueued job ${job.jobType} for ${job.connectionId} with message ID ${messageId}`,
       );
 
-      return messageId;
+      return { jobId: messageId, isExisting: false };
     } catch (error) {
       this.logger.error(
         `Failed to enqueue job ${job.jobType} for ${job.connectionId}`,

--- a/libs/core/src/sync/infrastructure/persistence/repositories/__tests__/sync-job.repository.spec.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/__tests__/sync-job.repository.spec.ts
@@ -567,7 +567,7 @@ describe('SyncJobRepository', () => {
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-      expect(() => (repository as any).toDomain(ormEntity)).toThrow('Invalid job type in database');
+      expect(() => (repository as any).toDomain(ormEntity)).toThrow('Invalid sync job jobType');
     });
 
     it('should throw error for invalid job status', () => {
@@ -578,7 +578,7 @@ describe('SyncJobRepository', () => {
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-      expect(() => (repository as any).toDomain(ormEntity)).toThrow('Invalid job status in database');
+      expect(() => (repository as any).toDomain(ormEntity)).toThrow('Invalid sync job status');
     });
   });
 });

--- a/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.spec.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Sync Job Repository Unit Tests
+ *
+ * Tests for the read methods added to SyncJobRepository:
+ * findById and findMany (with filters and pagination).
+ *
+ * @module libs/core/src/sync/infrastructure/persistence/repositories
+ */
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Repository } from 'typeorm';
+import { SyncJobRepository } from './sync-job.repository';
+import { SyncJobOrmEntity } from '../entities/sync-job.orm-entity';
+
+function makeOrmEntity(overrides: Partial<SyncJobOrmEntity> = {}): SyncJobOrmEntity {
+  const e = new SyncJobOrmEntity();
+  e.id = 'job-1';
+  e.jobType = 'marketplace.orders.poll';
+  e.connectionId = 'conn-1';
+  e.payloadJson = {};
+  e.status = 'queued';
+  e.idempotencyKey = 'key-1';
+  e.attempts = 0;
+  e.maxAttempts = 10;
+  e.nextRunAt = new Date('2026-01-01T00:00:00Z');
+  e.lockedAt = null;
+  e.lockedBy = null;
+  e.lastError = null;
+  e.createdAt = new Date('2026-01-01T00:00:00Z');
+  e.updatedAt = new Date('2026-01-01T00:00:00Z');
+  return Object.assign(e, overrides);
+}
+
+describe('SyncJobRepository', () => {
+  let repo: SyncJobRepository;
+  let ormRepo: jest.Mocked<Repository<SyncJobOrmEntity>>;
+
+  beforeEach(async () => {
+    const mockOrmRepo = {
+      findOne: jest.fn(),
+      findAndCount: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
+      createQueryBuilder: jest.fn(),
+      manager: { connection: { transaction: jest.fn() } },
+    } as unknown as jest.Mocked<Repository<SyncJobOrmEntity>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SyncJobRepository,
+        {
+          provide: getRepositoryToken(SyncJobOrmEntity),
+          useValue: mockOrmRepo,
+        },
+      ],
+    }).compile();
+
+    repo = module.get(SyncJobRepository);
+    ormRepo = module.get(getRepositoryToken(SyncJobOrmEntity));
+  });
+
+  describe('findById', () => {
+    it('should return domain entity when job exists', async () => {
+      ormRepo.findOne.mockResolvedValue(makeOrmEntity());
+
+      const result = await repo.findById('job-1');
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('job-1');
+      expect(result?.jobType).toBe('marketplace.orders.poll');
+      expect(ormRepo.findOne).toHaveBeenCalledWith({ where: { id: 'job-1' } });
+    });
+
+    it('should return null when job does not exist', async () => {
+      ormRepo.findOne.mockResolvedValue(null);
+
+      const result = await repo.findById('missing-id');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findMany', () => {
+    it('should return paginated items and total', async () => {
+      const entities = [makeOrmEntity(), makeOrmEntity({ id: 'job-2' })];
+      ormRepo.findAndCount.mockResolvedValue([entities, 2]);
+
+      const result = await repo.findMany({}, { limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(ormRepo.findAndCount).toHaveBeenCalledWith({
+        where: {},
+        order: { createdAt: 'DESC' },
+        take: 20,
+        skip: 0,
+      });
+    });
+
+    it('should apply status filter', async () => {
+      ormRepo.findAndCount.mockResolvedValue([[makeOrmEntity({ status: 'running' })], 1]);
+
+      await repo.findMany({ status: 'running' }, { limit: 10, offset: 0 });
+
+      expect(ormRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { status: 'running' } }),
+      );
+    });
+
+    it('should apply connectionId filter', async () => {
+      ormRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await repo.findMany({ connectionId: 'conn-abc' }, { limit: 20, offset: 0 });
+
+      expect(ormRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { connectionId: 'conn-abc' } }),
+      );
+    });
+
+    it('should apply jobType filter', async () => {
+      ormRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await repo.findMany({ jobType: 'marketplace.offers.sync' }, { limit: 20, offset: 0 });
+
+      expect(ormRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { jobType: 'marketplace.offers.sync' } }),
+      );
+    });
+
+    it('should return empty items and total 0 when no results', async () => {
+      ormRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await repo.findMany({}, { limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('should apply pagination offset', async () => {
+      ormRepo.findAndCount.mockResolvedValue([[], 5]);
+
+      await repo.findMany({}, { limit: 2, offset: 4 });
+
+      expect(ormRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 2, skip: 4 }),
+      );
+    });
+  });
+});

--- a/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
@@ -21,6 +21,7 @@ import { randomUUID } from 'crypto';
 import { SyncJobOrmEntity } from '../entities/sync-job.orm-entity';
 import { SyncJobRepositoryPort } from '../../../domain/ports/sync-job-repository.port';
 import { SyncJob } from '../../../domain/entities/sync-job.entity';
+import { InvalidSyncJobStateError } from '../../../domain/exceptions/invalid-sync-job-state.error';
 import {
   JobStatus,
   JobStatusValues,
@@ -175,10 +176,9 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
       throw new Error(`Job not found: ${id}`);
     }
 
-    // Set status back to 'queued' so job can be picked up again for retry
-    // The 'failed' status is implicit (job has lastError and nextRunAt in future)
+    // Requeue the job so it can be picked up again after nextRunAt
     await this.repository.update(id, {
-      status: 'queued', // Requeue for retry
+      status: 'queued',
       attempts: job.attempts + 1,
       nextRunAt,
       lockedAt: null,
@@ -242,12 +242,12 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
   private toDomain(entity: SyncJobOrmEntity): SyncJob {
     // Validate job type
     if (!this.isValidJobType(entity.jobType)) {
-      throw new Error(`Invalid job type in database: ${entity.jobType}`);
+      throw new InvalidSyncJobStateError('jobType', entity.jobType, entity.id);
     }
 
     // Validate job status
     if (!this.isValidJobStatus(entity.status)) {
-      throw new Error(`Invalid job status in database: ${entity.status}`);
+      throw new InvalidSyncJobStateError('status', entity.status, entity.id);
     }
 
     return new SyncJob(

--- a/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
@@ -26,6 +26,9 @@ import {
   JobStatusValues,
   JobType,
   JobTypeValues,
+  SyncJobFilters,
+  SyncJobPagination,
+  PaginatedSyncJobs,
 } from '../../../domain/types/sync-job.types';
 
 @Injectable()
@@ -191,6 +194,27 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
       lockedBy: null,
       lastError: error.length > 1000 ? error.substring(0, 1000) : error, // Truncate if too long
     });
+  }
+
+  async findById(id: string): Promise<SyncJob | null> {
+    const entity = await this.repository.findOne({ where: { id } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async findMany(filters: SyncJobFilters, pagination: SyncJobPagination): Promise<PaginatedSyncJobs> {
+    const where: { status?: string; connectionId?: string; jobType?: string } = {};
+    if (filters.status) where.status = filters.status;
+    if (filters.connectionId) where.connectionId = filters.connectionId;
+    if (filters.jobType) where.jobType = filters.jobType;
+
+    const [entities, total] = await this.repository.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      take: pagination.limit,
+      skip: pagination.offset,
+    });
+
+    return { items: entities.map((e) => this.toDomain(e)), total };
   }
 
   async requeueStuckJobs(lockTimeoutMinutes: number): Promise<number> {


### PR DESCRIPTION
## Summary
- Adds `GET /sync/jobs` and `GET /sync/jobs/:id` read endpoints with filtering (status, jobType, connectionId) and offset pagination
- Adds a frontend sync jobs dashboard at `/jobs-logs` with a paginated data table, filter bar, and a detail page showing full job metadata, lock info, and raw payload
- Introduces `InvalidSyncJobStateError` domain exception, `EnqueueJobResult` return type, and removes the unused `'failed'` job status

## Changes
- `libs/core/src/sync/domain/types/sync-job.types.ts` — removed `'failed'` from `JobStatusValues` (never written by any repository method); added `EnqueueJobResult { jobId, isExisting }`
- `libs/core/src/sync/domain/ports/job-enqueue.port.ts` — `enqueueJob` now returns `Promise<EnqueueJobResult>` instead of `Promise<string>`
- `libs/core/src/sync/domain/exceptions/invalid-sync-job-state.error.ts` — new domain exception for DB records with unknown jobType/status
- `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts` — added `findById`, `findMany`; `toDomain` throws `InvalidSyncJobStateError` instead of bare `Error`
- `apps/api/src/sync/http/sync.controller.ts` — new `GET /sync/jobs` and `GET /sync/jobs/:id` endpoints; uses destructured `EnqueueJobResult`
- `apps/web/src/features/sync-jobs/` — full feature slice: API client, query hooks, status badge, list and detail pages
- `apps/web/src/app/routes/jobs-logs.route.tsx` — registers list and detail sub-routes

## Test plan
- [x] Unit tests pass (`pnpm test`)
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [ ] Navigate to `/jobs-logs` — verify job table, filter controls, pagination render
- [ ] Filter by status/jobType — verify URL params update and results refresh
- [ ] Click a row — verify detail page shows job metadata, lock info, payload JSON
- [ ] Verify `GET /sync/jobs?status=dead` returns only dead jobs (not `failed`)

## Tech review
🔄 **Approve with changes** applied — all IMPORTANT and BLOCKING items fixed:
- `'failed'` status removed (was never written to DB; polluted filter UI)
- `EnqueueJobResult` replaces `existing:` string-prefix protocol coupling
- `InvalidSyncJobStateError` replaces bare `Error` in `toDomain`
- `SyncJobResponseDto.jobType/.status` typed as `JobType`/`JobStatus`
- Frontend `EnqueueSyncJobInput.syncType` renamed to `jobType`
- File headers added; `retry: false` added to both query hooks

Closes #70
Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)