### PR TITLE
feat(auth): password reset flow

### DIFF
--- a/apps/api/src/auth/adapters/console-password-reset-notifier.adapter.ts
+++ b/apps/api/src/auth/adapters/console-password-reset-notifier.adapter.ts
@@ -1,0 +1,28 @@
+/**
+ * Console Password Reset Notifier Adapter
+ *
+ * Dev-time implementation of PasswordResetNotifierPort that logs the reset
+ * link instead of sending email. Real mailer adapters (SMTP, SES, etc.)
+ * should replace this in production wiring.
+ *
+ * @module apps/api/src/auth/adapters
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { PasswordResetNotifierPort, User } from '@openlinker/core/users';
+
+@Injectable()
+export class ConsolePasswordResetNotifierAdapter implements PasswordResetNotifierPort {
+  private readonly logger = new Logger(ConsolePasswordResetNotifierAdapter.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async notifyResetRequested(user: User, rawToken: string): Promise<void> {
+    const base = this.configService.get<string>('WEB_URL', 'http://localhost:5173');
+    const link = `${base.replace(/\/$/, '')}/reset-password/${rawToken}`;
+    this.logger.log(
+      `[password-reset] user=${user.username} email=${user.email ?? '-'} link=${link}`,
+    );
+    return Promise.resolve();
+  }
+}

--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -12,7 +12,11 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
-import { User } from '@openlinker/core/users';
+import { User, InvalidPasswordResetTokenException } from '@openlinker/core/users';
+import { PASSWORD_RESET_SERVICE_TOKEN, IPasswordResetService } from './password-reset.service.interface';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+import { BadRequestException } from '@nestjs/common';
 
 const makeUser = (): User =>
   new User('user-uuid-123', 'admin', null, '$2a$10$hash', 'admin', new Date(), new Date());
@@ -26,6 +30,7 @@ const makeLoginResponse = (): LoginResponseDto => {
 describe('AuthController', () => {
   let controller: AuthController;
   let authService: jest.Mocked<AuthService>;
+  let passwordResetService: jest.Mocked<IPasswordResetService>;
 
   beforeEach(async () => {
     const mockAuthService = {
@@ -33,14 +38,22 @@ describe('AuthController', () => {
       login: jest.fn(),
       getMe: jest.fn(),
     } as unknown as jest.Mocked<AuthService>;
+    const mockPasswordResetService: jest.Mocked<IPasswordResetService> = {
+      requestReset: jest.fn(),
+      resetPassword: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [{ provide: AuthService, useValue: mockAuthService }],
+      providers: [
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: PASSWORD_RESET_SERVICE_TOKEN, useValue: mockPasswordResetService },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
     authService = module.get(AuthService);
+    passwordResetService = module.get(PASSWORD_RESET_SERVICE_TOKEN);
   });
 
   describe('POST /auth/login', () => {
@@ -67,6 +80,37 @@ describe('AuthController', () => {
 
       await expect(controller.login(dto)).rejects.toThrow(UnauthorizedException);
       expect(authService.login).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /auth/forgot-password', () => {
+    it('should always return 200 and delegate to service', async () => {
+      passwordResetService.requestReset.mockResolvedValue();
+      const dto: ForgotPasswordDto = Object.assign(new ForgotPasswordDto(), {
+        email: 'a@b.com',
+      });
+      const result = await controller.forgotPassword(dto);
+      expect(result).toEqual({ ok: true });
+      expect(passwordResetService.requestReset).toHaveBeenCalledWith('a@b.com');
+    });
+  });
+
+  describe('POST /auth/reset-password', () => {
+    const dto: ResetPasswordDto = Object.assign(new ResetPasswordDto(), {
+      token: 'raw',
+      newPassword: 'longenough',
+    });
+
+    it('should return ok on success', async () => {
+      passwordResetService.resetPassword.mockResolvedValue();
+      await expect(controller.resetPassword(dto)).resolves.toEqual({ ok: true });
+    });
+
+    it('should convert InvalidPasswordResetTokenException to 400', async () => {
+      passwordResetService.resetPassword.mockRejectedValue(
+        new InvalidPasswordResetTokenException(),
+      );
+      await expect(controller.resetPassword(dto)).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -24,7 +24,10 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { InvalidPasswordResetTokenException } from '@openlinker/core/users';
+import {
+  InvalidPasswordResetTokenException,
+  WeakPasswordException,
+} from '@openlinker/core/users';
 import { AuthService } from './auth.service';
 import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
@@ -33,6 +36,7 @@ import { LoginResponseDto } from './dto/login-response.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { OkResponseDto } from './dto/ok-response.dto';
 import { AuthenticatedUser } from './auth.types';
 import {
   IPasswordResetService,
@@ -79,8 +83,12 @@ export class AuthController {
   @ApiOperation({
     summary: 'Request a password reset email. Always returns 200 to prevent user enumeration.',
   })
-  @ApiResponse({ status: 200, description: 'Request accepted (regardless of account existence)' })
-  async forgotPassword(@Body() dto: ForgotPasswordDto): Promise<{ ok: true }> {
+  @ApiResponse({
+    status: 200,
+    description: 'Request accepted (regardless of account existence)',
+    type: OkResponseDto,
+  })
+  async forgotPassword(@Body() dto: ForgotPasswordDto): Promise<OkResponseDto> {
     await this.passwordResetService.requestReset(dto.email);
     return { ok: true };
   }
@@ -89,13 +97,16 @@ export class AuthController {
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Consume a reset token and set a new password' })
-  @ApiResponse({ status: 200, description: 'Password updated' })
+  @ApiResponse({ status: 200, description: 'Password updated', type: OkResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid or expired token, or weak password' })
-  async resetPassword(@Body() dto: ResetPasswordDto): Promise<{ ok: true }> {
+  async resetPassword(@Body() dto: ResetPasswordDto): Promise<OkResponseDto> {
     try {
       await this.passwordResetService.resetPassword(dto.token, dto.newPassword);
     } catch (error) {
-      if (error instanceof InvalidPasswordResetTokenException) {
+      if (
+        error instanceof InvalidPasswordResetTokenException ||
+        error instanceof WeakPasswordException
+      ) {
         throw new BadRequestException(error.message);
       }
       throw error;

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,18 +1,20 @@
 /**
  * Authentication Controller
  *
- * HTTP REST API endpoints for authentication. Provides login (POST /auth/login)
- * and current-user (GET /auth/me) endpoints. The login endpoint is public;
+ * HTTP REST API endpoints for authentication. Provides login, current-user,
+ * and password reset endpoints. Login and password-reset endpoints are public;
  * /auth/me requires a valid JWT bearer token (enforced by global guard).
  *
  * @module apps/api/src/auth
  */
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
   HttpCode,
   HttpStatus,
+  Inject,
   Post,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -22,18 +24,29 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
+import { InvalidPasswordResetTokenException } from '@openlinker/core/users';
 import { AuthService } from './auth.service';
 import { Public } from './decorators/public.decorator';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { LoginDto } from './dto/login.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { UserResponseDto } from './dto/user-response.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import { AuthenticatedUser } from './auth.types';
+import {
+  IPasswordResetService,
+  PASSWORD_RESET_SERVICE_TOKEN,
+} from './password-reset.service.interface';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    @Inject(PASSWORD_RESET_SERVICE_TOKEN)
+    private readonly passwordResetService: IPasswordResetService,
+  ) {}
 
   @Public()
   @Post('login')
@@ -58,5 +71,35 @@ export class AuthController {
   async getMe(@CurrentUser() user: AuthenticatedUser): Promise<UserResponseDto> {
     const fullUser = await this.authService.getMe(user.id);
     return UserResponseDto.fromDomain(fullUser);
+  }
+
+  @Public()
+  @Post('forgot-password')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Request a password reset email. Always returns 200 to prevent user enumeration.',
+  })
+  @ApiResponse({ status: 200, description: 'Request accepted (regardless of account existence)' })
+  async forgotPassword(@Body() dto: ForgotPasswordDto): Promise<{ ok: true }> {
+    await this.passwordResetService.requestReset(dto.email);
+    return { ok: true };
+  }
+
+  @Public()
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Consume a reset token and set a new password' })
+  @ApiResponse({ status: 200, description: 'Password updated' })
+  @ApiResponse({ status: 400, description: 'Invalid or expired token, or weak password' })
+  async resetPassword(@Body() dto: ResetPasswordDto): Promise<{ ok: true }> {
+    try {
+      await this.passwordResetService.resetPassword(dto.token, dto.newPassword);
+    } catch (error) {
+      if (error instanceof InvalidPasswordResetTokenException) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+    return { ok: true };
   }
 }

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -20,6 +20,12 @@ import { AuthController } from './auth.controller';
 import { BootstrapAdminService } from './bootstrap-admin.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RolesGuard } from './guards/roles.guard';
+import { PasswordResetService } from './password-reset.service';
+import {
+  PASSWORD_RESET_NOTIFIER_TOKEN,
+  PASSWORD_RESET_SERVICE_TOKEN,
+} from './password-reset.service.interface';
+import { ConsolePasswordResetNotifierAdapter } from './adapters/console-password-reset-notifier.adapter';
 
 @Module({
   imports: [
@@ -41,6 +47,10 @@ import { RolesGuard } from './guards/roles.guard';
     AuthService,
     BootstrapAdminService,
     JwtStrategy,
+    PasswordResetService,
+    { provide: PASSWORD_RESET_SERVICE_TOKEN, useExisting: PasswordResetService },
+    ConsolePasswordResetNotifierAdapter,
+    { provide: PASSWORD_RESET_NOTIFIER_TOKEN, useExisting: ConsolePasswordResetNotifierAdapter },
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
   ],

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -13,7 +13,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { UsersModule } from '@openlinker/core/users';
+import { PASSWORD_RESET_NOTIFIER_TOKEN, UsersModule } from '@openlinker/core/users';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
@@ -21,10 +21,7 @@ import { BootstrapAdminService } from './bootstrap-admin.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { RolesGuard } from './guards/roles.guard';
 import { PasswordResetService } from './password-reset.service';
-import {
-  PASSWORD_RESET_NOTIFIER_TOKEN,
-  PASSWORD_RESET_SERVICE_TOKEN,
-} from './password-reset.service.interface';
+import { PASSWORD_RESET_SERVICE_TOKEN } from './password-reset.service.interface';
 import { ConsolePasswordResetNotifierAdapter } from './adapters/console-password-reset-notifier.adapter';
 
 @Module({

--- a/apps/api/src/auth/bootstrap-admin.service.spec.ts
+++ b/apps/api/src/auth/bootstrap-admin.service.spec.ts
@@ -26,8 +26,10 @@ const makeConfig = (overrides: Record<string, string | undefined> = {}): ConfigS
 
 const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
   findByUsername: jest.fn(),
+  findByEmail: jest.fn(),
   findById: jest.fn(),
   save: jest.fn(),
+  updatePasswordHash: jest.fn(),
 });
 
 describe('BootstrapAdminService', () => {

--- a/apps/api/src/auth/dto/forgot-password.dto.ts
+++ b/apps/api/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,15 @@
+/**
+ * Forgot Password DTO
+ *
+ * Request body for POST /auth/forgot-password.
+ *
+ * @module apps/api/src/auth/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @ApiProperty({ description: 'Email associated with the account', example: 'admin@example.com' })
+  @IsEmail()
+  email!: string;
+}

--- a/apps/api/src/auth/dto/ok-response.dto.ts
+++ b/apps/api/src/auth/dto/ok-response.dto.ts
@@ -1,0 +1,13 @@
+/**
+ * Ok Response DTO
+ *
+ * Generic `{ ok: true }` response for endpoints with no meaningful payload.
+ *
+ * @module apps/api/src/auth/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OkResponseDto {
+  @ApiProperty({ example: true })
+  ok!: true;
+}

--- a/apps/api/src/auth/dto/reset-password.dto.ts
+++ b/apps/api/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,21 @@
+/**
+ * Reset Password DTO
+ *
+ * Request body for POST /auth/reset-password.
+ *
+ * @module apps/api/src/auth/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @ApiProperty({ description: 'One-time reset token from the reset email/link' })
+  @IsString()
+  @IsNotEmpty()
+  token!: string;
+
+  @ApiProperty({ description: 'New password (minimum 8 characters)', minLength: 8 })
+  @IsString()
+  @MinLength(8)
+  newPassword!: string;
+}

--- a/apps/api/src/auth/password-reset.service.interface.ts
+++ b/apps/api/src/auth/password-reset.service.interface.ts
@@ -1,0 +1,16 @@
+/**
+ * Password Reset Service Interface
+ *
+ * Contract for the password reset use cases: requesting a reset link and
+ * consuming a token to set a new password.
+ *
+ * @module apps/api/src/auth
+ */
+
+export interface IPasswordResetService {
+  requestReset(email: string): Promise<void>;
+  resetPassword(token: string, newPassword: string): Promise<void>;
+}
+
+export const PASSWORD_RESET_SERVICE_TOKEN = Symbol('IPasswordResetService');
+export const PASSWORD_RESET_NOTIFIER_TOKEN = Symbol('PasswordResetNotifierPort');

--- a/apps/api/src/auth/password-reset.service.interface.ts
+++ b/apps/api/src/auth/password-reset.service.interface.ts
@@ -13,4 +13,3 @@ export interface IPasswordResetService {
 }
 
 export const PASSWORD_RESET_SERVICE_TOKEN = Symbol('IPasswordResetService');
-export const PASSWORD_RESET_NOTIFIER_TOKEN = Symbol('PasswordResetNotifierPort');

--- a/apps/api/src/auth/password-reset.service.spec.ts
+++ b/apps/api/src/auth/password-reset.service.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * PasswordResetService unit tests.
+ */
+import { BadRequestException } from '@nestjs/common';
+import { createHash } from 'crypto';
+import * as bcrypt from 'bcryptjs';
+import { PasswordResetService } from './password-reset.service';
+import {
+  InvalidPasswordResetTokenException,
+  PasswordResetToken,
+  User,
+  type PasswordResetNotifierPort,
+  type PasswordResetTokenRepositoryPort,
+  type UserRepositoryPort,
+} from '@openlinker/core/users';
+
+const makeUser = (): User =>
+  new User('u-1', 'admin', 'admin@example.com', 'hash', 'admin', new Date(), new Date());
+
+const makeConfig = (ttl = 60) =>
+  ({ get: jest.fn(() => ttl) }) as unknown as import('@nestjs/config').ConfigService;
+
+function makeMocks() {
+  const userRepo: jest.Mocked<UserRepositoryPort> = {
+    findByUsername: jest.fn(),
+    findByEmail: jest.fn(),
+    findById: jest.fn(),
+    save: jest.fn(),
+    updatePasswordHash: jest.fn(),
+  };
+  const tokenRepo: jest.Mocked<PasswordResetTokenRepositoryPort> = {
+    save: jest.fn(),
+    findByTokenHash: jest.fn(),
+    markUsed: jest.fn(),
+    invalidateActiveForUser: jest.fn(),
+  };
+  const notifier: jest.Mocked<PasswordResetNotifierPort> = {
+    notifyResetRequested: jest.fn(),
+  };
+  return { userRepo, tokenRepo, notifier };
+}
+
+describe('PasswordResetService', () => {
+  describe('requestReset', () => {
+    it('returns silently when email is unknown (no enumeration, no notify)', async () => {
+      const { userRepo, tokenRepo, notifier } = makeMocks();
+      userRepo.findByEmail.mockResolvedValue(null);
+      const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig());
+
+      await service.requestReset('missing@example.com');
+
+      expect(tokenRepo.save).not.toHaveBeenCalled();
+      expect(notifier.notifyResetRequested).not.toHaveBeenCalled();
+    });
+
+    it('invalidates prior tokens, stores hashed token, and notifies', async () => {
+      const { userRepo, tokenRepo, notifier } = makeMocks();
+      const user = makeUser();
+      userRepo.findByEmail.mockResolvedValue(user);
+      tokenRepo.save.mockImplementation((t) =>
+        Promise.resolve(
+          new PasswordResetToken('t-1', t.userId, t.tokenHash, t.expiresAt, null, new Date()),
+        ),
+      );
+      const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig(60));
+
+      await service.requestReset(user.email!);
+
+      expect(tokenRepo.invalidateActiveForUser).toHaveBeenCalledWith(user.id, expect.any(Date));
+      expect(tokenRepo.save).toHaveBeenCalledTimes(1);
+      const saved = tokenRepo.save.mock.calls[0][0];
+      expect(saved.userId).toBe(user.id);
+      expect(saved.tokenHash).toHaveLength(64);
+      expect(notifier.notifyResetRequested).toHaveBeenCalledWith(user, expect.any(String));
+      const rawToken = notifier.notifyResetRequested.mock.calls[0][1];
+      // Notifier receives the raw token; storage keeps only its sha256 hash
+      expect(saved.tokenHash).toBe(createHash('sha256').update(rawToken).digest('hex'));
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('throws Invalid... when token is unknown', async () => {
+      const { userRepo, tokenRepo, notifier } = makeMocks();
+      tokenRepo.findByTokenHash.mockResolvedValue(null);
+      const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig());
+      await expect(service.resetPassword('nope', 'longenough')).rejects.toThrow(
+        InvalidPasswordResetTokenException,
+      );
+    });
+
+    it('throws Invalid... when token is expired', async () => {
+      const { userRepo, tokenRepo, notifier } = makeMocks();
+      const past = new Date(Date.now() - 1000);
+      tokenRepo.findByTokenHash.mockResolvedValue(
+        new PasswordResetToken('t-1', 'u-1', 'h', past, null, new Date()),
+      );
+      const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig());
+      await expect(service.resetPassword('raw', 'longenough')).rejects.toThrow(
+        InvalidPasswordResetTokenException,
+      );
+    });
+
+    it('throws Invalid... when token is already used', async () => {
+      const { userRepo, tokenRepo, notifier } = makeMocks();
+      const future = new Date(Date.now() + 60_000);
+      tokenRepo.findByTokenHash.mockResolvedValue(
+        new PasswordResetToken('t-1', 'u-1', 'h', future, new Date(), new Date()),
+      );
+      const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig());
+      await expect(service.resetPassword('raw', 'longenough')).rejects.toThrow(
+        InvalidPasswordResetTokenException,
+      );
+    });
+
+    it('throws BadRequest when password is too short', async () => {
+      const { userRepo, tokenRepo, notifier } = makeMocks();
+      const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig());
+      await expect(service.resetPassword('raw', 'short')).rejects.toThrow(BadRequestException);
+    });
+
+    it('hashes new password, updates user, marks token used', async () => {
+      const { userRepo, tokenRepo, notifier } = makeMocks();
+      const future = new Date(Date.now() + 60_000);
+      tokenRepo.findByTokenHash.mockResolvedValue(
+        new PasswordResetToken('t-1', 'u-1', 'h', future, null, new Date()),
+      );
+      const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig());
+
+      await service.resetPassword('raw', 'longenough');
+
+      expect(userRepo.updatePasswordHash).toHaveBeenCalledTimes(1);
+      const [userId, hash] = userRepo.updatePasswordHash.mock.calls[0];
+      expect(userId).toBe('u-1');
+      expect(await bcrypt.compare('longenough', hash)).toBe(true);
+      expect(tokenRepo.markUsed).toHaveBeenCalledWith('t-1', expect.any(Date));
+    });
+  });
+});

--- a/apps/api/src/auth/password-reset.service.spec.ts
+++ b/apps/api/src/auth/password-reset.service.spec.ts
@@ -1,7 +1,6 @@
 /**
  * PasswordResetService unit tests.
  */
-import { BadRequestException } from '@nestjs/common';
 import { createHash } from 'crypto';
 import * as bcrypt from 'bcryptjs';
 import { PasswordResetService } from './password-reset.service';
@@ -9,6 +8,7 @@ import {
   InvalidPasswordResetTokenException,
   PasswordResetToken,
   User,
+  WeakPasswordException,
   type PasswordResetNotifierPort,
   type PasswordResetTokenRepositoryPort,
   type UserRepositoryPort,
@@ -112,10 +112,10 @@ describe('PasswordResetService', () => {
       );
     });
 
-    it('throws BadRequest when password is too short', async () => {
+    it('throws WeakPasswordException when password is too short', async () => {
       const { userRepo, tokenRepo, notifier } = makeMocks();
       const service = new PasswordResetService(userRepo, tokenRepo, notifier, makeConfig());
-      await expect(service.resetPassword('raw', 'short')).rejects.toThrow(BadRequestException);
+      await expect(service.resetPassword('raw', 'short')).rejects.toThrow(WeakPasswordException);
     });
 
     it('hashes new password, updates user, marks token used', async () => {

--- a/apps/api/src/auth/password-reset.service.ts
+++ b/apps/api/src/auth/password-reset.service.ts
@@ -1,0 +1,90 @@
+/**
+ * Password Reset Service
+ *
+ * Implements the password reset flow: issuing single-use, short-lived tokens
+ * on request, and consuming them to set a new password. Raw tokens are never
+ * persisted — only SHA-256 hashes.
+ *
+ * @module apps/api/src/auth
+ */
+import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomBytes, createHash } from 'crypto';
+import * as bcrypt from 'bcryptjs';
+import {
+  InvalidPasswordResetTokenException,
+  PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN,
+  USER_REPOSITORY_TOKEN,
+  type PasswordResetNotifierPort,
+  type PasswordResetTokenRepositoryPort,
+  type UserRepositoryPort,
+} from '@openlinker/core/users';
+import {
+  IPasswordResetService,
+  PASSWORD_RESET_NOTIFIER_TOKEN,
+} from './password-reset.service.interface';
+
+const DEFAULT_TTL_MINUTES = 60;
+const BCRYPT_ROUNDS = 10;
+
+@Injectable()
+export class PasswordResetService implements IPasswordResetService {
+  private readonly logger = new Logger(PasswordResetService.name);
+  private readonly ttlMinutes: number;
+
+  constructor(
+    @Inject(USER_REPOSITORY_TOKEN)
+    private readonly userRepository: UserRepositoryPort,
+    @Inject(PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN)
+    private readonly tokenRepository: PasswordResetTokenRepositoryPort,
+    @Inject(PASSWORD_RESET_NOTIFIER_TOKEN)
+    private readonly notifier: PasswordResetNotifierPort,
+    private readonly configService: ConfigService,
+  ) {
+    this.ttlMinutes = Number(
+      this.configService.get<string | number>('PASSWORD_RESET_TTL_MINUTES', DEFAULT_TTL_MINUTES),
+    );
+  }
+
+  async requestReset(email: string): Promise<void> {
+    const user = await this.userRepository.findByEmail(email);
+    if (!user) {
+      // No-op; never signal whether the account exists.
+      this.logger.debug(`Password reset requested for unknown email`);
+      return;
+    }
+
+    const now = new Date();
+    await this.tokenRepository.invalidateActiveForUser(user.id, now);
+
+    const rawToken = randomBytes(32).toString('hex');
+    const tokenHash = this.hashToken(rawToken);
+    const expiresAt = new Date(now.getTime() + this.ttlMinutes * 60 * 1000);
+
+    await this.tokenRepository.save({ userId: user.id, tokenHash, expiresAt });
+    await this.notifier.notifyResetRequested(user, rawToken);
+  }
+
+  async resetPassword(token: string, newPassword: string): Promise<void> {
+    if (!token || !newPassword) {
+      throw new InvalidPasswordResetTokenException();
+    }
+    if (newPassword.length < 8) {
+      throw new BadRequestException('Password must be at least 8 characters');
+    }
+
+    const tokenHash = this.hashToken(token);
+    const record = await this.tokenRepository.findByTokenHash(tokenHash);
+    if (!record || !record.isUsable()) {
+      throw new InvalidPasswordResetTokenException();
+    }
+
+    const passwordHash = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
+    await this.userRepository.updatePasswordHash(record.userId, passwordHash);
+    await this.tokenRepository.markUsed(record.id, new Date());
+  }
+
+  private hashToken(rawToken: string): string {
+    return createHash('sha256').update(rawToken).digest('hex');
+  }
+}

--- a/apps/api/src/auth/password-reset.service.ts
+++ b/apps/api/src/auth/password-reset.service.ts
@@ -7,24 +7,24 @@
  *
  * @module apps/api/src/auth
  */
-import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomBytes, createHash } from 'crypto';
 import * as bcrypt from 'bcryptjs';
 import {
   InvalidPasswordResetTokenException,
+  PASSWORD_RESET_NOTIFIER_TOKEN,
   PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN,
   USER_REPOSITORY_TOKEN,
+  WeakPasswordException,
   type PasswordResetNotifierPort,
   type PasswordResetTokenRepositoryPort,
   type UserRepositoryPort,
 } from '@openlinker/core/users';
-import {
-  IPasswordResetService,
-  PASSWORD_RESET_NOTIFIER_TOKEN,
-} from './password-reset.service.interface';
+import { IPasswordResetService } from './password-reset.service.interface';
 
 const DEFAULT_TTL_MINUTES = 60;
+const MIN_PASSWORD_LENGTH = 8;
 const BCRYPT_ROUNDS = 10;
 
 @Injectable()
@@ -49,8 +49,7 @@ export class PasswordResetService implements IPasswordResetService {
   async requestReset(email: string): Promise<void> {
     const user = await this.userRepository.findByEmail(email);
     if (!user) {
-      // No-op; never signal whether the account exists.
-      this.logger.debug(`Password reset requested for unknown email`);
+      this.logger.debug('Password reset requested for unknown email');
       return;
     }
 
@@ -69,19 +68,22 @@ export class PasswordResetService implements IPasswordResetService {
     if (!token || !newPassword) {
       throw new InvalidPasswordResetTokenException();
     }
-    if (newPassword.length < 8) {
-      throw new BadRequestException('Password must be at least 8 characters');
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      throw new WeakPasswordException(
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters`,
+      );
     }
 
     const tokenHash = this.hashToken(token);
+    const now = new Date();
     const record = await this.tokenRepository.findByTokenHash(tokenHash);
-    if (!record || !record.isUsable()) {
+    if (!record || !record.isUsable(now)) {
       throw new InvalidPasswordResetTokenException();
     }
 
     const passwordHash = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
     await this.userRepository.updatePasswordHash(record.userId, passwordHash);
-    await this.tokenRepository.markUsed(record.id, new Date());
+    await this.tokenRepository.markUsed(record.id, now);
   }
 
   private hashToken(rawToken: string): string {

--- a/apps/api/src/migrations/1781000000000-add-password-reset-tokens.ts
+++ b/apps/api/src/migrations/1781000000000-add-password-reset-tokens.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPasswordResetTokens1781000000000 implements MigrationInterface {
+  name = 'AddPasswordResetTokens1781000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "password_reset_tokens" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "user_id" uuid NOT NULL,
+        "token_hash" varchar(128) NOT NULL,
+        "expires_at" timestamptz NOT NULL,
+        "used_at" timestamptz,
+        "created_at" timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_password_reset_tokens" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_password_reset_tokens_token_hash" ON "password_reset_tokens" ("token_hash")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_password_reset_tokens_user_id" ON "password_reset_tokens" ("user_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_password_reset_tokens_user_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_password_reset_tokens_token_hash"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "password_reset_tokens"`);
+  }
+}

--- a/apps/api/src/migrations/1781000000000-add-password-reset-tokens.ts
+++ b/apps/api/src/migrations/1781000000000-add-password-reset-tokens.ts
@@ -8,11 +8,13 @@ export class AddPasswordResetTokens1781000000000 implements MigrationInterface {
       CREATE TABLE "password_reset_tokens" (
         "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
         "user_id" uuid NOT NULL,
-        "token_hash" varchar(128) NOT NULL,
+        "token_hash" varchar(64) NOT NULL,
         "expires_at" timestamptz NOT NULL,
         "used_at" timestamptz,
         "created_at" timestamptz NOT NULL DEFAULT now(),
-        CONSTRAINT "PK_password_reset_tokens" PRIMARY KEY ("id")
+        CONSTRAINT "PK_password_reset_tokens" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_password_reset_tokens_user_id" FOREIGN KEY ("user_id")
+          REFERENCES "users"("id") ON DELETE CASCADE
       )
     `);
     await queryRunner.query(

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -1,5 +1,12 @@
 import { createBrowserRouter } from 'react-router-dom';
 import { loginRoute } from './routes/login.route';
+import { forgotPasswordRoute } from './routes/forgot-password.route';
+import { resetPasswordRoute } from './routes/reset-password.route';
 import { rootRoute } from './routes/root.route';
 
-export const appRouter = createBrowserRouter([loginRoute, rootRoute]);
+export const appRouter = createBrowserRouter([
+  loginRoute,
+  forgotPasswordRoute,
+  resetPasswordRoute,
+  rootRoute,
+]);

--- a/apps/web/src/app/routes/forgot-password.route.tsx
+++ b/apps/web/src/app/routes/forgot-password.route.tsx
@@ -1,0 +1,9 @@
+import type { RouteObject } from 'react-router-dom';
+import { GuestLayout } from '../layouts/guest-layout';
+import { ForgotPasswordPage } from '../../pages/auth/ForgotPasswordPage';
+
+export const forgotPasswordRoute: RouteObject = {
+  path: '/forgot-password',
+  element: <GuestLayout />,
+  children: [{ index: true, element: <ForgotPasswordPage /> }],
+};

--- a/apps/web/src/app/routes/reset-password.route.tsx
+++ b/apps/web/src/app/routes/reset-password.route.tsx
@@ -1,0 +1,9 @@
+import type { RouteObject } from 'react-router-dom';
+import { GuestLayout } from '../layouts/guest-layout';
+import { ResetPasswordPage } from '../../pages/auth/ResetPasswordPage';
+
+export const resetPasswordRoute: RouteObject = {
+  path: '/reset-password/:token',
+  element: <GuestLayout />,
+  children: [{ index: true, element: <ResetPasswordPage /> }],
+};

--- a/apps/web/src/features/auth/api/auth.api.ts
+++ b/apps/web/src/features/auth/api/auth.api.ts
@@ -1,4 +1,10 @@
-import type { LoginRequest, LoginResponse } from './auth.types';
+import type {
+  ForgotPasswordRequest,
+  LoginRequest,
+  LoginResponse,
+  OkResponse,
+  ResetPasswordRequest,
+} from './auth.types';
 
 interface ApiRequest {
   <T>(path: string, init?: RequestInit): Promise<T>;
@@ -6,12 +12,26 @@ interface ApiRequest {
 
 export interface AuthApi {
   login: (input: LoginRequest) => Promise<LoginResponse>;
+  forgotPassword: (input: ForgotPasswordRequest) => Promise<OkResponse>;
+  resetPassword: (input: ResetPasswordRequest) => Promise<OkResponse>;
 }
 
 export function createAuthApi(request: ApiRequest): AuthApi {
   return {
     login(input): Promise<LoginResponse> {
       return request<LoginResponse>('/auth/login', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      });
+    },
+    forgotPassword(input): Promise<OkResponse> {
+      return request<OkResponse>('/auth/forgot-password', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      });
+    },
+    resetPassword(input): Promise<OkResponse> {
+      return request<OkResponse>('/auth/reset-password', {
         method: 'POST',
         body: JSON.stringify(input),
       });

--- a/apps/web/src/features/auth/api/auth.types.ts
+++ b/apps/web/src/features/auth/api/auth.types.ts
@@ -7,4 +7,17 @@ export interface LoginResponse {
   access_token: string;
 }
 
+export interface ForgotPasswordRequest {
+  email: string;
+}
+
+export interface ResetPasswordRequest {
+  token: string;
+  newPassword: string;
+}
+
+export interface OkResponse {
+  ok: true;
+}
+
 export type { MeResponse } from '../../../shared/auth/session.types';

--- a/apps/web/src/features/auth/components/ForgotPasswordForm.tsx
+++ b/apps/web/src/features/auth/components/ForgotPasswordForm.tsx
@@ -29,7 +29,7 @@ export function ForgotPasswordForm(): ReactElement {
 
   const onSubmit = form.handleSubmit(async (values) => {
     try {
-      await mutation.mutateAsync({ email: values.email.trim() });
+      await mutation.mutateAsync({ email: values.email });
       setSubmitted(true);
     } catch {
       // mutation.error handles display

--- a/apps/web/src/features/auth/components/ForgotPasswordForm.tsx
+++ b/apps/web/src/features/auth/components/ForgotPasswordForm.tsx
@@ -1,0 +1,88 @@
+import { useState, type ReactElement } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { Link } from 'react-router-dom';
+import { useForgotPassword } from '../hooks/use-forgot-password';
+import {
+  forgotPasswordFormSchema,
+  type ForgotPasswordFormValues,
+} from './forgot-password-form.schema';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+
+const DEFAULT_VALUES: ForgotPasswordFormValues = { email: '' };
+
+export function ForgotPasswordForm(): ReactElement {
+  const mutation = useForgotPassword();
+  const [submitted, setSubmitted] = useState(false);
+  const form = useForm<ForgotPasswordFormValues>({
+    defaultValues: DEFAULT_VALUES,
+    resolver: zodResolver(forgotPasswordFormSchema),
+  });
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      await mutation.mutateAsync({ email: values.email.trim() });
+      setSubmitted(true);
+    } catch {
+      // mutation.error handles display
+    }
+  });
+
+  if (submitted) {
+    return (
+      <div className="form-card guest-form">
+        <Alert tone="info" title="Check your email">
+          If an account exists for that email, you&apos;ll receive password reset instructions
+          shortly.
+        </Alert>
+        <div className="form-actions">
+          <Link className="button" to="/login">
+            Back to sign in
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="form-card guest-form"
+      noValidate
+      onSubmit={(event) => void onSubmit(event)}
+    >
+      {form.formState.submitCount > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
+      {mutation.error ? (
+        <Alert tone="error" title="Request failed">
+          {mutation.error.message}
+        </Alert>
+      ) : null}
+
+      <FormField label="Email" name="email" error={form.formState.errors.email?.message}>
+        <Input
+          {...form.register('email')}
+          type="email"
+          placeholder="you@example.com"
+          autoComplete="email"
+          invalid={Boolean(form.formState.errors.email)}
+        />
+      </FormField>
+
+      <div className="form-actions">
+        <Button className="guest-form__submit" type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? 'Sending...' : 'Send reset link'}
+        </Button>
+        <Link className="guest-form__secondary" to="/login">
+          Back to sign in
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/features/auth/components/LoginForm.tsx
+++ b/apps/web/src/features/auth/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
+import { Link } from 'react-router-dom';
 import { useLogin } from '../hooks/use-login';
 import { loginFormSchema, type LoginFormValues } from './login-form.schema';
 import { Alert } from '../../../shared/ui/alert';
@@ -65,6 +66,9 @@ export function LoginForm(): ReactElement {
         <Button className="guest-form__submit" type="submit" disabled={login.isPending}>
           {login.isPending ? 'Signing in...' : 'Sign in'}
         </Button>
+        <Link className="guest-form__secondary" to="/forgot-password">
+          Forgot password?
+        </Link>
       </div>
     </form>
   );

--- a/apps/web/src/features/auth/components/ResetPasswordForm.tsx
+++ b/apps/web/src/features/auth/components/ResetPasswordForm.tsx
@@ -1,0 +1,100 @@
+import type { ReactElement } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { Link, useNavigate } from 'react-router-dom';
+import { useResetPassword } from '../hooks/use-reset-password';
+import { useToast } from '../../../shared/ui/toast-provider';
+import {
+  resetPasswordFormSchema,
+  type ResetPasswordFormValues,
+} from './reset-password-form.schema';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+
+interface ResetPasswordFormProps {
+  token: string;
+}
+
+const DEFAULT_VALUES: ResetPasswordFormValues = { newPassword: '', confirmPassword: '' };
+
+export function ResetPasswordForm({ token }: ResetPasswordFormProps): ReactElement {
+  const mutation = useResetPassword();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+  const form = useForm<ResetPasswordFormValues>({
+    defaultValues: DEFAULT_VALUES,
+    resolver: zodResolver(resetPasswordFormSchema),
+  });
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      await mutation.mutateAsync({ token, newPassword: values.newPassword });
+      form.reset();
+      showToast({
+        tone: 'success',
+        title: 'Password updated',
+        description: 'You can now sign in with your new password.',
+      });
+      void navigate('/login', { replace: true });
+    } catch {
+      // mutation.error displayed below
+    }
+  });
+
+  return (
+    <form
+      className="form-card guest-form"
+      noValidate
+      onSubmit={(event) => void onSubmit(event)}
+    >
+      {form.formState.submitCount > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
+      {mutation.error ? (
+        <Alert tone="error" title="Reset failed">
+          {mutation.error.message}
+        </Alert>
+      ) : null}
+
+      <FormField
+        label="New password"
+        name="newPassword"
+        error={form.formState.errors.newPassword?.message}
+      >
+        <Input
+          {...form.register('newPassword')}
+          type="password"
+          autoComplete="new-password"
+          invalid={Boolean(form.formState.errors.newPassword)}
+        />
+      </FormField>
+
+      <FormField
+        label="Confirm password"
+        name="confirmPassword"
+        error={form.formState.errors.confirmPassword?.message}
+      >
+        <Input
+          {...form.register('confirmPassword')}
+          type="password"
+          autoComplete="new-password"
+          invalid={Boolean(form.formState.errors.confirmPassword)}
+        />
+      </FormField>
+
+      <div className="form-actions">
+        <Button className="guest-form__submit" type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? 'Updating...' : 'Update password'}
+        </Button>
+        <Link className="guest-form__secondary" to="/login">
+          Back to sign in
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/features/auth/components/forgot-password-form.schema.ts
+++ b/apps/web/src/features/auth/components/forgot-password-form.schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const forgotPasswordFormSchema = z.object({
+  email: z.string().trim().email('Enter a valid email address'),
+});
+
+export type ForgotPasswordFormValues = z.input<typeof forgotPasswordFormSchema>;

--- a/apps/web/src/features/auth/components/reset-password-form.schema.ts
+++ b/apps/web/src/features/auth/components/reset-password-form.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const resetPasswordFormSchema = z
+  .object({
+    newPassword: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string().min(1, 'Please confirm your new password'),
+  })
+  .refine((v) => v.newPassword === v.confirmPassword, {
+    path: ['confirmPassword'],
+    message: 'Passwords do not match',
+  });
+
+export type ResetPasswordFormValues = z.input<typeof resetPasswordFormSchema>;

--- a/apps/web/src/features/auth/hooks/use-forgot-password.ts
+++ b/apps/web/src/features/auth/hooks/use-forgot-password.ts
@@ -1,0 +1,10 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import type { ForgotPasswordRequest, OkResponse } from '../api/auth.types';
+
+export function useForgotPassword(): UseMutationResult<OkResponse, Error, ForgotPasswordRequest> {
+  const apiClient = useApiClient();
+  return useMutation({
+    mutationFn: (input) => apiClient.auth.forgotPassword(input),
+  });
+}

--- a/apps/web/src/features/auth/hooks/use-reset-password.ts
+++ b/apps/web/src/features/auth/hooks/use-reset-password.ts
@@ -1,0 +1,10 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import type { OkResponse, ResetPasswordRequest } from '../api/auth.types';
+
+export function useResetPassword(): UseMutationResult<OkResponse, Error, ResetPasswordRequest> {
+  const apiClient = useApiClient();
+  return useMutation({
+    mutationFn: (input) => apiClient.auth.resetPassword(input),
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1215,6 +1215,19 @@ textarea {
   width: 100%;
 }
 
+.guest-form__secondary {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--accent-text);
+  text-align: center;
+  text-decoration: none;
+}
+
+.guest-form__secondary:hover {
+  text-decoration: underline;
+}
+
 /* Badge group (inline badge list) */
 .badge-group {
   display: flex;

--- a/apps/web/src/pages/auth/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,14 @@
+import type { ReactElement } from 'react';
+import { ForgotPasswordForm } from '../../features/auth/components/ForgotPasswordForm';
+
+export function ForgotPasswordPage(): ReactElement {
+  return (
+    <section className="guest-page">
+      <h1 className="guest-page__title">Forgot your password?</h1>
+      <p className="guest-page__description">
+        Enter your account email and we&apos;ll send you a link to reset your password.
+      </p>
+      <ForgotPasswordForm />
+    </section>
+  );
+}

--- a/apps/web/src/pages/auth/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/auth/ResetPasswordPage.tsx
@@ -1,0 +1,17 @@
+import type { ReactElement } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+import { ResetPasswordForm } from '../../features/auth/components/ResetPasswordForm';
+
+export function ResetPasswordPage(): ReactElement {
+  const { token } = useParams<{ token: string }>();
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return (
+    <section className="guest-page">
+      <h1 className="guest-page__title">Set a new password</h1>
+      <p className="guest-page__description">Choose a new password for your account.</p>
+      <ResetPasswordForm token={token} />
+    </section>
+  );
+}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -72,6 +72,8 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
     } as ApiClient['allegro'],
     auth: {
       login: vi.fn().mockResolvedValue({ access_token: 'mock-jwt-token' }),
+      forgotPassword: vi.fn().mockResolvedValue({ ok: true }),
+      resetPassword: vi.fn().mockResolvedValue({ ok: true }),
       ...overrides.auth,
     } as ApiClient['auth'],
     connections: {

--- a/docs/plans/implementation-plan-password-reset.md
+++ b/docs/plans/implementation-plan-password-reset.md
@@ -1,0 +1,86 @@
+# Implementation Plan — Password Reset Flow (#158)
+
+## Goal
+MVP password reset: `POST /auth/forgot-password`, `POST /auth/reset-password`, web pages, dev console delivery. No user enumeration, single-use tokens, 1h expiry.
+
+## Layer classification
+- CORE (users): repository port additions, domain entity + port for reset tokens, notifier port
+- Infrastructure: new ORM entity + migration, token repository, console notifier adapter
+- Interface (apps/api/auth): 2 new endpoints + DTOs, service wiring
+- Frontend (apps/web): forgot-password page, reset-password page, link on login
+
+## Non-goals
+- Real email delivery (SMTP/provider) — notifier port + console impl only
+- Rate limiting (document as follow-up)
+- MFA / security questions
+- Account lockouts
+
+## Backend steps
+
+### 1. Extend `UserRepositoryPort`
+File: `libs/core/src/users/domain/ports/user-repository.port.ts`
+- Add `findByEmail(email: string): Promise<User | null>`
+- Add `updatePasswordHash(userId: string, passwordHash: string): Promise<void>`
+
+### 2. Implement in `UserRepository`
+File: `libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts`
+
+### 3. Password reset token domain
+- `libs/core/src/users/domain/entities/password-reset-token.entity.ts` — `{ id, userId, tokenHash, expiresAt, usedAt|null, createdAt }`
+- `libs/core/src/users/domain/ports/password-reset-token-repository.port.ts` — `save`, `findActiveByTokenHash`, `markUsed`, `invalidateActiveForUser(userId)`
+- `libs/core/src/users/domain/ports/password-reset-notifier.port.ts` — `notifyResetRequested(user, rawToken)` + export token symbol
+
+### 4. ORM + repo + migration
+- `libs/core/src/users/infrastructure/persistence/entities/password-reset-token.orm-entity.ts` — table `password_reset_tokens` (id uuid PK, user_id FK→users, token_hash varchar unique, expires_at timestamptz, used_at timestamptz null, created_at timestamptz)
+- `libs/core/src/users/infrastructure/persistence/repositories/password-reset-token.repository.ts`
+- Migration via `pnpm --filter @openlinker/api migration:generate`
+- Export entity in `libs/core/src/users/index.ts`
+- Register in `UsersModule` (TypeOrmModule.forFeature, provider + token, export)
+
+### 5. Console notifier adapter
+- `apps/api/src/auth/adapters/console-password-reset-notifier.adapter.ts` — logs reset link (e.g. `${WEB_URL}/reset-password/${token}`) using shared Logger
+
+### 6. Application service
+- `apps/api/src/auth/password-reset.service.interface.ts`
+- `apps/api/src/auth/password-reset.service.ts`
+  - `requestReset(email)`: always success; if user exists, invalidate old tokens, generate 32-byte token, store SHA-256 hash, notify
+  - `resetPassword(rawToken, newPassword)`: lookup by hash, check expiry+unused, bcrypt hash new password, update user, mark token used
+- Validate `newPassword` min length 8 (domain error → 400)
+
+### 7. DTOs + controller endpoints
+- `apps/api/src/auth/dto/forgot-password.dto.ts` — `email` (@IsEmail)
+- `apps/api/src/auth/dto/reset-password.dto.ts` — `token` (@IsString), `newPassword` (@MinLength(8))
+- `AuthController`: `@Public() POST /auth/forgot-password` → always 200; `@Public() POST /auth/reset-password` → 200 on success, 400 on invalid/expired
+
+### 8. Module wiring
+- `AuthModule`: provide `PasswordResetService`, bind notifier port to `ConsolePasswordResetNotifier`, inject `WEB_URL` via ConfigService
+
+### 9. Unit tests
+- `password-reset.service.spec.ts`: success, expired token, used token, unknown token, unknown email still returns ok, invalidates existing tokens on new request
+- `auth.controller.spec.ts`: new endpoint tests (no enumeration)
+
+## Frontend steps
+
+### 10. API + types
+- `apps/web/src/features/auth/api/auth.api.ts`: add `forgotPassword({email})` and `resetPassword({token, newPassword})`
+- Types in `auth.types.ts`
+
+### 11. Hooks
+- `use-forgot-password.ts` (mutation)
+- `use-reset-password.ts` (mutation)
+
+### 12. Pages
+- `apps/web/src/pages/auth/ForgotPasswordPage.tsx` — email form; on submit show generic "If an account exists, you'll receive instructions"
+- `apps/web/src/pages/auth/ResetPasswordPage.tsx` — reads `:token` param; password + confirm fields; on success redirect to `/login`
+- Add "Forgot password?" link on `LoginForm.tsx`
+- Register routes in router
+
+### 13. Tests
+- Form schemas (zod) + component smoke tests
+
+## Quality gate
+`pnpm lint && pnpm type-check && pnpm test`
+
+## Risks
+- Migration generation requires running DB — use dev stack
+- No rate limiting → document follow-up issue

--- a/libs/core/src/users/domain/entities/password-reset-token.entity.ts
+++ b/libs/core/src/users/domain/entities/password-reset-token.entity.ts
@@ -1,0 +1,23 @@
+/**
+ * Password Reset Token Domain Entity
+ *
+ * Single-use, short-lived token allowing a user to reset their password.
+ * The raw token is never stored — only its SHA-256 hash.
+ *
+ * @module libs/core/src/users/domain/entities
+ */
+
+export class PasswordResetToken {
+  constructor(
+    public readonly id: string,
+    public readonly userId: string,
+    public readonly tokenHash: string,
+    public readonly expiresAt: Date,
+    public readonly usedAt: Date | null,
+    public readonly createdAt: Date,
+  ) {}
+
+  isUsable(now: Date = new Date()): boolean {
+    return this.usedAt === null && this.expiresAt.getTime() > now.getTime();
+  }
+}

--- a/libs/core/src/users/domain/entities/password-reset-token.entity.ts
+++ b/libs/core/src/users/domain/entities/password-reset-token.entity.ts
@@ -17,7 +17,7 @@ export class PasswordResetToken {
     public readonly createdAt: Date,
   ) {}
 
-  isUsable(now: Date = new Date()): boolean {
+  isUsable(now: Date): boolean {
     return this.usedAt === null && this.expiresAt.getTime() > now.getTime();
   }
 }

--- a/libs/core/src/users/domain/exceptions/invalid-password-reset-token.exception.ts
+++ b/libs/core/src/users/domain/exceptions/invalid-password-reset-token.exception.ts
@@ -1,0 +1,15 @@
+/**
+ * Invalid Password Reset Token Exception
+ *
+ * Thrown when a password reset token is unknown, expired, or already used.
+ *
+ * @module libs/core/src/users/domain/exceptions
+ */
+
+export class InvalidPasswordResetTokenException extends Error {
+  constructor() {
+    super('Invalid or expired password reset token');
+    this.name = 'InvalidPasswordResetTokenException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/users/domain/exceptions/weak-password.exception.ts
+++ b/libs/core/src/users/domain/exceptions/weak-password.exception.ts
@@ -1,0 +1,15 @@
+/**
+ * Weak Password Exception
+ *
+ * Thrown when a supplied password fails domain password-strength rules.
+ *
+ * @module libs/core/src/users/domain/exceptions
+ */
+
+export class WeakPasswordException extends Error {
+  constructor(message = 'Password does not meet the minimum requirements') {
+    super(message);
+    this.name = 'WeakPasswordException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/users/domain/ports/password-reset-notifier.port.ts
+++ b/libs/core/src/users/domain/ports/password-reset-notifier.port.ts
@@ -1,0 +1,13 @@
+/**
+ * Password Reset Notifier Port
+ *
+ * Delivery contract for password reset instructions (link). Implementations
+ * may log to console (dev), send email (prod), or push to a queue.
+ *
+ * @module libs/core/src/users/domain/ports
+ */
+import { User } from '../entities/user.entity';
+
+export interface PasswordResetNotifierPort {
+  notifyResetRequested(user: User, rawToken: string): Promise<void>;
+}

--- a/libs/core/src/users/domain/ports/password-reset-token-repository.port.ts
+++ b/libs/core/src/users/domain/ports/password-reset-token-repository.port.ts
@@ -1,0 +1,16 @@
+/**
+ * Password Reset Token Repository Port
+ *
+ * Persistence contract for password reset tokens. Implemented by
+ * PasswordResetTokenRepository in the infrastructure layer.
+ *
+ * @module libs/core/src/users/domain/ports
+ */
+import { PasswordResetToken } from '../entities/password-reset-token.entity';
+
+export interface PasswordResetTokenRepositoryPort {
+  save(token: Pick<PasswordResetToken, 'userId' | 'tokenHash' | 'expiresAt'>): Promise<PasswordResetToken>;
+  findByTokenHash(tokenHash: string): Promise<PasswordResetToken | null>;
+  markUsed(id: string, usedAt: Date): Promise<void>;
+  invalidateActiveForUser(userId: string, now: Date): Promise<void>;
+}

--- a/libs/core/src/users/domain/ports/user-repository.port.ts
+++ b/libs/core/src/users/domain/ports/user-repository.port.ts
@@ -10,6 +10,8 @@ import { User } from '../entities/user.entity';
 
 export interface UserRepositoryPort {
   findByUsername(username: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
   findById(id: string): Promise<User | null>;
   save(user: Pick<User, 'username' | 'email' | 'passwordHash' | 'role'>): Promise<User>;
+  updatePasswordHash(userId: string, passwordHash: string): Promise<void>;
 }

--- a/libs/core/src/users/index.ts
+++ b/libs/core/src/users/index.ts
@@ -13,10 +13,12 @@ export type { PasswordResetTokenRepositoryPort } from './domain/ports/password-r
 export type { PasswordResetNotifierPort } from './domain/ports/password-reset-notifier.port';
 export { UserNotFoundException } from './domain/exceptions/user-not-found.exception';
 export { InvalidPasswordResetTokenException } from './domain/exceptions/invalid-password-reset-token.exception';
+export { WeakPasswordException } from './domain/exceptions/weak-password.exception';
 export {
   UsersModule,
   USER_REPOSITORY_TOKEN,
   PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN,
+  PASSWORD_RESET_NOTIFIER_TOKEN,
 } from './users.module';
 export {
   UserRoleValues,

--- a/libs/core/src/users/index.ts
+++ b/libs/core/src/users/index.ts
@@ -7,9 +7,17 @@
  * @module libs/core/src/users
  */
 export { User } from './domain/entities/user.entity';
+export { PasswordResetToken } from './domain/entities/password-reset-token.entity';
 export type { UserRepositoryPort } from './domain/ports/user-repository.port';
+export type { PasswordResetTokenRepositoryPort } from './domain/ports/password-reset-token-repository.port';
+export type { PasswordResetNotifierPort } from './domain/ports/password-reset-notifier.port';
 export { UserNotFoundException } from './domain/exceptions/user-not-found.exception';
-export { UsersModule, USER_REPOSITORY_TOKEN } from './users.module';
+export { InvalidPasswordResetTokenException } from './domain/exceptions/invalid-password-reset-token.exception';
+export {
+  UsersModule,
+  USER_REPOSITORY_TOKEN,
+  PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN,
+} from './users.module';
 export {
   UserRoleValues,
   PermissionValues,
@@ -17,5 +25,6 @@ export {
 } from './domain/types/role.types';
 export type { UserRole, Permission } from './domain/types/role.types';
 
-// ORM entity exported for testing and TypeORM CLI usage
+// ORM entities exported for testing and TypeORM CLI usage
 export { UserOrmEntity } from './infrastructure/persistence/entities/user.orm-entity';
+export { PasswordResetTokenOrmEntity } from './infrastructure/persistence/entities/password-reset-token.orm-entity';

--- a/libs/core/src/users/infrastructure/persistence/entities/password-reset-token.orm-entity.ts
+++ b/libs/core/src/users/infrastructure/persistence/entities/password-reset-token.orm-entity.ts
@@ -23,7 +23,7 @@ export class PasswordResetTokenOrmEntity {
   userId!: string;
 
   @Index({ unique: true })
-  @Column({ name: 'token_hash', type: 'varchar', length: 128 })
+  @Column({ name: 'token_hash', type: 'varchar', length: 64 })
   tokenHash!: string;
 
   @Column({ name: 'expires_at', type: 'timestamptz' })

--- a/libs/core/src/users/infrastructure/persistence/entities/password-reset-token.orm-entity.ts
+++ b/libs/core/src/users/infrastructure/persistence/entities/password-reset-token.orm-entity.ts
@@ -1,0 +1,37 @@
+/**
+ * Password Reset Token ORM Entity
+ *
+ * TypeORM entity for the `password_reset_tokens` table.
+ *
+ * @module libs/core/src/users/infrastructure/persistence/entities
+ */
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('password_reset_tokens')
+export class PasswordResetTokenOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index()
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId!: string;
+
+  @Index({ unique: true })
+  @Column({ name: 'token_hash', type: 'varchar', length: 128 })
+  tokenHash!: string;
+
+  @Column({ name: 'expires_at', type: 'timestamptz' })
+  expiresAt!: Date;
+
+  @Column({ name: 'used_at', type: 'timestamptz', nullable: true })
+  usedAt!: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/libs/core/src/users/infrastructure/persistence/repositories/password-reset-token.repository.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/password-reset-token.repository.ts
@@ -1,0 +1,59 @@
+/**
+ * Password Reset Token Repository
+ *
+ * Implements PasswordResetTokenRepositoryPort using TypeORM.
+ *
+ * @module libs/core/src/users/infrastructure/persistence/repositories
+ * @implements {PasswordResetTokenRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { PasswordResetToken } from '../../../domain/entities/password-reset-token.entity';
+import { PasswordResetTokenRepositoryPort } from '../../../domain/ports/password-reset-token-repository.port';
+import { PasswordResetTokenOrmEntity } from '../entities/password-reset-token.orm-entity';
+
+@Injectable()
+export class PasswordResetTokenRepository implements PasswordResetTokenRepositoryPort {
+  constructor(
+    @InjectRepository(PasswordResetTokenOrmEntity)
+    private readonly ormRepository: Repository<PasswordResetTokenOrmEntity>,
+  ) {}
+
+  async save(
+    token: Pick<PasswordResetToken, 'userId' | 'tokenHash' | 'expiresAt'>,
+  ): Promise<PasswordResetToken> {
+    const entity = this.ormRepository.create({
+      userId: token.userId,
+      tokenHash: token.tokenHash,
+      expiresAt: token.expiresAt,
+      usedAt: null,
+    });
+    const saved = await this.ormRepository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  async findByTokenHash(tokenHash: string): Promise<PasswordResetToken | null> {
+    const entity = await this.ormRepository.findOne({ where: { tokenHash } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async markUsed(id: string, usedAt: Date): Promise<void> {
+    await this.ormRepository.update({ id }, { usedAt });
+  }
+
+  async invalidateActiveForUser(userId: string, now: Date): Promise<void> {
+    await this.ormRepository.update({ userId, usedAt: IsNull() }, { usedAt: now });
+  }
+
+  private toDomain(entity: PasswordResetTokenOrmEntity): PasswordResetToken {
+    return new PasswordResetToken(
+      entity.id,
+      entity.userId,
+      entity.tokenHash,
+      entity.expiresAt,
+      entity.usedAt,
+      entity.createdAt,
+    );
+  }
+}

--- a/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
@@ -28,9 +28,18 @@ export class UserRepository implements UserRepositoryPort {
     return entity ? this.toDomain(entity) : null;
   }
 
+  async findByEmail(email: string): Promise<User | null> {
+    const entity = await this.ormRepository.findOne({ where: { email } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
   async findById(id: string): Promise<User | null> {
     const entity = await this.ormRepository.findOne({ where: { id } });
     return entity ? this.toDomain(entity) : null;
+  }
+
+  async updatePasswordHash(userId: string, passwordHash: string): Promise<void> {
+    await this.ormRepository.update({ id: userId }, { passwordHash });
   }
 
   async save(user: Pick<User, 'username' | 'email' | 'passwordHash' | 'role'>): Promise<User> {

--- a/libs/core/src/users/users.module.ts
+++ b/libs/core/src/users/users.module.ts
@@ -16,6 +16,7 @@ import { PasswordResetTokenRepository } from './infrastructure/persistence/repos
 
 export const USER_REPOSITORY_TOKEN = Symbol('UserRepositoryPort');
 export const PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN = Symbol('PasswordResetTokenRepositoryPort');
+export const PASSWORD_RESET_NOTIFIER_TOKEN = Symbol('PasswordResetNotifierPort');
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserOrmEntity, PasswordResetTokenOrmEntity])],

--- a/libs/core/src/users/users.module.ts
+++ b/libs/core/src/users/users.module.ts
@@ -1,9 +1,9 @@
 /**
  * Users Module
  *
- * NestJS module for user persistence. Registers the UserRepository and exports
- * the USER_REPOSITORY_TOKEN so that AuthModule can inject the repository
- * without depending on the concrete class.
+ * NestJS module for user persistence. Registers the UserRepository and
+ * PasswordResetTokenRepository, exporting their port tokens so auth can
+ * inject them without depending on concrete classes.
  *
  * @module libs/core/src/users
  */
@@ -11,18 +11,20 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserOrmEntity } from './infrastructure/persistence/entities/user.orm-entity';
 import { UserRepository } from './infrastructure/persistence/repositories/user.repository';
+import { PasswordResetTokenOrmEntity } from './infrastructure/persistence/entities/password-reset-token.orm-entity';
+import { PasswordResetTokenRepository } from './infrastructure/persistence/repositories/password-reset-token.repository';
 
 export const USER_REPOSITORY_TOKEN = Symbol('UserRepositoryPort');
+export const PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN = Symbol('PasswordResetTokenRepositoryPort');
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserOrmEntity])],
+  imports: [TypeOrmModule.forFeature([UserOrmEntity, PasswordResetTokenOrmEntity])],
   providers: [
     UserRepository,
-    {
-      provide: USER_REPOSITORY_TOKEN,
-      useExisting: UserRepository,
-    },
+    { provide: USER_REPOSITORY_TOKEN, useExisting: UserRepository },
+    PasswordResetTokenRepository,
+    { provide: PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN, useExisting: PasswordResetTokenRepository },
   ],
-  exports: [USER_REPOSITORY_TOKEN],
+  exports: [USER_REPOSITORY_TOKEN, PASSWORD_RESET_TOKEN_REPOSITORY_TOKEN],
 })
 export class UsersModule {}


### PR DESCRIPTION
## Summary
- Adds password reset flow: `POST /auth/forgot-password` (always 200, no enumeration) and `POST /auth/reset-password`
- SHA-256-hashed single-use tokens with 1h TTL (`PASSWORD_RESET_TTL_MINUTES` override); `PasswordResetToken` domain entity + repo port, `PasswordResetNotifierPort` with dev `ConsolePasswordResetNotifierAdapter` logging the reset link
- FE: `/forgot-password` and `/reset-password/:token` pages, "Forgot password?" link on login, zod-validated forms

## Test plan
- [ ] `pnpm lint && pnpm type-check && pnpm test` pass
- [ ] Manual: request reset with unknown email → 200, no log; known email → reset link in API logs
- [ ] Manual: open link, submit new password → redirected to `/login`, can sign in with new password
- [ ] Manual: replay same token → 400; expired token → 400

## Follow-ups
- Rate limiting for `/auth/forgot-password` and `/auth/reset-password`
- Real mailer adapter (SMTP/SES) replacing the console notifier
- Integration test covering request → reset → login vertical slice

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)