### PR TITLE
feat(web): guided per-platform wizard for new connections

### DIFF
--- a/apps/web/src/app/routes/advanced-new-connection.route.tsx
+++ b/apps/web/src/app/routes/advanced-new-connection.route.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route: `/connections/new/advanced` — raw connection form fallback.
+ */
+import type { RouteObject } from 'react-router-dom';
+import { AdvancedNewConnectionPage } from '../../pages/connections/advanced-new-connection-page';
+
+export const advancedNewConnectionRoute: RouteObject = {
+  path: 'connections/new/advanced',
+  element: <AdvancedNewConnectionPage />,
+};

--- a/apps/web/src/app/routes/prestashop-setup.route.tsx
+++ b/apps/web/src/app/routes/prestashop-setup.route.tsx
@@ -1,0 +1,10 @@
+/**
+ * Route: `/connections/new/prestashop` — guided PrestaShop wizard.
+ */
+import type { RouteObject } from 'react-router-dom';
+import { PrestashopSetupPage } from '../../pages/connections/prestashop-setup-page';
+
+export const prestashopSetupRoute: RouteObject = {
+  path: 'connections/new/prestashop',
+  element: <PrestashopSetupPage />,
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -17,6 +17,8 @@ import { listingsRoute } from './listings.route';
 import { inventoryRoute } from './inventory.route';
 import { jobsLogsRoute } from './jobs-logs.route';
 import { newConnectionRoute } from './new-connection.route';
+import { prestashopSetupRoute } from './prestashop-setup.route';
+import { advancedNewConnectionRoute } from './advanced-new-connection.route';
 import { ordersRoute } from './orders.route';
 import { productsRoute } from './products.route';
 import { settingsRoute } from './settings.route';
@@ -36,6 +38,8 @@ export const rootRoute: RouteObject = {
     connectionsRoute,
     adaptersRoute,
     newConnectionRoute,
+    prestashopSetupRoute,
+    advancedNewConnectionRoute,
     allegroSetupRoute,
     connectionDetailRoute,
     connectionCategoryMappingsRoute,

--- a/apps/web/src/features/connections/components/platform-picker.test.tsx
+++ b/apps/web/src/features/connections/components/platform-picker.test.tsx
@@ -1,0 +1,22 @@
+import { within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PlatformPicker } from './platform-picker';
+import { renderWithProviders } from '../../../test/test-utils';
+
+describe('PlatformPicker', () => {
+  it('renders a card per platform linking to its guided setup route', () => {
+    const view = renderWithProviders(<PlatformPicker />);
+
+    const prestashop = within(view.container).getByRole('link', { name: /PrestaShop/i });
+    expect(prestashop).toHaveAttribute('href', '/connections/new/prestashop');
+
+    const allegro = within(view.container).getByRole('link', { name: /Allegro/i });
+    expect(allegro).toHaveAttribute('href', '/connections/new/allegro');
+  });
+
+  it('exposes an advanced-mode escape hatch', () => {
+    const view = renderWithProviders(<PlatformPicker />);
+    const advanced = within(view.container).getByRole('link', { name: /advanced mode/i });
+    expect(advanced).toHaveAttribute('href', '/connections/new/advanced');
+  });
+});

--- a/apps/web/src/features/connections/components/platform-picker.tsx
+++ b/apps/web/src/features/connections/components/platform-picker.tsx
@@ -1,0 +1,66 @@
+/**
+ * Platform Picker
+ *
+ * Step 1 of the connection setup flow. Renders one card per supported
+ * platform and links to that platform's guided wizard route. The
+ * metadata table is indexed by PlatformType so the compiler fails if a
+ * new platform type is added to PLATFORM_TYPES without a corresponding
+ * card entry.
+ */
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { PLATFORM_TYPES, type PlatformType } from '../api/connections.types';
+
+interface PlatformCard {
+  title: string;
+  description: string;
+  to: string;
+  badge: string;
+}
+
+const PLATFORM_CARDS: Record<PlatformType, PlatformCard> = {
+  prestashop: {
+    title: 'PrestaShop',
+    description:
+      'Connect a PrestaShop store via the Webservice API. You will need the shop URL and a webservice key.',
+    to: '/connections/new/prestashop',
+    badge: 'Webservice API',
+  },
+  allegro: {
+    title: 'Allegro',
+    description:
+      'Connect an Allegro seller account. Authorization uses OAuth 2.0 — no manual token paste.',
+    to: '/connections/new/allegro',
+    badge: 'OAuth 2.0',
+  },
+};
+
+export function PlatformPicker(): ReactElement {
+  return (
+    <div className="platform-picker">
+      <ul className="platform-picker__list">
+        {PLATFORM_TYPES.map((platformType) => {
+          const card = PLATFORM_CARDS[platformType];
+          return (
+            <li key={platformType}>
+              <Link to={card.to} className="platform-picker__card">
+                <div className="platform-picker__card-header">
+                  <h3 className="platform-picker__card-title">{card.title}</h3>
+                  <span className="toolbar-chip">{card.badge}</span>
+                </div>
+                <p className="platform-picker__card-description">{card.description}</p>
+                <span className="platform-picker__card-cta" aria-hidden="true">
+                  Continue →
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      <p className="platform-picker__advanced">
+        Need to configure a raw adapter key or bespoke config JSON?{' '}
+        <Link to="/connections/new/advanced">Use advanced mode</Link>.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PrestashopSetupForm } from './prestashop-setup-form';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
+
+describe('PrestashopSetupForm', () => {
+  it('submits a PrestaShop connection with the inferred adapter key and config', async () => {
+    const create = vi.fn().mockResolvedValue(sampleConnection);
+    const apiClient = createMockApiClient({ connections: { create } });
+    const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
+
+    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
+      target: { value: 'Main store' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
+      target: { value: 'https://shop.example.com' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
+      target: { value: 'WSKEY123' },
+    });
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    expect(await screen.findByText('Connection created')).toBeInTheDocument();
+    expect(create).toHaveBeenCalledWith({
+      name: 'Main store',
+      platformType: 'prestashop',
+      adapterKey: 'prestashop.webservice.v1',
+      credentialsRef: 'WSKEY123',
+      config: { baseUrl: 'https://shop.example.com' },
+    });
+  });
+
+  it('includes shopId in config when provided', async () => {
+    const create = vi.fn().mockResolvedValue(sampleConnection);
+    const apiClient = createMockApiClient({ connections: { create } });
+    const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
+
+    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
+      target: { value: 'Shop 2' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
+      target: { value: 'https://shop.example.com' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
+      target: { value: 'WSKEY' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Shop ID (optional)'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    await screen.findByText('Connection created');
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: { baseUrl: 'https://shop.example.com', shopId: '2' },
+      }),
+    );
+  });
+
+  it('surfaces API errors in a form-level alert', async () => {
+    const apiClient = createMockApiClient({
+      connections: {
+        create: vi.fn().mockRejectedValue(new Error('API create failed')),
+      },
+    });
+    const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
+
+    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
+      target: { value: 'Shop' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
+      target: { value: 'https://shop.example.com' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
+      target: { value: 'WSKEY' },
+    });
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    expect(await screen.findByText('Unable to create connection')).toBeInTheDocument();
+    expect(screen.getByText('API create failed')).toBeInTheDocument();
+  });
+
+  it('rejects an invalid shop URL', async () => {
+    const view = renderWithProviders(<PrestashopSetupForm />);
+
+    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
+      target: { value: 'Shop' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
+      target: { value: 'not-a-url' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
+      target: { value: 'WSKEY' },
+    });
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    expect(
+      (await screen.findAllByText('Shop URL must be a valid URL (e.g. https://shop.example.com)'))
+        .length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -1,0 +1,141 @@
+/**
+ * PrestaShop Setup Form
+ *
+ * Guided wizard form for creating a PrestaShop connection. Collects the
+ * values an operator can read directly from the PrestaShop admin (shop
+ * URL, webservice key, optional shop ID) and maps them to the generic
+ * CreateConnectionInput shape. The adapter key is inferred from the
+ * platform so the operator never edits raw config JSON.
+ */
+import type { ReactElement } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
+import {
+  PRESTASHOP_SETUP_DEFAULT_VALUES,
+  prestashopSetupSchema,
+  toCreateConnectionInput,
+  type PrestashopSetupFormSubmission,
+  type PrestashopSetupFormValues,
+} from './prestashop-setup.schema';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+export function PrestashopSetupForm(): ReactElement {
+  const createConnection = useCreateConnectionMutation();
+  const { showToast } = useToast();
+  const form = useForm<PrestashopSetupFormValues, undefined, PrestashopSetupFormSubmission>({
+    defaultValues: PRESTASHOP_SETUP_DEFAULT_VALUES,
+    resolver: zodResolver(prestashopSetupSchema),
+  });
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      const created = await createConnection.mutateAsync(toCreateConnectionInput(values));
+      form.reset(PRESTASHOP_SETUP_DEFAULT_VALUES);
+      showToast({
+        tone: 'success',
+        title: 'Connection created',
+        description: `PrestaShop connection "${created.name}" was created.`,
+      });
+    } catch {
+      return;
+    }
+  });
+
+  return (
+    <form className="form-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">PrestaShop</p>
+          <h3 className="section-title">Connect a PrestaShop store</h3>
+        </div>
+        <span className="panel__meta">Webservice API</span>
+      </div>
+
+      {form.formState.submitCount > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
+      {createConnection.error ? (
+        <Alert tone="error" title="Unable to create connection">
+          {createConnection.error.message}
+        </Alert>
+      ) : null}
+
+      <Alert tone="info" title="Before you start">
+        In your PrestaShop admin, enable Webservice under{' '}
+        <strong>Advanced Parameters → Webservice</strong> and generate a key with the required
+        resources enabled.
+      </Alert>
+
+      <Alert tone="warning" title="Webservice key handling (MVP)">
+        The key is stored as the connection&apos;s credentials reference until the dedicated
+        credentials service is available. Treat this connection as carrying a secret until the
+        follow-up backend work lands.
+      </Alert>
+
+      <div className="form-grid">
+        <FormField label="Connection name" name="name" error={form.formState.errors.name?.message}>
+          <Input
+            {...form.register('name')}
+            placeholder="Main PrestaShop Store"
+            invalid={Boolean(form.formState.errors.name)}
+          />
+        </FormField>
+
+        <FormField
+          label="Shop URL"
+          name="baseUrl"
+          error={form.formState.errors.baseUrl?.message}
+          description="The public URL of the PrestaShop storefront (no trailing path)."
+        >
+          <Input
+            {...form.register('baseUrl')}
+            placeholder="https://shop.example.com"
+            invalid={Boolean(form.formState.errors.baseUrl)}
+          />
+        </FormField>
+
+        <FormField
+          label="Webservice key"
+          name="webserviceKey"
+          error={form.formState.errors.webserviceKey?.message}
+          description="Generated in PrestaShop admin under Advanced Parameters → Webservice."
+        >
+          <Input
+            {...form.register('webserviceKey')}
+            type="password"
+            autoComplete="off"
+            placeholder="e.g. ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+            invalid={Boolean(form.formState.errors.webserviceKey)}
+          />
+        </FormField>
+
+        <FormField
+          label="Shop ID (optional)"
+          name="shopId"
+          error={form.formState.errors.shopId?.message}
+          description="Only needed for multi-shop PrestaShop installations."
+        >
+          <Input
+            {...form.register('shopId')}
+            placeholder="1"
+            invalid={Boolean(form.formState.errors.shopId)}
+          />
+        </FormField>
+      </div>
+
+      <div className="form-actions">
+        <Button type="submit" disabled={createConnection.isPending}>
+          {createConnection.isPending ? 'Creating...' : 'Create connection'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/features/connections/components/prestashop-setup.schema.ts
+++ b/apps/web/src/features/connections/components/prestashop-setup.schema.ts
@@ -1,0 +1,57 @@
+/**
+ * PrestaShop Setup Form Schema
+ *
+ * Zod schema and form → API payload mapping for the guided PrestaShop
+ * connection wizard. Maps user-visible fields (shop URL, webservice key,
+ * optional shop ID) to the generic CreateConnectionInput shape
+ * ({ platformType, adapterKey, config, credentialsRef }).
+ *
+ * NOTE: Until the API exposes an endpoint to register an integration
+ * credential from a raw key, the webservice key is sent directly as
+ * `credentialsRef`. This matches current MVP backend behavior but
+ * overloads a field documented as an opaque reference. Follow-up work
+ * will introduce a credentials-create step so the raw key never appears
+ * in the connection payload.
+ */
+import { z } from 'zod';
+import type { CreateConnectionInput } from '../api/connections.types';
+
+export const PRESTASHOP_ADAPTER_KEY = 'prestashop.webservice.v1';
+
+export const prestashopSetupSchema = z.object({
+  name: z.string().trim().min(1, 'Connection name is required'),
+  baseUrl: z
+    .url('Shop URL must be a valid URL (e.g. https://shop.example.com)')
+    .refine(
+      (value) => value.startsWith('http://') || value.startsWith('https://'),
+      'Shop URL must use http:// or https://',
+    ),
+  webserviceKey: z.string().trim().min(1, 'Webservice key is required'),
+  shopId: z.string().trim().optional(),
+});
+
+export type PrestashopSetupFormValues = z.input<typeof prestashopSetupSchema>;
+export type PrestashopSetupFormSubmission = z.output<typeof prestashopSetupSchema>;
+
+export const PRESTASHOP_SETUP_DEFAULT_VALUES: PrestashopSetupFormValues = {
+  name: '',
+  baseUrl: '',
+  webserviceKey: '',
+  shopId: '',
+};
+
+export function toCreateConnectionInput(
+  values: PrestashopSetupFormSubmission,
+): CreateConnectionInput {
+  const config: Record<string, unknown> = { baseUrl: values.baseUrl };
+  if (values.shopId && values.shopId.length > 0) {
+    config.shopId = values.shopId;
+  }
+  return {
+    name: values.name,
+    platformType: 'prestashop',
+    adapterKey: PRESTASHOP_ADAPTER_KEY,
+    credentialsRef: values.webserviceKey,
+    config,
+  };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -978,13 +978,19 @@ textarea {
 
 .dialog {
   width: min(100%, 28rem);
-  display: grid;
   gap: 1rem;
   border: 1px solid var(--border-default);
   border-radius: 0.75rem;
   padding: 1.25rem;
   background: var(--bg-surface);
   box-shadow: var(--shadow-soft);
+}
+
+/* Only render the dialog when `open` is set. Without this, base `.dialog`
+   styles override the native <dialog> user-agent `display: none` and the
+   modal becomes visible on page load (see #160). */
+.dialog[open] {
+  display: grid;
 }
 
 .dialog__header,
@@ -1468,4 +1474,68 @@ textarea {
   .category-mappings-layout {
     grid-template-columns: 1fr;
   }
+}
+
+.platform-picker {
+  display: grid;
+  gap: 1rem;
+}
+
+.platform-picker__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.platform-picker__card {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1rem 1.125rem;
+  border: 1px solid var(--border-default);
+  border-radius: 0.625rem;
+  background: var(--bg-surface);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.platform-picker__card:hover,
+.platform-picker__card:focus-visible {
+  border-color: var(--accent-primary);
+  box-shadow: var(--shadow-soft);
+}
+
+.platform-picker__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.platform-picker__card-title {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.platform-picker__card-description {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.platform-picker__card-cta {
+  margin-top: 0.25rem;
+  color: var(--accent-primary);
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+.platform-picker__advanced {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.875rem;
 }

--- a/apps/web/src/pages/connections/advanced-new-connection-page.tsx
+++ b/apps/web/src/pages/connections/advanced-new-connection-page.tsx
@@ -1,0 +1,35 @@
+/**
+ * Advanced New Connection Page
+ *
+ * Escape-hatch page exposing the raw connection form (platform dropdown,
+ * credentials reference, adapter key, config JSON). Used when a guided
+ * wizard does not yet exist for a platform or when direct control is
+ * needed.
+ */
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { CreateConnectionForm } from '../../features/connections/components/create-connection-form';
+import { PageLayout } from '../../shared/ui/page-layout';
+
+export function AdvancedNewConnectionPage(): ReactElement {
+  return (
+    <PageLayout
+      eyebrow="Integrations"
+      title="Advanced connection setup"
+      description="Direct form for connection fields — adapter key, credentials reference, and raw config JSON. Use the guided flows when possible."
+      actions={
+        <Link className="button button--secondary" to="/connections/new">
+          Back
+        </Link>
+      }
+      summary={
+        <div className="toolbar__group">
+          <span className="toolbar-chip">Raw form</span>
+          <span className="toolbar-chip">Escape hatch</span>
+        </div>
+      }
+    >
+      <CreateConnectionForm />
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/connections/new-connection-page.tsx
+++ b/apps/web/src/pages/connections/new-connection-page.tsx
@@ -1,32 +1,34 @@
+/**
+ * New Connection Page
+ *
+ * Step 1 of the connection setup flow: platform picker. Each platform
+ * links to its own guided wizard at `/connections/new/{platform}`; an
+ * advanced escape-hatch route is also exposed.
+ */
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { CreateConnectionForm } from '../../features/connections/components/create-connection-form';
+import { PlatformPicker } from '../../features/connections/components/platform-picker';
 import { PageLayout } from '../../shared/ui/page-layout';
 
 export function NewConnectionPage(): ReactElement {
   return (
     <PageLayout
       eyebrow="Integrations"
-      title="New integration setup"
-      description="Setup flows should be structured, explicit, and ready to evolve into step-based onboarding."
+      title="Add a connection"
+      description="Pick the platform you want to connect. Each platform has a guided setup flow — no raw adapter keys or config JSON required."
       actions={
         <Link className="button button--secondary" to="/connections">
           Back to integrations
         </Link>
       }
       summary={
-        <>
-          <div className="toolbar__group">
-            <span className="toolbar-chip">Setup pattern</span>
-            <span className="toolbar-chip">Validated form</span>
-          </div>
-          <div className="toolbar__group">
-            <span className="muted-text">Draft to validate to activate</span>
-          </div>
-        </>
+        <div className="toolbar__group">
+          <span className="toolbar-chip">Guided setup</span>
+          <span className="toolbar-chip">Per-platform wizards</span>
+        </div>
       }
     >
-      <CreateConnectionForm />
+      <PlatformPicker />
     </PageLayout>
   );
 }

--- a/apps/web/src/pages/connections/prestashop-setup-page.tsx
+++ b/apps/web/src/pages/connections/prestashop-setup-page.tsx
@@ -1,0 +1,32 @@
+/**
+ * PrestaShop Setup Page
+ *
+ * Page wrapper for the guided PrestaShop connection wizard.
+ */
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { PrestashopSetupForm } from '../../features/connections/components/prestashop-setup-form';
+import { PageLayout } from '../../shared/ui/page-layout';
+
+export function PrestashopSetupPage(): ReactElement {
+  return (
+    <PageLayout
+      eyebrow="Integrations"
+      title="Connect PrestaShop"
+      description="Provide your shop URL and webservice key. OpenLinker uses them to sync products, orders, and inventory."
+      actions={
+        <Link className="button button--secondary" to="/connections/new">
+          Back
+        </Link>
+      }
+      summary={
+        <div className="toolbar__group">
+          <span className="toolbar-chip">Webservice API</span>
+          <span className="toolbar-chip">Guided setup</span>
+        </div>
+      }
+    >
+      <PrestashopSetupForm />
+    </PageLayout>
+  );
+}

--- a/apps/web/src/shared/ui/confirm-dialog.test.tsx
+++ b/apps/web/src/shared/ui/confirm-dialog.test.tsx
@@ -41,6 +41,22 @@ describe('ConfirmDialog', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it('does not set the open attribute when rendered with open=false', () => {
+    const view = render(
+      <ConfirmDialog
+        open={false}
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        title="Delete item?"
+        description="This action cannot be undone."
+      />,
+    );
+
+    const dialog = view.container.querySelector('dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.hasAttribute('open')).toBe(false);
+  });
+
   // Focus trapping (Tab cycle) and Escape handling are provided natively by showModal() —
   // they are browser behaviours not exercisable via fireEvent in jsdom.
 


### PR DESCRIPTION
## Summary                                                                                                               
- Replace raw form at /connections/new with platform picker; per-platform wizards at /connections/new/prestashop and existing /connections/new/allegro.  
- Raw form remains at /connections/new/advanced as escape hatch.                                                                                         
- Fix Reset-draft modal appearing on page load: base .dialog styles overrode native <dialog> display:none.                                               
                                                                                                                                                           
## Scope caveat                                                                                                                                          
PrestaShop webservice key is sent as credentialsRef (current MVP behavior). A warning Alert surfaces this in the UI; true credentials-service abstraction is a backend follow-up.                                                                                                                                 
                                                                                                                           
## Test plan                                                                                                                                             
- [ ] /connections/new shows platform cards + advanced link, no modal on load
- [ ] PrestaShop wizard creates connection with adapterKey prestashop.webservice.v1 and config { baseUrl, shopId?}                                      
- [ ] Invalid shop URL rejected client-side                                                                                                              
- [ ] API errors surface in form alert                                                                                                                   
- [ ] Allegro card routes to existing OAuth flow                                                                                                         
- [ ] Advanced form still works; reset modal only opens on Reset click                                                   
                                                                                                                                                           
Closes #160                                                                                                              
Closes #161                                                                                                                                              
