### PR TITLE
feat(credentials): replace credentialsRef with credentialsBacked in connection response

### DIFF
--- a/apps/api/src/integrations/application/credentials/credential-shape.validator.spec.ts
+++ b/apps/api/src/integrations/application/credentials/credential-shape.validator.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Credential Shape Validator Unit Tests
+ *
+ * @module apps/api/src/integrations/application/credentials
+ */
+import { BadRequestException } from '@nestjs/common';
+import { validateCredentialsShape } from './credential-shape.validator';
+
+describe('validateCredentialsShape', () => {
+  describe('prestashop', () => {
+    it('should pass when webserviceApiKey is a non-empty string', () => {
+      expect(() =>
+        validateCredentialsShape('prestashop', { webserviceApiKey: 'ABC123' }),
+      ).not.toThrow();
+    });
+
+    it('should throw when webserviceApiKey is missing', () => {
+      expect(() =>
+        validateCredentialsShape('prestashop', { someOtherField: 'X' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should throw when webserviceApiKey is an empty string', () => {
+      expect(() =>
+        validateCredentialsShape('prestashop', { webserviceApiKey: '   ' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should throw when webserviceApiKey is not a string', () => {
+      expect(() =>
+        validateCredentialsShape('prestashop', { webserviceApiKey: 12345 }),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe('unknown platform', () => {
+    it('should pass without throwing for unrecognised platforms', () => {
+      expect(() =>
+        validateCredentialsShape('shopify', { accessToken: 'tok_xyz' }),
+      ).not.toThrow();
+    });
+
+    it('should pass for allegro (OAuth-managed, no shape enforced)', () => {
+      expect(() =>
+        validateCredentialsShape('allegro', { accessToken: 'tok', refreshToken: 'ref' }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -6,7 +6,7 @@
  *
  * @module apps/api/src/integrations/http
  */
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConnectionController } from './connection.controller';
 import { ConnectionService } from '../application/services/connection.service';
@@ -283,6 +283,38 @@ describe('ConnectionController', () => {
       expect(result.lastSucceededAt).toBeNull();
       expect(result.lastFailedAt).toBeNull();
       expect(result.recentErrors).toHaveLength(0);
+    });
+  });
+
+  describe('updateCredentials', () => {
+    it('should delegate to service and return 204', async () => {
+      service.updateCredentials.mockResolvedValue(undefined);
+
+      await controller.updateCredentials('connection-123', {
+        credentials: { webserviceApiKey: 'NEW_KEY' },
+      });
+
+      expect(service.updateCredentials).toHaveBeenCalledWith('connection-123', {
+        webserviceApiKey: 'NEW_KEY',
+      });
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      service.updateCredentials.mockRejectedValue(new NotFoundException('Connection not found'));
+
+      await expect(
+        controller.updateCredentials('connection-123', { credentials: { webserviceApiKey: 'K' } }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should propagate BadRequestException when connection is not db-backed', async () => {
+      service.updateCredentials.mockRejectedValue(
+        new BadRequestException('does not have a db-backed credentials reference'),
+      );
+
+      await expect(
+        controller.updateCredentials('connection-123', { credentials: { webserviceApiKey: 'K' } }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -196,7 +196,7 @@ export class ConnectionController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Rotate the credentials stored for this connection' })
   @ApiResponse({ status: 204, description: 'Credentials rotated' })
-  @ApiResponse({ status: 400, description: 'Invalid payload or connection not db-backed' })
+  @ApiResponse({ status: 400, description: 'Invalid credential payload, failed shape validation, or connection is not db-backed' })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   @ApiResponse({ status: 404, description: 'Connection not found' })
   async updateCredentials(

--- a/apps/api/src/integrations/http/dto/connection-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/connection-response.dto.ts
@@ -26,8 +26,11 @@ export class ConnectionResponseDto {
   @ApiProperty({ description: 'Connection configuration (JSONB)', example: { baseUrl: 'https://example.com' } })
   config!: Record<string, unknown>;
 
-  @ApiProperty({ description: 'Credentials reference', example: 'cred_abc123' })
-  credentialsRef!: string;
+  @ApiProperty({
+    description: 'Whether credentials are stored in the database (true = editable via PUT /credentials; false = sourced from environment variable)',
+    example: true,
+  })
+  credentialsBacked!: boolean;
 
   @ApiPropertyOptional({ description: 'Adapter key', example: 'prestashop.webservice.v1' })
   adapterKey?: string;
@@ -62,7 +65,7 @@ export class ConnectionResponseDto {
     dto.name = connection.name;
     dto.status = connection.status;
     dto.config = connection.config;
-    dto.credentialsRef = connection.credentialsRef;
+    dto.credentialsBacked = connection.credentialsRef.startsWith('db:');
     dto.adapterKey = connection.adapterKey;
     dto.enabledCapabilities = connection.enabledCapabilities;
     dto.supportedCapabilities = supportedCapabilities;

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -20,7 +20,8 @@ export interface Connection {
   platformType: PlatformType;
   status: ConnectionStatus;
   config: Record<string, unknown>;
-  credentialsRef: string;
+  /** True when credentials are stored in the database and can be rotated via PUT /credentials. */
+  credentialsBacked: boolean;
   adapterKey?: string;
   enabledCapabilities: Capability[];
   supportedCapabilities: Capability[];

--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -20,8 +20,8 @@ describe('EditConnectionForm', () => {
     const platformInput = screen.getByDisplayValue(sampleConnection.platformType);
     expect(platformInput).toBeDisabled();
     expect(screen.getByText('Rotate webservice key')).toBeInTheDocument();
-    // The opaque db: ref must not be exposed in the UI any more.
-    expect(screen.queryByDisplayValue(sampleConnection.credentialsRef)).not.toBeInTheDocument();
+    // The internal credential reference must not be exposed in the UI.
+    expect(screen.queryByDisplayValue('db:')).not.toBeInTheDocument();
   });
 
   it('submits the update with changed values', async () => {

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -122,16 +122,15 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
 }
 
 function CredentialsPanel({ connection }: { connection: Connection }): ReactElement {
-  const isDbBacked = connection.credentialsRef.startsWith('db:');
   const [showRotate, setShowRotate] = useState(false);
   const [newKey, setNewKey] = useState('');
   const rotate = useUpdateConnectionCredentialsMutation();
   const { showToast } = useToast();
 
-  if (!isDbBacked) {
+  if (!connection.credentialsBacked) {
     return (
-      <FormField label="Credentials reference" name="credentialsRef">
-        <Input value={connection.credentialsRef} disabled />
+      <FormField label="Credentials" name="credentials">
+        <Input value="Environment variable (not editable via UI)" disabled />
       </FormField>
     );
   }

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -112,8 +112,8 @@ export function ConnectionDetailPage(): ReactElement {
                 <dd>{connection.platformType}</dd>
               </div>
               <div>
-                <dt>Credentials ref</dt>
-                <dd className="mono-text">{connection.credentialsRef}</dd>
+                <dt>Credentials</dt>
+                <dd>{connection.credentialsBacked ? 'DB-managed' : 'Environment variable'}</dd>
               </div>
               <div>
                 <dt>Adapter</dt>

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -34,8 +34,8 @@ describe('DashboardPage', () => {
     const apiClient = createMockApiClient({
       connections: {
         list: vi.fn().mockResolvedValue([
-          { id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop', config: {}, credentialsRef: 'ref', createdAt: '', updatedAt: '' },
-          { id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro', config: {}, credentialsRef: 'ref', createdAt: '', updatedAt: '' },
+          { id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop', config: {}, credentialsBacked: true, createdAt: '', updatedAt: '' },
+          { id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro', config: {}, credentialsBacked: true, createdAt: '', updatedAt: '' },
         ]),
       },
     });

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -26,7 +26,7 @@ export const sampleConnection: Connection = {
   config: {
     baseUrl: 'https://example.com',
   },
-  credentialsRef: 'db:cred_1',
+  credentialsBacked: true,
   adapterKey: 'prestashop.webservice.v1',
   enabledCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager', 'OrderSource'],
   supportedCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderProcessorManager', 'OrderSource'],


### PR DESCRIPTION
## Summary

- Replaces the internal `credentialsRef: string` field (which leaked the `db:{uuid}` storage reference) with `credentialsBacked: boolean` in `ConnectionResponseDto` and the frontend `Connection` type
- Frontend `EditConnectionForm` and `ConnectionDetailPage` now branch on `credentialsBacked` instead of parsing the `db:` prefix
- Fills test gaps: adds `describe('updateCredentials')` block to `connection.controller.spec.ts` and a new `credential-shape.validator.spec.ts`

## Test plan

- [ ] `pnpm lint` — zero errors
- [ ] `pnpm type-check` — zero errors
- [ ] `pnpm test` — all unit tests pass (API + FE)
- [ ] Connection detail page shows "DB-managed" / "Environment variable" instead of the raw `db:...` ref
- [ ] `PUT /connections/:id/credentials` returns 204 for valid payload, 400 for invalid shape or non-db-backed connection

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)