### PR TITLE
feat(api): add inventory and orders read APIs

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,8 @@ import { AuthModule } from './auth/auth.module';
 import { IntegrationsModule } from './integrations/integrations.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { SyncModule } from './sync/sync.module';
+import { InventoryModule } from './inventory/inventory.module';
+import { OrdersModule } from './orders/orders.module';
 
 @Module({
   imports: [
@@ -38,6 +40,8 @@ import { SyncModule } from './sync/sync.module';
     IntegrationsModule,
     WebhooksModule,
     SyncModule,
+    InventoryModule,
+    OrdersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -68,6 +68,8 @@ describe('ConnectionController', () => {
       markDead: jest.fn(),
       requeueStuckJobs: jest.fn(),
       findRecentByConnectionId: jest.fn(),
+      findMany: jest.fn(),
+      findById: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/inventory/http/dto/inventory-item-response.dto.ts
+++ b/apps/api/src/inventory/http/dto/inventory-item-response.dto.ts
@@ -1,0 +1,32 @@
+/**
+ * Inventory Item Response DTO
+ *
+ * Response shape for a single inventory item. Used in both list and detail responses.
+ * Dates are serialised as ISO 8601 strings.
+ *
+ * @module apps/api/src/inventory/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class InventoryItemResponseDto {
+  @ApiProperty({ description: 'Inventory item UUID' })
+  id!: string;
+
+  @ApiProperty({ description: 'Internal product ID' })
+  productId!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Internal product variant ID (null for product-level inventory)' })
+  productVariantId!: string | null;
+
+  @ApiProperty({ description: 'Available stock quantity' })
+  availableQuantity!: number;
+
+  @ApiProperty({ description: 'Reserved stock quantity' })
+  reservedQuantity!: number;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Location ID (null for default location)' })
+  locationId!: string | null;
+
+  @ApiProperty({ description: 'Last update timestamp (ISO 8601)' })
+  updatedAt!: string;
+}

--- a/apps/api/src/inventory/http/dto/list-inventory-query.dto.ts
+++ b/apps/api/src/inventory/http/dto/list-inventory-query.dto.ts
@@ -1,0 +1,42 @@
+/**
+ * List Inventory Query DTO
+ *
+ * Query parameters for GET /inventory. All fields are optional.
+ *
+ * @module apps/api/src/inventory/http/dto
+ */
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListInventoryQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by internal product ID' })
+  @IsOptional()
+  @IsString()
+  productId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by internal product variant ID' })
+  @IsOptional()
+  @IsString()
+  productVariantId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by location ID' })
+  @IsOptional()
+  @IsString()
+  locationId?: string;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/apps/api/src/inventory/http/dto/paginated-inventory-response.dto.ts
+++ b/apps/api/src/inventory/http/dto/paginated-inventory-response.dto.ts
@@ -1,0 +1,23 @@
+/**
+ * Paginated Inventory Response DTO
+ *
+ * Response shape for GET /inventory.
+ *
+ * @module apps/api/src/inventory/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { InventoryItemResponseDto } from './inventory-item-response.dto';
+
+export class PaginatedInventoryResponseDto {
+  @ApiProperty({ type: [InventoryItemResponseDto] })
+  items!: InventoryItemResponseDto[];
+
+  @ApiProperty({ description: 'Total number of items matching the filters' })
+  total!: number;
+
+  @ApiProperty({ description: 'Page size used for this response' })
+  limit!: number;
+
+  @ApiProperty({ description: 'Offset used for this response' })
+  offset!: number;
+}

--- a/apps/api/src/inventory/http/inventory.controller.spec.ts
+++ b/apps/api/src/inventory/http/inventory.controller.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Inventory Controller Unit Tests
+ *
+ * @module apps/api/src/inventory/http
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { InventoryController } from './inventory.controller';
+import {
+  INVENTORY_REPOSITORY_TOKEN,
+  InventoryItemEntity as InventoryItem,
+} from '@openlinker/core/inventory';
+import type { InventoryRepositoryPort } from '@openlinker/core/inventory';
+
+describe('InventoryController', () => {
+  let controller: InventoryController;
+  let repository: jest.Mocked<InventoryRepositoryPort>;
+
+  const mockItem = new InventoryItem(
+    'inv-001',
+    'prod-001',
+    'var-001',
+    50,
+    5,
+    null,
+    new Date('2026-04-01T00:00:00Z'),
+  );
+
+  beforeEach(async () => {
+    const mockRepository: jest.Mocked<InventoryRepositoryPort> = {
+      findByProductAndVariant: jest.fn(),
+      upsert: jest.fn(),
+      findById: jest.fn(),
+      findMany: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InventoryController],
+      providers: [
+        {
+          provide: INVENTORY_REPOSITORY_TOKEN,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InventoryController>(InventoryController);
+    repository = module.get(INVENTORY_REPOSITORY_TOKEN);
+  });
+
+  describe('listInventory', () => {
+    it('should return paginated inventory items', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
+
+      const result = await controller.listInventory({ limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      expect(result.items[0].id).toBe('inv-001');
+      expect(result.items[0].updatedAt).toBe('2026-04-01T00:00:00.000Z');
+    });
+
+    it('should pass filters to repository', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listInventory({
+        productId: 'prod-001',
+        productVariantId: 'var-001',
+        locationId: 'loc-001',
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(repository.findMany).toHaveBeenCalledWith(
+        { productId: 'prod-001', productVariantId: 'var-001', locationId: 'loc-001' },
+        { limit: 10, offset: 5 },
+      );
+    });
+
+    it('should return empty list when no items match', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      const result = await controller.listInventory({ limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('getInventoryItem', () => {
+    it('should return inventory item when found', async () => {
+      repository.findById.mockResolvedValue(mockItem);
+
+      const result = await controller.getInventoryItem('inv-001');
+
+      expect(result.id).toBe('inv-001');
+      expect(result.productId).toBe('prod-001');
+      expect(result.availableQuantity).toBe(50);
+      expect(result.reservedQuantity).toBe(5);
+    });
+
+    it('should throw NotFoundException when item not found', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(controller.getInventoryItem('inv-999')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/inventory/http/inventory.controller.ts
+++ b/apps/api/src/inventory/http/inventory.controller.ts
@@ -1,0 +1,90 @@
+/**
+ * Inventory Controller
+ *
+ * HTTP REST API endpoints for inventory read operations. Provides endpoints
+ * for listing inventory items with filters and retrieving individual items.
+ *
+ * @module apps/api/src/inventory/http
+ */
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Inject,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import {
+  InventoryRepositoryPort,
+  INVENTORY_REPOSITORY_TOKEN,
+} from '@openlinker/core/inventory';
+import type { InventoryItem } from '@openlinker/core/inventory/domain/entities/inventory-item.entity';
+import { ListInventoryQueryDto } from './dto/list-inventory-query.dto';
+import { InventoryItemResponseDto } from './dto/inventory-item-response.dto';
+import { PaginatedInventoryResponseDto } from './dto/paginated-inventory-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('inventory')
+@Controller('inventory')
+export class InventoryController {
+  constructor(
+    @Inject(INVENTORY_REPOSITORY_TOKEN)
+    private readonly inventoryRepository: InventoryRepositoryPort,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List inventory items',
+    description:
+      'Returns a paginated list of inventory items. Supports filtering by productId, productVariantId, and locationId.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated inventory list', type: PaginatedInventoryResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listInventory(@Query() query: ListInventoryQueryDto): Promise<PaginatedInventoryResponseDto> {
+    const { productId, productVariantId, locationId, limit = 20, offset = 0 } = query;
+
+    const { items, total } = await this.inventoryRepository.findMany(
+      { productId, productVariantId, locationId },
+      { limit, offset },
+    );
+
+    return {
+      items: items.map((item) => this.toDto(item)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get inventory item by ID' })
+  @ApiResponse({ status: 200, description: 'Inventory item detail', type: InventoryItemResponseDto })
+  @ApiResponse({ status: 404, description: 'Inventory item not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getInventoryItem(@Param('id') id: string): Promise<InventoryItemResponseDto> {
+    const item = await this.inventoryRepository.findById(id);
+    if (!item) {
+      throw new NotFoundException(`Inventory item not found: ${id}`);
+    }
+    return this.toDto(item);
+  }
+
+  private toDto(item: InventoryItem): InventoryItemResponseDto {
+    return {
+      id: item.id,
+      productId: item.productId,
+      productVariantId: item.productVariantId,
+      availableQuantity: item.availableQuantity,
+      reservedQuantity: item.reservedQuantity,
+      locationId: item.locationId,
+      updatedAt: item.updatedAt instanceof Date ? item.updatedAt.toISOString() : item.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/inventory/inventory.module.ts
+++ b/apps/api/src/inventory/inventory.module.ts
@@ -1,0 +1,17 @@
+/**
+ * Inventory API Module
+ *
+ * NestJS module for inventory read API endpoints. Imports core inventory
+ * module and registers the inventory controller.
+ *
+ * @module apps/api/src/inventory
+ */
+import { Module } from '@nestjs/common';
+import { InventoryModule as CoreInventoryModule } from '@openlinker/core/inventory';
+import { InventoryController } from './http/inventory.controller';
+
+@Module({
+  imports: [CoreInventoryModule],
+  controllers: [InventoryController],
+})
+export class InventoryModule {}

--- a/apps/api/src/orders/http/dto/list-orders-query.dto.ts
+++ b/apps/api/src/orders/http/dto/list-orders-query.dto.ts
@@ -1,0 +1,57 @@
+/**
+ * List Orders Query DTO
+ *
+ * Query parameters for GET /orders. All fields are optional.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { IsOptional, IsString, IsUUID, IsEnum, IsInt, Min, Max, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { OrderSyncStatusFilterValues } from '@openlinker/core/orders';
+import type { OrderSyncStatusFilter } from '@openlinker/core/orders';
+
+export class ListOrdersQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by source connection ID (UUID)' })
+  @IsOptional()
+  @IsUUID()
+  sourceConnectionId?: string;
+
+  @ApiPropertyOptional({
+    enum: OrderSyncStatusFilterValues,
+    description: 'Filter by sync status (matches any destination with this status)',
+  })
+  @IsOptional()
+  @IsEnum(OrderSyncStatusFilterValues)
+  syncStatus?: OrderSyncStatusFilter;
+
+  @ApiPropertyOptional({ description: 'Filter by internal customer ID' })
+  @IsOptional()
+  @IsString()
+  customerId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter orders created on or after this date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  createdFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Filter orders created on or before this date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  createdTo?: string;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -1,0 +1,36 @@
+/**
+ * Order Record Response DTO
+ *
+ * Response shape for a single order record. Used in both list and detail responses.
+ * Dates are serialised as ISO 8601 strings.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { OrderSyncStatusResponseDto } from './order-sync-status-response.dto';
+
+export class OrderRecordResponseDto {
+  @ApiProperty({ description: 'Internal order ID (e.g. ol_order_...)' })
+  internalOrderId!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Internal customer ID' })
+  customerId!: string | null;
+
+  @ApiProperty({ description: 'Source connection ID' })
+  sourceConnectionId!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Source event ID for tracking' })
+  sourceEventId!: string | null;
+
+  @ApiProperty({ description: 'Order snapshot (PII-aware)' })
+  orderSnapshot!: Record<string, unknown>;
+
+  @ApiProperty({ type: [OrderSyncStatusResponseDto], description: 'Sync status per destination' })
+  syncStatus!: OrderSyncStatusResponseDto[];
+
+  @ApiProperty({ description: 'Order creation timestamp (ISO 8601)' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Order last-update timestamp (ISO 8601)' })
+  updatedAt!: string;
+}

--- a/apps/api/src/orders/http/dto/order-sync-status-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-sync-status-response.dto.ts
@@ -1,0 +1,30 @@
+/**
+ * Order Sync Status Response DTO
+ *
+ * Response shape for an individual destination sync status within an order record.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { OrderSyncStatusFilterValues } from '@openlinker/core/orders';
+import type { OrderSyncStatusFilter } from '@openlinker/core/orders';
+
+export class OrderSyncStatusResponseDto {
+  @ApiProperty({ description: 'Destination connection ID' })
+  destinationConnectionId!: string;
+
+  @ApiProperty({ enum: OrderSyncStatusFilterValues, description: 'Sync status' })
+  status!: OrderSyncStatusFilter;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Timestamp when sync completed (ISO 8601)' })
+  syncedAt!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'External order ID in destination system' })
+  externalOrderId!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'External order number in destination system' })
+  externalOrderNumber!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Error message if sync failed' })
+  error!: string | null;
+}

--- a/apps/api/src/orders/http/dto/paginated-orders-response.dto.ts
+++ b/apps/api/src/orders/http/dto/paginated-orders-response.dto.ts
@@ -1,0 +1,23 @@
+/**
+ * Paginated Orders Response DTO
+ *
+ * Response shape for GET /orders.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { OrderRecordResponseDto } from './order-record-response.dto';
+
+export class PaginatedOrdersResponseDto {
+  @ApiProperty({ type: [OrderRecordResponseDto] })
+  items!: OrderRecordResponseDto[];
+
+  @ApiProperty({ description: 'Total number of orders matching the filters' })
+  total!: number;
+
+  @ApiProperty({ description: 'Page size used for this response' })
+  limit!: number;
+
+  @ApiProperty({ description: 'Offset used for this response' })
+  offset!: number;
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Orders Controller Unit Tests
+ *
+ * @module apps/api/src/orders/http
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { OrdersController } from './orders.controller';
+import {
+  ORDER_RECORD_REPOSITORY_TOKEN,
+  OrderRecord,
+} from '@openlinker/core/orders';
+import type { OrderRecordRepositoryPort } from '@openlinker/core/orders';
+
+describe('OrdersController', () => {
+  let controller: OrdersController;
+  let repository: jest.Mocked<OrderRecordRepositoryPort>;
+
+  const mockOrder = new OrderRecord(
+    'ol_order_001',
+    'ol_customer_001',
+    'conn-source-001',
+    'event-001',
+    { externalOrderId: 'EXT-123', items: [] },
+    [
+      {
+        destinationConnectionId: 'conn-dest-001',
+        status: 'synced',
+        syncedAt: new Date('2026-04-01T12:00:00Z'),
+        externalOrderId: 'PS-456',
+        externalOrderNumber: '000456',
+      },
+    ],
+    new Date('2026-04-01T00:00:00Z'),
+    new Date('2026-04-01T12:00:00Z'),
+  );
+
+  beforeEach(async () => {
+    const mockRepository: jest.Mocked<OrderRecordRepositoryPort> = {
+      findById: jest.fn(),
+      upsert: jest.fn(),
+      updateSyncStatus: jest.fn(),
+      findMany: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrdersController],
+      providers: [
+        {
+          provide: ORDER_RECORD_REPOSITORY_TOKEN,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OrdersController>(OrdersController);
+    repository = module.get(ORDER_RECORD_REPOSITORY_TOKEN);
+  });
+
+  describe('listOrders', () => {
+    it('should return paginated order records', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockOrder], total: 1 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      expect(result.items[0].internalOrderId).toBe('ol_order_001');
+      expect(result.items[0].syncStatus).toHaveLength(1);
+      expect(result.items[0].syncStatus[0].status).toBe('synced');
+      expect(result.items[0].syncStatus[0].externalOrderId).toBe('PS-456');
+    });
+
+    it('should pass filters to repository', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listOrders({
+        sourceConnectionId: 'conn-001',
+        syncStatus: 'failed',
+        customerId: 'cust-001',
+        createdFrom: '2026-01-01T00:00:00Z',
+        createdTo: '2026-12-31T23:59:59Z',
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(repository.findMany).toHaveBeenCalledWith(
+        {
+          sourceConnectionId: 'conn-001',
+          syncStatus: 'failed',
+          customerId: 'cust-001',
+          createdFrom: new Date('2026-01-01T00:00:00Z'),
+          createdTo: new Date('2026-12-31T23:59:59Z'),
+        },
+        { limit: 10, offset: 5 },
+      );
+    });
+
+    it('should return empty list when no orders match', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('should serialize dates as ISO strings', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockOrder], total: 1 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items[0].createdAt).toBe('2026-04-01T00:00:00.000Z');
+      expect(result.items[0].updatedAt).toBe('2026-04-01T12:00:00.000Z');
+      expect(result.items[0].syncStatus[0].syncedAt).toBe('2026-04-01T12:00:00.000Z');
+    });
+
+    it('should handle sync status with undefined optional fields', async () => {
+      const orderWithMinimalSync = new OrderRecord(
+        'ol_order_002',
+        null,
+        'conn-source-001',
+        null,
+        {},
+        [{ destinationConnectionId: 'conn-dest-001', status: 'pending' }],
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T00:00:00Z'),
+      );
+      repository.findMany.mockResolvedValue({ items: [orderWithMinimalSync], total: 1 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items[0].syncStatus[0].syncedAt).toBeNull();
+      expect(result.items[0].syncStatus[0].externalOrderId).toBeNull();
+      expect(result.items[0].syncStatus[0].error).toBeNull();
+    });
+  });
+
+  describe('getOrder', () => {
+    it('should return order record when found', async () => {
+      repository.findById.mockResolvedValue(mockOrder);
+
+      const result = await controller.getOrder('ol_order_001');
+
+      expect(result.internalOrderId).toBe('ol_order_001');
+      expect(result.customerId).toBe('ol_customer_001');
+      expect(result.sourceConnectionId).toBe('conn-source-001');
+      expect(result.orderSnapshot).toEqual({ externalOrderId: 'EXT-123', items: [] });
+    });
+
+    it('should throw NotFoundException when order not found', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(controller.getOrder('ol_order_999')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -1,0 +1,109 @@
+/**
+ * Orders Controller
+ *
+ * HTTP REST API endpoints for order record read operations. Provides endpoints
+ * for listing order records with filters and retrieving individual orders.
+ *
+ * @module apps/api/src/orders/http
+ */
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Inject,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import {
+  OrderRecordRepositoryPort,
+  ORDER_RECORD_REPOSITORY_TOKEN,
+} from '@openlinker/core/orders';
+import type { OrderRecord, OrderSyncStatus } from '@openlinker/core/orders';
+import { ListOrdersQueryDto } from './dto/list-orders-query.dto';
+import { OrderRecordResponseDto } from './dto/order-record-response.dto';
+import { OrderSyncStatusResponseDto } from './dto/order-sync-status-response.dto';
+import { PaginatedOrdersResponseDto } from './dto/paginated-orders-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('orders')
+@Controller('orders')
+export class OrdersController {
+  constructor(
+    @Inject(ORDER_RECORD_REPOSITORY_TOKEN)
+    private readonly orderRecordRepository: OrderRecordRepositoryPort,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List order records',
+    description:
+      'Returns a paginated list of order records. Supports filtering by sourceConnectionId, syncStatus, customerId, and date range.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated order list', type: PaginatedOrdersResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listOrders(@Query() query: ListOrdersQueryDto): Promise<PaginatedOrdersResponseDto> {
+    const { sourceConnectionId, syncStatus, customerId, createdFrom, createdTo, limit = 20, offset = 0 } = query;
+
+    const { items, total } = await this.orderRecordRepository.findMany(
+      {
+        sourceConnectionId,
+        syncStatus,
+        customerId,
+        createdFrom: createdFrom ? new Date(createdFrom) : undefined,
+        createdTo: createdTo ? new Date(createdTo) : undefined,
+      },
+      { limit, offset },
+    );
+
+    return {
+      items: items.map((order) => this.toDto(order)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  @Get(':internalOrderId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get order record by internal order ID' })
+  @ApiResponse({ status: 200, description: 'Order record detail', type: OrderRecordResponseDto })
+  @ApiResponse({ status: 404, description: 'Order not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getOrder(@Param('internalOrderId') internalOrderId: string): Promise<OrderRecordResponseDto> {
+    const order = await this.orderRecordRepository.findById(internalOrderId);
+    if (!order) {
+      throw new NotFoundException(`Order not found: ${internalOrderId}`);
+    }
+    return this.toDto(order);
+  }
+
+  private toDto(order: OrderRecord): OrderRecordResponseDto {
+    return {
+      internalOrderId: order.internalOrderId,
+      customerId: order.customerId,
+      sourceConnectionId: order.sourceConnectionId,
+      sourceEventId: order.sourceEventId,
+      orderSnapshot: order.orderSnapshot,
+      syncStatus: order.syncStatus.map((s) => this.toSyncStatusDto(s)),
+      createdAt: order.createdAt instanceof Date ? order.createdAt.toISOString() : order.createdAt,
+      updatedAt: order.updatedAt instanceof Date ? order.updatedAt.toISOString() : order.updatedAt,
+    };
+  }
+
+  private toSyncStatusDto(s: OrderSyncStatus): OrderSyncStatusResponseDto {
+    return {
+      destinationConnectionId: s.destinationConnectionId,
+      status: s.status,
+      syncedAt: s.syncedAt instanceof Date ? s.syncedAt.toISOString() : (s.syncedAt ?? null),
+      externalOrderId: s.externalOrderId ?? null,
+      externalOrderNumber: s.externalOrderNumber ?? null,
+      error: s.error ?? null,
+    };
+  }
+}

--- a/apps/api/src/orders/orders.module.ts
+++ b/apps/api/src/orders/orders.module.ts
@@ -1,0 +1,17 @@
+/**
+ * Orders API Module
+ *
+ * NestJS module for order record read API endpoints. Imports core orders
+ * module and registers the orders controller.
+ *
+ * @module apps/api/src/orders
+ */
+import { Module } from '@nestjs/common';
+import { OrdersModule as CoreOrdersModule } from '@openlinker/core/orders';
+import { OrdersController } from './http/orders.controller';
+
+@Module({
+  imports: [CoreOrdersModule],
+  controllers: [OrdersController],
+})
+export class OrdersModule {}

--- a/apps/api/src/sync/http/sync.controller.spec.ts
+++ b/apps/api/src/sync/http/sync.controller.spec.ts
@@ -55,6 +55,7 @@ describe('SyncController', () => {
     markFailed: jest.fn(),
     markDead: jest.fn(),
     requeueStuckJobs: jest.fn(),
+    findRecentByConnectionId: jest.fn(),
   };
 
   beforeEach(async () => {

--- a/libs/core/src/inventory/domain/ports/inventory-repository.port.ts
+++ b/libs/core/src/inventory/domain/ports/inventory-repository.port.ts
@@ -10,6 +10,7 @@
  * @see {@link InventoryRepository} for the TypeORM implementation
  */
 import { InventoryItem } from '../entities/inventory-item.entity';
+import type { InventoryFilters, InventoryPagination, PaginatedInventoryItems } from '../types/inventory.types';
 
 /**
  * Inventory Repository Port
@@ -43,5 +44,18 @@ export interface InventoryRepositoryPort {
    * @returns Upserted inventory item domain entity
    */
   upsert(item: InventoryItem): Promise<InventoryItem>;
+
+  /**
+   * Find inventory item by ID
+   */
+  findById(id: string): Promise<InventoryItem | null>;
+
+  /**
+   * Find inventory items with filters and pagination
+   */
+  findMany(
+    filters: InventoryFilters,
+    pagination: InventoryPagination,
+  ): Promise<PaginatedInventoryItems>;
 }
 

--- a/libs/core/src/inventory/domain/types/inventory.types.ts
+++ b/libs/core/src/inventory/domain/types/inventory.types.ts
@@ -6,6 +6,7 @@
  *
  * @module libs/core/src/inventory/domain/types
  */
+import type { InventoryItem } from '../entities/inventory-item.entity';
 
 /**
  * Inventory adjustment
@@ -44,6 +45,31 @@ export interface InventoryAdjustment {
    * Additional metadata (optional)
    */
   metadata?: Record<string, unknown>;
+}
+
+/**
+ * Inventory filters for list queries
+ */
+export interface InventoryFilters {
+  productId?: string;
+  productVariantId?: string;
+  locationId?: string;
+}
+
+/**
+ * Pagination parameters for inventory queries
+ */
+export interface InventoryPagination {
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Paginated inventory items result
+ */
+export interface PaginatedInventoryItems {
+  items: InventoryItem[];
+  total: number;
 }
 
 

--- a/libs/core/src/inventory/index.ts
+++ b/libs/core/src/inventory/index.ts
@@ -34,7 +34,12 @@ export { IMasterInventorySyncService, MasterInventorySyncResult } from './applic
 export { MasterInventorySyncService } from './application/services/master-inventory-sync.service';
 
 // Types
-export { InventoryAdjustment } from './domain/types/inventory.types';
+export {
+  InventoryAdjustment,
+  InventoryFilters,
+  InventoryPagination,
+  PaginatedInventoryItems,
+} from './domain/types/inventory.types';
 
 // ORM Entities (exported for testing and TypeORM CLI usage)
 export { InventoryItemOrmEntity } from './infrastructure/persistence/entities/inventory-item.orm-entity';

--- a/libs/core/src/inventory/infrastructure/persistence/repositories/inventory.repository.ts
+++ b/libs/core/src/inventory/infrastructure/persistence/repositories/inventory.repository.ts
@@ -20,6 +20,7 @@ import { randomUUID } from 'crypto';
 import { InventoryItemOrmEntity } from '../entities/inventory-item.orm-entity';
 import { InventoryRepositoryPort } from '../../../domain/ports/inventory-repository.port';
 import { InventoryItem } from '../../../domain/entities/inventory-item.entity';
+import type { InventoryFilters, InventoryPagination, PaginatedInventoryItems } from '../../../domain/types/inventory.types';
 
 @Injectable()
 export class InventoryRepository implements InventoryRepositoryPort {
@@ -58,6 +59,40 @@ export class InventoryRepository implements InventoryRepositoryPort {
     }
 
     return this.toDomain(entity);
+  }
+
+  async findById(id: string): Promise<InventoryItem | null> {
+    const entity = await this.repository.findOne({ where: { id } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async findMany(
+    filters: InventoryFilters,
+    pagination: InventoryPagination,
+  ): Promise<PaginatedInventoryItems> {
+    const where: Record<string, unknown> = {};
+
+    if (filters.productId) {
+      where.productId = filters.productId;
+    }
+    if (filters.productVariantId) {
+      where.productVariantId = filters.productVariantId;
+    }
+    if (filters.locationId) {
+      where.locationId = filters.locationId;
+    }
+
+    const [entities, total] = await this.repository.findAndCount({
+      where,
+      order: { updatedAt: 'DESC' },
+      take: pagination.limit,
+      skip: pagination.offset,
+    });
+
+    return {
+      items: entities.map((e) => this.toDomain(e)),
+      total,
+    };
   }
 
   async upsert(item: InventoryItem): Promise<InventoryItem> {

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -8,6 +8,7 @@
  * @module libs/core/src/orders/domain/ports
  */
 import { OrderRecord } from '../entities/order-record.entity';
+import type { OrderRecordFilters, OrderRecordPagination, PaginatedOrderRecords } from '../types/order-record.types';
 
 export interface OrderRecordRepositoryPort {
   /**
@@ -29,4 +30,12 @@ export interface OrderRecordRepositoryPort {
     destinationConnectionId: string,
     status: OrderRecord['syncStatus'][0],
   ): Promise<void>;
+
+  /**
+   * Find order records with filters and pagination
+   */
+  findMany(
+    filters: OrderRecordFilters,
+    pagination: OrderRecordPagination,
+  ): Promise<PaginatedOrderRecords>;
 }

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -1,0 +1,46 @@
+/**
+ * Order Record Types
+ *
+ * Type definitions for order record read operations. Defines filters,
+ * pagination, and paginated result types for querying order records.
+ *
+ * @module libs/core/src/orders/domain/types
+ */
+import type { OrderRecord } from '../entities/order-record.entity';
+
+/**
+ * Sync status filter values for order queries
+ */
+export const OrderSyncStatusFilterValues = ['pending', 'syncing', 'synced', 'failed'] as const;
+
+/**
+ * Sync status filter type
+ */
+export type OrderSyncStatusFilter = (typeof OrderSyncStatusFilterValues)[number];
+
+/**
+ * Order record filters for list queries
+ */
+export interface OrderRecordFilters {
+  sourceConnectionId?: string;
+  syncStatus?: OrderSyncStatusFilter;
+  customerId?: string;
+  createdFrom?: Date;
+  createdTo?: Date;
+}
+
+/**
+ * Pagination parameters for order record queries
+ */
+export interface OrderRecordPagination {
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Paginated order records result
+ */
+export interface PaginatedOrderRecords {
+  items: OrderRecord[];
+  total: number;
+}

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -21,6 +21,13 @@ export {
   IncomingOrderTotals,
   IncomingOrderAddress,
 } from './domain/types/incoming-order.types';
+export {
+  OrderRecordFilters,
+  OrderRecordPagination,
+  PaginatedOrderRecords,
+  OrderSyncStatusFilter,
+  OrderSyncStatusFilterValues,
+} from './domain/types/order-record.types';
 
 // Services
 export { IOrderSyncService, OrderSyncRequest, OrderSyncResult } from './application/interfaces/order-sync.service.interface';

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -10,11 +10,12 @@
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import { OrderRecordOrmEntity, OrderSyncStatusJson } from '../entities/order-record.orm-entity';
 import { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
 import { OrderRecord, OrderSyncStatus } from '../../../domain/entities/order-record.entity';
 import { OrderRecordNotFoundException } from '../../../domain/exceptions/order-record-not-found.exception';
+import type { OrderRecordFilters, OrderRecordPagination, PaginatedOrderRecords } from '../../../domain/types/order-record.types';
 
 @Injectable()
 export class OrderRecordRepository implements OrderRecordRepositoryPort {
@@ -33,6 +34,57 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     }
 
     return this.toDomain(entity);
+  }
+
+  async findMany(
+    filters: OrderRecordFilters,
+    pagination: OrderRecordPagination,
+  ): Promise<PaginatedOrderRecords> {
+    const qb: SelectQueryBuilder<OrderRecordOrmEntity> = this.repository
+      .createQueryBuilder('order')
+      .orderBy('order.createdAt', 'DESC')
+      .take(pagination.limit)
+      .skip(pagination.offset);
+
+    if (filters.sourceConnectionId) {
+      qb.andWhere('order.sourceConnectionId = :sourceConnectionId', {
+        sourceConnectionId: filters.sourceConnectionId,
+      });
+    }
+
+    if (filters.customerId) {
+      qb.andWhere('order.customerId = :customerId', {
+        customerId: filters.customerId,
+      });
+    }
+
+    if (filters.createdFrom) {
+      qb.andWhere('order.createdAt >= :createdFrom', {
+        createdFrom: filters.createdFrom,
+      });
+    }
+
+    if (filters.createdTo) {
+      qb.andWhere('order.createdAt <= :createdTo', {
+        createdTo: filters.createdTo,
+      });
+    }
+
+    if (filters.syncStatus) {
+      // JSONB containment: find orders where any destination has this status
+      // Use quoted column name to match TypeORM's camelCase mapping
+      qb.andWhere(
+        `"order_records"."syncStatus" @> :syncStatusFilter::jsonb`,
+        { syncStatusFilter: JSON.stringify([{ status: filters.syncStatus }]) },
+      );
+    }
+
+    const [entities, total] = await qb.getManyAndCount();
+
+    return {
+      items: entities.map((e) => this.toDomain(e)),
+      total,
+    };
   }
 
   async upsert(orderRecord: OrderRecord): Promise<OrderRecord> {


### PR DESCRIPTION
## Summary

- Add read-only REST endpoints for inventory items (`GET /inventory`, `GET /inventory/:id`)
- Add read-only REST endpoints for order records (`GET /orders`, `GET /orders/:internalOrderId`)
- Extend `InventoryRepositoryPort` and `OrderRecordRepositoryPort` with `findMany`/`findById` methods
- Orders `syncStatus` filter uses JSONB containment query to match any destination with a given status

## Changes

- **CORE domain** — new pagination/filter types in `inventory.types.ts` and `order-record.types.ts`; extended repository ports
- **CORE infrastructure** — `findMany`/`findById` implementations in `InventoryRepository` and `OrderRecordRepository`
- **API interface** — new `InventoryController`, `OrdersController` with DTOs, query validation, Swagger docs
- **API modules** — `InventoryModule` and `OrdersModule` registered in `AppModule`
- **Pre-existing fixes** — added missing mock methods in `sync.controller.spec.ts` and `connection.controller.spec.ts`

## Test plan

- [x] Unit tests pass (`pnpm test`) — 15 suites, 127 tests
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] No database migrations needed (querying existing tables)

## Tech review

✅ Self-reviewed — all BLOCKING and IMPORTANT items addressed:
- JSONB query uses explicit table/column reference instead of alias cast
- Test imports use public module exports instead of deep paths
- `OrderSyncStatusResponseDto.status` properly typed with `OrderSyncStatusFilter`

Closes #84
Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)