### PR TITLE
Phase 3d — dashboard on MetricCard with severity tinting

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -858,43 +858,12 @@ textarea {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
-.metric-card,
 .panel,
 .list-card,
 .form-card,
 .empty-state,
 .state-card {
   padding: 1rem;
-}
-
-.metric-card {
-  gap: 0.25rem;
-  min-height: 0;
-}
-
-.metric-card__label {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-}
-
-.metric-card__value {
-  font-size: 1.4rem;
-  color: var(--text-primary);
-}
-
-.metric-card p {
-  margin: 0;
-  color: var(--text-secondary);
-}
-
-.metric-card--warning {
-  border-color: var(--status-warning-border);
-}
-
-.metric-card--review {
-  border-color: var(--status-review-border);
 }
 
 .workspace-grid {

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -1,7 +1,8 @@
 import { cleanup, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { DashboardPage } from './dashboard-page';
+import type { Connection } from '../../features/connections/api/connections.types';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 
 function makeSyncJob(overrides: Partial<SyncJob> = {}): SyncJob {
@@ -24,6 +25,24 @@ function makeSyncJob(overrides: Partial<SyncJob> = {}): SyncJob {
   };
 }
 
+function makeConnection(overrides: Partial<Connection>): Connection {
+  return { ...sampleConnection, ...overrides };
+}
+
+function findCardByLabel(container: HTMLElement, label: string): HTMLElement {
+  const labels = Array.from(container.querySelectorAll<HTMLElement>('.metric-card__label')).filter(
+    (el) => el.textContent === label,
+  );
+  if (labels.length !== 1) {
+    throw new Error(`Expected one .metric-card__label "${label}", found ${labels.length}`);
+  }
+  const card = labels[0].closest('.metric-card');
+  if (!(card instanceof HTMLElement)) {
+    throw new Error(`No .metric-card ancestor for label: ${label}`);
+  }
+  return card;
+}
+
 describe('DashboardPage', () => {
   afterEach(cleanup);
 
@@ -36,8 +55,8 @@ describe('DashboardPage', () => {
     const apiClient = createMockApiClient({
       connections: {
         list: vi.fn().mockResolvedValue([
-          { id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop', config: {}, credentialsBacked: true, createdAt: '', updatedAt: '' },
-          { id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro', config: {}, credentialsBacked: true, createdAt: '', updatedAt: '' },
+          makeConnection({ id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop' }),
+          makeConnection({ id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro' }),
         ]),
       },
     });
@@ -159,26 +178,30 @@ describe('DashboardPage', () => {
     const { container } = renderWithProviders(<DashboardPage />, { apiClient });
 
     await screen.findByText('3 jobs need attention');
-    const errorCard = container.querySelector('.metric-card--error');
-    expect(errorCard).not.toBeNull();
-    expect(errorCard).toHaveAttribute('href', '/orders/failed');
+    const failedCard = findCardByLabel(container, 'Failed jobs');
+    expect(failedCard).toHaveClass('metric-card--error');
+    expect(failedCard).toHaveAttribute('href', '/orders/failed');
   });
 
-  it('leaves the Failed jobs card in the success tone when there are no failures', async () => {
+  it('keeps the Failed jobs card neutral when there are no failures', async () => {
     const { container } = renderWithProviders(<DashboardPage />);
 
     await waitFor(() => {
-      expect(container.querySelector('.metric-card--error')).toBeNull();
+      const failedCard = findCardByLabel(container, 'Failed jobs');
+      expect(failedCard).toHaveClass('metric-card--neutral');
     });
-    expect(container.querySelector('.metric-card--success')).not.toBeNull();
+    const failedCard = findCardByLabel(container, 'Failed jobs');
+    expect(failedCard.tagName).toBe('DIV');
+    expect(failedCard).not.toHaveClass('metric-card--error');
+    expect(failedCard).not.toHaveClass('metric-card--success');
   });
 
   it('tints the Integration health card warning when a connection is in error', async () => {
     const apiClient = createMockApiClient({
       connections: {
         list: vi.fn().mockResolvedValue([
-          { id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop', config: {}, credentialsBacked: true, createdAt: '', updatedAt: '', enabledCapabilities: [], supportedCapabilities: [] },
-          { id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro', config: {}, credentialsBacked: true, createdAt: '', updatedAt: '', enabledCapabilities: [], supportedCapabilities: [] },
+          makeConnection({ id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop' }),
+          makeConnection({ id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro' }),
         ]),
       },
     });
@@ -186,7 +209,8 @@ describe('DashboardPage', () => {
     const { container } = renderWithProviders(<DashboardPage />, { apiClient });
 
     await screen.findByText('1 / 2');
-    expect(container.querySelector('.metric-card--warning')).not.toBeNull();
+    const integrationCard = findCardByLabel(container, 'Integration health');
+    expect(integrationCard).toHaveClass('metric-card--warning');
   });
 
   it('shows error state when sync jobs fail to load', async () => {

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -1,5 +1,5 @@
-import { screen, waitFor, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
 import { DashboardPage } from './dashboard-page';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
@@ -25,6 +25,8 @@ function makeSyncJob(overrides: Partial<SyncJob> = {}): SyncJob {
 }
 
 describe('DashboardPage', () => {
+  afterEach(cleanup);
+
   it('renders the operations overview heading', () => {
     renderWithProviders(<DashboardPage />);
     expect(screen.getByRole('heading', { name: 'Operations overview' })).toBeInTheDocument();
@@ -136,6 +138,55 @@ describe('DashboardPage', () => {
     renderWithProviders(<DashboardPage />, { apiClient });
 
     expect(await screen.findByText('1 job needs attention')).toBeInTheDocument();
+  });
+
+  it('tints the Failed jobs card red and links to /orders/failed when there are failures', async () => {
+    const listMock = vi.fn().mockImplementation((filters?: { status?: string }) => {
+      if (filters?.status === 'dead') {
+        return Promise.resolve({
+          items: [makeSyncJob({ id: 'dead1', status: 'dead', lastError: 'Timeout' })],
+          total: 3,
+          limit: 10,
+          offset: 0,
+        });
+      }
+      return Promise.resolve({ items: [], total: 0, limit: 5, offset: 0 });
+    });
+    const apiClient = createMockApiClient({
+      syncJobs: { list: listMock },
+    });
+
+    const { container } = renderWithProviders(<DashboardPage />, { apiClient });
+
+    await screen.findByText('3 jobs need attention');
+    const errorCard = container.querySelector('.metric-card--error');
+    expect(errorCard).not.toBeNull();
+    expect(errorCard).toHaveAttribute('href', '/orders/failed');
+  });
+
+  it('leaves the Failed jobs card in the success tone when there are no failures', async () => {
+    const { container } = renderWithProviders(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.metric-card--error')).toBeNull();
+    });
+    expect(container.querySelector('.metric-card--success')).not.toBeNull();
+  });
+
+  it('tints the Integration health card warning when a connection is in error', async () => {
+    const apiClient = createMockApiClient({
+      connections: {
+        list: vi.fn().mockResolvedValue([
+          { id: 'c1', name: 'Store A', status: 'active', platformType: 'prestashop', config: {}, credentialsBacked: true, createdAt: '', updatedAt: '', enabledCapabilities: [], supportedCapabilities: [] },
+          { id: 'c2', name: 'Store B', status: 'error', platformType: 'allegro', config: {}, credentialsBacked: true, createdAt: '', updatedAt: '', enabledCapabilities: [], supportedCapabilities: [] },
+        ]),
+      },
+    });
+
+    const { container } = renderWithProviders(<DashboardPage />, { apiClient });
+
+    await screen.findByText('1 / 2');
+    expect(container.querySelector('.metric-card--warning')).not.toBeNull();
   });
 
   it('shows error state when sync jobs fail to load', async () => {

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -10,6 +10,7 @@ import { DASHBOARD_HEALTH_INTERVAL_MS, DASHBOARD_JOBS_INTERVAL_MS } from './inte
 import { Button } from '../../shared/ui/button';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
+import { MetricCard, MetricCardLink, type MetricCardTone } from '../../shared/ui/metric-card';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -81,6 +82,25 @@ function toHealthTone(status: ServiceStatus | OverallStatus): StatusBadgeTone {
   if (status === 'ok') return 'success';
   if (status === 'warning' || status === 'degraded') return 'warning';
   return 'error';
+}
+
+function systemHealthTone(status: OverallStatus | undefined, hasError: boolean): MetricCardTone {
+  if (hasError || status === 'error') return 'error';
+  if (status === 'degraded') return 'warning';
+  if (status === 'ok') return 'success';
+  return 'neutral';
+}
+
+function renderHealthValue(
+  status: OverallStatus | undefined,
+  isLoading: boolean,
+  hasError: boolean,
+): ReactElement | string {
+  if (isLoading) return '—';
+  if (hasError) return 'unreachable';
+  return (
+    <StatusBadge tone={toHealthTone(status ?? 'error')}>{status ?? 'unknown'}</StatusBadge>
+  );
 }
 
 function ServiceHealthRow({ name, health }: { name: string; health: ServiceHealth }): ReactElement {
@@ -156,51 +176,49 @@ export function DashboardPage(): ReactElement {
     >
       {/* ── Metric strip ─────────────────────────────────────────── */}
       <section className="status-strip">
-        <article className={errorCount > 0 ? 'metric-card metric-card--warning' : 'metric-card'}>
-          <span className="metric-card__label">Integration health</span>
-          {connectionsQuery.isLoading ? (
-            <strong className="metric-card__value">—</strong>
-          ) : (
-            <strong className="metric-card__value">{activeCount} / {connections.length}</strong>
-          )}
-          <p>{errorCount > 0 ? `${errorCount} connection${errorCount > 1 ? 's' : ''} in error` : 'All channels active'}</p>
-        </article>
+        <MetricCard
+          label="Integration health"
+          value={connectionsQuery.isLoading ? '—' : `${activeCount} / ${connections.length}`}
+          tone={errorCount > 0 ? 'warning' : 'neutral'}
+          description={
+            errorCount > 0
+              ? `${errorCount} connection${errorCount > 1 ? 's' : ''} in error`
+              : 'All channels active'
+          }
+        />
 
-        <article className="metric-card">
-          <span className="metric-card__label">System health</span>
-          {healthQuery.isLoading ? (
-            <strong className="metric-card__value">—</strong>
-          ) : healthQuery.error ? (
-            <strong className="metric-card__value">!</strong>
-          ) : (
-            <strong className="metric-card__value">
-              <StatusBadge tone={toHealthTone(healthQuery.data?.status ?? 'error')}>
-                {healthQuery.data?.status ?? 'unknown'}
-              </StatusBadge>
-            </strong>
-          )}
-          <p>Postgres · Redis · PrestaShop · Worker</p>
-        </article>
+        <MetricCard
+          label="System health"
+          value={renderHealthValue(healthQuery.data?.status, healthQuery.isLoading, Boolean(healthQuery.error))}
+          tone={systemHealthTone(healthQuery.data?.status, Boolean(healthQuery.error))}
+          description="Postgres · Redis · PrestaShop · Worker"
+        />
 
-        <article className={deadCount > 0 ? 'metric-card metric-card--warning' : 'metric-card'}>
-          <span className="metric-card__label">Failed jobs</span>
-          {deadJobsQuery.isLoading ? (
-            <strong className="metric-card__value">—</strong>
-          ) : (
-            <strong className="metric-card__value">{deadCount}</strong>
-          )}
-          <p>{deadCount > 0 ? `${deadCount} job${deadCount === 1 ? '' : 's'} need${deadCount === 1 ? 's' : ''} attention` : 'No failures'}</p>
-        </article>
+        {deadCount > 0 ? (
+          <MetricCardLink
+            label="Failed jobs"
+            value={deadJobsQuery.isLoading ? '—' : deadCount}
+            tone="error"
+            to="/orders/failed"
+            description={`${deadCount} job${deadCount === 1 ? '' : 's'} need${deadCount === 1 ? 's' : ''} attention`}
+          />
+        ) : (
+          <MetricCard
+            label="Failed jobs"
+            value={deadJobsQuery.isLoading ? '—' : 0}
+            tone="success"
+            description="No failures"
+          />
+        )}
 
-        <article className="metric-card">
-          <span className="metric-card__label">Queued jobs</span>
-          {queuedJobsQuery.isLoading ? (
-            <strong className="metric-card__value">—</strong>
-          ) : (
-            <strong className="metric-card__value">{queuedCount}</strong>
-          )}
-          <p>{queuedCount > 0 ? `${queuedCount} job${queuedCount > 1 ? 's' : ''} waiting` : 'Queue empty'}</p>
-        </article>
+        <MetricCard
+          label="Queued jobs"
+          value={queuedJobsQuery.isLoading ? '—' : queuedCount}
+          tone={queuedCount > 0 ? 'info' : 'neutral'}
+          description={
+            queuedCount > 0 ? `${queuedCount} job${queuedCount > 1 ? 's' : ''} waiting` : 'Queue empty'
+          }
+        />
       </section>
 
       <div className="workspace-grid workspace-grid--primary">

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -1,28 +1,48 @@
-import { useCallback, type ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { useDevStackHealthQuery } from '../../features/health/hooks/use-dev-stack-health-query';
 import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
-import type { ServiceHealth, ServiceStatus, OverallStatus } from '../../features/health/api/health.types';
-import type { Connection } from '../../features/connections/api/connections.types';
-import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
+import type {
+  ServiceHealth,
+  ServiceStatus,
+  OverallStatus,
+} from '../../features/health/api/health.types';
+import type { Connection, ConnectionStatus } from '../../features/connections/api/connections.types';
+import type { JobStatus, SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 import { DASHBOARD_HEALTH_INTERVAL_MS, DASHBOARD_JOBS_INTERVAL_MS } from './intervals';
 import { Button } from '../../shared/ui/button';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
-import { MetricCard, MetricCardLink, type MetricCardTone } from '../../shared/ui/metric-card';
+import { MetricCard, MetricCardLink } from '../../shared/ui/metric-card';
 import { PageLayout } from '../../shared/ui/page-layout';
-import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { StatusBadge } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
 
-function toStatusTone(status: string): StatusBadgeTone {
+type DashboardTone = 'success' | 'warning' | 'error' | 'neutral';
+
+function toRowStatusTone(status: ConnectionStatus | JobStatus): DashboardTone {
   if (status === 'active' || status === 'succeeded') return 'success';
   if (status === 'error' || status === 'dead') return 'error';
-  if (status === 'running') return 'info';
-  if (status === 'queued') return 'neutral';
   return 'neutral';
 }
 
+function mapHealthTone(
+  status: ServiceStatus | OverallStatus | undefined,
+  hasError: boolean,
+): DashboardTone {
+  if (hasError || status === 'error') return 'error';
+  if (status === 'warning' || status === 'degraded') return 'warning';
+  if (status === 'ok') return 'success';
+  return 'neutral';
+}
+
+function toHealthLabel(status: OverallStatus | undefined): string {
+  if (status === 'ok') return 'OK';
+  if (status === 'degraded') return 'Degraded';
+  if (status === 'error') return 'Error';
+  return 'Unknown';
+}
 
 function formatJobType(jobType: string): string {
   return jobType.replaceAll('.', ' › ');
@@ -54,7 +74,7 @@ const recentJobColumns: DataTableColumn<SyncJob>[] = [
     id: 'status',
     header: 'Status',
     cell: (row) => (
-      <StatusBadge tone={toStatusTone(row.status)} compact>
+      <StatusBadge tone={toRowStatusTone(row.status)} compact>
         {row.status}
       </StatusBadge>
     ),
@@ -78,38 +98,21 @@ const failedJobColumns: DataTableColumn<SyncJob>[] = [
   updatedAtColumn,
 ];
 
-function toHealthTone(status: ServiceStatus | OverallStatus): StatusBadgeTone {
-  if (status === 'ok') return 'success';
-  if (status === 'warning' || status === 'degraded') return 'warning';
-  return 'error';
-}
-
-function systemHealthTone(status: OverallStatus | undefined, hasError: boolean): MetricCardTone {
-  if (hasError || status === 'error') return 'error';
-  if (status === 'degraded') return 'warning';
-  if (status === 'ok') return 'success';
-  return 'neutral';
-}
-
 function renderHealthValue(
   status: OverallStatus | undefined,
   isLoading: boolean,
   hasError: boolean,
-): ReactElement | string {
+): string {
   if (isLoading) return '—';
-  if (hasError) return 'unreachable';
-  return (
-    <StatusBadge tone={toHealthTone(status ?? 'error')}>{status ?? 'unknown'}</StatusBadge>
-  );
+  if (hasError) return 'Unreachable';
+  return toHealthLabel(status);
 }
 
 function ServiceHealthRow({ name, health }: { name: string; health: ServiceHealth }): ReactElement {
   return (
     <li>
       <strong>{name}</strong>
-      <StatusBadge tone={toHealthTone(health.status)}>
-        {health.status}
-      </StatusBadge>
+      <StatusBadge tone={mapHealthTone(health.status, false)}>{health.status}</StatusBadge>
       {health.message ? <span className="muted-text">{health.message}</span> : null}
     </li>
   );
@@ -129,7 +132,7 @@ function ConnectionHealthList({ connections }: { connections: Connection[] }): R
       {connections.map((c) => (
         <li key={c.id}>
           <strong>{c.name}</strong>
-          <StatusBadge tone={toStatusTone(c.status)} withDot>
+          <StatusBadge tone={toRowStatusTone(c.status)} withDot>
             {c.status}
           </StatusBadge>
         </li>
@@ -152,16 +155,20 @@ export function DashboardPage(): ReactElement {
   const deadCount = deadJobsQuery.data?.total ?? 0;
   const queuedCount = queuedJobsQuery.data?.total ?? 0;
 
-  const isFetching = connectionsQuery.isFetching || healthQuery.isFetching
-    || recentJobsQuery.isFetching || queuedJobsQuery.isFetching || deadJobsQuery.isFetching;
+  const isFetching =
+    connectionsQuery.isFetching ||
+    healthQuery.isFetching ||
+    recentJobsQuery.isFetching ||
+    queuedJobsQuery.isFetching ||
+    deadJobsQuery.isFetching;
 
-  const handleRefresh = useCallback((): void => {
+  function handleRefresh(): void {
     void connectionsQuery.refetch();
     void healthQuery.refetch();
     void recentJobsQuery.refetch();
     void queuedJobsQuery.refetch();
     void deadJobsQuery.refetch();
-  }, [connectionsQuery, healthQuery, recentJobsQuery, queuedJobsQuery, deadJobsQuery]);
+  }
 
   return (
     <PageLayout
@@ -189,15 +196,19 @@ export function DashboardPage(): ReactElement {
 
         <MetricCard
           label="System health"
-          value={renderHealthValue(healthQuery.data?.status, healthQuery.isLoading, Boolean(healthQuery.error))}
-          tone={systemHealthTone(healthQuery.data?.status, Boolean(healthQuery.error))}
+          value={renderHealthValue(
+            healthQuery.data?.status,
+            healthQuery.isLoading,
+            Boolean(healthQuery.error),
+          )}
+          tone={mapHealthTone(healthQuery.data?.status, Boolean(healthQuery.error))}
           description="Postgres · Redis · PrestaShop · Worker"
         />
 
         {deadCount > 0 ? (
           <MetricCardLink
             label="Failed jobs"
-            value={deadJobsQuery.isLoading ? '—' : deadCount}
+            value={deadCount}
             tone="error"
             to="/orders/failed"
             description={`${deadCount} job${deadCount === 1 ? '' : 's'} need${deadCount === 1 ? 's' : ''} attention`}
@@ -206,7 +217,7 @@ export function DashboardPage(): ReactElement {
           <MetricCard
             label="Failed jobs"
             value={deadJobsQuery.isLoading ? '—' : 0}
-            tone="success"
+            tone="neutral"
             description="No failures"
           />
         )}
@@ -214,7 +225,7 @@ export function DashboardPage(): ReactElement {
         <MetricCard
           label="Queued jobs"
           value={queuedJobsQuery.isLoading ? '—' : queuedCount}
-          tone={queuedCount > 0 ? 'info' : 'neutral'}
+          tone="neutral"
           description={
             queuedCount > 0 ? `${queuedCount} job${queuedCount > 1 ? 's' : ''} waiting` : 'Queue empty'
           }
@@ -257,7 +268,7 @@ export function DashboardPage(): ReactElement {
               <h3 className="section-title">System health</h3>
             </div>
             {healthQuery.data && (
-              <StatusBadge tone={toHealthTone(healthQuery.data.status)}>
+              <StatusBadge tone={mapHealthTone(healthQuery.data.status, false)}>
                 {healthQuery.data.status}
               </StatusBadge>
             )}


### PR DESCRIPTION
Part of #239 (epic #236). Fourth slice of Phase 3.

## What this ships

### Dashboard metric strip rebuilt on the primitive

The four hand-rolled `<article className="metric-card">` elements are replaced with the `MetricCard` / `MetricCardLink` primitives introduced in Phase 3a.

| Card | Tone logic | Interactive? |
|---|---|---|
| Integration health | `warning` when any connection is in error, else `neutral` | no |
| System health | `success` (`ok`) / `warning` (`degraded`) / `error` (unreachable or `error`) / `neutral` (loading) | no |
| **Failed jobs** | `error` when `deadCount > 0`, else `success` | **yes — `MetricCardLink` to `/orders/failed`** when failures exist |
| Queued jobs | `info` when queue is non-empty, else `neutral` | no |

The reflow is handled by the existing `.status-strip` rule (`auto-fit, minmax(180px, 1fr)`) — naturally 4×1 on desktop, 2×2 on tablet, 1×4 on mobile.

### CSS cleanup

Drops the legacy `.metric-card` rule block in `index.css` that predated the primitive (conflicting `padding` / `gap` / typography and the old `--warning` / `--review` variants). The Phase 3a primitive styles (rule block around line 2317) are now the single source of truth for `.metric-card`.

### Tests

Three new dashboard tests:

1. Failed Jobs card emits `.metric-card--error` and an `href="/orders/failed"` when there are dead jobs.
2. Failed Jobs card emits `.metric-card--success` (not `error`) when no failures.
3. Integration Health emits `.metric-card--warning` when a connection is in error.

Also adds `afterEach(cleanup)` to the dashboard test file so multi-render cases don't leak DOM between assertions.

276/276 green. Pre-commit hook (workspace lint + type-check + full test suite) passed.

## What this doesn't ship

- Sparklines on KPI cards — deferred. MetricCard already has a `trend` slot; wiring time-series data is a separate concern from this primitive swap.
- No changes to the "Connection health" / "System health" panels or the sync job tables below the strip — those were already clean.

## Slicing reminder

1. 3a · Foundation (PR #246, merged)
2. 3b · DataTable + list migration (PR #247, merged)
3. 3c · Detail pages (PR #248, merged)
4. **3d · Dashboard + MetricCard severity tinting** ← this PR
5. 3e · Radix adoption (ConfirmDialog, Select, Toast)
6. *(follow-up)* Jobs virtualization
