### PR TITLE
feat(mappings,categories): Allegro category tree API and category mapping CRUD + UI

### DIFF
--- a/apps/api/src/categories/__tests__/categories-cache.service.spec.ts
+++ b/apps/api/src/categories/__tests__/categories-cache.service.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * CategoriesCacheService unit tests
+ *
+ * @module apps/api/src/categories/__tests__
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CategoriesCacheService } from '../categories-cache.service';
+import { AllegroCategoryCacheOrmEntity } from '../persistence/allegro-category-cache.orm-entity';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type { MarketplaceCategory } from '@openlinker/core/integrations';
+
+const CONNECTION_ID = 'conn-uuid-1';
+
+function createMockCategory(overrides: Partial<AllegroCategoryCacheOrmEntity> = {}): AllegroCategoryCacheOrmEntity {
+  const entity = new AllegroCategoryCacheOrmEntity();
+  entity.id = 'cache-id-1';
+  entity.connectionId = CONNECTION_ID;
+  entity.allegroCategoryId = '100';
+  entity.name = 'Electronics';
+  entity.parentId = null;
+  entity.leaf = false;
+  entity.fetchedAt = new Date();
+  return Object.assign(entity, overrides);
+}
+
+describe('CategoriesCacheService', () => {
+  let service: CategoriesCacheService;
+  let cacheRepo: {
+    find: jest.Mock;
+    delete: jest.Mock;
+    upsert: jest.Mock;
+  };
+  let integrationsService: { getCapabilityAdapter: jest.Mock };
+
+  beforeEach(async () => {
+    cacheRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(undefined),
+      upsert: jest.fn().mockResolvedValue(undefined),
+    };
+
+    integrationsService = {
+      getCapabilityAdapter: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoriesCacheService,
+        {
+          provide: getRepositoryToken(AllegroCategoryCacheOrmEntity),
+          useValue: cacheRepo,
+        },
+        {
+          provide: INTEGRATIONS_SERVICE_TOKEN,
+          useValue: integrationsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(CategoriesCacheService);
+  });
+
+  describe('getAllegroCategories', () => {
+    it('should return cached categories when cache is fresh', async () => {
+      const cached = [
+        createMockCategory({ allegroCategoryId: '1', name: 'Electronics', fetchedAt: new Date() }),
+        createMockCategory({ allegroCategoryId: '2', name: 'Fashion', fetchedAt: new Date() }),
+      ];
+      cacheRepo.find.mockResolvedValue(cached);
+
+      const result = await service.getAllegroCategories(CONNECTION_ID);
+
+      expect(result).toEqual([
+        { id: '1', name: 'Electronics', parentId: null, leaf: false },
+        { id: '2', name: 'Fashion', parentId: null, leaf: false },
+      ]);
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('should fetch from API and store when cache is empty', async () => {
+      cacheRepo.find.mockResolvedValue([]);
+
+      const apiCategories: MarketplaceCategory[] = [
+        { id: '10', name: 'Phones', parentId: '1', leaf: true },
+      ];
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        fetchCategories: jest.fn().mockResolvedValue(apiCategories),
+      });
+
+      const result = await service.getAllegroCategories(CONNECTION_ID, '1');
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(CONNECTION_ID, 'Marketplace');
+      expect(cacheRepo.upsert).toHaveBeenCalled();
+      expect(result).toEqual(apiCategories);
+    });
+
+    it('should re-fetch when cache entries are stale (>24h)', async () => {
+      const staleDate = new Date();
+      staleDate.setHours(staleDate.getHours() - 25);
+
+      cacheRepo.find.mockResolvedValue([
+        createMockCategory({ fetchedAt: staleDate }),
+      ]);
+
+      const freshCategories: MarketplaceCategory[] = [
+        { id: '100', name: 'Electronics (updated)', parentId: null, leaf: false },
+      ];
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        fetchCategories: jest.fn().mockResolvedValue(freshCategories),
+      });
+
+      const result = await service.getAllegroCategories(CONNECTION_ID);
+
+      expect(cacheRepo.delete).toHaveBeenCalled(); // Stale entries cleaned up
+      expect(result).toEqual(freshCategories);
+    });
+
+    it('should return empty array when adapter does not support fetchCategories', async () => {
+      cacheRepo.find.mockResolvedValue([]);
+      integrationsService.getCapabilityAdapter.mockResolvedValue({});
+
+      const result = await service.getAllegroCategories(CONNECTION_ID);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('invalidateCache', () => {
+    it('should delete all cached entries for a connection', async () => {
+      await service.invalidateCache(CONNECTION_ID);
+
+      expect(cacheRepo.delete).toHaveBeenCalledWith({ connectionId: CONNECTION_ID });
+    });
+  });
+});

--- a/apps/api/src/categories/categories-cache.service.interface.ts
+++ b/apps/api/src/categories/categories-cache.service.interface.ts
@@ -1,0 +1,41 @@
+/**
+ * Categories Cache Service Interface
+ *
+ * Contract for fetching and caching marketplace categories per connection.
+ *
+ * @module apps/api/src/categories
+ */
+
+import type { MarketplaceCategory } from '@openlinker/core/integrations';
+
+export interface PrestashopCategoryDto {
+  id: string;
+  name: string;
+  parentId: string | null;
+  depth: number;
+  active: boolean;
+}
+
+export interface ICategoriesCacheService {
+  /**
+   * Get Allegro categories for a connection, using DB cache with 24h TTL.
+   * Fetches from the Allegro API and stores in cache when stale or missing.
+   *
+   * @param connectionId - Connection UUID
+   * @param parentId - Optional parent category ID (omit for root categories)
+   */
+  getAllegroCategories(connectionId: string, parentId?: string): Promise<MarketplaceCategory[]>;
+
+  /**
+   * Get PrestaShop categories for a connection.
+   * Fetches live from the PrestaShop WebService API (no caching — small dataset).
+   *
+   * @param connectionId - Connection UUID
+   */
+  getPrestashopCategories(connectionId: string): Promise<PrestashopCategoryDto[]>;
+
+  /**
+   * Invalidate all cached Allegro categories for a connection.
+   */
+  invalidateCache(connectionId: string): Promise<void>;
+}

--- a/apps/api/src/categories/categories-cache.service.ts
+++ b/apps/api/src/categories/categories-cache.service.ts
@@ -1,0 +1,155 @@
+/**
+ * Categories Cache Service
+ *
+ * Fetches Allegro categories via the MarketplacePort adapter and caches
+ * them in the allegro_category_cache DB table with a 24-hour TTL.
+ * Falls back to live API call when cache is stale or missing.
+ *
+ * @module apps/api/src/categories
+ * @implements {ICategoriesCacheService}
+ */
+
+import { Injectable, Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ICategoriesCacheService, PrestashopCategoryDto } from './categories-cache.service.interface';
+import { AllegroCategoryCacheOrmEntity } from './persistence/allegro-category-cache.orm-entity';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  MarketplacePort,
+} from '@openlinker/core/integrations';
+import type { MarketplaceCategory } from '@openlinker/core/integrations';
+import type { ProductMasterPort } from '@openlinker/core/products';
+import { Logger } from '@openlinker/shared/logging';
+
+const CACHE_TTL_HOURS = 24;
+
+@Injectable()
+export class CategoriesCacheService implements ICategoriesCacheService {
+  private readonly logger = new Logger(CategoriesCacheService.name);
+
+  constructor(
+    @InjectRepository(AllegroCategoryCacheOrmEntity)
+    private readonly cacheRepo: Repository<AllegroCategoryCacheOrmEntity>,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+  ) {}
+
+  async getAllegroCategories(connectionId: string, parentId?: string): Promise<MarketplaceCategory[]> {
+    // Check cache for this parent level
+    const cached = await this.findCached(connectionId, parentId);
+    if (cached.length > 0) {
+      return cached.map((e) => this.toDomain(e));
+    }
+
+    // Cache miss or stale — fetch from Allegro API
+    this.logger.debug(
+      `Cache miss for Allegro categories (connection: ${connectionId}, parentId: ${parentId ?? 'root'}), fetching from API`,
+    );
+
+    const adapter = await this.integrationsService.getCapabilityAdapter<MarketplacePort>(
+      connectionId,
+      'Marketplace',
+    );
+
+    if (!adapter.fetchCategories) {
+      this.logger.warn(`Marketplace adapter for connection ${connectionId} does not support fetchCategories`);
+      return [];
+    }
+
+    const categories = await adapter.fetchCategories(parentId);
+
+    // Store in cache
+    await this.storeInCache(connectionId, categories);
+
+    return categories;
+  }
+
+  async getPrestashopCategories(connectionId: string): Promise<PrestashopCategoryDto[]> {
+    this.logger.debug(`Fetching PrestaShop categories (connection: ${connectionId})`);
+
+    const adapter = await this.integrationsService.getCapabilityAdapter<ProductMasterPort>(
+      connectionId,
+      'ProductMaster',
+    );
+
+    if (!adapter.getCategories) {
+      this.logger.warn(`ProductMaster adapter for connection ${connectionId} does not support getCategories`);
+      return [];
+    }
+
+    const categories = await adapter.getCategories();
+
+    return categories.map((cat) => ({
+      id: cat.id,
+      name: cat.name,
+      parentId: cat.parentId ?? null,
+      depth: typeof cat['depth'] === 'number' ? cat['depth'] : 0,
+      active: cat['active'] !== false,
+    }));
+  }
+
+  async invalidateCache(connectionId: string): Promise<void> {
+    await this.cacheRepo.delete({ connectionId });
+    this.logger.debug(`Invalidated Allegro category cache for connection: ${connectionId}`);
+  }
+
+  private async findCached(
+    connectionId: string,
+    parentId?: string,
+  ): Promise<AllegroCategoryCacheOrmEntity[]> {
+    const staleThreshold = new Date();
+    staleThreshold.setHours(staleThreshold.getHours() - CACHE_TTL_HOURS);
+
+    // Query for cached entries that are not stale
+    const where: Record<string, unknown> = {
+      connectionId,
+      parentId: parentId ?? null,
+    };
+
+    const entities = await this.cacheRepo.find({ where: where });
+
+    // If any entry is stale, treat entire set as stale
+    if (entities.length > 0 && entities.some((e) => e.fetchedAt < staleThreshold)) {
+      // Clean up stale entries for this parent level
+      await this.cacheRepo.delete(where);
+      return [];
+    }
+
+    return entities;
+  }
+
+  private async storeInCache(
+    connectionId: string,
+    categories: MarketplaceCategory[],
+  ): Promise<void> {
+    if (categories.length === 0) {
+      return;
+    }
+
+    const now = new Date();
+    const entities = categories.map((cat) => {
+      const entity = new AllegroCategoryCacheOrmEntity();
+      entity.connectionId = connectionId;
+      entity.allegroCategoryId = cat.id;
+      entity.name = cat.name;
+      entity.parentId = cat.parentId;
+      entity.leaf = cat.leaf;
+      entity.fetchedAt = now;
+      return entity;
+    });
+
+    // Upsert to handle re-fetches without duplicates
+    await this.cacheRepo.upsert(entities, ['connectionId', 'allegroCategoryId']);
+  }
+
+  private toDomain(entity: AllegroCategoryCacheOrmEntity): MarketplaceCategory {
+    return {
+      id: entity.allegroCategoryId,
+      name: entity.name,
+      parentId: entity.parentId,
+      leaf: entity.leaf,
+    };
+  }
+}

--- a/apps/api/src/categories/categories.module.ts
+++ b/apps/api/src/categories/categories.module.ts
@@ -1,0 +1,31 @@
+/**
+ * Categories Module
+ *
+ * NestJS module for Allegro category caching. Registers the cache
+ * ORM entity and service for use by the mappings controller.
+ *
+ * @module apps/api/src/categories
+ */
+
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AllegroCategoryCacheOrmEntity } from './persistence/allegro-category-cache.orm-entity';
+import { CategoriesCacheService } from './categories-cache.service';
+import { CATEGORIES_CACHE_SERVICE_TOKEN } from './categories.tokens';
+import { IntegrationsModule } from '@openlinker/core/integrations';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([AllegroCategoryCacheOrmEntity]),
+    IntegrationsModule,
+  ],
+  providers: [
+    CategoriesCacheService,
+    {
+      provide: CATEGORIES_CACHE_SERVICE_TOKEN,
+      useExisting: CategoriesCacheService,
+    },
+  ],
+  exports: [CATEGORIES_CACHE_SERVICE_TOKEN],
+})
+export class CategoriesModule {}

--- a/apps/api/src/categories/categories.tokens.ts
+++ b/apps/api/src/categories/categories.tokens.ts
@@ -1,0 +1,7 @@
+/**
+ * Categories Module DI Tokens
+ *
+ * @module apps/api/src/categories
+ */
+
+export const CATEGORIES_CACHE_SERVICE_TOKEN = Symbol('ICategoriesCacheService');

--- a/apps/api/src/categories/persistence/allegro-category-cache.orm-entity.ts
+++ b/apps/api/src/categories/persistence/allegro-category-cache.orm-entity.ts
@@ -1,0 +1,42 @@
+/**
+ * Allegro Category Cache ORM Entity
+ *
+ * TypeORM entity for the allegro_category_cache table.
+ * Stores fetched Allegro categories per connection for fast retrieval
+ * without repeated API calls. Entries are considered stale after 24 hours.
+ *
+ * @module apps/api/src/categories/persistence
+ */
+
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  Index,
+} from 'typeorm';
+
+@Entity('allegro_category_cache')
+@Index(['connectionId', 'allegroCategoryId'], { unique: true })
+@Index(['connectionId', 'parentId'])
+export class AllegroCategoryCacheOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', name: 'connection_id' })
+  connectionId!: string;
+
+  @Column({ type: 'varchar', length: 100, name: 'allegro_category_id' })
+  allegroCategoryId!: string;
+
+  @Column({ type: 'varchar', length: 500 })
+  name!: string;
+
+  @Column({ type: 'varchar', length: 100, name: 'parent_id', nullable: true })
+  parentId!: string | null;
+
+  @Column({ type: 'boolean', default: false })
+  leaf!: boolean;
+
+  @Column({ type: 'timestamptz', name: 'fetched_at', default: () => 'now()' })
+  fetchedAt!: Date;
+}

--- a/apps/api/src/mappings/http/dto/allegro-category-response.dto.ts
+++ b/apps/api/src/mappings/http/dto/allegro-category-response.dto.ts
@@ -1,0 +1,33 @@
+/**
+ * Allegro Category Response DTO
+ *
+ * Response shape for Allegro category tree browsing endpoints.
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { MarketplaceCategory } from '@openlinker/core/integrations';
+
+export class AllegroCategoryResponseDto {
+  @ApiProperty({ example: '258066' })
+  id!: string;
+
+  @ApiProperty({ example: 'Smartphones' })
+  name!: string;
+
+  @ApiPropertyOptional({ example: '258060', nullable: true })
+  parentId!: string | null;
+
+  @ApiProperty({ example: true })
+  leaf!: boolean;
+
+  static fromDomain(cat: MarketplaceCategory): AllegroCategoryResponseDto {
+    const dto = new AllegroCategoryResponseDto();
+    dto.id = cat.id;
+    dto.name = cat.name;
+    dto.parentId = cat.parentId;
+    dto.leaf = cat.leaf;
+    return dto;
+  }
+}

--- a/apps/api/src/mappings/http/dto/category-mapping-input.dto.ts
+++ b/apps/api/src/mappings/http/dto/category-mapping-input.dto.ts
@@ -1,0 +1,27 @@
+/**
+ * Category Mapping Input DTO
+ *
+ * Request body for upserting a single category mapping.
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CategoryMappingInputDto {
+  @ApiProperty({ description: 'Allegro category ID', example: '258066' })
+  @IsString()
+  @IsNotEmpty()
+  allegroCategoryId!: string;
+
+  @ApiProperty({ description: 'Allegro category display name', example: 'Smartphones' })
+  @IsString()
+  @IsNotEmpty()
+  allegroCategoryName!: string;
+
+  @ApiPropertyOptional({ description: 'Allegro category breadcrumb path', example: 'Electronics > Phones > Smartphones' })
+  @IsString()
+  @IsOptional()
+  allegroCategoryPath?: string;
+}

--- a/apps/api/src/mappings/http/dto/category-mapping-response.dto.ts
+++ b/apps/api/src/mappings/http/dto/category-mapping-response.dto.ts
@@ -1,0 +1,41 @@
+/**
+ * Category Mapping Response DTO
+ *
+ * Response shape for category mapping endpoints.
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CategoryMapping } from '@openlinker/core/mappings';
+
+export class CategoryMappingResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  connectionId!: string;
+
+  @ApiProperty()
+  prestashopCategoryId!: string;
+
+  @ApiProperty()
+  allegroCategoryId!: string;
+
+  @ApiProperty()
+  allegroCategoryName!: string;
+
+  @ApiPropertyOptional()
+  allegroCategoryPath!: string | null;
+
+  static fromDomain(m: CategoryMapping): CategoryMappingResponseDto {
+    const dto = new CategoryMappingResponseDto();
+    dto.id = m.id;
+    dto.connectionId = m.connectionId;
+    dto.prestashopCategoryId = m.prestashopCategoryId;
+    dto.allegroCategoryId = m.allegroCategoryId;
+    dto.allegroCategoryName = m.allegroCategoryName;
+    dto.allegroCategoryPath = m.allegroCategoryPath;
+    return dto;
+  }
+}

--- a/apps/api/src/mappings/http/mapping-options.controller.ts
+++ b/apps/api/src/mappings/http/mapping-options.controller.ts
@@ -8,10 +8,13 @@
  * @module apps/api/src/mappings/http
  */
 
-import { Controller, Get, Param } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { Controller, Get, Param, Query, Inject } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { MappingOptionResponseDto } from './dto/mapping-option-response.dto';
+import { AllegroCategoryResponseDto } from './dto/allegro-category-response.dto';
+import { ICategoriesCacheService } from '../../categories/categories-cache.service.interface';
+import { CATEGORIES_CACHE_SERVICE_TOKEN } from '../../categories/categories.tokens';
 
 /**
  * Well-known Allegro order/payment statuses.
@@ -104,6 +107,11 @@ const PRESTASHOP_PAYMENT_MODULES: MappingOptionResponseDto[] = [
 @ApiTags('mappings')
 @Controller('connections/:connectionId')
 export class MappingOptionsController {
+  constructor(
+    @Inject(CATEGORIES_CACHE_SERVICE_TOKEN)
+    private readonly categoriesCacheService: ICategoriesCacheService,
+  ) {}
+
   // ── Allegro options ───────────────────────────────────────────────────────
 
   @Get('allegro/order-statuses')
@@ -172,5 +180,32 @@ export class MappingOptionsController {
     @Param('connectionId') _connectionId: string,
   ): MappingOptionResponseDto[] {
     return PRESTASHOP_PAYMENT_MODULES;
+  }
+
+  // ── PrestaShop categories ────────────────────────────────────────────────
+
+  @Get('prestashop/categories')
+  @ApiOperation({ summary: 'List PrestaShop categories for a connection (live fetch)' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, description: 'Array of PrestaShop categories' })
+  async getPrestashopCategories(
+    @Param('connectionId') connectionId: string,
+  ): Promise<unknown[]> {
+    return this.categoriesCacheService.getPrestashopCategories(connectionId);
+  }
+
+  // ── Allegro categories ──────────────────────────────────────────────────
+
+  @Get('allegro/categories')
+  @ApiOperation({ summary: 'Browse Allegro category tree (cached, 24h TTL)' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiQuery({ name: 'parentId', required: false, type: String, description: 'Parent category ID (omit for root)' })
+  @ApiResponse({ status: 200, type: [AllegroCategoryResponseDto] })
+  async getAllegroCategories(
+    @Param('connectionId') connectionId: string,
+    @Query('parentId') parentId?: string,
+  ): Promise<AllegroCategoryResponseDto[]> {
+    const categories = await this.categoriesCacheService.getAllegroCategories(connectionId, parentId);
+    return categories.map((c) => AllegroCategoryResponseDto.fromDomain(c));
   }
 }

--- a/apps/api/src/mappings/http/mappings.controller.ts
+++ b/apps/api/src/mappings/http/mappings.controller.ts
@@ -12,6 +12,7 @@ import {
   Controller,
   Get,
   Put,
+  Delete,
   Body,
   Param,
   HttpCode,
@@ -36,6 +37,8 @@ import { UpsertPaymentMappingsDto } from './dto/upsert-payment-mappings.dto';
 import { StatusMappingResponseDto } from './dto/status-mapping-response.dto';
 import { CarrierMappingResponseDto } from './dto/carrier-mapping-response.dto';
 import { PaymentMappingResponseDto } from './dto/payment-mapping-response.dto';
+import { CategoryMappingInputDto } from './dto/category-mapping-input.dto';
+import { CategoryMappingResponseDto } from './dto/category-mapping-response.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -132,5 +135,55 @@ export class MappingsController {
   ): Promise<PaymentMappingResponseDto[]> {
     const mappings = await this.mappingConfigService.upsertPaymentMappings(connectionId, dto.items);
     return mappings.map((m) => PaymentMappingResponseDto.fromDomain(m));
+  }
+
+  // ── Category mappings ───────────────────────────────────────────────────
+
+  @Get('categories')
+  @ApiOperation({ summary: 'Get category mappings for a connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [CategoryMappingResponseDto] })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getCategoryMappings(
+    @Param('connectionId') connectionId: string,
+  ): Promise<CategoryMappingResponseDto[]> {
+    const mappings = await this.mappingConfigService.getCategoryMappings(connectionId);
+    return mappings.map((m) => CategoryMappingResponseDto.fromDomain(m));
+  }
+
+  @Put('categories/:prestashopCategoryId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Create or update a category mapping for a PrestaShop category' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiParam({ name: 'prestashopCategoryId', type: String })
+  @ApiResponse({ status: 200, type: CategoryMappingResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid input' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async upsertCategoryMapping(
+    @Param('connectionId') connectionId: string,
+    @Param('prestashopCategoryId') prestashopCategoryId: string,
+    @Body() dto: CategoryMappingInputDto,
+  ): Promise<CategoryMappingResponseDto> {
+    const mapping = await this.mappingConfigService.upsertCategoryMapping(connectionId, {
+      prestashopCategoryId,
+      allegroCategoryId: dto.allegroCategoryId,
+      allegroCategoryName: dto.allegroCategoryName,
+      allegroCategoryPath: dto.allegroCategoryPath,
+    });
+    return CategoryMappingResponseDto.fromDomain(mapping);
+  }
+
+  @Delete('categories/:prestashopCategoryId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a category mapping for a PrestaShop category' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiParam({ name: 'prestashopCategoryId', type: String })
+  @ApiResponse({ status: 204, description: 'Mapping deleted' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async deleteCategoryMapping(
+    @Param('connectionId') connectionId: string,
+    @Param('prestashopCategoryId') prestashopCategoryId: string,
+  ): Promise<void> {
+    await this.mappingConfigService.deleteCategoryMapping(connectionId, prestashopCategoryId);
   }
 }

--- a/apps/api/src/mappings/mappings.module.ts
+++ b/apps/api/src/mappings/mappings.module.ts
@@ -9,11 +9,12 @@
 
 import { Module } from '@nestjs/common';
 import { MappingsModule as CoreMappingsModule } from '@openlinker/core/mappings';
+import { CategoriesModule } from '../categories/categories.module';
 import { MappingsController } from './http/mappings.controller';
 import { MappingOptionsController } from './http/mapping-options.controller';
 
 @Module({
-  imports: [CoreMappingsModule],
+  imports: [CoreMappingsModule, CategoriesModule],
   controllers: [MappingsController, MappingOptionsController],
 })
 export class MappingsApiModule {}

--- a/apps/api/src/migrations/1779000000000-add-category-mappings-table.ts
+++ b/apps/api/src/migrations/1779000000000-add-category-mappings-table.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCategoryMappingsTable1779000000000 implements MigrationInterface {
+  name = 'AddCategoryMappingsTable1779000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "category_mappings" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "connection_id" uuid NOT NULL,
+        "prestashop_category_id" varchar(100) NOT NULL,
+        "allegro_category_id" varchar(100) NOT NULL,
+        "allegro_category_name" varchar(500) NOT NULL,
+        "allegro_category_path" varchar(1000),
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_category_mappings" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_category_mappings_connection" FOREIGN KEY ("connection_id")
+          REFERENCES "connections"("id") ON DELETE CASCADE,
+        CONSTRAINT "UQ_category_mappings_connection_prestashop" UNIQUE ("connection_id", "prestashop_category_id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_category_mappings_connection_id"
+        ON "category_mappings" ("connection_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "category_mappings"`);
+  }
+}

--- a/apps/api/src/migrations/1779000000001-add-allegro-category-cache-table.ts
+++ b/apps/api/src/migrations/1779000000001-add-allegro-category-cache-table.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAllegroCategoryCacheTable1779000000001 implements MigrationInterface {
+  name = 'AddAllegroCategoryCacheTable1779000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "allegro_category_cache" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "connection_id" uuid NOT NULL,
+        "allegro_category_id" varchar(100) NOT NULL,
+        "name" varchar(500) NOT NULL,
+        "parent_id" varchar(100),
+        "leaf" boolean NOT NULL DEFAULT false,
+        "fetched_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_allegro_category_cache" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_allegro_category_cache_connection" FOREIGN KEY ("connection_id")
+          REFERENCES "connections"("id") ON DELETE CASCADE,
+        CONSTRAINT "UQ_allegro_category_cache_connection_category" UNIQUE ("connection_id", "allegro_category_id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_allegro_category_cache_connection_parent"
+        ON "allegro_category_cache" ("connection_id", "parent_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "allegro_category_cache"`);
+  }
+}

--- a/apps/web/src/app/routes/connection-category-mappings.route.tsx
+++ b/apps/web/src/app/routes/connection-category-mappings.route.tsx
@@ -1,0 +1,7 @@
+import type { RouteObject } from 'react-router-dom';
+import { ConnectionCategoryMappingsPage } from '../../pages/connections/connection-category-mappings-page';
+
+export const connectionCategoryMappingsRoute: RouteObject = {
+  path: 'connections/:connectionId/mappings/categories',
+  element: <ConnectionCategoryMappingsPage />,
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -5,6 +5,7 @@ import { allegroCallbackRoute } from './allegro-callback.route';
 import { allegroSetupRoute } from './allegro-setup.route';
 import { automationsRoute } from './automations.route';
 import { connectionDetailRoute } from './connection-detail.route';
+import { connectionCategoryMappingsRoute } from './connection-category-mappings.route';
 import { connectionMappingsRoute } from './connection-mappings.route';
 import { editConnectionRoute } from './edit-connection.route';
 import { connectionsRoute } from './connections.route';
@@ -37,6 +38,7 @@ export const rootRoute: RouteObject = {
     newConnectionRoute,
     allegroSetupRoute,
     connectionDetailRoute,
+    connectionCategoryMappingsRoute,
     connectionMappingsRoute,
     editConnectionRoute,
     allegroCallbackRoute,

--- a/apps/web/src/features/mappings/api/mappings.api.ts
+++ b/apps/web/src/features/mappings/api/mappings.api.ts
@@ -10,10 +10,13 @@ import type {
   StatusMapping,
   CarrierMapping,
   PaymentMapping,
+  CategoryMapping,
+  AllegroCategory,
   MappingOption,
   UpsertStatusMappingsPayload,
   UpsertCarrierMappingsPayload,
   UpsertPaymentMappingsPayload,
+  UpsertCategoryMappingPayload,
 } from './mappings.types';
 
 export interface MappingsApi {
@@ -32,6 +35,11 @@ export interface MappingsApi {
   getPrestashopOrderStatuses: (connectionId: string) => Promise<MappingOption[]>;
   getPrestashopCarriers: (connectionId: string) => Promise<MappingOption[]>;
   getPrestashopPaymentModules: (connectionId: string) => Promise<MappingOption[]>;
+
+  getCategoryMappings: (connectionId: string) => Promise<CategoryMapping[]>;
+  upsertCategoryMapping: (connectionId: string, prestashopCategoryId: string, payload: UpsertCategoryMappingPayload) => Promise<CategoryMapping>;
+  deleteCategoryMapping: (connectionId: string, prestashopCategoryId: string) => Promise<void>;
+  getAllegroCategories: (connectionId: string, parentId?: string) => Promise<AllegroCategory[]>;
 }
 
 interface ApiRequest {
@@ -84,5 +92,24 @@ export function createMappingsApi(request: ApiRequest): MappingsApi {
 
     getPrestashopPaymentModules: (connectionId) =>
       request<MappingOption[]>(`/connections/${connectionId}/prestashop/payment-modules`),
+
+    getCategoryMappings: (connectionId) =>
+      request<CategoryMapping[]>(`/connections/${connectionId}/mappings/categories`),
+
+    upsertCategoryMapping: (connectionId, prestashopCategoryId, payload) =>
+      request<CategoryMapping>(`/connections/${connectionId}/mappings/categories/${prestashopCategoryId}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      }),
+
+    deleteCategoryMapping: (connectionId, prestashopCategoryId) =>
+      request<void>(`/connections/${connectionId}/mappings/categories/${prestashopCategoryId}`, {
+        method: 'DELETE',
+      }),
+
+    getAllegroCategories: (connectionId, parentId?) => {
+      const qs = parentId ? `?parentId=${encodeURIComponent(parentId)}` : '';
+      return request<AllegroCategory[]>(`/connections/${connectionId}/allegro/categories${qs}`);
+    },
   };
 }

--- a/apps/web/src/features/mappings/api/mappings.query-keys.ts
+++ b/apps/web/src/features/mappings/api/mappings.query-keys.ts
@@ -9,4 +9,7 @@ export const mappingsQueryKeys = {
   carriers: (connectionId: string) => ['mappings', connectionId, 'carriers'] as const,
   payments: (connectionId: string) => ['mappings', connectionId, 'payments'] as const,
   options: (connectionId: string) => ['mappings', connectionId, 'options'] as const,
+  categories: (connectionId: string) => ['mappings', connectionId, 'categories'] as const,
+  allegroCategories: (connectionId: string, parentId?: string) =>
+    ['mappings', connectionId, 'allegro-categories', parentId ?? 'root'] as const,
 };

--- a/apps/web/src/features/mappings/api/mappings.types.ts
+++ b/apps/web/src/features/mappings/api/mappings.types.ts
@@ -48,6 +48,30 @@ export interface UpsertPaymentMappingsPayload {
   items: { allegroPaymentProvider: string; prestashopPaymentModule: string }[];
 }
 
+// ── Category mapping types ────────────────────────────────────────────────
+
+export interface AllegroCategory {
+  id: string;
+  name: string;
+  parentId: string | null;
+  leaf: boolean;
+}
+
+export interface CategoryMapping {
+  id: string;
+  connectionId: string;
+  prestashopCategoryId: string;
+  allegroCategoryId: string;
+  allegroCategoryName: string;
+  allegroCategoryPath: string | null;
+}
+
+export interface UpsertCategoryMappingPayload {
+  allegroCategoryId: string;
+  allegroCategoryName: string;
+  allegroCategoryPath?: string;
+}
+
 // ── Mapping options bundle ────────────────────────────────────────────────
 
 export interface MappingOptions {

--- a/apps/web/src/features/mappings/components/AllegroCategorySearch.tsx
+++ b/apps/web/src/features/mappings/components/AllegroCategorySearch.tsx
@@ -1,0 +1,147 @@
+/**
+ * AllegroCategorySearch
+ *
+ * Browseable Allegro category tree with lazy-loaded children.
+ * Shows breadcrumb path, allows selecting a category for mapping,
+ * and clearing an existing mapping.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import { useState, type ReactElement } from 'react';
+import { useAllegroCategoriesQuery } from '../hooks/use-allegro-categories';
+import { Button } from '../../../shared/ui/button';
+import { LoadingState, ErrorState, EmptyState } from '../../../shared/ui/feedback-state';
+import type { AllegroCategory, CategoryMapping } from '../api/mappings.types';
+
+interface AllegroCategorySearchProps {
+  connectionId: string;
+  currentMapping: CategoryMapping | undefined;
+  onSelect: (category: AllegroCategory, path: string) => void;
+  onClear: () => void;
+  isSaving: boolean;
+}
+
+interface BreadcrumbItem {
+  id: string;
+  name: string;
+}
+
+export function AllegroCategorySearch({
+  connectionId,
+  currentMapping,
+  onSelect,
+  onClear,
+  isSaving,
+}: AllegroCategorySearchProps): ReactElement {
+  const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([]);
+  const currentParentId = breadcrumbs.length > 0 ? breadcrumbs[breadcrumbs.length - 1].id : undefined;
+
+  const categoriesQuery = useAllegroCategoriesQuery(connectionId, currentParentId);
+
+  function navigateInto(category: AllegroCategory): void {
+    setBreadcrumbs((prev) => [...prev, { id: category.id, name: category.name }]);
+  }
+
+  function navigateTo(index: number): void {
+    setBreadcrumbs((prev) => prev.slice(0, index));
+  }
+
+  function buildPath(category: AllegroCategory): string {
+    const parts = breadcrumbs.map((b) => b.name);
+    parts.push(category.name);
+    return parts.join(' > ');
+  }
+
+  function handleSelect(category: AllegroCategory): void {
+    onSelect(category, buildPath(category));
+  }
+
+  return (
+    <div className="allegro-category-search">
+      {currentMapping && (
+        <div className="allegro-category-search__current">
+          <span className="mono-text">{currentMapping.allegroCategoryName}</span>
+          {currentMapping.allegroCategoryPath && (
+            <span className="allegro-category-search__path">{currentMapping.allegroCategoryPath}</span>
+          )}
+          <Button
+            className="button--ghost button--sm"
+            onClick={onClear}
+            disabled={isSaving}
+          >
+            Clear mapping
+          </Button>
+        </div>
+      )}
+
+      {/* Breadcrumb navigation */}
+      <nav className="allegro-category-search__breadcrumbs" aria-label="Category breadcrumbs">
+        <button
+          type="button"
+          className="allegro-category-search__crumb"
+          onClick={() => { navigateTo(0); }}
+        >
+          Root
+        </button>
+        {breadcrumbs.map((crumb, i) => (
+          <span key={crumb.id}>
+            <span className="allegro-category-search__separator"> / </span>
+            <button
+              type="button"
+              className="allegro-category-search__crumb"
+              onClick={() => { navigateTo(i + 1); }}
+            >
+              {crumb.name}
+            </button>
+          </span>
+        ))}
+      </nav>
+
+      {/* Category list */}
+      {categoriesQuery.isLoading && (
+        <LoadingState liveRegion="off" title="Loading categories" message="Fetching Allegro categories..." />
+      )}
+
+      {categoriesQuery.error && (
+        <ErrorState
+          title="Unable to load categories"
+          message={categoriesQuery.error.message}
+          action={<Button onClick={() => { void categoriesQuery.refetch(); }}>Retry</Button>}
+        />
+      )}
+
+      {categoriesQuery.data && categoriesQuery.data.length === 0 && (
+        <EmptyState title="No subcategories" message="This category has no children." />
+      )}
+
+      {categoriesQuery.data && categoriesQuery.data.length > 0 && (
+        <ul className="allegro-category-search__list" role="list">
+          {categoriesQuery.data.map((cat) => (
+            <li key={cat.id} className="allegro-category-search__item">
+              <span className="allegro-category-search__name">{cat.name}</span>
+              <span className="allegro-category-search__actions">
+                {!cat.leaf && (
+                  <button
+                    type="button"
+                    className="button button--ghost button--sm"
+                    onClick={() => { navigateInto(cat); }}
+                  >
+                    Browse
+                  </button>
+                )}
+                <Button
+                  className="button--primary button--sm"
+                  onClick={() => { handleSelect(cat); }}
+                  disabled={isSaving}
+                >
+                  {isSaving ? 'Saving...' : 'Select'}
+                </Button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/mappings/components/CategoryMappingRow.tsx
+++ b/apps/web/src/features/mappings/components/CategoryMappingRow.tsx
@@ -1,0 +1,52 @@
+/**
+ * CategoryMappingRow
+ *
+ * A single row in the PrestaShop category tree. Shows the category name,
+ * its mapped Allegro category (or unmapped indicator), and responds to clicks.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import type { ReactElement } from 'react';
+import type { CategoryMapping } from '../api/mappings.types';
+
+interface CategoryMappingRowProps {
+  id: string;
+  name: string;
+  depth: number;
+  mapping: CategoryMapping | undefined;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}
+
+export function CategoryMappingRow({
+  id,
+  name,
+  depth,
+  mapping,
+  isSelected,
+  onSelect,
+}: CategoryMappingRowProps): ReactElement {
+  const paddingLeft = `${depth * 1.25}rem`;
+
+  return (
+    <button
+      type="button"
+      className={['category-row', isSelected ? 'category-row--selected' : ''].filter(Boolean).join(' ')}
+      style={{ paddingLeft }}
+      onClick={() => { onSelect(id); }}
+      aria-pressed={isSelected}
+    >
+      <span className="category-row__name">{name}</span>
+      {mapping ? (
+        <span className="category-row__badge category-row__badge--mapped">
+          {mapping.allegroCategoryName}
+        </span>
+      ) : (
+        <span className="category-row__badge category-row__badge--unmapped">
+          — not mapped —
+        </span>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/features/mappings/components/CategoryMappingTree.tsx
+++ b/apps/web/src/features/mappings/components/CategoryMappingTree.tsx
@@ -1,0 +1,138 @@
+/**
+ * CategoryMappingTree
+ *
+ * Expandable/collapsible tree rendering PrestaShop categories.
+ * Each row shows the category name and its mapping status.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import { useState, useMemo, type ReactElement } from 'react';
+import { CategoryMappingRow } from './CategoryMappingRow';
+import type { CategoryMapping } from '../api/mappings.types';
+
+interface TreeCategory {
+  id: string;
+  name: string;
+  parentId: string | null;
+  depth: number;
+}
+
+interface CategoryMappingTreeProps {
+  categories: TreeCategory[];
+  mappings: CategoryMapping[];
+  selectedCategoryId: string | null;
+  onSelect: (categoryId: string) => void;
+}
+
+interface TreeNode extends TreeCategory {
+  children: TreeNode[];
+}
+
+function buildTree(categories: TreeCategory[]): TreeNode[] {
+  const byId = new Map<string, TreeNode>();
+  const roots: TreeNode[] = [];
+
+  for (const cat of categories) {
+    byId.set(cat.id, { ...cat, children: [] });
+  }
+
+  for (const node of byId.values()) {
+    if (node.parentId && byId.has(node.parentId)) {
+      byId.get(node.parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  return roots;
+}
+
+function flattenVisible(nodes: TreeNode[], expanded: Set<string>): TreeNode[] {
+  const result: TreeNode[] = [];
+  function walk(list: TreeNode[]): void {
+    for (const node of list) {
+      result.push(node);
+      if (node.children.length > 0 && expanded.has(node.id)) {
+        walk(node.children);
+      }
+    }
+  }
+  walk(nodes);
+  return result;
+}
+
+export function CategoryMappingTree({
+  categories,
+  mappings,
+  selectedCategoryId,
+  onSelect,
+}: CategoryMappingTreeProps): ReactElement {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const tree = useMemo(() => buildTree(categories), [categories]);
+
+  const mappingIndex = useMemo(() => {
+    const index = new Map<string, CategoryMapping>();
+    for (const m of mappings) {
+      index.set(m.prestashopCategoryId, m);
+    }
+    return index;
+  }, [mappings]);
+
+  const visible = useMemo(() => flattenVisible(tree, expanded), [tree, expanded]);
+
+  function toggleExpand(id: string): void {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  // Determine which nodes have children for the expand toggle
+  const hasChildren = useMemo(() => {
+    const parentIds = new Set<string>();
+    for (const cat of categories) {
+      if (cat.parentId) {
+        parentIds.add(cat.parentId);
+      }
+    }
+    return parentIds;
+  }, [categories]);
+
+  return (
+    <div className="category-tree" role="tree" aria-label="PrestaShop categories">
+      {visible.map((node) => (
+        <div key={node.id} role="treeitem" aria-expanded={hasChildren.has(node.id) ? expanded.has(node.id) : undefined}>
+          <div className="category-tree__row">
+            {hasChildren.has(node.id) ? (
+              <button
+                type="button"
+                className="category-tree__toggle"
+                onClick={() => { toggleExpand(node.id); }}
+                aria-label={expanded.has(node.id) ? `Collapse ${node.name}` : `Expand ${node.name}`}
+              >
+                {expanded.has(node.id) ? '▾' : '▸'}
+              </button>
+            ) : (
+              <span className="category-tree__toggle-placeholder" />
+            )}
+            <CategoryMappingRow
+              id={node.id}
+              name={node.name}
+              depth={node.depth}
+              mapping={mappingIndex.get(node.id)}
+              isSelected={selectedCategoryId === node.id}
+              onSelect={onSelect}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/mappings/hooks/use-allegro-categories.ts
+++ b/apps/web/src/features/mappings/hooks/use-allegro-categories.ts
@@ -1,0 +1,27 @@
+/**
+ * Allegro Categories Hook
+ *
+ * TanStack Query hook for lazy-loading Allegro category tree nodes.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mappingsQueryKeys } from '../api/mappings.query-keys';
+import type { AllegroCategory } from '../api/mappings.types';
+
+export function useAllegroCategoriesQuery(
+  connectionId: string,
+  parentId?: string,
+  enabled = true,
+): UseQueryResult<AllegroCategory[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: mappingsQueryKeys.allegroCategories(connectionId, parentId),
+    queryFn: () => apiClient.mappings.getAllegroCategories(connectionId, parentId),
+    enabled,
+    retry: false,
+    staleTime: 1000 * 60 * 60, // 1 hour — categories change infrequently
+  });
+}

--- a/apps/web/src/features/mappings/hooks/use-category-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-category-mappings.ts
@@ -1,0 +1,49 @@
+/**
+ * Category Mappings Hooks
+ *
+ * TanStack Query hooks for category mapping CRUD operations.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { useQuery, useMutation, useQueryClient, type UseQueryResult, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mappingsQueryKeys } from '../api/mappings.query-keys';
+import type { CategoryMapping, UpsertCategoryMappingPayload } from '../api/mappings.types';
+
+export function useCategoryMappingsQuery(connectionId: string): UseQueryResult<CategoryMapping[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: mappingsQueryKeys.categories(connectionId),
+    queryFn: () => apiClient.mappings.getCategoryMappings(connectionId),
+    retry: false,
+  });
+}
+
+export function useUpsertCategoryMapping(
+  connectionId: string,
+): UseMutationResult<CategoryMapping, Error, { prestashopCategoryId: string; payload: UpsertCategoryMappingPayload }> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ prestashopCategoryId, payload }) =>
+      apiClient.mappings.upsertCategoryMapping(connectionId, prestashopCategoryId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: mappingsQueryKeys.categories(connectionId) });
+    },
+  });
+}
+
+export function useDeleteCategoryMapping(
+  connectionId: string,
+): UseMutationResult<void, Error, string> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (prestashopCategoryId: string) =>
+      apiClient.mappings.deleteCategoryMapping(connectionId, prestashopCategoryId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: mappingsQueryKeys.categories(connectionId) });
+    },
+  });
+}

--- a/apps/web/src/features/mappings/hooks/use-prestashop-categories.ts
+++ b/apps/web/src/features/mappings/hooks/use-prestashop-categories.ts
@@ -1,0 +1,63 @@
+/**
+ * PrestaShop Categories Hook
+ *
+ * TanStack Query hook for fetching PrestaShop categories for a connection.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+interface PrestashopCategoryRaw {
+  id: string | number;
+  name: string | Array<{ language: Array<{ attrs: { id: string }; value: string }> }>;
+  id_parent: string | number;
+  level_depth: string | number;
+  active: string | number;
+}
+
+export interface PrestashopCategoryFlat {
+  id: string;
+  name: string;
+  parentId: string | null;
+  depth: number;
+}
+
+function parsePrestashopCategories(raw: PrestashopCategoryRaw[]): PrestashopCategoryFlat[] {
+  return raw
+    .map((cat) => {
+      const id = String(cat.id);
+      const parentId = String(cat.id_parent);
+      const depth = Number(cat.level_depth);
+      let name: string;
+      if (typeof cat.name === 'string') {
+        name = cat.name;
+      } else if (Array.isArray(cat.name)) {
+        name = cat.name[0]?.language?.[0]?.value ?? `Category ${id}`;
+      } else {
+        name = `Category ${id}`;
+      }
+      return {
+        id,
+        name,
+        parentId: parentId === '0' ? null : parentId,
+        depth,
+      };
+    })
+    .filter((cat) => cat.depth > 0);
+}
+
+export function usePrestashopCategoriesQuery(connectionId: string): UseQueryResult<PrestashopCategoryFlat[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: ['prestashop-categories', connectionId],
+    queryFn: async () => {
+      const raw = await apiClient.request<PrestashopCategoryRaw[]>(
+        `/connections/${connectionId}/prestashop/categories`,
+      );
+      return parsePrestashopCategories(raw);
+    },
+    retry: false,
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1259,3 +1259,213 @@ textarea {
   gap: 0.5rem;
   align-items: center;
 }
+
+/* ── Category Mappings Layout ────────────────────────────────────── */
+
+.category-mappings-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) minmax(320px, 1.2fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.category-mappings-layout__tree,
+.category-mappings-layout__search {
+  border: 1px solid var(--border-default);
+  border-radius: 0.5rem;
+  background: var(--bg-surface);
+  padding: 1rem;
+  max-height: 36rem;
+  overflow-y: auto;
+}
+
+.category-mappings-layout__tree h3,
+.category-mappings-layout__search h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+/* ── Category Tree ───────────────────────────────────────────────── */
+
+.category-tree {
+  display: flex;
+  flex-direction: column;
+}
+
+.category-tree__row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.category-tree__toggle,
+.category-tree__toggle-placeholder {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  padding: 0;
+}
+
+.category-tree__toggle-placeholder {
+  cursor: default;
+}
+
+/* ── Category Row ────────────────────────────────────────────────── */
+
+.category-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid transparent;
+  background: none;
+  cursor: pointer;
+  border-radius: 0.375rem;
+  text-align: left;
+  font-size: 0.8125rem;
+  transition: background 0.1s;
+}
+
+.category-row:hover {
+  background: var(--bg-surface-elevated);
+  border-color: var(--border-default);
+}
+
+.category-row--selected {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary-soft);
+}
+
+.category-row__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.category-row__badge {
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.category-row__badge--mapped {
+  background: var(--status-success-soft);
+  color: var(--status-success);
+  border: 1px solid var(--status-success-border);
+}
+
+.category-row__badge--unmapped {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ── Allegro Category Search ─────────────────────────────────────── */
+
+.allegro-category-search__current {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  background: var(--status-success-soft);
+  border: 1px solid var(--status-success-border);
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  flex-wrap: wrap;
+}
+
+.allegro-category-search__path {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.allegro-category-search__breadcrumbs {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.125rem;
+  padding: 0.375rem 0;
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+  border-bottom: 1px solid var(--border-default);
+}
+
+.allegro-category-search__crumb {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--accent-primary);
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.allegro-category-search__crumb:hover {
+  background: var(--accent-primary-soft);
+}
+
+.allegro-category-search__separator {
+  color: var(--text-muted);
+}
+
+.allegro-category-search__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.allegro-category-search__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 0.8125rem;
+}
+
+.allegro-category-search__item:last-child {
+  border-bottom: none;
+}
+
+.allegro-category-search__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.allegro-category-search__actions {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+@media (max-width: 900px) {
+  .category-mappings-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/pages/connections/connection-category-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-category-mappings-page.tsx
@@ -1,0 +1,145 @@
+/**
+ * Connection Category Mappings Page
+ *
+ * Two-column layout for mapping PrestaShop categories to Allegro categories.
+ * Left: PrestaShop category tree with mapping indicators.
+ * Right: Allegro category browser for the selected PrestaShop category.
+ *
+ * @module apps/web/src/pages/connections
+ */
+
+import { useState, useMemo, type ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { CategoryMappingTree } from '../../features/mappings/components/CategoryMappingTree';
+import { AllegroCategorySearch } from '../../features/mappings/components/AllegroCategorySearch';
+import {
+  useCategoryMappingsQuery,
+  useUpsertCategoryMapping,
+  useDeleteCategoryMapping,
+} from '../../features/mappings/hooks/use-category-mappings';
+import { usePrestashopCategoriesQuery } from '../../features/mappings/hooks/use-prestashop-categories';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import type { AllegroCategory } from '../../features/mappings/api/mappings.types';
+
+export function ConnectionCategoryMappingsPage(): ReactElement {
+  const { connectionId = '' } = useParams();
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
+
+  const mappingsQuery = useCategoryMappingsQuery(connectionId);
+  const prestashopCategoriesQuery = usePrestashopCategoriesQuery(connectionId);
+
+  const upsertMutation = useUpsertCategoryMapping(connectionId);
+  const deleteMutation = useDeleteCategoryMapping(connectionId);
+
+  const mappings = mappingsQuery.data ?? [];
+  const categories = prestashopCategoriesQuery.data ?? [];
+
+  const mappedCount = useMemo(() => {
+    const mappedIds = new Set(mappings.map((m) => m.prestashopCategoryId));
+    return categories.filter((c) => mappedIds.has(c.id)).length;
+  }, [mappings, categories]);
+
+  const selectedMapping = useMemo(
+    () => selectedCategoryId ? mappings.find((m) => m.prestashopCategoryId === selectedCategoryId) : undefined,
+    [mappings, selectedCategoryId],
+  );
+
+  function handleAllegroSelect(category: AllegroCategory, path: string): void {
+    if (!selectedCategoryId) return;
+    upsertMutation.mutate({
+      prestashopCategoryId: selectedCategoryId,
+      payload: {
+        allegroCategoryId: category.id,
+        allegroCategoryName: category.name,
+        allegroCategoryPath: path,
+      },
+    });
+  }
+
+  function handleClear(): void {
+    if (!selectedCategoryId) return;
+    deleteMutation.mutate(selectedCategoryId);
+  }
+
+  const isLoading = mappingsQuery.isLoading || prestashopCategoriesQuery.isLoading;
+  const loadError = mappingsQuery.error ?? prestashopCategoriesQuery.error ?? null;
+
+  if (isLoading) {
+    return (
+      <PageLayout eyebrow="Connection" title="Category Mappings">
+        <LoadingState liveRegion="off" title="Loading" message="Fetching categories and mappings..." />
+      </PageLayout>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <PageLayout eyebrow="Connection" title="Category Mappings">
+        <ErrorState title="Unable to load" message={loadError.message} />
+      </PageLayout>
+    );
+  }
+
+  if (categories.length === 0) {
+    return (
+      <PageLayout
+        eyebrow="Connection"
+        title="Category Mappings"
+        actions={
+          <Link className="button button--secondary" to={`/connections/${connectionId}`}>
+            Back to connection
+          </Link>
+        }
+      >
+        <EmptyState
+          title="No PrestaShop categories"
+          message="No categories were found for this connection. Ensure the PrestaShop store has categories configured."
+        />
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout
+      eyebrow="Connection"
+      title="Category Mappings"
+      description={`${mappedCount} of ${categories.length} categories mapped`}
+      actions={
+        <Link className="button button--secondary" to={`/connections/${connectionId}`}>
+          Back to connection
+        </Link>
+      }
+    >
+      <div className="category-mappings-layout">
+        <div className="category-mappings-layout__tree">
+          <h3>PrestaShop Categories</h3>
+          <CategoryMappingTree
+            categories={categories}
+            mappings={mappings}
+            selectedCategoryId={selectedCategoryId}
+            onSelect={setSelectedCategoryId}
+          />
+        </div>
+
+        <div className="category-mappings-layout__search">
+          <h3>Allegro Category</h3>
+          {selectedCategoryId ? (
+            <AllegroCategorySearch
+              connectionId={connectionId}
+              currentMapping={selectedMapping}
+              onSelect={handleAllegroSelect}
+              onClear={handleClear}
+              isSaving={upsertMutation.isPending || deleteMutation.isPending}
+            />
+          ) : (
+            <EmptyState
+              title="Select a category"
+              message="Click a PrestaShop category on the left to assign an Allegro category."
+            />
+          )}
+        </div>
+      </div>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -41,6 +41,9 @@ export function ConnectionDetailPage(): ReactElement {
               <Link className="button button--secondary" to={`/connections/${connectionId}/mappings`}>
                 Mappings
               </Link>
+              <Link className="button button--secondary" to={`/connections/${connectionId}/mappings/categories`}>
+                Category Mappings
+              </Link>
             </>
           ) : null}
           <Link className="button button--secondary" to="/connections">

--- a/docs/plans/implementation-plan-category-mapping-api-ui.md
+++ b/docs/plans/implementation-plan-category-mapping-api-ui.md
@@ -1,0 +1,434 @@
+# Implementation Plan: Allegro Category Tree API & Category Mapping CRUD + UI
+
+**Date**: 2026-04-11
+**Status**: Draft
+**Issues**: #138 (BE), #139 (FE)
+**Estimated Effort**: 2–3 days
+
+---
+
+## 1. Task Summary
+
+**Objective**: Enable merchants to map PrestaShop categories to Allegro categories so that offer creation can pre-populate the correct Allegro category.
+
+**Context**: Without category mappings, merchants must manually select an Allegro category for every offer. This is a prerequisite for automated and batch offer creation (future #143).
+
+**Classification**: CORE / Infrastructure / Interface / Frontend
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- Allegro category tree API endpoint (fetched live, cached in DB)
+- PrestaShop category list endpoint (fetched live via webservice)
+- Category mapping CRUD (per-connection, PrestaShop → Allegro)
+- `resolveAllegroCategory()` method for future offer creation use
+- Frontend: two-column category mapping page with tree + search
+- Migration for `category_mappings` table
+- Unit tests for service, repository, adapter, and FE components
+
+### Out of Scope
+- Wiring category resolution into offer creation flow (deferred to #143)
+- GTIN-based auto-detection of Allegro categories (#143)
+- Bulk import/export of category mappings
+- Category tree full-depth pre-loading (lazy-load children only)
+
+### Constraints
+- Must follow existing mapping module patterns (`libs/core/src/mappings/`)
+- Category mapping is **per-row save** (not bulk replace like status/carrier/payment)
+- Allegro category tree is large (~30K nodes) — must use lazy loading with DB cache
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layers**:
+- **CORE** (`libs/core/src/mappings/`) — CategoryMapping entity, repository port, service extension
+- **Integration** (`libs/integrations/allegro/src/`) — Allegro category tree fetch method on adapter
+- **Infrastructure** (`apps/api/`) — Controller endpoints, DB-cached category service, migration
+- **Frontend** (`apps/web/src/`) — Category mapping page, tree component, search component
+
+**Capabilities Involved**:
+- `MarketplacePort` — extended with optional `fetchCategories?()` method
+- `IPrestashopWebserviceClient` — existing `listResources('categories')` for PrestaShop categories
+- `IMappingConfigService` — extended with category mapping methods
+
+**Existing Services Reused**:
+- `MappingConfigService` — add category mapping methods
+- `MappingsModule` — register new entity/repository/token
+- `MappingsController` — add category mapping CRUD endpoints
+- `MappingOptionsController` — add category tree endpoints
+- FE `mappings` feature module — extend API, hooks, components
+
+**New Components Required**:
+- `CategoryMapping` domain entity
+- `CategoryMappingOrmEntity` + migration
+- `CategoryMappingRepositoryPort` + `CategoryMappingRepository`
+- `AllegroCategoryCacheOrmEntity` + migration (DB cache table)
+- `AllegroCategoryCacheService` (thin cache-aside service in `apps/api/`)
+- `MarketplacePort.fetchCategories?()` optional method
+- `AllegroMarketplaceAdapter.fetchCategories()` implementation
+- FE: `CategoryMappingTree`, `CategoryMappingRow`, `AllegroCategorySearch` components
+- FE: `connection-category-mappings.route.tsx` page
+
+---
+
+## 4. External / Domain Research
+
+### Allegro Category API
+- **Endpoint**: `GET /sale/categories` — returns top-level categories
+- **With parent**: `GET /sale/categories?parent.id={parentId}` — returns children
+- **Response shape**: `{ categories: [{ id, name, parent: { id } | null, leaf: boolean }] }`
+- **Rate limits**: Standard Allegro rate limits apply (handled by existing HTTP client retry logic)
+- **Stability**: Categories change ~monthly; 24h DB cache TTL is safe
+- **Size**: ~30K total categories; top-level ~20 nodes; deepest path ~6 levels
+
+### PrestaShop Category API
+- **Endpoint**: `GET /api/categories` via `IPrestashopWebserviceClient.listResources('categories')`
+- **Response shape**: Each category has `id`, `name` (localized), `id_parent`, `active`, `level_depth`
+- **Size**: Typically 10–500 per merchant; safe to fetch all at once
+
+### Existing Patterns
+- **Mapping entity**: `StatusMapping` — pure domain class with readonly fields
+- **ORM entity**: `StatusMappingOrmEntity` — TypeORM with UUID PK, unique constraint, FK to connections
+- **Repository port**: `StatusMappingRepositoryPort` — `findByConnectionId()`, `replaceForConnection()`
+- **Repository impl**: Uses `@InjectRepository` + `@InjectDataSource` for transactions
+- **Service**: `MappingConfigService` — delegates to repository ports via `@Inject(TOKEN)`
+- **Controller**: `MappingsController` — `@Roles('admin')`, `@ApiBearerAuth()`, `@ApiTags('mappings')`
+- **FE API**: `createMappingsApi(request)` factory, query key factory, TanStack Query hooks
+
+---
+
+## 5. Questions & Assumptions
+
+### Assumptions
+- Category mapping uses **PUT/DELETE per row** (not bulk replace like other mappings) since the tree has many nodes and merchants map one at a time
+- Allegro categories are cached in a **DB table** (`allegro_category_cache`) with 24h staleness check — survives restarts, queryable for breadcrumbs
+- PrestaShop categories are fetched **live per request** (small dataset, no cache needed for MVP)
+- The `MarketplacePort` gets an optional `fetchCategories?()` method following the existing `listOfferEvents?()` pattern
+- FE category tree uses **lazy loading** — only fetches children when a node is expanded
+
+### Documentation Gaps
+- Allegro `GET /sale/categories` response format assumed from public API docs; adapter test should verify
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: Domain & Infrastructure (Category Mapping CRUD)
+
+**Goal**: Add CategoryMapping entity, persistence, and service methods following the existing mapping pattern.
+
+#### Step 1.1: Domain entity
+- **File**: `libs/core/src/mappings/domain/entities/category-mapping.entity.ts`
+- **Action**: Create `CategoryMapping` domain entity with `id`, `connectionId`, `prestashopCategoryId`, `allegroCategoryId`, `allegroCategoryName` (denormalized for display), `allegroCategoryPath` (breadcrumb string, nullable)
+- **Pattern**: Follow `StatusMapping` — pure class, no framework deps
+
+#### Step 1.2: Domain types
+- **File**: `libs/core/src/mappings/domain/types/mapping.types.ts`
+- **Action**: Add `CategoryMappingInput` interface: `{ prestashopCategoryId: string; allegroCategoryId: string; allegroCategoryName: string; allegroCategoryPath?: string }`
+
+#### Step 1.3: Repository port
+- **File**: `libs/core/src/mappings/domain/ports/category-mapping-repository.port.ts`
+- **Action**: Define `CategoryMappingRepositoryPort` with:
+  - `findByConnectionId(connectionId: string): Promise<CategoryMapping[]>`
+  - `upsertMapping(connectionId: string, input: CategoryMappingInput): Promise<CategoryMapping>`
+  - `deleteMapping(connectionId: string, prestashopCategoryId: string): Promise<void>`
+  - `findByPrestashopCategoryId(connectionId: string, prestashopCategoryId: string): Promise<CategoryMapping | null>`
+
+#### Step 1.4: ORM entity
+- **File**: `libs/core/src/mappings/infrastructure/persistence/entities/category-mapping.orm-entity.ts`
+- **Action**: Create TypeORM entity for `category_mappings` table:
+  - UUID PK, `connection_id` FK (ON DELETE CASCADE), unique constraint on `(connection_id, prestashop_category_id)`
+  - Columns: `prestashop_category_id`, `allegro_category_id`, `allegro_category_name`, `allegro_category_path` (nullable), timestamps
+
+#### Step 1.5: Repository implementation
+- **File**: `libs/core/src/mappings/infrastructure/persistence/repositories/category-mapping.repository.ts`
+- **Action**: Implement `CategoryMappingRepositoryPort`. `upsertMapping` uses TypeORM `upsert` (INSERT ON CONFLICT UPDATE) on the unique constraint.
+- **Pattern**: Follow `StatusMappingRepository` structure
+
+#### Step 1.6: Service interface extension
+- **File**: `libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts`
+- **Action**: Add to `IMappingConfigService`:
+  - `getCategoryMappings(connectionId: string): Promise<CategoryMapping[]>`
+  - `upsertCategoryMapping(connectionId: string, input: CategoryMappingInput): Promise<CategoryMapping>`
+  - `deleteCategoryMapping(connectionId: string, prestashopCategoryId: string): Promise<void>`
+  - `resolveAllegroCategory(connectionId: string, prestashopCategoryId: string): Promise<string | null>`
+
+#### Step 1.7: Service implementation
+- **File**: `libs/core/src/mappings/application/services/mapping-config.service.ts`
+- **Action**: Add category mapping methods. `resolveAllegroCategory` returns `allegroCategoryId` or `null`.
+
+#### Step 1.8: DI tokens + module wiring
+- **File**: `libs/core/src/mappings/mappings.tokens.ts` — add `CATEGORY_MAPPING_REPOSITORY_TOKEN`
+- **File**: `libs/core/src/mappings/mappings.module.ts` — register ORM entity, repository, token binding
+- **File**: `libs/core/src/mappings/index.ts` — export new types
+
+#### Step 1.9: Migration
+- **File**: `apps/api/src/migrations/{timestamp}-add-category-mapping-table.ts`
+- **Action**: Create `category_mappings` table with columns, FK, unique constraint, indexes
+- **Verify**: `pnpm --filter @openlinker/api migration:show`
+
+#### Step 1.10: Unit tests
+- **File**: `libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts`
+- **Action**: Add tests for category mapping methods: upsert, delete, resolve (hit + miss)
+
+---
+
+### Phase 2: Allegro Category Tree Fetch + DB Cache
+
+**Goal**: Fetch Allegro categories via the adapter and cache them in DB.
+
+#### Step 2.1: MarketplacePort extension
+- **File**: `libs/core/src/integrations/domain/ports/marketplace.port.ts`
+- **Action**: Add optional method:
+  ```typescript
+  fetchCategories?(parentId?: string): Promise<MarketplaceCategory[]>;
+  ```
+- **File**: `libs/core/src/integrations/domain/types/marketplace.types.ts` (or create)
+- **Action**: Define `MarketplaceCategory` type: `{ id: string; name: string; parentId: string | null; leaf: boolean }`
+
+#### Step 2.2: Allegro API types
+- **File**: `libs/integrations/allegro/src/domain/types/allegro-api.types.ts`
+- **Action**: Add `AllegroCategoriesResponse` and `AllegroCategoryItem` interfaces matching the Allegro `GET /sale/categories` response
+
+#### Step 2.3: Allegro adapter implementation
+- **File**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts`
+- **Action**: Implement `fetchCategories(parentId?)`:
+  - Call `GET /sale/categories` with optional `parent.id` query param
+  - Map to `MarketplaceCategory[]`
+
+#### Step 2.4: Allegro adapter unit test
+- **File**: `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts`
+- **Action**: Add test for `fetchCategories` — mock HTTP client, verify mapping
+
+#### Step 2.5: DB cache table — ORM entity
+- **File**: `apps/api/src/categories/persistence/allegro-category-cache.orm-entity.ts`
+- **Action**: Create ORM entity for `allegro_category_cache`:
+  - Columns: `id` (PK, UUID), `connection_id`, `allegro_category_id`, `name`, `parent_id` (nullable), `leaf` (boolean), `fetched_at` (timestamptz)
+  - Unique constraint: `(connection_id, allegro_category_id)`
+
+#### Step 2.6: DB cache migration
+- **File**: `apps/api/src/migrations/{timestamp}-add-allegro-category-cache-table.ts`
+- **Action**: Create `allegro_category_cache` table
+
+#### Step 2.7: Category cache service
+- **File**: `apps/api/src/categories/categories-cache.service.ts`
+- **Action**: `AllegroCategoryCacheService` with:
+  - `getCategories(connectionId, parentId?): Promise<MarketplaceCategory[]>` — check DB cache first; if stale (>24h) or missing, fetch via adapter, store, return
+  - `invalidateCache(connectionId): Promise<void>` — delete cached entries
+- Injects `IntegrationsService` to resolve marketplace adapter for the connection
+
+#### Step 2.8: Categories API module
+- **File**: `apps/api/src/categories/categories.module.ts`
+- **Action**: Register ORM entity, cache service, export for use in mappings/controller
+
+---
+
+### Phase 3: Controller Endpoints
+
+**Goal**: Add REST endpoints for category tree browsing and category mapping CRUD.
+
+#### Step 3.1: Allegro category tree endpoint
+- **Endpoint**: `GET /connections/:connectionId/categories/allegro?parentId=`
+- **File**: `apps/api/src/mappings/http/mapping-options.controller.ts` (extend existing)
+- **Action**: Add `getAllegroCategories(connectionId, parentId?)` — delegates to `AllegroCategoryCacheService`
+- **Response**: `AllegroCategoryResponseDto[]` — `{ id, name, parentId, leaf }`
+
+#### Step 3.2: PrestaShop category list endpoint
+- **Endpoint**: `GET /connections/:connectionId/categories/prestashop`
+- **File**: `apps/api/src/mappings/http/mapping-options.controller.ts` (extend existing)
+- **Action**: Add `getPrestashopCategories(connectionId)` — resolves PrestaShop adapter, calls `listResources('categories')`, maps to response DTOs
+- **Response**: `PrestashopCategoryResponseDto[]` — `{ id, name, parentId, depth, active }`
+
+#### Step 3.3: Category mapping CRUD endpoints
+- **Endpoints**:
+  - `GET /connections/:connectionId/mappings/categories` → list all
+  - `PUT /connections/:connectionId/mappings/categories/:prestashopCategoryId` → upsert one
+  - `DELETE /connections/:connectionId/mappings/categories/:prestashopCategoryId` → delete one
+- **File**: `apps/api/src/mappings/http/mappings.controller.ts` (extend existing)
+- **Action**: Add three methods delegating to `IMappingConfigService`
+
+#### Step 3.4: Request/response DTOs
+- **Files**: `apps/api/src/mappings/http/dto/`
+  - `allegro-category-response.dto.ts`
+  - `prestashop-category-response.dto.ts`
+  - `category-mapping-input.dto.ts` — class-validator: `allegroCategoryId` required, `allegroCategoryName` required, `allegroCategoryPath` optional
+  - `category-mapping-response.dto.ts`
+
+#### Step 3.5: Module wiring
+- **File**: `apps/api/src/mappings/mappings.module.ts` — import `CategoriesModule`
+- **File**: `apps/api/src/app.module.ts` — register `CategoriesModule` if needed
+
+---
+
+### Phase 4: Frontend — Category Mapping UI
+
+**Goal**: Build the two-column category mapping page.
+
+#### Step 4.1: API types + client extension
+- **File**: `apps/web/src/features/mappings/api/mappings.types.ts` — add `AllegroCategory`, `PrestashopCategory`, `CategoryMapping`, `UpsertCategoryMappingPayload`
+- **File**: `apps/web/src/features/mappings/api/mappings.api.ts` — add methods:
+  - `getAllegroCategories(connectionId, parentId?)` → `GET .../categories/allegro`
+  - `getPrestashopCategories(connectionId)` → `GET .../categories/prestashop`
+  - `getCategoryMappings(connectionId)` → `GET .../mappings/categories`
+  - `upsertCategoryMapping(connectionId, prestashopCategoryId, payload)` → `PUT .../mappings/categories/:id`
+  - `deleteCategoryMapping(connectionId, prestashopCategoryId)` → `DELETE .../mappings/categories/:id`
+- **File**: `apps/web/src/features/mappings/api/mappings.query-keys.ts` — add `categories`, `allegroCategories`, `prestashopCategories` keys
+
+#### Step 4.2: Query and mutation hooks
+- **File**: `apps/web/src/features/mappings/hooks/use-category-mappings.ts`
+  - `useCategoryMappingsQuery(connectionId)`
+  - `useUpsertCategoryMapping(connectionId)` — invalidates category mappings on success
+  - `useDeleteCategoryMapping(connectionId)` — invalidates category mappings on success
+- **File**: `apps/web/src/features/mappings/hooks/use-allegro-category-search.ts`
+  - `useAllegroCategoriesQuery(connectionId, parentId)` — lazy load children
+- **File**: `apps/web/src/features/mappings/hooks/use-prestashop-categories.ts`
+  - `usePrestashopCategoriesQuery(connectionId)` — full tree
+
+#### Step 4.3: PrestaShop category tree component
+- **File**: `apps/web/src/features/mappings/components/CategoryMappingTree.tsx`
+- **Action**: Expandable/collapsible tree rendering PrestaShop categories. Each row shows:
+  - Category name (indented by depth)
+  - Mapped badge (Allegro category name) or "— not mapped —"
+  - Click to select for mapping
+- Props: `categories`, `mappings`, `selectedCategoryId`, `onSelect`
+
+#### Step 4.4: Category mapping row component
+- **File**: `apps/web/src/features/mappings/components/CategoryMappingRow.tsx`
+- **Action**: Single row in the tree — category name, mapping status indicator, click handler
+
+#### Step 4.5: Allegro category search component
+- **File**: `apps/web/src/features/mappings/components/AllegroCategorySearch.tsx`
+- **Action**: Searchable panel for browsing/selecting Allegro categories:
+  - Lazy-loaded tree (expand to see children)
+  - Search input with debounced filtering
+  - Shows breadcrumb path for context
+  - "Select" button to confirm, "Clear" to remove mapping
+- Props: `connectionId`, `onSelect(category)`, `onClear`, `currentMapping`
+
+#### Step 4.6: Category mappings page
+- **File**: `apps/web/src/pages/connections/connection-category-mappings-page.tsx`
+- **Action**: Two-column layout:
+  - Left: `CategoryMappingTree` with PrestaShop categories
+  - Right: `AllegroCategorySearch` (shown when a PrestaShop category is selected)
+  - Header with summary count: "X of Y categories mapped"
+  - Back link to connection detail
+- Handles loading/error/empty states
+
+#### Step 4.7: Route registration
+- **File**: `apps/web/src/app/routes/connection-category-mappings.route.tsx`
+  - Path: `connections/:connectionId/mappings/categories`
+  - Element: `<ConnectionCategoryMappingsPage />`
+- **File**: `apps/web/src/app/routes/root.route.tsx` — add to children array
+
+#### Step 4.8: Link from connection detail
+- **File**: Find connection detail page and add "Category Mappings" link alongside existing "Mapping Configuration" link
+
+#### Step 4.9: FE tests
+- **File**: `apps/web/src/pages/connections/connection-category-mappings-page.test.tsx`
+- **Tests**: Tree render, search interaction, save success, save error, clear mapping, empty state, loading state
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Extend existing MappingPanel for categories
+- **Description**: Reuse the generic `MappingPanel` component with dropdowns for source/target
+- **Why Rejected**: Categories are hierarchical (tree), not flat lists. `MappingPanel` uses flat dropdowns. A tree UI is essential for navigating ~30K Allegro categories and hierarchical PrestaShop categories.
+
+### Alternative 2: Redis-only caching for Allegro categories
+- **Description**: Cache categories in Redis with TTL
+- **Why Rejected**: Redis is ephemeral — categories would need re-fetching after every restart. DB cache survives restarts, is queryable for breadcrumb construction, and doesn't require Redis availability.
+
+### Alternative 3: Store category mappings in listings module
+- **Description**: Create `CategoryMapping` in `libs/core/src/listings/` as the issue suggests
+- **Why Rejected**: All other mapping types live in `libs/core/src/mappings/`. Putting categories there maintains consistency and reuses the existing module infrastructure (tokens, module registration, service interface).
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Follows hexagonal architecture: domain entity → port → repository → service → controller
+- ✅ CORE/Integration boundary respected: adapter fetches, CORE stores mappings
+- ✅ Uses existing patterns: extends `IMappingConfigService`, same token/module approach
+
+### Naming Conventions
+- ✅ Entity: `category-mapping.entity.ts` → `CategoryMapping`
+- ✅ ORM: `category-mapping.orm-entity.ts` → `CategoryMappingOrmEntity`
+- ✅ Port: `category-mapping-repository.port.ts` → `CategoryMappingRepositoryPort`
+- ✅ Types in `mapping.types.ts`
+
+### Risks
+- **Allegro API response format**: Assumed from public docs. Mitigated by adapter unit test with fixture.
+- **Large category tree performance**: ~30K nodes. Mitigated by lazy loading (children on expand) + DB cache.
+- **PrestaShop category fetch via generic `listResources`**: May need field filtering. Mitigated by testing with real PrestaShop instance.
+
+### Edge Cases
+- **Orphan mappings**: If a PrestaShop category is deleted, the mapping persists. Acceptable — merchant can delete manually.
+- **Stale Allegro cache**: If Allegro renames a category, the cache shows old data for up to 24h. Acceptable for MVP. Manual cache invalidation endpoint can be added later.
+- **Multiple PrestaShop categories mapping to same Allegro category**: Allowed — no unique constraint on `allegro_category_id`.
+
+### Backward Compatibility
+- ✅ No breaking changes — all new endpoints and entities; existing mapping CRUD untouched
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `MappingConfigService`: category upsert, delete, resolve (hit/miss)
+- `CategoryMappingRepository`: upsert (new + update), delete, findByConnectionId
+- `AllegroMarketplaceAdapter.fetchCategories`: HTTP client mock, response mapping
+- `AllegroCategoryCacheService`: cache hit, cache miss (fetches + stores), stale cache (re-fetches)
+- FE: Tree render, search interaction, save/delete mutations, empty/loading/error states
+
+### Integration Tests
+- Category mapping CRUD via HTTP endpoints (if integration test infra supports it)
+
+### Mocking Strategy
+- Unit tests mock all ports (repository, HTTP client, adapter)
+- FE tests use `createMockApiClient()` with mocked category endpoints
+
+### Acceptance Criteria
+- [ ] Allegro category tree is fetchable per connection with DB caching (24h TTL)
+- [ ] PrestaShop categories are fetchable per connection
+- [ ] Category mappings support create, read, update, delete per connection
+- [ ] Unique constraint prevents duplicate mappings for the same PrestaShop category per connection
+- [ ] `resolveAllegroCategory` returns the mapped Allegro category ID or null
+- [ ] Migration exists for `category_mappings` and `allegro_category_cache`; verified via `migration:show`
+- [ ] PrestaShop category tree renders with expand/collapse in FE
+- [ ] Each category row shows its mapped Allegro category or an unmapped indicator
+- [ ] Allegro category browsing supports lazy-loaded tree navigation
+- [ ] Selecting an Allegro category saves immediately and updates the row
+- [ ] Clearing a mapping removes it via the delete endpoint
+- [ ] Summary count "X of Y categories mapped" is accurate
+- [ ] Unit tests cover all service, repository, adapter, and FE component logic
+- [ ] Quality gate passes: `pnpm lint && pnpm type-check && pnpm test`
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture
+- [x] Respects CORE vs Integration boundaries
+- [x] Uses existing patterns (extends mappings module, no new abstractions)
+- [x] Idempotency considered (upsert with ON CONFLICT)
+- [x] Rate limits & retries addressed (existing Allegro HTTP client handles this)
+- [x] Error handling comprehensive (adapter exceptions, domain errors)
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)
+- [Code Review Guide](../code-review-guide.md)

--- a/libs/core/src/integrations/domain/ports/marketplace.port.ts
+++ b/libs/core/src/integrations/domain/ports/marketplace.port.ts
@@ -23,6 +23,7 @@ import {
   UpdateOfferQuantitiesBatchResult,
 } from '../types/marketplace-quantity-update.types';
 import type { UpdateOfferFieldsCommand } from '../types/marketplace-offer-update.types';
+import type { MarketplaceCategory } from '../types/marketplace-category.types';
 
 export interface MarketplacePort {
   /**
@@ -65,5 +66,10 @@ export interface MarketplacePort {
    * Partial update semantics: only fields present in cmd.fields are sent to the marketplace.
    */
   updateOfferFields?(cmd: UpdateOfferFieldsCommand): Promise<void>;
+
+  /**
+   * Fetch marketplace categories (optional).
+   */
+  fetchCategories?(parentId?: string): Promise<MarketplaceCategory[]>;
 }
 

--- a/libs/core/src/integrations/domain/types/marketplace-category.types.ts
+++ b/libs/core/src/integrations/domain/types/marketplace-category.types.ts
@@ -1,0 +1,15 @@
+/**
+ * Marketplace Category Types
+ *
+ * Unified category type returned by MarketplacePort.fetchCategories().
+ * Platform-agnostic representation of a marketplace category node.
+ *
+ * @module libs/core/src/integrations/domain/types
+ */
+
+export interface MarketplaceCategory {
+  id: string;
+  name: string;
+  parentId: string | null;
+  leaf: boolean;
+}

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -50,6 +50,7 @@ export {
   UpdateOfferQuantitiesBatchFailure,
 } from './domain/types/marketplace-quantity-update.types';
 export type { UpdateOfferFieldsCommand } from './domain/types/marketplace-offer-update.types';
+export type { MarketplaceCategory } from './domain/types/marketplace-category.types';
 
 // Exceptions
 export { AdapterNotFoundException } from './domain/exceptions/adapter-not-found.exception';

--- a/libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts
+++ b/libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts
@@ -10,10 +10,12 @@
 import { StatusMapping } from '../../domain/entities/status-mapping.entity';
 import { CarrierMapping } from '../../domain/entities/carrier-mapping.entity';
 import { PaymentMapping } from '../../domain/entities/payment-mapping.entity';
+import { CategoryMapping } from '../../domain/entities/category-mapping.entity';
 import {
   StatusMappingInput,
   CarrierMappingInput,
   PaymentMappingInput,
+  CategoryMappingInput,
 } from '../../domain/types/mapping.types';
 
 export interface IMappingConfigService {
@@ -31,4 +33,14 @@ export interface IMappingConfigService {
    * Returns null if no mapping is configured for this connection + allegroStatus pair.
    */
   resolveStatusMapping(connectionId: string, allegroStatus: string): Promise<string | null>;
+
+  getCategoryMappings(connectionId: string): Promise<CategoryMapping[]>;
+  upsertCategoryMapping(connectionId: string, input: CategoryMappingInput): Promise<CategoryMapping>;
+  deleteCategoryMapping(connectionId: string, prestashopCategoryId: string): Promise<void>;
+
+  /**
+   * Resolve configured Allegro category ID for a given PrestaShop category.
+   * Returns null if no mapping is configured for this connection + prestashopCategoryId pair.
+   */
+  resolveAllegroCategory(connectionId: string, prestashopCategoryId: string): Promise<string | null>;
 }

--- a/libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts
+++ b/libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts
@@ -10,19 +10,23 @@ import {
   STATUS_MAPPING_REPOSITORY_TOKEN,
   CARRIER_MAPPING_REPOSITORY_TOKEN,
   PAYMENT_MAPPING_REPOSITORY_TOKEN,
+  CATEGORY_MAPPING_REPOSITORY_TOKEN,
 } from '../../../mappings.tokens';
 import { StatusMappingRepositoryPort } from '../../../domain/ports/status-mapping-repository.port';
 import { CarrierMappingRepositoryPort } from '../../../domain/ports/carrier-mapping-repository.port';
 import { PaymentMappingRepositoryPort } from '../../../domain/ports/payment-mapping-repository.port';
+import { CategoryMappingRepositoryPort } from '../../../domain/ports/category-mapping-repository.port';
 import { StatusMapping } from '../../../domain/entities/status-mapping.entity';
 import { CarrierMapping } from '../../../domain/entities/carrier-mapping.entity';
 import { PaymentMapping } from '../../../domain/entities/payment-mapping.entity';
+import { CategoryMapping } from '../../../domain/entities/category-mapping.entity';
 
 describe('MappingConfigService', () => {
   let service: MappingConfigService;
   let statusRepo: jest.Mocked<StatusMappingRepositoryPort>;
   let carrierRepo: jest.Mocked<CarrierMappingRepositoryPort>;
   let paymentRepo: jest.Mocked<PaymentMappingRepositoryPort>;
+  let categoryRepo: jest.Mocked<CategoryMappingRepositoryPort>;
 
   const CONNECTION_ID = 'conn-uuid-1';
 
@@ -39,6 +43,12 @@ describe('MappingConfigService', () => {
       findByConnectionId: jest.fn(),
       replaceForConnection: jest.fn(),
     };
+    categoryRepo = {
+      findByConnectionId: jest.fn(),
+      findByPrestashopCategoryId: jest.fn(),
+      upsertMapping: jest.fn(),
+      deleteMapping: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -46,6 +56,7 @@ describe('MappingConfigService', () => {
         { provide: STATUS_MAPPING_REPOSITORY_TOKEN, useValue: statusRepo },
         { provide: CARRIER_MAPPING_REPOSITORY_TOKEN, useValue: carrierRepo },
         { provide: PAYMENT_MAPPING_REPOSITORY_TOKEN, useValue: paymentRepo },
+        { provide: CATEGORY_MAPPING_REPOSITORY_TOKEN, useValue: categoryRepo },
       ],
     }).compile();
 
@@ -167,6 +178,69 @@ describe('MappingConfigService', () => {
 
       expect(paymentRepo.replaceForConnection).toHaveBeenCalledWith(CONNECTION_ID, input);
       expect(result).toEqual(saved);
+    });
+  });
+
+  // ── Category mappings ─────────────────────────────────────────────────
+
+  describe('getCategoryMappings', () => {
+    it('should return category mappings from repository', async () => {
+      const mappings = [
+        new CategoryMapping('id-1', CONNECTION_ID, '3', '258066', 'Smartphones', 'Electronics > Phones > Smartphones'),
+      ];
+      categoryRepo.findByConnectionId.mockResolvedValue(mappings);
+
+      const result = await service.getCategoryMappings(CONNECTION_ID);
+
+      expect(categoryRepo.findByConnectionId).toHaveBeenCalledWith(CONNECTION_ID);
+      expect(result).toEqual(mappings);
+    });
+  });
+
+  describe('upsertCategoryMapping', () => {
+    it('should delegate to repository upsertMapping', async () => {
+      const input = {
+        prestashopCategoryId: '5',
+        allegroCategoryId: '258066',
+        allegroCategoryName: 'Smartphones',
+        allegroCategoryPath: 'Electronics > Phones > Smartphones',
+      };
+      const saved = new CategoryMapping('id-5', CONNECTION_ID, '5', '258066', 'Smartphones', 'Electronics > Phones > Smartphones');
+      categoryRepo.upsertMapping.mockResolvedValue(saved);
+
+      const result = await service.upsertCategoryMapping(CONNECTION_ID, input);
+
+      expect(categoryRepo.upsertMapping).toHaveBeenCalledWith(CONNECTION_ID, input);
+      expect(result).toEqual(saved);
+    });
+  });
+
+  describe('deleteCategoryMapping', () => {
+    it('should delegate to repository deleteMapping', async () => {
+      categoryRepo.deleteMapping.mockResolvedValue(undefined);
+
+      await service.deleteCategoryMapping(CONNECTION_ID, '5');
+
+      expect(categoryRepo.deleteMapping).toHaveBeenCalledWith(CONNECTION_ID, '5');
+    });
+  });
+
+  describe('resolveAllegroCategory', () => {
+    it('should return allegroCategoryId when mapping exists', async () => {
+      const mapping = new CategoryMapping('id-1', CONNECTION_ID, '3', '258066', 'Smartphones', null);
+      categoryRepo.findByPrestashopCategoryId.mockResolvedValue(mapping);
+
+      const result = await service.resolveAllegroCategory(CONNECTION_ID, '3');
+
+      expect(result).toBe('258066');
+    });
+
+    it('should return null when no mapping exists', async () => {
+      categoryRepo.findByPrestashopCategoryId.mockResolvedValue(null);
+
+      const result = await service.resolveAllegroCategory(CONNECTION_ID, '999');
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/libs/core/src/mappings/application/services/mapping-config.service.ts
+++ b/libs/core/src/mappings/application/services/mapping-config.service.ts
@@ -14,18 +14,22 @@ import { IMappingConfigService } from '../interfaces/mapping-config.service.inte
 import { StatusMapping } from '../../domain/entities/status-mapping.entity';
 import { CarrierMapping } from '../../domain/entities/carrier-mapping.entity';
 import { PaymentMapping } from '../../domain/entities/payment-mapping.entity';
+import { CategoryMapping } from '../../domain/entities/category-mapping.entity';
 import {
   StatusMappingInput,
   CarrierMappingInput,
   PaymentMappingInput,
+  CategoryMappingInput,
 } from '../../domain/types/mapping.types';
 import { StatusMappingRepositoryPort } from '../../domain/ports/status-mapping-repository.port';
 import { CarrierMappingRepositoryPort } from '../../domain/ports/carrier-mapping-repository.port';
 import { PaymentMappingRepositoryPort } from '../../domain/ports/payment-mapping-repository.port';
+import { CategoryMappingRepositoryPort } from '../../domain/ports/category-mapping-repository.port';
 import {
   STATUS_MAPPING_REPOSITORY_TOKEN,
   CARRIER_MAPPING_REPOSITORY_TOKEN,
   PAYMENT_MAPPING_REPOSITORY_TOKEN,
+  CATEGORY_MAPPING_REPOSITORY_TOKEN,
 } from '../../mappings.tokens';
 
 @Injectable()
@@ -37,6 +41,8 @@ export class MappingConfigService implements IMappingConfigService {
     private readonly carrierRepo: CarrierMappingRepositoryPort,
     @Inject(PAYMENT_MAPPING_REPOSITORY_TOKEN)
     private readonly paymentRepo: PaymentMappingRepositoryPort,
+    @Inject(CATEGORY_MAPPING_REPOSITORY_TOKEN)
+    private readonly categoryRepo: CategoryMappingRepositoryPort,
   ) {}
 
   getStatusMappings(connectionId: string): Promise<StatusMapping[]> {
@@ -69,5 +75,22 @@ export class MappingConfigService implements IMappingConfigService {
     const mappings = await this.statusRepo.findByConnectionId(connectionId);
     const match = mappings.find((m) => m.allegroStatus === allegroStatus);
     return match?.prestashopStatusId ?? null;
+  }
+
+  getCategoryMappings(connectionId: string): Promise<CategoryMapping[]> {
+    return this.categoryRepo.findByConnectionId(connectionId);
+  }
+
+  upsertCategoryMapping(connectionId: string, input: CategoryMappingInput): Promise<CategoryMapping> {
+    return this.categoryRepo.upsertMapping(connectionId, input);
+  }
+
+  deleteCategoryMapping(connectionId: string, prestashopCategoryId: string): Promise<void> {
+    return this.categoryRepo.deleteMapping(connectionId, prestashopCategoryId);
+  }
+
+  async resolveAllegroCategory(connectionId: string, prestashopCategoryId: string): Promise<string | null> {
+    const mapping = await this.categoryRepo.findByPrestashopCategoryId(connectionId, prestashopCategoryId);
+    return mapping?.allegroCategoryId ?? null;
   }
 }

--- a/libs/core/src/mappings/domain/entities/category-mapping.entity.ts
+++ b/libs/core/src/mappings/domain/entities/category-mapping.entity.ts
@@ -1,0 +1,24 @@
+/**
+ * Category Mapping Domain Entity
+ *
+ * Represents a connection-scoped mapping from a PrestaShop category
+ * to an Allegro category. Pure domain entity with no framework deps.
+ *
+ * Note: Unlike other mapping types (StatusMapping, CarrierMapping, PaymentMapping)
+ * which map Allegro source values to PrestaShop target values, CategoryMapping
+ * maps PrestaShop → Allegro because the use case is "given a PrestaShop product
+ * category, which Allegro category should be used for offer creation?"
+ *
+ * @module libs/core/src/mappings/domain/entities
+ */
+
+export class CategoryMapping {
+  constructor(
+    public readonly id: string,
+    public readonly connectionId: string,
+    public readonly prestashopCategoryId: string,
+    public readonly allegroCategoryId: string,
+    public readonly allegroCategoryName: string,
+    public readonly allegroCategoryPath: string | null,
+  ) {}
+}

--- a/libs/core/src/mappings/domain/ports/category-mapping-repository.port.ts
+++ b/libs/core/src/mappings/domain/ports/category-mapping-repository.port.ts
@@ -1,0 +1,29 @@
+/**
+ * Category Mapping Repository Port
+ *
+ * Persistence contract for category mapping operations.
+ * Unlike other mapping types (bulk replace), category mappings
+ * support per-row upsert and delete for tree-based UI interaction.
+ *
+ * @module libs/core/src/mappings/domain/ports
+ */
+
+import { CategoryMapping } from '../entities/category-mapping.entity';
+import { CategoryMappingInput } from '../types/mapping.types';
+
+export interface CategoryMappingRepositoryPort {
+  findByConnectionId(connectionId: string): Promise<CategoryMapping[]>;
+
+  findByPrestashopCategoryId(
+    connectionId: string,
+    prestashopCategoryId: string,
+  ): Promise<CategoryMapping | null>;
+
+  /**
+   * Create or update a single category mapping.
+   * Uses upsert on (connectionId, prestashopCategoryId) unique constraint.
+   */
+  upsertMapping(connectionId: string, input: CategoryMappingInput): Promise<CategoryMapping>;
+
+  deleteMapping(connectionId: string, prestashopCategoryId: string): Promise<void>;
+}

--- a/libs/core/src/mappings/domain/types/mapping.types.ts
+++ b/libs/core/src/mappings/domain/types/mapping.types.ts
@@ -20,3 +20,10 @@ export interface PaymentMappingInput {
   allegroPaymentProvider: string;
   prestashopPaymentModule: string;
 }
+
+export interface CategoryMappingInput {
+  prestashopCategoryId: string;
+  allegroCategoryId: string;
+  allegroCategoryName: string;
+  allegroCategoryPath?: string;
+}

--- a/libs/core/src/mappings/index.ts
+++ b/libs/core/src/mappings/index.ts
@@ -13,14 +13,17 @@ export {
   STATUS_MAPPING_REPOSITORY_TOKEN,
   CARRIER_MAPPING_REPOSITORY_TOKEN,
   PAYMENT_MAPPING_REPOSITORY_TOKEN,
+  CATEGORY_MAPPING_REPOSITORY_TOKEN,
 } from './mappings.tokens';
 export type { IMappingConfigService } from './application/interfaces/mapping-config.service.interface';
 export { MappingConfigService } from './application/services/mapping-config.service';
 export { StatusMapping } from './domain/entities/status-mapping.entity';
 export { CarrierMapping } from './domain/entities/carrier-mapping.entity';
 export { PaymentMapping } from './domain/entities/payment-mapping.entity';
+export { CategoryMapping } from './domain/entities/category-mapping.entity';
 export type {
   StatusMappingInput,
   CarrierMappingInput,
   PaymentMappingInput,
+  CategoryMappingInput,
 } from './domain/types/mapping.types';

--- a/libs/core/src/mappings/infrastructure/persistence/entities/category-mapping.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/category-mapping.orm-entity.ts
@@ -1,0 +1,45 @@
+/**
+ * Category Mapping ORM Entity
+ *
+ * TypeORM entity for the category_mappings table.
+ * Maps PrestaShop categories to Allegro categories per connection.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/entities
+ */
+
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('category_mappings')
+@Index(['connectionId', 'prestashopCategoryId'], { unique: true })
+export class CategoryMappingOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', name: 'connection_id' })
+  connectionId!: string;
+
+  @Column({ type: 'varchar', length: 100, name: 'prestashop_category_id' })
+  prestashopCategoryId!: string;
+
+  @Column({ type: 'varchar', length: 100, name: 'allegro_category_id' })
+  allegroCategoryId!: string;
+
+  @Column({ type: 'varchar', length: 500, name: 'allegro_category_name' })
+  allegroCategoryName!: string;
+
+  @Column({ type: 'varchar', length: 1000, name: 'allegro_category_path', nullable: true })
+  allegroCategoryPath!: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/mappings/infrastructure/persistence/repositories/category-mapping.repository.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/repositories/category-mapping.repository.ts
@@ -1,0 +1,76 @@
+/**
+ * Category Mapping Repository
+ *
+ * Implements CategoryMappingRepositoryPort using TypeORM.
+ * Supports per-row upsert (INSERT ON CONFLICT UPDATE) and delete,
+ * unlike other mapping types which use bulk replace.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/repositories
+ * @implements {CategoryMappingRepositoryPort}
+ */
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CategoryMappingOrmEntity } from '../entities/category-mapping.orm-entity';
+import { CategoryMappingRepositoryPort } from '../../../domain/ports/category-mapping-repository.port';
+import { CategoryMapping } from '../../../domain/entities/category-mapping.entity';
+import { CategoryMappingInput } from '../../../domain/types/mapping.types';
+
+@Injectable()
+export class CategoryMappingRepository implements CategoryMappingRepositoryPort {
+  constructor(
+    @InjectRepository(CategoryMappingOrmEntity)
+    private readonly repo: Repository<CategoryMappingOrmEntity>,
+  ) {}
+
+  async findByConnectionId(connectionId: string): Promise<CategoryMapping[]> {
+    const entities = await this.repo.find({ where: { connectionId } });
+    return entities.map((e) => this.toDomain(e));
+  }
+
+  async findByPrestashopCategoryId(
+    connectionId: string,
+    prestashopCategoryId: string,
+  ): Promise<CategoryMapping | null> {
+    const entity = await this.repo.findOne({
+      where: { connectionId, prestashopCategoryId },
+    });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async upsertMapping(connectionId: string, input: CategoryMappingInput): Promise<CategoryMapping> {
+    // Use upsert to handle both create and update on the unique constraint
+    await this.repo.upsert(
+      {
+        connectionId,
+        prestashopCategoryId: input.prestashopCategoryId,
+        allegroCategoryId: input.allegroCategoryId,
+        allegroCategoryName: input.allegroCategoryName,
+        allegroCategoryPath: input.allegroCategoryPath ?? null,
+      },
+      ['connectionId', 'prestashopCategoryId'],
+    );
+
+    // Fetch the upserted entity to return with generated/updated fields
+    const saved = await this.repo.findOneOrFail({
+      where: { connectionId, prestashopCategoryId: input.prestashopCategoryId },
+    });
+    return this.toDomain(saved);
+  }
+
+  async deleteMapping(connectionId: string, prestashopCategoryId: string): Promise<void> {
+    await this.repo.delete({ connectionId, prestashopCategoryId });
+  }
+
+  private toDomain(entity: CategoryMappingOrmEntity): CategoryMapping {
+    return new CategoryMapping(
+      entity.id,
+      entity.connectionId,
+      entity.prestashopCategoryId,
+      entity.allegroCategoryId,
+      entity.allegroCategoryName,
+      entity.allegroCategoryPath,
+    );
+  }
+}

--- a/libs/core/src/mappings/mappings.module.ts
+++ b/libs/core/src/mappings/mappings.module.ts
@@ -13,15 +13,18 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { StatusMappingOrmEntity } from './infrastructure/persistence/entities/status-mapping.orm-entity';
 import { CarrierMappingOrmEntity } from './infrastructure/persistence/entities/carrier-mapping.orm-entity';
 import { PaymentMappingOrmEntity } from './infrastructure/persistence/entities/payment-mapping.orm-entity';
+import { CategoryMappingOrmEntity } from './infrastructure/persistence/entities/category-mapping.orm-entity';
 import { StatusMappingRepository } from './infrastructure/persistence/repositories/status-mapping.repository';
 import { CarrierMappingRepository } from './infrastructure/persistence/repositories/carrier-mapping.repository';
 import { PaymentMappingRepository } from './infrastructure/persistence/repositories/payment-mapping.repository';
+import { CategoryMappingRepository } from './infrastructure/persistence/repositories/category-mapping.repository';
 import { MappingConfigService } from './application/services/mapping-config.service';
 import {
   MAPPING_CONFIG_SERVICE_TOKEN,
   STATUS_MAPPING_REPOSITORY_TOKEN,
   CARRIER_MAPPING_REPOSITORY_TOKEN,
   PAYMENT_MAPPING_REPOSITORY_TOKEN,
+  CATEGORY_MAPPING_REPOSITORY_TOKEN,
 } from './mappings.tokens';
 
 @Module({
@@ -30,12 +33,14 @@ import {
       StatusMappingOrmEntity,
       CarrierMappingOrmEntity,
       PaymentMappingOrmEntity,
+      CategoryMappingOrmEntity,
     ]),
   ],
   providers: [
     StatusMappingRepository,
     CarrierMappingRepository,
     PaymentMappingRepository,
+    CategoryMappingRepository,
     MappingConfigService,
     {
       provide: STATUS_MAPPING_REPOSITORY_TOKEN,
@@ -48,6 +53,10 @@ import {
     {
       provide: PAYMENT_MAPPING_REPOSITORY_TOKEN,
       useExisting: PaymentMappingRepository,
+    },
+    {
+      provide: CATEGORY_MAPPING_REPOSITORY_TOKEN,
+      useExisting: CategoryMappingRepository,
     },
     {
       provide: MAPPING_CONFIG_SERVICE_TOKEN,

--- a/libs/core/src/mappings/mappings.tokens.ts
+++ b/libs/core/src/mappings/mappings.tokens.ts
@@ -10,3 +10,4 @@ export const MAPPING_CONFIG_SERVICE_TOKEN = Symbol('IMappingConfigService');
 export const STATUS_MAPPING_REPOSITORY_TOKEN = Symbol('StatusMappingRepositoryPort');
 export const CARRIER_MAPPING_REPOSITORY_TOKEN = Symbol('CarrierMappingRepositoryPort');
 export const PAYMENT_MAPPING_REPOSITORY_TOKEN = Symbol('PaymentMappingRepositoryPort');
+export const CATEGORY_MAPPING_REPOSITORY_TOKEN = Symbol('CategoryMappingRepositoryPort');

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -42,6 +42,10 @@ describe('OrderSyncService', () => {
       getPaymentMappings: jest.fn().mockResolvedValue([]),
       upsertPaymentMappings: jest.fn().mockResolvedValue([]),
       resolveStatusMapping: jest.fn().mockResolvedValue(null),
+      getCategoryMappings: jest.fn(),
+      upsertCategoryMapping: jest.fn(),
+      deleteCategoryMapping: jest.fn(),
+      resolveAllegroCategory: jest.fn(),
     } as jest.Mocked<IMappingConfigService>;
 
     // Set environment variable

--- a/libs/core/src/products/domain/ports/product-master.port.ts
+++ b/libs/core/src/products/domain/ports/product-master.port.ts
@@ -176,6 +176,14 @@ export interface ProductMasterPort {
    * @returns Array of matching products with internal IDs
    */
   searchProducts(query: string, filters?: ProductFilters): Promise<Product[]>;
+
+  /**
+   * List all categories from the product catalog (optional).
+   *
+   * Returns the full category tree for the connection.
+   * Implementations that do not support this should omit the method.
+   */
+  getCategories?(): Promise<Category[]>;
 }
 
 

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -190,6 +190,25 @@ export interface AllegroProductOffer {
 }
 
 /**
+ * Allegro category item (from GET /sale/categories)
+ */
+export interface AllegroCategoryItem {
+  id: string;
+  name: string;
+  parent?: {
+    id: string;
+  } | null;
+  leaf: boolean;
+}
+
+/**
+ * Allegro categories response (from GET /sale/categories)
+ */
+export interface AllegroCategoriesResponse {
+  categories: AllegroCategoryItem[];
+}
+
+/**
  * Allegro category parameters response (from GET /sale/categories/{categoryId}/parameters)
  */
 export interface AllegroCategoryParametersResponse {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
@@ -476,6 +476,62 @@ describe('AllegroMarketplaceAdapter', () => {
       ).rejects.toThrow('Allegro API error');
     });
   });
+
+  describe('fetchCategories', () => {
+    it('should fetch root categories when no parentId provided', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          categories: [
+            { id: '1', name: 'Electronics', parent: null, leaf: false },
+            { id: '2', name: 'Fashion', parent: null, leaf: false },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.fetchCategories();
+
+      expect(result).toEqual([
+        { id: '1', name: 'Electronics', parentId: null, leaf: false },
+        { id: '2', name: 'Fashion', parentId: null, leaf: false },
+      ]);
+      expect(httpClient.get).toHaveBeenCalledWith('/sale/categories', { queryParams: {} });
+    });
+
+    it('should fetch child categories when parentId provided', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          categories: [
+            { id: '10', name: 'Smartphones', parent: { id: '1' }, leaf: true },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.fetchCategories('1');
+
+      expect(result).toEqual([
+        { id: '10', name: 'Smartphones', parentId: '1', leaf: true },
+      ]);
+      expect(httpClient.get).toHaveBeenCalledWith('/sale/categories', {
+        queryParams: { 'parent.id': '1' },
+      });
+    });
+
+    it('should return empty array when no categories returned', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: { categories: [] },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.fetchCategories('999');
+
+      expect(result).toEqual([]);
+    });
+  });
 });
 
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
@@ -18,6 +18,7 @@ import {
   UpdateOfferQuantityCommand,
   UpdateOfferFieldsCommand,
 } from '@openlinker/core/integrations';
+import type { MarketplaceCategory } from '@openlinker/core/integrations';
 import type { IncomingOrder } from '@openlinker/core/orders';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CustomerIdentityResolverPort } from '@openlinker/core/customers';
@@ -27,6 +28,7 @@ import {
   AllegroOrderEventsResponse,
   AllegroOfferQuantityChangeCommandResponse,
   AllegroCategoryParametersResponse,
+  AllegroCategoriesResponse,
   AllegroOfferParameter,
   AllegroProductOffer,
   AllegroOffersResponse,
@@ -490,6 +492,27 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
       ean: this.pickSingleValue(eanValues),
       gtin: this.pickSingleValue(gtinValues),
     };
+  }
+
+  async fetchCategories(parentId?: string): Promise<MarketplaceCategory[]> {
+    this.logger.debug(
+      `Fetching Allegro categories (connection: ${this.connectionId}, parentId: ${parentId ?? 'root'})`,
+    );
+    const queryParams: Record<string, string | number> = {};
+    if (parentId) {
+      queryParams['parent.id'] = parentId;
+    }
+    const response = await this.httpClient.get<AllegroCategoriesResponse>(
+      '/sale/categories',
+      { queryParams },
+    );
+    const categories = response.data.categories ?? [];
+    return categories.map((cat) => ({
+      id: cat.id,
+      name: cat.name,
+      parentId: cat.parent?.id ?? null,
+      leaf: cat.leaf,
+    }));
   }
 
   private findIdentifierParameterIds(

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -312,6 +312,46 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     return Promise.reject(error);
   }
 
+  async getCategories(): Promise<Category[]> {
+    this.logger.debug(`Fetching all categories (connection: ${this.connection.id})`);
+
+    const raw = await this.httpClient.listResources<Record<string, unknown>>('categories');
+
+    const langId = this.getLangId();
+
+    return raw.map((cat) => {
+      const id = String(cat['id'] ?? '');
+      const nameField = cat['name'];
+      let name = `Category ${id}`;
+      if (typeof nameField === 'string') {
+        name = nameField;
+      } else if (Array.isArray(nameField)) {
+        const lang = (nameField as Array<{ language?: Array<{ attrs?: { id: string }; value: string }> }>)
+          .flatMap((n) => n.language ?? [])
+          .find((l) => String(l.attrs?.id) === String(langId));
+        if (lang) {
+          name = lang.value;
+        }
+      }
+
+      const parentId = String(cat['id_parent'] ?? '0');
+      const depth = Number(cat['level_depth'] ?? 0);
+
+      return {
+        id,
+        name,
+        parentId: parentId === '0' ? undefined : parentId,
+        depth,
+        active: String(cat['active']) === '1',
+      };
+    }).filter((c) => Number(c.depth) > 0); // Exclude root node
+  }
+
+  private getLangId(): number {
+    const config = this.connection.config as Record<string, unknown> | undefined;
+    return Number(config?.['languageId'] ?? 1);
+  }
+
   async searchProducts(_query: string, _filters?: ProductFilters): Promise<Product[]> {
     // For MVP, we can use getProducts with query filter
     return this.getProducts({


### PR DESCRIPTION
## Summary

- Full-stack category mapping: PrestaShop categories → Allegro categories per connection
- DB-cached Allegro category tree (24h TTL) with lazy-loaded children via `GET /sale/categories`
- Two-column FE page: expandable PrestaShop tree (left) + browseable Allegro category selector (right)
- Per-row immediate save/delete (not bulk replace like other mapping types)
- `resolveAllegroCategory()` method ready for future offer creation wiring (#143)

## Changes

**Backend (24 modified + 19 new files):**
- `CategoryMapping` entity + ORM + repository + service + controller endpoints
- `MarketplacePort.fetchCategories()` + `ProductMasterPort.getCategories()` optional methods
- Allegro + PrestaShop adapter implementations
- `CategoriesCacheService` with DB-backed 24h cache
- 2 migrations: `category_mappings` + `allegro_category_cache` tables
- Request/response DTOs with class-validator

**Frontend (12 new files):**
- `CategoryMappingTree`, `CategoryMappingRow`, `AllegroCategorySearch` components
- Query/mutation hooks for categories and mappings
- Page at `/connections/:id/mappings/categories`
- CSS styles using design tokens

**Tests (19 new tests):**
- `MappingConfigService`: category CRUD + resolve
- `AllegroMarketplaceAdapter`: fetchCategories
- `CategoriesCacheService`: cache hit/miss/stale
- Mock updates for `IMappingConfigService` in order-sync tests

## Test plan

- [ ] Quality gate passes: `pnpm lint && pnpm type-check && pnpm test`
- [ ] Allegro category tree loads via API with DB caching
- [ ] PrestaShop categories load from webservice
- [ ] Category mapping CRUD works (upsert + delete per row)
- [ ] FE: tree renders, expand/collapse works, mapping badges show
- [ ] FE: Allegro browser navigates with breadcrumbs, select/clear works
- [ ] Summary count "X of Y categories mapped" is accurate

Closes #138, Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)