### PR TITLE
fix(web): fix disabled button cursor and add accessible disabled styling

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -148,8 +148,11 @@ button:focus-visible,
 
 button:disabled,
 .button:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.7;
+  border-color: var(--status-disabled-border);
+  background: var(--status-disabled-soft);
+  color: var(--text-disabled);
 }
 
 .control,


### PR DESCRIPTION
## Summary

- Replace `cursor: wait` with `cursor: not-allowed` on disabled buttons (the original bug — pagination Prev/Next showed a loading cursor)
- Add token-based disabled visual treatment (`border-color`, `background`, `color`) so the disabled state is communicated via shape/color/text, not opacity alone

## Test plan

- [ ] Verify pagination Previous/Next buttons show `not-allowed` cursor when disabled
- [ ] Verify disabled buttons render with muted border, background, and text color
- [ ] Verify no regression on other button states (primary, secondary, hover, active)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)