### PR TITLE
feat(inventory): show product name/SKU in inventory list and stock on product detail

### DIFF
--- a/apps/api/src/inventory/http/dto/inventory-item-response.dto.ts
+++ b/apps/api/src/inventory/http/dto/inventory-item-response.dto.ts
@@ -29,4 +29,10 @@ export class InventoryItemResponseDto {
 
   @ApiProperty({ description: 'Last update timestamp (ISO 8601)' })
   updatedAt!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Product name from the master catalog (null if product not found)' })
+  productName!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Product SKU from the master catalog (null if product not found or no SKU)' })
+  productSku!: string | null;
 }

--- a/apps/api/src/inventory/http/inventory.controller.spec.ts
+++ b/apps/api/src/inventory/http/inventory.controller.spec.ts
@@ -11,10 +11,16 @@ import {
   InventoryItemEntity as InventoryItem,
 } from '@openlinker/core/inventory';
 import type { InventoryRepositoryPort } from '@openlinker/core/inventory';
+import {
+  PRODUCT_REPOSITORY_TOKEN,
+  ProductEntity as Product,
+} from '@openlinker/core/products';
+import type { ProductRepositoryPort } from '@openlinker/core/products';
 
 describe('InventoryController', () => {
   let controller: InventoryController;
   let repository: jest.Mocked<InventoryRepositoryPort>;
+  let productRepository: jest.Mocked<ProductRepositoryPort>;
 
   const mockItem = new InventoryItem(
     'inv-001',
@@ -26,12 +32,29 @@ describe('InventoryController', () => {
     new Date('2026-04-01T00:00:00Z'),
   );
 
+  const mockProduct = new Product(
+    'prod-001',
+    'Test Product',
+    'SKU-001',
+    99.99,
+    null,
+    null,
+    new Date('2026-01-01T00:00:00Z'),
+    new Date('2026-04-01T00:00:00Z'),
+  );
+
   beforeEach(async () => {
     const mockRepository: jest.Mocked<InventoryRepositoryPort> = {
       findByProductAndVariant: jest.fn(),
       upsert: jest.fn(),
       findById: jest.fn(),
       findMany: jest.fn(),
+    };
+
+    const mockProductRepository: jest.Mocked<ProductRepositoryPort> = {
+      findById: jest.fn(),
+      findMany: jest.fn(),
+      upsert: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -41,16 +64,22 @@ describe('InventoryController', () => {
           provide: INVENTORY_REPOSITORY_TOKEN,
           useValue: mockRepository,
         },
+        {
+          provide: PRODUCT_REPOSITORY_TOKEN,
+          useValue: mockProductRepository,
+        },
       ],
     }).compile();
 
     controller = module.get<InventoryController>(InventoryController);
     repository = module.get(INVENTORY_REPOSITORY_TOKEN);
+    productRepository = module.get(PRODUCT_REPOSITORY_TOKEN);
   });
 
   describe('listInventory', () => {
-    it('should return paginated inventory items', async () => {
+    it('should return paginated inventory items with product name and SKU', async () => {
       repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
+      productRepository.findById.mockResolvedValue(mockProduct);
 
       const result = await controller.listInventory({ limit: 20, offset: 0 });
 
@@ -60,6 +89,18 @@ describe('InventoryController', () => {
       expect(result.offset).toBe(0);
       expect(result.items[0].id).toBe('inv-001');
       expect(result.items[0].updatedAt).toBe('2026-04-01T00:00:00.000Z');
+      expect(result.items[0].productName).toBe('Test Product');
+      expect(result.items[0].productSku).toBe('SKU-001');
+    });
+
+    it('should return null productName and productSku when product not found', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
+      productRepository.findById.mockResolvedValue(null);
+
+      const result = await controller.listInventory({ limit: 20, offset: 0 });
+
+      expect(result.items[0].productName).toBeNull();
+      expect(result.items[0].productSku).toBeNull();
     });
 
     it('should pass filters to repository', async () => {
@@ -90,8 +131,9 @@ describe('InventoryController', () => {
   });
 
   describe('getInventoryItem', () => {
-    it('should return inventory item when found', async () => {
+    it('should return inventory item with product name and SKU when found', async () => {
       repository.findById.mockResolvedValue(mockItem);
+      productRepository.findById.mockResolvedValue(mockProduct);
 
       const result = await controller.getInventoryItem('inv-001');
 
@@ -99,6 +141,8 @@ describe('InventoryController', () => {
       expect(result.productId).toBe('prod-001');
       expect(result.availableQuantity).toBe(50);
       expect(result.reservedQuantity).toBe(5);
+      expect(result.productName).toBe('Test Product');
+      expect(result.productSku).toBe('SKU-001');
     });
 
     it('should throw NotFoundException when item not found', async () => {

--- a/apps/api/src/inventory/http/inventory.controller.spec.ts
+++ b/apps/api/src/inventory/http/inventory.controller.spec.ts
@@ -120,6 +120,17 @@ describe('InventoryController', () => {
       );
     });
 
+    it('should deduplicate product lookups when multiple items share the same productId', async () => {
+      const secondItem = new InventoryItem('inv-002', 'prod-001', null, 10, 0, null, new Date('2026-04-01T00:00:00Z'));
+      repository.findMany.mockResolvedValue({ items: [mockItem, secondItem], total: 2 });
+      productRepository.findById.mockResolvedValue(mockProduct);
+
+      await controller.listInventory({ limit: 20, offset: 0 });
+
+      expect(productRepository.findById).toHaveBeenCalledTimes(1);
+      expect(productRepository.findById).toHaveBeenCalledWith('prod-001');
+    });
+
     it('should return empty list when no items match', async () => {
       repository.findMany.mockResolvedValue({ items: [], total: 0 });
 

--- a/apps/api/src/inventory/http/inventory.controller.ts
+++ b/apps/api/src/inventory/http/inventory.controller.ts
@@ -23,6 +23,11 @@ import {
   INVENTORY_REPOSITORY_TOKEN,
   InventoryItemEntity as InventoryItem,
 } from '@openlinker/core/inventory';
+import {
+  ProductRepositoryPort,
+  PRODUCT_REPOSITORY_TOKEN,
+  ProductEntity as Product,
+} from '@openlinker/core/products';
 import { ListInventoryQueryDto } from './dto/list-inventory-query.dto';
 import { InventoryItemResponseDto } from './dto/inventory-item-response.dto';
 import { PaginatedInventoryResponseDto } from './dto/paginated-inventory-response.dto';
@@ -35,6 +40,8 @@ export class InventoryController {
   constructor(
     @Inject(INVENTORY_REPOSITORY_TOKEN)
     private readonly inventoryRepository: InventoryRepositoryPort,
+    @Inject(PRODUCT_REPOSITORY_TOKEN)
+    private readonly productRepository: ProductRepositoryPort,
   ) {}
 
   @Get()
@@ -54,8 +61,10 @@ export class InventoryController {
       { limit, offset },
     );
 
+    const productMap = await this.buildProductMap(items.map((i) => i.productId));
+
     return {
-      items: items.map((item) => this.toDto(item)),
+      items: items.map((item) => this.toDto(item, productMap.get(item.productId))),
       total,
       limit,
       offset,
@@ -73,10 +82,24 @@ export class InventoryController {
     if (!item) {
       throw new NotFoundException(`Inventory item not found: ${id}`);
     }
-    return this.toDto(item);
+    const product = await this.productRepository.findById(item.productId);
+    return this.toDto(item, product);
   }
 
-  private toDto(item: InventoryItem): InventoryItemResponseDto {
+  private async buildProductMap(productIds: string[]): Promise<Map<string, Product>> {
+    const uniqueIds = [...new Set(productIds)];
+    const products = await Promise.all(uniqueIds.map((id) => this.productRepository.findById(id)));
+    const map = new Map<string, Product>();
+    uniqueIds.forEach((id, idx) => {
+      const product = products[idx];
+      if (product) {
+        map.set(id, product);
+      }
+    });
+    return map;
+  }
+
+  private toDto(item: InventoryItem, product?: Product | null): InventoryItemResponseDto {
     return {
       id: item.id,
       productId: item.productId,
@@ -85,6 +108,8 @@ export class InventoryController {
       reservedQuantity: item.reservedQuantity,
       locationId: item.locationId,
       updatedAt: item.updatedAt instanceof Date ? item.updatedAt.toISOString() : item.updatedAt,
+      productName: product?.name ?? null,
+      productSku: product?.sku ?? null,
     };
   }
 }

--- a/apps/api/src/inventory/http/inventory.controller.ts
+++ b/apps/api/src/inventory/http/inventory.controller.ts
@@ -86,6 +86,9 @@ export class InventoryController {
     return this.toDto(item, product);
   }
 
+  // TODO: Replace with a single findByIds(ids) call once ProductRepositoryPort supports batch lookup.
+  // Current implementation issues N individual findById calls (one per unique productId).
+  // For typical page sizes (≤20 items) this is acceptable, but a batch method would be more efficient.
   private async buildProductMap(productIds: string[]): Promise<Map<string, Product>> {
     const uniqueIds = [...new Set(productIds)];
     const products = await Promise.all(uniqueIds.map((id) => this.productRepository.findById(id)));

--- a/apps/api/src/inventory/inventory.module.ts
+++ b/apps/api/src/inventory/inventory.module.ts
@@ -8,10 +8,11 @@
  */
 import { Module } from '@nestjs/common';
 import { InventoryModule as CoreInventoryModule } from '@openlinker/core/inventory';
+import { ProductsModule } from '@openlinker/core/products';
 import { InventoryController } from './http/inventory.controller';
 
 @Module({
-  imports: [CoreInventoryModule],
+  imports: [CoreInventoryModule, ProductsModule],
   controllers: [InventoryController],
 })
 export class InventoryModule {}

--- a/apps/web/src/features/inventory/api/inventory.types.ts
+++ b/apps/web/src/features/inventory/api/inventory.types.ts
@@ -16,6 +16,8 @@ export interface InventoryItem {
   reservedQuantity: number;
   locationId: string | null;
   updatedAt: string;
+  productName: string | null;
+  productSku: string | null;
 }
 
 export interface InventoryFilters {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -885,6 +885,10 @@ textarea {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
+.sku-label {
+  margin-left: 0.5rem;
+}
+
 .data-table {
   width: 100%;
   border-collapse: collapse;

--- a/apps/web/src/pages/inventory/inventory-detail-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.tsx
@@ -49,6 +49,18 @@ export function InventoryDetailPage(): ReactElement {
             <dt>Item ID</dt>
             <dd><span className="mono-text">{item.id}</span></dd>
           </div>
+          {item.productName ? (
+            <div className="detail-list__row">
+              <dt>Product</dt>
+              <dd>{item.productName}</dd>
+            </div>
+          ) : null}
+          {item.productSku ? (
+            <div className="detail-list__row">
+              <dt>Product SKU</dt>
+              <dd><span className="mono-text">{item.productSku}</span></dd>
+            </div>
+          ) : null}
           <div className="detail-list__row">
             <dt>Product ID</dt>
             <dd><span className="mono-text">{item.productId}</span></dd>

--- a/apps/web/src/pages/inventory/inventory-list-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.tsx
@@ -13,9 +13,26 @@ const SEARCH_DEBOUNCE_MS = 300;
 
 const COLUMNS: DataTableColumn<InventoryItem>[] = [
   {
-    id: 'productId',
-    header: 'Product ID',
-    cell: (item) => <span className="mono-text">{item.productId}</span>,
+    id: 'product',
+    header: 'Product',
+    cell: (item) => {
+      if (item.productName) {
+        return (
+          <span>
+            {item.productName}
+            {item.productSku ? (
+              <span className="text-muted" style={{ marginLeft: '0.5rem' }}>
+                <span className="mono-text">{item.productSku}</span>
+              </span>
+            ) : null}
+          </span>
+        );
+      }
+      if (item.productSku) {
+        return <span className="mono-text">{item.productSku}</span>;
+      }
+      return <span className="mono-text text-muted">{item.productId}</span>;
+    },
   },
   {
     id: 'productVariantId',

--- a/apps/web/src/pages/inventory/inventory-list-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.tsx
@@ -21,7 +21,7 @@ const COLUMNS: DataTableColumn<InventoryItem>[] = [
           <span>
             {item.productName}
             {item.productSku ? (
-              <span className="text-muted" style={{ marginLeft: '0.5rem' }}>
+              <span className="text-muted sku-label">
                 <span className="mono-text">{item.productSku}</span>
               </span>
             ) : null}

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
-import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { useProductQuery } from '../../features/products/hooks/use-product-query';
 import { ExternalIdsList } from '../../features/products/components/ExternalIdsList';
@@ -217,11 +217,17 @@ export function ProductDetailPage(): ReactElement {
       <section className="detail-section">
         <h3 className="detail-section__title">Stock</h3>
         {inventoryQuery.isLoading ? (
-          <p className="text-muted">Loading stock…</p>
+          <LoadingState liveRegion="off" title="Loading stock" message="Fetching inventory data…" />
         ) : inventoryQuery.error ? (
-          <p className="text-muted">Unable to load stock data.</p>
+          <ErrorState
+            title="Unable to load stock"
+            message={inventoryQuery.error.message}
+            action={
+              <Button onClick={() => { void inventoryQuery.refetch(); }}>Retry</Button>
+            }
+          />
         ) : (inventoryQuery.data?.items.length ?? 0) === 0 ? (
-          <p className="text-muted">No inventory records found for this product.</p>
+          <EmptyState liveRegion="off" title="No stock records" message="No inventory records found for this product." />
         ) : (
           <DataTable
             caption="Stock levels"

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -6,7 +6,49 @@ import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { useProductQuery } from '../../features/products/hooks/use-product-query';
 import { ExternalIdsList } from '../../features/products/components/ExternalIdsList';
+import { useInventoryQuery } from '../../features/inventory/hooks/use-inventory-query';
 import type { ProductVariant } from '../../features/products/api/products.types';
+import type { InventoryItem } from '../../features/inventory/api/inventory.types';
+
+const STOCK_COLUMNS: DataTableColumn<InventoryItem>[] = [
+  {
+    id: 'productVariantId',
+    header: 'Variant ID',
+    cell: (item) =>
+      item.productVariantId ? (
+        <span className="mono-text">{item.productVariantId}</span>
+      ) : (
+        <span className="text-muted">—</span>
+      ),
+  },
+  {
+    id: 'availableQuantity',
+    header: 'Available',
+    align: 'right',
+    cell: (item) => item.availableQuantity,
+  },
+  {
+    id: 'reservedQuantity',
+    header: 'Reserved',
+    align: 'right',
+    cell: (item) =>
+      item.reservedQuantity > 0 ? (
+        item.reservedQuantity
+      ) : (
+        <span className="text-muted">0</span>
+      ),
+  },
+  {
+    id: 'locationId',
+    header: 'Location',
+    cell: (item) =>
+      item.locationId ? (
+        <span className="mono-text">{item.locationId}</span>
+      ) : (
+        <span className="text-muted">default</span>
+      ),
+  },
+];
 
 const VARIANT_COLUMNS: DataTableColumn<ProductVariant>[] = [
   {
@@ -74,6 +116,7 @@ const VARIANT_COLUMNS: DataTableColumn<ProductVariant>[] = [
 export function ProductDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
   const query = useProductQuery(id);
+  const inventoryQuery = useInventoryQuery({ productId: id });
 
   if (query.isLoading) {
     return (
@@ -167,6 +210,25 @@ export function ProductDetailPage(): ReactElement {
           />
         ) : (
           <p className="text-muted">No variants found for this product.</p>
+        )}
+      </section>
+
+      {/* Stock */}
+      <section className="detail-section">
+        <h3 className="detail-section__title">Stock</h3>
+        {inventoryQuery.isLoading ? (
+          <p className="text-muted">Loading stock…</p>
+        ) : inventoryQuery.error ? (
+          <p className="text-muted">Unable to load stock data.</p>
+        ) : (inventoryQuery.data?.items.length ?? 0) === 0 ? (
+          <p className="text-muted">No inventory records found for this product.</p>
+        ) : (
+          <DataTable
+            caption="Stock levels"
+            columns={STOCK_COLUMNS}
+            rows={inventoryQuery.data?.items ?? []}
+            rowKey={(item) => item.id}
+          />
         )}
       </section>
     </PageLayout>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Inventory list now shows product name + SKU alongside each item; falls back to raw product ID when name/SKU are unavailable
- Product detail page now includes a Stock section showing available/reserved quantities per variant, powered by `useInventoryQuery`
- `InventoryController` enriches responses with `productName` and `productSku` by injecting `ProductRepositoryPort` and resolving products in parallel via `Promise.all` with deduplication

## Changes

**Backend**
- `InventoryItemResponseDto` — added `productName: string | null` and `productSku: string | null`
- `InventoryController` — injected `ProductRepositoryPort`; added `buildProductMap()` (deduplicates IDs, parallel `findById` via `Promise.all`); `toDto()` populates name/SKU
- `InventoryModule` — imported `ProductsModule` to make `PRODUCT_REPOSITORY_TOKEN` available
- Controller unit tests updated; deduplication test added

**Frontend**
- `InventoryItem` type — added `productName` and `productSku` fields
- Inventory list page — replaced raw product ID column with name+SKU display
- Inventory detail page — added conditional Product and Product SKU rows
- Product detail page — added Stock section with `DataTable` and proper `LoadingState`/`ErrorState`/`EmptyState` feedback components
- `index.css` — added `.sku-label` utility class (`margin-left: 0.5rem`)

Closes #198
EOF
)