### PR TITLE
feat(connections): add enabledCapabilities with per-connection gating

### DIFF
--- a/apps/api/src/integrations/application/services/connection.service.spec.ts
+++ b/apps/api/src/integrations/application/services/connection.service.spec.ts
@@ -39,6 +39,9 @@ describe('ConnectionService', () => {
     'cred_123',
     new Date(),
     new Date(),
+  
+    undefined,
+    ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
   );
 
   beforeEach(async () => {
@@ -58,6 +61,11 @@ describe('ConnectionService', () => {
       }),
       getCapabilityAdapter: jest.fn(),
       listCapabilityAdapters: jest.fn(),
+      resolveAdapterMetadata: jest.fn().mockResolvedValue({
+        adapterKey: 'prestashop.webservice.v1',
+        platformType: 'prestashop',
+        supportedCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager'],
+      }),
     } as unknown as jest.Mocked<IIntegrationsService>;
 
     const mockJobEnqueue = {
@@ -93,7 +101,12 @@ describe('ConnectionService', () => {
       const result = await service.create(payload);
 
       expect(result).toEqual(mockConnection);
-      expect(connectionPort.create).toHaveBeenCalledWith(payload);
+      expect(connectionPort.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...payload,
+          enabledCapabilities: expect.any(Array),
+        }),
+      );
     });
 
     it('should enqueue master.product.syncAll when adapter supports ProductMaster', async () => {
@@ -189,8 +202,12 @@ describe('ConnectionService', () => {
         'cred_123',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
+      connectionPort.get.mockResolvedValue(mockConnection);
       connectionPort.update.mockResolvedValue(updatedConnection);
 
       const result = await service.update('connection-123', patch);
@@ -200,7 +217,7 @@ describe('ConnectionService', () => {
     });
 
     it('should throw NotFoundException when connection not found', async () => {
-      connectionPort.update.mockRejectedValue(
+      connectionPort.get.mockRejectedValue(
         new ConnectionNotFoundException('connection-123'),
       );
 
@@ -221,6 +238,9 @@ describe('ConnectionService', () => {
         'cred_123',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       connectionPort.disable.mockResolvedValue(disabledConnection);

--- a/apps/api/src/integrations/application/services/connection.service.ts
+++ b/apps/api/src/integrations/application/services/connection.service.ts
@@ -10,7 +10,7 @@
  * @see {@link IConnectionService} for the interface
  * @see {@link ConnectionPort} for the core port
  */
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { IConnectionService } from '../interfaces/connection.service.interface';
 import {
   ConnectionPort,
@@ -49,7 +49,31 @@ export class ConnectionService implements IConnectionService {
   async create(payload: ConnectionCreate): Promise<Connection> {
     try {
       this.logger.log(`Creating connection: ${payload.name} (platform: ${payload.platformType})`);
-      const connection = await this.connectionPort.create(payload);
+
+      // Resolve adapter metadata to (a) default enabledCapabilities when the
+      // caller omits them and (b) validate any explicit subset against the
+      // adapter's supportedCapabilities.
+      const metadata = await this.integrationsService.resolveAdapterMetadata({
+        platformType: payload.platformType,
+        adapterKey: payload.adapterKey,
+      });
+
+      const enabledCapabilities =
+        payload.enabledCapabilities ?? [...metadata.supportedCapabilities];
+
+      const invalid = enabledCapabilities.filter(
+        (c) => !metadata.supportedCapabilities.includes(c),
+      );
+      if (invalid.length > 0) {
+        throw new BadRequestException(
+          `Capabilities not supported by adapter ${metadata.adapterKey}: ${invalid.join(', ')}`,
+        );
+      }
+
+      const connection = await this.connectionPort.create({
+        ...payload,
+        enabledCapabilities,
+      });
       this.logger.log(`Connection created successfully: ${connection.id} (${connection.name})`);
       await this.enqueueInitialCatalogSync(connection);
       return connection;
@@ -131,6 +155,32 @@ export class ConnectionService implements IConnectionService {
   ): Promise<Connection> {
     try {
       this.logger.log(`Updating connection: ${connectionId}${patch.status ? ` (status: ${patch.status})` : ''}`);
+
+      const existing = await this.connectionPort.get(connectionId);
+
+      // adapterKey is immutable post-create. Silently accept the unchanged
+      // value (so naive round-trip patches work) but reject any real change.
+      if (patch.adapterKey !== undefined && patch.adapterKey !== existing.adapterKey) {
+        throw new BadRequestException(
+          `adapterKey is immutable after connection creation (current: ${existing.adapterKey ?? 'derived from platformType'})`,
+        );
+      }
+
+      if (patch.enabledCapabilities !== undefined) {
+        const metadata = await this.integrationsService.resolveAdapterMetadata({
+          platformType: existing.platformType,
+          adapterKey: existing.adapterKey,
+        });
+        const invalid = patch.enabledCapabilities.filter(
+          (c) => !metadata.supportedCapabilities.includes(c),
+        );
+        if (invalid.length > 0) {
+          throw new BadRequestException(
+            `Capabilities not supported by adapter ${metadata.adapterKey}: ${invalid.join(', ')}`,
+          );
+        }
+      }
+
       const connection = await this.connectionPort.update(connectionId, patch);
       this.logger.log(`Connection updated successfully: ${connection.id} (status: ${connection.status})`);
       return connection;

--- a/apps/api/src/integrations/http/allegro.controller.spec.ts
+++ b/apps/api/src/integrations/http/allegro.controller.spec.ts
@@ -33,6 +33,9 @@ describe('AllegroController', () => {
     'db:allegro_123',
     new Date('2025-01-01'),
     new Date('2025-01-01'),
+  
+    undefined,
+    ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
   );
 
   beforeEach(async () => {

--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -14,6 +14,7 @@ import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/
 import { ConnectionResponseDto } from './dto/connection-response.dto';
 import { ConnectionDiagnosticsResponseDto } from './dto/connection-diagnostics-response.dto';
 import { SYNC_JOB_REPOSITORY_TOKEN } from '@openlinker/core/sync';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { SyncJobRepositoryPort } from '@openlinker/core/sync/domain/ports/sync-job-repository.port';
 import { SyncJob } from '@openlinker/core/sync/domain/entities/sync-job.entity';
 
@@ -31,6 +32,9 @@ describe('ConnectionController', () => {
     'cred_123',
     new Date('2025-01-01'),
     new Date('2025-01-01'),
+  
+    undefined,
+    ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
   );
 
   const makeSyncJob = (overrides: Partial<SyncJob> = {}): SyncJob =>
@@ -83,6 +87,16 @@ describe('ConnectionController', () => {
         {
           provide: SYNC_JOB_REPOSITORY_TOKEN,
           useValue: mockSyncJobRepository,
+        },
+        {
+          provide: INTEGRATIONS_SERVICE_TOKEN,
+          useValue: {
+            resolveAdapterMetadata: jest.fn().mockResolvedValue({
+              adapterKey: 'prestashop.webservice.v1',
+              platformType: 'prestashop',
+              supportedCapabilities: ['ProductMaster'],
+            }),
+          },
         },
       ],
     }).compile();
@@ -157,6 +171,9 @@ describe('ConnectionController', () => {
         'cred_123',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       service.update.mockResolvedValue(updatedConnection);
@@ -194,6 +211,9 @@ describe('ConnectionController', () => {
         'cred_123',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       service.disable.mockResolvedValue(disabledConnection);

--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -19,6 +19,7 @@ import {
   Inject,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Logger } from '@openlinker/shared/logging';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { CreateConnectionDto } from './dto/create-connection.dto';
 import { UpdateConnectionDto } from './dto/update-connection.dto';
@@ -26,19 +27,49 @@ import { ConnectionFiltersDto } from './dto/connection-filters.dto';
 import { ConnectionResponseDto } from './dto/connection-response.dto';
 import { ConnectionDiagnosticsResponseDto } from './dto/connection-diagnostics-response.dto';
 import { ConnectionService } from '../application/services/connection.service';
-import { ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier-mapping';
+import { Connection, ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier-mapping';
 import { SyncJobRepositoryPort } from '@openlinker/core/sync/domain/ports/sync-job-repository.port';
 import { SYNC_JOB_REPOSITORY_TOKEN } from '@openlinker/core/sync';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  Capability,
+} from '@openlinker/core/integrations';
 
 @ApiBearerAuth()
 @ApiTags('connections')
 @Controller('connections')
 export class ConnectionController {
+  private readonly logger = new Logger(ConnectionController.name);
+
   constructor(
     private readonly connectionService: ConnectionService,
     @Inject(SYNC_JOB_REPOSITORY_TOKEN)
     private readonly syncJobRepository: SyncJobRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
   ) {}
+
+  private async toResponse(connection: Connection): Promise<ConnectionResponseDto> {
+    let supported: Capability[] = [];
+    try {
+      const metadata = await this.integrationsService.resolveAdapterMetadata({
+        platformType: connection.platformType,
+        adapterKey: connection.adapterKey,
+      });
+      supported = metadata.supportedCapabilities;
+    } catch (error) {
+      // Unknown adapter (e.g., legacy row with unmapped platformType). Leave
+      // supportedCapabilities empty; the FE will render an "adapter not
+      // recognized" notice. We still want this to be observable in the API
+      // logs so operators can spot and fix the offending row.
+      this.logger.warn(
+        `Could not resolve adapter metadata for connection ${connection.id} (platformType=${connection.platformType}, adapterKey=${connection.adapterKey ?? '<derived>'}): ${(error as Error).message}`,
+      );
+      supported = [];
+    }
+    return ConnectionResponseDto.fromDomain(connection, supported);
+  }
 
   @Roles('admin')
   @Post()
@@ -55,7 +86,7 @@ export class ConnectionController {
     @Body() dto: CreateConnectionDto,
   ): Promise<ConnectionResponseDto> {
     const connection = await this.connectionService.create(dto);
-    return ConnectionResponseDto.fromDomain(connection);
+    return this.toResponse(connection);
   }
 
   @Get()
@@ -73,9 +104,7 @@ export class ConnectionController {
       ...(filtersDto.status && { status: filtersDto.status }),
     };
     const connections = await this.connectionService.list(filters);
-    return connections.map((connection) =>
-      ConnectionResponseDto.fromDomain(connection),
-    );
+    return Promise.all(connections.map((connection) => this.toResponse(connection)));
   }
 
   @Get(':id')
@@ -88,7 +117,7 @@ export class ConnectionController {
   @ApiResponse({ status: 404, description: 'Connection not found' })
   async get(@Param('id') id: string): Promise<ConnectionResponseDto> {
     const connection = await this.connectionService.get(id);
-    return ConnectionResponseDto.fromDomain(connection);
+    return this.toResponse(connection);
   }
 
   @Roles('admin')
@@ -110,9 +139,12 @@ export class ConnectionController {
       ...(dto.status !== undefined && { status: dto.status }),
       ...(dto.config !== undefined && { config: dto.config }),
       ...(dto.adapterKey !== undefined && { adapterKey: dto.adapterKey }),
+      ...(dto.enabledCapabilities !== undefined && {
+        enabledCapabilities: dto.enabledCapabilities,
+      }),
     };
     const connection = await this.connectionService.update(id, patch);
-    return ConnectionResponseDto.fromDomain(connection);
+    return this.toResponse(connection);
   }
 
   @Get(':id/diagnostics')
@@ -141,7 +173,7 @@ export class ConnectionController {
   @ApiResponse({ status: 404, description: 'Connection not found' })
   async disable(@Param('id') id: string): Promise<ConnectionResponseDto> {
     const connection = await this.connectionService.disable(id);
-    return ConnectionResponseDto.fromDomain(connection);
+    return this.toResponse(connection);
   }
 }
 

--- a/apps/api/src/integrations/http/dto/connection-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/connection-response.dto.ts
@@ -8,6 +8,7 @@
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Connection } from '@openlinker/core/identifier-mapping';
+import { Capability, CapabilityValues } from '@openlinker/core/integrations';
 
 export class ConnectionResponseDto {
   @ApiProperty({ description: 'Connection ID (UUID)', example: '123e4567-e89b-12d3-a456-426614174000' })
@@ -31,13 +32,30 @@ export class ConnectionResponseDto {
   @ApiPropertyOptional({ description: 'Adapter key', example: 'prestashop.webservice.v1' })
   adapterKey?: string;
 
+  @ApiProperty({
+    description: 'Capabilities enabled on this connection (operator-chosen subset of supportedCapabilities)',
+    isArray: true,
+    enum: CapabilityValues,
+  })
+  enabledCapabilities!: Capability[];
+
+  @ApiProperty({
+    description: 'Capabilities supported by the resolved adapter (derived, not persisted)',
+    isArray: true,
+    enum: CapabilityValues,
+  })
+  supportedCapabilities!: Capability[];
+
   @ApiProperty({ description: 'Creation timestamp' })
   createdAt!: Date;
 
   @ApiProperty({ description: 'Last update timestamp' })
   updatedAt!: Date;
 
-  static fromDomain(connection: Connection): ConnectionResponseDto {
+  static fromDomain(
+    connection: Connection,
+    supportedCapabilities: Capability[],
+  ): ConnectionResponseDto {
     const dto = new ConnectionResponseDto();
     dto.id = connection.id;
     dto.platformType = connection.platformType;
@@ -46,6 +64,8 @@ export class ConnectionResponseDto {
     dto.config = connection.config;
     dto.credentialsRef = connection.credentialsRef;
     dto.adapterKey = connection.adapterKey;
+    dto.enabledCapabilities = connection.enabledCapabilities;
+    dto.supportedCapabilities = supportedCapabilities;
     dto.createdAt = connection.createdAt;
     dto.updatedAt = connection.updatedAt;
     return dto;

--- a/apps/api/src/integrations/http/dto/create-connection.dto.ts
+++ b/apps/api/src/integrations/http/dto/create-connection.dto.ts
@@ -6,8 +6,9 @@
  *
  * @module apps/api/src/integrations/http/dto
  */
-import { IsString, IsNotEmpty, IsOptional, IsObject } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsObject, IsArray, IsIn } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Capability, CapabilityValues } from '@openlinker/core/integrations';
 
 export class CreateConnectionDto {
   @ApiProperty({
@@ -50,5 +51,16 @@ export class CreateConnectionDto {
   @IsString()
   @IsOptional()
   adapterKey?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Capabilities this connection should fulfil. Defaults to the adapter\u2019s full supported set when omitted. Must be a subset of supportedCapabilities.',
+    isArray: true,
+    enum: CapabilityValues,
+  })
+  @IsArray()
+  @IsIn(CapabilityValues, { each: true })
+  @IsOptional()
+  enabledCapabilities?: Capability[];
 }
 

--- a/apps/api/src/integrations/http/dto/update-connection.dto.ts
+++ b/apps/api/src/integrations/http/dto/update-connection.dto.ts
@@ -6,9 +6,10 @@
  *
  * @module apps/api/src/integrations/http/dto
  */
-import { IsString, IsOptional, IsObject, IsEnum } from 'class-validator';
+import { IsString, IsOptional, IsObject, IsEnum, IsArray, IsIn } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ConnectionStatusValues } from '@openlinker/core/identifier-mapping';
+import { Capability, CapabilityValues } from '@openlinker/core/integrations';
 
 export class UpdateConnectionDto {
   @ApiPropertyOptional({
@@ -43,5 +44,15 @@ export class UpdateConnectionDto {
   @IsString()
   @IsOptional()
   adapterKey?: string;
+
+  @ApiPropertyOptional({
+    description: 'Capabilities enabled on this connection. Subset of the adapter\u2019s supportedCapabilities.',
+    isArray: true,
+    enum: CapabilityValues,
+  })
+  @IsArray()
+  @IsIn(CapabilityValues, { each: true })
+  @IsOptional()
+  enabledCapabilities?: Capability[];
 }
 

--- a/apps/api/src/migrations/1780000000000-add-enabled-capabilities-to-connections.ts
+++ b/apps/api/src/migrations/1780000000000-add-enabled-capabilities-to-connections.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEnabledCapabilitiesToConnections1780000000000 implements MigrationInterface {
+  name = 'AddEnabledCapabilitiesToConnections1780000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "connections" ADD COLUMN "enabledCapabilities" jsonb NOT NULL DEFAULT '[]'`,
+    );
+
+    // Backfill existing rows with the full supported capability set for their
+    // resolved adapter. Hardcoded per known adapterKey / platformType fallback
+    // to match AdapterRegistryService at time of writing. Unknown rows stay at
+    // '[]' and are logged so operators can fix them manually.
+    await queryRunner.query(
+      `UPDATE "connections"
+         SET "enabledCapabilities" =
+           '["ProductMaster","InventoryMaster","OrderSource","OrderProcessorManager"]'::jsonb
+         WHERE COALESCE("adapterKey", '') = 'prestashop.webservice.v1'
+            OR ("adapterKey" IS NULL AND "platformType" = 'prestashop')`,
+    );
+
+    await queryRunner.query(
+      `UPDATE "connections"
+         SET "enabledCapabilities" = '["Marketplace"]'::jsonb
+         WHERE COALESCE("adapterKey", '') = 'allegro.publicapi.v1'
+            OR ("adapterKey" IS NULL AND "platformType" = 'allegro')`,
+    );
+
+    // GIN index so `listCapabilityAdapters` can filter by a single capability
+    // without scanning every active connection when this grows past hundreds.
+    await queryRunner.query(
+      `CREATE INDEX "IDX_connections_enabled_capabilities" ON "connections" USING gin ("enabledCapabilities" jsonb_path_ops)`,
+    );
+
+    await queryRunner.query(`
+      DO $$
+      DECLARE unknown_count integer;
+      BEGIN
+        SELECT COUNT(*) INTO unknown_count
+          FROM "connections"
+          WHERE "enabledCapabilities" = '[]'::jsonb;
+        IF unknown_count > 0 THEN
+          RAISE NOTICE
+            '[166] % connection row(s) left with empty enabledCapabilities — unknown adapterKey/platformType. Review via SELECT id, "platformType", "adapterKey" FROM connections WHERE "enabledCapabilities" = ''[]''::jsonb;',
+            unknown_count;
+        END IF;
+      END$$;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_connections_enabled_capabilities"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "connections" DROP COLUMN "enabledCapabilities"`,
+    );
+  }
+}

--- a/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
+++ b/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
@@ -22,7 +22,18 @@ describe('SchedulerService', () => {
   let schedulerRegistry: jest.Mocked<SchedulerRegistry>;
 
   const createConnection = (id: string, platformType = 'prestashop'): Connection =>
-    new Connection(id, platformType, `Test ${id}`, 'active', {}, 'cred-ref', new Date(), new Date());
+    new Connection(
+      id,
+      platformType,
+      `Test ${id}`,
+      'active',
+      {},
+      'cred-ref',
+      new Date(),
+      new Date(),
+      undefined,
+      ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
+    );
 
   beforeEach(() => {
     connectionPort = {

--- a/apps/api/src/webhooks/application/services/webhook-auth.service.spec.ts
+++ b/apps/api/src/webhooks/application/services/webhook-auth.service.spec.ts
@@ -28,6 +28,7 @@ describe('WebhookAuthService', () => {
     new Date(),
     new Date(),
     'prestashop.webservice.v1',
+    ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager'],
   );
 
   beforeEach(async () => {
@@ -143,6 +144,7 @@ describe('WebhookAuthService', () => {
         mockConnection.createdAt,
         mockConnection.updatedAt,
         mockConnection.adapterKey,
+        mockConnection.enabledCapabilities,
       );
       connectionPort.get.mockResolvedValue(disabledConnection);
 

--- a/apps/api/test/integration/connection-capabilities.int-spec.ts
+++ b/apps/api/test/integration/connection-capabilities.int-spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Connection Capabilities Integration Test
+ *
+ * Verifies the `enabledCapabilities` gate end-to-end:
+ *   - Create defaults enabledCapabilities to the adapter's full supported set.
+ *   - GET / LIST expose `enabledCapabilities` and derived `supportedCapabilities`.
+ *   - PATCH can narrow the enabled set and rejects values outside the adapter's
+ *     supported set.
+ *   - PATCH cannot change `adapterKey`.
+ *   - Capability validation at create time rejects unsupported values.
+ *
+ * @module apps/api/test/integration
+ */
+import { getTestHarness, resetTestHarness, teardownTestHarness, IntegrationTestHarness } from './setup';
+import { createPrestashopConnectionDto } from './fixtures/connection.fixtures';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+
+describe('Connection Capabilities Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function createConnection(body: Record<string, unknown>): Promise<{ id: string; enabledCapabilities: string[]; supportedCapabilities: string[] }> {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+    const response = await http
+      .post('/connections')
+      .set('Authorization', `Bearer ${token}`)
+      .send(body)
+      .expect(201);
+    return response.body;
+  }
+
+  it('defaults enabledCapabilities to the adapter full supported set', async () => {
+    const dto = createPrestashopConnectionDto({ name: 'Default caps store' });
+    const created = await createConnection(dto);
+
+    expect(created.supportedCapabilities.sort()).toEqual(
+      ['InventoryMaster', 'OrderProcessorManager', 'OrderSource', 'ProductMaster'],
+    );
+    expect(created.enabledCapabilities.sort()).toEqual(created.supportedCapabilities.sort());
+  });
+
+  it('respects explicit enabledCapabilities on create and validates subset', async () => {
+    const dto = createPrestashopConnectionDto({
+      name: 'Destination only',
+      enabledCapabilities: ['ProductMaster', 'OrderProcessorManager'],
+    } as Record<string, unknown>);
+    const created = await createConnection(dto);
+
+    expect(created.enabledCapabilities.sort()).toEqual(['OrderProcessorManager', 'ProductMaster']);
+  });
+
+  it('rejects create with a capability the adapter does not support', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const dto = createPrestashopConnectionDto({
+      name: 'Bad caps',
+      enabledCapabilities: ['ProductMaster', 'Marketplace'], // Marketplace not supported by prestashop.webservice.v1
+    } as Record<string, unknown>);
+
+    await http
+      .post('/connections')
+      .set('Authorization', `Bearer ${token}`)
+      .send(dto)
+      .expect(400);
+  });
+
+  it('allows PATCH to narrow enabledCapabilities', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const created = await createConnection(createPrestashopConnectionDto({ name: 'Narrow me' }));
+
+    const updated = await http
+      .patch(`/connections/${created.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ enabledCapabilities: ['ProductMaster'] })
+      .expect(200);
+
+    expect(updated.body.enabledCapabilities).toEqual(['ProductMaster']);
+    expect(updated.body.supportedCapabilities.sort()).toEqual(
+      ['InventoryMaster', 'OrderProcessorManager', 'OrderSource', 'ProductMaster'],
+    );
+  });
+
+  it('rejects PATCH that changes adapterKey', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const created = await createConnection(createPrestashopConnectionDto({ name: 'Immutable key' }));
+
+    await http
+      .patch(`/connections/${created.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ adapterKey: 'prestashop.webservice.v2' })
+      .expect(400);
+  });
+
+  it('rejects PATCH with an unsupported capability', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const created = await createConnection(createPrestashopConnectionDto({ name: 'Validate subset' }));
+
+    await http
+      .patch(`/connections/${created.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ enabledCapabilities: ['Marketplace'] })
+      .expect(400);
+  });
+});

--- a/apps/web/src/features/adapters/api/adapters.types.ts
+++ b/apps/web/src/features/adapters/api/adapters.types.ts
@@ -1,7 +1,9 @@
+import type { Capability } from '../../connections/api/connections.types';
+
 export interface AdapterSummary {
   adapterKey: string;
   platformType: string;
-  supportedCapabilities: string[];
+  supportedCapabilities: Capability[];
   displayName?: string;
   version?: string;
 }

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -4,6 +4,16 @@ export type PlatformType = (typeof PLATFORM_TYPES)[number];
 
 export type ConnectionStatus = 'active' | 'disabled' | 'error';
 
+export const CAPABILITY_VALUES = [
+  'ProductMaster',
+  'InventoryMaster',
+  'OrderProcessorManager',
+  'OrderSource',
+  'Marketplace',
+] as const;
+
+export type Capability = (typeof CAPABILITY_VALUES)[number];
+
 export interface Connection {
   id: string;
   name: string;
@@ -12,6 +22,8 @@ export interface Connection {
   config: Record<string, unknown>;
   credentialsRef: string;
   adapterKey?: string;
+  enabledCapabilities: Capability[];
+  supportedCapabilities: Capability[];
   createdAt: string;
   updatedAt: string;
 }
@@ -27,6 +39,7 @@ export interface CreateConnectionInput {
   config: Record<string, unknown>;
   credentialsRef: string;
   adapterKey?: string;
+  enabledCapabilities?: Capability[];
 }
 
 export interface UpdateConnectionInput {
@@ -34,6 +47,7 @@ export interface UpdateConnectionInput {
   status?: ConnectionStatus;
   config?: Record<string, unknown>;
   adapterKey?: string;
+  enabledCapabilities?: Capability[];
 }
 
 export interface RecentJobSummary {

--- a/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMockApiClient,
+  renderWithProviders,
+  sampleConnection,
+} from '../../../test/test-utils';
+import { ConnectionCapabilitiesPanel } from './ConnectionCapabilitiesPanel';
+import type { Connection } from '../api/connections.types';
+
+describe('ConnectionCapabilitiesPanel', () => {
+  afterEach(cleanup);
+
+  it('renders one checkbox per supported capability, checked when enabled', () => {
+    const connection: Connection = {
+      ...sampleConnection,
+      supportedCapabilities: ['ProductMaster', 'OrderSource'],
+      enabledCapabilities: ['ProductMaster'],
+    };
+    renderWithProviders(<ConnectionCapabilitiesPanel connection={connection} />);
+
+    expect(screen.getByRole('checkbox', { name: /ProductMaster/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /OrderSource/ })).not.toBeChecked();
+    expect(screen.getByText(/1 of 2 enabled/)).toBeInTheDocument();
+  });
+
+  it('calls update mutation with new set when a capability is toggled', async () => {
+    const update = vi.fn().mockResolvedValue({ ...sampleConnection });
+    const apiClient = createMockApiClient({ connections: { update } });
+
+    const connection: Connection = {
+      ...sampleConnection,
+      supportedCapabilities: ['ProductMaster', 'OrderSource'],
+      enabledCapabilities: ['ProductMaster'],
+    };
+    renderWithProviders(<ConnectionCapabilitiesPanel connection={connection} />, {
+      apiClient,
+    });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /OrderSource/ }));
+
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith(
+        connection.id,
+        expect.objectContaining({
+          enabledCapabilities: expect.arrayContaining(['ProductMaster', 'OrderSource']),
+        }),
+      ),
+    );
+  });
+
+  it('shows a warning when no capabilities are enabled', () => {
+    const connection: Connection = {
+      ...sampleConnection,
+      supportedCapabilities: ['ProductMaster'],
+      enabledCapabilities: [],
+    };
+    renderWithProviders(<ConnectionCapabilitiesPanel connection={connection} />);
+
+    expect(screen.getByText(/No capabilities enabled/)).toBeInTheDocument();
+  });
+
+  it('renders the mutation error in an Alert when update fails', async () => {
+    const update = vi.fn().mockRejectedValue(new Error('API update failed'));
+    const apiClient = createMockApiClient({ connections: { update } });
+
+    const connection: Connection = {
+      ...sampleConnection,
+      supportedCapabilities: ['ProductMaster', 'OrderSource'],
+      enabledCapabilities: ['ProductMaster'],
+    };
+    renderWithProviders(<ConnectionCapabilitiesPanel connection={connection} />, {
+      apiClient,
+    });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /OrderSource/ }));
+
+    expect(await screen.findByText(/Unable to update capabilities/)).toBeInTheDocument();
+    expect(screen.getByText('API update failed')).toBeInTheDocument();
+  });
+
+  it('shows a notice when adapter is unknown (no supported capabilities)', () => {
+    const connection: Connection = {
+      ...sampleConnection,
+      supportedCapabilities: [],
+      enabledCapabilities: [],
+    };
+    renderWithProviders(<ConnectionCapabilitiesPanel connection={connection} />);
+
+    expect(screen.getByText(/adapter is not recognized/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.tsx
@@ -1,0 +1,118 @@
+/**
+ * Connection Capabilities Panel
+ *
+ * Renders the adapter's supported capabilities as togglable checkboxes.
+ * Checked = enabled on this connection, unchecked = supported but disabled.
+ * Toggling fires the update-connection mutation with the new set.
+ *
+ * @module apps/web/src/features/connections/components
+ */
+import { useState, type ReactElement } from 'react';
+import type { Capability, Connection } from '../api/connections.types';
+import { useUpdateConnectionMutation } from '../hooks/use-update-connection-mutation';
+import { Alert } from '../../../shared/ui/alert';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+interface ConnectionCapabilitiesPanelProps {
+  connection: Connection;
+}
+
+const CAPABILITY_HELP: Record<Capability, string> = {
+  ProductMaster: 'Read the product catalog (variants, attributes, categories) from this connection.',
+  InventoryMaster: 'Read stock levels from this connection as the inventory source of truth.',
+  OrderProcessorManager: 'Create and manage orders in this connection (typically the destination shop).',
+  OrderSource: 'Fetch new orders from this connection (e.g. a marketplace).',
+  Marketplace: 'Manage offers and listings on this marketplace connection.',
+};
+
+export function ConnectionCapabilitiesPanel({
+  connection,
+}: ConnectionCapabilitiesPanelProps): ReactElement {
+  const updateMutation = useUpdateConnectionMutation();
+  const { showToast } = useToast();
+  const [pending, setPending] = useState<Capability | null>(null);
+
+  const supported = connection.supportedCapabilities;
+  const enabled = new Set(connection.enabledCapabilities);
+
+  async function handleToggle(capability: Capability, checked: boolean): Promise<void> {
+    const next = new Set(enabled);
+    if (checked) {
+      next.add(capability);
+    } else {
+      next.delete(capability);
+    }
+    setPending(capability);
+    try {
+      await updateMutation.mutateAsync({
+        connectionId: connection.id,
+        input: { enabledCapabilities: Array.from(next) },
+      });
+      showToast({
+        tone: 'success',
+        title: 'Capabilities updated',
+        description: `${capability} ${checked ? 'enabled' : 'disabled'}.`,
+      });
+    } catch {
+      // mutation.error renders via Alert below
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Capabilities</p>
+          <h3 className="section-title">Enabled roles</h3>
+        </div>
+        <span className="panel__meta">
+          {enabled.size} of {supported.length} enabled
+        </span>
+      </div>
+
+      {updateMutation.error ? (
+        <Alert tone="error" title="Unable to update capabilities">
+          {updateMutation.error.message}
+        </Alert>
+      ) : null}
+
+      {supported.length === 0 ? (
+        <p className="muted-text">
+          This connection\u2019s adapter is not recognized. Capability toggles are unavailable.
+        </p>
+      ) : (
+        <ul className="capability-list">
+          {supported.map((capability) => {
+            const id = `cap-${connection.id}-${capability}`;
+            const isChecked = enabled.has(capability);
+            return (
+              <li key={capability} className="capability-list__item">
+                <label htmlFor={id} className="capability-list__label">
+                  <input
+                    id={id}
+                    type="checkbox"
+                    checked={isChecked}
+                    disabled={pending === capability || updateMutation.isPending}
+                    onChange={(e) => void handleToggle(capability, e.target.checked)}
+                  />
+                  <span className="capability-list__name mono-text">{capability}</span>
+                </label>
+                <p className="capability-list__help muted-text">
+                  {CAPABILITY_HELP[capability]}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {enabled.size === 0 && supported.length > 0 ? (
+        <Alert tone="warning" title="No capabilities enabled">
+          This connection is inactive for every capability. No sync jobs will use it.
+        </Alert>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
@@ -1,9 +1,11 @@
-import { fireEvent, screen, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PrestashopSetupForm } from './prestashop-setup-form';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
 
 describe('PrestashopSetupForm', () => {
+  afterEach(cleanup);
+
   it('submits a PrestaShop connection with the inferred adapter key and config', async () => {
     const create = vi.fn().mockResolvedValue(sampleConnection);
     const apiClient = createMockApiClient({ connections: { create } });
@@ -27,7 +29,36 @@ describe('PrestashopSetupForm', () => {
       adapterKey: 'prestashop.webservice.v1',
       credentialsRef: 'WSKEY123',
       config: { baseUrl: 'https://shop.example.com' },
+      enabledCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager', 'OrderSource'],
     });
+  });
+
+  it('submits only the capabilities the user left checked', async () => {
+    const create = vi.fn().mockResolvedValue(sampleConnection);
+    const apiClient = createMockApiClient({ connections: { create } });
+    const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
+
+    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
+      target: { value: 'Dest only' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
+      target: { value: 'https://shop.example.com' },
+    });
+    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
+      target: { value: 'WSKEY123' },
+    });
+
+    // Uncheck OrderSource (this PrestaShop is order destination, not source)
+    fireEvent.click(within(view.container).getByRole('checkbox', { name: /OrderSource/ }));
+
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    await screen.findByText('Connection created');
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabledCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager'],
+      }),
+    );
   });
 
   it('includes shopId in config when provided', async () => {

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -12,12 +12,16 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
 import {
+  PRESTASHOP_ADAPTER_KEY,
+  PRESTASHOP_FALLBACK_CAPABILITIES,
   PRESTASHOP_SETUP_DEFAULT_VALUES,
   prestashopSetupSchema,
   toCreateConnectionInput,
   type PrestashopSetupFormSubmission,
   type PrestashopSetupFormValues,
 } from './prestashop-setup.schema';
+import type { Capability } from '../api/connections.types';
+import { useAdaptersQuery } from '../../adapters/hooks/use-adapters-query';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
@@ -25,13 +29,31 @@ import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { useToast } from '../../../shared/ui/toast-provider';
 
+const CAPABILITY_HELP: Record<Capability, string> = {
+  ProductMaster: 'Read the product catalog (variants, attributes, categories) from this shop.',
+  InventoryMaster: 'Read stock levels from this shop as the inventory source of truth.',
+  OrderProcessorManager: 'Create and manage orders in this shop (typically the order destination).',
+  OrderSource: 'Fetch new orders from this shop (disable if orders come from a marketplace instead).',
+  Marketplace: 'Manage offers and listings on this marketplace.',
+};
+
 export function PrestashopSetupForm(): ReactElement {
   const createConnection = useCreateConnectionMutation();
   const { showToast } = useToast();
+  const adaptersQuery = useAdaptersQuery();
   const form = useForm<PrestashopSetupFormValues, undefined, PrestashopSetupFormSubmission>({
     defaultValues: PRESTASHOP_SETUP_DEFAULT_VALUES,
     resolver: zodResolver(prestashopSetupSchema),
   });
+
+  // Prefer the live adapter registry as the source of truth for supported
+  // capabilities; fall back to a hardcoded list if the /adapters call fails so
+  // the wizard still works offline or under partial outage.
+  const adapterMetadata = adaptersQuery.data?.find(
+    (a) => a.adapterKey === PRESTASHOP_ADAPTER_KEY,
+  );
+  const supportedCapabilities: Capability[] =
+    adapterMetadata?.supportedCapabilities ?? PRESTASHOP_FALLBACK_CAPABILITIES;
 
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : [],
@@ -130,6 +152,35 @@ export function PrestashopSetupForm(): ReactElement {
           />
         </FormField>
       </div>
+
+      <fieldset className="capability-fieldset">
+        <legend className="capability-fieldset__legend">Capabilities</legend>
+        <p className="muted-text capability-fieldset__help">
+          Pick which roles this connection should fulfil. You can change this later on the
+          connection\u2019s detail page.
+        </p>
+        <ul className="capability-list">
+          {supportedCapabilities.map((capability) => {
+            const id = `new-cap-${capability}`;
+            return (
+              <li key={capability} className="capability-list__item">
+                <label htmlFor={id} className="capability-list__label">
+                  <input
+                    id={id}
+                    type="checkbox"
+                    value={capability}
+                    {...form.register('enabledCapabilities')}
+                  />
+                  <span className="capability-list__name mono-text">{capability}</span>
+                </label>
+                <p className="capability-list__help muted-text">
+                  {CAPABILITY_HELP[capability]}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      </fieldset>
 
       <div className="form-actions">
         <Button type="submit" disabled={createConnection.isPending}>

--- a/apps/web/src/features/connections/components/prestashop-setup.schema.ts
+++ b/apps/web/src/features/connections/components/prestashop-setup.schema.ts
@@ -14,9 +14,21 @@
  * in the connection payload.
  */
 import { z } from 'zod';
-import type { CreateConnectionInput } from '../api/connections.types';
+import type { Capability, CreateConnectionInput } from '../api/connections.types';
 
 export const PRESTASHOP_ADAPTER_KEY = 'prestashop.webservice.v1';
+
+/**
+ * Fallback set used only when the adapter registry cannot be queried (network
+ * failure, stale cache, etc.). The source of truth is the `/adapters` endpoint
+ * consumed by the wizard via `useAdaptersQuery`.
+ */
+export const PRESTASHOP_FALLBACK_CAPABILITIES: Capability[] = [
+  'ProductMaster',
+  'InventoryMaster',
+  'OrderProcessorManager',
+  'OrderSource',
+];
 
 export const prestashopSetupSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
@@ -28,6 +40,17 @@ export const prestashopSetupSchema = z.object({
     ),
   webserviceKey: z.string().trim().min(1, 'Webservice key is required'),
   shopId: z.string().trim().optional(),
+  enabledCapabilities: z
+    .array(
+      z.enum([
+        'ProductMaster',
+        'InventoryMaster',
+        'OrderProcessorManager',
+        'OrderSource',
+        'Marketplace',
+      ]),
+    )
+    .default(PRESTASHOP_FALLBACK_CAPABILITIES),
 });
 
 export type PrestashopSetupFormValues = z.input<typeof prestashopSetupSchema>;
@@ -38,6 +61,7 @@ export const PRESTASHOP_SETUP_DEFAULT_VALUES: PrestashopSetupFormValues = {
   baseUrl: '',
   webserviceKey: '',
   shopId: '',
+  enabledCapabilities: PRESTASHOP_FALLBACK_CAPABILITIES,
 };
 
 export function toCreateConnectionInput(
@@ -53,5 +77,6 @@ export function toCreateConnectionInput(
     adapterKey: PRESTASHOP_ADAPTER_KEY,
     credentialsRef: values.webserviceKey,
     config,
+    enabledCapabilities: values.enabledCapabilities,
   };
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1539,3 +1539,62 @@ textarea {
   color: var(--text-muted);
   font-size: 0.875rem;
 }
+
+.capability-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.capability-list__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.capability-list__item:last-child {
+  border-bottom: none;
+}
+
+.capability-list__label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.capability-list__name {
+  font-weight: 500;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+
+.capability-list__help {
+  margin: 0;
+  font-size: 0.8125rem;
+  padding-left: 1.5rem;
+}
+
+.capability-fieldset {
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin: 0;
+}
+
+.capability-fieldset__legend {
+  font-weight: 600;
+  font-size: 0.9375rem;
+  color: var(--text-primary);
+  padding: 0 0.5rem;
+}
+
+.capability-fieldset__help {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.8125rem;
+}

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
 import { ConnectionActionsPanel } from '../../features/connections/components/ConnectionActionsPanel';
+import { ConnectionCapabilitiesPanel } from '../../features/connections/components/ConnectionCapabilitiesPanel';
 import { ConnectionConfigPanel } from '../../features/connections/components/ConnectionConfigPanel';
 import { ConnectionDiagnosticsPanel } from '../../features/connections/components/ConnectionDiagnosticsPanel';
 import type { ConnectionStatus } from '../../features/connections/api/connections.types';
@@ -128,6 +129,7 @@ export function ConnectionDetailPage(): ReactElement {
           </div>
 
           <ConnectionConfigPanel config={connection.config} />
+          <ConnectionCapabilitiesPanel connection={connection} />
           <ConnectionDiagnosticsPanel connectionId={connection.id} />
           <ConnectionActionsPanel connection={connection} />
         </div>

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -28,6 +28,8 @@ export const sampleConnection: Connection = {
   },
   credentialsRef: 'db:cred_1',
   adapterKey: 'prestashop.webservice.v1',
+  enabledCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager', 'OrderSource'],
+  supportedCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager', 'OrderSource'],
   createdAt: '2026-01-01T00:00:00.000Z',
   updatedAt: '2026-01-01T00:00:00.000Z',
 };

--- a/docs/plans/implementation-plan-connection-enabled-capabilities.md
+++ b/docs/plans/implementation-plan-connection-enabled-capabilities.md
@@ -1,0 +1,44 @@
+# Connection `enabledCapabilities` (#166)
+
+## Goal
+
+Let users select which capabilities a connection should fulfil. Defaults to the adapter's full supported set; capability-based resolution filters by this field.
+
+## Decisions
+
+- **Source of truth**: `Connection.enabledCapabilities: Capability[]` persisted on the row.
+- **Default on create**: if the client omits the field, `ConnectionService.create` sets it to the adapter's `supportedCapabilities`.
+- **Validation**: on create + update, every value must be in `adapter.supportedCapabilities`.
+- **`adapterKey` immutable post-create**: update endpoint rejects any change to `adapterKey` (avoids "validate against which adapter" ambiguity).
+- **Backfill**: one-shot migration hardcodes the two known adapter mappings; unknown rows get `[]` with a `RAISE NOTICE`. Behavior-preserving: today every row implicitly has all caps.
+- **Runtime gate**: `IntegrationsService.getCapabilityAdapter` and `listCapabilityAdapters` additionally require `connection.enabledCapabilities.includes(capability)`.
+- **Exception**: `CapabilityNotEnabledException extends CapabilityNotSupportedException` — existing `instanceof` callers keep working; new callers can distinguish "enable it" vs "switch connection".
+- **Response DTO**: carries persisted `enabledCapabilities` + derived `supportedCapabilities` (resolved from registry at read time) so the detail page can render both checked and unchecked supported capabilities without a second request.
+
+## Follow-ups (explicitly deferred)
+
+- **Allegro wizard capability UI**: Allegro's only capability is `Marketplace`, and the wizard starts an OAuth redirect rather than a direct create, so the picker adds no user-visible value today. If additional Allegro capabilities appear, revisit.
+- **Object-param Connection constructor**: the positional 10-arg constructor is getting noisy; a follow-up PR should refactor to `new Connection({ ... })`.
+- **Cross-context coupling** (`Capability` in `integrations`, consumed by `Connection` entity in `identifier-mapping`): type-only import today, no runtime cycle. If another bounded context needs `Capability`, consider promoting it to a shared domain types module.
+
+## Non-goals
+- Per-org "default destination for capability X" pointer (deferred, see #166 open questions).
+- Bulk PATCH / capability toggling across multiple connections.
+- Boot-time backfill service.
+- Credentials store rework (#165).
+
+## Steps
+
+1. **Types**: add `enabledCapabilities: Capability[]` to `ConnectionCreate` / `ConnectionUpdate`.
+2. **Domain**: add field to `Connection` entity.
+3. **ORM**: add `enabledCapabilities` jsonb column to `ConnectionOrmEntity`.
+4. **Migration** `1780000000000-add-enabled-capabilities-to-connections.ts`: add column with `DEFAULT '[]'`, backfill by adapterKey (hardcoded mapping), log unknowns.
+5. **Repository**: map field in `toDomain` / `toOrm`; apply in `update`.
+6. **Exception**: new `CapabilityNotEnabledException`.
+7. **ConnectionService.create**: default `enabledCapabilities` from registry when omitted; validate subset.
+8. **ConnectionService.update**: reject `adapterKey` changes; validate subset for `enabledCapabilities`.
+9. **IntegrationsService**: add `enabledCapabilities` gate in both `getCapabilityAdapter` + `listCapabilityAdapters`.
+10. **DTOs**: input `enabledCapabilities?: Capability[]`; response includes persisted + derived supported set.
+11. **Backend tests**: update existing specs; add cases for disabled capability, adapterKey-immutable, invalid capability on create.
+12. **Frontend**: `Connection` type gains `enabledCapabilities` + `supportedCapabilities`; wizard shows capability checkboxes (pre-checked to supported); detail page renders `ConnectionCapabilitiesPanel` with toggle calling the existing update mutation.
+13. **Quality gate**: lint, type-check, unit tests.

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts
@@ -67,6 +67,8 @@ describe('IdentifierMappingService', () => {
       'credentials-ref',
       new Date(),
       new Date(),
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
     );
 
     beforeEach(() => {
@@ -223,6 +225,8 @@ describe('IdentifierMappingService', () => {
       'credentials-ref',
       new Date(),
       new Date(),
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
     );
 
     beforeEach(() => {
@@ -318,6 +322,8 @@ describe('IdentifierMappingService', () => {
       'credentials-ref',
       new Date(),
       new Date(),
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
     );
 
     beforeEach(() => {
@@ -381,6 +387,8 @@ describe('IdentifierMappingService', () => {
         'credentials-ref',
         new Date(),
         new Date(),
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
       const connection2 = new Connection(
         'connection-2',
@@ -391,6 +399,8 @@ describe('IdentifierMappingService', () => {
         'credentials-ref',
         new Date(),
         new Date(),
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       // batchGetOrCreateInternalIds deduplicates connectionIds and calls get() once per unique ID

--- a/libs/core/src/identifier-mapping/domain/entities/connection.entity.ts
+++ b/libs/core/src/identifier-mapping/domain/entities/connection.entity.ts
@@ -3,9 +3,10 @@
  *
  * Represents a configured integration instance (e.g., a specific PrestaShop store,
  * a specific Allegro account). This entity encapsulates platform-specific
- * configuration, credentials reference, status, and optional adapter key for
- * adapter resolution. Used by the identifier mapping service to resolve platform
- * type from connection ID and by the integrations service for adapter resolution.
+ * configuration, credentials reference, status, optional adapter key, and the
+ * set of capabilities the operator has enabled for this connection. Used by the
+ * identifier mapping service to resolve platform type from connection ID and by
+ * the integrations service for adapter resolution.
  *
  * @module libs/core/src/identifier-mapping/domain/entities
  * @see {@link ConnectionPort} for the port interface
@@ -15,6 +16,7 @@ import {
   ConnectionStatus,
   ConnectionConfig,
 } from '../types/connection.types';
+import type { Capability } from '@openlinker/core/integrations/domain/types/adapter.types';
 
 export class Connection {
   constructor(
@@ -26,9 +28,7 @@ export class Connection {
     public readonly credentialsRef: string,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
-    public readonly adapterKey?: string,
+    public readonly adapterKey: string | undefined,
+    public readonly enabledCapabilities: Capability[],
   ) {}
 }
-
-
-

--- a/libs/core/src/identifier-mapping/domain/types/connection.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/connection.types.ts
@@ -7,6 +7,7 @@
  *
  * @module libs/core/src/identifier-mapping/domain/types
  */
+import type { Capability } from '@openlinker/core/integrations/domain/types/adapter.types';
 
 /**
  * Platform type identifier (e.g., 'prestashop', 'allegro', 'shopify')
@@ -54,6 +55,12 @@ export interface ConnectionCreate {
   config: ConnectionConfig;
   credentialsRef: string;
   adapterKey?: string;
+  /**
+   * Capabilities this connection should fulfil. Subset of the resolved adapter's
+   * supportedCapabilities. When omitted at create time, ConnectionService defaults
+   * this to the adapter's full supported set (behavior-preserving).
+   */
+  enabledCapabilities?: Capability[];
 }
 
 /**
@@ -66,7 +73,13 @@ export interface ConnectionUpdate {
   name?: string;
   status?: ConnectionStatus;
   config?: ConnectionConfig;
+  /**
+   * `adapterKey` is immutable post-create. Passing a value different from the
+   * persisted one must cause ConnectionService.update to throw. Kept optional
+   * here so existing callers that pass the unchanged value still type-check.
+   */
   adapterKey?: string;
+  enabledCapabilities?: Capability[];
 }
 
 /**

--- a/libs/core/src/identifier-mapping/infrastructure/persistence/entities/connection.orm-entity.ts
+++ b/libs/core/src/identifier-mapping/infrastructure/persistence/entities/connection.orm-entity.ts
@@ -43,6 +43,9 @@ export class ConnectionOrmEntity {
   @Column({ nullable: true })
   adapterKey?: string;
 
+  @Column({ type: 'jsonb', default: () => "'[]'" })
+  enabledCapabilities!: string[];
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/connection.repository.spec.ts
+++ b/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/connection.repository.spec.ts
@@ -31,6 +31,7 @@ describe('ConnectionRepository', () => {
     config: { baseUrl: 'https://example.com' },
     credentialsRef: 'cred_123',
     adapterKey: 'prestashop.webservice.v1',
+    enabledCapabilities: ['ProductMaster'],
     createdAt: new Date('2025-01-01'),
     updatedAt: new Date('2025-01-01'),
   };
@@ -45,6 +46,7 @@ describe('ConnectionRepository', () => {
     new Date('2025-01-01'),
     new Date('2025-01-01'),
     'prestashop.webservice.v1',
+    ['ProductMaster'],
   );
 
   beforeEach(async () => {
@@ -160,6 +162,7 @@ describe('ConnectionRepository', () => {
         platformType: 'prestashop',
         config: { baseUrl: 'https://new.com' },
         credentialsRef: 'cred_new',
+        enabledCapabilities: ['ProductMaster'],
       };
 
       const savedEntity = {
@@ -185,6 +188,7 @@ describe('ConnectionRepository', () => {
         config: {},
         credentialsRef: 'cred_new',
         adapterKey: 'prestashop.webservice.v2',
+        enabledCapabilities: ['ProductMaster'],
       };
 
       const savedEntity = {

--- a/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/connection.repository.ts
+++ b/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/connection.repository.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../domain/types/connection.types';
 import { ConnectionNotFoundException } from '../../../domain/exceptions/connection-not-found.exception';
 import { Logger } from '@openlinker/shared/logging';
+import type { Capability } from '@openlinker/core/integrations/domain/types/adapter.types';
 
 @Injectable()
 export class ConnectionRepository implements ConnectionPort {
@@ -115,6 +116,9 @@ export class ConnectionRepository implements ConnectionPort {
     if (patch.adapterKey !== undefined) {
       existing.adapterKey = patch.adapterKey;
     }
+    if (patch.enabledCapabilities !== undefined) {
+      existing.enabledCapabilities = patch.enabledCapabilities;
+    }
 
       // Save updated entity
       const saved = await this.repository.save(existing);
@@ -149,6 +153,7 @@ export class ConnectionRepository implements ConnectionPort {
       entity.createdAt,
       entity.updatedAt,
       entity.adapterKey,
+      (entity.enabledCapabilities ?? []) as Capability[],
     );
   }
 
@@ -166,6 +171,7 @@ export class ConnectionRepository implements ConnectionPort {
       entity.config = payload.config;
       entity.credentialsRef = payload.credentialsRef;
       entity.adapterKey = payload.adapterKey;
+      entity.enabledCapabilities = payload.enabledCapabilities;
       entity.createdAt = payload.createdAt;
       entity.updatedAt = payload.updatedAt;
     } else {
@@ -176,6 +182,12 @@ export class ConnectionRepository implements ConnectionPort {
       entity.config = payload.config;
       entity.credentialsRef = payload.credentialsRef;
       entity.adapterKey = payload.adapterKey;
+      if (payload.enabledCapabilities === undefined) {
+        throw new Error(
+          'ConnectionCreate.enabledCapabilities must be set by ConnectionService before reaching the repository',
+        );
+      }
+      entity.enabledCapabilities = payload.enabledCapabilities;
     }
 
     return entity;

--- a/libs/core/src/integrations/application/interfaces/integrations.service.interface.ts
+++ b/libs/core/src/integrations/application/interfaces/integrations.service.interface.ts
@@ -60,6 +60,20 @@ export interface IIntegrationsService {
    * @param filters - Filter criteria (capability required, platformType optional)
    * @returns Array of objects containing connectionId, connection, adapter, and metadata
    */
+  /**
+   * Resolve adapter metadata by platformType and optional explicit adapterKey.
+   *
+   * Used during connection creation (before the connection exists) to determine
+   * defaults for fields like `enabledCapabilities`. Mirrors the adapterKey
+   * derivation used by getAdapter() but does not require a persisted connection.
+   *
+   * @throws AdapterNotFoundException if no adapter matches
+   */
+  resolveAdapterMetadata(params: {
+    platformType: string;
+    adapterKey?: string;
+  }): Promise<AdapterMetadata>;
+
   listCapabilityAdapters<T>(filters: {
     capability: Capability;
     platformType?: string;

--- a/libs/core/src/integrations/application/services/integrations.service.spec.ts
+++ b/libs/core/src/integrations/application/services/integrations.service.spec.ts
@@ -40,6 +40,9 @@ describe('IntegrationsService', () => {
     'cred_123',
     new Date(),
     new Date(),
+  
+    undefined,
+    ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
   );
 
   const mockAdapterMetadata: AdapterMetadata = {
@@ -129,6 +132,7 @@ describe('IntegrationsService', () => {
         new Date(),
         new Date(),
         'prestashop.webservice.v1',
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager'],
       );
 
       connectionPort.get.mockResolvedValue(connectionWithKey);
@@ -178,6 +182,9 @@ describe('IntegrationsService', () => {
         'cred_123',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       connectionPort.get.mockResolvedValue(disabledConnection);
@@ -242,6 +249,9 @@ describe('IntegrationsService', () => {
         'cred_1',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       const allegroConnection = new Connection(
@@ -253,6 +263,9 @@ describe('IntegrationsService', () => {
         'cred_2',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       // Mock both adapters to support the same capability for testing purposes
@@ -305,6 +318,9 @@ describe('IntegrationsService', () => {
         'cred_1',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       const prestashopMetadata: AdapterMetadata = {
@@ -342,6 +358,9 @@ describe('IntegrationsService', () => {
         'cred_1',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       // connectionPort.list is called with { status: 'active' } filter,
@@ -380,6 +399,9 @@ describe('IntegrationsService', () => {
         'cred_1',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       const invalidConnection = new Connection(
@@ -391,6 +413,9 @@ describe('IntegrationsService', () => {
         'cred_2',
         new Date(),
         new Date(),
+      
+        undefined,
+        ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
       );
 
       connectionPort.list.mockResolvedValue([validConnection, invalidConnection]);

--- a/libs/core/src/integrations/application/services/integrations.service.ts
+++ b/libs/core/src/integrations/application/services/integrations.service.ts
@@ -28,6 +28,7 @@ import {
 } from '../../integrations.tokens';
 import { AdapterNotFoundException } from '../../domain/exceptions/adapter-not-found.exception';
 import { CapabilityNotSupportedException } from '../../domain/exceptions/capability-not-supported.exception';
+import { CapabilityNotEnabledException } from '../../domain/exceptions/capability-not-enabled.exception';
 import { AdapterFactoryResolverService } from '../../infrastructure/adapters/adapter-factory-resolver.service';
 import { CredentialsResolverPort } from '../../domain/ports/credentials-resolver.port';
 import { Logger } from '@openlinker/shared/logging';
@@ -96,12 +97,20 @@ export class IntegrationsService implements IIntegrationsService {
 
     const { connection, metadata } = await this.getAdapter(connectionId);
 
-    // Validate capability support
+    // Validate capability support (adapter level)
     if (!metadata.supportedCapabilities.includes(capability)) {
       this.logger.warn(
         `Capability ${capability} not supported by adapter ${metadata.adapterKey} (supported: ${metadata.supportedCapabilities.join(', ')})`,
       );
       throw new CapabilityNotSupportedException(metadata.adapterKey, capability);
+    }
+
+    // Validate capability is enabled on this specific connection
+    if (!connection.enabledCapabilities.includes(capability)) {
+      this.logger.warn(
+        `Capability ${capability} disabled on connection ${connectionId} (enabled: ${connection.enabledCapabilities.join(', ') || '<none>'})`,
+      );
+      throw new CapabilityNotEnabledException(connectionId, metadata.adapterKey, capability);
     }
 
     // Try to create adapter using factory resolver
@@ -143,6 +152,14 @@ export class IntegrationsService implements IIntegrationsService {
     return adapter as T;
   }
 
+  async resolveAdapterMetadata(params: {
+    platformType: string;
+    adapterKey?: string;
+  }): Promise<AdapterMetadata> {
+    const adapterKey = params.adapterKey ?? this.deriveAdapterKey(params.platformType);
+    return this.adapterRegistry.getAdapterMetadata(adapterKey);
+  }
+
   async listCapabilityAdapters<T>(filters: {
     capability: Capability;
     platformType?: string;
@@ -182,8 +199,11 @@ export class IntegrationsService implements IIntegrationsService {
 
         const metadata = await this.adapterRegistry.getAdapterMetadata(adapterKey);
 
-        // Filter to only connections whose adapter supports the requested capability
-        if (metadata.supportedCapabilities.includes(filters.capability)) {
+        // Filter to only connections whose adapter supports AND whose operator
+        // has enabled the requested capability on this connection.
+        const adapterSupports = metadata.supportedCapabilities.includes(filters.capability);
+        const connectionEnabled = connection.enabledCapabilities.includes(filters.capability);
+        if (adapterSupports && connectionEnabled) {
           // Try to create adapter using factory resolver (mirrors getCapabilityAdapter logic)
           // If factory is not registered, fall back to placeholder from registry
           let adapter: T | null = null;
@@ -236,9 +256,13 @@ export class IntegrationsService implements IIntegrationsService {
               `Connection ${connection.id} supports ${filters.capability} (adapter: ${adapterKey})`,
             );
           }
-        } else {
+        } else if (!adapterSupports) {
           this.logger.debug(
             `Connection ${connection.id} does not support ${filters.capability} (adapter: ${adapterKey}, supported: ${metadata.supportedCapabilities.join(', ')})`,
+          );
+        } else {
+          this.logger.debug(
+            `Connection ${connection.id} has ${filters.capability} disabled (adapter supports it; enabled: ${connection.enabledCapabilities.join(', ') || '<none>'})`,
           );
         }
       } catch (error) {

--- a/libs/core/src/integrations/domain/exceptions/capability-not-enabled.exception.ts
+++ b/libs/core/src/integrations/domain/exceptions/capability-not-enabled.exception.ts
@@ -1,0 +1,26 @@
+/**
+ * Capability Not Enabled Exception
+ *
+ * Thrown when an adapter supports a capability but the operator has not
+ * enabled it for this specific connection. Extends CapabilityNotSupportedException
+ * so existing `instanceof` callers continue to catch both cases; new callers
+ * that want to distinguish "not supported by adapter" from "disabled on this
+ * connection" can catch this subtype explicitly.
+ *
+ * @module libs/core/src/integrations/domain/exceptions
+ */
+import { Capability } from '../types/adapter.types';
+import { CapabilityNotSupportedException } from './capability-not-supported.exception';
+
+export class CapabilityNotEnabledException extends CapabilityNotSupportedException {
+  constructor(
+    public readonly connectionId: string,
+    adapterKey: string,
+    capability: Capability,
+  ) {
+    super(adapterKey, capability);
+    this.message = `Connection ${connectionId} has capability ${capability} disabled (adapter ${adapterKey} supports it)`;
+    this.name = 'CapabilityNotEnabledException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -55,6 +55,7 @@ export type { MarketplaceCategory } from './domain/types/marketplace-category.ty
 // Exceptions
 export { AdapterNotFoundException } from './domain/exceptions/adapter-not-found.exception';
 export { CapabilityNotSupportedException } from './domain/exceptions/capability-not-supported.exception';
+export { CapabilityNotEnabledException } from './domain/exceptions/capability-not-enabled.exception';
 export { CredentialNotFoundException } from './domain/exceptions/credential-not-found.exception';
 
 // Tokens

--- a/libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts
@@ -128,6 +128,8 @@ describe('OfferMappingSyncService', () => {
         status: 'active',
         config: {},
         credentialsRef: 'cred',
+        adapterKey: undefined,
+        enabledCapabilities: ['Marketplace'],
         createdAt: new Date(),
         updatedAt: new Date(),
       },

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
@@ -52,6 +52,9 @@ describe('AllegroMarketplaceAdapter', () => {
       'credentials-ref',
       new Date(),
       new Date(),
+    
+      undefined,
+      ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager', 'Marketplace'],
     );
 
     adapter = new AllegroMarketplaceAdapter(connectionId, httpClient, identifierMapping, connection);

--- a/libs/integrations/prestashop/src/application/__tests__/prestashop-adapter.factory.spec.ts
+++ b/libs/integrations/prestashop/src/application/__tests__/prestashop-adapter.factory.spec.ts
@@ -45,6 +45,8 @@ describe('PrestashopAdapterFactory', () => {
           ...config,
         },
         credentialsRef: 'test_credentials',
+        adapterKey: undefined,
+        enabledCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager'],
         createdAt: new Date(),
         updatedAt: new Date(),
       } as Connection;


### PR DESCRIPTION
## Summary
- `Connection` gains `enabledCapabilities: Capability[]` — operator-chosen subset of the adapter's supported set; defaults to full supported set on create and is validated as a subset at create + PATCH.
- `IntegrationsService.getCapabilityAdapter` / `listCapabilityAdapters` now gate on `enabledCapabilities` in addition to adapter support. New `CapabilityNotEnabledException extends CapabilityNotSupportedException` preserves existing `instanceof` catches.
- `adapterKey` is now immutable post-create.
- Response DTO carries persisted `enabledCapabilities` + derived `supportedCapabilities` so the FE can render both checked and unchecked supported capabilities in one request.
- PrestaShop wizard shows a capability picker (fetches `/adapters` live; static fallback on registry failure). Connection detail page has a `ConnectionCapabilitiesPanel` to toggle capabilities after creation.

## Migration
Adds `"enabledCapabilities" jsonb NOT NULL DEFAULT '[]'` + GIN index, backfills existing rows by known `adapterKey` / `platformType`. Behavior-preserving: every pre-existing connection keeps all capabilities. Unknown rows stay at `[]` and are flagged via `RAISE NOTICE`.

Run `pnpm --filter @openlinker/api migration:run` before testing.

## Deferred follow-ups (documented in plan doc)
- Allegro wizard capability picker (Allegro currently exposes only `Marketplace`; OAuth-start flow doesn't take create params directly).
- Object-param `Connection` constructor refactor — positional 10-arg signature is noisy.
- Cross-context coupling: `Capability` lives in `integrations`, imported as `type` by `identifier-mapping` domain. No runtime cycle; worth an ADR if a third context needs it.

## Test plan
- [x] `pnpm lint && pnpm type-check && pnpm test` green (backend 709 tests, web 149)
- [x] New integration test `connection-capabilities.int-spec.ts` covers: default caps, explicit subset, rejection of unsupported cap, PATCH narrow, `adapterKey` immutable, PATCH reject unsupported
- [x] New FE tests: capability panel toggle + mutation error; wizard uncheck submits narrowed set
- [ ] Manual: fresh `docker compose down -v && pnpm dev:stack:up && migration:run` then create a PrestaShop connection with `OrderSource` unchecked and verify `listCapabilityAdapters({ capability: 'OrderSource' })` excludes it

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)