### PR TITLE
feat(allegro): surface masterCatalogConnectionId in connection wizard

### DIFF
--- a/apps/api/src/integrations/application/interfaces/allegro-oauth.service.interface.ts
+++ b/apps/api/src/integrations/application/interfaces/allegro-oauth.service.interface.ts
@@ -26,6 +26,7 @@ export interface IAllegroOAuthService {
     environment?: string,
     state?: string,
     connectionName?: string,
+    masterCatalogConnectionId?: string,
   ): Promise<AllegroOAuthAuthorizationResponse>;
 
   /**

--- a/apps/api/src/integrations/application/interfaces/allegro-oauth.service.types.ts
+++ b/apps/api/src/integrations/application/interfaces/allegro-oauth.service.types.ts
@@ -39,6 +39,7 @@ export interface OAuthStateData {
   redirectUri: string;
   environment: string;
   connectionName?: string;
+  masterCatalogConnectionId?: string;
 }
 
 /**

--- a/apps/api/src/integrations/application/services/allegro-oauth.service.spec.ts
+++ b/apps/api/src/integrations/application/services/allegro-oauth.service.spec.ts
@@ -158,6 +158,81 @@ describe('AllegroOAuthService', () => {
     });
   });
 
+  describe('generateAuthorizationUrl', () => {
+    it('should store masterCatalogConnectionId in Redis state when provided', async () => {
+      const masterCatalogConnectionId = '123e4567-e89b-12d3-a456-426614174000';
+
+      await service.generateAuthorizationUrl(
+        'cid',
+        'csec',
+        'https://example.com/cb',
+        'sandbox',
+        undefined,
+        'My Store',
+        masterCatalogConnectionId,
+      );
+
+      expect(redisClient.setEx).toHaveBeenCalledWith(
+        expect.stringMatching(/^allegro:oauth:state:/),
+        600,
+        expect.stringContaining(masterCatalogConnectionId),
+      );
+    });
+
+    it('should not include masterCatalogConnectionId in state when not provided', async () => {
+      await service.generateAuthorizationUrl('cid', 'csec', 'https://example.com/cb');
+
+      const rawCall = (redisClient.setEx).mock.calls[0] as unknown[];
+      const storedJson = JSON.parse(rawCall[2] as string) as Record<string, unknown>;
+
+      expect(storedJson.masterCatalogConnectionId).toBeUndefined();
+    });
+  });
+
+  describe('storeCredentialsAndCreateConnection', () => {
+    it('should set masterCatalogConnectionId in connection config when present in stateData', async () => {
+      const masterCatalogConnectionId = '123e4567-e89b-12d3-a456-426614174000';
+      credentialRepository.create.mockResolvedValue(undefined as never);
+      connectionService.create.mockResolvedValue({ id: 'conn-1', name: 'Test' } as never);
+
+      await service.storeCredentialsAndCreateConnection(
+        { access_token: 'tok', token_type: 'bearer' },
+        {
+          clientId: 'cid',
+          clientSecret: 'csec',
+          redirectUri: 'https://example.com/cb',
+          environment: 'sandbox',
+          masterCatalogConnectionId,
+        },
+      );
+
+      expect(connectionService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ masterCatalogConnectionId }),
+        }),
+      );
+    });
+
+    it('should not include masterCatalogConnectionId in config when absent from stateData', async () => {
+      credentialRepository.create.mockResolvedValue(undefined as never);
+      connectionService.create.mockResolvedValue({ id: 'conn-1', name: 'Test' } as never);
+
+      await service.storeCredentialsAndCreateConnection(
+        { access_token: 'tok', token_type: 'bearer' },
+        {
+          clientId: 'cid',
+          clientSecret: 'csec',
+          redirectUri: 'https://example.com/cb',
+          environment: 'sandbox',
+        },
+      );
+
+      const createCall = (connectionService.create as jest.Mock).mock.calls[0] as unknown[];
+      const createdConfig = (createCall[0] as { config: Record<string, unknown> }).config;
+      expect(createdConfig.masterCatalogConnectionId).toBeUndefined();
+    });
+  });
+
   describe('exchangeCodeForToken', () => {
     it('should throw BadRequestException when token endpoint returns non-OK status', async () => {
       global.fetch = jest.fn().mockResolvedValue({

--- a/apps/api/src/integrations/application/services/allegro-oauth.service.ts
+++ b/apps/api/src/integrations/application/services/allegro-oauth.service.ts
@@ -55,6 +55,7 @@ export class AllegroOAuthService implements IAllegroOAuthService {
     environment: string = 'sandbox',
     state?: string,
     connectionName?: string,
+    masterCatalogConnectionId?: string,
   ): Promise<AllegroOAuthAuthorizationResponse> {
     // Generate state if not provided
     const oauthState = state || randomBytes(32).toString('hex');
@@ -67,6 +68,7 @@ export class AllegroOAuthService implements IAllegroOAuthService {
       redirectUri,
       environment,
       connectionName,
+      masterCatalogConnectionId,
     };
     const stateKey = `allegro:oauth:state:${oauthState}`;
     await this.redisClient.setEx(
@@ -322,6 +324,9 @@ export class AllegroOAuthService implements IAllegroOAuthService {
     // Prepare connection config
     const config: AllegroConnectionConfig = {
       environment: stateData.environment as 'sandbox' | 'production',
+      ...(stateData.masterCatalogConnectionId
+        ? { masterCatalogConnectionId: stateData.masterCatalogConnectionId }
+        : {}),
     };
 
     // Create connection with database credentials reference

--- a/apps/api/src/integrations/http/allegro.controller.spec.ts
+++ b/apps/api/src/integrations/http/allegro.controller.spec.ts
@@ -118,6 +118,7 @@ describe('AllegroController', () => {
         'sandbox',
         undefined,
         'Test Connection',
+        undefined,
       );
     });
 
@@ -142,6 +143,7 @@ describe('AllegroController', () => {
         'test-client-secret',
         'https://example.com/callback',
         'sandbox',
+        undefined,
         undefined,
         undefined,
       );

--- a/apps/api/src/integrations/http/allegro.controller.ts
+++ b/apps/api/src/integrations/http/allegro.controller.ts
@@ -89,6 +89,7 @@ export class AllegroController {
       dto.environment || 'sandbox',
       dto.state,
       dto.connectionName,
+      dto.masterCatalogConnectionId,
     );
 
     return result;

--- a/apps/api/src/integrations/http/dto/allegro-oauth-connect.dto.ts
+++ b/apps/api/src/integrations/http/dto/allegro-oauth-connect.dto.ts
@@ -6,7 +6,7 @@
  *
  * @module apps/api/src/integrations/http/dto
  */
-import { IsString, IsNotEmpty, IsOptional, IsUrl } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsUrl, IsUUID } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
@@ -64,5 +64,13 @@ export class AllegroOAuthConnectDto {
   @IsString()
   @IsOptional()
   connectionName?: string;
+
+  @ApiPropertyOptional({
+    description: 'UUID of the ProductMaster connection to use for offer-product barcode linking',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsUUID()
+  @IsOptional()
+  masterCatalogConnectionId?: string;
 }
 

--- a/apps/web/src/features/allegro/api/allegro.api.ts
+++ b/apps/web/src/features/allegro/api/allegro.api.ts
@@ -4,6 +4,7 @@ export interface StartAllegroOAuthInput {
   redirectUri: string;
   environment?: 'sandbox' | 'production';
   connectionName?: string;
+  masterCatalogConnectionId?: string;
 }
 
 export interface StartAllegroOAuthResponse {

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
@@ -1,7 +1,9 @@
 import type { ReactElement } from 'react';
+import { useEffect } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { useStartAllegroOAuthMutation } from '../hooks/use-start-allegro-oauth-mutation';
+import { useProductMasterConnections } from '../../connections/hooks/use-product-master-connections';
 import {
   allegroSetupSchema,
   ALLEGRO_SETUP_DEFAULT_VALUES,
@@ -18,10 +20,18 @@ import { Select } from '../../../shared/ui/select';
 
 export function AllegroSetupForm(): ReactElement {
   const startOAuth = useStartAllegroOAuthMutation();
+  const { connectionsQuery, productMasterConnections, autoSelectedConnectionId } =
+    useProductMasterConnections();
   const form = useForm<AllegroSetupFormValues, undefined, AllegroSetupFormSubmission>({
     defaultValues: ALLEGRO_SETUP_DEFAULT_VALUES,
     resolver: zodResolver(allegroSetupSchema),
   });
+
+  useEffect(() => {
+    if (autoSelectedConnectionId) {
+      form.setValue('masterCatalogConnectionId', autoSelectedConnectionId);
+    }
+  }, [autoSelectedConnectionId, form]);
 
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : [],
@@ -108,6 +118,35 @@ export function AllegroSetupForm(): ReactElement {
             invalid={Boolean(form.formState.errors.clientSecret)}
             autoComplete="off"
           />
+        </FormField>
+
+        <FormField
+          label="Product catalog connection"
+          name="masterCatalogConnectionId"
+          error={form.formState.errors.masterCatalogConnectionId?.message}
+          description="Select the ProductMaster connection to use for offer-product barcode linking. Optional — can be configured later."
+        >
+          {connectionsQuery.isLoading ? (
+            <Select disabled>
+              <option>Loading connections…</option>
+            </Select>
+          ) : connectionsQuery.error ? (
+            <Select disabled>
+              <option>Failed to load connections</option>
+            </Select>
+          ) : (
+            <Select
+              {...form.register('masterCatalogConnectionId')}
+              invalid={Boolean(form.formState.errors.masterCatalogConnectionId)}
+            >
+              <option value="">None (configure later)</option>
+              {productMasterConnections.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </Select>
+          )}
         </FormField>
       </div>
 

--- a/apps/web/src/features/allegro/components/allegro-setup.schema.ts
+++ b/apps/web/src/features/allegro/components/allegro-setup.schema.ts
@@ -6,6 +6,8 @@ export const allegroSetupSchema = z.object({
   environment: z.enum(['sandbox', 'production']),
   clientId: z.string().trim().min(1, 'Client ID is required'),
   clientSecret: z.string().trim().min(1, 'Client secret is required'),
+  // Empty string is coerced to undefined so the backend IsUUID validator is never sent an empty string
+  masterCatalogConnectionId: z.string().uuid('Invalid connection ID').optional().or(z.literal('')).transform((v) => v || undefined),
 });
 
 export type AllegroSetupFormValues = z.input<typeof allegroSetupSchema>;
@@ -16,6 +18,7 @@ export const ALLEGRO_SETUP_DEFAULT_VALUES: AllegroSetupFormValues = {
   environment: 'sandbox',
   clientId: '',
   clientSecret: '',
+  masterCatalogConnectionId: '',
 };
 
 export function toStartOAuthInput(
@@ -28,5 +31,8 @@ export function toStartOAuthInput(
     redirectUri,
     environment: values.environment,
     connectionName: values.name,
+    ...(values.masterCatalogConnectionId
+      ? { masterCatalogConnectionId: values.masterCatalogConnectionId }
+      : {}),
   };
 }

--- a/apps/web/src/features/connections/hooks/use-product-master-connections.ts
+++ b/apps/web/src/features/connections/hooks/use-product-master-connections.ts
@@ -1,0 +1,26 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useConnectionsQuery } from './use-connections-query';
+import type { Connection } from '../api/connections.types';
+
+export interface ProductMasterConnectionsResult {
+  connectionsQuery: UseQueryResult<Connection[]>;
+  productMasterConnections: Connection[];
+  autoSelectedConnectionId: string | undefined;
+}
+
+/**
+ * Returns active ProductMaster connections and auto-selects the only one if exactly one exists.
+ * Encapsulates the fetch + filter + auto-select pattern used in integration setup forms.
+ */
+export function useProductMasterConnections(): ProductMasterConnectionsResult {
+  const connectionsQuery = useConnectionsQuery();
+
+  const productMasterConnections = (connectionsQuery.data ?? []).filter(
+    (c) => c.status === 'active' && c.enabledCapabilities.includes('ProductMaster'),
+  );
+
+  const autoSelectedConnectionId =
+    productMasterConnections.length === 1 ? productMasterConnections[0].id : undefined;
+
+  return { connectionsQuery, productMasterConnections, autoSelectedConnectionId };
+}

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -9,6 +9,7 @@ import type { ConnectionStatus } from '../../features/connections/api/connection
 import { EmptyState, ErrorState, LoadingState } from '../../shared/ui/feedback-state';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { Alert } from '../../shared/ui/alert';
 
 function toStatusTone(status: ConnectionStatus): StatusBadgeTone {
   switch (status) {
@@ -90,6 +91,14 @@ export function ConnectionDetailPage(): ReactElement {
           title="Connection not found"
           message="No connection data was returned for this route. Retry from the integrations list or verify the selected identifier."
         />
+      ) : null}
+      {connection &&
+      connection.enabledCapabilities.includes('Marketplace') &&
+      typeof connection.config.masterCatalogConnectionId !== 'string' ? (
+        <Alert tone="warning" title="Product catalog not linked">
+          Offer-to-product barcode linking is disabled. Edit this connection to select a ProductMaster
+          catalog connection, or barcode sync will be skipped.
+        </Alert>
       ) : null}
       {connection ? (
         <div className="workspace-grid">


### PR DESCRIPTION
## Summary

- Threads `masterCatalogConnectionId` through the Allegro OAuth redirect flow (same Redis state pattern as `connectionName`) so offer-product barcode linking is configured at connection creation time rather than silently disabled
- Adds a ProductMaster connection dropdown to the Allegro setup form with loading, error, and empty states; auto-selects if exactly one active ProductMaster connection exists
- Shows a warning `Alert` on the connection detail page when a Marketplace connection has no `masterCatalogConnectionId` set

## Changes

**Backend:**
- `OAuthStateData` — added `masterCatalogConnectionId?`
- `IAllegroOAuthService` — extended `generateAuthorizationUrl()` signature
- `AllegroOAuthService` — threads param through to Redis state and then into connection config
- `AllegroOAuthConnectDto` — added `masterCatalogConnectionId` (`IsUUID, IsOptional`)
- `AllegroController` — passes `dto.masterCatalogConnectionId` to service
- `allegro-oauth.service.spec.ts` — new tests for state storage and config propagation
- `allegro.controller.spec.ts` — updated call assertions for new parameter

**Frontend:**
- `allegro.api.ts` — added `masterCatalogConnectionId?` to `StartAllegroOAuthInput`
- `allegro-setup.schema.ts` — added Zod field with empty-string→undefined coercion to avoid backend `IsUUID` rejection
- `AllegroSetupForm.tsx` — consumes new `useProductMasterConnections` hook; renders dropdown with loading/error/empty states
- `use-product-master-connections.ts` — new hook encapsulating fetch + filter (active + ProductMaster) + auto-select logic
- `connection-detail-page.tsx` — warning alert when `Marketplace` connection lacks `masterCatalogConnectionId`

## Test plan

- [ ] Create a new Allegro connection with a ProductMaster connection selected — verify `config.masterCatalogConnectionId` is set on the created connection
- [ ] Create a new Allegro connection without selecting a catalog — verify `config.masterCatalogConnectionId` is absent and no backend error
- [ ] Open detail page for an active Allegro (Marketplace) connection without `masterCatalogConnectionId` — verify warning alert is shown
- [ ] Open detail page for a connection with `masterCatalogConnectionId` set — verify no warning shown
- [ ] With exactly one active ProductMaster connection, open the wizard — verify it is auto-selected in the dropdown
- [ ] With no active ProductMaster connections, open the wizard — dropdown shows only "None (configure later)"

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)