### PR TITLE
feat(products): auto-match variant-to-offer by SKU/EAN

### DIFF
--- a/apps/api/src/listings/http/dto/auto-match-variants.dto.ts
+++ b/apps/api/src/listings/http/dto/auto-match-variants.dto.ts
@@ -1,0 +1,21 @@
+/**
+ * Auto-Match Variants DTOs
+ *
+ * Request and response DTOs for the auto-match variants endpoint.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class AutoMatchVariantsRequestDto {
+  @ApiPropertyOptional({ description: 'When true, return results without persisting mappings', default: false })
+  @IsOptional()
+  @IsBoolean()
+  dryRun?: boolean;
+}
+
+export class AutoMatchVariantsResponseDto {
+  @ApiProperty({ description: 'Job ID for the enqueued auto-match job' })
+  jobId!: string;
+}

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -31,6 +31,7 @@ import { ListOfferMappingsQueryDto } from './dto/list-offer-mappings-query.dto';
 import { OfferMappingResponseDto } from './dto/offer-mapping-response.dto';
 import { PaginatedOfferMappingsResponseDto } from './dto/paginated-offer-mappings-response.dto';
 import { UpdateOfferFieldsDto, UpdateOfferFieldsResponseDto } from './dto/update-offer-fields.dto';
+import { AutoMatchVariantsRequestDto, AutoMatchVariantsResponseDto } from './dto/auto-match-variants.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -116,6 +117,34 @@ export class ListingsController {
           ...(dto.title !== undefined && { title: dto.title }),
           ...(dto.description !== undefined && { description: dto.description }),
         },
+      },
+    });
+
+    return { jobId };
+  }
+
+  @Post('connections/:connectionId/sync/auto-match-variants')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID (e.g., Allegro)' })
+  @ApiOperation({
+    summary: 'Auto-match variants to offers',
+    description:
+      'Dispatches a background job that matches PrestaShop product variants to marketplace offers by EAN/SKU. Returns 202 Accepted with a job ID.',
+  })
+  @ApiResponse({ status: 202, description: 'Auto-match job dispatched', type: AutoMatchVariantsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async autoMatchVariants(
+    @Param('connectionId') connectionId: string,
+    @Body() dto: AutoMatchVariantsRequestDto,
+    @Headers('x-idempotency-key') clientIdempotencyKey?: string,
+  ): Promise<AutoMatchVariantsResponseDto> {
+    const { jobId } = await this.jobEnqueue.enqueueJob({
+      jobType: 'master.variants.autoMatch',
+      connectionId,
+      idempotencyKey: clientIdempotencyKey ?? `auto-match-variants:${connectionId}:${randomUUID()}`,
+      payload: {
+        schemaVersion: 1,
+        dryRun: dto.dryRun ?? false,
       },
     });
 

--- a/apps/worker/src/sync/handlers/auto-match-variants.handler.ts
+++ b/apps/worker/src/sync/handlers/auto-match-variants.handler.ts
@@ -1,0 +1,75 @@
+/**
+ * Auto-Match Variants Handler
+ *
+ * Thin delegate for jobs of type 'master.variants.autoMatch'. Delegates
+ * variant-to-offer matching to core AutoMatchVariantOffersService.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  SyncJobHandler,
+  SyncJob as SyncJobEntity,
+  SyncJobExecutionError,
+} from '@openlinker/core/sync';
+import {
+  IAutoMatchVariantOffersService,
+  AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
+  AutoMatchVariantsJobPayload,
+} from '@openlinker/core/products';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+@Injectable()
+export class AutoMatchVariantsHandler implements SyncJobHandler {
+  private readonly logger = new Logger(AutoMatchVariantsHandler.name);
+
+  constructor(
+    @Inject(AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN)
+    private readonly autoMatchService: IAutoMatchVariantOffersService,
+  ) {}
+
+  async execute(job: SyncJob): Promise<void> {
+    const payload = this.getPayload(job);
+
+    this.logger.log(
+      `Executing master.variants.autoMatch job ${job.id} for connection ${job.connectionId} (dryRun=${payload.dryRun ?? false})`,
+    );
+
+    try {
+      const result = await this.autoMatchService.autoMatch(job.connectionId, {
+        dryRun: payload.dryRun,
+      });
+
+      this.logger.log(
+        `Auto-match complete (job=${job.id}): matched=${result.matched}, skippedAmbiguous=${result.skippedAmbiguous}, skippedNoMatch=${result.skippedNoMatch}, errors=${result.errors.length}`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `Auto-match variants failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+
+  private getPayload(job: SyncJob): AutoMatchVariantsJobPayload {
+    const payload = job.payload as unknown as Partial<AutoMatchVariantsJobPayload>;
+    if (!payload || typeof payload !== 'object') {
+      throw new SyncJobExecutionError(
+        `Missing payload for job: ${job.id}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+      );
+    }
+    return {
+      schemaVersion: 1,
+      dryRun: payload.dryRun ?? false,
+    };
+  }
+}

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -16,6 +16,7 @@ import { MarketplaceOfferFieldUpdateHandler } from './marketplace-offer-field-up
 import { MarketplaceOffersSyncHandler } from './marketplace-offers-sync.handler';
 import { MasterProductSyncHandler } from './master-product-sync.handler';
 import { MasterInventorySyncHandler } from './master-inventory-sync.handler';
+import { AutoMatchVariantsHandler } from './auto-match-variants.handler';
 
 @Injectable()
 export class HandlerRegistrationService implements OnModuleInit {
@@ -29,6 +30,7 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly marketplaceOffersSyncHandler: MarketplaceOffersSyncHandler,
     private readonly masterProductSyncHandler: MasterProductSyncHandler,
     private readonly masterInventorySyncHandler: MasterInventorySyncHandler,
+    private readonly autoMatchVariantsHandler: AutoMatchVariantsHandler,
   ) {}
 
   onModuleInit(): void {
@@ -42,6 +44,9 @@ export class HandlerRegistrationService implements OnModuleInit {
     // Register generic master handlers (Option B)
     this.handlerRegistry.register('master.product.syncByExternalId', this.masterProductSyncHandler);
     this.handlerRegistry.register('master.inventory.syncByExternalId', this.masterInventorySyncHandler);
+
+    // Register auto-match variants handler
+    this.handlerRegistry.register('master.variants.autoMatch', this.autoMatchVariantsHandler);
 
     // Register inventory propagate to marketplaces handler
     this.handlerRegistry.register('inventory.propagateToMarketplaces', this.inventoryPropagateHandler);

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -27,6 +27,7 @@ import { MarketplaceOfferFieldUpdateHandler } from './handlers/marketplace-offer
 import { MarketplaceOffersSyncHandler } from './handlers/marketplace-offers-sync.handler';
 import { MasterProductSyncHandler } from './handlers/master-product-sync.handler';
 import { MasterInventorySyncHandler } from './handlers/master-inventory-sync.handler';
+import { AutoMatchVariantsHandler } from './handlers/auto-match-variants.handler';
 import { HandlerRegistrationService } from './handlers/handler-registration.service';
 
 @Module({
@@ -53,6 +54,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MarketplaceOffersSyncHandler,
     MasterProductSyncHandler,
     MasterInventorySyncHandler,
+    AutoMatchVariantsHandler,
     HandlerRegistrationService,
   ],
 })

--- a/docs/plans/implementation-plan-auto-match-variants.md
+++ b/docs/plans/implementation-plan-auto-match-variants.md
@@ -1,0 +1,214 @@
+# Implementation Plan: Auto-Match Product Variants to Allegro Offers by SKU/EAN
+
+**Date**: 2026-04-11  
+**Status**: Draft  
+**Issue**: #135  
+
+---
+
+## 1. Task Summary
+
+**Objective**: Automatically match PrestaShop product variants to Allegro offers using shared identifiers (EAN/GTIN and SKU), eliminating manual mapping friction.
+
+**Context**: Merchants must manually map every variant → offer via identifier mappings. When platforms share EAN/SKU, this can be automated. This implements US-8.
+
+**Classification**: CORE / Application — `libs/core/src/products/application/`
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- `AutoMatchVariantOffersService` — core matching logic
+- `dryRun` mode (preview without persisting)
+- Job type `master.variants.autoMatch` + worker handler
+- Controller endpoint `POST /connections/:connectionId/sync/auto-match-variants`
+- Unit tests for all matching paths
+
+### Out of Scope
+- UI for triggering auto-match (future FE issue)
+- Partial/incremental matching (this is a full one-shot scan)
+- Matching by product name or fuzzy logic
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: CORE Application (`libs/core/src/products/application/services/`)
+
+**Capabilities Involved**:
+- `MarketplacePort.listOffers()` — fetch Allegro offers
+- `ProductVariantRepositoryPort` — fetch variants with EAN/SKU
+- `IIdentifierMappingService.createMapping()` — persist matches
+
+**Existing Services Reused**:
+- `OfferMappingSyncService` — pattern reference (not called directly; different iteration direction)
+- `OfferLinkingService` — not reused directly (it iterates offers, we iterate variants)
+- `normalizeBarcode()` from `@openlinker/core/products`
+
+**New Components**:
+1. `auto-match-variant-offers.service.interface.ts` — service interface
+2. `auto-match-variant-offers.service.ts` — service implementation
+3. `auto-match.types.ts` — result/payload types
+4. `auto-match-variants.handler.ts` — worker handler
+5. `auto-match-variants.dto.ts` — request/response DTOs
+6. Controller endpoint addition to `ListingsController`
+
+**Core vs Integration Justification**: This is platform-agnostic matching logic using ports. It belongs in CORE because it works against `MarketplacePort` and `ProductVariantRepositoryPort` abstractions.
+
+---
+
+## 4. Internal Patterns
+
+**Similar Implementation**: `OfferMappingSyncService` (offer-mapping-sync.service.ts)
+- Same dependency injection pattern (INTEGRATIONS_SERVICE_TOKEN, IDENTIFIER_MAPPING_SERVICE_TOKEN, PRODUCT_VARIANT_REPOSITORY_TOKEN)
+- Same lookup-building pattern (buildUniqueMap with null for ambiguous)
+- Same conflict handling (IdentifierMappingConflictException)
+
+**Key Difference**: Auto-match builds **offer** lookups and iterates **variants** (reverse of offer-mapping-sync which builds variant lookups and iterates offers).
+
+---
+
+## 5. Questions & Assumptions
+
+### Assumptions
+- The marketplace connection's `config.masterCatalogConnectionId` identifies the PrestaShop connection (same as offer-mapping-sync)
+- `MarketplacePort.listOffers()` returns all active offers when paginated exhaustively
+- We match on EAN first (higher confidence), then SKU — matching the issue's priority order
+- Ambiguous matches (>1 variant per EAN/SKU, or >1 offer per EAN/SKU) are skipped
+- The `createMapping` entity type is `'Offer'` (variant internal ID → offer external ID), matching existing offer-mapping-sync pattern
+
+### Documentation Gaps
+- None significant — the issue is well-specified
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: Types & Interface
+
+**Step 1**: Create auto-match types
+- **File**: `libs/core/src/products/application/types/auto-match.types.ts`
+- **Action**: Define `AutoMatchResult`, `AutoMatchOptions`, `MatchError`, `AutoMatchVariantsJobPayload`
+
+**Step 2**: Create service interface
+- **File**: `libs/core/src/products/application/services/auto-match-variant-offers.service.interface.ts`
+- **Action**: Define `IAutoMatchVariantOffersService` with `autoMatch(connectionId, options)` method
+
+### Phase 2: Service Implementation
+
+**Step 3**: Implement `AutoMatchVariantOffersService`
+- **File**: `libs/core/src/products/application/services/auto-match-variant-offers.service.ts`
+- **Action**: Implement the matching algorithm:
+  1. Get marketplace adapter via `integrationsService.getCapabilityAdapter<MarketplacePort>`
+  2. Paginate through all offers, collecting EAN/SKU identifiers
+  3. Build `eanToOffer` and `skuToOffer` lookup maps (null for ambiguous)
+  4. Load all variants from master connection with non-empty EAN or SKU
+  5. For each variant: try EAN match first, then SKU match
+  6. If unique match and not `dryRun`: call `identifierMapping.createMapping()`
+  7. Track and return `AutoMatchResult`
+
+**Step 4**: Register service in `ProductsModule`
+- **File**: `libs/core/src/products/products.module.ts`
+- **Action**: Add provider + token binding + export
+
+### Phase 3: Job Infrastructure
+
+**Step 5**: Add job type `master.variants.autoMatch`
+- **File**: `libs/core/src/sync/domain/types/sync-job.types.ts`
+- **Action**: Add to `JobTypeValues` array
+
+**Step 6**: Create worker handler
+- **File**: `apps/worker/src/sync/handlers/auto-match-variants.handler.ts`
+- **Action**: Implement `SyncJobHandler`, delegate to `AutoMatchVariantOffersService`
+
+**Step 7**: Register handler
+- **Files**: `handler-registration.service.ts`, `sync-worker.module.ts`
+- **Action**: Import, inject, and register the new handler
+
+### Phase 4: Controller Endpoint
+
+**Step 8**: Create request/response DTOs
+- **File**: `apps/api/src/listings/http/dto/auto-match-variants.dto.ts`
+- **Action**: `AutoMatchVariantsRequestDto` (optional `dryRun` boolean), `AutoMatchVariantsResponseDto`
+
+**Step 9**: Add controller endpoint
+- **File**: `apps/api/src/listings/http/listings.controller.ts`
+- **Action**: Add `POST /connections/:connectionId/sync/auto-match-variants` that enqueues a job and returns `{ jobId }`
+
+### Phase 5: Testing
+
+**Step 10**: Unit tests for `AutoMatchVariantOffersService`
+- **File**: `libs/core/src/products/application/services/auto-match-variant-offers.service.spec.ts`
+- **Scenarios**:
+  - Exact EAN match → mapped
+  - Exact SKU match (no EAN) → mapped
+  - Ambiguous match (>1 offer for same EAN) → skipped with warning
+  - No match → skipped silently
+  - `dryRun: true` → result returned, no `createMapping` called
+  - Mapping conflict → handled gracefully
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative: Extend OfferMappingSyncService
+- **Description**: Add an "auto-match" mode to the existing offer-mapping-sync service
+- **Why Rejected**: Different iteration direction (variants→offers vs offers→variants), different result semantics (one-shot summary vs cursor-based), would complicate the existing service
+- **Trade-offs**: Less code duplication but higher coupling
+
+### Alternative: Reuse OfferLinkingService directly
+- **Description**: Reuse the existing linking service by feeding it synthetic offer feed items
+- **Why Rejected**: The linking service is designed for offer→variant direction; forcing variant→offer through it would be awkward
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Service depends on ports only (MarketplacePort, ProductVariantRepositoryPort, IIdentifierMappingService)
+- ✅ Types in separate `*.types.ts` file
+- ✅ Service implements interface in separate file
+- ✅ No framework dependencies in domain layer
+
+### Risks
+- **Large catalog performance**: Paginating all offers + loading all variants could be slow for large catalogs. Mitigation: this runs as a background job, not synchronously.
+- **Race condition with offer-mapping-sync**: Both services create offer mappings. Mitigation: `getOrCreateExactMapping` handles conflicts gracefully (same as existing pattern).
+
+### Edge Cases
+- Variant with both EAN and SKU matching different offers → EAN wins (higher confidence)
+- Offer already mapped → `IdentifierMappingConflictException` caught and skipped
+- No masterCatalogConnectionId configured → warn and return empty result
+
+### Backward Compatibility
+- ✅ No breaking changes — additive only (new job type, new endpoint, new service)
+
+---
+
+## 9. Testing Strategy
+
+### Unit Tests
+- `auto-match-variant-offers.service.spec.ts` — 6 scenarios listed above
+- Mock: `MarketplacePort`, `ProductVariantRepositoryPort`, `IIdentifierMappingService`, `IIntegrationsService`
+
+### Acceptance Criteria (from issue)
+- [ ] Variants with unique EAN match are automatically mapped
+- [ ] Variants with unique SKU match are mapped when no EAN present
+- [ ] Ambiguous matches (>1 offer) are skipped and logged as warnings
+- [ ] `dryRun: true` returns result without persisting mappings
+- [ ] Result counts (`matched`, `skippedAmbiguous`, `skippedNoMatch`) are accurate
+- [ ] Unit tests cover all paths
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture
+- [x] Respects CORE vs Integration boundaries
+- [x] Uses existing patterns (mirrors OfferMappingSyncService structure)
+- [x] Idempotency considered (getOrCreateExactMapping + conflict handling)
+- [x] Error handling comprehensive
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready

--- a/libs/core/src/products/application/services/auto-match-variant-offers.service.interface.ts
+++ b/libs/core/src/products/application/services/auto-match-variant-offers.service.interface.ts
@@ -1,0 +1,24 @@
+/**
+ * Auto-Match Variant Offers Service Interface
+ *
+ * Defines the contract for automatically matching product variants to marketplace
+ * offers using shared identifiers (EAN/SKU).
+ *
+ * @module libs/core/src/products/application/services
+ */
+import { AutoMatchResult, AutoMatchOptions } from '../types/auto-match.types';
+
+export interface IAutoMatchVariantOffersService {
+  /**
+   * Auto-match variants from the master catalog to marketplace offers.
+   *
+   * Fetches all offers from the marketplace connection, builds EAN/SKU lookup
+   * indexes, then iterates variants from the master catalog and creates
+   * identifier mappings for unique matches.
+   *
+   * @param connectionId - Marketplace connection ID (e.g., Allegro)
+   * @param options - Options including dryRun mode
+   * @returns Result with match/skip/error counts
+   */
+  autoMatch(connectionId: string, options: AutoMatchOptions): Promise<AutoMatchResult>;
+}

--- a/libs/core/src/products/application/services/auto-match-variant-offers.service.spec.ts
+++ b/libs/core/src/products/application/services/auto-match-variant-offers.service.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * Auto-Match Variant Offers Service Tests
+ *
+ * @module libs/core/src/products/application/services
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { AutoMatchVariantOffersService } from './auto-match-variant-offers.service';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import { IDENTIFIER_MAPPING_SERVICE_TOKEN, IdentifierMappingConflictException } from '@openlinker/core/identifier-mapping';
+import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '../../products.tokens';
+
+const createMockIntegrationsService = () => ({
+  getAdapter: jest.fn(),
+  getCapabilityAdapter: jest.fn(),
+  listCapabilityAdapters: jest.fn(),
+});
+
+const createMockIdentifierMapping = () => ({
+  getOrCreateInternalId: jest.fn(),
+  getInternalId: jest.fn(),
+  getExternalIds: jest.fn(),
+  createMapping: jest.fn(),
+  batchGetOrCreateInternalIds: jest.fn(),
+  getOrCreateExactMapping: jest.fn(),
+  deleteMapping: jest.fn(),
+});
+
+const createMockVariantRepository = () => ({
+  findById: jest.fn(),
+  findByProductId: jest.fn(),
+  findBySku: jest.fn(),
+  findBySkuIn: jest.fn(),
+  findByEanOrGtinIn: jest.fn(),
+  upsert: jest.fn(),
+  upsertMany: jest.fn(),
+  findMany: jest.fn(),
+});
+
+const createMockMarketplace = () => ({
+  listOrderFeed: jest.fn(),
+  getOrder: jest.fn(),
+  updateOfferQuantity: jest.fn(),
+  listOffers: jest.fn(),
+});
+
+describe('AutoMatchVariantOffersService', () => {
+  let service: AutoMatchVariantOffersService;
+  let integrationsService: ReturnType<typeof createMockIntegrationsService>;
+  let identifierMapping: ReturnType<typeof createMockIdentifierMapping>;
+  let variantRepository: ReturnType<typeof createMockVariantRepository>;
+  let marketplace: ReturnType<typeof createMockMarketplace>;
+
+  beforeEach(async () => {
+    integrationsService = createMockIntegrationsService();
+    identifierMapping = createMockIdentifierMapping();
+    variantRepository = createMockVariantRepository();
+    marketplace = createMockMarketplace();
+
+    integrationsService.getAdapter.mockResolvedValue({
+      connection: { config: { masterCatalogConnectionId: 'master-conn-1' } },
+      adapter: {},
+      metadata: {},
+    });
+    integrationsService.getCapabilityAdapter.mockResolvedValue(marketplace);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AutoMatchVariantOffersService,
+        { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
+        { provide: IDENTIFIER_MAPPING_SERVICE_TOKEN, useValue: identifierMapping },
+        { provide: PRODUCT_VARIANT_REPOSITORY_TOKEN, useValue: variantRepository },
+      ],
+    }).compile();
+
+    service = module.get(AutoMatchVariantOffersService);
+  });
+
+  function setupOffers(offers: Array<{ offerId: string; ean?: string | null; sku?: string | null; externalRef?: string | null }>) {
+    marketplace.listOffers.mockResolvedValueOnce({
+      items: offers.map((o) => ({
+        offerId: o.offerId,
+        ean: o.ean ?? null,
+        sku: o.sku ?? null,
+        externalRef: o.externalRef ?? null,
+      })),
+      nextCursor: null,
+    });
+  }
+
+  function setupVariants(variants: Array<{ id: string; ean?: string | null; sku?: string | null }>) {
+    variantRepository.findMany.mockResolvedValue({
+      items: variants.map((v) => ({
+        id: v.id,
+        productId: 'prod-1',
+        sku: v.sku ?? null,
+        ean: v.ean ?? null,
+        gtin: null,
+        attributes: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })),
+      total: variants.length,
+    });
+  }
+
+  it('should match variant to offer by exact EAN', async () => {
+    setupOffers([{ offerId: 'offer-1', ean: '5901234123457' }]);
+    setupVariants([{ id: 'variant-1', ean: '5901234123457' }]);
+    identifierMapping.getOrCreateExactMapping.mockResolvedValue('offer-1');
+
+    const result = await service.autoMatch('conn-1', {});
+
+    expect(result.matched).toBe(1);
+    expect(result.skippedAmbiguous).toBe(0);
+    expect(result.skippedNoMatch).toBe(0);
+    expect(identifierMapping.getOrCreateExactMapping).toHaveBeenCalledWith(
+      'Offer',
+      'offer-1',
+      'variant-1',
+      'conn-1',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ linkMethod: 'ean' }),
+      }),
+    );
+  });
+
+  it('should match variant to offer by SKU when no EAN match', async () => {
+    setupOffers([{ offerId: 'offer-1', sku: 'SKU-ABC' }]);
+    setupVariants([{ id: 'variant-1', sku: 'SKU-ABC' }]);
+    identifierMapping.getOrCreateExactMapping.mockResolvedValue('offer-1');
+
+    const result = await service.autoMatch('conn-1', {});
+
+    expect(result.matched).toBe(1);
+    expect(identifierMapping.getOrCreateExactMapping).toHaveBeenCalledWith(
+      'Offer',
+      'offer-1',
+      'variant-1',
+      'conn-1',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ linkMethod: 'sku' }),
+      }),
+    );
+  });
+
+  it('should skip ambiguous matches when multiple offers share the same EAN', async () => {
+    setupOffers([
+      { offerId: 'offer-1', ean: '5901234123457' },
+      { offerId: 'offer-2', ean: '5901234123457' },
+    ]);
+    setupVariants([{ id: 'variant-1', ean: '5901234123457' }]);
+
+    const result = await service.autoMatch('conn-1', {});
+
+    expect(result.matched).toBe(0);
+    expect(result.skippedAmbiguous).toBe(1);
+    expect(identifierMapping.getOrCreateExactMapping).not.toHaveBeenCalled();
+  });
+
+  it('should skip variants with no matching offer', async () => {
+    setupOffers([{ offerId: 'offer-1', ean: '1111111111111' }]);
+    setupVariants([{ id: 'variant-1', ean: '9999999999999' }]);
+
+    const result = await service.autoMatch('conn-1', {});
+
+    expect(result.matched).toBe(0);
+    expect(result.skippedNoMatch).toBe(1);
+    expect(identifierMapping.getOrCreateExactMapping).not.toHaveBeenCalled();
+  });
+
+  it('should not persist mappings when dryRun is true', async () => {
+    setupOffers([{ offerId: 'offer-1', ean: '5901234123457' }]);
+    setupVariants([{ id: 'variant-1', ean: '5901234123457' }]);
+
+    const result = await service.autoMatch('conn-1', { dryRun: true });
+
+    expect(result.matched).toBe(1);
+    expect(identifierMapping.getOrCreateExactMapping).not.toHaveBeenCalled();
+  });
+
+  it('should handle mapping conflict gracefully', async () => {
+    setupOffers([{ offerId: 'offer-1', ean: '5901234123457' }]);
+    setupVariants([{ id: 'variant-1', ean: '5901234123457' }]);
+    identifierMapping.getOrCreateExactMapping.mockRejectedValue(
+      new IdentifierMappingConflictException('Offer', 'offer-1', 'conn-1', 'existing-variant', 'variant-1'),
+    );
+
+    const result = await service.autoMatch('conn-1', {});
+
+    expect(result.matched).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].variantId).toBe('variant-1');
+    expect(result.errors[0].offerId).toBe('offer-1');
+  });
+
+  it('should prefer EAN match over SKU match', async () => {
+    setupOffers([
+      { offerId: 'offer-ean', ean: '5901234123457', sku: 'SKU-A' },
+      { offerId: 'offer-sku', sku: 'SKU-A' },
+    ]);
+    setupVariants([{ id: 'variant-1', ean: '5901234123457', sku: 'SKU-A' }]);
+    identifierMapping.getOrCreateExactMapping.mockResolvedValue('offer-ean');
+
+    const result = await service.autoMatch('conn-1', {});
+
+    expect(result.matched).toBe(1);
+    expect(identifierMapping.getOrCreateExactMapping).toHaveBeenCalledWith(
+      'Offer',
+      'offer-ean',
+      'variant-1',
+      'conn-1',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ linkMethod: 'ean' }),
+      }),
+    );
+  });
+
+  it('should return empty result when masterCatalogConnectionId is not configured', async () => {
+    integrationsService.getAdapter.mockResolvedValue({
+      connection: { config: {} },
+      adapter: {},
+      metadata: {},
+    });
+
+    const result = await service.autoMatch('conn-1', {});
+
+    expect(result.matched).toBe(0);
+    expect(result.skippedNoMatch).toBe(0);
+    expect(marketplace.listOffers).not.toHaveBeenCalled();
+  });
+
+  it('should use externalRef as SKU fallback for offers', async () => {
+    setupOffers([{ offerId: 'offer-1', externalRef: 'REF-123' }]);
+    setupVariants([{ id: 'variant-1', sku: 'REF-123' }]);
+    identifierMapping.getOrCreateExactMapping.mockResolvedValue('offer-1');
+
+    const result = await service.autoMatch('conn-1', {});
+
+    expect(result.matched).toBe(1);
+    expect(identifierMapping.getOrCreateExactMapping).toHaveBeenCalledWith(
+      'Offer',
+      'offer-1',
+      'variant-1',
+      'conn-1',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ linkMethod: 'sku' }),
+      }),
+    );
+  });
+});

--- a/libs/core/src/products/application/services/auto-match-variant-offers.service.ts
+++ b/libs/core/src/products/application/services/auto-match-variant-offers.service.ts
@@ -1,0 +1,269 @@
+/**
+ * Auto-Match Variant Offers Service
+ *
+ * Automatically matches product variants from the master catalog to marketplace
+ * offers using shared identifiers (EAN first, then SKU fallback). Creates
+ * identifier mappings for unique matches.
+ *
+ * @module libs/core/src/products/application/services
+ * @implements {IAutoMatchVariantOffersService}
+ */
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  MarketplacePort,
+} from '@openlinker/core/integrations';
+import {
+  IIdentifierMappingService,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  IdentifierMappingConflictException,
+} from '@openlinker/core/identifier-mapping';
+import { Logger } from '@openlinker/shared/logging';
+import { IAutoMatchVariantOffersService } from './auto-match-variant-offers.service.interface';
+import {
+  AutoMatchResult,
+  AutoMatchOptions,
+  MatchError,
+  OfferIdentifiers,
+  MatchResult,
+} from '../types/auto-match.types';
+import {
+  PRODUCT_VARIANT_REPOSITORY_TOKEN,
+} from '../../products.tokens';
+import { ProductVariantRepositoryPort } from '../../domain/ports/product-variant-repository.port';
+import { normalizeBarcode } from '../../domain/utils/barcode-normalization';
+
+const OFFER_FEED_PAGE_SIZE = 100;
+const VARIANT_PAGE_SIZE = 1000;
+
+@Injectable()
+export class AutoMatchVariantOffersService implements IAutoMatchVariantOffersService {
+  private readonly logger = new Logger(AutoMatchVariantOffersService.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IIdentifierMappingService,
+    @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
+    private readonly variantRepository: ProductVariantRepositoryPort,
+  ) {}
+
+  async autoMatch(
+    connectionId: string,
+    options: AutoMatchOptions,
+  ): Promise<AutoMatchResult> {
+    const dryRun = options.dryRun ?? false;
+    const { connection } = await this.integrationsService.getAdapter(connectionId);
+    const masterConnectionId = this.getMasterCatalogConnectionId(connection.config);
+
+    if (!masterConnectionId) {
+      this.logger.warn(
+        `No masterCatalogConnectionId configured for connection=${connectionId}; cannot auto-match`,
+      );
+      return { matched: 0, skippedAmbiguous: 0, skippedNoMatch: 0, errors: [] };
+    }
+
+    const marketplace = await this.integrationsService.getCapabilityAdapter<MarketplacePort>(
+      connectionId,
+      'Marketplace',
+    );
+
+    const allOffers = await this.loadAllOffers(marketplace);
+    this.logger.log(`Loaded ${allOffers.length} offers from marketplace (connection=${connectionId})`);
+
+    const { eanToOffer, skuToOffer } = this.buildOfferLookups(allOffers);
+
+    const variants = await this.loadVariantsWithIdentifiers(masterConnectionId);
+    this.logger.log(`Loaded ${variants.length} variants with identifiers from master catalog (connection=${masterConnectionId})`);
+
+    let matched = 0;
+    let skippedAmbiguous = 0;
+    let skippedNoMatch = 0;
+    const errors: MatchError[] = [];
+
+    for (const variant of variants) {
+      const matchResult = this.findMatch(variant, eanToOffer, skuToOffer);
+
+      if (matchResult.status === 'no_match') {
+        skippedNoMatch += 1;
+        continue;
+      }
+
+      if (matchResult.status === 'ambiguous') {
+        skippedAmbiguous += 1;
+        this.logger.warn(
+          `Ambiguous ${matchResult.method} match for variant=${variant.id}`,
+        );
+        continue;
+      }
+
+      if (dryRun) {
+        matched += 1;
+        continue;
+      }
+
+      try {
+        await this.identifierMapping.getOrCreateExactMapping(
+          'Offer',
+          matchResult.offerId,
+          variant.id,
+          connectionId,
+          {
+            metadata: {
+              linkMethod: matchResult.method,
+              source: 'master.variants.autoMatch',
+            },
+          },
+        );
+        matched += 1;
+      } catch (error) {
+        if (error instanceof IdentifierMappingConflictException) {
+          this.logger.warn(
+            `Mapping conflict for variant=${variant.id}, offer=${matchResult.offerId}: ${error.message}`,
+          );
+          errors.push({
+            variantId: variant.id,
+            offerId: matchResult.offerId,
+            method: matchResult.method,
+            reason: error.message,
+          });
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    this.logger.log(
+      `Auto-match complete (connection=${connectionId}, dryRun=${dryRun}): matched=${matched}, skippedAmbiguous=${skippedAmbiguous}, skippedNoMatch=${skippedNoMatch}, errors=${errors.length}`,
+    );
+
+    return { matched, skippedAmbiguous, skippedNoMatch, errors };
+  }
+
+  private async loadAllOffers(marketplace: MarketplacePort): Promise<OfferIdentifiers[]> {
+    if (!marketplace.listOffers) {
+      throw new Error('Marketplace adapter does not support listOffers');
+    }
+
+    const allOffers: OfferIdentifiers[] = [];
+    let cursor: string | null = null;
+
+    do {
+      const feed = await marketplace.listOffers({ cursor, limit: OFFER_FEED_PAGE_SIZE });
+      for (const item of feed.items) {
+        allOffers.push({
+          offerId: item.offerId,
+          ean: this.normalizeBarcodeValue(item.ean),
+          sku: this.normalize(item.sku) ?? this.normalize(item.externalRef),
+        });
+      }
+      cursor = feed.nextCursor;
+    } while (cursor !== null);
+
+    return allOffers;
+  }
+
+  private buildOfferLookups(offers: OfferIdentifiers[]): {
+    eanToOffer: Map<string, string | null>;
+    skuToOffer: Map<string, string | null>;
+  } {
+    const eanToOffer = new Map<string, string | null>();
+    const skuToOffer = new Map<string, string | null>();
+
+    for (const offer of offers) {
+      if (offer.ean) {
+        this.addToUniqueMap(eanToOffer, offer.ean, offer.offerId);
+      }
+      if (offer.sku) {
+        this.addToUniqueMap(skuToOffer, offer.sku, offer.offerId);
+      }
+    }
+
+    return { eanToOffer, skuToOffer };
+  }
+
+  private addToUniqueMap(
+    map: Map<string, string | null>,
+    key: string,
+    value: string,
+  ): void {
+    const existing = map.get(key);
+    if (existing === undefined) {
+      map.set(key, value);
+    } else if (existing !== value) {
+      map.set(key, null);
+    }
+  }
+
+  private findMatch(
+    variant: { id: string; ean: string | null; sku: string | null },
+    eanToOffer: Map<string, string | null>,
+    skuToOffer: Map<string, string | null>,
+  ): MatchResult {
+    const ean = this.normalizeBarcodeValue(variant.ean);
+    if (ean) {
+      const match = eanToOffer.get(ean);
+      if (match) {
+        return { status: 'matched', offerId: match, method: 'ean' };
+      }
+      if (match === null) {
+        return { status: 'ambiguous', method: 'ean' };
+      }
+    }
+
+    const sku = this.normalize(variant.sku);
+    if (sku) {
+      const match = skuToOffer.get(sku);
+      if (match) {
+        return { status: 'matched', offerId: match, method: 'sku' };
+      }
+      if (match === null) {
+        return { status: 'ambiguous', method: 'sku' };
+      }
+    }
+
+    return { status: 'no_match' };
+  }
+
+  private async loadVariantsWithIdentifiers(
+    masterConnectionId: string,
+  ): Promise<Array<{ id: string; ean: string | null; sku: string | null }>> {
+    const allVariants: Array<{ id: string; ean: string | null; sku: string | null }> = [];
+    let offset = 0;
+
+    do {
+      const page = await this.variantRepository.findMany(
+        { connectionId: masterConnectionId, hasIdentifiers: true },
+        { limit: VARIANT_PAGE_SIZE, offset },
+      );
+      for (const v of page.items) {
+        allVariants.push({ id: v.id, ean: v.ean ?? null, sku: v.sku ?? null });
+      }
+      offset += page.items.length;
+      if (page.items.length < VARIANT_PAGE_SIZE || offset >= page.total) {
+        break;
+      }
+    } while (true);
+
+    return allVariants;
+  }
+
+  private normalize(value?: string | null): string | null {
+    if (!value) {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private normalizeBarcodeValue(value?: string | null): string | null {
+    return normalizeBarcode(value ?? null);
+  }
+
+  private getMasterCatalogConnectionId(config: Record<string, unknown>): string | null {
+    const masterConnectionId = config.masterCatalogConnectionId;
+    return typeof masterConnectionId === 'string' ? masterConnectionId : null;
+  }
+}

--- a/libs/core/src/products/application/types/auto-match.types.ts
+++ b/libs/core/src/products/application/types/auto-match.types.ts
@@ -1,0 +1,66 @@
+/**
+ * Auto-Match Types
+ *
+ * Types for the auto-match variant-to-offer feature. Defines result structures,
+ * options, and job payloads for matching PrestaShop variants to Allegro offers
+ * by shared identifiers (EAN/SKU).
+ *
+ * @module libs/core/src/products/application/types
+ */
+
+/**
+ * Match method used to link a variant to an offer.
+ */
+export type AutoMatchMethod = 'ean' | 'sku';
+
+/**
+ * Error encountered during auto-match for a specific variant.
+ */
+export interface MatchError {
+  variantId: string;
+  offerId: string;
+  method: AutoMatchMethod;
+  reason: string;
+}
+
+/**
+ * Result of an auto-match operation.
+ */
+export interface AutoMatchResult {
+  matched: number;
+  skippedAmbiguous: number;
+  skippedNoMatch: number;
+  errors: MatchError[];
+}
+
+/**
+ * Options for running an auto-match operation.
+ */
+export interface AutoMatchOptions {
+  dryRun?: boolean;
+}
+
+/**
+ * Job payload for the master.variants.autoMatch job type.
+ */
+export interface AutoMatchVariantsJobPayload {
+  schemaVersion: 1;
+  dryRun?: boolean;
+}
+
+/**
+ * Identifiers extracted from a marketplace offer for matching.
+ */
+export interface OfferIdentifiers {
+  offerId: string;
+  ean: string | null;
+  sku: string | null;
+}
+
+/**
+ * Internal result of matching a single variant against offer lookups.
+ */
+export type MatchResult =
+  | { status: 'matched'; offerId: string; method: AutoMatchMethod }
+  | { status: 'ambiguous'; method: AutoMatchMethod }
+  | { status: 'no_match' };

--- a/libs/core/src/products/domain/types/product.types.ts
+++ b/libs/core/src/products/domain/types/product.types.ts
@@ -114,6 +114,10 @@ export interface ProductVariantListFilters {
   productId?: string;
   /** Case-insensitive search on SKU, EAN, or GTIN */
   search?: string;
+  /** Scope to variants linked to a specific connection via identifier mappings */
+  connectionId?: string;
+  /** When true, only return variants with at least one non-empty identifier (EAN, GTIN, or SKU) */
+  hasIdentifiers?: boolean;
 }
 
 /**

--- a/libs/core/src/products/index.ts
+++ b/libs/core/src/products/index.ts
@@ -16,6 +16,7 @@ export {
   PRODUCT_VARIANT_REPOSITORY_TOKEN,
   PRODUCTS_SERVICE_TOKEN,
   MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
+  AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
 } from './products.tokens';
 
 // Ports
@@ -40,6 +41,11 @@ export { IProductsService } from './application/services/products.service.interf
 export { ProductsService } from './application/services/products.service';
 export { IMasterProductSyncService, MasterProductSyncResult } from './application/services/master-product-sync.service.interface';
 export { MasterProductSyncService } from './application/services/master-product-sync.service';
+export { IAutoMatchVariantOffersService } from './application/services/auto-match-variant-offers.service.interface';
+export { AutoMatchVariantOffersService } from './application/services/auto-match-variant-offers.service';
+
+// Auto-match types
+export { AutoMatchResult, AutoMatchOptions, AutoMatchMethod, MatchError, AutoMatchVariantsJobPayload, OfferIdentifiers, MatchResult } from './application/types/auto-match.types';
 
 // Types
 export {

--- a/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
@@ -138,6 +138,21 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
       );
     }
 
+    if (filters.connectionId) {
+      qb.innerJoin(
+        'identifier_mappings',
+        'mapping',
+        `mapping.internalId = variant.id AND mapping.connectionId = :connectionId AND mapping.entityType = :entityType AND (mapping.context -> 'metadata' ->> 'isVariant') = 'true'`,
+        { connectionId: filters.connectionId, entityType: 'Product' },
+      );
+    }
+
+    if (filters.hasIdentifiers) {
+      qb.andWhere(
+        '(variant.ean IS NOT NULL OR variant.gtin IS NOT NULL OR variant.sku IS NOT NULL)',
+      );
+    }
+
     qb.orderBy('variant.createdAt', 'DESC')
       .skip(pagination.offset)
       .take(pagination.limit);

--- a/libs/core/src/products/products.module.ts
+++ b/libs/core/src/products/products.module.ts
@@ -15,11 +15,13 @@ import { ProductRepository } from './infrastructure/persistence/repositories/pro
 import { ProductVariantRepository } from './infrastructure/persistence/repositories/product-variant.repository';
 import { ProductsService } from './application/services/products.service';
 import { MasterProductSyncService } from './application/services/master-product-sync.service';
+import { AutoMatchVariantOffersService } from './application/services/auto-match-variant-offers.service';
 import {
   PRODUCT_REPOSITORY_TOKEN,
   PRODUCT_VARIANT_REPOSITORY_TOKEN,
   PRODUCTS_SERVICE_TOKEN,
   MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
+  AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
 } from './products.tokens';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
@@ -44,6 +46,7 @@ export {
     ProductVariantRepository,
     ProductsService,
     MasterProductSyncService,
+    AutoMatchVariantOffersService,
     // Then provide token bindings using useExisting
     {
       provide: PRODUCT_REPOSITORY_TOKEN,
@@ -60,6 +63,10 @@ export {
     {
       provide: MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
       useExisting: MasterProductSyncService,
+    },
+    {
+      provide: AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
+      useExisting: AutoMatchVariantOffersService,
     },
     // Also provide as string tokens for convenience
     {
@@ -78,16 +85,22 @@ export {
       provide: 'IMasterProductSyncService',
       useExisting: MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
     },
+    {
+      provide: 'IAutoMatchVariantOffersService',
+      useExisting: AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
+    },
   ],
   exports: [
     PRODUCT_REPOSITORY_TOKEN,
     PRODUCT_VARIANT_REPOSITORY_TOKEN,
     PRODUCTS_SERVICE_TOKEN,
     MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
+    AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
     'ProductRepositoryPort',
     'ProductVariantRepositoryPort',
     'IProductsService',
     'IMasterProductSyncService',
+    'IAutoMatchVariantOffersService',
   ],
 })
 export class ProductsModule {}

--- a/libs/core/src/products/products.tokens.ts
+++ b/libs/core/src/products/products.tokens.ts
@@ -13,4 +13,5 @@ export const PRODUCT_REPOSITORY_TOKEN = Symbol('ProductRepositoryPort');
 export const PRODUCT_VARIANT_REPOSITORY_TOKEN = Symbol('ProductVariantRepositoryPort');
 export const PRODUCTS_SERVICE_TOKEN = Symbol('IProductsService');
 export const MASTER_PRODUCT_SYNC_SERVICE_TOKEN = Symbol('IMasterProductSyncService');
+export const AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN = Symbol('IAutoMatchVariantOffersService');
 

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -23,6 +23,8 @@ export const JobTypeValues = [
   'master.product.syncByExternalId',
   'master.inventory.syncByExternalId',
 
+  'master.variants.autoMatch',
+
   // Internal orchestration (core-owned policies; executed by worker)
   'inventory.propagateToMarketplaces',
 ] as const;


### PR DESCRIPTION
## Summary

- Add `AutoMatchVariantOffersService` that automatically matches PrestaShop product variants to Allegro offers using shared identifiers (EAN first, SKU fallback)
- New job type `master.variants.autoMatch` with worker handler and controller endpoint `POST /connections/:connectionId/sync/auto-match-variants`
- Supports `dryRun` mode to preview matches without persisting mappings

Closes #135

## Test plan

- [x] Unit tests cover: exact EAN match, exact SKU match, ambiguous skip, no-match skip, dry-run mode, mapping conflict, EAN priority over SKU, externalRef as SKU fallback, missing masterCatalogConnectionId
- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 24/24 suites, 208/208 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)