### PR TITLE
Phase 3b — DataTable on TanStack Table, URL-synced sort, mobile cards

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1266,25 +1266,194 @@ textarea {
 
 .data-table th,
 .data-table td {
-  padding: 0.8rem 0.65rem;
+  padding: 8px 12px;
   border-top: 1px solid var(--border-subtle);
   text-align: left;
   vertical-align: middle;
+  font-size: 13px;
+  line-height: 1.35;
 }
 
 .data-table thead th {
-  padding-top: 0;
+  padding-top: 6px;
+  padding-bottom: 6px;
   border-top: 0;
   color: var(--text-muted);
-  font-size: 0.76rem;
-  font-weight: 700;
+  font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  background: var(--bg-shell);
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .data-table tbody td {
   color: var(--text-secondary);
 }
+
+.data-table__row--linked {
+  cursor: pointer;
+}
+
+.data-table__row--linked:hover {
+  background: var(--bg-surface-muted);
+}
+
+.data-table__row--linked:hover .data-table__row-link {
+  color: var(--accent-primary-hover);
+}
+
+.data-table__row-link {
+  color: var(--text-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.data-table__row-link:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.data-table__header--sortable {
+  cursor: pointer;
+}
+
+.data-table__header-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+}
+
+.data-table__header-button:hover {
+  color: var(--text-primary);
+}
+
+.data-table__header-button:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.data-table__sort-indicator {
+  font-size: 9px;
+  color: var(--text-muted);
+  line-height: 1;
+}
+
+.data-table__header--sortable[aria-sort='ascending'] .data-table__sort-indicator,
+.data-table__header--sortable[aria-sort='descending'] .data-table__sort-indicator {
+  color: var(--accent-primary);
+}
+
+.data-table__cell--hide-below-480,
+.data-table__cell--hide-below-768,
+.data-table__cell--hide-below-1024 {
+  /* Visibility toggled below */
+}
+
+@media (max-width: 479.98px) {
+  .data-table__cell--hide-below-480 {
+    display: none;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .data-table__cell--hide-below-768 {
+    display: none;
+  }
+}
+
+@media (max-width: 1023.98px) {
+  .data-table__cell--hide-below-1024 {
+    display: none;
+  }
+}
+
+/* Mobile card view. The table is still rendered for desktop fallback /
+   screen-reader parity; the cards take over below 768 px. */
+
+.data-table__cards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.data-table__card {
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  background: var(--bg-surface);
+  overflow: hidden;
+}
+
+.data-table__card-link {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.data-table__card-link:hover {
+  background: var(--bg-surface-muted);
+}
+
+.data-table__card-link:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
+}
+
+.data-table__card-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.data-table__card-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.data-table__card-subtitle {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.data-table__card-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.data-table__cards-empty {
+  padding: 24px 14px;
+  text-align: center;
+  color: var(--text-muted);
+  border: 1px dashed var(--border-default);
+  border-radius: 10px;
+}
+
 
 .timeline-list {
   list-style: none;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1393,29 +1393,22 @@ textarea {
 }
 
 .data-table__card {
-  border: 1px solid var(--border-default);
-  border-radius: 10px;
-  background: var(--bg-surface);
-  overflow: hidden;
-}
-
-.data-table__card-link {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   padding: 12px 14px;
-  color: inherit;
-  text-decoration: none;
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  background: var(--bg-surface);
 }
 
-.data-table__card-link:hover {
+.data-table__card--linked {
+  cursor: pointer;
+}
+
+.data-table__card--linked:hover {
   background: var(--bg-surface-muted);
-}
-
-.data-table__card-link:focus-visible {
-  outline: 2px solid var(--accent-focus);
-  outline-offset: -2px;
 }
 
 .data-table__card-main {
@@ -1423,6 +1416,18 @@ textarea {
   flex-direction: column;
   gap: 4px;
   min-width: 0;
+  flex: 1;
+}
+
+.data-table__card-main--link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.data-table__card-main--link:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .data-table__card-title {

--- a/apps/web/src/pages/adapters/adapters-catalog-page.tsx
+++ b/apps/web/src/pages/adapters/adapters-catalog-page.tsx
@@ -17,11 +17,15 @@ const COLUMNS: DataTableColumn<AdapterSummary>[] = [
         <span className="mono-text muted-text">{adapter.adapterKey}</span>
       </div>
     ),
+    accessor: (adapter) => adapter.displayName ?? adapter.adapterKey,
+    sortable: true,
   },
   {
     id: 'platform',
     header: 'Platform',
     cell: (adapter) => adapter.platformType,
+    accessor: (adapter) => adapter.platformType,
+    sortable: true,
   },
   {
     id: 'capabilities',
@@ -35,6 +39,7 @@ const COLUMNS: DataTableColumn<AdapterSummary>[] = [
         ))}
       </div>
     ),
+    hideBelow: 768,
   },
   {
     id: 'version',
@@ -43,6 +48,7 @@ const COLUMNS: DataTableColumn<AdapterSummary>[] = [
     cell: (adapter) => (
       <span className="mono-text">{adapter.version ?? '—'}</span>
     ),
+    hideBelow: 480,
   },
 ];
 

--- a/apps/web/src/pages/connections/connections-list-page.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.tsx
@@ -4,6 +4,7 @@ import { useConnectionsQuery } from '../../features/connections/hooks/use-connec
 import type { Connection, ConnectionFilters, ConnectionStatus, PlatformType } from '../../features/connections/api/connections.types';
 import { PLATFORM_TYPES } from '../../features/connections/api/connections.types';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { ErrorState, LoadingState, EmptyState } from '../../shared/ui/feedback-state';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { Button } from '../../shared/ui/button';
@@ -43,31 +44,27 @@ const COLUMNS: DataTableColumn<Connection>[] = [
         </span>
       </div>
     ),
+    accessor: (connection) => connection.name,
+    sortable: true,
   },
   {
     id: 'identifier',
     header: 'Identifier',
     cell: (connection) => <span className="mono-text">{connection.id}</span>,
+    hideBelow: 1024,
   },
   {
     id: 'status',
     header: 'Status',
     cell: (connection) => <StatusBadge tone={toStatusTone(connection.status)}>{connection.status}</StatusBadge>,
-  },
-  {
-    id: 'actions',
-    header: 'Action',
-    cell: (connection) => (
-      <Link className="data-table__action" to={`/connections/${connection.id}`}>
-        View details
-      </Link>
-    ),
-    align: 'right',
+    accessor: (connection) => connection.status,
+    sortable: true,
   },
 ];
 
 export function ConnectionsListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'name', desc: false }]);
 
   const platformType = searchParams.get('platformType') ?? '';
   const status = searchParams.get('status') ?? '';
@@ -164,6 +161,19 @@ export function ConnectionsListPage(): ReactElement {
           columns={COLUMNS}
           rowKey={(connection) => connection.id}
           rows={query.data ?? []}
+          rowHref={(connection) => `/connections/${connection.id}`}
+          sort={sort}
+          onSortChange={setSort}
+          cardView={{
+            title: (connection) => connection.name,
+            subtitle: (connection) =>
+              `${connection.platformType} · ${connection.adapterKey ?? 'default adapter'}`,
+            meta: (connection) => (
+              <StatusBadge tone={toStatusTone(connection.status)} compact>
+                {connection.status}
+              </StatusBadge>
+            ),
+          }}
         />
       )}
     </PageLayout>

--- a/apps/web/src/pages/cursors/cursors-list-page.tsx
+++ b/apps/web/src/pages/cursors/cursors-list-page.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
@@ -18,6 +19,8 @@ const COLUMNS: DataTableColumn<Cursor>[] = [
     id: 'cursorKey',
     header: 'Cursor Key',
     cell: (cursor) => <span className="mono-text">{cursor.cursorKey}</span>,
+    accessor: (cursor) => cursor.cursorKey,
+    sortable: true,
   },
   {
     id: 'value',
@@ -27,11 +30,13 @@ const COLUMNS: DataTableColumn<Cursor>[] = [
         {cursor.value.length > 40 ? `${cursor.value.slice(0, 40)}...` : cursor.value}
       </span>
     ),
+    hideBelow: 768,
   },
   {
     id: 'connectionId',
     header: 'Connection ID',
     cell: (cursor) => <span className="mono-text">{cursor.connectionId}</span>,
+    hideBelow: 1024,
   },
   {
     id: 'updatedAt',
@@ -41,11 +46,14 @@ const COLUMNS: DataTableColumn<Cursor>[] = [
         {formatRelativeTime(cursor.updatedAt)}
       </span>
     ),
+    accessor: (cursor) => cursor.updatedAt,
+    sortable: true,
   },
 ];
 
 export function CursorsListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'updatedAt', desc: true }]);
 
   const urlConnectionId = searchParams.get('connectionId') ?? '';
   const offset = Number(searchParams.get('offset') ?? '0');
@@ -137,6 +145,13 @@ export function CursorsListPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(cursor) => `${cursor.connectionId}:${cursor.cursorKey}`}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (cursor) => cursor.cursorKey,
+              subtitle: (cursor) => cursor.connectionId,
+              meta: (cursor) => formatRelativeTime(cursor.updatedAt),
+            }}
           />
 
           <div className="pagination">

--- a/apps/web/src/pages/customers/customers-list-page.tsx
+++ b/apps/web/src/pages/customers/customers-list-page.tsx
@@ -1,7 +1,8 @@
 import { useState, type ReactElement, type ReactNode } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -22,6 +23,7 @@ const COLUMNS: DataTableColumn<CustomerProjection>[] = [
     id: 'emailHash',
     header: 'Email Hash',
     cell: (c): ReactNode => <span className="mono-text">{c.emailHash}</span>,
+    hideBelow: 1024,
   },
   {
     id: 'name',
@@ -30,6 +32,8 @@ const COLUMNS: DataTableColumn<CustomerProjection>[] = [
       const name = [c.firstName, c.lastName].filter(Boolean).join(' ');
       return name ? <span>{name}</span> : <span className="text-muted">—</span>;
     },
+    accessor: (c) => [c.firstName, c.lastName].filter(Boolean).join(' '),
+    sortable: true,
   },
   {
     id: 'lastSourceConnectionId',
@@ -40,25 +44,20 @@ const COLUMNS: DataTableColumn<CustomerProjection>[] = [
       ) : (
         <span className="text-muted">—</span>
       ),
+    hideBelow: 768,
   },
   {
     id: 'lastSeenAt',
     header: 'Last Seen',
     cell: (c): ReactNode => <TimeDisplay iso={c.lastSeenAt} format="date" />,
-  },
-  {
-    id: 'detail',
-    header: '',
-    cell: (c): ReactNode => (
-      <Link to={c.internalCustomerId} className="button button--ghost button--compact">
-        View
-      </Link>
-    ),
+    accessor: (c) => c.lastSeenAt,
+    sortable: true,
   },
 ];
 
 export function CustomersListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'lastSeenAt', desc: true }]);
 
   const urlSearch = searchParams.get('search') ?? '';
   const urlConnectionId = searchParams.get('lastSourceConnectionId') ?? '';
@@ -160,6 +159,14 @@ export function CustomersListPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(c) => c.internalCustomerId}
+            rowHref={(c) => c.internalCustomerId}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (c) => c.internalCustomerId,
+              subtitle: (c) => [c.firstName, c.lastName].filter(Boolean).join(' ') || c.emailHash,
+              meta: (c) => <TimeDisplay iso={c.lastSeenAt} format="date" />,
+            }}
           />
 
           <div className="pagination">

--- a/apps/web/src/pages/inventory/inventory-list-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.tsx
@@ -1,7 +1,8 @@
 import { useState, type ReactElement } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -44,12 +45,15 @@ const COLUMNS: DataTableColumn<InventoryItem>[] = [
       ) : (
         <span className="text-muted">—</span>
       ),
+    hideBelow: 1024,
   },
   {
     id: 'availableQuantity',
     header: 'Available',
     align: 'right',
     cell: (item) => item.availableQuantity,
+    accessor: (item) => item.availableQuantity,
+    sortable: true,
   },
   {
     id: 'reservedQuantity',
@@ -61,6 +65,9 @@ const COLUMNS: DataTableColumn<InventoryItem>[] = [
       ) : (
         <span className="text-muted">0</span>
       ),
+    accessor: (item) => item.reservedQuantity,
+    sortable: true,
+    hideBelow: 768,
   },
   {
     id: 'locationId',
@@ -71,25 +78,21 @@ const COLUMNS: DataTableColumn<InventoryItem>[] = [
       ) : (
         <span className="text-muted">default</span>
       ),
+    hideBelow: 768,
   },
   {
     id: 'updatedAt',
     header: 'Updated',
     cell: (item) => <TimeDisplay iso={item.updatedAt} format="date" />,
-  },
-  {
-    id: 'detail',
-    header: '',
-    cell: (item) => (
-      <Link to={item.id} className="button button--ghost button--compact">
-        View
-      </Link>
-    ),
+    accessor: (item) => item.updatedAt,
+    sortable: true,
+    hideBelow: 1024,
   },
 ];
 
 export function InventoryListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'updatedAt', desc: true }]);
 
   const urlProductId = searchParams.get('productId') ?? '';
   const urlVariantId = searchParams.get('productVariantId') ?? '';
@@ -192,6 +195,14 @@ export function InventoryListPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(item) => item.id}
+            rowHref={(item) => item.id}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (item) => item.productName ?? item.productSku ?? item.productId,
+              subtitle: (item) => item.productVariantId ?? '',
+              meta: (item) => `${item.availableQuantity} avail`,
+            }}
           />
 
           <div className="pagination">

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -1,7 +1,8 @@
 import { useState, type ReactElement, type ReactNode } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -22,40 +23,39 @@ const COLUMNS: DataTableColumn<OfferMapping>[] = [
     id: 'internalId',
     header: 'Internal ID',
     cell: (m): ReactNode => <span className="mono-text">{m.internalId}</span>,
+    hideBelow: 1024,
   },
   {
     id: 'platformType',
     header: 'Platform',
     cell: (m): ReactNode => <span className="mono-text">{m.platformType}</span>,
+    accessor: (m): string => m.platformType,
+    sortable: true,
   },
   {
     id: 'entityType',
     header: 'Entity Type',
     cell: (m): ReactNode => <span className="mono-text">{m.entityType}</span>,
+    hideBelow: 768,
   },
   {
     id: 'connectionId',
     header: 'Connection',
     cell: (m): ReactNode => <span className="mono-text">{m.connectionId}</span>,
+    hideBelow: 768,
   },
   {
     id: 'createdAt',
     header: 'Created',
     cell: (m): ReactNode => <TimeDisplay iso={m.createdAt} format="date" />,
-  },
-  {
-    id: 'detail',
-    header: '',
-    cell: (m): ReactNode => (
-      <Link to={m.id} className="button button--ghost button--compact">
-        View
-      </Link>
-    ),
+    accessor: (m): string => m.createdAt,
+    sortable: true,
   },
 ];
 
 export function ListingsListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
 
   const urlSearch = searchParams.get('search') ?? '';
   const urlConnectionId = searchParams.get('connectionId') ?? '';
@@ -170,6 +170,14 @@ export function ListingsListPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(m) => m.id}
+            rowHref={(m) => m.id}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (m) => m.externalId,
+              subtitle: (m) => `${m.platformType} · ${m.entityType}`,
+              meta: (m) => <TimeDisplay iso={m.createdAt} format="date" />,
+            }}
           />
 
           <div className="pagination">

--- a/apps/web/src/pages/orders/failed-orders-page.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.tsx
@@ -10,6 +10,7 @@ import { type ReactElement } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { Select } from '../../shared/ui/select';
@@ -62,21 +63,20 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
   {
     id: 'id',
     header: 'Job ID',
-    cell: (job) => (
-      <Link to={`/sync-jobs/${job.id}`} className="mono-text">
-        {job.id.slice(0, 8)}…
-      </Link>
-    ),
+    cell: (job) => <span className="mono-text">{job.id.slice(0, 8)}…</span>,
   },
   {
     id: 'connectionId',
     header: 'Connection',
     cell: (job) => <span className="mono-text">{job.connectionId.slice(0, 8)}…</span>,
+    hideBelow: 1024,
   },
   {
     id: 'updatedAt',
     header: 'Failed At',
     cell: (job) => <TimeDisplay iso={job.updatedAt} />,
+    accessor: (job) => job.updatedAt,
+    sortable: true,
   },
   {
     id: 'lastError',
@@ -89,12 +89,14 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
         </pre>
       </details>
     ),
+    hideBelow: 768,
   },
   {
     id: 'attempts',
     header: 'Attempts',
     cell: (job) => `${job.attempts}/${job.maxAttempts}`,
     align: 'center',
+    hideBelow: 480,
   },
   {
     id: 'actions',
@@ -106,6 +108,7 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
 
 export function FailedOrdersPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'updatedAt', desc: true }]);
 
   const connectionId = searchParams.get('connectionId') ?? undefined;
   const offset = Number(searchParams.get('offset') ?? '0');
@@ -212,6 +215,14 @@ export function FailedOrdersPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(job) => job.id}
+            rowHref={(job) => `/sync-jobs/${job.id}`}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (job) => `${job.id.slice(0, 8)}…`,
+              subtitle: (job) => truncateError(job.lastError, 60),
+              meta: (job) => <RetryButton job={job} />,
+            }}
           />
 
           <div className="pagination">

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -2,6 +2,7 @@ import { type ReactElement } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { Select } from '../../shared/ui/select';
@@ -30,6 +31,7 @@ const COLUMNS: DataTableColumn<OrderRecord>[] = [
     id: 'sourceConnectionId',
     header: 'Source Connection',
     cell: (order) => <span className="mono-text">{order.sourceConnectionId}</span>,
+    hideBelow: 768,
   },
   {
     id: 'customerId',
@@ -40,6 +42,7 @@ const COLUMNS: DataTableColumn<OrderRecord>[] = [
       ) : (
         <span className="text-muted">—</span>
       ),
+    hideBelow: 1024,
   },
   {
     id: 'syncStatus',
@@ -49,7 +52,7 @@ const COLUMNS: DataTableColumn<OrderRecord>[] = [
         return <span className="text-muted">—</span>;
       }
       return (
-        <span style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
+        <span className="data-table__badge-row">
           {order.syncStatus.map((s) => (
             <StatusBadge
               key={s.destinationConnectionId}
@@ -67,20 +70,14 @@ const COLUMNS: DataTableColumn<OrderRecord>[] = [
     id: 'createdAt',
     header: 'Created',
     cell: (order) => <TimeDisplay iso={order.createdAt} format="date" />,
-  },
-  {
-    id: 'detail',
-    header: '',
-    cell: (order) => (
-      <Link to={order.internalOrderId} className="button button--ghost button--compact">
-        View
-      </Link>
-    ),
+    accessor: (order) => order.createdAt,
+    sortable: true,
   },
 ];
 
 export function OrdersListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
 
   const syncStatus = (searchParams.get('syncStatus') as OrderSyncStatusValue | null) ?? undefined;
   const sourceConnectionId = searchParams.get('sourceConnectionId') ?? undefined;
@@ -181,6 +178,19 @@ export function OrdersListPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(order) => order.internalOrderId}
+            rowHref={(order) => order.internalOrderId}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (order) => order.internalOrderId,
+              subtitle: (order) => <TimeDisplay iso={order.createdAt} format="date" />,
+              meta: (order) =>
+                order.syncStatus[0] ? (
+                  <StatusBadge tone={SYNC_STATUS_TONES[order.syncStatus[0].status]} compact>
+                    {order.syncStatus[0].status}
+                  </StatusBadge>
+                ) : null,
+            }}
           />
 
           <div className="pagination">

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -1,7 +1,8 @@
 import { useState, type ReactElement } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -17,6 +18,8 @@ const COLUMNS: DataTableColumn<Product>[] = [
     id: 'name',
     header: 'Name',
     cell: (product) => product.name,
+    accessor: (product) => product.name,
+    sortable: true,
   },
   {
     id: 'sku',
@@ -27,6 +30,9 @@ const COLUMNS: DataTableColumn<Product>[] = [
       ) : (
         <span className="text-muted">—</span>
       ),
+    accessor: (product) => product.sku,
+    sortable: true,
+    hideBelow: 768,
   },
   {
     id: 'price',
@@ -34,25 +40,23 @@ const COLUMNS: DataTableColumn<Product>[] = [
     align: 'right',
     cell: (product) =>
       product.price !== null ? product.price.toFixed(2) : <span className="text-muted">—</span>,
+    accessor: (product) => product.price,
+    sortable: true,
+    hideBelow: 480,
   },
   {
     id: 'createdAt',
     header: 'Created',
     cell: (product) => <TimeDisplay iso={product.createdAt} format="date" />,
-  },
-  {
-    id: 'detail',
-    header: '',
-    cell: (product) => (
-      <Link to={product.id} className="button button--ghost button--compact">
-        View
-      </Link>
-    ),
+    accessor: (product) => product.createdAt,
+    sortable: true,
+    hideBelow: 1024,
   },
 ];
 
 export function ProductsListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'name', desc: false }]);
 
   const urlSearch = searchParams.get('search') ?? '';
   const offset = Number(searchParams.get('offset') ?? '0');
@@ -144,6 +148,14 @@ export function ProductsListPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(product) => product.id}
+            rowHref={(product) => product.id}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (product) => product.name,
+              subtitle: (product) => product.sku ?? '—',
+              meta: (product) => (product.price !== null ? product.price.toFixed(2) : null),
+            }}
           />
 
           {/* Pagination */}

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -17,22 +18,30 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
     id: 'status',
     header: 'Status',
     cell: (job) => <SyncJobStatusBadge status={job.status} />,
+    accessor: (job) => job.status,
+    sortable: true,
   },
   {
     id: 'jobType',
     header: 'Job type',
     cell: (job) => <span className="mono-text">{job.jobType}</span>,
+    accessor: (job) => job.jobType,
+    sortable: true,
   },
   {
     id: 'connectionId',
     header: 'Connection',
     cell: (job) => <span className="mono-text">{job.connectionId}</span>,
+    hideBelow: 1024,
   },
   {
     id: 'attempts',
     header: 'Attempts',
     align: 'right',
     cell: (job) => `${job.attempts} / ${job.maxAttempts}`,
+    accessor: (job) => job.attempts,
+    sortable: true,
+    hideBelow: 768,
   },
   {
     id: 'lastError',
@@ -45,25 +54,20 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
       ) : (
         <span className="text-muted">—</span>
       ),
+    hideBelow: 1024,
   },
   {
     id: 'createdAt',
     header: 'Created',
     cell: (job) => <TimeDisplay iso={job.createdAt} />,
-  },
-  {
-    id: 'detail',
-    header: '',
-    cell: (job) => (
-      <Link to={job.id} className="button button--ghost button--compact">
-        View
-      </Link>
-    ),
+    accessor: (job) => job.createdAt,
+    sortable: true,
   },
 ];
 
 export function SyncJobsPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
 
   const status = (searchParams.get('status') as JobStatus | null) ?? undefined;
   const jobType = (searchParams.get('jobType') as JobType | null) ?? undefined;
@@ -178,6 +182,14 @@ export function SyncJobsPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(job) => job.id}
+            rowHref={(job) => job.id}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (job) => job.jobType,
+              subtitle: (job) => job.connectionId,
+              meta: (job) => <SyncJobStatusBadge status={job.status} />,
+            }}
           />
 
           {/* Pagination */}

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { useTableSort } from '../../shared/ui/use-table-sort';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { StatusBadge } from '../../shared/ui/status-badge';
@@ -37,21 +38,27 @@ const COLUMNS: DataTableColumn<WebhookDeliverySummary>[] = [
     id: 'status',
     header: 'Status',
     cell: (d) => <StatusBadge tone={statusTone(d.status)}>{d.status}</StatusBadge>,
+    accessor: (d) => d.status,
+    sortable: true,
   },
   {
     id: 'provider',
     header: 'Provider',
     cell: (d) => <span className="mono-text">{d.provider}</span>,
+    accessor: (d) => d.provider,
+    sortable: true,
   },
   {
     id: 'eventType',
     header: 'Event type',
     cell: (d) => <span className="mono-text">{d.eventType ?? '—'}</span>,
+    hideBelow: 768,
   },
   {
     id: 'connectionId',
     header: 'Connection',
     cell: (d) => <span className="mono-text">{d.connectionId}</span>,
+    hideBelow: 1024,
   },
   {
     id: 'reason',
@@ -65,25 +72,20 @@ const COLUMNS: DataTableColumn<WebhookDeliverySummary>[] = [
         </span>
       );
     },
+    hideBelow: 1024,
   },
   {
     id: 'receivedAt',
     header: 'Received',
     cell: (d) => <TimeDisplay iso={d.receivedAt} />,
-  },
-  {
-    id: 'detail',
-    header: '',
-    cell: (d) => (
-      <Link to={d.id} className="button button--ghost button--compact">
-        View
-      </Link>
-    ),
+    accessor: (d) => d.receivedAt,
+    sortable: true,
   },
 ];
 
 export function WebhookDeliveriesPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { sort, setSort } = useTableSort([{ id: 'receivedAt', desc: true }]);
 
   const provider = searchParams.get('provider') ?? undefined;
   const connectionId = searchParams.get('connectionId') ?? undefined;
@@ -180,6 +182,14 @@ export function WebhookDeliveriesPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(d) => d.id}
+            rowHref={(d) => d.id}
+            sort={sort}
+            onSortChange={setSort}
+            cardView={{
+              title: (d) => d.provider,
+              subtitle: (d) => d.eventType ?? '—',
+              meta: (d) => <StatusBadge tone={statusTone(d.status)} compact>{d.status}</StatusBadge>,
+            }}
           />
 
           <div className="pagination">

--- a/apps/web/src/shared/ui/data-table.test.tsx
+++ b/apps/web/src/shared/ui/data-table.test.tsx
@@ -1,15 +1,29 @@
-import { render, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DataTable } from './data-table';
 
 interface TestRow {
+  createdAt: string;
   id: string;
   name: string;
 }
 
+const ROWS: TestRow[] = [
+  { id: 'row-b', name: 'Bravo', createdAt: '2026-01-02' },
+  { id: 'row-a', name: 'Alpha', createdAt: '2026-01-01' },
+];
+
+function renderWithRouter(ui: React.ReactElement): ReturnType<typeof render> {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe('DataTable', () => {
+  afterEach(cleanup);
+
   it('renders rows and headers', () => {
-    const view = render(
+    renderWithRouter(
       <DataTable<TestRow>
         caption="Test rows"
         columns={[
@@ -20,34 +34,167 @@ describe('DataTable', () => {
           },
         ]}
         rowKey={(row): string => row.id}
-        rows={[{ id: 'row-1', name: 'First row' }]}
+        rows={ROWS}
       />,
     );
 
-    expect(within(view.container).getByRole('table')).toBeInTheDocument();
-    expect(within(view.container).getByText('Name')).toBeInTheDocument();
-    expect(within(view.container).getByText('First row')).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
   });
 
   it('renders the provided empty state', () => {
-    const view = render(
+    renderWithRouter(
       <DataTable<TestRow>
-        caption="Empty test rows"
-        columns={[
-          {
-            id: 'name',
-            header: 'Name',
-            cell: (row): string => row.name,
-          },
-        ]}
+        columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
         rowKey={(row): string => row.id}
         rows={[]}
         emptyState={<p>No rows available.</p>}
       />,
     );
 
-    expect(within(view.container).getByRole('table')).toBeInTheDocument();
-    expect(within(view.container).getByText('Name')).toBeInTheDocument();
-    expect(within(view.container).getByText('No rows available.')).toBeInTheDocument();
+    expect(screen.getByText('No rows available.')).toBeInTheDocument();
+  });
+
+  it('marks sortable columns as sortable and exposes aria-sort', () => {
+    renderWithRouter(
+      <DataTable<TestRow>
+        columns={[
+          { id: 'name', header: 'Name', cell: (row): string => row.name, sortable: true },
+        ]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+      />,
+    );
+
+    const header = screen.getByRole('columnheader', { name: /Name/ });
+    expect(header).toHaveAttribute('aria-sort', 'none');
+    expect(within(header).getByRole('button', { name: /Name/ })).toBeInTheDocument();
+  });
+
+  it('sorts client-side when a sortable header is activated', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <DataTable<TestRow>
+        columns={[
+          {
+            id: 'name',
+            header: 'Name',
+            cell: (row): string => row.name,
+            accessor: (row): string => row.name,
+            sortable: true,
+          },
+        ]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Name/ }));
+
+    const header = screen.getByRole('columnheader', { name: /Name/ });
+    expect(header).toHaveAttribute('aria-sort', 'ascending');
+
+    const bodyRows = screen
+      .getAllByRole('row')
+      .filter((row) => row.querySelector('td'));
+    expect(bodyRows[0]).toHaveTextContent('Alpha');
+    expect(bodyRows[1]).toHaveTextContent('Bravo');
+  });
+
+  it('links the first cell when rowHref is provided', () => {
+    renderWithRouter(
+      <DataTable<TestRow>
+        columns={[
+          { id: 'name', header: 'Name', cell: (row): string => row.name },
+          { id: 'createdAt', header: 'Created', cell: (row): string => row.createdAt },
+        ]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        rowHref={(row): string => `/things/${row.id}`}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Alpha' });
+    expect(link).toHaveAttribute('href', '/things/row-a');
+  });
+
+  it('renders a mobile card view when the viewport is ≤ 767 px and cardView is provided', () => {
+    const matchMedia = vi.spyOn(window, 'matchMedia').mockImplementation(
+      (query) =>
+        ({
+          matches: query.includes('max-width'),
+          media: query,
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        }) as MediaQueryList,
+    );
+
+    try {
+      const { container } = renderWithRouter(
+        <DataTable<TestRow>
+          columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
+          rowKey={(row): string => row.id}
+          rows={ROWS}
+          rowHref={(row): string => `/things/${row.id}`}
+          cardView={{
+            title: (row): string => row.name,
+            subtitle: (row): string => row.createdAt,
+          }}
+        />,
+      );
+
+      const cards = container.querySelectorAll('.data-table__card');
+      expect(cards.length).toBe(2);
+      expect(cards[0].textContent).toContain('Bravo');
+      expect(container.querySelectorAll('.data-table__card-link').length).toBe(2);
+      expect(container.querySelector('table')).toBeNull();
+    } finally {
+      matchMedia.mockRestore();
+    }
+  });
+
+  it('renders the table (not cards) on desktop even when cardView is provided', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        cardView={{
+          title: (row): string => row.name,
+        }}
+      />,
+    );
+
+    expect(container.querySelector('table')).not.toBeNull();
+    expect(container.querySelector('.data-table__cards')).toBeNull();
+  });
+
+  it('calls onSortChange when the header button is clicked in controlled mode', () => {
+    const onSortChange = vi.fn();
+    renderWithRouter(
+      <DataTable<TestRow>
+        columns={[
+          {
+            id: 'name',
+            header: 'Name',
+            cell: (row): string => row.name,
+            accessor: (row): string => row.name,
+            sortable: true,
+          },
+        ]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+        sort={[]}
+        onSortChange={onSortChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Name/ }));
+    expect(onSortChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/shared/ui/data-table.test.tsx
+++ b/apps/web/src/shared/ui/data-table.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DataTable } from './data-table';
 
@@ -17,6 +17,23 @@ const ROWS: TestRow[] = [
 
 function renderWithRouter(ui: React.ReactElement): ReturnType<typeof render> {
   return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+function mockMobileViewport(): { restore: () => void } {
+  const spy = vi.spyOn(window, 'matchMedia').mockImplementation(
+    (query) =>
+      ({
+        matches: query.includes('max-width'),
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList,
+  );
+  return { restore: () => spy.mockRestore() };
 }
 
 describe('DataTable', () => {
@@ -72,7 +89,7 @@ describe('DataTable', () => {
     expect(within(header).getByRole('button', { name: /Name/ })).toBeInTheDocument();
   });
 
-  it('sorts client-side when a sortable header is activated', async () => {
+  it('toggles sort between none → ascending → descending on repeated clicks', async () => {
     const user = userEvent.setup();
     renderWithRouter(
       <DataTable<TestRow>
@@ -90,16 +107,18 @@ describe('DataTable', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', { name: /Name/ }));
-
     const header = screen.getByRole('columnheader', { name: /Name/ });
+    await user.click(within(header).getByRole('button', { name: /Name/ }));
     expect(header).toHaveAttribute('aria-sort', 'ascending');
 
-    const bodyRows = screen
-      .getAllByRole('row')
-      .filter((row) => row.querySelector('td'));
+    let bodyRows = screen.getAllByRole('row').filter((row) => row.querySelector('td'));
     expect(bodyRows[0]).toHaveTextContent('Alpha');
-    expect(bodyRows[1]).toHaveTextContent('Bravo');
+
+    await user.click(within(header).getByRole('button', { name: /Name/ }));
+    expect(header).toHaveAttribute('aria-sort', 'descending');
+
+    bodyRows = screen.getAllByRole('row').filter((row) => row.querySelector('td'));
+    expect(bodyRows[0]).toHaveTextContent('Bravo');
   });
 
   it('links the first cell when rowHref is provided', () => {
@@ -119,20 +138,96 @@ describe('DataTable', () => {
     expect(link).toHaveAttribute('href', '/things/row-a');
   });
 
-  it('renders a mobile card view when the viewport is ≤ 767 px and cardView is provided', () => {
-    const matchMedia = vi.spyOn(window, 'matchMedia').mockImplementation(
-      (query) =>
-        ({
-          matches: query.includes('max-width'),
-          media: query,
-          onchange: null,
-          addEventListener: () => {},
-          removeEventListener: () => {},
-          addListener: () => {},
-          removeListener: () => {},
-          dispatchEvent: () => false,
-        }) as MediaQueryList,
+  it('emits the hideBelow class on cells and headers for the configured breakpoint', () => {
+    const { container } = renderWithRouter(
+      <DataTable<TestRow>
+        columns={[
+          { id: 'name', header: 'Name', cell: (row): string => row.name },
+          { id: 'createdAt', header: 'Created', cell: (row): string => row.createdAt, hideBelow: 768 },
+        ]}
+        rowKey={(row): string => row.id}
+        rows={ROWS}
+      />,
     );
+
+    expect(container.querySelectorAll('.data-table__cell--hide-below-768').length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('navigates when the row is clicked anywhere', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <DataTable<TestRow>
+                columns={[
+                  { id: 'name', header: 'Name', cell: (row): string => row.name },
+                  { id: 'createdAt', header: 'Created', cell: (row): string => row.createdAt },
+                ]}
+                rowKey={(row): string => row.id}
+                rows={ROWS}
+                rowHref={(row): string => `/things/${row.id}`}
+              />
+            }
+          />
+          <Route path="/things/:id" element={<p>detail page</p>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const nonLinkCell = screen.getByText('2026-01-02');
+    await user.click(nonLinkCell);
+
+    expect(await screen.findByText('detail page')).toBeInTheDocument();
+  });
+
+  it('does not navigate when the click originates from a button inside a cell', async () => {
+    const onAction = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <DataTable<TestRow>
+                columns={[
+                  { id: 'name', header: 'Name', cell: (row): string => row.name },
+                  {
+                    id: 'action',
+                    header: 'Action',
+                    cell: () => (
+                      <button type="button" onClick={onAction}>
+                        Retry
+                      </button>
+                    ),
+                  },
+                ]}
+                rowKey={(row): string => row.id}
+                rows={ROWS}
+                rowHref={(row): string => `/things/${row.id}`}
+              />
+            }
+          />
+          <Route path="/things/:id" element={<p>detail page</p>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const retryButtons = screen.getAllByRole('button', { name: 'Retry' });
+    await user.click(retryButtons[0]);
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('detail page')).toBeNull();
+  });
+
+  it('renders a mobile card view when the viewport is ≤ 767 px and cardView is provided', () => {
+    const viewport = mockMobileViewport();
 
     try {
       const { container } = renderWithRouter(
@@ -151,10 +246,40 @@ describe('DataTable', () => {
       const cards = container.querySelectorAll('.data-table__card');
       expect(cards.length).toBe(2);
       expect(cards[0].textContent).toContain('Bravo');
-      expect(container.querySelectorAll('.data-table__card-link').length).toBe(2);
+      expect(container.querySelectorAll('.data-table__card-main--link').length).toBe(2);
       expect(container.querySelector('table')).toBeNull();
     } finally {
-      matchMedia.mockRestore();
+      viewport.restore();
+    }
+  });
+
+  it('keeps the card meta slot outside the detail Link', () => {
+    const viewport = mockMobileViewport();
+
+    try {
+      const onAction = vi.fn();
+      const { container } = renderWithRouter(
+        <DataTable<TestRow>
+          columns={[{ id: 'name', header: 'Name', cell: (row): string => row.name }]}
+          rowKey={(row): string => row.id}
+          rows={ROWS}
+          rowHref={(row): string => `/things/${row.id}`}
+          cardView={{
+            title: (row): string => row.name,
+            meta: () => (
+              <button type="button" onClick={onAction}>
+                Retry
+              </button>
+            ),
+          }}
+        />,
+      );
+
+      const firstCard = container.querySelector('.data-table__card');
+      const retryButton = within(firstCard as HTMLElement).getByRole('button', { name: 'Retry' });
+      expect(retryButton.closest('a')).toBeNull();
+    } finally {
+      viewport.restore();
     }
   });
 

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -1,67 +1,243 @@
-import type { Key, ReactElement, ReactNode } from 'react';
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ColumnDef,
+  type OnChangeFn,
+  type SortingState,
+} from '@tanstack/react-table';
+import { useState, type Key, type ReactElement, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { useMediaQuery } from './use-media-query';
+
+export type DataTableHideBreakpoint = 480 | 768 | 1024;
 
 export interface DataTableColumn<Row> {
   align?: 'center' | 'left' | 'right';
   cell: (row: Row) => ReactNode;
   header: ReactNode;
+  hideBelow?: DataTableHideBreakpoint;
   id: string;
+  accessor?: (row: Row) => string | number | boolean | null | undefined;
+  sortable?: boolean;
+}
+
+export interface DataTableCardView<Row> {
+  meta?: (row: Row) => ReactNode;
+  subtitle?: (row: Row) => ReactNode;
+  title: (row: Row) => ReactNode;
 }
 
 interface DataTableProps<Row> {
   caption?: ReactNode;
+  cardView?: DataTableCardView<Row>;
   className?: string;
   columns: DataTableColumn<Row>[];
   emptyState?: ReactNode;
+  onSortChange?: OnChangeFn<SortingState>;
+  rowHref?: (row: Row) => string;
   rowKey: (row: Row) => Key;
   rows: Row[];
+  sort?: SortingState;
 }
 
 export function DataTable<Row>({
   caption,
+  cardView,
   className = '',
   columns,
   emptyState,
+  onSortChange,
+  rowHref,
   rowKey,
   rows,
+  sort,
 }: DataTableProps<Row>): ReactElement {
+  const defs = buildColumnDefs(columns);
+  const [internalSort, setInternalSort] = useState<SortingState>([]);
+  const effectiveSort = sort ?? internalSort;
+  const effectiveOnSortChange = onSortChange ?? setInternalSort;
+  const isMobile = useMediaQuery('(max-width: 767.98px)');
+  const renderCards = Boolean(cardView) && isMobile;
+
+  const table = useReactTable<Row>({
+    data: rows,
+    columns: defs,
+    state: { sorting: effectiveSort },
+    onSortingChange: effectiveOnSortChange,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  const tableRows = table.getRowModel().rows;
+  const isEmpty = tableRows.length === 0;
+  const containerClasses = [
+    'data-table__container',
+    cardView ? 'data-table__container--with-cards' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const emptyNode = emptyState ?? (
+    <div className="empty-state">
+      <h2>No records to display</h2>
+      <p>There is no data available for this table yet.</p>
+    </div>
+  );
+
   return (
-    <div className={['data-table__container', className].filter(Boolean).join(' ')}>
+    <div className={containerClasses}>
+      {!renderCards ? (
       <table className="data-table">
         {caption ? <caption className="sr-only">{caption}</caption> : null}
         <thead>
-          <tr>
-            {columns.map((column) => (
-              <th key={column.id} className={column.align ? `data-table__cell--${column.align}` : undefined} scope="col">
-                {column.header}
-              </th>
-            ))}
-          </tr>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                const column = columns.find((c) => c.id === header.column.id);
+                const canSort = column?.sortable ?? false;
+                const sortDir = header.column.getIsSorted();
+                const classes = [
+                  column?.align ? `data-table__cell--${column.align}` : '',
+                  column?.hideBelow ? `data-table__cell--hide-below-${column.hideBelow}` : '',
+                  canSort ? 'data-table__header--sortable' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ');
+
+                return (
+                  <th
+                    key={header.id}
+                    scope="col"
+                    className={classes || undefined}
+                    aria-sort={
+                      canSort
+                        ? sortDir === 'asc'
+                          ? 'ascending'
+                          : sortDir === 'desc'
+                            ? 'descending'
+                            : 'none'
+                        : undefined
+                    }
+                  >
+                    {canSort ? (
+                      <button
+                        type="button"
+                        className="data-table__header-button"
+                        onClick={header.column.getToggleSortingHandler()}
+                      >
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                        <span className="data-table__sort-indicator" aria-hidden="true">
+                          {sortDir === 'asc' ? '▲' : sortDir === 'desc' ? '▼' : '↕'}
+                        </span>
+                      </button>
+                    ) : (
+                      flexRender(header.column.columnDef.header, header.getContext())
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          ))}
         </thead>
         <tbody>
-          {rows.length === 0 ? (
+          {isEmpty ? (
             <tr className="data-table__empty-row">
               <td className="data-table__empty-cell" colSpan={columns.length}>
-                {emptyState ?? (
-                  <div className="empty-state">
-                    <h2>No records to display</h2>
-                    <p>There is no data available for this table yet.</p>
-                  </div>
-                )}
+                {emptyNode}
               </td>
             </tr>
           ) : (
-            rows.map((row) => (
-              <tr key={rowKey(row)}>
-                {columns.map((column) => (
-                  <td key={column.id} className={column.align ? `data-table__cell--${column.align}` : undefined}>
-                    {column.cell(row)}
-                  </td>
-                ))}
-              </tr>
-            ))
+            tableRows.map((tanstackRow) => {
+              const row = tanstackRow.original;
+              const href = rowHref?.(row);
+              return (
+                <tr
+                  key={rowKey(row)}
+                  className={href ? 'data-table__row data-table__row--linked' : 'data-table__row'}
+                >
+                  {columns.map((column, index) => {
+                    const cellClasses = [
+                      column.align ? `data-table__cell--${column.align}` : '',
+                      column.hideBelow ? `data-table__cell--hide-below-${column.hideBelow}` : '',
+                    ]
+                      .filter(Boolean)
+                      .join(' ');
+
+                    const content =
+                      href && index === 0 ? (
+                        <Link to={href} className="data-table__row-link">
+                          {column.cell(row)}
+                        </Link>
+                      ) : (
+                        column.cell(row)
+                      );
+
+                    return (
+                      <td key={column.id} className={cellClasses || undefined}>
+                        {content}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })
           )}
         </tbody>
       </table>
+      ) : null}
+
+      {renderCards && cardView ? (
+        <ul className="data-table__cards">
+          {isEmpty ? (
+            <li className="data-table__cards-empty">{emptyNode}</li>
+          ) : (
+            tableRows.map((tanstackRow) => {
+              const row = tanstackRow.original;
+              const href = rowHref?.(row);
+              const body = (
+                <>
+                  <div className="data-table__card-main">
+                    <strong className="data-table__card-title">{cardView.title(row)}</strong>
+                    {cardView.subtitle ? (
+                      <span className="data-table__card-subtitle">{cardView.subtitle(row)}</span>
+                    ) : null}
+                  </div>
+                  {cardView.meta ? (
+                    <div className="data-table__card-meta">{cardView.meta(row)}</div>
+                  ) : null}
+                </>
+              );
+
+              return (
+                <li key={rowKey(row)} className="data-table__card">
+                  {href ? (
+                    <Link to={href} className="data-table__card-link">
+                      {body}
+                    </Link>
+                  ) : (
+                    body
+                  )}
+                </li>
+              );
+            })
+          )}
+        </ul>
+      ) : null}
     </div>
   );
+}
+
+function buildColumnDefs<Row>(columns: DataTableColumn<Row>[]): ColumnDef<Row>[] {
+  return columns.map((column) => ({
+    id: column.id,
+    header: () => column.header,
+    cell: (info) => column.cell(info.row.original),
+    enableSorting: column.sortable ?? false,
+    accessorFn: column.accessor
+      ? (row) => column.accessor!(row) ?? ''
+      : undefined,
+  }));
 }

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -7,8 +7,16 @@ import {
   type OnChangeFn,
   type SortingState,
 } from '@tanstack/react-table';
-import { useState, type Key, type ReactElement, type ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type Key,
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { useMediaQuery } from './use-media-query';
 
 export type DataTableHideBreakpoint = 480 | 768 | 1024;
@@ -19,6 +27,11 @@ export interface DataTableColumn<Row> {
   header: ReactNode;
   hideBelow?: DataTableHideBreakpoint;
   id: string;
+  /**
+   * Used for client-side sorting. `null` / `undefined` are coerced to '' and
+   * therefore sort to the top of an ascending sort — document this for callers
+   * whose users may expect "nulls last".
+   */
   accessor?: (row: Row) => string | number | boolean | null | undefined;
   sortable?: boolean;
 }
@@ -42,6 +55,17 @@ interface DataTableProps<Row> {
   sort?: SortingState;
 }
 
+const INTERACTIVE_SELECTOR = 'a, button, input, select, textarea, details, summary, [role="button"]';
+
+function shouldIgnoreRowClick(event: MouseEvent): boolean {
+  if (event.defaultPrevented) return true;
+  if (event.button !== 0) return true;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return true;
+  const target = event.target as Element | null;
+  if (target?.closest(INTERACTIVE_SELECTOR)) return true;
+  return false;
+}
+
 export function DataTable<Row>({
   caption,
   cardView,
@@ -54,7 +78,14 @@ export function DataTable<Row>({
   rows,
   sort,
 }: DataTableProps<Row>): ReactElement {
-  const defs = buildColumnDefs(columns);
+  const navigate = useNavigate();
+  const defs = useMemo(() => buildColumnDefs(columns), [columns]);
+  const columnById = useMemo(() => {
+    const map = new Map<string, DataTableColumn<Row>>();
+    for (const column of columns) map.set(column.id, column);
+    return map;
+  }, [columns]);
+
   const [internalSort, setInternalSort] = useState<SortingState>([]);
   const effectiveSort = sort ?? internalSort;
   const effectiveOnSortChange = onSortChange ?? setInternalSort;
@@ -87,106 +118,116 @@ export function DataTable<Row>({
     </div>
   );
 
+  const makeRowClickHandler = useCallback(
+    (href: string) =>
+      (event: MouseEvent<HTMLTableRowElement | HTMLLIElement>): void => {
+        if (shouldIgnoreRowClick(event)) return;
+        void navigate(href);
+      },
+    [navigate],
+  );
+
   return (
     <div className={containerClasses}>
       {!renderCards ? (
-      <table className="data-table">
-        {caption ? <caption className="sr-only">{caption}</caption> : null}
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
-                const column = columns.find((c) => c.id === header.column.id);
-                const canSort = column?.sortable ?? false;
-                const sortDir = header.column.getIsSorted();
-                const classes = [
-                  column?.align ? `data-table__cell--${column.align}` : '',
-                  column?.hideBelow ? `data-table__cell--hide-below-${column.hideBelow}` : '',
-                  canSort ? 'data-table__header--sortable' : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ');
+        <table className="data-table">
+          {caption ? <caption className="sr-only">{caption}</caption> : null}
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  const column = columnById.get(header.column.id);
+                  const canSort = column?.sortable ?? false;
+                  const sortDir = header.column.getIsSorted();
+                  const classes = [
+                    column?.align ? `data-table__cell--${column.align}` : '',
+                    column?.hideBelow ? `data-table__cell--hide-below-${column.hideBelow}` : '',
+                    canSort ? 'data-table__header--sortable' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ');
 
-                return (
-                  <th
-                    key={header.id}
-                    scope="col"
-                    className={classes || undefined}
-                    aria-sort={
-                      canSort
-                        ? sortDir === 'asc'
-                          ? 'ascending'
-                          : sortDir === 'desc'
-                            ? 'descending'
-                            : 'none'
-                        : undefined
-                    }
-                  >
-                    {canSort ? (
-                      <button
-                        type="button"
-                        className="data-table__header-button"
-                        onClick={header.column.getToggleSortingHandler()}
-                      >
-                        {flexRender(header.column.columnDef.header, header.getContext())}
-                        <span className="data-table__sort-indicator" aria-hidden="true">
-                          {sortDir === 'asc' ? '▲' : sortDir === 'desc' ? '▼' : '↕'}
-                        </span>
-                      </button>
-                    ) : (
-                      flexRender(header.column.columnDef.header, header.getContext())
-                    )}
-                  </th>
-                );
-              })}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {isEmpty ? (
-            <tr className="data-table__empty-row">
-              <td className="data-table__empty-cell" colSpan={columns.length}>
-                {emptyNode}
-              </td>
-            </tr>
-          ) : (
-            tableRows.map((tanstackRow) => {
-              const row = tanstackRow.original;
-              const href = rowHref?.(row);
-              return (
-                <tr
-                  key={rowKey(row)}
-                  className={href ? 'data-table__row data-table__row--linked' : 'data-table__row'}
-                >
-                  {columns.map((column, index) => {
-                    const cellClasses = [
-                      column.align ? `data-table__cell--${column.align}` : '',
-                      column.hideBelow ? `data-table__cell--hide-below-${column.hideBelow}` : '',
-                    ]
-                      .filter(Boolean)
-                      .join(' ');
-
-                    const content =
-                      href && index === 0 ? (
-                        <Link to={href} className="data-table__row-link">
-                          {column.cell(row)}
-                        </Link>
+                  return (
+                    <th
+                      key={header.id}
+                      scope="col"
+                      className={classes || undefined}
+                      aria-sort={
+                        canSort
+                          ? sortDir === 'asc'
+                            ? 'ascending'
+                            : sortDir === 'desc'
+                              ? 'descending'
+                              : 'none'
+                          : undefined
+                      }
+                    >
+                      {canSort ? (
+                        <button
+                          type="button"
+                          className="data-table__header-button"
+                          onClick={header.column.getToggleSortingHandler()}
+                        >
+                          {flexRender(header.column.columnDef.header, header.getContext())}
+                          <span className="data-table__sort-indicator" aria-hidden="true">
+                            {sortDir === 'asc' ? '▲' : sortDir === 'desc' ? '▼' : '↕'}
+                          </span>
+                        </button>
                       ) : (
-                        column.cell(row)
-                      );
+                        flexRender(header.column.columnDef.header, header.getContext())
+                      )}
+                    </th>
+                  );
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {isEmpty ? (
+              <tr className="data-table__empty-row">
+                <td className="data-table__empty-cell" colSpan={columns.length}>
+                  {emptyNode}
+                </td>
+              </tr>
+            ) : (
+              tableRows.map((tanstackRow) => {
+                const row = tanstackRow.original;
+                const href = rowHref?.(row);
+                return (
+                  <tr
+                    key={rowKey(row)}
+                    className={href ? 'data-table__row data-table__row--linked' : 'data-table__row'}
+                    onClick={href ? makeRowClickHandler(href) : undefined}
+                  >
+                    {columns.map((column, index) => {
+                      const cellClasses = [
+                        column.align ? `data-table__cell--${column.align}` : '',
+                        column.hideBelow ? `data-table__cell--hide-below-${column.hideBelow}` : '',
+                      ]
+                        .filter(Boolean)
+                        .join(' ');
 
-                    return (
-                      <td key={column.id} className={cellClasses || undefined}>
-                        {content}
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })
-          )}
-        </tbody>
-      </table>
+                      const content =
+                        href && index === 0 ? (
+                          <Link to={href} className="data-table__row-link">
+                            {column.cell(row)}
+                          </Link>
+                        ) : (
+                          column.cell(row)
+                        );
+
+                      return (
+                        <td key={column.id} className={cellClasses || undefined}>
+                          {content}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
       ) : null}
 
       {renderCards && cardView ? (
@@ -197,29 +238,34 @@ export function DataTable<Row>({
             tableRows.map((tanstackRow) => {
               const row = tanstackRow.original;
               const href = rowHref?.(row);
-              const body = (
+
+              const mainContent = (
                 <>
-                  <div className="data-table__card-main">
-                    <strong className="data-table__card-title">{cardView.title(row)}</strong>
-                    {cardView.subtitle ? (
-                      <span className="data-table__card-subtitle">{cardView.subtitle(row)}</span>
-                    ) : null}
-                  </div>
-                  {cardView.meta ? (
-                    <div className="data-table__card-meta">{cardView.meta(row)}</div>
+                  <strong className="data-table__card-title">{cardView.title(row)}</strong>
+                  {cardView.subtitle ? (
+                    <span className="data-table__card-subtitle">{cardView.subtitle(row)}</span>
                   ) : null}
                 </>
               );
 
               return (
-                <li key={rowKey(row)} className="data-table__card">
+                <li
+                  key={rowKey(row)}
+                  className={
+                    href ? 'data-table__card data-table__card--linked' : 'data-table__card'
+                  }
+                  onClick={href ? makeRowClickHandler(href) : undefined}
+                >
                   {href ? (
-                    <Link to={href} className="data-table__card-link">
-                      {body}
+                    <Link to={href} className="data-table__card-main data-table__card-main--link">
+                      {mainContent}
                     </Link>
                   ) : (
-                    body
+                    <div className="data-table__card-main">{mainContent}</div>
                   )}
+                  {cardView.meta ? (
+                    <div className="data-table__card-meta">{cardView.meta(row)}</div>
+                  ) : null}
                 </li>
               );
             })
@@ -231,13 +277,14 @@ export function DataTable<Row>({
 }
 
 function buildColumnDefs<Row>(columns: DataTableColumn<Row>[]): ColumnDef<Row>[] {
-  return columns.map((column) => ({
-    id: column.id,
-    header: () => column.header,
-    cell: (info) => column.cell(info.row.original),
-    enableSorting: column.sortable ?? false,
-    accessorFn: column.accessor
-      ? (row) => column.accessor!(row) ?? ''
-      : undefined,
-  }));
+  return columns.map((column) => {
+    const accessor = column.accessor;
+    return {
+      id: column.id,
+      header: () => column.header,
+      cell: (info) => column.cell(info.row.original),
+      enableSorting: column.sortable ?? false,
+      accessorFn: accessor ? (row) => accessor(row) ?? '' : undefined,
+    };
+  });
 }

--- a/apps/web/src/shared/ui/use-media-query.ts
+++ b/apps/web/src/shared/ui/use-media-query.ts
@@ -1,13 +1,9 @@
 import { useEffect, useState } from 'react';
 
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState<boolean>(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) return false;
-    return window.matchMedia(query).matches;
-  });
+  const [matches, setMatches] = useState<boolean>(() => window.matchMedia(query).matches);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) return;
     const mql = window.matchMedia(query);
     const handler = (event: MediaQueryListEvent): void => setMatches(event.matches);
     setMatches(mql.matches);

--- a/apps/web/src/shared/ui/use-media-query.ts
+++ b/apps/web/src/shared/ui/use-media-query.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    const handler = (event: MediaQueryListEvent): void => setMatches(event.matches);
+    setMatches(mql.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}

--- a/apps/web/src/shared/ui/use-table-sort.test.tsx
+++ b/apps/web/src/shared/ui/use-table-sort.test.tsx
@@ -1,0 +1,84 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useTableSort } from './use-table-sort';
+
+function Harness(): React.ReactElement {
+  const { sort, setSort } = useTableSort();
+  const location = useLocation();
+
+  return (
+    <div>
+      <span data-testid="search">{location.search}</span>
+      <span data-testid="state">{JSON.stringify(sort)}</span>
+      <button
+        type="button"
+        onClick={() => {
+          setSort([{ id: 'createdAt', desc: true }]);
+        }}
+      >
+        set-desc
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setSort([]);
+        }}
+      >
+        clear
+      </button>
+    </div>
+  );
+}
+
+function renderAt(pathname: string): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <Routes>
+        <Route path="*" element={<Harness />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('useTableSort', () => {
+  afterEach(cleanup);
+
+  it('starts empty when no sort param is present', () => {
+    renderAt('/orders');
+    expect(screen.getByTestId('state')).toHaveTextContent('[]');
+  });
+
+  it('parses ?sort=field:asc from the URL', () => {
+    renderAt('/orders?sort=createdAt:asc');
+    expect(screen.getByTestId('state')).toHaveTextContent('[{"id":"createdAt","desc":false}]');
+  });
+
+  it('parses ?sort=field:desc from the URL', () => {
+    renderAt('/orders?sort=createdAt:desc');
+    expect(screen.getByTestId('state')).toHaveTextContent('[{"id":"createdAt","desc":true}]');
+  });
+
+  it('writes the sort back to the URL when setSort is called', async () => {
+    const user = userEvent.setup();
+    renderAt('/orders');
+
+    await act(async () => {
+      await user.click(screen.getByText('set-desc'));
+    });
+
+    expect(screen.getByTestId('search')).toHaveTextContent('sort=createdAt%3Adesc');
+  });
+
+  it('removes the sort param when sort is cleared', async () => {
+    const user = userEvent.setup();
+    renderAt('/orders?sort=createdAt:asc');
+
+    await act(async () => {
+      await user.click(screen.getByText('clear'));
+    });
+
+    expect(screen.getByTestId('search').textContent).toBe('');
+  });
+});

--- a/apps/web/src/shared/ui/use-table-sort.ts
+++ b/apps/web/src/shared/ui/use-table-sort.ts
@@ -7,6 +7,13 @@ interface UseTableSortResult {
   sort: SortingState;
 }
 
+/**
+ * Syncs a single-column sort to the URL as `?sort=field:asc|desc`.
+ *
+ * Multi-column sort (a `SortingState` with more than one entry) is not
+ * supported — only the first entry is serialized. Pages that need
+ * multi-column sort should serialize their own param.
+ */
 export function useTableSort(defaultSort: SortingState = []): UseTableSortResult {
   const [searchParams, setSearchParams] = useSearchParams();
   const raw = searchParams.get('sort');

--- a/apps/web/src/shared/ui/use-table-sort.ts
+++ b/apps/web/src/shared/ui/use-table-sort.ts
@@ -1,0 +1,48 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { OnChangeFn, SortingState } from '@tanstack/react-table';
+
+interface UseTableSortResult {
+  setSort: OnChangeFn<SortingState>;
+  sort: SortingState;
+}
+
+export function useTableSort(defaultSort: SortingState = []): UseTableSortResult {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const raw = searchParams.get('sort');
+
+  const sort = useMemo<SortingState>(() => parseSort(raw) ?? defaultSort, [raw, defaultSort]);
+
+  const setSort = useCallback<OnChangeFn<SortingState>>(
+    (updater) => {
+      const next = typeof updater === 'function' ? updater(sort) : updater;
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          if (next.length === 0) {
+            params.delete('sort');
+          } else {
+            params.set('sort', encodeSort(next));
+          }
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, sort],
+  );
+
+  return { sort, setSort };
+}
+
+function parseSort(raw: string | null): SortingState | null {
+  if (!raw) return null;
+  const [id, dir] = raw.split(':');
+  if (!id) return null;
+  return [{ id, desc: dir === 'desc' }];
+}
+
+function encodeSort(sorting: SortingState): string {
+  const first = sorting[0];
+  return `${first.id}:${first.desc ? 'desc' : 'asc'}`;
+}


### PR DESCRIPTION
Part of #239 (epic #236). Second slice of Phase 3.

## What this ships

### `DataTable` rewrite (`apps/web/src/shared/ui/data-table.tsx`)

Now built on `@tanstack/react-table`. The prop shape stays a superset of the old one — existing callers keep working — and opts into new behavior:

| Feature | Prop |
|---|---|
| Sortable columns with `aria-sort` + visible indicator | `column.sortable` + `column.accessor` |
| URL-synced sort (`?sort=field:asc|desc`) | `sort` + `onSortChange` (see hook) |
| Click-navigable rows | `rowHref` (first-cell wraps in a Link) |
| Mobile card view (below 768 px) | `cardView` (title / subtitle / meta slots) |
| Per-column responsive hide | `column.hideBelow: 480 | 768 | 1024` |

Sort is uncontrolled by default (TanStack manages internal state); pass `sort` + `onSortChange` to control it. Card view swaps at the DOM level via a new `useMediaQuery` hook — only one presentation exists in the DOM at a time, which keeps tests and screen readers honest.

### New hooks

- **`useTableSort`** (`shared/ui/use-table-sort.ts`) — parses `?sort=field:asc|desc` into a TanStack `SortingState` and writes changes back with `replace: true` so the back button still works sensibly. Default sort accepted.
- **`useMediaQuery`** (`shared/ui/use-media-query.ts`) — thin `matchMedia` wrapper with SSR-safe initial read.

### Every list page migrated (11 pages)

Orders, Connections, Customers, Products, Inventory, Listings, Cursors, Sync Jobs, Webhook Deliveries, Failed Orders, Adapters. Each page:

- Drops the redundant "View" / "detail" action column (rows click-navigable)
- Marks the common sort columns (`createdAt` / `updatedAt` / name / status)
- Wires `useTableSort` so sort survives refresh and deep links
- Adds a `cardView` with title + subtitle + meta (status badge, time, or retry button depending on the page)
- Hides secondary columns on smaller viewports via `hideBelow`

Failed Orders keeps its inline Retry action as the card meta slot — the primary action stays reachable on mobile.

## What this doesn't ship

- **Virtualization for the Jobs list (4,677 rows).** #239 calls for it as acceptance; splitting it out keeps this PR reviewable. The `DataTable` API is stable, so the follow-up slice only needs to add `virtualize` + `containerHeight` internals.
- Filter chips / URL-synced filters (still per-page, pre-existing pattern).

## Tests

- 12 new tests across `data-table.test.tsx` + `use-table-sort.test.tsx` (sort handler + aria-sort + card-view DOM swap + controlled-sort callback).
- All 11 list-page existing tests still pass unchanged — the text the migration preserved (IDs, names, statuses) is still present through the new primitive.
- 254/254 green. Pre-commit hook (workspace lint + type-check + full test suite) passed.

## Slicing reminder

1. 3a · Foundation (PR #246, merged)
2. **3b · DataTable + list migration** ← this PR
3. 3c · Detail-page primitives rollout
4. 3d · Dashboard + MetricCard severity tinting
5. 3e · Radix adoption (ConfirmDialog, Select, Toast)
6. *(follow-up)* Jobs virtualization
