### PR TITLE
Phase 4 — detail page restructure (order banner, connection tabs, job retry, related lists)

### DIFF
--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -8,6 +8,14 @@
  * @module apps/web/src/features/listings/api
  */
 
+/**
+ * Known mapping entity types. The wire value is a plain string — unknown
+ * values pass through unchanged (UI falls back to non-linkified text) so this
+ * list stays forward-compatible with new backend entity kinds.
+ */
+export const KNOWN_MAPPING_ENTITY_TYPES = ['Product', 'ProductVariant', 'InventoryItem'] as const;
+export type KnownMappingEntityType = (typeof KNOWN_MAPPING_ENTITY_TYPES)[number];
+
 export interface OfferMapping {
   id: string;
   entityType: string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -797,6 +797,42 @@ textarea {
   flex-shrink: 0;
 }
 
+/* Order detail — failed-destinations banner list */
+.order-detail__failed-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.order-detail__failed-list li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.order-detail__failed-error {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--status-error-strong);
+  word-break: break-word;
+}
+
+@media (max-width: 767.98px) {
+  .alert {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .alert__actions {
+    display: flex;
+  }
+}
+
 .connection-list,
 .activity-list,
 .check-list {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2798,6 +2798,12 @@ textarea {
   outline-offset: 2px;
 }
 
+.tabs__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .tabs__content:focus-visible {
   outline: none;
 }

--- a/apps/web/src/pages/connections/connection-detail-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { ConnectionDetailPage } from './connection-detail-page';
 
 // Note: renderWithProviders uses MemoryRouter. The page reads connectionId via
@@ -31,5 +33,33 @@ describe('ConnectionDetailPage', () => {
 
     // With no route params, connectionId defaults to '' and query is disabled
     expect(await screen.findByRole('heading', { name: 'Connection not found' })).toBeInTheDocument();
+  });
+
+  it('organizes the detail surface into Overview / Health / Actions / Config tabs', async () => {
+    const user = userEvent.setup();
+    const apiClient = createMockApiClient();
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/connections/:connectionId" element={<ConnectionDetailPage />} />
+      </Routes>,
+      { apiClient, route: `/connections/${sampleConnection.id}` },
+    );
+
+    await screen.findByRole('heading', { name: 'Overview' });
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', { name: 'Health' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Actions' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Config' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'Config' }));
+    expect(screen.getByRole('tab', { name: 'Config' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByText('Connection config')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/connections/connection-detail-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.test.tsx
@@ -62,4 +62,18 @@ describe('ConnectionDetailPage', () => {
     );
     expect(screen.getByText('Connection config')).toBeInTheDocument();
   });
+
+  it('honors ?tab=config in the URL on first render', async () => {
+    const apiClient = createMockApiClient();
+
+    renderWithProviders(
+      <Routes>
+        <Route path="/connections/:connectionId" element={<ConnectionDetailPage />} />
+      </Routes>,
+      { apiClient, route: `/connections/${sampleConnection.id}?tab=config` },
+    );
+
+    const configTab = await screen.findByRole('tab', { name: 'Config' });
+    expect(configTab).toHaveAttribute('aria-selected', 'true');
+  });
 });

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
 import { ConnectionActionsPanel } from '../../features/connections/components/ConnectionActionsPanel';
 import { ConnectionCapabilitiesPanel } from '../../features/connections/components/ConnectionCapabilitiesPanel';
@@ -25,9 +25,35 @@ function toStatusTone(status: ConnectionStatus): StatusBadgeTone {
   }
 }
 
+const TAB_VALUES = ['overview', 'health', 'actions', 'config'] as const;
+type TabValue = (typeof TAB_VALUES)[number];
+
+function isTabValue(value: string | null): value is TabValue {
+  return value !== null && (TAB_VALUES as readonly string[]).includes(value);
+}
+
 export function ConnectionDetailPage(): ReactElement {
   const { connectionId = '' } = useParams();
   const connectionQuery = useConnectionQuery(connectionId);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const tabParam = searchParams.get('tab');
+  const activeTab: TabValue = isTabValue(tabParam) ? tabParam : 'overview';
+
+  const handleTabChange = (value: string): void => {
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        if (value === 'overview') {
+          params.delete('tab');
+        } else {
+          params.set('tab', value);
+        }
+        return params;
+      },
+      { replace: true },
+    );
+  };
 
   const connection = connectionQuery.data;
 
@@ -104,7 +130,7 @@ export function ConnectionDetailPage(): ReactElement {
         </Alert>
       ) : null}
       {connection ? (
-        <Tabs defaultValue="overview">
+        <Tabs value={activeTab} onValueChange={handleTabChange}>
           <TabsList>
             <TabsTrigger value="overview">Overview</TabsTrigger>
             <TabsTrigger value="health">Health</TabsTrigger>

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -9,6 +9,7 @@ import type { ConnectionStatus } from '../../features/connections/api/connection
 import { EmptyState, ErrorState, LoadingState } from '../../shared/ui/feedback-state';
 import { KeyValueList } from '../../shared/ui/key-value-list';
 import { PageLayout } from '../../shared/ui/page-layout';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { Alert } from '../../shared/ui/alert';
@@ -103,46 +104,66 @@ export function ConnectionDetailPage(): ReactElement {
         </Alert>
       ) : null}
       {connection ? (
-        <div className="workspace-grid">
-          <div className="panel panel--dense">
-            <div className="panel__header">
-              <div>
-                <p className="eyebrow">Connection summary</p>
-                <h3 className="section-title">Overview</h3>
+        <Tabs defaultValue="overview">
+          <TabsList>
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="health">Health</TabsTrigger>
+            <TabsTrigger value="actions">Actions</TabsTrigger>
+            <TabsTrigger value="config">Config</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="overview">
+            <div className="panel panel--dense">
+              <div className="panel__header">
+                <div>
+                  <p className="eyebrow">Connection summary</p>
+                  <h3 className="section-title">Overview</h3>
+                </div>
+                <StatusBadge tone={toStatusTone(connection.status)}>
+                  {connection.status}
+                </StatusBadge>
               </div>
-              <StatusBadge tone={toStatusTone(connection.status)}>{connection.status}</StatusBadge>
+
+              <KeyValueList
+                items={[
+                  { id: 'name', label: 'Name', value: connection.name },
+                  { id: 'platform', label: 'Platform', value: connection.platformType },
+                  {
+                    id: 'credentials',
+                    label: 'Credentials',
+                    value: connection.credentialsBacked ? 'DB-managed' : 'Environment variable',
+                  },
+                  {
+                    id: 'adapter',
+                    label: 'Adapter',
+                    value: connection.adapterKey ?? 'default adapter',
+                    mono: true,
+                  },
+                  { id: 'id', label: 'Connection ID', value: connection.id, mono: true },
+                  {
+                    id: 'updatedAt',
+                    label: 'Last updated',
+                    value: <TimeDisplay iso={connection.updatedAt} />,
+                  },
+                ]}
+              />
             </div>
 
-            <KeyValueList
-              items={[
-                { id: 'name', label: 'Name', value: connection.name },
-                { id: 'platform', label: 'Platform', value: connection.platformType },
-                {
-                  id: 'credentials',
-                  label: 'Credentials',
-                  value: connection.credentialsBacked ? 'DB-managed' : 'Environment variable',
-                },
-                {
-                  id: 'adapter',
-                  label: 'Adapter',
-                  value: connection.adapterKey ?? 'default adapter',
-                  mono: true,
-                },
-                { id: 'id', label: 'Connection ID', value: connection.id, mono: true },
-                {
-                  id: 'updatedAt',
-                  label: 'Last updated',
-                  value: <TimeDisplay iso={connection.updatedAt} />,
-                },
-              ]}
-            />
-          </div>
+            <ConnectionCapabilitiesPanel connection={connection} />
+          </TabsContent>
 
-          <ConnectionConfigPanel config={connection.config} />
-          <ConnectionCapabilitiesPanel connection={connection} />
-          <ConnectionDiagnosticsPanel connectionId={connection.id} />
-          <ConnectionActionsPanel connection={connection} />
-        </div>
+          <TabsContent value="health">
+            <ConnectionDiagnosticsPanel connectionId={connection.id} />
+          </TabsContent>
+
+          <TabsContent value="actions">
+            <ConnectionActionsPanel connection={connection} />
+          </TabsContent>
+
+          <TabsContent value="config">
+            <ConnectionConfigPanel config={connection.config} />
+          </TabsContent>
+        </Tabs>
       ) : null}
     </PageLayout>
   );

--- a/apps/web/src/pages/customers/customer-detail-page.test.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { CustomerDetailPage } from './customer-detail-page';
 import type { CustomerProjectionDetail } from '../../features/customers/api/customers.types';
+import type { OrderRecord } from '../../features/orders/api/orders.types';
 
 const sampleCustomer: CustomerProjectionDetail = {
   internalCustomerId: 'ol_customer_abc',
@@ -56,5 +57,39 @@ describe('CustomerDetailPage', () => {
     await screen.findByText('ol_customer_abc');
     expect(screen.queryByRole('link', { name: sampleConnection.name })).toBeNull();
     expect(screen.getAllByLabelText('No value').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders the customer orders list below the details', async () => {
+    const order: OrderRecord = {
+      internalOrderId: 'ol_order_xyz789',
+      customerId: sampleCustomer.internalCustomerId,
+      sourceConnectionId: sampleConnection.id,
+      sourceEventId: null,
+      orderSnapshot: {},
+      syncStatus: [
+        {
+          destinationConnectionId: sampleConnection.id,
+          status: 'synced',
+          syncedAt: '2026-04-20T10:00:00.000Z',
+          externalOrderId: '99',
+          externalOrderNumber: null,
+          error: null,
+        },
+      ],
+      createdAt: '2026-04-20T09:00:00.000Z',
+      updatedAt: '2026-04-20T10:00:00.000Z',
+    };
+
+    const api = createMockApiClient({
+      customers: { getById: vi.fn().mockResolvedValue(sampleCustomer) },
+      orders: {
+        list: vi.fn().mockResolvedValue({ items: [order], total: 1, limit: 20, offset: 0 }),
+      },
+    });
+
+    renderDetail(api);
+
+    await screen.findByText(/Orders \(1\)/);
+    expect(screen.getByText('ol_order_xyz789')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/customers/customer-detail-page.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.tsx
@@ -6,9 +6,15 @@ import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-s
 import { Button } from '../../shared/ui/button';
 import { EmptyValue } from '../../shared/ui/empty-value';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useCustomerQuery } from '../../features/customers/hooks/use-customer-query';
+import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
 import type { CustomerAddress } from '../../features/customers/api/customers.types';
+import type {
+  OrderRecord,
+  OrderSyncStatusValue,
+} from '../../features/orders/api/orders.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 
 function buildCustomerItems(customer: {
@@ -56,6 +62,49 @@ function buildCustomerItems(customer: {
   return items;
 }
 
+const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
+  pending: 'info',
+  syncing: 'warning',
+  synced: 'success',
+  failed: 'error',
+};
+
+const CUSTOMER_ORDER_COLUMNS: DataTableColumn<OrderRecord>[] = [
+  {
+    id: 'internalOrderId',
+    header: 'Order ID',
+    cell: (order) => <span className="mono-text">{order.internalOrderId}</span>,
+  },
+  {
+    id: 'syncStatus',
+    header: 'Status',
+    cell: (order) => {
+      const first = order.syncStatus[0];
+      if (!first) return <EmptyValue />;
+      return (
+        <StatusBadge tone={SYNC_STATUS_TONES[first.status]} compact>
+          {first.status}
+        </StatusBadge>
+      );
+    },
+  },
+  {
+    id: 'sourceConnection',
+    header: 'Source',
+    cell: (order) => (
+      <ConnectionEntityLabel connectionId={order.sourceConnectionId} showId={false} />
+    ),
+    hideBelow: 768,
+  },
+  {
+    id: 'createdAt',
+    header: 'Created',
+    cell: (order) => <TimeDisplay iso={order.createdAt} format="date" />,
+    accessor: (order) => order.createdAt,
+    sortable: true,
+  },
+];
+
 const ADDRESS_COLUMNS: DataTableColumn<CustomerAddress>[] = [
   {
     id: 'addressType',
@@ -95,6 +144,7 @@ const ADDRESS_COLUMNS: DataTableColumn<CustomerAddress>[] = [
 export function CustomerDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
   const query = useCustomerQuery(id);
+  const ordersQuery = useOrdersQuery(id ? { customerId: id } : undefined, { limit: 20 });
 
   if (query.isLoading) {
     return (
@@ -131,6 +181,39 @@ export function CustomerDetailPage(): ReactElement {
     >
       <section className="detail-section">
         <KeyValueList items={buildCustomerItems(customer)} />
+      </section>
+
+      <section className="detail-section">
+        <h2 className="detail-section__title">
+          Orders{ordersQuery.data ? ` (${ordersQuery.data.total})` : ''}
+        </h2>
+        {ordersQuery.isLoading ? (
+          <LoadingState
+            liveRegion="off"
+            title="Loading orders"
+            message="Fetching orders placed by this customer…"
+          />
+        ) : ordersQuery.error ? (
+          <ErrorState
+            title="Unable to load customer orders"
+            message={ordersQuery.error.message}
+            action={<Button onClick={() => { void ordersQuery.refetch(); }}>Retry</Button>}
+          />
+        ) : (ordersQuery.data?.items.length ?? 0) === 0 ? (
+          <EmptyState
+            liveRegion="off"
+            title="No orders yet"
+            message="This customer has no orders on record."
+          />
+        ) : (
+          <DataTable
+            caption="Customer orders"
+            columns={CUSTOMER_ORDER_COLUMNS}
+            rows={ordersQuery.data?.items ?? []}
+            rowKey={(order) => order.internalOrderId}
+            rowHref={(order) => `/orders/${order.internalOrderId}`}
+          />
+        )}
       </section>
 
       <section className="detail-section">

--- a/apps/web/src/pages/listings/listing-detail-page.test.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, screen } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
+import { ListingDetailPage } from './listing-detail-page';
+import type { OfferMapping } from '../../features/listings/api/listings.types';
+
+function buildMapping(overrides: Partial<OfferMapping>): OfferMapping {
+  return {
+    id: 'mapping_1',
+    entityType: 'Product',
+    internalId: 'ol_product_abc',
+    externalId: 'ext-42',
+    platformType: 'allegro',
+    connectionId: sampleConnection.id,
+    context: null,
+    createdAt: '2026-04-20T10:00:00.000Z',
+    updatedAt: '2026-04-20T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function renderDetail(mapping: OfferMapping): void {
+  const api = createMockApiClient({
+    listings: { getById: vi.fn().mockResolvedValue(mapping) },
+  });
+  renderWithProviders(
+    <Routes>
+      <Route path="/listings/:id" element={<ListingDetailPage />} />
+    </Routes>,
+    { apiClient: api, route: `/listings/${mapping.id}` },
+  );
+}
+
+describe('ListingDetailPage', () => {
+  afterEach(cleanup);
+
+  it('links the internal ID to the product detail when entityType is Product', async () => {
+    renderDetail(buildMapping({ entityType: 'Product', internalId: 'ol_product_abc' }));
+
+    const link = await screen.findByRole('link', { name: 'ol_product_abc' });
+    expect(link).toHaveAttribute('href', '/products/ol_product_abc');
+  });
+
+  it('links the internal ID to the product detail when entityType is ProductVariant', async () => {
+    renderDetail(buildMapping({ entityType: 'ProductVariant', internalId: 'ol_variant_xyz' }));
+
+    const link = await screen.findByRole('link', { name: 'ol_variant_xyz' });
+    expect(link).toHaveAttribute('href', '/products/ol_variant_xyz');
+  });
+
+  it('links the internal ID to the inventory detail when entityType is InventoryItem', async () => {
+    renderDetail(buildMapping({ entityType: 'InventoryItem', internalId: 'ol_inventory_99' }));
+
+    const link = await screen.findByRole('link', { name: 'ol_inventory_99' });
+    expect(link).toHaveAttribute('href', '/inventory/ol_inventory_99');
+  });
+
+  it('renders the internal ID as plain text for unknown entity types', async () => {
+    renderDetail(buildMapping({ entityType: 'SomethingElse', internalId: 'ol_opaque_42' }));
+
+    await screen.findByText('ol_opaque_42');
+    expect(screen.queryByRole('link', { name: 'ol_opaque_42' })).toBeNull();
+  });
+});

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -9,23 +9,29 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
 import { EditOfferDrawer } from '../../features/listings/components/EditOfferDrawer';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+import {
+  KNOWN_MAPPING_ENTITY_TYPES,
+  type KnownMappingEntityType,
+} from '../../features/listings/api/listings.types';
+
+const ENTITY_TYPE_ROUTES: Record<KnownMappingEntityType, (id: string) => string> = {
+  Product: (id) => `/products/${id}`,
+  ProductVariant: (id) => `/products/${id}`,
+  InventoryItem: (id) => `/inventory/${id}`,
+};
+
+function isKnownEntityType(value: string): value is KnownMappingEntityType {
+  return (KNOWN_MAPPING_ENTITY_TYPES as readonly string[]).includes(value);
+}
 
 function renderInternalIdValue(entityType: string, internalId: string): ReactNode {
-  if (entityType === 'Product' || entityType === 'ProductVariant') {
-    return (
-      <Link to={`/products/${internalId}`} className="mono-text">
-        {internalId}
-      </Link>
-    );
-  }
-  if (entityType === 'InventoryItem') {
-    return (
-      <Link to={`/inventory/${internalId}`} className="mono-text">
-        {internalId}
-      </Link>
-    );
-  }
-  return internalId;
+  if (!isKnownEntityType(entityType)) return internalId;
+  const to = ENTITY_TYPE_ROUTES[entityType](internalId);
+  return (
+    <Link to={to} className="mono-text">
+      {internalId}
+    </Link>
+  );
 }
 
 export function ListingDetailPage(): ReactElement {

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useState } from 'react';
+import { type ReactElement, type ReactNode, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
@@ -9,6 +9,24 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
 import { EditOfferDrawer } from '../../features/listings/components/EditOfferDrawer';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+
+function renderInternalIdValue(entityType: string, internalId: string): ReactNode {
+  if (entityType === 'Product' || entityType === 'ProductVariant') {
+    return (
+      <Link to={`/products/${internalId}`} className="mono-text">
+        {internalId}
+      </Link>
+    );
+  }
+  if (entityType === 'InventoryItem') {
+    return (
+      <Link to={`/inventory/${internalId}`} className="mono-text">
+        {internalId}
+      </Link>
+    );
+  }
+  return internalId;
+}
 
 export function ListingDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
@@ -60,7 +78,12 @@ export function ListingDetailPage(): ReactElement {
             { id: 'mappingId', label: 'Mapping ID', value: mapping.id, mono: true },
             { id: 'entityType', label: 'Entity Type', value: mapping.entityType, mono: true },
             { id: 'externalId', label: 'External ID', value: mapping.externalId, mono: true },
-            { id: 'internalId', label: 'Internal ID', value: mapping.internalId, mono: true },
+            {
+              id: 'internalId',
+              label: 'Internal ID',
+              value: renderInternalIdValue(mapping.entityType, mapping.internalId),
+              mono: true,
+            },
             { id: 'platform', label: 'Platform Type', value: mapping.platformType, mono: true },
             {
               id: 'connection',

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -66,4 +66,44 @@ describe('OrderDetailPage', () => {
     fireEvent.click(expandButton);
     expect(screen.getByLabelText('Payload content').textContent).toContain('SKU-1');
   });
+
+  it('does not render the failed-destinations banner when every destination is synced', async () => {
+    const api = createMockApiClient({
+      orders: { getById: vi.fn().mockResolvedValue(sampleOrder) },
+    });
+
+    renderDetail(api);
+
+    await screen.findByText('ol_order_abc123');
+    expect(screen.queryByText(/destination.*failed/i)).toBeNull();
+  });
+
+  it('elevates failed destinations into an alert banner with retry action', async () => {
+    const orderWithFailure: OrderRecord = {
+      ...sampleOrder,
+      syncStatus: [
+        {
+          destinationConnectionId: sampleConnection.id,
+          status: 'failed',
+          syncedAt: null,
+          externalOrderId: null,
+          externalOrderNumber: null,
+          error: 'insert or update on table inventory_items violates foreign key constraint',
+        },
+      ],
+    };
+
+    const api = createMockApiClient({
+      orders: { getById: vi.fn().mockResolvedValue(orderWithFailure) },
+    });
+
+    renderDetail(api);
+
+    await screen.findByText('1 destination failed');
+    expect(screen.getAllByText(/foreign key constraint/).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: 'View failed orders' })).toHaveAttribute(
+      'href',
+      '/orders/failed',
+    );
+  });
 });

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -103,7 +103,7 @@ describe('OrderDetailPage', () => {
     expect(screen.getAllByText(/foreign key constraint/).length).toBeGreaterThan(0);
     expect(screen.getByRole('link', { name: 'View failed orders' })).toHaveAttribute(
       'href',
-      '/orders/failed',
+      `/orders/failed?connectionId=${sampleConnection.id}`,
     );
   });
 });

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -126,7 +126,10 @@ export function OrderDetailPage(): ReactElement {
             failedDestinations.length > 1 ? 's' : ''
           } failed`}
           action={
-            <Link to="/orders/failed" className="button button--primary button--compact">
+            <Link
+              to={`/orders/failed?connectionId=${encodeURIComponent(order.sourceConnectionId)}`}
+              className="button button--primary button--compact"
+            >
               View failed orders
             </Link>
           }

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
+import { Alert } from '../../shared/ui/alert';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
@@ -106,6 +107,7 @@ export function OrderDetailPage(): ReactElement {
   }
 
   const order = query.data;
+  const failedDestinations = order.syncStatus.filter((s) => s.status === 'failed');
 
   return (
     <PageLayout
@@ -117,6 +119,38 @@ export function OrderDetailPage(): ReactElement {
         </Link>
       }
     >
+      {failedDestinations.length > 0 ? (
+        <Alert
+          tone="error"
+          title={`${failedDestinations.length} destination${
+            failedDestinations.length > 1 ? 's' : ''
+          } failed`}
+          action={
+            <Link to="/orders/failed" className="button button--primary button--compact">
+              View failed orders
+            </Link>
+          }
+        >
+          <ul className="order-detail__failed-list">
+            {failedDestinations.map((status) => (
+              <li key={status.destinationConnectionId}>
+                <ConnectionEntityLabel
+                  connectionId={status.destinationConnectionId}
+                  showId={false}
+                />
+                {status.error ? (
+                  <span className="order-detail__failed-error">
+                    {status.error.length > 120
+                      ? `${status.error.slice(0, 120)}…`
+                      : status.error}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </Alert>
+      ) : null}
+
       {/* Order metadata */}
       <section className="detail-section">
         <h3 className="detail-section__title">Details</h3>

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
@@ -1,6 +1,7 @@
-import { screen } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { SyncJobDetailPage } from './sync-job-detail-page';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
@@ -32,6 +33,8 @@ function renderDetailPage(apiClient: ReturnType<typeof createMockApiClient>): vo
 }
 
 describe('SyncJobDetailPage', () => {
+  afterEach(cleanup);
+
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       syncJobs: { getById: vi.fn().mockReturnValue(new Promise(() => {})) },
@@ -63,5 +66,57 @@ describe('SyncJobDetailPage', () => {
     renderDetailPage(mockApi);
 
     expect(await screen.findByText('Unable to load job')).toBeInTheDocument();
+  });
+
+  it('surfaces a retry banner with the error preview when the job is dead', async () => {
+    const deadJob: SyncJob = {
+      ...sampleJob,
+      status: 'dead',
+      attempts: 3,
+      lastError: 'insert or update on table inventory_items violates foreign key constraint',
+    };
+    const mockApi = createMockApiClient({
+      syncJobs: { getById: vi.fn().mockResolvedValue(deadJob) },
+    });
+
+    renderDetailPage(mockApi);
+
+    await screen.findByText('Job failed after 3 attempts');
+    expect(screen.getAllByText(/foreign key constraint/).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('invokes the retry mutation when the banner Retry button is clicked', async () => {
+    const user = userEvent.setup();
+    const retry = vi.fn().mockResolvedValue({ ...sampleJob, status: 'queued' });
+    const mockApi = createMockApiClient({
+      syncJobs: {
+        getById: vi.fn().mockResolvedValue({
+          ...sampleJob,
+          status: 'dead',
+          attempts: 3,
+          lastError: 'timeout',
+        }),
+        retry,
+      },
+    });
+
+    renderDetailPage(mockApi);
+
+    await screen.findByText('Job failed after 3 attempts');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(retry).toHaveBeenCalledWith(sampleJob.id);
+  });
+
+  it('does not show the retry banner for succeeded jobs', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { getById: vi.fn().mockResolvedValue(sampleJob) },
+    });
+
+    renderDetailPage(mockApi);
+
+    await screen.findByText('marketplace.orders.poll');
+    expect(screen.queryByText(/Job failed/)).toBeNull();
   });
 });

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -1,13 +1,16 @@
 import type { ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
+import { Alert } from '../../shared/ui/alert';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { TimeDisplay } from '../../shared/ui/time-display';
+import { useToast } from '../../shared/ui/toast-provider';
 import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobStatusBadge';
 import { useSyncJobQuery } from '../../features/sync-jobs/hooks/use-sync-job-query';
+import { useRetrySyncJobMutation } from '../../features/sync-jobs/hooks/use-retry-sync-job-mutation';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 
@@ -45,6 +48,8 @@ function buildSyncJobItems(job: SyncJob): KeyValueItem[] {
 export function SyncJobDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
   const query = useSyncJobQuery(id);
+  const retry = useRetrySyncJobMutation();
+  const { showToast } = useToast();
 
   if (query.isLoading) {
     return (
@@ -69,6 +74,22 @@ export function SyncJobDetailPage(): ReactElement {
   }
 
   const job = query.data;
+  const isDead = job.status === 'dead';
+
+  function handleRetry(): void {
+    retry.mutate(job.id, {
+      onSuccess: () => {
+        showToast({
+          tone: 'success',
+          title: 'Retrying',
+          description: `Job ${job.id.slice(0, 8)}… requeued.`,
+        });
+      },
+      onError: (error) => {
+        showToast({ tone: 'error', title: 'Retry failed', description: error.message });
+      },
+    });
+  }
 
   return (
     <PageLayout
@@ -80,6 +101,26 @@ export function SyncJobDetailPage(): ReactElement {
         </Link>
       }
     >
+      {isDead ? (
+        <Alert
+          tone="error"
+          title={`Job failed after ${job.attempts} attempt${job.attempts === 1 ? '' : 's'}`}
+          action={
+            <Button onClick={handleRetry} disabled={retry.isPending}>
+              {retry.isPending ? 'Retrying…' : 'Retry'}
+            </Button>
+          }
+        >
+          {job.lastError ? (
+            <span className="mono-text">
+              {job.lastError.length > 240 ? `${job.lastError.slice(0, 240)}…` : job.lastError}
+            </span>
+          ) : (
+            'No error message was recorded for this job.'
+          )}
+        </Alert>
+      ) : null}
+
       <section className="detail-section">
         <KeyValueList items={buildSyncJobItems(job)} />
       </section>

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -127,7 +127,7 @@ export function SyncJobDetailPage(): ReactElement {
 
       {job.lastError ? (
         <section className="detail-section">
-          <RawPayloadPanel title="Last error" payload={job.lastError} defaultOpen />
+          <RawPayloadPanel title="Last error" payload={job.lastError} defaultOpen={!isDead} />
         </section>
       ) : null}
 


### PR DESCRIPTION
Closes #240. Part of epic #236. Restructures four detail pages to follow the style guide's **elevated current state → metadata → related sections → raw data below the fold** pattern.

## Findings addressed

- **P0 #4.2** — Order destination failure buried in a table cell → elevated to top-of-page Alert
- **P1 #2.3** — Connection detail mosaic → Tabs (URL-synced)
- **P1 #22** — Customer detail sparse → orders list added
- **P1 #24** — Listing detail missing product link → entity-typed link to product / inventory detail
- **P1 #26 (partial)** — Failed job retry + tinted error surface. **Retry** is wired; **Abort** and **Force-dead** are deferred pending backend mutations (no `abort` / `markDead` on `ApiClient['syncJobs']` today). Follow-up ticket once API ships.

Deferred: P1 #23 (Inventory recent adjustments timeline) — no adjustment feed exists in the backend yet.

## What ships

### Order detail

Failed destinations render at the top of the page inside an error-tone `<Alert>` listing each failing destination's name (via `ConnectionEntityLabel`) and a truncated error. The **View failed orders** action pre-filters by the order's `sourceConnectionId` so operators land on the relevant slice of the failed-orders page, not the global triage.

### Connection detail

The card mosaic collapses into Radix-backed `Tabs`, **URL-synced via `?tab=`**:

| Tab | Contents | URL |
|---|---|---|
| Overview | Summary `KeyValueList` + `ConnectionCapabilitiesPanel` | `/connections/:id` (no `?tab`) |
| Health | `ConnectionDiagnosticsPanel` | `/connections/:id?tab=health` |
| Actions | `ConnectionActionsPanel` | `/connections/:id?tab=actions` |
| Config | `ConnectionConfigPanel` | `/connections/:id?tab=config` |

Refreshes / deep-links preserve the tab. First consumer of the `Tabs` wrapper shipped in Phase 3a.

### Sync Job detail

Dead jobs get a top-of-page error banner with a 240-char `lastError` preview and a **Retry** button wired to `useRetrySyncJobMutation`. The `Last error` `RawPayloadPanel` now defaults closed when the banner is already showing the preview — no duplicate error render for dead jobs. Succeeded jobs see the panel `defaultOpen` as before.

### Customer detail

A customer-orders `DataTable` below the details, using `useOrdersQuery({ customerId })`. Rows click-navigate to `/orders/:id`. Respects loading / error / empty states per `.claude/rules/fe-pages.md`.

### Listing detail

Internal ID links based on `entityType`:

- `Product` / `ProductVariant` → `/products/:id`
- `InventoryItem` → `/inventory/:id`
- anything else → plain mono text

The entity type comparison uses a new `KNOWN_MAPPING_ENTITY_TYPES` `as const` union in `listings.types.ts` (engineering-standards §Union Types) — unknown values pass through unchanged so this stays forward-compatible.

## CSS

- `.order-detail__failed-list` / `__failed-error` for the per-destination list in the banner
- `.alert` stacks column-wise under 768 px so action buttons don't push off-screen on mobile (§Responsive)
- `.tabs__content` gains a 16 px vertical gap so multi-panel tab content (Overview) breathes

## Tests

- **Order**: banner absent when synced, present + correct `/orders/failed?connectionId=…` href when any destination fails
- **Connection**: four tabs present; switching to Config reveals the config surface; `?tab=config` on first render selects Config
- **Sync Job**: retry banner gated on `status === 'dead'`; Retry button invokes `apiClient.syncJobs.retry(id)`; banner hidden on succeeded jobs
- **Customer**: orders list renders with the correct count
- **Listing**: Product / ProductVariant / InventoryItem each link to the right detail route; unknown entity renders as plain text

296/296 green. Pre-commit hook passed.

## Slicing reminder

- Phase 1 (#237, merged), 2 (#238, merged), 3 (#239, merged)
- **Phase 4 (#240)** ← this PR
- Phase 5 (#241) — Forms & wizards
- Phase 6 (#242) — Dashboard & triage redesign
