### PR TITLE
feat(api,web): add cursor read API and cursors visibility page

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -26,6 +26,7 @@ import { OrdersModule } from './orders/orders.module';
 import { ProductsApiModule } from './products/products.module';
 import { CustomersApiModule } from './customers/customers.module';
 import { ListingsApiModule } from './listings/listings.module';
+import { CursorsModule } from './cursors/cursors.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { ListingsApiModule } from './listings/listings.module';
     ProductsApiModule,
     CustomersApiModule,
     ListingsApiModule,
+    CursorsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/cursors/cursors.module.ts
+++ b/apps/api/src/cursors/cursors.module.ts
@@ -1,0 +1,17 @@
+/**
+ * Cursors API Module
+ *
+ * NestJS module for cursor read API endpoints. Imports core sync module
+ * (which provides the cursor repository) and registers the cursors controller.
+ *
+ * @module apps/api/src/cursors
+ */
+import { Module } from '@nestjs/common';
+import { SyncModule as CoreSyncModule } from '@openlinker/core/sync';
+import { CursorsController } from './http/cursors.controller';
+
+@Module({
+  imports: [CoreSyncModule],
+  controllers: [CursorsController],
+})
+export class CursorsModule {}

--- a/apps/api/src/cursors/http/cursors.controller.spec.ts
+++ b/apps/api/src/cursors/http/cursors.controller.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Cursors Controller Unit Tests
+ *
+ * @module apps/api/src/cursors/http
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { CursorsController } from './cursors.controller';
+import {
+  CONNECTION_CURSOR_REPOSITORY_TOKEN,
+} from '@openlinker/core/sync';
+import type { ConnectionCursorRepositoryPort, ConnectionCursor } from '@openlinker/core/sync';
+
+describe('CursorsController', () => {
+  let controller: CursorsController;
+  let repository: jest.Mocked<ConnectionCursorRepositoryPort>;
+
+  const mockCursor: ConnectionCursor = {
+    connectionId: 'conn-001',
+    cursorKey: 'allegro.orders.lastEventId',
+    value: 'evt-12345',
+    createdAt: new Date('2026-04-01T00:00:00Z'),
+    updatedAt: new Date('2026-04-10T12:00:00Z'),
+  };
+
+  beforeEach(async () => {
+    const mockRepository: jest.Mocked<ConnectionCursorRepositoryPort> = {
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+      findMany: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CursorsController],
+      providers: [
+        {
+          provide: CONNECTION_CURSOR_REPOSITORY_TOKEN,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CursorsController>(CursorsController);
+    repository = module.get(CONNECTION_CURSOR_REPOSITORY_TOKEN);
+  });
+
+  describe('listCursors', () => {
+    it('should return paginated cursors', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockCursor], total: 1 });
+
+      const result = await controller.listCursors({ limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      expect(result.items[0].connectionId).toBe('conn-001');
+      expect(result.items[0].cursorKey).toBe('allegro.orders.lastEventId');
+      expect(result.items[0].value).toBe('evt-12345');
+      expect(result.items[0].updatedAt).toBe('2026-04-10T12:00:00.000Z');
+    });
+
+    it('should pass connectionId filter to repository', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.listCursors({
+        connectionId: 'conn-001',
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(repository.findMany).toHaveBeenCalledWith(
+        { connectionId: 'conn-001' },
+        { limit: 10, offset: 5 },
+      );
+    });
+
+    it('should return empty list when no cursors match', async () => {
+      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      const result = await controller.listCursors({ limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe('getCursor', () => {
+    it('should return cursor when found', async () => {
+      repository.findOne.mockResolvedValue(mockCursor);
+
+      const result = await controller.getCursor('conn-001', 'allegro.orders.lastEventId');
+
+      expect(result.connectionId).toBe('conn-001');
+      expect(result.cursorKey).toBe('allegro.orders.lastEventId');
+      expect(result.value).toBe('evt-12345');
+      expect(result.createdAt).toBe('2026-04-01T00:00:00.000Z');
+    });
+
+    it('should throw NotFoundException when cursor not found', async () => {
+      repository.findOne.mockResolvedValue(null);
+
+      await expect(
+        controller.getCursor('conn-999', 'nonexistent.key'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/cursors/http/cursors.controller.ts
+++ b/apps/api/src/cursors/http/cursors.controller.ts
@@ -1,0 +1,94 @@
+/**
+ * Cursors Controller
+ *
+ * HTTP REST API endpoints for connection cursor read operations. Provides
+ * endpoints for listing cursors with filters and retrieving individual cursors.
+ * Cursors track incremental sync position per connection.
+ *
+ * @module apps/api/src/cursors/http
+ */
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Inject,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import {
+  ConnectionCursorRepositoryPort,
+  CONNECTION_CURSOR_REPOSITORY_TOKEN,
+} from '@openlinker/core/sync';
+import type { ConnectionCursor } from '@openlinker/core/sync';
+import { ListCursorsQueryDto } from './dto/list-cursors-query.dto';
+import { CursorResponseDto } from './dto/cursor-response.dto';
+import { PaginatedCursorsResponseDto } from './dto/paginated-cursors-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('cursors')
+@Controller('cursors')
+export class CursorsController {
+  constructor(
+    @Inject(CONNECTION_CURSOR_REPOSITORY_TOKEN)
+    private readonly cursorRepository: ConnectionCursorRepositoryPort,
+  ) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List connection cursors',
+    description:
+      'Returns a paginated list of connection cursors. Supports filtering by connectionId.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated cursor list', type: PaginatedCursorsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listCursors(@Query() query: ListCursorsQueryDto): Promise<PaginatedCursorsResponseDto> {
+    const { connectionId, limit = 20, offset = 0 } = query;
+
+    const { items, total } = await this.cursorRepository.findMany(
+      { connectionId },
+      { limit, offset },
+    );
+
+    return {
+      items: items.map((cursor) => this.toDto(cursor)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  @Get(':connectionId/:cursorKey')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get a single cursor by connection ID and cursor key' })
+  @ApiResponse({ status: 200, description: 'Cursor detail', type: CursorResponseDto })
+  @ApiResponse({ status: 404, description: 'Cursor not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getCursor(
+    @Param('connectionId') connectionId: string,
+    @Param('cursorKey') cursorKey: string,
+  ): Promise<CursorResponseDto> {
+    const cursor = await this.cursorRepository.findOne(connectionId, cursorKey);
+    if (!cursor) {
+      throw new NotFoundException(
+        `Cursor not found: ${cursorKey} for connection ${connectionId}`,
+      );
+    }
+    return this.toDto(cursor);
+  }
+
+  private toDto(cursor: ConnectionCursor): CursorResponseDto {
+    return {
+      connectionId: cursor.connectionId,
+      cursorKey: cursor.cursorKey,
+      value: cursor.value,
+      createdAt: cursor.createdAt instanceof Date ? cursor.createdAt.toISOString() : cursor.createdAt,
+      updatedAt: cursor.updatedAt instanceof Date ? cursor.updatedAt.toISOString() : cursor.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/cursors/http/dto/cursor-response.dto.ts
+++ b/apps/api/src/cursors/http/dto/cursor-response.dto.ts
@@ -1,0 +1,26 @@
+/**
+ * Cursor Response DTO
+ *
+ * Response shape for a single connection cursor. Used in both list and detail responses.
+ * Dates are serialised as ISO 8601 strings.
+ *
+ * @module apps/api/src/cursors/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CursorResponseDto {
+  @ApiProperty({ description: 'Connection ID (UUID)' })
+  connectionId!: string;
+
+  @ApiProperty({ description: 'Cursor key identifier (e.g., allegro.orders.lastEventId)' })
+  cursorKey!: string;
+
+  @ApiProperty({ description: 'Current cursor value' })
+  value!: string;
+
+  @ApiProperty({ description: 'First created timestamp (ISO 8601)' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'Last updated timestamp (ISO 8601)' })
+  updatedAt!: string;
+}

--- a/apps/api/src/cursors/http/dto/list-cursors-query.dto.ts
+++ b/apps/api/src/cursors/http/dto/list-cursors-query.dto.ts
@@ -1,0 +1,32 @@
+/**
+ * List Cursors Query DTO
+ *
+ * Query parameters for GET /cursors. All fields are optional.
+ *
+ * @module apps/api/src/cursors/http/dto
+ */
+import { IsOptional, IsUUID, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListCursorsQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by connection ID (UUID)' })
+  @IsOptional()
+  @IsUUID('4')
+  connectionId?: string;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/apps/api/src/cursors/http/dto/paginated-cursors-response.dto.ts
+++ b/apps/api/src/cursors/http/dto/paginated-cursors-response.dto.ts
@@ -1,0 +1,23 @@
+/**
+ * Paginated Cursors Response DTO
+ *
+ * Response shape for GET /cursors.
+ *
+ * @module apps/api/src/cursors/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { CursorResponseDto } from './cursor-response.dto';
+
+export class PaginatedCursorsResponseDto {
+  @ApiProperty({ type: [CursorResponseDto] })
+  items!: CursorResponseDto[];
+
+  @ApiProperty({ description: 'Total number of cursors matching the filters' })
+  total!: number;
+
+  @ApiProperty({ description: 'Page size used for this response' })
+  limit!: number;
+
+  @ApiProperty({ description: 'Offset used for this response' })
+  offset!: number;
+}

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -2,6 +2,7 @@ import { createAdaptersApi, type AdaptersApi } from '../../features/adapters/api
 import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/allegro.api';
 import { createAuthApi, type AuthApi } from '../../features/auth/api/auth.api';
 import { createConnectionsApi, type ConnectionsApi } from '../../features/connections/api/connections.api';
+import { createCursorsApi, type CursorsApi } from '../../features/cursors/api/cursors.api';
 import { createHealthApi, type HealthApi } from '../../features/health/api/health.api';
 import { createInventoryApi, type InventoryApi } from '../../features/inventory/api/inventory.api';
 import { createOrdersApi, type OrdersApi } from '../../features/orders/api/orders.api';
@@ -24,6 +25,7 @@ export interface ApiClient {
   allegro: AllegroApi;
   auth: AuthApi;
   connections: ConnectionsApi;
+  cursors: CursorsApi;
   health: HealthApi;
   inventory: InventoryApi;
   orders: OrdersApi;
@@ -113,6 +115,7 @@ export function createApiClient({
     allegro: createAllegroApi(request),
     auth: createAuthApi(request),
     connections: createConnectionsApi(request),
+    cursors: createCursorsApi(request),
     health: createHealthApi(request),
     inventory: createInventoryApi(request),
     orders: createOrdersApi(request),

--- a/apps/web/src/app/routes/cursors.route.tsx
+++ b/apps/web/src/app/routes/cursors.route.tsx
@@ -1,0 +1,9 @@
+import type { RouteObject } from 'react-router-dom';
+import { CursorsListPage } from '../../pages/cursors/cursors-list-page';
+
+export const cursorsRoute: RouteObject = {
+  path: 'cursors',
+  children: [
+    { index: true, element: <CursorsListPage /> },
+  ],
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -5,6 +5,7 @@ import { allegroSetupRoute } from './allegro-setup.route';
 import { automationsRoute } from './automations.route';
 import { connectionDetailRoute } from './connection-detail.route';
 import { connectionsRoute } from './connections.route';
+import { cursorsRoute } from './cursors.route';
 import { dashboardRoute } from './dashboard.route';
 import { invoicesRoute } from './invoices.route';
 import { inventoryRoute } from './inventory.route';
@@ -23,6 +24,7 @@ export const rootRoute: RouteObject = {
     ordersRoute,
     productsRoute,
     inventoryRoute,
+    cursorsRoute,
     connectionsRoute,
     newConnectionRoute,
     allegroSetupRoute,

--- a/apps/web/src/features/cursors/api/cursors.api.ts
+++ b/apps/web/src/features/cursors/api/cursors.api.ts
@@ -1,0 +1,38 @@
+/**
+ * Cursors API Client
+ *
+ * Thin API module for the cursors feature. Provides typed methods for
+ * listing connection cursors with optional filters and pagination.
+ *
+ * @module apps/web/src/features/cursors/api
+ */
+import type {
+  CursorFilters,
+  CursorPagination,
+  PaginatedCursors,
+} from './cursors.types';
+
+export interface CursorsApi {
+  list: (filters?: CursorFilters, pagination?: CursorPagination) => Promise<PaginatedCursors>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+function buildQuery(filters?: CursorFilters, pagination?: CursorPagination): string {
+  const params = new URLSearchParams();
+  if (filters?.connectionId) params.set('connectionId', filters.connectionId);
+  if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
+  if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}
+
+export function createCursorsApi(request: ApiRequest): CursorsApi {
+  return {
+    list(filters, pagination): Promise<PaginatedCursors> {
+      return request<PaginatedCursors>(`/cursors${buildQuery(filters, pagination)}`);
+    },
+  };
+}

--- a/apps/web/src/features/cursors/api/cursors.query-keys.ts
+++ b/apps/web/src/features/cursors/api/cursors.query-keys.ts
@@ -1,0 +1,7 @@
+import type { CursorFilters, CursorPagination } from './cursors.types';
+
+export const cursorsQueryKeys = {
+  all: ['cursors'] as const,
+  list: (filters?: CursorFilters, pagination?: CursorPagination) =>
+    ['cursors', 'list', filters ?? {}, pagination ?? {}] as const,
+};

--- a/apps/web/src/features/cursors/api/cursors.types.ts
+++ b/apps/web/src/features/cursors/api/cursors.types.ts
@@ -1,0 +1,33 @@
+/**
+ * Cursors Feature Types
+ *
+ * Frontend transport types for the cursors API. Mirrors the backend
+ * CursorResponseDto and PaginatedCursorsResponseDto contracts.
+ * All date fields are ISO 8601 strings.
+ *
+ * @module apps/web/src/features/cursors/api
+ */
+
+export interface Cursor {
+  connectionId: string;
+  cursorKey: string;
+  value: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CursorFilters {
+  connectionId?: string;
+}
+
+export interface CursorPagination {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedCursors {
+  items: Cursor[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/web/src/features/cursors/hooks/use-cursors-query.ts
+++ b/apps/web/src/features/cursors/hooks/use-cursors-query.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { cursorsQueryKeys } from '../api/cursors.query-keys';
+import type { PaginatedCursors, CursorFilters, CursorPagination } from '../api/cursors.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useCursorsQuery(
+  filters?: CursorFilters,
+  pagination?: CursorPagination,
+): UseQueryResult<PaginatedCursors> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: cursorsQueryKeys.list(filters, pagination),
+    queryFn: () => apiClient.cursors.list(filters, pagination),
+    retry: false,
+  });
+}

--- a/apps/web/src/pages/cursors/cursors-list-page.tsx
+++ b/apps/web/src/pages/cursors/cursors-list-page.tsx
@@ -1,0 +1,164 @@
+import { useState, type ReactElement } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
+import { formatRelativeTime } from '../../shared/format/format-relative-time';
+import { useCursorsQuery } from '../../features/cursors/hooks/use-cursors-query';
+import type { Cursor, CursorFilters } from '../../features/cursors/api/cursors.types';
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+
+const COLUMNS: DataTableColumn<Cursor>[] = [
+  {
+    id: 'cursorKey',
+    header: 'Cursor Key',
+    cell: (cursor) => <span className="mono-text">{cursor.cursorKey}</span>,
+  },
+  {
+    id: 'value',
+    header: 'Value',
+    cell: (cursor) => (
+      <span className="mono-text" title={cursor.value}>
+        {cursor.value.length > 40 ? `${cursor.value.slice(0, 40)}...` : cursor.value}
+      </span>
+    ),
+  },
+  {
+    id: 'connectionId',
+    header: 'Connection ID',
+    cell: (cursor) => <span className="mono-text">{cursor.connectionId}</span>,
+  },
+  {
+    id: 'updatedAt',
+    header: 'Last Updated',
+    cell: (cursor) => (
+      <span title={new Date(cursor.updatedAt).toLocaleString()}>
+        {formatRelativeTime(cursor.updatedAt)}
+      </span>
+    ),
+  },
+];
+
+export function CursorsListPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const urlConnectionId = searchParams.get('connectionId') ?? '';
+  const offset = Number(searchParams.get('offset') ?? '0');
+
+  const [connectionIdInput, setConnectionIdInput] = useState(urlConnectionId);
+  const debouncedConnectionId = useDebouncedValue(connectionIdInput, SEARCH_DEBOUNCE_MS);
+
+  const filters: CursorFilters = {
+    connectionId: debouncedConnectionId || undefined,
+  };
+  const pagination = { limit: PAGE_SIZE, offset };
+
+  const query = useCursorsQuery(filters, pagination);
+
+  function handleFilterChange(value: string): void {
+    setConnectionIdInput(value);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set('connectionId', value);
+      } else {
+        next.delete('connectionId');
+      }
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  function setOffset(next: number): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === 0) {
+        p.delete('offset');
+      } else {
+        p.set('offset', String(next));
+      }
+      return p;
+    });
+  }
+
+  const total = query.data?.total ?? 0;
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  return (
+    <PageLayout
+      eyebrow="Operations"
+      title="Cursors"
+      description="Sync cursor state per connection — track incremental sync positions."
+    >
+      {/* Filters */}
+      <div className="toolbar" style={{ gap: '0.5rem' }}>
+        <input
+          aria-label="Filter by connection ID"
+          placeholder="Connection ID..."
+          value={connectionIdInput}
+          onChange={(e) => { handleFilterChange(e.target.value); }}
+        />
+      </div>
+
+      {query.isLoading ? (
+        <LoadingState
+          liveRegion="off"
+          title="Loading cursors"
+          message="Fetching cursor data..."
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load cursors"
+          message={query.error.message}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      ) : (query.data?.items.length ?? 0) === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No cursors found"
+          message={
+            debouncedConnectionId
+              ? 'No cursors match the current filter.'
+              : 'No sync cursors have been created yet. Cursors appear after the first sync job runs.'
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Connection cursors"
+            columns={COLUMNS}
+            rows={query.data?.items ?? []}
+            rowKey={(cursor) => `${cursor.connectionId}:${cursor.cursorKey}`}
+          />
+
+          <div className="toolbar" style={{ justifyContent: 'space-between' }}>
+            <span className="text-muted">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <Button
+                disabled={!hasPrev}
+                onClick={() => { setOffset(offset - PAGE_SIZE); }}
+              >
+                Previous
+              </Button>
+              <Button
+                disabled={!hasNext}
+                onClick={() => { setOffset(offset + PAGE_SIZE); }}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -145,7 +145,9 @@ describe('DashboardPage', () => {
     });
     renderWithProviders(<DashboardPage />, { apiClient });
 
-    expect(await screen.findByRole('heading', { name: 'Unable to load sync jobs' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'Unable to load sync jobs' }, { timeout: 5000 }),
+    ).toBeInTheDocument();
   });
 
   it('shows empty state when no sync jobs exist', async () => {

--- a/apps/web/src/shared/format/format-relative-time.ts
+++ b/apps/web/src/shared/format/format-relative-time.ts
@@ -1,0 +1,21 @@
+/**
+ * Format Relative Time
+ *
+ * Converts an ISO 8601 timestamp to a human-readable relative time string
+ * (e.g., "5m ago", "2h ago", "3d ago"). Useful for displaying recency
+ * in data tables and status displays.
+ *
+ * @module apps/web/src/shared/format
+ */
+
+export function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/apps/web/src/shared/ui/app-shell.tsx
+++ b/apps/web/src/shared/ui/app-shell.tsx
@@ -27,6 +27,7 @@ const navigationGroups: NavigationGroup[] = [
       { to: '/orders', label: 'Orders', state: 'live' },
       { to: '/products', label: 'Products', state: 'live' },
       { to: '/inventory', label: 'Inventory', state: 'live' },
+      { to: '/cursors', label: 'Cursors', state: 'live' },
       { to: '/jobs-logs', label: 'Jobs & Logs', state: 'planned' },
       { to: '/automations', label: 'Automations', state: 'planned' },
     ],

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -38,6 +38,7 @@ type DeepPartialApiClient = {
   allegro?: Partial<ApiClient['allegro']>;
   auth?: Partial<ApiClient['auth']>;
   connections?: Partial<ApiClient['connections']>;
+  cursors?: Partial<ApiClient['cursors']>;
   health?: Partial<ApiClient['health']>;
   inventory?: Partial<ApiClient['inventory']>;
   orders?: Partial<ApiClient['orders']>;
@@ -84,6 +85,15 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       update: vi.fn().mockResolvedValue(sampleConnection),
       ...overrides.connections,
     } as ApiClient['connections'],
+    cursors: {
+      list: vi.fn().mockResolvedValue({
+        items: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      }),
+      ...overrides.cursors,
+    } as ApiClient['cursors'],
     health: {
       getDevStackHealth: vi.fn().mockResolvedValue({
         status: 'ok',

--- a/docs/plans/implementation-plan-cursor-api-and-ui.md
+++ b/docs/plans/implementation-plan-cursor-api-and-ui.md
@@ -1,0 +1,196 @@
+# Implementation Plan: Cursor API & Cursors Visibility Page
+
+**Date**: 2026-04-11  
+**Status**: Ready for Review  
+**Issues**: #77 (BE — Improve cursor API), #75 (FE — Build cursors visibility page)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Expose connection cursors via a read API and build a frontend page to display cursor state per connection.
+
+**Context**: Cursors track incremental sync position (e.g., `allegro.orders.lastEventId`). They are currently backend-only with no API or UI. Operators need visibility into cursor state for debugging sync issues — stale cursors, regression detection, last-updated timestamps.
+
+**Classification**: Interface (BE controller + DTOs) + Frontend (page + feature module)
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- `GET /cursors` — list all cursors, filterable by `connectionId`
+- `GET /cursors/:connectionId/:cursorKey` — get single cursor detail
+- Stable response format with `connectionId`, `cursorKey`, `value`, `updatedAt`
+- Swagger documentation
+- Frontend cursors list page with connection filter
+- Read-only MVP
+
+### Out of Scope
+- Cursor reset/delete from UI (future: #72 retry/remediation APIs)
+- Cursor edit/manual advance
+- Real-time cursor updates (polling on page is sufficient)
+- Cursor history/audit trail
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layers**: 
+- CORE: Extend `ConnectionCursorRepositoryPort` with `findMany`
+- Interface (BE): New `CursorsController` in `apps/api/src/cursors/`
+- Frontend: New `cursors` feature module + page
+
+**Existing Services Reused**:
+- `ConnectionCursorRepositoryPort` / `ConnectionCursorRepository` — extend with list method
+- `CONNECTION_CURSOR_REPOSITORY_TOKEN` — already exported from SyncModule
+
+**New Components**:
+- BE: `CursorsController`, query/response DTOs, `CursorsModule`
+- BE: `findMany` method on cursor repository port + implementation
+- FE: `cursors.api.ts`, `cursors.types.ts`, `cursors.query-keys.ts`, `use-cursors-query.ts`, `cursors-list-page.tsx`, `cursors.route.tsx`
+
+---
+
+## 4. Questions & Assumptions
+
+### Assumptions
+- Cursor count is small (tens per connection, not thousands) — no need for cursor-based pagination; offset pagination is sufficient
+- `updatedAt` from the ORM entity is reliable for "last advanced" timestamp
+- No detail page needed for MVP — list view shows all relevant info
+
+---
+
+## 5. Proposed Implementation Plan
+
+### Phase 1: Backend — Extend Repository Port & Implementation
+
+**Step 1.1**: Add `findMany` to `ConnectionCursorRepositoryPort`
+- **File**: `libs/core/src/sync/domain/ports/connection-cursor-repository.port.ts`
+- **Action**: Add `findMany(filters?: { connectionId?: string }, pagination?: { limit: number; offset: number }): Promise<{ items: ConnectionCursor[]; total: number }>`
+- **Also**: Define `ConnectionCursor` domain type in `libs/core/src/sync/domain/types/connection-cursor.types.ts` with fields: `connectionId`, `cursorKey`, `value`, `createdAt`, `updatedAt`
+
+**Step 1.2**: Implement `findMany` in `ConnectionCursorRepository`
+- **File**: `libs/core/src/sync/infrastructure/persistence/repositories/connection-cursor.repository.ts`
+- **Action**: Add `findMany` with TypeORM `findAndCount`, filter by `connectionId` if provided, order by `updatedAt DESC`
+
+**Step 1.3**: Export new types from sync index
+- **File**: `libs/core/src/sync/index.ts`
+- **Action**: Export `ConnectionCursor` type and updated port
+
+### Phase 2: Backend — Cursors Controller & Module
+
+**Step 2.1**: Create response DTO
+- **File**: `apps/api/src/cursors/http/dto/cursor-response.dto.ts`
+- **Action**: `CursorResponseDto` with `connectionId`, `cursorKey`, `value`, `updatedAt` (ISO 8601)
+
+**Step 2.2**: Create paginated response DTO
+- **File**: `apps/api/src/cursors/http/dto/paginated-cursors-response.dto.ts`
+- **Action**: `PaginatedCursorsResponseDto` wrapping `items`, `total`, `limit`, `offset`
+
+**Step 2.3**: Create list query DTO
+- **File**: `apps/api/src/cursors/http/dto/list-cursors-query.dto.ts`
+- **Action**: Optional `connectionId` (UUID), `limit` (default 20, max 100), `offset` (default 0)
+
+**Step 2.4**: Create CursorsController
+- **File**: `apps/api/src/cursors/http/cursors.controller.ts`
+- **Action**: `@Roles('admin')`, `@ApiTags('cursors')`, `@Controller('cursors')`
+  - `GET /` — list cursors with filters
+  - `GET /:connectionId/:cursorKey` — single cursor detail
+- **Pattern**: Follow `InventoryController` exactly
+
+**Step 2.5**: Create CursorsModule
+- **File**: `apps/api/src/cursors/cursors.module.ts`
+- **Action**: Import `SyncModule` (provides `CONNECTION_CURSOR_REPOSITORY_TOKEN`), declare controller
+
+**Step 2.6**: Register in AppModule
+- **File**: `apps/api/src/app.module.ts`
+- **Action**: Add `CursorsModule` to imports
+
+### Phase 3: Backend — Unit Tests
+
+**Step 3.1**: Test CursorsController
+- **File**: `apps/api/src/cursors/http/cursors.controller.spec.ts`
+- **Action**: Mock `ConnectionCursorRepositoryPort`, test list with/without filters, test detail found/not-found
+
+### Phase 4: Frontend — API Layer
+
+**Step 4.1**: Define types
+- **File**: `apps/web/src/features/cursors/api/cursors.types.ts`
+- **Action**: `Cursor`, `CursorFilters`, `CursorPagination`, `PaginatedCursors` — mirror BE DTOs
+
+**Step 4.2**: Create API client
+- **File**: `apps/web/src/features/cursors/api/cursors.api.ts`
+- **Action**: `createCursorsApi(request)` with `list(filters, pagination)` method
+
+**Step 4.3**: Create query keys
+- **File**: `apps/web/src/features/cursors/api/cursors.query-keys.ts`
+- **Action**: `cursorsQueryKeys.all`, `.list(filters, pagination)`
+
+**Step 4.4**: Create query hook
+- **File**: `apps/web/src/features/cursors/hooks/use-cursors-query.ts`
+- **Action**: `useCursorsQuery(filters, pagination)` — standard pattern
+
+**Step 4.5**: Register in API client
+- **File**: `apps/web/src/app/api/api-client.ts`
+- **Action**: Add `cursors: createCursorsApi(request)` to `ApiClient`
+
+### Phase 5: Frontend — Cursors Page
+
+**Step 5.1**: Build cursors list page
+- **File**: `apps/web/src/pages/cursors/cursors-list-page.tsx`
+- **Action**: Follow `InventoryListPage` pattern
+  - Filter: `connectionId` (debounced text input)
+  - Columns: `cursorKey`, `value` (mono), `connectionId` (mono), `updatedAt` (relative time)
+  - Pagination: offset-based, 20 per page
+  - States: loading → error → empty → data
+
+**Step 5.2**: Create route
+- **File**: `apps/web/src/app/routes/cursors.route.tsx`
+- **Action**: `path: 'cursors'`, index → `CursorsListPage`
+
+**Step 5.3**: Register route
+- **File**: `apps/web/src/app/routes/root.route.tsx`
+- **Action**: Add `cursorsRoute` to children
+
+**Step 5.4**: Add nav link (if sidebar exists)
+- Check existing nav and add "Cursors" under Operations section
+
+---
+
+## 6. Alternatives Considered
+
+### Alternative: Expose cursors as sub-resource of connections (`GET /connections/:id/cursors`)
+- **Why Rejected**: Cursors span multiple connections in the list view; a top-level `/cursors` endpoint with optional `connectionId` filter is more flexible and matches the existing pattern (sync jobs also have a top-level endpoint with connection filter).
+
+---
+
+## 7. Testing Strategy
+
+### Unit Tests
+- `CursorsController`: mock repository, test list/detail endpoints, test 404
+
+### Manual Testing
+- Start dev API + web, verify cursor list loads, filter works, pagination works, empty state shows
+
+### Acceptance Criteria
+- [ ] `GET /cursors` returns paginated list with `connectionId`, `cursorKey`, `value`, `updatedAt`
+- [ ] `GET /cursors?connectionId=X` filters correctly
+- [ ] `GET /cursors/:connectionId/:cursorKey` returns single cursor or 404
+- [ ] Swagger documents all endpoints
+- [ ] Frontend page shows cursor list with connection filter
+- [ ] Frontend handles loading, error, empty states
+- [ ] Frontend pagination works
+- [ ] Quality gate passes (lint, type-check, test)
+
+---
+
+## 8. Alignment Checklist
+
+- [x] Follows hexagonal architecture (port extension in domain, implementation in infrastructure)
+- [x] Respects CORE vs Integration boundaries (no integration code touched)
+- [x] Uses existing patterns (mirrors InventoryController, InventoryListPage)
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Testing strategy complete
+- [x] Plan is execution-ready

--- a/libs/core/src/sync/domain/ports/connection-cursor-repository.port.ts
+++ b/libs/core/src/sync/domain/ports/connection-cursor-repository.port.ts
@@ -18,6 +18,13 @@
  * Implementations handle the specifics of the underlying database technology
  * and ensure atomic updates for cursor advancement.
  */
+import type {
+  ConnectionCursor,
+  ConnectionCursorFilters,
+  ConnectionCursorPagination,
+  PaginatedConnectionCursors,
+} from '../types/connection-cursor.types';
+
 export interface ConnectionCursorRepositoryPort {
   /**
    * Get cursor value for a connection and cursor key
@@ -50,6 +57,30 @@ export interface ConnectionCursorRepositoryPort {
    * @param cursorKey - Cursor key identifier
    */
   delete(connectionId: string, cursorKey: string): Promise<void>;
+
+  /**
+   * Find cursors with optional filters and pagination
+   *
+   * Returns a paginated list of cursors, optionally filtered by connectionId.
+   * Results are ordered by updatedAt descending (most recently updated first).
+   *
+   * @param filters - Optional filters (connectionId)
+   * @param pagination - Pagination options (limit, offset)
+   * @returns Paginated cursor list with total count
+   */
+  findMany(
+    filters?: ConnectionCursorFilters,
+    pagination?: ConnectionCursorPagination,
+  ): Promise<PaginatedConnectionCursors>;
+
+  /**
+   * Find a single cursor by connectionId and cursorKey
+   *
+   * @param connectionId - Connection identifier (UUID)
+   * @param cursorKey - Cursor key identifier
+   * @returns Full cursor object or null if not found
+   */
+  findOne(connectionId: string, cursorKey: string): Promise<ConnectionCursor | null>;
 }
 
 

--- a/libs/core/src/sync/domain/types/connection-cursor.types.ts
+++ b/libs/core/src/sync/domain/types/connection-cursor.types.ts
@@ -1,0 +1,31 @@
+/**
+ * Connection Cursor Types
+ *
+ * Type definitions for connection cursor domain objects. Cursors track
+ * incremental sync position per connection (e.g., lastEventId for
+ * Allegro order event journal).
+ *
+ * @module libs/core/src/sync/domain/types
+ */
+
+export interface ConnectionCursor {
+  connectionId: string;
+  cursorKey: string;
+  value: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ConnectionCursorFilters {
+  connectionId?: string;
+}
+
+export interface ConnectionCursorPagination {
+  limit: number;
+  offset: number;
+}
+
+export interface PaginatedConnectionCursors {
+  items: ConnectionCursor[];
+  total: number;
+}

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -18,6 +18,14 @@ export { SyncLockPort, SyncLockToken } from './application/ports/sync-lock.port'
 // Domain Entities
 export { SyncJob as SyncJobEntity } from './domain/entities/sync-job.entity';
 
+// Connection Cursor Types
+export type {
+  ConnectionCursor,
+  ConnectionCursorFilters,
+  ConnectionCursorPagination,
+  PaginatedConnectionCursors,
+} from './domain/types/connection-cursor.types';
+
 // Types
 export type {
   SyncJob,

--- a/libs/core/src/sync/infrastructure/persistence/repositories/connection-cursor.repository.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/connection-cursor.repository.ts
@@ -18,6 +18,12 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, QueryFailedError } from 'typeorm';
 import { ConnectionCursorOrmEntity } from '../entities/connection-cursor.orm-entity';
 import { ConnectionCursorRepositoryPort } from '../../../domain/ports/connection-cursor-repository.port';
+import type {
+  ConnectionCursor,
+  ConnectionCursorFilters,
+  ConnectionCursorPagination,
+  PaginatedConnectionCursors,
+} from '../../../domain/types/connection-cursor.types';
 import { Logger } from '@openlinker/shared/logging';
 
 @Injectable()
@@ -105,6 +111,62 @@ export class ConnectionCursorRepository implements ConnectionCursorRepositoryPor
       }
       throw error;
     }
+  }
+
+  async findMany(
+    filters?: ConnectionCursorFilters,
+    pagination?: ConnectionCursorPagination,
+  ): Promise<PaginatedConnectionCursors> {
+    const where: Record<string, string> = {};
+    if (filters?.connectionId) {
+      where.connectionId = filters.connectionId;
+    }
+
+    const limit = pagination?.limit ?? 20;
+    const offset = pagination?.offset ?? 0;
+
+    const [entities, total] = await this.repository.findAndCount({
+      where,
+      order: { updatedAt: 'DESC' },
+      take: limit,
+      skip: offset,
+    });
+
+    this.logger.debug(
+      `Found ${total} cursors (limit=${limit}, offset=${offset}, connectionId=${filters?.connectionId ?? 'all'})`,
+    );
+
+    return {
+      items: entities.map((entity) => this.toDomain(entity)),
+      total,
+    };
+  }
+
+  async findOne(connectionId: string, cursorKey: string): Promise<ConnectionCursor | null> {
+    try {
+      const entity = await this.repository.findOne({
+        where: { connectionId, cursorKey },
+      });
+      return entity ? this.toDomain(entity) : null;
+    } catch (error) {
+      if (error instanceof QueryFailedError) {
+        this.logger.warn(
+          `Failed to find cursor ${cursorKey} for connection ${connectionId}: ${error.message}`,
+        );
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private toDomain(entity: ConnectionCursorOrmEntity): ConnectionCursor {
+    return {
+      connectionId: entity.connectionId,
+      cursorKey: entity.cursorKey,
+      value: entity.value,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary\n\n- Add `GET /cursors` and `GET /cursors/:connectionId/:cursorKey` read API endpoints to expose sync cursor state per connection\n- Build frontend cursors list page with connection ID filter, data table, and pagination\n- Extend `ConnectionCursorRepositoryPort` with `findMany`/`findOne` methods\n- Extract reusable `formatRelativeTime` helper to `shared/format/`\n\nCloses #77\nCloses #75\n\n## Test plan\n\n- [ ] `GET /cursors` returns paginated list with correct fields\n- [ ] `GET /cursors?connectionId=X` filters correctly\n- [ ] `GET /cursors/:connectionId/:cursorKey` returns 200 or 404\n- [ ] Swagger documents all cursor endpoints\n- [ ] Frontend cursors page loads at `/cursors`\n- [ ] Connection filter works with debounced input\n- [ ] Pagination Previous/Next buttons work\n- [ ] Loading, error, and empty states render correctly\n- [ ] Quality gate passes: `pnpm lint && pnpm type-check && pnpm test`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)