### PR TITLE
refactor(web): remove redundant retry: false and add page tests

### DIFF
--- a/apps/web/src/features/connections/hooks/use-connection-diagnostics-query.ts
+++ b/apps/web/src/features/connections/hooks/use-connection-diagnostics-query.ts
@@ -12,6 +12,5 @@ export function useConnectionDiagnosticsQuery(
     queryKey: connectionsQueryKeys.diagnostics(connectionId ?? ''),
     queryFn: () => apiClient.connections.getDiagnostics(connectionId!),
     enabled: connectionId !== undefined && connectionId.length > 0,
-    retry: false,
   });
 }

--- a/apps/web/src/features/cursors/hooks/use-cursors-query.ts
+++ b/apps/web/src/features/cursors/hooks/use-cursors-query.ts
@@ -12,6 +12,5 @@ export function useCursorsQuery(
   return useQuery({
     queryKey: cursorsQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.cursors.list(filters, pagination),
-    retry: false,
   });
 }

--- a/apps/web/src/features/customers/hooks/use-customer-query.ts
+++ b/apps/web/src/features/customers/hooks/use-customer-query.ts
@@ -10,6 +10,5 @@ export function useCustomerQuery(id: string): UseQueryResult<CustomerProjectionD
     queryKey: customersQueryKeys.detail(id),
     queryFn: () => apiClient.customers.getById(id),
     enabled: id.length > 0,
-    retry: false,
   });
 }

--- a/apps/web/src/features/customers/hooks/use-customers-query.ts
+++ b/apps/web/src/features/customers/hooks/use-customers-query.ts
@@ -12,6 +12,5 @@ export function useCustomersQuery(
   return useQuery({
     queryKey: customersQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.customers.list(filters, pagination),
-    retry: false,
   });
 }

--- a/apps/web/src/features/health/hooks/use-dev-stack-health-query.ts
+++ b/apps/web/src/features/health/hooks/use-dev-stack-health-query.ts
@@ -9,6 +9,5 @@ export function useDevStackHealthQuery(): UseQueryResult<DevStackHealth> {
   return useQuery({
     queryKey: healthQueryKeys.devStack(),
     queryFn: () => apiClient.health.getDevStackHealth(),
-    retry: false,
   });
 }

--- a/apps/web/src/features/inventory/hooks/use-inventory-item-query.ts
+++ b/apps/web/src/features/inventory/hooks/use-inventory-item-query.ts
@@ -10,6 +10,5 @@ export function useInventoryItemQuery(id: string): UseQueryResult<InventoryItem>
     queryKey: inventoryQueryKeys.detail(id),
     queryFn: () => apiClient.inventory.getById(id),
     enabled: Boolean(id),
-    retry: false,
   });
 }

--- a/apps/web/src/features/inventory/hooks/use-inventory-query.ts
+++ b/apps/web/src/features/inventory/hooks/use-inventory-query.ts
@@ -12,6 +12,5 @@ export function useInventoryQuery(
   return useQuery({
     queryKey: inventoryQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.inventory.list(filters, pagination),
-    retry: false,
   });
 }

--- a/apps/web/src/features/listings/hooks/use-listing-query.ts
+++ b/apps/web/src/features/listings/hooks/use-listing-query.ts
@@ -10,6 +10,5 @@ export function useListingQuery(id: string): UseQueryResult<OfferMapping> {
     queryKey: listingsQueryKeys.detail(id),
     queryFn: () => apiClient.listings.getById(id),
     enabled: id.length > 0,
-    retry: false,
   });
 }

--- a/apps/web/src/features/listings/hooks/use-listings-query.ts
+++ b/apps/web/src/features/listings/hooks/use-listings-query.ts
@@ -12,6 +12,5 @@ export function useListingsQuery(
   return useQuery({
     queryKey: listingsQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.listings.list(filters, pagination),
-    retry: false,
   });
 }

--- a/apps/web/src/features/mappings/hooks/use-allegro-categories.ts
+++ b/apps/web/src/features/mappings/hooks/use-allegro-categories.ts
@@ -21,7 +21,6 @@ export function useAllegroCategoriesQuery(
     queryKey: mappingsQueryKeys.allegroCategories(connectionId, parentId),
     queryFn: () => apiClient.mappings.getAllegroCategories(connectionId, parentId),
     enabled,
-    retry: false,
     staleTime: 1000 * 60 * 60, // 1 hour — categories change infrequently
   });
 }

--- a/apps/web/src/features/mappings/hooks/use-carrier-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-carrier-mappings.ts
@@ -14,7 +14,6 @@ export function useCarrierMappingsQuery(connectionId: string): UseQueryResult<Ca
   return useQuery({
     queryKey: mappingsQueryKeys.carriers(connectionId),
     queryFn: () => apiClient.mappings.getCarrierMappings(connectionId),
-    retry: false,
   });
 }
 

--- a/apps/web/src/features/mappings/hooks/use-category-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-category-mappings.ts
@@ -16,7 +16,6 @@ export function useCategoryMappingsQuery(connectionId: string): UseQueryResult<C
   return useQuery({
     queryKey: mappingsQueryKeys.categories(connectionId),
     queryFn: () => apiClient.mappings.getCategoryMappings(connectionId),
-    retry: false,
   });
 }
 

--- a/apps/web/src/features/mappings/hooks/use-mapping-options.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-options.ts
@@ -35,32 +35,26 @@ export function useMappingOptions(connectionId: string): UseMappingOptionsResult
       {
         queryKey: [...mappingsQueryKeys.options(connectionId), 'allegro-statuses'],
         queryFn: () => apiClient.mappings.getAllegroOrderStatuses(connectionId),
-        retry: false,
       },
       {
         queryKey: [...mappingsQueryKeys.options(connectionId), 'allegro-delivery'],
         queryFn: () => apiClient.mappings.getAllegroDeliveryMethods(connectionId),
-        retry: false,
       },
       {
         queryKey: [...mappingsQueryKeys.options(connectionId), 'allegro-payments'],
         queryFn: () => apiClient.mappings.getAllegroPaymentProviders(connectionId),
-        retry: false,
       },
       {
         queryKey: [...mappingsQueryKeys.options(connectionId), 'ps-statuses'],
         queryFn: () => apiClient.mappings.getPrestashopOrderStatuses(connectionId),
-        retry: false,
       },
       {
         queryKey: [...mappingsQueryKeys.options(connectionId), 'ps-carriers'],
         queryFn: () => apiClient.mappings.getPrestashopCarriers(connectionId),
-        retry: false,
       },
       {
         queryKey: [...mappingsQueryKeys.options(connectionId), 'ps-payments'],
         queryFn: () => apiClient.mappings.getPrestashopPaymentModules(connectionId),
-        retry: false,
       },
     ],
   });

--- a/apps/web/src/features/mappings/hooks/use-payment-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-payment-mappings.ts
@@ -14,7 +14,6 @@ export function usePaymentMappingsQuery(connectionId: string): UseQueryResult<Pa
   return useQuery({
     queryKey: mappingsQueryKeys.payments(connectionId),
     queryFn: () => apiClient.mappings.getPaymentMappings(connectionId),
-    retry: false,
   });
 }
 

--- a/apps/web/src/features/mappings/hooks/use-prestashop-categories.ts
+++ b/apps/web/src/features/mappings/hooks/use-prestashop-categories.ts
@@ -31,6 +31,5 @@ export function usePrestashopCategoriesQuery(connectionId: string): UseQueryResu
           depth,
         }));
     },
-    retry: false,
   });
 }

--- a/apps/web/src/features/mappings/hooks/use-status-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-status-mappings.ts
@@ -16,7 +16,6 @@ export function useStatusMappingsQuery(connectionId: string): UseQueryResult<Sta
   return useQuery({
     queryKey: mappingsQueryKeys.status(connectionId),
     queryFn: () => apiClient.mappings.getStatusMappings(connectionId),
-    retry: false,
   });
 }
 

--- a/apps/web/src/features/orders/hooks/use-order-query.ts
+++ b/apps/web/src/features/orders/hooks/use-order-query.ts
@@ -10,6 +10,5 @@ export function useOrderQuery(internalOrderId: string): UseQueryResult<OrderReco
     queryKey: ordersQueryKeys.detail(internalOrderId),
     queryFn: () => apiClient.orders.getById(internalOrderId),
     enabled: Boolean(internalOrderId),
-    retry: false,
   });
 }

--- a/apps/web/src/features/orders/hooks/use-orders-query.ts
+++ b/apps/web/src/features/orders/hooks/use-orders-query.ts
@@ -12,6 +12,5 @@ export function useOrdersQuery(
   return useQuery({
     queryKey: ordersQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.orders.list(filters, pagination),
-    retry: false,
   });
 }

--- a/apps/web/src/features/products/hooks/use-product-query.ts
+++ b/apps/web/src/features/products/hooks/use-product-query.ts
@@ -10,6 +10,5 @@ export function useProductQuery(id: string): UseQueryResult<Product> {
     queryKey: productsQueryKeys.detail(id),
     queryFn: () => apiClient.products.getById(id),
     enabled: Boolean(id),
-    retry: false,
   });
 }

--- a/apps/web/src/features/products/hooks/use-products-query.ts
+++ b/apps/web/src/features/products/hooks/use-products-query.ts
@@ -12,6 +12,5 @@ export function useProductsQuery(
   return useQuery({
     queryKey: productsQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.products.list(filters, pagination),
-    retry: false,
   });
 }

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.ts
@@ -10,6 +10,5 @@ export function useSyncJobQuery(id: string): UseQueryResult<SyncJob> {
     queryKey: syncJobsQueryKeys.detail(id),
     queryFn: () => apiClient.syncJobs.getById(id),
     enabled: Boolean(id),
-    retry: false,
   });
 }

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts
@@ -12,6 +12,5 @@ export function useSyncJobsQuery(
   return useQuery({
     queryKey: syncJobsQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.syncJobs.list(filters, pagination),
-    retry: false,
   });
 }

--- a/apps/web/src/features/webhook-deliveries/hooks/use-webhook-deliveries-query.ts
+++ b/apps/web/src/features/webhook-deliveries/hooks/use-webhook-deliveries-query.ts
@@ -16,6 +16,5 @@ export function useWebhookDeliveriesQuery(
   return useQuery({
     queryKey: webhookDeliveriesQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.webhookDeliveries.list(filters, pagination),
-    retry: false,
   });
 }

--- a/apps/web/src/features/webhook-deliveries/hooks/use-webhook-delivery-query.ts
+++ b/apps/web/src/features/webhook-deliveries/hooks/use-webhook-delivery-query.ts
@@ -12,6 +12,5 @@ export function useWebhookDeliveryQuery(
     queryKey: webhookDeliveriesQueryKeys.detail(id ?? ''),
     queryFn: () => apiClient.webhookDeliveries.getById(id ?? ''),
     enabled: Boolean(id),
-    retry: false,
   });
 }

--- a/apps/web/src/pages/inventory/inventory-detail-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { InventoryDetailPage } from './inventory-detail-page';
+import type { InventoryItem } from '../../features/inventory/api/inventory.types';
+
+const sampleItem: InventoryItem = {
+  id: 'ol_inv_abc123',
+  productId: 'ol_product_abc123',
+  productVariantId: 'ol_variant_xyz',
+  availableQuantity: 10,
+  reservedQuantity: 2,
+  locationId: 'warehouse-1',
+  updatedAt: '2026-01-15T10:00:00.000Z',
+  productName: 'Test Product',
+  productSku: 'SKU-001',
+};
+
+function renderDetailPage(apiClient: ReturnType<typeof createMockApiClient>): void {
+  renderWithProviders(
+    <Routes>
+      <Route path="/inventory/:id" element={<InventoryDetailPage />} />
+    </Routes>,
+    { apiClient, route: '/inventory/ol_inv_abc123' },
+  );
+}
+
+describe('InventoryDetailPage', () => {
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      inventory: { getById: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+
+    renderDetailPage(mockApi);
+
+    expect(screen.getByText('Loading inventory item')).toBeInTheDocument();
+  });
+
+  it('should show inventory item detail when data loads', async () => {
+    const mockApi = createMockApiClient({
+      inventory: { getById: vi.fn().mockResolvedValue(sampleItem) },
+    });
+
+    renderDetailPage(mockApi);
+
+    expect(await screen.findByText('ol_inv_abc123')).toBeInTheDocument();
+    expect(screen.getByText('Test Product')).toBeInTheDocument();
+    expect(screen.getByText('SKU-001')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('warehouse-1')).toBeInTheDocument();
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      inventory: { getById: vi.fn().mockRejectedValue(new Error('Not found')) },
+    });
+
+    renderDetailPage(mockApi);
+
+    expect(await screen.findByText('Unable to load inventory item')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/inventory/inventory-list-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.test.tsx
@@ -1,0 +1,78 @@
+import { screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { InventoryListPage } from './inventory-list-page';
+import type { PaginatedInventory } from '../../features/inventory/api/inventory.types';
+
+const sampleInventory: PaginatedInventory = {
+  items: [
+    {
+      id: 'ol_inv_abc123',
+      productId: 'ol_product_abc123',
+      productVariantId: 'ol_variant_xyz',
+      availableQuantity: 10,
+      reservedQuantity: 2,
+      locationId: null,
+      updatedAt: '2026-01-15T10:00:00.000Z',
+      productName: 'Test Product',
+      productSku: 'SKU-001',
+    },
+  ],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+describe('InventoryListPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      inventory: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+
+    renderWithProviders(<InventoryListPage />, { apiClient: mockApi });
+
+    expect(screen.getByText('Loading inventory')).toBeInTheDocument();
+  });
+
+  it('should show inventory table when data loads', async () => {
+    const mockApi = createMockApiClient({
+      inventory: { list: vi.fn().mockResolvedValue(sampleInventory) },
+    });
+
+    renderWithProviders(<InventoryListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Test Product')).toBeInTheDocument();
+    expect(screen.getByText('SKU-001')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      inventory: { list: vi.fn().mockRejectedValue(new Error('Network error')) },
+    });
+
+    renderWithProviders(<InventoryListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Unable to load inventory')).toBeInTheDocument();
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no inventory items exist', async () => {
+    const mockApi = createMockApiClient({
+      inventory: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+    });
+
+    renderWithProviders(<InventoryListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No inventory items found')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/orders/failed-orders-page.test.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.test.tsx
@@ -37,6 +37,9 @@ describe('FailedOrdersPage', () => {
       syncJobs: {
         list: vi.fn().mockReturnValue(new Promise(() => {})),
       },
+      connections: {
+        list: vi.fn().mockResolvedValue([]),
+      },
     });
 
     renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
@@ -48,6 +51,9 @@ describe('FailedOrdersPage', () => {
     const mockApi = createMockApiClient({
       syncJobs: {
         list: vi.fn().mockResolvedValue(sampleData),
+      },
+      connections: {
+        list: vi.fn().mockResolvedValue([]),
       },
     });
 
@@ -62,6 +68,9 @@ describe('FailedOrdersPage', () => {
     const mockApi = createMockApiClient({
       syncJobs: {
         list: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+      connections: {
+        list: vi.fn().mockResolvedValue([]),
       },
     });
 
@@ -80,6 +89,9 @@ describe('FailedOrdersPage', () => {
           offset: 0,
         }),
       },
+      connections: {
+        list: vi.fn().mockResolvedValue([]),
+      },
     });
 
     renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
@@ -91,6 +103,9 @@ describe('FailedOrdersPage', () => {
     const mockApi = createMockApiClient({
       syncJobs: {
         list: vi.fn().mockResolvedValue(sampleData),
+      },
+      connections: {
+        list: vi.fn().mockResolvedValue([]),
       },
     });
 

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -1,0 +1,68 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { OrdersListPage } from './orders-list-page';
+import type { PaginatedOrders } from '../../features/orders/api/orders.types';
+
+const sampleOrders: PaginatedOrders = {
+  items: [
+    {
+      internalOrderId: 'ol_order_abc123',
+      customerId: 'ol_customer_xyz',
+      sourceConnectionId: 'conn_allegro_1',
+      sourceEventId: null,
+      orderSnapshot: {},
+      syncStatus: [{ destinationConnectionId: 'conn_ps_1', status: 'synced', syncedAt: '2026-01-15T10:00:00.000Z', externalOrderId: '42', externalOrderNumber: null, error: null }],
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:00:00.000Z',
+    },
+  ],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+describe('OrdersListPage', () => {
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    expect(screen.getByText('Loading orders')).toBeInTheDocument();
+  });
+
+  it('should show orders table when data loads', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(sampleOrders) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('ol_order_abc123')).toBeInTheDocument();
+    expect(screen.getByText('conn_allegro_1')).toBeInTheDocument();
+    expect(screen.getByText('ol_customer_xyz')).toBeInTheDocument();
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockRejectedValue(new Error('Network error')) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Unable to load orders')).toBeInTheDocument();
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no orders exist', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No orders found')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { SyncJobDetailPage } from './sync-job-detail-page';
+import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
+
+const sampleJob: SyncJob = {
+  id: 'job_abc12345-1111-2222-3333-444444444444',
+  jobType: 'marketplace.orders.poll',
+  connectionId: 'conn_allegro_1',
+  status: 'succeeded',
+  attempts: 1,
+  maxAttempts: 3,
+  nextRunAt: '2026-01-15T10:05:00.000Z',
+  lastError: null,
+  payloadJson: null,
+  idempotencyKey: 'idem_key_1',
+  lockedAt: null,
+  lockedBy: null,
+  createdAt: '2026-01-15T10:00:00.000Z',
+  updatedAt: '2026-01-15T10:01:00.000Z',
+};
+
+function renderDetailPage(apiClient: ReturnType<typeof createMockApiClient>): void {
+  renderWithProviders(
+    <Routes>
+      <Route path="/sync-jobs/:id" element={<SyncJobDetailPage />} />
+    </Routes>,
+    { apiClient, route: '/sync-jobs/job_abc12345-1111-2222-3333-444444444444' },
+  );
+}
+
+describe('SyncJobDetailPage', () => {
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { getById: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+
+    renderDetailPage(mockApi);
+
+    expect(screen.getByText('Loading job')).toBeInTheDocument();
+  });
+
+  it('should show job detail when data loads', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { getById: vi.fn().mockResolvedValue(sampleJob) },
+    });
+
+    renderDetailPage(mockApi);
+
+    expect(await screen.findByText('marketplace.orders.poll')).toBeInTheDocument();
+    expect(screen.getByText('conn_allegro_1')).toBeInTheDocument();
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    expect(screen.getByText('idem_key_1')).toBeInTheDocument();
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { getById: vi.fn().mockRejectedValue(new Error('Not found')) },
+    });
+
+    renderDetailPage(mockApi);
+
+    expect(await screen.findByText('Unable to load job')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
@@ -47,6 +47,7 @@ describe('SyncJobsPage', () => {
     renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
 
     expect(await screen.findByText(/1 \/ 3/)).toBeInTheDocument();
+    expect(screen.getAllByText('marketplace.orders.poll').length).toBeGreaterThan(1);
   });
 
   it('should show error state when fetch fails', async () => {

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
@@ -1,0 +1,72 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { SyncJobsPage } from './sync-jobs-page';
+import type { PaginatedSyncJobs } from '../../features/sync-jobs/api/sync-jobs.types';
+
+const sampleJobs: PaginatedSyncJobs = {
+  items: [
+    {
+      id: 'job_abc12345-1111-2222-3333-444444444444',
+      jobType: 'marketplace.orders.poll',
+      connectionId: 'conn_allegro_1',
+      status: 'succeeded',
+      attempts: 1,
+      maxAttempts: 3,
+      nextRunAt: '2026-01-15T10:05:00.000Z',
+      lastError: null,
+      payloadJson: null,
+      idempotencyKey: null,
+      lockedAt: null,
+      lockedBy: null,
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:01:00.000Z',
+    },
+  ],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+describe('SyncJobsPage', () => {
+  it('should show loading state initially', () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+
+    renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+    expect(screen.getByText('Loading jobs')).toBeInTheDocument();
+  });
+
+  it('should show jobs table when data loads', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { list: vi.fn().mockResolvedValue(sampleJobs) },
+    });
+
+    renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText(/1 \/ 3/)).toBeInTheDocument();
+  });
+
+  it('should show error state when fetch fails', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { list: vi.fn().mockRejectedValue(new Error('Service unavailable')) },
+    });
+
+    renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Unable to load sync jobs')).toBeInTheDocument();
+    expect(screen.getByText('Service unavailable')).toBeInTheDocument();
+  });
+
+  it('should show empty state when no jobs exist', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+    });
+
+    renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No jobs found')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Remove `retry: false` duplication from 24 query hooks — it's already set globally in `QueryClient.defaultOptions` (`apps/web/src/app/providers/app-providers.tsx:16`)
- Add missing page-level tests for 6 pages using the established `createMockApiClient` + `renderWithProviders` pattern: orders-list, failed-orders, inventory-list, inventory-detail, sync-jobs, sync-job-detail
- Inventory list test uses `vi.useFakeTimers({ shouldAdvanceTime: true })` to handle the 300ms debounced search input

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 189 web + 241 API + 97 worker tests pass
- [x] Manually verified global `retry: false` in `app-providers.tsx` before wholesale removal
- [x] Verified `use-dev-stack-health-query.ts` had no intentional retry policy

Closes #230
Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)