### PR TITLE
feat(sync,allegro): periodic inventory sync scheduler and Allegro command polling

### DIFF
--- a/apps/api/env.example
+++ b/apps/api/env.example
@@ -37,13 +37,25 @@ PRESTASHOP_WEBHOOK_SECRET=your-webhook-secret-optional
 # Scheduler Configuration
 # Allegro Orders Poll Scheduler
 # Enable/disable the Allegro orders poll scheduler (default: true)
-ALLEGRO_POLL_SCHEDULER_ENABLED=true
+OL_ALLEGRO_POLL_SCHEDULER_ENABLED=true
 # Cron expression for Allegro orders poll interval (default: every 5 minutes)
 # Examples:
 #   */5 * * * *   - Every 5 minutes
 #   */10 * * * *  - Every 10 minutes
 #   0 * * * *     - Every hour
-ALLEGRO_POLL_INTERVAL_CRON=*/5 * * * *
+OL_ALLEGRO_POLL_INTERVAL_CRON=*/5 * * * *
+
+# Allegro quantity command polling tuning (overrides; defaults shown)
+# OL_ALLEGRO_QUANTITY_POLL_MAX_ATTEMPTS=5
+# OL_ALLEGRO_QUANTITY_POLL_INITIAL_DELAY_MS=2000
+# OL_ALLEGRO_QUANTITY_POLL_MAX_DELAY_MS=30000
+# OL_ALLEGRO_QUANTITY_POLL_BACKOFF_MULTIPLIER=2
+
+# Periodic Inventory Sync Configuration
+# Enables periodic background inventory sync for all InventoryMaster connections (default: true)
+OL_INVENTORY_SYNC_ENABLED=true
+# Cron expression for inventory sync interval (default: every 15 minutes)
+OL_INVENTORY_SYNC_CRON=*/15 * * * *
 
 # Customer Identity & PII Configuration
 # Customer identity resolution mode (default: email_fallback)

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -62,6 +62,7 @@ function createMockIdentifierMapping(): jest.Mocked<IdentifierMappingPort> {
     batchGetOrCreateInternalIds: jest.fn(),
     getOrCreateExactMapping: jest.fn(),
     deleteMapping: jest.fn(),
+    listExternalIdsByConnection: jest.fn(),
   };
 }
 

--- a/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
+++ b/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Scheduler Service Tests
+ *
+ * Unit tests for SchedulerService. Tests task registration,
+ * connection filtering, and inventory sync scheduler configuration.
+ *
+ * @module apps/api/src/sync/application/services/__tests__
+ */
+import { SchedulerService } from '../scheduler.service';
+import { ConnectionPort, Connection } from '@openlinker/core/identifier-mapping';
+import { JobEnqueuePort } from '@openlinker/core/sync';
+import { IIntegrationsService } from '@openlinker/core/integrations';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+
+describe('SchedulerService', () => {
+  let service: SchedulerService;
+  let connectionPort: jest.Mocked<ConnectionPort>;
+  let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+  let integrationsService: jest.Mocked<IIntegrationsService>;
+  let configService: jest.Mocked<ConfigService>;
+  let schedulerRegistry: jest.Mocked<SchedulerRegistry>;
+
+  const createConnection = (id: string, platformType = 'prestashop'): Connection =>
+    new Connection(id, platformType, `Test ${id}`, 'active', {}, 'cred-ref', new Date(), new Date());
+
+  beforeEach(() => {
+    connectionPort = {
+      get: jest.fn(),
+      list: jest.fn(),
+    } as unknown as jest.Mocked<ConnectionPort>;
+
+    jobEnqueue = {
+      enqueueJob: jest.fn().mockResolvedValue({ jobId: 'j1', isExisting: false }),
+    } as unknown as jest.Mocked<JobEnqueuePort>;
+
+    integrationsService = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    configService = {
+      get: jest.fn().mockReturnValue('true'),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    schedulerRegistry = {
+      addCronJob: jest.fn(),
+    } as unknown as jest.Mocked<SchedulerRegistry>;
+
+    service = new SchedulerService(
+      connectionPort,
+      jobEnqueue,
+      integrationsService,
+      configService,
+      schedulerRegistry,
+    );
+  });
+
+  describe('onModuleInit', () => {
+    const defaultConfigGet = (key: string, defaultValue?: unknown): unknown => {
+      const cronKeys = [
+        'OL_ALLEGRO_POLL_INTERVAL_CRON',
+        'OL_ALLEGRO_OFFERS_SYNC_INTERVAL_CRON',
+        'OL_INVENTORY_SYNC_CRON',
+      ];
+      if (cronKeys.includes(key)) return defaultValue ?? '*/15 * * * *';
+      if (key === 'OL_ALLEGRO_OFFERS_SYNC_PAGE_LIMIT') return '100';
+      if (key === 'OL_ALLEGRO_OFFERS_SYNC_FEED_TYPE') return 'events';
+      return 'true';
+    };
+
+    it('should register inventory sync task when enabled', () => {
+      configService.get.mockImplementation(defaultConfigGet);
+
+      service.onModuleInit();
+
+      const registeredJobs = schedulerRegistry.addCronJob.mock.calls.map((c) => c[0]);
+      expect(registeredJobs).toContain('master-inventory-sync');
+    });
+
+    it('should not register inventory sync task when disabled', () => {
+      configService.get.mockImplementation((key: string, defaultValue?: unknown) => {
+        if (key === 'OL_INVENTORY_SYNC_ENABLED') return 'false';
+        return defaultConfigGet(key, defaultValue);
+      });
+
+      service.onModuleInit();
+
+      const registeredJobs = schedulerRegistry.addCronJob.mock.calls.map((c) => c[0]);
+      expect(registeredJobs).not.toContain('master-inventory-sync');
+    });
+  });
+
+  describe('executeTask with connectionFilter', () => {
+    it('should use connectionFilter when provided instead of platformType filter', () => {
+      const conn = createConnection('conn-1');
+      integrationsService.listCapabilityAdapters.mockResolvedValue([
+        { connectionId: 'conn-1', connection: conn, adapter: {} as never, metadata: {} as never },
+      ]);
+
+      service.registerTask({
+        taskId: 'test-capability-task',
+        platformType: '*',
+        jobType: 'master.inventory.syncAll',
+        cronExpression: '*/15 * * * *',
+        connectionFilter: async () => {
+          const adapters = await integrationsService.listCapabilityAdapters({
+            capability: 'InventoryMaster',
+          });
+          return adapters.map((a) => a.connection);
+        },
+        generatePayload: () => ({ schemaVersion: 1 }),
+        generateIdempotencyKey: (connection, timestamp) =>
+          `master:${connection.id}:inventory:syncAll:${timestamp}`,
+      });
+
+      // Access private method via any cast for testing
+      const tasks = (service as unknown as { tasks: Array<{ taskId: string }> }).tasks;
+      const task = tasks.find((t) => t.taskId === 'test-capability-task');
+      expect(task).toBeDefined();
+
+      // connectionPort.list should NOT be called when connectionFilter is present
+      expect(connectionPort.list).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/sync/application/services/scheduler.service.ts
+++ b/apps/api/src/sync/application/services/scheduler.service.ts
@@ -13,6 +13,7 @@ import { ConfigService } from '@nestjs/config';
 import { CronJob } from 'cron';
 import { ConnectionPort, CONNECTION_PORT_TOKEN, Connection } from '@openlinker/core/identifier-mapping';
 import { JobEnqueuePort, JOB_ENQUEUE_TOKEN, SyncJobRequest, JobType } from '@openlinker/core/sync';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { Logger } from '@openlinker/shared/logging';
 
 /**
@@ -27,9 +28,11 @@ export interface SchedulerTaskConfig {
   taskId: string;
 
   /**
-   * Platform type to filter connections (e.g., 'allegro', 'prestashop')
+   * Platform type to filter connections (e.g., 'allegro', 'prestashop').
+   *
+   * Ignored when `connectionFilter` is provided. Required otherwise.
    */
-  platformType: string;
+  platformType?: string;
 
   /**
    * Job type to enqueue (e.g., 'allegro.orders.poll')
@@ -44,9 +47,17 @@ export interface SchedulerTaskConfig {
 
   /**
    * Environment variable name to enable/disable this task (default: true)
-   * Example: 'ALLEGRO_POLL_SCHEDULER_ENABLED'
+   * Example: 'OL_ALLEGRO_POLL_SCHEDULER_ENABLED'
    */
   enabledEnvVar?: string;
+
+  /**
+   * Optional custom connection filter (overrides default platformType-based lookup).
+   *
+   * When provided, the scheduler calls this instead of filtering by platformType.
+   * Useful for capability-based filtering that spans multiple platform types.
+   */
+  connectionFilter?: () => Promise<Connection[]>;
 
   /**
    * Generate job payload for a connection
@@ -76,6 +87,8 @@ export class SchedulerService implements OnModuleInit {
     private readonly connectionPort: ConnectionPort,
     @Inject(JOB_ENQUEUE_TOKEN)
     private readonly jobEnqueue: JobEnqueuePort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
     private readonly configService: ConfigService,
     private readonly schedulerRegistry: SchedulerRegistry,
   ) {}
@@ -107,12 +120,12 @@ export class SchedulerService implements OnModuleInit {
   private registerDefaultTasks(): void {
     // Marketplace orders poll task (for Allegro connections)
     const allegroPollEnabled = this.configService.get<string>(
-      'ALLEGRO_POLL_SCHEDULER_ENABLED',
+      'OL_ALLEGRO_POLL_SCHEDULER_ENABLED',
       'true',
     );
     if (allegroPollEnabled !== 'false') {
       const allegroCronExpression = this.configService.get<string>(
-        'ALLEGRO_POLL_INTERVAL_CRON',
+        'OL_ALLEGRO_POLL_INTERVAL_CRON',
         '*/5 * * * *', // Every 5 minutes
       );
 
@@ -121,7 +134,7 @@ export class SchedulerService implements OnModuleInit {
         platformType: 'allegro',
         jobType: 'marketplace.orders.poll',
         cronExpression: allegroCronExpression,
-        enabledEnvVar: 'ALLEGRO_POLL_SCHEDULER_ENABLED',
+        enabledEnvVar: 'OL_ALLEGRO_POLL_SCHEDULER_ENABLED',
         generatePayload: () => ({
           schemaVersion: 1,
           cursorKey: 'allegro.orders.lastEventId',
@@ -134,19 +147,19 @@ export class SchedulerService implements OnModuleInit {
 
     // Marketplace offers sync task (for Allegro connections)
     const allegroOffersSyncEnabled = this.configService.get<string>(
-      'ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED',
+      'OL_ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED',
       'true',
     );
     if (allegroOffersSyncEnabled !== 'false') {
       const offersCronExpression = this.configService.get<string>(
-        'ALLEGRO_OFFERS_SYNC_INTERVAL_CRON',
+        'OL_ALLEGRO_OFFERS_SYNC_INTERVAL_CRON',
         '*/30 * * * *', // Every 30 minutes
       );
       const pageLimit = Number(
-        this.configService.get<string>('ALLEGRO_OFFERS_SYNC_PAGE_LIMIT', '100'),
+        this.configService.get<string>('OL_ALLEGRO_OFFERS_SYNC_PAGE_LIMIT', '100'),
       );
       const offersFeedTypeRaw = this.configService
-        .get<string>('ALLEGRO_OFFERS_SYNC_FEED_TYPE', 'events')
+        .get<string>('OL_ALLEGRO_OFFERS_SYNC_FEED_TYPE', 'events')
         .toLowerCase();
       const offersFeedType = offersFeedTypeRaw === 'offers' ? 'offers' : 'events';
 
@@ -155,7 +168,7 @@ export class SchedulerService implements OnModuleInit {
         platformType: 'allegro',
         jobType: 'marketplace.offers.sync',
         cronExpression: offersCronExpression,
-        enabledEnvVar: 'ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED',
+        enabledEnvVar: 'OL_ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED',
         generatePayload: (connection) => ({
           schemaVersion: 1,
           limit: Number.isFinite(pageLimit) && pageLimit > 0 ? pageLimit : 100,
@@ -168,6 +181,9 @@ export class SchedulerService implements OnModuleInit {
           `marketplace:${connection.id}:offers:sync:${timestamp}`,
       });
     }
+
+    // Periodic inventory sync (capability-based, cross-platform)
+    this.registerInventorySyncTask();
   }
 
   /**
@@ -197,7 +213,7 @@ export class SchedulerService implements OnModuleInit {
     cronJob.start();
 
     this.logger.log(
-      `Registered scheduler task: ${task.taskId} (platform: ${task.platformType}, jobType: ${task.jobType}, cron: ${task.cronExpression})`,
+      `Registered scheduler task: ${task.taskId} (scope: ${task.connectionFilter ? 'capability' : (task.platformType ?? 'none')}, jobType: ${task.jobType}, cron: ${task.cronExpression})`,
     );
   }
 
@@ -218,22 +234,34 @@ export class SchedulerService implements OnModuleInit {
 
     this.logger.debug(`Executing scheduler task: ${task.taskId}`);
 
+    const scope = task.connectionFilter ? 'capability' : (task.platformType ?? 'unknown');
+
     try {
-      // Get all active connections for this platform
-      const connections = await this.connectionPort.list({
-        platformType: task.platformType,
-        status: 'active',
-      });
+      // Get connections: use custom filter if provided, otherwise filter by platformType
+      let connections;
+      if (task.connectionFilter) {
+        connections = await task.connectionFilter();
+      } else if (task.platformType) {
+        connections = await this.connectionPort.list({
+          platformType: task.platformType,
+          status: 'active',
+        });
+      } else {
+        this.logger.error(
+          `Scheduler task ${task.taskId} has neither platformType nor connectionFilter — skipping`,
+        );
+        return;
+      }
 
       if (connections.length === 0) {
         this.logger.debug(
-          `No active ${task.platformType} connections found for task ${task.taskId}, skipping`,
+          `No active ${scope} connections found for task ${task.taskId}, skipping`,
         );
         return;
       }
 
       this.logger.log(
-        `Found ${connections.length} active ${task.platformType} connection(s) for task ${task.taskId}, enqueuing jobs`,
+        `Found ${connections.length} active ${scope} connection(s) for task ${task.taskId}, enqueuing jobs`,
       );
 
       // Enqueue job for each connection
@@ -307,6 +335,45 @@ export class SchedulerService implements OnModuleInit {
     );
 
     return jobId;
+  }
+
+  /**
+   * Register periodic inventory sync task.
+   *
+   * Enqueues master.inventory.syncAll jobs for all active connections
+   * that support the InventoryMaster capability.
+   */
+  private registerInventorySyncTask(): void {
+    const inventorySyncEnabled = this.configService.get<string>(
+      'OL_INVENTORY_SYNC_ENABLED',
+      'true',
+    );
+    if (inventorySyncEnabled === 'false') {
+      return;
+    }
+
+    const inventoryCron = this.configService.get<string>(
+      'OL_INVENTORY_SYNC_CRON',
+      '*/15 * * * *',
+    );
+
+    this.registerTask({
+      taskId: 'master-inventory-sync',
+      jobType: 'master.inventory.syncAll',
+      cronExpression: inventoryCron,
+      enabledEnvVar: 'OL_INVENTORY_SYNC_ENABLED',
+      connectionFilter: async () => {
+        const adapters = await this.integrationsService.listCapabilityAdapters({
+          capability: 'InventoryMaster',
+        });
+        return adapters.map((a) => a.connection);
+      },
+      generatePayload: () => ({
+        schemaVersion: 1,
+      }),
+      generateIdempotencyKey: (connection, timestamp) =>
+        `master:${connection.id}:inventory:syncAll:${timestamp}`,
+    });
   }
 
   private getMasterCatalogConnectionId(connection: Connection): string | null {

--- a/apps/api/src/sync/sync.module.ts
+++ b/apps/api/src/sync/sync.module.ts
@@ -10,6 +10,7 @@
 import { Module } from '@nestjs/common';
 import { SyncModule as CoreSyncModule } from '@openlinker/core/sync';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
+import { IntegrationsModule } from '@openlinker/core/integrations';
 import { SyncController } from './http/sync.controller';
 import { SchedulerService } from './application/services/scheduler.service';
 
@@ -17,6 +18,7 @@ import { SchedulerService } from './application/services/scheduler.service';
   imports: [
     CoreSyncModule, // Provides JobEnqueuePort
     IdentifierMappingModule, // Provides ConnectionPort
+    IntegrationsModule, // Provides IIntegrationsService (for capability-based scheduling)
   ],
   controllers: [SyncController],
   providers: [SchedulerService],

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,7 +12,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:integration": "jest --config ./test/jest-integration.js",
+    "test:integration": "jest --config ./test/jest-integration.cjs",
     "lint": "eslint \"src/**/*.ts\" --fix",
     "type-check": "tsc --noEmit"
   },

--- a/apps/worker/src/sync/handlers/__tests__/master-inventory-sync-all.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/master-inventory-sync-all.handler.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Master Inventory Sync All Handler Tests
+ *
+ * Unit tests for MasterInventorySyncAllHandler. Tests fan-out of
+ * per-product inventory sync jobs from connection-level syncAll job.
+ *
+ * @module apps/worker/src/sync/handlers/__tests__
+ */
+import { MasterInventorySyncAllHandler } from '../master-inventory-sync-all.handler';
+import { IdentifierMappingQueryPort } from '@openlinker/core/identifier-mapping';
+import { JobEnqueuePort } from '@openlinker/core/sync';
+import { SyncJob } from '@openlinker/core/sync/domain/entities/sync-job.entity';
+import { SyncJobExecutionError } from '@openlinker/core/sync/domain/exceptions/sync-job-execution.error';
+
+describe('MasterInventorySyncAllHandler', () => {
+  let handler: MasterInventorySyncAllHandler;
+  let identifierMapping: jest.Mocked<IdentifierMappingQueryPort>;
+  let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+
+  beforeEach(() => {
+    identifierMapping = {
+      getInternalId: jest.fn(),
+      getExternalIds: jest.fn(),
+      listExternalIdsByConnection: jest.fn(),
+    };
+
+    jobEnqueue = {
+      enqueueJob: jest.fn(),
+    } as unknown as jest.Mocked<JobEnqueuePort>;
+
+    handler = new MasterInventorySyncAllHandler(identifierMapping, jobEnqueue);
+  });
+
+  const createJob = (connectionId: string): SyncJob => ({
+    id: 'job-id',
+    jobType: 'master.inventory.syncAll',
+    connectionId,
+    payload: { schemaVersion: 1 },
+    idempotencyKey: 'key',
+    status: 'queued',
+    attempts: 0,
+    maxAttempts: 3,
+    nextRunAt: new Date(),
+    lockedAt: null,
+    lockedBy: null,
+    lastError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  it('should enqueue syncByExternalId jobs for all products', async () => {
+    identifierMapping.listExternalIdsByConnection.mockResolvedValue(['ext-1', 'ext-2', 'ext-3']);
+    jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'new-job', isExisting: false });
+
+    await handler.execute(createJob('conn-1'));
+
+    expect(identifierMapping.listExternalIdsByConnection).toHaveBeenCalledWith('Product', 'conn-1');
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(3);
+
+    const firstCall = jobEnqueue.enqueueJob.mock.calls[0][0];
+    expect(firstCall.jobType).toBe('master.inventory.syncByExternalId');
+    expect(firstCall.connectionId).toBe('conn-1');
+    expect(firstCall.payload).toEqual(
+      expect.objectContaining({ schemaVersion: 1, externalId: 'ext-1', objectType: 'Product' }),
+    );
+  });
+
+  it('should handle empty product list gracefully', async () => {
+    identifierMapping.listExternalIdsByConnection.mockResolvedValue([]);
+
+    await handler.execute(createJob('conn-1'));
+
+    expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+  });
+
+  it('should not throw when some enqueue calls fail', async () => {
+    identifierMapping.listExternalIdsByConnection.mockResolvedValue(['ext-1', 'ext-2']);
+    jobEnqueue.enqueueJob
+      .mockResolvedValueOnce({ jobId: 'j1', isExisting: false })
+      .mockRejectedValueOnce(new Error('queue full'));
+
+    await expect(handler.execute(createJob('conn-1'))).resolves.toBeUndefined();
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw SyncJobExecutionError when listing mappings fails', async () => {
+    identifierMapping.listExternalIdsByConnection.mockRejectedValue(new Error('db down'));
+
+    await expect(handler.execute(createJob('conn-1'))).rejects.toThrow(SyncJobExecutionError);
+  });
+});

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -17,6 +17,7 @@ import { MarketplaceOffersSyncHandler } from './marketplace-offers-sync.handler'
 import { MasterProductSyncHandler } from './master-product-sync.handler';
 import { MasterInventorySyncHandler } from './master-inventory-sync.handler';
 import { AutoMatchVariantsHandler } from './auto-match-variants.handler';
+import { MasterInventorySyncAllHandler } from './master-inventory-sync-all.handler';
 
 @Injectable()
 export class HandlerRegistrationService implements OnModuleInit {
@@ -31,6 +32,7 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly masterProductSyncHandler: MasterProductSyncHandler,
     private readonly masterInventorySyncHandler: MasterInventorySyncHandler,
     private readonly autoMatchVariantsHandler: AutoMatchVariantsHandler,
+    private readonly masterInventorySyncAllHandler: MasterInventorySyncAllHandler,
   ) {}
 
   onModuleInit(): void {
@@ -47,6 +49,9 @@ export class HandlerRegistrationService implements OnModuleInit {
 
     // Register auto-match variants handler
     this.handlerRegistry.register('master.variants.autoMatch', this.autoMatchVariantsHandler);
+
+    // Register master inventory sync all handler (periodic full sync)
+    this.handlerRegistry.register('master.inventory.syncAll', this.masterInventorySyncAllHandler);
 
     // Register inventory propagate to marketplaces handler
     this.handlerRegistry.register('inventory.propagateToMarketplaces', this.inventoryPropagateHandler);

--- a/apps/worker/src/sync/handlers/master-inventory-sync-all.handler.ts
+++ b/apps/worker/src/sync/handlers/master-inventory-sync-all.handler.ts
@@ -1,0 +1,116 @@
+/**
+ * Master Inventory Sync All Handler
+ *
+ * Handles jobs of type 'master.inventory.syncAll'. Enumerates all known product
+ * external IDs for a connection and enqueues per-product 'master.inventory.syncByExternalId'
+ * sub-jobs. Acts as a fan-out mechanism for periodic inventory synchronization.
+ *
+ * Fan-out resilience: individual sub-job enqueue failures are logged but do not
+ * fail the outer job — partial fan-out is preferred over dropping the entire sweep.
+ * Only failure to enumerate mappings (e.g., DB outage) propagates as a job failure.
+ *
+ * Sub-job idempotency key is derived from the outer job ID, so retries of the same
+ * outer job produce the same sub-job keys and dedupe against the queue.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  SyncJobHandler,
+  SyncJob as SyncJobEntity,
+  SyncJobExecutionError,
+  JobEnqueuePort,
+  JOB_ENQUEUE_TOKEN,
+  SyncJobRequest,
+} from '@openlinker/core/sync';
+import {
+  IdentifierMappingQueryPort,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+} from '@openlinker/core/identifier-mapping';
+import { Logger } from '@openlinker/shared/logging';
+
+type SyncJob = SyncJobEntity;
+
+@Injectable()
+export class MasterInventorySyncAllHandler implements SyncJobHandler {
+  private readonly logger = new Logger(MasterInventorySyncAllHandler.name);
+
+  constructor(
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IdentifierMappingQueryPort,
+    @Inject(JOB_ENQUEUE_TOKEN)
+    private readonly jobEnqueue: JobEnqueuePort,
+  ) {}
+
+  async execute(job: SyncJob): Promise<void> {
+    this.logger.log(
+      `Executing master.inventory.syncAll job ${job.id} for connection ${job.connectionId}`,
+    );
+
+    try {
+      const externalIds = await this.identifierMapping.listExternalIdsByConnection(
+        'Product',
+        job.connectionId,
+      );
+
+      if (externalIds.length === 0) {
+        this.logger.log(
+          `No product mappings found for connection ${job.connectionId}. Skipping inventory sync.`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Found ${externalIds.length} product(s) for connection ${job.connectionId}. Enqueuing inventory sync jobs.`,
+      );
+
+      const enqueuePromises = externalIds.map(async (externalId) => {
+        const jobRequest: SyncJobRequest = {
+          jobType: 'master.inventory.syncByExternalId',
+          connectionId: job.connectionId,
+          payload: {
+            schemaVersion: 1,
+            externalId,
+            objectType: 'Product',
+          },
+          // Derive from outer job id so retries of this outer job produce the same
+          // sub-job keys and dedupe against the queue.
+          idempotencyKey: `master:${job.connectionId}:inventory:sync:${externalId}:${job.id}`,
+        };
+        return this.jobEnqueue.enqueueJob(jobRequest);
+      });
+
+      const results = await Promise.allSettled(enqueuePromises);
+
+      const succeeded = results.filter((r) => r.status === 'fulfilled').length;
+      const failed = results.filter((r) => r.status === 'rejected').length;
+
+      if (failed > 0) {
+        this.logger.warn(
+          `master.inventory.syncAll for connection ${job.connectionId}: ${succeeded} enqueued, ${failed} failed`,
+        );
+        results.forEach((result, index) => {
+          if (result.status === 'rejected') {
+            this.logger.error(
+              `Failed to enqueue inventory sync for externalId ${externalIds[index]} (connection: ${job.connectionId}): ${String(result.reason)}`,
+            );
+          }
+        });
+      } else {
+        this.logger.log(
+          `master.inventory.syncAll for connection ${job.connectionId}: ${succeeded} inventory sync job(s) enqueued`,
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SyncJobExecutionError(
+        `master.inventory.syncAll failed: ${message}`,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+}

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -28,6 +28,7 @@ import { MarketplaceOffersSyncHandler } from './handlers/marketplace-offers-sync
 import { MasterProductSyncHandler } from './handlers/master-product-sync.handler';
 import { MasterInventorySyncHandler } from './handlers/master-inventory-sync.handler';
 import { AutoMatchVariantsHandler } from './handlers/auto-match-variants.handler';
+import { MasterInventorySyncAllHandler } from './handlers/master-inventory-sync-all.handler';
 import { HandlerRegistrationService } from './handlers/handler-registration.service';
 
 @Module({
@@ -55,6 +56,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     MasterProductSyncHandler,
     MasterInventorySyncHandler,
     AutoMatchVariantsHandler,
+    MasterInventorySyncAllHandler,
     HandlerRegistrationService,
   ],
 })

--- a/apps/worker/test/integration/master-inventory-sync-all-e2e.int-spec.ts
+++ b/apps/worker/test/integration/master-inventory-sync-all-e2e.int-spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Master Inventory Sync All End-to-End Integration Test
+ *
+ * Integration test for the fan-out behavior of `master.inventory.syncAll`:
+ * 1. Seed identifier mappings for a connection (simulating previously-synced products)
+ * 2. Execute MasterInventorySyncAllHandler with a syncAll job
+ * 3. Verify one `master.inventory.syncByExternalId` sub-job is enqueued per mapping
+ * 4. Verify sub-job idempotency keys are stable (derived from outer job id)
+ *
+ * @module apps/worker/test/integration
+ */
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { WorkerIntegrationTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import { SYNC_JOB_REPOSITORY_TOKEN, JOB_ENQUEUE_TOKEN, SyncJobRequest } from '@openlinker/core/sync';
+import { SyncJobRepositoryPort } from '@openlinker/core/sync/domain/ports/sync-job-repository.port';
+import { JobEnqueuePort } from '@openlinker/core/sync/domain/ports/job-enqueue.port';
+import { IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping';
+import { DataSource } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+describe('Master Inventory Sync All End-to-End Integration', () => {
+  let harness: WorkerIntegrationTestHarness;
+  let jobRepository: SyncJobRepositoryPort;
+  let jobEnqueue: JobEnqueuePort;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    jobRepository = harness.get(SYNC_JOB_REPOSITORY_TOKEN);
+    jobEnqueue = harness.get(JOB_ENQUEUE_TOKEN);
+    dataSource = harness.getDataSource();
+  });
+
+  beforeEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function seedProductMappings(
+    connectionId: string,
+    platformType: string,
+    externalIds: string[],
+  ): Promise<void> {
+    const repo = dataSource.getRepository(IdentifierMappingOrmEntity);
+    for (const externalId of externalIds) {
+      await repo.save(
+        repo.create({
+          entityType: 'Product',
+          internalId: `ol_product_${randomUUID().replace(/-/g, '')}`,
+          externalId,
+          platformType,
+          connectionId,
+          context: null,
+        }),
+      );
+    }
+  }
+
+  it('enqueues one sub-job per known product mapping and uses stable idempotency keys', async () => {
+    const connection = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      status: 'active',
+      credentialsRef: 'test-credentials-ref',
+      adapterKey: 'prestashop.webservice.v1',
+    });
+
+    const externalIds = ['ext-1', 'ext-2', 'ext-3'];
+    await seedProductMappings(connection.id, 'prestashop', externalIds);
+
+    const syncAllRequest: SyncJobRequest = {
+      jobType: 'master.inventory.syncAll',
+      connectionId: connection.id,
+      payload: { schemaVersion: 1 },
+      idempotencyKey: `inventory-sync-all-${randomUUID()}`,
+    };
+
+    const outerJob = await jobRepository.createIfNotExistsByIdempotencyKey({
+      jobType: syncAllRequest.jobType,
+      connectionId: syncAllRequest.connectionId,
+      payload: syncAllRequest.payload,
+      idempotencyKey: syncAllRequest.idempotencyKey,
+      maxAttempts: 3,
+    });
+
+    const enqueueSpy = jest.spyOn(jobEnqueue, 'enqueueJob');
+
+    const { MasterInventorySyncAllHandler } = require('../../src/sync/handlers/master-inventory-sync-all.handler');
+    const handler = harness.get(MasterInventorySyncAllHandler);
+
+    await handler.execute(outerJob);
+
+    const subJobCalls = enqueueSpy.mock.calls.filter(
+      ([req]) => req.jobType === 'master.inventory.syncByExternalId',
+    );
+    expect(subJobCalls).toHaveLength(externalIds.length);
+
+    const enqueuedExternalIds = subJobCalls.map(([req]) => (req.payload as { externalId: string }).externalId).sort();
+    expect(enqueuedExternalIds).toEqual([...externalIds].sort());
+
+    // Every sub-job idempotency key embeds the outer job id, so re-running the
+    // same outer job produces identical keys (queue dedupe handles the rest).
+    for (const [req] of subJobCalls) {
+      expect(req.idempotencyKey).toContain(outerJob.id);
+      expect(req.connectionId).toBe(connection.id);
+    }
+  });
+
+  it('is a no-op when no product mappings exist for the connection', async () => {
+    const connection = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      status: 'active',
+      credentialsRef: 'test-credentials-ref',
+      adapterKey: 'prestashop.webservice.v1',
+    });
+
+    const outerJob = await jobRepository.createIfNotExistsByIdempotencyKey({
+      jobType: 'master.inventory.syncAll',
+      connectionId: connection.id,
+      payload: { schemaVersion: 1 },
+      idempotencyKey: `inventory-sync-all-empty-${randomUUID()}`,
+      maxAttempts: 3,
+    });
+
+    const enqueueSpy = jest.spyOn(jobEnqueue, 'enqueueJob');
+
+    const { MasterInventorySyncAllHandler } = require('../../src/sync/handlers/master-inventory-sync-all.handler');
+    const handler = harness.get(MasterInventorySyncAllHandler);
+
+    await expect(handler.execute(outerJob)).resolves.toBeUndefined();
+
+    const subJobCalls = enqueueSpy.mock.calls.filter(
+      ([req]) => req.jobType === 'master.inventory.syncByExternalId',
+    );
+    expect(subJobCalls).toHaveLength(0);
+  });
+});

--- a/apps/worker/test/jest-integration.cjs
+++ b/apps/worker/test/jest-integration.cjs
@@ -1,0 +1,35 @@
+const path = require('path');
+
+module.exports = {
+  rootDir: '..',
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  testEnvironment: 'node',
+  testRegex: 'test/integration/.*\\.int-spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  maxWorkers: 1,
+  testTimeout: 120000,
+  moduleNameMapper: {
+    '^@openlinker/core$': path.resolve(__dirname, '../../../libs/core/src/index.ts'),
+    '^@openlinker/core/(.*)$': path.resolve(__dirname, '../../../libs/core/src/$1'),
+    '^@openlinker/shared$': path.resolve(__dirname, '../../../libs/shared/src/index.ts'),
+    '^@openlinker/shared/(.*)$': path.resolve(__dirname, '../../../libs/shared/src/$1'),
+    '^@openlinker/integrations-allegro$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/allegro/src/index.ts',
+    ),
+    '^@openlinker/integrations-allegro/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/allegro/src/$1',
+    ),
+    '^@openlinker/integrations-prestashop$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/prestashop/src/index.ts',
+    ),
+    '^@openlinker/integrations-prestashop/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/prestashop/src/$1',
+    ),
+  },
+};

--- a/docs/next-steps-issue-47-offer-sync.md
+++ b/docs/next-steps-issue-47-offer-sync.md
@@ -22,10 +22,10 @@
 
 Set/verify these env vars in API runtime:
 
-- `ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED` (default `true`)
-- `ALLEGRO_OFFERS_SYNC_INTERVAL_CRON` (default `*/30 * * * *`)
-- `ALLEGRO_OFFERS_SYNC_PAGE_LIMIT` (default `100`)
-- `ALLEGRO_OFFERS_SYNC_FEED_TYPE` (`events` by default; set to `offers` for full-crawl bootstrap)
+- `OL_ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED` (default `true`)
+- `OL_ALLEGRO_OFFERS_SYNC_INTERVAL_CRON` (default `*/30 * * * *`)
+- `OL_ALLEGRO_OFFERS_SYNC_PAGE_LIMIT` (default `100`)
+- `OL_ALLEGRO_OFFERS_SYNC_FEED_TYPE` (`events` by default; set to `offers` for full-crawl bootstrap)
 
 Confirm the API instance logs the registration of `allegro-offers-sync`.
 
@@ -59,7 +59,7 @@ If you want to force a full run immediately, enqueue a seed job:
 
 Follow-up jobs are automatically enqueued by the worker handler until `nextCursor` is empty.
 
-For initial backfill, you can temporarily set `ALLEGRO_OFFERS_SYNC_FEED_TYPE=offers` (or enqueue a manual job with `feedType: "offers"`), then switch back to `events` for incremental runs.
+For initial backfill, you can temporarily set `OL_ALLEGRO_OFFERS_SYNC_FEED_TYPE=offers` (or enqueue a manual job with `feedType: "offers"`), then switch back to `events` for incremental runs.
 
 ---
 
@@ -101,7 +101,7 @@ Pick an order whose offers have been mapped and trigger `marketplace.order.sync`
 ## Optional Follow-Ups
 
 - Add a per-connection “offers sync in progress” guard if cron overlap becomes a problem.
-- Tune `ALLEGRO_OFFERS_SYNC_INTERVAL_CRON` based on account size and rate limits.
+- Tune `OL_ALLEGRO_OFFERS_SYNC_INTERVAL_CRON` based on account size and rate limits.
 - Extend linking to support EAN/GTIN if you confirm data availability.
 
 ---

--- a/docs/plans/implementation-plan-inventory-sync-scheduler-allegro-command-polling.md
+++ b/docs/plans/implementation-plan-inventory-sync-scheduler-allegro-command-polling.md
@@ -1,0 +1,198 @@
+# Implementation Plan: Periodic Inventory Sync Scheduler (#136) & Allegro Command Status Polling (#102)
+
+## Overview
+
+**Issues**: #136, #102
+**Branch**: `136-102-inventory-sync-allegro-polling`
+**Classification**: CORE/Infrastructure (#136), Integration (#102)
+
+### Goals
+
+1. **#136**: Add a periodic scheduler that enqueues `master.inventory.syncAll` jobs for all active `InventoryMaster` connections, with overlap detection and configurable cron/feature-flag.
+2. **#102**: After Allegro quantity update commands are submitted, poll for async command result status and persist the outcome.
+
+### Non-Goals
+
+- No new REST API endpoints
+- No frontend changes
+- No distributed locking (#136 uses job-queue idempotency for overlap)
+- No retry of failed Allegro commands (#102 only detects and surfaces failures)
+
+---
+
+## Issue #136 — Periodic Inventory Sync Scheduler
+
+### Design
+
+The existing `SchedulerService` already supports registering arbitrary `SchedulerTaskConfig` entries with per-platform connection enumeration and idempotency-key-based dedup. We add a new task config for inventory sync.
+
+However, `SchedulerService` currently filters by `platformType`. Inventory sync needs **all** active connections with `InventoryMaster` capability, which may span multiple platform types. Two options:
+
+**Option A (chosen)**: Use `platformType: '*'` or add a `connectionFilter` callback to `SchedulerTaskConfig` that overrides the default platform-based filter. This keeps all scheduling logic in one place.
+
+**Option B**: Create a separate `PeriodicInventorySyncScheduler` class as the issue suggests.
+
+**Decision**: Option A — extend `SchedulerTaskConfig` with an optional `connectionFilter` to allow capability-based filtering. This is a small change that keeps the scheduler unified and avoids a parallel scheduling mechanism.
+
+### New Job Type
+
+Add `master.inventory.syncAll` to `JobTypeValues`. This job will be handled by a new `MasterInventorySyncAllHandler` that:
+1. Receives `connectionId` from the enqueued job
+2. Fetches all products with inventory for that connection (via `ProductMasterPort.getProducts()`)
+3. For each product, enqueues a `master.inventory.syncByExternalId` job
+
+This fan-out pattern keeps individual inventory sync jobs small and retryable.
+
+### Steps
+
+#### Step 1: Add `master.inventory.syncAll` job type
+- **File**: `libs/core/src/sync/domain/types/sync-job.types.ts`
+- **Change**: Add `'master.inventory.syncAll'` to `JobTypeValues`
+
+#### Step 2: Extend `SchedulerTaskConfig` with optional `connectionFilter`
+- **File**: `apps/api/src/sync/application/services/scheduler.service.ts`
+- **Change**: Add optional `connectionFilter?: () => Promise<Connection[]>` to `SchedulerTaskConfig`
+- In `executeTask()`, use `connectionFilter()` if provided, otherwise fall back to `connectionPort.list({ platformType, status: 'active' })`
+
+#### Step 3: Register inventory sync scheduler task
+- **File**: `apps/api/src/sync/application/services/scheduler.service.ts`
+- **Change**: In `registerDefaultTasks()`, add a new task block:
+  - `taskId`: `'master-inventory-sync'`
+  - `platformType`: `'*'` (cosmetic, overridden by connectionFilter)
+  - `jobType`: `'master.inventory.syncAll'`
+  - `cronExpression`: from `OL_INVENTORY_SYNC_CRON` env (default `*/15 * * * *`)
+  - `enabledEnvVar`: `'OL_INVENTORY_SYNC_ENABLED'`
+  - `connectionFilter`: calls `IntegrationsService.listCapabilityAdapters({ capability: 'InventoryMaster' })` and maps to connections
+  - `generatePayload`: `{ schemaVersion: 1 }`
+  - `generateIdempotencyKey`: `master:${connectionId}:inventory:syncAll:${timestamp}`
+
+#### Step 4: Inject `IIntegrationsService` into `SchedulerService`
+- **File**: `apps/api/src/sync/application/services/scheduler.service.ts`
+- **Change**: Add `@Inject(INTEGRATIONS_SERVICE_TOKEN) private readonly integrationsService: IIntegrationsService` to constructor
+- **File**: `apps/api/src/sync/sync.module.ts`
+- **Change**: Ensure `IntegrationsModule` is imported
+
+#### Step 5a: Add `listByEntityTypeAndConnection` to identifier mapping repository
+- **File**: `libs/core/src/identifier-mapping/domain/ports/identifier-mapping-repository.port.ts`
+- **Change**: Add `listByEntityTypeAndConnection(entityType: EntityType, connectionId: string): Promise<IdentifierMapping[]>`
+- **File**: `libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts`
+- **Change**: Implement the new method (simple `find` with `where: { entityType, connectionId }`)
+- **File**: `libs/core/src/identifier-mapping/application/services/identifier-mapping.service.interface.ts`
+- **Change**: Add `listExternalIdsByConnection(entityType: EntityType, connectionId: string): Promise<string[]>` 
+- **File**: `libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts`
+- **Change**: Implement — delegates to repo, maps results to `externalId[]`
+
+#### Step 5b: Create `MasterInventorySyncAllHandler`
+- **File**: `apps/worker/src/sync/handlers/master-inventory-sync-all.handler.ts` (new)
+- **Pattern**: Follow existing handler pattern (implements `SyncJobHandler`)
+- **Logic**:
+  1. Call `identifierMappingService.listExternalIdsByConnection('Product', job.connectionId)` to get all known product external IDs for this connection
+  2. For each external ID, enqueue `master.inventory.syncByExternalId` job with `{ schemaVersion: 1, externalId, objectType: 'Product' }`
+  3. Use `Promise.allSettled()` for resilience
+  4. Log summary: total, enqueued, skipped (already existing), failed
+
+#### Step 6: Register handler
+- **File**: `apps/worker/src/sync/handlers/handler-registration.service.ts`
+- **Change**: Import and register `MasterInventorySyncAllHandler` for `'master.inventory.syncAll'`
+- **File**: `apps/worker/src/sync/sync-worker.module.ts`
+- **Change**: Add `MasterInventorySyncAllHandler` to providers
+
+#### Step 7: Add env vars to example
+- **File**: `apps/api/env.example`
+- **Change**: Add `OL_INVENTORY_SYNC_ENABLED=true` and `OL_INVENTORY_SYNC_CRON=*/15 * * * *`
+
+#### Step 8: Unit tests
+- **File**: `apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts` (update existing or create)
+  - Test: inventory sync task is registered when enabled
+  - Test: inventory sync task is NOT registered when `OL_INVENTORY_SYNC_ENABLED=false`
+  - Test: connectionFilter returns InventoryMaster connections
+  - Test: idempotency key prevents double-enqueue within same minute
+- **File**: `apps/worker/src/sync/handlers/__tests__/master-inventory-sync-all.handler.spec.ts` (new)
+  - Test: enqueues `syncByExternalId` jobs for all products
+  - Test: handles empty product list gracefully
+  - Test: partial enqueue failures don't block others
+
+---
+
+## Issue #102 — Allegro Offer Quantity Command Status Polling
+
+### Design
+
+Allegro's quantity change commands are async. After `PUT /sale/offer-quantity-change-commands/{commandId}`, the actual result is available at `GET /sale/offer-quantity-change-commands/{commandId}`. The response includes a `status` field.
+
+**Approach**: Add a `pollQuantityCommandStatus` method to the Allegro marketplace adapter. The existing `updateOfferQuantity` method will call this after submitting the command, with backoff polling until a terminal status is reached.
+
+### Allegro Command Statuses
+
+From Allegro API docs:
+- `NEW` — command accepted, not yet processed
+- `IN_PROGRESS` — processing
+- `SUCCESS` — completed successfully  
+- `FAIL` — failed (includes error details in `taskReport`)
+
+### Steps
+
+#### Step 1: Add Allegro response types
+- **File**: `libs/integrations/allegro/src/infrastructure/types/allegro-quantity-command.types.ts` (new)
+- **Content**: Type definitions for `GET /sale/offer-quantity-change-commands/{commandId}` response
+
+```typescript
+export interface AllegroQuantityChangeCommandStatusResponse {
+  id: string;
+  status: 'NEW' | 'IN_PROGRESS' | 'SUCCESS' | 'FAIL';
+  taskReport?: {
+    totalCount: number;
+    successCount: number;
+    failedCount: number;
+    errors?: Array<{
+      offerId: string;
+      message: string;
+    }>;
+  };
+}
+```
+
+#### Step 2: Add `pollQuantityCommandStatus` to Allegro adapter
+- **File**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts`
+- **Change**: Add private `pollQuantityCommandStatus(commandId: string): Promise<AllegroQuantityChangeCommandStatusResponse>` method
+- **Logic**:
+  1. Poll `GET /sale/offer-quantity-change-commands/${commandId}` 
+  2. Retry with exponential backoff: initial 2s, max 30s, up to 5 attempts (configurable)
+  3. Return on terminal status (`SUCCESS` or `FAIL`)
+  4. On timeout (all attempts exhausted with still `NEW`/`IN_PROGRESS`): return last status
+
+#### Step 3: Integrate polling into `updateOfferQuantity`
+- **File**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts`
+- **Change**: After the PUT call succeeds, call `pollQuantityCommandStatus(commandId)` 
+- On `FAIL`: update command status in repository to `'failed'` with error, then throw
+- On `SUCCESS`: update command status to `'accepted'`
+- On timeout (still pending): update status to `'queued'`, log warning, do NOT throw (fire-and-forget for timeout case)
+
+#### Step 4: Add `'succeeded'` status to command entity
+- **File**: `libs/integrations/allegro/src/domain/entities/allegro-quantity-command.entity.ts`
+- **Change**: Add `'succeeded'` to `AllegroQuantityCommandStatusValues` (currently missing — `accepted` was the closest but semantically different from confirmed success)
+
+#### Step 5: Unit tests
+- **File**: `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace-quantity-polling.spec.ts` (new)
+  - Test: polling returns on SUCCESS — command status updated to `succeeded`
+  - Test: polling returns on FAIL — command status updated to `failed` with error, method throws
+  - Test: polling times out — command stays `queued`, warning logged, no throw
+  - Test: HTTP errors during polling are handled gracefully (retry continues)
+
+---
+
+## Implementation Order
+
+1. Step 1 (#136): Add job type `master.inventory.syncAll`
+2. Steps 1-3 (#102): Allegro types, polling method, integration into adapter
+3. Step 4 (#102): Add `succeeded` status to command entity
+4. Steps 2-4 (#136): Extend scheduler, register task, inject integrations service
+5. Steps 5-6 (#136): Create handler, register in worker
+6. Step 7 (#136): Env vars
+7. Steps 5 (#102) + Step 8 (#136): All unit tests
+
+## Risks & Open Questions
+
+1. **Allegro polling delay** — The 2s initial delay adds latency to quantity updates. Acceptable since updates are already async via the job queue.
+2. **Large product catalogs** — `listExternalIdsByConnection` may return thousands of product IDs. The handler enqueues all sub-jobs at once with `Promise.allSettled`. For very large catalogs, batching could be added later.
+3. **Identifier mapping completeness** — The `syncAll` handler only syncs products that already have identifier mappings (i.e., previously synced products). New products added directly in PrestaShop without a prior product sync won't be picked up. This is acceptable for the periodic safety-net use case.

--- a/libs/core/src/customers/application/services/customer-identity-resolver.service.spec.ts
+++ b/libs/core/src/customers/application/services/customer-identity-resolver.service.spec.ts
@@ -40,6 +40,7 @@ describe('CustomerIdentityResolverService', () => {
       batchGetOrCreateInternalIds: jest.fn(),
       getOrCreateExactMapping: jest.fn(),
       deleteMapping: jest.fn(),
+      listExternalIdsByConnection: jest.fn(),
     } as unknown as jest.Mocked<IdentifierMappingPort>;
 
     projectionRepository = {

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts
@@ -29,6 +29,7 @@ describe('IdentifierMappingService', () => {
       create: jest.fn(),
       insertMapping: jest.fn(),
       deleteByExternalKey: jest.fn(),
+      findByEntityTypeAndConnection: jest.fn(),
     } as unknown as jest.Mocked<IdentifierMappingRepositoryPort>;
 
     const mockConnectionPort = {
@@ -450,6 +451,29 @@ describe('IdentifierMappingService', () => {
       expect(id1).toMatch(/^ol_product_[a-f0-9]{32}$/);
       expect(id2).toMatch(/^ol_product_[a-f0-9]{32}$/);
       expect(id1).not.toBe(id2); // Ensure they are different
+    });
+  });
+
+  describe('listExternalIdsByConnection', () => {
+    it('should return external IDs from repository mappings', async () => {
+      const mappings = [
+        new IdentifierMapping('m1', 'Product', 'ol_product_abc', 'ext-1', 'prestashop', 'conn-1', null, new Date(), new Date()),
+        new IdentifierMapping('m2', 'Product', 'ol_product_def', 'ext-2', 'prestashop', 'conn-1', null, new Date(), new Date()),
+      ];
+      repository.findByEntityTypeAndConnection.mockResolvedValue(mappings);
+
+      const result = await service.listExternalIdsByConnection('Product', 'conn-1');
+
+      expect(repository.findByEntityTypeAndConnection).toHaveBeenCalledWith('Product', 'conn-1');
+      expect(result).toEqual(['ext-1', 'ext-2']);
+    });
+
+    it('should return empty array when no mappings found', async () => {
+      repository.findByEntityTypeAndConnection.mockResolvedValue([]);
+
+      const result = await service.listExternalIdsByConnection('Product', 'conn-1');
+
+      expect(result).toEqual([]);
     });
   });
 });

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
@@ -146,6 +146,17 @@ export class IdentifierMappingService implements IIdentifierMappingService {
     );
   }
 
+  async listExternalIdsByConnection(
+    entityType: EntityType,
+    connectionId: string,
+  ): Promise<string[]> {
+    const mappings = await this.repository.findByEntityTypeAndConnection(
+      entityType,
+      connectionId,
+    );
+    return mappings.map((m) => m.externalId);
+  }
+
   async batchGetOrCreateInternalIds(
     requests: IdentifierMappingRequest[],
   ): Promise<Map<string, string>> {

--- a/libs/core/src/identifier-mapping/domain/ports/identifier-mapping-repository.port.ts
+++ b/libs/core/src/identifier-mapping/domain/ports/identifier-mapping-repository.port.ts
@@ -55,5 +55,13 @@ export interface IdentifierMappingRepositoryPort {
     connectionId: string,
     externalId: string,
   ): Promise<void>;
+
+  /**
+   * Find all mappings for a given entity type and connection.
+   */
+  findByEntityTypeAndConnection(
+    entityType: EntityType,
+    connectionId: string,
+  ): Promise<IdentifierMapping[]>;
 }
 

--- a/libs/core/src/identifier-mapping/domain/ports/identifier-mapping.port.ts
+++ b/libs/core/src/identifier-mapping/domain/ports/identifier-mapping.port.ts
@@ -1,10 +1,10 @@
 /**
- * Identifier Mapping Port
+ * Identifier Mapping Ports
  *
- * Defines the contract for identifier mapping operations. This port interface
- * specifies how external platform identifiers are mapped to internal OpenLinker
- * identifiers. Implemented by IdentifierMappingService to provide identifier
- * translation capabilities across all adapters.
+ * Split into a read-only Query port and a write Command port, with a combined
+ * IdentifierMappingPort (the backwards-compatible union) for consumers that
+ * need both sides. New read-only consumers should depend on the narrower
+ * IdentifierMappingQueryPort to keep mocks small.
  *
  * Adapters pass only `connectionId`; the service derives `platformType` from
  * the Connection internally to ensure consistency.
@@ -19,24 +19,16 @@ import {
   ExternalIdMapping,
 } from '../types/identifier-mapping.types';
 
-export interface IdentifierMappingPort {
-  /**
-   * Get or create internal identifier for an external entity
-   * If mapping exists, returns existing internal ID
-   * If not, generates new internal ID and creates mapping
-   * Service resolves platformType from Connection internally
-   */
-  getOrCreateInternalId(
-    entityType: EntityType,
-    externalId: string,
-    connectionId: string,
-    context?: MappingContext,
-  ): Promise<string>;
-
+/**
+ * Read-only view of the identifier mapping store.
+ *
+ * Prefer this over the combined {@link IdentifierMappingPort} when a consumer
+ * only reads mappings.
+ */
+export interface IdentifierMappingQueryPort {
   /**
    * Get internal identifier for an external entity
    * Returns null if mapping doesn't exist
-   * Service resolves platformType from Connection internally
    */
   getInternalId(
     entityType: EntityType,
@@ -51,9 +43,35 @@ export interface IdentifierMappingPort {
   getExternalIds(entityType: EntityType, internalId: string): Promise<ExternalIdMapping[]>;
 
   /**
-   * Create explicit mapping between external and internal identifiers
-   * Used for manual mapping or when internal ID already exists
-   * Service resolves platformType from Connection internally
+   * List all external IDs for a given entity type and connection.
+   *
+   * Used by periodic sync to enumerate all known entities for a connection
+   * without calling the external platform API.
+   */
+  listExternalIdsByConnection(
+    entityType: EntityType,
+    connectionId: string,
+  ): Promise<string[]>;
+}
+
+/**
+ * Write-side operations on the identifier mapping store.
+ */
+export interface IdentifierMappingCommandPort {
+  /**
+   * Get or create internal identifier for an external entity.
+   * If mapping exists, returns existing internal ID; otherwise generates a new
+   * internal ID and creates the mapping.
+   */
+  getOrCreateInternalId(
+    entityType: EntityType,
+    externalId: string,
+    connectionId: string,
+    context?: MappingContext,
+  ): Promise<string>;
+
+  /**
+   * Create explicit mapping between external and internal identifiers.
    * @throws Error if mapping already exists
    */
   createMapping(
@@ -65,20 +83,17 @@ export interface IdentifierMappingPort {
   ): Promise<void>;
 
   /**
-   * Batch get or create internal identifiers
-   * Optimized for processing multiple entities at once
-   * Service resolves platformType from Connection for each item internally
-   * Returns map with composite key: `${externalId}:${connectionId}` -> internalId
+   * Batch get or create internal identifiers.
+   * Returns map with composite key `${externalId}:${connectionId}` -> internalId.
    */
   batchGetOrCreateInternalIds(
     requests: IdentifierMappingRequest[],
   ): Promise<Map<string, string>>;
 
   /**
-   * Get or create exact mapping between external and internal identifiers
-   * Checks both directions (by external ID and by internal ID) to handle conflicts
-   * Returns the external ID if mapping exists or was created successfully
-   * @throws Error if there's a conflict (e.g., external ID mapped to different internal ID)
+   * Get or create exact mapping between external and internal identifiers.
+   * Checks both directions (by external ID and by internal ID) to handle conflicts.
+   * @throws Error on conflict (external ID mapped to different internal ID)
    */
   getOrCreateExactMapping(
     entityType: EntityType,
@@ -89,8 +104,7 @@ export interface IdentifierMappingPort {
   ): Promise<string>;
 
   /**
-   * Delete mapping by external key (idempotent)
-   * Service resolves platformType from Connection internally
+   * Delete mapping by external key (idempotent).
    */
   deleteMapping(
     entityType: EntityType,
@@ -99,3 +113,10 @@ export interface IdentifierMappingPort {
   ): Promise<void>;
 }
 
+/**
+ * Combined identifier mapping port — union of query and command operations.
+ *
+ * Kept for backwards compatibility. Prefer {@link IdentifierMappingQueryPort}
+ * or {@link IdentifierMappingCommandPort} in new code.
+ */
+export type IdentifierMappingPort = IdentifierMappingQueryPort & IdentifierMappingCommandPort;

--- a/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts
+++ b/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts
@@ -116,6 +116,19 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
     }
   }
 
+  async findByEntityTypeAndConnection(
+    entityType: EntityType,
+    connectionId: string,
+  ): Promise<IdentifierMapping[]> {
+    const entities = await this.repository.find({
+      where: {
+        entityType,
+        connectionId,
+      },
+    });
+    return entities.map((entity: IdentifierMappingOrmEntity) => this.toDomain(entity));
+  }
+
   async deleteByExternalKey(
     entityType: EntityType,
     platformType: string,

--- a/libs/core/src/integrations/application/services/integrations.service.spec.ts
+++ b/libs/core/src/integrations/application/services/integrations.service.spec.ts
@@ -78,6 +78,7 @@ describe('IntegrationsService', () => {
       getOrCreateInternalId: jest.fn(),
       batchGetOrCreateInternalIds: jest.fn(),
       deleteMapping: jest.fn(),
+      listExternalIdsByConnection: jest.fn(),
     } as unknown as jest.Mocked<IdentifierMappingPort>;
 
     const mockCredentialsResolver = {

--- a/libs/core/src/sync/domain/types/master-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/master-job-payloads.types.ts
@@ -18,3 +18,7 @@ export interface MasterInventorySyncByExternalIdPayloadV1 {
   objectType: 'Inventory' | 'Product';
 }
 
+export interface MasterInventorySyncAllPayloadV1 {
+  schemaVersion: 1;
+}
+

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -22,6 +22,7 @@ export const JobTypeValues = [
   'marketplace.offer.updateFields',
   'master.product.syncByExternalId',
   'master.inventory.syncByExternalId',
+  'master.inventory.syncAll',
 
   'master.variants.autoMatch',
 

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -48,6 +48,7 @@ export {
 export {
   MasterProductSyncByExternalIdPayloadV1,
   MasterInventorySyncByExternalIdPayloadV1,
+  MasterInventorySyncAllPayloadV1,
 } from './domain/types/master-job-payloads.types';
 
 // Exceptions

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -8,6 +8,7 @@
  * @module libs/integrations/allegro/src
  */
 import { Module, OnModuleInit, Inject, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import {
   IntegrationsModule,
@@ -77,6 +78,8 @@ export class AllegroIntegrationModule implements OnModuleInit {
     @Optional()
     @Inject(ALLEGRO_QUANTITY_COMMAND_REPOSITORY_TOKEN)
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
+    @Optional()
+    private readonly configService?: ConfigService,
   ) {}
 
   onModuleInit(): void {
@@ -85,9 +88,32 @@ export class AllegroIntegrationModule implements OnModuleInit {
       this.customerIdentityResolver,
       this.tokenRefreshService,
       this.commandRepository,
+      this.readQuantityPollConfig(),
     );
     this.factoryResolver.registerFactory('allegro.publicapi.v1', factory);
     this.logger.log('Allegro adapter factory registered successfully');
+  }
+
+  private readQuantityPollConfig(): Record<string, number> | undefined {
+    if (!this.configService) {
+      return undefined;
+    }
+    const parseInt = (key: string): number | undefined => {
+      const raw = this.configService?.get<string>(key);
+      if (!raw) return undefined;
+      const n = Number(raw);
+      return Number.isFinite(n) && n > 0 ? n : undefined;
+    };
+    const config: Record<string, number> = {};
+    const maxAttempts = parseInt('OL_ALLEGRO_QUANTITY_POLL_MAX_ATTEMPTS');
+    const initialDelayMs = parseInt('OL_ALLEGRO_QUANTITY_POLL_INITIAL_DELAY_MS');
+    const maxDelayMs = parseInt('OL_ALLEGRO_QUANTITY_POLL_MAX_DELAY_MS');
+    const backoffMultiplier = parseInt('OL_ALLEGRO_QUANTITY_POLL_BACKOFF_MULTIPLIER');
+    if (maxAttempts !== undefined) config.maxAttempts = maxAttempts;
+    if (initialDelayMs !== undefined) config.initialDelayMs = initialDelayMs;
+    if (maxDelayMs !== undefined) config.maxDelayMs = maxDelayMs;
+    if (backoffMultiplier !== undefined) config.backoffMultiplier = backoffMultiplier;
+    return Object.keys(config).length > 0 ? config : undefined;
   }
 }
 

--- a/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
+++ b/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
@@ -15,7 +15,7 @@ import { AllegroConnectionConfig, AllegroEnvironmentValues } from '../domain/typ
 import { AllegroCredentials } from '../domain/types/allegro-credentials.types';
 import { AllegroConfigException } from '../domain/exceptions/allegro-config.exception';
 import { AllegroHttpClient } from '../infrastructure/http/allegro-http-client';
-import { AllegroMarketplaceAdapter } from '../infrastructure/adapters/allegro-marketplace.adapter';
+import { AllegroMarketplaceAdapter, QuantityPollConfig } from '../infrastructure/adapters/allegro-marketplace.adapter';
 import { AllegroTokenRefreshService } from '../infrastructure/token-refresh/allegro-token-refresh.service';
 import { Logger } from '@openlinker/shared/logging';
 import { AllegroQuantityCommandRepositoryPort } from '../domain/ports/allegro-quantity-command-repository.port';
@@ -32,6 +32,7 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
     private readonly customerIdentityResolver?: CustomerIdentityResolverPort,
     private readonly tokenRefreshService?: AllegroTokenRefreshService,
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
+    private readonly quantityPollConfig?: Partial<QuantityPollConfig>,
   ) {}
 
   async createAdapters(
@@ -80,6 +81,7 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
       connection,
       this.customerIdentityResolver,
       this.commandRepository,
+      this.quantityPollConfig,
     );
 
     this.logger.log(`Allegro adapters created successfully for connection: ${connection.id}`);

--- a/libs/integrations/allegro/src/domain/entities/allegro-quantity-command.entity.ts
+++ b/libs/integrations/allegro/src/domain/entities/allegro-quantity-command.entity.ts
@@ -9,6 +9,7 @@
 export const AllegroQuantityCommandStatusValues = [
   'queued',
   'accepted',
+  'succeeded',
   'rejected',
   'failed',
 ] as const;

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -138,6 +138,29 @@ export interface AllegroOfferQuantityChangeCommandResponse {
 }
 
 /**
+ * Allegro offer quantity change command status response
+ *
+ * Response from GET /sale/offer-quantity-change-commands/{commandId} endpoint.
+ * Used to poll for async command completion status.
+ */
+export type AllegroCommandTaskStatus = 'NEW' | 'IN_PROGRESS' | 'SUCCESS' | 'FAIL';
+
+export interface AllegroQuantityChangeCommandStatusResponse {
+  id: string;
+  taskCount: number;
+  completedTaskCount?: number;
+  tasks: Array<{
+    offerId: string;
+    status: AllegroCommandTaskStatus;
+    message?: string;
+    errors?: Array<{
+      code: string;
+      message: string;
+    }>;
+  }>;
+}
+
+/**
  * Allegro offers list item (from GET /sale/offers)
  */
 export interface AllegroOfferListItem {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
@@ -9,6 +9,7 @@
 import { AllegroMarketplaceAdapter } from '../allegro-marketplace.adapter';
 import { IAllegroHttpClient } from '../../http/allegro-http-client.interface';
 import { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import { AllegroQuantityCommandRepositoryPort } from '../../../domain/ports/allegro-quantity-command-repository.port';
 import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';
 import {
   AllegroCheckoutForm,
@@ -39,6 +40,7 @@ describe('AllegroMarketplaceAdapter', () => {
       createMapping: jest.fn(),
       batchGetOrCreateInternalIds: jest.fn(),
       deleteMapping: jest.fn(),
+      listExternalIdsByConnection: jest.fn(),
     } as unknown as jest.Mocked<IdentifierMappingPort>;
 
     connection = new Connection(
@@ -265,6 +267,20 @@ describe('AllegroMarketplaceAdapter', () => {
   });
 
   describe('updateOfferQuantity', () => {
+    beforeEach(() => {
+      // Mock polling response for command status (SUCCESS by default)
+      httpClient.get.mockResolvedValue({
+        data: {
+          id: 'command-123',
+          taskCount: 1,
+          completedTaskCount: 1,
+          tasks: [{ offerId: 'offer-1', status: 'SUCCESS' }],
+        },
+        status: 200,
+        headers: {},
+      });
+    });
+
     it('should submit offer quantity change command successfully', async () => {
       const mockCommandResponse: AllegroOfferQuantityChangeCommandResponse = {
         id: 'command-123',
@@ -381,6 +397,118 @@ describe('AllegroMarketplaceAdapter', () => {
           idempotencyKey: 'idempotency-key-123',
         }),
       ).rejects.toThrow('Network error');
+    });
+
+    it('should throw when polling returns FAIL status', async () => {
+      const mockCommandResponse: AllegroOfferQuantityChangeCommandResponse = {
+        id: 'command-fail',
+        status: 'ACCEPTED',
+      };
+
+      httpClient.put.mockResolvedValueOnce({
+        data: mockCommandResponse,
+        status: 200,
+        headers: {},
+      });
+
+      httpClient.get.mockResolvedValue({
+        data: {
+          id: 'command-fail',
+          taskCount: 1,
+          tasks: [{
+            offerId: 'offer-1',
+            status: 'FAIL',
+            errors: [{ code: 'INVALID', message: 'bad quantity' }],
+          }],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      await expect(
+        adapter.updateOfferQuantity({
+          offerId: 'offer-1',
+          quantity: 10,
+          idempotencyKey: 'fail-key',
+        }),
+      ).rejects.toThrow('Allegro quantity command command-fail failed');
+    });
+
+    it('should not throw when polling times out (still pending)', async () => {
+      jest.useFakeTimers();
+
+      const mockCommandResponse: AllegroOfferQuantityChangeCommandResponse = {
+        id: 'command-pending',
+        status: 'ACCEPTED',
+      };
+
+      httpClient.put.mockResolvedValueOnce({
+        data: mockCommandResponse,
+        status: 200,
+        headers: {},
+      });
+
+      // Return pending status on every poll attempt
+      httpClient.get.mockResolvedValue({
+        data: {
+          id: 'command-pending',
+          taskCount: 1,
+          tasks: [{ offerId: 'offer-1', status: 'NEW' }],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      // Start the update (will be pending due to polling sleeps)
+      const promise = adapter.updateOfferQuantity({
+        offerId: 'offer-1',
+        quantity: 10,
+        idempotencyKey: 'pending-key',
+      });
+
+      // Advance timers through all polling attempts
+      for (let i = 0; i < 5; i++) {
+        await jest.advanceTimersByTimeAsync(60000);
+      }
+
+      // Should not throw — timeout is treated as non-fatal
+      await expect(promise).resolves.toBeUndefined();
+
+      jest.useRealTimers();
+    });
+
+    it('should persist succeeded status via command repository', async () => {
+      const commandRepository: jest.Mocked<AllegroQuantityCommandRepositoryPort> = {
+        findByCommandId: jest.fn(),
+        find: jest.fn(),
+        create: jest.fn(),
+        updateStatus: jest.fn(),
+      };
+
+      const adapterWithRepo = new AllegroMarketplaceAdapter(
+        connectionId,
+        httpClient,
+        identifierMapping,
+        connection,
+        undefined,
+        commandRepository,
+      );
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-1', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+
+      commandRepository.create.mockResolvedValue({} as never);
+
+      await adapterWithRepo.updateOfferQuantity({
+        offerId: 'offer-1',
+        quantity: 5,
+        idempotencyKey: 'repo-key',
+      });
+
+      expect(commandRepository.updateStatus).toHaveBeenCalledWith('cmd-1', 'succeeded');
     });
   });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-adapter-factory-wrapper.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-adapter-factory-wrapper.ts
@@ -13,6 +13,7 @@ import { CustomerIdentityResolverPort } from '@openlinker/core/customers';
 import { AllegroAdapterFactory } from '../../application/allegro-adapter.factory';
 import { AllegroTokenRefreshService } from '../token-refresh/allegro-token-refresh.service';
 import { AllegroQuantityCommandRepositoryPort } from '../../domain/ports/allegro-quantity-command-repository.port';
+import { QuantityPollConfig } from './allegro-marketplace.adapter';
 // Adapters are created by factory, no need to import here
 
 /**
@@ -27,11 +28,13 @@ export class AllegroAdapterFactoryWrapper implements AdapterFactoryPort {
     private readonly customerIdentityResolver?: CustomerIdentityResolverPort,
     private readonly tokenRefreshService?: AllegroTokenRefreshService,
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
+    private readonly quantityPollConfig?: Partial<QuantityPollConfig>,
   ) {
     this.factory = new AllegroAdapterFactory(
       this.customerIdentityResolver,
       this.tokenRefreshService,
       this.commandRepository,
+      this.quantityPollConfig,
     );
   }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
@@ -27,6 +27,7 @@ import {
   AllegroCheckoutForm,
   AllegroOrderEventsResponse,
   AllegroOfferQuantityChangeCommandResponse,
+  AllegroQuantityChangeCommandStatusResponse,
   AllegroCategoryParametersResponse,
   AllegroCategoriesResponse,
   AllegroOfferParameter,
@@ -46,12 +47,27 @@ import {
 type MarketplaceOrderFeedItem = MarketplaceOrderFeedOutput['items'][number];
 
 /**
+ * Polling configuration for Allegro async quantity change commands.
+ *
+ * Defaults: 5 attempts, 2s initial delay, 30s max delay, 2x backoff multiplier
+ * (worst case ~62s total). Override via factory when ops need different tuning.
+ */
+export interface QuantityPollConfig {
+  maxAttempts: number;
+  initialDelayMs: number;
+  maxDelayMs: number;
+  backoffMultiplier: number;
+}
+
+/**
  * Allegro Marketplace Adapter
  *
  * Adapter for Allegro marketplace operations (order ingestion and offer quantity updates).
  */
 export class AllegroMarketplaceAdapter implements MarketplacePort {
   private readonly logger = new Logger(AllegroMarketplaceAdapter.name);
+
+  private readonly quantityPollConfig: QuantityPollConfig;
 
   constructor(
     private readonly connectionId: string,
@@ -60,7 +76,14 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
     _connection: Connection,
     private readonly customerIdentityResolver?: CustomerIdentityResolverPort,
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
+    quantityPollConfig?: Partial<QuantityPollConfig>,
   ) {
+    this.quantityPollConfig = {
+      maxAttempts: quantityPollConfig?.maxAttempts ?? 5,
+      initialDelayMs: quantityPollConfig?.initialDelayMs ?? 2000,
+      maxDelayMs: quantityPollConfig?.maxDelayMs ?? 30000,
+      backoffMultiplier: quantityPollConfig?.backoffMultiplier ?? 2,
+    };
     // Connection is stored for potential future use but not currently accessed
     void _connection;
     // Keep deps in constructor for backward compatibility with factory, but do not use
@@ -374,6 +397,9 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
       this.logger.debug(
         `Allegro offer quantity command submitted: commandId=${response.data.id} (connection: ${this.connectionId})`,
       );
+
+      // Poll for async command completion
+      await this.pollAndUpdateCommandStatus(response.data.id, cmd.offerId);
     } catch (error) {
       this.logger.error(
         `Failed to update Allegro offer quantity (offerId: ${cmd.offerId}, connection: ${this.connectionId}): ${(error as Error).message}`,
@@ -680,6 +706,118 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
       );
       throw error;
     }
+  }
+
+  /**
+   * Poll Allegro for quantity change command completion status.
+   *
+   * Uses exponential backoff: 2s initial, 2x multiplier, 30s max, 5 attempts.
+   * Returns the final status response, or the last response if still pending after timeout.
+   */
+  private async pollQuantityCommandStatus(
+    commandId: string,
+  ): Promise<AllegroQuantityChangeCommandStatusResponse | null> {
+    const { maxAttempts, initialDelayMs, maxDelayMs, backoffMultiplier } = this.quantityPollConfig;
+
+    let delayMs = initialDelayMs;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      await this.sleep(delayMs);
+
+      try {
+        const response = await this.httpClient.get<AllegroQuantityChangeCommandStatusResponse>(
+          `/sale/offer-quantity-change-commands/${commandId}`,
+        );
+
+        const tasks = response.data.tasks ?? [];
+        const allTerminal = tasks.length > 0 && tasks.every(
+          (t) => t.status === 'SUCCESS' || t.status === 'FAIL',
+        );
+
+        if (allTerminal) {
+          return response.data;
+        }
+
+        this.logger.debug(
+          `Allegro command ${commandId} still pending (attempt ${attempt}/${maxAttempts}, connection: ${this.connectionId})`,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to poll Allegro command status (commandId: ${commandId}, attempt ${attempt}/${maxAttempts}): ${(error as Error).message}`,
+        );
+      }
+
+      delayMs = Math.min(delayMs * backoffMultiplier, maxDelayMs);
+    }
+
+    this.logger.warn(
+      `Allegro command ${commandId} did not reach terminal status after ${maxAttempts} polling attempts (connection: ${this.connectionId})`,
+    );
+    return null;
+  }
+
+  /**
+   * Poll for command status and update the persisted command record.
+   *
+   * On SUCCESS: update to 'succeeded'
+   * On FAIL: update to 'failed' with error details, then throw
+   * On timeout: leave as 'queued', log warning
+   */
+  private async pollAndUpdateCommandStatus(
+    commandId: string,
+    offerId: string,
+  ): Promise<void> {
+    const result = await this.pollQuantityCommandStatus(commandId);
+
+    if (!result) {
+      // Polling timed out — command may still be processing
+      return;
+    }
+
+    const tasks = result.tasks ?? [];
+    const failedTasks = tasks.filter((t) => t.status === 'FAIL');
+
+    if (failedTasks.length > 0) {
+      const errorMessages = failedTasks
+        .map((t) => {
+          const errDetails = t.errors?.map((e) => `${e.code}: ${e.message}`).join('; ') ?? t.message ?? 'unknown';
+          return `offer ${t.offerId}: ${errDetails}`;
+        })
+        .join(', ');
+
+      try {
+        if (this.commandRepository) {
+          await this.commandRepository.updateStatus(commandId, 'failed', errorMessages);
+        }
+      } catch (persistError) {
+        this.logger.warn(
+          `Failed to persist command failure status (commandId: ${commandId}): ${(persistError as Error).message}`,
+        );
+      }
+
+      throw new Error(
+        `Allegro quantity command ${commandId} failed for offer ${offerId}: ${errorMessages}`,
+      );
+    }
+
+    // All tasks succeeded
+    try {
+      if (this.commandRepository) {
+        await this.commandRepository.updateStatus(commandId, 'succeeded');
+      }
+    } catch (persistError) {
+      this.logger.warn(
+        `Failed to persist command success status (commandId: ${commandId}): ${(persistError as Error).message}`,
+      );
+    }
+
+    this.logger.debug(
+      `Allegro quantity command ${commandId} confirmed SUCCESS (connection: ${this.connectionId})`,
+    );
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   private mapAllegroEventType(type: string): MarketplaceOrderEventType {

--- a/libs/integrations/allegro/src/infrastructure/persistence/entities/allegro-quantity-command.orm-entity.ts
+++ b/libs/integrations/allegro/src/infrastructure/persistence/entities/allegro-quantity-command.orm-entity.ts
@@ -14,18 +14,7 @@ import {
   UpdateDateColumn,
   Index,
 } from 'typeorm';
-
-/**
- * Command status values
- */
-export const AllegroQuantityCommandStatusValues = [
-  'queued',
-  'accepted',
-  'rejected',
-  'failed',
-] as const;
-
-export type AllegroQuantityCommandStatus = (typeof AllegroQuantityCommandStatusValues)[number];
+import { AllegroQuantityCommandStatus } from '../../../domain/entities/allegro-quantity-command.entity';
 
 @Entity('allegro_quantity_commands')
 @Index(['commandId'], { unique: true })

--- a/libs/integrations/prestashop/src/__tests__/mocks/mock-identifier-mapping.factory.ts
+++ b/libs/integrations/prestashop/src/__tests__/mocks/mock-identifier-mapping.factory.ts
@@ -17,6 +17,7 @@ export function createMockIdentifierMapping(
     createMapping: jest.fn().mockResolvedValue(undefined),
     batchGetOrCreateInternalIds: jest.fn().mockResolvedValue(new Map()),
     deleteMapping: jest.fn().mockResolvedValue(undefined),
+    listExternalIdsByConnection: jest.fn().mockResolvedValue([]),
     ...overrides,
   } as jest.Mocked<IdentifierMappingPort>;
 }

--- a/libs/integrations/prestashop/src/application/__tests__/prestashop-adapter.factory.spec.ts
+++ b/libs/integrations/prestashop/src/application/__tests__/prestashop-adapter.factory.spec.ts
@@ -26,6 +26,7 @@ describe('PrestashopAdapterFactory', () => {
       batchGetOrCreateInternalIds: jest.fn(),
       getOrCreateExactMapping: jest.fn(),
       deleteMapping: jest.fn(),
+      listExternalIdsByConnection: jest.fn(),
     } as jest.Mocked<IdentifierMappingPort>;
     mockCredentialsResolver = {
       get: jest.fn(),


### PR DESCRIPTION
## Summary

- **#136** — Add periodic `master.inventory.syncAll` scheduler: fan-out handler enqueues per-product `master.inventory.syncByExternalId` jobs for all known product mappings on each InventoryMaster connection. Configurable via `OL_INVENTORY_SYNC_ENABLED` / `OL_INVENTORY_SYNC_CRON` (default: every 15 min). Extends existing `SchedulerService` with an optional `connectionFilter` for capability-based scoping instead of adding a parallel scheduler.
- **#102** — Poll Allegro offer quantity change commands after submission. Terminal `SUCCESS` persists as `succeeded`; `FAIL` persists as `failed` with error details and re-throws so the job queue retries. Polling is tunable via `OL_ALLEGRO_QUANTITY_POLL_*` env vars (defaults: 5 attempts, 2s to 30s backoff).

## Also in this PR

- Split `IdentifierMappingPort` into narrower `IdentifierMappingQueryPort` + `IdentifierMappingCommandPort` (existing combined port kept for back-compat). New read-only consumers — including the new sync-all handler — depend on the query port, keeping mocks small.
- Renamed legacy `ALLEGRO_*` scheduler env vars to `OL_ALLEGRO_*` for consistency with `OL_INVENTORY_SYNC_*` (credentials and API config vars untouched).
- Added `listExternalIdsByConnection` on the query port to enumerate previously-synced entities without calling the external platform.
- Fixed pre-existing broken `test:integration` script in `apps/worker` (config file had been removed but script was never updated).

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm type-check` clean
- [x] `pnpm test` — 689 unit tests pass across all packages
- [x] `pnpm --filter @openlinker/worker test:integration master-inventory-sync-all-e2e` — 2 tests pass against real Postgres + Redis via Testcontainers (fan-out + empty-connection cases)
- [ ] Manual: set `OL_INVENTORY_SYNC_CRON=*/1 * * * *` locally, verify sub-jobs enqueued for PrestaShop connection
- [ ] Manual: trigger quantity update against Allegro sandbox, verify command record reaches `succeeded`

Closes #136
Closes #102