### PR TITLE
fix(prestashop): fall back to combination-level stock for inventory sync

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-inventory-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-inventory-master.adapter.spec.ts
@@ -230,6 +230,9 @@ describe('PrestashopInventoryMasterAdapter', () => {
       await expect(adapter.getInventory(productId)).rejects.toThrow(
         PrestashopResourceNotFoundException,
       );
+      // Both the product-level and combination-level queries must be attempted
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockHttpClient.listResources).toHaveBeenCalledTimes(2);
     });
 
     it('should create internal ID for inventory with parent context', async () => {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-inventory-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-inventory-master.adapter.spec.ts
@@ -141,6 +141,76 @@ describe('PrestashopInventoryMasterAdapter', () => {
       );
     });
 
+    it('should fetch inventory for combination product via id_product_attribute fallback', async () => {
+      const productId = 'internal-product-456';
+      const combinationExternalId = '15';
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      mockIdentifierMapping.getExternalIds = jest.fn().mockResolvedValue([
+        {
+          connectionId: connection.id,
+          externalId: combinationExternalId,
+          entityType: 'Product',
+        },
+      ]);
+
+      const combinationStockRecord: PrestashopStockAvailable = {
+        id: '201',
+        id_product: '38',
+        id_product_attribute: '15',
+        quantity: '30',
+        out_of_stock: '0',
+      };
+
+      // First call (id_product_attribute=0) returns empty; second call returns combination stock
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      mockHttpClient.listResources = jest
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([combinationStockRecord]);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      mockIdentifierMapping.getOrCreateInternalId = jest.fn().mockResolvedValue('internal-inventory-456');
+
+      const result = await adapter.getInventory(productId);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockHttpClient.listResources).toHaveBeenCalledTimes(2);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockHttpClient.listResources).toHaveBeenNthCalledWith(
+        2,
+        'stock_availables',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          custom: expect.objectContaining({ id_product_attribute: combinationExternalId }),
+        }),
+      );
+      expect(result.quantity).toBe(30);
+    });
+
+    it('should throw PrestashopResourceNotFoundException when both product-level and combination-level queries return empty', async () => {
+      const productId = 'internal-product-789';
+      const externalId = '99';
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      mockIdentifierMapping.getExternalIds = jest.fn().mockResolvedValue([
+        {
+          connectionId: connection.id,
+          externalId,
+          entityType: 'Product',
+        },
+      ]);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      mockHttpClient.listResources = jest.fn().mockResolvedValue([]);
+
+      await expect(adapter.getInventory(productId)).rejects.toThrow(
+        PrestashopResourceNotFoundException,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(mockHttpClient.listResources).toHaveBeenCalledTimes(2);
+    });
+
     it('should throw PrestashopResourceNotFoundException when no stock record found', async () => {
       const productId = 'internal-product-123';
       const externalProductId = '42';

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts
@@ -58,8 +58,10 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort {
       ? rawExternalId.slice('product:'.length)
       : rawExternalId;
 
-    // First try product-level stock (simple products: id_product_attribute = 0).
-    // If empty, fall back to combination-level stock (psProductId is then a combination ID).
+    // The identifier mapping stores combination IDs under entityType='Product', so
+    // psProductId is either a plain product ID (simple products) or a combination ID.
+    // Try product-level stock first (id_product_attribute=0); if empty, the external ID
+    // is a combination ID and its stock record is keyed by id_product_attribute instead.
     let stockRecords = await this.httpClient.listResources<PrestashopStockAvailable>(
       'stock_availables',
       {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts
@@ -58,16 +58,28 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort {
       ? rawExternalId.slice('product:'.length)
       : rawExternalId;
 
-    // Fetch stock_available for product (id_product_attribute = 0 for product stock)
-    const stockRecords = await this.httpClient.listResources<PrestashopStockAvailable>(
+    // First try product-level stock (simple products: id_product_attribute = 0).
+    // If empty, fall back to combination-level stock (psProductId is then a combination ID).
+    let stockRecords = await this.httpClient.listResources<PrestashopStockAvailable>(
       'stock_availables',
       {
         custom: {
           id_product: psProductId,
-          id_product_attribute: 0, // Product stock, not variant
+          id_product_attribute: 0,
         },
       },
     );
+
+    if (stockRecords.length === 0) {
+      stockRecords = await this.httpClient.listResources<PrestashopStockAvailable>(
+        'stock_availables',
+        {
+          custom: {
+            id_product_attribute: psProductId,
+          },
+        },
+      );
+    }
 
     if (stockRecords.length === 0) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
@@ -80,7 +92,7 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort {
       throw error;
     }
 
-    // Use first stock record (should be only one for product stock)
+    // Use first stock record (should be only one for product/combination stock)
     const stockRecord = stockRecords[0];
 
     // Map to OpenLinker schema


### PR DESCRIPTION
## Summary

- `PrestashopInventoryMasterAdapter.getInventory` previously always queried `stock_availables` with `id_product_attribute=0`, which only returns product-level (simple product) stock records
- For products with combinations, the external ID is a PrestaShop combination ID, and its stock record has `id_product_attribute=<combinationId>` — the old code always got an empty response and threw `PrestashopResourceNotFoundException`
- Added a two-phase query: try product-level first (`id_product_attribute=0`), fall back to combination-level (`id_product_attribute=<externalId>`) if empty, throw only if both return empty

## Test plan

- [ ] All existing unit tests pass (`pnpm --filter @openlinker/integrations-prestashop test`)
- [ ] New test: combination product fetches inventory via fallback query
- [ ] New test: both queries returning empty throws `PrestashopResourceNotFoundException`
- [ ] `pnpm lint && pnpm type-check` pass with zero errors

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)