### PR TITLE
feat(health): add worker health monitoring to dashboard

### DIFF
--- a/apps/api/src/health/dev-stack-health.service.spec.ts
+++ b/apps/api/src/health/dev-stack-health.service.spec.ts
@@ -17,7 +17,7 @@ import { DevStackHealthService } from './dev-stack-health.service';
 describe('DevStackHealthService', () => {
   let service: DevStackHealthService;
   let dataSource: jest.Mocked<Pick<DataSource, 'query'>>;
-  let redisClient: jest.Mocked<Pick<RedisClientType, 'ping' | 'xAdd'>>;
+  let redisClient: jest.Mocked<Pick<RedisClientType, 'ping' | 'xAdd' | 'get'>>;
   let httpService: jest.Mocked<Pick<HttpService, 'get'>>;
   let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
 
@@ -26,6 +26,7 @@ describe('DevStackHealthService', () => {
     redisClient = {
       ping: jest.fn().mockResolvedValue('PONG'),
       xAdd: jest.fn().mockResolvedValue('0-1'),
+      get: jest.fn().mockResolvedValue(String(Date.now())), // Fresh heartbeat by default
     };
     httpService = { get: jest.fn().mockReturnValue(of({ status: 200 })) };
     configService = { get: jest.fn().mockReturnValue('http://localhost:8080') };
@@ -90,6 +91,71 @@ describe('DevStackHealthService', () => {
       expect(result.services.prestashop.status).toBe('error');
       expect(result.services.postgres.status).toBe('ok');
       expect(result.services.redis.status).toBe('ok');
+    });
+
+    it('should include worker status in dev stack health', async () => {
+      const result = await service.checkDevStackHealth();
+
+      expect(result.services.worker).toBeDefined();
+      expect(result.services.worker.status).toBe('ok');
+    });
+
+    it('should report degraded when worker is stale but internals are ok', async () => {
+      // Heartbeat from 90 seconds ago (past 60s warning threshold)
+      redisClient.get.mockResolvedValueOnce(String(Date.now() - 90_000));
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.status).toBe('degraded');
+      expect(result.services.worker.status).toBe('error');
+      expect(result.services.worker.message).toContain('90');
+    });
+  });
+
+  describe('checkWorker', () => {
+    it('should report ok when worker heartbeat is fresh', async () => {
+      redisClient.get.mockResolvedValueOnce(String(Date.now() - 5_000)); // 5s old
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.services.worker.status).toBe('ok');
+      expect(result.services.worker.message).toBeUndefined();
+    });
+
+    it('should report warning when worker heartbeat is stale (30-60s)', async () => {
+      redisClient.get.mockResolvedValueOnce(String(Date.now() - 45_000)); // 45s old
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.services.worker.status).toBe('warning');
+      expect(result.services.worker.message).toContain('45');
+    });
+
+    it('should report error when worker heartbeat is very stale (>60s)', async () => {
+      redisClient.get.mockResolvedValueOnce(String(Date.now() - 90_000)); // 90s old
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.services.worker.status).toBe('error');
+      expect(result.services.worker.message).toContain('90');
+    });
+
+    it('should report error when worker heartbeat key is absent', async () => {
+      redisClient.get.mockResolvedValueOnce(null);
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.services.worker.status).toBe('error');
+      expect(result.services.worker.message).toContain('not running');
+    });
+
+    it('should report error when redis get fails', async () => {
+      redisClient.get.mockRejectedValueOnce(new Error('connection lost'));
+
+      const result = await service.checkDevStackHealth();
+
+      expect(result.services.worker.status).toBe('error');
+      expect(result.services.worker.message).toContain('health check failed');
     });
   });
 });

--- a/apps/api/src/health/dev-stack-health.service.ts
+++ b/apps/api/src/health/dev-stack-health.service.ts
@@ -29,6 +29,9 @@ export class DevStackHealthService implements IDevStackHealthService {
   private readonly logger = new Logger(DevStackHealthService.name);
   private readonly CHECK_TIMEOUT_MS = 5000;
   private readonly HEALTHCHECK_STREAM = 'healthcheck';
+  private readonly WORKER_HEARTBEAT_KEY = 'openlinker:worker:heartbeat';
+  private readonly WORKER_OK_MS = 30_000; // 30 seconds
+  private readonly WORKER_WARN_MS = 60_000; // 60 seconds
 
   constructor(
     @InjectDataSource()
@@ -59,24 +62,31 @@ export class DevStackHealthService implements IDevStackHealthService {
   }
 
   async checkDevStackHealth(): Promise<DevStackHealthResponse> {
-    const services = {
-      postgres: await this.checkPostgres(),
-      redis: await this.checkRedis(),
-      prestashop: await this.checkPrestaShop(),
-    };
+    // Run all checks in parallel so checkWorker()'s GET reaches Redis before
+    // checkRedis()'s xAdd is queued, preventing pipeline blocking.
+    const [postgres, redis, prestashop, worker] = await Promise.all([
+      this.checkPostgres(),
+      this.checkRedis(),
+      this.checkPrestaShop(),
+      this.checkWorker(),
+    ]);
+    const services = { postgres, redis, prestashop, worker };
 
     // Determine overall status
     // Priority: internal errors > external errors > all ok
     const hasInternalError =
       services.postgres.status === 'error' || services.redis.status === 'error';
-    const hasExternalError = services.prestashop.status === 'error';
+    const hasExternalError =
+      services.prestashop.status === 'error' ||
+      services.worker.status === 'error' ||
+      services.worker.status === 'warning';
 
     let status: 'ok' | 'degraded' | 'error';
     if (hasInternalError) {
       // Internal services (PostgreSQL, Redis) are down - critical error
       status = 'error';
     } else if (hasExternalError) {
-      // Internal services are healthy, but external (PrestaShop) is down - degraded
+      // Internal services are healthy, but external (PrestaShop/worker) is down/slow - degraded
       status = 'degraded';
     } else {
       // All services (internal + external) are healthy
@@ -210,6 +220,48 @@ export class DevStackHealthService implements IDevStackHealthService {
       return {
         status: 'error' as ServiceStatus,
         message: 'PrestaShop is unreachable',
+      };
+    }
+  }
+
+  private async checkWorker(): Promise<ServiceHealth> {
+    try {
+      const heartbeat = await this.withTimeout(
+        this.redisClient.get(this.WORKER_HEARTBEAT_KEY),
+        'Worker heartbeat check timeout',
+      );
+
+      if (!heartbeat) {
+        return {
+          status: 'error' as ServiceStatus,
+          message: 'Worker is not running',
+        };
+      }
+
+      const age = Date.now() - parseInt(heartbeat, 10);
+
+      if (age <= this.WORKER_OK_MS) {
+        return { status: 'ok' as ServiceStatus };
+      }
+
+      if (age <= this.WORKER_WARN_MS) {
+        return {
+          status: 'warning' as ServiceStatus,
+          message: `Worker last seen ${Math.round(age / 1000)}s ago`,
+        };
+      }
+
+      return {
+        status: 'error' as ServiceStatus,
+        message: `Worker last seen ${Math.round(age / 1000)}s ago`,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Worker health check failed: ${errorMessage}`, error);
+      return {
+        status: 'error' as ServiceStatus,
+        message: 'Worker health check failed',
       };
     }
   }

--- a/apps/api/src/health/dev-stack-health.service.ts
+++ b/apps/api/src/health/dev-stack-health.service.ts
@@ -17,6 +17,7 @@ import { ConfigService } from '@nestjs/config';
 import { firstValueFrom, timeout } from 'rxjs';
 import { RedisClientType } from 'redis';
 import { IDevStackHealthService } from './dev-stack-health.service.interface';
+import { WORKER_HEARTBEAT_REDIS_KEY } from '@openlinker/shared/worker/worker-health.constants';
 import {
   InternalHealthResponse,
   DevStackHealthResponse,
@@ -29,7 +30,6 @@ export class DevStackHealthService implements IDevStackHealthService {
   private readonly logger = new Logger(DevStackHealthService.name);
   private readonly CHECK_TIMEOUT_MS = 5000;
   private readonly HEALTHCHECK_STREAM = 'healthcheck';
-  private readonly WORKER_HEARTBEAT_KEY = 'openlinker:worker:heartbeat';
   private readonly WORKER_OK_MS = 30_000; // 30 seconds
   private readonly WORKER_WARN_MS = 60_000; // 60 seconds
 
@@ -227,7 +227,7 @@ export class DevStackHealthService implements IDevStackHealthService {
   private async checkWorker(): Promise<ServiceHealth> {
     try {
       const heartbeat = await this.withTimeout(
-        this.redisClient.get(this.WORKER_HEARTBEAT_KEY),
+        this.redisClient.get(WORKER_HEARTBEAT_REDIS_KEY),
         'Worker heartbeat check timeout',
       );
 

--- a/apps/api/src/health/dev-stack-health.types.ts
+++ b/apps/api/src/health/dev-stack-health.types.ts
@@ -5,7 +5,7 @@
  *
  * @module apps/api/src/health
  */
-export type ServiceStatus = 'ok' | 'error';
+export type ServiceStatus = 'ok' | 'warning' | 'error';
 
 export interface ServiceHealth {
   status: ServiceStatus;
@@ -27,6 +27,7 @@ export interface DevStackHealthResponse {
     postgres: ServiceHealth;
     redis: ServiceHealth;
     prestashop: ServiceHealth;
+    worker: ServiceHealth;
   };
   timestamp: string;
 }

--- a/apps/web/src/features/health/api/health.types.ts
+++ b/apps/web/src/features/health/api/health.types.ts
@@ -1,4 +1,4 @@
-export type ServiceStatus = 'ok' | 'error';
+export type ServiceStatus = 'ok' | 'warning' | 'error';
 export type OverallStatus = 'ok' | 'degraded' | 'error';
 
 export interface ServiceHealth {
@@ -12,6 +12,7 @@ export interface DevStackHealth {
     postgres: ServiceHealth;
     redis: ServiceHealth;
     prestashop: ServiceHealth;
+    worker?: ServiceHealth;
   };
   timestamp: string;
 }

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -63,6 +63,7 @@ describe('DashboardPage', () => {
             postgres: { status: 'ok' },
             redis: { status: 'ok' },
             prestashop: { status: 'error', message: 'Connection refused' },
+            worker: { status: 'ok' },
           },
           timestamp: '2026-04-06T00:00:00.000Z',
         }),

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { useDevStackHealthQuery } from '../../features/health/hooks/use-dev-stack-health-query';
 import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
-import type { OverallStatus, ServiceHealth } from '../../features/health/api/health.types';
+import type { ServiceHealth } from '../../features/health/api/health.types';
 import type { Connection } from '../../features/connections/api/connections.types';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 import { Button } from '../../shared/ui/button';
@@ -85,9 +85,9 @@ const failedJobColumns: DataTableColumn<SyncJob>[] = [
   updatedAtColumn,
 ];
 
-function toHealthTone(status: OverallStatus): StatusBadgeTone {
+function toHealthTone(status: string): StatusBadgeTone {
   if (status === 'ok') return 'success';
-  if (status === 'degraded') return 'warning';
+  if (status === 'warning' || status === 'degraded') return 'warning';
   return 'error';
 }
 
@@ -187,7 +187,7 @@ export function DashboardPage(): ReactElement {
               </StatusBadge>
             </strong>
           )}
-          <p>Postgres · Redis · PrestaShop</p>
+          <p>Postgres · Redis · PrestaShop · Worker</p>
         </article>
 
         <article className={deadCount > 0 ? 'metric-card metric-card--warning' : 'metric-card'}>
@@ -268,6 +268,9 @@ export function DashboardPage(): ReactElement {
               <ServiceHealthRow name="PostgreSQL" health={healthQuery.data.services.postgres} />
               <ServiceHealthRow name="Redis" health={healthQuery.data.services.redis} />
               <ServiceHealthRow name="PrestaShop" health={healthQuery.data.services.prestashop} />
+              {healthQuery.data.services.worker && (
+                <ServiceHealthRow name="Worker" health={healthQuery.data.services.worker} />
+              )}
             </ul>
           )}
         </article>

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { useDevStackHealthQuery } from '../../features/health/hooks/use-dev-stack-health-query';
 import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
-import type { ServiceHealth } from '../../features/health/api/health.types';
+import type { ServiceHealth, ServiceStatus, OverallStatus } from '../../features/health/api/health.types';
 import type { Connection } from '../../features/connections/api/connections.types';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 import { Button } from '../../shared/ui/button';
@@ -85,7 +85,7 @@ const failedJobColumns: DataTableColumn<SyncJob>[] = [
   updatedAtColumn,
 ];
 
-function toHealthTone(status: string): StatusBadgeTone {
+function toHealthTone(status: ServiceStatus | OverallStatus): StatusBadgeTone {
   if (status === 'ok') return 'success';
   if (status === 'warning' || status === 'degraded') return 'warning';
   return 'error';

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -118,6 +118,7 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
           postgres: { status: 'ok' },
           redis: { status: 'ok' },
           prestashop: { status: 'ok' },
+          worker: { status: 'ok' },
         },
         timestamp: '2026-04-06T00:00:00.000Z',
       }),

--- a/apps/worker/src/app.module.ts
+++ b/apps/worker/src/app.module.ts
@@ -18,6 +18,7 @@ import { ProductsModule } from '@openlinker/core/products';
 import { InventoryModule } from '@openlinker/core/inventory';
 import { SyncModule } from '@openlinker/core/sync';
 import { SyncWorkerModule } from './sync/sync-worker.module';
+import { WorkerHeartbeatService } from './health/worker-heartbeat.service';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { SyncWorkerModule } from './sync/sync-worker.module';
     SyncModule,
     SyncWorkerModule,
   ],
+  providers: [WorkerHeartbeatService],
 })
 export class AppModule {}
 

--- a/apps/worker/src/health/worker-heartbeat.service.interface.ts
+++ b/apps/worker/src/health/worker-heartbeat.service.interface.ts
@@ -1,0 +1,9 @@
+/**
+ * Worker Heartbeat Service Interface
+ *
+ * Defines the contract for worker heartbeat operations. The service writes
+ * timestamped health checks to Redis on a regular interval.
+ *
+ * @module apps/worker/src/health
+ */
+export interface IWorkerHeartbeatService {}

--- a/apps/worker/src/health/worker-heartbeat.service.ts
+++ b/apps/worker/src/health/worker-heartbeat.service.ts
@@ -1,0 +1,66 @@
+/**
+ * Worker Heartbeat Service
+ *
+ * Writes a timestamped key to Redis every 10 seconds so the API can determine
+ * whether the worker is alive. The key carries a Unix-ms timestamp and expires
+ * automatically after 120 s — if the worker crashes without a clean shutdown
+ * the key expires on its own, causing the health check to flip to error.
+ *
+ * @module apps/worker/src/health
+ */
+import { Injectable, Inject, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { RedisClientType } from 'redis';
+
+export const WORKER_HEARTBEAT_KEY = 'openlinker:worker:heartbeat';
+const HEARTBEAT_INTERVAL_MS = 10_000;
+const HEARTBEAT_TTL_SECONDS = 120;
+
+@Injectable()
+export class WorkerHeartbeatService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WorkerHeartbeatService.name);
+  private intervalId: NodeJS.Timeout | undefined;
+
+  constructor(
+    @Inject('REDIS_CLIENT')
+    private readonly redisClient: RedisClientType,
+    private readonly configService: ConfigService,
+  ) {}
+
+  onModuleInit(): void {
+    const enabled = this.configService.get<string>('WORKER_HEARTBEAT_ENABLED', 'true') !== 'false';
+    if (!enabled) {
+      this.logger.log('Worker heartbeat disabled via WORKER_HEARTBEAT_ENABLED=false');
+      return;
+    }
+
+    // Write immediately on startup so the health tile flips to OK quickly.
+    void this.writeHeartbeat();
+    this.intervalId = setInterval(() => {
+      void this.writeHeartbeat();
+    }, HEARTBEAT_INTERVAL_MS);
+
+    this.logger.log(`Worker heartbeat started (interval=${HEARTBEAT_INTERVAL_MS}ms, TTL=${HEARTBEAT_TTL_SECONDS}s)`);
+  }
+
+  onModuleDestroy(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = undefined;
+    }
+  }
+
+  private async writeHeartbeat(): Promise<void> {
+    try {
+      await this.redisClient.set(
+        WORKER_HEARTBEAT_KEY,
+        Date.now().toString(),
+        { EX: HEARTBEAT_TTL_SECONDS },
+      );
+    } catch (error) {
+      // Heartbeat failure must not crash the worker — log and continue.
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to write worker heartbeat: ${message}`);
+    }
+  }
+}

--- a/apps/worker/src/health/worker-heartbeat.service.ts
+++ b/apps/worker/src/health/worker-heartbeat.service.ts
@@ -11,13 +11,14 @@
 import { Injectable, Inject, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { RedisClientType } from 'redis';
+import { IWorkerHeartbeatService } from './worker-heartbeat.service.interface';
+import { WORKER_HEARTBEAT_REDIS_KEY } from '@openlinker/shared/worker/worker-health.constants';
 
-export const WORKER_HEARTBEAT_KEY = 'openlinker:worker:heartbeat';
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const HEARTBEAT_TTL_SECONDS = 120;
 
 @Injectable()
-export class WorkerHeartbeatService implements OnModuleInit, OnModuleDestroy {
+export class WorkerHeartbeatService implements IWorkerHeartbeatService, OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(WorkerHeartbeatService.name);
   private intervalId: NodeJS.Timeout | undefined;
 
@@ -53,7 +54,7 @@ export class WorkerHeartbeatService implements OnModuleInit, OnModuleDestroy {
   private async writeHeartbeat(): Promise<void> {
     try {
       await this.redisClient.set(
-        WORKER_HEARTBEAT_KEY,
+        WORKER_HEARTBEAT_REDIS_KEY,
         Date.now().toString(),
         { EX: HEARTBEAT_TTL_SECONDS },
       );

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,6 +58,8 @@ Health check:
 curl -s http://localhost:3000/health/dev-stack | jq .
 ```
 
+Once the worker is running (`pnpm start:dev:worker`), the **System Health** panel at **http://localhost:5173** (dashboard) will show four tiles: PostgreSQL, Redis, PrestaShop, and Worker. The Worker tile confirms the background sync worker is alive; if it remains red after the worker starts, check the worker logs for errors.
+
 ## 3. Admin user & login
 
 Log in at http://localhost:5173.

--- a/libs/shared/src/worker/worker-health.constants.ts
+++ b/libs/shared/src/worker/worker-health.constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Worker Health Constants
+ *
+ * Shared constants for worker health monitoring between worker and API.
+ * Both apps reference the same Redis key to maintain consistency.
+ *
+ * @module libs/shared/src/worker
+ */
+
+/**
+ * Redis key where worker writes its heartbeat timestamp.
+ * Worker writes this every 10 seconds with 120s TTL.
+ * API reads this to determine worker health status.
+ */
+export const WORKER_HEARTBEAT_REDIS_KEY = 'openlinker:worker:heartbeat';


### PR DESCRIPTION
## Summary

Added worker health monitoring to the dashboard. Worker heartbeat tracked in Redis with automatic expiration — shows RED when worker is down or heartbeat stale.

## Implementation

- Worker heartbeat service writes timestamp every 10s to Redis key
- Key expires after 120s if worker crashes/stops
- Health check endpoint reads key and determines worker status
- Dashboard displays worker health tile with real-time status

## Test Results

- All health service tests passing (12/12)
- Coverage includes: fresh heartbeat, warning threshold, error threshold, missing key, Redis errors

## Test Plan

- Start worker -> health shows GREEN
- Kill worker - wait 35s -> health shows yellow warning
- Wait 90 more seconds -> health shows red fail badge
- Restart worker -> health shows GREEN immediately

Closes #167