### PR TITLE
feat(web): add customer projection and offer mapping UIs

### DIFF
--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -3,8 +3,10 @@ import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/al
 import { createAuthApi, type AuthApi } from '../../features/auth/api/auth.api';
 import { createConnectionsApi, type ConnectionsApi } from '../../features/connections/api/connections.api';
 import { createCursorsApi, type CursorsApi } from '../../features/cursors/api/cursors.api';
+import { createCustomersApi, type CustomersApi } from '../../features/customers/api/customers.api';
 import { createHealthApi, type HealthApi } from '../../features/health/api/health.api';
 import { createInventoryApi, type InventoryApi } from '../../features/inventory/api/inventory.api';
+import { createListingsApi, type ListingsApi } from '../../features/listings/api/listings.api';
 import { createOrdersApi, type OrdersApi } from '../../features/orders/api/orders.api';
 import { createProductsApi, type ProductsApi } from '../../features/products/api/products.api';
 import { createSyncJobsApi, type SyncJobsApi } from '../../features/sync-jobs/api/sync.api';
@@ -26,8 +28,10 @@ export interface ApiClient {
   auth: AuthApi;
   connections: ConnectionsApi;
   cursors: CursorsApi;
+  customers: CustomersApi;
   health: HealthApi;
   inventory: InventoryApi;
+  listings: ListingsApi;
   orders: OrdersApi;
   products: ProductsApi;
   request: <T>(path: string, init?: RequestInit) => Promise<T>;
@@ -116,8 +120,10 @@ export function createApiClient({
     auth: createAuthApi(request),
     connections: createConnectionsApi(request),
     cursors: createCursorsApi(request),
+    customers: createCustomersApi(request),
     health: createHealthApi(request),
     inventory: createInventoryApi(request),
+    listings: createListingsApi(request),
     orders: createOrdersApi(request),
     products: createProductsApi(request),
     request,

--- a/apps/web/src/app/routes/customers.route.tsx
+++ b/apps/web/src/app/routes/customers.route.tsx
@@ -1,0 +1,11 @@
+import type { RouteObject } from 'react-router-dom';
+import { CustomersListPage } from '../../pages/customers/customers-list-page';
+import { CustomerDetailPage } from '../../pages/customers/customer-detail-page';
+
+export const customersRoute: RouteObject = {
+  path: 'customers',
+  children: [
+    { index: true, element: <CustomersListPage /> },
+    { path: ':id', element: <CustomerDetailPage /> },
+  ],
+};

--- a/apps/web/src/app/routes/listings.route.tsx
+++ b/apps/web/src/app/routes/listings.route.tsx
@@ -1,0 +1,11 @@
+import type { RouteObject } from 'react-router-dom';
+import { ListingsListPage } from '../../pages/listings/listings-list-page';
+import { ListingDetailPage } from '../../pages/listings/listing-detail-page';
+
+export const listingsRoute: RouteObject = {
+  path: 'listings',
+  children: [
+    { index: true, element: <ListingsListPage /> },
+    { path: ':id', element: <ListingDetailPage /> },
+  ],
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -8,8 +8,10 @@ import { connectionDetailRoute } from './connection-detail.route';
 import { editConnectionRoute } from './edit-connection.route';
 import { connectionsRoute } from './connections.route';
 import { cursorsRoute } from './cursors.route';
+import { customersRoute } from './customers.route';
 import { dashboardRoute } from './dashboard.route';
 import { invoicesRoute } from './invoices.route';
+import { listingsRoute } from './listings.route';
 import { inventoryRoute } from './inventory.route';
 import { jobsLogsRoute } from './jobs-logs.route';
 import { newConnectionRoute } from './new-connection.route';
@@ -27,6 +29,8 @@ export const rootRoute: RouteObject = {
     productsRoute,
     inventoryRoute,
     cursorsRoute,
+    customersRoute,
+    listingsRoute,
     connectionsRoute,
     adaptersRoute,
     newConnectionRoute,

--- a/apps/web/src/features/customers/api/customers.api.ts
+++ b/apps/web/src/features/customers/api/customers.api.ts
@@ -1,0 +1,45 @@
+/**
+ * Customers API Client
+ *
+ * Thin API module for the customers feature. Provides typed methods for
+ * listing customer projections and fetching individual customer details
+ * with addresses.
+ *
+ * @module apps/web/src/features/customers/api
+ */
+import type {
+  CustomerFilters,
+  CustomerPagination,
+  CustomerProjectionDetail,
+  PaginatedCustomers,
+} from './customers.types';
+
+export interface CustomersApi {
+  list: (filters?: CustomerFilters, pagination?: CustomerPagination) => Promise<PaginatedCustomers>;
+  getById: (id: string) => Promise<CustomerProjectionDetail>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+function buildQuery(filters?: CustomerFilters, pagination?: CustomerPagination): string {
+  const params = new URLSearchParams();
+  if (filters?.search) params.set('search', filters.search);
+  if (filters?.lastSourceConnectionId) params.set('lastSourceConnectionId', filters.lastSourceConnectionId);
+  if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
+  if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}
+
+export function createCustomersApi(request: ApiRequest): CustomersApi {
+  return {
+    list(filters, pagination): Promise<PaginatedCustomers> {
+      return request<PaginatedCustomers>(`/customers${buildQuery(filters, pagination)}`);
+    },
+    getById(id): Promise<CustomerProjectionDetail> {
+      return request<CustomerProjectionDetail>(`/customers/${id}`);
+    },
+  };
+}

--- a/apps/web/src/features/customers/api/customers.query-keys.ts
+++ b/apps/web/src/features/customers/api/customers.query-keys.ts
@@ -1,0 +1,8 @@
+import type { CustomerFilters, CustomerPagination } from './customers.types';
+
+export const customersQueryKeys = {
+  all: ['customers'] as const,
+  list: (filters?: CustomerFilters, pagination?: CustomerPagination) =>
+    ['customers', 'list', filters ?? {}, pagination ?? {}] as const,
+  detail: (id: string) => ['customers', 'detail', id] as const,
+};

--- a/apps/web/src/features/customers/api/customers.types.ts
+++ b/apps/web/src/features/customers/api/customers.types.ts
@@ -1,0 +1,55 @@
+/**
+ * Customers Feature Types
+ *
+ * Frontend transport types for the customers API. Mirrors the backend
+ * CustomerProjectionResponseDto and PaginatedCustomersResponseDto contracts.
+ * All date fields are ISO 8601 strings.
+ *
+ * @module apps/web/src/features/customers/api
+ */
+
+export interface CustomerAddress {
+  addressHash: string;
+  addressType: string;
+  address1: string | null;
+  address2: string | null;
+  city: string | null;
+  postcode: string | null;
+  countryIso2: string | null;
+  lastSeenAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerProjection {
+  internalCustomerId: string;
+  emailHash: string;
+  normalizedEmail: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  lastSeenAt: string;
+  lastSourceConnectionId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerProjectionDetail extends CustomerProjection {
+  addresses: CustomerAddress[];
+}
+
+export interface CustomerFilters {
+  search?: string;
+  lastSourceConnectionId?: string;
+}
+
+export interface CustomerPagination {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedCustomers {
+  items: CustomerProjection[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/web/src/features/customers/hooks/use-customer-query.ts
+++ b/apps/web/src/features/customers/hooks/use-customer-query.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { customersQueryKeys } from '../api/customers.query-keys';
+import type { CustomerProjectionDetail } from '../api/customers.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useCustomerQuery(id: string): UseQueryResult<CustomerProjectionDetail> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: customersQueryKeys.detail(id),
+    queryFn: () => apiClient.customers.getById(id),
+    enabled: id.length > 0,
+    retry: false,
+  });
+}

--- a/apps/web/src/features/customers/hooks/use-customers-query.ts
+++ b/apps/web/src/features/customers/hooks/use-customers-query.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { customersQueryKeys } from '../api/customers.query-keys';
+import type { CustomerFilters, CustomerPagination, PaginatedCustomers } from '../api/customers.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useCustomersQuery(
+  filters?: CustomerFilters,
+  pagination?: CustomerPagination,
+): UseQueryResult<PaginatedCustomers> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: customersQueryKeys.list(filters, pagination),
+    queryFn: () => apiClient.customers.list(filters, pagination),
+    retry: false,
+  });
+}

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -1,0 +1,46 @@
+/**
+ * Listings API Client
+ *
+ * Thin API module for the listings (offer mapping) feature. Provides typed
+ * methods for listing offer mappings and fetching individual mapping details.
+ *
+ * @module apps/web/src/features/listings/api
+ */
+import type {
+  ListingsFilters,
+  ListingsPagination,
+  OfferMapping,
+  PaginatedOfferMappings,
+} from './listings.types';
+
+export interface ListingsApi {
+  list: (filters?: ListingsFilters, pagination?: ListingsPagination) => Promise<PaginatedOfferMappings>;
+  getById: (id: string) => Promise<OfferMapping>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+function buildQuery(filters?: ListingsFilters, pagination?: ListingsPagination): string {
+  const params = new URLSearchParams();
+  if (filters?.connectionId) params.set('connectionId', filters.connectionId);
+  if (filters?.platformType) params.set('platformType', filters.platformType);
+  if (filters?.internalId) params.set('internalId', filters.internalId);
+  if (filters?.search) params.set('search', filters.search);
+  if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
+  if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}
+
+export function createListingsApi(request: ApiRequest): ListingsApi {
+  return {
+    list(filters, pagination): Promise<PaginatedOfferMappings> {
+      return request<PaginatedOfferMappings>(`/listings${buildQuery(filters, pagination)}`);
+    },
+    getById(id): Promise<OfferMapping> {
+      return request<OfferMapping>(`/listings/${id}`);
+    },
+  };
+}

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -1,0 +1,8 @@
+import type { ListingsFilters, ListingsPagination } from './listings.types';
+
+export const listingsQueryKeys = {
+  all: ['listings'] as const,
+  list: (filters?: ListingsFilters, pagination?: ListingsPagination) =>
+    ['listings', 'list', filters ?? {}, pagination ?? {}] as const,
+  detail: (id: string) => ['listings', 'detail', id] as const,
+};

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -1,0 +1,40 @@
+/**
+ * Listings Feature Types
+ *
+ * Frontend transport types for the listings (offer mapping) API. Mirrors the
+ * backend OfferMappingResponseDto and PaginatedOfferMappingsResponseDto contracts.
+ * All date fields are ISO 8601 strings.
+ *
+ * @module apps/web/src/features/listings/api
+ */
+
+export interface OfferMapping {
+  id: string;
+  entityType: string;
+  internalId: string;
+  externalId: string;
+  platformType: string;
+  connectionId: string;
+  context: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListingsFilters {
+  connectionId?: string;
+  platformType?: string;
+  internalId?: string;
+  search?: string;
+}
+
+export interface ListingsPagination {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedOfferMappings {
+  items: OfferMapping[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/web/src/features/listings/hooks/use-listing-query.ts
+++ b/apps/web/src/features/listings/hooks/use-listing-query.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { OfferMapping } from '../api/listings.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useListingQuery(id: string): UseQueryResult<OfferMapping> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: listingsQueryKeys.detail(id),
+    queryFn: () => apiClient.listings.getById(id),
+    enabled: id.length > 0,
+    retry: false,
+  });
+}

--- a/apps/web/src/features/listings/hooks/use-listings-query.ts
+++ b/apps/web/src/features/listings/hooks/use-listings-query.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { ListingsFilters, ListingsPagination, PaginatedOfferMappings } from '../api/listings.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useListingsQuery(
+  filters?: ListingsFilters,
+  pagination?: ListingsPagination,
+): UseQueryResult<PaginatedOfferMappings> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: listingsQueryKeys.list(filters, pagination),
+    queryFn: () => apiClient.listings.list(filters, pagination),
+    retry: false,
+  });
+}

--- a/apps/web/src/pages/customers/customer-detail-page.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.tsx
@@ -1,0 +1,151 @@
+import type { ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { useCustomerQuery } from '../../features/customers/hooks/use-customer-query';
+import type { CustomerAddress } from '../../features/customers/api/customers.types';
+
+const ADDRESS_COLUMNS: DataTableColumn<CustomerAddress>[] = [
+  {
+    id: 'addressType',
+    header: 'Type',
+    cell: (a) => <span className="mono-text">{a.addressType}</span>,
+  },
+  {
+    id: 'address1',
+    header: 'Address',
+    cell: (a) => {
+      const parts = [a.address1, a.address2].filter(Boolean).join(', ');
+      return parts ? <span>{parts}</span> : <span className="text-muted">—</span>;
+    },
+  },
+  {
+    id: 'city',
+    header: 'City',
+    cell: (a) => a.city ?? <span className="text-muted">—</span>,
+  },
+  {
+    id: 'postcode',
+    header: 'Postcode',
+    cell: (a) => a.postcode ?? <span className="text-muted">—</span>,
+  },
+  {
+    id: 'countryIso2',
+    header: 'Country',
+    cell: (a) => a.countryIso2 ?? <span className="text-muted">—</span>,
+  },
+  {
+    id: 'lastSeenAt',
+    header: 'Last Seen',
+    cell: (a) => new Date(a.lastSeenAt).toLocaleDateString(),
+  },
+];
+
+export function CustomerDetailPage(): ReactElement {
+  const { id = '' } = useParams<{ id: string }>();
+  const query = useCustomerQuery(id);
+
+  if (query.isLoading) {
+    return (
+      <PageLayout eyebrow="Customers" title="Customer">
+        <LoadingState liveRegion="off" title="Loading customer" message="Fetching customer details…" />
+      </PageLayout>
+    );
+  }
+
+  if (query.error || !query.data) {
+    return (
+      <PageLayout eyebrow="Customers" title="Customer">
+        <ErrorState
+          title="Unable to load customer"
+          message={query.error?.message ?? 'Customer not found'}
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
+        />
+      </PageLayout>
+    );
+  }
+
+  const customer = query.data;
+  const name = [customer.firstName, customer.lastName].filter(Boolean).join(' ');
+
+  return (
+    <PageLayout
+      eyebrow="Customers"
+      title={name || customer.internalCustomerId}
+      actions={
+        <Link to=".." relative="path" className="button button--ghost">
+          ← Back to customers
+        </Link>
+      }
+    >
+      <section className="detail-section">
+        <dl className="detail-list">
+          <div className="detail-list__row">
+            <dt>Customer ID</dt>
+            <dd><span className="mono-text">{customer.internalCustomerId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Email Hash</dt>
+            <dd><span className="mono-text">{customer.emailHash}</span></dd>
+          </div>
+          {customer.normalizedEmail ? (
+            <div className="detail-list__row">
+              <dt>Normalized Email</dt>
+              <dd><span className="mono-text">{customer.normalizedEmail}</span></dd>
+            </div>
+          ) : null}
+          <div className="detail-list__row">
+            <dt>First Name</dt>
+            <dd>{customer.firstName ?? <span className="text-muted">—</span>}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Last Name</dt>
+            <dd>{customer.lastName ?? <span className="text-muted">—</span>}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Last Source Connection</dt>
+            <dd>
+              {customer.lastSourceConnectionId ? (
+                <span className="mono-text">{customer.lastSourceConnectionId}</span>
+              ) : (
+                <span className="text-muted">—</span>
+              )}
+            </dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Last Seen</dt>
+            <dd>{new Date(customer.lastSeenAt).toLocaleString()}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Created</dt>
+            <dd>{new Date(customer.createdAt).toLocaleString()}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Updated</dt>
+            <dd>{new Date(customer.updatedAt).toLocaleString()}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="detail-section">
+        <h2 className="detail-section__title">Addresses</h2>
+        {customer.addresses.length === 0 ? (
+          <EmptyState
+            liveRegion="off"
+            title="No addresses"
+            message="No address projections have been recorded for this customer."
+          />
+        ) : (
+          <DataTable
+            caption="Customer addresses"
+            columns={ADDRESS_COLUMNS}
+            rows={customer.addresses}
+            rowKey={(a) => a.addressHash}
+          />
+        )}
+      </section>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/customers/customers-list-page.test.tsx
+++ b/apps/web/src/pages/customers/customers-list-page.test.tsx
@@ -1,0 +1,114 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { CustomersListPage } from './customers-list-page';
+import type { PaginatedCustomers } from '../../features/customers/api/customers.types';
+
+const sampleCustomers: PaginatedCustomers = {
+  items: [
+    {
+      internalCustomerId: 'ol_customer_abc123',
+      emailHash: 'abc123hash',
+      normalizedEmail: 'buyer@example.com',
+      firstName: 'Jane',
+      lastName: 'Smith',
+      lastSeenAt: '2026-03-01T10:00:00.000Z',
+      lastSourceConnectionId: 'conn_allegro_1',
+      createdAt: '2026-01-10T08:00:00.000Z',
+      updatedAt: '2026-03-01T10:00:00.000Z',
+    },
+    {
+      internalCustomerId: 'ol_customer_def456',
+      emailHash: 'def456hash',
+      normalizedEmail: null,
+      firstName: null,
+      lastName: null,
+      lastSeenAt: '2026-02-15T12:00:00.000Z',
+      lastSourceConnectionId: null,
+      createdAt: '2026-02-15T12:00:00.000Z',
+      updatedAt: '2026-02-15T12:00:00.000Z',
+    },
+  ],
+  total: 2,
+  limit: 20,
+  offset: 0,
+};
+
+describe('CustomersListPage', () => {
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      customers: {
+        list: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    });
+
+    renderWithProviders(<CustomersListPage />, { apiClient: mockApi });
+
+    expect(screen.getByText('Loading customers')).toBeInTheDocument();
+  });
+
+  it('should show customers table when data loads', async () => {
+    const mockApi = createMockApiClient({
+      customers: {
+        list: vi.fn().mockResolvedValue(sampleCustomers),
+      },
+    });
+
+    renderWithProviders(<CustomersListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('abc123hash')).toBeInTheDocument();
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    expect(screen.getByText('conn_allegro_1')).toBeInTheDocument();
+    expect(screen.getByText('def456hash')).toBeInTheDocument();
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      customers: {
+        list: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+    });
+
+    renderWithProviders(<CustomersListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Unable to load customers')).toBeInTheDocument();
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no customers exist', async () => {
+    const mockApi = createMockApiClient({
+      customers: {
+        list: vi.fn().mockResolvedValue({
+          items: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+      },
+    });
+
+    renderWithProviders(<CustomersListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No customers found')).toBeInTheDocument();
+  });
+
+  it('should show empty state with filter message when filters are active', async () => {
+    const mockApi = createMockApiClient({
+      customers: {
+        list: vi.fn().mockResolvedValue({
+          items: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+      },
+    });
+
+    renderWithProviders(<CustomersListPage />, {
+      apiClient: mockApi,
+      route: '/customers?search=unknown',
+    });
+
+    expect(await screen.findByText('No customer projections match the current filters.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/customers/customers-list-page.tsx
+++ b/apps/web/src/pages/customers/customers-list-page.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useState, type ReactElement, type ReactNode } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
@@ -15,17 +15,17 @@ const COLUMNS: DataTableColumn<CustomerProjection>[] = [
   {
     id: 'internalCustomerId',
     header: 'Customer ID',
-    cell: (c) => <span className="mono-text">{c.internalCustomerId}</span>,
+    cell: (c): ReactNode => <span className="mono-text">{c.internalCustomerId}</span>,
   },
   {
     id: 'emailHash',
     header: 'Email Hash',
-    cell: (c) => <span className="mono-text">{c.emailHash}</span>,
+    cell: (c): ReactNode => <span className="mono-text">{c.emailHash}</span>,
   },
   {
     id: 'name',
     header: 'Name',
-    cell: (c) => {
+    cell: (c): ReactNode => {
       const name = [c.firstName, c.lastName].filter(Boolean).join(' ');
       return name ? <span>{name}</span> : <span className="text-muted">—</span>;
     },
@@ -33,7 +33,7 @@ const COLUMNS: DataTableColumn<CustomerProjection>[] = [
   {
     id: 'lastSourceConnectionId',
     header: 'Last Source',
-    cell: (c) =>
+    cell: (c): ReactNode =>
       c.lastSourceConnectionId ? (
         <span className="mono-text">{c.lastSourceConnectionId}</span>
       ) : (
@@ -43,12 +43,12 @@ const COLUMNS: DataTableColumn<CustomerProjection>[] = [
   {
     id: 'lastSeenAt',
     header: 'Last Seen',
-    cell: (c) => new Date(c.lastSeenAt).toLocaleDateString(),
+    cell: (c): ReactNode => new Date(c.lastSeenAt).toLocaleDateString(),
   },
   {
     id: 'detail',
     header: '',
-    cell: (c) => (
+    cell: (c): ReactNode => (
       <Link to={c.internalCustomerId} className="button button--ghost button--compact">
         View
       </Link>

--- a/apps/web/src/pages/customers/customers-list-page.tsx
+++ b/apps/web/src/pages/customers/customers-list-page.tsx
@@ -1,0 +1,181 @@
+import { useState, type ReactElement } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
+import { useCustomersQuery } from '../../features/customers/hooks/use-customers-query';
+import type { CustomerFilters, CustomerProjection } from '../../features/customers/api/customers.types';
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+
+const COLUMNS: DataTableColumn<CustomerProjection>[] = [
+  {
+    id: 'internalCustomerId',
+    header: 'Customer ID',
+    cell: (c) => <span className="mono-text">{c.internalCustomerId}</span>,
+  },
+  {
+    id: 'emailHash',
+    header: 'Email Hash',
+    cell: (c) => <span className="mono-text">{c.emailHash}</span>,
+  },
+  {
+    id: 'name',
+    header: 'Name',
+    cell: (c) => {
+      const name = [c.firstName, c.lastName].filter(Boolean).join(' ');
+      return name ? <span>{name}</span> : <span className="text-muted">—</span>;
+    },
+  },
+  {
+    id: 'lastSourceConnectionId',
+    header: 'Last Source',
+    cell: (c) =>
+      c.lastSourceConnectionId ? (
+        <span className="mono-text">{c.lastSourceConnectionId}</span>
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+  {
+    id: 'lastSeenAt',
+    header: 'Last Seen',
+    cell: (c) => new Date(c.lastSeenAt).toLocaleDateString(),
+  },
+  {
+    id: 'detail',
+    header: '',
+    cell: (c) => (
+      <Link to={c.internalCustomerId} className="button button--ghost button--compact">
+        View
+      </Link>
+    ),
+  },
+];
+
+export function CustomersListPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const urlSearch = searchParams.get('search') ?? '';
+  const urlConnectionId = searchParams.get('lastSourceConnectionId') ?? '';
+  const offset = Number(searchParams.get('offset') ?? '0');
+
+  const [searchInput, setSearchInput] = useState(urlSearch);
+  const [connectionIdInput, setConnectionIdInput] = useState(urlConnectionId);
+  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
+  const debouncedConnectionId = useDebouncedValue(connectionIdInput, SEARCH_DEBOUNCE_MS);
+
+  const filters: CustomerFilters = {
+    search: debouncedSearch || undefined,
+    lastSourceConnectionId: debouncedConnectionId || undefined,
+  };
+  const pagination = { limit: PAGE_SIZE, offset };
+
+  const query = useCustomersQuery(filters, pagination);
+
+  function handleFilterChange(key: string, value: string): void {
+    if (key === 'search') setSearchInput(value);
+    if (key === 'lastSourceConnectionId') setConnectionIdInput(value);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  function setOffset(next: number): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === 0) {
+        p.delete('offset');
+      } else {
+        p.set('offset', String(next));
+      }
+      return p;
+    });
+  }
+
+  const total = query.data?.total ?? 0;
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  return (
+    <PageLayout
+      eyebrow="Operations"
+      title="Customers"
+      description="Customer identity projections — browse resolved identities and address history."
+    >
+      <div className="toolbar" style={{ gap: '0.5rem' }}>
+        <input
+          aria-label="Search customers"
+          placeholder="Search by email or name…"
+          value={searchInput}
+          onChange={(e) => { handleFilterChange('search', e.target.value); }}
+        />
+        <input
+          aria-label="Filter by source connection ID"
+          placeholder="Source connection ID…"
+          value={connectionIdInput}
+          onChange={(e) => { handleFilterChange('lastSourceConnectionId', e.target.value); }}
+        />
+      </div>
+
+      {query.isLoading ? (
+        <LoadingState
+          liveRegion="off"
+          title="Loading customers"
+          message="Fetching customer projection data…"
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load customers"
+          message={query.error.message}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      ) : (query.data?.items.length ?? 0) === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No customers found"
+          message={
+            debouncedSearch || debouncedConnectionId
+              ? 'No customer projections match the current filters.'
+              : 'No customer projections have been recorded yet.'
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Customer projections"
+            columns={COLUMNS}
+            rows={query.data?.items ?? []}
+            rowKey={(c) => c.internalCustomerId}
+          />
+
+          <div className="toolbar" style={{ justifyContent: 'space-between' }}>
+            <span className="text-muted">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <Button disabled={!hasPrev} onClick={() => { setOffset(offset - PAGE_SIZE); }}>
+                Previous
+              </Button>
+              <Button disabled={!hasNext} onClick={() => { setOffset(offset + PAGE_SIZE); }}>
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -1,0 +1,91 @@
+import type { ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
+
+export function ListingDetailPage(): ReactElement {
+  const { id = '' } = useParams<{ id: string }>();
+  const query = useListingQuery(id);
+
+  if (query.isLoading) {
+    return (
+      <PageLayout eyebrow="Listings" title="Offer mapping">
+        <LoadingState liveRegion="off" title="Loading offer mapping" message="Fetching mapping details…" />
+      </PageLayout>
+    );
+  }
+
+  if (query.error || !query.data) {
+    return (
+      <PageLayout eyebrow="Listings" title="Offer mapping">
+        <ErrorState
+          title="Unable to load offer mapping"
+          message={query.error?.message ?? 'Offer mapping not found'}
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
+        />
+      </PageLayout>
+    );
+  }
+
+  const mapping = query.data;
+
+  return (
+    <PageLayout
+      eyebrow="Listings"
+      title={`Mapping — ${mapping.externalId}`}
+      actions={
+        <Link to=".." relative="path" className="button button--ghost">
+          ← Back to listings
+        </Link>
+      }
+    >
+      <section className="detail-section">
+        <dl className="detail-list">
+          <div className="detail-list__row">
+            <dt>Mapping ID</dt>
+            <dd><span className="mono-text">{mapping.id}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Entity Type</dt>
+            <dd><span className="mono-text">{mapping.entityType}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>External ID</dt>
+            <dd><span className="mono-text">{mapping.externalId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Internal ID</dt>
+            <dd><span className="mono-text">{mapping.internalId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Platform Type</dt>
+            <dd><span className="mono-text">{mapping.platformType}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Connection ID</dt>
+            <dd><span className="mono-text">{mapping.connectionId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Created</dt>
+            <dd>{new Date(mapping.createdAt).toLocaleString()}</dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Updated</dt>
+            <dd>{new Date(mapping.updatedAt).toLocaleString()}</dd>
+          </div>
+        </dl>
+      </section>
+
+      {mapping.context !== null ? (
+        <section className="detail-section">
+          <h2 className="detail-section__title">Context</h2>
+          <pre className="mono-text" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+            {JSON.stringify(mapping.context, null, 2)}
+          </pre>
+        </section>
+      ) : null}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -81,7 +81,7 @@ export function ListingDetailPage(): ReactElement {
       {mapping.context !== null ? (
         <section className="detail-section">
           <h2 className="detail-section__title">Context</h2>
-          <pre className="mono-text" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+          <pre className="raw-payload">
             {JSON.stringify(mapping.context, null, 2)}
           </pre>
         </section>

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -1,0 +1,114 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { ListingsListPage } from './listings-list-page';
+import type { PaginatedOfferMappings } from '../../features/listings/api/listings.types';
+
+const sampleMappings: PaginatedOfferMappings = {
+  items: [
+    {
+      id: 'uuid-mapping-1',
+      entityType: 'Offer',
+      internalId: 'ol_offer_abc123',
+      externalId: 'allegro-offer-999',
+      platformType: 'allegro',
+      connectionId: 'conn_allegro_1',
+      context: null,
+      createdAt: '2026-01-20T09:00:00.000Z',
+      updatedAt: '2026-01-20T09:00:00.000Z',
+    },
+    {
+      id: 'uuid-mapping-2',
+      entityType: 'Offer',
+      internalId: 'ol_offer_def456',
+      externalId: 'allegro-offer-888',
+      platformType: 'allegro',
+      connectionId: 'conn_allegro_1',
+      context: { parentEntityType: 'Order' },
+      createdAt: '2026-02-10T11:00:00.000Z',
+      updatedAt: '2026-02-10T11:00:00.000Z',
+    },
+  ],
+  total: 2,
+  limit: 20,
+  offset: 0,
+};
+
+describe('ListingsListPage', () => {
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(screen.getByText('Loading listings')).toBeInTheDocument();
+  });
+
+  it('should show mappings table when data loads', async () => {
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockResolvedValue(sampleMappings),
+      },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('allegro-offer-999')).toBeInTheDocument();
+    expect(screen.getByText('ol_offer_abc123')).toBeInTheDocument();
+    expect(screen.getByText('allegro-offer-888')).toBeInTheDocument();
+    expect(screen.getAllByText('allegro')).toHaveLength(2);
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Unable to load listings')).toBeInTheDocument();
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no mappings exist', async () => {
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockResolvedValue({
+          items: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+      },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No offer mappings found')).toBeInTheDocument();
+  });
+
+  it('should show empty state with filter message when filters are active', async () => {
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockResolvedValue({
+          items: [],
+          total: 0,
+          limit: 20,
+          offset: 0,
+        }),
+      },
+    });
+
+    renderWithProviders(<ListingsListPage />, {
+      apiClient: mockApi,
+      route: '/listings?search=unknown-offer',
+    });
+
+    expect(await screen.findByText('No offer mappings match the current filters.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useState, type ReactElement, type ReactNode } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
@@ -15,37 +15,37 @@ const COLUMNS: DataTableColumn<OfferMapping>[] = [
   {
     id: 'externalId',
     header: 'External ID',
-    cell: (m) => <span className="mono-text">{m.externalId}</span>,
+    cell: (m): ReactNode => <span className="mono-text">{m.externalId}</span>,
   },
   {
     id: 'internalId',
     header: 'Internal ID',
-    cell: (m) => <span className="mono-text">{m.internalId}</span>,
+    cell: (m): ReactNode => <span className="mono-text">{m.internalId}</span>,
   },
   {
     id: 'platformType',
     header: 'Platform',
-    cell: (m) => <span className="mono-text">{m.platformType}</span>,
+    cell: (m): ReactNode => <span className="mono-text">{m.platformType}</span>,
   },
   {
     id: 'entityType',
     header: 'Entity Type',
-    cell: (m) => <span className="mono-text">{m.entityType}</span>,
+    cell: (m): ReactNode => <span className="mono-text">{m.entityType}</span>,
   },
   {
     id: 'connectionId',
     header: 'Connection',
-    cell: (m) => <span className="mono-text">{m.connectionId}</span>,
+    cell: (m): ReactNode => <span className="mono-text">{m.connectionId}</span>,
   },
   {
     id: 'createdAt',
     header: 'Created',
-    cell: (m) => new Date(m.createdAt).toLocaleDateString(),
+    cell: (m): ReactNode => new Date(m.createdAt).toLocaleDateString(),
   },
   {
     id: 'detail',
     header: '',
-    cell: (m) => (
+    cell: (m): ReactNode => (
       <Link to={m.id} className="button button--ghost button--compact">
         View
       </Link>

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -1,0 +1,191 @@
+import { useState, type ReactElement } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
+import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
+import type { ListingsFilters, OfferMapping } from '../../features/listings/api/listings.types';
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+
+const COLUMNS: DataTableColumn<OfferMapping>[] = [
+  {
+    id: 'externalId',
+    header: 'External ID',
+    cell: (m) => <span className="mono-text">{m.externalId}</span>,
+  },
+  {
+    id: 'internalId',
+    header: 'Internal ID',
+    cell: (m) => <span className="mono-text">{m.internalId}</span>,
+  },
+  {
+    id: 'platformType',
+    header: 'Platform',
+    cell: (m) => <span className="mono-text">{m.platformType}</span>,
+  },
+  {
+    id: 'entityType',
+    header: 'Entity Type',
+    cell: (m) => <span className="mono-text">{m.entityType}</span>,
+  },
+  {
+    id: 'connectionId',
+    header: 'Connection',
+    cell: (m) => <span className="mono-text">{m.connectionId}</span>,
+  },
+  {
+    id: 'createdAt',
+    header: 'Created',
+    cell: (m) => new Date(m.createdAt).toLocaleDateString(),
+  },
+  {
+    id: 'detail',
+    header: '',
+    cell: (m) => (
+      <Link to={m.id} className="button button--ghost button--compact">
+        View
+      </Link>
+    ),
+  },
+];
+
+export function ListingsListPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const urlSearch = searchParams.get('search') ?? '';
+  const urlConnectionId = searchParams.get('connectionId') ?? '';
+  const urlPlatformType = searchParams.get('platformType') ?? '';
+  const offset = Number(searchParams.get('offset') ?? '0');
+
+  const [searchInput, setSearchInput] = useState(urlSearch);
+  const [connectionIdInput, setConnectionIdInput] = useState(urlConnectionId);
+  const [platformTypeInput, setPlatformTypeInput] = useState(urlPlatformType);
+
+  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
+  const debouncedConnectionId = useDebouncedValue(connectionIdInput, SEARCH_DEBOUNCE_MS);
+  const debouncedPlatformType = useDebouncedValue(platformTypeInput, SEARCH_DEBOUNCE_MS);
+
+  const filters: ListingsFilters = {
+    search: debouncedSearch || undefined,
+    connectionId: debouncedConnectionId || undefined,
+    platformType: debouncedPlatformType || undefined,
+  };
+  const pagination = { limit: PAGE_SIZE, offset };
+
+  const query = useListingsQuery(filters, pagination);
+
+  function handleFilterChange(key: string, value: string): void {
+    if (key === 'search') setSearchInput(value);
+    if (key === 'connectionId') setConnectionIdInput(value);
+    if (key === 'platformType') setPlatformTypeInput(value);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  function setOffset(next: number): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === 0) {
+        p.delete('offset');
+      } else {
+        p.set('offset', String(next));
+      }
+      return p;
+    });
+  }
+
+  const hasFilters = !!(debouncedSearch || debouncedConnectionId || debouncedPlatformType);
+  const total = query.data?.total ?? 0;
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  return (
+    <PageLayout
+      eyebrow="Operations"
+      title="Listings"
+      description="Offer mapping workbench — browse offer-to-variant identifier mappings across platforms."
+    >
+      <div className="toolbar" style={{ gap: '0.5rem' }}>
+        <input
+          aria-label="Search by external ID"
+          placeholder="External ID…"
+          value={searchInput}
+          onChange={(e) => { handleFilterChange('search', e.target.value); }}
+        />
+        <input
+          aria-label="Filter by connection ID"
+          placeholder="Connection ID…"
+          value={connectionIdInput}
+          onChange={(e) => { handleFilterChange('connectionId', e.target.value); }}
+        />
+        <input
+          aria-label="Filter by platform type"
+          placeholder="Platform type…"
+          value={platformTypeInput}
+          onChange={(e) => { handleFilterChange('platformType', e.target.value); }}
+        />
+      </div>
+
+      {query.isLoading ? (
+        <LoadingState
+          liveRegion="off"
+          title="Loading listings"
+          message="Fetching offer mapping data…"
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load listings"
+          message={query.error.message}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      ) : (query.data?.items.length ?? 0) === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No offer mappings found"
+          message={
+            hasFilters
+              ? 'No offer mappings match the current filters.'
+              : 'No offer mappings have been synced yet.'
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Offer mappings"
+            columns={COLUMNS}
+            rows={query.data?.items ?? []}
+            rowKey={(m) => m.id}
+          />
+
+          <div className="toolbar" style={{ justifyContent: 'space-between' }}>
+            <span className="text-muted">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <Button disabled={!hasPrev} onClick={() => { setOffset(offset - PAGE_SIZE); }}>
+                Previous
+              </Button>
+              <Button disabled={!hasNext} onClick={() => { setOffset(offset + PAGE_SIZE); }}>
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/shared/ui/app-shell.tsx
+++ b/apps/web/src/shared/ui/app-shell.tsx
@@ -27,6 +27,8 @@ const navigationGroups: NavigationGroup[] = [
       { to: '/orders', label: 'Orders', state: 'live' },
       { to: '/products', label: 'Products', state: 'live' },
       { to: '/inventory', label: 'Inventory', state: 'live' },
+      { to: '/customers', label: 'Customers', state: 'live' },
+      { to: '/listings', label: 'Listings', state: 'live' },
       { to: '/cursors', label: 'Cursors', state: 'live' },
       { to: '/jobs-logs', label: 'Jobs & Logs', state: 'planned' },
       { to: '/automations', label: 'Automations', state: 'planned' },

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -39,8 +39,10 @@ type DeepPartialApiClient = {
   auth?: Partial<ApiClient['auth']>;
   connections?: Partial<ApiClient['connections']>;
   cursors?: Partial<ApiClient['cursors']>;
+  customers?: Partial<ApiClient['customers']>;
   health?: Partial<ApiClient['health']>;
   inventory?: Partial<ApiClient['inventory']>;
+  listings?: Partial<ApiClient['listings']>;
   orders?: Partial<ApiClient['orders']>;
   products?: Partial<ApiClient['products']>;
   syncJobs?: Partial<ApiClient['syncJobs']>;
@@ -95,6 +97,16 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       }),
       ...overrides.cursors,
     } as ApiClient['cursors'],
+    customers: {
+      list: vi.fn().mockResolvedValue({
+        items: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      }),
+      getById: vi.fn().mockResolvedValue(null),
+      ...overrides.customers,
+    } as ApiClient['customers'],
     health: {
       getDevStackHealth: vi.fn().mockResolvedValue({
         status: 'ok',
@@ -127,6 +139,16 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       getById: vi.fn().mockResolvedValue(null),
       ...overrides.orders,
     } as ApiClient['orders'],
+    listings: {
+      list: vi.fn().mockResolvedValue({
+        items: [],
+        total: 0,
+        limit: 20,
+        offset: 0,
+      }),
+      getById: vi.fn().mockResolvedValue(null),
+      ...overrides.listings,
+    } as ApiClient['listings'],
     products: {
       list: vi.fn().mockResolvedValue({
         items: [],


### PR DESCRIPTION
## Summary

- Adds **Customers** explorer (`/customers`) — paginated list with search + source connection filter, detail page showing projection fields and addresses table
- Adds **Listings** explorer (`/listings`) — paginated list with external ID search + connection/platform filters, detail page showing mapping fields and context JSON
- Wires both into app shell nav (Operations group) and router
- Extends `createMockApiClient` in test-utils with `customers` and `listings` stubs

Both features consume the read APIs added in PR #123 (`GET /customers`, `GET /customers/:id`, `GET /listings`, `GET /listings/:id`).

## Test plan

- [ ] `pnpm lint` — zero errors
- [ ] `pnpm type-check` — zero errors
- [ ] `pnpm test` — all tests pass
- [ ] Navigate to `/customers` — list renders, search and connection filters work, pagination works
- [ ] Click a customer row → `/customers/:id` — fields and addresses table render
- [ ] Navigate to `/listings` — list renders, all three filters work, pagination works
- [ ] Click a listing row → `/listings/:id` — mapping fields and context JSON render
- [ ] Nav links for Customers and Listings appear in sidebar under Operations

Closes #91
Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)