### PR TITLE
fix(webhooks): dedicate separate Redis client to blocking xReadGroup consumer

### DIFF
--- a/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
+++ b/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
@@ -31,7 +31,7 @@ describe('WebhookToJobHandler', () => {
       providers: [
         WebhookToJobHandler,
         {
-          provide: 'REDIS_CLIENT',
+          provide: 'REDIS_CLIENT_BLOCKING',
           useValue: mockRedisClient,
         },
         {

--- a/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
+++ b/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
@@ -11,16 +11,19 @@ import { WebhookToJobHandler } from '../webhook-to-job.handler';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import { InboundWebhookEvent } from '@openlinker/core/events';
 import { JobTypeValues } from '@openlinker/core/sync';
+import { REDIS_CLIENT_BLOCKING_TOKEN } from '../../../webhooks.tokens';
 
 describe('WebhookToJobHandler', () => {
   let handler: WebhookToJobHandler;
+  let mockRedisClient: { xGroupCreate: jest.Mock; xReadGroup: jest.Mock; xAck: jest.Mock; xAdd: jest.Mock; quit: jest.Mock };
 
   beforeEach(async () => {
-    const mockRedisClient = {
+    mockRedisClient = {
       xGroupCreate: jest.fn(),
       xReadGroup: jest.fn(),
       xAck: jest.fn(),
       xAdd: jest.fn(),
+      quit: jest.fn().mockResolvedValue(undefined),
     };
 
     const mockJobEnqueue = {
@@ -31,7 +34,7 @@ describe('WebhookToJobHandler', () => {
       providers: [
         WebhookToJobHandler,
         {
-          provide: 'REDIS_CLIENT_BLOCKING',
+          provide: REDIS_CLIENT_BLOCKING_TOKEN,
           useValue: mockRedisClient,
         },
         {
@@ -42,8 +45,22 @@ describe('WebhookToJobHandler', () => {
     }).compile();
 
     handler = module.get<WebhookToJobHandler>(WebhookToJobHandler);
-    // Note: redisClient and jobEnqueue are not used in these tests
-    // as we're only testing private mapping methods
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should call redisClient.quit() on module destroy', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const onModuleDestroyPromise = handler.onModuleDestroy();
+        await jest.advanceTimersByTimeAsync(2000);
+        await onModuleDestroyPromise;
+
+        expect(mockRedisClient.quit).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe('mapObjectType (via mapToSyncJob)', () => {

--- a/apps/api/src/webhooks/application/handlers/webhook-handler.types.ts
+++ b/apps/api/src/webhooks/application/handlers/webhook-handler.types.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal types for webhook-to-job handler stream field parsing.
+ *
+ * @module apps/api/src/webhooks/application/handlers
+ */
+
+export interface WebhookPayload {
+  objectType?: string;
+  externalId?: string;
+  payload?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface WebhookMetadata {
+  provider?: string;
+  connectionId?: string;
+  [key: string]: unknown;
+}

--- a/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
+++ b/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
@@ -15,6 +15,8 @@ import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import { EventEnvelope, InboundWebhookEvent } from '@openlinker/core/events';
 import { SyncJobRequest, JobType, JobTypeValues } from '@openlinker/core/sync';
 import { Logger } from '@openlinker/shared/logging';
+import { REDIS_CLIENT_BLOCKING_TOKEN } from '../../webhooks.tokens';
+import { WebhookPayload, WebhookMetadata } from './webhook-handler.types';
 
 @Injectable()
 export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
@@ -30,7 +32,7 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
   private isRunning = false;
 
   constructor(
-    @Inject('REDIS_CLIENT_BLOCKING')
+    @Inject(REDIS_CLIENT_BLOCKING_TOKEN)
     private readonly redisClient: RedisClientType,
     @Inject(JOB_ENQUEUE_TOKEN)
     private readonly jobEnqueue: JobEnqueuePort,
@@ -259,19 +261,6 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
    * Map event envelope to inbound webhook event
    */
   private mapToInboundWebhookEvent(envelope: EventEnvelope): InboundWebhookEvent {
-    interface WebhookPayload {
-      objectType?: string;
-      externalId?: string;
-      payload?: Record<string, unknown>;
-      [key: string]: unknown;
-    }
-
-    interface WebhookMetadata {
-      provider?: string;
-      connectionId?: string;
-      [key: string]: unknown;
-    }
-
     const payload = JSON.parse(envelope.payloadJson) as WebhookPayload;
     const metadata = (envelope.metadataJson ? JSON.parse(envelope.metadataJson) : {}) as WebhookMetadata;
 

--- a/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
+++ b/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
@@ -30,7 +30,7 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
   private isRunning = false;
 
   constructor(
-    @Inject('REDIS_CLIENT')
+    @Inject('REDIS_CLIENT_BLOCKING')
     private readonly redisClient: RedisClientType,
     @Inject(JOB_ENQUEUE_TOKEN)
     private readonly jobEnqueue: JobEnqueuePort,
@@ -43,6 +43,7 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
 
   async onModuleDestroy(): Promise<void> {
     await this.stopConsumptionLoop();
+    await this.redisClient.quit();
   }
 
   /**

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -20,6 +20,7 @@ import { WebhookAuthService } from './application/services/webhook-auth.service'
 import { WebhookDedupService } from './application/services/webhook-dedup.service';
 import { WebhookEventPublisher } from './application/services/webhook-event-publisher.service';
 import { WebhookToJobHandler } from './application/handlers/webhook-to-job.handler';
+import { REDIS_CLIENT_BLOCKING_TOKEN } from './webhooks.tokens';
 
 /**
  * Webhooks Module
@@ -44,7 +45,7 @@ import { WebhookToJobHandler } from './application/handlers/webhook-to-job.handl
     WebhookToJobHandler,
     {
       // Dedicated client for blocking xReadGroup loop — must not share with health check client
-      provide: 'REDIS_CLIENT_BLOCKING',
+      provide: REDIS_CLIENT_BLOCKING_TOKEN,
       useFactory: async (configService: ConfigService): Promise<RedisClientType> => {
         const client = createClient({
           socket: {
@@ -54,7 +55,13 @@ import { WebhookToJobHandler } from './application/handlers/webhook-to-job.handl
           password: configService.get<string>('REDIS_PASSWORD'),
           database: configService.get<number>('REDIS_DB', 0),
         });
-        await client.connect();
+        try {
+          await client.connect();
+        } catch (error) {
+          throw new Error(
+            `WebhooksModule: Failed to connect REDIS_CLIENT_BLOCKING: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
         return client as RedisClientType;
       },
       inject: [ConfigService],

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -8,6 +8,8 @@
  * @module apps/api/src/webhooks
  */
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createClient, RedisClientType } from 'redis';
 import { EventsModule } from '@openlinker/core/events';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
@@ -40,6 +42,23 @@ import { WebhookToJobHandler } from './application/handlers/webhook-to-job.handl
     WebhookDedupService,
     WebhookEventPublisher,
     WebhookToJobHandler,
+    {
+      // Dedicated client for blocking xReadGroup loop — must not share with health check client
+      provide: 'REDIS_CLIENT_BLOCKING',
+      useFactory: async (configService: ConfigService): Promise<RedisClientType> => {
+        const client = createClient({
+          socket: {
+            host: configService.get<string>('REDIS_HOST', 'localhost'),
+            port: configService.get<number>('REDIS_PORT', 6379),
+          },
+          password: configService.get<string>('REDIS_PASSWORD'),
+          database: configService.get<number>('REDIS_DB', 0),
+        });
+        await client.connect();
+        return client as RedisClientType;
+      },
+      inject: [ConfigService],
+    },
   ],
 })
 export class WebhooksModule {}

--- a/apps/api/src/webhooks/webhooks.tokens.ts
+++ b/apps/api/src/webhooks/webhooks.tokens.ts
@@ -1,0 +1,7 @@
+/**
+ * Webhooks Module DI Tokens
+ *
+ * @module apps/api/src/webhooks
+ */
+
+export const REDIS_CLIENT_BLOCKING_TOKEN = Symbol('REDIS_CLIENT_BLOCKING');


### PR DESCRIPTION
## Summary
- `WebhookToJobHandler` was sharing `REDIS_CLIENT` with `DevStackHealthService`; the blocking `xReadGroup` call (BLOCK_MS=5000) held the connection, causing the health check `xAdd` to queue behind it and hit the 5s timeout
- Added `REDIS_CLIENT_BLOCKING` provider in `WebhooksModule` — a dedicated Redis connection scoped to the webhook consumer
- Handler now injects `REDIS_CLIENT_BLOCKING` and calls `quit()` on module destroy
- `DevStackHealthService` unchanged

## Test plan
- [ ] `pnpm lint && pnpm type-check && pnpm test` — all pass
- [ ] Start dev stack + API, confirm `GET /health/dev-stack` returns `redis: ok` while webhook consumer loop is active

Closes #183
Related to #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)