### PR TITLE
feat(mappings): connection-scoped mapping config API and UI

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -27,6 +27,7 @@ import { ProductsApiModule } from './products/products.module';
 import { CustomersApiModule } from './customers/customers.module';
 import { ListingsApiModule } from './listings/listings.module';
 import { CursorsModule } from './cursors/cursors.module';
+import { MappingsApiModule } from './mappings/mappings.module';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { CursorsModule } from './cursors/cursors.module';
     CustomersApiModule,
     ListingsApiModule,
     CursorsModule,
+    MappingsApiModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/mappings/http/dto/carrier-mapping-input.dto.ts
+++ b/apps/api/src/mappings/http/dto/carrier-mapping-input.dto.ts
@@ -1,5 +1,7 @@
 /**
- * Carrier Mapping Item DTO
+ * Carrier Mapping Input DTO
+ *
+ * Single carrier mapping item used in upsert requests.
  *
  * @module apps/api/src/mappings/http/dto
  */
@@ -7,7 +9,7 @@
 import { IsString, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class CarrierMappingItemDto {
+export class CarrierMappingInputDto {
   @ApiProperty({ description: 'Allegro delivery method ID', example: 'INPOST_PACZKOMAT' })
   @IsString()
   @IsNotEmpty()

--- a/apps/api/src/mappings/http/dto/carrier-mapping-item.dto.ts
+++ b/apps/api/src/mappings/http/dto/carrier-mapping-item.dto.ts
@@ -1,0 +1,20 @@
+/**
+ * Carrier Mapping Item DTO
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CarrierMappingItemDto {
+  @ApiProperty({ description: 'Allegro delivery method ID', example: 'INPOST_PACZKOMAT' })
+  @IsString()
+  @IsNotEmpty()
+  allegroDeliveryMethodId!: string;
+
+  @ApiProperty({ description: 'PrestaShop carrier ID', example: '2' })
+  @IsString()
+  @IsNotEmpty()
+  prestashopCarrierId!: string;
+}

--- a/apps/api/src/mappings/http/dto/carrier-mapping-response.dto.ts
+++ b/apps/api/src/mappings/http/dto/carrier-mapping-response.dto.ts
@@ -1,0 +1,31 @@
+/**
+ * Carrier Mapping Response DTO
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { CarrierMapping } from '@openlinker/core/mappings';
+
+export class CarrierMappingResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  connectionId!: string;
+
+  @ApiProperty()
+  allegroDeliveryMethodId!: string;
+
+  @ApiProperty()
+  prestashopCarrierId!: string;
+
+  static fromDomain(m: CarrierMapping): CarrierMappingResponseDto {
+    const dto = new CarrierMappingResponseDto();
+    dto.id = m.id;
+    dto.connectionId = m.connectionId;
+    dto.allegroDeliveryMethodId = m.allegroDeliveryMethodId;
+    dto.prestashopCarrierId = m.prestashopCarrierId;
+    return dto;
+  }
+}

--- a/apps/api/src/mappings/http/dto/mapping-option-response.dto.ts
+++ b/apps/api/src/mappings/http/dto/mapping-option-response.dto.ts
@@ -1,0 +1,18 @@
+/**
+ * Mapping Option Response DTO
+ *
+ * Single option item returned by helper endpoints used to populate
+ * FE dropdowns (Allegro/PrestaShop available values).
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MappingOptionResponseDto {
+  @ApiProperty({ description: 'Option value used in mapping configuration' })
+  value!: string;
+
+  @ApiProperty({ description: 'Human-readable label for display' })
+  label!: string;
+}

--- a/apps/api/src/mappings/http/dto/payment-mapping-input.dto.ts
+++ b/apps/api/src/mappings/http/dto/payment-mapping-input.dto.ts
@@ -1,5 +1,7 @@
 /**
- * Payment Mapping Item DTO
+ * Payment Mapping Input DTO
+ *
+ * Single payment mapping item used in upsert requests.
  *
  * @module apps/api/src/mappings/http/dto
  */
@@ -7,7 +9,7 @@
 import { IsString, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class PaymentMappingItemDto {
+export class PaymentMappingInputDto {
   @ApiProperty({ description: 'Allegro payment provider name', example: 'P24' })
   @IsString()
   @IsNotEmpty()

--- a/apps/api/src/mappings/http/dto/payment-mapping-item.dto.ts
+++ b/apps/api/src/mappings/http/dto/payment-mapping-item.dto.ts
@@ -1,0 +1,20 @@
+/**
+ * Payment Mapping Item DTO
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PaymentMappingItemDto {
+  @ApiProperty({ description: 'Allegro payment provider name', example: 'P24' })
+  @IsString()
+  @IsNotEmpty()
+  allegroPaymentProvider!: string;
+
+  @ApiProperty({ description: 'PrestaShop payment module name', example: 'ps_wirepayment' })
+  @IsString()
+  @IsNotEmpty()
+  prestashopPaymentModule!: string;
+}

--- a/apps/api/src/mappings/http/dto/payment-mapping-response.dto.ts
+++ b/apps/api/src/mappings/http/dto/payment-mapping-response.dto.ts
@@ -1,0 +1,31 @@
+/**
+ * Payment Mapping Response DTO
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { PaymentMapping } from '@openlinker/core/mappings';
+
+export class PaymentMappingResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  connectionId!: string;
+
+  @ApiProperty()
+  allegroPaymentProvider!: string;
+
+  @ApiProperty()
+  prestashopPaymentModule!: string;
+
+  static fromDomain(m: PaymentMapping): PaymentMappingResponseDto {
+    const dto = new PaymentMappingResponseDto();
+    dto.id = m.id;
+    dto.connectionId = m.connectionId;
+    dto.allegroPaymentProvider = m.allegroPaymentProvider;
+    dto.prestashopPaymentModule = m.prestashopPaymentModule;
+    return dto;
+  }
+}

--- a/apps/api/src/mappings/http/dto/status-mapping-input.dto.ts
+++ b/apps/api/src/mappings/http/dto/status-mapping-input.dto.ts
@@ -1,5 +1,5 @@
 /**
- * Status Mapping Item DTO
+ * Status Mapping Input DTO
  *
  * Single status mapping item used in upsert requests.
  *
@@ -9,7 +9,7 @@
 import { IsString, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class StatusMappingItemDto {
+export class StatusMappingInputDto {
   @ApiProperty({ description: 'Allegro order status value', example: 'READY_FOR_PROCESSING' })
   @IsString()
   @IsNotEmpty()

--- a/apps/api/src/mappings/http/dto/status-mapping-item.dto.ts
+++ b/apps/api/src/mappings/http/dto/status-mapping-item.dto.ts
@@ -1,0 +1,22 @@
+/**
+ * Status Mapping Item DTO
+ *
+ * Single status mapping item used in upsert requests.
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class StatusMappingItemDto {
+  @ApiProperty({ description: 'Allegro order status value', example: 'READY_FOR_PROCESSING' })
+  @IsString()
+  @IsNotEmpty()
+  allegroStatus!: string;
+
+  @ApiProperty({ description: 'PrestaShop order status ID', example: '2' })
+  @IsString()
+  @IsNotEmpty()
+  prestashopStatusId!: string;
+}

--- a/apps/api/src/mappings/http/dto/status-mapping-response.dto.ts
+++ b/apps/api/src/mappings/http/dto/status-mapping-response.dto.ts
@@ -1,0 +1,33 @@
+/**
+ * Status Mapping Response DTO
+ *
+ * Response shape for status mapping endpoints.
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { StatusMapping } from '@openlinker/core/mappings';
+
+export class StatusMappingResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  connectionId!: string;
+
+  @ApiProperty()
+  allegroStatus!: string;
+
+  @ApiProperty()
+  prestashopStatusId!: string;
+
+  static fromDomain(m: StatusMapping): StatusMappingResponseDto {
+    const dto = new StatusMappingResponseDto();
+    dto.id = m.id;
+    dto.connectionId = m.connectionId;
+    dto.allegroStatus = m.allegroStatus;
+    dto.prestashopStatusId = m.prestashopStatusId;
+    return dto;
+  }
+}

--- a/apps/api/src/mappings/http/dto/upsert-carrier-mappings.dto.ts
+++ b/apps/api/src/mappings/http/dto/upsert-carrier-mappings.dto.ts
@@ -1,0 +1,18 @@
+/**
+ * Upsert Carrier Mappings DTO
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { CarrierMappingItemDto } from './carrier-mapping-item.dto';
+
+export class UpsertCarrierMappingsDto {
+  @ApiProperty({ type: [CarrierMappingItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CarrierMappingItemDto)
+  items!: CarrierMappingItemDto[];
+}

--- a/apps/api/src/mappings/http/dto/upsert-carrier-mappings.dto.ts
+++ b/apps/api/src/mappings/http/dto/upsert-carrier-mappings.dto.ts
@@ -7,12 +7,12 @@
 import { IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
-import { CarrierMappingItemDto } from './carrier-mapping-item.dto';
+import { CarrierMappingInputDto } from './carrier-mapping-input.dto';
 
 export class UpsertCarrierMappingsDto {
-  @ApiProperty({ type: [CarrierMappingItemDto] })
+  @ApiProperty({ type: [CarrierMappingInputDto] })
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => CarrierMappingItemDto)
-  items!: CarrierMappingItemDto[];
+  @Type(() => CarrierMappingInputDto)
+  items!: CarrierMappingInputDto[];
 }

--- a/apps/api/src/mappings/http/dto/upsert-payment-mappings.dto.ts
+++ b/apps/api/src/mappings/http/dto/upsert-payment-mappings.dto.ts
@@ -7,12 +7,12 @@
 import { IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
-import { PaymentMappingItemDto } from './payment-mapping-item.dto';
+import { PaymentMappingInputDto } from './payment-mapping-input.dto';
 
 export class UpsertPaymentMappingsDto {
-  @ApiProperty({ type: [PaymentMappingItemDto] })
+  @ApiProperty({ type: [PaymentMappingInputDto] })
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => PaymentMappingItemDto)
-  items!: PaymentMappingItemDto[];
+  @Type(() => PaymentMappingInputDto)
+  items!: PaymentMappingInputDto[];
 }

--- a/apps/api/src/mappings/http/dto/upsert-payment-mappings.dto.ts
+++ b/apps/api/src/mappings/http/dto/upsert-payment-mappings.dto.ts
@@ -1,0 +1,18 @@
+/**
+ * Upsert Payment Mappings DTO
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { PaymentMappingItemDto } from './payment-mapping-item.dto';
+
+export class UpsertPaymentMappingsDto {
+  @ApiProperty({ type: [PaymentMappingItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PaymentMappingItemDto)
+  items!: PaymentMappingItemDto[];
+}

--- a/apps/api/src/mappings/http/dto/upsert-status-mappings.dto.ts
+++ b/apps/api/src/mappings/http/dto/upsert-status-mappings.dto.ts
@@ -1,0 +1,21 @@
+/**
+ * Upsert Status Mappings DTO
+ *
+ * Request body for PUT /connections/:connectionId/mappings/status.
+ * Replaces all status mappings for the given connection.
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { StatusMappingItemDto } from './status-mapping-item.dto';
+
+export class UpsertStatusMappingsDto {
+  @ApiProperty({ type: [StatusMappingItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => StatusMappingItemDto)
+  items!: StatusMappingItemDto[];
+}

--- a/apps/api/src/mappings/http/dto/upsert-status-mappings.dto.ts
+++ b/apps/api/src/mappings/http/dto/upsert-status-mappings.dto.ts
@@ -10,12 +10,12 @@
 import { IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
-import { StatusMappingItemDto } from './status-mapping-item.dto';
+import { StatusMappingInputDto } from './status-mapping-input.dto';
 
 export class UpsertStatusMappingsDto {
-  @ApiProperty({ type: [StatusMappingItemDto] })
+  @ApiProperty({ type: [StatusMappingInputDto] })
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => StatusMappingItemDto)
-  items!: StatusMappingItemDto[];
+  @Type(() => StatusMappingInputDto)
+  items!: StatusMappingInputDto[];
 }

--- a/apps/api/src/mappings/http/mapping-options.controller.ts
+++ b/apps/api/src/mappings/http/mapping-options.controller.ts
@@ -111,6 +111,7 @@ export class MappingOptionsController {
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
   getAllegroOrderStatuses(
+    // TODO: use connectionId to fetch live values from the Allegro adapter once adapters expose option lists
     @Param('connectionId') _connectionId: string,
   ): MappingOptionResponseDto[] {
     return ALLEGRO_ORDER_STATUSES;
@@ -121,6 +122,7 @@ export class MappingOptionsController {
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
   getAllegroDeliveryMethods(
+    // TODO: use connectionId to fetch live values from the Allegro adapter once adapters expose option lists
     @Param('connectionId') _connectionId: string,
   ): MappingOptionResponseDto[] {
     return ALLEGRO_DELIVERY_METHODS;
@@ -131,6 +133,7 @@ export class MappingOptionsController {
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
   getAllegroPaymentProviders(
+    // TODO: use connectionId to fetch live values from the Allegro adapter once adapters expose option lists
     @Param('connectionId') _connectionId: string,
   ): MappingOptionResponseDto[] {
     return ALLEGRO_PAYMENT_PROVIDERS;
@@ -143,6 +146,7 @@ export class MappingOptionsController {
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
   getPrestashopOrderStatuses(
+    // TODO: use connectionId to fetch live values from the PrestaShop adapter once adapters expose option lists
     @Param('connectionId') _connectionId: string,
   ): MappingOptionResponseDto[] {
     return PRESTASHOP_ORDER_STATUSES;
@@ -153,6 +157,7 @@ export class MappingOptionsController {
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
   getPrestashopCarriers(
+    // TODO: use connectionId to fetch live values from the PrestaShop adapter once adapters expose option lists
     @Param('connectionId') _connectionId: string,
   ): MappingOptionResponseDto[] {
     return PRESTASHOP_CARRIERS;
@@ -163,6 +168,7 @@ export class MappingOptionsController {
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
   getPrestashopPaymentModules(
+    // TODO: use connectionId to fetch live values from the PrestaShop adapter once adapters expose option lists
     @Param('connectionId') _connectionId: string,
   ): MappingOptionResponseDto[] {
     return PRESTASHOP_PAYMENT_MODULES;

--- a/apps/api/src/mappings/http/mapping-options.controller.ts
+++ b/apps/api/src/mappings/http/mapping-options.controller.ts
@@ -1,0 +1,170 @@
+/**
+ * Mapping Options Controller
+ *
+ * Helper endpoints that return available option values for FE dropdowns.
+ * For MVP, all lists are hardcoded with well-known Allegro and PrestaShop values.
+ * Live platform calls (fetching actual PS order states, carriers) are deferred to a follow-up.
+ *
+ * @module apps/api/src/mappings/http
+ */
+
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { MappingOptionResponseDto } from './dto/mapping-option-response.dto';
+
+/**
+ * Well-known Allegro order/payment statuses.
+ * Source: Allegro REST API documentation — CheckoutForm.status and payment.type values.
+ */
+const ALLEGRO_ORDER_STATUSES: MappingOptionResponseDto[] = [
+  { value: 'BOUGHT', label: 'Bought (checkout started)' },
+  { value: 'FILLED_IN', label: 'Filled in (buyer data provided)' },
+  { value: 'READY_FOR_PROCESSING', label: 'Ready for processing' },
+  { value: 'CANCELLED', label: 'Cancelled' },
+];
+
+/**
+ * Well-known Allegro delivery method IDs.
+ * Source: Allegro REST API — /sale/delivery-methods endpoint values.
+ */
+const ALLEGRO_DELIVERY_METHODS: MappingOptionResponseDto[] = [
+  { value: 'INPOST_PACZKOMAT', label: 'InPost Paczkomat' },
+  { value: 'INPOST_KURIER', label: 'InPost Kurier' },
+  { value: 'DPD', label: 'DPD' },
+  { value: 'DHL', label: 'DHL' },
+  { value: 'UPS', label: 'UPS' },
+  { value: 'POCZTEX', label: 'Pocztex' },
+  { value: 'GLS', label: 'GLS' },
+  { value: 'FEDEX', label: 'FedEx' },
+  { value: 'PICKUP', label: 'Personal pickup' },
+  { value: 'OTHER', label: 'Other' },
+];
+
+/**
+ * Well-known Allegro payment provider names.
+ * Source: Allegro REST API — CheckoutForm.payment.type values.
+ */
+const ALLEGRO_PAYMENT_PROVIDERS: MappingOptionResponseDto[] = [
+  { value: 'P24', label: 'Przelewy24' },
+  { value: 'CARD', label: 'Card payment' },
+  { value: 'BLIK', label: 'BLIK' },
+  { value: 'WIRE_TRANSFER', label: 'Wire transfer' },
+  { value: 'CASH_ON_DELIVERY', label: 'Cash on delivery' },
+  { value: 'INSTALLMENTS', label: 'Installments' },
+  { value: 'SPLIT_PAYMENT', label: 'Split payment' },
+];
+
+/**
+ * Common PrestaShop default order status IDs and labels.
+ * Values correspond to PrestaShop's built-in order_state IDs (1–12).
+ * Merchants with custom statuses should extend their mapping via the PS admin panel.
+ */
+const PRESTASHOP_ORDER_STATUSES: MappingOptionResponseDto[] = [
+  { value: '1', label: 'Awaiting check payment' },
+  { value: '2', label: 'Payment accepted' },
+  { value: '3', label: 'Processing in progress' },
+  { value: '4', label: 'Shipped' },
+  { value: '5', label: 'Delivered' },
+  { value: '6', label: 'Cancelled' },
+  { value: '7', label: 'Refunded' },
+  { value: '8', label: 'Payment error' },
+  { value: '9', label: 'On backorder (paid)' },
+  { value: '10', label: 'Awaiting bank wire payment' },
+  { value: '11', label: 'Remote payment accepted' },
+  { value: '12', label: 'On backorder (not paid)' },
+];
+
+/**
+ * Common PrestaShop default carrier IDs and labels.
+ * Merchants should configure carrier IDs matching their PS installation.
+ */
+const PRESTASHOP_CARRIERS: MappingOptionResponseDto[] = [
+  { value: '1', label: 'My carrier' },
+  { value: '2', label: 'My cheap carrier' },
+];
+
+/**
+ * Common PrestaShop payment module names.
+ * Corresponds to the `module_name` field on PS orders.
+ */
+const PRESTASHOP_PAYMENT_MODULES: MappingOptionResponseDto[] = [
+  { value: 'ps_wirepayment', label: 'Wire payment (ps_wirepayment)' },
+  { value: 'ps_checkpayment', label: 'Check payment (ps_checkpayment)' },
+  { value: 'ps_cashondelivery', label: 'Cash on delivery (ps_cashondelivery)' },
+  { value: 'paypal', label: 'PayPal' },
+  { value: 'przelewy24', label: 'Przelewy24' },
+  { value: 'stripe', label: 'Stripe' },
+  { value: 'dotpay', label: 'Dotpay' },
+  { value: 'payu', label: 'PayU' },
+];
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('mappings')
+@Controller('connections/:connectionId')
+export class MappingOptionsController {
+  // ── Allegro options ───────────────────────────────────────────────────────
+
+  @Get('allegro/order-statuses')
+  @ApiOperation({ summary: 'List available Allegro order status values' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  getAllegroOrderStatuses(
+    @Param('connectionId') _connectionId: string,
+  ): MappingOptionResponseDto[] {
+    return ALLEGRO_ORDER_STATUSES;
+  }
+
+  @Get('allegro/delivery-methods')
+  @ApiOperation({ summary: 'List available Allegro delivery method IDs' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  getAllegroDeliveryMethods(
+    @Param('connectionId') _connectionId: string,
+  ): MappingOptionResponseDto[] {
+    return ALLEGRO_DELIVERY_METHODS;
+  }
+
+  @Get('allegro/payment-providers')
+  @ApiOperation({ summary: 'List available Allegro payment provider names' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  getAllegroPaymentProviders(
+    @Param('connectionId') _connectionId: string,
+  ): MappingOptionResponseDto[] {
+    return ALLEGRO_PAYMENT_PROVIDERS;
+  }
+
+  // ── PrestaShop options ────────────────────────────────────────────────────
+
+  @Get('prestashop/order-statuses')
+  @ApiOperation({ summary: 'List available PrestaShop order status IDs' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  getPrestashopOrderStatuses(
+    @Param('connectionId') _connectionId: string,
+  ): MappingOptionResponseDto[] {
+    return PRESTASHOP_ORDER_STATUSES;
+  }
+
+  @Get('prestashop/carriers')
+  @ApiOperation({ summary: 'List available PrestaShop carrier IDs' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  getPrestashopCarriers(
+    @Param('connectionId') _connectionId: string,
+  ): MappingOptionResponseDto[] {
+    return PRESTASHOP_CARRIERS;
+  }
+
+  @Get('prestashop/payment-modules')
+  @ApiOperation({ summary: 'List available PrestaShop payment module names' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  getPrestashopPaymentModules(
+    @Param('connectionId') _connectionId: string,
+  ): MappingOptionResponseDto[] {
+    return PRESTASHOP_PAYMENT_MODULES;
+  }
+}

--- a/apps/api/src/mappings/http/mappings.controller.ts
+++ b/apps/api/src/mappings/http/mappings.controller.ts
@@ -1,0 +1,136 @@
+/**
+ * Mappings Controller
+ *
+ * HTTP REST API endpoints for connection-scoped mapping configuration.
+ * Supports CRUD for status, carrier, and payment mapping types.
+ * All endpoints require admin role and JWT authentication.
+ *
+ * @module apps/api/src/mappings/http
+ */
+
+import {
+  Controller,
+  Get,
+  Put,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  Inject,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+} from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import {
+  IMappingConfigService,
+  MAPPING_CONFIG_SERVICE_TOKEN,
+} from '@openlinker/core/mappings';
+import { UpsertStatusMappingsDto } from './dto/upsert-status-mappings.dto';
+import { UpsertCarrierMappingsDto } from './dto/upsert-carrier-mappings.dto';
+import { UpsertPaymentMappingsDto } from './dto/upsert-payment-mappings.dto';
+import { StatusMappingResponseDto } from './dto/status-mapping-response.dto';
+import { CarrierMappingResponseDto } from './dto/carrier-mapping-response.dto';
+import { PaymentMappingResponseDto } from './dto/payment-mapping-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('mappings')
+@Controller('connections/:connectionId/mappings')
+export class MappingsController {
+  constructor(
+    @Inject(MAPPING_CONFIG_SERVICE_TOKEN)
+    private readonly mappingConfigService: IMappingConfigService,
+  ) {}
+
+  // ── Status mappings ──────────────────────────────────────────────────────
+
+  @Get('status')
+  @ApiOperation({ summary: 'Get status mappings for a connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [StatusMappingResponseDto] })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getStatusMappings(
+    @Param('connectionId') connectionId: string,
+  ): Promise<StatusMappingResponseDto[]> {
+    const mappings = await this.mappingConfigService.getStatusMappings(connectionId);
+    return mappings.map((m) => StatusMappingResponseDto.fromDomain(m));
+  }
+
+  @Put('status')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Replace all status mappings for a connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [StatusMappingResponseDto] })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async upsertStatusMappings(
+    @Param('connectionId') connectionId: string,
+    @Body() dto: UpsertStatusMappingsDto,
+  ): Promise<StatusMappingResponseDto[]> {
+    const mappings = await this.mappingConfigService.upsertStatusMappings(connectionId, dto.items);
+    return mappings.map((m) => StatusMappingResponseDto.fromDomain(m));
+  }
+
+  // ── Carrier mappings ─────────────────────────────────────────────────────
+
+  @Get('carriers')
+  @ApiOperation({ summary: 'Get carrier mappings for a connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [CarrierMappingResponseDto] })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getCarrierMappings(
+    @Param('connectionId') connectionId: string,
+  ): Promise<CarrierMappingResponseDto[]> {
+    const mappings = await this.mappingConfigService.getCarrierMappings(connectionId);
+    return mappings.map((m) => CarrierMappingResponseDto.fromDomain(m));
+  }
+
+  @Put('carriers')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Replace all carrier mappings for a connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [CarrierMappingResponseDto] })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async upsertCarrierMappings(
+    @Param('connectionId') connectionId: string,
+    @Body() dto: UpsertCarrierMappingsDto,
+  ): Promise<CarrierMappingResponseDto[]> {
+    const mappings = await this.mappingConfigService.upsertCarrierMappings(connectionId, dto.items);
+    return mappings.map((m) => CarrierMappingResponseDto.fromDomain(m));
+  }
+
+  // ── Payment mappings ─────────────────────────────────────────────────────
+
+  @Get('payments')
+  @ApiOperation({ summary: 'Get payment mappings for a connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [PaymentMappingResponseDto] })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getPaymentMappings(
+    @Param('connectionId') connectionId: string,
+  ): Promise<PaymentMappingResponseDto[]> {
+    const mappings = await this.mappingConfigService.getPaymentMappings(connectionId);
+    return mappings.map((m) => PaymentMappingResponseDto.fromDomain(m));
+  }
+
+  @Put('payments')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Replace all payment mappings for a connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [PaymentMappingResponseDto] })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async upsertPaymentMappings(
+    @Param('connectionId') connectionId: string,
+    @Body() dto: UpsertPaymentMappingsDto,
+  ): Promise<PaymentMappingResponseDto[]> {
+    const mappings = await this.mappingConfigService.upsertPaymentMappings(connectionId, dto.items);
+    return mappings.map((m) => PaymentMappingResponseDto.fromDomain(m));
+  }
+}

--- a/apps/api/src/mappings/mappings.module.ts
+++ b/apps/api/src/mappings/mappings.module.ts
@@ -1,0 +1,19 @@
+/**
+ * Mappings API Module
+ *
+ * NestJS module that wires the mappings HTTP layer. Imports the core MappingsModule
+ * for service/repository providers and registers both mapping controllers.
+ *
+ * @module apps/api/src/mappings
+ */
+
+import { Module } from '@nestjs/common';
+import { MappingsModule as CoreMappingsModule } from '@openlinker/core/mappings';
+import { MappingsController } from './http/mappings.controller';
+import { MappingOptionsController } from './http/mapping-options.controller';
+
+@Module({
+  imports: [CoreMappingsModule],
+  controllers: [MappingsController, MappingOptionsController],
+})
+export class MappingsApiModule {}

--- a/apps/api/src/migrations/1778000000000-add-connection-mapping-tables.ts
+++ b/apps/api/src/migrations/1778000000000-add-connection-mapping-tables.ts
@@ -1,0 +1,68 @@
+/**
+ * Migration: Add connection mapping tables
+ *
+ * Creates three connection-scoped mapping tables:
+ *   - connection_status_mappings  (Allegro order status → PrestaShop status ID)
+ *   - connection_carrier_mappings (Allegro delivery method ID → PrestaShop carrier ID)
+ *   - connection_payment_mappings (Allegro payment provider → PrestaShop payment module)
+ *
+ * Each table has a unique constraint on (connection_id, source_value) to
+ * enforce one mapping per Allegro value per connection.
+ *
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddConnectionMappingTables1778000000000 implements MigrationInterface {
+  name = 'AddConnectionMappingTables1778000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "connection_status_mappings" (
+        "id"                    uuid                NOT NULL DEFAULT gen_random_uuid(),
+        "connection_id"         uuid                NOT NULL,
+        "allegro_status"        character varying   NOT NULL,
+        "prestashop_status_id"  character varying   NOT NULL,
+        "created_at"            timestamptz         NOT NULL DEFAULT now(),
+        "updated_at"            timestamptz         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_connection_status_mappings_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_connection_status_mappings_conn_status"
+          UNIQUE ("connection_id", "allegro_status")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "connection_carrier_mappings" (
+        "id"                          uuid                NOT NULL DEFAULT gen_random_uuid(),
+        "connection_id"               uuid                NOT NULL,
+        "allegro_delivery_method_id"  character varying   NOT NULL,
+        "prestashop_carrier_id"       character varying   NOT NULL,
+        "created_at"                  timestamptz         NOT NULL DEFAULT now(),
+        "updated_at"                  timestamptz         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_connection_carrier_mappings_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_connection_carrier_mappings_conn_method"
+          UNIQUE ("connection_id", "allegro_delivery_method_id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "connection_payment_mappings" (
+        "id"                          uuid                NOT NULL DEFAULT gen_random_uuid(),
+        "connection_id"               uuid                NOT NULL,
+        "allegro_payment_provider"    character varying   NOT NULL,
+        "prestashop_payment_module"   character varying   NOT NULL,
+        "created_at"                  timestamptz         NOT NULL DEFAULT now(),
+        "updated_at"                  timestamptz         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_connection_payment_mappings_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_connection_payment_mappings_conn_provider"
+          UNIQUE ("connection_id", "allegro_payment_provider")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "connection_payment_mappings"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "connection_carrier_mappings"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "connection_status_mappings"`);
+  }
+}

--- a/apps/api/src/migrations/1778000000000-add-connection-mapping-tables.ts
+++ b/apps/api/src/migrations/1778000000000-add-connection-mapping-tables.ts
@@ -27,7 +27,9 @@ export class AddConnectionMappingTables1778000000000 implements MigrationInterfa
         "updated_at"            timestamptz         NOT NULL DEFAULT now(),
         CONSTRAINT "PK_connection_status_mappings_id" PRIMARY KEY ("id"),
         CONSTRAINT "UQ_connection_status_mappings_conn_status"
-          UNIQUE ("connection_id", "allegro_status")
+          UNIQUE ("connection_id", "allegro_status"),
+        CONSTRAINT "FK_connection_status_mappings_connection"
+          FOREIGN KEY ("connection_id") REFERENCES "connections" ("id") ON DELETE CASCADE
       )
     `);
 
@@ -41,7 +43,9 @@ export class AddConnectionMappingTables1778000000000 implements MigrationInterfa
         "updated_at"                  timestamptz         NOT NULL DEFAULT now(),
         CONSTRAINT "PK_connection_carrier_mappings_id" PRIMARY KEY ("id"),
         CONSTRAINT "UQ_connection_carrier_mappings_conn_method"
-          UNIQUE ("connection_id", "allegro_delivery_method_id")
+          UNIQUE ("connection_id", "allegro_delivery_method_id"),
+        CONSTRAINT "FK_connection_carrier_mappings_connection"
+          FOREIGN KEY ("connection_id") REFERENCES "connections" ("id") ON DELETE CASCADE
       )
     `);
 
@@ -55,7 +59,9 @@ export class AddConnectionMappingTables1778000000000 implements MigrationInterfa
         "updated_at"                  timestamptz         NOT NULL DEFAULT now(),
         CONSTRAINT "PK_connection_payment_mappings_id" PRIMARY KEY ("id"),
         CONSTRAINT "UQ_connection_payment_mappings_conn_provider"
-          UNIQUE ("connection_id", "allegro_payment_provider")
+          UNIQUE ("connection_id", "allegro_payment_provider"),
+        CONSTRAINT "FK_connection_payment_mappings_connection"
+          FOREIGN KEY ("connection_id") REFERENCES "connections" ("id") ON DELETE CASCADE
       )
     `);
   }

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -5,7 +5,17 @@
     "outDir": "./dist",
     "noEmit": false,
     "emitDeclarationOnly": false,
-    "incremental": false
+    "incremental": false,
+    "paths": {
+      "@openlinker/api/*": ["./src/*"],
+      "@openlinker/core": ["../../libs/core/src/index.ts"],
+      "@openlinker/core/mappings": ["../../libs/core/src/mappings/index.ts"],
+      "@openlinker/core/*": ["../../libs/core/src/*"],
+      "@openlinker/shared": ["../../libs/shared/src/index.ts"],
+      "@openlinker/shared/*": ["../../libs/shared/src/*"],
+      "@openlinker/integrations-allegro": ["../../libs/integrations/allegro/src/index.ts"],
+      "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules", "test", "**/*.spec.ts", "**/*.test.ts"]

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "../../",
     "outDir": "./dist",
     "noEmit": false,
     "emitDeclarationOnly": false,

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "../../",
+    "rootDir": "../../", // widened to monorepo root — path aliases resolve lib .ts sources outside apps/api/src (matches tsconfig.type-check.json pattern)
     "outDir": "./dist",
     "noEmit": false,
     "emitDeclarationOnly": false,

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -5,19 +5,8 @@
     "outDir": "./dist",
     "noEmit": false,
     "emitDeclarationOnly": false,
-    "incremental": false,
-    "paths": {
-      "@openlinker/api/*": ["./src/*"],
-      "@openlinker/core": ["../../libs/core/src/index.ts"],
-      "@openlinker/core/mappings": ["../../libs/core/src/mappings/index.ts"],
-      "@openlinker/core/*": ["../../libs/core/src/*"],
-      "@openlinker/shared": ["../../libs/shared/src/index.ts"],
-      "@openlinker/shared/*": ["../../libs/shared/src/*"],
-      "@openlinker/integrations-allegro": ["../../libs/integrations/allegro/src/index.ts"],
-      "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"]
-    }
+    "incremental": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules", "test", "**/*.spec.ts", "**/*.test.ts"]
 }
-

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -7,7 +7,14 @@
     "emitDeclarationOnly": false,
     "incremental": false,
     "paths": {
-      "@openlinker/api/*": ["./src/*"]
+      "@openlinker/api/*": ["./src/*"],
+      "@openlinker/core": ["../../libs/core/src/index.ts"],
+      "@openlinker/core/mappings": ["../../libs/core/src/mappings/index.ts"],
+      "@openlinker/core/*": ["../../libs/core/src/*"],
+      "@openlinker/shared": ["../../libs/shared/src/index.ts"],
+      "@openlinker/shared/*": ["../../libs/shared/src/*"],
+      "@openlinker/integrations-allegro": ["../../libs/integrations/allegro/src/index.ts"],
+      "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"]
     }
   },
   "include": ["src/**/*.ts"],

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -14,6 +14,7 @@
       "@openlinker/core": ["../../libs/core/src/index.ts"],
       "@openlinker/core/mappings": ["../../libs/core/src/mappings/index.ts"],
       "@openlinker/core/*": ["../../libs/core/src/*"],
+      "@openlinker/shared": ["../../libs/shared/src/index.ts"],
       "@openlinker/shared/*": ["../../libs/shared/src/*"],
       "@openlinker/integrations-allegro": ["../../libs/integrations/allegro/src/index.ts"],
       "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"]
@@ -22,4 +23,3 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test", "../../libs/**/*"]
 }
-

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -11,6 +11,8 @@
     "allowJs": true,
     "paths": {
       "@openlinker/api/*": ["./src/*"],
+      "@openlinker/core": ["../../libs/core/src/index.ts"],
+      "@openlinker/core/mappings": ["../../libs/core/src/mappings/index.ts"],
       "@openlinker/core/*": ["../../libs/core/src/*"],
       "@openlinker/shared/*": ["../../libs/shared/src/*"],
       "@openlinker/integrations-allegro": ["../../libs/integrations/allegro/src/index.ts"],

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -10,6 +10,7 @@ import { createListingsApi, type ListingsApi } from '../../features/listings/api
 import { createOrdersApi, type OrdersApi } from '../../features/orders/api/orders.api';
 import { createProductsApi, type ProductsApi } from '../../features/products/api/products.api';
 import { createSyncJobsApi, type SyncJobsApi } from '../../features/sync-jobs/api/sync.api';
+import { createMappingsApi, type MappingsApi } from '../../features/mappings/api/mappings.api';
 import { ApiError } from '../../shared/api/api-error';
 import type { SessionAdapter } from '../../shared/auth/session-adapter';
 
@@ -34,6 +35,7 @@ export interface ApiClient {
   listings: ListingsApi;
   orders: OrdersApi;
   products: ProductsApi;
+  mappings: MappingsApi;
   request: <T>(path: string, init?: RequestInit) => Promise<T>;
   syncJobs: SyncJobsApi;
 }
@@ -124,6 +126,7 @@ export function createApiClient({
     health: createHealthApi(request),
     inventory: createInventoryApi(request),
     listings: createListingsApi(request),
+    mappings: createMappingsApi(request),
     orders: createOrdersApi(request),
     products: createProductsApi(request),
     request,

--- a/apps/web/src/app/app.test.tsx
+++ b/apps/web/src/app/app.test.tsx
@@ -33,7 +33,7 @@ describe('App', () => {
   it('renders the authenticated shell for live routes', async () => {
     const view = renderApp(['/']);
 
-    expect(await screen.findByRole('heading', { name: 'Operations overview' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Operations overview' }, { timeout: 10000 })).toBeInTheDocument();
     const primaryNavigation = within(view.container).getByRole('navigation', { name: 'Primary' });
     expect(within(primaryNavigation).getByText('Integrations').closest('a')).toHaveAttribute('href', '/connections');
     expect(screen.getAllByText('Development')).not.toHaveLength(0);

--- a/apps/web/src/app/routes/connection-mappings.route.tsx
+++ b/apps/web/src/app/routes/connection-mappings.route.tsx
@@ -1,0 +1,7 @@
+import type { RouteObject } from 'react-router-dom';
+import { ConnectionMappingsPage } from '../../pages/connections/connection-mappings-page';
+
+export const connectionMappingsRoute: RouteObject = {
+  path: 'connections/:connectionId/mappings',
+  element: <ConnectionMappingsPage />,
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -5,6 +5,7 @@ import { allegroCallbackRoute } from './allegro-callback.route';
 import { allegroSetupRoute } from './allegro-setup.route';
 import { automationsRoute } from './automations.route';
 import { connectionDetailRoute } from './connection-detail.route';
+import { connectionMappingsRoute } from './connection-mappings.route';
 import { editConnectionRoute } from './edit-connection.route';
 import { connectionsRoute } from './connections.route';
 import { cursorsRoute } from './cursors.route';
@@ -36,6 +37,7 @@ export const rootRoute: RouteObject = {
     newConnectionRoute,
     allegroSetupRoute,
     connectionDetailRoute,
+    connectionMappingsRoute,
     editConnectionRoute,
     allegroCallbackRoute,
     jobsLogsRoute,

--- a/apps/web/src/features/mappings/api/mappings.api.ts
+++ b/apps/web/src/features/mappings/api/mappings.api.ts
@@ -1,0 +1,88 @@
+/**
+ * Mappings API Client
+ *
+ * Typed API methods for connection-scoped mapping configuration endpoints.
+ *
+ * @module apps/web/src/features/mappings/api
+ */
+
+import type {
+  StatusMapping,
+  CarrierMapping,
+  PaymentMapping,
+  MappingOption,
+  UpsertStatusMappingsPayload,
+  UpsertCarrierMappingsPayload,
+  UpsertPaymentMappingsPayload,
+} from './mappings.types';
+
+export interface MappingsApi {
+  getStatusMappings: (connectionId: string) => Promise<StatusMapping[]>;
+  upsertStatusMappings: (connectionId: string, payload: UpsertStatusMappingsPayload) => Promise<StatusMapping[]>;
+
+  getCarrierMappings: (connectionId: string) => Promise<CarrierMapping[]>;
+  upsertCarrierMappings: (connectionId: string, payload: UpsertCarrierMappingsPayload) => Promise<CarrierMapping[]>;
+
+  getPaymentMappings: (connectionId: string) => Promise<PaymentMapping[]>;
+  upsertPaymentMappings: (connectionId: string, payload: UpsertPaymentMappingsPayload) => Promise<PaymentMapping[]>;
+
+  getAllegroOrderStatuses: (connectionId: string) => Promise<MappingOption[]>;
+  getAllegroDeliveryMethods: (connectionId: string) => Promise<MappingOption[]>;
+  getAllegroPaymentProviders: (connectionId: string) => Promise<MappingOption[]>;
+  getPrestashopOrderStatuses: (connectionId: string) => Promise<MappingOption[]>;
+  getPrestashopCarriers: (connectionId: string) => Promise<MappingOption[]>;
+  getPrestashopPaymentModules: (connectionId: string) => Promise<MappingOption[]>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+export function createMappingsApi(request: ApiRequest): MappingsApi {
+  return {
+    getStatusMappings: (connectionId) =>
+      request<StatusMapping[]>(`/connections/${connectionId}/mappings/status`),
+
+    upsertStatusMappings: (connectionId, payload) =>
+      request<StatusMapping[]>(`/connections/${connectionId}/mappings/status`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      }),
+
+    getCarrierMappings: (connectionId) =>
+      request<CarrierMapping[]>(`/connections/${connectionId}/mappings/carriers`),
+
+    upsertCarrierMappings: (connectionId, payload) =>
+      request<CarrierMapping[]>(`/connections/${connectionId}/mappings/carriers`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      }),
+
+    getPaymentMappings: (connectionId) =>
+      request<PaymentMapping[]>(`/connections/${connectionId}/mappings/payments`),
+
+    upsertPaymentMappings: (connectionId, payload) =>
+      request<PaymentMapping[]>(`/connections/${connectionId}/mappings/payments`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      }),
+
+    getAllegroOrderStatuses: (connectionId) =>
+      request<MappingOption[]>(`/connections/${connectionId}/allegro/order-statuses`),
+
+    getAllegroDeliveryMethods: (connectionId) =>
+      request<MappingOption[]>(`/connections/${connectionId}/allegro/delivery-methods`),
+
+    getAllegroPaymentProviders: (connectionId) =>
+      request<MappingOption[]>(`/connections/${connectionId}/allegro/payment-providers`),
+
+    getPrestashopOrderStatuses: (connectionId) =>
+      request<MappingOption[]>(`/connections/${connectionId}/prestashop/order-statuses`),
+
+    getPrestashopCarriers: (connectionId) =>
+      request<MappingOption[]>(`/connections/${connectionId}/prestashop/carriers`),
+
+    getPrestashopPaymentModules: (connectionId) =>
+      request<MappingOption[]>(`/connections/${connectionId}/prestashop/payment-modules`),
+  };
+}

--- a/apps/web/src/features/mappings/api/mappings.query-keys.ts
+++ b/apps/web/src/features/mappings/api/mappings.query-keys.ts
@@ -1,0 +1,12 @@
+/**
+ * Mappings Query Keys
+ *
+ * @module apps/web/src/features/mappings/api
+ */
+
+export const mappingsQueryKeys = {
+  status: (connectionId: string) => ['mappings', connectionId, 'status'] as const,
+  carriers: (connectionId: string) => ['mappings', connectionId, 'carriers'] as const,
+  payments: (connectionId: string) => ['mappings', connectionId, 'payments'] as const,
+  options: (connectionId: string) => ['mappings', connectionId, 'options'] as const,
+};

--- a/apps/web/src/features/mappings/api/mappings.types.ts
+++ b/apps/web/src/features/mappings/api/mappings.types.ts
@@ -1,0 +1,60 @@
+/**
+ * Mappings Feature Types
+ *
+ * Frontend transport types for the mappings API. Mirrors the backend
+ * mapping response DTOs and option list contracts.
+ *
+ * @module apps/web/src/features/mappings/api
+ */
+
+export interface StatusMapping {
+  id: string;
+  connectionId: string;
+  allegroStatus: string;
+  prestashopStatusId: string;
+}
+
+export interface CarrierMapping {
+  id: string;
+  connectionId: string;
+  allegroDeliveryMethodId: string;
+  prestashopCarrierId: string;
+}
+
+export interface PaymentMapping {
+  id: string;
+  connectionId: string;
+  allegroPaymentProvider: string;
+  prestashopPaymentModule: string;
+}
+
+/** A single option for a source/target dropdown. */
+export interface MappingOption {
+  value: string;
+  label: string;
+}
+
+// ── Upsert payloads ──────────────────────────────────────────────────────
+
+export interface UpsertStatusMappingsPayload {
+  items: { allegroStatus: string; prestashopStatusId: string }[];
+}
+
+export interface UpsertCarrierMappingsPayload {
+  items: { allegroDeliveryMethodId: string; prestashopCarrierId: string }[];
+}
+
+export interface UpsertPaymentMappingsPayload {
+  items: { allegroPaymentProvider: string; prestashopPaymentModule: string }[];
+}
+
+// ── Mapping options bundle ────────────────────────────────────────────────
+
+export interface MappingOptions {
+  allegroOrderStatuses: MappingOption[];
+  allegroDeliveryMethods: MappingOption[];
+  allegroPaymentProviders: MappingOption[];
+  prestashopOrderStatuses: MappingOption[];
+  prestashopCarriers: MappingOption[];
+  prestashopPaymentModules: MappingOption[];
+}

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -1,0 +1,208 @@
+/**
+ * MappingPanel
+ *
+ * Generic panel for displaying and editing a list of source→target mappings.
+ * Used for status, carrier, and payment mapping panels on the connection
+ * mappings page.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import { useState, type ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { EmptyState, ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
+import type { MappingOption } from '../api/mappings.types';
+
+export interface MappingRow {
+  sourceValue: string;
+  targetValue: string;
+}
+
+interface MappingPanelProps {
+  title: string;
+  description: string;
+  sourceLabel: string;
+  targetLabel: string;
+  sourceOptions: MappingOption[];
+  targetOptions: MappingOption[];
+  /** Current saved state from the server. */
+  savedRows: MappingRow[];
+  /** Called with the full replacement list when the user saves. */
+  onSave: (rows: MappingRow[]) => void;
+  isSaving: boolean;
+  saveError: Error | null;
+  optionsLoading: boolean;
+  optionsError: Error | null;
+}
+
+function labelFor(options: MappingOption[], value: string): string {
+  return options.find((o) => o.value === value)?.label ?? value;
+}
+
+export function MappingPanel({
+  title,
+  description,
+  sourceLabel,
+  targetLabel,
+  sourceOptions,
+  targetOptions,
+  savedRows,
+  onSave,
+  isSaving,
+  saveError,
+  optionsLoading,
+  optionsError,
+}: MappingPanelProps): ReactElement {
+  const [localRows, setLocalRows] = useState<MappingRow[]>(savedRows);
+  const [pendingSource, setPendingSource] = useState('');
+  const [pendingTarget, setPendingTarget] = useState('');
+
+  // Track dirty state by comparing local rows to saved rows
+  const isDirty =
+    localRows.length !== savedRows.length ||
+    localRows.some(
+      (row, i) =>
+        row.sourceValue !== savedRows[i]?.sourceValue ||
+        row.targetValue !== savedRows[i]?.targetValue,
+    );
+
+  // Sync local rows when saved rows update (after a successful save)
+  const [prevSaved, setPrevSaved] = useState(savedRows);
+  if (prevSaved !== savedRows) {
+    setPrevSaved(savedRows);
+    setLocalRows(savedRows);
+  }
+
+  function handleAddRow(): void {
+    if (!pendingSource || !pendingTarget) return;
+    // Prevent duplicate source values
+    if (localRows.some((r) => r.sourceValue === pendingSource)) return;
+    setLocalRows((prev) => [...prev, { sourceValue: pendingSource, targetValue: pendingTarget }]);
+    setPendingSource('');
+    setPendingTarget('');
+  }
+
+  function handleDeleteRow(sourceValue: string): void {
+    setLocalRows((prev) => prev.filter((r) => r.sourceValue !== sourceValue));
+  }
+
+  function handleSave(): void {
+    onSave(localRows);
+  }
+
+  if (optionsLoading) {
+    return <LoadingState liveRegion="off" title={`Loading ${title.toLowerCase()} options`} message="Fetching available values…" />;
+  }
+
+  if (optionsError) {
+    return <ErrorState title="Unable to load options" message={optionsError.message} />;
+  }
+
+  // Source options not already mapped
+  const availableSourceOptions = sourceOptions.filter(
+    (o) => !localRows.some((r) => r.sourceValue === o.value),
+  );
+
+  return (
+    <div className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Configuration</p>
+          <h3 className="section-title">{title}</h3>
+        </div>
+        {isDirty && (
+          <span className="status-badge status-badge--warning" aria-live="polite">
+            Unsaved changes
+          </span>
+        )}
+      </div>
+
+      <p className="muted-text" style={{ marginBottom: '1rem' }}>{description}</p>
+
+      {localRows.length === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No mappings configured"
+          message="Orders may sync with incorrect status/carrier/payment. Add a mapping below."
+        />
+      ) : (
+        <table className="data-table" aria-label={`${title} mappings`}>
+          <thead>
+            <tr>
+              <th>{sourceLabel}</th>
+              <th>{targetLabel}</th>
+              <th aria-label="Actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {localRows.map((row) => (
+              <tr key={row.sourceValue}>
+                <td>{labelFor(sourceOptions, row.sourceValue)}</td>
+                <td>{labelFor(targetOptions, row.targetValue)}</td>
+                <td>
+                  <Button
+                    tone="ghost"
+                    aria-label={`Remove mapping for ${labelFor(sourceOptions, row.sourceValue)}`}
+                    onClick={() => { handleDeleteRow(row.sourceValue); }}
+                  >
+                    Remove
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {/* Add row form */}
+      <div className="toolbar" style={{ marginTop: '1rem', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <select
+          aria-label={`Select ${sourceLabel}`}
+          value={pendingSource}
+          onChange={(e) => { setPendingSource(e.target.value); }}
+          disabled={availableSourceOptions.length === 0}
+        >
+          <option value="">— {sourceLabel} —</option>
+          {availableSourceOptions.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+
+        <select
+          aria-label={`Select ${targetLabel}`}
+          value={pendingTarget}
+          onChange={(e) => { setPendingTarget(e.target.value); }}
+        >
+          <option value="">— {targetLabel} —</option>
+          {targetOptions.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+
+        <Button
+          tone="secondary"
+          disabled={!pendingSource || !pendingTarget}
+          onClick={handleAddRow}
+        >
+          Add
+        </Button>
+      </div>
+
+      {saveError && (
+        <p className="error-message" role="alert" style={{ marginTop: '0.5rem' }}>
+          {saveError.message}
+        </p>
+      )}
+
+      <div style={{ marginTop: '1rem' }}>
+        <Button
+          tone="primary"
+          disabled={!isDirty || isSaving}
+          onClick={handleSave}
+        >
+          {isSaving ? 'Saving…' : 'Save mappings'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -8,7 +8,7 @@
  * @module apps/web/src/features/mappings/components
  */
 
-import { useState, type ReactElement } from 'react';
+import { useState, useEffect, type ReactElement } from 'react';
 import { Button } from '../../../shared/ui/button';
 import { EmptyState, ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import type { MappingOption } from '../api/mappings.types';
@@ -56,6 +56,7 @@ export function MappingPanel({
   const [localRows, setLocalRows] = useState<MappingRow[]>(savedRows);
   const [pendingSource, setPendingSource] = useState('');
   const [pendingTarget, setPendingTarget] = useState('');
+  const [addError, setAddError] = useState<string | null>(null);
 
   // Track dirty state by comparing local rows to saved rows
   const isDirty =
@@ -67,16 +68,17 @@ export function MappingPanel({
     );
 
   // Sync local rows when saved rows update (after a successful save)
-  const [prevSaved, setPrevSaved] = useState(savedRows);
-  if (prevSaved !== savedRows) {
-    setPrevSaved(savedRows);
+  useEffect(() => {
     setLocalRows(savedRows);
-  }
+  }, [savedRows]);
 
   function handleAddRow(): void {
     if (!pendingSource || !pendingTarget) return;
-    // Prevent duplicate source values
-    if (localRows.some((r) => r.sourceValue === pendingSource)) return;
+    if (localRows.some((r) => r.sourceValue === pendingSource)) {
+      setAddError('A mapping for this source value already exists.');
+      return;
+    }
+    setAddError(null);
     setLocalRows((prev) => [...prev, { sourceValue: pendingSource, targetValue: pendingTarget }]);
     setPendingSource('');
     setPendingTarget('');
@@ -187,6 +189,12 @@ export function MappingPanel({
           Add
         </Button>
       </div>
+
+      {addError && (
+        <p className="error-message" role="alert" style={{ marginTop: '0.25rem' }}>
+          {addError}
+        </p>
+      )}
 
       {saveError && (
         <p className="error-message" role="alert" style={{ marginTop: '0.5rem' }}>

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -202,7 +202,7 @@ export function MappingPanel({
         </p>
       )}
 
-      <div style={{ marginTop: '1rem' }}>
+      <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
         <Button
           tone="primary"
           disabled={!isDirty || isSaving}
@@ -210,6 +210,11 @@ export function MappingPanel({
         >
           {isSaving ? 'Saving…' : 'Save mappings'}
         </Button>
+        {saveError && (
+          <Button tone="secondary" disabled={isSaving} onClick={handleSave}>
+            Try again
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/features/mappings/hooks/use-carrier-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-carrier-mappings.ts
@@ -1,0 +1,31 @@
+/**
+ * Carrier Mappings Hooks
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { useQuery, useMutation, useQueryClient, type UseQueryResult, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mappingsQueryKeys } from '../api/mappings.query-keys';
+import type { CarrierMapping, UpsertCarrierMappingsPayload } from '../api/mappings.types';
+
+export function useCarrierMappingsQuery(connectionId: string): UseQueryResult<CarrierMapping[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: mappingsQueryKeys.carriers(connectionId),
+    queryFn: () => apiClient.mappings.getCarrierMappings(connectionId),
+    retry: false,
+  });
+}
+
+export function useUpsertCarrierMappings(connectionId: string): UseMutationResult<CarrierMapping[], Error, UpsertCarrierMappingsPayload> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: UpsertCarrierMappingsPayload) =>
+      apiClient.mappings.upsertCarrierMappings(connectionId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: mappingsQueryKeys.carriers(connectionId) });
+    },
+  });
+}

--- a/apps/web/src/features/mappings/hooks/use-mapping-options.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-options.ts
@@ -1,0 +1,92 @@
+/**
+ * Mapping Options Hook
+ *
+ * Fetches all 6 dropdown option lists in parallel for a given connection.
+ * Returns a combined MappingOptions bundle plus loading/error state.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { useQueries } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mappingsQueryKeys } from '../api/mappings.query-keys';
+import type { MappingOptions } from '../api/mappings.types';
+
+interface UseMappingOptionsResult {
+  options: MappingOptions;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const EMPTY_OPTIONS: MappingOptions = {
+  allegroOrderStatuses: [],
+  allegroDeliveryMethods: [],
+  allegroPaymentProviders: [],
+  prestashopOrderStatuses: [],
+  prestashopCarriers: [],
+  prestashopPaymentModules: [],
+};
+
+export function useMappingOptions(connectionId: string): UseMappingOptionsResult {
+  const apiClient = useApiClient();
+
+  const results = useQueries({
+    queries: [
+      {
+        queryKey: [...mappingsQueryKeys.options(connectionId), 'allegro-statuses'],
+        queryFn: () => apiClient.mappings.getAllegroOrderStatuses(connectionId),
+        retry: false,
+      },
+      {
+        queryKey: [...mappingsQueryKeys.options(connectionId), 'allegro-delivery'],
+        queryFn: () => apiClient.mappings.getAllegroDeliveryMethods(connectionId),
+        retry: false,
+      },
+      {
+        queryKey: [...mappingsQueryKeys.options(connectionId), 'allegro-payments'],
+        queryFn: () => apiClient.mappings.getAllegroPaymentProviders(connectionId),
+        retry: false,
+      },
+      {
+        queryKey: [...mappingsQueryKeys.options(connectionId), 'ps-statuses'],
+        queryFn: () => apiClient.mappings.getPrestashopOrderStatuses(connectionId),
+        retry: false,
+      },
+      {
+        queryKey: [...mappingsQueryKeys.options(connectionId), 'ps-carriers'],
+        queryFn: () => apiClient.mappings.getPrestashopCarriers(connectionId),
+        retry: false,
+      },
+      {
+        queryKey: [...mappingsQueryKeys.options(connectionId), 'ps-payments'],
+        queryFn: () => apiClient.mappings.getPrestashopPaymentModules(connectionId),
+        retry: false,
+      },
+    ],
+  });
+
+  const isLoading = results.some((r) => r.isLoading);
+  const firstError = results.find((r) => r.error)?.error ?? null;
+
+  const [
+    allegroStatuses,
+    allegroDelivery,
+    allegroPayments,
+    psStatuses,
+    psCarriers,
+    psPayments,
+  ] = results;
+
+  const options: MappingOptions = isLoading
+    ? EMPTY_OPTIONS
+    : {
+        allegroOrderStatuses: allegroStatuses.data ?? [],
+        allegroDeliveryMethods: allegroDelivery.data ?? [],
+        allegroPaymentProviders: allegroPayments.data ?? [],
+        prestashopOrderStatuses: psStatuses.data ?? [],
+        prestashopCarriers: psCarriers.data ?? [],
+        prestashopPaymentModules: psPayments.data ?? [],
+      };
+
+  return { options, isLoading, error: firstError instanceof Error ? firstError : null };
+}

--- a/apps/web/src/features/mappings/hooks/use-payment-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-payment-mappings.ts
@@ -1,0 +1,31 @@
+/**
+ * Payment Mappings Hooks
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { useQuery, useMutation, useQueryClient, type UseQueryResult, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mappingsQueryKeys } from '../api/mappings.query-keys';
+import type { PaymentMapping, UpsertPaymentMappingsPayload } from '../api/mappings.types';
+
+export function usePaymentMappingsQuery(connectionId: string): UseQueryResult<PaymentMapping[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: mappingsQueryKeys.payments(connectionId),
+    queryFn: () => apiClient.mappings.getPaymentMappings(connectionId),
+    retry: false,
+  });
+}
+
+export function useUpsertPaymentMappings(connectionId: string): UseMutationResult<PaymentMapping[], Error, UpsertPaymentMappingsPayload> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: UpsertPaymentMappingsPayload) =>
+      apiClient.mappings.upsertPaymentMappings(connectionId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: mappingsQueryKeys.payments(connectionId) });
+    },
+  });
+}

--- a/apps/web/src/features/mappings/hooks/use-status-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-status-mappings.ts
@@ -1,0 +1,33 @@
+/**
+ * Status Mappings Hooks
+ *
+ * TanStack Query hooks for fetching and mutating status mappings.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { useQuery, useMutation, useQueryClient, type UseQueryResult, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mappingsQueryKeys } from '../api/mappings.query-keys';
+import type { StatusMapping, UpsertStatusMappingsPayload } from '../api/mappings.types';
+
+export function useStatusMappingsQuery(connectionId: string): UseQueryResult<StatusMapping[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: mappingsQueryKeys.status(connectionId),
+    queryFn: () => apiClient.mappings.getStatusMappings(connectionId),
+    retry: false,
+  });
+}
+
+export function useUpsertStatusMappings(connectionId: string): UseMutationResult<StatusMapping[], Error, UpsertStatusMappingsPayload> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: UpsertStatusMappingsPayload) =>
+      apiClient.mappings.upsertStatusMappings(connectionId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: mappingsQueryKeys.status(connectionId) });
+    },
+  });
+}

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -34,9 +34,14 @@ export function ConnectionDetailPage(): ReactElement {
       actions={
         <div className="button-group">
           {connection ? (
-            <Link className="button button--primary" to={`/connections/${connectionId}/edit`}>
-              Edit connection
-            </Link>
+            <>
+              <Link className="button button--primary" to={`/connections/${connectionId}/edit`}>
+                Edit connection
+              </Link>
+              <Link className="button button--secondary" to={`/connections/${connectionId}/mappings`}>
+                Mappings
+              </Link>
+            </>
           ) : null}
           <Link className="button button--secondary" to="/connections">
             Back to integrations

--- a/apps/web/src/pages/connections/connection-mappings-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * ConnectionMappingsPage tests
+ *
+ * @module apps/web/src/pages/connections
+ */
+
+import { cleanup, screen, waitFor, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
+import { ConnectionMappingsPage } from './connection-mappings-page';
+import type { StatusMapping, MappingOption } from '../../features/mappings/api/mappings.types';
+
+const STATUS_OPTIONS: MappingOption[] = [
+  { value: 'READY_FOR_PROCESSING', label: 'Ready for processing' },
+  { value: 'CANCELLED', label: 'Cancelled' },
+];
+
+const PS_STATUS_OPTIONS: MappingOption[] = [
+  { value: '2', label: 'Payment accepted' },
+  { value: '6', label: 'Cancelled' },
+];
+
+const SAVED_STATUS_MAPPINGS: StatusMapping[] = [
+  {
+    id: 'mapping-1',
+    connectionId: 'conn-1',
+    allegroStatus: 'READY_FOR_PROCESSING',
+    prestashopStatusId: '2',
+  },
+];
+
+const BASE_MAPPINGS_MOCKS = {
+  getStatusMappings: vi.fn().mockResolvedValue([]),
+  upsertStatusMappings: vi.fn().mockResolvedValue([]),
+  getCarrierMappings: vi.fn().mockResolvedValue([]),
+  upsertCarrierMappings: vi.fn().mockResolvedValue([]),
+  getPaymentMappings: vi.fn().mockResolvedValue([]),
+  upsertPaymentMappings: vi.fn().mockResolvedValue([]),
+  getAllegroOrderStatuses: vi.fn().mockResolvedValue(STATUS_OPTIONS),
+  getAllegroDeliveryMethods: vi.fn().mockResolvedValue([]),
+  getAllegroPaymentProviders: vi.fn().mockResolvedValue([]),
+  getPrestashopOrderStatuses: vi.fn().mockResolvedValue(PS_STATUS_OPTIONS),
+  getPrestashopCarriers: vi.fn().mockResolvedValue([]),
+  getPrestashopPaymentModules: vi.fn().mockResolvedValue([]),
+};
+
+function buildApiClient(mappingsOverrides: Partial<typeof BASE_MAPPINGS_MOCKS> = {}): ReturnType<typeof createMockApiClient> {
+  return createMockApiClient({
+    mappings: { ...BASE_MAPPINGS_MOCKS, ...mappingsOverrides },
+  });
+}
+
+describe('ConnectionMappingsPage', () => {
+  afterEach(cleanup);
+
+  it('renders the page layout with tab navigation', async () => {
+    renderWithProviders(<ConnectionMappingsPage />, { apiClient: buildApiClient() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('tab', { name: 'Order Statuses' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Carriers' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Payments' })).toBeInTheDocument();
+  });
+
+  it('renders empty state when no status mappings exist', async () => {
+    renderWithProviders(<ConnectionMappingsPage />, { apiClient: buildApiClient() });
+
+    await waitFor(() => {
+      expect(screen.getByText('No mappings configured')).toBeInTheDocument();
+    });
+  });
+
+  it('renders table rows when status mappings exist', async () => {
+    const apiClient = buildApiClient({
+      getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS),
+    });
+    renderWithProviders(<ConnectionMappingsPage />, { apiClient });
+
+    await waitFor(() => {
+      // Labels appear in both the table cell and the dropdown options — verify the table cell
+      const cells = screen.getAllByText('Ready for processing');
+      expect(cells.length).toBeGreaterThan(0);
+      expect(cells.some((el) => el.tagName === 'TD')).toBe(true);
+    });
+  });
+
+  it('shows unsaved changes indicator after adding a row', async () => {
+    const apiClient = buildApiClient();
+    renderWithProviders(<ConnectionMappingsPage />, { apiClient });
+
+    // Wait for page to finish loading
+    await waitFor(() => {
+      expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
+    });
+
+    // Select source option
+    const sourceSelect = screen.getByRole('combobox', { name: /Select Allegro status/i });
+    fireEvent.change(sourceSelect, { target: { value: 'READY_FOR_PROCESSING' } });
+
+    // Select target option
+    const targetSelect = screen.getByRole('combobox', { name: /Select PrestaShop status/i });
+    fireEvent.change(targetSelect, { target: { value: '2' } });
+
+    // Add the row
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    });
+  });
+
+  it('calls upsertStatusMappings on save', async () => {
+    const upsertFn = vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS);
+    const apiClient = buildApiClient({
+      getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS),
+      upsertStatusMappings: upsertFn,
+    });
+    renderWithProviders(<ConnectionMappingsPage />, { apiClient });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ready for processing')).toBeInTheDocument();
+    });
+
+    // Delete the existing row to make the state dirty
+    fireEvent.click(screen.getByRole('button', { name: /Remove mapping for Ready for processing/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }));
+
+    await waitFor(() => {
+      expect(upsertFn).toHaveBeenCalledWith('', { items: [] });
+    });
+  });
+
+  it('displays error message on save failure', async () => {
+    const apiClient = buildApiClient({
+      getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS),
+      upsertStatusMappings: vi.fn().mockRejectedValue(new Error('Server error')),
+    });
+    renderWithProviders(<ConnectionMappingsPage />, { apiClient });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ready for processing')).toBeInTheDocument();
+    });
+
+    // Make dirty by deleting a row
+    fireEvent.click(screen.getByRole('button', { name: /Remove mapping for Ready for processing/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Server error');
+    });
+  });
+
+  it('switches between tabs', async () => {
+    renderWithProviders(<ConnectionMappingsPage />, { apiClient: buildApiClient() });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Carriers' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Carriers' }));
+
+    expect(screen.getByRole('tab', { name: 'Carriers' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Carrier Mappings')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -1,0 +1,174 @@
+/**
+ * Connection Mappings Page
+ *
+ * Provides three tabbed panels for configuring Allegro → PrestaShop mappings
+ * per connection: order statuses, delivery carriers, and payment methods.
+ *
+ * @module apps/web/src/pages/connections
+ */
+
+import { useState, type ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { MappingPanel, type MappingRow } from '../../features/mappings/components/MappingPanel';
+import { useStatusMappingsQuery, useUpsertStatusMappings } from '../../features/mappings/hooks/use-status-mappings';
+import { useCarrierMappingsQuery, useUpsertCarrierMappings } from '../../features/mappings/hooks/use-carrier-mappings';
+import { usePaymentMappingsQuery, useUpsertPaymentMappings } from '../../features/mappings/hooks/use-payment-mappings';
+import { useMappingOptions } from '../../features/mappings/hooks/use-mapping-options';
+import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
+
+type TabId = 'status' | 'carriers' | 'payments';
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'status', label: 'Order Statuses' },
+  { id: 'carriers', label: 'Carriers' },
+  { id: 'payments', label: 'Payments' },
+];
+
+export function ConnectionMappingsPage(): ReactElement {
+  const { connectionId = '' } = useParams();
+  const [activeTab, setActiveTab] = useState<TabId>('status');
+
+  const statusQuery = useStatusMappingsQuery(connectionId);
+  const carrierQuery = useCarrierMappingsQuery(connectionId);
+  const paymentQuery = usePaymentMappingsQuery(connectionId);
+  const { options, isLoading: optionsLoading, error: optionsError } = useMappingOptions(connectionId);
+
+  const upsertStatus = useUpsertStatusMappings(connectionId);
+  const upsertCarrier = useUpsertCarrierMappings(connectionId);
+  const upsertPayment = useUpsertPaymentMappings(connectionId);
+
+  const isLoading = statusQuery.isLoading || carrierQuery.isLoading || paymentQuery.isLoading;
+  const loadError = statusQuery.error ?? carrierQuery.error ?? paymentQuery.error ?? null;
+
+  if (isLoading) {
+    return (
+      <PageLayout eyebrow="Connection" title="Mappings" description="Loading mapping configuration…">
+        <LoadingState liveRegion="off" title="Loading mappings" message="Fetching configured mappings for this connection." />
+      </PageLayout>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <PageLayout eyebrow="Connection" title="Mappings" description="Unable to load mapping configuration.">
+        <ErrorState title="Unable to load mappings" message={loadError.message} />
+      </PageLayout>
+    );
+  }
+
+  const statusRows: MappingRow[] = (statusQuery.data ?? []).map((m) => ({
+    sourceValue: m.allegroStatus,
+    targetValue: m.prestashopStatusId,
+  }));
+
+  const carrierRows: MappingRow[] = (carrierQuery.data ?? []).map((m) => ({
+    sourceValue: m.allegroDeliveryMethodId,
+    targetValue: m.prestashopCarrierId,
+  }));
+
+  const paymentRows: MappingRow[] = (paymentQuery.data ?? []).map((m) => ({
+    sourceValue: m.allegroPaymentProvider,
+    targetValue: m.prestashopPaymentModule,
+  }));
+
+  function handleSaveStatus(rows: MappingRow[]): void {
+    upsertStatus.mutate({
+      items: rows.map((r) => ({ allegroStatus: r.sourceValue, prestashopStatusId: r.targetValue })),
+    });
+  }
+
+  function handleSaveCarriers(rows: MappingRow[]): void {
+    upsertCarrier.mutate({
+      items: rows.map((r) => ({ allegroDeliveryMethodId: r.sourceValue, prestashopCarrierId: r.targetValue })),
+    });
+  }
+
+  function handleSavePayments(rows: MappingRow[]): void {
+    upsertPayment.mutate({
+      items: rows.map((r) => ({ allegroPaymentProvider: r.sourceValue, prestashopPaymentModule: r.targetValue })),
+    });
+  }
+
+  return (
+    <PageLayout
+      eyebrow="Connection"
+      title="Mapping Configuration"
+      description="Configure Allegro → PrestaShop mappings for order statuses, delivery carriers, and payment methods."
+      actions={
+        <Link className="button button--secondary" to={`/connections/${connectionId}`}>
+          Back to connection
+        </Link>
+      }
+    >
+      {/* Tab navigation */}
+      <div role="tablist" aria-label="Mapping types" className="toolbar" style={{ marginBottom: '1.5rem', gap: '0.25rem' }}>
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            className={`button ${activeTab === tab.id ? 'button--primary' : 'button--ghost'}`}
+            onClick={() => { setActiveTab(tab.id); }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab panels */}
+      <div role="tabpanel" aria-label={TABS.find((t) => t.id === activeTab)?.label}>
+        {activeTab === 'status' && (
+          <MappingPanel
+            title="Order Status Mappings"
+            description="Map Allegro order statuses to the corresponding PrestaShop order status IDs."
+            sourceLabel="Allegro status"
+            targetLabel="PrestaShop status"
+            sourceOptions={options.allegroOrderStatuses}
+            targetOptions={options.prestashopOrderStatuses}
+            savedRows={statusRows}
+            onSave={handleSaveStatus}
+            isSaving={upsertStatus.isPending}
+            saveError={upsertStatus.error}
+            optionsLoading={optionsLoading}
+            optionsError={optionsError}
+          />
+        )}
+
+        {activeTab === 'carriers' && (
+          <MappingPanel
+            title="Carrier Mappings"
+            description="Map Allegro delivery method IDs to the corresponding PrestaShop carrier IDs."
+            sourceLabel="Allegro delivery method"
+            targetLabel="PrestaShop carrier"
+            sourceOptions={options.allegroDeliveryMethods}
+            targetOptions={options.prestashopCarriers}
+            savedRows={carrierRows}
+            onSave={handleSaveCarriers}
+            isSaving={upsertCarrier.isPending}
+            saveError={upsertCarrier.error}
+            optionsLoading={optionsLoading}
+            optionsError={optionsError}
+          />
+        )}
+
+        {activeTab === 'payments' && (
+          <MappingPanel
+            title="Payment Mappings"
+            description="Map Allegro payment provider names to the corresponding PrestaShop payment module names."
+            sourceLabel="Allegro payment provider"
+            targetLabel="PrestaShop payment module"
+            sourceOptions={options.allegroPaymentProviders}
+            targetOptions={options.prestashopPaymentModules}
+            savedRows={paymentRows}
+            onSave={handleSavePayments}
+            isSaving={upsertPayment.isPending}
+            saveError={upsertPayment.error}
+            optionsLoading={optionsLoading}
+            optionsError={optionsError}
+          />
+        )}
+      </div>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -90,8 +90,8 @@ describe('DashboardPage', () => {
     });
     renderWithProviders(<DashboardPage />, { apiClient });
 
-    expect(await screen.findByRole('heading', { name: 'Health check failed' })).toBeInTheDocument();
-  });
+    expect(await screen.findByRole('heading', { name: 'Health check failed' }, { timeout: 10000 })).toBeInTheDocument();
+  }, 15000);
 
   it('shows recent sync jobs in a table', async () => {
     const listMock = vi.fn().mockImplementation((filters?: { status?: string }) => {

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -45,6 +45,7 @@ type DeepPartialApiClient = {
   listings?: Partial<ApiClient['listings']>;
   orders?: Partial<ApiClient['orders']>;
   products?: Partial<ApiClient['products']>;
+  mappings?: Partial<ApiClient['mappings']>;
   syncJobs?: Partial<ApiClient['syncJobs']>;
 };
 
@@ -159,6 +160,21 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       getById: vi.fn().mockResolvedValue(null),
       ...overrides.products,
     } as ApiClient['products'],
+    mappings: {
+      getStatusMappings: vi.fn().mockResolvedValue([]),
+      upsertStatusMappings: vi.fn().mockResolvedValue([]),
+      getCarrierMappings: vi.fn().mockResolvedValue([]),
+      upsertCarrierMappings: vi.fn().mockResolvedValue([]),
+      getPaymentMappings: vi.fn().mockResolvedValue([]),
+      upsertPaymentMappings: vi.fn().mockResolvedValue([]),
+      getAllegroOrderStatuses: vi.fn().mockResolvedValue([]),
+      getAllegroDeliveryMethods: vi.fn().mockResolvedValue([]),
+      getAllegroPaymentProviders: vi.fn().mockResolvedValue([]),
+      getPrestashopOrderStatuses: vi.fn().mockResolvedValue([]),
+      getPrestashopCarriers: vi.fn().mockResolvedValue([]),
+      getPrestashopPaymentModules: vi.fn().mockResolvedValue([]),
+      ...overrides.mappings,
+    } as ApiClient['mappings'],
     syncJobs: {
       enqueue: vi.fn().mockResolvedValue({
         jobId: 'job_1',

--- a/docs/plans/implementation-plan-mapping-config-api-ui.md
+++ b/docs/plans/implementation-plan-mapping-config-api-ui.md
@@ -1,0 +1,438 @@
+# Implementation Plan: Connection-Scoped Mapping Configuration API + UI
+
+**Issues:** #133 (BE), #134 (FE)  
+**Branch:** `133-134-mapping-config-api-ui`  
+**Classification:** CORE/Application + Interface (BE), Frontend (FE)
+
+---
+
+## 1. Goal & Non-Goals
+
+### Goal
+Introduce a `mappings` bounded context that lets merchants configure Allegro → PrestaShop status, carrier, and payment mappings per connection. Expose a REST API and a React UI. Wire the status mapping into `OrderSyncService` so ingested orders use the configured mapping rather than the hardcoded `'pending'` default.
+
+### Non-Goals
+- Automatic inference of mappings from live platform data (helper endpoints return static Allegro data + live PrestaShop data)
+- Mapping validation against live PrestaShop configuration
+- Any mapping type beyond status, carrier, and payment
+
+---
+
+## 2. Architecture
+
+### Layers touched
+
+| Layer | Location |
+|---|---|
+| Domain entities + ports | `libs/core/src/mappings/domain/` |
+| Application service + interface | `libs/core/src/mappings/application/` |
+| ORM entities + repositories | `libs/core/src/mappings/infrastructure/` |
+| NestJS module | `libs/core/src/mappings/mappings.module.ts` |
+| REST controller + DTOs | `apps/api/src/mappings/` |
+| TypeORM migration | `apps/api/src/migrations/` |
+| FE feature (API, hooks) | `apps/web/src/features/mappings/` |
+| FE pages + route | `apps/web/src/pages/connections/` + `apps/web/src/app/routes/` |
+
+### Helper endpoints for dropdowns
+- **Allegro options** (status, delivery methods, payment providers): returned as hardcoded lists (Allegro values are stable, well-known enums). Placed in a new `MappingsController` under `connections/:connectionId/allegro/*`.
+- **PrestaShop options** (order statuses, carriers, payment modules): calls through the PrestaShop webservice client, resolved via `IntegrationsService.getCapabilityAdapter`. These are live calls. Placed under `connections/:connectionId/prestashop/*`.
+
+---
+
+## 3. Step-by-Step Implementation Plan
+
+### Phase A — Core domain + infrastructure
+
+#### A1. Domain entities
+**Files:**
+- `libs/core/src/mappings/domain/entities/status-mapping.entity.ts`
+- `libs/core/src/mappings/domain/entities/carrier-mapping.entity.ts`
+- `libs/core/src/mappings/domain/entities/payment-mapping.entity.ts`
+
+Each entity: pure TypeScript class, no framework imports. Example:
+```
+StatusMapping(id, connectionId, allegroStatus, prestashopStatusId)
+CarrierMapping(id, connectionId, allegroDeliveryMethodId, prestashopCarrierId)
+PaymentMapping(id, connectionId, allegroPaymentProvider, prestashopPaymentModule)
+```
+IDs are UUID strings (generated at persistence layer).
+
+#### A2. Domain types
+**File:** `libs/core/src/mappings/domain/types/mapping.types.ts`
+- `StatusMappingInput` / `CarrierMappingInput` / `PaymentMappingInput` (upsert payloads)
+
+#### A3. Repository ports
+**Files:**
+- `libs/core/src/mappings/domain/ports/status-mapping-repository.port.ts`
+- `libs/core/src/mappings/domain/ports/carrier-mapping-repository.port.ts`
+- `libs/core/src/mappings/domain/ports/payment-mapping-repository.port.ts`
+
+Each port defines:
+```
+findByConnectionId(connectionId: string): Promise<T[]>
+replaceForConnection(connectionId: string, items: TInput[]): Promise<T[]>
+```
+The `replaceForConnection` method is a "delete + insert" upsert (idiomatic for bulk mapping tables).
+
+#### A4. Application service interface
+**File:** `libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts`
+```
+IMappingConfigService {
+  getStatusMappings(connectionId): Promise<StatusMapping[]>
+  upsertStatusMappings(connectionId, items): Promise<StatusMapping[]>
+  getCarrierMappings(connectionId): Promise<CarrierMapping[]>
+  upsertCarrierMappings(connectionId, items): Promise<CarrierMapping[]>
+  getPaymentMappings(connectionId): Promise<PaymentMapping[]>
+  upsertPaymentMappings(connectionId, items): Promise<PaymentMapping[]>
+  resolveStatusMapping(connectionId, allegroStatus): Promise<string | null>
+}
+```
+
+#### A5. Application service
+**File:** `libs/core/src/mappings/application/services/mapping-config.service.ts`
+
+Implements `IMappingConfigService`. Each `upsert*` delegates to `replaceForConnection`. `resolveStatusMapping` calls `statusMappingRepository.findByConnectionId` and returns the `prestashopStatusId` for a matching `allegroStatus`, or `null` if not found.
+
+#### A6. ORM entities
+**Files:**
+- `libs/core/src/mappings/infrastructure/persistence/entities/status-mapping.orm-entity.ts`
+- `libs/core/src/mappings/infrastructure/persistence/entities/carrier-mapping.orm-entity.ts`
+- `libs/core/src/mappings/infrastructure/persistence/entities/payment-mapping.orm-entity.ts`
+
+Tables: `connection_status_mappings`, `connection_carrier_mappings`, `connection_payment_mappings`.
+Each has: `id` (uuid PK), `connection_id` (uuid FK-like, not enforced), `source_value`, `target_value`, timestamps.
+Unique constraint on `(connection_id, source_value)`.
+
+#### A7. Repositories
+**Files:**
+- `libs/core/src/mappings/infrastructure/persistence/repositories/status-mapping.repository.ts`
+- `libs/core/src/mappings/infrastructure/persistence/repositories/carrier-mapping.repository.ts`
+- `libs/core/src/mappings/infrastructure/persistence/repositories/payment-mapping.repository.ts`
+
+Each implements the port. `replaceForConnection` deletes all rows for `connectionId` then inserts the new items in a transaction.
+
+#### A8. DI tokens
+**File:** `libs/core/src/mappings/mappings.tokens.ts`
+```
+MAPPING_CONFIG_SERVICE_TOKEN
+STATUS_MAPPING_REPOSITORY_TOKEN
+CARRIER_MAPPING_REPOSITORY_TOKEN
+PAYMENT_MAPPING_REPOSITORY_TOKEN
+```
+
+#### A9. NestJS core module
+**File:** `libs/core/src/mappings/mappings.module.ts`
+
+Registers ORM entities, repositories, service; exports `MAPPING_CONFIG_SERVICE_TOKEN`.
+
+#### A10. Core library index
+**File:** `libs/core/src/mappings/index.ts`
+
+Exports module, tokens, interfaces, and entity types needed by the API layer.
+
+---
+
+### Phase B — Migration
+
+#### B1. Migration file
+**File:** `apps/api/src/migrations/1778000000000-add-connection-mapping-tables.ts`
+
+Creates three tables:
+- `connection_status_mappings (id uuid PK, connection_id uuid NOT NULL, allegro_status varchar NOT NULL, prestashop_status_id varchar NOT NULL, created_at timestamptz, updated_at timestamptz, UNIQUE(connection_id, allegro_status))`
+- `connection_carrier_mappings (id uuid PK, connection_id uuid NOT NULL, allegro_delivery_method_id varchar NOT NULL, prestashop_carrier_id varchar NOT NULL, ..., UNIQUE(connection_id, allegro_delivery_method_id))`
+- `connection_payment_mappings (id uuid PK, connection_id uuid NOT NULL, allegro_payment_provider varchar NOT NULL, prestashop_payment_module varchar NOT NULL, ..., UNIQUE(connection_id, allegro_payment_provider))`
+
+---
+
+### Phase C — API layer
+
+#### C1. Request/response DTOs
+**Files in `apps/api/src/mappings/http/dto/`:**
+- `status-mapping-item.dto.ts` — `{ allegroStatus, prestashopStatusId }`
+- `upsert-status-mappings.dto.ts` — `{ items: StatusMappingItemDto[] }`
+- `status-mapping-response.dto.ts`
+- Same pattern for carrier and payment
+- Helper response DTOs: `allegro-order-status-option.dto.ts`, `prestashop-order-status-option.dto.ts`, etc.
+
+#### C2. Mappings controller
+**File:** `apps/api/src/mappings/http/mappings.controller.ts`
+
+Routes:
+```
+GET  /connections/:connectionId/mappings/status    → getStatusMappings
+PUT  /connections/:connectionId/mappings/status    → upsertStatusMappings
+GET  /connections/:connectionId/mappings/carriers  → getCarrierMappings
+PUT  /connections/:connectionId/mappings/carriers  → upsertCarrierMappings
+GET  /connections/:connectionId/mappings/payments  → getPaymentMappings
+PUT  /connections/:connectionId/mappings/payments  → upsertPaymentMappings
+```
+
+All endpoints: `@UseGuards(JwtAuthGuard)`, `@Roles('admin')`, `@ApiBearerAuth()`, full Swagger decorators.
+
+#### C3. Options controller
+**File:** `apps/api/src/mappings/http/mapping-options.controller.ts`
+
+Routes:
+```
+GET /connections/:connectionId/allegro/order-statuses      → hardcoded Allegro status list
+GET /connections/:connectionId/allegro/delivery-methods    → hardcoded Allegro delivery method list  
+GET /connections/:connectionId/prestashop/order-statuses   → live PrestaShop order_states call
+GET /connections/:connectionId/prestashop/carriers         → live PrestaShop carriers call
+GET /connections/:connectionId/prestashop/payment-modules  → live PrestaShop payment module list
+```
+
+For PrestaShop live calls: inject `IntegrationsService`, get the `OrderProcessorManager` adapter (which has access to the PS webservice client), call appropriate PS API resources. For the MVP, these will use the PrestaShop webservice adapter directly via the integrations service.
+
+**Note:** The PrestaShop webservice adapter doesn't currently expose `getOrderStatuses()` etc. — the options controller will call the PrestaShop HTTP client directly. To avoid adding new port methods for a helper endpoint, we can inject the `PrestashopWebserviceClient` directly from the integrations module (since this controller lives in the API app, not core). Alternatively, for MVP simplicity, we return hardcoded PrestaShop option stubs with a note for expansion. **Decision: for MVP, return hardcoded known values for all helper endpoints.** This avoids coupling to live platform state and unblocks the FE. Live data can be added in a follow-up.
+
+#### C4. Mappings API module
+**File:** `apps/api/src/mappings/mappings.module.ts`
+
+Imports `MappingsModule` from core, `IntegrationsModule` (for options endpoints). Registers both controllers.
+
+#### C5. Register in AppModule
+**File:** `apps/api/src/app.module.ts`
+
+Add `MappingsApiModule` to imports.
+
+---
+
+### Phase D — Wire into OrderSyncService
+
+#### D1. Inject `IMappingConfigService` into `OrderSyncService`
+**File:** `libs/core/src/orders/application/services/order-sync.service.ts`
+
+- Inject `MAPPING_CONFIG_SERVICE_TOKEN → IMappingConfigService`
+- In `syncOrder`, after resolving `orderStatus`, call `resolveStatusMapping(sourceConnectionId, order.status)`. If a mapping is found, use it as `orderStatus`; otherwise fall back to the existing `validateOrderStatus` logic.
+
+#### D2. Update `OrdersModule` to import `MappingsModule`
+**File:** `libs/core/src/orders/orders.module.ts`
+
+Add `MappingsModule` to imports so `MAPPING_CONFIG_SERVICE_TOKEN` is available.
+
+---
+
+### Phase E — Unit tests (BE)
+
+#### E1. `MappingConfigService` unit tests
+**File:** `libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts`
+
+Tests:
+- `getStatusMappings` returns mappings from repository
+- `upsertStatusMappings` delegates to `replaceForConnection`
+- `resolveStatusMapping` returns matched prestashopStatusId
+- `resolveStatusMapping` returns null when no match
+- Same patterns for carrier and payment
+
+---
+
+### Phase F — Frontend (#134)
+
+#### F1. API types
+**File:** `apps/web/src/features/mappings/api/mappings.types.ts`
+
+```typescript
+export interface StatusMapping { id: string; connectionId: string; allegroStatus: string; prestashopStatusId: string; }
+export interface CarrierMapping { ... }
+export interface PaymentMapping { ... }
+export interface MappingOption { value: string; label: string; }
+export interface UpsertStatusMappingsPayload { items: { allegroStatus: string; prestashopStatusId: string }[]; }
+// similar for carrier, payment
+```
+
+#### F2. API client
+**File:** `apps/web/src/features/mappings/api/mappings.api.ts`
+
+Methods:
+```
+getStatusMappings(connectionId), upsertStatusMappings(connectionId, payload)
+getCarrierMappings(connectionId), upsertCarrierMappings(connectionId, payload)
+getPaymentMappings(connectionId), upsertPaymentMappings(connectionId, payload)
+getAllegroOrderStatuses(connectionId), getAllegroDeliveryMethods(connectionId)
+getPrestashopOrderStatuses(connectionId), getPrestashopCarriers(connectionId), getPrestashopPaymentModules(connectionId)
+```
+
+#### F3. Query keys
+**File:** `apps/web/src/features/mappings/api/mappings.query-keys.ts`
+
+#### F4. Hooks
+**Files in `apps/web/src/features/mappings/hooks/`:**
+- `use-status-mappings.ts` — query + mutation hooks for status mappings
+- `use-carrier-mappings.ts`
+- `use-payment-mappings.ts`
+- `use-mapping-options.ts` — single hook that fetches all 5 option lists in parallel for a connectionId
+
+#### F5. Shared MappingPanel component
+**File:** `apps/web/src/features/mappings/components/MappingPanel.tsx`
+
+Generic panel that renders a mapping table for any mapping type. Props:
+```typescript
+interface MappingPanelProps<S extends string, T extends string> {
+  title: string;
+  description: string;
+  sourceLabel: string;
+  targetLabel: string;
+  sourceOptions: MappingOption[];
+  targetOptions: MappingOption[];
+  value: { sourceValue: S; targetValue: T }[];
+  onChange: (items: { sourceValue: S; targetValue: T }[]) => void;
+  isSaving: boolean;
+  onSave: () => void;
+  isDirty: boolean;
+  optionsLoading: boolean;
+  optionsError: Error | null;
+}
+```
+
+Features:
+- Table listing current rows with delete button per row
+- Add row form: source dropdown + target dropdown + Add button
+- Bulk save button (disabled when no changes or saving)
+- Empty state when no rows
+- Unsaved changes indicator
+
+#### F6. Connection Mappings Page
+**File:** `apps/web/src/pages/connections/connection-mappings-page.tsx`
+
+- Uses `useParams` for `connectionId`
+- Renders 3 tabs (Status / Carriers / Payments) using a simple tab component or CSS tab pattern (follow existing UI patterns)
+- Each tab renders a `MappingPanel` wired to the appropriate hooks
+- Success toast on save via shared toast/notification mechanism (or simple inline confirmation)
+- Error displayed inline on failure
+
+#### F7. Route
+**File:** `apps/web/src/app/routes/connection-mappings.route.tsx`
+
+```typescript
+export const connectionMappingsRoute: RouteObject = {
+  path: 'connections/:connectionId/mappings',
+  element: <ConnectionMappingsPage />,
+};
+```
+
+Register in `root.route.tsx`.
+
+#### F8. Add "Mappings" link to ConnectionDetailPage
+**File:** `apps/web/src/pages/connections/connection-detail-page.tsx`
+
+Add a `Link` to `/connections/:connectionId/mappings` in the actions/navigation area.
+
+#### F9. Register mappings API in ApiClient
+**File:** `apps/web/src/app/api/api-client.ts`
+
+Add `mappings: MappingsApi` field and wire in `createApiClient`.
+
+#### F10. Frontend tests
+**File:** `apps/web/src/pages/connections/connection-mappings-page.test.tsx`
+
+Tests:
+- Renders empty state when no mappings
+- Renders table rows when mappings exist
+- Add row updates the table
+- Delete row removes from table
+- Save button calls mutation
+- Error displays on API failure
+- Dirty state indicator shows when changes pending
+
+---
+
+## 4. File Map Summary
+
+### New files (BE core)
+```
+libs/core/src/mappings/
+  domain/
+    entities/status-mapping.entity.ts
+    entities/carrier-mapping.entity.ts
+    entities/payment-mapping.entity.ts
+    ports/status-mapping-repository.port.ts
+    ports/carrier-mapping-repository.port.ts
+    ports/payment-mapping-repository.port.ts
+    types/mapping.types.ts
+  application/
+    interfaces/mapping-config.service.interface.ts
+    services/mapping-config.service.ts
+    services/__tests__/mapping-config.service.spec.ts
+  infrastructure/
+    persistence/entities/status-mapping.orm-entity.ts
+    persistence/entities/carrier-mapping.orm-entity.ts
+    persistence/entities/payment-mapping.orm-entity.ts
+    persistence/repositories/status-mapping.repository.ts
+    persistence/repositories/carrier-mapping.repository.ts
+    persistence/repositories/payment-mapping.repository.ts
+  index.ts
+  mappings.module.ts
+  mappings.tokens.ts
+```
+
+### New files (BE API)
+```
+apps/api/src/migrations/1778000000000-add-connection-mapping-tables.ts
+apps/api/src/mappings/
+  http/
+    dto/status-mapping-item.dto.ts
+    dto/upsert-status-mappings.dto.ts
+    dto/status-mapping-response.dto.ts
+    dto/carrier-mapping-item.dto.ts
+    dto/upsert-carrier-mappings.dto.ts
+    dto/carrier-mapping-response.dto.ts
+    dto/payment-mapping-item.dto.ts
+    dto/upsert-payment-mappings.dto.ts
+    dto/payment-mapping-response.dto.ts
+    dto/mapping-option-response.dto.ts
+    mappings.controller.ts
+    mapping-options.controller.ts
+  mappings.module.ts
+```
+
+### Modified files (BE)
+```
+libs/core/src/orders/application/services/order-sync.service.ts  (inject + use resolveStatusMapping)
+libs/core/src/orders/orders.module.ts                            (import MappingsModule)
+apps/api/src/app.module.ts                                       (import MappingsApiModule)
+```
+
+### New files (FE)
+```
+apps/web/src/features/mappings/
+  api/mappings.types.ts
+  api/mappings.api.ts
+  api/mappings.query-keys.ts
+  hooks/use-status-mappings.ts
+  hooks/use-carrier-mappings.ts
+  hooks/use-payment-mappings.ts
+  hooks/use-mapping-options.ts
+  components/MappingPanel.tsx
+apps/web/src/pages/connections/connection-mappings-page.tsx
+apps/web/src/pages/connections/connection-mappings-page.test.tsx
+apps/web/src/app/routes/connection-mappings.route.tsx
+```
+
+### Modified files (FE)
+```
+apps/web/src/app/routes/root.route.tsx          (add connectionMappingsRoute)
+apps/web/src/app/api/api-client.ts              (add mappings field)
+apps/web/src/pages/connections/connection-detail-page.tsx  (add Mappings link)
+```
+
+---
+
+## 5. Risks & Open Questions
+
+| Risk | Mitigation |
+|---|---|
+| PrestaShop option endpoints require live PS call | Deferred to follow-up — MVP returns hardcoded lists |
+| `replaceForConnection` in a transaction — TypeORM transaction pattern | Use `queryRunner.manager` in repository |
+| FE tab component — no existing tab primitive | Build inline using CSS tab pattern or render as stacked panels |
+| `resolveStatusMapping` called on every order sync — N+1 if uncached | Acceptable for MVP; cache-aware resolver is a follow-up |
+
+---
+
+## 6. Acceptance Criteria Checklist
+
+- [ ] Status, carrier, and payment mappings CRUD per connection
+- [ ] Mappings consumed by `order-ingestion.service.ts` (via `OrderSyncService`)
+- [ ] Helper endpoints return available options (hardcoded for MVP)
+- [ ] Migration verified via `migration:show`
+- [ ] Unit tests for `MappingConfigService`
+- [ ] FE: all three types configurable; empty state; dirty state; error handling; tests

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -16,4 +16,5 @@ export * from './inventory';
 export * from './sync';
 export * from './listings';
 export * from './users';
+export * from './mappings';
 

--- a/libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts
+++ b/libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts
@@ -1,0 +1,34 @@
+/**
+ * Mapping Config Service Interface
+ *
+ * Contract for connection-scoped mapping configuration operations.
+ * Covers status, carrier, and payment mapping types.
+ *
+ * @module libs/core/src/mappings/application/interfaces
+ */
+
+import { StatusMapping } from '../../domain/entities/status-mapping.entity';
+import { CarrierMapping } from '../../domain/entities/carrier-mapping.entity';
+import { PaymentMapping } from '../../domain/entities/payment-mapping.entity';
+import {
+  StatusMappingInput,
+  CarrierMappingInput,
+  PaymentMappingInput,
+} from '../../domain/types/mapping.types';
+
+export interface IMappingConfigService {
+  getStatusMappings(connectionId: string): Promise<StatusMapping[]>;
+  upsertStatusMappings(connectionId: string, items: StatusMappingInput[]): Promise<StatusMapping[]>;
+
+  getCarrierMappings(connectionId: string): Promise<CarrierMapping[]>;
+  upsertCarrierMappings(connectionId: string, items: CarrierMappingInput[]): Promise<CarrierMapping[]>;
+
+  getPaymentMappings(connectionId: string): Promise<PaymentMapping[]>;
+  upsertPaymentMappings(connectionId: string, items: PaymentMappingInput[]): Promise<PaymentMapping[]>;
+
+  /**
+   * Resolve configured PrestaShop status ID for a given Allegro status.
+   * Returns null if no mapping is configured for this connection + allegroStatus pair.
+   */
+  resolveStatusMapping(connectionId: string, allegroStatus: string): Promise<string | null>;
+}

--- a/libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts
+++ b/libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * MappingConfigService unit tests
+ *
+ * @module libs/core/src/mappings/application/services/__tests__
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { MappingConfigService } from '../mapping-config.service';
+import {
+  STATUS_MAPPING_REPOSITORY_TOKEN,
+  CARRIER_MAPPING_REPOSITORY_TOKEN,
+  PAYMENT_MAPPING_REPOSITORY_TOKEN,
+} from '../../../mappings.tokens';
+import { StatusMappingRepositoryPort } from '../../../domain/ports/status-mapping-repository.port';
+import { CarrierMappingRepositoryPort } from '../../../domain/ports/carrier-mapping-repository.port';
+import { PaymentMappingRepositoryPort } from '../../../domain/ports/payment-mapping-repository.port';
+import { StatusMapping } from '../../../domain/entities/status-mapping.entity';
+import { CarrierMapping } from '../../../domain/entities/carrier-mapping.entity';
+import { PaymentMapping } from '../../../domain/entities/payment-mapping.entity';
+
+describe('MappingConfigService', () => {
+  let service: MappingConfigService;
+  let statusRepo: jest.Mocked<StatusMappingRepositoryPort>;
+  let carrierRepo: jest.Mocked<CarrierMappingRepositoryPort>;
+  let paymentRepo: jest.Mocked<PaymentMappingRepositoryPort>;
+
+  const CONNECTION_ID = 'conn-uuid-1';
+
+  beforeEach(async () => {
+    statusRepo = {
+      findByConnectionId: jest.fn(),
+      replaceForConnection: jest.fn(),
+    };
+    carrierRepo = {
+      findByConnectionId: jest.fn(),
+      replaceForConnection: jest.fn(),
+    };
+    paymentRepo = {
+      findByConnectionId: jest.fn(),
+      replaceForConnection: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MappingConfigService,
+        { provide: STATUS_MAPPING_REPOSITORY_TOKEN, useValue: statusRepo },
+        { provide: CARRIER_MAPPING_REPOSITORY_TOKEN, useValue: carrierRepo },
+        { provide: PAYMENT_MAPPING_REPOSITORY_TOKEN, useValue: paymentRepo },
+      ],
+    }).compile();
+
+    service = module.get(MappingConfigService);
+  });
+
+  // ── Status mappings ────────────────────────────────────────────────────
+
+  describe('getStatusMappings', () => {
+    it('should return mappings from repository', async () => {
+      const mappings = [
+        new StatusMapping('id-1', CONNECTION_ID, 'READY_FOR_PROCESSING', '2'),
+      ];
+      statusRepo.findByConnectionId.mockResolvedValue(mappings);
+
+      const result = await service.getStatusMappings(CONNECTION_ID);
+
+      expect(statusRepo.findByConnectionId).toHaveBeenCalledWith(CONNECTION_ID);
+      expect(result).toEqual(mappings);
+    });
+  });
+
+  describe('upsertStatusMappings', () => {
+    it('should delegate to replaceForConnection and return saved mappings', async () => {
+      const input = [{ allegroStatus: 'BOUGHT', prestashopStatusId: '1' }];
+      const saved = [new StatusMapping('id-2', CONNECTION_ID, 'BOUGHT', '1')];
+      statusRepo.replaceForConnection.mockResolvedValue(saved);
+
+      const result = await service.upsertStatusMappings(CONNECTION_ID, input);
+
+      expect(statusRepo.replaceForConnection).toHaveBeenCalledWith(CONNECTION_ID, input);
+      expect(result).toEqual(saved);
+    });
+  });
+
+  // ── resolveStatusMapping ───────────────────────────────────────────────
+
+  describe('resolveStatusMapping', () => {
+    it('should return prestashopStatusId when allegroStatus matches', async () => {
+      statusRepo.findByConnectionId.mockResolvedValue([
+        new StatusMapping('id-1', CONNECTION_ID, 'READY_FOR_PROCESSING', '2'),
+        new StatusMapping('id-2', CONNECTION_ID, 'CANCELLED', '6'),
+      ]);
+
+      const result = await service.resolveStatusMapping(CONNECTION_ID, 'READY_FOR_PROCESSING');
+
+      expect(result).toBe('2');
+    });
+
+    it('should return null when no mapping matches the given allegroStatus', async () => {
+      statusRepo.findByConnectionId.mockResolvedValue([
+        new StatusMapping('id-1', CONNECTION_ID, 'READY_FOR_PROCESSING', '2'),
+      ]);
+
+      const result = await service.resolveStatusMapping(CONNECTION_ID, 'UNKNOWN_STATUS');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when connection has no mappings configured', async () => {
+      statusRepo.findByConnectionId.mockResolvedValue([]);
+
+      const result = await service.resolveStatusMapping(CONNECTION_ID, 'READY_FOR_PROCESSING');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── Carrier mappings ───────────────────────────────────────────────────
+
+  describe('getCarrierMappings', () => {
+    it('should return carrier mappings from repository', async () => {
+      const mappings = [
+        new CarrierMapping('id-1', CONNECTION_ID, 'INPOST_PACZKOMAT', '2'),
+      ];
+      carrierRepo.findByConnectionId.mockResolvedValue(mappings);
+
+      const result = await service.getCarrierMappings(CONNECTION_ID);
+
+      expect(result).toEqual(mappings);
+    });
+  });
+
+  describe('upsertCarrierMappings', () => {
+    it('should delegate to replaceForConnection', async () => {
+      const input = [{ allegroDeliveryMethodId: 'DPD', prestashopCarrierId: '3' }];
+      const saved = [new CarrierMapping('id-3', CONNECTION_ID, 'DPD', '3')];
+      carrierRepo.replaceForConnection.mockResolvedValue(saved);
+
+      const result = await service.upsertCarrierMappings(CONNECTION_ID, input);
+
+      expect(carrierRepo.replaceForConnection).toHaveBeenCalledWith(CONNECTION_ID, input);
+      expect(result).toEqual(saved);
+    });
+  });
+
+  // ── Payment mappings ───────────────────────────────────────────────────
+
+  describe('getPaymentMappings', () => {
+    it('should return payment mappings from repository', async () => {
+      const mappings = [
+        new PaymentMapping('id-1', CONNECTION_ID, 'P24', 'przelewy24'),
+      ];
+      paymentRepo.findByConnectionId.mockResolvedValue(mappings);
+
+      const result = await service.getPaymentMappings(CONNECTION_ID);
+
+      expect(result).toEqual(mappings);
+    });
+  });
+
+  describe('upsertPaymentMappings', () => {
+    it('should delegate to replaceForConnection', async () => {
+      const input = [{ allegroPaymentProvider: 'BLIK', prestashopPaymentModule: 'payu' }];
+      const saved = [new PaymentMapping('id-4', CONNECTION_ID, 'BLIK', 'payu')];
+      paymentRepo.replaceForConnection.mockResolvedValue(saved);
+
+      const result = await service.upsertPaymentMappings(CONNECTION_ID, input);
+
+      expect(paymentRepo.replaceForConnection).toHaveBeenCalledWith(CONNECTION_ID, input);
+      expect(result).toEqual(saved);
+    });
+  });
+});

--- a/libs/core/src/mappings/application/services/mapping-config.service.ts
+++ b/libs/core/src/mappings/application/services/mapping-config.service.ts
@@ -64,6 +64,8 @@ export class MappingConfigService implements IMappingConfigService {
   }
 
   async resolveStatusMapping(connectionId: string, allegroStatus: string): Promise<string | null> {
+    // TODO: cache per sync session to avoid N+1 queries when resolving status for every order.
+    // Acceptable for MVP; a session-scoped Map<connectionId, StatusMapping[]> would eliminate the per-order DB fetch.
     const mappings = await this.statusRepo.findByConnectionId(connectionId);
     const match = mappings.find((m) => m.allegroStatus === allegroStatus);
     return match?.prestashopStatusId ?? null;

--- a/libs/core/src/mappings/application/services/mapping-config.service.ts
+++ b/libs/core/src/mappings/application/services/mapping-config.service.ts
@@ -1,0 +1,71 @@
+/**
+ * Mapping Config Service
+ *
+ * Application service for connection-scoped mapping configuration.
+ * Delegates persistence to repository ports and provides a resolution
+ * helper for use during order ingestion.
+ *
+ * @module libs/core/src/mappings/application/services
+ * @implements {IMappingConfigService}
+ */
+
+import { Injectable, Inject } from '@nestjs/common';
+import { IMappingConfigService } from '../interfaces/mapping-config.service.interface';
+import { StatusMapping } from '../../domain/entities/status-mapping.entity';
+import { CarrierMapping } from '../../domain/entities/carrier-mapping.entity';
+import { PaymentMapping } from '../../domain/entities/payment-mapping.entity';
+import {
+  StatusMappingInput,
+  CarrierMappingInput,
+  PaymentMappingInput,
+} from '../../domain/types/mapping.types';
+import { StatusMappingRepositoryPort } from '../../domain/ports/status-mapping-repository.port';
+import { CarrierMappingRepositoryPort } from '../../domain/ports/carrier-mapping-repository.port';
+import { PaymentMappingRepositoryPort } from '../../domain/ports/payment-mapping-repository.port';
+import {
+  STATUS_MAPPING_REPOSITORY_TOKEN,
+  CARRIER_MAPPING_REPOSITORY_TOKEN,
+  PAYMENT_MAPPING_REPOSITORY_TOKEN,
+} from '../../mappings.tokens';
+
+@Injectable()
+export class MappingConfigService implements IMappingConfigService {
+  constructor(
+    @Inject(STATUS_MAPPING_REPOSITORY_TOKEN)
+    private readonly statusRepo: StatusMappingRepositoryPort,
+    @Inject(CARRIER_MAPPING_REPOSITORY_TOKEN)
+    private readonly carrierRepo: CarrierMappingRepositoryPort,
+    @Inject(PAYMENT_MAPPING_REPOSITORY_TOKEN)
+    private readonly paymentRepo: PaymentMappingRepositoryPort,
+  ) {}
+
+  getStatusMappings(connectionId: string): Promise<StatusMapping[]> {
+    return this.statusRepo.findByConnectionId(connectionId);
+  }
+
+  upsertStatusMappings(connectionId: string, items: StatusMappingInput[]): Promise<StatusMapping[]> {
+    return this.statusRepo.replaceForConnection(connectionId, items);
+  }
+
+  getCarrierMappings(connectionId: string): Promise<CarrierMapping[]> {
+    return this.carrierRepo.findByConnectionId(connectionId);
+  }
+
+  upsertCarrierMappings(connectionId: string, items: CarrierMappingInput[]): Promise<CarrierMapping[]> {
+    return this.carrierRepo.replaceForConnection(connectionId, items);
+  }
+
+  getPaymentMappings(connectionId: string): Promise<PaymentMapping[]> {
+    return this.paymentRepo.findByConnectionId(connectionId);
+  }
+
+  upsertPaymentMappings(connectionId: string, items: PaymentMappingInput[]): Promise<PaymentMapping[]> {
+    return this.paymentRepo.replaceForConnection(connectionId, items);
+  }
+
+  async resolveStatusMapping(connectionId: string, allegroStatus: string): Promise<string | null> {
+    const mappings = await this.statusRepo.findByConnectionId(connectionId);
+    const match = mappings.find((m) => m.allegroStatus === allegroStatus);
+    return match?.prestashopStatusId ?? null;
+  }
+}

--- a/libs/core/src/mappings/domain/entities/carrier-mapping.entity.ts
+++ b/libs/core/src/mappings/domain/entities/carrier-mapping.entity.ts
@@ -1,0 +1,17 @@
+/**
+ * Carrier Mapping Domain Entity
+ *
+ * Represents a connection-scoped mapping from an Allegro delivery method ID
+ * to a PrestaShop carrier ID. Pure domain entity with no framework deps.
+ *
+ * @module libs/core/src/mappings/domain/entities
+ */
+
+export class CarrierMapping {
+  constructor(
+    public readonly id: string,
+    public readonly connectionId: string,
+    public readonly allegroDeliveryMethodId: string,
+    public readonly prestashopCarrierId: string,
+  ) {}
+}

--- a/libs/core/src/mappings/domain/entities/payment-mapping.entity.ts
+++ b/libs/core/src/mappings/domain/entities/payment-mapping.entity.ts
@@ -1,0 +1,17 @@
+/**
+ * Payment Mapping Domain Entity
+ *
+ * Represents a connection-scoped mapping from an Allegro payment provider name
+ * to a PrestaShop payment module name. Pure domain entity with no framework deps.
+ *
+ * @module libs/core/src/mappings/domain/entities
+ */
+
+export class PaymentMapping {
+  constructor(
+    public readonly id: string,
+    public readonly connectionId: string,
+    public readonly allegroPaymentProvider: string,
+    public readonly prestashopPaymentModule: string,
+  ) {}
+}

--- a/libs/core/src/mappings/domain/entities/status-mapping.entity.ts
+++ b/libs/core/src/mappings/domain/entities/status-mapping.entity.ts
@@ -1,0 +1,17 @@
+/**
+ * Status Mapping Domain Entity
+ *
+ * Represents a connection-scoped mapping from an Allegro order status
+ * to a PrestaShop order status ID. Pure domain entity with no framework deps.
+ *
+ * @module libs/core/src/mappings/domain/entities
+ */
+
+export class StatusMapping {
+  constructor(
+    public readonly id: string,
+    public readonly connectionId: string,
+    public readonly allegroStatus: string,
+    public readonly prestashopStatusId: string,
+  ) {}
+}

--- a/libs/core/src/mappings/domain/ports/carrier-mapping-repository.port.ts
+++ b/libs/core/src/mappings/domain/ports/carrier-mapping-repository.port.ts
@@ -1,0 +1,19 @@
+/**
+ * Carrier Mapping Repository Port
+ *
+ * Persistence contract for carrier mapping operations.
+ * Implemented by the infrastructure layer.
+ *
+ * @module libs/core/src/mappings/domain/ports
+ */
+
+import { CarrierMapping } from '../entities/carrier-mapping.entity';
+import { CarrierMappingInput } from '../types/mapping.types';
+
+export interface CarrierMappingRepositoryPort {
+  findByConnectionId(connectionId: string): Promise<CarrierMapping[]>;
+  /**
+   * Replace all mappings for a connection atomically (delete + insert in transaction).
+   */
+  replaceForConnection(connectionId: string, items: CarrierMappingInput[]): Promise<CarrierMapping[]>;
+}

--- a/libs/core/src/mappings/domain/ports/payment-mapping-repository.port.ts
+++ b/libs/core/src/mappings/domain/ports/payment-mapping-repository.port.ts
@@ -1,0 +1,19 @@
+/**
+ * Payment Mapping Repository Port
+ *
+ * Persistence contract for payment mapping operations.
+ * Implemented by the infrastructure layer.
+ *
+ * @module libs/core/src/mappings/domain/ports
+ */
+
+import { PaymentMapping } from '../entities/payment-mapping.entity';
+import { PaymentMappingInput } from '../types/mapping.types';
+
+export interface PaymentMappingRepositoryPort {
+  findByConnectionId(connectionId: string): Promise<PaymentMapping[]>;
+  /**
+   * Replace all mappings for a connection atomically (delete + insert in transaction).
+   */
+  replaceForConnection(connectionId: string, items: PaymentMappingInput[]): Promise<PaymentMapping[]>;
+}

--- a/libs/core/src/mappings/domain/ports/status-mapping-repository.port.ts
+++ b/libs/core/src/mappings/domain/ports/status-mapping-repository.port.ts
@@ -1,0 +1,19 @@
+/**
+ * Status Mapping Repository Port
+ *
+ * Persistence contract for status mapping operations.
+ * Implemented by the infrastructure layer.
+ *
+ * @module libs/core/src/mappings/domain/ports
+ */
+
+import { StatusMapping } from '../entities/status-mapping.entity';
+import { StatusMappingInput } from '../types/mapping.types';
+
+export interface StatusMappingRepositoryPort {
+  findByConnectionId(connectionId: string): Promise<StatusMapping[]>;
+  /**
+   * Replace all mappings for a connection atomically (delete + insert in transaction).
+   */
+  replaceForConnection(connectionId: string, items: StatusMappingInput[]): Promise<StatusMapping[]>;
+}

--- a/libs/core/src/mappings/domain/types/mapping.types.ts
+++ b/libs/core/src/mappings/domain/types/mapping.types.ts
@@ -1,0 +1,22 @@
+/**
+ * Mapping Domain Types
+ *
+ * Input types for upsert operations on connection-scoped mapping tables.
+ *
+ * @module libs/core/src/mappings/domain/types
+ */
+
+export interface StatusMappingInput {
+  allegroStatus: string;
+  prestashopStatusId: string;
+}
+
+export interface CarrierMappingInput {
+  allegroDeliveryMethodId: string;
+  prestashopCarrierId: string;
+}
+
+export interface PaymentMappingInput {
+  allegroPaymentProvider: string;
+  prestashopPaymentModule: string;
+}

--- a/libs/core/src/mappings/index.ts
+++ b/libs/core/src/mappings/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Mappings Bounded Context — Public API
+ *
+ * Exports everything needed by the API layer and other consumers
+ * of the mappings module.
+ *
+ * @module libs/core/src/mappings
+ */
+
+export { MappingsModule } from './mappings.module';
+export {
+  MAPPING_CONFIG_SERVICE_TOKEN,
+  STATUS_MAPPING_REPOSITORY_TOKEN,
+  CARRIER_MAPPING_REPOSITORY_TOKEN,
+  PAYMENT_MAPPING_REPOSITORY_TOKEN,
+} from './mappings.tokens';
+export type { IMappingConfigService } from './application/interfaces/mapping-config.service.interface';
+export { MappingConfigService } from './application/services/mapping-config.service';
+export { StatusMapping } from './domain/entities/status-mapping.entity';
+export { CarrierMapping } from './domain/entities/carrier-mapping.entity';
+export { PaymentMapping } from './domain/entities/payment-mapping.entity';
+export type {
+  StatusMappingInput,
+  CarrierMappingInput,
+  PaymentMappingInput,
+} from './domain/types/mapping.types';

--- a/libs/core/src/mappings/infrastructure/persistence/entities/carrier-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/carrier-mapping.orm-entity.ts
@@ -1,0 +1,39 @@
+/**
+ * Carrier Mapping ORM Entity
+ *
+ * TypeORM entity for the connection_carrier_mappings table.
+ * Maps Allegro delivery method IDs to PrestaShop carrier IDs per connection.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/entities
+ */
+
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('connection_carrier_mappings')
+@Index(['connectionId', 'allegroDeliveryMethodId'], { unique: true })
+export class CarrierMappingOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', name: 'connection_id' })
+  connectionId!: string;
+
+  @Column({ type: 'varchar', name: 'allegro_delivery_method_id' })
+  allegroDeliveryMethodId!: string;
+
+  @Column({ type: 'varchar', name: 'prestashop_carrier_id' })
+  prestashopCarrierId!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/mappings/infrastructure/persistence/entities/carrier-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/carrier-mapping.orm-entity.ts
@@ -25,10 +25,10 @@ export class CarrierMappingOrmEntity {
   @Column({ type: 'uuid', name: 'connection_id' })
   connectionId!: string;
 
-  @Column({ type: 'varchar', name: 'allegro_delivery_method_id' })
+  @Column({ type: 'varchar', length: 100, name: 'allegro_delivery_method_id' })
   allegroDeliveryMethodId!: string;
 
-  @Column({ type: 'varchar', name: 'prestashop_carrier_id' })
+  @Column({ type: 'varchar', length: 20, name: 'prestashop_carrier_id' })
   prestashopCarrierId!: string;
 
   @CreateDateColumn({ name: 'created_at' })

--- a/libs/core/src/mappings/infrastructure/persistence/entities/payment-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/payment-mapping.orm-entity.ts
@@ -25,10 +25,10 @@ export class PaymentMappingOrmEntity {
   @Column({ type: 'uuid', name: 'connection_id' })
   connectionId!: string;
 
-  @Column({ type: 'varchar', name: 'allegro_payment_provider' })
+  @Column({ type: 'varchar', length: 100, name: 'allegro_payment_provider' })
   allegroPaymentProvider!: string;
 
-  @Column({ type: 'varchar', name: 'prestashop_payment_module' })
+  @Column({ type: 'varchar', length: 100, name: 'prestashop_payment_module' })
   prestashopPaymentModule!: string;
 
   @CreateDateColumn({ name: 'created_at' })

--- a/libs/core/src/mappings/infrastructure/persistence/entities/payment-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/payment-mapping.orm-entity.ts
@@ -1,0 +1,39 @@
+/**
+ * Payment Mapping ORM Entity
+ *
+ * TypeORM entity for the connection_payment_mappings table.
+ * Maps Allegro payment provider names to PrestaShop payment module names per connection.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/entities
+ */
+
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('connection_payment_mappings')
+@Index(['connectionId', 'allegroPaymentProvider'], { unique: true })
+export class PaymentMappingOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', name: 'connection_id' })
+  connectionId!: string;
+
+  @Column({ type: 'varchar', name: 'allegro_payment_provider' })
+  allegroPaymentProvider!: string;
+
+  @Column({ type: 'varchar', name: 'prestashop_payment_module' })
+  prestashopPaymentModule!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/mappings/infrastructure/persistence/entities/status-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/status-mapping.orm-entity.ts
@@ -1,0 +1,39 @@
+/**
+ * Status Mapping ORM Entity
+ *
+ * TypeORM entity for the connection_status_mappings table.
+ * Maps Allegro order statuses to PrestaShop order status IDs per connection.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/entities
+ */
+
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('connection_status_mappings')
+@Index(['connectionId', 'allegroStatus'], { unique: true })
+export class StatusMappingOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', name: 'connection_id' })
+  connectionId!: string;
+
+  @Column({ type: 'varchar', name: 'allegro_status' })
+  allegroStatus!: string;
+
+  @Column({ type: 'varchar', name: 'prestashop_status_id' })
+  prestashopStatusId!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/mappings/infrastructure/persistence/entities/status-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/status-mapping.orm-entity.ts
@@ -25,10 +25,10 @@ export class StatusMappingOrmEntity {
   @Column({ type: 'uuid', name: 'connection_id' })
   connectionId!: string;
 
-  @Column({ type: 'varchar', name: 'allegro_status' })
+  @Column({ type: 'varchar', length: 100, name: 'allegro_status' })
   allegroStatus!: string;
 
-  @Column({ type: 'varchar', name: 'prestashop_status_id' })
+  @Column({ type: 'varchar', length: 20, name: 'prestashop_status_id' })
   prestashopStatusId!: string;
 
   @CreateDateColumn({ name: 'created_at' })

--- a/libs/core/src/mappings/infrastructure/persistence/repositories/carrier-mapping.repository.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/repositories/carrier-mapping.repository.ts
@@ -1,0 +1,63 @@
+/**
+ * Carrier Mapping Repository
+ *
+ * Implements CarrierMappingRepositoryPort using TypeORM.
+ * The replaceForConnection method uses a transaction to atomically
+ * delete and re-insert all mappings for a connection.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/repositories
+ * @implements {CarrierMappingRepositoryPort}
+ */
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { CarrierMappingOrmEntity } from '../entities/carrier-mapping.orm-entity';
+import { CarrierMappingRepositoryPort } from '../../../domain/ports/carrier-mapping-repository.port';
+import { CarrierMapping } from '../../../domain/entities/carrier-mapping.entity';
+import { CarrierMappingInput } from '../../../domain/types/mapping.types';
+
+@Injectable()
+export class CarrierMappingRepository implements CarrierMappingRepositoryPort {
+  constructor(
+    @InjectRepository(CarrierMappingOrmEntity)
+    private readonly repo: Repository<CarrierMappingOrmEntity>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async findByConnectionId(connectionId: string): Promise<CarrierMapping[]> {
+    const entities = await this.repo.find({ where: { connectionId } });
+    return entities.map((e) => this.toDomain(e));
+  }
+
+  async replaceForConnection(connectionId: string, items: CarrierMappingInput[]): Promise<CarrierMapping[]> {
+    return this.dataSource.transaction(async (manager) => {
+      await manager.delete(CarrierMappingOrmEntity, { connectionId });
+
+      if (items.length === 0) {
+        return [];
+      }
+
+      const entities = items.map((item) => {
+        const entity = new CarrierMappingOrmEntity();
+        entity.connectionId = connectionId;
+        entity.allegroDeliveryMethodId = item.allegroDeliveryMethodId;
+        entity.prestashopCarrierId = item.prestashopCarrierId;
+        return entity;
+      });
+
+      const saved = await manager.save(CarrierMappingOrmEntity, entities);
+      return saved.map((e) => this.toDomain(e));
+    });
+  }
+
+  private toDomain(entity: CarrierMappingOrmEntity): CarrierMapping {
+    return new CarrierMapping(
+      entity.id,
+      entity.connectionId,
+      entity.allegroDeliveryMethodId,
+      entity.prestashopCarrierId,
+    );
+  }
+}

--- a/libs/core/src/mappings/infrastructure/persistence/repositories/payment-mapping.repository.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/repositories/payment-mapping.repository.ts
@@ -1,0 +1,63 @@
+/**
+ * Payment Mapping Repository
+ *
+ * Implements PaymentMappingRepositoryPort using TypeORM.
+ * The replaceForConnection method uses a transaction to atomically
+ * delete and re-insert all mappings for a connection.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/repositories
+ * @implements {PaymentMappingRepositoryPort}
+ */
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { PaymentMappingOrmEntity } from '../entities/payment-mapping.orm-entity';
+import { PaymentMappingRepositoryPort } from '../../../domain/ports/payment-mapping-repository.port';
+import { PaymentMapping } from '../../../domain/entities/payment-mapping.entity';
+import { PaymentMappingInput } from '../../../domain/types/mapping.types';
+
+@Injectable()
+export class PaymentMappingRepository implements PaymentMappingRepositoryPort {
+  constructor(
+    @InjectRepository(PaymentMappingOrmEntity)
+    private readonly repo: Repository<PaymentMappingOrmEntity>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async findByConnectionId(connectionId: string): Promise<PaymentMapping[]> {
+    const entities = await this.repo.find({ where: { connectionId } });
+    return entities.map((e) => this.toDomain(e));
+  }
+
+  async replaceForConnection(connectionId: string, items: PaymentMappingInput[]): Promise<PaymentMapping[]> {
+    return this.dataSource.transaction(async (manager) => {
+      await manager.delete(PaymentMappingOrmEntity, { connectionId });
+
+      if (items.length === 0) {
+        return [];
+      }
+
+      const entities = items.map((item) => {
+        const entity = new PaymentMappingOrmEntity();
+        entity.connectionId = connectionId;
+        entity.allegroPaymentProvider = item.allegroPaymentProvider;
+        entity.prestashopPaymentModule = item.prestashopPaymentModule;
+        return entity;
+      });
+
+      const saved = await manager.save(PaymentMappingOrmEntity, entities);
+      return saved.map((e) => this.toDomain(e));
+    });
+  }
+
+  private toDomain(entity: PaymentMappingOrmEntity): PaymentMapping {
+    return new PaymentMapping(
+      entity.id,
+      entity.connectionId,
+      entity.allegroPaymentProvider,
+      entity.prestashopPaymentModule,
+    );
+  }
+}

--- a/libs/core/src/mappings/infrastructure/persistence/repositories/status-mapping.repository.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/repositories/status-mapping.repository.ts
@@ -1,0 +1,63 @@
+/**
+ * Status Mapping Repository
+ *
+ * Implements StatusMappingRepositoryPort using TypeORM.
+ * The replaceForConnection method uses a transaction to atomically
+ * delete and re-insert all mappings for a connection.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/repositories
+ * @implements {StatusMappingRepositoryPort}
+ */
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { StatusMappingOrmEntity } from '../entities/status-mapping.orm-entity';
+import { StatusMappingRepositoryPort } from '../../../domain/ports/status-mapping-repository.port';
+import { StatusMapping } from '../../../domain/entities/status-mapping.entity';
+import { StatusMappingInput } from '../../../domain/types/mapping.types';
+
+@Injectable()
+export class StatusMappingRepository implements StatusMappingRepositoryPort {
+  constructor(
+    @InjectRepository(StatusMappingOrmEntity)
+    private readonly repo: Repository<StatusMappingOrmEntity>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async findByConnectionId(connectionId: string): Promise<StatusMapping[]> {
+    const entities = await this.repo.find({ where: { connectionId } });
+    return entities.map((e) => this.toDomain(e));
+  }
+
+  async replaceForConnection(connectionId: string, items: StatusMappingInput[]): Promise<StatusMapping[]> {
+    return this.dataSource.transaction(async (manager) => {
+      await manager.delete(StatusMappingOrmEntity, { connectionId });
+
+      if (items.length === 0) {
+        return [];
+      }
+
+      const entities = items.map((item) => {
+        const entity = new StatusMappingOrmEntity();
+        entity.connectionId = connectionId;
+        entity.allegroStatus = item.allegroStatus;
+        entity.prestashopStatusId = item.prestashopStatusId;
+        return entity;
+      });
+
+      const saved = await manager.save(StatusMappingOrmEntity, entities);
+      return saved.map((e) => this.toDomain(e));
+    });
+  }
+
+  private toDomain(entity: StatusMappingOrmEntity): StatusMapping {
+    return new StatusMapping(
+      entity.id,
+      entity.connectionId,
+      entity.allegroStatus,
+      entity.prestashopStatusId,
+    );
+  }
+}

--- a/libs/core/src/mappings/mappings.module.ts
+++ b/libs/core/src/mappings/mappings.module.ts
@@ -1,0 +1,62 @@
+/**
+ * Mappings Module
+ *
+ * NestJS module for the connection-scoped mapping configuration bounded context.
+ * Registers ORM entities, repositories, and the MappingConfigService.
+ * Exports MAPPING_CONFIG_SERVICE_TOKEN for use in other modules (e.g., OrdersModule).
+ *
+ * @module libs/core/src/mappings
+ */
+
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StatusMappingOrmEntity } from './infrastructure/persistence/entities/status-mapping.orm-entity';
+import { CarrierMappingOrmEntity } from './infrastructure/persistence/entities/carrier-mapping.orm-entity';
+import { PaymentMappingOrmEntity } from './infrastructure/persistence/entities/payment-mapping.orm-entity';
+import { StatusMappingRepository } from './infrastructure/persistence/repositories/status-mapping.repository';
+import { CarrierMappingRepository } from './infrastructure/persistence/repositories/carrier-mapping.repository';
+import { PaymentMappingRepository } from './infrastructure/persistence/repositories/payment-mapping.repository';
+import { MappingConfigService } from './application/services/mapping-config.service';
+import {
+  MAPPING_CONFIG_SERVICE_TOKEN,
+  STATUS_MAPPING_REPOSITORY_TOKEN,
+  CARRIER_MAPPING_REPOSITORY_TOKEN,
+  PAYMENT_MAPPING_REPOSITORY_TOKEN,
+} from './mappings.tokens';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      StatusMappingOrmEntity,
+      CarrierMappingOrmEntity,
+      PaymentMappingOrmEntity,
+    ]),
+  ],
+  providers: [
+    StatusMappingRepository,
+    CarrierMappingRepository,
+    PaymentMappingRepository,
+    MappingConfigService,
+    {
+      provide: STATUS_MAPPING_REPOSITORY_TOKEN,
+      useExisting: StatusMappingRepository,
+    },
+    {
+      provide: CARRIER_MAPPING_REPOSITORY_TOKEN,
+      useExisting: CarrierMappingRepository,
+    },
+    {
+      provide: PAYMENT_MAPPING_REPOSITORY_TOKEN,
+      useExisting: PaymentMappingRepository,
+    },
+    {
+      provide: MAPPING_CONFIG_SERVICE_TOKEN,
+      useExisting: MappingConfigService,
+    },
+  ],
+  exports: [
+    MAPPING_CONFIG_SERVICE_TOKEN,
+    MappingConfigService,
+  ],
+})
+export class MappingsModule {}

--- a/libs/core/src/mappings/mappings.tokens.ts
+++ b/libs/core/src/mappings/mappings.tokens.ts
@@ -1,0 +1,12 @@
+/**
+ * Mappings Module DI Tokens
+ *
+ * Symbol tokens for dependency injection in the mappings module.
+ *
+ * @module libs/core/src/mappings
+ */
+
+export const MAPPING_CONFIG_SERVICE_TOKEN = Symbol('IMappingConfigService');
+export const STATUS_MAPPING_REPOSITORY_TOKEN = Symbol('StatusMappingRepositoryPort');
+export const CARRIER_MAPPING_REPOSITORY_TOKEN = Symbol('CarrierMappingRepositoryPort');
+export const PAYMENT_MAPPING_REPOSITORY_TOKEN = Symbol('PaymentMappingRepositoryPort');

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -12,11 +12,13 @@ import { OrderProcessorManagerPort } from '../../../domain/ports/order-processor
 import { OrderSyncRequest } from '../../interfaces/order-sync.service.interface';
 import { Order } from '../../../domain/ports/order-source.port';
 import { OrderRef } from '../../../domain/types/order-processor.types';
+import { IMappingConfigService } from '@openlinker/core/mappings';
 
 describe('OrderSyncService', () => {
   let service: OrderSyncService;
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let processorAdapter: jest.Mocked<OrderProcessorManagerPort>;
+  let mappingConfigService: jest.Mocked<IMappingConfigService>;
 
   const destinationConnectionId = 'destination-connection-123';
   const originalEnv = process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID;
@@ -32,10 +34,20 @@ describe('OrderSyncService', () => {
       listCapabilityAdapters: jest.fn(),
     } as unknown as jest.Mocked<IIntegrationsService>;
 
+    mappingConfigService = {
+      getStatusMappings: jest.fn().mockResolvedValue([]),
+      upsertStatusMappings: jest.fn().mockResolvedValue([]),
+      getCarrierMappings: jest.fn().mockResolvedValue([]),
+      upsertCarrierMappings: jest.fn().mockResolvedValue([]),
+      getPaymentMappings: jest.fn().mockResolvedValue([]),
+      upsertPaymentMappings: jest.fn().mockResolvedValue([]),
+      resolveStatusMapping: jest.fn().mockResolvedValue(null),
+    } as jest.Mocked<IMappingConfigService>;
+
     // Set environment variable
     process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID = destinationConnectionId;
 
-    service = new OrderSyncService(integrationsService);
+    service = new OrderSyncService(integrationsService, mappingConfigService);
   });
 
   afterEach(() => {
@@ -195,7 +207,7 @@ describe('OrderSyncService', () => {
 
     it('should throw error if destination connection ID not configured', async () => {
       delete process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID;
-      const serviceWithoutConfig = new OrderSyncService(integrationsService);
+      const serviceWithoutConfig = new OrderSyncService(integrationsService, mappingConfigService);
 
       const order = createOrder();
       const request: OrderSyncRequest = {

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -245,6 +245,64 @@ describe('OrderSyncService', () => {
 
       await expect(service.syncOrder(request)).rejects.toThrow('Order creation failed');
     });
+
+    // ── MappingConfigService integration ──────────────────────────────────
+
+    it('should use resolved status from mapping config when a mapping exists', async () => {
+      const order = createOrder();
+      order.status = 'READY_FOR_PROCESSING';
+      const request: OrderSyncRequest = {
+        order,
+        sourceConnectionId: 'source-connection-123',
+      };
+
+      // Mapping resolves Allegro status to PS status ID '3' (Processing in progress)
+      mappingConfigService.resolveStatusMapping.mockResolvedValue('processing');
+      processorAdapter.createOrder.mockResolvedValue({ orderId: 'dest_order_789' });
+
+      await service.syncOrder(request);
+
+      expect(mappingConfigService.resolveStatusMapping).toHaveBeenCalledWith(
+        'source-connection-123',
+        'READY_FOR_PROCESSING',
+      );
+      expect(processorAdapter.createOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'processing' }),
+      );
+    });
+
+    it('should fall back to order status when no mapping is configured', async () => {
+      const order = createOrder();
+      order.status = 'shipped';
+      const request: OrderSyncRequest = {
+        order,
+        sourceConnectionId: 'source-connection-123',
+      };
+
+      mappingConfigService.resolveStatusMapping.mockResolvedValue(null);
+      processorAdapter.createOrder.mockResolvedValue({ orderId: 'dest_order_789' });
+
+      await service.syncOrder(request);
+
+      expect(processorAdapter.createOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'shipped' }),
+      );
+    });
+
+    it('should propagate error if mapping config service throws', async () => {
+      const order = createOrder();
+      const request: OrderSyncRequest = {
+        order,
+        sourceConnectionId: 'source-connection-123',
+      };
+
+      mappingConfigService.resolveStatusMapping.mockRejectedValue(
+        new Error('Mapping service unavailable'),
+      );
+
+      await expect(service.syncOrder(request)).rejects.toThrow('Mapping service unavailable');
+      expect(processorAdapter.createOrder).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -17,6 +17,7 @@ import { OrderCreate } from '../../domain/types/order-processor.types';
 import { OrderStatusValues } from '../../domain/types/order.types';
 import { IIntegrationsService } from '@openlinker/core/integrations/application/interfaces/integrations.service.interface';
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations/integrations.tokens';
+import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
 import { Logger } from '@openlinker/shared/logging';
 
 /**
@@ -33,6 +34,8 @@ export class OrderSyncService implements IOrderSyncService {
   constructor(
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrationsService: IIntegrationsService,
+    @Inject(MAPPING_CONFIG_SERVICE_TOKEN)
+    private readonly mappingConfigService: IMappingConfigService,
   ) {
     // MVP: Read destination connection ID from environment variable
     // TODO: Phase 8+ - Support multiple destinations, connection-based routing, etc.
@@ -74,8 +77,14 @@ export class OrderSyncService implements IOrderSyncService {
     );
 
     // Map unified Order to OrderCreate request
-    // Validate and map order status to OrderStatus type
-    const orderStatus = this.validateOrderStatus(order.status);
+    // Resolve status via configured mapping first; fall back to validated default.
+    const resolvedStatus = await this.mappingConfigService.resolveStatusMapping(
+      sourceConnectionId,
+      order.status,
+    );
+    const orderStatus = resolvedStatus
+      ? this.validateOrderStatus(resolvedStatus)
+      : this.validateOrderStatus(order.status);
     const orderCreate: OrderCreate = {
       orderNumber: order.orderNumber,
       status: orderStatus,

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -24,6 +24,7 @@ import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { SyncModule } from '@openlinker/core/sync';
 import { ProductsModule } from '@openlinker/core/products';
+import { MappingsModule } from '@openlinker/core/mappings';
 
 // Re-export tokens for convenience
 export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
@@ -35,6 +36,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     IdentifierMappingModule, // Required for IDENTIFIER_MAPPING_SERVICE_TOKEN
     SyncModule, // Required for cursor repository, job queue, and locks
     ProductsModule, // Required for PRODUCT_VARIANT_REPOSITORY_TOKEN
+    MappingsModule, // Required for MAPPING_CONFIG_SERVICE_TOKEN
   ],
   providers: [
     // Provide classes directly first

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
     "paths": {
       "@openlinker/api/*": ["apps/api/src/*"],
       "@openlinker/core": ["libs/core/src/index.ts"],
+      "@openlinker/core/mappings": ["libs/core/src/mappings/index.ts"],
       "@openlinker/core/*": ["libs/core/src/*"],
       "@openlinker/shared": ["libs/shared/src/index.ts"],
       "@openlinker/shared/*": ["libs/shared/src/*"],


### PR DESCRIPTION
## Summary

- Introduces a `mappings` bounded context (`libs/core/src/mappings/`) with domain entities, repository ports, `MappingConfigService`, ORM entities, repositories, and a TypeORM migration for three tables: `connection_status_mappings`, `connection_carrier_mappings`, `connection_payment_mappings`
- Adds REST API endpoints (`apps/api/src/mappings/`) under `GET|PUT /connections/:connectionId/mappings/statuses|carriers|payments` plus five helper endpoints for Allegro/PrestaShop dropdown options
- Wires `MappingConfigService.resolveStatusMapping` into `OrderSyncService` so configured Allegro→PrestaShop status mappings are applied during order sync
- Adds a React UI (`apps/web/src/features/mappings/`, `connection-mappings-page.tsx`) with a 3-tab layout (Order Statuses / Carriers / Payments), each backed by `MappingPanel` — dropdowns, add row, remove row, dirty state, save, error handling
- Links the new page from the connection detail page via a "Mappings" button

## Test plan

- [ ] Unit tests for `MappingConfigService` — 8 tests covering all CRUD methods and `resolveStatusMapping` (match, no-match, empty)
- [ ] Updated `OrderSyncService` tests to pass `mappingConfigService` mock (all pre-existing assertions still pass)
- [ ] `ConnectionMappingsPage` component tests — 7 tests: layout, empty state, table rows, unsaved changes indicator, save mutation call, error display, tab switching
- [ ] `pnpm lint` — 0 errors
- [ ] `pnpm type-check` — all packages pass
- [ ] `pnpm test` — 116 tests pass across 30 test suites
- [ ] `pnpm --filter @openlinker/api migration:show` — `AddConnectionMappingTables1778000000000` listed and pending

Closes #133
Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)