### PR TITLE
feat(web): centralize date formatting and add dashboard auto-refresh

### DIFF
--- a/apps/web/src/features/connections/components/ConnectionDiagnosticsPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionDiagnosticsPanel.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import { useConnectionDiagnosticsQuery } from '../hooks/use-connection-diagnostics-query';
 import type { RecentJobSummary } from '../api/connections.types';
 import { DataTable, type DataTableColumn } from '../../../shared/ui/data-table';
+import { formatDateTime } from '../../../shared/format/format-date';
 import { LoadingState, ErrorState } from '../../../shared/ui/feedback-state';
 import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
 
@@ -26,7 +27,7 @@ function toJobStatusTone(status: string): StatusBadgeTone {
 
 function formatDate(value: string | null): string {
   if (value === null) return 'Never';
-  return new Date(value).toLocaleString();
+  return formatDateTime(value);
 }
 
 const jobColumns: DataTableColumn<RecentJobSummary>[] = [

--- a/apps/web/src/features/connections/hooks/use-connections-query.ts
+++ b/apps/web/src/features/connections/hooks/use-connections-query.ts
@@ -3,11 +3,15 @@ import { connectionsQueryKeys } from '../api/connections.query-keys';
 import type { Connection, ConnectionFilters } from '../api/connections.types';
 import { useApiClient } from '../../../app/api/api-client-provider';
 
-export function useConnectionsQuery(filters?: ConnectionFilters): UseQueryResult<Connection[]> {
+export function useConnectionsQuery(
+  filters?: ConnectionFilters,
+  options?: { refetchInterval?: number | false },
+): UseQueryResult<Connection[]> {
   const apiClient = useApiClient();
 
   return useQuery({
     queryKey: connectionsQueryKeys.list(filters),
     queryFn: () => apiClient.connections.list(filters),
+    ...options,
   });
 }

--- a/apps/web/src/features/health/hooks/use-dev-stack-health-query.ts
+++ b/apps/web/src/features/health/hooks/use-dev-stack-health-query.ts
@@ -3,12 +3,15 @@ import { useApiClient } from '../../../app/api/api-client-provider';
 import { healthQueryKeys } from '../api/health.query-keys';
 import type { DevStackHealth } from '../api/health.types';
 
-export function useDevStackHealthQuery(): UseQueryResult<DevStackHealth> {
+export function useDevStackHealthQuery(
+  options?: { refetchInterval?: number | false },
+): UseQueryResult<DevStackHealth> {
   const apiClient = useApiClient();
 
   return useQuery({
     queryKey: healthQueryKeys.devStack(),
     queryFn: () => apiClient.health.getDevStackHealth(),
     retry: false,
+    ...options,
   });
 }

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts
@@ -6,6 +6,7 @@ import { useApiClient } from '../../../app/api/api-client-provider';
 export function useSyncJobsQuery(
   filters?: SyncJobFilters,
   pagination?: SyncJobPagination,
+  options?: { refetchInterval?: number | false },
 ): UseQueryResult<PaginatedSyncJobs> {
   const apiClient = useApiClient();
 
@@ -13,5 +14,6 @@ export function useSyncJobsQuery(
     queryKey: syncJobsQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.syncJobs.list(filters, pagination),
     retry: false,
+    ...options,
   });
 }

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -8,6 +8,7 @@ import { ConnectionDiagnosticsPanel } from '../../features/connections/component
 import type { ConnectionStatus } from '../../features/connections/api/connections.types';
 import { EmptyState, ErrorState, LoadingState } from '../../shared/ui/feedback-state';
 import { PageLayout } from '../../shared/ui/page-layout';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { Alert } from '../../shared/ui/alert';
 
@@ -63,7 +64,7 @@ export function ConnectionDetailPage(): ReactElement {
               <StatusBadge tone={toStatusTone(connection.status)}>{connection.status}</StatusBadge>
             </div>
             <div className="toolbar__group">
-              <span className="muted-text">Created {new Date(connection.createdAt).toLocaleDateString()}</span>
+              <span className="muted-text">Created <TimeDisplay iso={connection.createdAt} format="date" /></span>
             </div>
           </>
         ) : undefined
@@ -134,7 +135,7 @@ export function ConnectionDetailPage(): ReactElement {
               </div>
               <div>
                 <dt>Last updated</dt>
-                <dd>{new Date(connection.updatedAt).toLocaleString()}</dd>
+                <dd><TimeDisplay iso={connection.updatedAt} /></dd>
               </div>
             </dl>
           </div>

--- a/apps/web/src/pages/cursors/cursors-list-page.tsx
+++ b/apps/web/src/pages/cursors/cursors-list-page.tsx
@@ -6,6 +6,7 @@ import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-s
 import { Button } from '../../shared/ui/button';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { formatRelativeTime } from '../../shared/format/format-relative-time';
+import { formatDateTime } from '../../shared/format/format-date';
 import { useCursorsQuery } from '../../features/cursors/hooks/use-cursors-query';
 import type { Cursor, CursorFilters } from '../../features/cursors/api/cursors.types';
 
@@ -36,7 +37,7 @@ const COLUMNS: DataTableColumn<Cursor>[] = [
     id: 'updatedAt',
     header: 'Last Updated',
     cell: (cursor) => (
-      <span title={new Date(cursor.updatedAt).toLocaleString()}>
+      <span title={formatDateTime(cursor.updatedAt)}>
         {formatRelativeTime(cursor.updatedAt)}
       </span>
     ),

--- a/apps/web/src/pages/customers/customer-detail-page.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useCustomerQuery } from '../../features/customers/hooks/use-customer-query';
 import type { CustomerAddress } from '../../features/customers/api/customers.types';
 
@@ -39,7 +40,7 @@ const ADDRESS_COLUMNS: DataTableColumn<CustomerAddress>[] = [
   {
     id: 'lastSeenAt',
     header: 'Last Seen',
-    cell: (a) => new Date(a.lastSeenAt).toLocaleDateString(),
+    cell: (a) => <TimeDisplay iso={a.lastSeenAt} format="date" />,
   },
 ];
 
@@ -116,15 +117,15 @@ export function CustomerDetailPage(): ReactElement {
           </div>
           <div className="detail-list__row">
             <dt>Last Seen</dt>
-            <dd>{new Date(customer.lastSeenAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={customer.lastSeenAt} /></dd>
           </div>
           <div className="detail-list__row">
             <dt>Created</dt>
-            <dd>{new Date(customer.createdAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={customer.createdAt} /></dd>
           </div>
           <div className="detail-list__row">
             <dt>Updated</dt>
-            <dd>{new Date(customer.updatedAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={customer.updatedAt} /></dd>
           </div>
         </dl>
       </section>

--- a/apps/web/src/pages/customers/customers-list-page.tsx
+++ b/apps/web/src/pages/customers/customers-list-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useCustomersQuery } from '../../features/customers/hooks/use-customers-query';
 import type { CustomerFilters, CustomerProjection } from '../../features/customers/api/customers.types';
@@ -43,7 +44,7 @@ const COLUMNS: DataTableColumn<CustomerProjection>[] = [
   {
     id: 'lastSeenAt',
     header: 'Last Seen',
-    cell: (c): ReactNode => new Date(c.lastSeenAt).toLocaleDateString(),
+    cell: (c): ReactNode => <TimeDisplay iso={c.lastSeenAt} format="date" />,
   },
   {
     id: 'detail',

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -6,11 +6,13 @@ import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-q
 import type { ServiceHealth, ServiceStatus, OverallStatus } from '../../features/health/api/health.types';
 import type { Connection } from '../../features/connections/api/connections.types';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
+import { DASHBOARD_HEALTH_INTERVAL_MS, DASHBOARD_JOBS_INTERVAL_MS } from '../../shared/config/dashboard-intervals';
 import { Button } from '../../shared/ui/button';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { TimeDisplay } from '../../shared/ui/time-display';
 
 function toStatusTone(status: string): StatusBadgeTone {
   if (status === 'active' || status === 'succeeded') return 'success';
@@ -20,16 +22,6 @@ function toStatusTone(status: string): StatusBadgeTone {
   return 'neutral';
 }
 
-function formatRelativeTime(iso: string, now: number = Date.now()): string {
-  const diff = now - new Date(iso).getTime();
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 1) return 'just now';
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
 function formatJobType(jobType: string): string {
   return jobType.replaceAll('.', ' › ');
@@ -52,7 +44,7 @@ const updatedAtColumn: DataTableColumn<SyncJob> = {
   id: 'updatedAt',
   header: 'Updated',
   align: 'right',
-  cell: (row) => <span className="muted-text">{formatRelativeTime(row.updatedAt)}</span>,
+  cell: (row) => <span className="muted-text"><TimeDisplay iso={row.updatedAt} format="relative" /></span>,
 };
 
 const recentJobColumns: DataTableColumn<SyncJob>[] = [
@@ -127,11 +119,11 @@ function ConnectionHealthList({ connections }: { connections: Connection[] }): R
 }
 
 export function DashboardPage(): ReactElement {
-  const connectionsQuery = useConnectionsQuery();
-  const healthQuery = useDevStackHealthQuery();
-  const recentJobsQuery = useSyncJobsQuery(undefined, { limit: 5 });
-  const queuedJobsQuery = useSyncJobsQuery({ status: 'queued' }, { limit: 1 });
-  const deadJobsQuery = useSyncJobsQuery({ status: 'dead' }, { limit: 10 });
+  const connectionsQuery = useConnectionsQuery(undefined, { refetchInterval: DASHBOARD_HEALTH_INTERVAL_MS });
+  const healthQuery = useDevStackHealthQuery({ refetchInterval: DASHBOARD_HEALTH_INTERVAL_MS });
+  const recentJobsQuery = useSyncJobsQuery(undefined, { limit: 5 }, { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS });
+  const queuedJobsQuery = useSyncJobsQuery({ status: 'queued' }, { limit: 1 }, { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS });
+  const deadJobsQuery = useSyncJobsQuery({ status: 'dead' }, { limit: 10 }, { refetchInterval: DASHBOARD_JOBS_INTERVAL_MS });
 
   const connections = connectionsQuery.data ?? [];
   const activeCount = connections.filter((c) => c.status === 'active').length;

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -6,7 +6,7 @@ import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-q
 import type { ServiceHealth, ServiceStatus, OverallStatus } from '../../features/health/api/health.types';
 import type { Connection } from '../../features/connections/api/connections.types';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
-import { DASHBOARD_HEALTH_INTERVAL_MS, DASHBOARD_JOBS_INTERVAL_MS } from '../../shared/config/dashboard-intervals';
+import { DASHBOARD_HEALTH_INTERVAL_MS, DASHBOARD_JOBS_INTERVAL_MS } from './intervals';
 import { Button } from '../../shared/ui/button';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
@@ -44,7 +44,7 @@ const updatedAtColumn: DataTableColumn<SyncJob> = {
   id: 'updatedAt',
   header: 'Updated',
   align: 'right',
-  cell: (row) => <span className="muted-text"><TimeDisplay iso={row.updatedAt} format="relative" /></span>,
+  cell: (row) => <TimeDisplay iso={row.updatedAt} format="relative" className="muted-text" />,
 };
 
 const recentJobColumns: DataTableColumn<SyncJob>[] = [

--- a/apps/web/src/pages/dashboard/intervals.ts
+++ b/apps/web/src/pages/dashboard/intervals.ts
@@ -4,7 +4,7 @@
  * Centralised interval constants for dashboard auto-refresh. Tune here to
  * adjust polling frequency without touching individual query call-sites.
  *
- * @module apps/web/src/shared/config
+ * @module apps/web/src/pages/dashboard
  */
 
 export const DASHBOARD_HEALTH_INTERVAL_MS = 30_000;

--- a/apps/web/src/pages/inventory/inventory-detail-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useInventoryItemQuery } from '../../features/inventory/hooks/use-inventory-item-query';
 
 export function InventoryDetailPage(): ReactElement {
@@ -95,7 +96,7 @@ export function InventoryDetailPage(): ReactElement {
           </div>
           <div className="detail-list__row">
             <dt>Updated</dt>
-            <dd>{new Date(item.updatedAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={item.updatedAt} /></dd>
           </div>
         </dl>
       </section>

--- a/apps/web/src/pages/inventory/inventory-list-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useInventoryQuery } from '../../features/inventory/hooks/use-inventory-query';
 import type { InventoryItem, InventoryFilters } from '../../features/inventory/api/inventory.types';
@@ -74,7 +75,7 @@ const COLUMNS: DataTableColumn<InventoryItem>[] = [
   {
     id: 'updatedAt',
     header: 'Updated',
-    cell: (item) => new Date(item.updatedAt).toLocaleDateString(),
+    cell: (item) => <TimeDisplay iso={item.updatedAt} format="date" />,
   },
   {
     id: 'detail',

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
 import { EditOfferDrawer } from '../../features/listings/components/EditOfferDrawer';
 
@@ -78,11 +79,11 @@ export function ListingDetailPage(): ReactElement {
           </div>
           <div className="detail-list__row">
             <dt>Created</dt>
-            <dd>{new Date(mapping.createdAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={mapping.createdAt} /></dd>
           </div>
           <div className="detail-list__row">
             <dt>Updated</dt>
-            <dd>{new Date(mapping.updatedAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={mapping.updatedAt} /></dd>
           </div>
         </dl>
       </section>

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
 import type { ListingsFilters, OfferMapping } from '../../features/listings/api/listings.types';
@@ -40,7 +41,7 @@ const COLUMNS: DataTableColumn<OfferMapping>[] = [
   {
     id: 'createdAt',
     header: 'Created',
-    cell: (m): ReactNode => new Date(m.createdAt).toLocaleDateString(),
+    cell: (m): ReactNode => <TimeDisplay iso={m.createdAt} format="date" />,
   },
   {
     id: 'detail',

--- a/apps/web/src/pages/orders/failed-orders-page.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.tsx
@@ -18,6 +18,7 @@ import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-q
 import { useRetrySyncJobMutation } from '../../features/sync-jobs/hooks/use-retry-sync-job-mutation';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { useToast } from '../../shared/ui/toast-provider';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import type { SyncJob, SyncJobFilters } from '../../features/sync-jobs/api/sync-jobs.types';
 
 const PAGE_SIZE = 25;
@@ -75,7 +76,7 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
   {
     id: 'updatedAt',
     header: 'Failed At',
-    cell: (job) => new Date(job.updatedAt).toLocaleString(),
+    cell: (job) => <TimeDisplay iso={job.updatedAt} />,
   },
   {
     id: 'lastError',

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -5,6 +5,7 @@ import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useOrderQuery } from '../../features/orders/hooks/use-order-query';
 import type { OrderSyncStatus, OrderSyncStatusValue } from '../../features/orders/api/orders.types';
 
@@ -55,7 +56,7 @@ const SYNC_COLUMNS: DataTableColumn<OrderSyncStatus>[] = [
     header: 'Synced At',
     cell: (s) =>
       s.syncedAt ? (
-        new Date(s.syncedAt).toLocaleString()
+        <TimeDisplay iso={s.syncedAt} />
       ) : (
         <span className="text-muted">—</span>
       ),
@@ -146,11 +147,11 @@ export function OrderDetailPage(): ReactElement {
           </div>
           <div className="detail-list__row">
             <dt>Created</dt>
-            <dd>{new Date(order.createdAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={order.createdAt} /></dd>
           </div>
           <div className="detail-list__row">
             <dt>Updated</dt>
-            <dd>{new Date(order.updatedAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={order.updatedAt} /></dd>
           </div>
         </dl>
       </section>

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -5,6 +5,7 @@ import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { Select } from '../../shared/ui/select';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
 import type { OrderRecord, OrderFilters, OrderSyncStatusValue } from '../../features/orders/api/orders.types';
@@ -65,7 +66,7 @@ const COLUMNS: DataTableColumn<OrderRecord>[] = [
   {
     id: 'createdAt',
     header: 'Created',
-    cell: (order) => new Date(order.createdAt).toLocaleDateString(),
+    cell: (order) => <TimeDisplay iso={order.createdAt} format="date" />,
   },
   {
     id: 'detail',

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useProductQuery } from '../../features/products/hooks/use-product-query';
 import { ExternalIdsList } from '../../features/products/components/ExternalIdsList';
 import { useInventoryQuery } from '../../features/inventory/hooks/use-inventory-query';
@@ -175,11 +176,11 @@ export function ProductDetailPage(): ReactElement {
           </div>
           <div className="detail-list__row">
             <dt>Created</dt>
-            <dd>{new Date(product.createdAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={product.createdAt} /></dd>
           </div>
           <div className="detail-list__row">
             <dt>Updated</dt>
-            <dd>{new Date(product.updatedAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={product.updatedAt} /></dd>
           </div>
           {product.description ? (
             <div className="detail-list__row">

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useProductsQuery } from '../../features/products/hooks/use-products-query';
 import type { Product, ProductFilters } from '../../features/products/api/products.types';
@@ -37,7 +38,7 @@ const COLUMNS: DataTableColumn<Product>[] = [
   {
     id: 'createdAt',
     header: 'Created',
-    cell: (product) => new Date(product.createdAt).toLocaleDateString(),
+    cell: (product) => <TimeDisplay iso={product.createdAt} format="date" />,
   },
   {
     id: 'detail',

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobStatusBadge';
 import { useSyncJobQuery } from '../../features/sync-jobs/hooks/use-sync-job-query';
 
@@ -65,15 +66,15 @@ export function SyncJobDetailPage(): ReactElement {
           </div>
           <div className="detail-list__row">
             <dt>Next run at</dt>
-            <dd>{new Date(job.nextRunAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={job.nextRunAt} /></dd>
           </div>
           <div className="detail-list__row">
             <dt>Created</dt>
-            <dd>{new Date(job.createdAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={job.createdAt} /></dd>
           </div>
           <div className="detail-list__row">
             <dt>Updated</dt>
-            <dd>{new Date(job.updatedAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={job.updatedAt} /></dd>
           </div>
           {job.idempotencyKey ? (
             <div className="detail-list__row">
@@ -84,7 +85,7 @@ export function SyncJobDetailPage(): ReactElement {
           {job.lockedAt ? (
             <div className="detail-list__row">
               <dt>Locked at</dt>
-              <dd>{new Date(job.lockedAt).toLocaleString()}</dd>
+              <dd><TimeDisplay iso={job.lockedAt} /></dd>
             </div>
           ) : null}
           {job.lockedBy ? (

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobStatusBadge';
 import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
 import type { SyncJob, SyncJobFilters, JobStatus, JobType } from '../../features/sync-jobs/api/sync-jobs.types';
@@ -48,7 +49,7 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
   {
     id: 'createdAt',
     header: 'Created',
-    cell: (job) => new Date(job.createdAt).toLocaleString(),
+    cell: (job) => <TimeDisplay iso={job.createdAt} />,
   },
   {
     id: 'detail',

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
@@ -5,6 +5,7 @@ import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { StatusBadge } from '../../shared/ui/status-badge';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useWebhookDeliveriesQuery } from '../../features/webhook-deliveries/hooks/use-webhook-deliveries-query';
 import {
   WEBHOOK_DELIVERY_STATUS_VALUES,
@@ -68,7 +69,7 @@ const COLUMNS: DataTableColumn<WebhookDeliverySummary>[] = [
   {
     id: 'receivedAt',
     header: 'Received',
-    cell: (d) => new Date(d.receivedAt).toLocaleString(),
+    cell: (d) => <TimeDisplay iso={d.receivedAt} />,
   },
   {
     id: 'detail',

--- a/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { TimeDisplay } from '../../shared/ui/time-display';
 import { useWebhookDeliveryQuery } from '../../features/webhook-deliveries/hooks/use-webhook-delivery-query';
 import type { WebhookDeliveryStatus } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
 
@@ -120,7 +121,7 @@ export function WebhookDeliveryDetailPage(): ReactElement {
           ) : null}
           <div className="detail-list__row">
             <dt>Received</dt>
-            <dd>{new Date(d.receivedAt).toLocaleString()}</dd>
+            <dd><TimeDisplay iso={d.receivedAt} /></dd>
           </div>
         </dl>
       </section>

--- a/apps/web/src/shared/config/dashboard-intervals.ts
+++ b/apps/web/src/shared/config/dashboard-intervals.ts
@@ -1,0 +1,11 @@
+/**
+ * Dashboard Polling Intervals
+ *
+ * Centralised interval constants for dashboard auto-refresh. Tune here to
+ * adjust polling frequency without touching individual query call-sites.
+ *
+ * @module apps/web/src/shared/config
+ */
+
+export const DASHBOARD_HEALTH_INTERVAL_MS = 30_000;
+export const DASHBOARD_JOBS_INTERVAL_MS = 60_000;

--- a/apps/web/src/shared/format/format-date.ts
+++ b/apps/web/src/shared/format/format-date.ts
@@ -1,0 +1,17 @@
+/**
+ * Date Formatters
+ *
+ * Centralised date/time formatting utilities. All functions use the browser's
+ * locale so output respects the user's regional settings.
+ *
+ * @module apps/web/src/shared/format
+ * @see {@link formatRelativeTime} for relative ("5m ago") formatting
+ */
+
+export function formatAbsoluteDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { dateStyle: 'medium' });
+}
+
+export function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}

--- a/apps/web/src/shared/format/format-relative-time.ts
+++ b/apps/web/src/shared/format/format-relative-time.ts
@@ -2,8 +2,8 @@
  * Format Relative Time
  *
  * Converts an ISO 8601 timestamp to a human-readable relative time string
- * (e.g., "5m ago", "2h ago", "3d ago"). Useful for displaying recency
- * in data tables and status displays.
+ * (e.g., "just now", "5m ago", "2h ago", "3d ago"). Useful for displaying
+ * recency in data tables and status displays.
  *
  * @module apps/web/src/shared/format
  */
@@ -11,7 +11,7 @@
 export function formatRelativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();
   const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 60) return 'just now';
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m ago`;
   const hours = Math.floor(minutes / 60);

--- a/apps/web/src/shared/ui/time-display.test.tsx
+++ b/apps/web/src/shared/ui/time-display.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { TimeDisplay } from './time-display';
+
+const ISO = '2024-06-15T10:30:00.000Z';
+
+describe('TimeDisplay', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders a <time> element with the iso as dateTime attribute', () => {
+    const { container } = render(<TimeDisplay iso={ISO} />);
+    const el = container.querySelector('time');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('dateTime')).toBe(ISO);
+  });
+
+  it('renders datetime format by default', () => {
+    const { container } = render(<TimeDisplay iso={ISO} />);
+    const el = container.querySelector('time');
+    // Should contain both date and time portions — not empty
+    expect(el?.textContent).toBeTruthy();
+  });
+
+  it('renders date-only format when format="date"', () => {
+    const { container } = render(<TimeDisplay iso={ISO} format="date" />);
+    const el = container.querySelector('time');
+    expect(el?.textContent).toBeTruthy();
+  });
+
+  it('renders relative format when format="relative"', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T10:35:00.000Z')); // 5 min after ISO
+    const { container } = render(<TimeDisplay iso={ISO} format="relative" />);
+    const el = container.querySelector('time');
+    expect(el?.textContent).toBe('5m ago');
+  });
+});

--- a/apps/web/src/shared/ui/time-display.test.tsx
+++ b/apps/web/src/shared/ui/time-display.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { TimeDisplay } from './time-display';
@@ -13,13 +14,12 @@ describe('TimeDisplay', () => {
     const { container } = render(<TimeDisplay iso={ISO} />);
     const el = container.querySelector('time');
     expect(el).not.toBeNull();
-    expect(el?.getAttribute('dateTime')).toBe(ISO);
+    expect(el?.getAttribute('datetime')).toBe(ISO);
   });
 
   it('renders datetime format by default', () => {
     const { container } = render(<TimeDisplay iso={ISO} />);
     const el = container.querySelector('time');
-    // Should contain both date and time portions — not empty
     expect(el?.textContent).toBeTruthy();
   });
 
@@ -35,5 +35,21 @@ describe('TimeDisplay', () => {
     const { container } = render(<TimeDisplay iso={ISO} format="relative" />);
     const el = container.querySelector('time');
     expect(el?.textContent).toBe('5m ago');
+  });
+
+  it('forwards ref to the native <time> element', () => {
+    const ref = createRef<HTMLTimeElement>();
+    render(<TimeDisplay iso={ISO} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLTimeElement);
+  });
+
+  it('applies the className prop to the <time> element', () => {
+    const { container } = render(<TimeDisplay iso={ISO} className="muted-text" />);
+    expect(container.querySelector('time')).toHaveClass('muted-text');
+  });
+
+  it('spreads extra props (e.g., title) onto the <time> element', () => {
+    const { container } = render(<TimeDisplay iso={ISO} title="Hover me" />);
+    expect(container.querySelector('time')?.getAttribute('title')).toBe('Hover me');
   });
 });

--- a/apps/web/src/shared/ui/time-display.tsx
+++ b/apps/web/src/shared/ui/time-display.tsx
@@ -7,20 +7,26 @@
  * @module apps/web/src/shared/ui
  */
 
-import type { ReactElement } from 'react';
+import { forwardRef, type ComponentPropsWithoutRef } from 'react';
 import { formatAbsoluteDate, formatDateTime } from '../format/format-date';
 import { formatRelativeTime } from '../format/format-relative-time';
 
-interface TimeDisplayProps {
+interface TimeDisplayProps extends Omit<ComponentPropsWithoutRef<'time'>, 'dateTime' | 'children'> {
   iso: string;
   format?: 'date' | 'datetime' | 'relative';
 }
 
-export function TimeDisplay({ iso, format = 'datetime' }: TimeDisplayProps): ReactElement {
-  const label =
-    format === 'relative' ? formatRelativeTime(iso) :
-    format === 'date'     ? formatAbsoluteDate(iso) :
-                            formatDateTime(iso);
+export const TimeDisplay = forwardRef<HTMLTimeElement, TimeDisplayProps>(
+  function TimeDisplay({ iso, format = 'datetime', className = '', ...props }, ref) {
+    const label =
+      format === 'relative' ? formatRelativeTime(iso) :
+      format === 'date'     ? formatAbsoluteDate(iso) :
+                              formatDateTime(iso);
 
-  return <time dateTime={iso}>{label}</time>;
-}
+    return (
+      <time ref={ref} {...props} dateTime={iso} className={className}>
+        {label}
+      </time>
+    );
+  },
+);

--- a/apps/web/src/shared/ui/time-display.tsx
+++ b/apps/web/src/shared/ui/time-display.tsx
@@ -1,0 +1,26 @@
+/**
+ * TimeDisplay Component
+ *
+ * Renders a timestamp as a semantic <time> element using shared date formatters.
+ * Wrapping dates in <time> improves accessibility (screen readers) and SEO.
+ *
+ * @module apps/web/src/shared/ui
+ */
+
+import type { ReactElement } from 'react';
+import { formatAbsoluteDate, formatDateTime } from '../format/format-date';
+import { formatRelativeTime } from '../format/format-relative-time';
+
+interface TimeDisplayProps {
+  iso: string;
+  format?: 'date' | 'datetime' | 'relative';
+}
+
+export function TimeDisplay({ iso, format = 'datetime' }: TimeDisplayProps): ReactElement {
+  const label =
+    format === 'relative' ? formatRelativeTime(iso) :
+    format === 'date'     ? formatAbsoluteDate(iso) :
+                            formatDateTime(iso);
+
+  return <time dateTime={iso}>{label}</time>;
+}


### PR DESCRIPTION
## Summary

- **#227**: Centralise date formatting — new `TimeDisplay` component (wraps timestamps in a semantic `<time>` element) and `formatAbsoluteDate` / `formatDateTime` helpers. Replaces all 28 raw `toLocale*` callsites across 17 page/component files. Removes the duplicate `formatRelativeTime` from `dashboard-page.tsx`.
- **#229**: Add auto-refresh to the dashboard — `useDevStackHealthQuery`, `useSyncJobsQuery`, and `useConnectionsQuery` now accept an optional `{ refetchInterval }` override. Dashboard polls health every 30s and job queries every 60s via named constants in `pages/dashboard/intervals.ts`.

`TimeDisplay` follows the shared UI contract (`forwardRef`, extends `ComponentPropsWithoutRef<'time'>`, accepts/merges `className`, spreads remaining props). `formatRelativeTime` returns `just now` for under 60s to match the dashboard's prior wording.

## Test plan

- [x] `pnpm type-check` passes (0 errors)
- [x] `pnpm lint` passes (0 errors; 10 pre-existing warnings unchanged)
- [x] `pnpm test` passes — 178/178 (3 new tests for `TimeDisplay` ref-forwarding, className merge, and prop-spread)
- [ ] Manual: open `/dashboard` and verify health card updates every 30s, job counts every 60s, without clicking Refresh
- [ ] Manual: verify relative-time cells in dashboard show `just now` / `Nm ago` / `Nh ago`
- [ ] Manual: spot-check absolute dates on orders/products/customers list pages render correctly in the browser locale

Closes #227
Closes #229

Generated with [Claude Code](https://claude.com/claude-code)