### PR TITLE
feat(orders): persist OrderRecord after marketplace order sync

### DIFF
--- a/docs/plans/implementation-plan-207-order-record-persistence.md
+++ b/docs/plans/implementation-plan-207-order-record-persistence.md
@@ -1,0 +1,144 @@
+# Implementation Plan — #207: Persist OrderRecord after marketplace order sync
+
+## 1. Goal
+
+Wire `OrderRecordService` into `OrderIngestionService.syncOrderFromMarketplace` so that an `OrderRecord` is persisted for every order successfully hydrated from the marketplace, capturing sync outcomes per destination.
+
+**Layer**: Application (CORE — `libs/core/src/orders/`)  
+**Non-goals**: No schema changes, no new domain entities, no API endpoints, no UI changes.
+
+---
+
+## 2. Current State
+
+`OrderIngestionService.syncOrderFromMarketplace`:
+1. Fetches order from marketplace adapter
+2. Calls `toUnifiedOrder()` → hydrates to `Order` with internal IDs
+3. Calls `orderSyncService.syncOrder()` → returns `OrderSyncResult[]`
+4. **Never calls `OrderRecordService`** — `order_records` table stays empty
+
+`OrderRecordService` exists and is fully wired in `OrdersModule` with token `ORDER_RECORD_SERVICE_TOKEN`, but is not injected into `OrderIngestionService`.
+
+---
+
+## 3. Solution Design
+
+### Three scenarios to handle
+
+| Scenario | What happens | Record state |
+|---|---|---|
+| Successful sync | `syncOrder` returns `status: 'success'` entries | Persisted before sync; updated with `externalOrderId`/`externalOrderNumber` |
+| Per-destination failure | `syncOrder` returns some `status: 'failed'` entries | Persisted before sync; updated with `error` message |
+| Full `syncOrder` throw | `syncOrder` throws (e.g. `NoOrderDestinationsAvailableException`) | Persisted before sync; no status update (record exists without sync entries) |
+
+### Sequencing
+
+```
+1. toUnifiedOrder()  →  order (with internal IDs)
+2. orderRecordService.persistOrder(order, connectionId, sourceEventId ?? null)
+3. orderSyncService.syncOrder(...)  →  results[]   [may throw]
+4. Promise.allSettled → updateSyncStatus per result
+5. return results
+```
+
+Step 2 runs before step 3 — ensures a record exists even when `syncOrder` throws.  
+Step 4 uses `Promise.allSettled` — one failing status update doesn't block others.
+
+---
+
+## 4. Implementation Steps
+
+### Step 1 — Inject `IOrderRecordService` into `OrderIngestionService`
+
+**File**: `libs/core/src/orders/application/services/order-ingestion.service.ts`
+
+- Add `@Inject(ORDER_RECORD_SERVICE_TOKEN) private readonly orderRecordService: IOrderRecordService` to constructor
+- Import `IOrderRecordService` and `ORDER_RECORD_SERVICE_TOKEN`
+
+**Acceptance**: Service compiles; existing tests still pass (mock added to test setup).
+
+### Step 2 — Update `syncOrderFromMarketplace` with record persistence
+
+**File**: `libs/core/src/orders/application/services/order-ingestion.service.ts`
+
+Replace the current `syncOrderFromMarketplace` body with:
+
+```typescript
+async syncOrderFromMarketplace(connectionId, externalOrderId, sourceEventId?) {
+  const marketplace = await this.integrationsService.getCapabilityAdapter<MarketplacePort>(connectionId, 'Marketplace');
+  const incoming = await marketplace.getOrder({ externalOrderId });
+  const order = await this.toUnifiedOrder(incoming, connectionId);
+
+  // Persist before routing — ensures record exists even if syncOrder throws
+  await this.orderRecordService.persistOrder(order, connectionId, sourceEventId ?? null);
+
+  const results = await this.orderSyncService.syncOrder({ order, sourceConnectionId: connectionId, sourceEventId });
+
+  // Update per-destination sync status; allSettled — one failure doesn't block others
+  const settlements = await Promise.allSettled(
+    results.map((result) => {
+      if (result.status === 'success') {
+        return this.orderRecordService.updateSyncStatus(order.id, result.destinationConnectionId, {
+          destinationConnectionId: result.destinationConnectionId,
+          status: 'synced',
+          syncedAt: new Date(),
+          externalOrderId: result.orderRef.orderId,
+          externalOrderNumber: result.orderRef.orderNumber,
+        });
+      } else {
+        return this.orderRecordService.updateSyncStatus(order.id, result.destinationConnectionId, {
+          destinationConnectionId: result.destinationConnectionId,
+          status: 'failed',
+          error: result.error.message,
+        });
+      }
+    }),
+  );
+  for (const settlement of settlements) {
+    if (settlement.status === 'rejected') {
+      this.logger.warn('Failed to update order record sync status', settlement.reason);
+    }
+  }
+
+  return results;
+}
+```
+
+**Acceptance**: `order_records` row created before `syncOrder` is called; sync outcomes recorded after.
+
+### Step 3 — Update unit tests for `OrderIngestionService`
+
+**File**: `libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts`
+
+Add `orderRecordService` mock to test setup and update `syncOrderFromMarketplace` tests:
+
+1. Add `orderRecordService: jest.Mocked<IOrderRecordService>` to test setup
+2. Add mock to `OrderIngestionService` constructor call
+3. Add/update test cases:
+   - **successful sync**: verify `persistOrder` called before `syncOrder` using `mock.invocationCallOrder` (assert `persistOrder.mock.invocationCallOrder[0] < orderSyncService.syncOrder.mock.invocationCallOrder[0]`); verify `updateSyncStatus` called with `status: 'synced'`
+   - **per-destination failure**: verify `updateSyncStatus` called with `status: 'failed'` and error message
+   - **multiple destinations, mixed results**: verify `updateSyncStatus` called for each result independently
+   - **`syncOrder` throws entirely**: verify `persistOrder` was still called; `updateSyncStatus` not called
+   - **`updateSyncStatus` rejects for one destination**: mock one `updateSyncStatus` call to reject; verify `logger.warn` called once; verify the method still resolves (does not throw)
+
+**Acceptance**: All new tests pass; all existing tests still pass.
+
+---
+
+## 5. Validation
+
+- **Architecture compliance**: Application service depends on `IOrderRecordService` port (not concrete class). ✅
+- **Naming**: No new files — only modifying existing service and test. ✅
+- **Error safety**: `persistOrder` failure propagates (caller can retry). `Promise.allSettled` for status updates; rejected settlements logged via `this.logger.warn`. ✅
+- **PII**: `persistOrder` internally respects `OL_STORE_PII` — no change needed. ✅
+- **Idempotency**: `OrderRecordRepository.upsert` is used by `persistOrder` — safe to re-run. ✅
+- **No migration needed**: `order_records` table already exists. ✅
+
+---
+
+## 6. Files Changed
+
+| File | Change |
+|---|---|
+| `libs/core/src/orders/application/services/order-ingestion.service.ts` | Inject `IOrderRecordService`; update `syncOrderFromMarketplace` |
+| `libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts` | Add mock; add/update `syncOrderFromMarketplace` test cases |

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -288,6 +288,7 @@ describe('OrderIngestionService', () => {
     });
 
     it('should log warning and continue when updateSyncStatus rejects for one destination', async () => {
+      const warnSpy = jest.spyOn(service['logger'], 'warn');
       orderSyncService.syncOrder.mockResolvedValue([
         {
           status: 'success',
@@ -307,6 +308,12 @@ describe('OrderIngestionService', () => {
       await expect(
         service.syncOrderFromMarketplace(connectionId, externalOrderId),
       ).resolves.not.toThrow();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to update order record sync status',
+        expect.any(Error),
+      );
     });
   });
 
@@ -325,7 +332,7 @@ describe('OrderIngestionService', () => {
 
     beforeEach(() => {
       identifierMapping.getOrCreateInternalId.mockResolvedValue('ol_order_test');
-      orderSyncService.syncOrder.mockResolvedValue([] as never);
+      orderSyncService.syncOrder.mockResolvedValue([]);
     });
 
     it('should call resolveCustomerIdentity when customerExternalId and customerEmail are present', async () => {

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -16,6 +16,7 @@ import {
 import { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 import { ICustomerIdentityResolverService } from '@openlinker/core/customers';
 import { IOrderSyncService } from '../../interfaces/order-sync.service.interface';
+import { IOrderRecordService } from '../../interfaces/order-record.service.interface';
 import { OrderItemRefResolverService } from '../order-item-ref-resolver.service';
 
 describe('OrderIngestionService', () => {
@@ -27,6 +28,7 @@ describe('OrderIngestionService', () => {
   let lock: jest.Mocked<SyncLockPort>;
   let identifierMapping: jest.Mocked<IIdentifierMappingService>;
   let orderSyncService: jest.Mocked<IOrderSyncService>;
+  let orderRecordService: jest.Mocked<IOrderRecordService>;
   let marketplace: jest.Mocked<MarketplacePort>;
   let orderItemRefResolver: jest.Mocked<OrderItemRefResolverService>;
   let customerIdentityResolver: jest.Mocked<ICustomerIdentityResolverService>;
@@ -80,6 +82,12 @@ describe('OrderIngestionService', () => {
       syncOrder: jest.fn(),
     } as unknown as jest.Mocked<IOrderSyncService>;
 
+    orderRecordService = {
+      persistOrder: jest.fn().mockResolvedValue({}),
+      updateSyncStatus: jest.fn().mockResolvedValue(undefined),
+      getOrderRecord: jest.fn(),
+    } as unknown as jest.Mocked<IOrderRecordService>;
+
     customerIdentityResolver = {
       resolveCustomerIdentity: jest.fn().mockResolvedValue({
         internalCustomerId: 'ol_customer_test',
@@ -97,6 +105,7 @@ describe('OrderIngestionService', () => {
       orderItemRefResolver,
       orderSyncService,
       customerIdentityResolver,
+      orderRecordService,
     );
   });
 
@@ -197,6 +206,110 @@ describe('OrderIngestionService', () => {
     });
   });
 
+  describe('syncOrderFromMarketplace – order record persistence', () => {
+    const externalOrderId = 'checkout-1';
+
+    const baseIncoming = {
+      externalOrderId,
+      orderNumber: externalOrderId,
+      status: 'BOUGHT',
+      items: [],
+      totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN' },
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    };
+
+    beforeEach(() => {
+      identifierMapping.getOrCreateInternalId.mockResolvedValue('ol_order_test');
+      marketplace.getOrder.mockResolvedValue(baseIncoming);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(marketplace);
+    });
+
+    it('should persist order before calling syncOrder', async () => {
+      orderSyncService.syncOrder.mockResolvedValue([]);
+
+      await service.syncOrderFromMarketplace(connectionId, externalOrderId);
+
+      expect(orderRecordService.persistOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'ol_order_test' }),
+        connectionId,
+        null,
+      );
+      expect(orderRecordService.persistOrder.mock.invocationCallOrder[0]).toBeLessThan(
+        orderSyncService.syncOrder.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should call updateSyncStatus with synced when syncOrder succeeds', async () => {
+      orderSyncService.syncOrder.mockResolvedValue([
+        {
+          status: 'success',
+          destinationConnectionId: 'dest-conn-1',
+          orderRef: { orderId: 'ext-order-1', orderNumber: 'ORD-001' },
+        },
+      ]);
+
+      await service.syncOrderFromMarketplace(connectionId, externalOrderId);
+
+      expect(orderRecordService.updateSyncStatus).toHaveBeenCalledWith(
+        'ol_order_test',
+        'dest-conn-1',
+        expect.objectContaining({ status: 'synced', externalOrderId: 'ext-order-1' }),
+      );
+    });
+
+    it('should call updateSyncStatus with failed when syncOrder returns a failure result', async () => {
+      orderSyncService.syncOrder.mockResolvedValue([
+        {
+          status: 'failed',
+          destinationConnectionId: 'dest-conn-1',
+          error: { message: 'destination unavailable' },
+        },
+      ]);
+
+      await service.syncOrderFromMarketplace(connectionId, externalOrderId);
+
+      expect(orderRecordService.updateSyncStatus).toHaveBeenCalledWith(
+        'ol_order_test',
+        'dest-conn-1',
+        expect.objectContaining({ status: 'failed', error: 'destination unavailable' }),
+      );
+    });
+
+    it('should still persist order when syncOrder throws', async () => {
+      orderSyncService.syncOrder.mockRejectedValue(new Error('no destinations'));
+
+      await expect(
+        service.syncOrderFromMarketplace(connectionId, externalOrderId),
+      ).rejects.toThrow('no destinations');
+
+      expect(orderRecordService.persistOrder).toHaveBeenCalled();
+      expect(orderRecordService.updateSyncStatus).not.toHaveBeenCalled();
+    });
+
+    it('should log warning and continue when updateSyncStatus rejects for one destination', async () => {
+      orderSyncService.syncOrder.mockResolvedValue([
+        {
+          status: 'success',
+          destinationConnectionId: 'dest-conn-1',
+          orderRef: { orderId: 'ext-order-1' },
+        },
+        {
+          status: 'success',
+          destinationConnectionId: 'dest-conn-2',
+          orderRef: { orderId: 'ext-order-2' },
+        },
+      ]);
+      orderRecordService.updateSyncStatus
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('db write failed'));
+
+      await expect(
+        service.syncOrderFromMarketplace(connectionId, externalOrderId),
+      ).resolves.not.toThrow();
+    });
+  });
+
   describe('syncOrderFromMarketplace – customer resolution', () => {
     const externalOrderId = 'checkout-1';
 
@@ -212,7 +325,7 @@ describe('OrderIngestionService', () => {
 
     beforeEach(() => {
       identifierMapping.getOrCreateInternalId.mockResolvedValue('ol_order_test');
-      orderSyncService.syncOrder.mockResolvedValue({} as never);
+      orderSyncService.syncOrder.mockResolvedValue([] as never);
     });
 
     it('should call resolveCustomerIdentity when customerExternalId and customerEmail are present', async () => {

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -40,7 +40,8 @@ import {
   MarketplaceIngestionOptions,
   MarketplaceIngestionResult,
 } from '../interfaces/order-ingestion.service.interface';
-import { ORDER_SYNC_SERVICE_TOKEN } from '../../orders.tokens';
+import { ORDER_SYNC_SERVICE_TOKEN, ORDER_RECORD_SERVICE_TOKEN } from '../../orders.tokens';
+import { IOrderRecordService } from '../interfaces/order-record.service.interface';
 import type { IncomingOrder } from '../../domain/types/incoming-order.types';
 import { Order } from '../../domain/ports/order-source.port';
 import { Logger } from '@openlinker/shared/logging';
@@ -69,6 +70,8 @@ export class OrderIngestionService implements IOrderIngestionService {
     private readonly orderSyncService: IOrderSyncService,
     @Inject(CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN)
     private readonly customerIdentityResolver: ICustomerIdentityResolverService,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecordService: IOrderRecordService,
   ) {}
 
   async syncFromMarketplace(
@@ -179,11 +182,43 @@ export class OrderIngestionService implements IOrderIngestionService {
 
     const incoming = await marketplace.getOrder({ externalOrderId });
     const order = await this.toUnifiedOrder(incoming, connectionId);
-    return await this.orderSyncService.syncOrder({
+
+    // Persist before routing — ensures record exists even if syncOrder throws
+    await this.orderRecordService.persistOrder(order, connectionId, sourceEventId ?? null);
+
+    const results = await this.orderSyncService.syncOrder({
       order,
       sourceConnectionId: connectionId,
       sourceEventId,
     });
+
+    // Update per-destination sync status; allSettled — one failure doesn't block others
+    const settlements = await Promise.allSettled(
+      results.map((result) => {
+        if (result.status === 'success') {
+          return this.orderRecordService.updateSyncStatus(order.id, result.destinationConnectionId, {
+            destinationConnectionId: result.destinationConnectionId,
+            status: 'synced',
+            syncedAt: new Date(),
+            externalOrderId: result.orderRef.orderId,
+            externalOrderNumber: result.orderRef.orderNumber,
+          });
+        } else {
+          return this.orderRecordService.updateSyncStatus(order.id, result.destinationConnectionId, {
+            destinationConnectionId: result.destinationConnectionId,
+            status: 'failed',
+            error: result.error.message,
+          });
+        }
+      }),
+    );
+    for (const settlement of settlements) {
+      if (settlement.status === 'rejected') {
+        this.logger.warn('Failed to update order record sync status', settlement.reason);
+      }
+    }
+
+    return results;
   }
 
   private async toUnifiedOrder(incoming: IncomingOrder, connectionId: string): Promise<Order> {


### PR DESCRIPTION
## Summary

- Wire `IOrderRecordService` into `OrderIngestionService.syncOrderFromMarketplace` so `order_records` is populated after every marketplace order sync
- `persistOrder` called before `syncOrder` — record exists even if routing throws
- `updateSyncStatus` called per destination via `Promise.allSettled` for per-destination isolation; rejected settlements logged via `logger.warn`

## Test plan

- [ ] `should persist order before calling syncOrder` — verifies persist-before-route ordering via `invocationCallOrder`
- [ ] `should call updateSyncStatus with synced when syncOrder succeeds`
- [ ] `should call updateSyncStatus with failed when syncOrder returns a failure result`
- [ ] `should still persist order when syncOrder throws`
- [ ] `should log warning and continue when updateSyncStatus rejects for one destination` — asserts `logger.warn` fires once and method still resolves

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)