### PR TITLE
fix(connections): persist credentials in integration_credentials store

### DIFF
--- a/apps/api/src/integrations/application/credentials/credential-shape.validator.ts
+++ b/apps/api/src/integrations/application/credentials/credential-shape.validator.ts
@@ -1,0 +1,25 @@
+/**
+ * Credential Shape Validator
+ *
+ * Per-platform validation of the raw `credentials` payload submitted on
+ * connection create / rotation. Enforces the minimum fields each adapter
+ * requires before we persist arbitrary user-supplied JSON into the
+ * credentials store.
+ *
+ * @module apps/api/src/integrations/application/credentials
+ */
+import { BadRequestException } from '@nestjs/common';
+
+export function validateCredentialsShape(
+  platformType: string,
+  credentials: Record<string, unknown>,
+): void {
+  if (platformType === 'prestashop') {
+    const key = credentials.webserviceApiKey;
+    if (typeof key !== 'string' || key.trim().length === 0) {
+      throw new BadRequestException(
+        'PrestaShop credentials must include a non-empty `webserviceApiKey` string',
+      );
+    }
+  }
+}

--- a/apps/api/src/integrations/application/interfaces/connection.service.interface.ts
+++ b/apps/api/src/integrations/application/interfaces/connection.service.interface.ts
@@ -9,13 +9,26 @@
  */
 import { Connection, ConnectionCreate, ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier-mapping';
 
+/**
+ * Connection create input accepted by the API service.
+ *
+ * Extends the core `ConnectionCreate` with an optional `credentials` payload.
+ * When `credentials` is supplied, the service persists it in the integration
+ * credentials store and sets `credentialsRef` to the resulting `db:<uuid>`
+ * automatically. Exactly one of `credentials` or `credentialsRef` must be set.
+ */
+export type ConnectionCreateInput = Omit<ConnectionCreate, 'credentialsRef'> & {
+  credentialsRef?: string;
+  credentials?: Record<string, unknown>;
+};
+
 export interface IConnectionService {
   /**
    * Create a new connection
    * @param payload - Connection creation payload
    * @returns Created Connection entity
    */
-  create(payload: ConnectionCreate): Promise<Connection>;
+  create(payload: ConnectionCreateInput): Promise<Connection>;
 
   /**
    * List connections with optional filters
@@ -40,14 +53,21 @@ export interface IConnectionService {
   update(connectionId: string, patch: ConnectionUpdate): Promise<Connection>;
 
   /**
+   * Rotate the credentials stored for a connection. Writes to the credential
+   * row referenced by `credentialsRef`; the connection row is not modified.
+   *
+   * @param connectionId - The connection identifier (UUID)
+   * @param credentials - Platform-specific credential payload (replaces stored value)
+   */
+  updateCredentials(
+    connectionId: string,
+    credentials: Record<string, unknown>,
+  ): Promise<void>;
+
+  /**
    * Disable a connection
    * @param connectionId - The connection identifier (UUID)
    * @returns Disabled Connection entity or throws if not found
    */
   disable(connectionId: string): Promise<Connection>;
 }
-
-
-
-
-

--- a/apps/api/src/integrations/application/interfaces/connection.service.interface.ts
+++ b/apps/api/src/integrations/application/interfaces/connection.service.interface.ts
@@ -7,20 +7,10 @@
  * @module apps/api/src/integrations/application/interfaces
  * @see {@link ConnectionService} for the implementation
  */
-import { Connection, ConnectionCreate, ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier-mapping';
+import { Connection, ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier-mapping';
+import { ConnectionCreateInput } from './connection.service.types';
 
-/**
- * Connection create input accepted by the API service.
- *
- * Extends the core `ConnectionCreate` with an optional `credentials` payload.
- * When `credentials` is supplied, the service persists it in the integration
- * credentials store and sets `credentialsRef` to the resulting `db:<uuid>`
- * automatically. Exactly one of `credentials` or `credentialsRef` must be set.
- */
-export type ConnectionCreateInput = Omit<ConnectionCreate, 'credentialsRef'> & {
-  credentialsRef?: string;
-  credentials?: Record<string, unknown>;
-};
+export type { ConnectionCreateInput };
 
 export interface IConnectionService {
   /**

--- a/apps/api/src/integrations/application/interfaces/connection.service.types.ts
+++ b/apps/api/src/integrations/application/interfaces/connection.service.types.ts
@@ -1,0 +1,22 @@
+/**
+ * Connection Service Types
+ *
+ * Input/output types for the API-layer ConnectionService. Kept separate from
+ * the interface and implementation per engineering-standards.md.
+ *
+ * @module apps/api/src/integrations/application/interfaces
+ */
+import { ConnectionCreate } from '@openlinker/core/identifier-mapping';
+
+/**
+ * Connection create input accepted by the API service.
+ *
+ * Extends the core `ConnectionCreate` with an optional `credentials` payload.
+ * When `credentials` is supplied, the service persists it in the integration
+ * credentials store and sets `credentialsRef` to the resulting `db:<uuid>`
+ * automatically. Exactly one of `credentials` or `credentialsRef` must be set.
+ */
+export type ConnectionCreateInput = Omit<ConnectionCreate, 'credentialsRef'> & {
+  credentialsRef?: string;
+  credentials?: Record<string, unknown>;
+};

--- a/apps/api/src/integrations/application/services/connection.service.spec.ts
+++ b/apps/api/src/integrations/application/services/connection.service.spec.ts
@@ -24,7 +24,7 @@ import {
   INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
 } from '@openlinker/core/integrations';
 import { JobEnqueuePort, JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
-import { ConnectionCreateInput } from '../interfaces/connection.service.interface';
+import { ConnectionCreateInput } from '../interfaces/connection.service.types';
 
 describe('ConnectionService', () => {
   let service: ConnectionService;

--- a/apps/api/src/integrations/application/services/connection.service.spec.ts
+++ b/apps/api/src/integrations/application/services/connection.service.spec.ts
@@ -14,21 +14,24 @@ import {
   CONNECTION_PORT_TOKEN,
   Connection,
   ConnectionNotFoundException,
-  ConnectionCreate,
   ConnectionUpdate,
   ConnectionFilters,
 } from '@openlinker/core/identifier-mapping';
 import {
   IIntegrationsService,
   INTEGRATIONS_SERVICE_TOKEN,
+  IntegrationCredentialRepositoryPort,
+  INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
 } from '@openlinker/core/integrations';
 import { JobEnqueuePort, JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
+import { ConnectionCreateInput } from '../interfaces/connection.service.interface';
 
 describe('ConnectionService', () => {
   let service: ConnectionService;
   let connectionPort: jest.Mocked<ConnectionPort>;
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+  let credentialRepository: jest.Mocked<IntegrationCredentialRepositoryPort>;
 
   const mockConnection = new Connection(
     'connection-123',
@@ -72,12 +75,30 @@ describe('ConnectionService', () => {
       enqueueJob: jest.fn().mockResolvedValue({ jobId: 'job-1', isExisting: false }),
     } as unknown as jest.Mocked<JobEnqueuePort>;
 
+    const mockCredentialRepository = {
+      getByRef: jest.fn(),
+      create: jest.fn().mockImplementation((payload: { ref: string; platformType: string; credentialsJson: Record<string, unknown> }) =>
+        Promise.resolve({
+          id: 'cred-row-1',
+          ref: payload.ref,
+          platformType: payload.platformType,
+          credentialsJson: payload.credentialsJson,
+          encrypted: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      ),
+      update: jest.fn(),
+      delete: jest.fn().mockResolvedValue(true),
+    } as unknown as jest.Mocked<IntegrationCredentialRepositoryPort>;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ConnectionService,
         { provide: CONNECTION_PORT_TOKEN, useValue: mockConnectionPort },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: mockIntegrationsService },
         { provide: JOB_ENQUEUE_TOKEN, useValue: mockJobEnqueue },
+        { provide: INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN, useValue: mockCredentialRepository },
       ],
     }).compile();
 
@@ -85,14 +106,15 @@ describe('ConnectionService', () => {
     connectionPort = module.get(CONNECTION_PORT_TOKEN);
     integrationsService = module.get(INTEGRATIONS_SERVICE_TOKEN);
     jobEnqueue = module.get(JOB_ENQUEUE_TOKEN);
+    credentialRepository = module.get(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN);
   });
 
   describe('create', () => {
-    const payload: ConnectionCreate = {
+    const payload: ConnectionCreateInput = {
       name: 'New Connection',
       platformType: 'prestashop',
       config: { baseUrl: 'https://new.com' },
-      credentialsRef: 'cred_new',
+      credentialsRef: 'db:existing-ref',
     };
 
     it('should create and return connection', async () => {
@@ -107,6 +129,83 @@ describe('ConnectionService', () => {
           enabledCapabilities: expect.any(Array),
         }),
       );
+      expect(credentialRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject raw-key credentialsRef without db: prefix', async () => {
+      await expect(
+        service.create({ ...payload, credentialsRef: 'RAW_KEY_XYZ' }),
+      ).rejects.toThrow(/must start with "db:"/);
+      expect(connectionPort.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject when both credentials and credentialsRef are provided', async () => {
+      await expect(
+        service.create({
+          ...payload,
+          credentials: { webserviceApiKey: 'X' },
+        }),
+      ).rejects.toThrow(/Exactly one of/);
+    });
+
+    it('should reject when neither credentials nor credentialsRef are provided', async () => {
+      const rest: ConnectionCreateInput = { ...payload };
+      delete rest.credentialsRef;
+      await expect(service.create(rest)).rejects.toThrow(/Exactly one of/);
+    });
+
+    it('should persist credentials and store db: ref when credentials payload is provided', async () => {
+      connectionPort.create.mockResolvedValue(mockConnection);
+
+      await service.create({
+        name: 'Wizard Connection',
+        platformType: 'prestashop',
+        config: { baseUrl: 'https://new.com' },
+        credentials: { webserviceApiKey: 'SECRET123' },
+      });
+
+      expect(credentialRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platformType: 'prestashop',
+          credentialsJson: { webserviceApiKey: 'SECRET123' },
+          ref: expect.any(String),
+        }),
+      );
+      const credentialCall = credentialRepository.create.mock.calls[0][0];
+      expect(connectionPort.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentialsRef: `db:${credentialCall.ref}`,
+        }),
+      );
+    });
+
+    it('should reject PrestaShop credentials missing webserviceApiKey', async () => {
+      await expect(
+        service.create({
+          name: 'Wizard Connection',
+          platformType: 'prestashop',
+          config: { baseUrl: 'https://new.com' },
+          credentials: { someOtherField: 'X' },
+        }),
+      ).rejects.toThrow(/webserviceApiKey/);
+      expect(credentialRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should roll back the credential row if connection creation fails', async () => {
+      connectionPort.create.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        service.create({
+          name: 'Wizard Connection',
+          platformType: 'prestashop',
+          config: { baseUrl: 'https://new.com' },
+          credentials: { webserviceApiKey: 'SECRET123' },
+        }),
+      ).rejects.toThrow(/boom/);
+
+      expect(credentialRepository.create).toHaveBeenCalledTimes(1);
+      const createdRef = credentialRepository.create.mock.calls[0][0].ref;
+      expect(credentialRepository.delete).toHaveBeenCalledWith(createdRef);
     });
 
     it('should enqueue master.product.syncAll when adapter supports ProductMaster', async () => {
@@ -224,6 +323,51 @@ describe('ConnectionService', () => {
       await expect(
         service.update('connection-123', { name: 'Updated' }),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateCredentials', () => {
+    it('should rotate credentials for a db-backed connection', async () => {
+      const dbConnection = new Connection(
+        'connection-123',
+        'prestashop',
+        'Test Connection',
+        'active',
+        {},
+        'db:cred-ref-1',
+        new Date(),
+        new Date(),
+        undefined,
+        ['ProductMaster'],
+      );
+      connectionPort.get.mockResolvedValue(dbConnection);
+
+      await service.updateCredentials('connection-123', { webserviceApiKey: 'NEW' });
+
+      expect(credentialRepository.update).toHaveBeenCalledWith('cred-ref-1', {
+        credentialsJson: { webserviceApiKey: 'NEW' },
+      });
+    });
+
+    it('should reject rotation on non-db-backed connection', async () => {
+      const legacy = new Connection(
+        'connection-123',
+        'prestashop',
+        'Test Connection',
+        'active',
+        {},
+        'LEGACY_RAW_KEY',
+        new Date(),
+        new Date(),
+        undefined,
+        ['ProductMaster'],
+      );
+      connectionPort.get.mockResolvedValue(legacy);
+
+      await expect(
+        service.updateCredentials('connection-123', { webserviceApiKey: 'NEW' }),
+      ).rejects.toThrow(/does not have a db-backed/);
+      expect(credentialRepository.update).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/integrations/application/services/connection.service.ts
+++ b/apps/api/src/integrations/application/services/connection.service.ts
@@ -12,7 +12,9 @@
  */
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
-import { IConnectionService, ConnectionCreateInput } from '../interfaces/connection.service.interface';
+import { IConnectionService } from '../interfaces/connection.service.interface';
+import { ConnectionCreateInput } from '../interfaces/connection.service.types';
+import { validateCredentialsShape } from '../credentials/credential-shape.validator';
 import {
   ConnectionPort,
   Connection,
@@ -280,20 +282,3 @@ export class ConnectionService implements IConnectionService {
   }
 }
 
-/**
- * Enforce the minimum credential shape required by each platform before we
- * persist arbitrary user-supplied JSON into the credentials store.
- */
-function validateCredentialsShape(
-  platformType: string,
-  credentials: Record<string, unknown>,
-): void {
-  if (platformType === 'prestashop') {
-    const key = credentials.webserviceApiKey;
-    if (typeof key !== 'string' || key.trim().length === 0) {
-      throw new BadRequestException(
-        'PrestaShop credentials must include a non-empty `webserviceApiKey` string',
-      );
-    }
-  }
-}

--- a/apps/api/src/integrations/application/services/connection.service.ts
+++ b/apps/api/src/integrations/application/services/connection.service.ts
@@ -11,11 +11,11 @@
  * @see {@link ConnectionPort} for the core port
  */
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { IConnectionService } from '../interfaces/connection.service.interface';
+import { randomUUID } from 'node:crypto';
+import { IConnectionService, ConnectionCreateInput } from '../interfaces/connection.service.interface';
 import {
   ConnectionPort,
   Connection,
-  ConnectionCreate,
   ConnectionUpdate,
   ConnectionFilters,
   CONNECTION_PORT_TOKEN,
@@ -24,6 +24,8 @@ import {
 import {
   IIntegrationsService,
   INTEGRATIONS_SERVICE_TOKEN,
+  IntegrationCredentialRepositoryPort,
+  INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
 } from '@openlinker/core/integrations';
 import {
   JobEnqueuePort,
@@ -44,22 +46,34 @@ export class ConnectionService implements IConnectionService {
     private readonly integrationsService: IIntegrationsService,
     @Inject(JOB_ENQUEUE_TOKEN)
     private readonly jobEnqueue: JobEnqueuePort,
+    @Inject(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN)
+    private readonly credentialRepository: IntegrationCredentialRepositoryPort,
   ) {}
 
-  async create(payload: ConnectionCreate): Promise<Connection> {
-    try {
-      this.logger.log(`Creating connection: ${payload.name} (platform: ${payload.platformType})`);
+  async create(payload: ConnectionCreateInput): Promise<Connection> {
+    const { credentials, credentialsRef, ...rest } = payload;
 
-      // Resolve adapter metadata to (a) default enabledCapabilities when the
-      // caller omits them and (b) validate any explicit subset against the
-      // adapter's supportedCapabilities.
+    if ((credentials && credentialsRef) || (!credentials && !credentialsRef)) {
+      throw new BadRequestException(
+        'Exactly one of `credentials` or `credentialsRef` must be provided',
+      );
+    }
+    if (credentialsRef && !credentialsRef.startsWith('db:')) {
+      throw new BadRequestException(
+        'credentialsRef must start with "db:" — raw keys are no longer accepted',
+      );
+    }
+
+    try {
+      this.logger.log(`Creating connection: ${rest.name} (platform: ${rest.platformType})`);
+
       const metadata = await this.integrationsService.resolveAdapterMetadata({
-        platformType: payload.platformType,
-        adapterKey: payload.adapterKey,
+        platformType: rest.platformType,
+        adapterKey: rest.adapterKey,
       });
 
       const enabledCapabilities =
-        payload.enabledCapabilities ?? [...metadata.supportedCapabilities];
+        rest.enabledCapabilities ?? [...metadata.supportedCapabilities];
 
       const invalid = enabledCapabilities.filter(
         (c) => !metadata.supportedCapabilities.includes(c),
@@ -70,15 +84,55 @@ export class ConnectionService implements IConnectionService {
         );
       }
 
-      const connection = await this.connectionPort.create({
-        ...payload,
-        enabledCapabilities,
-      });
+      // Persist credentials if the caller supplied raw values. We write the
+      // credential row *before* the connection row so the connection is never
+      // persisted pointing at a missing credential. If connection creation
+      // fails afterwards we best-effort delete the credential to avoid leaks.
+      let resolvedCredentialsRef = credentialsRef;
+      let createdCredentialRef: string | null = null;
+      if (credentials) {
+        validateCredentialsShape(rest.platformType, credentials);
+        const ref = randomUUID();
+        await this.credentialRepository.create({
+          ref,
+          platformType: rest.platformType,
+          credentialsJson: credentials,
+        });
+        createdCredentialRef = ref;
+        resolvedCredentialsRef = `db:${ref}`;
+        this.logger.log(
+          `Persisted credentials for new ${rest.platformType} connection (ref: db:${ref})`,
+        );
+      }
+
+      let connection: Connection;
+      try {
+        connection = await this.connectionPort.create({
+          ...rest,
+          credentialsRef: resolvedCredentialsRef!,
+          enabledCapabilities,
+        });
+      } catch (error) {
+        if (createdCredentialRef) {
+          try {
+            await this.credentialRepository.delete(createdCredentialRef);
+            this.logger.warn(
+              `Rolled back orphaned credential ${createdCredentialRef} after connection create failure`,
+            );
+          } catch (cleanupError) {
+            this.logger.error(
+              `Failed to roll back orphaned credential ${createdCredentialRef}: ${(cleanupError as Error).message}`,
+            );
+          }
+        }
+        throw error;
+      }
+
       this.logger.log(`Connection created successfully: ${connection.id} (${connection.name})`);
       await this.enqueueInitialCatalogSync(connection);
       return connection;
     } catch (error) {
-      this.logger.error(`Failed to create connection: ${payload.name}`, error);
+      this.logger.error(`Failed to create connection: ${rest.name}`, error);
       throw error;
     }
   }
@@ -158,8 +212,6 @@ export class ConnectionService implements IConnectionService {
 
       const existing = await this.connectionPort.get(connectionId);
 
-      // adapterKey is immutable post-create. Silently accept the unchanged
-      // value (so naive round-trip patches work) but reject any real change.
       if (patch.adapterKey !== undefined && patch.adapterKey !== existing.adapterKey) {
         throw new BadRequestException(
           `adapterKey is immutable after connection creation (current: ${existing.adapterKey ?? 'derived from platformType'})`,
@@ -194,6 +246,23 @@ export class ConnectionService implements IConnectionService {
     }
   }
 
+  async updateCredentials(
+    connectionId: string,
+    credentials: Record<string, unknown>,
+  ): Promise<void> {
+    const connection = await this.get(connectionId);
+    if (!connection.credentialsRef.startsWith('db:')) {
+      throw new BadRequestException(
+        `Connection ${connectionId} does not have a db-backed credentials reference ` +
+          `(current: ${connection.credentialsRef}); in-place credential rotation is not supported`,
+      );
+    }
+    validateCredentialsShape(connection.platformType, credentials);
+    const ref = connection.credentialsRef.slice('db:'.length);
+    await this.credentialRepository.update(ref, { credentialsJson: credentials });
+    this.logger.log(`Rotated credentials for connection ${connectionId}`);
+  }
+
   async disable(connectionId: string): Promise<Connection> {
     try {
       this.logger.log(`Disabling connection: ${connectionId}`);
@@ -211,3 +280,20 @@ export class ConnectionService implements IConnectionService {
   }
 }
 
+/**
+ * Enforce the minimum credential shape required by each platform before we
+ * persist arbitrary user-supplied JSON into the credentials store.
+ */
+function validateCredentialsShape(
+  platformType: string,
+  credentials: Record<string, unknown>,
+): void {
+  if (platformType === 'prestashop') {
+    const key = credentials.webserviceApiKey;
+    if (typeof key !== 'string' || key.trim().length === 0) {
+      throw new BadRequestException(
+        'PrestaShop credentials must include a non-empty `webserviceApiKey` string',
+      );
+    }
+  }
+}

--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -61,6 +61,7 @@ describe('ConnectionController', () => {
       list: jest.fn(),
       get: jest.fn(),
       update: jest.fn(),
+      updateCredentials: jest.fn(),
       disable: jest.fn(),
     } as unknown as jest.Mocked<ConnectionService>;
 
@@ -114,7 +115,7 @@ describe('ConnectionController', () => {
         name: 'Test Connection',
         platformType: 'prestashop',
         config: { baseUrl: 'https://example.com' },
-        credentialsRef: 'cred_123',
+        credentialsRef: 'db:cred_123',
       };
 
       const result = await controller.create(dto);

--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -11,6 +11,7 @@ import {
   Get,
   Post,
   Patch,
+  Put,
   Body,
   Param,
   Query,
@@ -23,6 +24,7 @@ import { Logger } from '@openlinker/shared/logging';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { CreateConnectionDto } from './dto/create-connection.dto';
 import { UpdateConnectionDto } from './dto/update-connection.dto';
+import { UpdateConnectionCredentialsDto } from './dto/update-connection-credentials.dto';
 import { ConnectionFiltersDto } from './dto/connection-filters.dto';
 import { ConnectionResponseDto } from './dto/connection-response.dto';
 import { ConnectionDiagnosticsResponseDto } from './dto/connection-diagnostics-response.dto';
@@ -159,6 +161,21 @@ export class ConnectionController {
     const connection = await this.connectionService.get(id);
     const recentJobs = await this.syncJobRepository.findRecentByConnectionId(id, 10);
     return ConnectionDiagnosticsResponseDto.fromDomain(connection, recentJobs);
+  }
+
+  @Roles('admin')
+  @Put(':id/credentials')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Rotate the credentials stored for this connection' })
+  @ApiResponse({ status: 204, description: 'Credentials rotated' })
+  @ApiResponse({ status: 400, description: 'Invalid payload or connection not db-backed' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
+  async updateCredentials(
+    @Param('id') id: string,
+    @Body() dto: UpdateConnectionCredentialsDto,
+  ): Promise<void> {
+    await this.connectionService.updateCredentials(id, dto.credentials);
   }
 
   @Roles('admin')

--- a/apps/api/src/integrations/http/dto/create-connection.dto.ts
+++ b/apps/api/src/integrations/http/dto/create-connection.dto.ts
@@ -23,10 +23,26 @@ import {
   IsArray,
   IsIn,
   Matches,
-  ValidateIf,
+  Validate,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Capability, CapabilityValues } from '@openlinker/core/integrations';
+
+@ValidatorConstraint({ name: 'CredentialsXor', async: false })
+class CredentialsXorConstraint implements ValidatorConstraintInterface {
+  validate(_value: unknown, args: ValidationArguments): boolean {
+    const obj = args.object as CreateConnectionDto;
+    const hasCreds = obj.credentials !== undefined && obj.credentials !== null;
+    const hasRef = typeof obj.credentialsRef === 'string' && obj.credentialsRef.length > 0;
+    return hasCreds !== hasRef; // exactly one
+  }
+  defaultMessage(): string {
+    return 'Exactly one of `credentials` or `credentialsRef` must be provided';
+  }
+}
 
 export class CreateConnectionDto {
   @ApiProperty({
@@ -60,9 +76,10 @@ export class CreateConnectionDto {
       'credentialsRef to `db:<uuid>` automatically. Mutually exclusive with credentialsRef.',
     example: { webserviceApiKey: 'XXXXX' },
   })
-  @ValidateIf((o: CreateConnectionDto) => o.credentials !== undefined || o.credentialsRef === undefined)
+  @IsOptional()
   @IsObject()
   @IsNotEmpty()
+  @Validate(CredentialsXorConstraint)
   credentials?: Record<string, unknown>;
 
   @ApiPropertyOptional({
@@ -71,7 +88,7 @@ export class CreateConnectionDto {
       'that persist the credential themselves. Mutually exclusive with `credentials`.',
     example: 'db:550e8400-e29b-41d4-a716-446655440000',
   })
-  @ValidateIf((o: CreateConnectionDto) => o.credentialsRef !== undefined || o.credentials === undefined)
+  @IsOptional()
   @IsString()
   @IsNotEmpty()
   @Matches(/^db:/, {

--- a/apps/api/src/integrations/http/dto/create-connection.dto.ts
+++ b/apps/api/src/integrations/http/dto/create-connection.dto.ts
@@ -4,9 +4,27 @@
  * Request DTO for creating a new connection. Validates input and provides
  * Swagger documentation for the API endpoint.
  *
+ * Callers supply credentials one of two ways:
+ *  - `credentials`: a platform-specific JSON object (e.g. `{ webserviceApiKey }`
+ *    for PrestaShop). The service persists it in the `integration_credentials`
+ *    table and stores a `db:<uuid>` reference on the connection.
+ *  - `credentialsRef`: an already-issued reference (must start with `db:`),
+ *    used by OAuth flows that persist the credential themselves.
+ *
+ * Exactly one of the two must be provided.
+ *
  * @module apps/api/src/integrations/http/dto
  */
-import { IsString, IsNotEmpty, IsOptional, IsObject, IsArray, IsIn } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsObject,
+  IsArray,
+  IsIn,
+  Matches,
+  ValidateIf,
+} from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Capability, CapabilityValues } from '@openlinker/core/integrations';
 
@@ -35,13 +53,31 @@ export class CreateConnectionDto {
   @IsNotEmpty()
   config!: Record<string, unknown>;
 
-  @ApiProperty({
-    description: 'Credentials reference',
-    example: 'cred_abc123',
+  @ApiPropertyOptional({
+    description:
+      'Platform-specific credential payload (e.g. `{ webserviceApiKey }` for PrestaShop). ' +
+      'When provided, the API persists it in the integration credentials store and sets ' +
+      'credentialsRef to `db:<uuid>` automatically. Mutually exclusive with credentialsRef.',
+    example: { webserviceApiKey: 'XXXXX' },
   })
+  @ValidateIf((o: CreateConnectionDto) => o.credentials !== undefined || o.credentialsRef === undefined)
+  @IsObject()
+  @IsNotEmpty()
+  credentials?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    description:
+      'Existing credentials reference (must start with `db:`). Used by OAuth flows ' +
+      'that persist the credential themselves. Mutually exclusive with `credentials`.',
+    example: 'db:550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ValidateIf((o: CreateConnectionDto) => o.credentialsRef !== undefined || o.credentials === undefined)
   @IsString()
   @IsNotEmpty()
-  credentialsRef!: string;
+  @Matches(/^db:/, {
+    message: 'credentialsRef must start with "db:" — raw keys are no longer accepted',
+  })
+  credentialsRef?: string;
 
   @ApiPropertyOptional({
     description:
@@ -63,4 +99,3 @@ export class CreateConnectionDto {
   @IsOptional()
   enabledCapabilities?: Capability[];
 }
-

--- a/apps/api/src/integrations/http/dto/update-connection-credentials.dto.ts
+++ b/apps/api/src/integrations/http/dto/update-connection-credentials.dto.ts
@@ -1,0 +1,22 @@
+/**
+ * Update Connection Credentials DTO
+ *
+ * Request DTO for rotating a connection's stored credentials. The payload is
+ * a platform-specific JSON object written into the `integration_credentials`
+ * row referenced by the connection's `credentialsRef`. The connection row
+ * itself is not modified.
+ *
+ * @module apps/api/src/integrations/http/dto
+ */
+import { IsObject, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateConnectionCredentialsDto {
+  @ApiProperty({
+    description: 'Platform-specific credential payload (replaces the stored value).',
+    example: { webserviceApiKey: 'NEW_KEY' },
+  })
+  @IsObject()
+  @IsNotEmpty()
+  credentials!: Record<string, unknown>;
+}

--- a/apps/api/test/integration/connection-capabilities.int-spec.ts
+++ b/apps/api/test/integration/connection-capabilities.int-spec.ts
@@ -30,13 +30,16 @@ describe('Connection Capabilities Integration', () => {
     await teardownTestHarness();
   });
 
-  async function createConnection(body: Record<string, unknown>): Promise<{ id: string; enabledCapabilities: string[]; supportedCapabilities: string[] }> {
+  async function createConnection(
+    body: object,
+    token?: string,
+  ): Promise<{ id: string; enabledCapabilities: string[]; supportedCapabilities: string[] }> {
     const http = harness.getHttp();
     const dataSource = harness.getDataSource();
-    const token = await loginAsAdmin(http, dataSource);
+    const authToken = token ?? (await loginAsAdmin(http, dataSource));
     const response = await http
       .post('/connections')
-      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send(body)
       .expect(201);
     return response.body;
@@ -84,7 +87,7 @@ describe('Connection Capabilities Integration', () => {
     const dataSource = harness.getDataSource();
     const token = await loginAsAdmin(http, dataSource);
 
-    const created = await createConnection(createPrestashopConnectionDto({ name: 'Narrow me' }));
+    const created = await createConnection(createPrestashopConnectionDto({ name: 'Narrow me' }), token);
 
     const updated = await http
       .patch(`/connections/${created.id}`)
@@ -103,7 +106,7 @@ describe('Connection Capabilities Integration', () => {
     const dataSource = harness.getDataSource();
     const token = await loginAsAdmin(http, dataSource);
 
-    const created = await createConnection(createPrestashopConnectionDto({ name: 'Immutable key' }));
+    const created = await createConnection(createPrestashopConnectionDto({ name: 'Immutable key' }), token);
 
     await http
       .patch(`/connections/${created.id}`)
@@ -117,7 +120,7 @@ describe('Connection Capabilities Integration', () => {
     const dataSource = harness.getDataSource();
     const token = await loginAsAdmin(http, dataSource);
 
-    const created = await createConnection(createPrestashopConnectionDto({ name: 'Validate subset' }));
+    const created = await createConnection(createPrestashopConnectionDto({ name: 'Validate subset' }), token);
 
     await http
       .patch(`/connections/${created.id}`)

--- a/apps/api/test/integration/connection-credentials.int-spec.ts
+++ b/apps/api/test/integration/connection-credentials.int-spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Connection Credentials Integration Test
+ *
+ * Vertical slice for the credentials persistence flow added in #165:
+ *  - POST /connections with `credentials` writes integration_credentials
+ *    and stores `db:<uuid>` on the connection
+ *  - PUT /connections/:id/credentials updates the credential row
+ *
+ * @module apps/api/test/integration
+ */
+import { DataSource } from 'typeorm';
+import { IntegrationCredentialOrmEntity } from '@openlinker/core/integrations/infrastructure/persistence/entities/integration-credential.orm-entity';
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { IntegrationTestHarness } from './setup';
+import {
+  createPrestashopConnectionDto,
+  createPrestashopWizardConnectionDto,
+} from './fixtures/connection.fixtures';
+import { getConnectionById } from './helpers/test-database.helper';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+
+async function findCredentialByRef(
+  dataSource: DataSource,
+  ref: string,
+): Promise<IntegrationCredentialOrmEntity | null> {
+  return dataSource.getRepository(IntegrationCredentialOrmEntity).findOne({ where: { ref } });
+}
+
+describe('Connection Credentials Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  describe('POST /connections with credentials payload', () => {
+    it('persists credentials and stores db: ref on the connection row', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const dto = createPrestashopWizardConnectionDto({ name: 'Wizard Store' });
+
+      const response = await http
+        .post('/connections')
+        .set('Authorization', `Bearer ${token}`)
+        .send(dto)
+        .expect(201);
+
+      const connection = await getConnectionById(dataSource, response.body.id);
+      expect(connection?.credentialsRef.startsWith('db:')).toBe(true);
+
+      const ref = connection!.credentialsRef.slice('db:'.length);
+      const credential = await findCredentialByRef(dataSource, ref);
+      expect(credential).toBeDefined();
+      expect(credential?.platformType).toBe('prestashop');
+      expect(credential?.credentialsJson).toEqual({ webserviceApiKey: 'WS_KEY_TEST' });
+    });
+
+    it('rejects raw-key credentialsRef without db: prefix', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const dto = createPrestashopConnectionDto({
+        credentialsRef: 'RAW_KEY_NO_PREFIX',
+      });
+
+      await http
+        .post('/connections')
+        .set('Authorization', `Bearer ${token}`)
+        .send(dto)
+        .expect(400);
+    });
+
+    it('rejects when both credentials and credentialsRef are provided', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const dto = createPrestashopWizardConnectionDto({
+        credentialsRef: 'db:explicit-ref',
+      });
+
+      await http
+        .post('/connections')
+        .set('Authorization', `Bearer ${token}`)
+        .send(dto)
+        .expect(400);
+    });
+
+    it('rejects PrestaShop credentials missing webserviceApiKey', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const dto = createPrestashopWizardConnectionDto({
+        credentials: { someOtherField: 'X' },
+      });
+
+      await http
+        .post('/connections')
+        .set('Authorization', `Bearer ${token}`)
+        .send(dto)
+        .expect(400);
+    });
+  });
+
+  describe('PUT /connections/:id/credentials', () => {
+    it('rotates the stored credential without touching the connection row', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const created = await http
+        .post('/connections')
+        .set('Authorization', `Bearer ${token}`)
+        .send(createPrestashopWizardConnectionDto())
+        .expect(201);
+
+      const before = await getConnectionById(dataSource, created.body.id);
+      const refBefore = before!.credentialsRef;
+
+      await http
+        .put(`/connections/${created.body.id}/credentials`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ credentials: { webserviceApiKey: 'ROTATED_KEY' } })
+        .expect(204);
+
+      const after = await getConnectionById(dataSource, created.body.id);
+      expect(after!.credentialsRef).toBe(refBefore);
+
+      const ref = refBefore.slice('db:'.length);
+      const credential = await findCredentialByRef(dataSource, ref);
+      expect(credential?.credentialsJson).toEqual({ webserviceApiKey: 'ROTATED_KEY' });
+    });
+
+    it('returns 400 when the connection has a non-db credentials reference', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const created = await http
+        .post('/connections')
+        .set('Authorization', `Bearer ${token}`)
+        .send(createPrestashopConnectionDto({ credentialsRef: 'db:explicit-ref' }))
+        .expect(201);
+
+      // Hand-edit the connection row to a legacy raw-key state to simulate
+      // the broken pre-#165 connections that the docs say require workaround.
+      await dataSource
+        .getRepository('connections')
+        .update({ id: created.body.id }, { credentialsRef: 'LEGACY_RAW_KEY' });
+
+      await http
+        .put(`/connections/${created.body.id}/credentials`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ credentials: { webserviceApiKey: 'X' } })
+        .expect(400);
+    });
+  });
+});

--- a/apps/api/test/integration/fixtures/connection.fixtures.ts
+++ b/apps/api/test/integration/fixtures/connection.fixtures.ts
@@ -21,8 +21,23 @@ export function createPrestashopConnectionDto(
       shopId: 1,
       langId: 1,
     },
-    credentialsRef: 'test-credentials-ref',
+    credentialsRef: 'db:test-credentials-ref',
     adapterKey: 'prestashop.webservice.v1',
+    ...overrides,
+  };
+}
+
+/**
+ * Create a PrestaShop connection DTO that asks the API to persist credentials
+ * (the wizard path). Mutually exclusive with `credentialsRef`.
+ */
+export function createPrestashopWizardConnectionDto(
+  overrides?: Partial<CreateConnectionDto>,
+): CreateConnectionDto {
+  const { credentialsRef: _ignore, ...base } = createPrestashopConnectionDto();
+  return {
+    ...base,
+    credentials: { webserviceApiKey: 'WS_KEY_TEST' },
     ...overrides,
   };
 }
@@ -40,7 +55,7 @@ export function createAllegroConnectionDto(
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret',
     },
-    credentialsRef: 'test-allegro-credentials-ref',
+    credentialsRef: 'db:test-allegro-credentials-ref',
     adapterKey: 'allegro.api.v1',
     ...overrides,
   };

--- a/apps/api/test/integration/helpers/test-connection.helper.ts
+++ b/apps/api/test/integration/helpers/test-connection.helper.ts
@@ -24,7 +24,7 @@ export async function createTestConnection(
     name: 'Test Connection',
     status: 'active',
     config: { baseUrl: 'https://shop.example.com' },
-    credentialsRef: 'test-credentials-ref',
+    credentialsRef: 'db:test-credentials-ref',
     adapterKey: 'prestashop.webservice.v1',
     ...overrides,
   });

--- a/apps/web/src/features/connections/api/connections.api.ts
+++ b/apps/web/src/features/connections/api/connections.api.ts
@@ -13,6 +13,10 @@ export interface ConnectionsApi {
   getById: (connectionId: string) => Promise<Connection>;
   list: (filters?: ConnectionFilters) => Promise<Connection[]>;
   update: (connectionId: string, input: UpdateConnectionInput) => Promise<Connection>;
+  updateCredentials: (
+    connectionId: string,
+    credentials: Record<string, unknown>,
+  ) => Promise<void>;
 }
 
 interface ApiRequest {
@@ -60,6 +64,12 @@ export function createConnectionsApi(request: ApiRequest): ConnectionsApi {
       return request<Connection>(`/connections/${connectionId}`, {
         method: 'PATCH',
         body: JSON.stringify(input),
+      });
+    },
+    updateCredentials(connectionId, credentials): Promise<void> {
+      return request<void>(`/connections/${connectionId}/credentials`, {
+        method: 'PUT',
+        body: JSON.stringify({ credentials }),
       });
     },
   };

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -37,7 +37,10 @@ export interface CreateConnectionInput {
   name: string;
   platformType: PlatformType;
   config: Record<string, unknown>;
-  credentialsRef: string;
+  /** Platform-specific credential payload (e.g. `{ webserviceApiKey }` for PrestaShop). */
+  credentials?: Record<string, unknown>;
+  /** Existing db-backed reference (must start with `db:`). Used by OAuth flows. */
+  credentialsRef?: string;
   adapterKey?: string;
   enabledCapabilities?: Capability[];
 }

--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -11,17 +11,17 @@ describe('EditConnectionForm', () => {
 
     expect(screen.getByDisplayValue(sampleConnection.name)).toBeInTheDocument();
     expect(screen.getByDisplayValue(sampleConnection.platformType)).toBeInTheDocument();
-    expect(screen.getByDisplayValue(sampleConnection.credentialsRef)).toBeInTheDocument();
+    expect(screen.getByText('Rotate webservice key')).toBeInTheDocument();
   });
 
-  it('shows platform type and credentials ref as disabled fields', () => {
+  it('shows platform type as disabled and credentials behind a rotate button', () => {
     renderWithProviders(<EditConnectionForm connection={sampleConnection} />);
 
     const platformInput = screen.getByDisplayValue(sampleConnection.platformType);
-    const credentialsInput = screen.getByDisplayValue(sampleConnection.credentialsRef);
-
     expect(platformInput).toBeDisabled();
-    expect(credentialsInput).toBeDisabled();
+    expect(screen.getByText('Rotate webservice key')).toBeInTheDocument();
+    // The opaque db: ref must not be exposed in the UI any more.
+    expect(screen.queryByDisplayValue(sampleConnection.credentialsRef)).not.toBeInTheDocument();
   });
 
   it('submits the update with changed values', async () => {

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -1,9 +1,10 @@
-import type { ReactElement } from 'react';
+import { useState, type FormEvent, type ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import type { Connection } from '../api/connections.types';
 import { useUpdateConnectionMutation } from '../hooks/use-update-connection-mutation';
+import { useUpdateConnectionCredentialsMutation } from '../hooks/use-update-connection-credentials-mutation';
 import {
   editConnectionSchema,
   toUpdateConnectionInput,
@@ -83,9 +84,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
           <Input value={connection.platformType} disabled />
         </FormField>
 
-        <FormField label="Credentials reference" name="credentialsRef">
-          <Input value={connection.credentialsRef} disabled />
-        </FormField>
+        <CredentialsPanel connection={connection} />
 
         <FormField
           label="Adapter key"
@@ -119,5 +118,93 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
         </Button>
       </div>
     </form>
+  );
+}
+
+function CredentialsPanel({ connection }: { connection: Connection }): ReactElement {
+  const isDbBacked = connection.credentialsRef.startsWith('db:');
+  const [showRotate, setShowRotate] = useState(false);
+  const [newKey, setNewKey] = useState('');
+  const rotate = useUpdateConnectionCredentialsMutation();
+  const { showToast } = useToast();
+
+  if (!isDbBacked) {
+    return (
+      <FormField label="Credentials reference" name="credentialsRef">
+        <Input value={connection.credentialsRef} disabled />
+      </FormField>
+    );
+  }
+
+  if (connection.platformType !== 'prestashop') {
+    return (
+      <FormField label="Credentials" name="credentials">
+        <Input value="Stored securely (managed by integration)" disabled />
+      </FormField>
+    );
+  }
+
+  const onRotate = async (event: FormEvent): Promise<void> => {
+    event.preventDefault();
+    if (newKey.trim().length === 0) return;
+    try {
+      await rotate.mutateAsync({
+        connectionId: connection.id,
+        credentials: { webserviceApiKey: newKey.trim() },
+      });
+      showToast({
+        tone: 'success',
+        title: 'Credentials rotated',
+        description: 'The new webservice key is now in use.',
+      });
+      setNewKey('');
+      setShowRotate(false);
+    } catch {
+      // surfaced via rotate.error
+    }
+  };
+
+  return (
+    <FormField
+      label="Webservice key"
+      name="credentials"
+      description="Stored securely on the server. Rotate to replace the key without restarting the API."
+    >
+      {showRotate ? (
+        <div className="form-grid">
+          {rotate.error ? <Alert tone="error">{rotate.error.message}</Alert> : null}
+          <Input
+            type="password"
+            autoComplete="off"
+            placeholder="New webservice key"
+            value={newKey}
+            onChange={(event) => setNewKey(event.target.value)}
+          />
+          <div className="form-actions">
+            <Button
+              type="button"
+              onClick={(event) => void onRotate(event)}
+              disabled={rotate.isPending || newKey.trim().length === 0}
+            >
+              {rotate.isPending ? 'Rotating...' : 'Save new key'}
+            </Button>
+            <Button
+              tone="secondary"
+              type="button"
+              onClick={() => {
+                setShowRotate(false);
+                setNewKey('');
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button tone="secondary" type="button" onClick={() => setShowRotate(true)}>
+          Rotate webservice key
+        </Button>
+      )}
+    </FormField>
   );
 }

--- a/apps/web/src/features/connections/components/create-connection.schema.ts
+++ b/apps/web/src/features/connections/components/create-connection.schema.ts
@@ -19,7 +19,14 @@ export const createConnectionSchema = z.object({
         return false;
       }
     }, 'Configuration must be valid JSON'),
-  credentialsRef: z.string().trim().min(1, 'Credentials reference is required'),
+  credentialsRef: z
+    .string()
+    .trim()
+    .min(1, 'Credentials reference is required')
+    .refine(
+      (value) => value.startsWith('db:'),
+      'Credentials reference must start with "db:" — raw keys are no longer accepted',
+    ),
   name: z.string().trim().min(1, 'Connection name is required'),
   platformType: platformTypeFormSchema,
 });

--- a/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
@@ -27,7 +27,7 @@ describe('PrestashopSetupForm', () => {
       name: 'Main store',
       platformType: 'prestashop',
       adapterKey: 'prestashop.webservice.v1',
-      credentialsRef: 'WSKEY123',
+      credentials: { webserviceApiKey: 'WSKEY123' },
       config: { baseUrl: 'https://shop.example.com' },
       enabledCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager', 'OrderSource'],
     });

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -96,12 +96,6 @@ export function PrestashopSetupForm(): ReactElement {
         resources enabled.
       </Alert>
 
-      <Alert tone="warning" title="Webservice key handling (MVP)">
-        The key is stored as the connection&apos;s credentials reference until the dedicated
-        credentials service is available. Treat this connection as carrying a secret until the
-        follow-up backend work lands.
-      </Alert>
-
       <div className="form-grid">
         <FormField label="Connection name" name="name" error={form.formState.errors.name?.message}>
           <Input

--- a/apps/web/src/features/connections/components/prestashop-setup.schema.ts
+++ b/apps/web/src/features/connections/components/prestashop-setup.schema.ts
@@ -3,15 +3,10 @@
  *
  * Zod schema and form → API payload mapping for the guided PrestaShop
  * connection wizard. Maps user-visible fields (shop URL, webservice key,
- * optional shop ID) to the generic CreateConnectionInput shape
- * ({ platformType, adapterKey, config, credentialsRef }).
- *
- * NOTE: Until the API exposes an endpoint to register an integration
- * credential from a raw key, the webservice key is sent directly as
- * `credentialsRef`. This matches current MVP backend behavior but
- * overloads a field documented as an opaque reference. Follow-up work
- * will introduce a credentials-create step so the raw key never appears
- * in the connection payload.
+ * optional shop ID) to the generic CreateConnectionInput shape. The
+ * webservice key is submitted as the `credentials` payload; the API
+ * persists it in the integration credentials store and assigns a
+ * `db:<uuid>` reference automatically.
  */
 import { z } from 'zod';
 import type { Capability, CreateConnectionInput } from '../api/connections.types';
@@ -75,7 +70,7 @@ export function toCreateConnectionInput(
     name: values.name,
     platformType: 'prestashop',
     adapterKey: PRESTASHOP_ADAPTER_KEY,
-    credentialsRef: values.webserviceKey,
+    credentials: { webserviceApiKey: values.webserviceKey },
     config,
     enabledCapabilities: values.enabledCapabilities,
   };

--- a/apps/web/src/features/connections/hooks/use-update-connection-credentials-mutation.ts
+++ b/apps/web/src/features/connections/hooks/use-update-connection-credentials-mutation.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { connectionsQueryKeys } from '../api/connections.query-keys';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+interface UpdateCredentialsVariables {
+  connectionId: string;
+  credentials: Record<string, unknown>;
+}
+
+export function useUpdateConnectionCredentialsMutation(): UseMutationResult<
+  void,
+  Error,
+  UpdateCredentialsVariables
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ connectionId, credentials }: UpdateCredentialsVariables) =>
+      apiClient.connections.updateCredentials(connectionId, credentials),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: connectionsQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -89,6 +89,7 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       getById: vi.fn().mockResolvedValue(sampleConnection),
       list: vi.fn().mockResolvedValue([sampleConnection]),
       update: vi.fn().mockResolvedValue(sampleConnection),
+      updateCredentials: vi.fn().mockResolvedValue(undefined),
       ...overrides.connections,
     } as ApiClient['connections'],
     cursors: {


### PR DESCRIPTION
## Summary
- Wizard-created PrestaShop connections were unusable: raw webservice keys stored as `credentialsRef` made every adapter call 500 (`Credentials not found for reference: ...`).
- `ConnectionService.create` now accepts a `credentials` payload, persists it in `integration_credentials`, and stores `db:<uuid>` on the connection. The credential is written before the connection and rolled back if connection create fails.
- DTO rejects raw-key `credentialsRef` (must start with `db:`) via class-level XOR validator (`credentials` XOR `credentialsRef`).
- Per-platform credential shape validation lives in `credential-shape.validator.ts` (PrestaShop requires `webserviceApiKey`).
- New `PUT /connections/:id/credentials` endpoint rotates the credential row in place — no API restart needed.
- FE: PrestaShop wizard sends `credentials: { webserviceApiKey }` instead of overloading `credentialsRef`. Edit form replaces the disabled opaque `db:<uuid>` field with a "Rotate webservice key" flow.

Closes #165

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 717 unit tests pass
- [x] `pnpm test:integration` — 67 integration tests pass, including new `connection-credentials.int-spec.ts`
- [ ] Manual: clean stack → create PrestaShop connection via wizard → open `/connections/:id/mappings/categories` succeeds with no `CREDENTIALS_*` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)