### PR TITLE
fix(health): stop false Redis error on cold stack

### DIFF
--- a/apps/api/src/health/dev-stack-health.service.spec.ts
+++ b/apps/api/src/health/dev-stack-health.service.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Dev Stack Health Service — Unit Tests
+ *
+ * Covers the Redis probe behavior that caused #159: a successful
+ * PING + XADD must report `ok` even on a cold stack (no prior stream
+ * entries), and Redis failures must surface as `error`.
+ *
+ * @module apps/api/src/health
+ */
+import { DataSource } from 'typeorm';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { RedisClientType } from 'redis';
+import { of, throwError } from 'rxjs';
+import { DevStackHealthService } from './dev-stack-health.service';
+
+describe('DevStackHealthService', () => {
+  let service: DevStackHealthService;
+  let dataSource: jest.Mocked<Pick<DataSource, 'query'>>;
+  let redisClient: jest.Mocked<Pick<RedisClientType, 'ping' | 'xAdd'>>;
+  let httpService: jest.Mocked<Pick<HttpService, 'get'>>;
+  let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
+
+  beforeEach(() => {
+    dataSource = { query: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
+    redisClient = {
+      ping: jest.fn().mockResolvedValue('PONG'),
+      xAdd: jest.fn().mockResolvedValue('0-1'),
+    };
+    httpService = { get: jest.fn().mockReturnValue(of({ status: 200 })) };
+    configService = { get: jest.fn().mockReturnValue('http://localhost:8080') };
+
+    service = new DevStackHealthService(
+      dataSource as unknown as DataSource,
+      redisClient as unknown as RedisClientType,
+      httpService as unknown as HttpService,
+      configService as unknown as ConfigService,
+    );
+  });
+
+  describe('checkInternalHealth', () => {
+    it('should report ok when postgres and redis are healthy on a cold stack', async () => {
+      const result = await service.checkInternalHealth();
+
+      expect(result.status).toBe('ok');
+      expect(result.services.postgres.status).toBe('ok');
+      expect(result.services.redis.status).toBe('ok');
+      // #159 regression guard: probe must not depend on xRead / pre-seeded entries
+      expect(redisClient.ping).toHaveBeenCalledTimes(1);
+      expect(redisClient.xAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report error when redis ping fails', async () => {
+      redisClient.ping.mockRejectedValueOnce(new Error('connection refused'));
+
+      const result = await service.checkInternalHealth();
+
+      expect(result.status).toBe('error');
+      expect(result.services.redis.status).toBe('error');
+      expect(result.services.redis.message).toContain('connection refused');
+    });
+
+    it('should report error when redis xAdd fails', async () => {
+      redisClient.xAdd.mockRejectedValueOnce(new Error('streams unavailable'));
+
+      const result = await service.checkInternalHealth();
+
+      expect(result.status).toBe('error');
+      expect(result.services.redis.status).toBe('error');
+      expect(result.services.redis.message).toContain('streams unavailable');
+    });
+
+    it('should report error when postgres query fails', async () => {
+      dataSource.query.mockRejectedValueOnce(new Error('db down'));
+
+      const result = await service.checkInternalHealth();
+
+      expect(result.status).toBe('error');
+      expect(result.services.postgres.status).toBe('error');
+    });
+  });
+
+  describe('checkDevStackHealth', () => {
+    it('should report degraded when prestashop is unreachable but internals are ok', async () => {
+      httpService.get.mockReturnValueOnce(throwError(() => new Error('ECONNREFUSED')));
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.status).toBe('degraded');
+      expect(result.services.prestashop.status).toBe('error');
+      expect(result.services.postgres.status).toBe('ok');
+      expect(result.services.redis.status).toBe('ok');
+    });
+  });
+});

--- a/apps/api/src/health/dev-stack-health.service.ts
+++ b/apps/api/src/health/dev-stack-health.service.ts
@@ -92,22 +92,11 @@ export class DevStackHealthService implements IDevStackHealthService {
 
   private async checkPostgres(): Promise<ServiceHealth> {
     try {
-      let timeoutId: NodeJS.Timeout | undefined;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error('PostgreSQL health check timeout')),
-          this.CHECK_TIMEOUT_MS,
-        );
-      });
-
-      try {
-        await Promise.race([this.dataSource.query('SELECT 1'), timeoutPromise]);
-        return { status: 'ok' as ServiceStatus };
-      } finally {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-      }
+      await this.withTimeout(
+        this.dataSource.query('SELECT 1'),
+        'PostgreSQL health check timeout',
+      );
+      return { status: 'ok' as ServiceStatus };
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
@@ -119,67 +108,52 @@ export class DevStackHealthService implements IDevStackHealthService {
     }
   }
 
+  private async withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+    let timeoutId: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error(message)),
+        this.CHECK_TIMEOUT_MS,
+      );
+    });
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
   private async checkRedis(): Promise<ServiceHealth> {
     try {
-      // Test Redis Streams by writing and reading from a dedicated healthcheck stream
       const streamKey = this.HEALTHCHECK_STREAM;
       const timestamp = Date.now().toString();
 
-      // Write test entry with MAXLEN ~ 1 to cap stream size
-      // Redis v4 API: xAdd(key, id, fields, options?)
-      let timeoutId: NodeJS.Timeout | undefined;
-      const addTimeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error('Redis xAdd timeout')),
-          this.CHECK_TIMEOUT_MS,
-        );
-      });
+      await this.withTimeout(
+        this.redisClient.ping(),
+        'Redis ping timeout',
+      );
 
-      try {
-        await Promise.race([
-          this.redisClient.xAdd(
-            streamKey,
-            '*',
-            { timestamp },
-            {
-              TRIM: {
-                strategy: 'MAXLEN',
-                strategyModifier: '~',
-                threshold: 1,
-              },
+      // Exercise Redis Streams with a non-blocking write. XADD succeeds iff
+      // the server supports Streams and accepts writes; no read-back needed,
+      // which avoids false positives on cold boot when consumer groups or
+      // stream entries are not yet initialized.
+      await this.withTimeout(
+        this.redisClient.xAdd(
+          streamKey,
+          '*',
+          { timestamp },
+          {
+            TRIM: {
+              strategy: 'MAXLEN',
+              strategyModifier: '~',
+              threshold: 1,
             },
-          ),
-          addTimeoutPromise,
-        ]);
-      } finally {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-      }
-
-      // Read back to verify Streams are working
-      // Redis v4 API: xRead(commands, options?)
-      timeoutId = undefined;
-      const readTimeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error('Redis xRead timeout')),
-          this.CHECK_TIMEOUT_MS,
-        );
-      });
-
-      try {
-        await Promise.race([
-          this.redisClient.xRead(
-            [{ key: streamKey, id: '0' }],
-            { COUNT: 1 },
-          ),
-          readTimeoutPromise,
-        ]);
-      } finally {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-      }
+          },
+        ),
+        'Redis xAdd timeout',
+      );
 
       return { status: 'ok' as ServiceStatus };
     } catch (error) {


### PR DESCRIPTION
## Summary
- Replace flaky `XREAD id:'0'` read-back in the Redis dev-stack probe with `PING` + `XADD`. `XADD` lazily creates the stream, so a freshly started stack no longer reports a false `Redis xREAD timeout` error.
- Route the Postgres probe through a shared `withTimeout` helper (removes duplicated `Promise.race` boilerplate).
- Add `dev-stack-health.service.spec.ts` covering the cold-stack happy path plus Redis/Postgres failure modes (regression guard for #159).

Closes #159

## Test plan
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm --filter @openlinker/api test -- dev-stack-health` (5/5 passing)
- [ ] Manual: `docker compose down -v && pnpm dev:stack:up`, run migrations, start API → dashboard shows Redis OK