### PR TITLE
feat(listings): add category resolution service for offer creation

### DIFF
--- a/docs/plans/implementation-plan-category-resolution-offer-creation.md
+++ b/docs/plans/implementation-plan-category-resolution-offer-creation.md
@@ -1,0 +1,135 @@
+# Implementation Plan: Wire Category Mapping Resolution into Offer Creation Flow
+
+**Issue**: #143  
+**Classification**: CORE / Application + Integration  
+**Branch**: `143-category-mapping-offer-creation`
+
+---
+
+## 1. Goal
+
+When creating an Allegro offer from a PrestaShop product, automatically resolve the Allegro category using a 3-step fallback chain:
+
+1. **Auto-detect via GTIN/EAN** — query Allegro `GET /sale/matching-categories` by barcode
+2. **Category mapping fallback** — look up the product's PrestaShop category in `MappingConfigService.resolveAllegroCategory()`
+3. **Manual pick** — leave category `null` for merchant to fill in
+
+The resolution logic must be a dedicated application service, use ports only, and log which method was used.
+
+## 2. Non-Goals
+
+- Full offer creation endpoint / job handler (separate issue — this builds the resolution service and wires it into the port/adapter layer)
+- UI changes
+- Modifying existing offer sync (ingestion) flow
+
+## 3. Design
+
+### New Components
+
+#### 3.1 `MarketplacePort` extension — `matchCategoryByBarcode`
+
+Add an optional method to the marketplace port for barcode-based category matching:
+
+```typescript
+// In MarketplacePort
+matchCategoryByBarcode?(barcode: string): Promise<string | null>;
+```
+
+Returns the Allegro category ID if a single match is found, `null` otherwise.
+
+#### 3.2 Allegro adapter implementation
+
+In `AllegroMarketplaceAdapter`, implement `matchCategoryByBarcode` calling `GET /sale/matching-categories?ean={barcode}`. Return category ID from the first match, or `null` if no results / ambiguous.
+
+#### 3.3 `CategoryResolutionService`
+
+New application service in `libs/core/src/listings/application/services/`:
+
+```
+Interface: ICategoryResolutionService
+  resolveCategory(input: CategoryResolutionInput): Promise<CategoryResolutionResult>
+
+Input: { connectionId, masterConnectionId, productId, variantId? }
+Result: { allegroCategoryId: string | null, method: 'auto_detect' | 'category_mapping' | 'manual' }
+```
+
+**Resolution algorithm**:
+1. Get product variant EAN/GTIN via `ProductVariantRepositoryPort`
+2. If barcode exists → call `marketplace.matchCategoryByBarcode(barcode)`
+3. If auto-detect fails → get product's PrestaShop categories via `ProductMasterPort.getProduct()` (categories in associations) or `IdentifierMappingService` to find the PrestaShop external product ID, then query PrestaShop categories
+4. For each PrestaShop category → call `MappingConfigService.resolveAllegroCategory(connectionId, categoryId)`
+5. If no mapping resolves → return `{ allegroCategoryId: null, method: 'manual' }`
+6. Log the resolution method for observability
+
+#### 3.4 Types
+
+New types file: `libs/core/src/listings/application/types/category-resolution.types.ts`
+
+### Dependency Flow
+
+```
+CategoryResolutionService
+  → ProductVariantRepositoryPort (get EAN/GTIN)
+  → IIntegrationsService → MarketplacePort.matchCategoryByBarcode (auto-detect)
+  → IMappingConfigService.resolveAllegroCategory (fallback)
+```
+
+All via ports — no direct infrastructure imports.
+
+---
+
+## 4. Implementation Steps
+
+### Step 1: Types
+**File**: `libs/core/src/listings/application/types/category-resolution.types.ts`
+- Define `CategoryResolutionMethod` union (`'auto_detect' | 'category_mapping' | 'manual'`)
+- Define `CategoryResolutionInput` and `CategoryResolutionResult` interfaces
+
+### Step 2: Extend MarketplacePort
+**File**: `libs/core/src/integrations/domain/ports/marketplace.port.ts`
+- Add optional `matchCategoryByBarcode?(barcode: string): Promise<string | null>`
+
+### Step 3: Add Allegro API types
+**File**: `libs/integrations/allegro/src/domain/types/allegro-api.types.ts`
+- Add `AllegroMatchingCategoriesResponse` type
+
+### Step 4: Implement in Allegro adapter
+**File**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts`
+- Implement `matchCategoryByBarcode()` calling `GET /sale/matching-categories`
+
+### Step 5: Service interface
+**File**: `libs/core/src/listings/application/interfaces/allegro-category-resolution.service.interface.ts`
+- Define `ICategoryResolutionService`
+
+### Step 6: Service implementation
+**File**: `libs/core/src/listings/application/services/allegro-category-resolution.service.ts`
+- Implement the 3-step fallback chain
+- Log resolution method with structured fields
+
+### Step 7: Token + module wiring
+**File**: `libs/core/src/listings/listings.tokens.ts` (or existing tokens file)
+- Add `CATEGORY_RESOLUTION_SERVICE_TOKEN`
+- Wire in listings module
+
+### Step 8: Export from barrel
+- Export new service, interface, types, and token from `libs/core/src/listings/`
+
+### Step 9: Unit tests
+**File**: `libs/core/src/listings/application/services/allegro-category-resolution.service.spec.ts`
+- Test: auto-detect hit (barcode → category found)
+- Test: auto-detect miss → category mapping fallback hit
+- Test: both miss → manual (null)
+- Test: no barcode on variant → skip auto-detect, try mapping
+- Test: logging of resolution method
+
+### Step 10: Allegro adapter unit test
+**File**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.spec.ts`
+- Test `matchCategoryByBarcode` success/empty/error paths
+
+---
+
+## 5. Risks & Open Questions
+
+1. **Product categories access**: `ProductMasterPort.getProductCategories()` throws `NotSupportedException` in PrestaShop adapter. We'll use the product's `categories` field from `getProduct()` response or look up via identifier mapping + direct PrestaShop category ID. Need to verify product entity carries category associations.
+2. **Allegro `GET /sale/matching-categories` API shape**: Need to verify exact request/response format from Allegro docs. The adapter implementation should handle empty results gracefully.
+3. **Which PrestaShop category to use**: Products can have multiple categories. The resolution should try each category in order (deepest first) until a mapping is found.

--- a/libs/core/src/integrations/domain/ports/marketplace.port.ts
+++ b/libs/core/src/integrations/domain/ports/marketplace.port.ts
@@ -71,5 +71,13 @@ export interface MarketplacePort {
    * Fetch marketplace categories (optional).
    */
   fetchCategories?(parentId?: string): Promise<MarketplaceCategory[]>;
+
+  /**
+   * Match a marketplace category by product barcode (EAN/GTIN) — optional capability.
+   *
+   * Returns the category ID if the marketplace can auto-detect a category for the
+   * given barcode, or null if no match / ambiguous.
+   */
+  matchCategoryByBarcode?(barcode: string): Promise<string | null>;
 }
 

--- a/libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts
@@ -1,0 +1,25 @@
+/**
+ * Category Resolution Service Interface
+ *
+ * Contract for resolving the marketplace category for an offer using a 3-step
+ * fallback chain: auto-detect by barcode → category mapping → manual.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import {
+  CategoryResolutionInput,
+  CategoryResolutionResult,
+} from '../types/category-resolution.types';
+
+export interface ICategoryResolutionService {
+  /**
+   * Resolve the marketplace category for an offer.
+   *
+   * Fallback chain:
+   * 1. Auto-detect via GTIN/EAN — query marketplace for matching categories
+   * 2. Category mapping — look up source category in configured mappings
+   * 3. Manual — return null for merchant to pick
+   */
+  resolveCategory(input: CategoryResolutionInput): Promise<CategoryResolutionResult>;
+}

--- a/libs/core/src/listings/application/services/__tests__/category-resolution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/category-resolution.service.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Category Resolution Service Tests
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryResolutionService } from '../category-resolution.service';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import { MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
+import type { IIntegrationsService, MarketplacePort } from '@openlinker/core/integrations';
+import type { IMappingConfigService } from '@openlinker/core/mappings';
+
+describe('CategoryResolutionService', () => {
+  let service: CategoryResolutionService;
+  let integrationsService: jest.Mocked<Pick<IIntegrationsService, 'getCapabilityAdapter'>>;
+  let mappingConfig: jest.Mocked<Pick<IMappingConfigService, 'resolveAllegroCategory'>>;
+  let marketplace: { matchCategoryByBarcode: jest.Mock };
+
+  beforeEach(async () => {
+    marketplace = {
+      matchCategoryByBarcode: jest.fn(),
+    };
+
+    integrationsService = {
+      getCapabilityAdapter: jest.fn().mockResolvedValue(marketplace),
+    };
+
+    mappingConfig = {
+      resolveAllegroCategory: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoryResolutionService,
+        { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
+        { provide: MAPPING_CONFIG_SERVICE_TOKEN, useValue: mappingConfig },
+      ],
+    }).compile();
+
+    service = module.get(CategoryResolutionService);
+  });
+
+  it('should resolve via auto_detect when barcode matches a category', async () => {
+    marketplace.matchCategoryByBarcode.mockResolvedValue('allegro-cat-123');
+
+    const result = await service.resolveCategory({
+      connectionId: 'conn-1',
+      barcode: '5901234123457',
+      sourceCategoryIds: ['ps-cat-1'],
+    });
+
+    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-123', method: 'auto_detect' });
+    expect(marketplace.matchCategoryByBarcode).toHaveBeenCalledWith('5901234123457');
+    expect(mappingConfig.resolveAllegroCategory).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to category_mapping when auto-detect returns null', async () => {
+    marketplace.matchCategoryByBarcode.mockResolvedValue(null);
+    mappingConfig.resolveAllegroCategory.mockResolvedValue('allegro-cat-456');
+
+    const result = await service.resolveCategory({
+      connectionId: 'conn-1',
+      barcode: '5901234123457',
+      sourceCategoryIds: ['ps-cat-1'],
+    });
+
+    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-456', method: 'category_mapping' });
+    expect(mappingConfig.resolveAllegroCategory).toHaveBeenCalledWith('conn-1', 'ps-cat-1');
+  });
+
+  it('should return manual when both auto-detect and mapping fail', async () => {
+    marketplace.matchCategoryByBarcode.mockResolvedValue(null);
+    mappingConfig.resolveAllegroCategory.mockResolvedValue(null);
+
+    const result = await service.resolveCategory({
+      connectionId: 'conn-1',
+      barcode: '5901234123457',
+      sourceCategoryIds: ['ps-cat-1'],
+    });
+
+    expect(result).toEqual({ allegroCategoryId: null, method: 'manual' });
+  });
+
+  it('should skip auto-detect when no barcode is provided', async () => {
+    mappingConfig.resolveAllegroCategory.mockResolvedValue('allegro-cat-789');
+
+    const result = await service.resolveCategory({
+      connectionId: 'conn-1',
+      sourceCategoryIds: ['ps-cat-1'],
+    });
+
+    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-789', method: 'category_mapping' });
+    expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+  });
+
+  it('should try multiple source categories in order until one resolves', async () => {
+    mappingConfig.resolveAllegroCategory
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('allegro-cat-deep');
+
+    const result = await service.resolveCategory({
+      connectionId: 'conn-1',
+      sourceCategoryIds: ['ps-cat-shallow', 'ps-cat-deep'],
+    });
+
+    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-deep', method: 'category_mapping' });
+    expect(mappingConfig.resolveAllegroCategory).toHaveBeenCalledTimes(2);
+    expect(mappingConfig.resolveAllegroCategory).toHaveBeenCalledWith('conn-1', 'ps-cat-shallow');
+    expect(mappingConfig.resolveAllegroCategory).toHaveBeenCalledWith('conn-1', 'ps-cat-deep');
+  });
+
+  it('should return manual when no barcode and no source categories', async () => {
+    const result = await service.resolveCategory({
+      connectionId: 'conn-1',
+    });
+
+    expect(result).toEqual({ allegroCategoryId: null, method: 'manual' });
+  });
+
+  it('should handle auto-detect error gracefully and fall back to mapping', async () => {
+    integrationsService.getCapabilityAdapter.mockRejectedValue(new Error('adapter unavailable'));
+    mappingConfig.resolveAllegroCategory.mockResolvedValue('allegro-cat-fallback');
+
+    const result = await service.resolveCategory({
+      connectionId: 'conn-1',
+      barcode: '5901234123457',
+      sourceCategoryIds: ['ps-cat-1'],
+    });
+
+    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-fallback', method: 'category_mapping' });
+  });
+
+  it('should handle adapter without matchCategoryByBarcode support', async () => {
+    const adapterWithoutMethod = {} as MarketplacePort;
+    integrationsService.getCapabilityAdapter.mockResolvedValue(adapterWithoutMethod);
+    mappingConfig.resolveAllegroCategory.mockResolvedValue('allegro-cat-mapped');
+
+    const result = await service.resolveCategory({
+      connectionId: 'conn-1',
+      barcode: '5901234123457',
+      sourceCategoryIds: ['ps-cat-1'],
+    });
+
+    expect(result).toEqual({ allegroCategoryId: 'allegro-cat-mapped', method: 'category_mapping' });
+  });
+});

--- a/libs/core/src/listings/application/services/category-resolution.service.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.ts
@@ -1,0 +1,103 @@
+/**
+ * Category Resolution Service
+ *
+ * Resolves the marketplace category for an offer using a 3-step fallback chain:
+ * 1. Auto-detect via GTIN/EAN barcode (marketplace catalog lookup)
+ * 2. Category mapping fallback (configured source → marketplace mappings)
+ * 3. Manual pick (returns null for the merchant to choose)
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {ICategoryResolutionService}
+ */
+
+import { Injectable, Inject } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  MarketplacePort,
+} from '@openlinker/core/integrations';
+import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
+import { ICategoryResolutionService } from '../interfaces/category-resolution.service.interface';
+import {
+  CategoryResolutionInput,
+  CategoryResolutionResult,
+} from '../types/category-resolution.types';
+
+@Injectable()
+export class CategoryResolutionService implements ICategoryResolutionService {
+  private readonly logger = new Logger(CategoryResolutionService.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(MAPPING_CONFIG_SERVICE_TOKEN)
+    private readonly mappingConfig: IMappingConfigService,
+  ) {}
+
+  async resolveCategory(input: CategoryResolutionInput): Promise<CategoryResolutionResult> {
+    const { connectionId, barcode, sourceCategoryIds } = input;
+
+    // Step 1: Auto-detect via barcode
+    if (barcode) {
+      const autoDetected = await this.tryAutoDetect(connectionId, barcode);
+      if (autoDetected) {
+        this.logger.debug(
+          `Category resolved via auto_detect (connection=${connectionId}, barcode=${barcode}, categoryId=${autoDetected})`,
+        );
+        return { allegroCategoryId: autoDetected, method: 'auto_detect' };
+      }
+    }
+
+    // Step 2: Category mapping fallback
+    if (sourceCategoryIds && sourceCategoryIds.length > 0) {
+      const mapped = await this.tryCategoryMapping(connectionId, sourceCategoryIds);
+      if (mapped) {
+        this.logger.debug(
+          `Category resolved via category_mapping (connection=${connectionId}, categoryId=${mapped})`,
+        );
+        return { allegroCategoryId: mapped, method: 'category_mapping' };
+      }
+    }
+
+    // Step 3: Manual pick
+    this.logger.debug(
+      `Category unresolved, manual pick required (connection=${connectionId})`,
+    );
+    return { allegroCategoryId: null, method: 'manual' };
+  }
+
+  private async tryAutoDetect(connectionId: string, barcode: string): Promise<string | null> {
+    try {
+      const marketplace = await this.integrationsService.getCapabilityAdapter<MarketplacePort>(
+        connectionId,
+        'Marketplace',
+      );
+      if (!marketplace.matchCategoryByBarcode) {
+        this.logger.debug(
+          `Marketplace adapter does not support matchCategoryByBarcode (connection=${connectionId})`,
+        );
+        return null;
+      }
+      return await marketplace.matchCategoryByBarcode(barcode);
+    } catch (error) {
+      this.logger.warn(
+        `Auto-detect category failed (connection=${connectionId}): ${(error as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  private async tryCategoryMapping(
+    connectionId: string,
+    sourceCategoryIds: string[],
+  ): Promise<string | null> {
+    for (const categoryId of sourceCategoryIds) {
+      const resolved = await this.mappingConfig.resolveAllegroCategory(connectionId, categoryId);
+      if (resolved) {
+        return resolved;
+      }
+    }
+    return null;
+  }
+}

--- a/libs/core/src/listings/application/types/category-resolution.types.ts
+++ b/libs/core/src/listings/application/types/category-resolution.types.ts
@@ -1,0 +1,39 @@
+/**
+ * Category Resolution Types
+ *
+ * Types for Allegro category resolution during offer creation.
+ * The resolution service uses a 3-step fallback chain:
+ * auto-detect by barcode → category mapping → manual.
+ *
+ * @module libs/core/src/listings/application/types
+ */
+
+export const CategoryResolutionMethodValues = [
+  'auto_detect',
+  'category_mapping',
+  'manual',
+] as const;
+
+export type CategoryResolutionMethod = (typeof CategoryResolutionMethodValues)[number];
+
+export interface CategoryResolutionInput {
+  /** Allegro marketplace connection ID */
+  connectionId: string;
+  /**
+   * EAN or GTIN barcode for auto-detect (step 1).
+   * If omitted, auto-detect is skipped entirely.
+   */
+  barcode?: string | null;
+  /**
+   * Source platform category IDs for mapping fallback (step 2), ordered deepest-first.
+   * If both `barcode` and `sourceCategoryIds` are omitted, resolution returns `manual`.
+   */
+  sourceCategoryIds?: string[];
+}
+
+export interface CategoryResolutionResult {
+  /** Resolved Allegro category ID, or null if manual pick is needed */
+  allegroCategoryId: string | null;
+  /** Which resolution method produced the result */
+  method: CategoryResolutionMethod;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -9,9 +9,18 @@ export {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
+  CATEGORY_RESOLUTION_SERVICE_TOKEN,
 } from './listings.tokens';
 export { OfferLinkingService } from './application/services/offer-linking.service';
 export { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
+export { CategoryResolutionService } from './application/services/category-resolution.service';
+export type { ICategoryResolutionService } from './application/interfaces/category-resolution.service.interface';
+export type {
+  CategoryResolutionInput,
+  CategoryResolutionResult,
+  CategoryResolutionMethod,
+} from './application/types/category-resolution.types';
+export { CategoryResolutionMethodValues } from './application/types/category-resolution.types';
 export type {
   IOfferMappingSyncService,
   OfferMappingSyncOptions,

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -10,13 +10,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule, IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping';
 import { ProductsModule } from '@openlinker/core/products';
+import { MappingsModule } from '@openlinker/core/mappings';
 import { OfferLinkingService } from './application/services/offer-linking.service';
 import { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
+import { CategoryResolutionService } from './application/services/category-resolution.service';
 import { OfferMappingRepository } from './infrastructure/persistence/repositories/offer-mapping.repository';
 import {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
+  CATEGORY_RESOLUTION_SERVICE_TOKEN,
 } from './listings.tokens';
 
 // Re-export tokens for convenience
@@ -24,6 +27,7 @@ export {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
+  CATEGORY_RESOLUTION_SERVICE_TOKEN,
 } from './listings.tokens';
 
 @Module({
@@ -32,10 +36,12 @@ export {
     IntegrationsModule,
     IdentifierMappingModule,
     ProductsModule,
+    MappingsModule,
   ],
   providers: [
     OfferLinkingService,
     OfferMappingSyncService,
+    CategoryResolutionService,
     OfferMappingRepository,
     {
       provide: OFFER_LINKING_SERVICE_TOKEN,
@@ -58,6 +64,14 @@ export {
       useExisting: OFFER_MAPPING_SYNC_SERVICE_TOKEN,
     },
     {
+      provide: CATEGORY_RESOLUTION_SERVICE_TOKEN,
+      useExisting: CategoryResolutionService,
+    },
+    {
+      provide: 'ICategoryResolutionService',
+      useExisting: CATEGORY_RESOLUTION_SERVICE_TOKEN,
+    },
+    {
       provide: 'OfferMappingRepositoryPort',
       useExisting: OFFER_MAPPING_REPOSITORY_TOKEN,
     },
@@ -66,6 +80,8 @@ export {
     OFFER_LINKING_SERVICE_TOKEN,
     OFFER_MAPPING_SYNC_SERVICE_TOKEN,
     OFFER_MAPPING_REPOSITORY_TOKEN,
+    CATEGORY_RESOLUTION_SERVICE_TOKEN,
+    'ICategoryResolutionService',
     'OfferLinkingService',
     'IOfferMappingSyncService',
     'OfferMappingRepositoryPort',

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -7,3 +7,4 @@
 export const OFFER_LINKING_SERVICE_TOKEN = Symbol('OfferLinkingService');
 export const OFFER_MAPPING_SYNC_SERVICE_TOKEN = Symbol('OfferMappingSyncService');
 export const OFFER_MAPPING_REPOSITORY_TOKEN = Symbol('OfferMappingRepositoryPort');
+export const CATEGORY_RESOLUTION_SERVICE_TOKEN = Symbol('ICategoryResolutionService');

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -241,5 +241,17 @@ export interface AllegroOfferFieldsPatchBody extends Record<string, unknown> {
   };
 }
 
-
+/**
+ * Response from Allegro GET /sale/matching-categories
+ *
+ * Returns categories that match a given product identified by barcode (EAN/GTIN).
+ */
+export interface AllegroMatchingCategoriesResponse {
+  matchingCategories: Array<{
+    category: {
+      id: string;
+      name?: string;
+    };
+  }>;
+}
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
@@ -532,7 +532,63 @@ describe('AllegroMarketplaceAdapter', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('matchCategoryByBarcode', () => {
+    it('should return category ID when exactly one match is found', async () => {
+      httpClient.get.mockResolvedValue({
+        data: {
+          matchingCategories: [
+            { category: { id: 'cat-100', name: 'Electronics' } },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.matchCategoryByBarcode('5901234123457');
+
+      expect(result).toBe('cat-100');
+      expect(httpClient.get).toHaveBeenCalledWith('/sale/matching-categories', {
+        queryParams: { ean: '5901234123457' },
+      });
+    });
+
+    it('should return null when no matches are found', async () => {
+      httpClient.get.mockResolvedValue({
+        data: { matchingCategories: [] },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.matchCategoryByBarcode('0000000000000');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when multiple matches are found', async () => {
+      httpClient.get.mockResolvedValue({
+        data: {
+          matchingCategories: [
+            { category: { id: 'cat-1' } },
+            { category: { id: 'cat-2' } },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await adapter.matchCategoryByBarcode('5901234123457');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when the API call fails', async () => {
+      httpClient.get.mockRejectedValue(new Error('API error'));
+
+      const result = await adapter.matchCategoryByBarcode('5901234123457');
+
+      expect(result).toBeNull();
+    });
+  });
 });
-
-
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
@@ -34,6 +34,7 @@ import {
   AllegroOffersResponse,
   AllegroOfferEventsResponse,
   AllegroOfferFieldsPatchBody,
+  AllegroMatchingCategoriesResponse,
 } from '../../domain/types/allegro-api.types';
 import { Logger } from '@openlinker/shared/logging';
 import { createHash } from 'crypto';
@@ -513,6 +514,37 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
       parentId: cat.parent?.id ?? null,
       leaf: cat.leaf,
     }));
+  }
+
+  async matchCategoryByBarcode(barcode: string): Promise<string | null> {
+    this.logger.debug(
+      `Matching Allegro category by barcode (connection: ${this.connectionId}, barcode: ${barcode})`,
+    );
+    try {
+      const response = await this.httpClient.get<AllegroMatchingCategoriesResponse>(
+        '/sale/matching-categories',
+        { queryParams: { ean: barcode } },
+      );
+      const matches = response.data.matchingCategories ?? [];
+      if (matches.length === 1) {
+        const categoryId = matches[0].category.id;
+        this.logger.debug(
+          `Barcode auto-detect matched category ${categoryId} (connection: ${this.connectionId})`,
+        );
+        return categoryId;
+      }
+      if (matches.length > 1) {
+        this.logger.debug(
+          `Barcode auto-detect returned ${matches.length} categories, skipping (connection: ${this.connectionId})`,
+        );
+      }
+      return null;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to match category by barcode (connection: ${this.connectionId}): ${(error as Error).message}`,
+      );
+      return null;
+    }
   }
 
   private findIdentifierParameterIds(


### PR DESCRIPTION
## Summary

- Add `CategoryResolutionService` with a 3-step fallback chain for resolving marketplace categories during offer creation: auto-detect by barcode → category mapping → manual pick
- Extend `MarketplacePort` with optional `matchCategoryByBarcode()` method
- Implement Allegro adapter support for `GET /sale/matching-categories` barcode lookup
- Full unit test coverage (8 tests for resolution service, 4 for adapter)

Closes #143

## Test plan

- [x] Unit tests pass: `pnpm test` (all 266 tests green)
- [x] Type-check passes: `pnpm type-check`
- [x] Lint passes: `pnpm lint`
- [ ] Manual verification: invoke `CategoryResolutionService.resolveCategory()` with barcode / category mapping / neither to confirm all 3 fallback paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)