### PR TITLE
fix(mappings): add marketplace selector to category mappings page (cl…

### DIFF
--- a/apps/api/src/common/filters/capability-not-supported.filter.spec.ts
+++ b/apps/api/src/common/filters/capability-not-supported.filter.spec.ts
@@ -1,0 +1,44 @@
+import { ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { CapabilityNotSupportedException, CapabilityNotEnabledException } from '@openlinker/core/integrations';
+import { CapabilityNotSupportedFilter } from './capability-not-supported.filter';
+
+function createHost(): { host: ArgumentsHost; status: jest.Mock; json: jest.Mock } {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  const host = {
+    switchToHttp: () => ({ getResponse: () => ({ status }) }),
+  } as unknown as ArgumentsHost;
+  return { host, status, json };
+}
+
+describe('CapabilityNotSupportedFilter', () => {
+  const filter = new CapabilityNotSupportedFilter();
+
+  it('should return 400 when adapter does not support capability', () => {
+    const { host, status, json } = createHost();
+    const exception = new CapabilityNotSupportedException('prestashop.webservice.v1', 'Marketplace');
+
+    filter.catch(exception, host);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.BAD_REQUEST,
+      error: 'CapabilityNotSupportedException',
+      message: expect.stringContaining('does not support capability: Marketplace'),
+    });
+  });
+
+  it('should return 400 when capability is disabled on connection', () => {
+    const { host, status, json } = createHost();
+    const exception = new CapabilityNotEnabledException('conn-1', 'prestashop.webservice.v1', 'Marketplace');
+
+    filter.catch(exception, host);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.BAD_REQUEST,
+      error: 'CapabilityNotEnabledException',
+      message: expect.stringContaining('disabled'),
+    });
+  });
+});

--- a/apps/api/src/common/filters/capability-not-supported.filter.ts
+++ b/apps/api/src/common/filters/capability-not-supported.filter.ts
@@ -1,0 +1,28 @@
+/**
+ * Capability Not Supported Filter
+ *
+ * Maps CapabilityNotSupportedException (and its subclass CapabilityNotEnabledException)
+ * into a 400 Bad Request with a structured, operator-friendly message.
+ *
+ * Without this filter NestJS would default to 500 Internal Server Error, which
+ * misrepresents a user/configuration error as a server fault.
+ *
+ * @module apps/api/src/common/filters
+ * @see {@link CapabilityNotSupportedException} for the domain exception shape
+ */
+
+import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus } from '@nestjs/common';
+import type { Response } from 'express';
+import { CapabilityNotSupportedException } from '@openlinker/core/integrations';
+
+@Catch(CapabilityNotSupportedException)
+export class CapabilityNotSupportedFilter implements ExceptionFilter {
+  catch(exception: CapabilityNotSupportedException, host: ArgumentsHost): void {
+    const response = host.switchToHttp().getResponse<Response>();
+    response.status(HttpStatus.BAD_REQUEST).json({
+      statusCode: HttpStatus.BAD_REQUEST,
+      error: exception.name,
+      message: exception.message,
+    });
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -12,6 +12,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as express from 'express';
 import { AppModule } from './app.module';
+import { CapabilityNotSupportedFilter } from './common/filters/capability-not-supported.filter';
 
 async function bootstrap(): Promise<void> {
   // Disable Nest's default body parser so we can control parser order
@@ -48,6 +49,9 @@ async function bootstrap(): Promise<void> {
       transform: true,
     }),
   );
+
+  // Map capability-related domain errors to 400 instead of the default 500
+  app.useGlobalFilters(new CapabilityNotSupportedFilter());
 
   // Swagger API documentation
   const config = new DocumentBuilder()

--- a/apps/web/src/features/mappings/components/AllegroCategorySearch.tsx
+++ b/apps/web/src/features/mappings/components/AllegroCategorySearch.tsx
@@ -15,7 +15,7 @@ import { LoadingState, ErrorState, EmptyState } from '../../../shared/ui/feedbac
 import type { AllegroCategory, CategoryMapping } from '../api/mappings.types';
 
 interface AllegroCategorySearchProps {
-  connectionId: string;
+  marketplaceConnectionId: string;
   currentMapping: CategoryMapping | undefined;
   onSelect: (category: AllegroCategory, path: string) => void;
   onClear: () => void;
@@ -28,7 +28,7 @@ interface BreadcrumbItem {
 }
 
 export function AllegroCategorySearch({
-  connectionId,
+  marketplaceConnectionId,
   currentMapping,
   onSelect,
   onClear,
@@ -37,7 +37,7 @@ export function AllegroCategorySearch({
   const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([]);
   const currentParentId = breadcrumbs.length > 0 ? breadcrumbs[breadcrumbs.length - 1].id : undefined;
 
-  const categoriesQuery = useAllegroCategoriesQuery(connectionId, currentParentId);
+  const categoriesQuery = useAllegroCategoriesQuery(marketplaceConnectionId, currentParentId);
 
   function navigateInto(category: AllegroCategory): void {
     setBreadcrumbs((prev) => [...prev, { id: category.id, name: category.name }]);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1268,6 +1268,17 @@ textarea {
 
 /* ── Category Mappings Layout ────────────────────────────────────── */
 
+.category-mappings-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.category-mappings-toolbar__label {
+  font-weight: 600;
+}
+
 .category-mappings-layout {
   display: grid;
   grid-template-columns: minmax(280px, 1fr) minmax(320px, 1.2fr);

--- a/apps/web/src/pages/connections/connection-category-mappings-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-category-mappings-page.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * ConnectionCategoryMappingsPage tests
+ *
+ * Covers the marketplace-connection selector behavior introduced for #173:
+ * - empty state when no Marketplace-capable connection exists,
+ * - auto-pick when exactly one Marketplace connection is available.
+ *
+ * @module apps/web/src/pages/connections
+ */
+
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
+import { ConnectionCategoryMappingsPage } from './connection-category-mappings-page';
+import type { Connection } from '../../features/connections/api/connections.types';
+
+const PS_CATEGORIES = [{ id: '2', name: 'Men', parentId: '1', depth: 1, active: true }];
+
+const ALLEGRO_CONNECTION: Connection = {
+  ...sampleConnection,
+  id: 'conn_allegro_1',
+  name: 'Allegro store',
+  platformType: 'allegro',
+  status: 'active',
+  adapterKey: 'allegro.publicapi.v1',
+  enabledCapabilities: ['Marketplace'],
+  supportedCapabilities: ['Marketplace'],
+};
+
+describe('ConnectionCategoryMappingsPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(cleanup);
+
+  it('shows an empty state when no Marketplace-capable connection exists', async () => {
+    const apiClient = createMockApiClient({
+      connections: {
+        list: vi.fn().mockResolvedValue([sampleConnection]),
+      },
+      mappings: {
+        getCategoryMappings: vi.fn().mockResolvedValue([]),
+        getPrestashopCategories: vi.fn().mockResolvedValue(PS_CATEGORIES),
+      },
+    });
+
+    renderWithProviders(<ConnectionCategoryMappingsPage />, { apiClient });
+
+    expect(await screen.findByText('No marketplace connection configured')).toBeInTheDocument();
+  });
+
+  it('auto-picks the single available Marketplace connection', async () => {
+    const apiClient = createMockApiClient({
+      connections: {
+        list: vi.fn().mockResolvedValue([sampleConnection, ALLEGRO_CONNECTION]),
+      },
+      mappings: {
+        getCategoryMappings: vi.fn().mockResolvedValue([]),
+        getPrestashopCategories: vi.fn().mockResolvedValue(PS_CATEGORIES),
+      },
+    });
+
+    renderWithProviders(<ConnectionCategoryMappingsPage />, { apiClient });
+
+    const select = await screen.findByLabelText<HTMLSelectElement>('Marketplace connection');
+    await waitFor(() => {
+      expect(select.value).toBe(ALLEGRO_CONNECTION.id);
+    });
+  });
+
+  it('excludes disabled Marketplace connections from the selector', async () => {
+    const disabledAllegro: Connection = { ...ALLEGRO_CONNECTION, id: 'conn_allegro_disabled', status: 'disabled' };
+    const apiClient = createMockApiClient({
+      connections: {
+        list: vi.fn().mockResolvedValue([sampleConnection, disabledAllegro]),
+      },
+      mappings: {
+        getCategoryMappings: vi.fn().mockResolvedValue([]),
+        getPrestashopCategories: vi.fn().mockResolvedValue(PS_CATEGORIES),
+      },
+    });
+
+    renderWithProviders(<ConnectionCategoryMappingsPage />, { apiClient });
+
+    expect(await screen.findByText('No marketplace connection configured')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/connections/connection-category-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-category-mappings-page.tsx
@@ -2,14 +2,19 @@
  * Connection Category Mappings Page
  *
  * Two-column layout for mapping PrestaShop categories to Allegro categories.
- * Left: PrestaShop category tree with mapping indicators.
- * Right: Allegro category browser for the selected PrestaShop category.
+ * Left: PrestaShop category tree (from the source connection — must support ProductMaster).
+ * Right: Allegro category browser (from a marketplace connection — must support Marketplace).
+ *
+ * The URL carries the source connection id (`:connectionId`). The marketplace
+ * connection is chosen by the operator via a selector and persisted in the
+ * `?marketplaceConnectionId=` search param (also mirrored to localStorage so
+ * a returning user defaults back to their last pick).
  *
  * @module apps/web/src/pages/connections
  */
 
-import { useState, useMemo, type ReactElement } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { CategoryMappingTree } from '../../features/mappings/components/CategoryMappingTree';
 import { AllegroCategorySearch } from '../../features/mappings/components/AllegroCategorySearch';
@@ -19,16 +24,75 @@ import {
   useDeleteCategoryMapping,
 } from '../../features/mappings/hooks/use-category-mappings';
 import { usePrestashopCategoriesQuery } from '../../features/mappings/hooks/use-prestashop-categories';
+import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import type { AllegroCategory } from '../../features/mappings/api/mappings.types';
 
+const MARKETPLACE_PICK_STORAGE_PREFIX = 'openlinker.categoryMappings.lastMarketplace.';
+
+function storageKey(sourceConnectionId: string): string {
+  return `${MARKETPLACE_PICK_STORAGE_PREFIX}${sourceConnectionId}`;
+}
+
+function readPersistedPick(sourceConnectionId: string): string | null {
+  try {
+    return window.localStorage.getItem(storageKey(sourceConnectionId));
+  } catch {
+    return null;
+  }
+}
+
+function persistPick(sourceConnectionId: string, marketplaceConnectionId: string): void {
+  try {
+    window.localStorage.setItem(storageKey(sourceConnectionId), marketplaceConnectionId);
+  } catch {
+    // ignore — private browsing / quota issues should not break the page
+  }
+}
+
 export function ConnectionCategoryMappingsPage(): ReactElement {
   const { connectionId = '' } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
+
+  const connectionsQuery = useConnectionsQuery();
+  const marketplaceConnections = useMemo(
+    () =>
+      (connectionsQuery.data ?? []).filter(
+        (c) => c.status === 'active' && c.enabledCapabilities.includes('Marketplace'),
+      ),
+    [connectionsQuery.data],
+  );
+
+  const urlMarketplaceId = searchParams.get('marketplaceConnectionId');
+  const marketplaceConnectionId =
+    urlMarketplaceId && marketplaceConnections.some((c) => c.id === urlMarketplaceId) ? urlMarketplaceId : '';
+
+  // Resolve a default marketplace pick: URL → persisted → single available.
+  useEffect(() => {
+    if (marketplaceConnectionId) return;
+    if (marketplaceConnections.length === 0) return;
+
+    const persisted = readPersistedPick(connectionId);
+    const defaultId =
+      (persisted && marketplaceConnections.some((c) => c.id === persisted) ? persisted : null) ??
+      (marketplaceConnections.length === 1 ? marketplaceConnections[0].id : null);
+
+    if (defaultId) {
+      persistPick(connectionId, defaultId);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('marketplaceConnectionId', defaultId);
+          return next;
+        },
+        { replace: true },
+      );
+    }
+  }, [connectionId, marketplaceConnectionId, marketplaceConnections, setSearchParams]);
 
   const mappingsQuery = useCategoryMappingsQuery(connectionId);
   const prestashopCategoriesQuery = usePrestashopCategoriesQuery(connectionId);
-
   const upsertMutation = useUpsertCategoryMapping(connectionId);
   const deleteMutation = useDeleteCategoryMapping(connectionId);
 
@@ -41,9 +105,19 @@ export function ConnectionCategoryMappingsPage(): ReactElement {
   }, [mappings, categories]);
 
   const selectedMapping = useMemo(
-    () => selectedCategoryId ? mappings.find((m) => m.prestashopCategoryId === selectedCategoryId) : undefined,
+    () => (selectedCategoryId ? mappings.find((m) => m.prestashopCategoryId === selectedCategoryId) : undefined),
     [mappings, selectedCategoryId],
   );
+
+  function handleMarketplaceChange(nextId: string): void {
+    if (nextId) persistPick(connectionId, nextId);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (nextId) next.set('marketplaceConnectionId', nextId);
+      else next.delete('marketplaceConnectionId');
+      return next;
+    });
+  }
 
   function handleAllegroSelect(category: AllegroCategory, path: string): void {
     if (!selectedCategoryId) return;
@@ -62,8 +136,16 @@ export function ConnectionCategoryMappingsPage(): ReactElement {
     deleteMutation.mutate(selectedCategoryId);
   }
 
-  const isLoading = mappingsQuery.isLoading || prestashopCategoriesQuery.isLoading;
-  const loadError = mappingsQuery.error ?? prestashopCategoriesQuery.error ?? null;
+  const backLink = (
+    <Link className="button button--secondary" to={`/connections/${connectionId}`}>
+      Back to connection
+    </Link>
+  );
+
+  const isLoading =
+    connectionsQuery.isLoading || mappingsQuery.isLoading || prestashopCategoriesQuery.isLoading;
+  const loadError =
+    connectionsQuery.error ?? mappingsQuery.error ?? prestashopCategoriesQuery.error ?? null;
 
   if (isLoading) {
     return (
@@ -81,17 +163,25 @@ export function ConnectionCategoryMappingsPage(): ReactElement {
     );
   }
 
+  if (marketplaceConnections.length === 0) {
+    return (
+      <PageLayout eyebrow="Connection" title="Category Mappings" actions={backLink}>
+        <EmptyState
+          title="No marketplace connection configured"
+          message="Add an Allegro (or other Marketplace) connection before mapping categories."
+          action={
+            <Link className="button button--primary" to="/connections/new">
+              Add connection
+            </Link>
+          }
+        />
+      </PageLayout>
+    );
+  }
+
   if (categories.length === 0) {
     return (
-      <PageLayout
-        eyebrow="Connection"
-        title="Category Mappings"
-        actions={
-          <Link className="button button--secondary" to={`/connections/${connectionId}`}>
-            Back to connection
-          </Link>
-        }
-      >
+      <PageLayout eyebrow="Connection" title="Category Mappings" actions={backLink}>
         <EmptyState
           title="No PrestaShop categories"
           message="No categories were found for this connection. Ensure the PrestaShop store has categories configured."
@@ -105,12 +195,29 @@ export function ConnectionCategoryMappingsPage(): ReactElement {
       eyebrow="Connection"
       title="Category Mappings"
       description={`${mappedCount} of ${categories.length} categories mapped`}
-      actions={
-        <Link className="button button--secondary" to={`/connections/${connectionId}`}>
-          Back to connection
-        </Link>
-      }
+      actions={backLink}
     >
+      <div className="category-mappings-toolbar">
+        <label className="category-mappings-toolbar__label" htmlFor="marketplace-connection-select">
+          Marketplace connection
+        </label>
+        <select
+          id="marketplace-connection-select"
+          className="input"
+          value={marketplaceConnectionId}
+          onChange={(e) => { handleMarketplaceChange(e.target.value); }}
+        >
+          <option value="" disabled>
+            Select a marketplace connection…
+          </option>
+          {marketplaceConnections.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name} ({c.platformType})
+            </option>
+          ))}
+        </select>
+      </div>
+
       <div className="category-mappings-layout">
         <div className="category-mappings-layout__tree">
           <h3>PrestaShop Categories</h3>
@@ -124,18 +231,23 @@ export function ConnectionCategoryMappingsPage(): ReactElement {
 
         <div className="category-mappings-layout__search">
           <h3>Allegro Category</h3>
-          {selectedCategoryId ? (
+          {!marketplaceConnectionId ? (
+            <EmptyState
+              title="Select a marketplace connection"
+              message="Pick a marketplace connection above to browse its category tree."
+            />
+          ) : !selectedCategoryId ? (
+            <EmptyState
+              title="Select a category"
+              message="Click a PrestaShop category on the left to assign an Allegro category."
+            />
+          ) : (
             <AllegroCategorySearch
-              connectionId={connectionId}
+              marketplaceConnectionId={marketplaceConnectionId}
               currentMapping={selectedMapping}
               onSelect={handleAllegroSelect}
               onClear={handleClear}
               isSaving={upsertMutation.isPending || deleteMutation.isPending}
-            />
-          ) : (
-            <EmptyState
-              title="Select a category"
-              message="Click a PrestaShop category on the left to assign an Allegro category."
             />
           )}
         </div>

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -42,9 +42,11 @@ export function ConnectionDetailPage(): ReactElement {
               <Link className="button button--secondary" to={`/connections/${connectionId}/mappings`}>
                 Mappings
               </Link>
-              <Link className="button button--secondary" to={`/connections/${connectionId}/mappings/categories`}>
-                Category Mappings
-              </Link>
+              {connection.enabledCapabilities.includes('ProductMaster') ? (
+                <Link className="button button--secondary" to={`/connections/${connectionId}/mappings/categories`}>
+                  Category Mappings
+                </Link>
+              ) : null}
             </>
           ) : null}
           <Link className="button button--secondary" to="/connections">


### PR DESCRIPTION
…oses #173)

The Category Mappings page was keyed on a single connection id but needs both a source (ProductMaster) and a marketplace (Marketplace) connection. Whichever side the connection did not support crashed the page with a 500.

Changes:
- FE: marketplace connection picker persisted in the URL (marketplaceConnectionId search param) and mirrored to localStorage; auto-picks when exactly one active Marketplace connection exists; empty state otherwise.
- FE: hide the Category Mappings link on connections without ProductMaster.
- BE: map CapabilityNotSupportedException (and its subclass) to 400 via a global exception filter, so upstream misconfigurations stop surfacing as 500s.