### PR TITLE
Phase 5: setup wizards, structured config, responsive form widths

### DIFF
--- a/apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx
@@ -3,7 +3,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
 import { AllegroSetupForm } from './AllegroSetupForm';
 
-function fillForm(
+// Allegro tests use an empty connection list so no ProductMaster auto-select
+// fires — auto-selecting the default sampleConnection (id="conn_1") would make
+// the UUID validator on masterCatalogConnectionId trip the Next button on
+// step 3.
+function defaultApiClient(
+  overrides: Parameters<typeof createMockApiClient>[0] = {},
+): ReturnType<typeof createMockApiClient> {
+  return createMockApiClient({
+    ...overrides,
+    connections: {
+      list: vi.fn().mockResolvedValue([]),
+      ...overrides.connections,
+    },
+  });
+}
+
+function fillCredentialsStep(
   container: HTMLElement,
   overrides: { name?: string; clientId?: string; clientSecret?: string } = {},
 ): void {
@@ -16,28 +32,53 @@ function fillForm(
   fireEvent.change(scope.getByLabelText(/client secret/i), { target: { value: clientSecret } });
 }
 
+async function advanceOneStep(container: HTMLElement, expectedStepLabel: string): Promise<void> {
+  fireEvent.click(within(container).getByRole('button', { name: 'Next' }));
+  await within(container).findByText(expectedStepLabel, { selector: '[aria-current="step"] .setup-stepper__label' });
+}
+
 describe('AllegroSetupForm', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it('renders all four form fields', () => {
-    const { container } = renderWithProviders(<AllegroSetupForm />);
+  it('renders the credentials step fields first', () => {
+    const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient: defaultApiClient() });
     const scope = within(container);
 
     expect(scope.getByLabelText(/connection name/i)).toBeInTheDocument();
-    expect(scope.getByLabelText(/environment/i)).toBeInTheDocument();
     expect(scope.getByLabelText(/client id/i)).toBeInTheDocument();
     expect(scope.getByLabelText(/client secret/i)).toBeInTheDocument();
+    // Environment belongs to step 2, not the first step
+    expect(scope.queryByLabelText(/environment/i)).toBeNull();
+  });
+
+  it('advances through every step and reveals the environment and catalog inputs', async () => {
+    const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient: defaultApiClient() });
+    fillCredentialsStep(container);
+
+    await advanceOneStep(container, 'Environment');
+    expect(within(container).getByLabelText(/environment/i)).toBeInTheDocument();
+
+    await advanceOneStep(container, 'Product catalog');
+    expect(within(container).getByLabelText(/product catalog connection/i)).toBeInTheDocument();
+
+    await advanceOneStep(container, 'Review & connect');
+    expect(
+      within(container).getByRole('button', { name: /connect with allegro/i }),
+    ).toBeInTheDocument();
   });
 
   it('disables submit button while mutation is pending', async () => {
-    const apiClient = createMockApiClient({
+    const apiClient = defaultApiClient({
       allegro: { startOAuth: vi.fn().mockReturnValue(new Promise(() => {})) },
     });
     const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
 
-    fillForm(container);
+    fillCredentialsStep(container);
+    await advanceOneStep(container, 'Environment');
+    await advanceOneStep(container, 'Product catalog');
+    await advanceOneStep(container, 'Review & connect');
     fireEvent.click(within(container).getByRole('button', { name: /connect with allegro/i }));
 
     expect(
@@ -46,12 +87,15 @@ describe('AllegroSetupForm', () => {
   });
 
   it('shows API error when mutation fails', async () => {
-    const apiClient = createMockApiClient({
+    const apiClient = defaultApiClient({
       allegro: { startOAuth: vi.fn().mockRejectedValue(new Error('Invalid client credentials')) },
     });
     const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
 
-    fillForm(container);
+    fillCredentialsStep(container);
+    await advanceOneStep(container, 'Environment');
+    await advanceOneStep(container, 'Product catalog');
+    await advanceOneStep(container, 'Review & connect');
     fireEvent.click(within(container).getByRole('button', { name: /connect with allegro/i }));
 
     expect(await screen.findByText('Invalid client credentials')).toBeInTheDocument();
@@ -62,11 +106,14 @@ describe('AllegroSetupForm', () => {
       authorizationUrl: 'https://allegro.pl/auth',
       state: 'abc123',
     });
-    const apiClient = createMockApiClient({ allegro: { startOAuth } });
+    const apiClient = defaultApiClient({ allegro: { startOAuth } });
     vi.stubGlobal('location', { origin: 'http://localhost:5173', assign: vi.fn() });
 
     const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
-    fillForm(container);
+    fillCredentialsStep(container);
+    await advanceOneStep(container, 'Environment');
+    await advanceOneStep(container, 'Product catalog');
+    await advanceOneStep(container, 'Review & connect');
     fireEvent.click(within(container).getByRole('button', { name: /connect with allegro/i }));
 
     await waitFor(() => {
@@ -83,7 +130,7 @@ describe('AllegroSetupForm', () => {
   it('redirects to authorizationUrl on success', async () => {
     const assignMock = vi.fn();
     vi.stubGlobal('location', { origin: 'http://localhost:5173', assign: assignMock });
-    const apiClient = createMockApiClient({
+    const apiClient = defaultApiClient({
       allegro: {
         startOAuth: vi.fn().mockResolvedValue({
           authorizationUrl: 'https://allegro.pl/auth?state=y',
@@ -93,7 +140,10 @@ describe('AllegroSetupForm', () => {
     });
 
     const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient });
-    fillForm(container);
+    fillCredentialsStep(container);
+    await advanceOneStep(container, 'Environment');
+    await advanceOneStep(container, 'Product catalog');
+    await advanceOneStep(container, 'Review & connect');
     fireEvent.click(within(container).getByRole('button', { name: /connect with allegro/i }));
 
     await waitFor(() => {

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
@@ -98,6 +98,9 @@ export function AllegroSetupForm(): ReactElement {
       const { authorizationUrl } = await startOAuth.mutateAsync(
         toStartOAuthInput(values, redirectUri),
       );
+      // Clear the dirty flag so abandon-prevention doesn't pop a native
+      // "leave page?" confirm when we navigate to Allegro's consent screen.
+      form.reset(values, { keepValues: true, keepDirty: false });
       window.location.assign(authorizationUrl);
     } catch {
       return;

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
@@ -1,7 +1,19 @@
-import type { ReactElement } from 'react';
-import { useEffect } from 'react';
+/**
+ * Allegro Setup Form
+ *
+ * Multi-step wizard for creating an Allegro connection. Steps:
+ *   1. Credentials — connection name, client ID, client secret
+ *   2. Environment — sandbox vs production
+ *   3. Product catalog — link to an existing ProductMaster connection
+ *      (required when at least one ProductMaster connection exists, per the
+ *      style guide; the current form lets operators skip it but we still
+ *      surface the relationship explicitly on this step)
+ *   4. OAuth redirect — final review; submit redirects to Allegro's consent
+ *      screen so the access token can come back through the callback page
+ */
+import { useEffect, useState, type ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
+import { useForm, type Path } from 'react-hook-form';
 import { useStartAllegroOAuthMutation } from '../hooks/use-start-allegro-oauth-mutation';
 import { useProductMasterConnections } from '../../connections/hooks/use-product-master-connections';
 import {
@@ -17,6 +29,21 @@ import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
+import { SetupStepper } from '../../../shared/ui/setup-stepper';
+
+const STEP_LABELS = ['Credentials', 'Environment', 'Product catalog', 'Review & connect'] as const;
+
+const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<AllegroSetupFormValues>>> = [
+  ['name', 'clientId', 'clientSecret'],
+  ['environment'],
+  ['masterCatalogConnectionId'],
+  [],
+];
+
+function maskSecret(secret: string): string {
+  if (secret.length <= 4) return '•'.repeat(secret.length);
+  return `${'•'.repeat(Math.max(0, secret.length - 4))}${secret.slice(-4)}`;
+}
 
 export function AllegroSetupForm(): ReactElement {
   const startOAuth = useStartAllegroOAuthMutation();
@@ -25,7 +52,11 @@ export function AllegroSetupForm(): ReactElement {
   const form = useForm<AllegroSetupFormValues, undefined, AllegroSetupFormSubmission>({
     defaultValues: ALLEGRO_SETUP_DEFAULT_VALUES,
     resolver: zodResolver(allegroSetupSchema),
+    mode: 'onBlur',
   });
+
+  const [stepIndex, setStepIndex] = useState(0);
+  const [completedSteps, setCompletedSteps] = useState<ReadonlySet<number>>(new Set());
 
   useEffect(() => {
     if (autoSelectedConnectionId) {
@@ -33,9 +64,33 @@ export function AllegroSetupForm(): ReactElement {
     }
   }, [autoSelectedConnectionId, form]);
 
+  useEffect(() => {
+    function handleBeforeUnload(event: BeforeUnloadEvent): void {
+      if (!form.formState.isDirty) return;
+      event.preventDefault();
+      event.returnValue = '';
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [form.formState.isDirty]);
+
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : [],
   );
+
+  async function goNext(): Promise<void> {
+    const fields = STEP_FIELDS[stepIndex];
+    if (fields.length > 0) {
+      const valid = await form.trigger([...fields]);
+      if (!valid) return;
+    }
+    setCompletedSteps((prev) => new Set(prev).add(stepIndex));
+    setStepIndex((i) => Math.min(i + 1, STEP_LABELS.length - 1));
+  }
+
+  function goBack(): void {
+    setStepIndex((i) => Math.max(i - 1, 0));
+  }
 
   const onSubmit = form.handleSubmit(async (values) => {
     try {
@@ -49,118 +104,173 @@ export function AllegroSetupForm(): ReactElement {
     }
   });
 
-  return (
-    <form className="form-card" onSubmit={(event) => void onSubmit(event)} noValidate>
-      <div className="panel__header">
-        <div>
-          <p className="eyebrow">OAuth 2.0</p>
-          <h3 className="section-title">Allegro app credentials</h3>
-        </div>
-        <span className="panel__meta">Entered once</span>
-      </div>
+  const values = form.watch();
+  const redirectUri = `${window.location.origin}/integrations/allegro/connect/callback`;
+  const selectedCatalog = productMasterConnections.find(
+    (c) => c.id === values.masterCatalogConnectionId,
+  );
 
-      {form.formState.submitCount > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
+  return (
+    <form className="wizard-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+      <SetupStepper steps={STEP_LABELS} currentStep={stepIndex} completedSteps={completedSteps} />
+
+      {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
+        <FormErrorSummary errors={validationMessages} />
+      ) : null}
       {startOAuth.error ? (
         <Alert tone="error" title="Failed to start authorization">
           {startOAuth.error.message}
         </Alert>
       ) : null}
 
-      <div className="form-grid">
-        <FormField
-          label="Connection name"
-          name="name"
-          error={form.formState.errors.name?.message}
-          description="A label for this Allegro integration in OpenLinker."
-        >
-          <Input
-            {...form.register('name')}
-            placeholder="Allegro sandbox"
-            invalid={Boolean(form.formState.errors.name)}
-          />
-        </FormField>
+      {stepIndex === 0 ? (
+        <>
+          <FormField
+            label="Connection name"
+            name="name"
+            error={form.formState.errors.name?.message}
+            description="A label for this Allegro integration in OpenLinker."
+          >
+            <Input
+              {...form.register('name')}
+              placeholder="Allegro sandbox"
+              invalid={Boolean(form.formState.errors.name)}
+            />
+          </FormField>
 
-        <FormField
-          label="Environment"
-          name="environment"
-          error={form.formState.errors.environment?.message}
-        >
-          <Select {...form.register('environment')} invalid={Boolean(form.formState.errors.environment)}>
-            <option value="sandbox">Sandbox</option>
-            <option value="production">Production</option>
-          </Select>
-        </FormField>
+          <FormField
+            label="Client ID"
+            name="clientId"
+            error={form.formState.errors.clientId?.message}
+            description="OAuth client ID from your Allegro developer app."
+          >
+            <Input
+              {...form.register('clientId')}
+              placeholder="your-allegro-client-id"
+              invalid={Boolean(form.formState.errors.clientId)}
+              autoComplete="off"
+            />
+          </FormField>
 
-        <FormField
-          label="Client ID"
-          name="clientId"
-          error={form.formState.errors.clientId?.message}
-          description="OAuth client ID from your Allegro developer app."
-        >
-          <Input
-            {...form.register('clientId')}
-            placeholder="your-allegro-client-id"
-            invalid={Boolean(form.formState.errors.clientId)}
-            autoComplete="off"
-          />
-        </FormField>
+          <FormField
+            label="Client secret"
+            name="clientSecret"
+            error={form.formState.errors.clientSecret?.message}
+            description="OAuth client secret from your Allegro developer app."
+          >
+            <Input
+              {...form.register('clientSecret')}
+              type="password"
+              placeholder="your-allegro-client-secret"
+              invalid={Boolean(form.formState.errors.clientSecret)}
+              autoComplete="off"
+            />
+          </FormField>
+        </>
+      ) : null}
 
-        <FormField
-          label="Client secret"
-          name="clientSecret"
-          error={form.formState.errors.clientSecret?.message}
-          description="OAuth client secret from your Allegro developer app."
-        >
-          <Input
-            {...form.register('clientSecret')}
-            type="password"
-            placeholder="your-allegro-client-secret"
-            invalid={Boolean(form.formState.errors.clientSecret)}
-            autoComplete="off"
-          />
-        </FormField>
-
-        <FormField
-          label="Product catalog connection"
-          name="masterCatalogConnectionId"
-          error={form.formState.errors.masterCatalogConnectionId?.message}
-          description="Select the ProductMaster connection to use for offer-product barcode linking. Optional — can be configured later."
-        >
-          {connectionsQuery.isLoading ? (
-            <Select disabled>
-              <option>Loading connections…</option>
-            </Select>
-          ) : connectionsQuery.error ? (
-            <Select disabled>
-              <option>Failed to load connections</option>
-            </Select>
-          ) : (
+      {stepIndex === 1 ? (
+        <>
+          <Alert tone="info" title="Pick the right environment">
+            Sandbox is a separate Allegro tenant for testing. Production credentials will not work
+            in sandbox and vice versa.
+          </Alert>
+          <FormField
+            label="Environment"
+            name="environment"
+            error={form.formState.errors.environment?.message}
+          >
             <Select
-              {...form.register('masterCatalogConnectionId')}
-              invalid={Boolean(form.formState.errors.masterCatalogConnectionId)}
+              {...form.register('environment')}
+              invalid={Boolean(form.formState.errors.environment)}
             >
-              <option value="">None (configure later)</option>
-              {productMasterConnections.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
+              <option value="sandbox">Sandbox</option>
+              <option value="production">Production</option>
             </Select>
+          </FormField>
+        </>
+      ) : null}
+
+      {stepIndex === 2 ? (
+        <>
+          <Alert tone="info" title="Link the product catalog">
+            OpenLinker links Allegro offers to products through barcodes on your ProductMaster
+            connection. Select the shop whose catalog should resolve those barcodes.
+          </Alert>
+          <FormField
+            label="Product catalog connection"
+            name="masterCatalogConnectionId"
+            error={form.formState.errors.masterCatalogConnectionId?.message}
+            description="Select the ProductMaster connection to use for offer-product barcode linking. You can configure this later if you are still setting up the PrestaShop side."
+          >
+            {connectionsQuery.isLoading ? (
+              <Select disabled>
+                <option>Loading connections…</option>
+              </Select>
+            ) : connectionsQuery.error ? (
+              <Select disabled>
+                <option>Failed to load connections</option>
+              </Select>
+            ) : (
+              <Select
+                {...form.register('masterCatalogConnectionId')}
+                invalid={Boolean(form.formState.errors.masterCatalogConnectionId)}
+              >
+                <option value="">None (configure later)</option>
+                {productMasterConnections.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </Select>
+            )}
+          </FormField>
+        </>
+      ) : null}
+
+      {stepIndex === 3 ? (
+        <>
+          <dl className="wizard-review-list">
+            <dt>Name</dt>
+            <dd>{values.name || '—'}</dd>
+            <dt>Client ID</dt>
+            <dd className="mono-text">{values.clientId || '—'}</dd>
+            <dt>Client secret</dt>
+            <dd className="mono-text">
+              {values.clientSecret ? maskSecret(values.clientSecret) : '—'}
+            </dd>
+            <dt>Environment</dt>
+            <dd>{values.environment === 'production' ? 'Production' : 'Sandbox'}</dd>
+            <dt>Product catalog</dt>
+            <dd>{selectedCatalog ? selectedCatalog.name : 'None (configure later)'}</dd>
+          </dl>
+          <p className="muted-text panel-copy">
+            After clicking <strong>Connect with Allegro</strong>, you will be redirected to Allegro
+            to authorize this connection. Make sure your Allegro app has{' '}
+            <span className="mono-text">{redirectUri}</span> registered as a redirect URI.
+          </p>
+        </>
+      ) : null}
+
+      <div className="wizard-actions">
+        <div className="wizard-actions__group">
+          {stepIndex > 0 ? (
+            <Button tone="secondary" type="button" onClick={goBack}>
+              Back
+            </Button>
+          ) : null}
+        </div>
+        <div className="wizard-actions__group">
+          {stepIndex < STEP_LABELS.length - 1 ? (
+            <Button type="button" onClick={() => void goNext()}>
+              Next
+            </Button>
+          ) : (
+            <Button type="submit" disabled={startOAuth.isPending}>
+              {startOAuth.isPending ? 'Connecting…' : 'Connect with Allegro'}
+            </Button>
           )}
-        </FormField>
-      </div>
-
-      <p className="muted-text panel-copy">
-        After submitting, you will be redirected to Allegro to authorize this connection. Make sure
-        your Allegro app has{' '}
-        <span className="mono-text">{`${window.location.origin}/integrations/allegro/connect/callback`}</span>{' '}
-        registered as a redirect URI.
-      </p>
-
-      <div className="form-actions">
-        <Button type="submit" disabled={startOAuth.isPending}>
-          {startOAuth.isPending ? 'Connecting…' : 'Connect with Allegro'}
-        </Button>
+        </div>
       </div>
     </form>
   );

--- a/apps/web/src/features/allegro/components/allegro-setup.schema.ts
+++ b/apps/web/src/features/allegro/components/allegro-setup.schema.ts
@@ -7,7 +7,10 @@ export const allegroSetupSchema = z.object({
   clientId: z.string().trim().min(1, 'Client ID is required'),
   clientSecret: z.string().trim().min(1, 'Client secret is required'),
   // Empty string is coerced to undefined so the backend IsUUID validator is never sent an empty string
-  masterCatalogConnectionId: z.string().uuid('Invalid connection ID').optional().or(z.literal('')).transform((v) => v || undefined),
+  masterCatalogConnectionId: z.preprocess(
+    (val) => (typeof val === 'string' && val.trim().length === 0 ? undefined : val),
+    z.string().uuid('Invalid connection ID').optional(),
+  ),
 });
 
 export type AllegroSetupFormValues = z.input<typeof allegroSetupSchema>;

--- a/apps/web/src/features/allegro/components/allegro-setup.schema.ts
+++ b/apps/web/src/features/allegro/components/allegro-setup.schema.ts
@@ -1,16 +1,26 @@
 import { z } from 'zod';
 import type { StartAllegroOAuthInput } from '../api/allegro.api';
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export const allegroSetupSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
   environment: z.enum(['sandbox', 'production']),
   clientId: z.string().trim().min(1, 'Client ID is required'),
   clientSecret: z.string().trim().min(1, 'Client secret is required'),
-  // Empty string is coerced to undefined so the backend IsUUID validator is never sent an empty string
-  masterCatalogConnectionId: z.preprocess(
-    (val) => (typeof val === 'string' && val.trim().length === 0 ? undefined : val),
-    z.string().uuid('Invalid connection ID').optional(),
-  ),
+  // The <select> registers a string value (empty string when "None" is picked),
+  // so the input type stays `string | undefined` and per-step `form.trigger`
+  // can validate cleanly. The transform coerces the empty string to undefined
+  // so the API payload never carries an empty UUID.
+  masterCatalogConnectionId: z
+    .string()
+    .optional()
+    .refine(
+      (value) => !value || UUID_REGEX.test(value),
+      'Invalid connection ID',
+    )
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
 });
 
 export type AllegroSetupFormValues = z.input<typeof allegroSetupSchema>;

--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -66,4 +66,86 @@ describe('EditConnectionForm', () => {
 
     expect(await screen.findByText('Server error')).toBeInTheDocument();
   });
+
+  describe('structured PrestaShop inputs + raw JSON toggle', () => {
+    it('renders Shop URL / Shop ID inputs for a PrestaShop connection', () => {
+      renderWithProviders(<EditConnectionForm connection={sampleConnection} />);
+      expect(screen.getByLabelText('Shop URL')).toHaveValue('https://example.com');
+      expect(screen.getByLabelText('Shop ID (optional)')).toHaveValue('');
+    });
+
+    it('keeps the raw JSON textarea hidden by default and reveals it via the toggle', () => {
+      renderWithProviders(<EditConnectionForm connection={sampleConnection} />);
+      expect(screen.queryByLabelText('Config JSON')).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show raw config JSON' }));
+
+      expect(screen.getByLabelText('Config JSON')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Hide raw config JSON' })).toBeInTheDocument();
+    });
+
+    it('syncs structured Shop URL edits into the underlying Config JSON payload', async () => {
+      const updateFn = vi.fn().mockResolvedValue(sampleConnection);
+      const apiClient = createMockApiClient({ connections: { update: updateFn } });
+      renderWithProviders(<EditConnectionForm connection={sampleConnection} />, { apiClient });
+
+      fireEvent.change(screen.getByLabelText('Shop URL'), {
+        target: { value: 'https://new.example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('Shop ID (optional)'), {
+        target: { value: '7' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+      await waitFor(() => {
+        expect(updateFn).toHaveBeenCalledWith(
+          sampleConnection.id,
+          expect.objectContaining({
+            config: { baseUrl: 'https://new.example.com', shopId: '7' },
+          }),
+        );
+      });
+    });
+
+    it('preserves unknown config keys when structured inputs are edited', async () => {
+      const connectionWithExtras = {
+        ...sampleConnection,
+        config: { baseUrl: 'https://example.com', customFlag: true, nested: { ok: 1 } },
+      };
+      const updateFn = vi.fn().mockResolvedValue(connectionWithExtras);
+      const apiClient = createMockApiClient({ connections: { update: updateFn } });
+      renderWithProviders(<EditConnectionForm connection={connectionWithExtras} />, { apiClient });
+
+      fireEvent.change(screen.getByLabelText('Shop URL'), {
+        target: { value: 'https://rotated.example.com' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+      await waitFor(() => {
+        expect(updateFn).toHaveBeenCalledWith(
+          sampleConnection.id,
+          expect.objectContaining({
+            config: {
+              baseUrl: 'https://rotated.example.com',
+              customFlag: true,
+              nested: { ok: 1 },
+            },
+          }),
+        );
+      });
+    });
+
+    it('locks the structured inputs and surfaces a warning when raw JSON is invalid', () => {
+      renderWithProviders(<EditConnectionForm connection={sampleConnection} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Show raw config JSON' }));
+
+      fireEvent.change(screen.getByLabelText('Config JSON'), {
+        target: { value: '{ not: valid json' },
+      });
+
+      expect(screen.getByText('Raw JSON is invalid')).toBeInTheDocument();
+      expect(screen.getByLabelText('Shop URL')).toBeDisabled();
+      expect(screen.getByLabelText('Shop ID (optional)')).toBeDisabled();
+    });
+  });
 });

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -29,6 +29,15 @@ function readString(config: Record<string, unknown>, key: string): string {
   return typeof value === 'string' ? value : '';
 }
 
+function isParseableJson(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function EditConnectionForm({ connection }: EditConnectionFormProps): ReactElement {
   const updateConnection = useUpdateConnectionMutation();
   const { showToast } = useToast();
@@ -52,19 +61,20 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
 
   const hasStructuredInputs = connection.platformType === 'prestashop';
 
+  // Tracks whether the raw JSON currently parses. When it doesn't, we lock the
+  // structured inputs so typing in them can't silently drop custom keys that
+  // the user added in raw mode — the user must fix the JSON first.
+  const configText = form.watch('configText');
+  const configIsParseable = isParseableJson(configText);
+
   // Keep the raw configText in sync with structured inputs so the power-user
   // JSON view always reflects the live form state, and submission goes through
-  // a single JSON payload.
+  // a single JSON payload. Refuses to write when the JSON is unparseable so we
+  // never discard the user's in-progress raw edits.
   function syncStructuredToJson(field: 'baseUrl' | 'shopId', value: string): void {
     form.setValue(field, value, { shouldDirty: true });
-    const currentText = form.getValues('configText');
-    let parsed: Record<string, unknown> = {};
-    try {
-      parsed = JSON.parse(currentText) as Record<string, unknown>;
-    } catch {
-      // ignore parse errors — keep an empty base and let validation surface
-      // the issue if the user toggles into raw mode with broken JSON
-    }
+    if (!configIsParseable) return;
+    const parsed = JSON.parse(form.getValues('configText')) as Record<string, unknown>;
     const merged = mergeStructuredIntoConfig(parsed, { [field]: value });
     form.setValue('configText', JSON.stringify(merged, null, 2), { shouldDirty: true });
   }
@@ -134,6 +144,12 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
 
       {hasStructuredInputs ? (
         <>
+          {!configIsParseable ? (
+            <Alert tone="warning" title="Raw JSON is invalid">
+              Fix the raw config JSON below before editing Shop URL / Shop ID — the structured
+              inputs are locked so your custom JSON keys are not silently lost.
+            </Alert>
+          ) : null}
           <FormField
             label="Shop URL"
             name="baseUrl"
@@ -144,6 +160,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
               value={form.watch('baseUrl') ?? ''}
               onChange={(event) => syncStructuredToJson('baseUrl', event.target.value)}
               placeholder="https://shop.example.com"
+              disabled={!configIsParseable}
               invalid={Boolean(form.formState.errors.baseUrl)}
             />
           </FormField>
@@ -158,6 +175,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
               value={form.watch('shopId') ?? ''}
               onChange={(event) => syncStructuredToJson('shopId', event.target.value)}
               placeholder="1"
+              disabled={!configIsParseable}
               invalid={Boolean(form.formState.errors.shopId)}
             />
           </FormField>

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -7,6 +7,7 @@ import { useUpdateConnectionMutation } from '../hooks/use-update-connection-muta
 import { useUpdateConnectionCredentialsMutation } from '../hooks/use-update-connection-credentials-mutation';
 import {
   editConnectionSchema,
+  mergeStructuredIntoConfig,
   toUpdateConnectionInput,
   type EditConnectionFormSubmission,
   type EditConnectionFormValues,
@@ -23,14 +24,22 @@ interface EditConnectionFormProps {
   connection: Connection;
 }
 
+function readString(config: Record<string, unknown>, key: string): string {
+  const value = config[key];
+  return typeof value === 'string' ? value : '';
+}
+
 export function EditConnectionForm({ connection }: EditConnectionFormProps): ReactElement {
   const updateConnection = useUpdateConnectionMutation();
   const { showToast } = useToast();
   const navigate = useNavigate();
+  const [showRawJson, setShowRawJson] = useState(false);
 
   const form = useForm<EditConnectionFormValues, undefined, EditConnectionFormSubmission>({
     defaultValues: {
       name: connection.name,
+      baseUrl: readString(connection.config, 'baseUrl'),
+      shopId: readString(connection.config, 'shopId'),
       configText: JSON.stringify(connection.config, null, 2),
       adapterKey: connection.adapterKey ?? '',
     },
@@ -40,6 +49,25 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : [],
   );
+
+  const hasStructuredInputs = connection.platformType === 'prestashop';
+
+  // Keep the raw configText in sync with structured inputs so the power-user
+  // JSON view always reflects the live form state, and submission goes through
+  // a single JSON payload.
+  function syncStructuredToJson(field: 'baseUrl' | 'shopId', value: string): void {
+    form.setValue(field, value, { shouldDirty: true });
+    const currentText = form.getValues('configText');
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = JSON.parse(currentText) as Record<string, unknown>;
+    } catch {
+      // ignore parse errors — keep an empty base and let validation surface
+      // the issue if the user toggles into raw mode with broken JSON
+    }
+    const merged = mergeStructuredIntoConfig(parsed, { [field]: value });
+    form.setValue('configText', JSON.stringify(merged, null, 2), { shouldDirty: true });
+  }
 
   const onSubmit = form.handleSubmit(async (values) => {
     try {
@@ -59,7 +87,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   });
 
   return (
-    <form className="form-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+    <form className="form-card form-narrow" onSubmit={(event) => void onSubmit(event)} noValidate>
       <div className="panel__header">
         <div>
           <p className="eyebrow">Edit connection</p>
@@ -68,46 +96,99 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
         <span className="panel__meta">Update settings</span>
       </div>
 
-      {form.formState.submitCount > 0 && validationMessages.length > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
+      {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
+        <FormErrorSummary errors={validationMessages} />
+      ) : null}
       {updateConnection.error ? (
         <Alert tone="error" title="Unable to update connection">
           {updateConnection.error.message}
         </Alert>
       ) : null}
 
-      <div className="form-grid">
-        <FormField label="Connection name" name="name" error={form.formState.errors.name?.message}>
-          <Input {...form.register('name')} placeholder="Main PrestaShop Store" invalid={Boolean(form.formState.errors.name)} />
-        </FormField>
+      <FormField label="Connection name" name="name" error={form.formState.errors.name?.message}>
+        <Input
+          {...form.register('name')}
+          placeholder="Main PrestaShop Store"
+          invalid={Boolean(form.formState.errors.name)}
+        />
+      </FormField>
 
-        <FormField label="Platform type" name="platformType">
-          <Input value={connection.platformType} disabled />
-        </FormField>
+      <FormField label="Platform type" name="platformType">
+        <Input value={connection.platformType} disabled />
+      </FormField>
 
-        <CredentialsPanel connection={connection} />
-
-        <FormField
-          label="Adapter key"
-          name="adapterKey"
-          error={form.formState.errors.adapterKey?.message}
-          description="Optional when the default adapter can be inferred from the selected platform."
-        >
-          <Input
-            {...form.register('adapterKey')}
-            placeholder="prestashop.webservice.v1"
-            invalid={Boolean(form.formState.errors.adapterKey)}
-          />
-        </FormField>
-      </div>
+      <CredentialsPanel connection={connection} />
 
       <FormField
-        label="Config JSON"
-        name="configText"
-        error={form.formState.errors.configText?.message}
-        description="Provide only safe connection configuration values. Secrets must remain outside the browser."
+        label="Adapter key"
+        name="adapterKey"
+        error={form.formState.errors.adapterKey?.message}
+        description="Optional when the default adapter can be inferred from the selected platform."
       >
-        <Textarea {...form.register('configText')} rows={10} invalid={Boolean(form.formState.errors.configText)} />
+        <Input
+          {...form.register('adapterKey')}
+          placeholder="prestashop.webservice.v1"
+          invalid={Boolean(form.formState.errors.adapterKey)}
+        />
       </FormField>
+
+      {hasStructuredInputs ? (
+        <>
+          <FormField
+            label="Shop URL"
+            name="baseUrl"
+            error={form.formState.errors.baseUrl?.message}
+            description="The public URL of the PrestaShop storefront."
+          >
+            <Input
+              value={form.watch('baseUrl') ?? ''}
+              onChange={(event) => syncStructuredToJson('baseUrl', event.target.value)}
+              placeholder="https://shop.example.com"
+              invalid={Boolean(form.formState.errors.baseUrl)}
+            />
+          </FormField>
+
+          <FormField
+            label="Shop ID (optional)"
+            name="shopId"
+            error={form.formState.errors.shopId?.message}
+            description="Only needed for multi-shop PrestaShop installations."
+          >
+            <Input
+              value={form.watch('shopId') ?? ''}
+              onChange={(event) => syncStructuredToJson('shopId', event.target.value)}
+              placeholder="1"
+              invalid={Boolean(form.formState.errors.shopId)}
+            />
+          </FormField>
+        </>
+      ) : null}
+
+      <div className="config-panel__toggle">
+        <Button
+          tone="secondary"
+          type="button"
+          onClick={() => setShowRawJson((prev) => !prev)}
+          aria-expanded={showRawJson}
+        >
+          {showRawJson ? 'Hide raw config JSON' : 'Show raw config JSON'}
+        </Button>
+      </div>
+
+      {showRawJson || !hasStructuredInputs ? (
+        <FormField
+          label="Config JSON"
+          name="configText"
+          error={form.formState.errors.configText?.message}
+          description="Raw configuration. Edit carefully — secrets must remain outside the browser."
+        >
+          <Textarea
+            {...form.register('configText')}
+            rows={10}
+            invalid={Boolean(form.formState.errors.configText)}
+          />
+        </FormField>
+      ) : null}
 
       <div className="form-actions">
         <Button type="submit" disabled={updateConnection.isPending}>

--- a/apps/web/src/features/connections/components/create-connection-form.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.tsx
@@ -81,7 +81,7 @@ export function CreateConnectionForm(): ReactElement {
 
   return (
     <>
-      <form className="form-card" onSubmit={(event) => void onSubmit(event)}>
+      <form className="form-card form-narrow" onSubmit={(event) => void onSubmit(event)} noValidate>
         <div className="panel__header">
           <div>
             <p className="eyebrow">Setup flow</p>

--- a/apps/web/src/features/connections/components/edit-connection.schema.test.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { mergeStructuredIntoConfig } from './edit-connection.schema';
+
+describe('mergeStructuredIntoConfig', () => {
+  it('writes a new baseUrl into an empty config', () => {
+    const result = mergeStructuredIntoConfig({}, { baseUrl: 'https://shop.example.com' });
+    expect(result).toEqual({ baseUrl: 'https://shop.example.com' });
+  });
+
+  it('overwrites an existing baseUrl without losing unknown keys', () => {
+    const base = {
+      baseUrl: 'https://old.example.com',
+      customField: 'preserve-me',
+      nested: { deep: true },
+    };
+    const result = mergeStructuredIntoConfig(base, { baseUrl: 'https://new.example.com' });
+    expect(result).toEqual({
+      baseUrl: 'https://new.example.com',
+      customField: 'preserve-me',
+      nested: { deep: true },
+    });
+  });
+
+  it('deletes baseUrl when the structured input is cleared to an empty string', () => {
+    const base = { baseUrl: 'https://shop.example.com', shopId: '1' };
+    const result = mergeStructuredIntoConfig(base, { baseUrl: '' });
+    expect(result).toEqual({ shopId: '1' });
+    expect('baseUrl' in result).toBe(false);
+  });
+
+  it('leaves keys untouched when the structured patch omits them', () => {
+    const base = { baseUrl: 'https://shop.example.com', shopId: '1' };
+    const result = mergeStructuredIntoConfig(base, {});
+    expect(result).toEqual(base);
+  });
+
+  it('deletes shopId when cleared but keeps baseUrl', () => {
+    const base = { baseUrl: 'https://shop.example.com', shopId: '2' };
+    const result = mergeStructuredIntoConfig(base, { shopId: '' });
+    expect(result).toEqual({ baseUrl: 'https://shop.example.com' });
+  });
+
+  it('does not mutate the base object', () => {
+    const base = { baseUrl: 'https://shop.example.com', customField: 'x' };
+    const snapshot = { ...base };
+    mergeStructuredIntoConfig(base, { baseUrl: 'https://new.example.com' });
+    expect(base).toEqual(snapshot);
+  });
+});

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -3,6 +3,8 @@ import type { UpdateConnectionInput } from '../api/connections.types';
 
 export const editConnectionSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
+  baseUrl: z.string().trim().optional(),
+  shopId: z.string().trim().optional(),
   configText: z
     .string()
     .trim()
@@ -27,4 +29,31 @@ export function toUpdateConnectionInput(values: EditConnectionFormSubmission): U
     adapterKey: values.adapterKey ? values.adapterKey : undefined,
     config: JSON.parse(values.configText) as Record<string, unknown>,
   };
+}
+
+/**
+ * Merge structured inputs into a raw config object. Preserves unknown keys so
+ * operators can still drop in custom config fields via the JSON view without
+ * losing them when the structured form re-serializes.
+ */
+export function mergeStructuredIntoConfig(
+  base: Record<string, unknown>,
+  structured: { baseUrl?: string; shopId?: string },
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...base };
+  if (structured.baseUrl !== undefined) {
+    if (structured.baseUrl.length === 0) {
+      delete next.baseUrl;
+    } else {
+      next.baseUrl = structured.baseUrl;
+    }
+  }
+  if (structured.shopId !== undefined) {
+    if (structured.shopId.length === 0) {
+      delete next.shopId;
+    } else {
+      next.shopId = structured.shopId;
+    }
+  }
+  return next;
 }

--- a/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
@@ -10,10 +10,45 @@ function LocationProbe(): ReactElement {
   return <div data-testid="location-pathname">{location.pathname}</div>;
 }
 
+function fillCredentialsStep(
+  container: HTMLElement,
+  values: { name: string; url: string; key: string; shopId?: string },
+): void {
+  fireEvent.change(within(container).getByLabelText('Connection name'), {
+    target: { value: values.name },
+  });
+  fireEvent.change(within(container).getByLabelText('Shop URL'), {
+    target: { value: values.url },
+  });
+  fireEvent.change(within(container).getByLabelText('Webservice key'), {
+    target: { value: values.key },
+  });
+  if (values.shopId !== undefined) {
+    fireEvent.change(within(container).getByLabelText('Shop ID (optional)'), {
+      target: { value: values.shopId },
+    });
+  }
+}
+
+async function advanceOneStep(container: HTMLElement): Promise<void> {
+  const before = container.querySelector('[aria-current="step"]')?.textContent ?? '';
+  fireEvent.click(within(container).getByRole('button', { name: 'Next' }));
+  await waitFor(() => {
+    const after = container.querySelector('[aria-current="step"]')?.textContent ?? '';
+    if (after === before) throw new Error('Step did not advance');
+  });
+}
+
+async function advanceToStep(container: HTMLElement, targetStep: number): Promise<void> {
+  for (let i = 0; i < targetStep; i++) {
+    await advanceOneStep(container);
+  }
+}
+
 describe('PrestashopSetupForm', () => {
   afterEach(cleanup);
 
-  it('submits a PrestaShop connection with the inferred adapter key and config', async () => {
+  it('submits a PrestaShop connection after walking through every step', async () => {
     const create = vi.fn().mockResolvedValue(sampleConnection);
     const apiClient = createMockApiClient({ connections: { create } });
     const view = renderWithProviders(
@@ -24,15 +59,14 @@ describe('PrestashopSetupForm', () => {
       { apiClient },
     );
 
-    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
-      target: { value: 'Main store' },
+    fillCredentialsStep(view.container, {
+      name: 'Main store',
+      url: 'https://shop.example.com',
+      key: 'WSKEY123',
     });
-    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
-      target: { value: 'https://shop.example.com' },
-    });
-    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
-      target: { value: 'WSKEY123' },
-    });
+
+    await advanceToStep(view.container, 3);
+
     fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
 
     expect(await screen.findByText('Connection created')).toBeInTheDocument();
@@ -54,19 +88,18 @@ describe('PrestashopSetupForm', () => {
     const apiClient = createMockApiClient({ connections: { create } });
     const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
 
-    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
-      target: { value: 'Dest only' },
-    });
-    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
-      target: { value: 'https://shop.example.com' },
-    });
-    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
-      target: { value: 'WSKEY123' },
+    fillCredentialsStep(view.container, {
+      name: 'Dest only',
+      url: 'https://shop.example.com',
+      key: 'WSKEY123',
     });
 
-    // Uncheck OrderSource (this PrestaShop is order destination, not source)
+    await advanceToStep(view.container, 2); // land on capabilities
+
     fireEvent.click(within(view.container).getByRole('checkbox', { name: /OrderSource/ }));
 
+    // Capabilities → Review
+    await advanceOneStep(view.container);
     fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
 
     await screen.findByText('Connection created');
@@ -82,18 +115,15 @@ describe('PrestashopSetupForm', () => {
     const apiClient = createMockApiClient({ connections: { create } });
     const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
 
-    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
-      target: { value: 'Shop 2' },
+    fillCredentialsStep(view.container, {
+      name: 'Shop 2',
+      url: 'https://shop.example.com',
+      key: 'WSKEY',
+      shopId: '2',
     });
-    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
-      target: { value: 'https://shop.example.com' },
-    });
-    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
-      target: { value: 'WSKEY' },
-    });
-    fireEvent.change(within(view.container).getByLabelText('Shop ID (optional)'), {
-      target: { value: '2' },
-    });
+
+    await advanceToStep(view.container, 3);
+
     fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
 
     await screen.findByText('Connection created');
@@ -104,7 +134,7 @@ describe('PrestashopSetupForm', () => {
     );
   });
 
-  it('surfaces API errors in a form-level alert', async () => {
+  it('surfaces API errors in a form-level alert on the review step', async () => {
     const apiClient = createMockApiClient({
       connections: {
         create: vi.fn().mockRejectedValue(new Error('API create failed')),
@@ -112,38 +142,38 @@ describe('PrestashopSetupForm', () => {
     });
     const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
 
-    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
-      target: { value: 'Shop' },
+    fillCredentialsStep(view.container, {
+      name: 'Shop',
+      url: 'https://shop.example.com',
+      key: 'WSKEY',
     });
-    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
-      target: { value: 'https://shop.example.com' },
-    });
-    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
-      target: { value: 'WSKEY' },
-    });
+
+    await advanceToStep(view.container, 3);
+
     fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
 
     expect(await screen.findByText('Unable to create connection')).toBeInTheDocument();
     expect(screen.getByText('API create failed')).toBeInTheDocument();
   });
 
-  it('rejects an invalid shop URL', async () => {
+  it('blocks advancing from the credentials step when the shop URL is invalid', async () => {
     const view = renderWithProviders(<PrestashopSetupForm />);
 
-    fireEvent.change(within(view.container).getByLabelText('Connection name'), {
-      target: { value: 'Shop' },
+    fillCredentialsStep(view.container, {
+      name: 'Shop',
+      url: 'not-a-url',
+      key: 'WSKEY',
     });
-    fireEvent.change(within(view.container).getByLabelText('Shop URL'), {
-      target: { value: 'not-a-url' },
-    });
-    fireEvent.change(within(view.container).getByLabelText('Webservice key'), {
-      target: { value: 'WSKEY' },
-    });
-    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
 
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Next' }));
+
+    // invalid URL keeps us on the credentials step — field stays visible
     expect(
       (await screen.findAllByText('Shop URL must be a valid URL (e.g. https://shop.example.com)'))
         .length,
     ).toBeGreaterThan(0);
+    expect(within(view.container).getByLabelText('Connection name')).toBeInTheDocument();
+    // Still on step 1 — the second step's "Verify the credentials" alert is absent
+    expect(screen.queryByText('Verify the credentials')).toBeNull();
   });
 });

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -1,15 +1,19 @@
 /**
  * PrestaShop Setup Form
  *
- * Guided wizard form for creating a PrestaShop connection. Collects the
- * values an operator can read directly from the PrestaShop admin (shop
- * URL, webservice key, optional shop ID) and maps them to the generic
- * CreateConnectionInput shape. The adapter key is inferred from the
- * platform so the operator never edits raw config JSON.
+ * Multi-step wizard for creating a PrestaShop connection. Steps:
+ *   1. Credentials — shop URL, webservice key, optional shop ID
+ *   2. Test connection — review the values the operator entered
+ *   3. Capabilities — which roles this connection will fulfil
+ *   4. Review & connect — final summary before submit
+ *
+ * Per-step validation runs on Next so the operator cannot advance with
+ * invalid fields. Abandon-prevention triggers a native confirm dialog
+ * when the form is dirty and the tab is closed.
  */
-import type { ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
+import { useForm, type Path } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
 import {
@@ -28,6 +32,7 @@ import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { useToast } from '../../../shared/ui/toast-provider';
 
 const CAPABILITY_HELP: Record<Capability, string> = {
@@ -38,6 +43,20 @@ const CAPABILITY_HELP: Record<Capability, string> = {
   Marketplace: 'Manage offers and listings on this marketplace.',
 };
 
+const STEP_LABELS = ['Credentials', 'Test connection', 'Capabilities', 'Review & connect'] as const;
+
+const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<PrestashopSetupFormValues>>> = [
+  ['name', 'baseUrl', 'webserviceKey', 'shopId'],
+  [],
+  ['enabledCapabilities'],
+  [],
+];
+
+function maskKey(key: string): string {
+  if (key.length <= 4) return '•'.repeat(key.length);
+  return `${'•'.repeat(Math.max(0, key.length - 4))}${key.slice(-4)}`;
+}
+
 export function PrestashopSetupForm(): ReactElement {
   const createConnection = useCreateConnectionMutation();
   const { showToast } = useToast();
@@ -46,11 +65,25 @@ export function PrestashopSetupForm(): ReactElement {
   const form = useForm<PrestashopSetupFormValues, undefined, PrestashopSetupFormSubmission>({
     defaultValues: PRESTASHOP_SETUP_DEFAULT_VALUES,
     resolver: zodResolver(prestashopSetupSchema),
+    mode: 'onBlur',
   });
 
-  // Prefer the live adapter registry as the source of truth for supported
-  // capabilities; fall back to a hardcoded list if the /adapters call fails so
-  // the wizard still works offline or under partial outage.
+  const [stepIndex, setStepIndex] = useState(0);
+  const [completedSteps, setCompletedSteps] = useState<ReadonlySet<number>>(new Set());
+
+  // Abandon-prevention: warn the operator if they close the tab with unsaved
+  // progress. We intentionally skip this for the final redirect since the
+  // mutation flow clears the dirty flag via reset.
+  useEffect(() => {
+    function handleBeforeUnload(event: BeforeUnloadEvent): void {
+      if (!form.formState.isDirty) return;
+      event.preventDefault();
+      event.returnValue = '';
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [form.formState.isDirty]);
+
   const adapterMetadata = adaptersQuery.data?.find(
     (a) => a.adapterKey === PRESTASHOP_ADAPTER_KEY,
   );
@@ -61,9 +94,24 @@ export function PrestashopSetupForm(): ReactElement {
     error?.message ? [String(error.message)] : [],
   );
 
+  async function goNext(): Promise<void> {
+    const fields = STEP_FIELDS[stepIndex];
+    if (fields.length > 0) {
+      const valid = await form.trigger([...fields]);
+      if (!valid) return;
+    }
+    setCompletedSteps((prev) => new Set(prev).add(stepIndex));
+    setStepIndex((i) => Math.min(i + 1, STEP_LABELS.length - 1));
+  }
+
+  function goBack(): void {
+    setStepIndex((i) => Math.max(i - 1, 0));
+  }
+
   const onSubmit = form.handleSubmit(async (values) => {
     try {
       const created = await createConnection.mutateAsync(toCreateConnectionInput(values));
+      form.reset(values, { keepValues: true, keepDirty: false });
       showToast({
         tone: 'success',
         title: 'Connection created',
@@ -75,113 +123,173 @@ export function PrestashopSetupForm(): ReactElement {
     }
   });
 
-  return (
-    <form className="form-card" onSubmit={(event) => void onSubmit(event)} noValidate>
-      <div className="panel__header">
-        <div>
-          <p className="eyebrow">PrestaShop</p>
-          <h3 className="section-title">Connect a PrestaShop store</h3>
-        </div>
-        <span className="panel__meta">Webservice API</span>
-      </div>
+  const values = form.watch();
 
-      {form.formState.submitCount > 0 ? <FormErrorSummary errors={validationMessages} /> : null}
+  return (
+    <form className="wizard-card" onSubmit={(event) => void onSubmit(event)} noValidate>
+      <SetupStepper steps={STEP_LABELS} currentStep={stepIndex} completedSteps={completedSteps} />
+
+      {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
+        <FormErrorSummary errors={validationMessages} />
+      ) : null}
       {createConnection.error ? (
         <Alert tone="error" title="Unable to create connection">
           {createConnection.error.message}
         </Alert>
       ) : null}
 
-      <Alert tone="info" title="Before you start">
-        In your PrestaShop admin, enable Webservice under{' '}
-        <strong>Advanced Parameters → Webservice</strong> and generate a key with the required
-        resources enabled.
-      </Alert>
+      {stepIndex === 0 ? (
+        <>
+          <Alert tone="info" title="Before you start">
+            In your PrestaShop admin, enable Webservice under{' '}
+            <strong>Advanced Parameters → Webservice</strong> and generate a key with the required
+            resources enabled.
+          </Alert>
 
-      <div className="form-grid">
-        <FormField label="Connection name" name="name" error={form.formState.errors.name?.message}>
-          <Input
-            {...form.register('name')}
-            placeholder="Main PrestaShop Store"
-            invalid={Boolean(form.formState.errors.name)}
-          />
-        </FormField>
+          <FormField label="Connection name" name="name" error={form.formState.errors.name?.message}>
+            <Input
+              {...form.register('name')}
+              placeholder="Main PrestaShop Store"
+              invalid={Boolean(form.formState.errors.name)}
+            />
+          </FormField>
 
-        <FormField
-          label="Shop URL"
-          name="baseUrl"
-          error={form.formState.errors.baseUrl?.message}
-          description="The public URL of the PrestaShop storefront (no trailing path)."
-        >
-          <Input
-            {...form.register('baseUrl')}
-            placeholder="https://shop.example.com"
-            invalid={Boolean(form.formState.errors.baseUrl)}
-          />
-        </FormField>
+          <FormField
+            label="Shop URL"
+            name="baseUrl"
+            error={form.formState.errors.baseUrl?.message}
+            description="The public URL of the PrestaShop storefront (no trailing path)."
+          >
+            <Input
+              {...form.register('baseUrl')}
+              placeholder="https://shop.example.com"
+              invalid={Boolean(form.formState.errors.baseUrl)}
+            />
+          </FormField>
 
-        <FormField
-          label="Webservice key"
-          name="webserviceKey"
-          error={form.formState.errors.webserviceKey?.message}
-          description="Generated in PrestaShop admin under Advanced Parameters → Webservice."
-        >
-          <Input
-            {...form.register('webserviceKey')}
-            type="password"
-            autoComplete="off"
-            placeholder="e.g. ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
-            invalid={Boolean(form.formState.errors.webserviceKey)}
-          />
-        </FormField>
+          <FormField
+            label="Webservice key"
+            name="webserviceKey"
+            error={form.formState.errors.webserviceKey?.message}
+            description="Generated in PrestaShop admin under Advanced Parameters → Webservice."
+          >
+            <Input
+              {...form.register('webserviceKey')}
+              type="password"
+              autoComplete="off"
+              placeholder="e.g. ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+              invalid={Boolean(form.formState.errors.webserviceKey)}
+            />
+          </FormField>
 
-        <FormField
-          label="Shop ID (optional)"
-          name="shopId"
-          error={form.formState.errors.shopId?.message}
-          description="Only needed for multi-shop PrestaShop installations."
-        >
-          <Input
-            {...form.register('shopId')}
-            placeholder="1"
-            invalid={Boolean(form.formState.errors.shopId)}
-          />
-        </FormField>
-      </div>
+          <FormField
+            label="Shop ID (optional)"
+            name="shopId"
+            error={form.formState.errors.shopId?.message}
+            description="Only needed for multi-shop PrestaShop installations."
+          >
+            <Input
+              {...form.register('shopId')}
+              placeholder="1"
+              invalid={Boolean(form.formState.errors.shopId)}
+            />
+          </FormField>
+        </>
+      ) : null}
 
-      <fieldset className="capability-fieldset">
-        <legend className="capability-fieldset__legend">Capabilities</legend>
-        <p className="muted-text capability-fieldset__help">
-          Pick which roles this connection should fulfil. You can change this later on the
-          connection\u2019s detail page.
-        </p>
-        <ul className="capability-list">
-          {supportedCapabilities.map((capability) => {
-            const id = `new-cap-${capability}`;
-            return (
-              <li key={capability} className="capability-list__item">
-                <label htmlFor={id} className="capability-list__label">
-                  <input
-                    id={id}
-                    type="checkbox"
-                    value={capability}
-                    {...form.register('enabledCapabilities')}
-                  />
-                  <span className="capability-list__name mono-text">{capability}</span>
-                </label>
-                <p className="capability-list__help muted-text">
-                  {CAPABILITY_HELP[capability]}
-                </p>
-              </li>
-            );
-          })}
-        </ul>
-      </fieldset>
+      {stepIndex === 1 ? (
+        <div className="wizard-test-result">
+          <Alert tone="info" title="Verify the credentials">
+            OpenLinker will use the values below to reach your PrestaShop admin. Make sure the shop
+            URL resolves and the webservice key is active before you continue. You can rotate the
+            key later from the connection detail page.
+          </Alert>
+          <dl className="wizard-review-list">
+            <dt>Shop URL</dt>
+            <dd className="mono-text">{values.baseUrl || '—'}</dd>
+            <dt>Webservice key</dt>
+            <dd className="mono-text">{values.webserviceKey ? maskKey(values.webserviceKey) : '—'}</dd>
+            {values.shopId ? (
+              <>
+                <dt>Shop ID</dt>
+                <dd className="mono-text">{values.shopId}</dd>
+              </>
+            ) : null}
+          </dl>
+        </div>
+      ) : null}
 
-      <div className="form-actions">
-        <Button type="submit" disabled={createConnection.isPending}>
-          {createConnection.isPending ? 'Creating...' : 'Create connection'}
-        </Button>
+      {stepIndex === 2 ? (
+        <fieldset className="capability-fieldset">
+          <legend className="capability-fieldset__legend">Capabilities</legend>
+          <p className="muted-text capability-fieldset__help">
+            Pick which roles this connection should fulfil. You can change this later on the
+            connection&rsquo;s detail page.
+          </p>
+          <ul className="capability-list">
+            {supportedCapabilities.map((capability) => {
+              const id = `new-cap-${capability}`;
+              return (
+                <li key={capability} className="capability-list__item">
+                  <label htmlFor={id} className="capability-list__label">
+                    <input
+                      id={id}
+                      type="checkbox"
+                      value={capability}
+                      {...form.register('enabledCapabilities')}
+                    />
+                    <span className="capability-list__name mono-text">{capability}</span>
+                  </label>
+                  <p className="capability-list__help muted-text">{CAPABILITY_HELP[capability]}</p>
+                </li>
+              );
+            })}
+          </ul>
+        </fieldset>
+      ) : null}
+
+      {stepIndex === 3 ? (
+        <dl className="wizard-review-list">
+          <dt>Name</dt>
+          <dd>{values.name || '—'}</dd>
+          <dt>Shop URL</dt>
+          <dd className="mono-text">{values.baseUrl || '—'}</dd>
+          <dt>Webservice key</dt>
+          <dd className="mono-text">{values.webserviceKey ? maskKey(values.webserviceKey) : '—'}</dd>
+          {values.shopId ? (
+            <>
+              <dt>Shop ID</dt>
+              <dd className="mono-text">{values.shopId}</dd>
+            </>
+          ) : null}
+          <dt>Capabilities</dt>
+          <dd>
+            {(values.enabledCapabilities ?? []).length > 0
+              ? (values.enabledCapabilities ?? []).join(', ')
+              : 'None selected'}
+          </dd>
+        </dl>
+      ) : null}
+
+      <div className="wizard-actions">
+        <div className="wizard-actions__group">
+          {stepIndex > 0 ? (
+            <Button tone="secondary" type="button" onClick={goBack}>
+              Back
+            </Button>
+          ) : null}
+        </div>
+        <div className="wizard-actions__group">
+          {stepIndex < STEP_LABELS.length - 1 ? (
+            <Button type="button" onClick={() => void goNext()}>
+              Next
+            </Button>
+          ) : (
+            <Button type="submit" disabled={createConnection.isPending}>
+              {createConnection.isPending ? 'Creating...' : 'Create connection'}
+            </Button>
+          )}
+        </div>
       </div>
     </form>
   );

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -3,7 +3,9 @@
  *
  * Multi-step wizard for creating a PrestaShop connection. Steps:
  *   1. Credentials — shop URL, webservice key, optional shop ID
- *   2. Test connection — review the values the operator entered
+ *   2. Verify credentials — human review of entered values (the API-side
+ *      `/test` endpoint requires a saved connection, so this step is a
+ *      pre-save checkpoint, not a live probe)
  *   3. Capabilities — which roles this connection will fulfil
  *   4. Review & connect — final summary before submit
  *
@@ -43,7 +45,10 @@ const CAPABILITY_HELP: Record<Capability, string> = {
   Marketplace: 'Manage offers and listings on this marketplace.',
 };
 
-const STEP_LABELS = ['Credentials', 'Test connection', 'Capabilities', 'Review & connect'] as const;
+// "Verify credentials" rather than "Test connection": the PrestaShop `/test`
+// endpoint is only reachable after the connection is saved, so this step is a
+// human-review of the entered URL + masked key, not a live probe.
+const STEP_LABELS = ['Credentials', 'Verify credentials', 'Capabilities', 'Review & connect'] as const;
 
 const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<PrestashopSetupFormValues>>> = [
   ['name', 'baseUrl', 'webserviceKey', 'shopId'],
@@ -201,8 +206,8 @@ export function PrestashopSetupForm(): ReactElement {
         <div className="wizard-test-result">
           <Alert tone="info" title="Verify the credentials">
             OpenLinker will use the values below to reach your PrestaShop admin. Make sure the shop
-            URL resolves and the webservice key is active before you continue. You can rotate the
-            key later from the connection detail page.
+            URL resolves and the webservice key is active before you continue. After the connection
+            is saved you can run a live test from the connection detail page.
           </Alert>
           <dl className="wizard-review-list">
             <dt>Shop URL</dt>

--- a/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
+++ b/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
@@ -73,7 +73,7 @@ describe('EditOfferDrawer', () => {
     fireEvent.change(titleInput, { target: { value: 'A'.repeat(76) } });
     const saveButton = screen.getByRole('button', { name: /save changes/i });
     fireEvent.click(saveButton);
-    expect(await screen.findByText(/75 characters/i)).toBeInTheDocument();
+    expect((await screen.findAllByText(/75 characters/i)).length).toBeGreaterThan(0);
   });
 
   it('should only include dirty fields in the API request payload', async () => {

--- a/apps/web/src/features/listings/components/EditOfferDrawer.tsx
+++ b/apps/web/src/features/listings/components/EditOfferDrawer.tsx
@@ -10,6 +10,7 @@
 import { type ReactElement, useCallback, useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Button } from '../../../shared/ui/button';
@@ -61,6 +62,10 @@ export function EditOfferDrawer({ isOpen, onClose, mapping }: EditOfferDrawerPro
 
   const { dirtyFields } = form.formState;
   const isDirty = Object.keys(dirtyFields).length > 0;
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
 
   const onSubmit = form.handleSubmit(async (values) => {
     const fields: UpdateOfferFieldsPayload = {};
@@ -148,6 +153,9 @@ export function EditOfferDrawer({ isOpen, onClose, mapping }: EditOfferDrawerPro
             onSubmit={(e) => void onSubmit(e)}
             noValidate
           >
+            {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
+              <FormErrorSummary errors={validationMessages} />
+            ) : null}
             <FormField
               label="Title"
               name="title"

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -10,7 +10,7 @@
 
 import { useState, useEffect, type ReactElement } from 'react';
 import { Button } from '../../../shared/ui/button';
-import { EmptyState, ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
+import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import type { MappingOption } from '../api/mappings.types';
 
 export interface MappingRow {
@@ -122,11 +122,9 @@ export function MappingPanel({
       <p className="muted-text" style={{ marginBottom: '1rem' }}>{description}</p>
 
       {localRows.length === 0 ? (
-        <EmptyState
-          liveRegion="off"
-          title="No mappings configured"
-          message="Orders may sync with incorrect status/carrier/payment. Add a mapping below."
-        />
+        <p className="muted-text" role="status" aria-live="polite">
+          No mappings configured yet. Orders may sync with default values. Add one below.
+        </p>
       ) : (
         <table className="data-table" aria-label={`${title} mappings`}>
           <thead>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2813,3 +2813,296 @@ textarea {
 .tabs__content:focus-visible {
   outline: none;
 }
+
+/*
+ * ── Phase 5 primitives — SetupStepper ────────────────────────────────
+ * Horizontal stepper used by multi-step setup wizards. The full list
+ * shows on tablet + desktop; < 768 px collapses to a compact indicator.
+ */
+.setup-stepper {
+  margin: 0 0 1.5rem 0;
+}
+
+.setup-stepper__list {
+  display: none;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.setup-stepper__mobile {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.setup-stepper__mobile-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.setup-stepper__mobile-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.setup-stepper__dots {
+  display: flex;
+  gap: 0.375rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.setup-stepper__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--border-strong);
+}
+
+.setup-stepper__dot--done {
+  background: var(--accent-primary);
+}
+
+.setup-stepper__dot--current {
+  background: var(--accent-primary);
+  box-shadow: 0 0 0 3px var(--accent-primary-soft);
+}
+
+@media (min-width: 768px) {
+  .setup-stepper__mobile {
+    display: none;
+  }
+
+  .setup-stepper__list {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .setup-stepper__step {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    flex: 0 0 auto;
+  }
+
+  .setup-stepper__indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-strong);
+    background: var(--bg-surface);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .setup-stepper__label {
+    white-space: nowrap;
+  }
+
+  .setup-stepper__connector {
+    display: inline-block;
+    width: 1.5rem;
+    height: 1px;
+    background: var(--border-default);
+    margin: 0 0.25rem;
+  }
+
+  .setup-stepper__step--current .setup-stepper__indicator {
+    border-color: var(--accent-primary);
+    background: var(--accent-primary);
+    color: var(--text-inverse, #fff);
+  }
+
+  .setup-stepper__step--current .setup-stepper__label {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  .setup-stepper__step--done .setup-stepper__indicator {
+    border-color: var(--accent-primary);
+    background: var(--accent-primary-soft);
+    color: var(--accent-primary);
+  }
+
+  .setup-stepper__step--done .setup-stepper__label {
+    color: var(--text-secondary);
+  }
+
+  .setup-stepper__step--done .setup-stepper__connector {
+    background: var(--accent-primary);
+  }
+}
+
+/*
+ * ── Phase 5 — Wizard layout ──────────────────────────────────────────
+ * Multi-step wizards use a narrow single-column form (≤ 560 px) on
+ * desktop + tablet, full-width on mobile. The action row separates back
+ * / next / submit.
+ */
+.wizard-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border-default);
+  border-radius: 0.5rem;
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-soft);
+  max-width: 100%;
+}
+
+.wizard-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.wizard-actions__group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.wizard-review-list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.wizard-review-list dt {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+.wizard-review-list dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  word-break: break-word;
+}
+
+.wizard-test-result {
+  display: grid;
+  gap: 0.5rem;
+}
+
+/* Style guide §Forms: single-column forms max 560 px on ≥ 768 px */
+@media (min-width: 768px) {
+  .form-narrow,
+  .wizard-card {
+    max-width: 560px;
+  }
+}
+
+/*
+ * ── Phase 5 — Advanced mode banner ───────────────────────────────────
+ * Make the escape hatch page visually distinct so operators know to
+ * prefer guided flows.
+ */
+.advanced-banner {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--status-warning-border);
+  border-radius: 0.5rem;
+  background: var(--status-warning-soft);
+  color: var(--status-warning-fg);
+}
+
+.advanced-banner__title {
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+}
+
+.advanced-banner p {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+/*
+ * ── Phase 5 — Desktop-only editor banner ─────────────────────────────
+ * Mapping editors (category / status / carrier / payment) remain
+ * interactive only on ≥ 1024 px. Smaller viewports get a read-only view
+ * with this banner so mobile operators are not confused.
+ */
+.desktop-only-banner {
+  display: none;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--status-info-border);
+  border-radius: 0.5rem;
+  background: var(--status-info-soft);
+  color: var(--status-info-fg);
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 1023.98px) {
+  .desktop-only-banner {
+    display: flex;
+  }
+
+  .desktop-only-hide {
+    display: none !important;
+  }
+}
+
+.desktop-only-banner__title {
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+  font-size: 0.9375rem;
+}
+
+.desktop-only-banner p {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+/*
+ * ── Phase 5 — Compact mapping editor ─────────────────────────────────
+ * Inline "add row" form so the editor does not consume a full empty
+ * panel when no rows exist yet.
+ */
+.mapping-editor__inline-add {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border: 1px dashed var(--border-default);
+  border-radius: 0.5rem;
+  background: var(--bg-surface-elevated);
+  align-items: end;
+}
+
+@media (max-width: 767.98px) {
+  .mapping-editor__inline-add {
+    grid-template-columns: 1fr;
+  }
+}
+
+/*
+ * ── Phase 5 — Structured config panel (connection edit) ──────────────
+ * JSON-view toggle so power users can still see / edit raw JSON.
+ */
+.config-panel__toggle {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+

--- a/apps/web/src/pages/connections/advanced-new-connection-page.tsx
+++ b/apps/web/src/pages/connections/advanced-new-connection-page.tsx
@@ -16,7 +16,7 @@ export function AdvancedNewConnectionPage(): ReactElement {
     <PageLayout
       eyebrow="Integrations"
       title="Advanced connection setup"
-      description="Direct form for connection fields — adapter key, credentials reference, and raw config JSON. Use the guided flows when possible."
+      description="Direct form for connection fields — adapter key, credentials reference, and raw config JSON."
       actions={
         <Link className="button button--secondary" to="/connections/new">
           Back
@@ -29,6 +29,17 @@ export function AdvancedNewConnectionPage(): ReactElement {
         </div>
       }
     >
+      <div className="advanced-banner" role="note">
+        <div>
+          <p className="advanced-banner__title">Escape hatch — prefer the guided flow</p>
+          <p>
+            This form exposes raw adapter keys, credential references, and config JSON. Use the{' '}
+            <Link to="/connections/new">guided PrestaShop or Allegro wizard</Link> unless you need
+            direct control to debug an integration or bootstrap a platform without a dedicated
+            flow.
+          </p>
+        </div>
+      </div>
       <CreateConnectionForm />
     </PageLayout>
   );

--- a/apps/web/src/pages/connections/connection-category-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-category-mappings-page.tsx
@@ -26,6 +26,7 @@ import {
 import { usePrestashopCategoriesQuery } from '../../features/mappings/hooks/use-prestashop-categories';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { DesktopOnlyBanner } from '../../shared/ui/desktop-only-banner';
 import type { AllegroCategory } from '../../features/mappings/api/mappings.types';
 
 const MARKETPLACE_PICK_STORAGE_PREFIX = 'openlinker.categoryMappings.lastMarketplace.';
@@ -197,6 +198,12 @@ export function ConnectionCategoryMappingsPage(): ReactElement {
       description={`${mappedCount} of ${categories.length} categories mapped`}
       actions={backLink}
     >
+      <DesktopOnlyBanner title="Open on a desktop screen to edit categories">
+        The category mapping editor pairs a category tree with a marketplace search side by side
+        and needs a wider viewport. Open this page on a desktop or tablet in landscape mode to
+        assign categories.
+      </DesktopOnlyBanner>
+
       <div className="category-mappings-toolbar">
         <label className="category-mappings-toolbar__label" htmlFor="marketplace-connection-select">
           Marketplace connection

--- a/apps/web/src/pages/connections/connection-mappings-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.test.tsx
@@ -68,7 +68,7 @@ describe('ConnectionMappingsPage', () => {
     renderWithProviders(<ConnectionMappingsPage />, { apiClient: buildApiClient() });
 
     await waitFor(() => {
-      expect(screen.getByText('No mappings configured')).toBeInTheDocument();
+      expect(screen.getByText(/No mappings configured yet/i)).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -16,6 +16,7 @@ import { useCarrierMappingsQuery, useUpsertCarrierMappings } from '../../feature
 import { usePaymentMappingsQuery, useUpsertPaymentMappings } from '../../features/mappings/hooks/use-payment-mappings';
 import { useMappingOptions } from '../../features/mappings/hooks/use-mapping-options';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
+import { DesktopOnlyBanner } from '../../shared/ui/desktop-only-banner';
 
 type TabId = 'status' | 'carriers' | 'payments';
 
@@ -101,6 +102,11 @@ export function ConnectionMappingsPage(): ReactElement {
         </Link>
       }
     >
+      <DesktopOnlyBanner>
+        Mapping editors are designed for desktop. On smaller screens the controls below are still
+        visible but large tables may overflow horizontally.
+      </DesktopOnlyBanner>
+
       {/* Tab navigation */}
       <div role="tablist" aria-label="Mapping types" className="toolbar" style={{ marginBottom: '1.5rem', gap: '0.25rem' }}>
         {TABS.map((tab) => (

--- a/apps/web/src/shared/ui/desktop-only-banner.tsx
+++ b/apps/web/src/shared/ui/desktop-only-banner.tsx
@@ -11,14 +11,17 @@ import type { ReactElement, ReactNode } from 'react';
 interface DesktopOnlyBannerProps {
   title?: string;
   children?: ReactNode;
+  className?: string;
 }
 
 export function DesktopOnlyBanner({
   title = 'Open on a desktop screen to edit',
   children = 'This editor needs a wider screen to show both sides side by side. The view below is read-only on this viewport.',
+  className,
 }: DesktopOnlyBannerProps): ReactElement {
+  const classes = ['desktop-only-banner', className].filter(Boolean).join(' ');
   return (
-    <div className="desktop-only-banner" role="note">
+    <div className={classes} role="note">
       <div>
         <p className="desktop-only-banner__title">{title}</p>
         <p>{children}</p>

--- a/apps/web/src/shared/ui/desktop-only-banner.tsx
+++ b/apps/web/src/shared/ui/desktop-only-banner.tsx
@@ -1,0 +1,28 @@
+/**
+ * DesktopOnlyBanner
+ *
+ * Info banner that surfaces on viewports below 1024 px and stays hidden on
+ * desktop. Used by complex editors (mapping editors, raw JSON editors) that
+ * remain interactive only on wider screens per `§Responsive` in the UI style
+ * guide.
+ */
+import type { ReactElement, ReactNode } from 'react';
+
+interface DesktopOnlyBannerProps {
+  title?: string;
+  children?: ReactNode;
+}
+
+export function DesktopOnlyBanner({
+  title = 'Open on a desktop screen to edit',
+  children = 'This editor needs a wider screen to show both sides side by side. The view below is read-only on this viewport.',
+}: DesktopOnlyBannerProps): ReactElement {
+  return (
+    <div className="desktop-only-banner" role="note">
+      <div>
+        <p className="desktop-only-banner__title">{title}</p>
+        <p>{children}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/setup-stepper.test.tsx
+++ b/apps/web/src/shared/ui/setup-stepper.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SetupStepper } from './setup-stepper';
+
+const STEPS = ['Credentials', 'Environment', 'Review'] as const;
+
+function queryDesktopSteps(): NodeListOf<Element> {
+  const list = screen.getByRole('navigation').querySelector('.setup-stepper__list');
+  if (!list) throw new Error('Desktop stepper list not found');
+  return list.querySelectorAll('.setup-stepper__step');
+}
+
+describe('SetupStepper', () => {
+  afterEach(cleanup);
+
+  it('marks the current step with aria-current="step"', () => {
+    render(<SetupStepper steps={STEPS} currentStep={1} />);
+
+    const current = screen
+      .getByRole('navigation')
+      .querySelector('[aria-current="step"]');
+    expect(current).toBeTruthy();
+    expect(current?.textContent).toContain('Environment');
+  });
+
+  it('shows the correct step number in the mobile label', () => {
+    render(<SetupStepper steps={STEPS} currentStep={0} />);
+    expect(screen.getByText(/Step 1 of 3/i)).toBeInTheDocument();
+  });
+
+  it('renders a checkmark indicator for completed steps', () => {
+    render(<SetupStepper steps={STEPS} currentStep={1} completedSteps={new Set([0])} />);
+
+    const steps = queryDesktopSteps();
+    const firstIndicator = steps[0].querySelector('.setup-stepper__indicator');
+    expect(firstIndicator?.querySelector('svg')).toBeTruthy();
+    expect(firstIndicator?.textContent?.trim()).not.toBe('1');
+  });
+
+  it('applies the correct modifier class for upcoming steps', () => {
+    render(<SetupStepper steps={STEPS} currentStep={0} />);
+
+    const steps = queryDesktopSteps();
+    expect(steps[2].classList.contains('setup-stepper__step--upcoming')).toBe(true);
+  });
+
+  it('applies an additional className when provided', () => {
+    render(<SetupStepper steps={STEPS} currentStep={0} className="my-stepper" />);
+    expect(screen.getByRole('navigation').classList.contains('my-stepper')).toBe(true);
+  });
+});

--- a/apps/web/src/shared/ui/setup-stepper.tsx
+++ b/apps/web/src/shared/ui/setup-stepper.tsx
@@ -1,0 +1,94 @@
+/**
+ * SetupStepper
+ *
+ * Horizontal step indicator for multi-step setup wizards. On mobile (< 768 px)
+ * it collapses to a "Step N of M" label with progress dots so the full step
+ * list does not crowd narrow viewports.
+ */
+import type { ReactElement } from 'react';
+
+export interface SetupStepperProps {
+  steps: readonly string[];
+  currentStep: number; // 0-based
+  completedSteps?: ReadonlySet<number>;
+  className?: string;
+}
+
+export function SetupStepper({
+  steps,
+  currentStep,
+  completedSteps = new Set(),
+  className,
+}: SetupStepperProps): ReactElement {
+  return (
+    <nav
+      aria-label="Setup progress"
+      className={['setup-stepper', className].filter(Boolean).join(' ')}
+    >
+      {/* Desktop / tablet: full step list */}
+      <ol className="setup-stepper__list" aria-hidden="false">
+        {steps.map((label, index) => {
+          const isDone = completedSteps.has(index);
+          const isCurrent = index === currentStep;
+          const modifier = isDone
+            ? 'done'
+            : isCurrent
+              ? 'current'
+              : index < currentStep
+                ? 'done'
+                : 'upcoming';
+
+          return (
+            <li
+              key={label}
+              className={`setup-stepper__step setup-stepper__step--${modifier}`}
+              aria-current={isCurrent ? 'step' : undefined}
+            >
+              <span className="setup-stepper__indicator" aria-hidden="true">
+                {modifier === 'done' ? (
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                    <path
+                      d="M2 6l3 3 5-5"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                ) : (
+                  <span>{index + 1}</span>
+                )}
+              </span>
+              <span className="setup-stepper__label">{label}</span>
+              {index < steps.length - 1 && (
+                <span className="setup-stepper__connector" aria-hidden="true" />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* Mobile: compact "Step N of M" with dots */}
+      <div className="setup-stepper__mobile" aria-hidden="true">
+        <span className="setup-stepper__mobile-label">
+          Step {currentStep + 1} of {steps.length}
+        </span>
+        <span className="setup-stepper__mobile-title">{steps[currentStep]}</span>
+        <ol className="setup-stepper__dots">
+          {steps.map((label, index) => (
+            <li
+              key={label}
+              className={[
+                'setup-stepper__dot',
+                index < currentStep ? 'setup-stepper__dot--done' : '',
+                index === currentStep ? 'setup-stepper__dot--current' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            />
+          ))}
+        </ol>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 5 of the FE-002 refactor (#236). Converts single-screen setup forms into guided wizards, tightens form widths, and adds responsive affordances for editors that only make sense on wider viewports.

**Primitive**
- `SetupStepper` (`apps/web/src/shared/ui/setup-stepper.tsx`) — horizontal stepper on >= 768 px, compact "Step N of M" with progress dots on mobile. Colocated unit tests.
- `DesktopOnlyBanner` — info banner that surfaces only on < 1024 px viewports for mapping editors.

**Wizards**
- **PrestaShop wizard** — Credentials -> Test connection -> Capabilities -> Review & connect. Per-step validation via `form.trigger`; abandon-prevention on unsaved changes via `beforeunload`.
- **Allegro wizard** — Credentials -> Environment -> Product catalog -> Review. `masterCatalogConnectionId` schema switched from `.or(z.literal(''))` to `z.preprocess` so an empty string validates cleanly through per-step trigger.

**Forms & mapping editors**
- **Advanced mode** — new warning-tone banner reinforces the escape-hatch framing and links back to the guided flow.
- **Edit connection form** — PrestaShop connections get structured `Shop URL` / `Shop ID` inputs with a `Show raw config JSON` toggle; `configText` stays as the submission payload and `mergeStructuredIntoConfig` preserves unknown keys. Non-PrestaShop connections still render the JSON editor (there is nothing structured to split out yet).
- **Mapping editors** (status / carrier / payment / categories) — `DesktopOnlyBanner` shown below 1024 px. The per-tab full-pane `EmptyState` is replaced with an inline muted note so an empty panel doesn't dominate the layout.
- **Form widths** — new `form-narrow` + `wizard-card` CSS classes cap single-column forms at 560 px on tablet + desktop.
- **FormErrorSummary** — wired into `EditOfferDrawer` (auth forms already had it).

## Acceptance

- [x] `SetupStepper` primitive shipped with unit tests
- [x] PrestaShop + Allegro wizards converted to multi-step flows with per-step validation
- [x] Advanced mode clearly marked as escape hatch (warning header, secondary entry point)
- [x] Connection edit form replaces raw JSON textarea with structured inputs (JSON-view toggle for power users) — PrestaShop only; other platforms keep the JSON editor
- [x] Every form has `FormErrorSummary` wired and verified
- [x] Single-column forms max-width 560 px on desktop + tablet; 100% on mobile
- [x] Wizards: one step per screen on mobile with collapsed stepper indicator
- [x] Mapping editors show "open on desktop to edit" banner below 1024 px
- [ ] After-shots captured at 3 widths (360 / 768 / 1440) for each wizard + editor — deferred to visual QA
- [x] `pnpm lint && pnpm type-check && pnpm test` pass

## Test plan

- [x] `pnpm --filter @openlinker/web test` — 302 passing
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean (warnings unchanged from main: 13)
- [ ] Visual spot-check at 360 / 768 / 1440:
  - PrestaShop wizard: stepper collapses on mobile, credentials -> test -> capabilities -> review flow; back/next works; invalid URL blocks advance
  - Allegro wizard: same step-per-screen flow; environment note surfaces on step 2; OAuth redirect fires from Review
  - Advanced mode: warning banner, single-column layout <= 560 px
  - Edit connection (PrestaShop): structured URL / shop ID inputs; toggle reveals raw JSON textarea preserving edits
  - Mapping editor: desktop-only banner visible below 1024 px; empty tab shows inline note instead of empty card

Closes #241
