### PR TITLE
fix(scheduler): stop cron jobs on module destroy to prevent CI hang

### DIFF
--- a/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
+++ b/apps/api/src/sync/application/services/__tests__/scheduler.service.spec.ts
@@ -57,6 +57,8 @@ describe('SchedulerService', () => {
 
     schedulerRegistry = {
       addCronJob: jest.fn(),
+      getCronJobs: jest.fn().mockReturnValue(new Map()),
+      deleteCronJob: jest.fn(),
     } as unknown as jest.Mocked<SchedulerRegistry>;
 
     service = new SchedulerService(
@@ -122,6 +124,44 @@ describe('SchedulerService', () => {
 
       const registeredJobs = schedulerRegistry.addCronJob.mock.calls.map((c) => c[0]);
       expect(registeredJobs).not.toContain('master-product-sync');
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should stop and deregister all registered cron jobs', () => {
+      const mockStopA = jest.fn();
+      const mockStopB = jest.fn();
+      const cronJobs = new Map([
+        ['allegro-orders-poll', { stop: mockStopA }],
+        ['master-inventory-sync', { stop: mockStopB }],
+      ]);
+      schedulerRegistry.getCronJobs.mockReturnValue(
+        cronJobs as unknown as ReturnType<SchedulerRegistry['getCronJobs']>,
+      );
+
+      service.onModuleDestroy();
+
+      expect(mockStopA).toHaveBeenCalledTimes(1);
+      expect(mockStopB).toHaveBeenCalledTimes(1);
+      expect(schedulerRegistry.deleteCronJob).toHaveBeenCalledWith('allegro-orders-poll');
+      expect(schedulerRegistry.deleteCronJob).toHaveBeenCalledWith('master-inventory-sync');
+    });
+
+    it('should not throw when there are no registered cron jobs', () => {
+      schedulerRegistry.getCronJobs.mockReturnValue(new Map());
+
+      expect(() => service.onModuleDestroy()).not.toThrow();
+    });
+
+    it('should not throw when stopping a cron job fails', () => {
+      const cronJobs = new Map([
+        ['bad-job', { stop: jest.fn().mockImplementation(() => { throw new Error('stop failed'); }) }],
+      ]);
+      schedulerRegistry.getCronJobs.mockReturnValue(
+        cronJobs as unknown as ReturnType<SchedulerRegistry['getCronJobs']>,
+      );
+
+      expect(() => service.onModuleDestroy()).not.toThrow();
     });
   });
 

--- a/apps/api/src/sync/application/services/scheduler.service.ts
+++ b/apps/api/src/sync/application/services/scheduler.service.ts
@@ -7,7 +7,7 @@
  *
  * @module apps/api/src/sync/application/services
  */
-import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
+import { Injectable, Inject, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { CronJob } from 'cron';
@@ -78,7 +78,7 @@ export interface SchedulerTaskConfig {
 }
 
 @Injectable()
-export class SchedulerService implements OnModuleInit {
+export class SchedulerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(SchedulerService.name);
   private readonly tasks: SchedulerTaskConfig[] = [];
 
@@ -99,6 +99,25 @@ export class SchedulerService implements OnModuleInit {
 
     // Register all configured tasks (schedules cron jobs)
     this.tasks.forEach((task) => this.scheduleTask(task));
+  }
+
+  onModuleDestroy(): void {
+    // Stop all registered cron jobs so the Node.js event loop can drain cleanly.
+    // This is required for graceful shutdown in production and for integration
+    // tests where app.close() is called — without this, active CronJob timers
+    // keep the process alive indefinitely.
+    // Snapshot entries before iterating — deleteCronJob mutates the internal Map
+    // that getCronJobs() returns a reference to, which is fragile to modify mid-loop.
+    const entries = [...this.schedulerRegistry.getCronJobs().entries()];
+    for (const [name, job] of entries) {
+      try {
+        job.stop();
+        this.schedulerRegistry.deleteCronJob(name);
+        this.logger.debug(`Stopped scheduler task: ${name}`);
+      } catch {
+        // Ignore errors during teardown — the process is shutting down anyway
+      }
+    }
   }
 
   /**

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -57,6 +57,19 @@ export async function startHarness(): Promise<void> {
   process.env.JWT_SECRET = 'test-secret-for-integration-tests';
   process.env.JWT_EXPIRES_IN = '1d';
 
+  // Disable all background schedulers in integration tests.
+  // Cron jobs fire against an empty database and keep the Node.js event loop
+  // alive, causing Jest to hang after tests complete.
+  //
+  // If a future integration test needs to exercise scheduler behaviour, register
+  // the task via SchedulerService.registerTask() and then call scheduleTask()
+  // directly (or re-invoke onModuleInit()) — the env vars below will have already
+  // been evaluated by onModuleInit at boot, so they cannot be overridden mid-test.
+  process.env.OL_ALLEGRO_POLL_SCHEDULER_ENABLED = 'false';
+  process.env.OL_ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED = 'false';
+  process.env.OL_INVENTORY_SYNC_ENABLED = 'false';
+  process.env.OL_PRODUCT_SYNC_ENABLED = 'false';
+
   // Store containers on globalThis for teardown
   globalThis.__API_TEST_HARNESS__ = { postgres, redis };
 }

--- a/apps/api/test/jest-integration.cjs
+++ b/apps/api/test/jest-integration.cjs
@@ -10,6 +10,10 @@ module.exports = {
   },
   maxWorkers: 1,
   testTimeout: 120000,
+  // Prevent CI hangs caused by long-lived timers (e.g. SchedulerService CronJobs)
+  // that are not fully drained even after app.close(). onModuleDestroy stops them,
+  // but forceExit is a safety net for any other handles left open by NestJS internals.
+  forceExit: true,
   moduleNameMapper: {
     '^@openlinker/core$': path.resolve(__dirname, '../../../libs/core/src/index.ts'),
     '^@openlinker/core/(.*)$': path.resolve(__dirname, '../../../libs/core/src/$1'),


### PR DESCRIPTION
## Summary

- Add `OnModuleDestroy` to `SchedulerService` that stops and deregisters all cron jobs on module teardown, preventing active timers from keeping the Node.js event loop alive after `app.close()`
- Add `forceExit: true` to Jest integration config as a safety net for any remaining handles not drained by NestJS internals
- Disable all scheduler env vars in the integration test harness so cron jobs are never registered during tests

## Test plan

- [ ] `pnpm test` — all unit tests pass (includes new `onModuleDestroy` tests: stops all jobs, handles empty map, handles stop errors gracefully)
- [ ] `pnpm test:integration` — integration tests complete and Jest exits cleanly without hanging
- [ ] `pnpm lint && pnpm type-check` — no errors

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)