### PR TITLE
feat(api): add customer projection and listings read APIs

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -24,6 +24,8 @@ import { SyncModule } from './sync/sync.module';
 import { InventoryModule } from './inventory/inventory.module';
 import { OrdersModule } from './orders/orders.module';
 import { ProductsApiModule } from './products/products.module';
+import { CustomersApiModule } from './customers/customers.module';
+import { ListingsApiModule } from './listings/listings.module';
 
 @Module({
   imports: [
@@ -44,6 +46,8 @@ import { ProductsApiModule } from './products/products.module';
     InventoryModule,
     OrdersModule,
     ProductsApiModule,
+    CustomersApiModule,
+    ListingsApiModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/customers/customers.module.ts
+++ b/apps/api/src/customers/customers.module.ts
@@ -1,0 +1,17 @@
+/**
+ * Customers API Module
+ *
+ * NestJS module for customer projection read API endpoints. Imports core
+ * customers module and registers the customers controller.
+ *
+ * @module apps/api/src/customers
+ */
+import { Module } from '@nestjs/common';
+import { CustomersModule as CoreCustomersModule } from '@openlinker/core/customers';
+import { CustomersController } from './http/customers.controller';
+
+@Module({
+  imports: [CoreCustomersModule],
+  controllers: [CustomersController],
+})
+export class CustomersApiModule {}

--- a/apps/api/src/customers/http/customers.controller.spec.ts
+++ b/apps/api/src/customers/http/customers.controller.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Customers Controller Unit Tests
+ *
+ * @module apps/api/src/customers/http
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { CustomersController } from './customers.controller';
+import {
+  CustomerProjectionRepositoryPort,
+  CUSTOMER_PROJECTION_REPOSITORY_TOKEN,
+  CustomerProjection,
+  CustomerAddressProjection,
+} from '@openlinker/core/customers';
+
+describe('CustomersController', () => {
+  let controller: CustomersController;
+  let repository: jest.Mocked<CustomerProjectionRepositoryPort>;
+
+  const mockCustomer = new CustomerProjection(
+    'ol_customer_abc123',
+    'hash123',
+    'test@example.com',
+    'John',
+    'Doe',
+    new Date('2026-01-01T00:00:00Z'),
+    'conn-1',
+    new Date('2026-01-01T00:00:00Z'),
+    new Date('2026-01-01T00:00:00Z'),
+  );
+
+  const mockAddress = new CustomerAddressProjection(
+    'ol_customer_abc123',
+    'addr_hash_1',
+    'shipping',
+    '123 Main St',
+    null,
+    'Warsaw',
+    '00-001',
+    'PL',
+    new Date('2026-01-01T00:00:00Z'),
+    new Date('2026-01-01T00:00:00Z'),
+    new Date('2026-01-01T00:00:00Z'),
+  );
+
+  beforeEach(async () => {
+    const mockRepository: jest.Mocked<CustomerProjectionRepositoryPort> = {
+      findById: jest.fn(),
+      findByEmailHash: jest.fn(),
+      findMany: jest.fn(),
+      upsert: jest.fn(),
+      findAddressesByCustomerId: jest.fn(),
+      upsertAddress: jest.fn(),
+      findDestinationAddressMapping: jest.fn(),
+      upsertDestinationAddressMapping: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CustomersController],
+      providers: [
+        {
+          provide: CUSTOMER_PROJECTION_REPOSITORY_TOKEN,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CustomersController>(CustomersController);
+    repository = module.get(CUSTOMER_PROJECTION_REPOSITORY_TOKEN);
+  });
+
+  describe('listCustomers', () => {
+    it('should return paginated customers with default pagination', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockCustomer], total: 1 });
+
+      const result = await controller.listCustomers({});
+
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      expect(repository.findMany).toHaveBeenCalledWith(
+        { search: undefined, lastSourceConnectionId: undefined },
+        { limit: 20, offset: 0 },
+      );
+    });
+
+    it('should pass filters to repository', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listCustomers({
+        search: 'test',
+        lastSourceConnectionId: 'conn-1',
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(repository.findMany).toHaveBeenCalledWith(
+        { search: 'test', lastSourceConnectionId: 'conn-1' },
+        { limit: 10, offset: 5 },
+      );
+    });
+
+    it('should serialize dates as ISO 8601 strings', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockCustomer], total: 1 });
+
+      const result = await controller.listCustomers({});
+
+      expect(result.items[0].lastSeenAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(result.items[0].createdAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('getCustomer', () => {
+    it('should return customer with addresses when found', async () => {
+      repository.findById.mockResolvedValue(mockCustomer);
+      repository.findAddressesByCustomerId.mockResolvedValue([mockAddress]);
+
+      const result = await controller.getCustomer('ol_customer_abc123');
+
+      expect(result.internalCustomerId).toBe('ol_customer_abc123');
+      expect(result.addresses).toHaveLength(1);
+      expect(result.addresses![0].addressType).toBe('shipping');
+      expect(result.addresses![0].city).toBe('Warsaw');
+    });
+
+    it('should throw NotFoundException when customer not found', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(controller.getCustomer('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/customers/http/customers.controller.ts
+++ b/apps/api/src/customers/http/customers.controller.ts
@@ -1,0 +1,117 @@
+/**
+ * Customers Controller
+ *
+ * HTTP REST API endpoints for customer projection read operations. Provides
+ * endpoints for listing customer projections with filters and retrieving
+ * individual customer details with addresses.
+ *
+ * @module apps/api/src/customers/http
+ */
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Inject,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { CUSTOMER_PROJECTION_REPOSITORY_TOKEN } from '@openlinker/core/customers';
+import type {
+  CustomerProjectionRepositoryPort,
+  CustomerProjection,
+  CustomerAddressProjection,
+} from '@openlinker/core/customers';
+import { ListCustomersQueryDto } from './dto/list-customers-query.dto';
+import { CustomerProjectionResponseDto } from './dto/customer-projection-response.dto';
+import { CustomerAddressResponseDto } from './dto/customer-address-response.dto';
+import { PaginatedCustomersResponseDto } from './dto/paginated-customers-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('customers')
+@Controller('customers')
+export class CustomersController {
+  constructor(
+    @Inject(CUSTOMER_PROJECTION_REPOSITORY_TOKEN)
+    private readonly customerRepository: CustomerProjectionRepositoryPort,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List customer projections',
+    description:
+      'Returns a paginated list of customer projections. Supports filtering by search text and lastSourceConnectionId.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated customer list', type: PaginatedCustomersResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listCustomers(@Query() query: ListCustomersQueryDto): Promise<PaginatedCustomersResponseDto> {
+    const { search, lastSourceConnectionId, limit = 20, offset = 0 } = query;
+
+    const { items, total } = await this.customerRepository.findMany(
+      { search, lastSourceConnectionId },
+      { limit, offset },
+    );
+
+    return {
+      items: items.map((c) => this.toDto(c)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'id', description: 'Internal customer ID (e.g. ol_customer_...)' })
+  @ApiOperation({ summary: 'Get customer projection by internal customer ID' })
+  @ApiResponse({ status: 200, description: 'Customer projection detail with addresses', type: CustomerProjectionResponseDto })
+  @ApiResponse({ status: 404, description: 'Customer not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getCustomer(@Param('id') id: string): Promise<CustomerProjectionResponseDto> {
+    const customer = await this.customerRepository.findById(id);
+    if (!customer) {
+      throw new NotFoundException(`Customer not found: ${id}`);
+    }
+
+    const addresses = await this.customerRepository.findAddressesByCustomerId(id);
+
+    return {
+      ...this.toDto(customer),
+      addresses: addresses.map((a) => this.toAddressDto(a)),
+    };
+  }
+
+  private toDto(customer: CustomerProjection): CustomerProjectionResponseDto {
+    return {
+      internalCustomerId: customer.internalCustomerId,
+      emailHash: customer.emailHash,
+      normalizedEmail: customer.normalizedEmail,
+      firstName: customer.firstName,
+      lastName: customer.lastName,
+      lastSeenAt: customer.lastSeenAt instanceof Date ? customer.lastSeenAt.toISOString() : customer.lastSeenAt,
+      lastSourceConnectionId: customer.lastSourceConnectionId,
+      createdAt: customer.createdAt instanceof Date ? customer.createdAt.toISOString() : customer.createdAt,
+      updatedAt: customer.updatedAt instanceof Date ? customer.updatedAt.toISOString() : customer.updatedAt,
+    };
+  }
+
+  private toAddressDto(address: CustomerAddressProjection): CustomerAddressResponseDto {
+    return {
+      addressHash: address.addressHash,
+      addressType: address.addressType,
+      address1: address.address1,
+      address2: address.address2,
+      city: address.city,
+      postcode: address.postcode,
+      countryIso2: address.countryIso2,
+      lastSeenAt: address.lastSeenAt instanceof Date ? address.lastSeenAt.toISOString() : address.lastSeenAt,
+      createdAt: address.createdAt instanceof Date ? address.createdAt.toISOString() : address.createdAt,
+      updatedAt: address.updatedAt instanceof Date ? address.updatedAt.toISOString() : address.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/customers/http/dto/customer-address-response.dto.ts
+++ b/apps/api/src/customers/http/dto/customer-address-response.dto.ts
@@ -1,0 +1,41 @@
+/**
+ * Customer Address Response DTO
+ *
+ * Response shape for a single customer address projection.
+ * Dates are serialised as ISO 8601 strings.
+ *
+ * @module apps/api/src/customers/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CustomerAddressResponseDto {
+  @ApiProperty({ description: 'Address hash fingerprint' })
+  addressHash!: string;
+
+  @ApiProperty({ description: 'Address type', enum: ['shipping', 'billing'] })
+  addressType!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Address line 1' })
+  address1!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Address line 2' })
+  address2!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'City' })
+  city!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Postal code' })
+  postcode!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Country ISO 2 code' })
+  countryIso2!: string | null;
+
+  @ApiProperty({ description: 'Last seen timestamp (ISO 8601)' })
+  lastSeenAt!: string;
+
+  @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Last update timestamp (ISO 8601)' })
+  updatedAt!: string;
+}

--- a/apps/api/src/customers/http/dto/customer-projection-response.dto.ts
+++ b/apps/api/src/customers/http/dto/customer-projection-response.dto.ts
@@ -1,0 +1,43 @@
+/**
+ * Customer Projection Response DTO
+ *
+ * Response shape for a single customer projection.
+ * Dates are serialised as ISO 8601 strings. PII fields may be null
+ * if OL_STORE_PII is disabled.
+ *
+ * @module apps/api/src/customers/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CustomerAddressResponseDto } from './customer-address-response.dto';
+
+export class CustomerProjectionResponseDto {
+  @ApiProperty({ description: 'Internal customer ID (e.g. ol_customer_...)' })
+  internalCustomerId!: string;
+
+  @ApiProperty({ description: 'Email hash (always present)' })
+  emailHash!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Normalized email (null if PII storage disabled)' })
+  normalizedEmail!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'First name (null if PII storage disabled)' })
+  firstName!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Last name (null if PII storage disabled)' })
+  lastName!: string | null;
+
+  @ApiProperty({ description: 'Last seen timestamp (ISO 8601)' })
+  lastSeenAt!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Last source connection ID' })
+  lastSourceConnectionId!: string | null;
+
+  @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Last update timestamp (ISO 8601)' })
+  updatedAt!: string;
+
+  @ApiPropertyOptional({ type: [CustomerAddressResponseDto], description: 'Customer addresses (detail only)' })
+  addresses?: CustomerAddressResponseDto[];
+}

--- a/apps/api/src/customers/http/dto/list-customers-query.dto.ts
+++ b/apps/api/src/customers/http/dto/list-customers-query.dto.ts
@@ -1,0 +1,39 @@
+/**
+ * List Customers Query DTO
+ *
+ * Query parameters for GET /customers. All fields are optional.
+ *
+ * @module apps/api/src/customers/http/dto
+ */
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListCustomersQueryDto {
+  @ApiPropertyOptional({
+    description: 'Case-insensitive search on emailHash, normalizedEmail, firstName, or lastName',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by last source connection ID' })
+  @IsOptional()
+  @IsString()
+  lastSourceConnectionId?: string;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/apps/api/src/customers/http/dto/paginated-customers-response.dto.ts
+++ b/apps/api/src/customers/http/dto/paginated-customers-response.dto.ts
@@ -1,0 +1,23 @@
+/**
+ * Paginated Customers Response DTO
+ *
+ * Response shape for GET /customers.
+ *
+ * @module apps/api/src/customers/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { CustomerProjectionResponseDto } from './customer-projection-response.dto';
+
+export class PaginatedCustomersResponseDto {
+  @ApiProperty({ type: [CustomerProjectionResponseDto] })
+  items!: CustomerProjectionResponseDto[];
+
+  @ApiProperty({ description: 'Total number of customer projections matching the filters' })
+  total!: number;
+
+  @ApiProperty({ description: 'Page size used for this response' })
+  limit!: number;
+
+  @ApiProperty({ description: 'Offset used for this response' })
+  offset!: number;
+}

--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -70,8 +70,6 @@ describe('ConnectionController', () => {
       markDead: jest.fn(),
       requeueStuckJobs: jest.fn(),
       findRecentByConnectionId: jest.fn(),
-      findMany: jest.fn(),
-      findById: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/listings/http/dto/list-offer-mappings-query.dto.ts
+++ b/apps/api/src/listings/http/dto/list-offer-mappings-query.dto.ts
@@ -1,0 +1,47 @@
+/**
+ * List Offer Mappings Query DTO
+ *
+ * Query parameters for GET /listings. All fields are optional.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListOfferMappingsQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by connection ID' })
+  @IsOptional()
+  @IsString()
+  connectionId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by platform type (e.g. allegro)' })
+  @IsOptional()
+  @IsString()
+  platformType?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by linked internal ID (variant ID)' })
+  @IsOptional()
+  @IsString()
+  internalId?: string;
+
+  @ApiPropertyOptional({ description: 'Case-insensitive search on external ID' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/apps/api/src/listings/http/dto/offer-mapping-response.dto.ts
+++ b/apps/api/src/listings/http/dto/offer-mapping-response.dto.ts
@@ -1,0 +1,37 @@
+/**
+ * Offer Mapping Response DTO
+ *
+ * Response shape for a single offer mapping. Dates are serialised as ISO 8601 strings.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class OfferMappingResponseDto {
+  @ApiProperty({ description: 'Mapping row ID' })
+  id!: string;
+
+  @ApiProperty({ description: 'Entity type (always Offer)' })
+  entityType!: string;
+
+  @ApiProperty({ description: 'Internal ID (linked variant ID)' })
+  internalId!: string;
+
+  @ApiProperty({ description: 'External offer ID on the platform' })
+  externalId!: string;
+
+  @ApiProperty({ description: 'Platform type (e.g. allegro, prestashop)' })
+  platformType!: string;
+
+  @ApiProperty({ description: 'Connection ID' })
+  connectionId!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Mapping context metadata' })
+  context!: Record<string, unknown> | null;
+
+  @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Last update timestamp (ISO 8601)' })
+  updatedAt!: string;
+}

--- a/apps/api/src/listings/http/dto/paginated-offer-mappings-response.dto.ts
+++ b/apps/api/src/listings/http/dto/paginated-offer-mappings-response.dto.ts
@@ -1,0 +1,23 @@
+/**
+ * Paginated Offer Mappings Response DTO
+ *
+ * Response shape for GET /listings.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { OfferMappingResponseDto } from './offer-mapping-response.dto';
+
+export class PaginatedOfferMappingsResponseDto {
+  @ApiProperty({ type: [OfferMappingResponseDto] })
+  items!: OfferMappingResponseDto[];
+
+  @ApiProperty({ description: 'Total number of offer mappings matching the filters' })
+  total!: number;
+
+  @ApiProperty({ description: 'Page size used for this response' })
+  limit!: number;
+
+  @ApiProperty({ description: 'Offset used for this response' })
+  offset!: number;
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Listings Controller Unit Tests
+ *
+ * @module apps/api/src/listings/http
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ListingsController } from './listings.controller';
+import { OFFER_MAPPING_REPOSITORY_TOKEN } from '@openlinker/core/listings';
+import type { OfferMappingRepositoryPort } from '@openlinker/core/listings';
+import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+
+describe('ListingsController', () => {
+  let controller: ListingsController;
+  let repository: jest.Mocked<OfferMappingRepositoryPort>;
+
+  const mockMapping = new IdentifierMapping(
+    'uuid-1',
+    'Offer',
+    'ol_offer_variant123',
+    'allegro-offer-456',
+    'allegro',
+    'conn-1',
+    null,
+    new Date('2026-01-01T00:00:00Z'),
+    new Date('2026-01-01T00:00:00Z'),
+  );
+
+  beforeEach(async () => {
+    const mockRepository: jest.Mocked<OfferMappingRepositoryPort> = {
+      findById: jest.fn(),
+      findMany: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ListingsController],
+      providers: [
+        {
+          provide: OFFER_MAPPING_REPOSITORY_TOKEN,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ListingsController>(ListingsController);
+    repository = module.get(OFFER_MAPPING_REPOSITORY_TOKEN);
+  });
+
+  describe('listOfferMappings', () => {
+    it('should return paginated offer mappings with default pagination', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockMapping], total: 1 });
+
+      const result = await controller.listOfferMappings({});
+
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      expect(repository.findMany).toHaveBeenCalledWith(
+        { connectionId: undefined, platformType: undefined, internalId: undefined, search: undefined },
+        { limit: 20, offset: 0 },
+      );
+    });
+
+    it('should pass filters to repository', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listOfferMappings({
+        connectionId: 'conn-1',
+        platformType: 'allegro',
+        internalId: 'ol_offer_variant123',
+        search: '456',
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(repository.findMany).toHaveBeenCalledWith(
+        { connectionId: 'conn-1', platformType: 'allegro', internalId: 'ol_offer_variant123', search: '456' },
+        { limit: 10, offset: 5 },
+      );
+    });
+
+    it('should serialize dates as ISO 8601 strings', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockMapping], total: 1 });
+
+      const result = await controller.listOfferMappings({});
+
+      expect(result.items[0].createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(result.items[0].updatedAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('getOfferMapping', () => {
+    it('should return offer mapping when found', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+
+      const result = await controller.getOfferMapping('uuid-1');
+
+      expect(result.id).toBe('uuid-1');
+      expect(result.entityType).toBe('Offer');
+      expect(result.externalId).toBe('allegro-offer-456');
+      expect(result.platformType).toBe('allegro');
+    });
+
+    it('should throw NotFoundException when offer mapping not found', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(controller.getOfferMapping('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -1,0 +1,94 @@
+/**
+ * Listings Controller
+ *
+ * HTTP REST API endpoints for offer mapping read operations. Provides endpoints
+ * for listing offer-to-variant mappings with filters and retrieving individual
+ * offer mapping details.
+ *
+ * @module apps/api/src/listings/http
+ */
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Inject,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { OFFER_MAPPING_REPOSITORY_TOKEN } from '@openlinker/core/listings';
+import type { OfferMappingRepositoryPort } from '@openlinker/core/listings';
+import type { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import { ListOfferMappingsQueryDto } from './dto/list-offer-mappings-query.dto';
+import { OfferMappingResponseDto } from './dto/offer-mapping-response.dto';
+import { PaginatedOfferMappingsResponseDto } from './dto/paginated-offer-mappings-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('listings')
+@Controller('listings')
+export class ListingsController {
+  constructor(
+    @Inject(OFFER_MAPPING_REPOSITORY_TOKEN)
+    private readonly offerMappingRepository: OfferMappingRepositoryPort,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List offer mappings',
+    description:
+      'Returns a paginated list of offer-to-variant mappings. Supports filtering by connectionId, platformType, internalId, and search on externalId.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated offer mappings list', type: PaginatedOfferMappingsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listOfferMappings(
+    @Query() query: ListOfferMappingsQueryDto,
+  ): Promise<PaginatedOfferMappingsResponseDto> {
+    const { connectionId, platformType, internalId, search, limit = 20, offset = 0 } = query;
+
+    const { items, total } = await this.offerMappingRepository.findMany(
+      { connectionId, platformType, internalId, search },
+      { limit, offset },
+    );
+
+    return {
+      items: items.map((m) => this.toDto(m)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'id', description: 'Offer mapping row ID (UUID)' })
+  @ApiOperation({ summary: 'Get offer mapping by ID' })
+  @ApiResponse({ status: 200, description: 'Offer mapping detail', type: OfferMappingResponseDto })
+  @ApiResponse({ status: 404, description: 'Offer mapping not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getOfferMapping(@Param('id') id: string): Promise<OfferMappingResponseDto> {
+    const mapping = await this.offerMappingRepository.findById(id);
+    if (!mapping) {
+      throw new NotFoundException(`Offer mapping not found: ${id}`);
+    }
+    return this.toDto(mapping);
+  }
+
+  private toDto(mapping: IdentifierMapping): OfferMappingResponseDto {
+    return {
+      id: mapping.id,
+      entityType: mapping.entityType,
+      internalId: mapping.internalId,
+      externalId: mapping.externalId,
+      platformType: mapping.platformType,
+      connectionId: mapping.connectionId,
+      context: mapping.context as Record<string, unknown> | null,
+      createdAt: mapping.createdAt instanceof Date ? mapping.createdAt.toISOString() : mapping.createdAt,
+      updatedAt: mapping.updatedAt instanceof Date ? mapping.updatedAt.toISOString() : mapping.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/listings/listings.module.ts
+++ b/apps/api/src/listings/listings.module.ts
@@ -1,0 +1,17 @@
+/**
+ * Listings API Module
+ *
+ * NestJS module for listings/offer mapping read API endpoints. Imports core
+ * listings module and registers the listings controller.
+ *
+ * @module apps/api/src/listings
+ */
+import { Module } from '@nestjs/common';
+import { ListingsModule as CoreListingsModule } from '@openlinker/core/listings';
+import { ListingsController } from './http/listings.controller';
+
+@Module({
+  imports: [CoreListingsModule],
+  controllers: [ListingsController],
+})
+export class ListingsApiModule {}

--- a/docs/plans/implementation-plan-customer-listings-read-api.md
+++ b/docs/plans/implementation-plan-customer-listings-read-api.md
@@ -1,0 +1,218 @@
+# Implementation Plan: Customer Projection & Listings Read APIs (#86, #87)
+
+## Goal
+
+Add read-only REST APIs for:
+1. **Customer projections** (`GET /customers`, `GET /customers/:id`) — expose safe customer/debug info
+2. **Offer mappings** (`GET /listings`, `GET /listings/:id`) — expose offer-to-variant mapping state
+
+## Classification
+
+- **CORE / Domain** — new filter/pagination types, extended repository ports
+- **CORE / Infrastructure** — `findMany`/`findById` repository implementations
+- **Interface / HTTP** — controllers, DTOs, API modules
+
+## Non-Goals
+
+- No write/mutation endpoints
+- No PII exposure beyond what OL_STORE_PII already allows
+- No new database migrations (querying existing tables)
+
+---
+
+## Part A: Customer Projection Read API (#86)
+
+### Step 1 — Domain types
+
+**File:** `libs/core/src/customers/domain/types/customer-projection.types.ts`
+
+Add:
+```typescript
+export interface CustomerProjectionFilters {
+  search?: string;           // ILIKE on emailHash, firstName, lastName
+  lastSourceConnectionId?: string;
+}
+
+export interface CustomerProjectionPagination {
+  limit: number;
+  offset: number;
+}
+
+export interface PaginatedCustomerProjections {
+  items: CustomerProjection[];
+  total: number;
+}
+```
+
+### Step 2 — Extend repository port
+
+**File:** `libs/core/src/customers/domain/ports/customer-projection-repository.port.ts`
+
+Add `findMany` method:
+```typescript
+findMany(
+  filters: CustomerProjectionFilters,
+  pagination: CustomerProjectionPagination,
+): Promise<PaginatedCustomerProjections>;
+```
+
+### Step 3 — Repository implementation
+
+**File:** `libs/core/src/customers/infrastructure/persistence/repositories/customer-projection.repository.ts`
+
+Implement `findMany` using QueryBuilder:
+- ILIKE search on `emailHash`, `normalizedEmail`, `firstName`, `lastName`
+- Optional filter by `lastSourceConnectionId`
+- Order by `lastSeenAt DESC`
+- `getManyAndCount()` for pagination
+
+### Step 4 — Update index exports
+
+**File:** `libs/core/src/customers/index.ts`
+
+Export new types (they're in an already-exported file, so likely automatic via `export *`).
+
+### Step 5 — HTTP DTOs
+
+**Files in** `apps/api/src/customers/http/dto/`:
+- `list-customers-query.dto.ts` — search, lastSourceConnectionId, limit, offset
+- `customer-projection-response.dto.ts` — maps CustomerProjection fields + addresses array
+- `customer-address-response.dto.ts` — maps CustomerAddressProjection fields
+- `paginated-customers-response.dto.ts` — items, total, limit, offset
+
+### Step 6 — Controller
+
+**File:** `apps/api/src/customers/http/customers.controller.ts`
+
+Endpoints:
+- `GET /customers` — list with filters, returns paginated customer projections
+- `GET /customers/:id` — detail with addresses (calls `findById` + `findAddressesByCustomerId`)
+
+Injects `CUSTOMER_PROJECTION_REPOSITORY_TOKEN`.
+
+### Step 7 — API module
+
+**File:** `apps/api/src/customers/customers.module.ts`
+
+Imports `CustomersModule` (core), registers `CustomersController`.
+
+### Step 8 — Register in AppModule
+
+**File:** `apps/api/src/app.module.ts`
+
+Add `CustomersApiModule` to imports.
+
+### Step 9 — Controller unit tests
+
+**File:** `apps/api/src/customers/http/customers.controller.spec.ts`
+
+Test list (with/without filters), detail (found/not found).
+
+---
+
+## Part B: Listings / Offer Mappings Read API (#87)
+
+### Step 10 — Domain types for listings
+
+**File:** `libs/core/src/listings/domain/types/offer-mapping.types.ts` (new)
+
+```typescript
+export interface OfferMappingFilters {
+  connectionId?: string;
+  platformType?: string;
+  internalId?: string;       // filter by linked variant ID
+  search?: string;           // search on externalId
+}
+
+export interface OfferMappingPagination {
+  limit: number;
+  offset: number;
+}
+
+export interface PaginatedOfferMappings {
+  items: IdentifierMapping[];
+  total: number;
+}
+```
+
+### Step 11 — Offer mapping repository port
+
+**File:** `libs/core/src/listings/domain/ports/offer-mapping-repository.port.ts` (new)
+
+Dedicated port for querying identifier_mappings with `entityType = 'Offer'`:
+```typescript
+export interface OfferMappingRepositoryPort {
+  findById(id: string): Promise<IdentifierMapping | null>;
+  findMany(filters: OfferMappingFilters, pagination: OfferMappingPagination): Promise<PaginatedOfferMappings>;
+}
+```
+
+### Step 12 — Repository implementation
+
+**File:** `libs/core/src/listings/infrastructure/persistence/repositories/offer-mapping.repository.ts` (new)
+
+Uses `@InjectRepository(IdentifierMappingOrmEntity)`, always scopes to `entityType = 'Offer'`.
+QueryBuilder with optional filters on connectionId, platformType, internalId, externalId search.
+Order by `createdAt DESC`.
+
+### Step 13 — Tokens and module wiring
+
+**File:** `libs/core/src/listings/listings.tokens.ts` — add `OFFER_MAPPING_REPOSITORY_TOKEN`
+
+**File:** `libs/core/src/listings/listings.module.ts` — register repository + token binding, import `TypeOrmModule.forFeature([IdentifierMappingOrmEntity])`
+
+### Step 14 — Update listings index exports
+
+**File:** `libs/core/src/listings/index.ts`
+
+Export new types, port, token.
+
+### Step 15 — HTTP DTOs
+
+**Files in** `apps/api/src/listings/http/dto/`:
+- `list-offer-mappings-query.dto.ts` — connectionId, platformType, internalId, search, limit, offset
+- `offer-mapping-response.dto.ts` — maps IdentifierMapping fields
+- `paginated-offer-mappings-response.dto.ts` — items, total, limit, offset
+
+### Step 16 — Controller
+
+**File:** `apps/api/src/listings/http/listings.controller.ts`
+
+Endpoints:
+- `GET /listings` — list offer mappings with filters
+- `GET /listings/:id` — single offer mapping detail
+
+Injects `OFFER_MAPPING_REPOSITORY_TOKEN`.
+
+### Step 17 — API module
+
+**File:** `apps/api/src/listings/listings.module.ts`
+
+Imports `ListingsModule` (core), registers `ListingsController`.
+
+### Step 18 — Register in AppModule
+
+**File:** `apps/api/src/app.module.ts`
+
+Add `ListingsApiModule` to imports.
+
+### Step 19 — Controller unit tests
+
+**File:** `apps/api/src/listings/http/listings.controller.spec.ts`
+
+Test list (with/without filters), detail (found/not found).
+
+---
+
+## Quality Gate
+
+```bash
+pnpm lint && pnpm type-check && pnpm test
+```
+
+No migrations needed — all queries target existing tables.
+
+## Risks
+
+- **PII in customer responses**: Controller must only expose fields that exist (null if OL_STORE_PII=false). No special handling needed since we read what's stored.
+- **Listings repo coupling**: Uses `IdentifierMappingOrmEntity` from identifier-mapping module. This is acceptable as a read-only query — no domain logic leakage.

--- a/libs/core/src/customers/domain/ports/customer-projection-repository.port.ts
+++ b/libs/core/src/customers/domain/ports/customer-projection-repository.port.ts
@@ -15,7 +15,12 @@
 import { CustomerProjection } from '../entities/customer-projection.entity';
 import { CustomerAddressProjection } from '../entities/customer-address-projection.entity';
 import { DestinationAddressMapping } from '../entities/destination-address-mapping.entity';
-import { AddressType } from '../types/customer-projection.types';
+import {
+  AddressType,
+  CustomerProjectionFilters,
+  CustomerProjectionPagination,
+  PaginatedCustomerProjections,
+} from '../types/customer-projection.types';
 
 export interface CustomerProjectionRepositoryPort {
   /**
@@ -28,6 +33,15 @@ export interface CustomerProjectionRepositoryPort {
    * Returns array to support collision detection (0, 1, or >1 matches)
    */
   findByEmailHash(emailHash: string): Promise<CustomerProjection[]>;
+
+  /**
+   * Find customer projections matching filters with offset pagination.
+   * Results are ordered by lastSeenAt DESC.
+   */
+  findMany(
+    filters: CustomerProjectionFilters,
+    pagination: CustomerProjectionPagination,
+  ): Promise<PaginatedCustomerProjections>;
 
   /**
    * Upsert customer projection (insert or update)

--- a/libs/core/src/customers/domain/types/customer-projection.types.ts
+++ b/libs/core/src/customers/domain/types/customer-projection.types.ts
@@ -6,6 +6,7 @@
  *
  * @module libs/core/src/customers/domain/types
  */
+import { CustomerProjection } from '../entities/customer-projection.entity';
 
 /**
  * Address type values
@@ -22,3 +23,32 @@ export const AddressTypeValues = ['shipping', 'billing'] as const;
  * without runtime overhead.
  */
 export type AddressType = (typeof AddressTypeValues)[number];
+
+/**
+ * Customer projection list filters
+ * Criteria for querying the internal customer projection store. All fields are optional.
+ */
+export interface CustomerProjectionFilters {
+  /** Case-insensitive search on emailHash, normalizedEmail, firstName, or lastName */
+  search?: string;
+  /** Filter by last source connection ID */
+  lastSourceConnectionId?: string;
+}
+
+/**
+ * Offset-based pagination parameters for customer projections
+ */
+export interface CustomerProjectionPagination {
+  /** Number of items to return (1–100) */
+  limit: number;
+  /** Number of items to skip */
+  offset: number;
+}
+
+/**
+ * Paginated customer projections result
+ */
+export interface PaginatedCustomerProjections {
+  items: CustomerProjection[];
+  total: number;
+}

--- a/libs/core/src/customers/infrastructure/persistence/repositories/customer-projection.repository.ts
+++ b/libs/core/src/customers/infrastructure/persistence/repositories/customer-projection.repository.ts
@@ -23,7 +23,12 @@ import { CustomerProjectionRepositoryPort } from '../../../domain/ports/customer
 import { CustomerProjection } from '../../../domain/entities/customer-projection.entity';
 import { CustomerAddressProjection } from '../../../domain/entities/customer-address-projection.entity';
 import { DestinationAddressMapping } from '../../../domain/entities/destination-address-mapping.entity';
-import { AddressType } from '../../../domain/types/customer-projection.types';
+import {
+  AddressType,
+  CustomerProjectionFilters,
+  CustomerProjectionPagination,
+  PaginatedCustomerProjections,
+} from '../../../domain/types/customer-projection.types';
 
 @Injectable()
 export class CustomerProjectionRepository implements CustomerProjectionRepositoryPort {
@@ -46,6 +51,34 @@ export class CustomerProjectionRepository implements CustomerProjectionRepositor
     }
 
     return this.toDomainCustomer(entity);
+  }
+
+  async findMany(
+    filters: CustomerProjectionFilters,
+    pagination: CustomerProjectionPagination,
+  ): Promise<PaginatedCustomerProjections> {
+    const qb = this.customerRepository.createQueryBuilder('customer');
+
+    if (filters.search) {
+      const escapedSearch = filters.search.replace(/[%_]/g, '\\$&');
+      qb.where(
+        '(customer.emailHash ILIKE :search OR customer.normalizedEmail ILIKE :search OR customer.firstName ILIKE :search OR customer.lastName ILIKE :search)',
+        { search: `%${escapedSearch}%` },
+      );
+    }
+
+    if (filters.lastSourceConnectionId) {
+      qb.andWhere('customer.lastSourceConnectionId = :connectionId', {
+        connectionId: filters.lastSourceConnectionId,
+      });
+    }
+
+    qb.orderBy('customer.lastSeenAt', 'DESC')
+      .skip(pagination.offset)
+      .take(pagination.limit);
+
+    const [entities, total] = await qb.getManyAndCount();
+    return { items: entities.map((e) => this.toDomainCustomer(e)), total };
   }
 
   async findByEmailHash(emailHash: string): Promise<CustomerProjection[]> {

--- a/libs/core/src/listings/domain/ports/offer-mapping-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/offer-mapping-repository.port.ts
@@ -1,0 +1,30 @@
+/**
+ * Offer Mapping Repository Port
+ *
+ * Defines the contract for offer mapping read operations. Queries the
+ * identifier_mappings table scoped to entityType = 'Offer'.
+ *
+ * @module libs/core/src/listings/domain/ports
+ */
+import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import {
+  OfferMappingFilters,
+  OfferMappingPagination,
+  PaginatedOfferMappings,
+} from '../types/offer-mapping.types';
+
+export interface OfferMappingRepositoryPort {
+  /**
+   * Find offer mapping by ID (primary key of identifier_mappings row)
+   */
+  findById(id: string): Promise<IdentifierMapping | null>;
+
+  /**
+   * Find offer mappings matching filters with offset pagination.
+   * Always scoped to entityType = 'Offer'. Results ordered by createdAt DESC.
+   */
+  findMany(
+    filters: OfferMappingFilters,
+    pagination: OfferMappingPagination,
+  ): Promise<PaginatedOfferMappings>;
+}

--- a/libs/core/src/listings/domain/types/offer-mapping.types.ts
+++ b/libs/core/src/listings/domain/types/offer-mapping.types.ts
@@ -1,0 +1,43 @@
+/**
+ * Offer Mapping Types
+ *
+ * Type definitions for offer mapping read operations. Defines filters,
+ * pagination, and paginated result types for querying offer-to-variant
+ * mappings stored in the identifier_mappings table.
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+
+/**
+ * Offer mapping list filters
+ * Criteria for querying offer mappings. All fields are optional.
+ */
+export interface OfferMappingFilters {
+  /** Filter by connection ID */
+  connectionId?: string;
+  /** Filter by platform type (e.g. 'allegro') */
+  platformType?: string;
+  /** Filter by linked internal ID (variant ID) */
+  internalId?: string;
+  /** Case-insensitive search on external ID */
+  search?: string;
+}
+
+/**
+ * Offset-based pagination parameters for offer mappings
+ */
+export interface OfferMappingPagination {
+  /** Number of items to return (1–100) */
+  limit: number;
+  /** Number of items to skip */
+  offset: number;
+}
+
+/**
+ * Paginated offer mappings result
+ */
+export interface PaginatedOfferMappings {
+  items: IdentifierMapping[];
+  total: number;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -8,6 +8,7 @@ export { ListingsModule } from './listings.module';
 export {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
+  OFFER_MAPPING_REPOSITORY_TOKEN,
 } from './listings.tokens';
 export { OfferLinkingService } from './application/services/offer-linking.service';
 export { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
@@ -16,3 +17,9 @@ export type {
   OfferMappingSyncOptions,
   OfferMappingSyncResult,
 } from './application/services/offer-mapping-sync.service.interface';
+export type { OfferMappingRepositoryPort } from './domain/ports/offer-mapping-repository.port';
+export type {
+  OfferMappingFilters,
+  OfferMappingPagination,
+  PaginatedOfferMappings,
+} from './domain/types/offer-mapping.types';

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-mapping.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-mapping.repository.ts
@@ -1,0 +1,96 @@
+/**
+ * Offer Mapping Repository
+ *
+ * Repository implementation for offer mapping read operations.
+ * Queries the identifier_mappings table scoped to entityType = 'Offer'.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/repositories
+ * @implements {OfferMappingRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  IdentifierMappingOrmEntity,
+  IdentifierMapping,
+  EntityType,
+} from '@openlinker/core/identifier-mapping';
+import { OfferMappingRepositoryPort } from '../../../domain/ports/offer-mapping-repository.port';
+import {
+  OfferMappingFilters,
+  OfferMappingPagination,
+  PaginatedOfferMappings,
+} from '../../../domain/types/offer-mapping.types';
+
+const OFFER_ENTITY_TYPE: EntityType = 'Offer';
+
+@Injectable()
+export class OfferMappingRepository implements OfferMappingRepositoryPort {
+  constructor(
+    @InjectRepository(IdentifierMappingOrmEntity)
+    private readonly repository: Repository<IdentifierMappingOrmEntity>,
+  ) {}
+
+  async findById(id: string): Promise<IdentifierMapping | null> {
+    const entity = await this.repository.findOne({
+      where: { id, entityType: OFFER_ENTITY_TYPE },
+    });
+    if (!entity) return null;
+    return this.toDomain(entity);
+  }
+
+  async findMany(
+    filters: OfferMappingFilters,
+    pagination: OfferMappingPagination,
+  ): Promise<PaginatedOfferMappings> {
+    const qb = this.repository.createQueryBuilder('mapping');
+
+    qb.where('mapping.entityType = :entityType', { entityType: OFFER_ENTITY_TYPE });
+
+    if (filters.connectionId) {
+      qb.andWhere('mapping.connectionId = :connectionId', {
+        connectionId: filters.connectionId,
+      });
+    }
+
+    if (filters.platformType) {
+      qb.andWhere('mapping.platformType = :platformType', {
+        platformType: filters.platformType,
+      });
+    }
+
+    if (filters.internalId) {
+      qb.andWhere('mapping.internalId = :internalId', {
+        internalId: filters.internalId,
+      });
+    }
+
+    if (filters.search) {
+      const escapedSearch = filters.search.replace(/[%_]/g, '\\$&');
+      qb.andWhere('mapping.externalId ILIKE :search', {
+        search: `%${escapedSearch}%`,
+      });
+    }
+
+    qb.orderBy('mapping.createdAt', 'DESC')
+      .skip(pagination.offset)
+      .take(pagination.limit);
+
+    const [entities, total] = await qb.getManyAndCount();
+    return { items: entities.map((e) => this.toDomain(e)), total };
+  }
+
+  private toDomain(entity: IdentifierMappingOrmEntity): IdentifierMapping {
+    return new IdentifierMapping(
+      entity.id,
+      entity.entityType as EntityType,
+      entity.internalId,
+      entity.externalId,
+      entity.platformType,
+      entity.connectionId,
+      entity.context ?? null,
+      entity.createdAt,
+      entity.updatedAt,
+    );
+  }
+}

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -6,27 +6,37 @@
  * @module libs/core/src/listings
  */
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { IntegrationsModule } from '@openlinker/core/integrations';
-import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
+import { IdentifierMappingModule, IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping';
 import { ProductsModule } from '@openlinker/core/products';
 import { OfferLinkingService } from './application/services/offer-linking.service';
 import { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
+import { OfferMappingRepository } from './infrastructure/persistence/repositories/offer-mapping.repository';
 import {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
+  OFFER_MAPPING_REPOSITORY_TOKEN,
 } from './listings.tokens';
 
 // Re-export tokens for convenience
 export {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
+  OFFER_MAPPING_REPOSITORY_TOKEN,
 } from './listings.tokens';
 
 @Module({
-  imports: [IntegrationsModule, IdentifierMappingModule, ProductsModule],
+  imports: [
+    TypeOrmModule.forFeature([IdentifierMappingOrmEntity]),
+    IntegrationsModule,
+    IdentifierMappingModule,
+    ProductsModule,
+  ],
   providers: [
     OfferLinkingService,
     OfferMappingSyncService,
+    OfferMappingRepository,
     {
       provide: OFFER_LINKING_SERVICE_TOKEN,
       useExisting: OfferLinkingService,
@@ -36,6 +46,10 @@ export {
       useExisting: OfferMappingSyncService,
     },
     {
+      provide: OFFER_MAPPING_REPOSITORY_TOKEN,
+      useExisting: OfferMappingRepository,
+    },
+    {
       provide: 'OfferLinkingService',
       useExisting: OFFER_LINKING_SERVICE_TOKEN,
     },
@@ -43,12 +57,18 @@ export {
       provide: 'IOfferMappingSyncService',
       useExisting: OFFER_MAPPING_SYNC_SERVICE_TOKEN,
     },
+    {
+      provide: 'OfferMappingRepositoryPort',
+      useExisting: OFFER_MAPPING_REPOSITORY_TOKEN,
+    },
   ],
   exports: [
     OFFER_LINKING_SERVICE_TOKEN,
     OFFER_MAPPING_SYNC_SERVICE_TOKEN,
+    OFFER_MAPPING_REPOSITORY_TOKEN,
     'OfferLinkingService',
     'IOfferMappingSyncService',
+    'OfferMappingRepositoryPort',
   ],
 })
 export class ListingsModule {}

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -6,3 +6,4 @@
 
 export const OFFER_LINKING_SERVICE_TOKEN = Symbol('OfferLinkingService');
 export const OFFER_MAPPING_SYNC_SERVICE_TOKEN = Symbol('OfferMappingSyncService');
+export const OFFER_MAPPING_REPOSITORY_TOKEN = Symbol('OfferMappingRepositoryPort');


### PR DESCRIPTION
## Summary

- Add read-only REST endpoints for customer projections (`GET /customers`, `GET /customers/:id` with addresses)
- Add read-only REST endpoints for offer mappings (`GET /listings`, `GET /listings/:id`)
- Extend `CustomerProjectionRepositoryPort` with `findMany` for pagination/filtering
- Add `OfferMappingRepositoryPort` in listings domain querying `identifier_mappings` scoped to `entityType=Offer`

## Changes

- **CORE domain** — new pagination/filter types in `customer-projection.types.ts` and `offer-mapping.types.ts`; extended customer repository port; new offer mapping repository port
- **CORE infrastructure** — `findMany` implementation in `CustomerProjectionRepository`; new `OfferMappingRepository`
- **API interface** — new `CustomersController`, `ListingsController` with DTOs, query validation, Swagger docs
- **API modules** — `CustomersApiModule` and `ListingsApiModule` registered in `AppModule`
- **Pre-existing fix** — removed duplicate mock properties in `connection.controller.spec.ts`

## Test plan

- [x] Unit tests pass (`pnpm test`) — 18 suites, 146 tests
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] No database migrations needed (querying existing tables)

Closes #86
Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)