### PR TITLE
feat(web): enforce frontend layer boundaries via ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,8 @@ module.exports = {
       },
     },
     {
+      // Layer boundary: shared/ must not import from higher layers.
+      // Exception: shared/auth/ is exempt from the fetch restriction (see override below).
       files: ['apps/web/src/shared/**/*.{ts,tsx}'],
       rules: {
         'no-restricted-imports': [
@@ -67,10 +69,17 @@ module.exports = {
           {
             patterns: [
               {
-                group: ['**/features/**', '**/pages/**'],
-                message: 'Shared modules must not import feature or page modules.',
+                group: ['**/features/**', '**/pages/**', '**/app/**'],
+                message: 'Shared modules must not import feature, page, or app modules.',
               },
             ],
+          },
+        ],
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'fetch',
+            message: 'Use API client modules from shared/api instead of raw fetch().',
           },
         ],
       },
@@ -87,6 +96,44 @@ module.exports = {
                 message: 'Feature modules must not import page modules.',
               },
             ],
+          },
+        ],
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'fetch',
+            message: 'Use API client modules from shared/api instead of raw fetch().',
+          },
+        ],
+      },
+    },
+    {
+      // Session adapter is low-level auth infra that the API client itself depends on —
+      // it must use raw fetch() and is exempt from the no-restricted-globals rule.
+      files: ['apps/web/src/shared/auth/**/*.{ts,tsx}'],
+      rules: {
+        'no-restricted-globals': 'off',
+      },
+    },
+    {
+      files: ['apps/web/src/pages/**/*.{ts,tsx}'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: ['**/app/**'],
+                message: 'Page modules must not import app modules.',
+              },
+            ],
+          },
+        ],
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'fetch',
+            message: 'Use API client modules from shared/api instead of raw fetch().',
           },
         ],
       },

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -262,7 +262,9 @@ Dependency direction must remain simple and enforceable:
 - `features` may import `shared`
 - `shared` must not import `features` or `pages`
 
-These boundaries should be enforced by lint rules, not only documented as team guidance.
+These boundaries are enforced by ESLint `no-restricted-imports` rules in `.eslintrc.js` — violations fail `pnpm lint`. Raw `fetch()` calls are also blocked in `shared/`, `features/`, and `pages/` via `no-restricted-globals` to ensure all HTTP calls go through shared API client modules.
+
+> **Note:** Features may import `useApiClient` from `app/api/` — this is the designed dependency-injection boundary for API access. A future refactor may move the hook to `shared/`, but the current crossing is intentional and not restricted by lint.
 
 Additional rules:
 

--- a/docs/plans/implementation-plan-fe-eslint-layer-boundaries.md
+++ b/docs/plans/implementation-plan-fe-eslint-layer-boundaries.md
@@ -1,0 +1,40 @@
+# Implementation Plan: Frontend ESLint Layer Boundaries (#99)
+
+## Goal
+
+Enforce the frontend dependency direction (`app` → `pages` → `features` → `shared`) via ESLint rules so violations fail `pnpm lint`.
+
+## Classification
+
+**Frontend / DX** — `apps/web/`
+
+## What existed before
+
+- `shared/**` blocked from importing `features/**` or `pages/**`
+- `features/**` blocked from importing `pages/**`
+
+## Changes made
+
+### 1. Strengthened `shared/` restriction
+- Added `**/app/**` to the blocked import patterns (shared must not import app modules)
+
+### 2. Added `pages/` restriction
+- New override: `pages/**` cannot import from `**/app/**`
+
+### 3. Added `no-restricted-globals` for `fetch`
+- `shared/**`, `features/**`, and `pages/**` all block raw `fetch()` calls
+- Forces use of API client modules from `shared/api`
+
+### 4. Exempted `shared/auth/` from fetch restriction
+- Session adapter (`jwt-bearer-session-adapter.ts`) is low-level auth infra that the API client itself depends on — it must use raw fetch
+
+### 5. Documented enforcement in `docs/frontend-architecture.md`
+
+## Files changed
+
+- `.eslintrc.js` — added/modified ESLint overrides
+- `docs/frontend-architecture.md` — updated dependency rules section
+
+## Not in scope
+
+- `features/` → `app/` restriction: `useApiClient()` is the designed DI boundary that all feature hooks use. Blocking this would require a larger architectural refactor (moving the API client context to shared). This can be addressed in a follow-up issue.


### PR DESCRIPTION
## Summary

- Add ESLint `no-restricted-imports` overrides enforcing frontend dependency direction (`app` → `pages` → `features` → `shared`)
- Add `no-restricted-globals` rules blocking raw `fetch()` in `shared/`, `features/`, and `pages/` (with `shared/auth/` exempted for the session adapter)
- Strengthen existing `shared/` restriction to also block `app/` imports
- Document enforcement in `docs/frontend-architecture.md`

## Test plan

- [x] `pnpm lint` passes with zero errors
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (all 85 unit tests)
- [x] Existing code has no violations of the new rules
- [ ] Verify a boundary violation (e.g. importing `features/` from `shared/`) triggers a lint error

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)