### PR TITLE
feat(web): add connection create/edit flows and detail page

### DIFF
--- a/apps/api/src/inventory/http/inventory.controller.ts
+++ b/apps/api/src/inventory/http/inventory.controller.ts
@@ -21,8 +21,8 @@ import { Roles } from '../../auth/decorators/roles.decorator';
 import {
   InventoryRepositoryPort,
   INVENTORY_REPOSITORY_TOKEN,
+  InventoryItemEntity as InventoryItem,
 } from '@openlinker/core/inventory';
-import type { InventoryItem } from '@openlinker/core/inventory/domain/entities/inventory-item.entity';
 import { ListInventoryQueryDto } from './dto/list-inventory-query.dto';
 import { InventoryItemResponseDto } from './dto/inventory-item-response.dto';
 import { PaginatedInventoryResponseDto } from './dto/paginated-inventory-response.dto';

--- a/apps/web/src/app/routes/edit-connection.route.tsx
+++ b/apps/web/src/app/routes/edit-connection.route.tsx
@@ -1,0 +1,7 @@
+import type { RouteObject } from 'react-router-dom';
+import { EditConnectionPage } from '../../pages/connections/edit-connection-page';
+
+export const editConnectionRoute: RouteObject = {
+  path: 'connections/:connectionId/edit',
+  element: <EditConnectionPage />,
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -5,6 +5,7 @@ import { allegroCallbackRoute } from './allegro-callback.route';
 import { allegroSetupRoute } from './allegro-setup.route';
 import { automationsRoute } from './automations.route';
 import { connectionDetailRoute } from './connection-detail.route';
+import { editConnectionRoute } from './edit-connection.route';
 import { connectionsRoute } from './connections.route';
 import { dashboardRoute } from './dashboard.route';
 import { invoicesRoute } from './invoices.route';
@@ -29,6 +30,7 @@ export const rootRoute: RouteObject = {
     newConnectionRoute,
     allegroSetupRoute,
     connectionDetailRoute,
+    editConnectionRoute,
     allegroCallbackRoute,
     jobsLogsRoute,
     automationsRoute,

--- a/apps/web/src/features/connections/api/connections.api.ts
+++ b/apps/web/src/features/connections/api/connections.api.ts
@@ -8,6 +8,7 @@ import type {
 
 export interface ConnectionsApi {
   create: (input: CreateConnectionInput) => Promise<Connection>;
+  disable: (connectionId: string) => Promise<Connection>;
   getDiagnostics: (connectionId: string) => Promise<ConnectionDiagnostics>;
   getById: (connectionId: string) => Promise<Connection>;
   list: (filters?: ConnectionFilters) => Promise<Connection[]>;
@@ -39,6 +40,11 @@ export function createConnectionsApi(request: ApiRequest): ConnectionsApi {
       return request<Connection>('/connections', {
         method: 'POST',
         body: JSON.stringify(input),
+      });
+    },
+    disable(connectionId): Promise<Connection> {
+      return request<Connection>(`/connections/${connectionId}/disable`, {
+        method: 'PATCH',
       });
     },
     getDiagnostics(connectionId): Promise<ConnectionDiagnostics> {

--- a/apps/web/src/features/connections/components/ConnectionActionsPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionActionsPanel.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import { ConnectionActionsPanel } from './ConnectionActionsPanel';
+
+describe('ConnectionActionsPanel', () => {
+  afterEach(cleanup);
+
+  it('renders edit and disable actions for an active connection', () => {
+    renderWithProviders(<ConnectionActionsPanel connection={sampleConnection} />);
+
+    expect(screen.getByRole('link', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Disable' })).toBeInTheDocument();
+  });
+
+  it('hides disable button when connection is already disabled', () => {
+    const disabledConnection = { ...sampleConnection, status: 'disabled' as const };
+    renderWithProviders(<ConnectionActionsPanel connection={disabledConnection} />);
+
+    expect(screen.getByRole('link', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Disable' })).not.toBeInTheDocument();
+  });
+
+  it('links edit action to the correct URL', () => {
+    renderWithProviders(<ConnectionActionsPanel connection={sampleConnection} />);
+
+    const editLink = screen.getByRole('link', { name: 'Edit' });
+    expect(editLink).toHaveAttribute('href', `/connections/${sampleConnection.id}/edit`);
+  });
+});

--- a/apps/web/src/features/connections/components/ConnectionActionsPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionActionsPanel.tsx
@@ -1,0 +1,89 @@
+import { useState, type ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import type { Connection } from '../api/connections.types';
+import { useDisableConnectionMutation } from '../hooks/use-disable-connection-mutation';
+import { Button } from '../../../shared/ui/button';
+import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
+import { Alert } from '../../../shared/ui/alert';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+interface ConnectionActionsPanelProps {
+  connection: Connection;
+}
+
+export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelProps): ReactElement {
+  const disableConnection = useDisableConnectionMutation();
+  const { showToast } = useToast();
+  const [isDisableDialogOpen, setIsDisableDialogOpen] = useState(false);
+
+  const isDisabled = connection.status === 'disabled';
+
+  return (
+    <div className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Operator</p>
+          <h3 className="section-title">Actions</h3>
+        </div>
+        <span className="panel__meta">Manage connection</span>
+      </div>
+
+      {disableConnection.error ? (
+        <Alert tone="error" title="Unable to disable connection">
+          {disableConnection.error.message}
+        </Alert>
+      ) : null}
+
+      <div className="action-list">
+        <div className="action-list__item">
+          <div>
+            <strong>Edit connection</strong>
+            <p className="muted-text">Update name, config, or adapter settings.</p>
+          </div>
+          <Link className="button button--secondary" to={`/connections/${connection.id}/edit`}>
+            Edit
+          </Link>
+        </div>
+
+        {isDisabled ? null : (
+          <div className="action-list__item">
+            <div>
+              <strong>Disable connection</strong>
+              <p className="muted-text">Stop all sync activity for this connection. This can be reversed by re-enabling.</p>
+            </div>
+            <Button
+              tone="danger"
+              onClick={() => setIsDisableDialogOpen(true)}
+              disabled={disableConnection.isPending}
+            >
+              {disableConnection.isPending ? 'Disabling...' : 'Disable'}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={isDisableDialogOpen}
+        onOpenChange={setIsDisableDialogOpen}
+        title="Disable this connection?"
+        description={`This will stop all sync activity for "${connection.name}". You can re-enable it later.`}
+        confirmLabel="Disable connection"
+        cancelLabel="Keep active"
+        tone="danger"
+        onConfirm={async () => {
+          try {
+            await disableConnection.mutateAsync(connection.id);
+            setIsDisableDialogOpen(false);
+            showToast({
+              tone: 'success',
+              title: 'Connection disabled',
+              description: `"${connection.name}" has been disabled.`,
+            });
+          } catch {
+            setIsDisableDialogOpen(false);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/connections/components/ConnectionConfigPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionConfigPanel.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../test/test-utils';
+import { ConnectionConfigPanel } from './ConnectionConfigPanel';
+
+describe('ConnectionConfigPanel', () => {
+  afterEach(cleanup);
+
+  it('renders config JSON when config has keys', () => {
+    const config = { baseUrl: 'https://example.com', apiKey: 'test' };
+    renderWithProviders(<ConnectionConfigPanel config={config} />);
+
+    expect(screen.getByText(/Connection config/)).toBeInTheDocument();
+    expect(screen.getByText(/example\.com/)).toBeInTheDocument();
+    expect(screen.getByText('2 keys')).toBeInTheDocument();
+  });
+
+  it('shows empty message when config is empty', () => {
+    renderWithProviders(<ConnectionConfigPanel config={{}} />);
+
+    expect(screen.getByText('No configuration values set.')).toBeInTheDocument();
+    expect(screen.getByText('0 keys')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/connections/components/ConnectionConfigPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionConfigPanel.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from 'react';
+
+interface ConnectionConfigPanelProps {
+  config: Record<string, unknown>;
+}
+
+export function ConnectionConfigPanel({ config }: ConnectionConfigPanelProps): ReactElement {
+  const keys = Object.keys(config);
+
+  return (
+    <div className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Configuration</p>
+          <h3 className="section-title">Connection config</h3>
+        </div>
+        <span className="panel__meta">{keys.length} {keys.length === 1 ? 'key' : 'keys'}</span>
+      </div>
+
+      {keys.length === 0 ? (
+        <p className="muted-text">No configuration values set.</p>
+      ) : (
+        <pre className="config-block mono-text">{JSON.stringify(config, null, 2)}</pre>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/connections/components/ConnectionDiagnosticsPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionDiagnosticsPanel.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { ConnectionDiagnosticsPanel } from './ConnectionDiagnosticsPanel';
+
+describe('ConnectionDiagnosticsPanel', () => {
+  afterEach(cleanup);
+
+  it('shows loading state while fetching diagnostics', () => {
+    const apiClient = createMockApiClient({
+      connections: { getDiagnostics: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+    renderWithProviders(<ConnectionDiagnosticsPanel connectionId="conn_1" />, { apiClient });
+
+    expect(screen.getByRole('heading', { name: 'Loading diagnostics' })).toBeInTheDocument();
+  });
+
+  it('shows error state when diagnostics fetch fails', async () => {
+    const apiClient = createMockApiClient({
+      connections: { getDiagnostics: vi.fn().mockRejectedValue(new Error('Failed')) },
+    });
+    renderWithProviders(<ConnectionDiagnosticsPanel connectionId="conn_1" />, { apiClient });
+
+    expect(await screen.findByRole('heading', { name: 'Unable to load diagnostics' })).toBeInTheDocument();
+  });
+
+  it('displays diagnostics data when loaded', async () => {
+    const apiClient = createMockApiClient({
+      connections: {
+        getDiagnostics: vi.fn().mockResolvedValue({
+          connectionId: 'conn_1',
+          connectionName: 'Test',
+          connectionStatus: 'active',
+          lastSucceededAt: '2026-01-15T10:00:00.000Z',
+          lastFailedAt: null,
+          recentErrors: [],
+          recentJobs: [],
+        }),
+      },
+    });
+    renderWithProviders(<ConnectionDiagnosticsPanel connectionId="conn_1" />, { apiClient });
+
+    expect(await screen.findByText('Last succeeded')).toBeInTheDocument();
+    expect(screen.getByText('Never')).toBeInTheDocument(); // lastFailedAt is null
+  });
+});

--- a/apps/web/src/features/connections/components/ConnectionDiagnosticsPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionDiagnosticsPanel.tsx
@@ -1,0 +1,107 @@
+import type { ReactElement } from 'react';
+import { useConnectionDiagnosticsQuery } from '../hooks/use-connection-diagnostics-query';
+import type { RecentJobSummary } from '../api/connections.types';
+import { DataTable, type DataTableColumn } from '../../../shared/ui/data-table';
+import { LoadingState, ErrorState } from '../../../shared/ui/feedback-state';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+
+interface ConnectionDiagnosticsPanelProps {
+  connectionId: string;
+}
+
+function toJobStatusTone(status: string): StatusBadgeTone {
+  switch (status) {
+    case 'succeeded':
+      return 'success';
+    case 'failed':
+      return 'error';
+    case 'running':
+      return 'info';
+    case 'queued':
+      return 'neutral';
+    default:
+      return 'neutral';
+  }
+}
+
+function formatDate(value: string | null): string {
+  if (value === null) return 'Never';
+  return new Date(value).toLocaleString();
+}
+
+const jobColumns: DataTableColumn<RecentJobSummary>[] = [
+  { id: 'jobType', header: 'Job type', cell: (row) => <span className="mono-text">{row.jobType}</span> },
+  {
+    id: 'status',
+    header: 'Status',
+    cell: (row) => <StatusBadge tone={toJobStatusTone(row.status)}>{row.status}</StatusBadge>,
+  },
+  { id: 'attempts', header: 'Attempts', align: 'right', cell: (row) => row.attempts },
+  { id: 'lastError', header: 'Last error', cell: (row) => row.lastError ?? '-' },
+  { id: 'updatedAt', header: 'Updated', cell: (row) => formatDate(row.updatedAt) },
+];
+
+export function ConnectionDiagnosticsPanel({ connectionId }: ConnectionDiagnosticsPanelProps): ReactElement {
+  const diagnosticsQuery = useConnectionDiagnosticsQuery(connectionId);
+
+  return (
+    <div className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Health</p>
+          <h3 className="section-title">Diagnostics</h3>
+        </div>
+        <span className="panel__meta">Recent activity</span>
+      </div>
+
+      {diagnosticsQuery.isLoading ? (
+        <LoadingState title="Loading diagnostics" message="Fetching recent job history." />
+      ) : null}
+
+      {diagnosticsQuery.error ? (
+        <ErrorState
+          title="Unable to load diagnostics"
+          message={diagnosticsQuery.error.message}
+          action={
+            <button type="button" className="button button--secondary" onClick={() => void diagnosticsQuery.refetch()}>
+              Retry
+            </button>
+          }
+        />
+      ) : null}
+
+      {diagnosticsQuery.data ? (
+        <>
+          <dl className="definition-list">
+            <div>
+              <dt>Last succeeded</dt>
+              <dd>{formatDate(diagnosticsQuery.data.lastSucceededAt)}</dd>
+            </div>
+            <div>
+              <dt>Last failed</dt>
+              <dd>{formatDate(diagnosticsQuery.data.lastFailedAt)}</dd>
+            </div>
+          </dl>
+
+          {diagnosticsQuery.data.recentErrors.length > 0 ? (
+            <div className="diagnostics-errors">
+              <p className="eyebrow">Recent errors</p>
+              <ul className="error-list">
+                {diagnosticsQuery.data.recentErrors.map((error, index) => (
+                  <li key={`${index}-${error.slice(0, 20)}`} className="mono-text">{error}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <DataTable
+            caption="Recent sync jobs"
+            columns={jobColumns}
+            rows={diagnosticsQuery.data.recentJobs}
+            rowKey={(job) => job.id}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import { EditConnectionForm } from './EditConnectionForm';
+
+describe('EditConnectionForm', () => {
+  afterEach(cleanup);
+
+  it('renders pre-filled form fields from the connection', () => {
+    renderWithProviders(<EditConnectionForm connection={sampleConnection} />);
+
+    expect(screen.getByDisplayValue(sampleConnection.name)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(sampleConnection.platformType)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(sampleConnection.credentialsRef)).toBeInTheDocument();
+  });
+
+  it('shows platform type and credentials ref as disabled fields', () => {
+    renderWithProviders(<EditConnectionForm connection={sampleConnection} />);
+
+    const platformInput = screen.getByDisplayValue(sampleConnection.platformType);
+    const credentialsInput = screen.getByDisplayValue(sampleConnection.credentialsRef);
+
+    expect(platformInput).toBeDisabled();
+    expect(credentialsInput).toBeDisabled();
+  });
+
+  it('submits the update with changed values', async () => {
+    const updateFn = vi.fn().mockResolvedValue(sampleConnection);
+    const apiClient = createMockApiClient({
+      connections: { update: updateFn, getById: vi.fn().mockResolvedValue(sampleConnection) },
+    });
+
+    renderWithProviders(<EditConnectionForm connection={sampleConnection} />, { apiClient });
+
+    const nameInput = screen.getByDisplayValue(sampleConnection.name);
+    fireEvent.change(nameInput, { target: { value: 'Updated Store' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(updateFn).toHaveBeenCalledWith(sampleConnection.id, expect.objectContaining({
+        name: 'Updated Store',
+      }));
+    });
+  });
+
+  it('shows validation errors in summary after submit attempt', async () => {
+    const connectionWithBadConfig = { ...sampleConnection, config: {}, name: '' };
+    renderWithProviders(<EditConnectionForm connection={connectionWithBadConfig} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    const errors = await screen.findAllByText('Connection name is required');
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('shows API error when update fails', async () => {
+    const apiClient = createMockApiClient({
+      connections: {
+        update: vi.fn().mockRejectedValue(new Error('Server error')),
+        getById: vi.fn().mockResolvedValue(sampleConnection),
+      },
+    });
+
+    renderWithProviders(<EditConnectionForm connection={sampleConnection} />, { apiClient });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    expect(await screen.findByText('Server error')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -1,0 +1,123 @@
+import type { ReactElement } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import type { Connection } from '../api/connections.types';
+import { useUpdateConnectionMutation } from '../hooks/use-update-connection-mutation';
+import {
+  editConnectionSchema,
+  toUpdateConnectionInput,
+  type EditConnectionFormSubmission,
+  type EditConnectionFormValues,
+} from './edit-connection.schema';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Textarea } from '../../../shared/ui/textarea';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+interface EditConnectionFormProps {
+  connection: Connection;
+}
+
+export function EditConnectionForm({ connection }: EditConnectionFormProps): ReactElement {
+  const updateConnection = useUpdateConnectionMutation();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
+  const form = useForm<EditConnectionFormValues, undefined, EditConnectionFormSubmission>({
+    defaultValues: {
+      name: connection.name,
+      configText: JSON.stringify(connection.config, null, 2),
+      adapterKey: connection.adapterKey ?? '',
+    },
+    resolver: zodResolver(editConnectionSchema),
+  });
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      await updateConnection.mutateAsync({
+        connectionId: connection.id,
+        input: toUpdateConnectionInput(values),
+      });
+      showToast({
+        tone: 'success',
+        title: 'Connection updated',
+        description: 'Connection settings have been saved.',
+      });
+      void navigate(`/connections/${connection.id}`);
+    } catch {
+      return;
+    }
+  });
+
+  return (
+    <form className="form-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Edit connection</p>
+          <h3 className="section-title">{connection.name}</h3>
+        </div>
+        <span className="panel__meta">Update settings</span>
+      </div>
+
+      {form.formState.submitCount > 0 && validationMessages.length > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
+      {updateConnection.error ? (
+        <Alert tone="error" title="Unable to update connection">
+          {updateConnection.error.message}
+        </Alert>
+      ) : null}
+
+      <div className="form-grid">
+        <FormField label="Connection name" name="name" error={form.formState.errors.name?.message}>
+          <Input {...form.register('name')} placeholder="Main PrestaShop Store" invalid={Boolean(form.formState.errors.name)} />
+        </FormField>
+
+        <FormField label="Platform type" name="platformType">
+          <Input value={connection.platformType} disabled />
+        </FormField>
+
+        <FormField label="Credentials reference" name="credentialsRef">
+          <Input value={connection.credentialsRef} disabled />
+        </FormField>
+
+        <FormField
+          label="Adapter key"
+          name="adapterKey"
+          error={form.formState.errors.adapterKey?.message}
+          description="Optional when the default adapter can be inferred from the selected platform."
+        >
+          <Input
+            {...form.register('adapterKey')}
+            placeholder="prestashop.webservice.v1"
+            invalid={Boolean(form.formState.errors.adapterKey)}
+          />
+        </FormField>
+      </div>
+
+      <FormField
+        label="Config JSON"
+        name="configText"
+        error={form.formState.errors.configText?.message}
+        description="Provide only safe connection configuration values. Secrets must remain outside the browser."
+      >
+        <Textarea {...form.register('configText')} rows={10} invalid={Boolean(form.formState.errors.configText)} />
+      </FormField>
+
+      <div className="form-actions">
+        <Button type="submit" disabled={updateConnection.isPending}>
+          {updateConnection.isPending ? 'Saving...' : 'Save changes'}
+        </Button>
+        <Button tone="secondary" onClick={() => void navigate(`/connections/${connection.id}`)}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import type { UpdateConnectionInput } from '../api/connections.types';
+
+export const editConnectionSchema = z.object({
+  name: z.string().trim().min(1, 'Connection name is required'),
+  configText: z
+    .string()
+    .trim()
+    .min(2, 'Configuration JSON is required')
+    .refine((value) => {
+      try {
+        JSON.parse(value);
+        return true;
+      } catch {
+        return false;
+      }
+    }, 'Configuration must be valid JSON'),
+  adapterKey: z.string().trim().optional(),
+});
+
+export type EditConnectionFormValues = z.input<typeof editConnectionSchema>;
+export type EditConnectionFormSubmission = z.output<typeof editConnectionSchema>;
+
+export function toUpdateConnectionInput(values: EditConnectionFormSubmission): UpdateConnectionInput {
+  return {
+    name: values.name,
+    adapterKey: values.adapterKey ? values.adapterKey : undefined,
+    config: JSON.parse(values.configText) as Record<string, unknown>,
+  };
+}

--- a/apps/web/src/features/connections/hooks/use-disable-connection-mutation.ts
+++ b/apps/web/src/features/connections/hooks/use-disable-connection-mutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { connectionsQueryKeys } from '../api/connections.query-keys';
+import type { Connection } from '../api/connections.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useDisableConnectionMutation(): UseMutationResult<Connection, Error, string> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (connectionId: string) => apiClient.connections.disable(connectionId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: connectionsQueryKeys.all,
+      });
+    },
+  });
+}

--- a/apps/web/src/features/connections/hooks/use-update-connection-mutation.ts
+++ b/apps/web/src/features/connections/hooks/use-update-connection-mutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { connectionsQueryKeys } from '../api/connections.query-keys';
+import type { Connection, UpdateConnectionInput } from '../api/connections.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+interface UpdateConnectionVariables {
+  connectionId: string;
+  input: UpdateConnectionInput;
+}
+
+export function useUpdateConnectionMutation(): UseMutationResult<Connection, Error, UpdateConnectionVariables> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ connectionId, input }: UpdateConnectionVariables) =>
+      apiClient.connections.update(connectionId, input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: connectionsQueryKeys.all,
+      });
+    },
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1198,15 +1198,64 @@ textarea {
   gap: 0.25rem;
 }
 
-/* Raw payload display */
-.raw-payload {
+/* Raw payload / config display */
+.raw-payload,
+.config-block {
   white-space: pre-wrap;
   word-break: break-word;
   padding: 1rem;
   background: var(--bg-surface-elevated);
   border: 1px solid var(--border-subtle);
   border-radius: 0.625rem;
-  font-size: 0.85rem;
-  max-height: 32rem;
+  font-size: 0.8125rem;
+  max-height: 24rem;
   overflow-y: auto;
+  margin: 0;
+}
+
+/* Action list */
+.action-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.action-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.action-list__item:last-child {
+  border-bottom: none;
+}
+
+/* Diagnostics errors */
+.diagnostics-errors {
+  margin-top: 0.5rem;
+}
+
+.error-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.25rem 0 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.error-list li {
+  font-size: 0.8125rem;
+  color: var(--status-error-fg, var(--status-error));
+  padding: 0.25rem 0.5rem;
+  background: var(--status-error-soft);
+  border-radius: 0.375rem;
+}
+
+/* Button group */
+.button-group {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 }

--- a/apps/web/src/pages/connections/connection-detail-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
+import { ConnectionDetailPage } from './connection-detail-page';
+
+// Note: renderWithProviders uses MemoryRouter. The page reads connectionId via
+// useParams which defaults to '' when no route pattern matches. To provide the
+// param, we pass the route option so MemoryRouter starts at the right path.
+// The query hook is enabled when connectionId.length > 0, so we rely on the
+// fallback param value from useParams ({ connectionId = '' }).
+//
+// However, without a <Route path=":connectionId"> wrapper, useParams returns {}.
+// We work around this by testing the page component through the route definition
+// using a Route wrapper inside test-utils. Since page tests cannot import from
+// app/, we test the rendered output at the feature component level and keep
+// page-level tests limited to what renderWithProviders supports.
+
+describe('ConnectionDetailPage', () => {
+  afterEach(cleanup);
+
+  it('renders the page layout', () => {
+    renderWithProviders(<ConnectionDetailPage />);
+    expect(screen.getByText(/Integration detail/)).toBeInTheDocument();
+  });
+
+  it('shows empty state when connectionId is not provided', async () => {
+    const apiClient = createMockApiClient({
+      connections: { getById: vi.fn().mockResolvedValue(null) },
+    });
+    renderWithProviders(<ConnectionDetailPage />, { apiClient });
+
+    // With no route params, connectionId defaults to '' and query is disabled
+    expect(await screen.findByRole('heading', { name: 'Connection not found' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -1,6 +1,9 @@
 import type { ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
+import { ConnectionActionsPanel } from '../../features/connections/components/ConnectionActionsPanel';
+import { ConnectionConfigPanel } from '../../features/connections/components/ConnectionConfigPanel';
+import { ConnectionDiagnosticsPanel } from '../../features/connections/components/ConnectionDiagnosticsPanel';
 import type { ConnectionStatus } from '../../features/connections/api/connections.types';
 import { EmptyState, ErrorState, LoadingState } from '../../shared/ui/feedback-state';
 import { PageLayout } from '../../shared/ui/page-layout';
@@ -21,25 +24,34 @@ export function ConnectionDetailPage(): ReactElement {
   const { connectionId = '' } = useParams();
   const connectionQuery = useConnectionQuery(connectionId);
 
+  const connection = connectionQuery.data;
+
   return (
     <PageLayout
       eyebrow="Integration detail"
-      title={`Connection ${connectionId}`}
-      description="Detail views should combine configuration, health, status, and action context without hiding debug value."
+      title={connection ? connection.name : `Connection ${connectionId}`}
+      description="Connection overview, configuration, health, and operator actions."
       actions={
-        <Link className="button button--secondary" to="/connections">
-          Back to integrations
-        </Link>
+        <div className="button-group">
+          {connection ? (
+            <Link className="button button--primary" to={`/connections/${connectionId}/edit`}>
+              Edit connection
+            </Link>
+          ) : null}
+          <Link className="button button--secondary" to="/connections">
+            Back to integrations
+          </Link>
+        </div>
       }
       summary={
-        connectionQuery.data ? (
+        connection ? (
           <>
             <div className="toolbar__group">
-              <span className="toolbar-chip">Detail workspace</span>
-              <span className={`status-pill status-pill--${connectionQuery.data.status}`}>{connectionQuery.data.status}</span>
+              <span className="toolbar-chip">{connection.platformType}</span>
+              <StatusBadge tone={toStatusTone(connection.status)}>{connection.status}</StatusBadge>
             </div>
             <div className="toolbar__group">
-              <span className="muted-text">Configuration, health, and operator guidance in one view.</span>
+              <span className="muted-text">Created {new Date(connection.createdAt).toLocaleDateString()}</span>
             </div>
           </>
         ) : undefined
@@ -48,7 +60,7 @@ export function ConnectionDetailPage(): ReactElement {
       {connectionQuery.isLoading ? (
         <LoadingState
           title="Loading connection"
-          message="Fetching the latest connection summary and operator guidance."
+          message="Fetching the latest connection summary and diagnostics."
         />
       ) : null}
       {connectionQuery.error ? (
@@ -62,67 +74,54 @@ export function ConnectionDetailPage(): ReactElement {
           }
         />
       ) : null}
-      {!connectionQuery.isLoading && !connectionQuery.error && !connectionQuery.data ? (
+      {!connectionQuery.isLoading && !connectionQuery.error && !connection ? (
         <EmptyState
           title="Connection not found"
           message="No connection data was returned for this route. Retry from the integrations list or verify the selected identifier."
         />
       ) : null}
-      {connectionQuery.data ? (
+      {connection ? (
         <div className="workspace-grid">
           <div className="panel panel--dense">
             <div className="panel__header">
               <div>
                 <p className="eyebrow">Connection summary</p>
-                <h3 className="section-title">Current state</h3>
+                <h3 className="section-title">Overview</h3>
               </div>
-              <StatusBadge tone={toStatusTone(connectionQuery.data.status)}>{connectionQuery.data.status}</StatusBadge>
+              <StatusBadge tone={toStatusTone(connection.status)}>{connection.status}</StatusBadge>
             </div>
 
             <dl className="definition-list">
               <div>
                 <dt>Name</dt>
-                <dd>{connectionQuery.data.name}</dd>
+                <dd>{connection.name}</dd>
               </div>
               <div>
                 <dt>Platform</dt>
-                <dd>{connectionQuery.data.platformType}</dd>
+                <dd>{connection.platformType}</dd>
               </div>
               <div>
                 <dt>Credentials ref</dt>
-                <dd className="mono-text">{connectionQuery.data.credentialsRef}</dd>
+                <dd className="mono-text">{connection.credentialsRef}</dd>
               </div>
               <div>
                 <dt>Adapter</dt>
-                <dd className="mono-text">{connectionQuery.data.adapterKey ?? 'default adapter'}</dd>
+                <dd className="mono-text">{connection.adapterKey ?? 'default adapter'}</dd>
+              </div>
+              <div>
+                <dt>Connection ID</dt>
+                <dd className="mono-text">{connection.id}</dd>
+              </div>
+              <div>
+                <dt>Last updated</dt>
+                <dd>{new Date(connection.updatedAt).toLocaleString()}</dd>
               </div>
             </dl>
           </div>
 
-          <div className="panel panel--dense">
-            <div className="panel__header">
-              <div>
-                <p className="eyebrow">Operator context</p>
-                <h3 className="section-title">Suggested next actions</h3>
-              </div>
-              <span className="panel__meta">Guidance</span>
-            </div>
-
-            <ul className="check-list">
-              <li>
-                <strong>Validate auth state</strong>
-                <span className="muted-text">Confirm credentials and permissions are still valid.</span>
-              </li>
-              <li>
-                <strong>Check sync history</strong>
-                <span className="muted-text">Future iterations should expose job runs and retry history here.</span>
-              </li>
-              <li>
-                <strong>Review raw payloads</strong>
-                <span className="muted-text">Debug access should become a first-class tab in later feature work.</span>
-              </li>
-            </ul>
-          </div>
+          <ConnectionConfigPanel config={connection.config} />
+          <ConnectionDiagnosticsPanel connectionId={connection.id} />
+          <ConnectionActionsPanel connection={connection} />
         </div>
       ) : null}
     </PageLayout>

--- a/apps/web/src/pages/connections/edit-connection-page.tsx
+++ b/apps/web/src/pages/connections/edit-connection-page.tsx
@@ -1,0 +1,51 @@
+import type { ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
+import { EditConnectionForm } from '../../features/connections/components/EditConnectionForm';
+import { EmptyState, ErrorState, LoadingState } from '../../shared/ui/feedback-state';
+import { PageLayout } from '../../shared/ui/page-layout';
+
+export function EditConnectionPage(): ReactElement {
+  const { connectionId = '' } = useParams();
+  const connectionQuery = useConnectionQuery(connectionId);
+
+  return (
+    <PageLayout
+      eyebrow="Connection settings"
+      title="Edit connection"
+      description="Update the connection name, configuration, and adapter settings."
+      actions={
+        <Link className="button button--secondary" to={`/connections/${connectionId}`}>
+          Back to detail
+        </Link>
+      }
+    >
+      {connectionQuery.isLoading ? (
+        <LoadingState
+          title="Loading connection"
+          message="Fetching connection data for editing."
+        />
+      ) : null}
+      {connectionQuery.error ? (
+        <ErrorState
+          title="Unable to load connection"
+          message={connectionQuery.error.message}
+          action={
+            <button type="button" className="button button--secondary" onClick={() => void connectionQuery.refetch()}>
+              Retry
+            </button>
+          }
+        />
+      ) : null}
+      {!connectionQuery.isLoading && !connectionQuery.error && !connectionQuery.data ? (
+        <EmptyState
+          title="Connection not found"
+          message="No connection data was returned. Check the connection ID or return to the list."
+        />
+      ) : null}
+      {connectionQuery.data ? (
+        <EditConnectionForm connection={connectionQuery.data} />
+      ) : null}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -70,6 +70,7 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
     } as ApiClient['auth'],
     connections: {
       create: vi.fn().mockResolvedValue(sampleConnection),
+      disable: vi.fn().mockResolvedValue({ ...sampleConnection, status: 'disabled' }),
       getDiagnostics: vi.fn().mockResolvedValue({
         connectionId: 'conn_1',
         connectionName: 'Main PrestaShop Store',

--- a/docs/plans/implementation-plan-connection-create-edit-detail.md
+++ b/docs/plans/implementation-plan-connection-create-edit-detail.md
@@ -1,0 +1,236 @@
+# Implementation Plan: Connection Create/Edit Flows & Detail Page
+
+**Date**: 2026-04-11  
+**Status**: Draft  
+**Issues**: #62, #63  
+**Estimated Effort**: ~6 hours
+
+---
+
+## 1. Task Summary
+
+**Objective**: Complete the connection management UI — allow operators to create, edit, disable, and inspect connections from the frontend.
+
+**Context**: The connections list page and adapter catalog were just shipped (#128). The backend CRUD API is fully implemented (`POST`, `GET`, `PATCH`, `PATCH :id/disable`, diagnostics). The frontend has the create form and a skeleton detail page. What's missing: update mutation, disable mutation+API method, edit form, enriched detail page with config/diagnostics/actions.
+
+**Classification**: Frontend (Interface layer — `apps/web`)
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- **#62**: Edit connection form (name, config, adapterKey), disable connection action with confirmation, validation and error handling, success UX
+- **#63**: Connection detail page with: overview panel, config display, diagnostics/health panel (using existing diagnostics API), actions area (edit link, disable button)
+
+### Out of Scope
+- Credential management (#64) — `credentialsRef` is read-only on edit
+- Connection health checks / validation endpoint
+- Platform-specific onboarding wizards (#67)
+- Status change to `active` from `error` (requires backend changes)
+
+### Constraints
+- Must follow existing frontend patterns (form schema, mutation hooks, page layout)
+- Backend API is complete — no backend changes needed
+- `platformType` and `credentialsRef` are immutable after creation
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: Frontend (`apps/web/src/`)
+
+**Existing Services Reused**:
+- `connections.api.ts` — add `disable` method
+- `connections.query-keys.ts` — already complete
+- `use-connection-query.ts`, `use-connection-diagnostics-query.ts` — for detail page
+- All shared UI components (PageLayout, FormField, Button, Alert, ConfirmDialog, StatusBadge, etc.)
+
+**New Components Required**:
+- `use-update-connection-mutation.ts` — mutation hook
+- `use-disable-connection-mutation.ts` — mutation hook
+- `EditConnectionForm.tsx` + `edit-connection.schema.ts` — edit form + validation
+- `ConnectionConfigPanel.tsx` — JSON config display
+- `ConnectionDiagnosticsPanel.tsx` — health/diagnostics display
+- `ConnectionActionsPanel.tsx` — edit + disable actions
+- `edit-connection.route.tsx` — new route `/connections/:connectionId/edit`
+- `edit-connection-page.tsx` — page composition
+
+---
+
+## 4. Internal Patterns
+
+**Similar Implementations Found**:
+- `CreateConnectionForm.tsx` — exact pattern to follow for edit form (RHF + Zod + mutation + toast)
+- `create-connection.schema.ts` — schema pattern to reuse/adapt
+- `use-create-connection-mutation.ts` — mutation hook pattern
+- `connection-detail-page.tsx` — skeleton to enrich
+- `connections-list-page.test.tsx` — test pattern with `renderWithProviders`
+
+---
+
+## 5. Questions & Assumptions
+
+### Assumptions
+- `platformType` and `credentialsRef` are immutable after creation (shown read-only on edit form)
+- Edit form pre-populates from the existing connection data via `useConnectionQuery`
+- Disable action uses `PATCH /connections/:id/disable` (not `PATCH` with `status: 'disabled'`)
+- Diagnostics panel shows `lastSucceededAt`, `lastFailedAt`, `recentErrors`, and `recentJobs` table
+- Config panel displays JSON in a read-only `<pre>` block (editing config is done via the edit form)
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: API Layer & Mutation Hooks
+
+**Goal**: Complete the data layer needed by the UI.
+
+1. **Add `disable` method to connections API**
+   - **File**: `features/connections/api/connections.api.ts`
+   - **Action**: Add `disable(connectionId: string): Promise<Connection>` method calling `PATCH /connections/{id}/disable`
+   - **Also**: Update `ConnectionsApi` interface
+   - **Acceptance**: Type-checks, method exists on apiClient
+
+2. **Create `use-update-connection-mutation` hook**
+   - **File**: `features/connections/hooks/use-update-connection-mutation.ts`
+   - **Action**: Mutation hook wrapping `apiClient.connections.update(connectionId, input)`, invalidates `connectionsQueryKeys.all`
+   - **Acceptance**: Hook compiles, invalidates cache on success
+
+3. **Create `use-disable-connection-mutation` hook**
+   - **File**: `features/connections/hooks/use-disable-connection-mutation.ts`
+   - **Action**: Mutation hook wrapping `apiClient.connections.disable(connectionId)`, invalidates `connectionsQueryKeys.all`
+   - **Acceptance**: Hook compiles, invalidates cache on success
+
+### Phase 2: Edit Connection Flow (#62)
+
+**Goal**: Working edit form accessible from the detail page.
+
+4. **Create edit connection Zod schema**
+   - **File**: `features/connections/components/edit-connection.schema.ts`
+   - **Action**: Schema with `name` (required), `configText` (valid JSON), `adapterKey` (optional). Export `EditConnectionFormValues`, `EditConnectionFormSubmission`, `toUpdateConnectionInput()`.
+   - **Acceptance**: Schema validates correctly, transforms to `UpdateConnectionInput`
+
+5. **Create `EditConnectionForm` component**
+   - **File**: `features/connections/components/EditConnectionForm.tsx`
+   - **Action**: RHF form pre-populated with connection data. Shows `platformType` and `credentialsRef` as read-only fields. Editable: `name`, `configText`, `adapterKey`. Uses `useUpdateConnectionMutation`. Toast on success, Alert on API error, FormErrorSummary on validation errors.
+   - **Props**: `connection: Connection` (the current connection to edit)
+   - **Acceptance**: Form renders with pre-filled values, submits PATCH, shows feedback
+
+6. **Create edit connection page**
+   - **File**: `pages/connections/edit-connection-page.tsx`
+   - **Action**: Page with `PageLayout`, fetches connection via `useConnectionQuery`, renders `EditConnectionForm`. Handles loading/error/empty states.
+   - **Acceptance**: Page loads connection and renders edit form
+
+7. **Create edit connection route**
+   - **File**: `app/routes/edit-connection.route.tsx`
+   - **Action**: Route at `connections/:connectionId/edit` pointing to `EditConnectionPage`
+   - **Also**: Register in `root.route.tsx`
+   - **Acceptance**: Navigation to `/connections/:id/edit` renders the edit page
+
+### Phase 3: Connection Detail Page (#63)
+
+**Goal**: Enriched detail page with config, diagnostics, and actions.
+
+8. **Create `ConnectionConfigPanel` component**
+   - **File**: `features/connections/components/ConnectionConfigPanel.tsx`
+   - **Action**: Panel displaying config JSON in a styled `<pre>` block with monospace text. Shows "No configuration" empty state if config is empty.
+   - **Acceptance**: Renders JSON readably
+
+9. **Create `ConnectionDiagnosticsPanel` component**
+   - **File**: `features/connections/components/ConnectionDiagnosticsPanel.tsx`
+   - **Action**: Panel using `useConnectionDiagnosticsQuery`. Shows `lastSucceededAt`/`lastFailedAt` timestamps, `recentErrors` list, `recentJobs` in a small DataTable (jobType, status, attempts, lastError, updatedAt). Handles loading/error states.
+   - **Acceptance**: Diagnostics data renders, loading/error handled
+
+10. **Create `ConnectionActionsPanel` component**
+    - **File**: `features/connections/components/ConnectionActionsPanel.tsx`
+    - **Action**: Panel with "Edit connection" link (`/connections/:id/edit`), "Disable connection" button (danger tone) with `ConfirmDialog`. Uses `useDisableConnectionMutation`. Disable button hidden when connection already disabled. Toast on success.
+    - **Props**: `connection: Connection`
+    - **Acceptance**: Edit navigates, disable shows confirmation, executes mutation, toasts
+
+11. **Enrich `ConnectionDetailPage`**
+    - **File**: `pages/connections/connection-detail-page.tsx`
+    - **Action**: Replace placeholder panels with: overview panel (existing, refined), `ConnectionConfigPanel`, `ConnectionDiagnosticsPanel`, `ConnectionActionsPanel`. Add "Edit" link in page actions. Update title to show connection name.
+    - **Acceptance**: Detail page shows all 4 panels with real data
+
+### Phase 4: Tests
+
+12. **Test edit connection form**
+    - **File**: `features/connections/components/EditConnectionForm.test.tsx`
+    - **Action**: Tests: renders pre-filled values, submits update, shows validation errors, shows API error, read-only fields not editable
+    - **Acceptance**: All tests pass
+
+13. **Test connection detail page**
+    - **File**: `pages/connections/connection-detail-page.test.tsx`
+    - **Action**: Tests: renders connection data, shows diagnostics, shows config, edit link navigates, disable button works with confirmation
+    - **Acceptance**: All tests pass
+
+14. **Update test utils if needed**
+    - **File**: `test/test-utils.ts`
+    - **Action**: Add `disable` to mock API client if not already present, add `sampleConnectionDiagnostics` fixture
+    - **Acceptance**: Mock API complete for new methods
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative: Inline editing on detail page (no separate edit route)
+- **Why Rejected**: The create form already uses a full-page form pattern. Inline editing adds complexity (toggle states, partial saves) for little benefit at MVP stage. A separate edit page is consistent with the existing create flow.
+
+### Alternative: Tabs on detail page
+- **Why Rejected**: No existing tab component in shared UI. Using panels in a grid layout is consistent with the existing detail page skeleton and dashboard patterns. Tabs can be added later if needed.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ All new code lives in `apps/web/src/` (frontend only)
+- ✅ Follows `pages` → `features` → `shared` dependency direction
+- ✅ Server state via TanStack Query, form state via RHF
+
+### Naming Conventions
+- ✅ Components: `PascalCase.tsx`
+- ✅ Hooks: `use-*.ts`
+- ✅ Routes: `*.route.tsx`
+- ✅ Schemas: `*.schema.ts`
+- ✅ Tests: `*.test.tsx`
+
+### Risks
+- **Diagnostics endpoint may be slow**: Mitigated by separate query hook with independent loading state
+- **Config JSON could be large**: `<pre>` block with `overflow: auto` and max-height
+
+### Backward Compatibility
+- ✅ No breaking changes — only additions to existing pages and new files
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `EditConnectionForm.test.tsx` — form rendering, submission, validation, API errors
+- `connection-detail-page.test.tsx` — page composition, all panels render, actions work
+
+### Mocking Strategy
+- Mock API client via `createMockApiClient()` with `update`, `disable`, `getDiagnostics` methods
+
+### Acceptance Criteria
+- [ ] Create connection flow unchanged (no regression)
+- [ ] Edit form pre-fills from existing connection, submits PATCH, shows success toast
+- [ ] Disable button shows confirmation dialog, disables connection, shows success toast
+- [ ] Detail page shows overview, config, diagnostics, and actions panels
+- [ ] All states handled: loading, error, empty, success
+- [ ] `pnpm lint && pnpm type-check && pnpm test` passes
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows frontend architecture conventions
+- [x] Uses existing patterns (form schema, mutation hooks, page layout)
+- [x] No unnecessary abstractions
+- [x] Error handling comprehensive (API errors, validation, empty states)
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready


### PR DESCRIPTION
## Summary
- **#62**: Add edit connection form (name, config, adapterKey), disable connection action with confirmation dialog, update/disable mutation hooks
- **#63**: Enrich connection detail page with config display panel, diagnostics/health panel with recent jobs table, and operator actions panel
- Add `disable` method to connections API client and mock test utils

## Changes
- **API layer**: `disable` method on `ConnectionsApi`, `useUpdateConnectionMutation`, `useDisableConnectionMutation` hooks
- **Edit flow**: `EditConnectionForm` + Zod schema, `EditConnectionPage`, edit route at `/connections/:id/edit`
- **Detail page**: `ConnectionConfigPanel`, `ConnectionDiagnosticsPanel`, `ConnectionActionsPanel` — replaces placeholder panels
- **CSS**: Shared `.config-block`/`.raw-payload` base, `.action-list`, `.error-list`, `.button-group` styles
- **Tests**: 15 new tests across 6 test files (27 test files, 99 tests total)

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — passes
- [x] `pnpm test` — 99/99 tests pass
- [ ] Manual: create connection, navigate to detail, verify all 4 panels render
- [ ] Manual: click Edit, change name, save — verify toast and redirect
- [ ] Manual: click Disable on active connection — verify confirmation dialog and status change
- [ ] Manual: verify disabled connection hides disable button

Closes #62
Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)