### PR TITLE
Phase 3c — detail pages on KeyValueList / RawPayloadPanel / EntityLabel

### DIFF
--- a/apps/web/src/features/connections/components/ConnectionConfigPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionConfigPanel.tsx
@@ -5,31 +5,31 @@ interface ConnectionConfigPanelProps {
   config: Record<string, unknown>;
 }
 
+const AUTO_OPEN_KEY_THRESHOLD = 6;
+
 export function ConnectionConfigPanel({ config }: ConnectionConfigPanelProps): ReactElement {
   const keys = Object.keys(config);
   const description = `${keys.length} ${keys.length === 1 ? 'key' : 'keys'}`;
 
-  if (keys.length === 0) {
-    return (
-      <div className="panel panel--dense">
-        <div className="panel__header">
-          <div>
-            <p className="eyebrow">Configuration</p>
-            <h3 className="section-title">Connection config</h3>
-          </div>
-          <span className="panel__meta">{description}</span>
-        </div>
-        <p className="muted-text">No configuration values set.</p>
-      </div>
-    );
-  }
-
   return (
-    <RawPayloadPanel
-      title="Connection config"
-      description={description}
-      payload={config}
-      defaultOpen
-    />
+    <div className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Configuration</p>
+          <h3 className="section-title">Connection config</h3>
+        </div>
+        <span className="panel__meta">{description}</span>
+      </div>
+
+      {keys.length === 0 ? (
+        <p className="muted-text">No configuration values set.</p>
+      ) : (
+        <RawPayloadPanel
+          title="Raw config"
+          payload={config}
+          defaultOpen={keys.length <= AUTO_OPEN_KEY_THRESHOLD}
+        />
+      )}
+    </div>
   );
 }

--- a/apps/web/src/features/connections/components/ConnectionConfigPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionConfigPanel.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import { RawPayloadPanel } from '../../../shared/ui/raw-payload-panel';
 
 interface ConnectionConfigPanelProps {
   config: Record<string, unknown>;
@@ -6,22 +7,29 @@ interface ConnectionConfigPanelProps {
 
 export function ConnectionConfigPanel({ config }: ConnectionConfigPanelProps): ReactElement {
   const keys = Object.keys(config);
+  const description = `${keys.length} ${keys.length === 1 ? 'key' : 'keys'}`;
+
+  if (keys.length === 0) {
+    return (
+      <div className="panel panel--dense">
+        <div className="panel__header">
+          <div>
+            <p className="eyebrow">Configuration</p>
+            <h3 className="section-title">Connection config</h3>
+          </div>
+          <span className="panel__meta">{description}</span>
+        </div>
+        <p className="muted-text">No configuration values set.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="panel panel--dense">
-      <div className="panel__header">
-        <div>
-          <p className="eyebrow">Configuration</p>
-          <h3 className="section-title">Connection config</h3>
-        </div>
-        <span className="panel__meta">{keys.length} {keys.length === 1 ? 'key' : 'keys'}</span>
-      </div>
-
-      {keys.length === 0 ? (
-        <p className="muted-text">No configuration values set.</p>
-      ) : (
-        <pre className="config-block mono-text">{JSON.stringify(config, null, 2)}</pre>
-      )}
-    </div>
+    <RawPayloadPanel
+      title="Connection config"
+      description={description}
+      payload={config}
+      defaultOpen
+    />
   );
 }

--- a/apps/web/src/features/connections/components/ConnectionEntityLabel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionEntityLabel.test.tsx
@@ -59,4 +59,99 @@ describe('ConnectionEntityLabel', () => {
 
     expect(await screen.findByText('Unknown')).toBeInTheDocument();
   });
+
+  it('renders nothing when connectionId is empty', () => {
+    const api = createMockApiClient({
+      connections: {
+        getById: vi.fn(),
+      },
+    });
+
+    const { container } = renderWithProviders(<ConnectionEntityLabel connectionId="" />, {
+      apiClient: api,
+    });
+
+    expect(container.querySelector('.entity-label')).toBeNull();
+  });
+
+  it('hides the id when showId={false}', async () => {
+    const api = createMockApiClient({
+      connections: {
+        getById: vi.fn().mockResolvedValue({
+          id: 'ol_connection_abc',
+          name: 'Allegro sandbox',
+          platformType: 'allegro',
+          status: 'active',
+          config: {},
+          credentialsBacked: true,
+          enabledCapabilities: [],
+          supportedCapabilities: [],
+          createdAt: '2026-04-20T00:00:00.000Z',
+          updatedAt: '2026-04-20T00:00:00.000Z',
+        }),
+      },
+    });
+
+    renderWithProviders(
+      <ConnectionEntityLabel connectionId="ol_connection_abc" showId={false} />,
+      { apiClient: api },
+    );
+
+    await screen.findByRole('link', { name: 'Allegro sandbox' });
+    expect(screen.queryByText(/ol_conne/)).toBeNull();
+  });
+
+  it('renders a span (not a link) when linkToDetail={false}', async () => {
+    const api = createMockApiClient({
+      connections: {
+        getById: vi.fn().mockResolvedValue({
+          id: 'ol_connection_abc',
+          name: 'Allegro sandbox',
+          platformType: 'allegro',
+          status: 'active',
+          config: {},
+          credentialsBacked: true,
+          enabledCapabilities: [],
+          supportedCapabilities: [],
+          createdAt: '2026-04-20T00:00:00.000Z',
+          updatedAt: '2026-04-20T00:00:00.000Z',
+        }),
+      },
+    });
+
+    renderWithProviders(
+      <ConnectionEntityLabel connectionId="ol_connection_abc" linkToDetail={false} />,
+      { apiClient: api },
+    );
+
+    expect(await screen.findByText('Allegro sandbox')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('drops the link when the current path already matches the connection detail', async () => {
+    const api = createMockApiClient({
+      connections: {
+        getById: vi.fn().mockResolvedValue({
+          id: 'ol_connection_abc',
+          name: 'Allegro sandbox',
+          platformType: 'allegro',
+          status: 'active',
+          config: {},
+          credentialsBacked: true,
+          enabledCapabilities: [],
+          supportedCapabilities: [],
+          createdAt: '2026-04-20T00:00:00.000Z',
+          updatedAt: '2026-04-20T00:00:00.000Z',
+        }),
+      },
+    });
+
+    renderWithProviders(<ConnectionEntityLabel connectionId="ol_connection_abc" />, {
+      apiClient: api,
+      route: '/connections/ol_connection_abc',
+    });
+
+    expect(await screen.findByText('Allegro sandbox')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
 });

--- a/apps/web/src/features/connections/components/ConnectionEntityLabel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionEntityLabel.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionEntityLabel } from './ConnectionEntityLabel';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+
+describe('ConnectionEntityLabel', () => {
+  afterEach(cleanup);
+
+  it('shows a loading placeholder while the connection is fetching', () => {
+    const api = createMockApiClient({
+      connections: {
+        getById: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    });
+
+    renderWithProviders(<ConnectionEntityLabel connectionId="ol_connection_abc" />, {
+      apiClient: api,
+    });
+
+    expect(screen.getByText('…')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('renders the resolved connection name with a link to the detail page', async () => {
+    const api = createMockApiClient({
+      connections: {
+        getById: vi.fn().mockResolvedValue({
+          id: 'ol_connection_abc',
+          name: 'Allegro sandbox',
+          platformType: 'allegro',
+          status: 'active',
+          config: {},
+          credentialsBacked: true,
+          enabledCapabilities: [],
+          supportedCapabilities: [],
+          createdAt: '2026-04-20T00:00:00.000Z',
+          updatedAt: '2026-04-20T00:00:00.000Z',
+        }),
+      },
+    });
+
+    renderWithProviders(<ConnectionEntityLabel connectionId="ol_connection_abc" />, {
+      apiClient: api,
+    });
+
+    const link = await screen.findByRole('link', { name: 'Allegro sandbox' });
+    expect(link).toHaveAttribute('href', '/connections/ol_connection_abc');
+  });
+
+  it('falls back to Unknown when the API errors', async () => {
+    const api = createMockApiClient({
+      connections: {
+        getById: vi.fn().mockRejectedValue(new Error('not found')),
+      },
+    });
+
+    renderWithProviders(<ConnectionEntityLabel connectionId="ol_connection_xyz" />, {
+      apiClient: api,
+    });
+
+    expect(await screen.findByText('Unknown')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/connections/components/ConnectionEntityLabel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionEntityLabel.tsx
@@ -1,0 +1,30 @@
+import type { ReactElement } from 'react';
+import { EntityLabel } from '../../../shared/ui/entity-label';
+import { useConnectionQuery } from '../hooks/use-connection-query';
+
+interface ConnectionEntityLabelProps {
+  className?: string;
+  connectionId: string;
+  linkToDetail?: boolean;
+  showId?: boolean;
+}
+
+export function ConnectionEntityLabel({
+  className,
+  connectionId,
+  linkToDetail = true,
+  showId = true,
+}: ConnectionEntityLabelProps): ReactElement {
+  const query = useConnectionQuery(connectionId);
+
+  return (
+    <EntityLabel
+      id={connectionId}
+      name={query.data?.name}
+      loading={query.isLoading}
+      showId={showId}
+      to={linkToDetail ? `/connections/${connectionId}` : undefined}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/features/connections/components/ConnectionEntityLabel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionEntityLabel.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import { useLocation } from 'react-router-dom';
 import { EntityLabel } from '../../../shared/ui/entity-label';
 import { useConnectionQuery } from '../hooks/use-connection-query';
 
@@ -14,8 +15,15 @@ export function ConnectionEntityLabel({
   connectionId,
   linkToDetail = true,
   showId = true,
-}: ConnectionEntityLabelProps): ReactElement {
+}: ConnectionEntityLabelProps): ReactElement | null {
+  const location = useLocation();
   const query = useConnectionQuery(connectionId);
+
+  if (!connectionId) return null;
+
+  const targetPath = `/connections/${connectionId}`;
+  const isSelfPage = location.pathname === targetPath;
+  const shouldLink = linkToDetail && !isSelfPage;
 
   return (
     <EntityLabel
@@ -23,7 +31,7 @@ export function ConnectionEntityLabel({
       name={query.data?.name}
       loading={query.isLoading}
       showId={showId}
-      to={linkToDetail ? `/connections/${connectionId}` : undefined}
+      to={shouldLink ? targetPath : undefined}
       className={className}
     />
   );

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -7,6 +7,7 @@ import { ConnectionConfigPanel } from '../../features/connections/components/Con
 import { ConnectionDiagnosticsPanel } from '../../features/connections/components/ConnectionDiagnosticsPanel';
 import type { ConnectionStatus } from '../../features/connections/api/connections.types';
 import { EmptyState, ErrorState, LoadingState } from '../../shared/ui/feedback-state';
+import { KeyValueList } from '../../shared/ui/key-value-list';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
@@ -112,32 +113,29 @@ export function ConnectionDetailPage(): ReactElement {
               <StatusBadge tone={toStatusTone(connection.status)}>{connection.status}</StatusBadge>
             </div>
 
-            <dl className="definition-list">
-              <div>
-                <dt>Name</dt>
-                <dd>{connection.name}</dd>
-              </div>
-              <div>
-                <dt>Platform</dt>
-                <dd>{connection.platformType}</dd>
-              </div>
-              <div>
-                <dt>Credentials</dt>
-                <dd>{connection.credentialsBacked ? 'DB-managed' : 'Environment variable'}</dd>
-              </div>
-              <div>
-                <dt>Adapter</dt>
-                <dd className="mono-text">{connection.adapterKey ?? 'default adapter'}</dd>
-              </div>
-              <div>
-                <dt>Connection ID</dt>
-                <dd className="mono-text">{connection.id}</dd>
-              </div>
-              <div>
-                <dt>Last updated</dt>
-                <dd><TimeDisplay iso={connection.updatedAt} /></dd>
-              </div>
-            </dl>
+            <KeyValueList
+              items={[
+                { id: 'name', label: 'Name', value: connection.name },
+                { id: 'platform', label: 'Platform', value: connection.platformType },
+                {
+                  id: 'credentials',
+                  label: 'Credentials',
+                  value: connection.credentialsBacked ? 'DB-managed' : 'Environment variable',
+                },
+                {
+                  id: 'adapter',
+                  label: 'Adapter',
+                  value: connection.adapterKey ?? 'default adapter',
+                  mono: true,
+                },
+                { id: 'id', label: 'Connection ID', value: connection.id, mono: true },
+                {
+                  id: 'updatedAt',
+                  label: 'Last updated',
+                  value: <TimeDisplay iso={connection.updatedAt} />,
+                },
+              ]}
+            />
           </div>
 
           <ConnectionConfigPanel config={connection.config} />

--- a/apps/web/src/pages/customers/customer-detail-page.test.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, screen } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
+import { CustomerDetailPage } from './customer-detail-page';
+import type { CustomerProjectionDetail } from '../../features/customers/api/customers.types';
+
+const sampleCustomer: CustomerProjectionDetail = {
+  internalCustomerId: 'ol_customer_abc',
+  emailHash: 'hash123',
+  normalizedEmail: 'jane@example.com',
+  firstName: 'Jane',
+  lastName: null,
+  lastSeenAt: '2026-04-20T10:00:00.000Z',
+  lastSourceConnectionId: sampleConnection.id,
+  createdAt: '2026-04-01T00:00:00.000Z',
+  updatedAt: '2026-04-20T10:00:00.000Z',
+  addresses: [],
+};
+
+function renderDetail(apiClient: ReturnType<typeof createMockApiClient>): void {
+  renderWithProviders(
+    <Routes>
+      <Route path="/customers/:id" element={<CustomerDetailPage />} />
+    </Routes>,
+    { apiClient, route: '/customers/ol_customer_abc' },
+  );
+}
+
+describe('CustomerDetailPage', () => {
+  afterEach(cleanup);
+
+  it('renders customer fields, uses EmptyValue for missing last name, resolves connection', async () => {
+    const api = createMockApiClient({
+      customers: { getById: vi.fn().mockResolvedValue(sampleCustomer) },
+    });
+
+    renderDetail(api);
+
+    await screen.findByText('ol_customer_abc');
+    expect(screen.getAllByText('Jane').length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText('No value').length).toBeGreaterThan(0);
+
+    await screen.findByRole('link', { name: sampleConnection.name });
+  });
+
+  it('falls back to EmptyValue for last-source when connectionId is null', async () => {
+    const api = createMockApiClient({
+      customers: {
+        getById: vi.fn().mockResolvedValue({ ...sampleCustomer, lastSourceConnectionId: null }),
+      },
+    });
+
+    renderDetail(api);
+
+    await screen.findByText('ol_customer_abc');
+    expect(screen.queryByRole('link', { name: sampleConnection.name })).toBeNull();
+    expect(screen.getAllByLabelText('No value').length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/web/src/pages/customers/customer-detail-page.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.tsx
@@ -1,16 +1,15 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { EmptyValue } from '../../shared/ui/empty-value';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useCustomerQuery } from '../../features/customers/hooks/use-customer-query';
 import type { CustomerAddress } from '../../features/customers/api/customers.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
-
-const NONE: ReactNode = <span className="text-muted">—</span>;
 
 function buildCustomerItems(customer: {
   internalCustomerId: string;
@@ -38,15 +37,15 @@ function buildCustomerItems(customer: {
   }
 
   items.push(
-    { id: 'firstName', label: 'First Name', value: customer.firstName ?? NONE },
-    { id: 'lastName', label: 'Last Name', value: customer.lastName ?? NONE },
+    { id: 'firstName', label: 'First Name', value: customer.firstName ?? <EmptyValue /> },
+    { id: 'lastName', label: 'Last Name', value: customer.lastName ?? <EmptyValue /> },
     {
       id: 'lastSource',
       label: 'Last Source Connection',
       value: customer.lastSourceConnectionId ? (
         <ConnectionEntityLabel connectionId={customer.lastSourceConnectionId} />
       ) : (
-        NONE
+        <EmptyValue />
       ),
     },
     { id: 'lastSeen', label: 'Last Seen', value: <TimeDisplay iso={customer.lastSeenAt} /> },
@@ -68,23 +67,23 @@ const ADDRESS_COLUMNS: DataTableColumn<CustomerAddress>[] = [
     header: 'Address',
     cell: (a) => {
       const parts = [a.address1, a.address2].filter(Boolean).join(', ');
-      return parts ? <span>{parts}</span> : <span className="text-muted">—</span>;
+      return parts ? <span>{parts}</span> : <EmptyValue />;
     },
   },
   {
     id: 'city',
     header: 'City',
-    cell: (a) => a.city ?? <span className="text-muted">—</span>,
+    cell: (a) => a.city ?? <EmptyValue />,
   },
   {
     id: 'postcode',
     header: 'Postcode',
-    cell: (a) => a.postcode ?? <span className="text-muted">—</span>,
+    cell: (a) => a.postcode ?? <EmptyValue />,
   },
   {
     id: 'countryIso2',
     header: 'Country',
-    cell: (a) => a.countryIso2 ?? <span className="text-muted">—</span>,
+    cell: (a) => a.countryIso2 ?? <EmptyValue />,
   },
   {
     id: 'lastSeenAt',

--- a/apps/web/src/pages/customers/customer-detail-page.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.tsx
@@ -1,12 +1,61 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useCustomerQuery } from '../../features/customers/hooks/use-customer-query';
 import type { CustomerAddress } from '../../features/customers/api/customers.types';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+
+const NONE: ReactNode = <span className="text-muted">—</span>;
+
+function buildCustomerItems(customer: {
+  internalCustomerId: string;
+  emailHash: string;
+  normalizedEmail: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  lastSourceConnectionId: string | null;
+  lastSeenAt: string;
+  createdAt: string;
+  updatedAt: string;
+}): KeyValueItem[] {
+  const items: KeyValueItem[] = [
+    { id: 'id', label: 'Customer ID', value: customer.internalCustomerId, mono: true },
+    { id: 'emailHash', label: 'Email Hash', value: customer.emailHash, mono: true },
+  ];
+
+  if (customer.normalizedEmail) {
+    items.push({
+      id: 'normalizedEmail',
+      label: 'Normalized Email',
+      value: customer.normalizedEmail,
+      mono: true,
+    });
+  }
+
+  items.push(
+    { id: 'firstName', label: 'First Name', value: customer.firstName ?? NONE },
+    { id: 'lastName', label: 'Last Name', value: customer.lastName ?? NONE },
+    {
+      id: 'lastSource',
+      label: 'Last Source Connection',
+      value: customer.lastSourceConnectionId ? (
+        <ConnectionEntityLabel connectionId={customer.lastSourceConnectionId} />
+      ) : (
+        NONE
+      ),
+    },
+    { id: 'lastSeen', label: 'Last Seen', value: <TimeDisplay iso={customer.lastSeenAt} /> },
+    { id: 'createdAt', label: 'Created', value: <TimeDisplay iso={customer.createdAt} /> },
+    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={customer.updatedAt} /> },
+  );
+
+  return items;
+}
 
 const ADDRESS_COLUMNS: DataTableColumn<CustomerAddress>[] = [
   {
@@ -82,52 +131,7 @@ export function CustomerDetailPage(): ReactElement {
       }
     >
       <section className="detail-section">
-        <dl className="detail-list">
-          <div className="detail-list__row">
-            <dt>Customer ID</dt>
-            <dd><span className="mono-text">{customer.internalCustomerId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Email Hash</dt>
-            <dd><span className="mono-text">{customer.emailHash}</span></dd>
-          </div>
-          {customer.normalizedEmail ? (
-            <div className="detail-list__row">
-              <dt>Normalized Email</dt>
-              <dd><span className="mono-text">{customer.normalizedEmail}</span></dd>
-            </div>
-          ) : null}
-          <div className="detail-list__row">
-            <dt>First Name</dt>
-            <dd>{customer.firstName ?? <span className="text-muted">—</span>}</dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Last Name</dt>
-            <dd>{customer.lastName ?? <span className="text-muted">—</span>}</dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Last Source Connection</dt>
-            <dd>
-              {customer.lastSourceConnectionId ? (
-                <span className="mono-text">{customer.lastSourceConnectionId}</span>
-              ) : (
-                <span className="text-muted">—</span>
-              )}
-            </dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Last Seen</dt>
-            <dd><TimeDisplay iso={customer.lastSeenAt} /></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Created</dt>
-            <dd><TimeDisplay iso={customer.createdAt} /></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Updated</dt>
-            <dd><TimeDisplay iso={customer.updatedAt} /></dd>
-          </div>
-        </dl>
+        <KeyValueList items={buildCustomerItems(customer)} />
       </section>
 
       <section className="detail-section">

--- a/apps/web/src/pages/inventory/inventory-detail-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.tsx
@@ -3,9 +3,40 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { EmptyValue } from '../../shared/ui/empty-value';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useInventoryItemQuery } from '../../features/inventory/hooks/use-inventory-item-query';
+import type { InventoryItem } from '../../features/inventory/api/inventory.types';
+
+function buildInventoryItems(item: InventoryItem): KeyValueItem[] {
+  const items: KeyValueItem[] = [{ id: 'itemId', label: 'Item ID', value: item.id, mono: true }];
+  if (item.productName) {
+    items.push({ id: 'productName', label: 'Product', value: item.productName });
+  }
+  if (item.productSku) {
+    items.push({ id: 'productSku', label: 'Product SKU', value: item.productSku, mono: true });
+  }
+  items.push(
+    { id: 'productId', label: 'Product ID', value: item.productId, mono: true },
+    {
+      id: 'variantId',
+      label: 'Variant ID',
+      value: item.productVariantId ?? <EmptyValue />,
+      mono: Boolean(item.productVariantId),
+    },
+    { id: 'available', label: 'Available Quantity', value: item.availableQuantity },
+    { id: 'reserved', label: 'Reserved Quantity', value: item.reservedQuantity },
+    {
+      id: 'location',
+      label: 'Location',
+      value: item.locationId ?? <EmptyValue label="Default location" />,
+      mono: Boolean(item.locationId),
+    },
+    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={item.updatedAt} /> },
+  );
+  return items;
+}
 
 export function InventoryDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
@@ -35,34 +66,6 @@ export function InventoryDetailPage(): ReactElement {
 
   const item = query.data;
 
-  const items: KeyValueItem[] = [
-    { id: 'itemId', label: 'Item ID', value: item.id, mono: true },
-  ];
-  if (item.productName) {
-    items.push({ id: 'productName', label: 'Product', value: item.productName });
-  }
-  if (item.productSku) {
-    items.push({ id: 'productSku', label: 'Product SKU', value: item.productSku, mono: true });
-  }
-  items.push(
-    { id: 'productId', label: 'Product ID', value: item.productId, mono: true },
-    {
-      id: 'variantId',
-      label: 'Variant ID',
-      value: item.productVariantId ?? <span className="text-muted">—</span>,
-      mono: Boolean(item.productVariantId),
-    },
-    { id: 'available', label: 'Available Quantity', value: item.availableQuantity },
-    { id: 'reserved', label: 'Reserved Quantity', value: item.reservedQuantity },
-    {
-      id: 'location',
-      label: 'Location',
-      value: item.locationId ?? <span className="text-muted">default</span>,
-      mono: Boolean(item.locationId),
-    },
-    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={item.updatedAt} /> },
-  );
-
   return (
     <PageLayout
       eyebrow="Inventory"
@@ -74,7 +77,7 @@ export function InventoryDetailPage(): ReactElement {
       }
     >
       <section className="detail-section">
-        <KeyValueList items={items} />
+        <KeyValueList items={buildInventoryItems(item)} />
       </section>
     </PageLayout>
   );

--- a/apps/web/src/pages/inventory/inventory-detail-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useInventoryItemQuery } from '../../features/inventory/hooks/use-inventory-item-query';
 
@@ -34,6 +35,34 @@ export function InventoryDetailPage(): ReactElement {
 
   const item = query.data;
 
+  const items: KeyValueItem[] = [
+    { id: 'itemId', label: 'Item ID', value: item.id, mono: true },
+  ];
+  if (item.productName) {
+    items.push({ id: 'productName', label: 'Product', value: item.productName });
+  }
+  if (item.productSku) {
+    items.push({ id: 'productSku', label: 'Product SKU', value: item.productSku, mono: true });
+  }
+  items.push(
+    { id: 'productId', label: 'Product ID', value: item.productId, mono: true },
+    {
+      id: 'variantId',
+      label: 'Variant ID',
+      value: item.productVariantId ?? <span className="text-muted">—</span>,
+      mono: Boolean(item.productVariantId),
+    },
+    { id: 'available', label: 'Available Quantity', value: item.availableQuantity },
+    { id: 'reserved', label: 'Reserved Quantity', value: item.reservedQuantity },
+    {
+      id: 'location',
+      label: 'Location',
+      value: item.locationId ?? <span className="text-muted">default</span>,
+      mono: Boolean(item.locationId),
+    },
+    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={item.updatedAt} /> },
+  );
+
   return (
     <PageLayout
       eyebrow="Inventory"
@@ -45,60 +74,7 @@ export function InventoryDetailPage(): ReactElement {
       }
     >
       <section className="detail-section">
-        <dl className="detail-list">
-          <div className="detail-list__row">
-            <dt>Item ID</dt>
-            <dd><span className="mono-text">{item.id}</span></dd>
-          </div>
-          {item.productName ? (
-            <div className="detail-list__row">
-              <dt>Product</dt>
-              <dd>{item.productName}</dd>
-            </div>
-          ) : null}
-          {item.productSku ? (
-            <div className="detail-list__row">
-              <dt>Product SKU</dt>
-              <dd><span className="mono-text">{item.productSku}</span></dd>
-            </div>
-          ) : null}
-          <div className="detail-list__row">
-            <dt>Product ID</dt>
-            <dd><span className="mono-text">{item.productId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Variant ID</dt>
-            <dd>
-              {item.productVariantId ? (
-                <span className="mono-text">{item.productVariantId}</span>
-              ) : (
-                <span className="text-muted">—</span>
-              )}
-            </dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Available Quantity</dt>
-            <dd>{item.availableQuantity}</dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Reserved Quantity</dt>
-            <dd>{item.reservedQuantity}</dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Location</dt>
-            <dd>
-              {item.locationId ? (
-                <span className="mono-text">{item.locationId}</span>
-              ) : (
-                <span className="text-muted">default</span>
-              )}
-            </dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Updated</dt>
-            <dd><TimeDisplay iso={item.updatedAt} /></dd>
-          </div>
-        </dl>
+        <KeyValueList items={items} />
       </section>
     </PageLayout>
   );

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -3,9 +3,12 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { KeyValueList } from '../../shared/ui/key-value-list';
+import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
 import { EditOfferDrawer } from '../../features/listings/components/EditOfferDrawer';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 
 export function ListingDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
@@ -52,48 +55,27 @@ export function ListingDetailPage(): ReactElement {
       }
     >
       <section className="detail-section">
-        <dl className="detail-list">
-          <div className="detail-list__row">
-            <dt>Mapping ID</dt>
-            <dd><span className="mono-text">{mapping.id}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Entity Type</dt>
-            <dd><span className="mono-text">{mapping.entityType}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>External ID</dt>
-            <dd><span className="mono-text">{mapping.externalId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Internal ID</dt>
-            <dd><span className="mono-text">{mapping.internalId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Platform Type</dt>
-            <dd><span className="mono-text">{mapping.platformType}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Connection ID</dt>
-            <dd><span className="mono-text">{mapping.connectionId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Created</dt>
-            <dd><TimeDisplay iso={mapping.createdAt} /></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Updated</dt>
-            <dd><TimeDisplay iso={mapping.updatedAt} /></dd>
-          </div>
-        </dl>
+        <KeyValueList
+          items={[
+            { id: 'mappingId', label: 'Mapping ID', value: mapping.id, mono: true },
+            { id: 'entityType', label: 'Entity Type', value: mapping.entityType, mono: true },
+            { id: 'externalId', label: 'External ID', value: mapping.externalId, mono: true },
+            { id: 'internalId', label: 'Internal ID', value: mapping.internalId, mono: true },
+            { id: 'platform', label: 'Platform Type', value: mapping.platformType, mono: true },
+            {
+              id: 'connection',
+              label: 'Connection',
+              value: <ConnectionEntityLabel connectionId={mapping.connectionId} />,
+            },
+            { id: 'createdAt', label: 'Created', value: <TimeDisplay iso={mapping.createdAt} /> },
+            { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={mapping.updatedAt} /> },
+          ]}
+        />
       </section>
 
       {mapping.context !== null ? (
         <section className="detail-section">
-          <h2 className="detail-section__title">Context</h2>
-          <pre className="raw-payload">
-            {JSON.stringify(mapping.context, null, 2)}
-          </pre>
+          <RawPayloadPanel title="Context" payload={mapping.context} />
         </section>
       ) : null}
 

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
+import { OrderDetailPage } from './order-detail-page';
+import type { OrderRecord } from '../../features/orders/api/orders.types';
+
+const sampleOrder: OrderRecord = {
+  internalOrderId: 'ol_order_abc123',
+  customerId: 'ol_customer_xyz',
+  sourceConnectionId: sampleConnection.id,
+  sourceEventId: 'evt_42',
+  orderSnapshot: { lineItems: [{ sku: 'SKU-1', qty: 2 }] },
+  syncStatus: [
+    {
+      destinationConnectionId: sampleConnection.id,
+      status: 'synced',
+      syncedAt: '2026-04-20T10:00:00.000Z',
+      externalOrderId: '42',
+      externalOrderNumber: null,
+      error: null,
+    },
+  ],
+  createdAt: '2026-04-20T09:00:00.000Z',
+  updatedAt: '2026-04-20T10:00:00.000Z',
+};
+
+function renderDetail(apiClient: ReturnType<typeof createMockApiClient>): void {
+  renderWithProviders(
+    <Routes>
+      <Route path="/orders/:internalOrderId" element={<OrderDetailPage />} />
+    </Routes>,
+    { apiClient, route: '/orders/ol_order_abc123' },
+  );
+}
+
+describe('OrderDetailPage', () => {
+  afterEach(cleanup);
+
+  it('renders key order fields and resolves the source connection name', async () => {
+    const api = createMockApiClient({
+      orders: { getById: vi.fn().mockResolvedValue(sampleOrder) },
+    });
+
+    renderDetail(api);
+
+    expect(await screen.findByText('ol_order_abc123')).toBeInTheDocument();
+    expect(screen.getByText('ol_customer_xyz')).toBeInTheDocument();
+    expect(screen.getByText('evt_42')).toBeInTheDocument();
+
+    const links = await screen.findAllByRole('link', { name: sampleConnection.name });
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  it('renders the order snapshot inside RawPayloadPanel (collapsed, expandable)', async () => {
+    const api = createMockApiClient({
+      orders: { getById: vi.fn().mockResolvedValue(sampleOrder) },
+    });
+
+    renderDetail(api);
+
+    await screen.findByText('ol_order_abc123');
+
+    expect(screen.getByText('Order Snapshot')).toBeInTheDocument();
+    const expandButton = screen.getByRole('button', { name: 'Expand' });
+    fireEvent.click(expandButton);
+    expect(screen.getByLabelText('Payload content').textContent).toContain('SKU-1');
+  });
+});

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -1,9 +1,10 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { EmptyValue } from '../../shared/ui/empty-value';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
@@ -23,7 +24,7 @@ const SYNC_COLUMNS: DataTableColumn<OrderSyncStatus>[] = [
   {
     id: 'destinationConnectionId',
     header: 'Destination',
-    cell: (s) => <span className="mono-text">{s.destinationConnectionId}</span>,
+    cell: (s) => <ConnectionEntityLabel connectionId={s.destinationConnectionId} showId={false} />,
   },
   {
     id: 'status',
@@ -147,8 +148,6 @@ export function OrderDetailPage(): ReactElement {
   );
 }
 
-const NONE: ReactNode = <span className="text-muted">—</span>;
-
 function buildOrderItems(order: {
   internalOrderId: string;
   sourceConnectionId: string;
@@ -167,13 +166,13 @@ function buildOrderItems(order: {
     {
       id: 'customer',
       label: 'Customer ID',
-      value: order.customerId ?? NONE,
+      value: order.customerId ?? <EmptyValue />,
       mono: Boolean(order.customerId),
     },
     {
       id: 'sourceEvent',
       label: 'Source Event ID',
-      value: order.sourceEventId ?? NONE,
+      value: order.sourceEventId ?? <EmptyValue />,
       mono: Boolean(order.sourceEventId),
     },
     { id: 'createdAt', label: 'Created', value: <TimeDisplay iso={order.createdAt} /> },

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -1,13 +1,16 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
+import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useOrderQuery } from '../../features/orders/hooks/use-order-query';
 import type { OrderSyncStatus, OrderSyncStatusValue } from '../../features/orders/api/orders.types';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 
 const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
   pending: 'info',
@@ -116,44 +119,7 @@ export function OrderDetailPage(): ReactElement {
       {/* Order metadata */}
       <section className="detail-section">
         <h3 className="detail-section__title">Details</h3>
-        <dl className="detail-list">
-          <div className="detail-list__row">
-            <dt>Order ID</dt>
-            <dd><span className="mono-text">{order.internalOrderId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Source Connection</dt>
-            <dd><span className="mono-text">{order.sourceConnectionId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Customer ID</dt>
-            <dd>
-              {order.customerId ? (
-                <span className="mono-text">{order.customerId}</span>
-              ) : (
-                <span className="text-muted">—</span>
-              )}
-            </dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Source Event ID</dt>
-            <dd>
-              {order.sourceEventId ? (
-                <span className="mono-text">{order.sourceEventId}</span>
-              ) : (
-                <span className="text-muted">—</span>
-              )}
-            </dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Created</dt>
-            <dd><TimeDisplay iso={order.createdAt} /></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Updated</dt>
-            <dd><TimeDisplay iso={order.updatedAt} /></dd>
-          </div>
-        </dl>
+        <KeyValueList items={buildOrderItems(order)} />
       </section>
 
       {/* Sync status */}
@@ -175,11 +141,42 @@ export function OrderDetailPage(): ReactElement {
 
       {/* Order snapshot */}
       <section className="detail-section">
-        <h3 className="detail-section__title">Order Snapshot</h3>
-        <pre className="mono-text raw-payload">
-          {JSON.stringify(order.orderSnapshot, null, 2)}
-        </pre>
+        <RawPayloadPanel title="Order Snapshot" payload={order.orderSnapshot} />
       </section>
     </PageLayout>
   );
+}
+
+const NONE: ReactNode = <span className="text-muted">—</span>;
+
+function buildOrderItems(order: {
+  internalOrderId: string;
+  sourceConnectionId: string;
+  customerId: string | null;
+  sourceEventId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}): KeyValueItem[] {
+  return [
+    { id: 'orderId', label: 'Order ID', value: order.internalOrderId, mono: true },
+    {
+      id: 'sourceConnection',
+      label: 'Source Connection',
+      value: <ConnectionEntityLabel connectionId={order.sourceConnectionId} />,
+    },
+    {
+      id: 'customer',
+      label: 'Customer ID',
+      value: order.customerId ?? NONE,
+      mono: Boolean(order.customerId),
+    },
+    {
+      id: 'sourceEvent',
+      label: 'Source Event ID',
+      value: order.sourceEventId ?? NONE,
+      mono: Boolean(order.sourceEventId),
+    },
+    { id: 'createdAt', label: 'Created', value: <TimeDisplay iso={order.createdAt} /> },
+    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={order.updatedAt} /> },
+  ];
 }

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -4,12 +4,44 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useProductQuery } from '../../features/products/hooks/use-product-query';
 import { ExternalIdsList } from '../../features/products/components/ExternalIdsList';
 import { useInventoryQuery } from '../../features/inventory/hooks/use-inventory-query';
 import type { ProductVariant } from '../../features/products/api/products.types';
 import type { InventoryItem } from '../../features/inventory/api/inventory.types';
+
+function buildProductItems(product: {
+  id: string;
+  sku: string | null;
+  price: number | null;
+  createdAt: string;
+  updatedAt: string;
+  description?: string | null;
+}): KeyValueItem[] {
+  const items: KeyValueItem[] = [
+    { id: 'productId', label: 'Product ID', value: product.id, mono: true },
+    {
+      id: 'sku',
+      label: 'SKU',
+      value: product.sku ?? <span className="text-muted">—</span>,
+      mono: Boolean(product.sku),
+    },
+    {
+      id: 'price',
+      label: 'Price',
+      value:
+        product.price !== null ? product.price.toFixed(2) : <span className="text-muted">—</span>,
+    },
+    { id: 'createdAt', label: 'Created', value: <TimeDisplay iso={product.createdAt} /> },
+    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={product.updatedAt} /> },
+  ];
+  if (product.description) {
+    items.push({ id: 'description', label: 'Description', value: product.description });
+  }
+  return items;
+}
 
 const STOCK_COLUMNS: DataTableColumn<InventoryItem>[] = [
   {
@@ -155,40 +187,7 @@ export function ProductDetailPage(): ReactElement {
     >
       {/* Product metadata */}
       <section className="detail-section">
-        <dl className="detail-list">
-          <div className="detail-list__row">
-            <dt>Product ID</dt>
-            <dd><span className="mono-text">{product.id}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>SKU</dt>
-            <dd>
-              {product.sku ? (
-                <span className="mono-text">{product.sku}</span>
-              ) : (
-                <span className="text-muted">—</span>
-              )}
-            </dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Price</dt>
-            <dd>{product.price !== null ? product.price.toFixed(2) : <span className="text-muted">—</span>}</dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Created</dt>
-            <dd><TimeDisplay iso={product.createdAt} /></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Updated</dt>
-            <dd><TimeDisplay iso={product.updatedAt} /></dd>
-          </div>
-          {product.description ? (
-            <div className="detail-list__row">
-              <dt>Description</dt>
-              <dd>{product.description}</dd>
-            </div>
-          ) : null}
-        </dl>
+        <KeyValueList items={buildProductItems(product)} />
       </section>
 
       {/* External IDs */}

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -3,9 +3,12 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
+import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobStatusBadge';
 import { useSyncJobQuery } from '../../features/sync-jobs/hooks/use-sync-job-query';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 
 export function SyncJobDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
@@ -35,6 +38,34 @@ export function SyncJobDetailPage(): ReactElement {
 
   const job = query.data;
 
+  const items: KeyValueItem[] = [
+    { id: 'status', label: 'Status', value: <SyncJobStatusBadge status={job.status} /> },
+    { id: 'jobId', label: 'Job ID', value: job.id, mono: true },
+    {
+      id: 'connection',
+      label: 'Connection',
+      value: <ConnectionEntityLabel connectionId={job.connectionId} />,
+    },
+    { id: 'attempts', label: 'Attempts', value: `${job.attempts} / ${job.maxAttempts}` },
+    { id: 'nextRun', label: 'Next run at', value: <TimeDisplay iso={job.nextRunAt} /> },
+    { id: 'createdAt', label: 'Created', value: <TimeDisplay iso={job.createdAt} /> },
+    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={job.updatedAt} /> },
+  ];
+  if (job.idempotencyKey) {
+    items.push({
+      id: 'idempotencyKey',
+      label: 'Idempotency key',
+      value: job.idempotencyKey,
+      mono: true,
+    });
+  }
+  if (job.lockedAt) {
+    items.push({ id: 'lockedAt', label: 'Locked at', value: <TimeDisplay iso={job.lockedAt} /> });
+  }
+  if (job.lockedBy) {
+    items.push({ id: 'lockedBy', label: 'Locked by', value: job.lockedBy, mono: true });
+  }
+
   return (
     <PageLayout
       eyebrow="Sync Jobs"
@@ -47,71 +78,20 @@ export function SyncJobDetailPage(): ReactElement {
     >
       {/* Status + metadata */}
       <section className="detail-section">
-        <dl className="detail-list">
-          <div className="detail-list__row">
-            <dt>Status</dt>
-            <dd><SyncJobStatusBadge status={job.status} /></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Job ID</dt>
-            <dd><span className="mono-text">{job.id}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Connection</dt>
-            <dd><span className="mono-text">{job.connectionId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Attempts</dt>
-            <dd>{job.attempts} / {job.maxAttempts}</dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Next run at</dt>
-            <dd><TimeDisplay iso={job.nextRunAt} /></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Created</dt>
-            <dd><TimeDisplay iso={job.createdAt} /></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Updated</dt>
-            <dd><TimeDisplay iso={job.updatedAt} /></dd>
-          </div>
-          {job.idempotencyKey ? (
-            <div className="detail-list__row">
-              <dt>Idempotency key</dt>
-              <dd><span className="mono-text">{job.idempotencyKey}</span></dd>
-            </div>
-          ) : null}
-          {job.lockedAt ? (
-            <div className="detail-list__row">
-              <dt>Locked at</dt>
-              <dd><TimeDisplay iso={job.lockedAt} /></dd>
-            </div>
-          ) : null}
-          {job.lockedBy ? (
-            <div className="detail-list__row">
-              <dt>Locked by</dt>
-              <dd><span className="mono-text">{job.lockedBy}</span></dd>
-            </div>
-          ) : null}
-        </dl>
+        <KeyValueList items={items} />
       </section>
 
       {/* Error section */}
       {job.lastError ? (
         <section className="detail-section">
-          <h3 className="detail-section__title">Last error</h3>
-          <pre className="mono-text detail-section__pre">{job.lastError}</pre>
+          <RawPayloadPanel title="Last error" payload={job.lastError} defaultOpen />
         </section>
       ) : null}
 
       {/* Payload section */}
       {job.payloadJson ? (
         <section className="detail-section">
-          <h3 className="detail-section__title">Payload</h3>
-          <pre className="mono-text detail-section__pre">
-            {JSON.stringify(job.payloadJson, null, 2)}
-          </pre>
+          <RawPayloadPanel title="Payload" payload={job.payloadJson} />
         </section>
       ) : null}
     </PageLayout>

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -8,7 +8,39 @@ import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobStatusBadge';
 import { useSyncJobQuery } from '../../features/sync-jobs/hooks/use-sync-job-query';
+import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+
+function buildSyncJobItems(job: SyncJob): KeyValueItem[] {
+  const items: KeyValueItem[] = [
+    { id: 'status', label: 'Status', value: <SyncJobStatusBadge status={job.status} /> },
+    { id: 'jobId', label: 'Job ID', value: job.id, mono: true },
+    {
+      id: 'connection',
+      label: 'Connection',
+      value: <ConnectionEntityLabel connectionId={job.connectionId} />,
+    },
+    { id: 'attempts', label: 'Attempts', value: `${job.attempts} / ${job.maxAttempts}` },
+    { id: 'nextRun', label: 'Next run at', value: <TimeDisplay iso={job.nextRunAt} /> },
+    { id: 'createdAt', label: 'Created', value: <TimeDisplay iso={job.createdAt} /> },
+    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={job.updatedAt} /> },
+  ];
+  if (job.idempotencyKey) {
+    items.push({
+      id: 'idempotencyKey',
+      label: 'Idempotency key',
+      value: job.idempotencyKey,
+      mono: true,
+    });
+  }
+  if (job.lockedAt) {
+    items.push({ id: 'lockedAt', label: 'Locked at', value: <TimeDisplay iso={job.lockedAt} /> });
+  }
+  if (job.lockedBy) {
+    items.push({ id: 'lockedBy', label: 'Locked by', value: job.lockedBy, mono: true });
+  }
+  return items;
+}
 
 export function SyncJobDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
@@ -38,34 +70,6 @@ export function SyncJobDetailPage(): ReactElement {
 
   const job = query.data;
 
-  const items: KeyValueItem[] = [
-    { id: 'status', label: 'Status', value: <SyncJobStatusBadge status={job.status} /> },
-    { id: 'jobId', label: 'Job ID', value: job.id, mono: true },
-    {
-      id: 'connection',
-      label: 'Connection',
-      value: <ConnectionEntityLabel connectionId={job.connectionId} />,
-    },
-    { id: 'attempts', label: 'Attempts', value: `${job.attempts} / ${job.maxAttempts}` },
-    { id: 'nextRun', label: 'Next run at', value: <TimeDisplay iso={job.nextRunAt} /> },
-    { id: 'createdAt', label: 'Created', value: <TimeDisplay iso={job.createdAt} /> },
-    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={job.updatedAt} /> },
-  ];
-  if (job.idempotencyKey) {
-    items.push({
-      id: 'idempotencyKey',
-      label: 'Idempotency key',
-      value: job.idempotencyKey,
-      mono: true,
-    });
-  }
-  if (job.lockedAt) {
-    items.push({ id: 'lockedAt', label: 'Locked at', value: <TimeDisplay iso={job.lockedAt} /> });
-  }
-  if (job.lockedBy) {
-    items.push({ id: 'lockedBy', label: 'Locked by', value: job.lockedBy, mono: true });
-  }
-
   return (
     <PageLayout
       eyebrow="Sync Jobs"
@@ -76,19 +80,16 @@ export function SyncJobDetailPage(): ReactElement {
         </Link>
       }
     >
-      {/* Status + metadata */}
       <section className="detail-section">
-        <KeyValueList items={items} />
+        <KeyValueList items={buildSyncJobItems(job)} />
       </section>
 
-      {/* Error section */}
       {job.lastError ? (
         <section className="detail-section">
           <RawPayloadPanel title="Last error" payload={job.lastError} defaultOpen />
         </section>
       ) : null}
 
-      {/* Payload section */}
       {job.payloadJson ? (
         <section className="detail-section">
           <RawPayloadPanel title="Payload" payload={job.payloadJson} />

--- a/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.test.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, screen } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
+import { WebhookDeliveryDetailPage } from './webhook-delivery-detail-page';
+import type { WebhookDeliveryDetail } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
+
+const sampleDelivery: WebhookDeliveryDetail = {
+  id: 'ol_webhook_abc',
+  eventId: 'evt_42',
+  provider: 'prestashop',
+  connectionId: sampleConnection.id,
+  objectType: 'order',
+  externalId: 'ps_order_123',
+  eventType: 'order.updated',
+  status: 'deadlettered',
+  signatureValid: true,
+  dedupResult: 'first',
+  publishedMessageId: null,
+  downstreamJobId: null,
+  downstreamJobType: null,
+  rejectionReason: null,
+  dlqReason: 'handler threw: timeout after 5s',
+  receivedAt: '2026-04-20T10:00:00.000Z',
+  payload: { orderId: 'ps_order_123', status: 'shipped' },
+  createdAt: '2026-04-20T10:00:00.000Z',
+  updatedAt: '2026-04-20T10:00:00.000Z',
+};
+
+function renderDetail(apiClient: ReturnType<typeof createMockApiClient>): void {
+  renderWithProviders(
+    <Routes>
+      <Route path="/webhook-deliveries/:id" element={<WebhookDeliveryDetailPage />} />
+    </Routes>,
+    { apiClient, route: '/webhook-deliveries/ol_webhook_abc' },
+  );
+}
+
+describe('WebhookDeliveryDetailPage', () => {
+  afterEach(cleanup);
+
+  it('renders delivery metadata and the dlq / payload payload panels', async () => {
+    const api = createMockApiClient({
+      webhookDeliveries: { getById: vi.fn().mockResolvedValue(sampleDelivery) },
+    });
+
+    renderDetail(api);
+
+    await screen.findByText('evt_42');
+    expect(screen.getByText('prestashop')).toBeInTheDocument();
+    expect(screen.getByText('ps_order_123')).toBeInTheDocument();
+
+    expect(screen.getByText('DLQ reason')).toBeInTheDocument();
+    expect(screen.getByText(/handler threw: timeout/)).toBeInTheDocument();
+
+    expect(screen.getByText('Payload')).toBeInTheDocument();
+  });
+
+  it('resolves the connection name via ConnectionEntityLabel', async () => {
+    const api = createMockApiClient({
+      webhookDeliveries: { getById: vi.fn().mockResolvedValue(sampleDelivery) },
+    });
+
+    renderDetail(api);
+
+    const links = await screen.findAllByRole('link', { name: sampleConnection.name });
+    expect(links.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
@@ -3,10 +3,13 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
+import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useWebhookDeliveryQuery } from '../../features/webhook-deliveries/hooks/use-webhook-delivery-query';
 import type { WebhookDeliveryStatus } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 
 function statusTone(status: WebhookDeliveryStatus): StatusBadgeTone {
   switch (status) {
@@ -50,6 +53,56 @@ export function WebhookDeliveryDetailPage(): ReactElement {
 
   const d = query.data;
 
+  const items: KeyValueItem[] = [
+    { id: 'status', label: 'Status', value: <StatusBadge tone={statusTone(d.status)}>{d.status}</StatusBadge> },
+    { id: 'eventId', label: 'Event ID', value: d.eventId, mono: true },
+    { id: 'provider', label: 'Provider', value: d.provider, mono: true },
+    {
+      id: 'connection',
+      label: 'Connection',
+      value: <ConnectionEntityLabel connectionId={d.connectionId} />,
+    },
+  ];
+  if (d.objectType) {
+    items.push({ id: 'objectType', label: 'Object type', value: d.objectType, mono: true });
+  }
+  if (d.externalId) {
+    items.push({ id: 'externalId', label: 'External ID', value: d.externalId, mono: true });
+  }
+  items.push({
+    id: 'sigValid',
+    label: 'Signature valid',
+    value: d.signatureValid === null ? '—' : d.signatureValid ? 'yes' : 'no',
+  });
+  if (d.dedupResult) {
+    items.push({ id: 'dedup', label: 'Dedup', value: d.dedupResult });
+  }
+  if (d.publishedMessageId) {
+    items.push({
+      id: 'publishedMessage',
+      label: 'Published message',
+      value: d.publishedMessageId,
+      mono: true,
+    });
+  }
+  if (d.downstreamJobId) {
+    items.push({
+      id: 'downstreamJob',
+      label: 'Downstream job',
+      value: (
+        <>
+          <Link to={`/jobs-logs/${d.downstreamJobId}`} className="mono-text">
+            {d.downstreamJobId}
+          </Link>
+          {d.downstreamJobType ? (
+            <span className="text-muted"> — {d.downstreamJobType}</span>
+          ) : null}
+        </>
+      ),
+    });
+  }
+  items.push({ id: 'received', label: 'Received', value: <TimeDisplay iso={d.receivedAt} /> });
+
   return (
     <PageLayout
       eyebrow="Webhook Deliveries"
@@ -61,91 +114,24 @@ export function WebhookDeliveryDetailPage(): ReactElement {
       }
     >
       <section className="detail-section">
-        <dl className="detail-list">
-          <div className="detail-list__row">
-            <dt>Status</dt>
-            <dd><StatusBadge tone={statusTone(d.status)}>{d.status}</StatusBadge></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Event ID</dt>
-            <dd><span className="mono-text">{d.eventId}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Provider</dt>
-            <dd><span className="mono-text">{d.provider}</span></dd>
-          </div>
-          <div className="detail-list__row">
-            <dt>Connection</dt>
-            <dd><span className="mono-text">{d.connectionId}</span></dd>
-          </div>
-          {d.objectType ? (
-            <div className="detail-list__row">
-              <dt>Object type</dt>
-              <dd><span className="mono-text">{d.objectType}</span></dd>
-            </div>
-          ) : null}
-          {d.externalId ? (
-            <div className="detail-list__row">
-              <dt>External ID</dt>
-              <dd><span className="mono-text">{d.externalId}</span></dd>
-            </div>
-          ) : null}
-          <div className="detail-list__row">
-            <dt>Signature valid</dt>
-            <dd>{d.signatureValid === null ? '—' : d.signatureValid ? 'yes' : 'no'}</dd>
-          </div>
-          {d.dedupResult ? (
-            <div className="detail-list__row">
-              <dt>Dedup</dt>
-              <dd>{d.dedupResult}</dd>
-            </div>
-          ) : null}
-          {d.publishedMessageId ? (
-            <div className="detail-list__row">
-              <dt>Published message</dt>
-              <dd><span className="mono-text">{d.publishedMessageId}</span></dd>
-            </div>
-          ) : null}
-          {d.downstreamJobId ? (
-            <div className="detail-list__row">
-              <dt>Downstream job</dt>
-              <dd>
-                <Link to={`/jobs-logs/${d.downstreamJobId}`} className="mono-text">
-                  {d.downstreamJobId}
-                </Link>
-                {d.downstreamJobType ? (
-                  <span className="text-muted"> — {d.downstreamJobType}</span>
-                ) : null}
-              </dd>
-            </div>
-          ) : null}
-          <div className="detail-list__row">
-            <dt>Received</dt>
-            <dd><TimeDisplay iso={d.receivedAt} /></dd>
-          </div>
-        </dl>
+        <KeyValueList items={items} />
       </section>
 
       {d.rejectionReason ? (
         <section className="detail-section">
-          <h3 className="detail-section__title">Rejection reason</h3>
-          <pre className="mono-text detail-section__pre">{d.rejectionReason}</pre>
+          <RawPayloadPanel title="Rejection reason" payload={d.rejectionReason} defaultOpen />
         </section>
       ) : null}
 
       {d.dlqReason ? (
         <section className="detail-section">
-          <h3 className="detail-section__title">DLQ reason</h3>
-          <pre className="mono-text detail-section__pre">{d.dlqReason}</pre>
+          <RawPayloadPanel title="DLQ reason" payload={d.dlqReason} defaultOpen />
         </section>
       ) : null}
 
       {d.payload ? (
         <section className="detail-section">
-          <h3 className="detail-section__title">Payload</h3>
-          <pre className="mono-text detail-section__pre">
-            {JSON.stringify(d.payload, null, 2)}
-          </pre>
+          <RawPayloadPanel title="Payload" payload={d.payload} />
         </section>
       ) : null}
     </PageLayout>

--- a/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-delivery-detail-page.tsx
@@ -3,12 +3,16 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { EmptyValue } from '../../shared/ui/empty-value';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useWebhookDeliveryQuery } from '../../features/webhook-deliveries/hooks/use-webhook-delivery-query';
-import type { WebhookDeliveryStatus } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
+import type {
+  WebhookDeliveryDetail,
+  WebhookDeliveryStatus,
+} from '../../features/webhook-deliveries/api/webhook-deliveries.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 
 function statusTone(status: WebhookDeliveryStatus): StatusBadgeTone {
@@ -27,34 +31,13 @@ function statusTone(status: WebhookDeliveryStatus): StatusBadgeTone {
   }
 }
 
-export function WebhookDeliveryDetailPage(): ReactElement {
-  const { id = '' } = useParams<{ id: string }>();
-  const query = useWebhookDeliveryQuery(id);
-
-  if (query.isLoading) {
-    return (
-      <PageLayout eyebrow="Webhook Deliveries" title="Delivery detail">
-        <LoadingState liveRegion="off" title="Loading delivery" message="Fetching delivery details…" />
-      </PageLayout>
-    );
-  }
-
-  if (query.error || !query.data) {
-    return (
-      <PageLayout eyebrow="Webhook Deliveries" title="Delivery detail">
-        <ErrorState
-          title="Unable to load delivery"
-          message={query.error?.message ?? 'Delivery not found'}
-          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
-        />
-      </PageLayout>
-    );
-  }
-
-  const d = query.data;
-
+function buildWebhookDeliveryItems(d: WebhookDeliveryDetail): KeyValueItem[] {
   const items: KeyValueItem[] = [
-    { id: 'status', label: 'Status', value: <StatusBadge tone={statusTone(d.status)}>{d.status}</StatusBadge> },
+    {
+      id: 'status',
+      label: 'Status',
+      value: <StatusBadge tone={statusTone(d.status)}>{d.status}</StatusBadge>,
+    },
     { id: 'eventId', label: 'Event ID', value: d.eventId, mono: true },
     { id: 'provider', label: 'Provider', value: d.provider, mono: true },
     {
@@ -72,7 +55,8 @@ export function WebhookDeliveryDetailPage(): ReactElement {
   items.push({
     id: 'sigValid',
     label: 'Signature valid',
-    value: d.signatureValid === null ? '—' : d.signatureValid ? 'yes' : 'no',
+    value:
+      d.signatureValid === null ? <EmptyValue /> : d.signatureValid ? 'yes' : 'no',
   });
   if (d.dedupResult) {
     items.push({ id: 'dedup', label: 'Dedup', value: d.dedupResult });
@@ -102,6 +86,34 @@ export function WebhookDeliveryDetailPage(): ReactElement {
     });
   }
   items.push({ id: 'received', label: 'Received', value: <TimeDisplay iso={d.receivedAt} /> });
+  return items;
+}
+
+export function WebhookDeliveryDetailPage(): ReactElement {
+  const { id = '' } = useParams<{ id: string }>();
+  const query = useWebhookDeliveryQuery(id);
+
+  if (query.isLoading) {
+    return (
+      <PageLayout eyebrow="Webhook Deliveries" title="Delivery detail">
+        <LoadingState liveRegion="off" title="Loading delivery" message="Fetching delivery details…" />
+      </PageLayout>
+    );
+  }
+
+  if (query.error || !query.data) {
+    return (
+      <PageLayout eyebrow="Webhook Deliveries" title="Delivery detail">
+        <ErrorState
+          title="Unable to load delivery"
+          message={query.error?.message ?? 'Delivery not found'}
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
+        />
+      </PageLayout>
+    );
+  }
+
+  const d = query.data;
 
   return (
     <PageLayout
@@ -114,7 +126,7 @@ export function WebhookDeliveryDetailPage(): ReactElement {
       }
     >
       <section className="detail-section">
-        <KeyValueList items={items} />
+        <KeyValueList items={buildWebhookDeliveryItems(d)} />
       </section>
 
       {d.rejectionReason ? (

--- a/apps/web/src/shared/ui/empty-value.test.tsx
+++ b/apps/web/src/shared/ui/empty-value.test.tsx
@@ -1,0 +1,18 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { EmptyValue } from './empty-value';
+
+describe('EmptyValue', () => {
+  afterEach(cleanup);
+
+  it('renders an em dash with a default accessible label', () => {
+    render(<EmptyValue />);
+    const el = screen.getByLabelText('No value');
+    expect(el).toHaveTextContent('—');
+  });
+
+  it('accepts a custom accessible label', () => {
+    render(<EmptyValue label="Not linked" />);
+    expect(screen.getByLabelText('Not linked')).toHaveTextContent('—');
+  });
+});

--- a/apps/web/src/shared/ui/empty-value.tsx
+++ b/apps/web/src/shared/ui/empty-value.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from 'react';
+
+interface EmptyValueProps {
+  label?: string;
+}
+
+export function EmptyValue({ label = 'No value' }: EmptyValueProps): ReactElement {
+  return (
+    <span className="text-muted" aria-label={label}>
+      —
+    </span>
+  );
+}


### PR DESCRIPTION
Part of #239 (epic #236). Third slice of Phase 3.

## What this ships

### New feature-level wrapper

**`ConnectionEntityLabel`** (`apps/web/src/features/connections/components/`) binds the presentational `EntityLabel` from `shared/ui/` to `useConnectionQuery`. Keeps the dependency direction clean (features → shared, not the other way) while giving pages a one-liner that turns a bare connection UUID into `Allegro sandbox · ol_connection_e4d3…1124 · 📋 (copy)`. Loading / resolved / error paths are tested.

### Detail pages migrated (8)

Every hand-rolled `<dl className="detail-list"><div className="detail-list__row"><dt>…</dt><dd>…</dd></div>…</dl>` is replaced by `<KeyValueList items={[…]} />`. Every raw-JSON `<pre>` is replaced by `<RawPayloadPanel payload={…} />`. Connection references that were bare UUIDs are now `<ConnectionEntityLabel connectionId={…} />`.

| Page | KeyValueList | RawPayloadPanel | ConnectionEntityLabel |
|---|---|---|---|
| Connection detail | ✓ | via ConnectionConfigPanel | — |
| Customer detail | ✓ | — | lastSourceConnection |
| Inventory detail | ✓ | — | — |
| Listing detail | ✓ | `mapping.context` | `connectionId` |
| Order detail | ✓ | `orderSnapshot` | `sourceConnectionId` |
| Product detail | ✓ | — | — |
| Sync Job detail | ✓ | `lastError` (defaultOpen) + `payloadJson` | `connectionId` |
| Webhook Delivery detail | ✓ | `rejectionReason` (defaultOpen) + `dlqReason` (defaultOpen) + `payload` | `connectionId` |

### Feature component updated

**`ConnectionConfigPanel`** now uses `RawPayloadPanel` for the config JSON (was a bare `<pre>`). The empty-config branch keeps its original layout so existing test assertions pass unchanged.

## What this doesn't ship

- `CustomerEntityLabel`, `OrderEntityLabel`, etc. — only `ConnectionEntityLabel` is introduced this slice since that's the only case where a raw ID appears in a detail page today and benefits from resolving to a name. Other wrappers can follow in 3d/3e as needed.
- No dashboard/metric work (that's 3d).

## Tests

- 3 new tests on `ConnectionEntityLabel` (loading / resolved / error).
- All 261/261 existing + new tests pass.
- Pre-commit hook (workspace lint + type-check + full test suite) passed.

## Slicing reminder

1. 3a · Foundation (PR #246, merged)
2. 3b · DataTable + list migration (PR #247, merged)
3. **3c · Detail pages** ← this PR
4. 3d · Dashboard + MetricCard severity tinting
5. 3e · Radix adoption (ConfirmDialog, Select, Toast)
6. *(follow-up)* Jobs virtualization
