### PR TITLE
fix(dev): pin docker compose project name to prevent worktree container conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: openlinker
+
 services:
   postgres:
     image: postgres:16-alpine

--- a/docs/claude-code-workflow-guide.md
+++ b/docs/claude-code-workflow-guide.md
@@ -122,6 +122,22 @@ git push -u origin worktree-auth-api
 # Create PR from worktree-auth-api → main
 ```
 
+### Dev Stack in Worktrees
+
+**Never run `pnpm dev:stack:up` from inside a worktree.** The dev stack (Postgres, Redis, MySQL, PrestaShop) is shared across all worktrees — always manage it from the **main repo directory**.
+
+Worktrees connect to the already-running dev stack via localhost ports. For tests, use `pnpm test` (unit, no Docker) or `pnpm test:integration` (Testcontainers, isolated ephemeral containers).
+
+```bash
+# ✅ Correct — run from main repo only
+cd /path/to/openlinker
+pnpm dev:stack:up
+
+# Then start the app from the worktree — it connects to the shared stack
+cd .claude/worktrees/my-feature/
+pnpm start:dev:api
+```
+
 ### Environment Files in Worktrees
 
 Gitignored files (`.env`, `.env.local`) don't copy automatically. The `.worktreeinclude` file in the repo root fixes this — any file matching both `.worktreeinclude` and `.gitignore` gets copied into new worktrees.


### PR DESCRIPTION
## Summary

- Add `name: openlinker` to `docker-compose.yml` to pin the Compose project name regardless of the working directory
- Document the dev stack rule in `claude-code-workflow-guide.md`: always manage the dev stack from the main repo, never from worktrees

## Why

Without a fixed project name, Docker Compose derives it from the working directory. Running `pnpm dev:stack:up` from a git worktree produces a different project name, which creates new containers with the same `openlinker-*` names — conflicting with the main repo's containers. Neither `docker compose down` removes the other's containers, leaving orphans that block future starts.

## Test plan

- [ ] Run `pnpm dev:stack:up` from main repo — stack starts cleanly
- [ ] Run `pnpm dev:stack:down` then `pnpm dev:stack:up` again — no container name conflicts
- [ ] Verify `docker compose ps --project-name openlinker` lists the containers regardless of working directory

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)