### PR TITLE
fix(worker,web): default missing optional payload fields; add missing dialog fields

### DIFF
--- a/apps/api/test/integration/helpers/test-database.helper.ts
+++ b/apps/api/test/integration/helpers/test-database.helper.ts
@@ -17,6 +17,7 @@ export async function truncateAllTables(dataSource: DataSource): Promise<void> {
   // Truncate in correct order (respecting foreign keys)
   await dataSource.query('TRUNCATE TABLE identifier_mappings CASCADE');
   await dataSource.query('TRUNCATE TABLE connections CASCADE');
+  await dataSource.query('TRUNCATE TABLE users CASCADE');
 }
 
 /**
@@ -54,4 +55,3 @@ export async function countConnections(
 ): Promise<number> {
   return dataSource.getRepository(ConnectionOrmEntity).count();
 }
-

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
@@ -23,6 +23,10 @@ interface PayloadField {
   label: string;
   required: boolean;
   placeholder?: string;
+  /** Coerce non-empty string value to number before sending in payload. */
+  type?: 'string' | 'number';
+  /** Pre-populate the field with this value when the dialog opens. */
+  defaultValue?: string;
 }
 
 interface TriggerableJob {
@@ -80,17 +84,67 @@ const ALL_TRIGGERABLE_JOBS: TriggerableJob[] = [
     jobType: 'marketplace.offers.sync',
     label: 'Sync marketplace offers',
     description: 'Pull offer listings from the marketplace.',
-    payloadFields: [],
+    payloadFields: [
+      {
+        name: 'limit',
+        label: 'Page limit',
+        required: false,
+        type: 'number',
+        defaultValue: '100',
+        placeholder: '100',
+      },
+    ],
+    requiredCapability: 'Marketplace',
+  },
+  {
+    jobType: 'marketplace.orders.poll',
+    label: 'Poll marketplace orders',
+    description: 'Fetch new orders from the marketplace event stream.',
+    payloadFields: [
+      {
+        name: 'cursorKey',
+        label: 'Cursor key',
+        required: false,
+        defaultValue: 'allegro.orders.lastEventId',
+        placeholder: 'allegro.orders.lastEventId',
+      },
+      {
+        name: 'limit',
+        label: 'Page limit',
+        required: false,
+        type: 'number',
+        defaultValue: '100',
+        placeholder: '100',
+      },
+    ],
     requiredCapability: 'Marketplace',
   },
   {
     jobType: 'inventory.propagateToMarketplaces',
     label: 'Propagate inventory to marketplaces',
     description: 'Push current inventory levels to all connected marketplaces.',
-    payloadFields: [],
+    payloadFields: [
+      {
+        name: 'productId',
+        label: 'Product ID',
+        required: true,
+        placeholder: 'ol_product_…',
+      },
+    ],
     // No requiredCapability — this is a cross-connection fan-out job, valid for any active connection.
   },
 ];
+
+/** Build initial payload values from field defaults. */
+function buildDefaultValues(fields: PayloadField[]): Record<string, string> {
+  const defaults: Record<string, string> = {};
+  for (const field of fields) {
+    if (field.defaultValue !== undefined) {
+      defaults[field.name] = field.defaultValue;
+    }
+  }
+  return defaults;
+}
 
 interface TriggerSyncDialogProps {
   connection: Connection;
@@ -143,8 +197,9 @@ export function TriggerSyncDialog({
   // Reset form state when dialog opens
   useEffect(() => {
     if (open) {
-      setSelectedJobType(triggerableJobs[0]?.jobType ?? '');
-      setPayloadValues({});
+      const firstJob = triggerableJobs[0];
+      setSelectedJobType(firstJob?.jobType ?? '');
+      setPayloadValues(firstJob ? buildDefaultValues(firstJob.payloadFields) : {});
       setFieldErrors({});
       enqueueSyncJob.reset();
     }
@@ -167,8 +222,9 @@ export function TriggerSyncDialog({
   }, [onOpenChange]);
 
   const handleJobTypeChange = (jobType: string): void => {
+    const job = triggerableJobs.find((j) => j.jobType === jobType);
     setSelectedJobType(jobType);
-    setPayloadValues({});
+    setPayloadValues(job ? buildDefaultValues(job.payloadFields) : {});
     setFieldErrors({});
     enqueueSyncJob.reset();
   };
@@ -190,9 +246,9 @@ export function TriggerSyncDialog({
 
     const payload: Record<string, unknown> = { schemaVersion: 1 };
     for (const field of selectedJob.payloadFields) {
-      const value = payloadValues[field.name]?.trim();
-      if (value) {
-        payload[field.name] = value;
+      const raw = payloadValues[field.name]?.trim();
+      if (raw) {
+        payload[field.name] = field.type === 'number' ? Number(raw) : raw;
       }
     }
 

--- a/apps/worker/src/sync/handlers/marketplace-offers-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offers-sync.handler.ts
@@ -127,17 +127,10 @@ export class MarketplaceOffersSyncHandler implements SyncJobHandler {
         job.connectionId,
       );
     }
-    if (payload.limit === undefined || payload.limit === null || typeof payload.limit !== 'number') {
-      throw new SyncJobExecutionError(
-        `Missing or invalid limit in payload: ${JSON.stringify(job.payload)}`,
-        job.id,
-        job.jobType,
-        job.connectionId,
-      );
-    }
+    const limit = typeof payload.limit === 'number' ? payload.limit : 100;
     return {
       schemaVersion: 1,
-      limit: payload.limit,
+      limit,
       cursor: payload.cursor ?? null,
       cursorKey: payload.cursorKey,
       feedType: payload.feedType,

--- a/apps/worker/src/sync/handlers/marketplace-orders-poll.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-orders-poll.handler.ts
@@ -77,26 +77,15 @@ export class MarketplaceOrdersPollHandler implements SyncJobHandler {
         job.connectionId,
       );
     }
-    if (!payload.cursorKey || typeof payload.cursorKey !== 'string') {
-      throw new SyncJobExecutionError(
-        `Missing or invalid cursorKey in payload: ${JSON.stringify(job.payload)}`,
-        job.id,
-        job.jobType,
-        job.connectionId,
-      );
-    }
-    if (payload.limit === undefined || payload.limit === null || typeof payload.limit !== 'number') {
-      throw new SyncJobExecutionError(
-        `Missing or invalid limit in payload: ${JSON.stringify(job.payload)}`,
-        job.id,
-        job.jobType,
-        job.connectionId,
-      );
-    }
+    const cursorKey =
+      typeof payload.cursorKey === 'string' && payload.cursorKey
+        ? payload.cursorKey
+        : 'allegro.orders.lastEventId';
+    const limit = typeof payload.limit === 'number' ? payload.limit : 100;
     return {
       schemaVersion: 1,
-      cursorKey: payload.cursorKey,
-      limit: payload.limit,
+      cursorKey,
+      limit,
       eventTypes: payload.eventTypes,
     };
   }


### PR DESCRIPTION
## Summary

- `marketplace.offers.sync` handler no longer throws when `limit` is absent — defaults to `100` (fixes #205)
- `marketplace.orders.poll` handler no longer throws when `cursorKey`/`limit` are absent — defaults match the scheduler's own values
- `TriggerSyncDialog` now exposes payload fields for `marketplace.offers.sync` (limit), `marketplace.orders.poll` (cursorKey + limit), and `inventory.propagateToMarketplaces` (productId), with sensible defaults pre-populated
- `marketplace.orders.poll` was missing from `ALL_TRIGGERABLE_JOBS` entirely — added with `Marketplace` capability guard
- `PayloadField` extended with optional `type: 'number'` (coerces form string to number before sending) and `defaultValue` (pre-populates field on dialog open)

## Test plan

- [ ] Trigger `marketplace.offers.sync` manually from the dialog — verify limit field shows `100` pre-filled and job enqueues without error
- [ ] Trigger `marketplace.orders.poll` — verify cursorKey defaults to `allegro.orders.lastEventId` and limit to `100`
- [ ] Trigger `inventory.propagateToMarketplaces` — verify productId field is required and blocks submission when empty
- [ ] Enqueue `marketplace.offers.sync` programmatically with `{"schemaVersion":1}` (no limit) — verify handler defaults to 100 instead of throwing
- [ ] `pnpm lint && pnpm type-check && pnpm test` — all green

Closes #205
Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)