### PR TITLE
feat(sync-dialog): extract types file and scope cursorKey default to platform

### DIFF
--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
@@ -91,6 +91,46 @@ describe('TriggerSyncDialog', () => {
       expect(screen.getByLabelText(/object type/i)).toBeInTheDocument();
     });
 
+    it('should default cursorKey to platform-scoped value for marketplace.orders.poll', () => {
+      const allegroConnection = {
+        ...sampleConnection,
+        platformType: 'allegro' as const,
+        supportedCapabilities: ['Marketplace' as const],
+        enabledCapabilities: ['Marketplace' as const],
+      };
+      const mockApi = createMockApiClient();
+      renderWithProviders(
+        <TriggerSyncDialog connection={allegroConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+
+      const select = screen.getByRole('combobox', { name: /job type/i });
+      fireEvent.change(select, { target: { value: 'marketplace.orders.poll' } });
+
+      const cursorKeyInput = screen.getByLabelText(/cursor key/i);
+      expect(cursorKeyInput).toHaveValue('allegro.orders.lastEventId');
+    });
+
+    it('should scope cursorKey default to the connection platform type', () => {
+      const prestashopMarketplaceConnection = {
+        ...sampleConnection,
+        platformType: 'prestashop' as const,
+        supportedCapabilities: ['Marketplace' as const],
+        enabledCapabilities: ['Marketplace' as const],
+      };
+      const mockApi = createMockApiClient();
+      renderWithProviders(
+        <TriggerSyncDialog connection={prestashopMarketplaceConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+
+      const select = screen.getByRole('combobox', { name: /job type/i });
+      fireEvent.change(select, { target: { value: 'marketplace.orders.poll' } });
+
+      const cursorKeyInput = screen.getByLabelText(/cursor key/i);
+      expect(cursorKeyInput).toHaveValue('prestashop.orders.lastEventId');
+    });
+
     it('should clear payload fields when job type changes', () => {
       renderDialog();
       const select = screen.getByRole('combobox', { name: /job type/i });

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
@@ -9,7 +9,6 @@
  */
 import { useEffect, useId, useMemo, useRef, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import type { Capability, Connection } from '../../connections/api/connections.types';
 import { useEnqueueSyncJobMutation } from '../hooks/use-enqueue-sync-job-mutation';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
@@ -17,26 +16,7 @@ import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
 import { useToast } from '../../../shared/ui/toast-provider';
-
-interface PayloadField {
-  name: string;
-  label: string;
-  required: boolean;
-  placeholder?: string;
-  /** Coerce non-empty string value to number before sending in payload. */
-  type?: 'string' | 'number';
-  /** Pre-populate the field with this value when the dialog opens. */
-  defaultValue?: string;
-}
-
-interface TriggerableJob {
-  jobType: string;
-  label: string;
-  description: string;
-  payloadFields: PayloadField[];
-  /** If set, only show this job when the connection supports this capability. */
-  requiredCapability?: Capability;
-}
+import type { PayloadField, TriggerableJob, TriggerSyncDialogProps } from './trigger-sync-dialog.types';
 
 const ALL_TRIGGERABLE_JOBS: TriggerableJob[] = [
   {
@@ -105,7 +85,7 @@ const ALL_TRIGGERABLE_JOBS: TriggerableJob[] = [
         name: 'cursorKey',
         label: 'Cursor key',
         required: false,
-        defaultValue: 'allegro.orders.lastEventId',
+        defaultValueFactory: ({ platformType }) => `${platformType}.orders.lastEventId`,
         placeholder: 'allegro.orders.lastEventId',
       },
       {
@@ -136,20 +116,19 @@ const ALL_TRIGGERABLE_JOBS: TriggerableJob[] = [
 ];
 
 /** Build initial payload values from field defaults. */
-function buildDefaultValues(fields: PayloadField[]): Record<string, string> {
+function buildDefaultValues(
+  fields: PayloadField[],
+  context: { platformType: string },
+): Record<string, string> {
   const defaults: Record<string, string> = {};
   for (const field of fields) {
-    if (field.defaultValue !== undefined) {
+    if (field.defaultValueFactory !== undefined) {
+      defaults[field.name] = field.defaultValueFactory(context);
+    } else if (field.defaultValue !== undefined) {
       defaults[field.name] = field.defaultValue;
     }
   }
   return defaults;
-}
-
-interface TriggerSyncDialogProps {
-  connection: Connection;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
 }
 
 export function TriggerSyncDialog({
@@ -199,7 +178,9 @@ export function TriggerSyncDialog({
     if (open) {
       const firstJob = triggerableJobs[0];
       setSelectedJobType(firstJob?.jobType ?? '');
-      setPayloadValues(firstJob ? buildDefaultValues(firstJob.payloadFields) : {});
+      setPayloadValues(
+        firstJob ? buildDefaultValues(firstJob.payloadFields, connection) : {},
+      );
       setFieldErrors({});
       enqueueSyncJob.reset();
     }
@@ -224,7 +205,7 @@ export function TriggerSyncDialog({
   const handleJobTypeChange = (jobType: string): void => {
     const job = triggerableJobs.find((j) => j.jobType === jobType);
     setSelectedJobType(jobType);
-    setPayloadValues(job ? buildDefaultValues(job.payloadFields) : {});
+    setPayloadValues(job ? buildDefaultValues(job.payloadFields, connection) : {});
     setFieldErrors({});
     enqueueSyncJob.reset();
   };

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
@@ -86,7 +86,6 @@ const ALL_TRIGGERABLE_JOBS: TriggerableJob[] = [
         label: 'Cursor key',
         required: false,
         defaultValueFactory: ({ platformType }) => `${platformType}.orders.lastEventId`,
-        placeholder: 'allegro.orders.lastEventId',
       },
       {
         name: 'limit',

--- a/apps/web/src/features/sync-jobs/components/trigger-sync-dialog.types.ts
+++ b/apps/web/src/features/sync-jobs/components/trigger-sync-dialog.types.ts
@@ -1,0 +1,40 @@
+/**
+ * TriggerSyncDialog Types
+ *
+ * Type definitions for the TriggerSyncDialog component, including payload field
+ * configuration and job descriptors used to drive the sync job trigger form.
+ *
+ * @module apps/web/src/features/sync-jobs/components
+ */
+import type { Capability, Connection } from '../../connections/api/connections.types';
+
+export interface PayloadField {
+  name: string;
+  label: string;
+  required: boolean;
+  placeholder?: string;
+  /** Coerce non-empty string value to number before sending in payload. */
+  type?: 'string' | 'number';
+  /** Pre-populate the field with this value when the dialog opens. */
+  defaultValue?: string;
+  /**
+   * Derive the default value from connection context (takes precedence over defaultValue).
+   * Used when the default depends on the platform type (e.g. cursorKey).
+   */
+  defaultValueFactory?: (context: { platformType: string }) => string;
+}
+
+export interface TriggerableJob {
+  jobType: string;
+  label: string;
+  description: string;
+  payloadFields: PayloadField[];
+  /** If set, only show this job when the connection supports this capability. */
+  requiredCapability?: Capability;
+}
+
+export interface TriggerSyncDialogProps {
+  connection: Connection;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Extract `PayloadField`, `TriggerableJob`, and `TriggerSyncDialogProps` interfaces into a dedicated `trigger-sync-dialog.types.ts` file per engineering standards (types in separate `*.types.ts` files)
- Add `defaultValueFactory` to `PayloadField` for context-dependent field defaults
- Scope the `marketplace.orders.poll` `cursorKey` default to the connection's platform type (e.g. `allegro.orders.lastEventId`, `prestashop.orders.lastEventId`)
- Remove stale placeholder from `cursorKey` field (field is always pre-filled via factory)
- Add tests covering cursorKey default scoping for Allegro and PrestaShop connections

## Test plan

- [ ] All unit tests pass (`pnpm test`)
- [ ] Lint and type-check pass (`pnpm lint && pnpm type-check`)
- [ ] `cursorKey` input pre-fills with `allegro.orders.lastEventId` for Allegro connections
- [ ] `cursorKey` input pre-fills with `prestashop.orders.lastEventId` for PrestaShop connections

Closes #211
Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)