### PR TITLE
feat(sync,orders): add retry API and failed orders diagnostics page

### DIFF
--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -69,6 +69,7 @@ describe('ConnectionController', () => {
       markFailed: jest.fn(),
       markDead: jest.fn(),
       requeueStuckJobs: jest.fn(),
+      requeueDeadJob: jest.fn(),
       findRecentByConnectionId: jest.fn(),
     };
 

--- a/apps/api/src/sync/http/sync.controller.spec.ts
+++ b/apps/api/src/sync/http/sync.controller.spec.ts
@@ -14,6 +14,7 @@ import {
   SyncJobRequest,
   SyncJobRepositoryPort,
   SYNC_JOB_REPOSITORY_TOKEN,
+  SYNC_JOB_RETRY_SERVICE_TOKEN,
   SyncJobEntity,
 } from '@openlinker/core/sync';
 import { EnqueueSyncJobDto } from './dto/enqueue-sync-job.dto';
@@ -55,7 +56,12 @@ describe('SyncController', () => {
     markFailed: jest.fn(),
     markDead: jest.fn(),
     requeueStuckJobs: jest.fn(),
+    requeueDeadJob: jest.fn(),
     findRecentByConnectionId: jest.fn(),
+  };
+
+  const mockRetryService = {
+    retryJob: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -64,6 +70,7 @@ describe('SyncController', () => {
       providers: [
         { provide: JOB_ENQUEUE_TOKEN, useValue: mockJobEnqueue },
         { provide: SYNC_JOB_REPOSITORY_TOKEN, useValue: mockSyncJobRepository },
+        { provide: SYNC_JOB_RETRY_SERVICE_TOKEN, useValue: mockRetryService },
       ],
     }).compile();
 

--- a/apps/api/src/sync/http/sync.controller.ts
+++ b/apps/api/src/sync/http/sync.controller.ts
@@ -16,6 +16,7 @@ import {
   HttpCode,
   HttpStatus,
   BadRequestException,
+  ConflictException,
   NotFoundException,
   Inject,
   ParseUUIDPipe,
@@ -28,8 +29,12 @@ import {
   SyncJobRequest,
   SyncJobRepositoryPort,
   SYNC_JOB_REPOSITORY_TOKEN,
+  SYNC_JOB_RETRY_SERVICE_TOKEN,
+  InvalidSyncJobStateError,
+  SyncJobNotFoundError,
 } from '@openlinker/core/sync';
 import type { SyncJob } from '@openlinker/core/sync';
+import type { ISyncJobRetryService } from '@openlinker/core/sync';
 import { EnqueueSyncJobDto } from './dto/enqueue-sync-job.dto';
 import { EnqueueSyncJobResponseDto } from './dto/enqueue-sync-job-response.dto';
 import { ListSyncJobsQueryDto } from './dto/list-sync-jobs-query.dto';
@@ -49,6 +54,8 @@ export class SyncController {
     private readonly jobEnqueue: JobEnqueuePort,
     @Inject(SYNC_JOB_REPOSITORY_TOKEN)
     private readonly syncJobRepository: SyncJobRepositoryPort,
+    @Inject(SYNC_JOB_RETRY_SERVICE_TOKEN)
+    private readonly retryService: ISyncJobRetryService,
   ) {}
 
   @Post('jobs')
@@ -144,6 +151,32 @@ export class SyncController {
       throw new NotFoundException(`Sync job not found: ${id}`);
     }
     return this.toDto(job);
+  }
+
+  @Post('jobs/:id/retry')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Retry a dead sync job',
+    description:
+      'Requeues a dead sync job for retry. Resets the job to queued status with zero attempts. Only jobs in dead status can be retried.',
+  })
+  @ApiResponse({ status: 200, description: 'Job requeued for retry', type: SyncJobResponseDto })
+  @ApiResponse({ status: 404, description: 'Job not found' })
+  @ApiResponse({ status: 409, description: 'Job is not in dead status' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async retryJob(@Param('id', ParseUUIDPipe) id: string): Promise<SyncJobResponseDto> {
+    try {
+      const job = await this.retryService.retryJob(id);
+      return this.toDto(job);
+    } catch (error) {
+      if (error instanceof SyncJobNotFoundError) {
+        throw new NotFoundException(`Sync job not found: ${id}`);
+      }
+      if (error instanceof InvalidSyncJobStateError) {
+        throw new ConflictException(`Job cannot be retried: ${error.message}`);
+      }
+      throw error;
+    }
   }
 
   private toDto(job: SyncJob): SyncJobResponseDto {

--- a/apps/web/src/app/routes/orders.route.tsx
+++ b/apps/web/src/app/routes/orders.route.tsx
@@ -1,11 +1,13 @@
 import type { RouteObject } from 'react-router-dom';
 import { OrdersListPage } from '../../pages/orders/orders-list-page';
 import { OrderDetailPage } from '../../pages/orders/order-detail-page';
+import { FailedOrdersPage } from '../../pages/orders/failed-orders-page';
 
 export const ordersRoute: RouteObject = {
   path: 'orders',
   children: [
     { index: true, element: <OrdersListPage /> },
+    { path: 'failed', element: <FailedOrdersPage /> },
     { path: ':internalOrderId', element: <OrderDetailPage /> },
   ],
 };

--- a/apps/web/src/features/sync-jobs/api/sync.api.ts
+++ b/apps/web/src/features/sync-jobs/api/sync.api.ts
@@ -28,6 +28,7 @@ export interface SyncJobsApi {
   enqueue: (input: EnqueueSyncJobInput) => Promise<SyncJobResponse>;
   list: (filters?: SyncJobFilters, pagination?: SyncJobPagination) => Promise<PaginatedSyncJobs>;
   getById: (id: string) => Promise<SyncJob>;
+  retry: (id: string) => Promise<SyncJob>;
 }
 
 interface ApiRequest {
@@ -58,6 +59,9 @@ export function createSyncJobsApi(request: ApiRequest): SyncJobsApi {
     },
     getById(id): Promise<SyncJob> {
       return request<SyncJob>(`/sync/jobs/${id}`);
+    },
+    retry(id): Promise<SyncJob> {
+      return request<SyncJob>(`/sync/jobs/${id}/retry`, { method: 'POST' });
     },
   };
 }

--- a/apps/web/src/features/sync-jobs/hooks/use-retry-sync-job-mutation.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-retry-sync-job-mutation.ts
@@ -1,0 +1,24 @@
+/**
+ * Retry Sync Job Mutation Hook
+ *
+ * Provides a mutation for retrying a dead sync job. Invalidates the sync jobs
+ * query cache on success so lists refresh automatically.
+ *
+ * @module apps/web/src/features/sync-jobs/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { syncJobsQueryKeys } from '../api/sync.query-keys';
+import type { SyncJob } from '../api/sync-jobs.types';
+
+export function useRetrySyncJobMutation(): UseMutationResult<SyncJob, Error, string> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiClient.syncJobs.retry(id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: syncJobsQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/pages/orders/failed-orders-page.test.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.test.tsx
@@ -1,0 +1,106 @@
+import { screen, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { FailedOrdersPage } from './failed-orders-page';
+import type { PaginatedSyncJobs, SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
+
+function makeSyncJob(overrides: Partial<SyncJob> = {}): SyncJob {
+  return {
+    id: 'aabbccdd-1111-2222-3333-444444444444',
+    jobType: 'marketplace.order.sync',
+    connectionId: 'conn-1111-2222-3333-444444444444',
+    status: 'dead',
+    attempts: 10,
+    maxAttempts: 10,
+    nextRunAt: '2026-04-10T10:00:00.000Z',
+    lastError: 'MissingOrderItemMappingError: No product mapping found for offer abc123',
+    payloadJson: { allegroOrderId: 'order-1' },
+    idempotencyKey: 'key-1',
+    lockedAt: null,
+    lockedBy: null,
+    createdAt: '2026-04-10T08:00:00.000Z',
+    updatedAt: '2026-04-10T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const sampleData: PaginatedSyncJobs = {
+  items: [makeSyncJob()],
+  total: 1,
+  limit: 25,
+  offset: 0,
+};
+
+describe('FailedOrdersPage', () => {
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      syncJobs: {
+        list: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    expect(screen.getByText('Loading failed orders')).toBeInTheDocument();
+  });
+
+  it('should show failed jobs table when data loads', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: {
+        list: vi.fn().mockResolvedValue(sampleData),
+      },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('aabbccdd…')).toBeInTheDocument();
+    expect(screen.getByText('10/10')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: {
+        list: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Unable to load failed orders')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no failed jobs', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: {
+        list: vi.fn().mockResolvedValue({
+          items: [],
+          total: 0,
+          limit: 25,
+          offset: 0,
+        }),
+      },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No failed orders')).toBeInTheDocument();
+  });
+
+  it('should render retry button scoped to each job row', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: {
+        list: vi.fn().mockResolvedValue(sampleData),
+      },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    const jobIdLink = await screen.findByText('aabbccdd…');
+    const row = jobIdLink.closest('tr')!;
+    const retryButton = within(row).getByRole('button', { name: 'Retry' });
+
+    expect(retryButton).toBeInTheDocument();
+    expect(retryButton).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/pages/orders/failed-orders-page.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.tsx
@@ -1,0 +1,239 @@
+/**
+ * Failed Orders Page
+ *
+ * Displays dead order-sync jobs with inline retry capability. Allows operators
+ * to diagnose and remediate failed order synchronizations.
+ *
+ * @module apps/web/src/pages/orders
+ */
+import { type ReactElement } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { Select } from '../../shared/ui/select';
+import { StatusBadge } from '../../shared/ui/status-badge';
+import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
+import { useRetrySyncJobMutation } from '../../features/sync-jobs/hooks/use-retry-sync-job-mutation';
+import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
+import { useToast } from '../../shared/ui/toast-provider';
+import type { SyncJob, SyncJobFilters } from '../../features/sync-jobs/api/sync-jobs.types';
+
+const PAGE_SIZE = 25;
+
+const ORDER_JOB_TYPES = ['marketplace.order.sync'] as const;
+
+function RetryButton({ job }: { job: SyncJob }): ReactElement {
+  const mutation = useRetrySyncJobMutation();
+  const { showToast } = useToast();
+
+  function handleRetry(): void {
+    mutation.mutate(job.id, {
+      onSuccess: () => {
+        showToast({ tone: 'success', title: 'Retrying', description: `Job ${job.id.slice(0, 8)}… requeued.` });
+      },
+      onError: (error) => {
+        showToast({ tone: 'error', title: 'Retry failed', description: error.message });
+      },
+    });
+  }
+
+  const isPending = mutation.isPending && mutation.variables === job.id;
+
+  return (
+    <Button
+      onClick={handleRetry}
+      disabled={isPending}
+      className="button--compact"
+    >
+      {isPending ? 'Retrying…' : 'Retry'}
+    </Button>
+  );
+}
+
+function truncateError(error: string | null, maxLength = 80): string {
+  if (!error) return '—';
+  return error.length > maxLength ? `${error.slice(0, maxLength)}…` : error;
+}
+
+const COLUMNS: DataTableColumn<SyncJob>[] = [
+  {
+    id: 'id',
+    header: 'Job ID',
+    cell: (job) => (
+      <Link to={`/sync-jobs/${job.id}`} className="mono-text">
+        {job.id.slice(0, 8)}…
+      </Link>
+    ),
+  },
+  {
+    id: 'connectionId',
+    header: 'Connection',
+    cell: (job) => <span className="mono-text">{job.connectionId.slice(0, 8)}…</span>,
+  },
+  {
+    id: 'updatedAt',
+    header: 'Failed At',
+    cell: (job) => new Date(job.updatedAt).toLocaleString(),
+  },
+  {
+    id: 'lastError',
+    header: 'Error',
+    cell: (job) => (
+      <details>
+        <summary style={{ cursor: 'pointer' }}>{truncateError(job.lastError)}</summary>
+        <pre style={{ whiteSpace: 'pre-wrap', fontSize: '0.8em', marginTop: '0.5rem' }}>
+          {job.lastError ?? '—'}
+        </pre>
+      </details>
+    ),
+  },
+  {
+    id: 'attempts',
+    header: 'Attempts',
+    cell: (job) => `${job.attempts}/${job.maxAttempts}`,
+    align: 'center',
+  },
+  {
+    id: 'actions',
+    header: '',
+    cell: (job) => <RetryButton job={job} />,
+    align: 'right',
+  },
+];
+
+export function FailedOrdersPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const connectionId = searchParams.get('connectionId') ?? undefined;
+  const offset = Number(searchParams.get('offset') ?? '0');
+
+  const filters: SyncJobFilters = {
+    status: 'dead',
+    jobType: ORDER_JOB_TYPES[0],
+    connectionId: connectionId || undefined,
+  };
+  const pagination = { limit: PAGE_SIZE, offset };
+
+  const query = useSyncJobsQuery(filters, pagination);
+  const connectionsQuery = useConnectionsQuery();
+
+  function handleConnectionFilterChange(value: string): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set('connectionId', value);
+      } else {
+        next.delete('connectionId');
+      }
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  function setOffset(next: number): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === 0) {
+        p.delete('offset');
+      } else {
+        p.set('offset', String(next));
+      }
+      return p;
+    });
+  }
+
+  const total = query.data?.total ?? 0;
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+  const connections = connectionsQuery.data ?? [];
+
+  return (
+    <PageLayout
+      eyebrow="Orders"
+      title="Failed Orders"
+      description="Order sync failures — diagnose errors and retry failed jobs."
+      actions={
+        <Link to="/orders" className="button button--ghost">
+          ← All Orders
+        </Link>
+      }
+    >
+      {/* Filter bar */}
+      <div className="toolbar">
+        <Select
+          aria-label="Filter by connection"
+          value={connectionId ?? ''}
+          onChange={(e) => { handleConnectionFilterChange(e.target.value); }}
+        >
+          <option value="">All connections</option>
+          {connections.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </Select>
+
+        <StatusBadge tone="error" compact>
+          {total} failed
+        </StatusBadge>
+      </div>
+
+      {query.isLoading ? (
+        <LoadingState
+          liveRegion="off"
+          title="Loading failed orders"
+          message="Fetching failed order sync jobs…"
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load failed orders"
+          message={query.error.message}
+          action={
+            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+          }
+        />
+      ) : (query.data?.items.length ?? 0) === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No failed orders"
+          message={
+            connectionId
+              ? 'No failed order sync jobs for the selected connection.'
+              : 'No failed order sync jobs found. All orders are syncing successfully.'
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Failed order sync jobs"
+            columns={COLUMNS}
+            rows={query.data?.items ?? []}
+            rowKey={(job) => job.id}
+          />
+
+          <div className="toolbar" style={{ justifyContent: 'space-between' }}>
+            <span className="text-muted">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <Button
+                disabled={!hasPrev}
+                onClick={() => { setOffset(offset - PAGE_SIZE); }}
+              >
+                Previous
+              </Button>
+              <Button
+                disabled={!hasNext}
+                onClick={() => { setOffset(offset + PAGE_SIZE); }}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -127,6 +127,11 @@ export function OrdersListPage(): ReactElement {
       eyebrow="Operations"
       title="Orders"
       description="Order monitoring — track sync status and troubleshoot failures."
+      actions={
+        <Link to="/orders/failed" className="button button--ghost">
+          Failed Orders
+        </Link>
+      }
     >
       {/* Filter bar */}
       <div className="toolbar">

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -188,6 +188,7 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
         offset: 0,
       }),
       getById: vi.fn().mockResolvedValue(null),
+      retry: vi.fn().mockResolvedValue(null),
       ...overrides.syncJobs,
     } as ApiClient['syncJobs'],
   };

--- a/docs/plans/implementation-plan-retry-apis-failed-orders.md
+++ b/docs/plans/implementation-plan-retry-apis-failed-orders.md
@@ -1,0 +1,212 @@
+# Implementation Plan: Retry & Remediation APIs (#72) + Failed Order Diagnostics Page (#137)
+
+## Overview
+
+**Goal**: Add backend retry/remediation endpoints for dead sync jobs, then build a frontend "Failed Orders" page that surfaces dead order-sync jobs with inline retry capability.
+
+**Layers**: Interface (BE controller + FE page), Application (retry service), Infrastructure (repository method)
+
+**Non-goals**:
+- Payload editing before retry (future remediation)
+- Batch retry across all job types (scope to order jobs initially, but build generic)
+- Audit trail / remediation history logging (defer)
+
+---
+
+## Architecture
+
+### Data Flow
+
+```
+FE: FailedOrdersPage
+  → useFailedOrderJobsQuery (GET /sync/jobs?status=dead&jobType=marketplace.order.sync)
+  → useRetrySyncJobMutation (POST /sync/jobs/:id/retry)
+      ↓
+BE: SyncController
+  → POST /sync/jobs/:id/retry
+  → SyncJobRetryService.retryJob(id)
+      → SyncJobRepository.requeueDeadJob(id) — resets status=queued, attempts=0
+      ↓
+  Worker picks up requeued job normally
+```
+
+### Key Design Decisions
+
+1. **Retry = requeue the existing DB row** (reset to `queued`, `attempts=0`). No new Redis stream message needed — the runner polls DB directly via `findAndLockDueJobs`.
+2. **Generic retry endpoint** — `POST /sync/jobs/:id/retry` works for any dead job, not just orders. The FE filters to order jobs.
+3. **No new idempotency key** — the existing idempotency dedup key in Redis has a 7-day TTL. We clear it on retry to allow re-enqueue if needed, but since we requeue in-place in DB, this is handled at DB level only.
+4. **Safety**: Only `dead` jobs can be retried. Retrying `queued`/`running`/`succeeded` returns 409 Conflict.
+
+---
+
+## Step-by-Step Plan
+
+### Step 1: Add `requeueDeadJob` to repository port and implementation
+
+**Files:**
+- `libs/core/src/sync/domain/ports/sync-job-repository.port.ts` — add method to port
+- `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts` — implement
+
+**Method signature:**
+```typescript
+requeueDeadJob(id: string): Promise<SyncJob>;
+```
+
+**Implementation:**
+- Find job by ID, verify `status === 'dead'`
+- If not dead → throw `InvalidSyncJobStateError`
+- Update: `status='queued'`, `attempts=0`, `nextRunAt=now()`, `lockedAt=null`, `lockedBy=null`, `lastError` preserved (for history)
+- Return updated domain entity
+
+**Acceptance:**
+- Unit test: requeue dead job succeeds
+- Unit test: requeue non-dead job throws
+
+---
+
+### Step 2: Add retry service (application layer)
+
+**Files:**
+- `libs/core/src/sync/application/services/sync-job-retry.service.interface.ts` — interface
+- `libs/core/src/sync/application/services/sync-job-retry.service.ts` — implementation
+
+**Interface:**
+```typescript
+export interface ISyncJobRetryService {
+  retryJob(id: string): Promise<SyncJob>;
+}
+```
+
+**Implementation:**
+- Inject `SyncJobRepositoryPort`
+- Call `requeueDeadJob(id)`
+- Log retry action with `jobId`, `jobType`, `connectionId`
+
+**Why a service?** Keeps controller thin, allows adding pre-retry validation / audit logging later.
+
+**Acceptance:**
+- Unit test: delegates to repository, logs
+
+---
+
+### Step 3: Add `POST /sync/jobs/:id/retry` endpoint
+
+**Files:**
+- `apps/api/src/sync/http/sync.controller.ts` — add endpoint
+- `apps/api/src/sync/http/dto/retry-sync-job-response.dto.ts` — response DTO
+
+**Endpoint:**
+```
+POST /sync/jobs/:id/retry
+@Roles('admin')
+Response: SyncJobResponseDto (existing DTO reused)
+Errors: 404 (not found), 409 (not in dead state)
+```
+
+**Controller logic:**
+- Call `retryService.retryJob(id)`
+- Catch `InvalidSyncJobStateError` → 409 Conflict
+- Catch not-found → 404
+
+**Wire up:** Register `SyncJobRetryService` in API sync module, inject into controller.
+
+**Acceptance:**
+- Endpoint returns updated job with `status: 'queued'`
+- 409 on non-dead job
+- 404 on missing job
+
+---
+
+### Step 4: Export retry service token and update modules
+
+**Files:**
+- `libs/core/src/sync/sync.tokens.ts` — add `SYNC_JOB_RETRY_SERVICE_TOKEN`
+- `libs/core/src/sync/sync.module.ts` — register provider
+- `apps/api/src/sync/sync.module.ts` — import and inject
+- `libs/core/src/sync/index.ts` — export new symbols
+
+---
+
+### Step 5: Add `retry` method to FE sync jobs API
+
+**Files:**
+- `apps/web/src/features/sync-jobs/api/sync.api.ts` — add `retry(id)` method to `SyncJobsApi`
+
+**Method:**
+```typescript
+retry(id: string): Promise<SyncJob> {
+  return request<SyncJob>(`/sync/jobs/${id}/retry`, { method: 'POST' });
+}
+```
+
+---
+
+### Step 6: Add `useRetrySyncJobMutation` hook
+
+**Files:**
+- `apps/web/src/features/sync-jobs/hooks/use-retry-sync-job-mutation.ts`
+
+**Pattern:**
+```typescript
+export function useRetrySyncJobMutation() {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiClient.syncJobs.retry(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: syncQueryKeys.all }),
+  });
+}
+```
+
+---
+
+### Step 7: Create Failed Orders page
+
+**Files:**
+- `apps/web/src/pages/orders/failed-orders-page.tsx`
+
+**Content:**
+- `PageLayout` with eyebrow "Orders", title "Failed Orders"
+- Filter bar: connection filter (Select), job type locked to order types
+- Uses `useSyncJobsQuery({ status: 'dead', jobType: 'marketplace.order.sync' })` — reuses existing hook with filters
+- `DataTable` with columns: Job ID (mono), Connection, Failed At, Error (truncated), Attempts, Retry button
+- Retry button uses `useRetrySyncJobMutation`, shows loading state per-row
+- Pagination (offset-based, 25/page)
+- Empty state: "No failed orders in the selected period"
+- Error row expand: full error message in a `<details>` element (no drawer needed for MVP)
+
+**State:**
+- Filters in URL search params (connectionId, offset)
+- Retry state per-row via mutation `variables` tracking
+
+---
+
+### Step 8: Add route and navigation
+
+**Files:**
+- `apps/web/src/app/routes/orders.route.tsx` — add `failed` child route
+- Navigation: add link from orders list page to failed orders
+
+**Route:**
+```typescript
+{ path: 'failed', element: <FailedOrdersPage /> }
+```
+
+---
+
+### Step 9: Add tests
+
+**BE tests:**
+- `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.spec.ts` — unit test for `requeueDeadJob`
+- `libs/core/src/sync/application/services/sync-job-retry.service.spec.ts` — unit test for retry service
+
+**FE tests:**
+- `apps/web/src/pages/orders/failed-orders-page.test.tsx` — render with data, empty state, retry success, retry error
+
+---
+
+## Risk & Open Questions
+
+1. **Idempotency key collision**: After retry, the old idempotency key remains. If the job was originally enqueued via Redis streams, the dedup key may still exist (7-day TTL). This is fine because retry works at DB level, not re-enqueuing to streams.
+2. **Concurrent retry**: Two admins clicking retry on the same job. The `requeueDeadJob` method should handle this gracefully — if status is already `queued` on second call, return 409.
+3. **Scope**: The page shows dead `marketplace.order.sync` jobs. Other job types could be surfaced later by removing the filter.

--- a/libs/core/src/sync/application/services/sync-job-retry.service.interface.ts
+++ b/libs/core/src/sync/application/services/sync-job-retry.service.interface.ts
@@ -1,0 +1,21 @@
+/**
+ * Sync Job Retry Service Interface
+ *
+ * Defines the contract for retrying dead sync jobs. Allows operators to
+ * manually requeue jobs that have exhausted automatic retries.
+ *
+ * @module libs/core/src/sync/application/services
+ */
+import { SyncJob } from '../../domain/entities/sync-job.entity';
+
+export interface ISyncJobRetryService {
+  /**
+   * Retry a dead sync job by requeuing it.
+   *
+   * @param id - Job ID to retry
+   * @returns Updated sync job with status 'queued'
+   * @throws InvalidSyncJobStateError if job is not in 'dead' status
+   * @throws Error if job is not found
+   */
+  retryJob(id: string): Promise<SyncJob>;
+}

--- a/libs/core/src/sync/application/services/sync-job-retry.service.spec.ts
+++ b/libs/core/src/sync/application/services/sync-job-retry.service.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Sync Job Retry Service Unit Tests
+ *
+ * @module libs/core/src/sync/application/services
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { SyncJobRetryService } from './sync-job-retry.service';
+import { SyncJobRepositoryPort } from '../../domain/ports/sync-job-repository.port';
+import { SYNC_JOB_REPOSITORY_TOKEN } from '../../sync.tokens';
+import { SyncJob } from '../../domain/entities/sync-job.entity';
+import { InvalidSyncJobStateError } from '../../domain/exceptions/invalid-sync-job-state.error';
+import type { JobType, JobStatus } from '../../domain/types/sync-job.types';
+
+interface SyncJobOverrides {
+  id?: string;
+  jobType?: JobType;
+  connectionId?: string;
+  payload?: Record<string, unknown>;
+  status?: JobStatus;
+  idempotencyKey?: string;
+  attempts?: number;
+  maxAttempts?: number;
+  nextRunAt?: Date;
+  lockedAt?: Date | null;
+  lockedBy?: string | null;
+  lastError?: string | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+function makeSyncJob(overrides: SyncJobOverrides = {}): SyncJob {
+  return new SyncJob(
+    overrides.id ?? 'job-1',
+    overrides.jobType ?? 'marketplace.order.sync',
+    overrides.connectionId ?? 'conn-1',
+    overrides.payload ?? {},
+    overrides.status ?? 'queued',
+    overrides.idempotencyKey ?? 'key-1',
+    overrides.attempts ?? 0,
+    overrides.maxAttempts ?? 10,
+    overrides.nextRunAt ?? new Date(),
+    overrides.lockedAt ?? null,
+    overrides.lockedBy ?? null,
+    overrides.lastError ?? null,
+    overrides.createdAt ?? new Date(),
+    overrides.updatedAt ?? new Date(),
+  );
+}
+
+describe('SyncJobRetryService', () => {
+  let service: SyncJobRetryService;
+  let mockRepository: jest.Mocked<Pick<SyncJobRepositoryPort, 'requeueDeadJob'>>;
+
+  beforeEach(async () => {
+    mockRepository = {
+      requeueDeadJob: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SyncJobRetryService,
+        {
+          provide: SYNC_JOB_REPOSITORY_TOKEN,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get(SyncJobRetryService);
+  });
+
+  it('should requeue dead job via repository', async () => {
+    const requeuedJob = makeSyncJob({ id: 'job-1', status: 'queued', attempts: 0 });
+    mockRepository.requeueDeadJob.mockResolvedValue(requeuedJob);
+
+    const result = await service.retryJob('job-1');
+
+    expect(result.id).toBe('job-1');
+    expect(result.status).toBe('queued');
+    expect(mockRepository.requeueDeadJob).toHaveBeenCalledWith('job-1');
+  });
+
+  it('should propagate InvalidSyncJobStateError from repository', async () => {
+    mockRepository.requeueDeadJob.mockRejectedValue(
+      new InvalidSyncJobStateError('status', 'queued', 'job-1'),
+    );
+
+    await expect(service.retryJob('job-1')).rejects.toThrow(InvalidSyncJobStateError);
+  });
+});

--- a/libs/core/src/sync/application/services/sync-job-retry.service.ts
+++ b/libs/core/src/sync/application/services/sync-job-retry.service.ts
@@ -1,0 +1,37 @@
+/**
+ * Sync Job Retry Service
+ *
+ * Allows operators to manually retry dead sync jobs by requeuing them.
+ * Delegates to the repository port for the actual state transition.
+ *
+ * @module libs/core/src/sync/application/services
+ * @implements {ISyncJobRetryService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { SYNC_JOB_REPOSITORY_TOKEN } from '../../sync.tokens';
+import { SyncJobRepositoryPort } from '../../domain/ports/sync-job-repository.port';
+import { SyncJob } from '../../domain/entities/sync-job.entity';
+import { ISyncJobRetryService } from './sync-job-retry.service.interface';
+
+@Injectable()
+export class SyncJobRetryService implements ISyncJobRetryService {
+  private readonly logger = new Logger(SyncJobRetryService.name);
+
+  constructor(
+    @Inject(SYNC_JOB_REPOSITORY_TOKEN)
+    private readonly syncJobRepository: SyncJobRepositoryPort,
+  ) {}
+
+  async retryJob(id: string): Promise<SyncJob> {
+    this.logger.log(`Retrying dead job: ${id}`);
+
+    const job = await this.syncJobRepository.requeueDeadJob(id);
+
+    this.logger.log(
+      `Job requeued for retry: ${job.id} (type: ${job.jobType}, connection: ${job.connectionId})`,
+    );
+
+    return job;
+  }
+}

--- a/libs/core/src/sync/domain/exceptions/sync-job-not-found.error.ts
+++ b/libs/core/src/sync/domain/exceptions/sync-job-not-found.error.ts
@@ -1,0 +1,16 @@
+/**
+ * Sync Job Not Found Error
+ *
+ * Domain exception thrown when a sync job cannot be found by its ID.
+ *
+ * @module libs/core/src/sync/domain/exceptions
+ */
+export class SyncJobNotFoundError extends Error {
+  constructor(public readonly jobId: string) {
+    super(`Sync job not found: ${jobId}`);
+    this.name = 'SyncJobNotFoundError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SyncJobNotFoundError);
+    }
+  }
+}

--- a/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
+++ b/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
@@ -91,6 +91,18 @@ export interface SyncJobRepositoryPort {
   requeueStuckJobs(lockTimeoutMinutes: number): Promise<number>;
 
   /**
+   * Requeue a dead job for retry
+   *
+   * Resets a job in 'dead' status back to 'queued' with attempts=0 and
+   * nextRunAt=now(), allowing the worker to pick it up again.
+   * Throws InvalidSyncJobStateError if the job is not in 'dead' status.
+   *
+   * @param id - Job ID
+   * @returns Updated sync job domain entity
+   */
+  requeueDeadJob(id: string): Promise<SyncJob>;
+
+  /**
    * Find recent jobs for a connection
    *
    * Returns the most recent sync jobs for the given connection, ordered by

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -53,9 +53,13 @@ export {
 // Exceptions
 export { SyncJobExecutionError } from './domain/exceptions/sync-job-execution.error';
 export { InvalidSyncJobStateError } from './domain/exceptions/invalid-sync-job-state.error';
+export { SyncJobNotFoundError } from './domain/exceptions/sync-job-not-found.error';
 
 // Infrastructure exports (for testing/mocking)
 export { RedisStreamsJobEnqueueService } from './infrastructure/adapters/redis-streams-job-enqueue.service';
+
+// Application Services (interfaces)
+export type { ISyncJobRetryService } from './application/services/sync-job-retry.service.interface';
 
 // Module and tokens
 export { SyncModule } from './sync.module';
@@ -65,6 +69,7 @@ export {
   CONNECTION_CURSOR_REPOSITORY_TOKEN,
   SYNC_JOB_QUEUE_TOKEN,
   SYNC_LOCK_TOKEN,
+  SYNC_JOB_RETRY_SERVICE_TOKEN,
 } from './sync.tokens';
 
 // ORM Entities (exported for testing and TypeORM CLI usage)

--- a/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.spec.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.spec.ts
@@ -11,6 +11,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Repository } from 'typeorm';
 import { SyncJobRepository } from './sync-job.repository';
 import { SyncJobOrmEntity } from '../entities/sync-job.orm-entity';
+import { InvalidSyncJobStateError } from '../../../domain/exceptions/invalid-sync-job-state.error';
+import { SyncJobNotFoundError } from '../../../domain/exceptions/sync-job-not-found.error';
 
 function makeOrmEntity(overrides: Partial<SyncJobOrmEntity> = {}): SyncJobOrmEntity {
   const e = new SyncJobOrmEntity();
@@ -144,6 +146,44 @@ describe('SyncJobRepository', () => {
       expect(ormRepo.findAndCount).toHaveBeenCalledWith(
         expect.objectContaining({ take: 2, skip: 4 }),
       );
+    });
+  });
+
+  describe('requeueDeadJob', () => {
+    function mockQueryBuilder(affected: number): void {
+      const qb = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected }),
+      };
+      ormRepo.createQueryBuilder.mockReturnValue(qb as never);
+    }
+
+    it('should requeue a dead job to queued status atomically', async () => {
+      mockQueryBuilder(1);
+      const requeuedEntity = makeOrmEntity({ id: 'dead-1', status: 'queued', attempts: 0, lastError: 'some error' });
+      ormRepo.findOne.mockResolvedValue(requeuedEntity);
+
+      const result = await repo.requeueDeadJob('dead-1');
+
+      expect(result.id).toBe('dead-1');
+      expect(result.status).toBe('queued');
+      expect(ormRepo.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('should throw SyncJobNotFoundError when job does not exist', async () => {
+      mockQueryBuilder(0);
+      ormRepo.findOne.mockResolvedValue(null);
+
+      await expect(repo.requeueDeadJob('missing')).rejects.toThrow(SyncJobNotFoundError);
+    });
+
+    it('should throw InvalidSyncJobStateError when job is not dead', async () => {
+      mockQueryBuilder(0);
+      ormRepo.findOne.mockResolvedValue(makeOrmEntity({ status: 'queued' }));
+
+      await expect(repo.requeueDeadJob('job-1')).rejects.toThrow(InvalidSyncJobStateError);
     });
   });
 });

--- a/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
@@ -22,6 +22,7 @@ import { SyncJobOrmEntity } from '../entities/sync-job.orm-entity';
 import { SyncJobRepositoryPort } from '../../../domain/ports/sync-job-repository.port';
 import { SyncJob } from '../../../domain/entities/sync-job.entity';
 import { InvalidSyncJobStateError } from '../../../domain/exceptions/invalid-sync-job-state.error';
+import { SyncJobNotFoundError } from '../../../domain/exceptions/sync-job-not-found.error';
 import {
   JobStatus,
   JobStatusValues,
@@ -234,6 +235,37 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
       .execute();
 
     return result.affected || 0;
+  }
+
+  async requeueDeadJob(id: string): Promise<SyncJob> {
+    // Atomic conditional update — avoids TOCTOU race between status check and update
+    const result = await this.repository
+      .createQueryBuilder()
+      .update(SyncJobOrmEntity)
+      .set({
+        status: 'queued',
+        attempts: 0,
+        nextRunAt: new Date(),
+        lockedAt: null,
+        lockedBy: null,
+      })
+      .where('id = :id AND status = :status', { id, status: 'dead' })
+      .execute();
+
+    if (result.affected === 0) {
+      // Distinguish not-found from wrong-status
+      const existing = await this.repository.findOne({ where: { id } });
+      if (!existing) {
+        throw new SyncJobNotFoundError(id);
+      }
+      throw new InvalidSyncJobStateError('status', existing.status, id);
+    }
+
+    const updated = await this.repository.findOne({ where: { id } });
+    if (!updated) {
+      throw new SyncJobNotFoundError(id);
+    }
+    return this.toDomain(updated);
   }
 
   async findRecentByConnectionId(connectionId: string, limit: number): Promise<SyncJob[]> {

--- a/libs/core/src/sync/sync.module.ts
+++ b/libs/core/src/sync/sync.module.ts
@@ -16,12 +16,14 @@ import { ConnectionCursorOrmEntity } from './infrastructure/persistence/entities
 import { ConnectionCursorRepository } from './infrastructure/persistence/repositories/connection-cursor.repository';
 import { SyncJobQueueService } from './application/services/sync-job-queue.service';
 import { RedisSyncLockService } from './application/services/redis-sync-lock.service';
+import { SyncJobRetryService } from './application/services/sync-job-retry.service';
 import {
   JOB_ENQUEUE_TOKEN,
   SYNC_JOB_REPOSITORY_TOKEN,
   CONNECTION_CURSOR_REPOSITORY_TOKEN,
   SYNC_JOB_QUEUE_TOKEN,
   SYNC_LOCK_TOKEN,
+  SYNC_JOB_RETRY_SERVICE_TOKEN,
 } from './sync.tokens';
 
 // Re-export tokens for convenience
@@ -31,6 +33,7 @@ export {
   CONNECTION_CURSOR_REPOSITORY_TOKEN,
   SYNC_JOB_QUEUE_TOKEN,
   SYNC_LOCK_TOKEN,
+  SYNC_JOB_RETRY_SERVICE_TOKEN,
 } from './sync.tokens';
 
 @Module({
@@ -81,6 +84,13 @@ export {
       useExisting: SYNC_JOB_QUEUE_TOKEN,
     },
 
+    // Retry service (application-level)
+    SyncJobRetryService,
+    {
+      provide: SYNC_JOB_RETRY_SERVICE_TOKEN,
+      useExisting: SyncJobRetryService,
+    },
+
     // Distributed lock (application-level)
     RedisSyncLockService,
     {
@@ -108,6 +118,8 @@ export {
     SYNC_LOCK_TOKEN,
     RedisSyncLockService,
     'SyncLockPort',
+    SYNC_JOB_RETRY_SERVICE_TOKEN,
+    SyncJobRetryService,
   ],
 })
 export class SyncModule {}

--- a/libs/core/src/sync/sync.tokens.ts
+++ b/libs/core/src/sync/sync.tokens.ts
@@ -14,6 +14,7 @@ export const SYNC_JOB_REPOSITORY_TOKEN = Symbol('SyncJobRepositoryPort');
 export const CONNECTION_CURSOR_REPOSITORY_TOKEN = Symbol('ConnectionCursorRepositoryPort');
 export const SYNC_JOB_QUEUE_TOKEN = Symbol('SyncJobQueuePort');
 export const SYNC_LOCK_TOKEN = Symbol('SyncLockPort');
+export const SYNC_JOB_RETRY_SERVICE_TOKEN = Symbol('SyncJobRetryServicePort');
 
 
 


### PR DESCRIPTION
## Summary

- Add `POST /sync/jobs/:id/retry` endpoint — atomically requeues dead sync jobs (409 if not dead, 404 if missing)
- Add `SyncJobRetryService` with proper hexagonal layering (port → repository → service → controller)
- Add `SyncJobNotFoundError` domain exception (replaces fragile string matching)
- Build Failed Orders page at `/orders/failed` with connection filter, pagination, inline retry buttons
- Add `useRetrySyncJobMutation` hook with cache invalidation

## Test plan

- [x] Unit tests: `requeueDeadJob` repository method (atomic update, not-found, wrong-status)
- [x] Unit tests: `SyncJobRetryService` (delegates to repository, propagates errors)
- [x] FE tests: loading, error, empty, data render, retry button scoped to row
- [x] Quality gate: `pnpm lint && pnpm type-check && pnpm test` all pass
- [ ] Manual: verify retry button requeues dead job and row refreshes
- [ ] Manual: verify connection filter and pagination work

Closes #72
Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)