### PR TITLE
fix(connections): redirect to list + toast after creating connection

### DIFF
--- a/apps/web/src/features/connections/components/create-connection-form.test.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.test.tsx
@@ -1,7 +1,14 @@
-import { fireEvent, screen, within } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { useLocation } from 'react-router-dom';
 import { CreateConnectionForm } from './create-connection-form';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+
+function LocationProbe(): ReactElement {
+  const location = useLocation();
+  return <div data-testid="location-pathname">{location.pathname}</div>;
+}
 
 describe('CreateConnectionForm', () => {
   it('shows validation feedback for invalid JSON configuration', async () => {
@@ -26,7 +33,12 @@ describe('CreateConnectionForm', () => {
   });
 
   it('shows a success toast after creating a connection', async () => {
-    const view = renderWithProviders(<CreateConnectionForm />);
+    const view = renderWithProviders(
+      <>
+        <CreateConnectionForm />
+        <LocationProbe />
+      </>,
+    );
 
     fireEvent.change(within(view.container).getAllByLabelText('Connection name')[0], {
       target: { value: 'Main store' },
@@ -44,8 +56,11 @@ describe('CreateConnectionForm', () => {
 
     expect(await screen.findByText('Connection created')).toBeInTheDocument();
     expect(
-      screen.getByText(/Connection ".*" was created\./),
+      screen.getByText('Connection "Main PrestaShop Store" was created.'),
     ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('location-pathname')).toHaveTextContent('/connections');
+    });
   });
 
   it('resets the draft through the confirm dialog', async () => {

--- a/apps/web/src/features/connections/components/create-connection-form.test.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.test.tsx
@@ -43,7 +43,9 @@ describe('CreateConnectionForm', () => {
     fireEvent.click(within(view.container).getAllByRole('button', { name: 'Create connection' })[0]);
 
     expect(await screen.findByText('Connection created')).toBeInTheDocument();
-    expect(screen.getByText('Connection request submitted successfully.')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Connection ".*" was created\./),
+    ).toBeInTheDocument();
   });
 
   it('resets the draft through the confirm dialog', async () => {

--- a/apps/web/src/features/connections/components/create-connection-form.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { PLATFORM_TYPES } from '../api/connections.types';
 import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
@@ -45,6 +45,7 @@ const PLATFORM_OPTIONS = [
 export function CreateConnectionForm(): ReactElement {
   const createConnection = useCreateConnectionMutation();
   const { showToast } = useToast();
+  const navigate = useNavigate();
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
   const form = useForm<CreateConnectionFormValues, undefined, CreateConnectionFormSubmission>({
     defaultValues: DEFAULT_VALUES,
@@ -66,13 +67,13 @@ export function CreateConnectionForm(): ReactElement {
     // submission would fail silently without visible feedback.
     if (isAllegroSelected) return;
     try {
-      await createConnection.mutateAsync(toCreateConnectionInput(values));
-      form.reset(DEFAULT_VALUES);
+      const created = await createConnection.mutateAsync(toCreateConnectionInput(values));
       showToast({
         tone: 'success',
         title: 'Connection created',
-        description: 'Connection request submitted successfully.',
+        description: `Connection "${created.name}" was created.`,
       });
+      void navigate('/connections');
     } catch {
       return;
     }

--- a/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
@@ -1,7 +1,14 @@
-import { cleanup, fireEvent, screen, within } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useLocation } from 'react-router-dom';
 import { PrestashopSetupForm } from './prestashop-setup-form';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
+
+function LocationProbe(): ReactElement {
+  const location = useLocation();
+  return <div data-testid="location-pathname">{location.pathname}</div>;
+}
 
 describe('PrestashopSetupForm', () => {
   afterEach(cleanup);
@@ -9,7 +16,13 @@ describe('PrestashopSetupForm', () => {
   it('submits a PrestaShop connection with the inferred adapter key and config', async () => {
     const create = vi.fn().mockResolvedValue(sampleConnection);
     const apiClient = createMockApiClient({ connections: { create } });
-    const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
+    const view = renderWithProviders(
+      <>
+        <PrestashopSetupForm />
+        <LocationProbe />
+      </>,
+      { apiClient },
+    );
 
     fireEvent.change(within(view.container).getByLabelText('Connection name'), {
       target: { value: 'Main store' },
@@ -23,6 +36,9 @@ describe('PrestashopSetupForm', () => {
     fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
 
     expect(await screen.findByText('Connection created')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('location-pathname')).toHaveTextContent('/connections');
+    });
     expect(create).toHaveBeenCalledWith({
       name: 'Main store',
       platformType: 'prestashop',

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -10,6 +10,7 @@
 import type { ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
 import {
   PRESTASHOP_ADAPTER_KEY,
@@ -40,6 +41,7 @@ const CAPABILITY_HELP: Record<Capability, string> = {
 export function PrestashopSetupForm(): ReactElement {
   const createConnection = useCreateConnectionMutation();
   const { showToast } = useToast();
+  const navigate = useNavigate();
   const adaptersQuery = useAdaptersQuery();
   const form = useForm<PrestashopSetupFormValues, undefined, PrestashopSetupFormSubmission>({
     defaultValues: PRESTASHOP_SETUP_DEFAULT_VALUES,
@@ -62,12 +64,12 @@ export function PrestashopSetupForm(): ReactElement {
   const onSubmit = form.handleSubmit(async (values) => {
     try {
       const created = await createConnection.mutateAsync(toCreateConnectionInput(values));
-      form.reset(PRESTASHOP_SETUP_DEFAULT_VALUES);
       showToast({
         tone: 'success',
         title: 'Connection created',
         description: `PrestaShop connection "${created.name}" was created.`,
       });
+      void navigate('/connections');
     } catch {
       return;
     }


### PR DESCRIPTION
## Summary
- On successful connection create, both the generic create form and the PrestaShop setup wizard now fire a success toast and navigate to `/connections` instead of silently resetting.
- On failure, forms keep their values and surface the existing inline `Alert` — no redirect.
- Tests tightened to assert the exact toast description and the post-submit route via a `useLocation` probe.

Closes #163

## Test plan
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm --filter @openlinker/web test` (152 passing)
- [ ] Manual: create a PrestaShop connection via the wizard → lands on `/connections` with success toast
- [ ] Manual: trigger an API error → stays on form, error alert visible