### PR TITLE
fix(web): add non-color signal to MetricCard warning/error tones

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2408,11 +2408,24 @@ textarea {
 }
 
 .metric-card__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--text-muted);
+}
+
+.metric-card__icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--status-warning-strong);
+}
+
+.metric-card--error .metric-card__icon {
+  color: var(--status-error-strong);
 }
 
 .metric-card__value {

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -211,6 +211,9 @@ describe('DashboardPage', () => {
     await screen.findByText('1 / 2');
     const integrationCard = findCardByLabel(container, 'Integration health');
     expect(integrationCard).toHaveClass('metric-card--warning');
+    const icon = integrationCard.querySelector('.metric-card__icon');
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute('aria-hidden')).toBe('true');
   });
 
   it('shows error state when sync jobs fail to load', async () => {

--- a/apps/web/src/shared/ui/metric-card.test.tsx
+++ b/apps/web/src/shared/ui/metric-card.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it } from 'vitest';
-import { MetricCard, MetricCardLink } from './metric-card';
+import { MetricCard, MetricCardLink, MetricCardToneValues } from './metric-card';
 
 function renderWithRouter(ui: React.ReactElement): ReturnType<typeof render> {
   return render(<MemoryRouter>{ui}</MemoryRouter>);
@@ -35,6 +35,34 @@ describe('MetricCard', () => {
     const { container } = render(<MetricCard label="Orders" value={42} />);
     expect(container.querySelector('.metric-card--neutral')).not.toBeNull();
     expect(container.querySelector('.metric-card--interactive')).toBeNull();
+  });
+
+  it('renders a warning icon for tone="warning" with aria-hidden on the wrapping span', () => {
+    const { container } = render(<MetricCard label="Integration health" value="3 / 4" tone="warning" />);
+    const icon = container.querySelector('.metric-card__icon');
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute('aria-hidden')).toBe('true');
+    expect(icon?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders an error icon for tone="error" with aria-hidden on the wrapping span', () => {
+    const { container } = render(<MetricCard label="Failed jobs" value={42} tone="error" />);
+    const icon = container.querySelector('.metric-card__icon');
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute('aria-hidden')).toBe('true');
+    expect(icon?.querySelector('svg')).not.toBeNull();
+  });
+
+  it.each(['neutral', 'success', 'info'] as const)(
+    'does not render a tone icon for tone="%s"',
+    (tone) => {
+      const { container } = render(<MetricCard label="Orders" value={42} tone={tone} />);
+      expect(container.querySelector('.metric-card__icon')).toBeNull();
+    },
+  );
+
+  it('MetricCardToneValues exposes all five supported tones', () => {
+    expect([...MetricCardToneValues]).toEqual(['neutral', 'success', 'warning', 'error', 'info']);
   });
 });
 

--- a/apps/web/src/shared/ui/metric-card.tsx
+++ b/apps/web/src/shared/ui/metric-card.tsx
@@ -1,7 +1,52 @@
 import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
 import { Link, type LinkProps } from 'react-router-dom';
 
-export type MetricCardTone = 'neutral' | 'success' | 'warning' | 'error' | 'info';
+export const MetricCardToneValues = ['neutral', 'success', 'warning', 'error', 'info'] as const;
+export type MetricCardTone = (typeof MetricCardToneValues)[number];
+
+function ToneIcon({ tone }: { tone: MetricCardTone }): ReactNode {
+  if (tone === 'warning') {
+    return (
+      <span className="metric-card__icon" aria-hidden="true">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M8 1.5 L14.5 13 H1.5 Z" />
+          <line x1="8" y1="6" x2="8" y2="9.5" />
+          <circle cx="8" cy="11.5" r="0.6" fill="currentColor" stroke="none" />
+        </svg>
+      </span>
+    );
+  }
+  if (tone === 'error') {
+    return (
+      <span className="metric-card__icon" aria-hidden="true">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="8" cy="8" r="6.5" />
+          <line x1="8" y1="4.5" x2="8" y2="8.5" />
+          <circle cx="8" cy="11" r="0.6" fill="currentColor" stroke="none" />
+        </svg>
+      </span>
+    );
+  }
+  return null;
+}
 
 interface MetricCardBody {
   description?: ReactNode;
@@ -20,10 +65,16 @@ interface MetricCardLinkProps
   to: LinkProps['to'];
 }
 
-function renderBody({ description, label, trend, value }: MetricCardBody): ReactNode {
+function renderBody(
+  { description, label, trend, value }: MetricCardBody,
+  tone: MetricCardTone,
+): ReactNode {
   return (
     <>
-      <span className="metric-card__label">{label}</span>
+      <span className="metric-card__label">
+        <ToneIcon tone={tone} />
+        {label}
+      </span>
       <span className="metric-card__value">{value}</span>
       {trend ? <span className="metric-card__trend">{trend}</span> : null}
       {description ? <span className="metric-card__description">{description}</span> : null}
@@ -48,7 +99,7 @@ export const MetricCard = forwardRef<HTMLDivElement, MetricCardProps>(function M
 ) {
   return (
     <div ref={ref} className={buildClasses(tone, className, false)} {...props}>
-      {renderBody({ description, label, trend, value })}
+      {renderBody({ description, label, trend, value }, tone)}
     </div>
   );
 });
@@ -60,7 +111,7 @@ export const MetricCardLink = forwardRef<HTMLAnchorElement, MetricCardLinkProps>
   ) {
     return (
       <Link ref={ref} to={to} className={buildClasses(tone, className, true)} {...props}>
-        {renderBody({ description, label, trend, value })}
+        {renderBody({ description, label, trend, value }, tone)}
       </Link>
     );
   },

--- a/docs/plans/implementation-plan-228-metric-card-warning-a11y.md
+++ b/docs/plans/implementation-plan-228-metric-card-warning-a11y.md
@@ -1,0 +1,134 @@
+# Implementation Plan: #228 — MetricCard warning/error needs shape, not just color
+
+## 1. Task Understanding
+
+**Goal**: Make warning and error states on `MetricCard` perceivable by color-blind users and quick to scan at a glance. Currently distinguished only by a tinted background + border + colored value; needs a non-color signal (icon) as well.
+
+**Layer**: Frontend (shared UI primitive + pages that consume it).
+
+**Non-goals**:
+- No change to neutral/success/info visual (those aren't signalling a problem state).
+- No new icon-library dependency; use an inline SVG we own.
+- No restructuring of `MetricCard` API beyond what's needed for the a11y fix.
+- **Defer `'review'` tone** — no current page renders a MetricCard with `review`. Per `.claude/rules/ui-components.md` ("Use the same primitive in a real page immediately after introducing it — no unused abstractions"), it'll land with its first consumer in a follow-up. Out of scope here.
+
+## 2. Research findings
+
+Since the issue was filed (2026-04-17), two things moved:
+
+1. **`.metric-card--warning` and `.metric-card--error` already have soft backgrounds** — the stale "only border changes" snippet in the issue no longer applies. PR #249 added those rules when the dashboard moved onto `MetricCard`. CSS state today (`apps/web/src/index.css:2450-2484`):
+   - `--warning`: `var(--status-warning-soft)` bg + `var(--status-warning-border)` + `--status-warning-strong` value color ✅
+   - `--error`: `var(--status-error-soft)` bg + `var(--status-error-border)` + `--status-error-strong` value color ✅
+   - Also `--success` and `--info` already tint correctly.
+2. **`.metric-card--review` does not exist**. The `MetricCardTone` union is `'neutral' | 'success' | 'warning' | 'error' | 'info'` — no `review`. The design tokens (`--status-review`, `--status-review-soft`, `--status-review-border`) do exist but nothing consumes them on the dashboard.
+
+So the real gap is the **"color is never the only signal"** a11y rule from `docs/frontend-ui-style-guide.md` and `.claude/rules/frontend.md`. Today a colour-blind operator sees identical shape/layout on a warning card and a neutral card.
+
+## 3. Solution
+
+### 3.1 `MetricCard` — migrate tone to `as const` + add tonal icon
+
+**Union migration** — align with engineering-standards "Union Types: `as const` Pattern":
+
+```tsx
+export const MetricCardToneValues = ['neutral', 'success', 'warning', 'error', 'info'] as const;
+export type MetricCardTone = (typeof MetricCardToneValues)[number];
+```
+
+This replaces the current inline union. Consumers (dashboard page, tests) don't change — the union shape is identical.
+
+**Tonal icon** — when `tone === 'warning' || tone === 'error'`, render an inline SVG icon before the label.
+
+Icon choice:
+- **warning** → triangle-with-exclamation (SVG, not the `⚠` glyph — inconsistent across fonts).
+- **error** → circle-with-exclamation.
+
+Both use `currentColor` so they inherit the tone-scoped value color (`--status-warning-strong` / `--status-error-strong`) already set on the value. Place the SVG inside a wrapping `<span className="metric-card__icon" aria-hidden="true">` — `aria-hidden` on the wrapper hides the whole subtree, matching the pattern in `app-shell.tsx` and `status-badge.tsx`.
+
+### 3.2 Markup change
+
+Before:
+```tsx
+<span className="metric-card__label">{label}</span>
+<span className="metric-card__value">{value}</span>
+```
+
+After:
+```tsx
+<span className="metric-card__label">
+  {showToneIcon(tone) ? <ToneIcon tone={tone} /> : null}
+  {label}
+</span>
+<span className="metric-card__value">{value}</span>
+```
+
+`ToneIcon` is a private component in the same file that emits `<span className="metric-card__icon" aria-hidden="true"><svg .../></span>`. `showToneIcon(tone)` returns `true` only for `'warning' | 'error'`.
+
+## 4. Step-by-step
+
+### Step 1 — Migrate tone union and add icon rendering
+
+**File**: `apps/web/src/shared/ui/metric-card.tsx`
+
+- Replace `type MetricCardTone = '...'` with `const MetricCardToneValues = [...] as const` + `type MetricCardTone = (typeof MetricCardToneValues)[number]` (keep the same five values — no `'review'`).
+- Add inline `ToneIcon` component that renders `<span className="metric-card__icon" aria-hidden="true"><svg>...</svg></span>` for `'warning' | 'error'` and `null` otherwise.
+- Render the icon inside `.metric-card__label` for warning/error tones.
+
+**Acceptance**: Component compiles; public API unchanged (tone union still accepts the same five values); neutral/success/info render without an icon; warning/error render with an icon wrapped in an `aria-hidden` span.
+
+### Step 2 — CSS for icon
+
+**File**: `apps/web/src/index.css`
+
+- Add `.metric-card__icon { display: inline-flex; align-items: center; margin-right: 0.375rem; color: inherit; }` and ensure the SVG inside is sized to 14px (consistent with body type scale) via `width/height`.
+- Update `.metric-card__label` to use `display: inline-flex; align-items: center;` so the icon aligns with label text cleanly. Verify no regression on existing neutral cards (no icon, no layout shift).
+
+**Acceptance**: Visual: neutral cards identical to before; warning/error cards show icon; no change to existing CSS for tone modifiers.
+
+### Step 3 — Tests
+
+**File**: `apps/web/src/shared/ui/metric-card.test.tsx`
+
+Add cases:
+- `renders a warning icon for tone="warning"` — `.metric-card__icon` is in the DOM with `aria-hidden="true"` on the span.
+- `renders an error icon for tone="error"` — same.
+- `does not render a tone icon for tone="neutral" | "success" | "info"`.
+- `MetricCardToneValues includes all five expected tones` — guards the runtime array so future additions require an explicit update.
+
+Keep existing tests passing.
+
+### Step 4 — Dashboard snapshot sanity
+
+**File**: `apps/web/src/pages/dashboard/dashboard-page.test.tsx`
+
+No behavioural change expected, but confirm the existing "Integration health" warning assertion still passes and add a check that the warning icon appears when there's an error connection. Keep to one extra assertion to avoid test bloat.
+
+### Step 5 — Quality gate
+
+```
+pnpm lint && pnpm type-check && pnpm test
+```
+
+Must pass with zero errors.
+
+### Step 6 — PR description
+
+Include a **desktop before/after screenshot** of the dashboard metric strip showing the warning card with and without the new icon. Makes the color-blind case visible to reviewers without running the app. Mobile/tablet shots optional — this is an a11y polish, not a Phase-3 primitive migration.
+
+## 5. Validation
+
+- **Architecture**: Change is confined to one shared primitive + its test + one CSS section. Respects `shared → no imports from features/pages`. ✅
+- **Rules**: `aria-hidden="true"` on decorative icon (frontend.md "Accessibility"); no color-only signal (frontend-ui-style-guide.md "Color Usage Rules"). ✅
+- **Tokens**: All new colors via existing `--status-*` tokens — no raw hex. ✅
+- **Scope discipline**: No new icon library; no changes outside the metric card + its callers' tests. ✅
+- **Non-goals respected**: no change to neutral/success/info visual, no API rename. ✅
+
+## 6. Open questions resolved
+
+| Question | Decision |
+|---|---|
+| Unicode vs SVG? | SVG — cross-font-consistent, inherits `currentColor`. |
+| Icon on info/success too? | No — only on problem states (warning/error). Others are already positive/neutral. |
+| Is `.metric-card--review` in scope? | **Deferred** — no consumer exists. Per `ui-components.md` "no unused abstractions", add with its first consumer in a follow-up. |
+| Should the icon be announced to screen readers? | No — tone is already in the label text + value; the icon is decorative. `aria-hidden` on the wrapping span. |
+| Inline union vs `as const` + typeof[number]? | Migrate to `as const` per engineering-standards "Union Types" guidance. Public type name and values unchanged. |


### PR DESCRIPTION
## Summary

- Dashboard warning and error metric cards were distinguished only by a tinted background and colored value — a color-only signal. Color-blind operators could not tell a warning card from a neutral one at a glance.
- Adds an inline SVG icon (triangle-exclamation for `warning`, circle-exclamation for `error`) inside the label, wrapped in an `aria-hidden="true"` span. The icon is purely decorative — the tone is already conveyed by the label text and value.
- Migrates `MetricCardTone` to the canonical `as const` + union-type pattern per `docs/engineering-standards.md` "Union Types: `as const` Pattern".

## Scope decisions

- **`review` tone deferred** — the original issue asked for `.metric-card--review` parity, but no page renders a MetricCard with `review` today. Per `ui-components.md` ("no unused abstractions"), it will land with its first consumer in a follow-up.
- **Icon only on problem tones** — `neutral`, `success`, `info` keep their iconless rendering; the signal is reserved for states that need operator attention.

## Test plan

- [x] `pnpm lint` — 0 errors (only pre-existing warnings on unrelated files)
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — all 302 web tests pass (6 new)
- [x] New unit tests assert icon presence, `aria-hidden` on wrapping span, and absence on neutral/success/info
- [x] Dashboard test asserts the icon appears when a connection is in error
- [ ] **Manual visual QA**: reviewer should run `pnpm start:dev:web` and confirm on `/` that the "Integration health" card renders with a warning triangle when a connection is in error, and that neutral cards are visually identical to before

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)