### PR TITLE
feat(listings): Allegro offer field editing (price, title, description)

### DIFF
--- a/apps/api/src/listings/http/dto/update-offer-fields.dto.ts
+++ b/apps/api/src/listings/http/dto/update-offer-fields.dto.ts
@@ -1,0 +1,107 @@
+/**
+ * Update Offer Fields DTOs
+ *
+ * Request DTO for POST /connections/:connectionId/offers/:offerId/fields.
+ * At least one of price, title, or description must be present.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  ValidateNested,
+  IsArray,
+  IsIn,
+  MaxLength,
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class OfferPriceDto {
+  @ApiProperty({ example: '99.99' })
+  @IsString()
+  @IsNotEmpty()
+  amount!: string;
+
+  @ApiProperty({ example: 'PLN' })
+  @IsString()
+  @IsNotEmpty()
+  currency!: string;
+}
+
+export class AllegroDescriptionSectionItemDto {
+  @ApiProperty({ enum: ['TEXT'] })
+  @IsIn(['TEXT'])
+  type!: 'TEXT';
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  content!: string;
+}
+
+export class AllegroDescriptionSectionDto {
+  @ApiProperty({ type: [AllegroDescriptionSectionItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AllegroDescriptionSectionItemDto)
+  items!: AllegroDescriptionSectionItemDto[];
+}
+
+export class OfferDescriptionDto {
+  @ApiProperty({ type: [AllegroDescriptionSectionDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AllegroDescriptionSectionDto)
+  sections!: AllegroDescriptionSectionDto[];
+}
+
+function AtLeastOneField(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string): void {
+    registerDecorator({
+      name: 'atLeastOneField',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(_value: unknown, args: ValidationArguments): boolean {
+          const obj = args.object as Record<string, unknown>;
+          return obj['price'] !== undefined || obj['title'] !== undefined || obj['description'] !== undefined;
+        },
+        defaultMessage(): string {
+          return 'At least one of price, title, or description must be provided';
+        },
+      },
+    });
+  };
+}
+
+export class UpdateOfferFieldsDto {
+  @ApiPropertyOptional({ type: OfferPriceDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => OfferPriceDto)
+  @AtLeastOneField()
+  price?: OfferPriceDto;
+
+  @ApiPropertyOptional({ maxLength: 75 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(75)
+  title?: string;
+
+  @ApiPropertyOptional({ type: OfferDescriptionDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => OfferDescriptionDto)
+  description?: OfferDescriptionDto;
+}
+
+export class UpdateOfferFieldsResponseDto {
+  @ApiProperty()
+  jobId!: string;
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -8,6 +8,8 @@ import { NotFoundException } from '@nestjs/common';
 import { ListingsController } from './listings.controller';
 import { OFFER_MAPPING_REPOSITORY_TOKEN } from '@openlinker/core/listings';
 import type { OfferMappingRepositoryPort } from '@openlinker/core/listings';
+import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
+import type { JobEnqueuePort } from '@openlinker/core/sync';
 import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
 
 describe('ListingsController', () => {
@@ -38,6 +40,10 @@ describe('ListingsController', () => {
         {
           provide: OFFER_MAPPING_REPOSITORY_TOKEN,
           useValue: mockRepository,
+        },
+        {
+          provide: JOB_ENQUEUE_TOKEN,
+          useValue: { enqueueJob: jest.fn() } as jest.Mocked<JobEnqueuePort>,
         },
       ],
     }).compile();

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -10,6 +10,9 @@
 import {
   Controller,
   Get,
+  Post,
+  Body,
+  Headers,
   Query,
   Param,
   HttpCode,
@@ -22,9 +25,12 @@ import { Roles } from '../../auth/decorators/roles.decorator';
 import { OFFER_MAPPING_REPOSITORY_TOKEN } from '@openlinker/core/listings';
 import type { OfferMappingRepositoryPort } from '@openlinker/core/listings';
 import type { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import { JobEnqueuePort, JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
+import { randomUUID } from 'crypto';
 import { ListOfferMappingsQueryDto } from './dto/list-offer-mappings-query.dto';
 import { OfferMappingResponseDto } from './dto/offer-mapping-response.dto';
 import { PaginatedOfferMappingsResponseDto } from './dto/paginated-offer-mappings-response.dto';
+import { UpdateOfferFieldsDto, UpdateOfferFieldsResponseDto } from './dto/update-offer-fields.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -34,6 +40,8 @@ export class ListingsController {
   constructor(
     @Inject(OFFER_MAPPING_REPOSITORY_TOKEN)
     private readonly offerMappingRepository: OfferMappingRepositoryPort,
+    @Inject(JOB_ENQUEUE_TOKEN)
+    private readonly jobEnqueue: JobEnqueuePort,
   ) {}
 
   @Get()
@@ -76,6 +84,42 @@ export class ListingsController {
       throw new NotFoundException(`Offer mapping not found: ${id}`);
     }
     return this.toDto(mapping);
+  }
+
+  @Post('connections/:connectionId/offers/:offerId/fields')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiParam({ name: 'connectionId', description: 'Connection ID' })
+  @ApiParam({ name: 'offerId', description: 'Internal OpenLinker offer ID' })
+  @ApiOperation({
+    summary: 'Update offer fields',
+    description:
+      'Dispatches an async job to update Allegro offer fields (price, title, description). At least one field must be provided. Returns 202 Accepted with a job ID.',
+  })
+  @ApiResponse({ status: 202, description: 'Update job dispatched', type: UpdateOfferFieldsResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation error — no fields provided or invalid values' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async updateOfferFields(
+    @Param('connectionId') connectionId: string,
+    @Param('offerId') offerId: string,
+    @Body() dto: UpdateOfferFieldsDto,
+    @Headers('x-idempotency-key') clientIdempotencyKey?: string,
+  ): Promise<UpdateOfferFieldsResponseDto> {
+    const { jobId } = await this.jobEnqueue.enqueueJob({
+      jobType: 'marketplace.offer.updateFields',
+      connectionId,
+      idempotencyKey: clientIdempotencyKey ?? randomUUID(),
+      payload: {
+        schemaVersion: 1,
+        offerId,
+        fields: {
+          ...(dto.price !== undefined && { price: dto.price }),
+          ...(dto.title !== undefined && { title: dto.title }),
+          ...(dto.description !== undefined && { description: dto.description }),
+        },
+      },
+    });
+
+    return { jobId };
   }
 
   private toDto(mapping: IdentifierMapping): OfferMappingResponseDto {

--- a/apps/api/src/listings/listings.module.ts
+++ b/apps/api/src/listings/listings.module.ts
@@ -8,10 +8,11 @@
  */
 import { Module } from '@nestjs/common';
 import { ListingsModule as CoreListingsModule } from '@openlinker/core/listings';
+import { SyncModule as CoreSyncModule } from '@openlinker/core/sync';
 import { ListingsController } from './http/listings.controller';
 
 @Module({
-  imports: [CoreListingsModule],
+  imports: [CoreListingsModule, CoreSyncModule],
   controllers: [ListingsController],
 })
 export class ListingsApiModule {}

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -11,11 +11,14 @@ import type {
   ListingsPagination,
   OfferMapping,
   PaginatedOfferMappings,
+  UpdateOfferFieldsPayload,
+  UpdateOfferFieldsResult,
 } from './listings.types';
 
 export interface ListingsApi {
   list: (filters?: ListingsFilters, pagination?: ListingsPagination) => Promise<PaginatedOfferMappings>;
   getById: (id: string) => Promise<OfferMapping>;
+  updateOfferFields: (connectionId: string, offerId: string, fields: UpdateOfferFieldsPayload) => Promise<UpdateOfferFieldsResult>;
 }
 
 interface ApiRequest {
@@ -41,6 +44,16 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
     },
     getById(id): Promise<OfferMapping> {
       return request<OfferMapping>(`/listings/${id}`);
+    },
+    updateOfferFields(connectionId, offerId, fields): Promise<UpdateOfferFieldsResult> {
+      return request<UpdateOfferFieldsResult>(
+        `/listings/connections/${connectionId}/offers/${offerId}/fields`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(fields),
+        },
+      );
     },
   };
 }

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -38,3 +38,22 @@ export interface PaginatedOfferMappings {
   limit: number;
   offset: number;
 }
+
+export interface UpdateOfferDescriptionSectionItem {
+  type: 'TEXT';
+  content: string;
+}
+
+export interface UpdateOfferDescriptionSection {
+  items: UpdateOfferDescriptionSectionItem[];
+}
+
+export interface UpdateOfferFieldsPayload {
+  price?: { amount: string; currency: string };
+  title?: string;
+  description?: { sections: UpdateOfferDescriptionSection[] };
+}
+
+export interface UpdateOfferFieldsResult {
+  jobId: string;
+}

--- a/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
+++ b/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * EditOfferDrawer Tests
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import { EditOfferDrawer } from './EditOfferDrawer';
+import type { OfferMapping } from '../api/listings.types';
+
+const mockMapping: OfferMapping = {
+  id: 'row-1',
+  entityType: 'Offer',
+  internalId: 'ol_offer_abc123',
+  externalId: 'allegro-offer-999',
+  platformType: 'Allegro',
+  connectionId: 'conn-1',
+  context: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+function renderDrawer(
+  isOpen: boolean,
+  overrides: Parameters<typeof createMockApiClient>[0] = {},
+  onClose = vi.fn(),
+) {
+  const mockApi = createMockApiClient(overrides);
+  renderWithProviders(
+    <EditOfferDrawer isOpen={isOpen} onClose={onClose} mapping={mockMapping} />,
+    { apiClient: mockApi },
+  );
+  return { mockApi, onClose };
+}
+
+describe('EditOfferDrawer', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('should not render when closed', () => {
+    renderDrawer(false);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should render title, price, and description fields when open', () => {
+    renderDrawer(true);
+    expect(screen.getByRole('dialog', { name: 'Edit offer' })).toBeInTheDocument();
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/price/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+  });
+
+  it('should disable save button when form is pristine', () => {
+    renderDrawer(true);
+    const saveButton = screen.getByRole('button', { name: /save changes/i });
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('should enable save button when a field is dirty', () => {
+    renderDrawer(true);
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: 'New title' } });
+    const saveButton = screen.getByRole('button', { name: /save changes/i });
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it('should show validation error when title exceeds 75 characters', async () => {
+    renderDrawer(true);
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: 'A'.repeat(76) } });
+    const saveButton = screen.getByRole('button', { name: /save changes/i });
+    fireEvent.click(saveButton);
+    expect(await screen.findByText(/75 characters/i)).toBeInTheDocument();
+  });
+
+  it('should only include dirty fields in the API request payload', async () => {
+    const updateOfferFields = vi.fn().mockResolvedValue({ jobId: 'job-1' });
+    renderDrawer(true, { listings: { updateOfferFields } });
+
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: 'Updated title' } });
+
+    const saveButton = screen.getByRole('button', { name: /save changes/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateOfferFields).toHaveBeenCalledWith(
+        'conn-1',
+        'ol_offer_abc123',
+        expect.not.objectContaining({ price: expect.anything() }),
+      );
+      expect(updateOfferFields).toHaveBeenCalledWith(
+        'conn-1',
+        'ol_offer_abc123',
+        expect.objectContaining({ title: 'Updated title' }),
+      );
+    });
+  });
+
+  it('should show success toast and close drawer on successful submit', async () => {
+    const onClose = vi.fn();
+    const updateOfferFields = vi.fn().mockResolvedValue({ jobId: 'job-42' });
+    const mockApi = createMockApiClient({ listings: { updateOfferFields } });
+    renderWithProviders(
+      <EditOfferDrawer isOpen={true} onClose={onClose} mapping={mockMapping} />,
+      { apiClient: mockApi },
+    );
+
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: 'My new title' } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+    expect(await screen.findByText(/update dispatched/i)).toBeInTheDocument();
+  });
+
+  it('should show inline error and not close drawer on API failure', async () => {
+    const onClose = vi.fn();
+    const updateOfferFields = vi.fn().mockRejectedValue(new Error('Allegro API error'));
+    const mockApi = createMockApiClient({ listings: { updateOfferFields } });
+    renderWithProviders(
+      <EditOfferDrawer isOpen={true} onClose={onClose} mapping={mockMapping} />,
+      { apiClient: mockApi },
+    );
+
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: 'My title' } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(await screen.findByText(/update failed/i)).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/listings/components/EditOfferDrawer.tsx
+++ b/apps/web/src/features/listings/components/EditOfferDrawer.tsx
@@ -1,0 +1,215 @@
+/**
+ * EditOfferDrawer
+ *
+ * Side-panel drawer for editing Allegro offer fields (price, title, description).
+ * Only modified (dirty) fields are sent in the API request.
+ * Update is async (job-based) — no optimistic UI; shows a success toast and closes on 202.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { type ReactElement, useCallback, useEffect, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Button } from '../../../shared/ui/button';
+import { Alert } from '../../../shared/ui/alert';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { useUpdateOfferFields } from '../hooks/use-update-offer-fields';
+import type { OfferMapping } from '../api/listings.types';
+import type { UpdateOfferFieldsPayload } from '../api/listings.types';
+import { editOfferFieldsSchema, type EditOfferFieldsValues } from './edit-offer-fields.schema';
+import { OfferDescriptionEditor } from './OfferDescriptionEditor';
+
+interface EditOfferDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mapping: OfferMapping;
+}
+
+export function EditOfferDrawer({ isOpen, onClose, mapping }: EditOfferDrawerProps): ReactElement {
+  const mutation = useUpdateOfferFields();
+  const { showToast } = useToast();
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const form = useForm<EditOfferFieldsValues>({
+    defaultValues: {
+      title: '',
+      priceAmount: '',
+      priceCurrency: 'PLN',
+      descriptionText: '',
+    },
+    resolver: zodResolver(editOfferFieldsSchema),
+  });
+
+  // Stable reset callback — avoids including form/mutation in useEffect deps,
+  // which would cause an infinite render loop (useMutation returns a new object every render).
+  const resetDrawerState = useCallback(() => {
+    closeButtonRef.current?.focus();
+    form.reset();
+    mutation.reset();
+  }, [form, mutation]);
+
+  // Reset form and mutation state each time the drawer opens
+  const prevIsOpenRef = useRef(false);
+  useEffect(() => {
+    if (isOpen && !prevIsOpenRef.current) {
+      resetDrawerState();
+    }
+    prevIsOpenRef.current = isOpen;
+  }, [isOpen, resetDrawerState]);
+
+  const { dirtyFields } = form.formState;
+  const isDirty = Object.keys(dirtyFields).length > 0;
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const fields: UpdateOfferFieldsPayload = {};
+
+    if (dirtyFields.title && values.title) {
+      fields.title = values.title;
+    }
+
+    if (dirtyFields.priceAmount && values.priceAmount) {
+      fields.price = {
+        amount: values.priceAmount,
+        currency: values.priceCurrency ?? 'PLN',
+      };
+    }
+
+    if (dirtyFields.descriptionText && values.descriptionText) {
+      fields.description = {
+        sections: [{ items: [{ type: 'TEXT', content: values.descriptionText }] }],
+      };
+    }
+
+    if (Object.keys(fields).length === 0) {
+      return;
+    }
+
+    try {
+      await mutation.mutateAsync({
+        connectionId: mapping.connectionId,
+        offerId: mapping.internalId,
+        fields,
+      });
+      showToast({
+        tone: 'success',
+        title: 'Update dispatched',
+        description: 'Changes will appear once the job completes.',
+      });
+      onClose();
+    } catch {
+      // Error displayed inline via mutation.error
+    }
+  });
+
+  if (!isOpen) {
+    return <></>;
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="drawer-backdrop"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+
+      {/* Drawer panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Edit offer"
+        className="drawer"
+      >
+        <div className="drawer__header">
+          <h2 className="drawer__title">Edit offer</h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="drawer__close"
+            aria-label="Close drawer"
+            onClick={onClose}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="drawer__body">
+          {mutation.error ? (
+            <Alert tone="error" title="Update failed">
+              {mutation.error.message}
+            </Alert>
+          ) : null}
+
+          <form
+            id="edit-offer-fields-form"
+            onSubmit={(e) => void onSubmit(e)}
+            noValidate
+          >
+            <FormField
+              label="Title"
+              name="title"
+              error={form.formState.errors.title?.message}
+            >
+              <Input
+                {...form.register('title')}
+                maxLength={75}
+                placeholder="Offer title (max 75 characters)"
+              />
+            </FormField>
+
+            <div className="form-grid form-grid--2col">
+              <FormField
+                label="Price"
+                name="priceAmount"
+                error={form.formState.errors.priceAmount?.message}
+              >
+                <Input
+                  {...form.register('priceAmount')}
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="e.g. 99.99"
+                />
+              </FormField>
+
+              <FormField label="Currency" name="priceCurrency">
+                <Input
+                  {...form.register('priceCurrency')}
+                  readOnly
+                  className="input--readonly"
+                  aria-label="Currency (read-only)"
+                />
+              </FormField>
+            </div>
+
+            <FormField
+              label="Description"
+              name="descriptionText"
+              error={form.formState.errors.descriptionText?.message}
+            >
+              <OfferDescriptionEditor
+                registration={form.register('descriptionText')}
+                error={form.formState.errors.descriptionText?.message}
+              />
+            </FormField>
+          </form>
+        </div>
+
+        <div className="drawer__footer">
+          <Button type="button" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="edit-offer-fields-form"
+            disabled={!isDirty || mutation.isPending}
+          >
+            {mutation.isPending ? 'Saving…' : 'Save changes'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/features/listings/components/OfferDescriptionEditor.tsx
+++ b/apps/web/src/features/listings/components/OfferDescriptionEditor.tsx
@@ -1,0 +1,43 @@
+/**
+ * OfferDescriptionEditor
+ *
+ * Simple text editor for Allegro offer descriptions. Allegro uses a structured
+ * section format; for MVP only a single text section is supported.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import type { ReactElement } from 'react';
+import type { UseFormRegisterReturn } from 'react-hook-form';
+
+interface OfferDescriptionEditorProps {
+  registration: UseFormRegisterReturn;
+  error?: string;
+  id?: string;
+}
+
+export function OfferDescriptionEditor({
+  registration,
+  error,
+  id,
+}: OfferDescriptionEditorProps): ReactElement {
+  return (
+    <div className="offer-description-editor">
+      <textarea
+        id={id}
+        {...registration}
+        className={['offer-description-editor__textarea', error ? 'input--error' : ''].filter(Boolean).join(' ')}
+        rows={6}
+        aria-invalid={error !== undefined}
+        aria-describedby={error ? 'description-error description-note' : 'description-note'}
+      />
+      {error ? (
+        <p id="description-error" className="field-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <p id="description-note" className="offer-description-editor__note">
+        Allegro formats description as structured sections. Only text content is supported for editing here.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/features/listings/components/edit-offer-fields.schema.ts
+++ b/apps/web/src/features/listings/components/edit-offer-fields.schema.ts
@@ -1,0 +1,24 @@
+/**
+ * Edit Offer Fields Schema
+ *
+ * Zod schema and types for the EditOfferDrawer form.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { z } from 'zod';
+
+export const editOfferFieldsSchema = z.object({
+  title: z.string().max(75, 'Title must be 75 characters or fewer').optional(),
+  priceAmount: z
+    .string()
+    .optional()
+    .refine(
+      (val) => val === undefined || val === '' || /^\d+(\.\d{1,2})?$/.test(val),
+      { message: 'Price must be a positive number with up to 2 decimal places' },
+    ),
+  priceCurrency: z.string().optional(),
+  descriptionText: z.string().optional(),
+});
+
+export type EditOfferFieldsValues = z.input<typeof editOfferFieldsSchema>;
+export type EditOfferFieldsSubmission = z.output<typeof editOfferFieldsSchema>;

--- a/apps/web/src/features/listings/hooks/use-update-offer-fields.ts
+++ b/apps/web/src/features/listings/hooks/use-update-offer-fields.ts
@@ -1,0 +1,26 @@
+/**
+ * use-update-offer-fields
+ *
+ * Mutation hook for dispatching an async offer field update job.
+ * Returns 202 Accepted with a job ID — does not optimistically update listing data.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useMutation } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import type { UpdateOfferFieldsPayload, UpdateOfferFieldsResult } from '../api/listings.types';
+
+interface UpdateOfferFieldsInput {
+  connectionId: string;
+  offerId: string;
+  fields: UpdateOfferFieldsPayload;
+}
+
+export function useUpdateOfferFields() {
+  const apiClient = useApiClient();
+
+  return useMutation<UpdateOfferFieldsResult, Error, UpdateOfferFieldsInput>({
+    mutationFn: ({ connectionId, offerId, fields }) =>
+      apiClient.listings.updateOfferFields(connectionId, offerId, fields),
+  });
+}

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -1,13 +1,15 @@
-import type { ReactElement } from 'react';
+import { type ReactElement, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
+import { EditOfferDrawer } from '../../features/listings/components/EditOfferDrawer';
 
 export function ListingDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
   const query = useListingQuery(id);
+  const [isEditDrawerOpen, setIsEditDrawerOpen] = useState(false);
 
   if (query.isLoading) {
     return (
@@ -36,9 +38,16 @@ export function ListingDetailPage(): ReactElement {
       eyebrow="Listings"
       title={`Mapping — ${mapping.externalId}`}
       actions={
-        <Link to=".." relative="path" className="button button--ghost">
-          ← Back to listings
-        </Link>
+        <>
+          {mapping.platformType.toLowerCase() === 'allegro' ? (
+            <Button onClick={() => setIsEditDrawerOpen(true)}>
+              Edit offer
+            </Button>
+          ) : null}
+          <Link to=".." relative="path" className="button button--ghost">
+            ← Back to listings
+          </Link>
+        </>
       }
     >
       <section className="detail-section">
@@ -86,6 +95,12 @@ export function ListingDetailPage(): ReactElement {
           </pre>
         </section>
       ) : null}
+
+      <EditOfferDrawer
+        isOpen={isEditDrawerOpen}
+        onClose={() => setIsEditDrawerOpen(false)}
+        mapping={mapping}
+      />
     </PageLayout>
   );
 }

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -148,6 +148,7 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
         offset: 0,
       }),
       getById: vi.fn().mockResolvedValue(null),
+      updateOfferFields: vi.fn().mockResolvedValue({ jobId: 'job-1' }),
       ...overrides.listings,
     } as ApiClient['listings'],
     products: {
@@ -227,6 +228,11 @@ export function renderWithProviders(ui: ReactElement, options: RenderWithProvide
     defaultOptions: {
       queries: {
         retry: false,
+        gcTime: Infinity,
+      },
+      mutations: {
+        retry: false,
+        gcTime: Infinity,
       },
     },
   });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    teardownTimeout: 10000,
     setupFiles: './src/test/setup.ts',
     css: true,
     coverage: {

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -12,6 +12,7 @@ import { InventoryPropagateToMarketplacesHandler } from './inventory-propagate-t
 import { MarketplaceOrdersPollHandler } from './marketplace-orders-poll.handler';
 import { MarketplaceOrderSyncHandler } from './marketplace-order-sync.handler';
 import { MarketplaceOfferQuantityUpdateHandler } from './marketplace-offer-quantity-update.handler';
+import { MarketplaceOfferFieldUpdateHandler } from './marketplace-offer-field-update.handler';
 import { MarketplaceOffersSyncHandler } from './marketplace-offers-sync.handler';
 import { MasterProductSyncHandler } from './master-product-sync.handler';
 import { MasterInventorySyncHandler } from './master-inventory-sync.handler';
@@ -24,6 +25,7 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly marketplaceOrdersPollHandler: MarketplaceOrdersPollHandler,
     private readonly marketplaceOrderSyncHandler: MarketplaceOrderSyncHandler,
     private readonly marketplaceOfferQuantityUpdateHandler: MarketplaceOfferQuantityUpdateHandler,
+    private readonly marketplaceOfferFieldUpdateHandler: MarketplaceOfferFieldUpdateHandler,
     private readonly marketplaceOffersSyncHandler: MarketplaceOffersSyncHandler,
     private readonly masterProductSyncHandler: MasterProductSyncHandler,
     private readonly masterInventorySyncHandler: MasterInventorySyncHandler,
@@ -35,6 +37,7 @@ export class HandlerRegistrationService implements OnModuleInit {
     this.handlerRegistry.register('marketplace.order.sync', this.marketplaceOrderSyncHandler);
     this.handlerRegistry.register('marketplace.offers.sync', this.marketplaceOffersSyncHandler);
     this.handlerRegistry.register('marketplace.offerQuantity.update', this.marketplaceOfferQuantityUpdateHandler);
+    this.handlerRegistry.register('marketplace.offer.updateFields', this.marketplaceOfferFieldUpdateHandler);
 
     // Register generic master handlers (Option B)
     this.handlerRegistry.register('master.product.syncByExternalId', this.masterProductSyncHandler);

--- a/apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts
@@ -1,0 +1,140 @@
+/**
+ * Marketplace Offer Field Update Handler
+ *
+ * Handles sync jobs of type 'marketplace.offer.updateFields'. Resolves the
+ * internal offer ID to the marketplace-native external ID via IdentifierMappingService,
+ * then dispatches the field update to the marketplace adapter.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  SyncJobHandler,
+  SyncJob as SyncJobEntity,
+  SyncJobExecutionError,
+  MarketplaceOfferFieldUpdatePayloadV1,
+} from '@openlinker/core/sync';
+import {
+  IIdentifierMappingService,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+} from '@openlinker/core/identifier-mapping';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  MarketplacePort,
+} from '@openlinker/core/integrations';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+@Injectable()
+export class MarketplaceOfferFieldUpdateHandler implements SyncJobHandler {
+  private readonly logger = new Logger(MarketplaceOfferFieldUpdateHandler.name);
+
+  constructor(
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IIdentifierMappingService,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+  ) {}
+
+  async execute(job: SyncJob): Promise<void> {
+    const payload = this.getPayload(job);
+
+    this.logger.log(
+      `Executing marketplace.offer.updateFields job ${job.id} for connection ${job.connectionId} (offerId=${payload.offerId}, fields=${Object.keys(payload.fields).join(',')})`,
+    );
+
+    // Resolve internal offer ID → external (marketplace-native) offer ID
+    const externalMappings = await this.identifierMapping.getExternalIds('Offer', payload.offerId);
+    const mapping = externalMappings.find((m) => m.connectionId === job.connectionId);
+
+    if (!mapping) {
+      throw new SyncJobExecutionError(
+        `No external offer mapping found for offerId=${payload.offerId} on connection ${job.connectionId}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+
+    const adapter = await this.integrationsService.getCapabilityAdapter<MarketplacePort>(
+      job.connectionId,
+      'Marketplace',
+    );
+
+    if (!adapter.updateOfferFields) {
+      throw new SyncJobExecutionError(
+        `Adapter for connection ${job.connectionId} does not support updateOfferFields`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+
+    try {
+      await adapter.updateOfferFields({
+        externalOfferId: mapping.externalId,
+        fields: payload.fields,
+        idempotencyKey: payload.idempotencyKey,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `Marketplace offer field update failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private getPayload(job: SyncJob): MarketplaceOfferFieldUpdatePayloadV1 {
+    const payload = job.payload as unknown as Partial<MarketplaceOfferFieldUpdatePayloadV1>;
+
+    if (!payload || typeof payload !== 'object') {
+      throw new SyncJobExecutionError(
+        `Missing payload for job: ${job.id}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+
+    if (!payload.offerId || typeof payload.offerId !== 'string') {
+      throw new SyncJobExecutionError(
+        `Missing or invalid offerId in payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+
+    if (!payload.fields || typeof payload.fields !== 'object') {
+      throw new SyncJobExecutionError(
+        `Missing or invalid fields in payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+
+    const { price, title, description } = payload.fields;
+    if (price === undefined && title === undefined && description === undefined) {
+      throw new SyncJobExecutionError(
+        `At least one field (price, title, description) must be present in payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+
+    return {
+      schemaVersion: 1,
+      offerId: payload.offerId,
+      fields: payload.fields,
+      idempotencyKey: payload.idempotencyKey,
+    };
+  }
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -23,6 +23,7 @@ import { InventoryPropagateToMarketplacesHandler } from './handlers/inventory-pr
 import { MarketplaceOrdersPollHandler } from './handlers/marketplace-orders-poll.handler';
 import { MarketplaceOrderSyncHandler } from './handlers/marketplace-order-sync.handler';
 import { MarketplaceOfferQuantityUpdateHandler } from './handlers/marketplace-offer-quantity-update.handler';
+import { MarketplaceOfferFieldUpdateHandler } from './handlers/marketplace-offer-field-update.handler';
 import { MarketplaceOffersSyncHandler } from './handlers/marketplace-offers-sync.handler';
 import { MasterProductSyncHandler } from './handlers/master-product-sync.handler';
 import { MasterInventorySyncHandler } from './handlers/master-inventory-sync.handler';
@@ -48,6 +49,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MarketplaceOrdersPollHandler,
     MarketplaceOrderSyncHandler,
     MarketplaceOfferQuantityUpdateHandler,
+    MarketplaceOfferFieldUpdateHandler,
     MarketplaceOffersSyncHandler,
     MasterProductSyncHandler,
     MasterInventorySyncHandler,

--- a/docs/plans/implementation-plan-allegro-offer-field-editing.md
+++ b/docs/plans/implementation-plan-allegro-offer-field-editing.md
@@ -1,0 +1,286 @@
+# Implementation Plan — Allegro Offer Field Editing (Issues #140 + #141)
+
+## 1. Goal
+
+Enable merchants to edit Allegro offer fields (price, title, description) from OpenLinker without logging into Allegro directly. Updates are async and dispatched as sync jobs.
+
+**Layer classification:** Integration + CORE/Application + Interface (BE) · Frontend (FE)
+
+**Non-goals:**
+- Polling for Allegro PATCH command result (tracked separately in #102)
+- Batch field editing
+- Image editing
+- Quantity field consolidation into this endpoint (keep existing `offerQuantity.update` job intact)
+
+---
+
+## 2. Architecture Overview
+
+```
+FE: EditOfferDrawer
+  → POST /connections/:connectionId/offers/:offerId/fields
+    → enqueues marketplace.offer.updateFields job
+      → worker handler resolves externalId via IdentifierMappingService
+        → AllegroMarketplaceAdapter.updateOfferFields()
+          → PATCH /sale/product-offers/{externalOfferId}
+```
+
+---
+
+## 3. Step-by-Step Implementation Plan
+
+### BE Step 1 — Domain types
+**File:** `libs/core/src/listings/domain/types/offer-update.types.ts`
+
+Define:
+```typescript
+export interface AllegroDescriptionSection {
+  items: Array<{ type: 'TEXT'; content: string }>;
+}
+
+export interface OfferFieldUpdate {
+  price?: { amount: string; currency: string };
+  title?: string;
+  description?: { sections: AllegroDescriptionSection[] };
+}
+```
+
+**Acceptance:** Types are in a `*.types.ts` file, no `any`, exported from listings barrel.
+
+---
+
+### BE Step 2 — Extend `MarketplacePort`
+**File:** `libs/core/src/integrations/domain/ports/marketplace.port.ts`
+
+Add optional method:
+```typescript
+updateOfferFields?(cmd: UpdateOfferFieldsCommand): Promise<void>;
+```
+
+**File:** `libs/core/src/integrations/domain/types/marketplace-quantity-update.types.ts` (or new `marketplace-offer-update.types.ts`)
+
+Define:
+```typescript
+export interface UpdateOfferFieldsCommand {
+  externalOfferId: string;
+  fields: OfferFieldUpdate;
+  idempotencyKey?: string;
+}
+```
+
+**Acceptance:** Port compiles; all existing implementations unaffected (method is optional).
+
+---
+
+### BE Step 3 — Implement `updateOfferFields` in `AllegroMarketplaceAdapter`
+**File:** `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts`
+
+- Add `updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void>`
+- Build Allegro PATCH payload from `cmd.fields` — only include keys present in input (partial update)
+- Call `PATCH /sale/product-offers/{cmd.externalOfferId}` via `this.httpClient`
+- Allegro PATCH payload shape:
+  ```json
+  {
+    "sellingMode": { "price": { "amount": "...", "currency": "..." } },
+    "name": "...",
+    "description": { "sections": [...] }
+  }
+  ```
+- Only include `sellingMode`, `name`, `description` keys when the corresponding field is present in `cmd.fields`
+- No `any` types — define inline Allegro payload type or add to `allegro-api.types.ts`
+
+**Unit tests:** `allegro-marketplace.adapter.spec.ts`
+- `should send only price when only price field provided`
+- `should send only title when only title field provided`
+- `should send only description when only description field provided`
+- `should send all fields when all fields provided`
+- `should not call HTTP when fields object is empty` (guard)
+
+---
+
+### BE Step 4 — Job payload type
+**File:** `libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts`
+
+Add:
+```typescript
+export interface MarketplaceOfferFieldUpdatePayloadV1 {
+  schemaVersion: 1;
+  offerId: string;          // internal OpenLinker offer ID
+  fields: OfferFieldUpdate;
+  idempotencyKey?: string;
+}
+```
+
+Export from sync barrel.
+
+---
+
+### BE Step 5 — Worker handler
+**File:** `apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts`
+
+Pattern mirrors `marketplace-offer-quantity-update.handler.ts`:
+1. Validate payload (offerId required, at least one field present)
+2. Resolve external offer ID: `identifierMapping.getExternalIds('Offer', payload.offerId)` — find the Allegro connection's external ID
+3. Call `adapter.updateOfferFields({ externalOfferId, fields: payload.fields, idempotencyKey })`
+4. Throw `SyncJobExecutionError` on failure
+
+Register in `handler-registration.service.ts` under `'marketplace.offer.updateFields'`.
+
+---
+
+### BE Step 6 — Controller endpoint + DTOs
+**File:** `apps/api/src/listings/http/dto/update-offer-fields.dto.ts`
+
+```typescript
+export class OfferPriceDto {
+  @IsString() @IsNotEmpty() amount: string;
+  @IsString() @IsNotEmpty() currency: string;
+}
+
+export class AllegroDescriptionSectionItemDto {
+  @IsIn(['TEXT']) type: 'TEXT';
+  @IsString() @IsNotEmpty() content: string;
+}
+
+export class AllegroDescriptionSectionDto {
+  @IsArray() @ValidateNested({ each: true }) @Type(...)
+  items: AllegroDescriptionSectionItemDto[];
+}
+
+export class OfferDescriptionDto {
+  @IsArray() @ValidateNested({ each: true }) @Type(...)
+  sections: AllegroDescriptionSectionDto[];
+}
+
+export class UpdateOfferFieldsDto {
+  @IsOptional() @ValidateNested() @Type(...) price?: OfferPriceDto;
+  @IsOptional() @IsString() @MaxLength(75) title?: string;
+  @IsOptional() @ValidateNested() @Type(...) description?: OfferDescriptionDto;
+  // Custom validator: at least one of price/title/description must be present
+}
+```
+
+**File:** `apps/api/src/listings/http/listings.controller.ts`
+
+Add endpoint:
+```
+POST /connections/:connectionId/offers/:offerId/fields
+```
+- `@UseGuards(JwtAuthGuard)` (already via `@Roles('admin')`)
+- Validate `UpdateOfferFieldsDto`
+- Enqueue `marketplace.offer.updateFields` job via `SyncJobService`
+- Return `202 Accepted` with `{ jobId }`
+
+**File:** `apps/api/src/listings/listings.module.ts` — import `SyncModule` if not already present.
+
+---
+
+### FE Step 7 — API client extension
+**File:** `apps/web/src/features/listings/api/listings.api.ts`
+
+Add method:
+```typescript
+updateOfferFields: (connectionId: string, offerId: string, fields: UpdateOfferFieldsPayload) => Promise<{ jobId: string }>
+```
+
+**File:** `apps/web/src/features/listings/api/listings.types.ts`
+
+Add:
+```typescript
+export interface UpdateOfferFieldsPayload {
+  price?: { amount: string; currency: string };
+  title?: string;
+  description?: { sections: Array<{ items: Array<{ type: 'TEXT'; content: string }> }> };
+}
+
+export interface UpdateOfferFieldsResult {
+  jobId: string;
+}
+```
+
+---
+
+### FE Step 8 — Mutation hook
+**File:** `apps/web/src/features/listings/hooks/use-update-offer-fields.ts`
+
+```typescript
+export function useUpdateOfferFields() {
+  return useMutation({ ... });
+}
+```
+
+Uses `apiClient.listings.updateOfferFields(...)`. No optimistic update.
+
+---
+
+### FE Step 9 — `EditOfferDrawer` component
+**File:** `apps/web/src/features/listings/components/EditOfferDrawer.tsx`
+
+- Props: `{ isOpen: boolean; onClose: () => void; mapping: OfferMapping }`
+- `useForm` with Zod schema validating title (max 75), price.amount (positive, ≤2 decimals), description
+- Only dirty fields included in payload (watch form state)
+- Save button disabled when pristine or invalid
+- On submit: calls mutation, shows loading state
+- On `202`: success toast + close drawer
+- On error: inline error alert inside drawer (do not close)
+- Currency read-only (not in form — display only from existing mapping context if available)
+- Description: single `<textarea>` rendered as structured single-text-section; note shown below
+
+**File:** `apps/web/src/features/listings/components/OfferDescriptionEditor.tsx`
+
+- Simple `<textarea>` for the text content of a single section
+- Shows note: "Allegro formats description as structured sections. Only text content is supported here."
+
+No existing Drawer shared component — implement as a `<dialog>` element or side-panel `<div>` with `role="dialog"` aria attributes, following the existing modal pattern from `confirm-dialog.tsx`.
+
+---
+
+### FE Step 10 — Wire into `ListingDetailPage`
+**File:** `apps/web/src/pages/listings/listing-detail-page.tsx`
+
+- Add `useState` for drawer open/close
+- Add "Edit offer" `<Button>` in page actions (only when `mapping.platformType === 'Allegro'`)
+- Render `<EditOfferDrawer>` conditionally
+
+---
+
+### FE Step 11 — Tests
+**Files:**
+- `apps/web/src/features/listings/components/EditOfferDrawer.test.tsx`
+
+Covers:
+- Drawer renders with title/price/description fields
+- Save button disabled when form is pristine
+- Zod validation shows inline errors (title too long, invalid price)
+- Submit success: toast shown, drawer closed
+- Submit error: inline error shown, drawer stays open
+- Only dirty fields included in payload (mock mutation, inspect call args)
+
+---
+
+## 4. Key Files Summary
+
+| Component | File |
+|---|---|
+| Domain types | `libs/core/src/listings/domain/types/offer-update.types.ts` |
+| MarketplacePort extension | `libs/core/src/integrations/domain/ports/marketplace.port.ts` |
+| UpdateOfferFieldsCommand | `libs/core/src/integrations/domain/types/marketplace-offer-update.types.ts` |
+| Allegro adapter impl | `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts` |
+| Job payload type | `libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts` |
+| Worker handler | `apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts` |
+| Handler registration | `apps/worker/src/sync/handlers/handler-registration.service.ts` |
+| Request DTOs | `apps/api/src/listings/http/dto/update-offer-fields.dto.ts` |
+| Listings controller | `apps/api/src/listings/http/listings.controller.ts` |
+| FE API client | `apps/web/src/features/listings/api/listings.api.ts` |
+| FE types | `apps/web/src/features/listings/api/listings.types.ts` |
+| Mutation hook | `apps/web/src/features/listings/hooks/use-update-offer-fields.ts` |
+| EditOfferDrawer | `apps/web/src/features/listings/components/EditOfferDrawer.tsx` |
+| OfferDescriptionEditor | `apps/web/src/features/listings/components/OfferDescriptionEditor.tsx` |
+| Detail page | `apps/web/src/pages/listings/listing-detail-page.tsx` |
+
+## 5. Risks & Open Questions
+
+- **Allegro PATCH shape:** The exact Allegro `PATCH /sale/product-offers/{offerId}` payload needs verification against the Allegro API docs — particularly whether `sellingMode.price` or a top-level `price` key is used. The adapter unit tests mock the HTTP client so this is safe to iterate.
+- **Currency source:** The issue specifies currency as read-only in the FE. The `OfferMapping` context may not include current price/currency. For MVP, currency defaults to `PLN` or is left for the user to provide alongside the amount.
+- **No migration needed:** No new ORM entities or DB tables are introduced.
+- **`at least one field` validation:** Implemented via a custom class-validator decorator on `UpdateOfferFieldsDto`.

--- a/libs/core/src/integrations/domain/ports/marketplace.port.ts
+++ b/libs/core/src/integrations/domain/ports/marketplace.port.ts
@@ -22,6 +22,7 @@ import {
   UpdateOfferQuantitiesBatchCommand,
   UpdateOfferQuantitiesBatchResult,
 } from '../types/marketplace-quantity-update.types';
+import type { UpdateOfferFieldsCommand } from '../types/marketplace-offer-update.types';
 
 export interface MarketplacePort {
   /**
@@ -57,5 +58,12 @@ export interface MarketplacePort {
   updateOfferQuantitiesBatch?(
     cmd: UpdateOfferQuantitiesBatchCommand,
   ): Promise<UpdateOfferQuantitiesBatchResult>;
+
+  /**
+   * Update offer fields (price, title, description) — optional capability.
+   *
+   * Partial update semantics: only fields present in cmd.fields are sent to the marketplace.
+   */
+  updateOfferFields?(cmd: UpdateOfferFieldsCommand): Promise<void>;
 }
 

--- a/libs/core/src/integrations/domain/types/marketplace-offer-update.types.ts
+++ b/libs/core/src/integrations/domain/types/marketplace-offer-update.types.ts
@@ -1,0 +1,19 @@
+/**
+ * Marketplace Offer Update Types
+ *
+ * Command types for full offer field updates (price, title, description).
+ * Distinct from quantity-only updates in marketplace-quantity-update.types.ts.
+ *
+ * @module libs/core/src/integrations/domain/types
+ */
+
+import type { OfferFieldUpdate } from '@openlinker/core/listings';
+
+export interface UpdateOfferFieldsCommand {
+  /** Marketplace-native (external) offer ID. */
+  externalOfferId: string;
+  /** Partial field update — at least one field must be set. */
+  fields: OfferFieldUpdate;
+  /** Optional idempotency key for deduplication. */
+  idempotencyKey?: string;
+}

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -49,6 +49,7 @@ export {
   UpdateOfferQuantitiesBatchResult,
   UpdateOfferQuantitiesBatchFailure,
 } from './domain/types/marketplace-quantity-update.types';
+export type { UpdateOfferFieldsCommand } from './domain/types/marketplace-offer-update.types';
 
 // Exceptions
 export { AdapterNotFoundException } from './domain/exceptions/adapter-not-found.exception';

--- a/libs/core/src/listings/domain/types/offer-update.types.ts
+++ b/libs/core/src/listings/domain/types/offer-update.types.ts
@@ -1,0 +1,36 @@
+/**
+ * Offer Field Update Types
+ *
+ * Domain types for partial offer field updates dispatched to marketplace adapters.
+ * At least one field must be present in OfferFieldUpdate (enforced at the interface layer).
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+export interface OfferDescriptionSectionItem {
+  type: 'TEXT';
+  content: string;
+}
+
+export interface OfferDescriptionSection {
+  items: OfferDescriptionSectionItem[];
+}
+
+export interface OfferPriceUpdate {
+  amount: string;
+  currency: string;
+}
+
+export interface OfferDescriptionUpdate {
+  sections: OfferDescriptionSection[];
+}
+
+/**
+ * Partial offer field update payload.
+ * All fields are optional but at least one must be present (validated at controller level).
+ */
+export interface OfferFieldUpdate {
+  price?: OfferPriceUpdate;
+  title?: string;
+  description?: OfferDescriptionUpdate;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -23,3 +23,10 @@ export type {
   OfferMappingPagination,
   PaginatedOfferMappings,
 } from './domain/types/offer-mapping.types';
+export type {
+  OfferDescriptionSectionItem,
+  OfferDescriptionSection,
+  OfferPriceUpdate,
+  OfferDescriptionUpdate,
+  OfferFieldUpdate,
+} from './domain/types/offer-update.types';

--- a/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
@@ -37,6 +37,14 @@ export interface MarketplaceOfferQuantityUpdatePayloadV1 {
   idempotencyKey?: string;
 }
 
+export interface MarketplaceOfferFieldUpdatePayloadV1 {
+  schemaVersion: 1;
+  /** Internal OpenLinker offer ID (resolved to external ID by the handler). */
+  offerId: string;
+  fields: import('@openlinker/core/listings').OfferFieldUpdate;
+  idempotencyKey?: string;
+}
+
 export interface MarketplaceOffersSyncPayloadV1 {
   schemaVersion: 1;
   limit: number;

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -19,6 +19,7 @@ export const JobTypeValues = [
   'marketplace.order.sync',
   'marketplace.offers.sync',
   'marketplace.offerQuantity.update',
+  'marketplace.offer.updateFields',
   'master.product.syncByExternalId',
   'master.inventory.syncByExternalId',
 

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -42,6 +42,7 @@ export {
   MarketplaceOrdersPollPayloadV1,
   MarketplaceOrderSyncPayloadV1,
   MarketplaceOfferQuantityUpdatePayloadV1,
+  MarketplaceOfferFieldUpdatePayloadV1,
   MarketplaceOffersSyncPayloadV1,
 } from './domain/types/marketplace-job-payloads.types';
 export {

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -199,5 +199,28 @@ export interface AllegroCategoryParametersResponse {
   }>;
 }
 
+/**
+ * Allegro offer fields PATCH request body (PATCH /sale/product-offers/{offerId})
+ *
+ * All fields are optional — only fields present in the object are sent to Allegro.
+ */
+export interface AllegroOfferFieldsPatchBody extends Record<string, unknown> {
+  name?: string;
+  sellingMode?: {
+    price?: {
+      amount: string;
+      currency: string;
+    };
+  };
+  description?: {
+    sections: Array<{
+      items: Array<{
+        type: 'TEXT';
+        content: string;
+      }>;
+    }>;
+  };
+}
+
 
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
@@ -29,6 +29,7 @@ describe('AllegroMarketplaceAdapter', () => {
       get: jest.fn(),
       post: jest.fn(),
       put: jest.fn(),
+      patch: jest.fn(),
     } as unknown as jest.Mocked<IAllegroHttpClient>;
 
     identifierMapping = {
@@ -380,6 +381,99 @@ describe('AllegroMarketplaceAdapter', () => {
           idempotencyKey: 'idempotency-key-123',
         }),
       ).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('updateOfferFields', () => {
+    beforeEach(() => {
+      httpClient.patch.mockResolvedValue({ data: undefined, status: 204, headers: {} });
+    });
+
+    it('should send only price when only price field provided', async () => {
+      await adapter.updateOfferFields({
+        externalOfferId: 'allegro-offer-1',
+        fields: { price: { amount: '99.99', currency: 'PLN' } },
+      });
+
+      expect(httpClient.patch).toHaveBeenCalledWith(
+        '/sale/product-offers/allegro-offer-1',
+        expect.objectContaining({
+          sellingMode: { price: { amount: '99.99', currency: 'PLN' } },
+        }),
+      );
+      const body = (httpClient.patch.mock.calls[0] as [string, Record<string, unknown>])[1];
+      expect(body).not.toHaveProperty('name');
+      expect(body).not.toHaveProperty('description');
+    });
+
+    it('should send only title when only title field provided', async () => {
+      await adapter.updateOfferFields({
+        externalOfferId: 'allegro-offer-1',
+        fields: { title: 'My new title' },
+      });
+
+      expect(httpClient.patch).toHaveBeenCalledWith(
+        '/sale/product-offers/allegro-offer-1',
+        expect.objectContaining({ name: 'My new title' }),
+      );
+      const body = (httpClient.patch.mock.calls[0] as [string, Record<string, unknown>])[1];
+      expect(body).not.toHaveProperty('sellingMode');
+      expect(body).not.toHaveProperty('description');
+    });
+
+    it('should send only description when only description field provided', async () => {
+      const description = {
+        sections: [{ items: [{ type: 'TEXT' as const, content: 'Hello world' }] }],
+      };
+
+      await adapter.updateOfferFields({
+        externalOfferId: 'allegro-offer-1',
+        fields: { description },
+      });
+
+      expect(httpClient.patch).toHaveBeenCalledWith(
+        '/sale/product-offers/allegro-offer-1',
+        expect.objectContaining({ description: { sections: [{ items: [{ type: 'TEXT', content: 'Hello world' }] }] } }),
+      );
+      const body = (httpClient.patch.mock.calls[0] as [string, Record<string, unknown>])[1];
+      expect(body).not.toHaveProperty('name');
+      expect(body).not.toHaveProperty('sellingMode');
+    });
+
+    it('should send all fields when all fields provided', async () => {
+      await adapter.updateOfferFields({
+        externalOfferId: 'allegro-offer-1',
+        fields: {
+          price: { amount: '49.00', currency: 'PLN' },
+          title: 'Updated title',
+          description: { sections: [{ items: [{ type: 'TEXT', content: 'Desc' }] }] },
+        },
+      });
+
+      const body = (httpClient.patch.mock.calls[0] as [string, Record<string, unknown>, unknown])[1];
+      expect(body).toHaveProperty('sellingMode');
+      expect(body).toHaveProperty('name', 'Updated title');
+      expect(body).toHaveProperty('description');
+    });
+
+    it('should not call HTTP when fields object is empty', async () => {
+      await adapter.updateOfferFields({
+        externalOfferId: 'allegro-offer-1',
+        fields: {},
+      });
+
+      expect(httpClient.patch).not.toHaveBeenCalled();
+    });
+
+    it('should propagate HTTP errors', async () => {
+      httpClient.patch.mockRejectedValueOnce(new Error('Allegro API error'));
+
+      await expect(
+        adapter.updateOfferFields({
+          externalOfferId: 'allegro-offer-1',
+          fields: { title: 'New title' },
+        }),
+      ).rejects.toThrow('Allegro API error');
     });
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
@@ -16,6 +16,7 @@ import {
   MarketplaceOfferFeedInput,
   MarketplaceOfferFeedOutput,
   UpdateOfferQuantityCommand,
+  UpdateOfferFieldsCommand,
 } from '@openlinker/core/integrations';
 import type { IncomingOrder } from '@openlinker/core/orders';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
@@ -30,6 +31,7 @@ import {
   AllegroProductOffer,
   AllegroOffersResponse,
   AllegroOfferEventsResponse,
+  AllegroOfferFieldsPatchBody,
 } from '../../domain/types/allegro-api.types';
 import { Logger } from '@openlinker/shared/logging';
 import { createHash } from 'crypto';
@@ -559,6 +561,69 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
         const status = allegroStatus as string;
         this.logger.warn(`Unknown Allegro command status: ${status}, defaulting to 'queued'`);
         return 'queued';
+    }
+  }
+
+  /**
+   * Update offer fields (price, title, description) via Allegro PATCH.
+   *
+   * Partial update semantics: only fields present in cmd.fields are included
+   * in the Allegro request payload. Uses PATCH /sale/product-offers/{offerId}.
+   */
+  async updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void> {
+    this.logger.debug(
+      `Updating Allegro offer fields: offerId=${cmd.externalOfferId} (connection: ${this.connectionId}, fields=${Object.keys(cmd.fields).join(',')})`,
+    );
+
+    // Build partial PATCH payload — only include keys that are present
+    const body: AllegroOfferFieldsPatchBody = {};
+
+    if (cmd.fields.price !== undefined) {
+      body.sellingMode = {
+        price: {
+          amount: cmd.fields.price.amount,
+          currency: cmd.fields.price.currency,
+        },
+      };
+    }
+
+    if (cmd.fields.title !== undefined) {
+      body.name = cmd.fields.title;
+    }
+
+    if (cmd.fields.description !== undefined) {
+      body.description = {
+        sections: cmd.fields.description.sections.map((section) => ({
+          items: section.items.map((item) => ({
+            type: item.type,
+            content: item.content,
+          })),
+        })),
+      };
+    }
+
+    if (Object.keys(body).length === 0) {
+      this.logger.warn(
+        `updateOfferFields called with empty fields for offerId=${cmd.externalOfferId} — skipping`,
+      );
+      return;
+    }
+
+    try {
+      await this.httpClient.patch<void>(
+        `/sale/product-offers/${cmd.externalOfferId}`,
+        body,
+      );
+
+      this.logger.debug(
+        `Allegro offer fields updated: offerId=${cmd.externalOfferId} (connection: ${this.connectionId})`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to update Allegro offer fields (offerId: ${cmd.externalOfferId}, connection: ${this.connectionId}): ${(error as Error).message}`,
+        error,
+      );
+      throw error;
     }
   }
 

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.interface.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.interface.ts
@@ -69,6 +69,20 @@ export interface IAllegroHttpClient {
     body?: Record<string, unknown> | string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>>;
+
+  /**
+   * Make PATCH request
+   *
+   * @param path - API path
+   * @param body - Request body (partial update)
+   * @param options - Request options (headers, query params)
+   * @returns Response data
+   */
+  patch<T = unknown>(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+  ): Promise<AllegroHttpResponse<T>>;
 }
 
 

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
@@ -103,6 +103,14 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     return this.request<T>('PUT', path, body, options);
   }
 
+  async patch<T = unknown>(
+    path: string,
+    body?: Record<string, unknown> | string,
+    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+  ): Promise<AllegroHttpResponse<T>> {
+    return this.request<T>('PATCH', path, body, options);
+  }
+
   /**
    * Make HTTP request with retry logic
    *


### PR DESCRIPTION
## Summary

- **BE**: New PATCH-based field-update pipeline for Allegro offers — domain types (`OfferFieldUpdate`), `updateOfferFields` on `MarketplacePort`, Allegro adapter implementation using `PATCH /sale/product-offers/{id}`, worker handler for `marketplace.offer.updateFields` job type, and `POST /connections/:id/offers/:id/fields` controller endpoint (202 Accepted) with optional `X-Idempotency-Key` header
- **FE**: `EditOfferDrawer` with dirty-field-only submission, `OfferDescriptionEditor`, Zod schema, mutation hook, and "Edit offer" button on the listing detail page (Allegro offers only)
- **Fixes**: Infinite render loop in `useEffect` (useMutation ref instability), `QueryClient` `gcTime` causing vitest fork worker hang, `OfferDescriptionEditor` label-textarea accessibility, platform-agnostic naming for CORE types

## Test plan

- [ ] BE: 6 unit tests for `AllegroMarketplaceAdapter.updateOfferFields` (partial fields, empty fields, error propagation)
- [ ] BE: Existing `ListingsController` tests updated with `JOB_ENQUEUE_TOKEN` provider
- [ ] FE: 8 unit tests for `EditOfferDrawer` (closed/open state, pristine/dirty, validation, dirty-only payload, success toast, error inline)
- [ ] Manual: Open listing detail for an Allegro offer → click "Edit offer" → modify title only → Save → verify only title sent in payload
- [ ] Manual: Verify form resets on re-open, validation errors display, API error shows inline alert

Closes #140
Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)