### PR TITLE
feat(web): add inventory and orders explorer UIs

### DIFF
--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -3,6 +3,8 @@ import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/al
 import { createAuthApi, type AuthApi } from '../../features/auth/api/auth.api';
 import { createConnectionsApi, type ConnectionsApi } from '../../features/connections/api/connections.api';
 import { createHealthApi, type HealthApi } from '../../features/health/api/health.api';
+import { createInventoryApi, type InventoryApi } from '../../features/inventory/api/inventory.api';
+import { createOrdersApi, type OrdersApi } from '../../features/orders/api/orders.api';
 import { createProductsApi, type ProductsApi } from '../../features/products/api/products.api';
 import { createSyncJobsApi, type SyncJobsApi } from '../../features/sync-jobs/api/sync.api';
 import { ApiError } from '../../shared/api/api-error';
@@ -23,6 +25,8 @@ export interface ApiClient {
   auth: AuthApi;
   connections: ConnectionsApi;
   health: HealthApi;
+  inventory: InventoryApi;
+  orders: OrdersApi;
   products: ProductsApi;
   request: <T>(path: string, init?: RequestInit) => Promise<T>;
   syncJobs: SyncJobsApi;
@@ -110,6 +114,8 @@ export function createApiClient({
     auth: createAuthApi(request),
     connections: createConnectionsApi(request),
     health: createHealthApi(request),
+    inventory: createInventoryApi(request),
+    orders: createOrdersApi(request),
     products: createProductsApi(request),
     request,
     syncJobs: createSyncJobsApi(request),

--- a/apps/web/src/app/app.test.tsx
+++ b/apps/web/src/app/app.test.tsx
@@ -39,12 +39,11 @@ describe('App', () => {
     expect(screen.getAllByText('Development')).not.toHaveLength(0);
   });
 
-  it('renders planned placeholder routes from the primary navigation', async () => {
+  it('renders orders list page from the primary navigation', async () => {
     const view = renderApp(['/orders']);
 
-    expect(await screen.findByRole('heading', { name: 'Orders workspace' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Orders' })).toBeInTheDocument();
     const primaryNavigation = within(view.container).getByRole('navigation', { name: 'Primary' });
     expect(within(primaryNavigation).getByText('Orders').closest('a')).toHaveAttribute('href', '/orders');
-    expect(screen.getByText('Orders is planned')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/routes/inventory.route.tsx
+++ b/apps/web/src/app/routes/inventory.route.tsx
@@ -1,14 +1,11 @@
 import type { RouteObject } from 'react-router-dom';
-import { ModulePlaceholderPage } from '../../pages/placeholders/module-placeholder-page';
+import { InventoryListPage } from '../../pages/inventory/inventory-list-page';
+import { InventoryDetailPage } from '../../pages/inventory/inventory-detail-page';
 
 export const inventoryRoute: RouteObject = {
   path: 'inventory',
-  element: (
-    <ModulePlaceholderPage
-      eyebrow="Operations"
-      title="Inventory workspace"
-      moduleName="Inventory"
-      description="Inventory health, conflict resolution, and stock synchronization workflows will expand into this area later."
-    />
-  ),
+  children: [
+    { index: true, element: <InventoryListPage /> },
+    { path: ':id', element: <InventoryDetailPage /> },
+  ],
 };

--- a/apps/web/src/app/routes/orders.route.tsx
+++ b/apps/web/src/app/routes/orders.route.tsx
@@ -1,14 +1,11 @@
 import type { RouteObject } from 'react-router-dom';
-import { ModulePlaceholderPage } from '../../pages/placeholders/module-placeholder-page';
+import { OrdersListPage } from '../../pages/orders/orders-list-page';
+import { OrderDetailPage } from '../../pages/orders/order-detail-page';
 
 export const ordersRoute: RouteObject = {
   path: 'orders',
-  element: (
-    <ModulePlaceholderPage
-      eyebrow="Operations"
-      title="Orders workspace"
-      moduleName="Orders"
-      description="Order intake, exceptions, and reconciliation will live here once the shell-level navigation contract is in place."
-    />
-  ),
+  children: [
+    { index: true, element: <OrdersListPage /> },
+    { path: ':internalOrderId', element: <OrderDetailPage /> },
+  ],
 };

--- a/apps/web/src/features/inventory/api/inventory.api.ts
+++ b/apps/web/src/features/inventory/api/inventory.api.ts
@@ -1,0 +1,45 @@
+/**
+ * Inventory API Client
+ *
+ * Thin API module for the inventory feature. Provides typed methods for
+ * listing inventory items and fetching individual item details.
+ *
+ * @module apps/web/src/features/inventory/api
+ */
+import type {
+  InventoryFilters,
+  InventoryPagination,
+  PaginatedInventory,
+  InventoryItem,
+} from './inventory.types';
+
+export interface InventoryApi {
+  list: (filters?: InventoryFilters, pagination?: InventoryPagination) => Promise<PaginatedInventory>;
+  getById: (id: string) => Promise<InventoryItem>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+function buildQuery(filters?: InventoryFilters, pagination?: InventoryPagination): string {
+  const params = new URLSearchParams();
+  if (filters?.productId) params.set('productId', filters.productId);
+  if (filters?.productVariantId) params.set('productVariantId', filters.productVariantId);
+  if (filters?.locationId) params.set('locationId', filters.locationId);
+  if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
+  if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}
+
+export function createInventoryApi(request: ApiRequest): InventoryApi {
+  return {
+    list(filters, pagination): Promise<PaginatedInventory> {
+      return request<PaginatedInventory>(`/inventory${buildQuery(filters, pagination)}`);
+    },
+    getById(id): Promise<InventoryItem> {
+      return request<InventoryItem>(`/inventory/${id}`);
+    },
+  };
+}

--- a/apps/web/src/features/inventory/api/inventory.query-keys.ts
+++ b/apps/web/src/features/inventory/api/inventory.query-keys.ts
@@ -1,0 +1,8 @@
+import type { InventoryFilters, InventoryPagination } from './inventory.types';
+
+export const inventoryQueryKeys = {
+  all: ['inventory'] as const,
+  list: (filters?: InventoryFilters, pagination?: InventoryPagination) =>
+    ['inventory', 'list', filters ?? {}, pagination ?? {}] as const,
+  detail: (id: string) => ['inventory', 'detail', id] as const,
+};

--- a/apps/web/src/features/inventory/api/inventory.types.ts
+++ b/apps/web/src/features/inventory/api/inventory.types.ts
@@ -1,0 +1,37 @@
+/**
+ * Inventory Feature Types
+ *
+ * Frontend transport types for the inventory API. Mirrors the backend
+ * InventoryItemResponseDto and PaginatedInventoryResponseDto contracts.
+ * All date fields are ISO 8601 strings.
+ *
+ * @module apps/web/src/features/inventory/api
+ */
+
+export interface InventoryItem {
+  id: string;
+  productId: string;
+  productVariantId: string | null;
+  availableQuantity: number;
+  reservedQuantity: number;
+  locationId: string | null;
+  updatedAt: string;
+}
+
+export interface InventoryFilters {
+  productId?: string;
+  productVariantId?: string;
+  locationId?: string;
+}
+
+export interface InventoryPagination {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedInventory {
+  items: InventoryItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/web/src/features/inventory/hooks/use-inventory-item-query.ts
+++ b/apps/web/src/features/inventory/hooks/use-inventory-item-query.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { inventoryQueryKeys } from '../api/inventory.query-keys';
+import type { InventoryItem } from '../api/inventory.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useInventoryItemQuery(id: string): UseQueryResult<InventoryItem> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: inventoryQueryKeys.detail(id),
+    queryFn: () => apiClient.inventory.getById(id),
+    enabled: Boolean(id),
+    retry: false,
+  });
+}

--- a/apps/web/src/features/inventory/hooks/use-inventory-query.ts
+++ b/apps/web/src/features/inventory/hooks/use-inventory-query.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { inventoryQueryKeys } from '../api/inventory.query-keys';
+import type { PaginatedInventory, InventoryFilters, InventoryPagination } from '../api/inventory.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useInventoryQuery(
+  filters?: InventoryFilters,
+  pagination?: InventoryPagination,
+): UseQueryResult<PaginatedInventory> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: inventoryQueryKeys.list(filters, pagination),
+    queryFn: () => apiClient.inventory.list(filters, pagination),
+    retry: false,
+  });
+}

--- a/apps/web/src/features/orders/api/orders.api.ts
+++ b/apps/web/src/features/orders/api/orders.api.ts
@@ -1,0 +1,47 @@
+/**
+ * Orders API Client
+ *
+ * Thin API module for the orders feature. Provides typed methods for
+ * listing orders and fetching individual order details.
+ *
+ * @module apps/web/src/features/orders/api
+ */
+import type {
+  OrderFilters,
+  OrderPagination,
+  PaginatedOrders,
+  OrderRecord,
+} from './orders.types';
+
+export interface OrdersApi {
+  list: (filters?: OrderFilters, pagination?: OrderPagination) => Promise<PaginatedOrders>;
+  getById: (internalOrderId: string) => Promise<OrderRecord>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+function buildQuery(filters?: OrderFilters, pagination?: OrderPagination): string {
+  const params = new URLSearchParams();
+  if (filters?.sourceConnectionId) params.set('sourceConnectionId', filters.sourceConnectionId);
+  if (filters?.syncStatus) params.set('syncStatus', filters.syncStatus);
+  if (filters?.customerId) params.set('customerId', filters.customerId);
+  if (filters?.createdFrom) params.set('createdFrom', filters.createdFrom);
+  if (filters?.createdTo) params.set('createdTo', filters.createdTo);
+  if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
+  if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}
+
+export function createOrdersApi(request: ApiRequest): OrdersApi {
+  return {
+    list(filters, pagination): Promise<PaginatedOrders> {
+      return request<PaginatedOrders>(`/orders${buildQuery(filters, pagination)}`);
+    },
+    getById(internalOrderId): Promise<OrderRecord> {
+      return request<OrderRecord>(`/orders/${internalOrderId}`);
+    },
+  };
+}

--- a/apps/web/src/features/orders/api/orders.query-keys.ts
+++ b/apps/web/src/features/orders/api/orders.query-keys.ts
@@ -1,0 +1,8 @@
+import type { OrderFilters, OrderPagination } from './orders.types';
+
+export const ordersQueryKeys = {
+  all: ['orders'] as const,
+  list: (filters?: OrderFilters, pagination?: OrderPagination) =>
+    ['orders', 'list', filters ?? {}, pagination ?? {}] as const,
+  detail: (internalOrderId: string) => ['orders', 'detail', internalOrderId] as const,
+};

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -1,0 +1,52 @@
+/**
+ * Orders Feature Types
+ *
+ * Frontend transport types for the orders API. Mirrors the backend
+ * OrderRecordResponseDto and OrderSyncStatusResponseDto contracts.
+ * All date fields are ISO 8601 strings.
+ *
+ * @module apps/web/src/features/orders/api
+ */
+
+export const OrderSyncStatusValues = ['pending', 'syncing', 'synced', 'failed'] as const;
+export type OrderSyncStatusValue = (typeof OrderSyncStatusValues)[number];
+
+export interface OrderSyncStatus {
+  destinationConnectionId: string;
+  status: OrderSyncStatusValue;
+  syncedAt: string | null;
+  externalOrderId: string | null;
+  externalOrderNumber: string | null;
+  error: string | null;
+}
+
+export interface OrderRecord {
+  internalOrderId: string;
+  customerId: string | null;
+  sourceConnectionId: string;
+  sourceEventId: string | null;
+  orderSnapshot: Record<string, unknown>;
+  syncStatus: OrderSyncStatus[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrderFilters {
+  sourceConnectionId?: string;
+  syncStatus?: OrderSyncStatusValue;
+  customerId?: string;
+  createdFrom?: string;
+  createdTo?: string;
+}
+
+export interface OrderPagination {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedOrders {
+  items: OrderRecord[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/web/src/features/orders/hooks/use-order-query.ts
+++ b/apps/web/src/features/orders/hooks/use-order-query.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { ordersQueryKeys } from '../api/orders.query-keys';
+import type { OrderRecord } from '../api/orders.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useOrderQuery(internalOrderId: string): UseQueryResult<OrderRecord> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: ordersQueryKeys.detail(internalOrderId),
+    queryFn: () => apiClient.orders.getById(internalOrderId),
+    enabled: Boolean(internalOrderId),
+    retry: false,
+  });
+}

--- a/apps/web/src/features/orders/hooks/use-orders-query.ts
+++ b/apps/web/src/features/orders/hooks/use-orders-query.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { ordersQueryKeys } from '../api/orders.query-keys';
+import type { PaginatedOrders, OrderFilters, OrderPagination } from '../api/orders.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useOrdersQuery(
+  filters?: OrderFilters,
+  pagination?: OrderPagination,
+): UseQueryResult<PaginatedOrders> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: ordersQueryKeys.list(filters, pagination),
+    queryFn: () => apiClient.orders.list(filters, pagination),
+    retry: false,
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1190,3 +1190,16 @@ textarea {
 .guest-form__submit {
   width: 100%;
 }
+
+/* Raw payload display */
+.raw-payload {
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 1rem;
+  background: var(--bg-surface-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.625rem;
+  font-size: 0.85rem;
+  max-height: 32rem;
+  overflow-y: auto;
+}

--- a/apps/web/src/pages/inventory/inventory-detail-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.tsx
@@ -1,0 +1,92 @@
+import type { ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { useInventoryItemQuery } from '../../features/inventory/hooks/use-inventory-item-query';
+
+export function InventoryDetailPage(): ReactElement {
+  const { id = '' } = useParams<{ id: string }>();
+  const query = useInventoryItemQuery(id);
+
+  if (query.isLoading) {
+    return (
+      <PageLayout eyebrow="Inventory" title="Inventory item">
+        <LoadingState liveRegion="off" title="Loading inventory item" message="Fetching item details…" />
+      </PageLayout>
+    );
+  }
+
+  if (query.error || !query.data) {
+    return (
+      <PageLayout eyebrow="Inventory" title="Inventory item">
+        <ErrorState
+          title="Unable to load inventory item"
+          message={query.error?.message ?? 'Item not found'}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      </PageLayout>
+    );
+  }
+
+  const item = query.data;
+
+  return (
+    <PageLayout
+      eyebrow="Inventory"
+      title={`Inventory — ${item.id}`}
+      actions={
+        <Link to=".." relative="path" className="button button--ghost">
+          ← Back to inventory
+        </Link>
+      }
+    >
+      <section className="detail-section">
+        <dl className="detail-list">
+          <div className="detail-list__row">
+            <dt>Item ID</dt>
+            <dd><span className="mono-text">{item.id}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Product ID</dt>
+            <dd><span className="mono-text">{item.productId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Variant ID</dt>
+            <dd>
+              {item.productVariantId ? (
+                <span className="mono-text">{item.productVariantId}</span>
+              ) : (
+                <span className="text-muted">—</span>
+              )}
+            </dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Available Quantity</dt>
+            <dd>{item.availableQuantity}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Reserved Quantity</dt>
+            <dd>{item.reservedQuantity}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Location</dt>
+            <dd>
+              {item.locationId ? (
+                <span className="mono-text">{item.locationId}</span>
+              ) : (
+                <span className="text-muted">default</span>
+              )}
+            </dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Updated</dt>
+            <dd>{new Date(item.updatedAt).toLocaleString()}</dd>
+          </div>
+        </dl>
+      </section>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/inventory/inventory-list-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.tsx
@@ -1,0 +1,202 @@
+import { useState, type ReactElement } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
+import { useInventoryQuery } from '../../features/inventory/hooks/use-inventory-query';
+import type { InventoryItem, InventoryFilters } from '../../features/inventory/api/inventory.types';
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+
+const COLUMNS: DataTableColumn<InventoryItem>[] = [
+  {
+    id: 'productId',
+    header: 'Product ID',
+    cell: (item) => <span className="mono-text">{item.productId}</span>,
+  },
+  {
+    id: 'productVariantId',
+    header: 'Variant ID',
+    cell: (item) =>
+      item.productVariantId ? (
+        <span className="mono-text">{item.productVariantId}</span>
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+  {
+    id: 'availableQuantity',
+    header: 'Available',
+    align: 'right',
+    cell: (item) => item.availableQuantity,
+  },
+  {
+    id: 'reservedQuantity',
+    header: 'Reserved',
+    align: 'right',
+    cell: (item) =>
+      item.reservedQuantity > 0 ? (
+        item.reservedQuantity
+      ) : (
+        <span className="text-muted">0</span>
+      ),
+  },
+  {
+    id: 'locationId',
+    header: 'Location',
+    cell: (item) =>
+      item.locationId ? (
+        <span className="mono-text">{item.locationId}</span>
+      ) : (
+        <span className="text-muted">default</span>
+      ),
+  },
+  {
+    id: 'updatedAt',
+    header: 'Updated',
+    cell: (item) => new Date(item.updatedAt).toLocaleDateString(),
+  },
+  {
+    id: 'detail',
+    header: '',
+    cell: (item) => (
+      <Link to={item.id} className="button button--ghost button--compact">
+        View
+      </Link>
+    ),
+  },
+];
+
+export function InventoryListPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const urlProductId = searchParams.get('productId') ?? '';
+  const urlVariantId = searchParams.get('productVariantId') ?? '';
+  const offset = Number(searchParams.get('offset') ?? '0');
+
+  const [productIdInput, setProductIdInput] = useState(urlProductId);
+  const [variantIdInput, setVariantIdInput] = useState(urlVariantId);
+  const debouncedProductId = useDebouncedValue(productIdInput, SEARCH_DEBOUNCE_MS);
+  const debouncedVariantId = useDebouncedValue(variantIdInput, SEARCH_DEBOUNCE_MS);
+
+  const filters: InventoryFilters = {
+    productId: debouncedProductId || undefined,
+    productVariantId: debouncedVariantId || undefined,
+  };
+  const pagination = { limit: PAGE_SIZE, offset };
+
+  const query = useInventoryQuery(filters, pagination);
+
+  function handleFilterChange(key: string, value: string): void {
+    if (key === 'productId') setProductIdInput(value);
+    if (key === 'productVariantId') setVariantIdInput(value);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  function setOffset(next: number): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === 0) {
+        p.delete('offset');
+      } else {
+        p.set('offset', String(next));
+      }
+      return p;
+    });
+  }
+
+  const total = query.data?.total ?? 0;
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  return (
+    <PageLayout
+      eyebrow="Operations"
+      title="Inventory"
+      description="Stock visibility — browse available and reserved quantities."
+    >
+      {/* Filters */}
+      <div className="toolbar" style={{ gap: '0.5rem' }}>
+        <input
+          aria-label="Filter by product ID"
+          placeholder="Product ID…"
+          value={productIdInput}
+          onChange={(e) => { handleFilterChange('productId', e.target.value); }}
+        />
+        <input
+          aria-label="Filter by variant ID"
+          placeholder="Variant ID…"
+          value={variantIdInput}
+          onChange={(e) => { handleFilterChange('productVariantId', e.target.value); }}
+        />
+      </div>
+
+      {query.isLoading ? (
+        <LoadingState
+          liveRegion="off"
+          title="Loading inventory"
+          message="Fetching inventory data…"
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load inventory"
+          message={query.error.message}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      ) : (query.data?.items.length ?? 0) === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No inventory items found"
+          message={
+            debouncedProductId || debouncedVariantId
+              ? 'No inventory items match the current filters.'
+              : 'No inventory records have been synced yet.'
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Inventory items"
+            columns={COLUMNS}
+            rows={query.data?.items ?? []}
+            rowKey={(item) => item.id}
+          />
+
+          <div className="toolbar" style={{ justifyContent: 'space-between' }}>
+            <span className="text-muted">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <Button
+                disabled={!hasPrev}
+                onClick={() => { setOffset(offset - PAGE_SIZE); }}
+              >
+                Previous
+              </Button>
+              <Button
+                disabled={!hasNext}
+                onClick={() => { setOffset(offset + PAGE_SIZE); }}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -1,0 +1,184 @@
+import type { ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { useOrderQuery } from '../../features/orders/hooks/use-order-query';
+import type { OrderSyncStatus, OrderSyncStatusValue } from '../../features/orders/api/orders.types';
+
+const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
+  pending: 'info',
+  syncing: 'warning',
+  synced: 'success',
+  failed: 'error',
+};
+
+const SYNC_COLUMNS: DataTableColumn<OrderSyncStatus>[] = [
+  {
+    id: 'destinationConnectionId',
+    header: 'Destination',
+    cell: (s) => <span className="mono-text">{s.destinationConnectionId}</span>,
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    cell: (s) => (
+      <StatusBadge tone={SYNC_STATUS_TONES[s.status]} compact>
+        {s.status}
+      </StatusBadge>
+    ),
+  },
+  {
+    id: 'externalOrderId',
+    header: 'External Order ID',
+    cell: (s) =>
+      s.externalOrderId ? (
+        <span className="mono-text">{s.externalOrderId}</span>
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+  {
+    id: 'externalOrderNumber',
+    header: 'External Order #',
+    cell: (s) =>
+      s.externalOrderNumber ? (
+        <span className="mono-text">{s.externalOrderNumber}</span>
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+  {
+    id: 'syncedAt',
+    header: 'Synced At',
+    cell: (s) =>
+      s.syncedAt ? (
+        new Date(s.syncedAt).toLocaleString()
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+  {
+    id: 'error',
+    header: 'Error',
+    cell: (s) =>
+      s.error ? (
+        <span className="text-muted" title={s.error}>
+          {s.error.length > 80 ? `${s.error.slice(0, 80)}…` : s.error}
+        </span>
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+];
+
+export function OrderDetailPage(): ReactElement {
+  const { internalOrderId = '' } = useParams<{ internalOrderId: string }>();
+  const query = useOrderQuery(internalOrderId);
+
+  if (query.isLoading) {
+    return (
+      <PageLayout eyebrow="Orders" title="Order detail">
+        <LoadingState liveRegion="off" title="Loading order" message="Fetching order details…" />
+      </PageLayout>
+    );
+  }
+
+  if (query.error || !query.data) {
+    return (
+      <PageLayout eyebrow="Orders" title="Order detail">
+        <ErrorState
+          title="Unable to load order"
+          message={query.error?.message ?? 'Order not found'}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      </PageLayout>
+    );
+  }
+
+  const order = query.data;
+
+  return (
+    <PageLayout
+      eyebrow="Orders"
+      title={`Order — ${order.internalOrderId}`}
+      actions={
+        <Link to=".." relative="path" className="button button--ghost">
+          ← Back to orders
+        </Link>
+      }
+    >
+      {/* Order metadata */}
+      <section className="detail-section">
+        <h3 className="detail-section__title">Details</h3>
+        <dl className="detail-list">
+          <div className="detail-list__row">
+            <dt>Order ID</dt>
+            <dd><span className="mono-text">{order.internalOrderId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Source Connection</dt>
+            <dd><span className="mono-text">{order.sourceConnectionId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Customer ID</dt>
+            <dd>
+              {order.customerId ? (
+                <span className="mono-text">{order.customerId}</span>
+              ) : (
+                <span className="text-muted">—</span>
+              )}
+            </dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Source Event ID</dt>
+            <dd>
+              {order.sourceEventId ? (
+                <span className="mono-text">{order.sourceEventId}</span>
+              ) : (
+                <span className="text-muted">—</span>
+              )}
+            </dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Created</dt>
+            <dd>{new Date(order.createdAt).toLocaleString()}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Updated</dt>
+            <dd>{new Date(order.updatedAt).toLocaleString()}</dd>
+          </div>
+        </dl>
+      </section>
+
+      {/* Sync status */}
+      <section className="detail-section">
+        <h3 className="detail-section__title">
+          Sync Status{order.syncStatus.length > 0 ? ` (${order.syncStatus.length})` : ''}
+        </h3>
+        {order.syncStatus.length > 0 ? (
+          <DataTable
+            caption="Order sync status"
+            columns={SYNC_COLUMNS}
+            rows={order.syncStatus}
+            rowKey={(s) => s.destinationConnectionId}
+          />
+        ) : (
+          <p className="text-muted">No sync destinations configured.</p>
+        )}
+      </section>
+
+      {/* Order snapshot */}
+      <section className="detail-section">
+        <h3 className="detail-section__title">Order Snapshot</h3>
+        <pre className="mono-text raw-payload">
+          {JSON.stringify(order.orderSnapshot, null, 2)}
+        </pre>
+      </section>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -1,0 +1,203 @@
+import { type ReactElement } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { Select } from '../../shared/ui/select';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
+import type { OrderRecord, OrderFilters, OrderSyncStatusValue } from '../../features/orders/api/orders.types';
+import { OrderSyncStatusValues } from '../../features/orders/api/orders.types';
+
+const PAGE_SIZE = 20;
+
+const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
+  pending: 'info',
+  syncing: 'warning',
+  synced: 'success',
+  failed: 'error',
+};
+
+const COLUMNS: DataTableColumn<OrderRecord>[] = [
+  {
+    id: 'internalOrderId',
+    header: 'Order ID',
+    cell: (order) => <span className="mono-text">{order.internalOrderId}</span>,
+  },
+  {
+    id: 'sourceConnectionId',
+    header: 'Source Connection',
+    cell: (order) => <span className="mono-text">{order.sourceConnectionId}</span>,
+  },
+  {
+    id: 'customerId',
+    header: 'Customer',
+    cell: (order) =>
+      order.customerId ? (
+        <span className="mono-text">{order.customerId}</span>
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+  {
+    id: 'syncStatus',
+    header: 'Sync Status',
+    cell: (order) => {
+      if (order.syncStatus.length === 0) {
+        return <span className="text-muted">—</span>;
+      }
+      return (
+        <span style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
+          {order.syncStatus.map((s) => (
+            <StatusBadge
+              key={s.destinationConnectionId}
+              tone={SYNC_STATUS_TONES[s.status]}
+              compact
+            >
+              {s.status}
+            </StatusBadge>
+          ))}
+        </span>
+      );
+    },
+  },
+  {
+    id: 'createdAt',
+    header: 'Created',
+    cell: (order) => new Date(order.createdAt).toLocaleDateString(),
+  },
+  {
+    id: 'detail',
+    header: '',
+    cell: (order) => (
+      <Link to={order.internalOrderId} className="button button--ghost button--compact">
+        View
+      </Link>
+    ),
+  },
+];
+
+export function OrdersListPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const syncStatus = (searchParams.get('syncStatus') as OrderSyncStatusValue | null) ?? undefined;
+  const sourceConnectionId = searchParams.get('sourceConnectionId') ?? undefined;
+  const offset = Number(searchParams.get('offset') ?? '0');
+
+  const filters: OrderFilters = {
+    syncStatus: syncStatus && OrderSyncStatusValues.includes(syncStatus) ? syncStatus : undefined,
+    sourceConnectionId: sourceConnectionId || undefined,
+  };
+  const pagination = { limit: PAGE_SIZE, offset };
+
+  const query = useOrdersQuery(filters, pagination);
+
+  function handleStatusFilterChange(value: string): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set('syncStatus', value);
+      } else {
+        next.delete('syncStatus');
+      }
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  function setOffset(next: number): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === 0) {
+        p.delete('offset');
+      } else {
+        p.set('offset', String(next));
+      }
+      return p;
+    });
+  }
+
+  const total = query.data?.total ?? 0;
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  return (
+    <PageLayout
+      eyebrow="Operations"
+      title="Orders"
+      description="Order monitoring — track sync status and troubleshoot failures."
+    >
+      {/* Filter bar */}
+      <div className="toolbar">
+        <Select
+          aria-label="Filter by sync status"
+          value={syncStatus ?? ''}
+          onChange={(e) => { handleStatusFilterChange(e.target.value); }}
+        >
+          <option value="">All statuses</option>
+          {OrderSyncStatusValues.map((status) => (
+            <option key={status} value={status}>
+              {status.charAt(0).toUpperCase() + status.slice(1)}
+            </option>
+          ))}
+        </Select>
+      </div>
+
+      {query.isLoading ? (
+        <LoadingState
+          liveRegion="off"
+          title="Loading orders"
+          message="Fetching order records…"
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load orders"
+          message={query.error.message}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      ) : (query.data?.items.length ?? 0) === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No orders found"
+          message={
+            syncStatus
+              ? 'No orders match the selected status filter.'
+              : 'No order records have been synced yet.'
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Orders"
+            columns={COLUMNS}
+            rows={query.data?.items ?? []}
+            rowKey={(order) => order.internalOrderId}
+          />
+
+          <div className="toolbar" style={{ justifyContent: 'space-between' }}>
+            <span className="text-muted">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <Button
+                disabled={!hasPrev}
+                onClick={() => { setOffset(offset - PAGE_SIZE); }}
+              >
+                Previous
+              </Button>
+              <Button
+                disabled={!hasNext}
+                onClick={() => { setOffset(offset + PAGE_SIZE); }}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/shared/ui/app-shell.tsx
+++ b/apps/web/src/shared/ui/app-shell.tsx
@@ -24,9 +24,9 @@ const navigationGroups: NavigationGroup[] = [
     label: 'Operations',
     items: [
       { to: '/', label: 'Dashboard', end: true, state: 'live' },
-      { to: '/orders', label: 'Orders', state: 'planned' },
+      { to: '/orders', label: 'Orders', state: 'live' },
       { to: '/products', label: 'Products', state: 'live' },
-      { to: '/inventory', label: 'Inventory', state: 'planned' },
+      { to: '/inventory', label: 'Inventory', state: 'live' },
       { to: '/jobs-logs', label: 'Jobs & Logs', state: 'planned' },
       { to: '/automations', label: 'Automations', state: 'planned' },
     ],

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -39,6 +39,8 @@ type DeepPartialApiClient = {
   auth?: Partial<ApiClient['auth']>;
   connections?: Partial<ApiClient['connections']>;
   health?: Partial<ApiClient['health']>;
+  inventory?: Partial<ApiClient['inventory']>;
+  orders?: Partial<ApiClient['orders']>;
   products?: Partial<ApiClient['products']>;
   syncJobs?: Partial<ApiClient['syncJobs']>;
 };
@@ -94,6 +96,26 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       }),
       ...overrides.health,
     } as ApiClient['health'],
+    inventory: {
+      list: vi.fn().mockResolvedValue({
+        items: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      }),
+      getById: vi.fn().mockResolvedValue(null),
+      ...overrides.inventory,
+    } as ApiClient['inventory'],
+    orders: {
+      list: vi.fn().mockResolvedValue({
+        items: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      }),
+      getById: vi.fn().mockResolvedValue(null),
+      ...overrides.orders,
+    } as ApiClient['orders'],
     products: {
       list: vi.fn().mockResolvedValue({
         items: [],

--- a/docs/plans/implementation-plan-inventory-orders-ui.md
+++ b/docs/plans/implementation-plan-inventory-orders-ui.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Inventory & Orders UI (#89 + #90)
+
+## Goal
+
+Build inventory visibility and orders monitoring frontend screens, replacing the current placeholder pages with functional list + detail views backed by the existing read APIs (merged in PR #122).
+
+## Classification
+
+- **Layer**: Frontend (Interface)
+- **Bounded Contexts**: Inventory, Orders
+- **Pattern**: Replicates products/variants explorer (PR #124)
+
+## Non-Goals
+
+- No create/update/delete mutations (read-only views)
+- No real-time updates or WebSocket subscriptions
+- No new backend endpoints — consume existing `GET /inventory`, `GET /inventory/:id`, `GET /orders`, `GET /orders/:internalOrderId`
+
+---
+
+## Step-by-Step Implementation
+
+### Step 1: Inventory Feature Module
+
+**1a. Types** — `features/inventory/api/inventory.types.ts`
+- `InventoryItem { id, productId, productVariantId, availableQuantity, reservedQuantity, locationId, updatedAt }`
+- `InventoryFilters { productId?, productVariantId?, locationId? }`
+- `InventoryPagination { limit?, offset? }`
+- `PaginatedInventory { items, total, limit, offset }`
+
+**1b. API client** — `features/inventory/api/inventory.api.ts`
+- `InventoryApi` interface with `list()` and `getById()`
+- `createInventoryApi(request)` factory
+- Query string builder for filters + pagination
+
+**1c. Query keys** — `features/inventory/api/inventory.query-keys.ts`
+- `inventoryQueryKeys.all`, `.list(filters, pagination)`, `.detail(id)`
+
+**1d. Query hooks** — `features/inventory/hooks/use-inventory-query.ts` and `use-inventory-item-query.ts`
+- Standard TanStack Query wrappers
+
+### Step 2: Inventory Pages
+
+**2a. List page** — `pages/inventory/inventory-list-page.tsx`
+- Columns: Product ID, Variant ID, Available Qty, Reserved Qty, Location, Updated, View link
+- Filters via URL search params: productId, productVariantId, locationId
+- Offset-based pagination (PAGE_SIZE = 20)
+- All 4 states: loading, error, empty, data
+
+**2b. Detail page** — `pages/inventory/inventory-detail-page.tsx`
+- Detail list: all inventory item fields
+- Back link to list
+
+### Step 3: Inventory Route
+
+**3a.** Update `app/routes/inventory.route.tsx` — replace placeholder with children (index + `:id`)
+
+### Step 4: Orders Feature Module
+
+**4a. Types** — `features/orders/api/orders.types.ts`
+- `OrderSyncStatus { destinationConnectionId, status, syncedAt, externalOrderId, externalOrderNumber, error }`
+- `OrderRecord { internalOrderId, customerId, sourceConnectionId, sourceEventId, orderSnapshot, syncStatus[], createdAt, updatedAt }`
+- `OrderFilters { sourceConnectionId?, syncStatus?, customerId?, createdFrom?, createdTo? }`
+- `OrderPagination { limit?, offset? }`
+- `PaginatedOrders { items, total, limit, offset }`
+- `OrderSyncStatusValue` union type
+
+**4b. API client** — `features/orders/api/orders.api.ts`
+- `OrdersApi` interface with `list()` and `getById()`
+- `createOrdersApi(request)` factory
+
+**4c. Query keys** — `features/orders/api/orders.query-keys.ts`
+
+**4d. Query hooks** — `features/orders/hooks/use-orders-query.ts` and `use-order-query.ts`
+
+### Step 5: Orders Pages
+
+**5a. List page** — `pages/orders/orders-list-page.tsx`
+- Columns: Order ID, Source Connection, Customer, Sync Status (badges), Created, View link
+- Filters via URL: syncStatus, sourceConnectionId
+- Status badges with appropriate tones (success=synced, warning=syncing, info=pending, error=failed)
+- Offset-based pagination
+
+**5b. Detail page** — `pages/orders/order-detail-page.tsx`
+- Order metadata in detail list
+- Sync status table showing per-destination status
+- Order snapshot as formatted JSON
+
+### Step 6: Orders Route
+
+**6a.** Update `app/routes/orders.route.tsx` — replace placeholder with children (index + `:internalOrderId`)
+
+### Step 7: Register API Modules
+
+**7a.** Add `inventory` and `orders` to `ApiClient` interface and `createApiClient()` in `app/api/api-client.ts`
+
+### Step 8: Update Navigation
+
+**8a.** Update `app-shell.tsx` — change Inventory and Orders nav items from `state: 'planned'` to `state: 'live'`
+
+### Step 9: Quality Gate
+
+- `pnpm lint`, `pnpm type-check`, `pnpm test` — all must pass
+
+---
+
+## Risks
+
+- None significant — pure frontend, follows established pattern, backend APIs already exist
+
+## Testing Strategy
+
+- Unit tests not strictly required for read-only pages (no complex logic), but can be added for query hooks if desired
+- Manual testing via dev server recommended


### PR DESCRIPTION
## Summary

- Replace inventory and orders placeholder pages with functional list + detail views
- Inventory explorer: stock visibility with product/variant ID filters, pagination, and detail view
- Orders monitor: sync status badges, status filter dropdown, order detail with sync status table and JSON snapshot viewer
- Both modules follow the established products explorer pattern (PR #124)

Closes #89
Closes #90

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — passes
- [x] `pnpm test` — 75/75 tests pass
- [ ] Manual: navigate to `/inventory`, verify list loads with filters and pagination
- [ ] Manual: navigate to `/inventory/:id`, verify detail view renders
- [ ] Manual: navigate to `/orders`, verify list loads with status filter and pagination
- [ ] Manual: navigate to `/orders/:id`, verify detail view with sync status table and JSON snapshot
- [ ] Manual: verify nav items show "Live" instead of "Planned"

🤖 Generated with [Claude Code](https://claude.com/claude-code)