### PR TITLE
feat(orders): multi-destination order routing via OrderProcessorManager fan-out

### DIFF
--- a/libs/core/src/orders/application/interfaces/order-sync.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-sync.service.interface.ts
@@ -67,12 +67,14 @@ export interface IOrderSyncService {
   /**
    * Sync order to destination processor(s)
    *
-   * Routes a unified order to configured destination OrderProcessorManager adapters.
-   * For MVP, routes to a single configured destination connection.
+   * Resolves all active OrderProcessorManager adapters (excluding the source
+   * connection) and dispatches the order to each in parallel. Per-destination
+   * failures are isolated — a failed destination yields a `status: 'failed'`
+   * result rather than aborting the entire sync.
    *
    * @param request - Order sync request with order and source metadata
-   * @returns Array of sync results (one per destination)
-   * @throws Error if destination connection not found or order creation fails
+   * @returns Array of sync results (one per destination, success or failed)
+   * @throws {NoOrderDestinationsAvailableException} if no eligible destinations are resolved
    */
   syncOrder(request: OrderSyncRequest): Promise<OrderSyncResult[]>;
 }

--- a/libs/core/src/orders/application/interfaces/order-sync.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-sync.service.interface.ts
@@ -53,6 +53,7 @@ export type OrderSyncResult =
       status: 'failed';
       error: {
         message: string;
+        code?: string;
       };
     };
 

--- a/libs/core/src/orders/application/interfaces/order-sync.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-sync.service.interface.ts
@@ -34,22 +34,27 @@ export interface OrderSyncRequest {
 /**
  * Order sync result
  *
- * Contains the result of order synchronization to destination processors.
+ * Discriminated union describing the outcome of syncing an order to a single
+ * destination processor. `status: 'success'` carries the destination order
+ * reference; `status: 'failed'` carries the error message so callers can
+ * surface partial failures without losing track of successful destinations.
  */
-export interface OrderSyncResult {
-  /**
-   * Destination connection ID where the order was synced
-   */
-  destinationConnectionId: string;
-
-  /**
-   * Order reference from the destination processor
-   */
-  orderRef: {
-    orderId: string;
-    orderNumber?: string;
-  };
-}
+export type OrderSyncResult =
+  | {
+      destinationConnectionId: string;
+      status: 'success';
+      orderRef: {
+        orderId: string;
+        orderNumber?: string;
+      };
+    }
+  | {
+      destinationConnectionId: string;
+      status: 'failed';
+      error: {
+        message: string;
+      };
+    };
 
 /**
  * Order Sync Service Interface

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -1,8 +1,8 @@
 /**
  * Order Sync Service Tests
  *
- * Unit tests for OrderSyncService. Tests order routing, adapter resolution,
- * order creation, and error handling.
+ * Unit tests for OrderSyncService. Covers single-destination, multi-destination,
+ * partial-failure, self-route exclusion, and env-var override behavior.
  *
  * @module libs/core/src/orders/application/services/__tests__
  */
@@ -17,21 +17,59 @@ import { IMappingConfigService } from '@openlinker/core/mappings';
 describe('OrderSyncService', () => {
   let service: OrderSyncService;
   let integrationsService: jest.Mocked<IIntegrationsService>;
-  let processorAdapter: jest.Mocked<OrderProcessorManagerPort>;
   let mappingConfigService: jest.Mocked<IMappingConfigService>;
 
-  const destinationConnectionId = 'destination-connection-123';
   const originalEnv = process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID;
 
-  beforeEach(() => {
-    processorAdapter = {
-      createOrder: jest.fn(),
-    } as unknown as jest.Mocked<OrderProcessorManagerPort>;
+  const makeAdapter = (orderRef: OrderRef = { orderId: 'dest_order' }) =>
+    ({
+      createOrder: jest.fn().mockResolvedValue(orderRef),
+    }) as unknown as jest.Mocked<OrderProcessorManagerPort>;
 
+  const registerDestinations = (
+    destinations: Array<{ connectionId: string; adapter: OrderProcessorManagerPort }>,
+  ): void => {
+    integrationsService.listCapabilityAdapters.mockResolvedValue(
+      destinations.map(({ connectionId, adapter }) => ({
+        connectionId,
+        connection: { id: connectionId } as never,
+        adapter,
+        metadata: {} as never,
+      })),
+    );
+  };
+
+  const createOrder = (): Order => ({
+    id: 'ol_order_123',
+    orderNumber: 'ORDER-001',
+    status: 'processing',
+    customerId: 'ol_customer_456',
+    items: [
+      {
+        id: 'item-1',
+        productId: 'ol_product_789',
+        quantity: 2,
+        price: 29.99,
+        sku: 'SKU-001',
+      },
+    ],
+    totals: {
+      subtotal: 59.98,
+      tax: 0,
+      shipping: 5.0,
+      total: 64.98,
+      currency: 'PLN',
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  beforeEach(() => {
     integrationsService = {
-      getCapabilityAdapter: jest.fn().mockResolvedValue(processorAdapter),
+      getCapabilityAdapter: jest.fn(),
       getAdapter: jest.fn(),
-      listCapabilityAdapters: jest.fn(),
+      listCapabilityAdapters: jest.fn().mockResolvedValue([]),
+      resolveAdapterMetadata: jest.fn(),
     } as unknown as jest.Mocked<IIntegrationsService>;
 
     mappingConfigService = {
@@ -48,15 +86,12 @@ describe('OrderSyncService', () => {
       resolveAllegroCategory: jest.fn(),
     } as jest.Mocked<IMappingConfigService>;
 
-    // Set environment variable
-    process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID = destinationConnectionId;
-
+    delete process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID;
     service = new OrderSyncService(integrationsService, mappingConfigService);
   });
 
   afterEach(() => {
-    // Restore original environment variable
-    if (originalEnv) {
+    if (originalEnv !== undefined) {
       process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID = originalEnv;
     } else {
       delete process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID;
@@ -64,250 +99,205 @@ describe('OrderSyncService', () => {
   });
 
   describe('syncOrder', () => {
-    const createOrder = (): Order => ({
-      id: 'ol_order_123',
-      orderNumber: 'ORDER-001',
-      status: 'processing',
-      customerId: 'ol_customer_456',
-      items: [
-        {
-          id: 'item-1',
-          productId: 'ol_product_789',
-          quantity: 2,
-          price: 29.99,
-          sku: 'SKU-001',
-        },
-      ],
-      totals: {
-        subtotal: 59.98,
-        tax: 0,
-        shipping: 5.00,
-        total: 64.98,
-        currency: 'PLN',
-      },
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+    it('should sync to a single destination and return a success result', async () => {
+      const adapter = makeAdapter({ orderId: 'dest_order_789', orderNumber: 'DEST-001' });
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
 
-    it('should sync order successfully', async () => {
-      const order = createOrder();
       const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
         sourceEventId: 'event-456',
       };
 
-      const orderRef: OrderRef = {
-        orderId: 'dest_order_789',
-        orderNumber: 'DEST-001',
-      };
-
-      processorAdapter.createOrder.mockResolvedValue(orderRef);
-
       const results = await service.syncOrder(request);
 
-      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
-        destinationConnectionId,
-        'OrderProcessorManager',
-      );
-      expect(processorAdapter.createOrder).toHaveBeenCalledWith(
+      expect(adapter.createOrder).toHaveBeenCalledWith(
         expect.objectContaining({
           orderNumber: 'ORDER-001',
-          status: 'processing',
-          customerId: 'ol_customer_456',
-          items: [
-            {
-              id: 'item-1',
-              productId: 'ol_product_789',
-              quantity: 2,
-              price: 29.99,
-              sku: 'SKU-001',
-            },
-          ],
-          totals: {
-            subtotal: 59.98,
-            tax: 0,
-            shipping: 5.00,
-            total: 64.98,
-            currency: 'PLN',
-          },
           metadata: expect.objectContaining({
-            sourceConnectionId: 'source-connection-123',
+            sourceConnectionId: 'source-1',
             sourceEventId: 'event-456',
+            internalOrderId: 'ol_order_123',
           }),
         }),
       );
       expect(results).toEqual([
         {
-          destinationConnectionId,
-          orderRef,
+          destinationConnectionId: 'dest-a',
+          status: 'success',
+          orderRef: { orderId: 'dest_order_789', orderNumber: 'DEST-001' },
         },
       ]);
     });
 
-    it('should handle order without sourceEventId', async () => {
-      const order = createOrder();
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
+    it('should fan out to every destination processor', async () => {
+      const a = makeAdapter({ orderId: 'a-1' });
+      const b = makeAdapter({ orderId: 'b-1' });
+      registerDestinations([
+        { connectionId: 'dest-a', adapter: a },
+        { connectionId: 'dest-b', adapter: b },
+      ]);
 
-      const orderRef: OrderRef = {
-        orderId: 'dest_order_789',
-      };
+      const results = await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
 
-      processorAdapter.createOrder.mockResolvedValue(orderRef);
+      expect(a.createOrder).toHaveBeenCalledTimes(1);
+      expect(b.createOrder).toHaveBeenCalledTimes(1);
+      expect(results).toHaveLength(2);
+      expect(results.every((r) => r.status === 'success')).toBe(true);
+    });
 
-      const results = await service.syncOrder(request);
+    it('should isolate partial failures and still report successful destinations', async () => {
+      const ok = makeAdapter({ orderId: 'ok-1' });
+      const failing = {
+        createOrder: jest.fn().mockRejectedValue(new Error('destination down')),
+      } as unknown as jest.Mocked<OrderProcessorManagerPort>;
+      registerDestinations([
+        { connectionId: 'dest-ok', adapter: ok },
+        { connectionId: 'dest-bad', adapter: failing },
+      ]);
 
-      expect(processorAdapter.createOrder).toHaveBeenCalledWith(
-        expect.objectContaining({
-          metadata: expect.objectContaining({
-            sourceConnectionId: 'source-connection-123',
-            sourceEventId: undefined,
-          }),
-        }),
-      );
+      const results = await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
+
+      expect(results).toHaveLength(2);
+      const okResult = results.find((r) => r.destinationConnectionId === 'dest-ok');
+      const badResult = results.find((r) => r.destinationConnectionId === 'dest-bad');
+      expect(okResult).toEqual({
+        destinationConnectionId: 'dest-ok',
+        status: 'success',
+        orderRef: { orderId: 'ok-1' },
+      });
+      expect(badResult).toEqual({
+        destinationConnectionId: 'dest-bad',
+        status: 'failed',
+        error: { message: 'destination down' },
+      });
+    });
+
+    it('should exclude the source connection from destinations', async () => {
+      const selfAdapter = makeAdapter();
+      const otherAdapter = makeAdapter({ orderId: 'other-1' });
+      registerDestinations([
+        { connectionId: 'source-1', adapter: selfAdapter },
+        { connectionId: 'dest-other', adapter: otherAdapter },
+      ]);
+
+      const results = await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
+
+      expect(selfAdapter.createOrder).not.toHaveBeenCalled();
+      expect(otherAdapter.createOrder).toHaveBeenCalledTimes(1);
       expect(results).toHaveLength(1);
+      expect(results[0].destinationConnectionId).toBe('dest-other');
     });
 
-    it('should validate and map order status', async () => {
-      const order = createOrder();
-      order.status = 'shipped';
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
+    it('should honor the ORDER_SYNC_DESTINATION_CONNECTION_ID override as an allowlist', async () => {
+      process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID = 'dest-only';
+      const overridden = new OrderSyncService(integrationsService, mappingConfigService);
 
-      processorAdapter.createOrder.mockResolvedValue({ orderId: 'dest_order_789' });
+      const picked = makeAdapter({ orderId: 'picked-1' });
+      const skipped = makeAdapter();
+      registerDestinations([
+        { connectionId: 'dest-only', adapter: picked },
+        { connectionId: 'dest-other', adapter: skipped },
+      ]);
 
-      await service.syncOrder(request);
+      const results = await overridden.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
 
-      expect(processorAdapter.createOrder).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: 'shipped',
+      expect(picked.createOrder).toHaveBeenCalledTimes(1);
+      expect(skipped.createOrder).not.toHaveBeenCalled();
+      expect(results).toHaveLength(1);
+      expect(results[0].destinationConnectionId).toBe('dest-only');
+    });
+
+    it('should throw when no destinations are available', async () => {
+      registerDestinations([]);
+
+      await expect(
+        service.syncOrder({
+          order: createOrder(),
+          sourceConnectionId: 'source-1',
         }),
-      );
+      ).rejects.toThrow('No OrderProcessorManager destinations available');
     });
 
-    it('should default to pending for unknown order status', async () => {
-      const order = createOrder();
-      order.status = 'unknown_status';
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
+    it('should throw when the only available destination is the source connection', async () => {
+      registerDestinations([{ connectionId: 'source-1', adapter: makeAdapter() }]);
 
-      processorAdapter.createOrder.mockResolvedValue({ orderId: 'dest_order_789' });
-
-      await service.syncOrder(request);
-
-      expect(processorAdapter.createOrder).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: 'pending',
+      await expect(
+        service.syncOrder({
+          order: createOrder(),
+          sourceConnectionId: 'source-1',
         }),
-      );
+      ).rejects.toThrow('No OrderProcessorManager destinations available');
     });
-
-    it('should throw error if destination connection ID not configured', async () => {
-      delete process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID;
-      const serviceWithoutConfig = new OrderSyncService(integrationsService, mappingConfigService);
-
-      const order = createOrder();
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
-
-      await expect(serviceWithoutConfig.syncOrder(request)).rejects.toThrow(
-        'ORDER_SYNC_DESTINATION_CONNECTION_ID not configured',
-      );
-    });
-
-    it('should throw error if adapter resolution fails', async () => {
-      const order = createOrder();
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
-
-      integrationsService.getCapabilityAdapter.mockRejectedValue(
-        new Error('Connection not found'),
-      );
-
-      await expect(service.syncOrder(request)).rejects.toThrow('Connection not found');
-    });
-
-    it('should throw error if order creation fails', async () => {
-      const order = createOrder();
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
-
-      processorAdapter.createOrder.mockRejectedValue(new Error('Order creation failed'));
-
-      await expect(service.syncOrder(request)).rejects.toThrow('Order creation failed');
-    });
-
-    // ── MappingConfigService integration ──────────────────────────────────
 
     it('should use resolved status from mapping config when a mapping exists', async () => {
+      const adapter = makeAdapter();
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+      mappingConfigService.resolveStatusMapping.mockResolvedValue('processing');
+
       const order = createOrder();
       order.status = 'READY_FOR_PROCESSING';
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
 
-      // Mapping resolves Allegro status to PS status ID '3' (Processing in progress)
-      mappingConfigService.resolveStatusMapping.mockResolvedValue('processing');
-      processorAdapter.createOrder.mockResolvedValue({ orderId: 'dest_order_789' });
-
-      await service.syncOrder(request);
+      await service.syncOrder({ order, sourceConnectionId: 'source-1' });
 
       expect(mappingConfigService.resolveStatusMapping).toHaveBeenCalledWith(
-        'source-connection-123',
+        'source-1',
         'READY_FOR_PROCESSING',
       );
-      expect(processorAdapter.createOrder).toHaveBeenCalledWith(
+      expect(adapter.createOrder).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'processing' }),
       );
     });
 
     it('should fall back to order status when no mapping is configured', async () => {
+      const adapter = makeAdapter();
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+
       const order = createOrder();
       order.status = 'shipped';
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
 
-      mappingConfigService.resolveStatusMapping.mockResolvedValue(null);
-      processorAdapter.createOrder.mockResolvedValue({ orderId: 'dest_order_789' });
+      await service.syncOrder({ order, sourceConnectionId: 'source-1' });
 
-      await service.syncOrder(request);
-
-      expect(processorAdapter.createOrder).toHaveBeenCalledWith(
+      expect(adapter.createOrder).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'shipped' }),
       );
     });
 
-    it('should propagate error if mapping config service throws', async () => {
-      const order = createOrder();
-      const request: OrderSyncRequest = {
-        order,
-        sourceConnectionId: 'source-connection-123',
-      };
+    it('should default to pending for unknown order status', async () => {
+      const adapter = makeAdapter();
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
 
+      const order = createOrder();
+      order.status = 'unknown_status';
+
+      await service.syncOrder({ order, sourceConnectionId: 'source-1' });
+
+      expect(adapter.createOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'pending' }),
+      );
+    });
+
+    it('should propagate mapping service errors', async () => {
+      registerDestinations([{ connectionId: 'dest-a', adapter: makeAdapter() }]);
       mappingConfigService.resolveStatusMapping.mockRejectedValue(
         new Error('Mapping service unavailable'),
       );
 
-      await expect(service.syncOrder(request)).rejects.toThrow('Mapping service unavailable');
-      expect(processorAdapter.createOrder).not.toHaveBeenCalled();
+      await expect(
+        service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' }),
+      ).rejects.toThrow('Mapping service unavailable');
     });
   });
 });
-
-

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -98,6 +98,7 @@ describe('OrderSyncService', () => {
     } else {
       delete process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID;
     }
+    jest.restoreAllMocks();
   });
 
   describe('syncOrder', () => {
@@ -190,8 +191,6 @@ describe('OrderSyncService', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('ORDER_SYNC_DESTINATION_CONNECTION_ID=dest-missing'),
       );
-
-      warnSpy.mockRestore();
     });
 
     it('should isolate partial failures and still report successful destinations', async () => {

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -13,7 +13,8 @@ import { OrderSyncRequest } from '../../interfaces/order-sync.service.interface'
 import { Order } from '../../../domain/ports/order-source.port';
 import { OrderRef } from '../../../domain/types/order-processor.types';
 import { IMappingConfigService } from '@openlinker/core/mappings';
-import { NoOrderDestinationsAvailableError } from '../../../domain/exceptions/no-order-destinations-available.exception';
+import { NoOrderDestinationsAvailableException } from '../../../domain/exceptions/no-order-destinations-available.exception';
+import { Logger } from '@openlinker/shared/logging';
 
 describe('OrderSyncService', () => {
   let service: OrderSyncService;
@@ -175,9 +176,7 @@ describe('OrderSyncService', () => {
     it('should warn when the env-var override resolves to zero destinations', async () => {
       process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID = 'dest-missing';
       const overridden = new OrderSyncService(integrationsService, mappingConfigService);
-      const warnSpy = jest
-        .spyOn(overridden['logger'] as unknown as { warn: (msg: string) => void }, 'warn')
-        .mockImplementation(() => undefined);
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
 
       registerDestinations([{ connectionId: 'dest-other', adapter: makeAdapter() }]);
 
@@ -186,11 +185,13 @@ describe('OrderSyncService', () => {
           order: createOrder(),
           sourceConnectionId: 'source-1',
         }),
-      ).rejects.toThrow(NoOrderDestinationsAvailableError);
+      ).rejects.toThrow(NoOrderDestinationsAvailableException);
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('ORDER_SYNC_DESTINATION_CONNECTION_ID=dest-missing'),
       );
+
+      warnSpy.mockRestore();
     });
 
     it('should isolate partial failures and still report successful destinations', async () => {
@@ -272,7 +273,24 @@ describe('OrderSyncService', () => {
           order: createOrder(),
           sourceConnectionId: 'source-1',
         }),
-      ).rejects.toThrow(NoOrderDestinationsAvailableError);
+      ).rejects.toThrow(NoOrderDestinationsAvailableException);
+    });
+
+    it('should attach internalOrderId and sourceConnectionId to the thrown exception', async () => {
+      registerDestinations([]);
+      const order = createOrder();
+
+      let caught: unknown;
+      try {
+        await service.syncOrder({ order, sourceConnectionId: 'source-1' });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(NoOrderDestinationsAvailableException);
+      const exception = caught as NoOrderDestinationsAvailableException;
+      expect(exception.internalOrderId).toBe(order.id);
+      expect(exception.sourceConnectionId).toBe('source-1');
     });
 
     it('should throw when the only available destination is the source connection', async () => {
@@ -283,7 +301,7 @@ describe('OrderSyncService', () => {
           order: createOrder(),
           sourceConnectionId: 'source-1',
         }),
-      ).rejects.toThrow(NoOrderDestinationsAvailableError);
+      ).rejects.toThrow(NoOrderDestinationsAvailableException);
     });
 
     it('should use resolved status from mapping config when a mapping exists', async () => {

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -13,6 +13,7 @@ import { OrderSyncRequest } from '../../interfaces/order-sync.service.interface'
 import { Order } from '../../../domain/ports/order-source.port';
 import { OrderRef } from '../../../domain/types/order-processor.types';
 import { IMappingConfigService } from '@openlinker/core/mappings';
+import { NoOrderDestinationsAvailableError } from '../../../domain/exceptions/no-order-destinations-available.exception';
 
 describe('OrderSyncService', () => {
   let service: OrderSyncService;
@@ -149,6 +150,49 @@ describe('OrderSyncService', () => {
       expect(results.every((r) => r.status === 'success')).toBe(true);
     });
 
+    it('should propagate internalOrderId metadata to every destination', async () => {
+      const a = makeAdapter({ orderId: 'a-1' });
+      const b = makeAdapter({ orderId: 'b-1' });
+      registerDestinations([
+        { connectionId: 'dest-a', adapter: a },
+        { connectionId: 'dest-b', adapter: b },
+      ]);
+
+      await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
+
+      for (const adapter of [a, b]) {
+        expect(adapter.createOrder).toHaveBeenCalledWith(
+          expect.objectContaining({
+            metadata: expect.objectContaining({ internalOrderId: 'ol_order_123' }),
+          }),
+        );
+      }
+    });
+
+    it('should warn when the env-var override resolves to zero destinations', async () => {
+      process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID = 'dest-missing';
+      const overridden = new OrderSyncService(integrationsService, mappingConfigService);
+      const warnSpy = jest
+        .spyOn(overridden['logger'] as unknown as { warn: (msg: string) => void }, 'warn')
+        .mockImplementation(() => undefined);
+
+      registerDestinations([{ connectionId: 'dest-other', adapter: makeAdapter() }]);
+
+      await expect(
+        overridden.syncOrder({
+          order: createOrder(),
+          sourceConnectionId: 'source-1',
+        }),
+      ).rejects.toThrow(NoOrderDestinationsAvailableError);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER_SYNC_DESTINATION_CONNECTION_ID=dest-missing'),
+      );
+    });
+
     it('should isolate partial failures and still report successful destinations', async () => {
       const ok = makeAdapter({ orderId: 'ok-1' });
       const failing = {
@@ -228,7 +272,7 @@ describe('OrderSyncService', () => {
           order: createOrder(),
           sourceConnectionId: 'source-1',
         }),
-      ).rejects.toThrow('No OrderProcessorManager destinations available');
+      ).rejects.toThrow(NoOrderDestinationsAvailableError);
     });
 
     it('should throw when the only available destination is the source connection', async () => {
@@ -239,7 +283,7 @@ describe('OrderSyncService', () => {
           order: createOrder(),
           sourceConnectionId: 'source-1',
         }),
-      ).rejects.toThrow('No OrderProcessorManager destinations available');
+      ).rejects.toThrow(NoOrderDestinationsAvailableError);
     });
 
     it('should use resolved status from mapping config when a mapping exists', async () => {

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -2,7 +2,8 @@
  * Order Sync Service
  *
  * Application service for synchronizing orders from sources to destination processors.
- * Routes unified orders (with internal IDs) to configured OrderProcessorManager adapters.
+ * Routes unified orders (with internal IDs) to every active connection whose adapter
+ * supports the `OrderProcessorManager` capability, with per-destination error isolation.
  *
  * @module libs/core/src/orders/application/services
  * @implements {IOrderSyncService}
@@ -23,13 +24,17 @@ import { Logger } from '@openlinker/shared/logging';
 /**
  * Order Sync Service
  *
- * Routes orders from sources (e.g., Allegro) to destination processors (e.g., PrestaShop).
- * For MVP, uses a single configured destination connection ID from environment variable.
+ * Routes orders from sources (e.g. Allegro) to every configured
+ * `OrderProcessorManager` destination (e.g. PrestaShop + secondary WMS).
+ *
+ * The optional env var `ORDER_SYNC_DESTINATION_CONNECTION_ID` acts as a
+ * single-destination allowlist filter (legacy MVP behavior) — when set, only
+ * that connection ID is dispatched to, even if more processors are registered.
  */
 @Injectable()
 export class OrderSyncService implements IOrderSyncService {
   private readonly logger = new Logger(OrderSyncService.name);
-  private readonly destinationConnectionId: string | null;
+  private readonly destinationConnectionIdOverride: string | null;
 
   constructor(
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
@@ -37,47 +42,31 @@ export class OrderSyncService implements IOrderSyncService {
     @Inject(MAPPING_CONFIG_SERVICE_TOKEN)
     private readonly mappingConfigService: IMappingConfigService,
   ) {
-    // MVP: Read destination connection ID from environment variable
-    // TODO: Phase 8+ - Support multiple destinations, connection-based routing, etc.
-    this.destinationConnectionId = process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID || null;
+    this.destinationConnectionIdOverride = process.env.ORDER_SYNC_DESTINATION_CONNECTION_ID || null;
 
-    if (!this.destinationConnectionId) {
-      this.logger.warn(
-        'ORDER_SYNC_DESTINATION_CONNECTION_ID not configured. Order sync will fail until configured.',
-      );
-    } else {
+    if (this.destinationConnectionIdOverride) {
       this.logger.log(
-        `OrderSyncService initialized with destination connection: ${this.destinationConnectionId}`,
+        `OrderSyncService: single-destination override active for connection ${this.destinationConnectionIdOverride}`,
       );
     }
   }
 
   async syncOrder(request: OrderSyncRequest): Promise<OrderSyncResult[]> {
     const { order, sourceConnectionId, sourceEventId } = request;
-    this.logger.debug(`request: ${JSON.stringify(request)}`);
 
     this.logger.log(
       `Syncing order ${order.id} from source connection ${sourceConnectionId}${sourceEventId ? ` (event: ${sourceEventId})` : ''}`,
     );
 
-    if (!this.destinationConnectionId) {
+    const destinations = await this.resolveDestinations(sourceConnectionId);
+
+    if (destinations.length === 0) {
       throw new Error(
-        'ORDER_SYNC_DESTINATION_CONNECTION_ID not configured. Set the environment variable to enable order sync.',
+        `No OrderProcessorManager destinations available for order ${order.id} (sourceConnectionId=${sourceConnectionId})`,
       );
     }
 
-    // Resolve destination OrderProcessorManager adapter
-    const processorAdapter = await this.integrationsService.getCapabilityAdapter<OrderProcessorManagerPort>(
-      this.destinationConnectionId,
-      'OrderProcessorManager',
-    );
-
-    this.logger.debug(
-      `Resolved OrderProcessorManager adapter for destination connection ${this.destinationConnectionId}`,
-    );
-
-    // Map unified Order to OrderCreate request
-    // Resolve status via configured mapping first; fall back to validated default.
+    // Resolve status mapping once — identical across all destinations
     const resolvedStatus = await this.mappingConfigService.resolveStatusMapping(
       sourceConnectionId,
       order.status,
@@ -85,6 +74,7 @@ export class OrderSyncService implements IOrderSyncService {
     const orderStatus = resolvedStatus
       ? this.validateOrderStatus(resolvedStatus)
       : this.validateOrderStatus(order.status);
+
     const orderCreate: OrderCreate = {
       orderNumber: order.orderNumber,
       status: orderStatus,
@@ -110,24 +100,71 @@ export class OrderSyncService implements IOrderSyncService {
         sourceConnectionId,
         sourceEventId,
         syncedAt: new Date().toISOString(),
-        internalOrderId: order.id, // Include internal order ID for idempotency checks
+        internalOrderId: order.id,
       },
     };
 
-    // Create order in destination system
-    this.logger.debug(`Creating order in destination system (connection: ${this.destinationConnectionId})`);
-    const orderRef = await processorAdapter.createOrder(orderCreate);
-
-    this.logger.log(
-      `Order ${order.id} synced successfully to destination ${this.destinationConnectionId} (destination order: ${orderRef.orderId}${orderRef.orderNumber ? `, orderNumber: ${orderRef.orderNumber}` : ''})`,
+    // Dispatch in parallel with per-destination error isolation
+    const settled = await Promise.allSettled(
+      destinations.map(({ connectionId, adapter }) =>
+        adapter
+          .createOrder(orderCreate)
+          .then((orderRef) => ({ connectionId, orderRef })),
+      ),
     );
 
-    return [
-      {
-        destinationConnectionId: this.destinationConnectionId,
-        orderRef,
-      },
-    ];
+    return settled.map((outcome, index): OrderSyncResult => {
+      const destinationConnectionId = destinations[index].connectionId;
+
+      if (outcome.status === 'fulfilled') {
+        const { orderRef } = outcome.value;
+        this.logger.log(
+          `Order ${order.id} synced to destination ${destinationConnectionId} (destination order: ${orderRef.orderId}${orderRef.orderNumber ? `, orderNumber: ${orderRef.orderNumber}` : ''})`,
+        );
+        return {
+          destinationConnectionId,
+          status: 'success',
+          orderRef,
+        };
+      }
+
+      const message =
+        outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason);
+      this.logger.error(
+        `Order ${order.id} failed to sync to destination ${destinationConnectionId}: ${message}`,
+        outcome.reason instanceof Error ? outcome.reason.stack : undefined,
+      );
+      return {
+        destinationConnectionId,
+        status: 'failed',
+        error: { message },
+      };
+    });
+  }
+
+  /**
+   * Resolve all active `OrderProcessorManager` destinations for this sync.
+   *
+   * - Excludes the source connection (never route an order back to its origin)
+   * - If `ORDER_SYNC_DESTINATION_CONNECTION_ID` is set, narrows the result to
+   *   that single connection (legacy single-destination override)
+   */
+  private async resolveDestinations(
+    sourceConnectionId: string,
+  ): Promise<Array<{ connectionId: string; adapter: OrderProcessorManagerPort }>> {
+    const resolved = await this.integrationsService.listCapabilityAdapters<OrderProcessorManagerPort>({
+      capability: 'OrderProcessorManager',
+    });
+
+    const filtered = resolved
+      .filter(({ connectionId }) => connectionId !== sourceConnectionId)
+      .filter(({ connectionId }) =>
+        this.destinationConnectionIdOverride
+          ? connectionId === this.destinationConnectionIdOverride
+          : true,
+      );
+
+    return filtered.map(({ connectionId, adapter }) => ({ connectionId, adapter }));
   }
 
   /**
@@ -135,18 +172,12 @@ export class OrderSyncService implements IOrderSyncService {
    *
    * Ensures type safety when mapping from Order (string status) to OrderCreate (OrderStatus union).
    * Defaults to 'pending' if status is not recognized.
-   *
-   * @param status - Order status string
-   * @returns Validated OrderStatus
    */
   private validateOrderStatus(status: string): OrderCreate['status'] {
     if (OrderStatusValues.includes(status as OrderCreate['status'])) {
       return status as OrderCreate['status'];
     }
-    this.logger.warn(
-      `Unknown order status: ${status}, defaulting to 'pending'`,
-    );
+    this.logger.warn(`Unknown order status: ${status}, defaulting to 'pending'`);
     return 'pending';
   }
 }
-

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -20,7 +20,7 @@ import { IIntegrationsService } from '@openlinker/core/integrations/application/
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations/integrations.tokens';
 import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
 import { Logger } from '@openlinker/shared/logging';
-import { NoOrderDestinationsAvailableError } from '../../domain/exceptions/no-order-destinations-available.exception';
+import { NoOrderDestinationsAvailableException } from '../../domain/exceptions/no-order-destinations-available.exception';
 
 /**
  * Order Sync Service
@@ -62,7 +62,7 @@ export class OrderSyncService implements IOrderSyncService {
     const destinations = await this.resolveDestinations(sourceConnectionId);
 
     if (destinations.length === 0) {
-      throw new NoOrderDestinationsAvailableError(order.id, sourceConnectionId);
+      throw new NoOrderDestinationsAvailableException(order.id, sourceConnectionId);
     }
 
     // Resolve status mapping once — identical across all destinations

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -20,6 +20,7 @@ import { IIntegrationsService } from '@openlinker/core/integrations/application/
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations/integrations.tokens';
 import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
 import { Logger } from '@openlinker/shared/logging';
+import { NoOrderDestinationsAvailableError } from '../../domain/exceptions/no-order-destinations-available.exception';
 
 /**
  * Order Sync Service
@@ -61,9 +62,7 @@ export class OrderSyncService implements IOrderSyncService {
     const destinations = await this.resolveDestinations(sourceConnectionId);
 
     if (destinations.length === 0) {
-      throw new Error(
-        `No OrderProcessorManager destinations available for order ${order.id} (sourceConnectionId=${sourceConnectionId})`,
-      );
+      throw new NoOrderDestinationsAvailableError(order.id, sourceConnectionId);
     }
 
     // Resolve status mapping once — identical across all destinations
@@ -99,6 +98,8 @@ export class OrderSyncService implements IOrderSyncService {
       metadata: {
         sourceConnectionId,
         sourceEventId,
+        // Stamped once and shared across destinations: marks when OL started
+        // dispatching this order, not per-destination completion time.
         syncedAt: new Date().toISOString(),
         internalOrderId: order.id,
       },
@@ -163,6 +164,12 @@ export class OrderSyncService implements IOrderSyncService {
           ? connectionId === this.destinationConnectionIdOverride
           : true,
       );
+
+    if (this.destinationConnectionIdOverride && filtered.length === 0) {
+      this.logger.warn(
+        `ORDER_SYNC_DESTINATION_CONNECTION_ID=${this.destinationConnectionIdOverride} is set but no matching active OrderProcessorManager adapter was resolved — check that the connection exists, is active, and is not the source connection`,
+      );
+    }
 
     return filtered.map(({ connectionId, adapter }) => ({ connectionId, adapter }));
   }

--- a/libs/core/src/orders/domain/exceptions/no-order-destinations-available.exception.ts
+++ b/libs/core/src/orders/domain/exceptions/no-order-destinations-available.exception.ts
@@ -10,7 +10,7 @@
  *
  * @module libs/core/src/orders/domain/exceptions
  */
-export class NoOrderDestinationsAvailableError extends Error {
+export class NoOrderDestinationsAvailableException extends Error {
   constructor(
     public readonly internalOrderId: string,
     public readonly sourceConnectionId: string,
@@ -18,9 +18,9 @@ export class NoOrderDestinationsAvailableError extends Error {
     super(
       `No OrderProcessorManager destinations available for order ${internalOrderId} (sourceConnectionId=${sourceConnectionId})`,
     );
-    this.name = 'NoOrderDestinationsAvailableError';
+    this.name = 'NoOrderDestinationsAvailableException';
     if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, NoOrderDestinationsAvailableError);
+      Error.captureStackTrace(this, NoOrderDestinationsAvailableException);
     }
   }
 }

--- a/libs/core/src/orders/domain/exceptions/no-order-destinations-available.exception.ts
+++ b/libs/core/src/orders/domain/exceptions/no-order-destinations-available.exception.ts
@@ -1,0 +1,26 @@
+/**
+ * No Order Destinations Available Exception
+ *
+ * Domain exception thrown by OrderSyncService when no active
+ * OrderProcessorManager destinations can be resolved for a given order.
+ * Signals an operational/configuration error (no processor connections, all
+ * disabled, or the allowlist override points at a missing connection) —
+ * distinct from transient adapter failures, which are surfaced per-destination
+ * in the OrderSyncResult array.
+ *
+ * @module libs/core/src/orders/domain/exceptions
+ */
+export class NoOrderDestinationsAvailableError extends Error {
+  constructor(
+    public readonly internalOrderId: string,
+    public readonly sourceConnectionId: string,
+  ) {
+    super(
+      `No OrderProcessorManager destinations available for order ${internalOrderId} (sourceConnectionId=${sourceConnectionId})`,
+    );
+    this.name = 'NoOrderDestinationsAvailableError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, NoOrderDestinationsAvailableError);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Replace single-destination `ORDER_SYNC_DESTINATION_CONNECTION_ID` hard-wiring with fan-out to all active `OrderProcessorManager` adapters via `listCapabilityAdapters`
- Dispatch to all destinations in parallel using `Promise.allSettled` with per-destination error isolation — a failed destination yields a `status: 'failed'` result without aborting the others
- Exclude source connection from destinations (never route an order back to its origin)
- Retain `ORDER_SYNC_DESTINATION_CONNECTION_ID` env var as a single-destination allowlist override for backward-compat deployments; warn in logs when the override resolves to zero matches
- Introduce `NoOrderDestinationsAvailableException` domain exception so callers can distinguish configuration errors from transient per-destination adapter failures
- Add `code?: string` field to failed `OrderSyncResult` for future diagnostics
- Full unit test coverage: single/multi-destination, partial failure, self-route exclusion, env-var override, exception field assertions

## Test plan

- [ ] `pnpm lint` passes with zero errors
- [ ] `pnpm type-check` passes with zero errors
- [ ] `pnpm test` passes — 14 unit tests in `order-sync.service.spec.ts` all green
- [ ] Verify fan-out behavior: connect two PrestaShop instances and confirm both receive the order
- [ ] Verify partial failure isolation: one destination down should not block the other
- [ ] Verify env-var override still narrows to a single destination when set

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)