### PR TITLE
fix(scheduler): guard against undefined connection lists

### DIFF
--- a/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
+++ b/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
@@ -156,5 +156,46 @@ describe('SchedulerService', () => {
       // connectionPort.list should NOT be called when connectionFilter is present
       expect(connectionPort.list).not.toHaveBeenCalled();
     });
+
+    it('should not throw when connectionFilter resolves to undefined', async () => {
+      const task = {
+        taskId: 'capability-undefined',
+        jobType: 'master.inventory.syncAll' as const,
+        cronExpression: '*/15 * * * *',
+        connectionFilter: (): Promise<Connection[]> =>
+          Promise.resolve(undefined as unknown as Connection[]),
+        generatePayload: (): Record<string, unknown> => ({ schemaVersion: 1 }),
+        generateIdempotencyKey: (c: Connection, t: string): string => `${c.id}:${t}`,
+      };
+
+      await expect(
+        (
+          service as unknown as { executeTask: (t: unknown) => Promise<void> }
+        ).executeTask(task),
+      ).resolves.not.toThrow();
+
+      expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when connectionPort.list resolves to undefined', async () => {
+      connectionPort.list.mockResolvedValue(undefined as unknown as Connection[]);
+
+      const task = {
+        taskId: 'platform-undefined',
+        platformType: 'allegro',
+        jobType: 'marketplace.orders.poll' as const,
+        cronExpression: '*/5 * * * *',
+        generatePayload: (): Record<string, unknown> => ({ schemaVersion: 1 }),
+        generateIdempotencyKey: (c: Connection, t: string): string => `${c.id}:${t}`,
+      };
+
+      await expect(
+        (
+          service as unknown as { executeTask: (t: unknown) => Promise<void> }
+        ).executeTask(task),
+      ).resolves.not.toThrow();
+
+      expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/sync/application/services/scheduler.service.ts
+++ b/apps/api/src/sync/application/services/scheduler.service.ts
@@ -241,14 +241,15 @@ export class SchedulerService implements OnModuleInit {
 
     try {
       // Get connections: use custom filter if provided, otherwise filter by platformType
-      let connections;
+      let connections: Connection[];
       if (task.connectionFilter) {
-        connections = await task.connectionFilter();
+        connections = (await task.connectionFilter()) ?? [];
       } else if (task.platformType) {
-        connections = await this.connectionPort.list({
-          platformType: task.platformType,
-          status: 'active',
-        });
+        connections =
+          (await this.connectionPort.list({
+            platformType: task.platformType,
+            status: 'active',
+          })) ?? [];
       } else {
         this.logger.error(
           `Scheduler task ${task.taskId} has neither platformType nor connectionFilter — skipping`,
@@ -369,7 +370,7 @@ export class SchedulerService implements OnModuleInit {
         const adapters = await this.integrationsService.listCapabilityAdapters({
           capability: 'InventoryMaster',
         });
-        return adapters.map((a) => a.connection);
+        return (adapters ?? []).map((a) => a.connection);
       },
       generatePayload: () => ({
         schemaVersion: 1,
@@ -410,7 +411,7 @@ export class SchedulerService implements OnModuleInit {
         const adapters = await this.integrationsService.listCapabilityAdapters({
           capability: 'ProductMaster',
         });
-        return adapters.map((a) => a.connection);
+        return (adapters ?? []).map((a) => a.connection);
       },
       generatePayload: () => ({
         schemaVersion: 1,

--- a/apps/api/src/sync/application/services/scheduler.service.ts
+++ b/apps/api/src/sync/application/services/scheduler.service.ts
@@ -243,13 +243,24 @@ export class SchedulerService implements OnModuleInit {
       // Get connections: use custom filter if provided, otherwise filter by platformType
       let connections: Connection[];
       if (task.connectionFilter) {
-        connections = (await task.connectionFilter()) ?? [];
+        const result = await task.connectionFilter();
+        if (result == null) {
+          this.logger.warn(
+            `Scheduler task ${task.taskId}: connectionFilter returned nullish — coercing to []. Upstream port contract violation.`,
+          );
+        }
+        connections = result ?? [];
       } else if (task.platformType) {
-        connections =
-          (await this.connectionPort.list({
-            platformType: task.platformType,
-            status: 'active',
-          })) ?? [];
+        const result = await this.connectionPort.list({
+          platformType: task.platformType,
+          status: 'active',
+        });
+        if (result == null) {
+          this.logger.warn(
+            `Scheduler task ${task.taskId}: connectionPort.list returned nullish — coercing to []. Upstream port contract violation.`,
+          );
+        }
+        connections = result ?? [];
       } else {
         this.logger.error(
           `Scheduler task ${task.taskId} has neither platformType nor connectionFilter — skipping`,


### PR DESCRIPTION
## Summary
- Coerce nullish returns from `connectionFilter()` / `connectionPort.list(...)` to `[]` in `executeTask`, and guard `(adapters ?? []).map(...)` in the inventory/product capability filters — fixes the recurring `TypeError: Cannot read properties of undefined (reading 'length' | 'map')` in scheduler cron ticks.
- Warn-log when the coercion actually kicks in, so upstream port contract violations stay visible instead of being silently swallowed as "no connections".
- Regression tests for both the `connectionFilter` and `connectionPort.list` nullish paths.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test` (scheduler.service.spec: 7/7 pass, including new undefined-path cases)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)