### PR TITLE
fix(api): add forceExit to Jest config to prevent CI hang

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
+  forceExit: true,
   moduleNameMapper: {
     '^@openlinker/integrations-allegro$': path.resolve(__dirname, '../../libs/integrations/allegro/src/index.ts'),
     '^@openlinker/integrations-allegro/(.*)$': path.resolve(__dirname, '../../libs/integrations/allegro/src/$1'),


### PR DESCRIPTION
## Summary
- `SchedulerService` registers cron jobs via `@nestjs/schedule` which keeps the Node.js event loop alive after all tests complete
- Jest hung indefinitely in CI after all 237 tests passed, with cron jobs firing every 5–15 minutes post-completion
- Added `forceExit: true` to `apps/api/jest.config.js` so Jest terminates cleanly regardless of open handles

## Changes
- `apps/api/jest.config.js` — added `forceExit: true`

## Test plan
- [x] Unit tests pass (`pnpm test`)
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] `apps/api` Jest process now exits immediately after all 237 tests complete

## Tech review
No architectural concerns — single config-level fix. `forceExit` is the standard Jest remedy for NestJS apps with schedulers; no test logic was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)