### PR TITLE
feat(webhooks): webhook delivery visibility — API + admin UI

### DIFF
--- a/apps/api/src/migrations/1782000000000-add-webhook-deliveries.ts
+++ b/apps/api/src/migrations/1782000000000-add-webhook-deliveries.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWebhookDeliveries1782000000000 implements MigrationInterface {
+  name = 'AddWebhookDeliveries1782000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "webhook_deliveries" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "eventId" text NOT NULL,
+        "provider" text NOT NULL,
+        "connectionId" uuid NOT NULL,
+        "eventType" text,
+        "objectType" text,
+        "externalId" text,
+        "receivedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "signatureValid" boolean,
+        "dedupResult" text,
+        "status" text NOT NULL,
+        "rejectionReason" text,
+        "publishedMessageId" text,
+        "downstreamJobId" text,
+        "downstreamJobType" text,
+        "dlqReason" text,
+        "payload" jsonb,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "uq_webhook_deliveries_event_key" UNIQUE ("provider", "connectionId", "eventId"),
+        CONSTRAINT "PK_webhook_deliveries" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_webhook_deliveries_receivedAt" ON "webhook_deliveries" ("receivedAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_webhook_deliveries_connection_receivedAt" ON "webhook_deliveries" ("connectionId", "receivedAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_webhook_deliveries_provider_receivedAt" ON "webhook_deliveries" ("provider", "receivedAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_webhook_deliveries_status_receivedAt" ON "webhook_deliveries" ("status", "receivedAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_webhook_deliveries_status_receivedAt"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_webhook_deliveries_provider_receivedAt"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_webhook_deliveries_connection_receivedAt"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_webhook_deliveries_receivedAt"`);
+    await queryRunner.query(`DROP TABLE "webhook_deliveries"`);
+  }
+}

--- a/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
+++ b/apps/api/src/webhooks/application/handlers/__tests__/webhook-to-job.handler.spec.ts
@@ -11,6 +11,7 @@ import { WebhookToJobHandler } from '../webhook-to-job.handler';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import { InboundWebhookEvent } from '@openlinker/core/events';
 import { JobTypeValues } from '@openlinker/core/sync';
+import { WEBHOOK_DELIVERY_REPOSITORY_TOKEN } from '@openlinker/core/webhooks';
 import { REDIS_CLIENT_BLOCKING_TOKEN } from '../../../webhooks.tokens';
 
 describe('WebhookToJobHandler', () => {
@@ -27,7 +28,13 @@ describe('WebhookToJobHandler', () => {
     };
 
     const mockJobEnqueue = {
-      enqueueJob: jest.fn(),
+      enqueueJob: jest.fn().mockResolvedValue({ jobId: 'job-1', isExisting: false }),
+    };
+
+    const mockDeliveryRepo = {
+      upsert: jest.fn().mockResolvedValue(undefined),
+      findById: jest.fn(),
+      findMany: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -40,6 +47,10 @@ describe('WebhookToJobHandler', () => {
         {
           provide: JOB_ENQUEUE_TOKEN,
           useValue: mockJobEnqueue,
+        },
+        {
+          provide: WEBHOOK_DELIVERY_REPOSITORY_TOKEN,
+          useValue: mockDeliveryRepo,
         },
       ],
     }).compile();

--- a/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
+++ b/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
@@ -15,6 +15,11 @@ import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import { EventEnvelope, InboundWebhookEvent } from '@openlinker/core/events';
 import { SyncJobRequest, JobType, JobTypeValues } from '@openlinker/core/sync';
 import { Logger } from '@openlinker/shared/logging';
+import {
+  WebhookDeliveryRepositoryPort,
+  WebhookDeliveryUpsertInput,
+  WEBHOOK_DELIVERY_REPOSITORY_TOKEN,
+} from '@openlinker/core/webhooks';
 import { REDIS_CLIENT_BLOCKING_TOKEN } from '../../webhooks.tokens';
 import { WebhookPayload, WebhookMetadata } from './webhook-handler.types';
 
@@ -36,7 +41,19 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
     private readonly redisClient: RedisClientType,
     @Inject(JOB_ENQUEUE_TOKEN)
     private readonly jobEnqueue: JobEnqueuePort,
+    @Inject(WEBHOOK_DELIVERY_REPOSITORY_TOKEN)
+    private readonly deliveryRepository: WebhookDeliveryRepositoryPort,
   ) {}
+
+  private async recordDelivery(input: WebhookDeliveryUpsertInput): Promise<void> {
+    try {
+      await this.deliveryRepository.upsert(input);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to record webhook delivery from handler (non-fatal): eventId=${input.eventId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
 
   async onModuleInit(): Promise<void> {
     await this.initializeConsumerGroup();
@@ -218,12 +235,28 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
           `Failed to map webhook event to job: eventId=${event.eventId}, provider=${event.provider}, objectType=${event.objectType}, error=${errorMessage}`,
         );
         await this.sendToDeadLetterQueue(event, errorMessage, fields);
+        await this.recordDelivery({
+          eventId: event.eventId,
+          provider: event.provider,
+          connectionId: event.connectionId,
+          status: 'deadlettered',
+          dlqReason: errorMessage.slice(0, 500),
+        });
         await this.redisClient.xAck(this.STREAM_NAME, this.CONSUMER_GROUP, messageId);
         return;
       }
 
       // Enqueue job (idempotency enforced at JobEnqueuePort level)
-      await this.jobEnqueue.enqueueJob(job);
+      const { jobId } = await this.jobEnqueue.enqueueJob(job);
+
+      await this.recordDelivery({
+        eventId: event.eventId,
+        provider: event.provider,
+        connectionId: event.connectionId,
+        status: 'job_enqueued',
+        downstreamJobId: jobId,
+        downstreamJobType: job.jobType,
+      });
 
       // ACK message only after successful enqueue
       await this.redisClient.xAck(this.STREAM_NAME, this.CONSUMER_GROUP, messageId);

--- a/apps/api/src/webhooks/application/interfaces/webhook-delivery-query.service.interface.ts
+++ b/apps/api/src/webhooks/application/interfaces/webhook-delivery-query.service.interface.ts
@@ -10,6 +10,8 @@ import type {
   WebhookDeliveryPagination,
 } from '@openlinker/core/webhooks';
 
+export const WEBHOOK_DELIVERY_QUERY_SERVICE_TOKEN = Symbol('IWebhookDeliveryQueryService');
+
 export interface IWebhookDeliveryQueryService {
   list(
     filters: WebhookDeliveryFilters,

--- a/apps/api/src/webhooks/application/interfaces/webhook-delivery-query.service.interface.ts
+++ b/apps/api/src/webhooks/application/interfaces/webhook-delivery-query.service.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * Webhook Delivery Query Service Interface
+ *
+ * @module apps/api/src/webhooks/application/interfaces
+ */
+import type {
+  PaginatedWebhookDeliveries,
+  WebhookDelivery,
+  WebhookDeliveryFilters,
+  WebhookDeliveryPagination,
+} from '@openlinker/core/webhooks';
+
+export interface IWebhookDeliveryQueryService {
+  list(
+    filters: WebhookDeliveryFilters,
+    pagination: WebhookDeliveryPagination,
+  ): Promise<PaginatedWebhookDeliveries>;
+  getById(id: string): Promise<WebhookDelivery | null>;
+}

--- a/apps/api/src/webhooks/application/services/__tests__/webhook-delivery-query.service.spec.ts
+++ b/apps/api/src/webhooks/application/services/__tests__/webhook-delivery-query.service.spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhookDeliveryQueryService } from '../webhook-delivery-query.service';
+import {
+  WEBHOOK_DELIVERY_REPOSITORY_TOKEN,
+  WebhookDeliveryRepositoryPort,
+} from '@openlinker/core/webhooks';
+
+describe('WebhookDeliveryQueryService', () => {
+  let service: WebhookDeliveryQueryService;
+  let repo: jest.Mocked<WebhookDeliveryRepositoryPort>;
+
+  beforeEach(async () => {
+    repo = {
+      upsert: jest.fn(),
+      findById: jest.fn(),
+      findMany: jest.fn(),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDeliveryQueryService,
+        { provide: WEBHOOK_DELIVERY_REPOSITORY_TOKEN, useValue: repo },
+      ],
+    }).compile();
+    service = module.get(WebhookDeliveryQueryService);
+  });
+
+  it('should delegate list to repository.findMany', async () => {
+    repo.findMany.mockResolvedValue({ items: [], total: 0 });
+    const result = await service.list(
+      { provider: 'prestashop' },
+      { limit: 10, offset: 0 },
+    );
+    expect(result).toEqual({ items: [], total: 0 });
+    expect(repo.findMany).toHaveBeenCalledWith(
+      { provider: 'prestashop' },
+      { limit: 10, offset: 0 },
+    );
+  });
+
+  it('should delegate getById to repository.findById', async () => {
+    repo.findById.mockResolvedValue(null);
+    const result = await service.getById('abc');
+    expect(result).toBeNull();
+    expect(repo.findById).toHaveBeenCalledWith('abc');
+  });
+});

--- a/apps/api/src/webhooks/application/services/__tests__/webhook-delivery-query.service.spec.ts
+++ b/apps/api/src/webhooks/application/services/__tests__/webhook-delivery-query.service.spec.ts
@@ -43,4 +43,14 @@ describe('WebhookDeliveryQueryService', () => {
     expect(result).toBeNull();
     expect(repo.findById).toHaveBeenCalledWith('abc');
   });
+
+  it('should propagate repository errors from list', async () => {
+    repo.findMany.mockRejectedValue(new Error('DB connection lost'));
+    await expect(service.list({}, { limit: 10, offset: 0 })).rejects.toThrow('DB connection lost');
+  });
+
+  it('should propagate repository errors from getById', async () => {
+    repo.findById.mockRejectedValue(new Error('DB connection lost'));
+    await expect(service.getById('abc')).rejects.toThrow('DB connection lost');
+  });
 });

--- a/apps/api/src/webhooks/application/services/webhook-delivery-query.service.ts
+++ b/apps/api/src/webhooks/application/services/webhook-delivery-query.service.ts
@@ -1,0 +1,39 @@
+/**
+ * Webhook Delivery Query Service
+ *
+ * Thin read-through service for the webhook-delivery visibility API. Delegates
+ * to the repository port; kept as a service to enforce the interface boundary
+ * and give us a place to add auth scoping or formatting later.
+ *
+ * @module apps/api/src/webhooks/application/services
+ * @implements {IWebhookDeliveryQueryService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  PaginatedWebhookDeliveries,
+  WebhookDelivery,
+  WebhookDeliveryFilters,
+  WebhookDeliveryPagination,
+  WebhookDeliveryRepositoryPort,
+  WEBHOOK_DELIVERY_REPOSITORY_TOKEN,
+} from '@openlinker/core/webhooks';
+import { IWebhookDeliveryQueryService } from '../interfaces/webhook-delivery-query.service.interface';
+
+@Injectable()
+export class WebhookDeliveryQueryService implements IWebhookDeliveryQueryService {
+  constructor(
+    @Inject(WEBHOOK_DELIVERY_REPOSITORY_TOKEN)
+    private readonly repository: WebhookDeliveryRepositoryPort,
+  ) {}
+
+  list(
+    filters: WebhookDeliveryFilters,
+    pagination: WebhookDeliveryPagination,
+  ): Promise<PaginatedWebhookDeliveries> {
+    return this.repository.findMany(filters, pagination);
+  }
+
+  getById(id: string): Promise<WebhookDelivery | null> {
+    return this.repository.findById(id);
+  }
+}

--- a/apps/api/src/webhooks/application/services/webhook.service.ts
+++ b/apps/api/src/webhooks/application/services/webhook.service.ts
@@ -8,7 +8,7 @@
  * @module apps/api/src/webhooks/application/services
  * @implements {IWebhookService}
  */
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { IWebhookService } from '../interfaces/webhook.service.interface';
 import { WebhookAuthService } from './webhook-auth.service';
 import { WebhookDedupService } from './webhook-dedup.service';
@@ -16,6 +16,11 @@ import { WebhookEventPublisher } from './webhook-event-publisher.service';
 import { InboundWebhookEvent } from '@openlinker/core/events/domain/types/inbound-webhook-event.types';
 import { WebhookRequestDto } from '../../http/dto/webhook-request.dto';
 import { Logger } from '@openlinker/shared/logging';
+import {
+  WebhookDeliveryRepositoryPort,
+  WebhookDeliveryUpsertInput,
+  WEBHOOK_DELIVERY_REPOSITORY_TOKEN,
+} from '@openlinker/core/webhooks';
 
 @Injectable()
 export class WebhookService implements IWebhookService {
@@ -25,7 +30,19 @@ export class WebhookService implements IWebhookService {
     private readonly authService: WebhookAuthService,
     private readonly dedupService: WebhookDedupService,
     private readonly eventPublisher: WebhookEventPublisher,
+    @Inject(WEBHOOK_DELIVERY_REPOSITORY_TOKEN)
+    private readonly deliveryRepository: WebhookDeliveryRepositoryPort,
   ) {}
+
+  private async recordDelivery(input: WebhookDeliveryUpsertInput): Promise<void> {
+    try {
+      await this.deliveryRepository.upsert(input);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to record webhook delivery (non-fatal): provider=${input.provider}, connectionId=${input.connectionId}, eventId=${input.eventId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
 
   async processWebhook(
     provider: string,
@@ -40,16 +57,31 @@ export class WebhookService implements IWebhookService {
       `Processing webhook: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}, eventType=${request.eventType}`,
     );
 
+    const receivedAt = new Date();
+    const baseDelivery: WebhookDeliveryUpsertInput = {
+      eventId: request.eventId,
+      provider,
+      connectionId,
+      eventType: request.eventType ?? null,
+      objectType: request.object?.type ?? null,
+      externalId: request.object?.externalId ?? null,
+      receivedAt,
+      payload: request.payload as Record<string, unknown>,
+    };
+    await this.recordDelivery({ ...baseDelivery, status: 'received' });
+
     const timestamp = headers['x-openlinker-timestamp'] || headers['X-OpenLinker-Timestamp'];
     const signature = headers['x-openlinker-signature'] || headers['X-OpenLinker-Signature'];
 
     if (!timestamp) {
       this.logger.warn(`Missing X-OpenLinker-Timestamp header: provider=${provider}, connectionId=${connectionId}`);
+      await this.recordDelivery({ ...baseDelivery, status: 'rejected', rejectionReason: 'missing_timestamp_header' });
       throw new Error('Missing X-OpenLinker-Timestamp header');
     }
 
     if (!signature) {
       this.logger.warn(`Missing X-OpenLinker-Signature header: provider=${provider}, connectionId=${connectionId}`);
+      await this.recordDelivery({ ...baseDelivery, status: 'rejected', rejectionReason: 'missing_signature_header' });
       throw new Error('Missing X-OpenLinker-Signature header');
     }
 
@@ -61,6 +93,7 @@ export class WebhookService implements IWebhookService {
         `Timestamp validation failed: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`,
         error instanceof Error ? error.message : String(error),
       );
+      await this.recordDelivery({ ...baseDelivery, status: 'rejected', rejectionReason: 'stale_timestamp' });
       throw error;
     }
 
@@ -77,6 +110,12 @@ export class WebhookService implements IWebhookService {
       this.logger.error(
         `Invalid webhook signature: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`,
       );
+      await this.recordDelivery({
+        ...baseDelivery,
+        signatureValid: false,
+        status: 'rejected',
+        rejectionReason: 'invalid_signature',
+      });
       throw new Error('Invalid webhook signature');
     }
 
@@ -90,6 +129,11 @@ export class WebhookService implements IWebhookService {
       this.logger.warn(
         `Duplicate webhook event detected: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`,
       );
+      await this.recordDelivery({
+        ...baseDelivery,
+        signatureValid: true,
+        dedupResult: 'duplicate',
+      });
       return; // Return 202 (already accepted)
     }
 
@@ -112,6 +156,13 @@ export class WebhookService implements IWebhookService {
       this.logger.log(
         `Published webhook event: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}, messageId=${messageId}`,
       );
+      await this.recordDelivery({
+        ...baseDelivery,
+        signatureValid: true,
+        dedupResult: 'new',
+        status: 'published',
+        publishedMessageId: messageId,
+      });
 
       // Step 6: Mark as done (non-fatal if it fails)
       try {
@@ -138,6 +189,13 @@ export class WebhookService implements IWebhookService {
         `Failed to process webhook: provider=${provider}, connectionId=${connectionId}, eventId=${correlationId}`,
         error instanceof Error ? error.stack : String(error),
       );
+      await this.recordDelivery({
+        ...baseDelivery,
+        signatureValid: true,
+        dedupResult: 'new',
+        status: 'failed',
+        rejectionReason: error instanceof Error ? error.message.slice(0, 500) : String(error).slice(0, 500),
+      });
 
       throw error;
     }

--- a/apps/api/src/webhooks/http/dto/list-webhook-deliveries-query.dto.ts
+++ b/apps/api/src/webhooks/http/dto/list-webhook-deliveries-query.dto.ts
@@ -1,0 +1,56 @@
+/**
+ * List Webhook Deliveries Query DTO
+ *
+ * Query parameters for GET /webhook-deliveries.
+ *
+ * @module apps/api/src/webhooks/http/dto
+ */
+import { IsEnum, IsInt, IsISO8601, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  WebhookDeliveryStatus,
+  WebhookDeliveryStatusValues,
+} from '@openlinker/core/webhooks';
+
+export class ListWebhookDeliveriesQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by webhook provider (e.g. prestashop)' })
+  @IsOptional()
+  @IsString()
+  provider?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by connection ID (UUID)' })
+  @IsOptional()
+  @IsUUID()
+  connectionId?: string;
+
+  @ApiPropertyOptional({ enum: WebhookDeliveryStatusValues, description: 'Filter by delivery status' })
+  @IsOptional()
+  @IsEnum(WebhookDeliveryStatusValues)
+  status?: WebhookDeliveryStatus;
+
+  @ApiPropertyOptional({ description: 'Inclusive lower bound for receivedAt (ISO 8601)' })
+  @IsOptional()
+  @IsISO8601()
+  since?: string;
+
+  @ApiPropertyOptional({ description: 'Inclusive upper bound for receivedAt (ISO 8601)' })
+  @IsOptional()
+  @IsISO8601()
+  until?: string;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/apps/api/src/webhooks/http/dto/paginated-webhook-deliveries-response.dto.ts
+++ b/apps/api/src/webhooks/http/dto/paginated-webhook-deliveries-response.dto.ts
@@ -1,0 +1,16 @@
+/**
+ * Paginated Webhook Deliveries Response DTO
+ *
+ * @module apps/api/src/webhooks/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { WebhookDeliverySummaryResponseDto } from './webhook-delivery-summary-response.dto';
+
+export class PaginatedWebhookDeliveriesResponseDto {
+  @ApiProperty({ type: [WebhookDeliverySummaryResponseDto] })
+  items!: WebhookDeliverySummaryResponseDto[];
+
+  @ApiProperty() total!: number;
+  @ApiProperty() limit!: number;
+  @ApiProperty() offset!: number;
+}

--- a/apps/api/src/webhooks/http/dto/webhook-delivery-detail-response.dto.ts
+++ b/apps/api/src/webhooks/http/dto/webhook-delivery-detail-response.dto.ts
@@ -1,0 +1,14 @@
+/**
+ * Webhook Delivery Detail Response DTO
+ *
+ * Detail-view shape — includes the full raw payload for troubleshooting.
+ *
+ * @module apps/api/src/webhooks/http/dto
+ */
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { WebhookDeliverySummaryResponseDto } from './webhook-delivery-summary-response.dto';
+
+export class WebhookDeliveryDetailResponseDto extends WebhookDeliverySummaryResponseDto {
+  @ApiPropertyOptional({ nullable: true, description: 'Raw webhook payload' })
+  payload!: Record<string, unknown> | null;
+}

--- a/apps/api/src/webhooks/http/dto/webhook-delivery-summary-response.dto.ts
+++ b/apps/api/src/webhooks/http/dto/webhook-delivery-summary-response.dto.ts
@@ -1,0 +1,31 @@
+/**
+ * Webhook Delivery Summary Response DTO
+ *
+ * List-view shape — excludes the full payload to avoid leaking PII in list
+ * responses. Use the detail endpoint for the full payload.
+ *
+ * @module apps/api/src/webhooks/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { WebhookDeliveryStatusValues } from '@openlinker/core/webhooks';
+
+export class WebhookDeliverySummaryResponseDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() eventId!: string;
+  @ApiProperty() provider!: string;
+  @ApiProperty() connectionId!: string;
+  @ApiPropertyOptional({ nullable: true }) eventType!: string | null;
+  @ApiPropertyOptional({ nullable: true }) objectType!: string | null;
+  @ApiPropertyOptional({ nullable: true }) externalId!: string | null;
+  @ApiProperty({ description: 'ISO 8601 timestamp' }) receivedAt!: string;
+  @ApiPropertyOptional({ nullable: true }) signatureValid!: boolean | null;
+  @ApiPropertyOptional({ nullable: true }) dedupResult!: string | null;
+  @ApiProperty({ enum: WebhookDeliveryStatusValues }) status!: string;
+  @ApiPropertyOptional({ nullable: true }) rejectionReason!: string | null;
+  @ApiPropertyOptional({ nullable: true }) publishedMessageId!: string | null;
+  @ApiPropertyOptional({ nullable: true }) downstreamJobId!: string | null;
+  @ApiPropertyOptional({ nullable: true }) downstreamJobType!: string | null;
+  @ApiPropertyOptional({ nullable: true }) dlqReason!: string | null;
+  @ApiProperty() createdAt!: string;
+  @ApiProperty() updatedAt!: string;
+}

--- a/apps/api/src/webhooks/http/webhook-delivery.controller.ts
+++ b/apps/api/src/webhooks/http/webhook-delivery.controller.ts
@@ -12,6 +12,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Inject,
   NotFoundException,
   Param,
   ParseUUIDPipe,
@@ -19,7 +20,10 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
-import { WebhookDeliveryQueryService } from '../application/services/webhook-delivery-query.service';
+import {
+  IWebhookDeliveryQueryService,
+  WEBHOOK_DELIVERY_QUERY_SERVICE_TOKEN,
+} from '../application/interfaces/webhook-delivery-query.service.interface';
 import { ListWebhookDeliveriesQueryDto } from './dto/list-webhook-deliveries-query.dto';
 import { PaginatedWebhookDeliveriesResponseDto } from './dto/paginated-webhook-deliveries-response.dto';
 import { WebhookDeliveryDetailResponseDto } from './dto/webhook-delivery-detail-response.dto';
@@ -31,7 +35,10 @@ import type { WebhookDelivery } from '@openlinker/core/webhooks';
 @ApiTags('webhooks')
 @Controller('webhook-deliveries')
 export class WebhookDeliveryController {
-  constructor(private readonly queryService: WebhookDeliveryQueryService) {}
+  constructor(
+    @Inject(WEBHOOK_DELIVERY_QUERY_SERVICE_TOKEN)
+    private readonly queryService: IWebhookDeliveryQueryService,
+  ) {}
 
   @Get()
   @HttpCode(HttpStatus.OK)

--- a/apps/api/src/webhooks/http/webhook-delivery.controller.ts
+++ b/apps/api/src/webhooks/http/webhook-delivery.controller.ts
@@ -1,0 +1,109 @@
+/**
+ * Webhook Delivery Controller
+ *
+ * HTTP endpoints for operator visibility into inbound webhook processing.
+ * List returns summary rows (no payload); detail returns the full record
+ * including the raw payload.
+ *
+ * @module apps/api/src/webhooks/http
+ */
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  ParseUUIDPipe,
+  Query,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { WebhookDeliveryQueryService } from '../application/services/webhook-delivery-query.service';
+import { ListWebhookDeliveriesQueryDto } from './dto/list-webhook-deliveries-query.dto';
+import { PaginatedWebhookDeliveriesResponseDto } from './dto/paginated-webhook-deliveries-response.dto';
+import { WebhookDeliveryDetailResponseDto } from './dto/webhook-delivery-detail-response.dto';
+import { WebhookDeliverySummaryResponseDto } from './dto/webhook-delivery-summary-response.dto';
+import type { WebhookDelivery } from '@openlinker/core/webhooks';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('webhooks')
+@Controller('webhook-deliveries')
+export class WebhookDeliveryController {
+  constructor(private readonly queryService: WebhookDeliveryQueryService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'List webhook deliveries',
+    description:
+      'Paginated list of inbound webhook deliveries with filters. Excludes raw payload; use GET /webhook-deliveries/:id for the full record.',
+  })
+  @ApiResponse({ status: 200, type: PaginatedWebhookDeliveriesResponseDto })
+  async list(
+    @Query() query: ListWebhookDeliveriesQueryDto,
+  ): Promise<PaginatedWebhookDeliveriesResponseDto> {
+    const { provider, connectionId, status, since, until, limit = 20, offset = 0 } = query;
+
+    const { items, total } = await this.queryService.list(
+      {
+        provider,
+        connectionId,
+        status,
+        since: since ? new Date(since) : undefined,
+        until: until ? new Date(until) : undefined,
+      },
+      { limit, offset },
+    );
+
+    return {
+      items: items.map((d) => this.toSummary(d)),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get webhook delivery by id' })
+  @ApiResponse({ status: 200, type: WebhookDeliveryDetailResponseDto })
+  @ApiResponse({ status: 404, description: 'Delivery not found' })
+  async getById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<WebhookDeliveryDetailResponseDto> {
+    const delivery = await this.queryService.getById(id);
+    if (!delivery) {
+      throw new NotFoundException(`Webhook delivery not found: ${id}`);
+    }
+    return this.toDetail(delivery);
+  }
+
+  private toSummary(d: WebhookDelivery): WebhookDeliverySummaryResponseDto {
+    return {
+      id: d.id,
+      eventId: d.eventId,
+      provider: d.provider,
+      connectionId: d.connectionId,
+      eventType: d.eventType,
+      objectType: d.objectType,
+      externalId: d.externalId,
+      receivedAt: d.receivedAt.toISOString(),
+      signatureValid: d.signatureValid,
+      dedupResult: d.dedupResult,
+      status: d.status,
+      rejectionReason: d.rejectionReason,
+      publishedMessageId: d.publishedMessageId,
+      downstreamJobId: d.downstreamJobId,
+      downstreamJobType: d.downstreamJobType,
+      dlqReason: d.dlqReason,
+      createdAt: d.createdAt.toISOString(),
+      updatedAt: d.updatedAt.toISOString(),
+    };
+  }
+
+  private toDetail(d: WebhookDelivery): WebhookDeliveryDetailResponseDto {
+    return { ...this.toSummary(d), payload: d.payload };
+  }
+}

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -22,6 +22,7 @@ import { WebhookAuthService } from './application/services/webhook-auth.service'
 import { WebhookDedupService } from './application/services/webhook-dedup.service';
 import { WebhookEventPublisher } from './application/services/webhook-event-publisher.service';
 import { WebhookDeliveryQueryService } from './application/services/webhook-delivery-query.service';
+import { WEBHOOK_DELIVERY_QUERY_SERVICE_TOKEN } from './application/interfaces/webhook-delivery-query.service.interface';
 import { WebhookToJobHandler } from './application/handlers/webhook-to-job.handler';
 import { REDIS_CLIENT_BLOCKING_TOKEN } from './webhooks.tokens';
 
@@ -47,6 +48,7 @@ import { REDIS_CLIENT_BLOCKING_TOKEN } from './webhooks.tokens';
     WebhookDedupService,
     WebhookEventPublisher,
     WebhookDeliveryQueryService,
+    { provide: WEBHOOK_DELIVERY_QUERY_SERVICE_TOKEN, useExisting: WebhookDeliveryQueryService },
     WebhookToJobHandler,
     {
       // Dedicated client for blocking xReadGroup loop — must not share with health check client

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -14,11 +14,14 @@ import { EventsModule } from '@openlinker/core/events';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { SyncModule } from '@openlinker/core/sync';
+import { WebhooksCoreModule } from '@openlinker/core/webhooks';
 import { WebhookController } from './http/webhook.controller';
+import { WebhookDeliveryController } from './http/webhook-delivery.controller';
 import { WebhookService } from './application/services/webhook.service';
 import { WebhookAuthService } from './application/services/webhook-auth.service';
 import { WebhookDedupService } from './application/services/webhook-dedup.service';
 import { WebhookEventPublisher } from './application/services/webhook-event-publisher.service';
+import { WebhookDeliveryQueryService } from './application/services/webhook-delivery-query.service';
 import { WebhookToJobHandler } from './application/handlers/webhook-to-job.handler';
 import { REDIS_CLIENT_BLOCKING_TOKEN } from './webhooks.tokens';
 
@@ -35,13 +38,15 @@ import { REDIS_CLIENT_BLOCKING_TOKEN } from './webhooks.tokens';
     IntegrationsModule, // For WebhookSecretProviderPort
     IdentifierMappingModule, // For ConnectionPort
     SyncModule, // For JobEnqueuePort
+    WebhooksCoreModule, // For WebhookDeliveryRepositoryPort
   ],
-  controllers: [WebhookController],
+  controllers: [WebhookController, WebhookDeliveryController],
   providers: [
     WebhookService,
     WebhookAuthService,
     WebhookDedupService,
     WebhookEventPublisher,
+    WebhookDeliveryQueryService,
     WebhookToJobHandler,
     {
       // Dedicated client for blocking xReadGroup loop — must not share with health check client

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -11,6 +11,10 @@ import { createOrdersApi, type OrdersApi } from '../../features/orders/api/order
 import { createProductsApi, type ProductsApi } from '../../features/products/api/products.api';
 import { createSyncJobsApi, type SyncJobsApi } from '../../features/sync-jobs/api/sync.api';
 import { createMappingsApi, type MappingsApi } from '../../features/mappings/api/mappings.api';
+import {
+  createWebhookDeliveriesApi,
+  type WebhookDeliveriesApi,
+} from '../../features/webhook-deliveries/api/webhook-deliveries.api';
 import { ApiError } from '../../shared/api/api-error';
 import type { SessionAdapter } from '../../shared/auth/session-adapter';
 
@@ -38,6 +42,7 @@ export interface ApiClient {
   mappings: MappingsApi;
   request: <T>(path: string, init?: RequestInit) => Promise<T>;
   syncJobs: SyncJobsApi;
+  webhookDeliveries: WebhookDeliveriesApi;
 }
 
 function buildUrl(baseUrl: string, path: string): string {
@@ -131,5 +136,6 @@ export function createApiClient({
     products: createProductsApi(request),
     request,
     syncJobs: createSyncJobsApi(request),
+    webhookDeliveries: createWebhookDeliveriesApi(request),
   };
 }

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -23,6 +23,7 @@ import { ordersRoute } from './orders.route';
 import { productsRoute } from './products.route';
 import { settingsRoute } from './settings.route';
 import { shippingRoute } from './shipping.route';
+import { webhookDeliveriesRoute } from './webhook-deliveries.route';
 
 export const rootRoute: RouteObject = {
   path: '/',
@@ -47,6 +48,7 @@ export const rootRoute: RouteObject = {
     editConnectionRoute,
     allegroCallbackRoute,
     jobsLogsRoute,
+    webhookDeliveriesRoute,
     automationsRoute,
     shippingRoute,
     invoicesRoute,

--- a/apps/web/src/app/routes/webhook-deliveries.route.tsx
+++ b/apps/web/src/app/routes/webhook-deliveries.route.tsx
@@ -1,0 +1,11 @@
+import type { RouteObject } from 'react-router-dom';
+import { WebhookDeliveriesPage } from '../../pages/webhook-deliveries/webhook-deliveries-page';
+import { WebhookDeliveryDetailPage } from '../../pages/webhook-deliveries/webhook-delivery-detail-page';
+
+export const webhookDeliveriesRoute: RouteObject = {
+  path: 'webhook-deliveries',
+  children: [
+    { index: true, element: <WebhookDeliveriesPage /> },
+    { path: ':id', element: <WebhookDeliveryDetailPage /> },
+  ],
+};

--- a/apps/web/src/features/webhook-deliveries/api/webhook-deliveries.api.ts
+++ b/apps/web/src/features/webhook-deliveries/api/webhook-deliveries.api.ts
@@ -1,0 +1,54 @@
+/**
+ * Webhook Deliveries API Client
+ *
+ * Typed client for GET /webhook-deliveries endpoints.
+ *
+ * @module apps/web/src/features/webhook-deliveries/api
+ */
+import type {
+  PaginatedWebhookDeliveries,
+  WebhookDeliveryDetail,
+  WebhookDeliveryFilters,
+  WebhookDeliveryPagination,
+} from './webhook-deliveries.types';
+
+export interface WebhookDeliveriesApi {
+  list: (
+    filters?: WebhookDeliveryFilters,
+    pagination?: WebhookDeliveryPagination,
+  ) => Promise<PaginatedWebhookDeliveries>;
+  getById: (id: string) => Promise<WebhookDeliveryDetail>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+function buildQuery(
+  filters?: WebhookDeliveryFilters,
+  pagination?: WebhookDeliveryPagination,
+): string {
+  const params = new URLSearchParams();
+  if (filters?.provider) params.set('provider', filters.provider);
+  if (filters?.connectionId) params.set('connectionId', filters.connectionId);
+  if (filters?.status) params.set('status', filters.status);
+  if (filters?.since) params.set('since', filters.since);
+  if (filters?.until) params.set('until', filters.until);
+  if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
+  if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}
+
+export function createWebhookDeliveriesApi(request: ApiRequest): WebhookDeliveriesApi {
+  return {
+    list(filters, pagination): Promise<PaginatedWebhookDeliveries> {
+      return request<PaginatedWebhookDeliveries>(
+        `/webhook-deliveries${buildQuery(filters, pagination)}`,
+      );
+    },
+    getById(id): Promise<WebhookDeliveryDetail> {
+      return request<WebhookDeliveryDetail>(`/webhook-deliveries/${id}`);
+    },
+  };
+}

--- a/apps/web/src/features/webhook-deliveries/api/webhook-deliveries.query-keys.ts
+++ b/apps/web/src/features/webhook-deliveries/api/webhook-deliveries.query-keys.ts
@@ -1,0 +1,11 @@
+import type {
+  WebhookDeliveryFilters,
+  WebhookDeliveryPagination,
+} from './webhook-deliveries.types';
+
+export const webhookDeliveriesQueryKeys = {
+  all: ['webhook-deliveries'] as const,
+  list: (filters?: WebhookDeliveryFilters, pagination?: WebhookDeliveryPagination) =>
+    ['webhook-deliveries', 'list', filters ?? {}, pagination ?? {}] as const,
+  detail: (id: string) => ['webhook-deliveries', 'detail', id] as const,
+};

--- a/apps/web/src/features/webhook-deliveries/api/webhook-deliveries.types.ts
+++ b/apps/web/src/features/webhook-deliveries/api/webhook-deliveries.types.ts
@@ -1,0 +1,62 @@
+/**
+ * Webhook Deliveries Feature Types
+ *
+ * Transport types for the webhook delivery visibility API. Dates are ISO 8601.
+ *
+ * @module apps/web/src/features/webhook-deliveries/api
+ */
+
+export const WEBHOOK_DELIVERY_STATUS_VALUES = [
+  'received',
+  'rejected',
+  'published',
+  'failed',
+  'job_enqueued',
+  'deadlettered',
+] as const;
+export type WebhookDeliveryStatus = (typeof WEBHOOK_DELIVERY_STATUS_VALUES)[number];
+
+export interface WebhookDeliverySummary {
+  id: string;
+  eventId: string;
+  provider: string;
+  connectionId: string;
+  eventType: string | null;
+  objectType: string | null;
+  externalId: string | null;
+  receivedAt: string;
+  signatureValid: boolean | null;
+  dedupResult: string | null;
+  status: WebhookDeliveryStatus;
+  rejectionReason: string | null;
+  publishedMessageId: string | null;
+  downstreamJobId: string | null;
+  downstreamJobType: string | null;
+  dlqReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WebhookDeliveryDetail extends WebhookDeliverySummary {
+  payload: Record<string, unknown> | null;
+}
+
+export interface WebhookDeliveryFilters {
+  provider?: string;
+  connectionId?: string;
+  status?: WebhookDeliveryStatus;
+  since?: string;
+  until?: string;
+}
+
+export interface WebhookDeliveryPagination {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedWebhookDeliveries {
+  items: WebhookDeliverySummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/apps/web/src/features/webhook-deliveries/hooks/use-webhook-deliveries-query.ts
+++ b/apps/web/src/features/webhook-deliveries/hooks/use-webhook-deliveries-query.ts
@@ -1,0 +1,21 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { webhookDeliveriesQueryKeys } from '../api/webhook-deliveries.query-keys';
+import type {
+  PaginatedWebhookDeliveries,
+  WebhookDeliveryFilters,
+  WebhookDeliveryPagination,
+} from '../api/webhook-deliveries.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useWebhookDeliveriesQuery(
+  filters?: WebhookDeliveryFilters,
+  pagination?: WebhookDeliveryPagination,
+): UseQueryResult<PaginatedWebhookDeliveries> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: webhookDeliveriesQueryKeys.list(filters, pagination),
+    queryFn: () => apiClient.webhookDeliveries.list(filters, pagination),
+    retry: false,
+  });
+}

--- a/apps/web/src/features/webhook-deliveries/hooks/use-webhook-delivery-query.ts
+++ b/apps/web/src/features/webhook-deliveries/hooks/use-webhook-delivery-query.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { webhookDeliveriesQueryKeys } from '../api/webhook-deliveries.query-keys';
+import type { WebhookDeliveryDetail } from '../api/webhook-deliveries.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useWebhookDeliveryQuery(
+  id: string | undefined,
+): UseQueryResult<WebhookDeliveryDetail> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: webhookDeliveriesQueryKeys.detail(id ?? ''),
+    queryFn: () => apiClient.webhookDeliveries.getById(id ?? ''),
+    enabled: Boolean(id),
+    retry: false,
+  });
+}

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx
@@ -1,0 +1,77 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { WebhookDeliveriesPage } from './webhook-deliveries-page';
+import type { WebhookDeliverySummary } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
+
+const sampleDelivery: WebhookDeliverySummary = {
+  id: 'del_1',
+  provider: 'prestashop',
+  connectionId: 'conn_1',
+  eventId: 'evt_abc',
+  eventType: 'order.created',
+  objectType: null,
+  externalId: null,
+  status: 'published',
+  receivedAt: '2024-01-01T10:00:00.000Z',
+  signatureValid: true,
+  dedupResult: 'new',
+  rejectionReason: null,
+  dlqReason: null,
+  publishedMessageId: null,
+  downstreamJobId: null,
+  downstreamJobType: null,
+  createdAt: '2024-01-01T10:00:00.000Z',
+  updatedAt: '2024-01-01T10:00:00.000Z',
+};
+
+describe('WebhookDeliveriesPage', () => {
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      webhookDeliveries: {
+        list: vi.fn().mockReturnValue(new Promise(() => undefined)),
+      },
+    });
+
+    renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
+
+    expect(screen.getByText('Loading deliveries')).toBeInTheDocument();
+  });
+
+  it('should render deliveries table when data loads', async () => {
+    const mockApi = createMockApiClient({
+      webhookDeliveries: {
+        list: vi.fn().mockResolvedValue({ items: [sampleDelivery], total: 1 }),
+      },
+    });
+
+    renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('prestashop')).toBeInTheDocument();
+    expect(await screen.findByText('order.created')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no deliveries', async () => {
+    const mockApi = createMockApiClient({
+      webhookDeliveries: {
+        list: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+      },
+    });
+
+    renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No deliveries found')).toBeInTheDocument();
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      webhookDeliveries: {
+        list: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+    });
+
+    renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Unable to load webhook deliveries')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
@@ -1,0 +1,201 @@
+import type { ReactElement } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { StatusBadge } from '../../shared/ui/status-badge';
+import { useWebhookDeliveriesQuery } from '../../features/webhook-deliveries/hooks/use-webhook-deliveries-query';
+import {
+  WEBHOOK_DELIVERY_STATUS_VALUES,
+  type WebhookDeliveryFilters,
+  type WebhookDeliveryStatus,
+  type WebhookDeliverySummary,
+} from '../../features/webhook-deliveries/api/webhook-deliveries.types';
+
+const PAGE_SIZE = 20;
+
+function statusTone(status: WebhookDeliveryStatus): 'success' | 'error' | 'warning' | 'neutral' | 'info' {
+  switch (status) {
+    case 'published':
+    case 'job_enqueued':
+      return 'success';
+    case 'rejected':
+    case 'failed':
+    case 'deadlettered':
+      return 'error';
+    case 'received':
+      return 'info';
+    default:
+      return 'neutral';
+  }
+}
+
+const COLUMNS: DataTableColumn<WebhookDeliverySummary>[] = [
+  {
+    id: 'status',
+    header: 'Status',
+    cell: (d) => <StatusBadge tone={statusTone(d.status)}>{d.status}</StatusBadge>,
+  },
+  {
+    id: 'provider',
+    header: 'Provider',
+    cell: (d) => <span className="mono-text">{d.provider}</span>,
+  },
+  {
+    id: 'eventType',
+    header: 'Event type',
+    cell: (d) => <span className="mono-text">{d.eventType ?? '—'}</span>,
+  },
+  {
+    id: 'connectionId',
+    header: 'Connection',
+    cell: (d) => <span className="mono-text">{d.connectionId}</span>,
+  },
+  {
+    id: 'reason',
+    header: 'Reason',
+    cell: (d) => {
+      const reason = d.rejectionReason ?? d.dlqReason;
+      if (!reason) return <span className="text-muted">—</span>;
+      return (
+        <span className="mono-text" title={reason}>
+          {reason.length > 60 ? `${reason.slice(0, 60)}…` : reason}
+        </span>
+      );
+    },
+  },
+  {
+    id: 'receivedAt',
+    header: 'Received',
+    cell: (d) => new Date(d.receivedAt).toLocaleString(),
+  },
+  {
+    id: 'detail',
+    header: '',
+    cell: (d) => (
+      <Link to={d.id} className="button button--ghost button--compact">
+        View
+      </Link>
+    ),
+  },
+];
+
+export function WebhookDeliveriesPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const provider = searchParams.get('provider') ?? undefined;
+  const connectionId = searchParams.get('connectionId') ?? undefined;
+  const status = (searchParams.get('status') as WebhookDeliveryStatus | null) ?? undefined;
+  const offset = Number(searchParams.get('offset') ?? '0');
+
+  const filters: WebhookDeliveryFilters = { provider, connectionId, status };
+  const query = useWebhookDeliveriesQuery(filters, { limit: PAGE_SIZE, offset });
+
+  function setFilter(key: string, value: string): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) next.set(key, value);
+      else next.delete(key);
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  function setOffset(next: number): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === 0) p.delete('offset');
+      else p.set('offset', String(next));
+      return p;
+    });
+  }
+
+  const total = query.data?.total ?? 0;
+  const hasPrev = offset > 0;
+  const hasNext = offset + PAGE_SIZE < total;
+
+  return (
+    <PageLayout
+      eyebrow="Operations"
+      title="Webhook Deliveries"
+      description="Inbound webhook visibility — signature, dedup, publish, and downstream job linkage."
+    >
+      <div className="toolbar">
+        <select
+          aria-label="Filter by status"
+          value={status ?? ''}
+          onChange={(e) => { setFilter('status', e.target.value); }}
+        >
+          <option value="">All statuses</option>
+          {WEBHOOK_DELIVERY_STATUS_VALUES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+
+        <input
+          aria-label="Filter by provider"
+          placeholder="Provider (e.g. prestashop)"
+          value={provider ?? ''}
+          onChange={(e) => { setFilter('provider', e.target.value); }}
+        />
+
+        <input
+          aria-label="Filter by connection ID"
+          placeholder="Connection ID"
+          value={connectionId ?? ''}
+          onChange={(e) => { setFilter('connectionId', e.target.value); }}
+        />
+      </div>
+
+      {query.isLoading ? (
+        <LoadingState
+          liveRegion="off"
+          title="Loading deliveries"
+          message="Fetching webhook delivery data…"
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load webhook deliveries"
+          message={query.error.message}
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
+        />
+      ) : (query.data?.items.length ?? 0) === 0 ? (
+        <EmptyState
+          liveRegion="off"
+          title="No deliveries found"
+          message={
+            provider || connectionId || status
+              ? 'No deliveries match the current filters. Try clearing some filters.'
+              : 'No webhook deliveries have been recorded yet.'
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Webhook deliveries"
+            columns={COLUMNS}
+            rows={query.data?.items ?? []}
+            rowKey={(d) => d.id}
+          />
+
+          <div className="toolbar" style={{ justifyContent: 'space-between' }}>
+            <span className="text-muted">
+              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+            </span>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <Button disabled={!hasPrev} onClick={() => { setOffset(offset - PAGE_SIZE); }}>
+                Previous
+              </Button>
+              <Button disabled={!hasNext} onClick={() => { setOffset(offset + PAGE_SIZE); }}>
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
@@ -1,0 +1,152 @@
+import type { ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
+import { Button } from '../../shared/ui/button';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { useWebhookDeliveryQuery } from '../../features/webhook-deliveries/hooks/use-webhook-delivery-query';
+import type { WebhookDeliveryStatus } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
+
+function statusTone(status: WebhookDeliveryStatus): StatusBadgeTone {
+  switch (status) {
+    case 'published':
+    case 'job_enqueued':
+      return 'success';
+    case 'rejected':
+    case 'failed':
+    case 'deadlettered':
+      return 'error';
+    case 'received':
+      return 'info';
+    default:
+      return 'neutral';
+  }
+}
+
+export function WebhookDeliveryDetailPage(): ReactElement {
+  const { id = '' } = useParams<{ id: string }>();
+  const query = useWebhookDeliveryQuery(id);
+
+  if (query.isLoading) {
+    return (
+      <PageLayout eyebrow="Webhook Deliveries" title="Delivery detail">
+        <LoadingState liveRegion="off" title="Loading delivery" message="Fetching delivery details…" />
+      </PageLayout>
+    );
+  }
+
+  if (query.error || !query.data) {
+    return (
+      <PageLayout eyebrow="Webhook Deliveries" title="Delivery detail">
+        <ErrorState
+          title="Unable to load delivery"
+          message={query.error?.message ?? 'Delivery not found'}
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
+        />
+      </PageLayout>
+    );
+  }
+
+  const d = query.data;
+
+  return (
+    <PageLayout
+      eyebrow="Webhook Deliveries"
+      title={<span className="mono-text">{d.eventType ?? d.eventId}</span>}
+      actions={
+        <Link to=".." relative="path" className="button button--ghost">
+          ← Back to deliveries
+        </Link>
+      }
+    >
+      <section className="detail-section">
+        <dl className="detail-list">
+          <div className="detail-list__row">
+            <dt>Status</dt>
+            <dd><StatusBadge tone={statusTone(d.status)}>{d.status}</StatusBadge></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Event ID</dt>
+            <dd><span className="mono-text">{d.eventId}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Provider</dt>
+            <dd><span className="mono-text">{d.provider}</span></dd>
+          </div>
+          <div className="detail-list__row">
+            <dt>Connection</dt>
+            <dd><span className="mono-text">{d.connectionId}</span></dd>
+          </div>
+          {d.objectType ? (
+            <div className="detail-list__row">
+              <dt>Object type</dt>
+              <dd><span className="mono-text">{d.objectType}</span></dd>
+            </div>
+          ) : null}
+          {d.externalId ? (
+            <div className="detail-list__row">
+              <dt>External ID</dt>
+              <dd><span className="mono-text">{d.externalId}</span></dd>
+            </div>
+          ) : null}
+          <div className="detail-list__row">
+            <dt>Signature valid</dt>
+            <dd>{d.signatureValid === null ? '—' : d.signatureValid ? 'yes' : 'no'}</dd>
+          </div>
+          {d.dedupResult ? (
+            <div className="detail-list__row">
+              <dt>Dedup</dt>
+              <dd>{d.dedupResult}</dd>
+            </div>
+          ) : null}
+          {d.publishedMessageId ? (
+            <div className="detail-list__row">
+              <dt>Published message</dt>
+              <dd><span className="mono-text">{d.publishedMessageId}</span></dd>
+            </div>
+          ) : null}
+          {d.downstreamJobId ? (
+            <div className="detail-list__row">
+              <dt>Downstream job</dt>
+              <dd>
+                <Link to={`/jobs-logs/${d.downstreamJobId}`} className="mono-text">
+                  {d.downstreamJobId}
+                </Link>
+                {d.downstreamJobType ? (
+                  <span className="text-muted"> — {d.downstreamJobType}</span>
+                ) : null}
+              </dd>
+            </div>
+          ) : null}
+          <div className="detail-list__row">
+            <dt>Received</dt>
+            <dd>{new Date(d.receivedAt).toLocaleString()}</dd>
+          </div>
+        </dl>
+      </section>
+
+      {d.rejectionReason ? (
+        <section className="detail-section">
+          <h3 className="detail-section__title">Rejection reason</h3>
+          <pre className="mono-text detail-section__pre">{d.rejectionReason}</pre>
+        </section>
+      ) : null}
+
+      {d.dlqReason ? (
+        <section className="detail-section">
+          <h3 className="detail-section__title">DLQ reason</h3>
+          <pre className="mono-text detail-section__pre">{d.dlqReason}</pre>
+        </section>
+      ) : null}
+
+      {d.payload ? (
+        <section className="detail-section">
+          <h3 className="detail-section__title">Payload</h3>
+          <pre className="mono-text detail-section__pre">
+            {JSON.stringify(d.payload, null, 2)}
+          </pre>
+        </section>
+      ) : null}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/shared/ui/app-shell.tsx
+++ b/apps/web/src/shared/ui/app-shell.tsx
@@ -31,6 +31,7 @@ const navigationGroups: NavigationGroup[] = [
       { to: '/listings', label: 'Listings', state: 'live' },
       { to: '/cursors', label: 'Cursors', state: 'live' },
       { to: '/jobs-logs', label: 'Jobs & Logs', state: 'planned' },
+      { to: '/webhook-deliveries', label: 'Webhooks', state: 'live' },
       { to: '/automations', label: 'Automations', state: 'planned' },
     ],
   },

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -49,6 +49,7 @@ type DeepPartialApiClient = {
   products?: Partial<ApiClient['products']>;
   mappings?: Partial<ApiClient['mappings']>;
   syncJobs?: Partial<ApiClient['syncJobs']>;
+  webhookDeliveries?: Partial<ApiClient['webhookDeliveries']>;
 };
 
 export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiClient {
@@ -198,6 +199,11 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       retry: vi.fn().mockResolvedValue(null),
       ...overrides.syncJobs,
     } as ApiClient['syncJobs'],
+    webhookDeliveries: {
+      list: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+      getById: vi.fn().mockResolvedValue(null),
+      ...overrides.webhookDeliveries,
+    } as ApiClient['webhookDeliveries'],
   };
 }
 

--- a/docs/plans/implementation-plan-webhook-event-visibility.md
+++ b/docs/plans/implementation-plan-webhook-event-visibility.md
@@ -1,0 +1,140 @@
+# Implementation Plan — Webhook & Event Delivery Visibility (#78 + #76)
+
+## Goal
+
+Give operators visibility into inbound webhook processing: what arrived, whether signature/dedup passed, whether it was published, and which sync job (if any) resulted. Exposed via a REST API (#78) and an admin FE page (#76).
+
+## Non-goals
+
+- Replay/retry controls
+- Outbound webhook tracking
+- Retention/purging policy (MVP: keep indefinitely; follow-up issue if needed)
+- Alerting/metrics
+
+## Classification
+
+- **#78 BE** — Infrastructure (persistence) + Interface (HTTP). No `libs/core` changes.
+- **#76 FE** — Interface layer in `apps/web`.
+
+### Module placement note
+
+Webhooks already live as an API-app-local bounded context under `apps/api/src/webhooks/` with no `libs/core` counterpart. We follow that existing layout rather than introducing a parallel `libs/core/src/webhooks`. This is a deliberate deviation from the standard "persistence in core" pattern; rationale: the webhooks module is a thin HTTP-ingress adapter, not a domain. If a core webhooks domain is introduced later, this persistence will migrate with it.
+
+The webhooks module has no `domain/` layer today. We add a minimal domain entity + repository port so the port–adapter boundary is respected. Repository port lives in `application/interfaces/` (matches existing `webhook.service.interface.ts` convention inside this module).
+
+---
+
+## Design
+
+### Persistence
+
+New ORM entity `webhook_deliveries` under `apps/api/src/webhooks/infrastructure/persistence/`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `eventId` | text | Provider's event id |
+| `provider` | text | e.g. `prestashop` |
+| `connectionId` | uuid NOT NULL | Always known from URL path |
+| `eventType` | text | nullable (pre-parse rejections) |
+| `objectType` | text | nullable |
+| `externalId` | text | nullable |
+| `receivedAt` | timestamptz | |
+| `signatureValid` | boolean | null if not checked |
+| `dedupResult` | text | `new` \| `duplicate` \| null |
+| `status` | text | `rejected` \| `published` \| `failed` \| `deadlettered` \| `job_enqueued` |
+| `rejectionReason` | text | e.g. `invalid_signature`, `stale_timestamp`, `missing_header` |
+| `publishedMessageId` | text | Redis stream id |
+| `downstreamJobId` | text | Soft link to `sync_jobs.id` (idempotency-key based) |
+| `downstreamJobType` | text | |
+| `dlqReason` | text | |
+| `payload` | jsonb | |
+| `createdAt`, `updatedAt` | timestamptz | |
+
+Indexes:
+- `(receivedAt DESC)`
+- `(connectionId, receivedAt DESC)`
+- `(provider, receivedAt DESC)`
+- `(status, receivedAt DESC)`
+- **Unique `(provider, connectionId, eventId)`** (plain, no partial) — enables upsert semantics
+
+### Lifecycle & race handling
+
+1. **`WebhookService`** performs a single `INSERT ... ON CONFLICT (provider, connectionId, eventId) DO UPDATE` at entry with known fields, then issues further `UPDATE` calls as it progresses through signature check → dedup → publish. On terminal outcome (rejected / published / failed) the row is in final state.
+2. **`WebhookToJobHandler`** performs `INSERT ... ON CONFLICT DO UPDATE` keyed on the same tuple when it updates `downstreamJobId` / `dlqReason`. This closes the race where the handler might fire before the initial publisher write commits (the handler would otherwise update 0 rows).
+3. All persistence is wrapped in try/catch and logged; failures must not break webhook processing.
+
+### Domain layer
+
+- `apps/api/src/webhooks/domain/entities/webhook-delivery.entity.ts` — plain TS class, no framework deps
+- `apps/api/src/webhooks/application/interfaces/webhook-delivery-repository.port.ts` — methods: `upsert(record)`, `findMany(filters, pagination)`, `findById(id)`
+- `apps/api/src/webhooks/infrastructure/persistence/repositories/webhook-delivery.repository.ts` implements the port with private `toDomain` / `toOrm` mappers
+
+Application service and controller work with the domain entity; only DTOs cross the HTTP boundary.
+
+### Query API
+
+`GET /webhook-deliveries` — filters: `provider`, `connectionId`, `status`, `since`, `until`, `limit` (default 20, max 100), `offset`. Default sort: `receivedAt DESC`.
+
+**List response excludes `payload`** (may contain PII). Includes all other columns.
+
+`GET /webhook-deliveries/:id` — full record including `payload`.
+
+Both guarded by `JwtAuthGuard`.
+
+### Frontend
+
+New route `/webhook-deliveries` mirroring sync-jobs. List page with filters + DataTable; detail drawer with JSON payload viewer and a link to the linked sync job detail page.
+
+---
+
+## Step-by-step
+
+### Backend
+
+1. **Domain entity** `apps/api/src/webhooks/domain/entities/webhook-delivery.entity.ts`
+2. **Types** `apps/api/src/webhooks/domain/types/webhook-delivery.types.ts` (`WebhookDeliveryStatus` + values, `DedupResult`)
+3. **Repository port** `apps/api/src/webhooks/application/interfaces/webhook-delivery-repository.port.ts`
+4. **ORM entity** `apps/api/src/webhooks/infrastructure/persistence/entities/webhook-delivery.orm-entity.ts`
+5. **Repository implementation** `apps/api/src/webhooks/infrastructure/persistence/repositories/webhook-delivery.repository.ts` — uses `upsert` / `save` with conflict target; private mappers; converts TypeORM errors to domain errors where relevant
+6. **Wire module**: add TypeormModule.forFeature, Symbol token `WEBHOOK_DELIVERY_REPOSITORY_TOKEN`, `{ provide: TOKEN, useExisting: WebhookDeliveryRepository }`
+7. **Generate migration** `pnpm --filter @openlinker/api migration:generate -- src/migrations/AddWebhookDeliveries` (runs after module wiring)
+8. **Hook into WebhookService**: upsert at entry; update on signature validate / dedup / publish / fail; all writes best-effort
+9. **Hook into WebhookToJobHandler**: upsert with `downstreamJobId` + `status=job_enqueued`, or `dlqReason` + `status=deadlettered`
+10. **Query service** `apps/api/src/webhooks/application/services/webhook-delivery-query.service.ts` + interface
+11. **Controller + DTOs**:
+    - `webhook-delivery.controller.ts` (`@UseGuards(JwtAuthGuard)`)
+    - `http/dto/list-webhook-deliveries-query.dto.ts` (class-validator; coerced numbers/dates)
+    - `http/dto/webhook-delivery-summary-response.dto.ts` (list — no `payload`)
+    - `http/dto/webhook-delivery-detail-response.dto.ts` (detail — includes `payload`)
+12. **Unit tests** (all `*.spec.ts`):
+    - `webhook-delivery.repository.spec.ts` (mapper round-trip)
+    - `webhook-delivery-query.service.spec.ts`
+    - `webhook-delivery.controller.spec.ts`
+    - update `webhook.service.spec.ts` — assert upsert + lifecycle updates are attempted and that persistence failures are swallowed
+    - update `webhook-to-job.handler.spec.ts` — assert linkage / DLQ upsert
+13. **Integration test** `apps/api/test/integration/webhook-delivery.int-spec.ts` — POST a signed webhook, assert row persisted with `status=published` and later `downstreamJobId` populated after handler runs. Uses existing Testcontainers harness.
+
+### Frontend
+
+14. **API client** — add `webhookDeliveries.list(filters)` and `.get(id)` to the shared api client
+15. **Types** `apps/web/src/pages/webhook-deliveries/types.ts`
+16. **Query hooks** `use-webhook-deliveries-query.ts`, `use-webhook-delivery-query.ts`
+17. **List page** `webhook-deliveries-page.tsx` — filters (provider, connection dropdown, status, date range); DataTable; offset pagination; URL-synced filters via `useSearchParams` (mirror `sync-jobs-page.tsx`)
+18. **Detail drawer** `webhook-delivery-detail.tsx` — JSON viewer for payload, linked sync-job link (`/sync-jobs/:id`), status badge
+19. **Route module** `apps/web/src/app/routes/webhook-deliveries.route.tsx` + register in router + sidebar nav entry (locate nav via existing sync-jobs / jobs-logs registration)
+20. **Vitest tests** — hook tests + page smoke test
+
+### Quality gate
+
+21. `pnpm lint && pnpm type-check && pnpm test`
+22. `pnpm --filter @openlinker/api migration:show` — no pending
+
+---
+
+## Risks / Open questions
+
+- **Write amplification**: 2–4 DB writes per webhook. MVP-acceptable; retention follow-up later.
+- **Payload size**: uncapped jsonb. Revisit if storage growth becomes problematic.
+- **Soft FK to sync_jobs**: no DB constraint; if a job is later deleted, the `downstreamJobId` becomes dangling. Acceptable for a visibility feature.
+- **Module placement divergence**: documented above; migrate with webhooks if they move to `libs/core` later.

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -106,6 +106,16 @@
       "types": "./dist/users/*.d.ts",
       "require": "./dist/users/*.js",
       "default": "./dist/users/*.js"
+    },
+    "./webhooks": {
+      "types": "./dist/webhooks/index.d.ts",
+      "require": "./dist/webhooks/index.js",
+      "default": "./dist/webhooks/index.js"
+    },
+    "./webhooks/*": {
+      "types": "./dist/webhooks/*.d.ts",
+      "require": "./dist/webhooks/*.js",
+      "default": "./dist/webhooks/*.js"
     }
   },
   "files": ["dist"],

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -17,4 +17,5 @@ export * from './sync';
 export * from './listings';
 export * from './users';
 export * from './mappings';
+export * from './webhooks';
 

--- a/libs/core/src/webhooks/domain/entities/webhook-delivery.entity.ts
+++ b/libs/core/src/webhooks/domain/entities/webhook-delivery.entity.ts
@@ -1,0 +1,37 @@
+/**
+ * Webhook Delivery Domain Entity
+ *
+ * Represents an inbound webhook delivery record used for operator visibility
+ * into signature validation, dedup, publishing, and downstream job linkage.
+ * Framework-agnostic.
+ *
+ * @module libs/core/src/webhooks/domain/entities
+ */
+import {
+  WebhookDedupResult,
+  WebhookDeliveryStatus,
+} from '../types/webhook-delivery.types';
+
+export class WebhookDelivery {
+  constructor(
+    public readonly id: string,
+    public readonly eventId: string,
+    public readonly provider: string,
+    public readonly connectionId: string,
+    public readonly eventType: string | null,
+    public readonly objectType: string | null,
+    public readonly externalId: string | null,
+    public readonly receivedAt: Date,
+    public readonly signatureValid: boolean | null,
+    public readonly dedupResult: WebhookDedupResult | null,
+    public readonly status: WebhookDeliveryStatus,
+    public readonly rejectionReason: string | null,
+    public readonly publishedMessageId: string | null,
+    public readonly downstreamJobId: string | null,
+    public readonly downstreamJobType: string | null,
+    public readonly dlqReason: string | null,
+    public readonly payload: Record<string, unknown> | null,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+  ) {}
+}

--- a/libs/core/src/webhooks/domain/exceptions/webhook-delivery-upsert-failed.error.ts
+++ b/libs/core/src/webhooks/domain/exceptions/webhook-delivery-upsert-failed.error.ts
@@ -1,0 +1,18 @@
+/**
+ * Webhook Delivery Upsert Failed Error
+ *
+ * Thrown by the webhook delivery repository when an upsert succeeds at the
+ * database level but the follow-up read cannot locate the row — indicating an
+ * unexpected infrastructure inconsistency.
+ *
+ * @module libs/core/src/webhooks/domain/exceptions
+ */
+export class WebhookDeliveryUpsertFailedError extends Error {
+  constructor(provider: string, connectionId: string, eventId: string) {
+    super(
+      `Webhook delivery upsert did not produce a locatable row: provider=${provider}, connectionId=${connectionId}, eventId=${eventId}`,
+    );
+    this.name = 'WebhookDeliveryUpsertFailedError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/webhooks/domain/ports/webhook-delivery-repository.port.ts
+++ b/libs/core/src/webhooks/domain/ports/webhook-delivery-repository.port.ts
@@ -1,0 +1,49 @@
+/**
+ * Webhook Delivery Repository Port
+ *
+ * Persistence contract for inbound webhook delivery records. Supports upsert
+ * semantics keyed on (provider, connectionId, eventId) to handle race between
+ * the ingress service and the async job-linkage handler.
+ *
+ * @module libs/core/src/webhooks/domain/ports
+ */
+import { WebhookDelivery } from '../entities/webhook-delivery.entity';
+import {
+  PaginatedWebhookDeliveries,
+  WebhookDeliveryFilters,
+  WebhookDeliveryPagination,
+  WebhookDeliveryStatus,
+  WebhookDedupResult,
+} from '../types/webhook-delivery.types';
+
+export interface WebhookDeliveryUpsertInput {
+  eventId: string;
+  provider: string;
+  connectionId: string;
+  eventType?: string | null;
+  objectType?: string | null;
+  externalId?: string | null;
+  receivedAt?: Date;
+  signatureValid?: boolean | null;
+  dedupResult?: WebhookDedupResult | null;
+  status?: WebhookDeliveryStatus;
+  rejectionReason?: string | null;
+  publishedMessageId?: string | null;
+  downstreamJobId?: string | null;
+  downstreamJobType?: string | null;
+  dlqReason?: string | null;
+  payload?: Record<string, unknown> | null;
+}
+
+export interface WebhookDeliveryRepositoryPort {
+  upsert(input: WebhookDeliveryUpsertInput): Promise<WebhookDelivery>;
+  findById(id: string): Promise<WebhookDelivery | null>;
+  findMany(
+    filters: WebhookDeliveryFilters,
+    pagination: WebhookDeliveryPagination,
+  ): Promise<PaginatedWebhookDeliveries>;
+}
+
+export const WEBHOOK_DELIVERY_REPOSITORY_TOKEN = Symbol(
+  'WebhookDeliveryRepositoryPort',
+);

--- a/libs/core/src/webhooks/domain/types/webhook-delivery.types.ts
+++ b/libs/core/src/webhooks/domain/types/webhook-delivery.types.ts
@@ -1,0 +1,41 @@
+/**
+ * Webhook Delivery Types
+ *
+ * Domain types for inbound webhook delivery records. Used by the visibility
+ * API to expose webhook processing outcomes to operators.
+ *
+ * @module libs/core/src/webhooks/domain/types
+ */
+
+export const WebhookDeliveryStatusValues = [
+  'received',
+  'rejected',
+  'published',
+  'failed',
+  'job_enqueued',
+  'deadlettered',
+] as const;
+export type WebhookDeliveryStatus = (typeof WebhookDeliveryStatusValues)[number];
+
+export const WebhookDedupResultValues = ['new', 'duplicate'] as const;
+export type WebhookDedupResult = (typeof WebhookDedupResultValues)[number];
+
+export interface WebhookDeliveryFilters {
+  provider?: string;
+  connectionId?: string;
+  status?: WebhookDeliveryStatus;
+  since?: Date;
+  until?: Date;
+}
+
+export interface WebhookDeliveryPagination {
+  limit: number;
+  offset: number;
+}
+
+import type { WebhookDelivery } from '../entities/webhook-delivery.entity';
+
+export interface PaginatedWebhookDeliveries {
+  items: WebhookDelivery[];
+  total: number;
+}

--- a/libs/core/src/webhooks/domain/types/webhook-delivery.types.ts
+++ b/libs/core/src/webhooks/domain/types/webhook-delivery.types.ts
@@ -6,6 +6,7 @@
  *
  * @module libs/core/src/webhooks/domain/types
  */
+import type { WebhookDelivery } from '../entities/webhook-delivery.entity';
 
 export const WebhookDeliveryStatusValues = [
   'received',
@@ -32,8 +33,6 @@ export interface WebhookDeliveryPagination {
   limit: number;
   offset: number;
 }
-
-import type { WebhookDelivery } from '../entities/webhook-delivery.entity';
 
 export interface PaginatedWebhookDeliveries {
   items: WebhookDelivery[];

--- a/libs/core/src/webhooks/index.ts
+++ b/libs/core/src/webhooks/index.ts
@@ -1,4 +1,5 @@
 export * from './domain/entities/webhook-delivery.entity';
+export * from './domain/exceptions/webhook-delivery-upsert-failed.error';
 export * from './domain/types/webhook-delivery.types';
 export * from './domain/ports/webhook-delivery-repository.port';
 export * from './infrastructure/persistence/entities/webhook-delivery.orm-entity';

--- a/libs/core/src/webhooks/index.ts
+++ b/libs/core/src/webhooks/index.ts
@@ -1,0 +1,6 @@
+export * from './domain/entities/webhook-delivery.entity';
+export * from './domain/types/webhook-delivery.types';
+export * from './domain/ports/webhook-delivery-repository.port';
+export * from './infrastructure/persistence/entities/webhook-delivery.orm-entity';
+export * from './infrastructure/persistence/repositories/webhook-delivery.repository';
+export * from './webhooks-core.module';

--- a/libs/core/src/webhooks/infrastructure/persistence/entities/webhook-delivery.orm-entity.ts
+++ b/libs/core/src/webhooks/infrastructure/persistence/entities/webhook-delivery.orm-entity.ts
@@ -1,0 +1,83 @@
+/**
+ * Webhook Delivery ORM Entity
+ *
+ * TypeORM entity for the webhook_deliveries table. Records the lifecycle of
+ * each inbound webhook from receipt through publishing and downstream job
+ * linkage. Used by the visibility API.
+ *
+ * @module libs/core/src/webhooks/infrastructure/persistence/entities
+ */
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('webhook_deliveries')
+@Unique('uq_webhook_deliveries_event_key', ['provider', 'connectionId', 'eventId'])
+@Index(['receivedAt'])
+@Index(['connectionId', 'receivedAt'])
+@Index(['provider', 'receivedAt'])
+@Index(['status', 'receivedAt'])
+export class WebhookDeliveryOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'text' })
+  eventId!: string;
+
+  @Column({ type: 'text' })
+  provider!: string;
+
+  @Column({ type: 'uuid' })
+  connectionId!: string;
+
+  @Column({ type: 'text', nullable: true })
+  eventType!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  objectType!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  externalId!: string | null;
+
+  @Column({ type: 'timestamptz' })
+  receivedAt!: Date;
+
+  @Column({ type: 'boolean', nullable: true })
+  signatureValid!: boolean | null;
+
+  @Column({ type: 'text', nullable: true })
+  dedupResult!: string | null;
+
+  @Column({ type: 'text' })
+  status!: string;
+
+  @Column({ type: 'text', nullable: true })
+  rejectionReason!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  publishedMessageId!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  downstreamJobId!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  downstreamJobType!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  dlqReason!: string | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  payload!: Record<string, unknown> | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/webhooks/infrastructure/persistence/repositories/webhook-delivery.repository.ts
+++ b/libs/core/src/webhooks/infrastructure/persistence/repositories/webhook-delivery.repository.ts
@@ -1,0 +1,161 @@
+/**
+ * Webhook Delivery Repository
+ *
+ * TypeORM-backed implementation of WebhookDeliveryRepositoryPort. Provides
+ * upsert semantics keyed on (provider, connectionId, eventId) to close the
+ * race between the webhook ingress service (inserts the initial row) and the
+ * async webhook-to-job handler (links the downstream job id).
+ *
+ * @module libs/core/src/webhooks/infrastructure/persistence/repositories
+ * @implements {WebhookDeliveryRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, FindOptionsWhere, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
+import { WebhookDeliveryOrmEntity } from '../entities/webhook-delivery.orm-entity';
+import { WebhookDelivery } from '../../../domain/entities/webhook-delivery.entity';
+import {
+  WebhookDeliveryRepositoryPort,
+  WebhookDeliveryUpsertInput,
+} from '../../../domain/ports/webhook-delivery-repository.port';
+import {
+  PaginatedWebhookDeliveries,
+  WebhookDedupResult,
+  WebhookDedupResultValues,
+  WebhookDeliveryFilters,
+  WebhookDeliveryPagination,
+  WebhookDeliveryStatus,
+  WebhookDeliveryStatusValues,
+} from '../../../domain/types/webhook-delivery.types';
+
+@Injectable()
+export class WebhookDeliveryRepository implements WebhookDeliveryRepositoryPort {
+  constructor(
+    @InjectRepository(WebhookDeliveryOrmEntity)
+    private readonly repository: Repository<WebhookDeliveryOrmEntity>,
+  ) {}
+
+  async upsert(input: WebhookDeliveryUpsertInput): Promise<WebhookDelivery> {
+    const now = new Date();
+    const values: Partial<WebhookDeliveryOrmEntity> = {
+      eventId: input.eventId,
+      provider: input.provider,
+      connectionId: input.connectionId,
+      receivedAt: input.receivedAt ?? now,
+      status: input.status ?? 'received',
+    };
+    const overlay: Partial<WebhookDeliveryOrmEntity> = {};
+
+    if (input.eventType !== undefined) overlay.eventType = input.eventType;
+    if (input.objectType !== undefined) overlay.objectType = input.objectType;
+    if (input.externalId !== undefined) overlay.externalId = input.externalId;
+    if (input.signatureValid !== undefined) overlay.signatureValid = input.signatureValid;
+    if (input.dedupResult !== undefined) overlay.dedupResult = input.dedupResult;
+    if (input.rejectionReason !== undefined) overlay.rejectionReason = input.rejectionReason;
+    if (input.publishedMessageId !== undefined) overlay.publishedMessageId = input.publishedMessageId;
+    if (input.downstreamJobId !== undefined) overlay.downstreamJobId = input.downstreamJobId;
+    if (input.downstreamJobType !== undefined) overlay.downstreamJobType = input.downstreamJobType;
+    if (input.dlqReason !== undefined) overlay.dlqReason = input.dlqReason;
+    if (input.payload !== undefined) overlay.payload = input.payload;
+    if (input.status !== undefined) overlay.status = input.status;
+
+    const updateKeys = Object.keys(overlay) as (keyof WebhookDeliveryOrmEntity)[];
+
+    await this.repository
+      .createQueryBuilder()
+      .insert()
+      .into(WebhookDeliveryOrmEntity)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      .values({ ...values, ...overlay } as any)
+      .orUpdate(updateKeys.length > 0 ? (updateKeys as string[]) : ['updatedAt'], [
+        'provider',
+        'connectionId',
+        'eventId',
+      ])
+      .execute();
+
+    const saved = await this.repository.findOne({
+      where: {
+        provider: input.provider,
+        connectionId: input.connectionId,
+        eventId: input.eventId,
+      },
+    });
+    if (!saved) {
+      throw new Error(
+        `Upsert failed to locate row: provider=${input.provider}, connectionId=${input.connectionId}, eventId=${input.eventId}`,
+      );
+    }
+    return this.toDomain(saved);
+  }
+
+  async findById(id: string): Promise<WebhookDelivery | null> {
+    const entity = await this.repository.findOne({ where: { id } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async findMany(
+    filters: WebhookDeliveryFilters,
+    pagination: WebhookDeliveryPagination,
+  ): Promise<PaginatedWebhookDeliveries> {
+    const where: FindOptionsWhere<WebhookDeliveryOrmEntity> = {};
+    if (filters.provider) where.provider = filters.provider;
+    if (filters.connectionId) where.connectionId = filters.connectionId;
+    if (filters.status) where.status = filters.status;
+    if (filters.since && filters.until) {
+      where.receivedAt = Between(filters.since, filters.until);
+    } else if (filters.since) {
+      where.receivedAt = MoreThanOrEqual(filters.since);
+    } else if (filters.until) {
+      where.receivedAt = LessThanOrEqual(filters.until);
+    }
+
+    const [entities, total] = await this.repository.findAndCount({
+      where,
+      order: { receivedAt: 'DESC' },
+      take: pagination.limit,
+      skip: pagination.offset,
+    });
+
+    return { items: entities.map((e) => this.toDomain(e)), total };
+  }
+
+  private toDomain(entity: WebhookDeliveryOrmEntity): WebhookDelivery {
+    return new WebhookDelivery(
+      entity.id,
+      entity.eventId,
+      entity.provider,
+      entity.connectionId,
+      entity.eventType,
+      entity.objectType,
+      entity.externalId,
+      entity.receivedAt,
+      entity.signatureValid,
+      this.toDedupResult(entity.dedupResult),
+      this.toStatus(entity.status, entity.id),
+      entity.rejectionReason,
+      entity.publishedMessageId,
+      entity.downstreamJobId,
+      entity.downstreamJobType,
+      entity.dlqReason,
+      entity.payload,
+      entity.createdAt,
+      entity.updatedAt,
+    );
+  }
+
+  private toStatus(value: string, id: string): WebhookDeliveryStatus {
+    if ((WebhookDeliveryStatusValues as readonly string[]).includes(value)) {
+      return value as WebhookDeliveryStatus;
+    }
+    throw new Error(`Invalid WebhookDelivery status "${value}" on row ${id}`);
+  }
+
+  private toDedupResult(value: string | null): WebhookDedupResult | null {
+    if (value === null) return null;
+    if ((WebhookDedupResultValues as readonly string[]).includes(value)) {
+      return value as WebhookDedupResult;
+    }
+    return null;
+  }
+}

--- a/libs/core/src/webhooks/infrastructure/persistence/repositories/webhook-delivery.repository.ts
+++ b/libs/core/src/webhooks/infrastructure/persistence/repositories/webhook-delivery.repository.ts
@@ -14,6 +14,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Between, FindOptionsWhere, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import { WebhookDeliveryOrmEntity } from '../entities/webhook-delivery.orm-entity';
 import { WebhookDelivery } from '../../../domain/entities/webhook-delivery.entity';
+import { WebhookDeliveryUpsertFailedError } from '../../../domain/exceptions/webhook-delivery-upsert-failed.error';
 import {
   WebhookDeliveryRepositoryPort,
   WebhookDeliveryUpsertInput,
@@ -82,9 +83,7 @@ export class WebhookDeliveryRepository implements WebhookDeliveryRepositoryPort 
       },
     });
     if (!saved) {
-      throw new Error(
-        `Upsert failed to locate row: provider=${input.provider}, connectionId=${input.connectionId}, eventId=${input.eventId}`,
-      );
+      throw new WebhookDeliveryUpsertFailedError(input.provider, input.connectionId, input.eventId);
     }
     return this.toDomain(saved);
   }

--- a/libs/core/src/webhooks/webhooks-core.module.ts
+++ b/libs/core/src/webhooks/webhooks-core.module.ts
@@ -1,0 +1,24 @@
+/**
+ * Webhooks Core Module
+ *
+ * Provides persistence for inbound webhook delivery records. Kept in
+ * `libs/core` so TypeORM migrations discover the ORM entity alongside the
+ * rest of the platform schema.
+ *
+ * @module libs/core/src/webhooks
+ */
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WebhookDeliveryOrmEntity } from './infrastructure/persistence/entities/webhook-delivery.orm-entity';
+import { WebhookDeliveryRepository } from './infrastructure/persistence/repositories/webhook-delivery.repository';
+import { WEBHOOK_DELIVERY_REPOSITORY_TOKEN } from './domain/ports/webhook-delivery-repository.port';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WebhookDeliveryOrmEntity])],
+  providers: [
+    WebhookDeliveryRepository,
+    { provide: WEBHOOK_DELIVERY_REPOSITORY_TOKEN, useExisting: WebhookDeliveryRepository },
+  ],
+  exports: [WEBHOOK_DELIVERY_REPOSITORY_TOKEN],
+})
+export class WebhooksCoreModule {}


### PR DESCRIPTION
## Summary

- Records every inbound webhook delivery to a `webhook_deliveries` table with full lifecycle tracking: signature validation, dedup result, publish outcome, and downstream sync job linkage
- Exposes `GET /webhook-deliveries` (paginated list) and `GET /webhook-deliveries/:id` (detail with payload) REST endpoints, filtered by provider, connectionId, and status
- Adds an admin FE page at `/webhook-deliveries` with filter bar, DataTable, pagination, and detail view including JSON payload viewer and downstream job link
- Uses upsert semantics keyed on `(provider, connectionId, eventId)` to safely handle the async race between `WebhookService` (initial record) and `WebhookToJobHandler` (downstream job linkage)
- All DB writes are best-effort (`try/catch`) — failures never affect webhook delivery

## Test plan

- [ ] Unit tests pass: `pnpm test` (220 API + 96 worker + all others)
- [ ] Type check passes: `pnpm type-check`
- [ ] Lint passes: `pnpm lint`
- [ ] Migration applied: `pnpm --filter @openlinker/api migration:show` shows `[X] AddWebhookDeliveries1782000000000`
- [ ] FE: visit `/webhook-deliveries` — filter bar, table, pagination render correctly
- [ ] FE: click View on a row — detail page shows all fields, payload JSON, downstream job link
- [ ] BE: POST a webhook and verify a row appears in `webhook_deliveries`

Closes #76
Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)