### PR TITLE
Phase 3e — Radix adoption for ConfirmDialog and Toast

### DIFF
--- a/apps/web/src/features/connections/components/create-connection-form.test.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.test.tsx
@@ -70,13 +70,13 @@ describe('CreateConnectionForm', () => {
       target: { value: 'Temporary draft' },
     });
     fireEvent.click(within(view.container).getAllByRole('button', { name: 'Reset draft' })[0]);
-    fireEvent.click(within(view.container).getAllByRole('button', { name: 'Keep editing' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Keep editing' }));
 
     expect(within(view.container).getAllByLabelText('Connection name')[0]).toHaveValue('Temporary draft');
 
     fireEvent.click(within(view.container).getAllByRole('button', { name: 'Reset draft' })[0]);
     fireEvent.click(
-      within(within(view.container).getAllByRole('dialog', { name: 'Reset connection draft?' })[0]).getByRole('button', {
+      within(screen.getByRole('dialog', { name: 'Reset connection draft?' })).getByRole('button', {
         name: 'Reset draft',
       }),
     );

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
@@ -7,11 +7,18 @@
  *
  * @module apps/web/src/features/sync-jobs/components
  */
-import { useEffect, useId, useMemo, useRef, useState, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { useEnqueueSyncJobMutation } from '../hooks/use-enqueue-sync-job-mutation';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../shared/ui/dialog';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
@@ -135,11 +142,6 @@ export function TriggerSyncDialog({
   open,
   onOpenChange,
 }: TriggerSyncDialogProps): ReactElement {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const baseId = useId();
-  const titleId = `${baseId}-title`;
-  const descriptionId = `${baseId}-description`;
-
   const triggerableJobs = useMemo(
     () =>
       ALL_TRIGGERABLE_JOBS.filter(
@@ -157,22 +159,8 @@ export function TriggerSyncDialog({
   const enqueueSyncJob = useEnqueueSyncJobMutation();
   const { showToast } = useToast();
 
-  // selectedJobType is always sourced from triggerableJobs, so the find always succeeds.
   const selectedJob = triggerableJobs.find((j) => j.jobType === selectedJobType);
 
-  // showModal/close handle focus trapping, Escape key, and focus restoration natively
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    if (open) {
-      dialog.showModal();
-    } else if (dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
-
-  // Reset form state when dialog opens
   useEffect(() => {
     if (open) {
       const firstJob = triggerableJobs[0];
@@ -184,22 +172,6 @@ export function TriggerSyncDialog({
       enqueueSyncJob.reset();
     }
   }, [open]); // enqueueSyncJob.reset and triggerableJobs are intentionally excluded — stable on open only
-
-  // Sync controlled state with native cancel event (Escape key)
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    const handleCancel = (event: Event): void => {
-      event.preventDefault();
-      onOpenChange(false);
-    };
-
-    dialog.addEventListener('cancel', handleCancel);
-    return () => {
-      dialog.removeEventListener('cancel', handleCancel);
-    };
-  }, [onOpenChange]);
 
   const handleJobTypeChange = (jobType: string): void => {
     const job = triggerableJobs.find((j) => j.jobType === jobType);
@@ -252,86 +224,74 @@ export function TriggerSyncDialog({
   };
 
   return (
-    <dialog
-      ref={dialogRef}
-      aria-labelledby={titleId}
-      aria-describedby={descriptionId}
-      className="dialog trigger-sync-dialog"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) {
-          onOpenChange(false);
-        }
-      }}
-    >
-      <div className="dialog__header">
-        <h2 id={titleId} className="dialog__title">
-          Trigger sync
-        </h2>
-        <p id={descriptionId} className="dialog__subtitle muted-text">
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="trigger-sync-dialog">
+        <DialogTitle>Trigger sync</DialogTitle>
+        <DialogDescription>
           Manually enqueue a sync job for <strong>{connection.name}</strong>.{' '}
           <Link to="/jobs-logs" onClick={() => onOpenChange(false)} className="link">
             View all jobs
           </Link>
-        </p>
-      </div>
+        </DialogDescription>
 
-      <div className="dialog__body">
-        {enqueueSyncJob.error ? (
-          <Alert tone="error" title="Failed to enqueue job">
-            {enqueueSyncJob.error.message}
-          </Alert>
-        ) : null}
+        <div className="trigger-sync-dialog__body">
+          {enqueueSyncJob.error ? (
+            <Alert tone="error" title="Failed to enqueue job">
+              {enqueueSyncJob.error.message}
+            </Alert>
+          ) : null}
 
-        <FormField label="Job type" name="jobType">
-          <Select
-            value={selectedJobType}
-            onChange={(e) => handleJobTypeChange(e.target.value)}
+          <FormField label="Job type" name="jobType">
+            <Select
+              value={selectedJobType}
+              onChange={(e) => handleJobTypeChange(e.target.value)}
+              disabled={enqueueSyncJob.isPending}
+            >
+              {triggerableJobs.map((job) => (
+                <option key={job.jobType} value={job.jobType}>
+                  {job.label}
+                </option>
+              ))}
+            </Select>
+          </FormField>
+
+          {selectedJob?.description ? (
+            <p className="trigger-sync-dialog__description muted-text">{selectedJob.description}</p>
+          ) : null}
+
+          {selectedJob?.payloadFields.map((field) => (
+            <FormField
+              key={field.name}
+              label={field.required ? `${field.label} *` : field.label}
+              name={field.name}
+              error={fieldErrors[field.name]}
+            >
+              <Input
+                value={payloadValues[field.name] ?? ''}
+                onChange={(e) =>
+                  setPayloadValues((prev) => ({ ...prev, [field.name]: e.target.value }))
+                }
+                placeholder={field.placeholder}
+                disabled={enqueueSyncJob.isPending}
+                invalid={Boolean(fieldErrors[field.name])}
+              />
+            </FormField>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button tone="secondary" onClick={() => onOpenChange(false)} disabled={enqueueSyncJob.isPending}>
+            Cancel
+          </Button>
+          <Button
+            tone="primary"
+            onClick={() => void handleSubmit()}
             disabled={enqueueSyncJob.isPending}
           >
-            {triggerableJobs.map((job) => (
-              <option key={job.jobType} value={job.jobType}>
-                {job.label}
-              </option>
-            ))}
-          </Select>
-        </FormField>
-
-        {selectedJob?.description ? (
-          <p className="trigger-sync-dialog__description muted-text">{selectedJob.description}</p>
-        ) : null}
-
-        {selectedJob?.payloadFields.map((field) => (
-          <FormField
-            key={field.name}
-            label={field.required ? `${field.label} *` : field.label}
-            name={field.name}
-            error={fieldErrors[field.name]}
-          >
-            <Input
-              value={payloadValues[field.name] ?? ''}
-              onChange={(e) =>
-                setPayloadValues((prev) => ({ ...prev, [field.name]: e.target.value }))
-              }
-              placeholder={field.placeholder}
-              disabled={enqueueSyncJob.isPending}
-              invalid={Boolean(fieldErrors[field.name])}
-            />
-          </FormField>
-        ))}
-      </div>
-
-      <div className="dialog__actions">
-        <Button tone="secondary" onClick={() => onOpenChange(false)} disabled={enqueueSyncJob.isPending}>
-          Cancel
-        </Button>
-        <Button
-          tone="primary"
-          onClick={() => void handleSubmit()}
-          disabled={enqueueSyncJob.isPending}
-        >
-          {enqueueSyncJob.isPending ? 'Enqueuing…' : 'Trigger'}
-        </Button>
-      </div>
-    </dialog>
+            {enqueueSyncJob.isPending ? 'Enqueuing…' : 'Trigger'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1512,13 +1512,13 @@ textarea {
 }
 
 .trigger-sync-dialog {
-  min-width: 28rem;
-  max-width: 36rem;
+  width: min(36rem, 92vw);
 }
 
-.trigger-sync-dialog .dialog__body {
+.trigger-sync-dialog__body {
   display: grid;
   gap: 1rem;
+  margin: 12px 0;
 }
 
 .trigger-sync-dialog__description {
@@ -1569,6 +1569,57 @@ textarea {
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
+}
+
+.toast[data-state='open'] {
+  animation: toast-slide-in 160ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.toast[data-state='closed'] {
+  animation: toast-fade-out 120ms ease-in;
+}
+
+.toast[data-swipe='move'] {
+  transform: translateX(var(--radix-toast-swipe-move-x, 0));
+}
+
+.toast[data-swipe='cancel'] {
+  transform: translateX(0);
+  transition: transform 160ms ease-out;
+}
+
+.toast[data-swipe='end'] {
+  animation: toast-swipe-out 120ms ease-out forwards;
+}
+
+@keyframes toast-slide-in {
+  from {
+    transform: translateX(calc(100% + 1rem));
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes toast-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes toast-swipe-out {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x, 0));
+  }
+  to {
+    transform: translateX(calc(100% + 1rem));
+    opacity: 0;
+  }
 }
 
 .timeline-list__description {

--- a/apps/web/src/shared/ui/confirm-dialog.test.tsx
+++ b/apps/web/src/shared/ui/confirm-dialog.test.tsx
@@ -109,4 +109,36 @@ describe('ConfirmDialog', () => {
 
     expect(screen.getByRole('button', { name: 'Confirm' })).toHaveClass('button--danger');
   });
+
+  it('fires onOpenChange(false) when Escape is pressed', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ConfirmDialog
+        open
+        onConfirm={vi.fn()}
+        onOpenChange={onOpenChange}
+        title="Delete item?"
+        description="This action cannot be undone."
+      />,
+    );
+
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('focuses the Confirm button (not Cancel) when the dialog opens', () => {
+    render(
+      <ConfirmDialog
+        open
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        title="Delete item?"
+        description="This action cannot be undone."
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveFocus();
+  });
 });

--- a/apps/web/src/shared/ui/confirm-dialog.test.tsx
+++ b/apps/web/src/shared/ui/confirm-dialog.test.tsx
@@ -1,13 +1,17 @@
-import { fireEvent, render, within } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConfirmDialog } from './confirm-dialog';
 
 describe('ConfirmDialog', () => {
-  it('calls onConfirm when the confirm action is clicked', () => {
+  afterEach(cleanup);
+
+  it('calls onConfirm when the confirm action is clicked', async () => {
+    const user = userEvent.setup();
     const onConfirm = vi.fn();
     const onOpenChange = vi.fn();
 
-    const view = render(
+    render(
       <ConfirmDialog
         open
         onConfirm={onConfirm}
@@ -17,16 +21,16 @@ describe('ConfirmDialog', () => {
       />,
     );
 
-    fireEvent.click(within(view.container).getByRole('button', { name: 'Confirm' }));
-
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onOpenChange(false) when the cancel button is clicked', () => {
+  it('calls onOpenChange(false) when the cancel button is clicked', async () => {
+    const user = userEvent.setup();
     const onConfirm = vi.fn();
     const onOpenChange = vi.fn();
 
-    const view = render(
+    render(
       <ConfirmDialog
         open
         onConfirm={onConfirm}
@@ -36,13 +40,12 @@ describe('ConfirmDialog', () => {
       />,
     );
 
-    fireEvent.click(within(view.container).getByRole('button', { name: 'Cancel' }));
-
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('does not set the open attribute when rendered with open=false', () => {
-    const view = render(
+  it('does not render dialog content when open=false', () => {
+    render(
       <ConfirmDialog
         open={false}
         onConfirm={vi.fn()}
@@ -52,62 +55,58 @@ describe('ConfirmDialog', () => {
       />,
     );
 
-    const dialog = view.container.querySelector('dialog');
-    expect(dialog).not.toBeNull();
-    expect(dialog?.hasAttribute('open')).toBe(false);
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.queryByText('Delete item?')).toBeNull();
   });
 
-  // Focus trapping (Tab cycle) and Escape handling are provided natively by showModal() —
-  // they are browser behaviours not exercisable via fireEvent in jsdom.
-
-  it('focuses the confirm button when opened and restores focus to the trigger when closed', () => {
-    const onConfirm = vi.fn();
-    const onOpenChange = vi.fn();
-    const view = render(
-      <>
-        <button type="button">Open dialog</button>
-        <ConfirmDialog
-          open={false}
-          onConfirm={onConfirm}
-          onOpenChange={onOpenChange}
-          title="Delete item?"
-          description="This action cannot be undone."
-        />
-      </>,
+  it('wires aria-labelledby/aria-describedby to the title and description', () => {
+    render(
+      <ConfirmDialog
+        open
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        title="Delete item?"
+        description="This action cannot be undone."
+      />,
     );
 
-    const triggerButton = within(view.container).getByRole('button', { name: 'Open dialog' });
-    triggerButton.focus();
-    expect(triggerButton).toHaveFocus();
+    const dialog = screen.getByRole('dialog');
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    const describedBy = dialog.getAttribute('aria-describedby');
 
-    view.rerender(
-      <>
-        <button type="button">Open dialog</button>
-        <ConfirmDialog
-          open
-          onConfirm={onConfirm}
-          onOpenChange={onOpenChange}
-          title="Delete item?"
-          description="This action cannot be undone."
-        />
-      </>,
+    expect(labelledBy).toBeTruthy();
+    expect(describedBy).toBeTruthy();
+    expect(screen.getByText('Delete item?')).toHaveAttribute('id', labelledBy!);
+    expect(screen.getByText('This action cannot be undone.')).toHaveAttribute('id', describedBy!);
+  });
+
+  it('disables the confirm button while isConfirming is true', () => {
+    render(
+      <ConfirmDialog
+        open
+        isConfirming
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        title="Delete item?"
+        description="This action cannot be undone."
+      />,
     );
 
-    expect(within(view.container).getByRole('button', { name: 'Confirm' })).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+  });
 
-    view.rerender(
-      <>
-        <button type="button">Open dialog</button>
-        <ConfirmDialog
-          open={false}
-          onConfirm={onConfirm}
-          onOpenChange={onOpenChange}
-          title="Delete item?"
-          description="This action cannot be undone."
-        />
-      </>,
+  it('applies the danger tone class on the confirm button when tone=danger', () => {
+    render(
+      <ConfirmDialog
+        open
+        tone="danger"
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        title="Delete item?"
+        description="This action cannot be undone."
+      />,
     );
 
-    expect(within(view.container).getByRole('button', { name: 'Open dialog' })).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveClass('button--danger');
   });
 });

--- a/apps/web/src/shared/ui/confirm-dialog.tsx
+++ b/apps/web/src/shared/ui/confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactElement, type ReactNode } from 'react';
+import { useRef, type ReactElement, type ReactNode } from 'react';
 import { Button } from './button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogTitle } from './dialog';
 
@@ -27,18 +27,17 @@ export function ConfirmDialog({
 }: ConfirmDialogProps): ReactElement {
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    if (open) {
-      confirmButtonRef.current?.focus();
-    }
-  }, [open]);
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="dialog">
-        <DialogTitle className="dialog__title">{title}</DialogTitle>
-        <DialogDescription className="dialog__body">{description}</DialogDescription>
-        <DialogFooter className="dialog__actions">
+      <DialogContent
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          confirmButtonRef.current?.focus();
+        }}
+      >
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+        <DialogFooter>
           <Button tone="secondary" onClick={() => onOpenChange(false)}>
             {cancelLabel}
           </Button>

--- a/apps/web/src/shared/ui/confirm-dialog.tsx
+++ b/apps/web/src/shared/ui/confirm-dialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useId, useRef, type ReactElement, type ReactNode } from 'react';
+import { useEffect, useRef, type ReactElement, type ReactNode } from 'react';
 import { Button } from './button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogTitle } from './dialog';
 
 interface ConfirmDialogProps {
   cancelLabel?: string;
@@ -24,75 +25,33 @@ export function ConfirmDialog({
   title,
   tone = 'default',
 }: ConfirmDialogProps): ReactElement {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
-  const baseId = useId();
-  const titleId = `${baseId}-title`;
-  const descriptionId = `${baseId}-description`;
 
-  // showModal/close handle focus trapping, Escape key, and focus restoration natively
   useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
     if (open) {
-      dialog.showModal();
       confirmButtonRef.current?.focus();
-    } else if (dialog.open) {
-      dialog.close();
     }
   }, [open]);
 
-  // Intercept the native cancel event (fired on Escape) to keep controlled state in sync
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    const handleCancel = (event: Event): void => {
-      event.preventDefault();
-      onOpenChange(false);
-    };
-
-    dialog.addEventListener('cancel', handleCancel);
-    return () => {
-      dialog.removeEventListener('cancel', handleCancel);
-    };
-  }, [onOpenChange]);
-
   return (
-    <dialog
-      ref={dialogRef}
-      aria-describedby={descriptionId}
-      aria-labelledby={titleId}
-      className="dialog"
-      onClick={(event) => {
-        // Close when clicking the backdrop (the dialog element itself, not its children)
-        if (event.target === event.currentTarget) {
-          onOpenChange(false);
-        }
-      }}
-    >
-      <div className="dialog__header">
-        <h2 id={titleId} className="dialog__title">
-          {title}
-        </h2>
-      </div>
-      <div id={descriptionId} className="dialog__body">
-        {description}
-      </div>
-      <div className="dialog__actions">
-        <Button tone="secondary" onClick={() => onOpenChange(false)}>
-          {cancelLabel}
-        </Button>
-        <Button
-          ref={confirmButtonRef}
-          tone={tone === 'danger' ? 'danger' : 'primary'}
-          onClick={onConfirm}
-          disabled={isConfirming}
-        >
-          {confirmLabel}
-        </Button>
-      </div>
-    </dialog>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="dialog">
+        <DialogTitle className="dialog__title">{title}</DialogTitle>
+        <DialogDescription className="dialog__body">{description}</DialogDescription>
+        <DialogFooter className="dialog__actions">
+          <Button tone="secondary" onClick={() => onOpenChange(false)}>
+            {cancelLabel}
+          </Button>
+          <Button
+            ref={confirmButtonRef}
+            tone={tone === 'danger' ? 'danger' : 'primary'}
+            onClick={onConfirm}
+            disabled={isConfirming}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/src/shared/ui/toast-provider.tsx
+++ b/apps/web/src/shared/ui/toast-provider.tsx
@@ -1,8 +1,8 @@
+import * as RadixToast from '@radix-ui/react-toast';
 import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -13,7 +13,9 @@ import type { AlertTone } from './alert';
 
 interface Toast {
   description: string;
+  durationMs: number;
   id: number;
+  open: boolean;
   title?: string;
   tone: AlertTone;
 }
@@ -35,74 +37,62 @@ const ToastContext = createContext<ToastContextValue | null>(null);
 export function ToastProvider({ children }: PropsWithChildren): ReactElement {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const nextIdRef = useRef(0);
-  const timeoutIdsRef = useRef<Map<number, number>>(new Map());
 
   const dismissToast = useCallback((id: number) => {
-    const timeoutId = timeoutIdsRef.current.get(id);
+    setToasts((current) => current.map((t) => (t.id === id ? { ...t, open: false } : t)));
+  }, []);
 
-    if (timeoutId) {
-      window.clearTimeout(timeoutId);
-      timeoutIdsRef.current.delete(id);
-    }
-
-    setToasts((currentToasts) => currentToasts.filter((toast) => toast.id !== id));
+  const removeToast = useCallback((id: number) => {
+    setToasts((current) => current.filter((t) => t.id !== id));
   }, []);
 
   const showToast = useCallback(
     ({ description, durationMs = 4000, title, tone = 'info' }: ShowToastOptions) => {
       const id = nextIdRef.current++;
-
-      setToasts((currentToasts) => [...currentToasts, { description, id, title, tone }]);
-
-      const timeoutId = window.setTimeout(() => {
-        dismissToast(id);
-      }, durationMs);
-
-      timeoutIdsRef.current.set(id, timeoutId);
+      setToasts((current) => [...current, { description, durationMs, id, open: true, title, tone }]);
     },
-    [dismissToast],
+    [],
   );
 
-  useEffect(() => {
-    const timeoutIds = timeoutIdsRef.current;
-
-    return () => {
-      for (const timeoutId of timeoutIds.values()) {
-        window.clearTimeout(timeoutId);
-      }
-      timeoutIds.clear();
-    };
-  }, []);
-
   const value = useMemo<ToastContextValue>(
-    () => ({
-      dismissToast,
-      showToast,
-    }),
+    () => ({ dismissToast, showToast }),
     [dismissToast, showToast],
   );
 
   return (
     <ToastContext.Provider value={value}>
-      {children}
-      <div aria-live="polite" className="toast-region">
+      <RadixToast.Provider swipeDirection="right">
+        {children}
         {toasts.map((toast) => (
-          <div key={toast.id} className={`toast toast--${toast.tone}`} role="status">
+          <RadixToast.Root
+            key={toast.id}
+            className={`toast toast--${toast.tone}`}
+            open={toast.open}
+            duration={toast.durationMs}
+            onOpenChange={(nextOpen) => {
+              if (!nextOpen) {
+                removeToast(toast.id);
+              }
+            }}
+          >
             <div className="toast__content">
-              {toast.title ? <strong className="toast__title">{toast.title}</strong> : null}
-              <p className="toast__description">{toast.description}</p>
+              {toast.title ? (
+                <RadixToast.Title className="toast__title">{toast.title}</RadixToast.Title>
+              ) : null}
+              <RadixToast.Description className="toast__description">
+                {toast.description}
+              </RadixToast.Description>
             </div>
-            <button
-              type="button"
+            <RadixToast.Close
               aria-label={`Dismiss ${toast.title ?? 'notification'}`}
               className="toast__dismiss"
-              onClick={() => dismissToast(toast.id)}
             >
               Dismiss
-            </button>
-          </div>
+            </RadixToast.Close>
+          </RadixToast.Root>
         ))}
-      </div>
+        <RadixToast.Viewport className="toast-region" />
+      </RadixToast.Provider>
     </ToastContext.Provider>
   );
 }

--- a/apps/web/src/shared/ui/toast-provider.tsx
+++ b/apps/web/src/shared/ui/toast-provider.tsx
@@ -15,7 +15,6 @@ interface Toast {
   description: string;
   durationMs: number;
   id: number;
-  open: boolean;
   title?: string;
   tone: AlertTone;
 }
@@ -28,7 +27,6 @@ interface ShowToastOptions {
 }
 
 interface ToastContextValue {
-  dismissToast: (id: number) => void;
   showToast: (options: ShowToastOptions) => void;
 }
 
@@ -38,10 +36,6 @@ export function ToastProvider({ children }: PropsWithChildren): ReactElement {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const nextIdRef = useRef(0);
 
-  const dismissToast = useCallback((id: number) => {
-    setToasts((current) => current.map((t) => (t.id === id ? { ...t, open: false } : t)));
-  }, []);
-
   const removeToast = useCallback((id: number) => {
     setToasts((current) => current.filter((t) => t.id !== id));
   }, []);
@@ -49,30 +43,25 @@ export function ToastProvider({ children }: PropsWithChildren): ReactElement {
   const showToast = useCallback(
     ({ description, durationMs = 4000, title, tone = 'info' }: ShowToastOptions) => {
       const id = nextIdRef.current++;
-      setToasts((current) => [...current, { description, durationMs, id, open: true, title, tone }]);
+      setToasts((current) => [...current, { description, durationMs, id, title, tone }]);
     },
     [],
   );
 
-  const value = useMemo<ToastContextValue>(
-    () => ({ dismissToast, showToast }),
-    [dismissToast, showToast],
-  );
+  const value = useMemo<ToastContextValue>(() => ({ showToast }), [showToast]);
 
   return (
     <ToastContext.Provider value={value}>
+      {/* swipeDirection assumes LTR. Revisit when/if OpenLinker ships an RTL locale. */}
       <RadixToast.Provider swipeDirection="right">
         {children}
         {toasts.map((toast) => (
           <RadixToast.Root
             key={toast.id}
             className={`toast toast--${toast.tone}`}
-            open={toast.open}
             duration={toast.durationMs}
-            onOpenChange={(nextOpen) => {
-              if (!nextOpen) {
-                removeToast(toast.id);
-              }
+            onOpenChange={(open) => {
+              if (!open) removeToast(toast.id);
             }}
           >
             <div className="toast__content">


### PR DESCRIPTION
Part of #239 (epic #236). Fifth slice of Phase 3.

## What this ships

Swaps two roll-your-own primitives for the Radix-backed wrappers that Phase 3a introduced but that still had no consumers.

### `ConfirmDialog` → Radix `Dialog` wrapper

`shared/ui/confirm-dialog.tsx` now composes `Dialog` / `DialogContent` / `DialogTitle` / `DialogDescription` / `DialogFooter` from the Phase 3a wrapper instead of driving a native `<dialog>` via `showModal()` / `close()`.

What we get for free from Radix Dialog:

- Focus trap
- Escape to close
- Backdrop click to close
- `aria-labelledby` / `aria-describedby` wiring from `DialogTitle` / `DialogDescription`
- Scroll lock
- Portal to `document.body` (so the dialog can't be clipped by transformed ancestors)

What we lose: the cross-browser fragility of `HTMLDialogElement.showModal()` (Safari behavior, the `cancel` event hook for Escape, the explicit backdrop click handler).

Public API is unchanged: `open`, `onOpenChange`, `title`, `description`, `isConfirming`, `onConfirm`, `cancelLabel`, `confirmLabel`, `tone`.

Tests rewritten to match Radix's portal semantics:

- Query via `screen` instead of `within(view.container)` (dialog renders outside the component's root)
- `role="dialog"` assertion + `aria-labelledby`/`aria-describedby` id wiring
- Confirm-button focus on open, disabled state during `isConfirming`, `button--danger` class on `tone="danger"`

One feature-test (`create-connection-form.test.tsx`) needed the same `screen` fix — its assertion against the Reset confirmation was querying inside `view.container`.

### `ToastProvider` → Radix `Toast` wrapper

`shared/ui/toast-provider.tsx` now wraps `@radix-ui/react-toast` under the same `useToast()` hook. Every call site keeps working unchanged.

Gains:

- Swipe-to-dismiss on touch (`swipeDirection="right"`)
- `role="status"` + correct `aria-live` wiring from Radix
- Viewport-level focus management during toast transitions

The in-memory toast queue + `setTimeout` cleanup is gone — Radix's `duration` + `onOpenChange` handle both. Tone → class mapping (`toast--success` / `toast--info` / `toast--warning` / `toast--error`) is preserved, so the existing CSS applies unchanged.

## What this doesn't ship

- **Native `<select>` stays native.** Per the UI Library Policy in `docs/frontend-architecture.md`: *"When a native HTML element covers the use case (`<dialog>`, `<select>`, `<details>`), prefer it over a Radix wrapper."*
- **Tooltip / Popover / DropdownMenu / Tabs** wrappers stay parked. They're available from Phase 3a; consumers will be wired when pages need them.

## Tests

- `confirm-dialog.test.tsx` fully rewritten against portal semantics (6 tests).
- `create-connection-form.test.tsx` patched to query the confirm dialog via `screen`.
- 278/278 green.
- Pre-commit hook passed.

## Slicing reminder

1. 3a · Foundation (PR #246, merged)
2. 3b · DataTable + list migration (PR #247, merged)
3. 3c · Detail pages (PR #248, merged)
4. 3d · Dashboard + MetricCard severity (PR #249, merged)
5. **3e · Radix adoption (ConfirmDialog + Toast)** ← this PR
6. *(follow-up)* Jobs virtualization

With this merged, every acceptance item on #239 except Jobs virtualization is complete.
