### PR TITLE
fix(orders): persist order with awaiting_mapping status when item refs unresolved

### DIFF
--- a/apps/api/src/migrations/1783000000000-add-order-record-status.ts
+++ b/apps/api/src/migrations/1783000000000-add-order-record-status.ts
@@ -1,0 +1,24 @@
+/**
+ * Add Order Record Status
+ *
+ * Adds a `recordStatus` column to `order_records` to track whether an order's
+ * item refs have been fully resolved (`ready`) or are awaiting offer→variant
+ * mapping (`awaiting_mapping`). Zero-downtime: existing rows default to `ready`.
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderRecordStatus1783000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN "recordStatus" VARCHAR NOT NULL DEFAULT 'ready'`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_order_records_record_status" ON "order_records" ("recordStatus")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_order_records_record_status"`);
+    await queryRunner.query(`ALTER TABLE "order_records" DROP COLUMN "recordStatus"`);
+  }
+}

--- a/apps/api/src/orders/http/dto/list-orders-query.dto.ts
+++ b/apps/api/src/orders/http/dto/list-orders-query.dto.ts
@@ -8,8 +8,8 @@
 import { IsOptional, IsString, IsUUID, IsEnum, IsInt, Min, Max, IsDateString } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { OrderSyncStatusFilterValues } from '@openlinker/core/orders';
-import type { OrderSyncStatusFilter } from '@openlinker/core/orders';
+import { OrderSyncStatusFilterValues, OrderRecordStatusValues } from '@openlinker/core/orders';
+import type { OrderSyncStatusFilter, OrderRecordStatus } from '@openlinker/core/orders';
 
 export class ListOrdersQueryDto {
   @ApiPropertyOptional({ description: 'Filter by source connection ID (UUID)' })
@@ -47,6 +47,14 @@ export class ListOrdersQueryDto {
   @Min(1)
   @Max(100)
   limit?: number = 20;
+
+  @ApiPropertyOptional({
+    enum: OrderRecordStatusValues,
+    description: 'Filter by record status (ready = fully resolved, awaiting_mapping = item refs unresolved)',
+  })
+  @IsOptional()
+  @IsEnum(OrderRecordStatusValues)
+  recordStatus?: OrderRecordStatus;
 
   @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
   @IsOptional()

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -7,6 +7,8 @@
  * @module apps/api/src/orders/http/dto
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { OrderRecordStatusValues } from '@openlinker/core/orders';
+import type { OrderRecordStatus } from '@openlinker/core/orders';
 import { OrderSyncStatusResponseDto } from './order-sync-status-response.dto';
 
 export class OrderRecordResponseDto {
@@ -30,6 +32,14 @@ export class OrderRecordResponseDto {
 
   @ApiProperty({ description: 'Order creation timestamp (ISO 8601)' })
   createdAt!: string;
+
+  @ApiProperty({
+    description:
+      'Record resolution status. "ready" = all item refs resolved (orderSnapshot contains internal IDs). ' +
+      '"awaiting_mapping" = item refs unresolved (orderSnapshot contains raw IncomingOrder with external offer refs).',
+    enum: OrderRecordStatusValues,
+  })
+  recordStatus!: OrderRecordStatus;
 
   @ApiProperty({ description: 'Order last-update timestamp (ISO 8601)' })
   updatedAt!: string;

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -31,6 +31,7 @@ describe('OrdersController', () => {
         externalOrderNumber: '000456',
       },
     ],
+    'ready',
     new Date('2026-04-01T00:00:00Z'),
     new Date('2026-04-01T12:00:00Z'),
   );
@@ -125,6 +126,7 @@ describe('OrdersController', () => {
         null,
         {},
         [{ destinationConnectionId: 'conn-dest-001', status: 'pending' }],
+        'ready',
         new Date('2026-04-01T00:00:00Z'),
         new Date('2026-04-01T00:00:00Z'),
       );

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -48,7 +48,7 @@ export class OrdersController {
   @ApiResponse({ status: 200, description: 'Paginated order list', type: PaginatedOrdersResponseDto })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async listOrders(@Query() query: ListOrdersQueryDto): Promise<PaginatedOrdersResponseDto> {
-    const { sourceConnectionId, syncStatus, customerId, createdFrom, createdTo, limit = 20, offset = 0 } = query;
+    const { sourceConnectionId, syncStatus, customerId, createdFrom, createdTo, recordStatus, limit = 20, offset = 0 } = query;
 
     const { items, total } = await this.orderRecordRepository.findMany(
       {
@@ -57,6 +57,7 @@ export class OrdersController {
         customerId,
         createdFrom: createdFrom ? new Date(createdFrom) : undefined,
         createdTo: createdTo ? new Date(createdTo) : undefined,
+        recordStatus,
       },
       { limit, offset },
     );
@@ -91,6 +92,7 @@ export class OrdersController {
       sourceEventId: order.sourceEventId,
       orderSnapshot: order.orderSnapshot,
       syncStatus: order.syncStatus.map((s) => this.toSyncStatusDto(s)),
+      recordStatus: order.recordStatus,
       createdAt: order.createdAt instanceof Date ? order.createdAt.toISOString() : order.createdAt,
       updatedAt: order.updatedAt instanceof Date ? order.updatedAt.toISOString() : order.updatedAt,
     };

--- a/apps/web/src/features/orders/api/orders.api.ts
+++ b/apps/web/src/features/orders/api/orders.api.ts
@@ -29,6 +29,7 @@ function buildQuery(filters?: OrderFilters, pagination?: OrderPagination): strin
   if (filters?.customerId) params.set('customerId', filters.customerId);
   if (filters?.createdFrom) params.set('createdFrom', filters.createdFrom);
   if (filters?.createdTo) params.set('createdTo', filters.createdTo);
+  if (filters?.recordStatus) params.set('recordStatus', filters.recordStatus);
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
   const qs = params.toString();

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -20,6 +20,11 @@ export interface OrderSyncStatus {
   error: string | null;
 }
 
+// Mirrors the backend `OrderRecordStatusValues` in `@openlinker/core/orders`.
+// Hand-written transport type per FE-001 contract strategy — keep in sync with backend.
+export const OrderRecordStatusValues = ['ready', 'awaiting_mapping'] as const;
+export type OrderRecordStatusValue = (typeof OrderRecordStatusValues)[number];
+
 export interface OrderRecord {
   internalOrderId: string;
   customerId: string | null;
@@ -27,6 +32,7 @@ export interface OrderRecord {
   sourceEventId: string | null;
   orderSnapshot: Record<string, unknown>;
   syncStatus: OrderSyncStatus[];
+  recordStatus: OrderRecordStatusValue;
   createdAt: string;
   updatedAt: string;
 }
@@ -37,6 +43,7 @@ export interface OrderFilters {
   customerId?: string;
   createdFrom?: string;
   createdTo?: string;
+  recordStatus?: OrderRecordStatusValue;
 }
 
 export interface OrderPagination {

--- a/apps/web/src/pages/customers/customer-detail-page.test.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.test.tsx
@@ -76,6 +76,7 @@ describe('CustomerDetailPage', () => {
           error: null,
         },
       ],
+      recordStatus: 'ready',
       createdAt: '2026-04-20T09:00:00.000Z',
       updatedAt: '2026-04-20T10:00:00.000Z',
     };

--- a/apps/web/src/pages/orders/failed-orders-page.test.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.test.tsx
@@ -1,31 +1,29 @@
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { FailedOrdersPage } from './failed-orders-page';
-import type { PaginatedSyncJobs, SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
+import type { PaginatedOrders, OrderRecord } from '../../features/orders/api/orders.types';
 
-function makeSyncJob(overrides: Partial<SyncJob> = {}): SyncJob {
+function makeOrderRecord(overrides: Partial<OrderRecord> = {}): OrderRecord {
   return {
-    id: 'aabbccdd-1111-2222-3333-444444444444',
-    jobType: 'marketplace.order.sync',
-    connectionId: 'conn-1111-2222-3333-444444444444',
-    status: 'dead',
-    attempts: 10,
-    maxAttempts: 10,
-    nextRunAt: '2026-04-10T10:00:00.000Z',
-    lastError: 'MissingOrderItemMappingError: No product mapping found for offer abc123',
-    payloadJson: { allegroOrderId: 'order-1' },
-    idempotencyKey: 'key-1',
-    lockedAt: null,
-    lockedBy: null,
+    internalOrderId: 'ol_order_aabbccdd1122334455',
+    customerId: null,
+    sourceConnectionId: 'conn-1111-2222-3333-444444444444',
+    sourceEventId: 'evt-001',
+    orderSnapshot: {
+      externalOrderId: 'EXT-123',
+      items: [{ id: 'item-1', productRef: { type: 'offer', externalId: 'offer-a' }, quantity: 1, price: 9.99 }],
+    },
+    syncStatus: [],
+    recordStatus: 'awaiting_mapping',
     createdAt: '2026-04-10T08:00:00.000Z',
     updatedAt: '2026-04-10T10:00:00.000Z',
     ...overrides,
   };
 }
 
-const sampleData: PaginatedSyncJobs = {
-  items: [makeSyncJob()],
+const sampleData: PaginatedOrders = {
+  items: [makeOrderRecord()],
   total: 1,
   limit: 25,
   offset: 0,
@@ -34,7 +32,7 @@ const sampleData: PaginatedSyncJobs = {
 describe('FailedOrdersPage', () => {
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
-      syncJobs: {
+      orders: {
         list: vi.fn().mockReturnValue(new Promise(() => {})),
       },
       connections: {
@@ -44,78 +42,58 @@ describe('FailedOrdersPage', () => {
 
     renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
 
-    expect(screen.getByText('Loading failed orders')).toBeInTheDocument();
+    expect(screen.getByText('Loading orders')).toBeInTheDocument();
   });
 
-  it('should show failed jobs table when data loads', async () => {
+  it('should fetch orders with recordStatus=awaiting_mapping filter', async () => {
+    const list = vi.fn().mockResolvedValue(sampleData);
     const mockApi = createMockApiClient({
-      syncJobs: {
-        list: vi.fn().mockResolvedValue(sampleData),
-      },
-      connections: {
-        list: vi.fn().mockResolvedValue([]),
-      },
+      orders: { list },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
 
-    expect(await screen.findByText('aabbccdd…')).toBeInTheDocument();
-    expect(screen.getByText('10/10')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    await screen.findByText(/ol_order_aabbccd/);
+
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ recordStatus: 'awaiting_mapping' }),
+      expect.any(Object),
+    );
+  });
+
+  it('should show awaiting-mapping orders table when data loads', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(sampleData) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText(/ol_order_aabbccd/)).toBeInTheDocument();
   });
 
   it('should show error state when fetch fails', async () => {
     const mockApi = createMockApiClient({
-      syncJobs: {
-        list: vi.fn().mockRejectedValue(new Error('Network error')),
-      },
-      connections: {
-        list: vi.fn().mockResolvedValue([]),
-      },
+      orders: { list: vi.fn().mockRejectedValue(new Error('Network error')) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
 
-    expect(await screen.findByText('Unable to load failed orders')).toBeInTheDocument();
+    expect(await screen.findByText('Unable to load orders')).toBeInTheDocument();
   });
 
-  it('should show empty state when no failed jobs', async () => {
+  it('should show empty state when no orders awaiting mapping', async () => {
     const mockApi = createMockApiClient({
-      syncJobs: {
-        list: vi.fn().mockResolvedValue({
-          items: [],
-          total: 0,
-          limit: 25,
-          offset: 0,
-        }),
+      orders: {
+        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 25, offset: 0 }),
       },
-      connections: {
-        list: vi.fn().mockResolvedValue([]),
-      },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
 
-    expect(await screen.findByText('No failed orders')).toBeInTheDocument();
-  });
-
-  it('should render retry button scoped to each job row', async () => {
-    const mockApi = createMockApiClient({
-      syncJobs: {
-        list: vi.fn().mockResolvedValue(sampleData),
-      },
-      connections: {
-        list: vi.fn().mockResolvedValue([]),
-      },
-    });
-
-    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
-
-    const jobIdLink = await screen.findByText('aabbccdd…');
-    const row = jobIdLink.closest('tr')!;
-    const retryButton = within(row).getByRole('button', { name: 'Retry' });
-
-    expect(retryButton).toBeInTheDocument();
-    expect(retryButton).not.toBeDisabled();
+    expect(await screen.findByText('No orders awaiting mapping')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/orders/failed-orders-page.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.tsx
@@ -1,8 +1,9 @@
 /**
  * Failed Orders Page
  *
- * Displays dead order-sync jobs with inline retry capability. Allows operators
- * to diagnose and remediate failed order synchronizations.
+ * Displays order records with awaiting_mapping status — orders where one or more
+ * offer→variant mappings were missing at ingestion time. The job runner retries
+ * these automatically once the mapping is created via marketplace.offers.sync.
  *
  * @module apps/web/src/pages/orders
  */
@@ -15,112 +16,58 @@ import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-s
 import { Button } from '../../shared/ui/button';
 import { Select } from '../../shared/ui/select';
 import { StatusBadge } from '../../shared/ui/status-badge';
-import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
-import { useRetrySyncJobMutation } from '../../features/sync-jobs/hooks/use-retry-sync-job-mutation';
+import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
-import { useToast } from '../../shared/ui/toast-provider';
 import { TimeDisplay } from '../../shared/ui/time-display';
-import type { SyncJob, SyncJobFilters } from '../../features/sync-jobs/api/sync-jobs.types';
+import type { OrderRecord } from '../../features/orders/api/orders.types';
 
 const PAGE_SIZE = 25;
 
-const ORDER_JOB_TYPES = ['marketplace.order.sync'] as const;
-
-function RetryButton({ job }: { job: SyncJob }): ReactElement {
-  const mutation = useRetrySyncJobMutation();
-  const { showToast } = useToast();
-
-  function handleRetry(): void {
-    mutation.mutate(job.id, {
-      onSuccess: () => {
-        showToast({ tone: 'success', title: 'Retrying', description: `Job ${job.id.slice(0, 8)}… requeued.` });
-      },
-      onError: (error) => {
-        showToast({ tone: 'error', title: 'Retry failed', description: error.message });
-      },
-    });
-  }
-
-  const isPending = mutation.isPending && mutation.variables === job.id;
-
-  return (
-    <Button
-      onClick={handleRetry}
-      disabled={isPending}
-      className="button--compact"
-    >
-      {isPending ? 'Retrying…' : 'Retry'}
-    </Button>
-  );
+function snapshotItemCount(snapshot: Record<string, unknown>): number {
+  const items = snapshot['items'];
+  if (Array.isArray(items)) return items.length;
+  return 0;
 }
 
-function truncateError(error: string | null, maxLength = 80): string {
-  if (!error) return '—';
-  return error.length > maxLength ? `${error.slice(0, maxLength)}…` : error;
-}
-
-const COLUMNS: DataTableColumn<SyncJob>[] = [
+const COLUMNS: DataTableColumn<OrderRecord>[] = [
   {
-    id: 'id',
-    header: 'Job ID',
-    cell: (job) => <span className="mono-text">{job.id.slice(0, 8)}…</span>,
+    id: 'internalOrderId',
+    header: 'Order ID',
+    cell: (order) => <span className="mono-text">{order.internalOrderId.slice(0, 16)}…</span>,
   },
   {
-    id: 'connectionId',
+    id: 'sourceConnectionId',
     header: 'Connection',
-    cell: (job) => <span className="mono-text">{job.connectionId.slice(0, 8)}…</span>,
+    cell: (order) => <span className="mono-text">{order.sourceConnectionId.slice(0, 8)}…</span>,
     hideBelow: 1024,
   },
   {
-    id: 'updatedAt',
-    header: 'Failed At',
-    cell: (job) => <TimeDisplay iso={job.updatedAt} />,
-    accessor: (job) => job.updatedAt,
-    sortable: true,
-  },
-  {
-    id: 'lastError',
-    header: 'Error',
-    cell: (job) => (
-      <details>
-        <summary style={{ cursor: 'pointer' }}>{truncateError(job.lastError)}</summary>
-        <pre style={{ whiteSpace: 'pre-wrap', fontSize: '0.8em', marginTop: '0.5rem' }}>
-          {job.lastError ?? '—'}
-        </pre>
-      </details>
-    ),
-    hideBelow: 768,
-  },
-  {
-    id: 'attempts',
-    header: 'Attempts',
-    cell: (job) => `${job.attempts}/${job.maxAttempts}`,
+    id: 'items',
+    header: 'Items',
+    cell: (order) => snapshotItemCount(order.orderSnapshot),
     align: 'center',
     hideBelow: 480,
   },
   {
-    id: 'actions',
-    header: '',
-    cell: (job) => <RetryButton job={job} />,
-    align: 'right',
+    id: 'createdAt',
+    header: 'First Seen',
+    cell: (order) => <TimeDisplay iso={order.createdAt} />,
+    accessor: (order) => order.createdAt,
+    sortable: true,
   },
 ];
 
 export function FailedOrdersPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { sort, setSort } = useTableSort([{ id: 'updatedAt', desc: true }]);
+  const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
 
   const connectionId = searchParams.get('connectionId') ?? undefined;
   const offset = Number(searchParams.get('offset') ?? '0');
 
-  const filters: SyncJobFilters = {
-    status: 'dead',
-    jobType: ORDER_JOB_TYPES[0],
-    connectionId: connectionId || undefined,
-  };
-  const pagination = { limit: PAGE_SIZE, offset };
-
-  const query = useSyncJobsQuery(filters, pagination);
+  const query = useOrdersQuery(
+    { recordStatus: 'awaiting_mapping', sourceConnectionId: connectionId },
+    { limit: PAGE_SIZE, offset },
+  );
   const connectionsQuery = useConnectionsQuery();
 
   function handleConnectionFilterChange(value: string): void {
@@ -156,15 +103,14 @@ export function FailedOrdersPage(): ReactElement {
   return (
     <PageLayout
       eyebrow="Orders"
-      title="Failed Orders"
-      description="Order sync failures — diagnose errors and retry failed jobs."
+      title="Awaiting Mapping"
+      description="Orders with unresolved offer→variant mappings. These retry automatically once the mapping is created."
       actions={
         <Link to="/orders" className="button button--ghost">
           ← All Orders
         </Link>
       }
     >
-      {/* Filter bar */}
       <div className="toolbar">
         <Select
           aria-label="Filter by connection"
@@ -179,20 +125,20 @@ export function FailedOrdersPage(): ReactElement {
           ))}
         </Select>
 
-        <StatusBadge tone="error" compact>
-          {total} failed
+        <StatusBadge tone="warning" compact>
+          {total} awaiting mapping
         </StatusBadge>
       </div>
 
       {query.isLoading ? (
         <LoadingState
           liveRegion="off"
-          title="Loading failed orders"
-          message="Fetching failed order sync jobs…"
+          title="Loading orders"
+          message="Fetching orders awaiting mapping…"
         />
       ) : query.error ? (
         <ErrorState
-          title="Unable to load failed orders"
+          title="Unable to load orders"
           message={query.error.message}
           action={
             <Button onClick={() => { void query.refetch(); }}>Retry</Button>
@@ -201,27 +147,25 @@ export function FailedOrdersPage(): ReactElement {
       ) : (query.data?.items.length ?? 0) === 0 ? (
         <EmptyState
           liveRegion="off"
-          title="No failed orders"
+          title="No orders awaiting mapping"
           message={
             connectionId
-              ? 'No failed order sync jobs for the selected connection.'
-              : 'No failed order sync jobs found. All orders are syncing successfully.'
+              ? 'No orders with missing mappings for the selected connection.'
+              : 'All orders have been fully resolved. No mapping issues detected.'
           }
         />
       ) : (
         <>
           <DataTable
-            caption="Failed order sync jobs"
+            caption="Orders awaiting offer→variant mapping"
             columns={COLUMNS}
             rows={query.data?.items ?? []}
-            rowKey={(job) => job.id}
-            rowHref={(job) => `/sync-jobs/${job.id}`}
+            rowKey={(order) => order.internalOrderId}
             sort={sort}
             onSortChange={setSort}
             cardView={{
-              title: (job) => `${job.id.slice(0, 8)}…`,
-              subtitle: (job) => truncateError(job.lastError, 60),
-              meta: (job) => <RetryButton job={job} />,
+              title: (order) => `${order.internalOrderId.slice(0, 16)}…`,
+              subtitle: (order) => `${snapshotItemCount(order.orderSnapshot)} item(s)`,
             }}
           />
 

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -21,6 +21,7 @@ const sampleOrder: OrderRecord = {
       error: null,
     },
   ],
+  recordStatus: 'ready',
   createdAt: '2026-04-20T09:00:00.000Z',
   updatedAt: '2026-04-20T10:00:00.000Z',
 };

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -13,6 +13,7 @@ const sampleOrders: PaginatedOrders = {
       sourceEventId: null,
       orderSnapshot: {},
       syncStatus: [{ destinationConnectionId: 'conn_ps_1', status: 'synced', syncedAt: '2026-01-15T10:00:00.000Z', externalOrderId: '42', externalOrderNumber: null, error: null }],
+      recordStatus: 'ready',
       createdAt: '2026-01-15T10:00:00.000Z',
       updatedAt: '2026-01-15T10:00:00.000Z',
     },

--- a/docs/plans/implementation-plan-235-persist-order-awaiting-mapping.md
+++ b/docs/plans/implementation-plan-235-persist-order-awaiting-mapping.md
@@ -1,0 +1,357 @@
+# Implementation Plan: #235 — Persist order with `awaiting_mapping` status
+
+## 1. Task Understanding
+
+**Goal**: Ensure that when `syncOrderFromMarketplace` fails to resolve one or more order items (because offer→variant mapping doesn't exist yet), the incoming order is **still persisted** in `order_records` with a `recordStatus = 'awaiting_mapping'` — so it is observable in the UI, can be diagnosed, and recovers automatically on the next retry once the mapping is created.
+
+**Layer**: CORE (orders) + Infrastructure (migration) + Interface (API DTO + FE page)
+
+**Non-goals**:
+- Triggering an ad-hoc `marketplace.offers.sync` for the unresolved offer (separate issue)
+- Making `MissingOrderItemMappingError` non-retryable after N attempts (out of scope)
+- Changing orphan `customer_projections` behavior (acceptable for now)
+- Storing order snapshot from the *stored* record on retry (each retry still re-fetches from marketplace once; snapshot is for observability, not to replace fetching)
+
+---
+
+## 2. Codebase Research
+
+### Key files
+
+| File | Role |
+|---|---|
+| `libs/core/src/orders/domain/entities/order-record.entity.ts` | `OrderRecord` domain entity — needs `recordStatus` field |
+| `libs/core/src/orders/domain/types/order-record.types.ts` | `OrderRecordFilters` — needs `recordStatus` filter |
+| `libs/core/src/orders/domain/ports/order-record-repository.port.ts` | Repository port — `findMany` signature covers new filter |
+| `libs/core/src/orders/application/interfaces/order-record.service.interface.ts` | Service interface — needs `persistIncomingSnapshot` |
+| `libs/core/src/orders/application/services/order-record.service.ts` | Service impl — implement `persistIncomingSnapshot` |
+| `libs/core/src/orders/application/services/order-ingestion.service.ts` | **Main fix**: reorder snapshot persist before item resolution |
+| `libs/core/src/orders/application/services/order-item-ref-resolver.service.ts` | Add `tryResolve` non-throwing variant |
+| `libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts` | Add `recordStatus` column |
+| `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts` | Map new field, support new filter |
+| `apps/api/src/migrations/` | New migration for `record_status` column |
+| `apps/api/src/orders/http/dto/list-orders-query.dto.ts` | Add `recordStatus` filter param |
+| `apps/api/src/orders/http/dto/order-record-response.dto.ts` | Add `recordStatus` to response |
+| `apps/api/src/orders/http/orders.controller.ts` | Pass `recordStatus` to repository query |
+| `apps/web/src/features/orders/api/orders.types.ts` | Add `recordStatus` to `OrderRecord` + `OrderFilters` |
+| `apps/web/src/features/orders/api/orders.api.ts` | Pass `recordStatus` filter param |
+| `apps/web/src/pages/orders/failed-orders-page.tsx` | Query `order_records` with `recordStatus=awaiting_mapping`, show real order data |
+
+### Current flow (broken)
+
+```
+syncOrderFromMarketplace(connectionId, externalOrderId, sourceEventId)
+  1. marketplace.getOrder()              ← fetches from Allegro
+  2. toUnifiedOrder()                    ← ❌ throws MissingOrderItemMappingError here
+  3. orderRecordService.persistOrder()   ← never reached → order lost
+  4. orderSyncService.syncOrder()
+  5. updateSyncStatus per destination
+```
+
+### Target flow (fixed)
+
+```
+syncOrderFromMarketplace(connectionId, externalOrderId, sourceEventId)
+  1. marketplace.getOrder()
+  2. resolve internalOrderId + customerId (existing identifierMapping + customerIdentityResolver calls)
+  3. orderRecordService.persistIncomingSnapshot(incoming, internalOrderId, customerId, …)
+       → upserts order_records with recordStatus='awaiting_mapping', raw IncomingOrder snapshot
+  4. tryResolveItems(incoming.items, connectionId)
+       → returns { resolved: OrderItem[], unresolved: UnresolvedItemRef[] }
+  5. if unresolved.length > 0:
+       → throw MissingOrderItemMappingError (job runner retries with backoff)
+         record already persisted — operator can see it in UI
+  6. construct unified Order (all items resolved)
+  7. orderRecordService.persistOrder(order, …)
+       → upserts with recordStatus='ready', resolved snapshot
+  8. orderSyncService.syncOrder()
+  9. updateSyncStatus per destination
+```
+
+---
+
+## 3. Solution Design
+
+### 3.1 Domain: `OrderRecord` entity
+
+Add `recordStatus: OrderRecordStatus` field (`'ready' | 'awaiting_mapping'`).
+
+```typescript
+// order-record.types.ts — add:
+export const OrderRecordStatusValues = ['ready', 'awaiting_mapping'] as const;
+export type OrderRecordStatus = (typeof OrderRecordStatusValues)[number];
+
+// order-record.entity.ts — add field:
+public readonly recordStatus: OrderRecordStatus,
+```
+
+### 3.2 `OrderItemRefResolverService` — add `tryResolve`
+
+Add a non-throwing variant that returns a discriminated union:
+```typescript
+type ItemResolutionResult =
+  | { resolved: true; internalProductId: string; internalVariantId?: string }
+  | { resolved: false; productRef: IncomingOrderItemRef; reason: string };
+
+async tryResolve(connectionId: string, productRef: IncomingOrderItemRef): Promise<ItemResolutionResult>
+```
+
+Internally calls `resolve()` and catches `MissingOrderItemMappingError`.
+
+### 3.3 `IOrderRecordService` / `OrderRecordService` — add `persistIncomingSnapshot`
+
+```typescript
+persistIncomingSnapshot(
+  incoming: IncomingOrder,
+  internalOrderId: string,
+  customerId: string | null,
+  sourceConnectionId: string,
+  sourceEventId: string | null,
+): Promise<OrderRecord>
+```
+
+Stores `incoming` as-is in `orderSnapshot` (raw `IncomingOrder` JSON — items retain external offer refs, no internal IDs). Sets `recordStatus = 'awaiting_mapping'`. PII rules still apply to address fields.
+
+**Snapshot shape contract**: `orderSnapshot` for `awaiting_mapping` records differs from `ready` records — it contains `IncomingOrderItem[]` with `productRef` (external offer ID) instead of resolved `OrderItem[]` with internal product/variant IDs. Consumers (API response, frontend page) must treat the snapshot as opaque debug data for `awaiting_mapping` records; only `ready` records have fully resolved item refs. The `OrderRecordResponseDto` documents this via an `@ApiProperty` description.
+
+### 3.4 `OrderIngestionService` — rework `syncOrderFromMarketplace` + `toUnifiedOrder`
+
+Split `toUnifiedOrder` so that:
+- ID resolution (order + customer) happens first and can be used to call `persistIncomingSnapshot`
+- Item resolution happens after, using `tryResolve` (non-throwing)
+- If any unresolved → throw after snapshot is persisted
+
+### 3.5 Database: migration
+
+```sql
+ALTER TABLE order_records ADD COLUMN record_status VARCHAR NOT NULL DEFAULT 'ready';
+CREATE INDEX idx_order_records_record_status ON order_records (record_status);
+```
+
+Existing rows default to `'ready'`.
+
+### 3.6 API: add `recordStatus` to list query + response
+
+- `ListOrdersQueryDto`: add `recordStatus?: OrderRecordStatus`
+- `OrderRecordResponseDto`: add `recordStatus: string`
+- `OrdersController`: pass `recordStatus` to `findMany`
+
+### 3.7 Frontend: `failed-orders-page.tsx`
+
+Current: queries `useSyncJobsQuery({ status: 'dead', jobType: 'marketplace.order.sync' })`
+
+New: query `useOrdersQuery({ recordStatus: 'awaiting_mapping' })` in addition (or replace entirely) so the page shows real order content (items, customer, totals from `orderSnapshot`) rather than just job error strings. Add a "Retry" action per order that re-queues the sync job by `sourceEventId`.
+
+The page will show two conceptually different rows today: records that are `awaiting_mapping` (waiting for offer sync to catch up) and sync jobs that went `dead` for other reasons. For this issue scope, we surface `awaiting_mapping` records with their real content. Dead jobs remain accessible via `/sync-jobs` if needed.
+
+---
+
+## 4. Step-by-Step Implementation Plan
+
+### Step 1 — Domain types
+
+**File**: `libs/core/src/orders/domain/types/order-record.types.ts`
+
+- Add `OrderRecordStatusValues` and `OrderRecordStatus` (as-const union).
+- Add `recordStatus?: OrderRecordStatus` to `OrderRecordFilters`.
+
+**Acceptance**: `OrderRecordStatus` is exported; existing tests pass.
+
+---
+
+### Step 2 — Domain entity
+
+**File**: `libs/core/src/orders/domain/entities/order-record.entity.ts`
+
+- Add `public readonly recordStatus: OrderRecordStatus` parameter to constructor (after `syncStatus`, before `createdAt`).
+
+**Acceptance**: Entity compiles; existing instantiations updated.
+
+---
+
+### Step 3 — ORM entity + migration
+
+**File**: `libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts`
+
+- Add `@Column({ type: 'varchar', default: 'ready' }) recordStatus!: string;`
+
+**File**: `apps/api/src/migrations/1783000000000-add-order-record-status.ts`
+
+- `ALTER TABLE order_records ADD COLUMN record_status VARCHAR NOT NULL DEFAULT 'ready'`
+- `CREATE INDEX idx_order_records_record_status ON order_records (record_status)`
+
+**Acceptance**: Migration runs cleanly; schema matches ORM entity.
+
+---
+
+### Step 4 — Repository
+
+**File**: `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts`
+
+- `toDomain`: map `entity.recordStatus` → `domain.recordStatus`
+- `toOrm`: map `domain.recordStatus` → `entity.recordStatus`
+- `findMany`: if `filters.recordStatus`, add `WHERE rec.record_status = :recordStatus` clause
+
+**Acceptance**: Unit tests for `toDomain`/`toOrm` pass; filter works.
+
+---
+
+### Step 5 — `OrderItemRefResolverService`: add `tryResolve`
+
+**File**: `libs/core/src/orders/application/services/order-item-ref-resolver.service.ts`
+
+Add `ItemResolutionResult` type (in `order-item-ref-resolver.types.ts` or inline — it's application-layer-only).
+Add `tryResolve(connectionId, productRef): Promise<ItemResolutionResult>` that wraps `resolve()` and catches `MissingOrderItemMappingError`.
+
+**Acceptance**: New unit tests for `tryResolve` covering resolved and unresolved cases.
+
+---
+
+### Step 6 — `IOrderRecordService` + `OrderRecordService`: add `persistIncomingSnapshot`
+
+**File**: `libs/core/src/orders/application/interfaces/order-record.service.interface.ts`
+
+Add:
+```typescript
+persistIncomingSnapshot(
+  incoming: IncomingOrder,
+  internalOrderId: string,
+  customerId: string | null,
+  sourceConnectionId: string,
+  sourceEventId: string | null,
+): Promise<OrderRecord>;
+```
+
+**File**: `libs/core/src/orders/application/services/order-record.service.ts`
+
+Implement: build snapshot from `IncomingOrder`, apply PII rules to addresses, set `recordStatus = 'awaiting_mapping'`, call `repository.upsert()`.
+
+Also update `persistOrder` to explicitly set `recordStatus = 'ready'`.
+
+**Acceptance**: `persistIncomingSnapshot` unit tests: snapshot shape, PII=off scrubs addresses, `recordStatus='awaiting_mapping'`. `persistOrder` sets `recordStatus='ready'`.
+
+---
+
+### Step 7 — `OrderIngestionService`: rework `syncOrderFromMarketplace`
+
+**File**: `libs/core/src/orders/application/services/order-ingestion.service.ts`
+
+New `syncOrderFromMarketplace` flow:
+1. `marketplace.getOrder()`
+2. Resolve `internalOrderId` (via `identifierMapping.getOrCreateInternalId`)
+3. Resolve customer identity (existing logic)
+4. **Call `orderRecordService.persistIncomingSnapshot(...)`** ← new, before item resolution
+5. Resolve items via `orderItemRefResolver.tryResolve()` for each item
+6. Collect `unresolvedRefs`
+7. If `unresolvedRefs.length > 0`: throw `MissingOrderItemMappingError` (using first unresolved ref details)
+8. Build unified `Order` from resolved items
+9. `orderRecordService.persistOrder(order, ...)` — upserts with `recordStatus='ready'`
+10. `orderSyncService.syncOrder(...)` + update sync statuses
+
+Replace `toUnifiedOrder` with a private `buildUnifiedOrder(incoming, resolvedItems, internalOrderId, customerId): Order` method that handles the happy-path construction only (all items already resolved). This keeps `syncOrderFromMarketplace` readable and makes the resolved-order construction independently testable.
+
+**Acceptance**: Unit tests covering:
+- Happy path (all items resolve): `persistIncomingSnapshot` called, then `persistOrder` called with `recordStatus='ready'`
+- Partial failure (one item unresolved): `persistIncomingSnapshot` called, `MissingOrderItemMappingError` thrown, `persistOrder` NOT called
+- All items unresolved: same as partial failure
+
+---
+
+### Step 8 — API layer
+
+**File**: `apps/api/src/orders/http/dto/list-orders-query.dto.ts`
+
+- Add `@IsOptional() @IsEnum(OrderRecordStatusValues) recordStatus?: OrderRecordStatus`
+
+**File**: `apps/api/src/orders/http/dto/order-record-response.dto.ts`
+
+- Add `@ApiProperty() recordStatus!: string`
+
+**File**: `apps/api/src/orders/http/orders.controller.ts`
+
+- Extract `recordStatus` from query, pass to `findMany()`
+- Include `recordStatus` in `toDto()` output
+
+**Acceptance**: API returns `recordStatus` field; filter param is accepted.
+
+---
+
+### Step 9 — Frontend types + API client
+
+**File**: `apps/web/src/features/orders/api/orders.types.ts`
+
+- Add `recordStatus: string` to `OrderRecord`
+- Add `recordStatus?: string` to `OrderFilters`
+
+**File**: `apps/web/src/features/orders/api/orders.api.ts`
+
+- Add `recordStatus` to `buildQuery`
+
+**Acceptance**: Types compile.
+
+---
+
+### Step 10 — `failed-orders-page.tsx` — surface `awaiting_mapping` records
+
+**File**: `apps/web/src/pages/orders/failed-orders-page.tsx`
+
+Replace `useSyncJobsQuery` with `useOrdersQuery({ recordStatus: 'awaiting_mapping' })`.
+
+Show columns:
+- Order ID (`internalOrderId` truncated)
+- Connection (`sourceConnectionId` truncated)
+- Snapshot items count (from raw `orderSnapshot` — treat as opaque debug data, count `items` array length)
+- First seen at (`createdAt`)
+
+**Retry button — deferred to follow-up issue**: A `POST /orders/:internalOrderId/retry` endpoint requires a new `IOrderRetryService` interface method, module wiring, a job-enqueue implementation using `sourceConnectionId` + `sourceEventId`, error handling for missing records, and unit tests. This is out of scope for #235 to keep the change set focused. The retry button will be omitted in this issue; operators can use the existing `/sync-jobs` page to re-queue manually. A follow-up issue will add the retry endpoint and button.
+
+**Acceptance**:
+- Page shows order records with `recordStatus=awaiting_mapping`
+- Shows order ID, connection, snapshot item count, and created-at date
+- All four data-fetch states handled: loading → error → empty → data
+
+---
+
+### Step 11 — Tests
+
+**Unit tests to add/update**:
+- `order-item-ref-resolver.service.spec.ts`: `tryResolve` — resolved, unresolved (offer missing, variant missing)
+- `order-record.service.spec.ts`: `persistIncomingSnapshot` — creates with `awaiting_mapping`; `persistOrder` sets `ready`
+- `order-ingestion.service.spec.ts`: three new cases (happy, partial unresolved, all unresolved)
+- `order-record.repository.spec.ts`: `findMany` with `recordStatus` filter; `findMany` without `recordStatus` returns all records (existing callers unaffected); `toDomain`/`toOrm` include `recordStatus`
+
+---
+
+## 5. Validation
+
+### Architecture compliance ✅
+- Domain entity change is framework-free
+- Application services depend on ports, not infrastructure
+- Repository maps domain ↔ ORM (no leakage)
+- New `persistIncomingSnapshot` lives in application service, not domain
+
+### Naming ✅
+- `recordStatus` follows `camelCase` for domain, `record_status` for DB column
+- New type `OrderRecordStatus` follows `PascalCase`
+- `tryResolve` follows `camelCase` function naming
+
+### Testing strategy ✅
+- Unit tests for all changed services (no Docker)
+- Existing integration tests should still pass (new column has a default)
+
+### Security ✅
+- No new user input injection surfaces (filter is enum-validated in DTO)
+- PII rules still apply in `persistIncomingSnapshot`
+
+### Migration risk ✅
+- `DEFAULT 'ready'` ensures zero-downtime migration (existing rows unaffected)
+
+### Open questions resolved
+| Question | Decision |
+|---|---|
+| Where does unresolved state live? | `recordStatus` column on `order_records` — efficient querying; snapshot stores raw `IncomingOrder` items for debugging |
+| Non-retryable after N attempts? | Out of scope; keep retryable |
+| Ad-hoc offers sync trigger? | Out of scope |
+| Orphan `customer_projections`? | Acceptable; not changed |
+| What does `orderSnapshot` contain for `awaiting_mapping`? | Raw `IncomingOrder` JSON — items keep external offer refs, not internal IDs. Shape differs from `ready` records; document in `OrderRecordResponseDto` |
+| Retry button on failed-orders page? | Deferred to follow-up issue; requires `IOrderRetryService`, module wiring, and tests out of scope for #235 |

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -9,6 +9,7 @@
  */
 import { Order } from '../../domain/ports/order-source.port';
 import { OrderRecord, OrderSyncStatus } from '../../domain/entities/order-record.entity';
+import type { IncomingOrder } from '../../domain/types/incoming-order.types';
 
 export interface IOrderRecordService {
   /**
@@ -44,6 +45,24 @@ export interface IOrderRecordService {
     destinationConnectionId: string,
     status: OrderSyncStatus,
   ): Promise<void>;
+
+  /**
+   * Persist raw incoming snapshot before item resolution.
+   *
+   * Called immediately after ID resolution but before offer→variant mapping.
+   * Sets recordStatus='awaiting_mapping'. On retry, once all items resolve,
+   * persistOrder() upserts with recordStatus='ready'.
+   *
+   * The orderSnapshot stores the raw IncomingOrder — items retain external offer
+   * refs and do NOT contain internal product/variant IDs.
+   */
+  persistIncomingSnapshot(
+    incoming: IncomingOrder,
+    internalOrderId: string,
+    customerId: string | null,
+    sourceConnectionId: string,
+    sourceEventId: string | null,
+  ): Promise<OrderRecord>;
 
   /**
    * Get order record by ID

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -18,6 +18,7 @@ import { ICustomerIdentityResolverService } from '@openlinker/core/customers';
 import { IOrderSyncService } from '../../interfaces/order-sync.service.interface';
 import { IOrderRecordService } from '../../interfaces/order-record.service.interface';
 import { OrderItemRefResolverService } from '../order-item-ref-resolver.service';
+import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
 
 describe('OrderIngestionService', () => {
   let service: OrderIngestionService;
@@ -76,6 +77,7 @@ describe('OrderIngestionService', () => {
 
     orderItemRefResolver = {
       resolve: jest.fn(),
+      tryResolve: jest.fn(),
     } as unknown as jest.Mocked<OrderItemRefResolverService>;
 
     orderSyncService = {
@@ -84,6 +86,7 @@ describe('OrderIngestionService', () => {
 
     orderRecordService = {
       persistOrder: jest.fn().mockResolvedValue({}),
+      persistIncomingSnapshot: jest.fn().mockResolvedValue({}),
       updateSyncStatus: jest.fn().mockResolvedValue(undefined),
       getOrderRecord: jest.fn(),
     } as unknown as jest.Mocked<IOrderRecordService>;
@@ -225,15 +228,25 @@ describe('OrderIngestionService', () => {
       integrationsService.getCapabilityAdapter.mockResolvedValue(marketplace);
     });
 
-    it('should persist order before calling syncOrder', async () => {
+    it('should call persistIncomingSnapshot before item resolution, then persistOrder before syncOrder', async () => {
       orderSyncService.syncOrder.mockResolvedValue([]);
 
       await service.syncOrderFromMarketplace(connectionId, externalOrderId);
 
+      expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalledWith(
+        baseIncoming,
+        'ol_order_test',
+        null,
+        connectionId,
+        null,
+      );
       expect(orderRecordService.persistOrder).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'ol_order_test' }),
         connectionId,
         null,
+      );
+      expect(orderRecordService.persistIncomingSnapshot.mock.invocationCallOrder[0]).toBeLessThan(
+        orderRecordService.persistOrder.mock.invocationCallOrder[0],
       );
       expect(orderRecordService.persistOrder.mock.invocationCallOrder[0]).toBeLessThan(
         orderSyncService.syncOrder.mock.invocationCallOrder[0],
@@ -276,13 +289,14 @@ describe('OrderIngestionService', () => {
       );
     });
 
-    it('should still persist order when syncOrder throws', async () => {
+    it('should persist snapshot and order even when syncOrder throws', async () => {
       orderSyncService.syncOrder.mockRejectedValue(new Error('no destinations'));
 
       await expect(
         service.syncOrderFromMarketplace(connectionId, externalOrderId),
       ).rejects.toThrow('no destinations');
 
+      expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalled();
       expect(orderRecordService.persistOrder).toHaveBeenCalled();
       expect(orderRecordService.updateSyncStatus).not.toHaveBeenCalled();
     });
@@ -376,6 +390,69 @@ describe('OrderIngestionService', () => {
         connectionId,
         expect.objectContaining({ parentEntityType: 'Order' }),
       );
+    });
+  });
+
+  describe('syncOrderFromMarketplace – item resolution', () => {
+    const externalOrderId = 'checkout-item-test';
+
+    const incomingWithItems = {
+      externalOrderId,
+      orderNumber: externalOrderId,
+      status: 'BOUGHT',
+      items: [
+        { id: 'item-1', productRef: { type: 'offer' as const, externalId: 'offer-a' }, quantity: 1, price: 9.99 },
+        { id: 'item-2', productRef: { type: 'offer' as const, externalId: 'offer-b' }, quantity: 2, price: 4.99 },
+      ],
+      totals: { subtotal: 19.97, tax: 0, shipping: 0, total: 19.97, currency: 'PLN' },
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    };
+
+    beforeEach(() => {
+      identifierMapping.getOrCreateInternalId.mockResolvedValue('ol_order_item_test');
+      marketplace.getOrder.mockResolvedValue(incomingWithItems);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(marketplace);
+      orderSyncService.syncOrder.mockResolvedValue([]);
+    });
+
+    it('happy path: all items resolve — persistIncomingSnapshot then persistOrder called', async () => {
+      orderItemRefResolver.tryResolve
+        .mockResolvedValueOnce({ resolved: true, internalProductId: 'p-1', internalVariantId: 'v-1' })
+        .mockResolvedValueOnce({ resolved: true, internalProductId: 'p-2', internalVariantId: 'v-2' });
+
+      await service.syncOrderFromMarketplace(connectionId, externalOrderId);
+
+      expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalledTimes(1);
+      expect(orderRecordService.persistOrder).toHaveBeenCalledTimes(1);
+      expect(orderSyncService.syncOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('partial unresolved: persistIncomingSnapshot called, MissingOrderItemMappingError thrown, persistOrder NOT called', async () => {
+      orderItemRefResolver.tryResolve
+        .mockResolvedValueOnce({ resolved: true, internalProductId: 'p-1', internalVariantId: 'v-1' })
+        .mockResolvedValueOnce({ resolved: false, productRef: { type: 'offer', externalId: 'offer-b' }, reason: 'no mapping' });
+
+      await expect(
+        service.syncOrderFromMarketplace(connectionId, externalOrderId),
+      ).rejects.toBeInstanceOf(MissingOrderItemMappingError);
+
+      expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalledTimes(1);
+      expect(orderRecordService.persistOrder).not.toHaveBeenCalled();
+      expect(orderSyncService.syncOrder).not.toHaveBeenCalled();
+    });
+
+    it('all unresolved: persistIncomingSnapshot called, MissingOrderItemMappingError thrown, persistOrder NOT called', async () => {
+      orderItemRefResolver.tryResolve
+        .mockResolvedValueOnce({ resolved: false, productRef: { type: 'offer', externalId: 'offer-a' }, reason: 'no mapping a' })
+        .mockResolvedValueOnce({ resolved: false, productRef: { type: 'offer', externalId: 'offer-b' }, reason: 'no mapping b' });
+
+      await expect(
+        service.syncOrderFromMarketplace(connectionId, externalOrderId),
+      ).rejects.toBeInstanceOf(MissingOrderItemMappingError);
+
+      expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalledTimes(1);
+      expect(orderRecordService.persistOrder).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts
@@ -103,5 +103,52 @@ describe('OrderItemRefResolverService', () => {
       service.resolve(connectionId, { type: 'sku', externalId: 'SKU-2' }),
     ).resolves.toEqual({ internalProductId: 'ol_product_1' });
   });
+
+  describe('tryResolve', () => {
+    it('should return resolved=true with IDs when offer mapping exists', async () => {
+      identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
+      variantRepository.findById.mockResolvedValueOnce(
+        new ProductVariantEntity('ol_variant_1', 'ol_product_1', null, null, new Date(), new Date()),
+      );
+
+      const result = await service.tryResolve(connectionId, { type: 'offer', externalId: 'offer-1' });
+
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.internalProductId).toBe('ol_product_1');
+        expect(result.internalVariantId).toBe('ol_variant_1');
+      }
+    });
+
+    it('should return resolved=false with reason when offer mapping is missing', async () => {
+      identifierMapping.getInternalId.mockResolvedValueOnce(null);
+
+      const productRef = { type: 'offer' as const, externalId: 'offer-404' };
+      const result = await service.tryResolve(connectionId, productRef);
+
+      expect(result.resolved).toBe(false);
+      if (!result.resolved) {
+        expect(result.productRef).toEqual(productRef);
+        expect(result.reason).toBeTruthy();
+      }
+    });
+
+    it('should return resolved=false when variant lookup fails after offer mapping', async () => {
+      identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_missing');
+      variantRepository.findById.mockResolvedValueOnce(null);
+
+      const result = await service.tryResolve(connectionId, { type: 'offer', externalId: 'offer-x' });
+
+      expect(result.resolved).toBe(false);
+    });
+
+    it('should re-throw non-MissingOrderItemMappingError errors', async () => {
+      identifierMapping.getInternalId.mockRejectedValueOnce(new Error('DB connection lost'));
+
+      await expect(
+        service.tryResolve(connectionId, { type: 'offer', externalId: 'offer-1' }),
+      ).rejects.toThrow('DB connection lost');
+    });
+  });
 });
 

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -11,6 +11,7 @@ import { OrderRecordService } from '../order-record.service';
 import { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
 import { OrderRecord, OrderSyncStatus } from '../../../domain/entities/order-record.entity';
 import { Order } from '../../../domain/ports/order-source.port';
+import type { IncomingOrder } from '../../../domain/types/incoming-order.types';
 import { ORDER_RECORD_REPOSITORY_TOKEN } from '../../../orders.tokens';
 
 describe('OrderRecordService', () => {
@@ -21,7 +22,6 @@ describe('OrderRecordService', () => {
   const originalPiiHashSalt = process.env.OL_PII_HASH_SALT;
 
   beforeEach(async () => {
-    // Set required environment variable for PII config
     process.env.OL_PII_HASH_SALT = 'test-salt-for-hashing';
     repository = {
       findById: jest.fn(),
@@ -102,10 +102,37 @@ describe('OrderRecordService', () => {
     updatedAt: new Date('2025-01-01T10:00:00Z'),
   });
 
+  const createMockIncomingOrder = (): IncomingOrder => ({
+    externalOrderId: 'ext-order-789',
+    orderNumber: 'ORD-001',
+    status: 'pending',
+    customerExternalId: 'ext-customer-456',
+    customerEmail: 'buyer@example.com',
+    items: [
+      {
+        id: 'item-1',
+        productRef: { type: 'offer', externalId: 'offer-abc' },
+        quantity: 2,
+        price: 10.99,
+        sku: 'SKU-001',
+      },
+    ],
+    totals: { subtotal: 21.98, tax: 4.40, shipping: 5.00, total: 31.38, currency: 'USD' },
+    shippingAddress: {
+      firstName: 'John',
+      lastName: 'Doe',
+      address1: '123 Main St',
+      city: 'New York',
+      postalCode: '10001',
+      country: 'US',
+    },
+    createdAt: '2025-01-01T10:00:00Z',
+    updatedAt: '2025-01-01T10:00:00Z',
+  });
+
   describe('persistOrder - PII enabled', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'true';
-      // Recreate service to pick up new env var
       service = new OrderRecordService(repository);
     });
 
@@ -126,6 +153,7 @@ describe('OrderRecordService', () => {
           billingAddress: order.billingAddress,
         }),
         [],
+        'ready',
         expect.any(Date),
         expect.any(Date),
       );
@@ -139,13 +167,13 @@ describe('OrderRecordService', () => {
       const callArg = repository.upsert.mock.calls[0][0];
       expect(callArg.orderSnapshot.shippingAddress).toEqual(order.shippingAddress);
       expect(callArg.orderSnapshot.billingAddress).toEqual(order.billingAddress);
+      expect(callArg.recordStatus).toBe('ready');
     });
   });
 
   describe('persistOrder - PII disabled', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'false';
-      // Recreate service to pick up new env var
       service = new OrderRecordService(repository);
     });
 
@@ -164,6 +192,7 @@ describe('OrderRecordService', () => {
           orderNumber: order.orderNumber,
         }),
         [],
+        'ready',
         expect.any(Date),
         expect.any(Date),
       );
@@ -179,7 +208,7 @@ describe('OrderRecordService', () => {
         address1: '[REDACTED]',
         city: '[REDACTED]',
         postalCode: '[REDACTED]',
-        country: 'US', // Country code is not PII
+        country: 'US',
       });
       expect(callArg.orderSnapshot.billingAddress).toEqual({
         address1: '[REDACTED]',
@@ -206,6 +235,7 @@ describe('OrderRecordService', () => {
           id: order.id,
         }),
         [],
+        'ready',
         expect.any(Date),
         expect.any(Date),
       );
@@ -218,6 +248,78 @@ describe('OrderRecordService', () => {
       const callArg = repository.upsert.mock.calls[0][0];
       expect(callArg.orderSnapshot.shippingAddress).toBeUndefined();
       expect(callArg.orderSnapshot.billingAddress).toBeUndefined();
+    });
+  });
+
+  describe('persistIncomingSnapshot', () => {
+    beforeEach(() => {
+      process.env.OL_STORE_PII = 'true';
+      service = new OrderRecordService(repository);
+    });
+
+    it('should persist incoming snapshot with awaiting_mapping status', async () => {
+      const incoming = createMockIncomingOrder();
+      const internalOrderId = 'ol_order_abc123';
+      const customerId = 'ol_customer_xyz';
+      const sourceConnectionId = 'conn-123';
+      const sourceEventId = 'event-456';
+
+      const expectedRecord = new OrderRecord(
+        internalOrderId,
+        customerId,
+        sourceConnectionId,
+        sourceEventId,
+        expect.objectContaining({ externalOrderId: incoming.externalOrderId }),
+        [],
+        'awaiting_mapping',
+        expect.any(Date),
+        expect.any(Date),
+      );
+
+      repository.upsert.mockResolvedValue(expectedRecord);
+
+      const result = await service.persistIncomingSnapshot(
+        incoming,
+        internalOrderId,
+        customerId,
+        sourceConnectionId,
+        sourceEventId,
+      );
+
+      expect(result).toBe(expectedRecord);
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.recordStatus).toBe('awaiting_mapping');
+      expect(callArg.orderSnapshot['externalOrderId']).toBe(incoming.externalOrderId);
+      expect(callArg.orderSnapshot['items']).toEqual(incoming.items);
+    });
+
+    it('should sanitize addresses in snapshot when PII is disabled', async () => {
+      process.env.OL_STORE_PII = 'false';
+      service = new OrderRecordService(repository);
+
+      const incoming = createMockIncomingOrder();
+      const expectedRecord = new OrderRecord(
+        'ol_order_abc',
+        null,
+        'conn-123',
+        null,
+        expect.objectContaining({}),
+        [],
+        'awaiting_mapping',
+        expect.any(Date),
+        expect.any(Date),
+      );
+      repository.upsert.mockResolvedValue(expectedRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['shippingAddress']).toEqual({
+        address1: '[REDACTED]',
+        city: '[REDACTED]',
+        postalCode: '[REDACTED]',
+        country: 'US',
+      });
     });
   });
 
@@ -275,6 +377,7 @@ describe('OrderRecordService', () => {
         'event-456',
         { id: internalOrderId },
         [],
+        'ready',
         new Date(),
         new Date(),
       );

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -46,6 +46,7 @@ import type { IncomingOrder } from '../../domain/types/incoming-order.types';
 import { Order } from '../../domain/ports/order-source.port';
 import { Logger } from '@openlinker/shared/logging';
 import { OrderItemRefResolverService } from './order-item-ref-resolver.service';
+import { MissingOrderItemMappingError } from '../../domain/exceptions/missing-order-item-mapping.error';
 
 @Injectable()
 export class OrderIngestionService implements IOrderIngestionService {
@@ -181,9 +182,58 @@ export class OrderIngestionService implements IOrderIngestionService {
     );
 
     const incoming = await marketplace.getOrder({ externalOrderId });
-    const order = await this.toUnifiedOrder(incoming, connectionId);
 
-    // Persist before routing — ensures record exists even if syncOrder throws
+    // Step 1: resolve order + customer IDs (no item mapping yet)
+    const internalOrderId = await this.identifierMapping.getOrCreateInternalId(
+      'Order',
+      incoming.externalOrderId,
+      connectionId,
+    );
+
+    const internalCustomerId = await this.resolveCustomerId(incoming, connectionId, internalOrderId);
+
+    // Step 2: persist raw snapshot immediately — operator can see the order even if item resolution fails
+    await this.orderRecordService.persistIncomingSnapshot(
+      incoming,
+      internalOrderId,
+      internalCustomerId ?? null,
+      connectionId,
+      sourceEventId ?? null,
+    );
+
+    // Step 3: attempt item resolution (non-throwing)
+    const resolvedItems: Order['items'] = [];
+    const unresolvedRefs: Array<{ itemId: string; reason: string }> = [];
+
+    for (const item of incoming.items) {
+      const result = await this.orderItemRefResolver.tryResolve(connectionId, item.productRef);
+      if (result.resolved) {
+        resolvedItems.push({
+          id: item.id,
+          productId: result.internalProductId,
+          variantId: result.internalVariantId,
+          quantity: item.quantity,
+          price: item.price,
+          sku: item.sku,
+        });
+      } else {
+        unresolvedRefs.push({ itemId: item.id, reason: result.reason });
+      }
+    }
+
+    // Step 4: if any unresolved, throw so the job runner retries with backoff
+    if (unresolvedRefs.length > 0) {
+      const first = unresolvedRefs[0];
+      const firstItem = incoming.items.find((i) => i.id === first.itemId);
+      throw new MissingOrderItemMappingError(
+        connectionId,
+        firstItem?.productRef ?? { type: 'offer', externalId: first.itemId },
+        first.reason,
+      );
+    }
+
+    // Step 5: all items resolved — build unified order and upsert with recordStatus='ready'
+    const order = this.buildUnifiedOrder(incoming, internalOrderId, internalCustomerId, resolvedItems);
     await this.orderRecordService.persistOrder(order, connectionId, sourceEventId ?? null);
 
     const results = await this.orderSyncService.syncOrder({
@@ -221,62 +271,48 @@ export class OrderIngestionService implements IOrderIngestionService {
     return results;
   }
 
-  private async toUnifiedOrder(incoming: IncomingOrder, connectionId: string): Promise<Order> {
-    // Order id: map marketplace externalOrderId -> internal OpenLinker order id
-    const internalOrderId = await this.identifierMapping.getOrCreateInternalId(
-      'Order',
-      incoming.externalOrderId,
-      connectionId,
-    );
-
-    let internalCustomerId: string | undefined;
-    if (incoming.customerExternalId) {
-      if (incoming.customerEmail) {
-        // Use identity resolver: creates/updates customer projection with email
-        const resolution = await this.customerIdentityResolver.resolveCustomerIdentity({
-          externalBuyerId: incoming.customerExternalId,
-          email: incoming.customerEmail,
-          sourceConnectionId: connectionId,
-        });
-        internalCustomerId = resolution.internalCustomerId;
-      } else {
-        internalCustomerId = await this.identifierMapping.getOrCreateInternalId(
-          'Customer',
-          incoming.customerExternalId,
-          connectionId,
-          { parentEntityType: 'Order', parentInternalId: internalOrderId },
-        );
-      }
+  private async resolveCustomerId(
+    incoming: IncomingOrder,
+    connectionId: string,
+    internalOrderId: string,
+  ): Promise<string | undefined> {
+    if (!incoming.customerExternalId) {
+      return undefined;
     }
-
-    const items: Order['items'] = [];
-    for (const item of incoming.items) {
-      const resolved = await this.orderItemRefResolver.resolve(connectionId, item.productRef);
-
-      items.push({
-        id: item.id,
-        productId: resolved.internalProductId,
-        variantId: resolved.internalVariantId,
-        quantity: item.quantity,
-        price: item.price,
-        sku: item.sku,
+    if (incoming.customerEmail) {
+      const resolution = await this.customerIdentityResolver.resolveCustomerIdentity({
+        externalBuyerId: incoming.customerExternalId,
+        email: incoming.customerEmail,
+        sourceConnectionId: connectionId,
       });
+      return resolution.internalCustomerId;
     }
+    return this.identifierMapping.getOrCreateInternalId(
+      'Customer',
+      incoming.customerExternalId,
+      connectionId,
+      { parentEntityType: 'Order', parentInternalId: internalOrderId },
+    );
+  }
 
-    const order: Order = {
+  private buildUnifiedOrder(
+    incoming: IncomingOrder,
+    internalOrderId: string,
+    internalCustomerId: string | undefined,
+    resolvedItems: Order['items'],
+  ): Order {
+    return {
       id: internalOrderId,
       orderNumber: incoming.orderNumber,
       status: incoming.status,
       customerId: internalCustomerId,
-      items,
+      items: resolvedItems,
       totals: incoming.totals,
       shippingAddress: incoming.shippingAddress,
       billingAddress: incoming.billingAddress,
       createdAt: new Date(incoming.createdAt),
       updatedAt: new Date(incoming.updatedAt),
     };
-
-    return order;
   }
 }
 

--- a/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
+++ b/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
@@ -16,11 +16,12 @@ import {
 import { ProductVariantRepositoryPort } from '@openlinker/core/products';
 import type { IncomingOrderItemRef } from '../../domain/types/incoming-order.types';
 import { MissingOrderItemMappingError } from '../../domain/exceptions/missing-order-item-mapping.error';
+import type {
+  ItemResolutionResult,
+  ResolvedOrderItemProduct,
+} from './order-item-ref-resolver.types';
 
-export interface ResolvedOrderItemProduct {
-  internalProductId: string;
-  internalVariantId?: string;
-}
+export type { ItemResolutionResult, ResolvedOrderItemProduct };
 
 @Injectable()
 export class OrderItemRefResolverService {
@@ -30,6 +31,21 @@ export class OrderItemRefResolverService {
     @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
     private readonly variantRepository: ProductVariantRepositoryPort,
   ) {}
+
+  async tryResolve(
+    connectionId: string,
+    productRef: IncomingOrderItemRef,
+  ): Promise<ItemResolutionResult> {
+    try {
+      const result = await this.resolve(connectionId, productRef);
+      return { resolved: true, ...result };
+    } catch (error) {
+      if (error instanceof MissingOrderItemMappingError) {
+        return { resolved: false, productRef, reason: error.message };
+      }
+      throw error;
+    }
+  }
 
   async resolve(
     connectionId: string,

--- a/libs/core/src/orders/application/services/order-item-ref-resolver.types.ts
+++ b/libs/core/src/orders/application/services/order-item-ref-resolver.types.ts
@@ -1,0 +1,17 @@
+/**
+ * Order Item Ref Resolver Types
+ *
+ * Types for OrderItemRefResolverService resolution results.
+ *
+ * @module libs/core/src/orders/application/services
+ */
+import type { IncomingOrderItemRef } from '../../domain/types/incoming-order.types';
+
+export interface ResolvedOrderItemProduct {
+  internalProductId: string;
+  internalVariantId?: string;
+}
+
+export type ItemResolutionResult =
+  | ({ resolved: true } & ResolvedOrderItemProduct)
+  | { resolved: false; productRef: IncomingOrderItemRef; reason: string };

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -13,6 +13,7 @@ import { Order } from '../../domain/ports/order-source.port';
 import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
 import { OrderRecord, OrderSyncStatus } from '../../domain/entities/order-record.entity';
 import { IOrderRecordService } from '../interfaces/order-record.service.interface';
+import type { IncomingOrder } from '../../domain/types/incoming-order.types';
 import { getPiiConfig } from '@openlinker/shared/config';
 import { ORDER_RECORD_REPOSITORY_TOKEN } from '../../orders.tokens';
 
@@ -77,6 +78,50 @@ export class OrderRecordService implements IOrderRecordService {
       sourceEventId,
       orderSnapshot,
       syncStatus,
+      'ready',
+      now,
+      now,
+    );
+
+    return this.repository.upsert(orderRecord);
+  }
+
+  async persistIncomingSnapshot(
+    incoming: IncomingOrder,
+    internalOrderId: string,
+    customerId: string | null,
+    sourceConnectionId: string,
+    sourceEventId: string | null,
+  ): Promise<OrderRecord> {
+    const piiConfig = getPiiConfig();
+    const now = new Date();
+
+    const snapshot: Record<string, unknown> = {
+      externalOrderId: incoming.externalOrderId,
+      orderNumber: incoming.orderNumber,
+      status: incoming.status,
+      customerExternalId: incoming.customerExternalId,
+      items: incoming.items,
+      totals: incoming.totals,
+      shippingAddress: piiConfig.storePii
+        ? incoming.shippingAddress
+        : this.sanitizeAddress(incoming.shippingAddress),
+      billingAddress: piiConfig.storePii
+        ? incoming.billingAddress
+        : this.sanitizeAddress(incoming.billingAddress),
+      createdAt: incoming.createdAt,
+      updatedAt: incoming.updatedAt,
+      metadata: incoming.metadata,
+    };
+
+    const orderRecord = new OrderRecord(
+      internalOrderId,
+      customerId,
+      sourceConnectionId,
+      sourceEventId,
+      snapshot,
+      [],
+      'awaiting_mapping',
       now,
       now,
     );
@@ -121,7 +166,7 @@ export class OrderRecordService implements IOrderRecordService {
    * while keeping structural information (hash can be computed separately).
    */
   private sanitizeAddress(
-    address: Order['shippingAddress'],
+    address: { address1?: string; city?: string; postalCode?: string; country?: string } | null | undefined,
   ): { address1: string; city: string; postalCode: string; country: string } | undefined {
     if (!address) {
       return undefined;
@@ -131,7 +176,7 @@ export class OrderRecordService implements IOrderRecordService {
       address1: '[REDACTED]',
       city: '[REDACTED]',
       postalCode: '[REDACTED]',
-      country: address.country, // Country code is not PII
+      country: address.country ?? '', // Country code is not PII
     };
   }
 }

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -7,6 +7,7 @@
  *
  * @module libs/core/src/orders/domain/entities
  */
+import type { OrderRecordStatus } from '../types/order-record.types';
 
 /**
  * Sync status for a destination connection
@@ -31,6 +32,9 @@ export interface OrderSyncStatus {
  *
  * Stores minimal order data for retry/debug support. Order snapshot contains
  * the full order data (PII-aware), and syncStatus tracks sync state per destination.
+ *
+ * recordStatus='awaiting_mapping': snapshot holds raw IncomingOrder (external refs, no internal IDs).
+ * recordStatus='ready': snapshot holds resolved Order (internal product/variant IDs).
  */
 export class OrderRecord {
   constructor(
@@ -40,6 +44,7 @@ export class OrderRecord {
     public readonly sourceEventId: string | null,
     public readonly orderSnapshot: Record<string, unknown>,
     public readonly syncStatus: OrderSyncStatus[],
+    public readonly recordStatus: OrderRecordStatus,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
   ) {}

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -19,6 +19,16 @@ export const OrderSyncStatusFilterValues = ['pending', 'syncing', 'synced', 'fai
 export type OrderSyncStatusFilter = (typeof OrderSyncStatusFilterValues)[number];
 
 /**
+ * Record status values — tracks whether all item refs have been resolved
+ */
+export const OrderRecordStatusValues = ['ready', 'awaiting_mapping'] as const;
+
+/**
+ * Record status type
+ */
+export type OrderRecordStatus = (typeof OrderRecordStatusValues)[number];
+
+/**
  * Order record filters for list queries
  */
 export interface OrderRecordFilters {
@@ -27,6 +37,7 @@ export interface OrderRecordFilters {
   customerId?: string;
   createdFrom?: Date;
   createdTo?: Date;
+  recordStatus?: OrderRecordStatus;
 }
 
 /**

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -27,6 +27,8 @@ export {
   PaginatedOrderRecords,
   OrderSyncStatusFilter,
   OrderSyncStatusFilterValues,
+  OrderRecordStatus,
+  OrderRecordStatusValues,
 } from './domain/types/order-record.types';
 
 // Services

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -59,6 +59,10 @@ export class OrderRecordOrmEntity {
   @Column({ type: 'jsonb' })
   syncStatus!: OrderSyncStatusJson[];
 
+  @Column({ type: 'varchar', default: 'ready' })
+  @Index()
+  recordStatus!: string;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -19,10 +19,21 @@ describe('OrderRecordRepository', () => {
   let ormRepository: jest.Mocked<Repository<OrderRecordOrmEntity>>;
 
   beforeEach(async () => {
+    const qb = {
+      orderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+
     const mockOrmRepository = {
       findOne: jest.fn(),
       save: jest.fn(),
-    } as unknown as jest.Mocked<Repository<OrderRecordOrmEntity>>;
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    } as unknown as jest.Mocked<Repository<OrderRecordOrmEntity>> & { _qb: typeof qb };
+
+    (mockOrmRepository as unknown as { _qb: typeof qb })._qb = qb;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -54,6 +65,7 @@ describe('OrderRecordRepository', () => {
       status: 'pending',
     };
     entity.syncStatus = [];
+    entity.recordStatus = 'ready';
     entity.createdAt = new Date('2025-01-01T10:00:00Z');
     entity.updatedAt = new Date('2025-01-01T10:00:00Z');
     return entity;
@@ -71,6 +83,7 @@ describe('OrderRecordRepository', () => {
         status: 'pending',
       },
       [],
+      'ready',
       new Date('2025-01-01T10:00:00Z'),
       new Date('2025-01-01T10:00:00Z'),
     );
@@ -171,6 +184,7 @@ describe('OrderRecordRepository', () => {
           status: 'pending',
         },
         syncStatus,
+        'ready',
         new Date('2025-01-01T10:00:00Z'),
         new Date('2025-01-01T10:00:00Z'),
       );
@@ -184,6 +198,66 @@ describe('OrderRecordRepository', () => {
       expect(callArg.syncStatus[0].destinationConnectionId).toBe('dest-connection-789');
       expect(callArg.syncStatus[0].status).toBe('synced');
       expect(callArg.syncStatus[0].syncedAt).toBe('2025-01-01T11:00:00.000Z');
+    });
+
+    it('should map recordStatus to ORM entity on toOrm path', async () => {
+      const domainEntity = new OrderRecord(
+        'order-123',
+        null,
+        'conn-123',
+        null,
+        {},
+        [],
+        'awaiting_mapping',
+        new Date(),
+        new Date(),
+      );
+      const savedEntity = createOrmEntity();
+      ormRepository.save.mockResolvedValue(savedEntity);
+
+      await repository.upsert(domainEntity);
+
+      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
+      expect(callArg.recordStatus).toBe('awaiting_mapping');
+    });
+  });
+
+  describe('findMany', () => {
+    it('should return all records when no recordStatus filter is provided', async () => {
+      const entity = createOrmEntity();
+      const andWhere = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        andWhere,
+        getManyAndCount: jest.fn().mockResolvedValue([[entity], 1]),
+      });
+
+      const result = await repository.findMany({}, { limit: 20, offset: 0 });
+
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(1);
+      const calls = andWhere.mock.calls.map((c: unknown[]) => c[0] as string);
+      expect(calls.some((c) => c.includes('recordStatus'))).toBe(false);
+    });
+
+    it('should add recordStatus WHERE clause when filter is provided', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        andWhere,
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+
+      await repository.findMany({ recordStatus: 'awaiting_mapping' }, { limit: 20, offset: 0 });
+
+      expect(andWhere).toHaveBeenCalledWith(
+        'rec.recordStatus = :recordStatus',
+        { recordStatus: 'awaiting_mapping' },
+      );
     });
   });
 
@@ -233,6 +307,16 @@ describe('OrderRecordRepository', () => {
       const savedEntity = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
       expect(savedEntity.syncStatus).toHaveLength(1);
       expect(savedEntity.syncStatus[0].destinationConnectionId).toBe('dest-connection-789');
+    });
+
+    it('should map recordStatus from ORM to domain on toDomain path', async () => {
+      const entity = createOrmEntity();
+      entity.recordStatus = 'awaiting_mapping';
+      ormRepository.findOne.mockResolvedValue(entity);
+
+      const result = await repository.findById('order-123');
+
+      expect(result?.recordStatus).toBe('awaiting_mapping');
     });
 
     it('should throw OrderRecordNotFoundException if order record not found', async () => {

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -15,7 +15,7 @@ import { OrderRecordOrmEntity, OrderSyncStatusJson } from '../entities/order-rec
 import { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
 import { OrderRecord, OrderSyncStatus } from '../../../domain/entities/order-record.entity';
 import { OrderRecordNotFoundException } from '../../../domain/exceptions/order-record-not-found.exception';
-import type { OrderRecordFilters, OrderRecordPagination, PaginatedOrderRecords } from '../../../domain/types/order-record.types';
+import type { OrderRecordFilters, OrderRecordPagination, PaginatedOrderRecords, OrderRecordStatus } from '../../../domain/types/order-record.types';
 
 @Injectable()
 export class OrderRecordRepository implements OrderRecordRepositoryPort {
@@ -77,6 +77,10 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
         `rec."syncStatus" @> :syncStatusFilter::jsonb`,
         { syncStatusFilter: JSON.stringify([{ status: filters.syncStatus }]) },
       );
+    }
+
+    if (filters.recordStatus) {
+      qb.andWhere('rec.recordStatus = :recordStatus', { recordStatus: filters.recordStatus });
     }
 
     const [entities, total] = await qb.getManyAndCount();
@@ -150,6 +154,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       entity.sourceEventId,
       entity.orderSnapshot,
       syncStatus,
+      (entity.recordStatus as OrderRecordStatus) ?? 'ready',
       entity.createdAt,
       entity.updatedAt,
     );
@@ -173,6 +178,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       externalOrderNumber: s.externalOrderNumber,
       error: s.error,
     }));
+    entity.recordStatus = orderRecord.recordStatus;
     entity.createdAt = orderRecord.createdAt;
     entity.updatedAt = orderRecord.updatedAt;
     return entity;


### PR DESCRIPTION
## Summary

- When `syncOrderFromMarketplace` failed to resolve an item's offer→variant mapping, the whole incoming order was lost — no `order_records` row, no UI trace, no retry breadcrumb. Operators had no way to see what was stuck or diagnose which offers needed mapping.
- Reworked the flow to persist a raw `IncomingOrder` snapshot **before** item resolution, with `recordStatus='awaiting_mapping'`. Once all items resolve on a retry, the record is upserted with `recordStatus='ready'` and the resolved unified `Order` snapshot.
- `/orders/failed` now queries `order_records` with `recordStatus=awaiting_mapping` and shows real order content (internal ID, connection, item count, first-seen) instead of dead sync job rows.

## Key changes

- **Domain**: `OrderRecord.recordStatus: 'ready' | 'awaiting_mapping'` + `OrderRecordFilters.recordStatus`
- **Application**: `IOrderRecordService.persistIncomingSnapshot()`, `OrderItemRefResolverService.tryResolve()` (non-throwing), reworked `OrderIngestionService.syncOrderFromMarketplace`
- **Infrastructure**: `recordStatus` column + index on `order_records`; repository maps + filters
- **Migration**: `1783000000000-add-order-record-status.ts` (zero-downtime, `DEFAULT 'ready'`)
- **API**: `recordStatus` filter on `ListOrdersQueryDto`, field on `OrderRecordResponseDto`
- **Frontend**: `useOrdersQuery({ recordStatus: 'awaiting_mapping' })` on the failed-orders page

## Non-goals (deferred follow-ups)

- Retry button on the failed-orders page — requires a dedicated `IOrderRetryService` + endpoint + tests, tracked separately
- Ad-hoc `marketplace.offers.sync` trigger for unresolved offers
- Non-retryable classification after N attempts
- Orphan `customer_projections` cleanup

## Test plan

- [x] `pnpm lint` — 0 errors across all packages
- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm test` — all unit suites pass (core, api, worker, web, allegro, prestashop)
- [x] New unit tests for `tryResolve` (resolved / missing-offer / missing-variant / re-throw)
- [x] New unit tests for `persistIncomingSnapshot` (awaiting_mapping + PII sanitization)
- [x] New unit tests for `OrderIngestionService` (happy path, partial unresolved, all unresolved)
- [x] Repository tests for `recordStatus` mapping both ways + filter applied / unfiltered
- [x] Rewritten `failed-orders-page.test.tsx` validates the new query filter
- [ ] Manual QA: ingest an Allegro order with an unmapped offer → confirm record appears in `/orders/failed` with `recordStatus=awaiting_mapping`, then sync offers and confirm retry promotes it to `ready`

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)