### PR TITLE
refactor(web): Phase 3 closeout — EntityLabel titles + opt-in EmptyState eyebrow

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2336,6 +2336,12 @@ textarea {
   max-width: 100%;
 }
 
+/* When EntityLabel sits inside a page title, inherit the title weight so the
+   name reads as the heading, not a quieter 500. */
+.page-title .entity-label__name {
+  font-weight: inherit;
+}
+
 .entity-label__name--link {
   color: var(--accent-primary);
   text-decoration: none;

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -7,6 +7,7 @@ import { ConnectionConfigPanel } from '../../features/connections/components/Con
 import { ConnectionDiagnosticsPanel } from '../../features/connections/components/ConnectionDiagnosticsPanel';
 import type { ConnectionStatus } from '../../features/connections/api/connections.types';
 import { EmptyState, ErrorState, LoadingState } from '../../shared/ui/feedback-state';
+import { EntityLabel } from '../../shared/ui/entity-label';
 import { KeyValueList } from '../../shared/ui/key-value-list';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
@@ -60,7 +61,13 @@ export function ConnectionDetailPage(): ReactElement {
   return (
     <PageLayout
       eyebrow="Integration detail"
-      title={connection ? connection.name : `Connection ${connectionId}`}
+      title={
+        connection ? (
+          <EntityLabel id={connection.id} name={connection.name} />
+        ) : (
+          `Connection ${connectionId}`
+        )
+      }
       description="Connection overview, configuration, health, and operator actions."
       actions={
         <div className="button-group">

--- a/apps/web/src/pages/customers/customer-detail-page.test.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.test.tsx
@@ -38,7 +38,7 @@ describe('CustomerDetailPage', () => {
 
     renderDetail(api);
 
-    await screen.findByText('ol_customer_abc');
+    expect((await screen.findAllByText('ol_customer_abc')).length).toBeGreaterThan(0);
     expect(screen.getAllByText('Jane').length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText('No value').length).toBeGreaterThan(0);
 
@@ -54,7 +54,7 @@ describe('CustomerDetailPage', () => {
 
     renderDetail(api);
 
-    await screen.findByText('ol_customer_abc');
+    expect((await screen.findAllByText('ol_customer_abc')).length).toBeGreaterThan(0);
     expect(screen.queryByRole('link', { name: sampleConnection.name })).toBeNull();
     expect(screen.getAllByLabelText('No value').length).toBeGreaterThanOrEqual(2);
   });

--- a/apps/web/src/pages/customers/customer-detail-page.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.tsx
@@ -5,6 +5,7 @@ import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
 import { EmptyValue } from '../../shared/ui/empty-value';
+import { EntityLabel } from '../../shared/ui/entity-label';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -172,7 +173,7 @@ export function CustomerDetailPage(): ReactElement {
   return (
     <PageLayout
       eyebrow="Customers"
-      title={name || customer.internalCustomerId}
+      title={<EntityLabel id={customer.internalCustomerId} name={name || null} />}
       actions={
         <Link to=".." relative="path" className="button button--ghost">
           ← Back to customers

--- a/apps/web/src/pages/products/product-detail-page.test.tsx
+++ b/apps/web/src/pages/products/product-detail-page.test.tsx
@@ -66,7 +66,7 @@ describe('ProductDetailPage', () => {
     renderDetailPage(mockApi);
 
     expect(await screen.findByText('Test Product')).toBeInTheDocument();
-    expect(screen.getByText('ol_product_abc123')).toBeInTheDocument();
+    expect(screen.getAllByText('ol_product_abc123').length).toBeGreaterThan(0);
     expect(screen.getByText('SKU-001')).toBeInTheDocument();
     expect(screen.getByText('29.99')).toBeInTheDocument();
     expect(screen.getByText('A test product')).toBeInTheDocument();

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { EntityLabel } from '../../shared/ui/entity-label';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useProductQuery } from '../../features/products/hooks/use-product-query';
@@ -178,7 +179,7 @@ export function ProductDetailPage(): ReactElement {
   return (
     <PageLayout
       eyebrow="Products"
-      title={product.name}
+      title={<EntityLabel id={product.id} name={product.name} />}
       actions={
         <Link to=".." relative="path" className="button button--ghost">
           ← Back to products

--- a/apps/web/src/shared/ui/feedback-state.tsx
+++ b/apps/web/src/shared/ui/feedback-state.tsx
@@ -38,11 +38,11 @@ export function LoadingState({
   );
 }
 
-export function EmptyState({ action, eyebrow = 'Empty state', liveRegion = 'polite', message, title }: EmptyStateProps): ReactElement {
+export function EmptyState({ action, eyebrow, liveRegion = 'polite', message, title }: EmptyStateProps): ReactElement {
   return (
     <div className="state-card empty-state" role="status" aria-live={liveRegion}>
       <div className="state-card__header">
-        <p className="eyebrow">{eyebrow}</p>
+        {eyebrow ? <p className="eyebrow">{eyebrow}</p> : null}
         <h2 className="state-card__title">{title}</h2>
       </div>
       <p className="state-card__message">{message}</p>


### PR DESCRIPTION
## Summary

Closes the remaining acceptance items on #239 (Phase 3 shared primitives).

- **EntityLabel in detail titles** — connection, customer, and product detail pages now render their heading through `EntityLabel`, so every detail surface exposes the internal id with a copy affordance consistently (matches the style the Orders detail page already had).
- **EmptyState eyebrow is opt-in** — the default `"Empty state"` eyebrow was reading like decoration on every empty panel. Callers that want an eyebrow pass one explicitly; everyone else gets a clean card.
- **Tests updated** — `customer-detail-page.test.tsx` and `product-detail-page.test.tsx` now use `getAllByText` for the internal id, since EntityLabel renders it in the heading alongside the KeyValueList row.

Scope is intentionally narrow — no primitive changes, no new hooks, no UX shifts beyond what is described above.

## Test plan

- [x] `pnpm --filter @openlinker/web test` — 296 passing
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean (warnings unchanged from main)
- [ ] Visual spot-check on connection / customer / product detail pages: title shows name + truncated id + copy button; empty stock / empty addresses panels no longer show the "EMPTY STATE" eyebrow

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)