### PR TITLE
feat(listings): offer creation foundation — port extension + OfferCreationRecord

### DIFF
--- a/apps/api/src/migrations/1783000000000-add-offer-creation-records-table.ts
+++ b/apps/api/src/migrations/1783000000000-add-offer-creation-records-table.ts
@@ -1,0 +1,61 @@
+/**
+ * Add Offer Creation Records Table Migration
+ *
+ * Creates the `offer_creation_records` table tracking OL-initiated offer creation
+ * attempts on marketplaces (OL → Allegro / WooCommerce / eBay / etc.). Separate
+ * from `identifier_mappings` (which tracks Offer ID linkage post-creation) so the
+ * lifecycle state (pending / draft / validating / active / failed) and structured
+ * validation errors can be queried and indexed without polluting the generic
+ * identifier mapping table.
+ *
+ * Generated: 2026-04-20
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOfferCreationRecordsTable1783000000000 implements MigrationInterface {
+  name = 'AddOfferCreationRecordsTable1783000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('offer_creation_records');
+
+    if (!table) {
+      await queryRunner.query(`
+        CREATE TABLE "offer_creation_records" (
+          "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+          "internalVariantId" text NOT NULL,
+          "connectionId" uuid NOT NULL,
+          "externalOfferId" text,
+          "status" text NOT NULL,
+          "errors" jsonb,
+          "publishImmediately" boolean NOT NULL DEFAULT false,
+          "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+          "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+          CONSTRAINT "PK_offer_creation_records" PRIMARY KEY ("id")
+        )
+      `);
+
+      await queryRunner.query(`
+        CREATE INDEX "IDX_offer_creation_records_variant_connection"
+          ON "offer_creation_records" ("internalVariantId", "connectionId")
+      `);
+
+      await queryRunner.query(`
+        CREATE INDEX "IDX_offer_creation_records_connectionId"
+          ON "offer_creation_records" ("connectionId")
+      `);
+
+      await queryRunner.query(`
+        CREATE INDEX "IDX_offer_creation_records_status"
+          ON "offer_creation_records" ("status")
+      `);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_offer_creation_records_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_offer_creation_records_connectionId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_offer_creation_records_variant_connection"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "offer_creation_records"`);
+  }
+}

--- a/apps/api/src/migrations/1784000000000-add-offer-creation-records-table.ts
+++ b/apps/api/src/migrations/1784000000000-add-offer-creation-records-table.ts
@@ -13,10 +13,15 @@
  */
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddOfferCreationRecordsTable1783000000000 implements MigrationInterface {
-  name = 'AddOfferCreationRecordsTable1783000000000';
+export class AddOfferCreationRecordsTable1784000000000 implements MigrationInterface {
+  name = 'AddOfferCreationRecordsTable1784000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Ensure uuid_generate_v4() is available. Defensive: existing tables also
+    // rely on uuid-ossp but no prior migration creates it, so fresh databases
+    // (CI, new environments) must have it provisioned before this DDL runs.
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+
     const table = await queryRunner.getTable('offer_creation_records');
 
     if (!table) {

--- a/docs/plans/implementation-plan-offer-creation-foundation.md
+++ b/docs/plans/implementation-plan-offer-creation-foundation.md
@@ -262,8 +262,8 @@ No unique constraint on `(variantId, connectionId)` — a variant may have multi
   - Import `OfferCreationRecordOrmEntity` and add to `TypeOrmModule.forFeature([...])`.
   - Import `OfferCreationRecordRepository`.
   - Register token binding: `{ provide: OFFER_CREATION_RECORD_REPOSITORY_TOKEN, useExisting: OfferCreationRecordRepository }`.
-  - Add string fallback: `{ provide: 'OfferCreationRecordRepositoryPort', useExisting: OFFER_CREATION_RECORD_REPOSITORY_TOKEN }`.
-  - Add to `exports` array.
+  - **No string-token fallback** — Engineering Standards §Repository Ports Pattern deprecates string tokens as fragile. Existing string fallbacks in this module (e.g. `'OfferMappingRepositoryPort'`) are kept for compatibility and tracked for removal in a follow-up issue. New ports are Symbol-only.
+  - Add to `exports` array (Symbol token only).
   - Re-export token at top of file (match existing pattern).
 
 ### Step 11 — Barrel exports

--- a/docs/plans/implementation-plan-offer-creation-foundation.md
+++ b/docs/plans/implementation-plan-offer-creation-foundation.md
@@ -47,7 +47,7 @@ Lay the groundwork for the `MarketplacePort.createOffer()` capability and the `O
 - Class: `{PascalDescription}{Timestamp} implements MigrationInterface` with `name` field matching class name.
 - `up()` checks `queryRunner.getTable(...)` before `CREATE TABLE` (defensive against re-runs).
 - `down()` drops indexes then table.
-- Latest migration timestamp in repo: `1782000000000`. **New timestamp for this plan: `1783000000000`.**
+- Latest migration timestamp in repo: `1782000000000`. **Initial timestamp was `1783000000000`; bumped to `1784000000000` after rebasing on `origin/main` which had merged a separate `1783000000000-add-order-record-status.ts` migration from PR #262.**
 
 ### Reference entity/repo pair (`Connection` + `connection.orm-entity.ts` + `connection.repository.ts`)
 - Domain entity: plain class, readonly constructor params, no framework imports.
@@ -275,7 +275,7 @@ No unique constraint on `(variantId, connectionId)` — a variant may have multi
 - **Acceptance:** `pnpm --filter @openlinker/api migration:show` runs without complaining.
 
 ### Step 13 — Migration
-- **File:** `apps/api/src/migrations/1783000000000-add-offer-creation-records-table.ts` (new)
+- **File:** `apps/api/src/migrations/1784000000000-add-offer-creation-records-table.ts` (new)
 - **Action:**
   - `up()`: check `getTable('offer_creation_records')`; if absent, CREATE TABLE with all columns, PK on `id` with `uuid_generate_v4()` default, plus three indexes.
   - `down()`: drop three indexes, then DROP TABLE.

--- a/docs/plans/implementation-plan-offer-creation-foundation.md
+++ b/docs/plans/implementation-plan-offer-creation-foundation.md
@@ -1,0 +1,352 @@
+# Implementation Plan — Offer Creation Foundation (#254 + #258)
+
+**Branch:** `254-258-offer-create-port-and-record-entity`
+**Scope:** Foundation layer for OpenLinker-initiated Allegro/Marketplace offer creation.
+
+---
+
+## 1. Understand the Task
+
+### Goal
+Lay the groundwork for the `MarketplacePort.createOffer()` capability and the `OfferCreationRecord` entity that tracks the OL-initiated lifecycle of a newly created offer.
+
+### Layer classification
+- **CORE — Domain layer**: new types (`CreateOfferCommand`, `CreateOfferResult`, `OfferCreationStatus`), new domain entity `OfferCreationRecord`, new repository port, new exception.
+- **CORE — Infrastructure layer**: new ORM entity, new repository implementation, new migration.
+- **CORE — Integrations domain layer**: extension of `MarketplacePort` with optional `createOffer?()`.
+
+### Explicit non-goals (deferred to later issues)
+- Allegro adapter `createOffer()` implementation — issue #255
+- `OfferBuilderService` — issue #256
+- Worker job handlers — issue #257
+- HTTP REST endpoint — issue #259
+- Seller policies endpoint — issue #260
+- Frontend wizard — issue #261
+- No `OfferCreationRecord` domain behaviour beyond holding state — no domain services here.
+
+---
+
+## 2. Research Findings (from codebase)
+
+### MarketplacePort (`libs/core/src/integrations/domain/ports/marketplace.port.ts`)
+- Optional methods use TypeScript optional property syntax: `method?(cmd: X): Promise<Y>`.
+- Mutation commands follow the `{Verb}{Noun}Command` / `{Verb}{Noun}Result` pattern (e.g. `UpdateOfferFieldsCommand`, `UpdateOfferQuantitiesBatchResult`).
+- Command/result types live in `libs/core/src/integrations/domain/types/marketplace-*.types.ts` alongside other marketplace types — **not** in the listings domain.
+- Types are imported as `import type {...}` when only used as types (no runtime import).
+
+### Capability values (`libs/core/src/integrations/domain/types/adapter.types.ts`)
+- `CapabilityValues` already includes `'Marketplace'`. No new capability needed — `createOffer` is a method *on* the `Marketplace` capability.
+
+### Listings module wiring (`libs/core/src/listings/listings.module.ts`, `listings.tokens.ts`)
+- Pattern: export `Symbol('X')` tokens from `listings.tokens.ts`, wire via `{ provide: TOKEN, useExisting: ConcreteClass }` in the module, and also expose a string fallback token for legacy lookups.
+- Module imports `TypeOrmModule.forFeature([...])` for the ORM entities it owns.
+- `OfferMappingRepositoryPort` binds with `OFFER_MAPPING_REPOSITORY_TOKEN = Symbol('OfferMappingRepositoryPort')`.
+
+### Migration convention (`apps/api/src/migrations/`)
+- Filename: `{unix-timestamp-ms}-{kebab-description}.ts`
+- Class: `{PascalDescription}{Timestamp} implements MigrationInterface` with `name` field matching class name.
+- `up()` checks `queryRunner.getTable(...)` before `CREATE TABLE` (defensive against re-runs).
+- `down()` drops indexes then table.
+- Latest migration timestamp in repo: `1782000000000`. **New timestamp for this plan: `1783000000000`.**
+
+### Reference entity/repo pair (`Connection` + `connection.orm-entity.ts` + `connection.repository.ts`)
+- Domain entity: plain class, readonly constructor params, no framework imports.
+- ORM entity: `@Entity('table_name')`, `@PrimaryGeneratedColumn('uuid')`, `@Column(...)`, `@CreateDateColumn()`, `@UpdateDateColumn()`, `@Index([...])` for composite indexes.
+- Domain exceptions live in `libs/core/src/{domain}/domain/exceptions/`.
+
+### Status type pattern (`sync-job.types.ts`, `order.types.ts`, `webhook-delivery.types.ts`)
+- `export const XValues = [...] as const;` + `export type X = (typeof XValues)[number];`
+- Always exports both the runtime array and the derived union type.
+
+---
+
+## 3. Design
+
+### Files to create
+
+**Integrations domain (marketplace types + port extension):**
+- `libs/core/src/integrations/domain/types/marketplace-offer-create.types.ts` — `CreateOfferCommand`, `CreateOfferResult`, `CreateOfferStatus` + values
+- `libs/core/src/integrations/domain/ports/marketplace.port.ts` — **modify**: add optional `createOffer?()`
+
+**Listings domain:**
+- `libs/core/src/listings/domain/entities/offer-creation-record.entity.ts` — domain entity
+- `libs/core/src/listings/domain/types/offer-creation-record.types.ts` — `OfferCreationStatusValues`, `OfferCreationStatus`, `OfferCreationError`
+- `libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts` — repository port
+- `libs/core/src/listings/domain/exceptions/offer-creation-record-not-found.exception.ts` — domain exception (`OfferCreationRecordNotFoundException`, matching the `ProductNotFoundException` / `connection-not-found.exception.ts` convention)
+
+**Listings infrastructure:**
+- `libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts` — ORM entity
+- `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts` — repository impl
+
+**Module wiring:**
+- `libs/core/src/listings/listings.tokens.ts` — **modify**: add `OFFER_CREATION_RECORD_REPOSITORY_TOKEN`
+- `libs/core/src/listings/listings.module.ts` — **modify**: register ORM entity + repo provider + export token
+- `libs/core/src/listings/index.ts` — **modify**: re-export new domain types, entity, port, token
+
+**Migration:**
+- `apps/api/src/migrations/1783000000000-add-offer-creation-records-table.ts`
+- Also add the new ORM entity to API's TypeORM data source config if it's not auto-discovered (will verify in step 1).
+
+**Tests:**
+- `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts` — unit tests with mocked TypeORM repository
+- `libs/core/src/listings/domain/entities/offer-creation-record.entity.spec.ts` — light tests for entity construction
+
+### Key type shapes
+
+**`CreateOfferCommand`** (in `marketplace-offer-create.types.ts`):
+```ts
+export interface CreateOfferCommand {
+  internalVariantId: string;
+  connectionId: string;
+  price: { amount: number; currency: string };
+  stock: number;
+  publishImmediately: boolean;
+  overrides?: CreateOfferOverrides;
+  idempotencyKey?: string;
+}
+
+export interface CreateOfferOverrides {
+  title?: string;
+  description?: string;
+  categoryId?: string;
+  imageUrls?: string[];
+  platformParams?: Record<string, unknown>;
+}
+
+export const CreateOfferResultStatusValues = ['draft', 'validating', 'active'] as const;
+export type CreateOfferResultStatus = (typeof CreateOfferResultStatusValues)[number];
+
+export interface CreateOfferResult {
+  externalOfferId: string;
+  status: CreateOfferResultStatus;
+}
+```
+
+**`OfferCreationStatus`** (in `offer-creation-record.types.ts`):
+```ts
+export const OfferCreationStatusValues = [
+  'pending',     // job enqueued, adapter not yet called
+  'draft',       // created on platform, not published
+  'validating',  // platform is async-validating
+  'active',      // published and live
+  'failed',      // creation or validation failed
+] as const;
+export type OfferCreationStatus = (typeof OfferCreationStatusValues)[number];
+
+export interface OfferCreationError {
+  field?: string;
+  code: string;
+  message: string;
+}
+```
+
+**`OfferCreationRecord` domain entity** — plain class, readonly props:
+```ts
+constructor(
+  public readonly id: string,                     // uuid
+  public readonly internalVariantId: string,
+  public readonly connectionId: string,
+  public readonly externalOfferId: string | null, // null until adapter returns it
+  public readonly status: OfferCreationStatus,
+  public readonly errors: OfferCreationError[] | null,
+  public readonly publishImmediately: boolean,
+  public readonly createdAt: Date,
+  public readonly updatedAt: Date,
+)
+```
+
+**`CreateOfferCreationRecordInput`** (dedicated input type, in `offer-creation-record.types.ts`):
+```ts
+export interface CreateOfferCreationRecordInput {
+  internalVariantId: string;
+  connectionId: string;
+  status: OfferCreationStatus;
+  publishImmediately: boolean;
+  externalOfferId?: string | null;
+  errors?: OfferCreationError[] | null;
+}
+```
+Explicit input type (not `Omit<OfferCreationRecord, ...>`) decouples the write contract from the entity shape and avoids the readonly-propagation awkwardness of omit-over-class.
+
+**`OfferCreationRecordRepositoryPort`** — minimal, only methods needed by future consumers (#257, #259):
+```ts
+create(input: CreateOfferCreationRecordInput): Promise<OfferCreationRecord>;
+findById(id: string): Promise<OfferCreationRecord | null>;
+/** Returns the most-recently-created record for (variantId, connectionId), ordered createdAt DESC. Null if none. */
+findLatestByVariantAndConnection(variantId: string, connectionId: string): Promise<OfferCreationRecord | null>;
+updateStatus(id: string, status: OfferCreationStatus, errors?: OfferCreationError[] | null): Promise<OfferCreationRecord>;
+updateExternalOfferId(id: string, externalOfferId: string): Promise<OfferCreationRecord>;
+```
+(Renamed `findByVariantAndConnection` → `findLatestByVariantAndConnection` so the ordering contract is visible at the call site, not only in JSDoc.)
+
+### Two distinct status unions — do not merge
+
+- **`CreateOfferResultStatus`** (`'draft' | 'validating' | 'active'`) — momentary status returned by the *adapter* right after the platform API call. Cannot be `pending` (adapter was already invoked) and cannot be `failed` (that would have thrown a domain exception). Lives in `marketplace-offer-create.types.ts`.
+- **`OfferCreationStatus`** (`'pending' | 'draft' | 'validating' | 'active' | 'failed'`) — persisted lifecycle state on `OfferCreationRecord`. Includes `pending` (job enqueued, adapter not yet called) and `failed` (post-validation failure). Lives in `offer-creation-record.types.ts`.
+
+These are not the same enum. Do not collapse them in the implementation.
+
+### Table shape (`offer_creation_records`)
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `id` | uuid | NO | PK, `uuid_generate_v4()` default |
+| `internalVariantId` | text | NO | OL variant id (`ol_variant_...`) |
+| `connectionId` | uuid | NO | FK-like reference to `connections.id` |
+| `externalOfferId` | text | YES | null until platform returns it |
+| `status` | text | NO | one of `OfferCreationStatusValues` |
+| `errors` | jsonb | YES | array of `OfferCreationError` when status=failed |
+| `publishImmediately` | boolean | NO | default false |
+| `createdAt` | timestamp | NO | `now()` default |
+| `updatedAt` | timestamp | NO | `now()` default |
+
+**Indexes:**
+- `IDX_offer_creation_records_variant_connection` on `(internalVariantId, connectionId)` — lookup in `findByVariantAndConnection`
+- `IDX_offer_creation_records_status` on `(status)` — future polling handler queries
+- `IDX_offer_creation_records_connection` on `(connectionId)` — admin queries
+
+No unique constraint on `(variantId, connectionId)` — a variant may have multiple creation attempts over time (e.g., after a failed one). `findByVariantAndConnection` returns the latest by `createdAt DESC`.
+
+---
+
+## 4. Step-by-Step Implementation
+
+### Step 1 (gating) — TypeORM data source config check
+- **File:** read `apps/api/src/database/data-source.ts` (per `docs/migrations.md`).
+- **Action:** verify the entity glob (e.g. `libs/core/src/**/*.orm-entity.{ts,js}`) will pick up the new `OfferCreationRecordOrmEntity` automatically. If explicit registration is required, capture that in Step 12.
+- **Acceptance:** gating — no other code is written until this is resolved. Prevents the "migration runs but app can't use the repo" failure mode.
+
+### Step 2 — Extend `MarketplacePort` with `createOffer?()`
+- **File:** `libs/core/src/integrations/domain/types/marketplace-offer-create.types.ts` (new)
+- **File:** `libs/core/src/integrations/domain/ports/marketplace.port.ts` (modify)
+- **Action:** define `CreateOfferCommand`, `CreateOfferOverrides`, `CreateOfferResult`, `CreateOfferResultStatusValues`, `CreateOfferResultStatus`. Add `createOffer?()` to the port with JSDoc explaining async semantics.
+- **Acceptance:** `pnpm type-check` passes; existing `AllegroMarketplaceAdapter` and `PrestashopOrderProcessorAdapter` still compile (they don't implement `MarketplacePort` adapters except the Allegro one, which has optional methods anyway).
+
+### Step 3 — Listings domain types
+- **File:** `libs/core/src/listings/domain/types/offer-creation-record.types.ts` (new)
+- **Action:** define `OfferCreationStatusValues`, `OfferCreationStatus`, `OfferCreationError`.
+- **Acceptance:** matches `as const` + union pattern from `sync-job.types.ts`.
+
+### Step 4 — Domain entity `OfferCreationRecord`
+- **File:** `libs/core/src/listings/domain/entities/offer-creation-record.entity.ts` (new)
+- **Action:** plain class with readonly constructor params. File header JSDoc. No framework imports.
+- **Acceptance:** no `@nestjs/*` or `typeorm` imports; `pnpm type-check` passes.
+
+### Step 5 — Domain exception
+- **File:** `libs/core/src/listings/domain/exceptions/offer-creation-record-not-found.exception.ts` (new)
+- **Action:** `OfferCreationRecordNotFoundException extends Error` with `name = 'OfferCreationRecordNotFoundException'` and `Error.captureStackTrace(this, this.constructor)`.
+- **Acceptance:** class/file naming matches the `ProductNotFoundException` pattern (Engineering Standards §Error Handling) and the existing `connection-not-found.exception.ts` file.
+
+### Step 6 — Repository port
+- **File:** `libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts` (new)
+- **Action:** define `OfferCreationRecordRepositoryPort` interface with the 5 methods in Section 3. Every method has JSDoc; `findLatestByVariantAndConnection` explicitly documents the `createdAt DESC` ordering contract.
+- **Acceptance:** port returns domain entity (`OfferCreationRecord`), never ORM entity. Uses `CreateOfferCreationRecordInput`, not `Omit<OfferCreationRecord, ...>`.
+
+### Step 7 — ORM entity
+- **File:** `libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts` (new)
+- **Action:** `@Entity('offer_creation_records')` with all columns from Section 3 and `@Index` for the three composite/single indexes.
+- **Acceptance:** compiles, field types match the table spec exactly.
+
+### Step 8 — Repository implementation
+- **File:** `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts` (new)
+- **Action:** `OfferCreationRecordRepository implements OfferCreationRecordRepositoryPort`. Uses `@InjectRepository(OfferCreationRecordOrmEntity)`. Private `toDomain()` method and a private helper to build ORM entity from `CreateOfferCreationRecordInput`. `updateStatus` and `updateExternalOfferId` throw `OfferCreationRecordNotFoundException` if row missing.
+- **Acceptance:** mapping stays inside the repository (per standards), never leaks ORM entity.
+
+### Step 9 — Token registration
+- **File:** `libs/core/src/listings/listings.tokens.ts` (modify)
+- **Action:** add `export const OFFER_CREATION_RECORD_REPOSITORY_TOKEN = Symbol('OfferCreationRecordRepositoryPort');`.
+
+### Step 10 — Module wiring
+- **File:** `libs/core/src/listings/listings.module.ts` (modify)
+- **Action:**
+  - Import `OfferCreationRecordOrmEntity` and add to `TypeOrmModule.forFeature([...])`.
+  - Import `OfferCreationRecordRepository`.
+  - Register token binding: `{ provide: OFFER_CREATION_RECORD_REPOSITORY_TOKEN, useExisting: OfferCreationRecordRepository }`.
+  - Add string fallback: `{ provide: 'OfferCreationRecordRepositoryPort', useExisting: OFFER_CREATION_RECORD_REPOSITORY_TOKEN }`.
+  - Add to `exports` array.
+  - Re-export token at top of file (match existing pattern).
+
+### Step 11 — Barrel exports
+- **File:** `libs/core/src/listings/index.ts` (modify)
+- **Action:** export `OfferCreationRecord`, `OfferCreationStatusValues`, `OfferCreationStatus`, `OfferCreationError`, `OfferCreationRecordRepositoryPort`, `OfferCreationRecordNotFoundError`, `OFFER_CREATION_RECORD_REPOSITORY_TOKEN`.
+
+### Step 12 — API TypeORM registration
+- **File:** locate where ORM entities are listed (data source or `app.module.ts`). Add `OfferCreationRecordOrmEntity` if not autoloaded.
+- **Acceptance:** `pnpm --filter @openlinker/api migration:show` runs without complaining.
+
+### Step 13 — Migration
+- **File:** `apps/api/src/migrations/1783000000000-add-offer-creation-records-table.ts` (new)
+- **Action:**
+  - `up()`: check `getTable('offer_creation_records')`; if absent, CREATE TABLE with all columns, PK on `id` with `uuid_generate_v4()` default, plus three indexes.
+  - `down()`: drop three indexes, then DROP TABLE.
+- **Acceptance:**
+  - `pnpm --filter @openlinker/api migration:show` lists it as pending
+  - `pnpm --filter @openlinker/api migration:run` applies cleanly
+  - `pnpm --filter @openlinker/api migration:revert` rolls back cleanly
+  - Re-run does not double-create (defensive check works)
+
+### Step 14 — Unit tests
+
+- **File:** `libs/core/src/listings/domain/entities/offer-creation-record.entity.spec.ts` (new)
+  - Verifies entity construction preserves all fields; tests are minimal (it's a data class).
+
+- **File:** `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts` (new)
+  - Mocks `Repository<OfferCreationRecordOrmEntity>`.
+  - Covers: `create` returns domain entity; `findById` returns null when absent; `findLatestByVariantAndConnection` orders by `createdAt DESC`; `updateStatus` throws `OfferCreationRecordNotFoundException` when row missing; `updateExternalOfferId` throws when missing; round-trip `toDomain` preserves fields.
+
+### Step 15 — Quality gate
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+pnpm --filter @openlinker/api migration:show
+pnpm --filter @openlinker/api migration:run
+pnpm --filter @openlinker/api migration:revert
+```
+All must pass.
+
+---
+
+## 5. Validation
+
+### Architecture compliance
+- ✅ Domain layer (`entities`, `types`, `ports`, `exceptions`) has no NestJS / TypeORM imports
+- ✅ Repository port defined in `domain/ports/`, implementation in `infrastructure/persistence/repositories/`
+- ✅ Symbol token wired per standards, string fallback for consistency with existing module
+- ✅ Port returns domain entity; ORM mapping is private inside repository
+- ✅ Repository throws domain exception (`OfferCreationRecordNotFoundException`), never TypeORM error
+- ✅ `MarketplacePort.createOffer?()` is optional (adapters can opt out), matching existing pattern
+- ✅ `createOffer` lives on existing `Marketplace` capability — no new capability enum value
+- ✅ Every new source file includes the standard `@module` header JSDoc per Engineering Standards §File Headers
+
+### Naming compliance
+- ✅ `*.entity.ts` for domain entity, `*.orm-entity.ts` for ORM, `*.port.ts` for port, `*.repository.ts` for impl
+- ✅ `*.types.ts` for types (separate file per engineering standards)
+- ✅ Token: `Symbol('OfferCreationRecordRepositoryPort')` — matches existing convention
+- ✅ Migration filename/class: `1783000000000-add-offer-creation-records-table.ts` → `AddOfferCreationRecordsTable1783000000000`
+
+### Testing strategy
+- Unit tests for the repository (mocked TypeORM repo) — matches `infrastructure/persistence/repositories/*.repository.spec.ts` pattern if it exists, else follow Jest conventions.
+- Integration tests deferred — they can be added in #257/#259 when there's a meaningful end-to-end flow to test. Single-table CRUD is thoroughly covered by the unit tests and migration run/revert.
+
+### Security
+- No user input surface added in this PR (no HTTP endpoint yet) — no class-validator DTOs needed at this layer.
+- No secrets in code / migrations.
+- `errors` JSONB is written only from trusted server code; not a user-input path.
+- No raw SQL interpolation of user values (migrations are DDL only, repository uses query builder).
+
+### Risks / open questions
+- **None are blocking.** Potential minor ambiguities:
+  - Should `OfferCreationRecord` track `publishImmediately` or is that only a command-time concern? → **Decision:** keep it on the record so retries/polling jobs can re-apply the intent without re-fetching the command; low cost (1 column).
+  - Should we denormalize `platformType` like `identifier_mappings` does? → **No.** The `connectionId` column lets you join to `connections` if needed; platform type isn't a hot filter on this table.
+  - Unique constraint on `(variantId, connectionId)`? → **No.** Multiple attempts are expected. Caller uses `findByVariantAndConnection` returning latest.
+
+---
+
+## Branch & commit plan
+
+- Single branch: `254-258-offer-create-port-and-record-entity`
+- Two logical commits for cleaner `git log` navigation:
+  1. `feat(integrations): add createOffer to MarketplacePort` (#254)
+  2. `feat(listings): add OfferCreationRecord entity and repository` (#258)
+- PR body: `Closes #254\nCloses #258`

--- a/libs/core/src/integrations/domain/ports/marketplace.port.ts
+++ b/libs/core/src/integrations/domain/ports/marketplace.port.ts
@@ -24,6 +24,7 @@ import {
 } from '../types/marketplace-quantity-update.types';
 import type { UpdateOfferFieldsCommand } from '../types/marketplace-offer-update.types';
 import type { MarketplaceCategory } from '../types/marketplace-category.types';
+import type { CreateOfferCommand, CreateOfferResult } from '../types/marketplace-offer-create.types';
 
 export interface MarketplacePort {
   /**
@@ -79,5 +80,18 @@ export interface MarketplacePort {
    * given barcode, or null if no match / ambiguous.
    */
   matchCategoryByBarcode?(barcode: string): Promise<string | null>;
+
+  /**
+   * Create a new offer on the marketplace — optional capability (outbound, OL → marketplace).
+   *
+   * Adapters that implement this translate the neutral `CreateOfferCommand` into
+   * their platform-specific create-offer API call (e.g. Allegro POST /sale/product-offers).
+   * Platform-specific fields (policy IDs, shipping classes, etc.) are carried in
+   * `cmd.overrides.platformParams`.
+   *
+   * Returns momentary status (`draft` / `validating` / `active`). For marketplaces that
+   * validate asynchronously (Allegro), callers must poll to observe the final outcome.
+   */
+  createOffer?(cmd: CreateOfferCommand): Promise<CreateOfferResult>;
 }
 

--- a/libs/core/src/integrations/domain/types/marketplace-offer-create.types.ts
+++ b/libs/core/src/integrations/domain/types/marketplace-offer-create.types.ts
@@ -1,0 +1,85 @@
+/**
+ * Marketplace Offer Create Types
+ *
+ * Command and result types for creating a new offer on a marketplace (outbound,
+ * OpenLinker → marketplace). Command is marketplace-neutral; adapter-specific
+ * fields (Allegro delivery policy IDs, eBay shipping options, WooCommerce tax
+ * classes, etc.) are carried through `overrides.platformParams` as an opaque
+ * record the adapter interprets.
+ *
+ * @module libs/core/src/integrations/domain/types
+ */
+
+/**
+ * Overrides for fields that can optionally be customized per-offer.
+ * Any field omitted here falls back to a value derived by the core builder
+ * service from the OL variant (e.g. variant.name, variant.description).
+ */
+export interface CreateOfferOverrides {
+  /** Offer title. Falls back to variant name. */
+  title?: string;
+  /** Offer description (HTML or rich text depending on platform). Falls back to variant description. */
+  description?: string;
+  /** Platform-specific category id (e.g. Allegro category id). */
+  categoryId?: string;
+  /** Image URLs in display order. Falls back to variant images. */
+  imageUrls?: string[];
+  /**
+   * Platform-specific parameters the adapter interprets directly.
+   *
+   * Examples by platform:
+   * - Allegro: `{ deliveryPolicyId, returnPolicyId, warrantyId, impliedWarrantyId }`
+   * - eBay: shipping service options, listing duration
+   * - WooCommerce: tax class, shipping class, product type
+   *
+   * The core command stays platform-neutral; adapters read only the keys they know.
+   */
+  platformParams?: Record<string, unknown>;
+}
+
+/**
+ * Command to create a new marketplace offer.
+ *
+ * Marketplace-neutral contract. Allegro, eBay, WooCommerce, Shopify adapters
+ * translate this into their platform-specific create-offer API call internally.
+ */
+export interface CreateOfferCommand {
+  /** OL internal variant id being listed. */
+  internalVariantId: string;
+  /** Target marketplace connection id. */
+  connectionId: string;
+  /** Offer price. Currency should match marketplace/connection locale. */
+  price: { amount: number; currency: string };
+  /** Offered quantity. */
+  stock: number;
+  /** If true, publish the offer immediately after creation; otherwise leave as draft. */
+  publishImmediately: boolean;
+  /** Optional overrides and platform-specific fields. */
+  overrides?: CreateOfferOverrides;
+  /** Optional idempotency key for deduplication at the adapter / job layer. */
+  idempotencyKey?: string;
+}
+
+/**
+ * Momentary status returned by the adapter right after the platform API call.
+ *
+ * - `draft`: Offer created on platform, not yet published.
+ * - `validating`: Platform is asynchronously validating the offer (Allegro pattern).
+ *   Caller must poll / listen for final outcome before treating the offer as live.
+ * - `active`: Offer is live and visible to buyers.
+ *
+ * Not to be confused with the persisted `OfferCreationStatus` lifecycle — see
+ * `offer-creation-record.types.ts`.
+ */
+export const CreateOfferResultStatusValues = ['draft', 'validating', 'active'] as const;
+export type CreateOfferResultStatus = (typeof CreateOfferResultStatusValues)[number];
+
+/**
+ * Result returned by `MarketplacePort.createOffer`.
+ */
+export interface CreateOfferResult {
+  /** Marketplace-native id of the newly created offer. */
+  externalOfferId: string;
+  /** Adapter-reported status immediately after the create call. */
+  status: CreateOfferResultStatus;
+}

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -54,6 +54,13 @@ export {
 } from './domain/types/marketplace-quantity-update.types';
 export type { UpdateOfferFieldsCommand } from './domain/types/marketplace-offer-update.types';
 export type { MarketplaceCategory } from './domain/types/marketplace-category.types';
+export { CreateOfferResultStatusValues } from './domain/types/marketplace-offer-create.types';
+export type {
+  CreateOfferCommand,
+  CreateOfferOverrides,
+  CreateOfferResult,
+  CreateOfferResultStatus,
+} from './domain/types/marketplace-offer-create.types';
 
 // Exceptions
 export { AdapterNotFoundException } from './domain/exceptions/adapter-not-found.exception';

--- a/libs/core/src/listings/domain/entities/offer-creation-record.entity.spec.ts
+++ b/libs/core/src/listings/domain/entities/offer-creation-record.entity.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Offer Creation Record Domain Entity — Unit Tests
+ *
+ * @module libs/core/src/listings/domain/entities
+ */
+import { OfferCreationRecord } from './offer-creation-record.entity';
+import type {
+  OfferCreationError,
+  OfferCreationStatus,
+} from '../types/offer-creation-record.types';
+
+describe('OfferCreationRecord', () => {
+  it('should preserve all constructor fields', () => {
+    const now = new Date('2026-04-20T10:00:00Z');
+    const errors: OfferCreationError[] = [
+      { field: 'parameters.EAN', code: 'MISSING', message: 'EAN is required' },
+    ];
+
+    const record = new OfferCreationRecord(
+      'rec-uuid',
+      'ol_variant_123',
+      'conn-uuid',
+      null,
+      'pending' as OfferCreationStatus,
+      errors,
+      true,
+      now,
+      now,
+    );
+
+    expect(record.id).toBe('rec-uuid');
+    expect(record.internalVariantId).toBe('ol_variant_123');
+    expect(record.connectionId).toBe('conn-uuid');
+    expect(record.externalOfferId).toBeNull();
+    expect(record.status).toBe('pending');
+    expect(record.errors).toBe(errors);
+    expect(record.publishImmediately).toBe(true);
+    expect(record.createdAt).toBe(now);
+    expect(record.updatedAt).toBe(now);
+  });
+
+  it('should accept externalOfferId when present', () => {
+    const now = new Date();
+    const record = new OfferCreationRecord(
+      'rec-uuid',
+      'ol_variant_123',
+      'conn-uuid',
+      'allegro-offer-9999',
+      'active' as OfferCreationStatus,
+      null,
+      false,
+      now,
+      now,
+    );
+
+    expect(record.externalOfferId).toBe('allegro-offer-9999');
+    expect(record.errors).toBeNull();
+  });
+});

--- a/libs/core/src/listings/domain/entities/offer-creation-record.entity.ts
+++ b/libs/core/src/listings/domain/entities/offer-creation-record.entity.ts
@@ -1,0 +1,31 @@
+/**
+ * Offer Creation Record Domain Entity
+ *
+ * Tracks the lifecycle of an OL-initiated offer creation on a marketplace
+ * (OL → Allegro / WooCommerce / eBay / etc.). Complements the existing
+ * IdentifierMapping row (`entityType: 'Offer'`) which tracks the linkage once
+ * the offer exists — this record tracks the *creation attempt* itself, including
+ * pending state before the adapter is called, structured validation errors when
+ * the platform rejects it, and the externalOfferId handoff.
+ *
+ * @module libs/core/src/listings/domain/entities
+ */
+
+import {
+  OfferCreationError,
+  OfferCreationStatus,
+} from '../types/offer-creation-record.types';
+
+export class OfferCreationRecord {
+  constructor(
+    public readonly id: string,
+    public readonly internalVariantId: string,
+    public readonly connectionId: string,
+    public readonly externalOfferId: string | null,
+    public readonly status: OfferCreationStatus,
+    public readonly errors: OfferCreationError[] | null,
+    public readonly publishImmediately: boolean,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+  ) {}
+}

--- a/libs/core/src/listings/domain/exceptions/offer-creation-record-not-found.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/offer-creation-record-not-found.exception.ts
@@ -1,0 +1,16 @@
+/**
+ * Offer Creation Record Not Found Exception
+ *
+ * Domain exception thrown when an OfferCreationRecord with the specified ID
+ * does not exist. Raised by the repository on update paths that require the
+ * record to already exist (e.g. updating status or assigning externalOfferId).
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+export class OfferCreationRecordNotFoundException extends Error {
+  constructor(id: string) {
+    super(`Offer creation record not found: ${id}`);
+    this.name = 'OfferCreationRecordNotFoundException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
@@ -1,0 +1,61 @@
+/**
+ * Offer Creation Record Repository Port
+ *
+ * Persistence contract for OfferCreationRecord. Implemented in the listings
+ * infrastructure layer. Returns domain entities only — ORM mapping stays inside
+ * the repository.
+ *
+ * @module libs/core/src/listings/domain/ports
+ */
+
+import { OfferCreationRecord } from '../entities/offer-creation-record.entity';
+import {
+  CreateOfferCreationRecordInput,
+  OfferCreationError,
+  OfferCreationStatus,
+} from '../types/offer-creation-record.types';
+
+export interface OfferCreationRecordRepositoryPort {
+  /**
+   * Persist a new offer creation record.
+   *
+   * `id`, `createdAt`, and `updatedAt` are assigned by the repository.
+   */
+  create(input: CreateOfferCreationRecordInput): Promise<OfferCreationRecord>;
+
+  /**
+   * Look up a record by primary key. Returns null when not found.
+   */
+  findById(id: string): Promise<OfferCreationRecord | null>;
+
+  /**
+   * Return the most-recently-created record for a given (internalVariantId, connectionId)
+   * pair, ordered by `createdAt DESC`. Returns null when no record exists.
+   *
+   * Multiple records for the same pair are expected (retry attempts after failures);
+   * callers that want the current state should always use this rather than a generic
+   * "find by variant + connection".
+   */
+  findLatestByVariantAndConnection(
+    variantId: string,
+    connectionId: string,
+  ): Promise<OfferCreationRecord | null>;
+
+  /**
+   * Update status (and optionally errors) for an existing record.
+   *
+   * Throws `OfferCreationRecordNotFoundException` if the record does not exist.
+   */
+  updateStatus(
+    id: string,
+    status: OfferCreationStatus,
+    errors?: OfferCreationError[] | null,
+  ): Promise<OfferCreationRecord>;
+
+  /**
+   * Assign the marketplace-native offer id to an existing record.
+   *
+   * Throws `OfferCreationRecordNotFoundException` if the record does not exist.
+   */
+  updateExternalOfferId(id: string, externalOfferId: string): Promise<OfferCreationRecord>;
+}

--- a/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
@@ -44,6 +44,11 @@ export interface OfferCreationRecordRepositoryPort {
   /**
    * Update status (and optionally errors) for an existing record.
    *
+   * `errors` semantics:
+   * - Omit the argument to preserve any previously-recorded errors.
+   * - Pass `null` to explicitly clear previously-recorded errors.
+   * - Pass an array to replace previously-recorded errors.
+   *
    * Throws `OfferCreationRecordNotFoundException` if the record does not exist.
    */
   updateStatus(

--- a/libs/core/src/listings/domain/types/offer-creation-record.types.ts
+++ b/libs/core/src/listings/domain/types/offer-creation-record.types.ts
@@ -1,0 +1,68 @@
+/**
+ * Offer Creation Record Types
+ *
+ * Types for OfferCreationRecord — OL's persisted lifecycle tracker for offers
+ * created outbound on a marketplace (OL → Allegro / WooCommerce / eBay / etc.).
+ *
+ * Not to be confused with `CreateOfferResultStatus` from
+ * `integrations/domain/types/marketplace-offer-create.types.ts`, which is the
+ * momentary status returned by the adapter right after the platform API call.
+ * `OfferCreationStatus` is the broader persisted lifecycle, including `pending`
+ * (before the adapter was called) and `failed` (post-validation failure).
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+/**
+ * Persisted lifecycle status for OL-initiated offer creation.
+ *
+ * - `pending`: Job enqueued, adapter not yet called.
+ * - `draft`: Adapter created the offer on the platform; not yet published.
+ * - `validating`: Platform is asynchronously validating (Allegro pattern).
+ * - `active`: Offer is published and live.
+ * - `failed`: Creation or async validation failed. See `errors` on the record.
+ */
+export const OfferCreationStatusValues = [
+  'pending',
+  'draft',
+  'validating',
+  'active',
+  'failed',
+] as const;
+
+export type OfferCreationStatus = (typeof OfferCreationStatusValues)[number];
+
+/**
+ * Structured error from the platform (or validation path).
+ * Persisted in `OfferCreationRecord.errors` when status is `failed`.
+ */
+export interface OfferCreationError {
+  /** Dotted field path reported by the platform, when available (e.g. `parameters.EAN`). */
+  field?: string;
+  /** Machine-readable error code (platform-specific or OL-defined). */
+  code: string;
+  /** Human-readable message suitable for showing an operator. */
+  message: string;
+}
+
+/**
+ * Input contract for `OfferCreationRecordRepositoryPort.create`.
+ *
+ * Dedicated input type (not `Omit<OfferCreationRecord, ...>`) so the write
+ * contract is decoupled from the entity's readonly shape and future entity
+ * changes (added fields, derived behavior) don't silently affect callers.
+ */
+export interface CreateOfferCreationRecordInput {
+  /** OL internal variant id being listed. */
+  internalVariantId: string;
+  /** Target marketplace connection id. */
+  connectionId: string;
+  /** Initial lifecycle status — typically `'pending'` or `'draft'`. */
+  status: OfferCreationStatus;
+  /** Intent flag: if true, the creator wants the offer published immediately once valid. */
+  publishImmediately: boolean;
+  /** Marketplace-native offer id, if already known at creation time. Null otherwise. */
+  externalOfferId?: string | null;
+  /** Structured errors when the initial status is already `'failed'`. Null otherwise. */
+  errors?: OfferCreationError[] | null;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -9,6 +9,7 @@ export {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
+  OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
 } from './listings.tokens';
 export { OfferLinkingService } from './application/services/offer-linking.service';
@@ -39,3 +40,12 @@ export type {
   OfferDescriptionUpdate,
   OfferFieldUpdate,
 } from './domain/types/offer-update.types';
+export { OfferCreationRecord } from './domain/entities/offer-creation-record.entity';
+export { OfferCreationStatusValues } from './domain/types/offer-creation-record.types';
+export type {
+  OfferCreationStatus,
+  OfferCreationError,
+  CreateOfferCreationRecordInput,
+} from './domain/types/offer-creation-record.types';
+export type { OfferCreationRecordRepositoryPort } from './domain/ports/offer-creation-record-repository.port';
+export { OfferCreationRecordNotFoundException } from './domain/exceptions/offer-creation-record-not-found.exception';

--- a/libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts
@@ -1,0 +1,55 @@
+/**
+ * Offer Creation Record ORM Entity
+ *
+ * TypeORM entity representing the `offer_creation_records` table in PostgreSQL.
+ * Tracks the lifecycle of OL-initiated offer creation attempts on marketplaces.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/entities
+ * @see {@link OfferCreationRecord} for the corresponding domain entity
+ */
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+import type {
+  OfferCreationError,
+  OfferCreationStatus,
+} from '../../../domain/types/offer-creation-record.types';
+
+@Entity('offer_creation_records')
+@Index(['internalVariantId', 'connectionId'])
+@Index(['connectionId'])
+@Index(['status'])
+export class OfferCreationRecordOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'text' })
+  internalVariantId!: string;
+
+  @Column({ type: 'uuid' })
+  connectionId!: string;
+
+  @Column({ type: 'text', nullable: true })
+  externalOfferId!: string | null;
+
+  @Column({ type: 'text' })
+  status!: OfferCreationStatus;
+
+  @Column({ type: 'jsonb', nullable: true })
+  errors!: OfferCreationError[] | null;
+
+  @Column({ type: 'boolean', default: false })
+  publishImmediately!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * Offer Creation Record Repository — Unit Tests
+ *
+ * Verifies CRUD operations, domain mapping, and not-found exception handling.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/repositories
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { OfferCreationRecordRepository } from './offer-creation-record.repository';
+import { OfferCreationRecordOrmEntity } from '../entities/offer-creation-record.orm-entity';
+import { OfferCreationRecord } from '../../../domain/entities/offer-creation-record.entity';
+import { OfferCreationRecordNotFoundException } from '../../../domain/exceptions/offer-creation-record-not-found.exception';
+import type {
+  CreateOfferCreationRecordInput,
+  OfferCreationError,
+} from '../../../domain/types/offer-creation-record.types';
+
+describe('OfferCreationRecordRepository', () => {
+  let repository: OfferCreationRecordRepository;
+  let ormRepository: jest.Mocked<Repository<OfferCreationRecordOrmEntity>>;
+
+  const now = new Date('2026-04-20T10:00:00Z');
+
+  const buildOrm = (
+    overrides: Partial<OfferCreationRecordOrmEntity> = {},
+  ): OfferCreationRecordOrmEntity => ({
+    id: 'rec-uuid',
+    internalVariantId: 'ol_variant_123',
+    connectionId: 'conn-uuid',
+    externalOfferId: null,
+    status: 'pending',
+    errors: null,
+    publishImmediately: false,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    const mockOrmRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+    } as unknown as jest.Mocked<Repository<OfferCreationRecordOrmEntity>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OfferCreationRecordRepository,
+        {
+          provide: getRepositoryToken(OfferCreationRecordOrmEntity),
+          useValue: mockOrmRepo,
+        },
+      ],
+    }).compile();
+
+    repository = module.get<OfferCreationRecordRepository>(OfferCreationRecordRepository);
+    ormRepository = module.get(getRepositoryToken(OfferCreationRecordOrmEntity));
+  });
+
+  describe('create', () => {
+    it('should persist a new record and return a domain entity', async () => {
+      const input: CreateOfferCreationRecordInput = {
+        internalVariantId: 'ol_variant_123',
+        connectionId: 'conn-uuid',
+        status: 'pending',
+        publishImmediately: true,
+      };
+      const saved = buildOrm({ publishImmediately: true });
+      ormRepository.save.mockResolvedValue(saved);
+
+      const result = await repository.create(input);
+
+      expect(ormRepository.save).toHaveBeenCalledTimes(1);
+      const savedArg = ormRepository.save.mock.calls[0][0] as OfferCreationRecordOrmEntity;
+      expect(savedArg.internalVariantId).toBe('ol_variant_123');
+      expect(savedArg.connectionId).toBe('conn-uuid');
+      expect(savedArg.status).toBe('pending');
+      expect(savedArg.publishImmediately).toBe(true);
+      expect(savedArg.externalOfferId).toBeNull();
+      expect(savedArg.errors).toBeNull();
+
+      expect(result).toBeInstanceOf(OfferCreationRecord);
+      expect(result.id).toBe('rec-uuid');
+      expect(result.publishImmediately).toBe(true);
+    });
+
+    it('should accept optional externalOfferId and errors on create', async () => {
+      const errors: OfferCreationError[] = [
+        { field: 'parameters.EAN', code: 'MISSING', message: 'EAN is required' },
+      ];
+      const input: CreateOfferCreationRecordInput = {
+        internalVariantId: 'ol_variant_123',
+        connectionId: 'conn-uuid',
+        status: 'failed',
+        publishImmediately: false,
+        externalOfferId: 'allegro-1',
+        errors,
+      };
+      ormRepository.save.mockResolvedValue(
+        buildOrm({ externalOfferId: 'allegro-1', status: 'failed', errors }),
+      );
+
+      const result = await repository.create(input);
+
+      const savedArg = ormRepository.save.mock.calls[0][0] as OfferCreationRecordOrmEntity;
+      expect(savedArg.externalOfferId).toBe('allegro-1');
+      expect(savedArg.errors).toEqual(errors);
+      expect(result.status).toBe('failed');
+      expect(result.externalOfferId).toBe('allegro-1');
+    });
+  });
+
+  describe('findById', () => {
+    it('should return domain entity when found', async () => {
+      ormRepository.findOne.mockResolvedValue(buildOrm());
+
+      const result = await repository.findById('rec-uuid');
+
+      expect(ormRepository.findOne).toHaveBeenCalledWith({ where: { id: 'rec-uuid' } });
+      expect(result).toBeInstanceOf(OfferCreationRecord);
+      expect(result?.id).toBe('rec-uuid');
+    });
+
+    it('should return null when not found', async () => {
+      ormRepository.findOne.mockResolvedValue(null);
+
+      const result = await repository.findById('missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findLatestByVariantAndConnection', () => {
+    it('should order by createdAt DESC and scope to the pair', async () => {
+      ormRepository.findOne.mockResolvedValue(buildOrm());
+
+      const result = await repository.findLatestByVariantAndConnection('ol_variant_123', 'conn-uuid');
+
+      expect(ormRepository.findOne).toHaveBeenCalledWith({
+        where: { internalVariantId: 'ol_variant_123', connectionId: 'conn-uuid' },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toBeInstanceOf(OfferCreationRecord);
+    });
+
+    it('should return null when no record exists for the pair', async () => {
+      ormRepository.findOne.mockResolvedValue(null);
+
+      const result = await repository.findLatestByVariantAndConnection('v', 'c');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update status and errors and return the updated domain entity', async () => {
+      const existing = buildOrm();
+      ormRepository.findOne.mockResolvedValue(existing);
+      const errors: OfferCreationError[] = [
+        { code: 'VALIDATION_TIMEOUT', message: 'Platform did not respond within window' },
+      ];
+      const saved = buildOrm({ status: 'failed', errors });
+      ormRepository.save.mockResolvedValue(saved);
+
+      const result = await repository.updateStatus('rec-uuid', 'failed', errors);
+
+      expect(ormRepository.findOne).toHaveBeenCalledWith({ where: { id: 'rec-uuid' } });
+      const savedArg = ormRepository.save.mock.calls[0][0] as OfferCreationRecordOrmEntity;
+      expect(savedArg.status).toBe('failed');
+      expect(savedArg.errors).toEqual(errors);
+      expect(result.status).toBe('failed');
+      expect(result.errors).toEqual(errors);
+    });
+
+    it('should preserve existing errors when errors argument is omitted', async () => {
+      const existing = buildOrm({ errors: [{ code: 'OLD', message: 'old error' }] });
+      ormRepository.findOne.mockResolvedValue(existing);
+      ormRepository.save.mockResolvedValue({ ...existing, status: 'active' });
+
+      await repository.updateStatus('rec-uuid', 'active');
+
+      const savedArg = ormRepository.save.mock.calls[0][0] as OfferCreationRecordOrmEntity;
+      expect(savedArg.status).toBe('active');
+      expect(savedArg.errors).toEqual([{ code: 'OLD', message: 'old error' }]);
+    });
+
+    it('should throw OfferCreationRecordNotFoundException when record is missing', async () => {
+      ormRepository.findOne.mockResolvedValue(null);
+
+      await expect(repository.updateStatus('missing', 'active')).rejects.toBeInstanceOf(
+        OfferCreationRecordNotFoundException,
+      );
+      expect(ormRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateExternalOfferId', () => {
+    it('should assign externalOfferId and return the updated entity', async () => {
+      const existing = buildOrm();
+      ormRepository.findOne.mockResolvedValue(existing);
+      const saved = buildOrm({ externalOfferId: 'allegro-offer-9999' });
+      ormRepository.save.mockResolvedValue(saved);
+
+      const result = await repository.updateExternalOfferId('rec-uuid', 'allegro-offer-9999');
+
+      const savedArg = ormRepository.save.mock.calls[0][0] as OfferCreationRecordOrmEntity;
+      expect(savedArg.externalOfferId).toBe('allegro-offer-9999');
+      expect(result.externalOfferId).toBe('allegro-offer-9999');
+    });
+
+    it('should throw OfferCreationRecordNotFoundException when record is missing', async () => {
+      ormRepository.findOne.mockResolvedValue(null);
+
+      await expect(repository.updateExternalOfferId('missing', 'x')).rejects.toBeInstanceOf(
+        OfferCreationRecordNotFoundException,
+      );
+      expect(ormRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toDomain mapping', () => {
+    it('should preserve all fields round-trip', async () => {
+      const errors: OfferCreationError[] = [{ code: 'X', message: 'y' }];
+      ormRepository.findOne.mockResolvedValue(
+        buildOrm({
+          externalOfferId: 'external-1',
+          status: 'validating',
+          errors,
+          publishImmediately: true,
+        }),
+      );
+
+      const result = await repository.findById('rec-uuid');
+
+      expect(result).toEqual(
+        new OfferCreationRecord(
+          'rec-uuid',
+          'ol_variant_123',
+          'conn-uuid',
+          'external-1',
+          'validating',
+          errors,
+          true,
+          now,
+          now,
+        ),
+      );
+    });
+  });
+});

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts
@@ -1,0 +1,106 @@
+/**
+ * Offer Creation Record Repository
+ *
+ * TypeORM implementation of `OfferCreationRecordRepositoryPort`. Handles all
+ * ORM ↔ domain mapping privately; callers receive domain entities only.
+ * Throws `OfferCreationRecordNotFoundException` on update paths when the row
+ * does not exist.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/repositories
+ * @implements {OfferCreationRecordRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { OfferCreationRecord } from '../../../domain/entities/offer-creation-record.entity';
+import { OfferCreationRecordNotFoundException } from '../../../domain/exceptions/offer-creation-record-not-found.exception';
+import { OfferCreationRecordRepositoryPort } from '../../../domain/ports/offer-creation-record-repository.port';
+import {
+  CreateOfferCreationRecordInput,
+  OfferCreationError,
+  OfferCreationStatus,
+} from '../../../domain/types/offer-creation-record.types';
+import { OfferCreationRecordOrmEntity } from '../entities/offer-creation-record.orm-entity';
+
+@Injectable()
+export class OfferCreationRecordRepository implements OfferCreationRecordRepositoryPort {
+  constructor(
+    @InjectRepository(OfferCreationRecordOrmEntity)
+    private readonly repository: Repository<OfferCreationRecordOrmEntity>,
+  ) {}
+
+  async create(input: CreateOfferCreationRecordInput): Promise<OfferCreationRecord> {
+    const entity = this.buildOrmEntity(input);
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  async findById(id: string): Promise<OfferCreationRecord | null> {
+    const entity = await this.repository.findOne({ where: { id } });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async findLatestByVariantAndConnection(
+    variantId: string,
+    connectionId: string,
+  ): Promise<OfferCreationRecord | null> {
+    const entity = await this.repository.findOne({
+      where: { internalVariantId: variantId, connectionId },
+      order: { createdAt: 'DESC' },
+    });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async updateStatus(
+    id: string,
+    status: OfferCreationStatus,
+    errors?: OfferCreationError[] | null,
+  ): Promise<OfferCreationRecord> {
+    const entity = await this.repository.findOne({ where: { id } });
+    if (!entity) {
+      throw new OfferCreationRecordNotFoundException(id);
+    }
+    entity.status = status;
+    if (errors !== undefined) {
+      entity.errors = errors;
+    }
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  async updateExternalOfferId(id: string, externalOfferId: string): Promise<OfferCreationRecord> {
+    const entity = await this.repository.findOne({ where: { id } });
+    if (!entity) {
+      throw new OfferCreationRecordNotFoundException(id);
+    }
+    entity.externalOfferId = externalOfferId;
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  private buildOrmEntity(input: CreateOfferCreationRecordInput): OfferCreationRecordOrmEntity {
+    const entity = new OfferCreationRecordOrmEntity();
+    entity.internalVariantId = input.internalVariantId;
+    entity.connectionId = input.connectionId;
+    entity.status = input.status;
+    entity.publishImmediately = input.publishImmediately;
+    entity.externalOfferId = input.externalOfferId ?? null;
+    entity.errors = input.errors ?? null;
+    return entity;
+  }
+
+  private toDomain(entity: OfferCreationRecordOrmEntity): OfferCreationRecord {
+    return new OfferCreationRecord(
+      entity.id,
+      entity.internalVariantId,
+      entity.connectionId,
+      entity.externalOfferId,
+      entity.status,
+      entity.errors,
+      entity.publishImmediately,
+      entity.createdAt,
+      entity.updatedAt,
+    );
+  }
+}

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -84,10 +84,10 @@ export {
       provide: 'OfferMappingRepositoryPort',
       useExisting: OFFER_MAPPING_REPOSITORY_TOKEN,
     },
-    {
-      provide: 'OfferCreationRecordRepositoryPort',
-      useExisting: OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
-    },
+    // Note: no string-token fallback for OfferCreationRecordRepositoryPort.
+    // Engineering Standards §Repository Ports Pattern deprecates string tokens
+    // as fragile; new ports opt into Symbol-only DI. Existing string fallbacks
+    // (above) are kept for compatibility and tracked for removal in #264.
   ],
   exports: [
     OFFER_LINKING_SERVICE_TOKEN,
@@ -99,7 +99,6 @@ export {
     'OfferLinkingService',
     'IOfferMappingSyncService',
     'OfferMappingRepositoryPort',
-    'OfferCreationRecordRepositoryPort',
   ],
 })
 export class ListingsModule {}

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -15,10 +15,13 @@ import { OfferLinkingService } from './application/services/offer-linking.servic
 import { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
 import { CategoryResolutionService } from './application/services/category-resolution.service';
 import { OfferMappingRepository } from './infrastructure/persistence/repositories/offer-mapping.repository';
+import { OfferCreationRecordOrmEntity } from './infrastructure/persistence/entities/offer-creation-record.orm-entity';
+import { OfferCreationRecordRepository } from './infrastructure/persistence/repositories/offer-creation-record.repository';
 import {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
+  OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
 } from './listings.tokens';
 
@@ -27,12 +30,13 @@ export {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
+  OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
 } from './listings.tokens';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([IdentifierMappingOrmEntity]),
+    TypeOrmModule.forFeature([IdentifierMappingOrmEntity, OfferCreationRecordOrmEntity]),
     IntegrationsModule,
     IdentifierMappingModule,
     ProductsModule,
@@ -43,6 +47,7 @@ export {
     OfferMappingSyncService,
     CategoryResolutionService,
     OfferMappingRepository,
+    OfferCreationRecordRepository,
     {
       provide: OFFER_LINKING_SERVICE_TOKEN,
       useExisting: OfferLinkingService,
@@ -54,6 +59,10 @@ export {
     {
       provide: OFFER_MAPPING_REPOSITORY_TOKEN,
       useExisting: OfferMappingRepository,
+    },
+    {
+      provide: OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
+      useExisting: OfferCreationRecordRepository,
     },
     {
       provide: 'OfferLinkingService',
@@ -75,16 +84,22 @@ export {
       provide: 'OfferMappingRepositoryPort',
       useExisting: OFFER_MAPPING_REPOSITORY_TOKEN,
     },
+    {
+      provide: 'OfferCreationRecordRepositoryPort',
+      useExisting: OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
+    },
   ],
   exports: [
     OFFER_LINKING_SERVICE_TOKEN,
     OFFER_MAPPING_SYNC_SERVICE_TOKEN,
     OFFER_MAPPING_REPOSITORY_TOKEN,
+    OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
     CATEGORY_RESOLUTION_SERVICE_TOKEN,
     'ICategoryResolutionService',
     'OfferLinkingService',
     'IOfferMappingSyncService',
     'OfferMappingRepositoryPort',
+    'OfferCreationRecordRepositoryPort',
   ],
 })
 export class ListingsModule {}

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -7,4 +7,5 @@
 export const OFFER_LINKING_SERVICE_TOKEN = Symbol('OfferLinkingService');
 export const OFFER_MAPPING_SYNC_SERVICE_TOKEN = Symbol('OfferMappingSyncService');
 export const OFFER_MAPPING_REPOSITORY_TOKEN = Symbol('OfferMappingRepositoryPort');
+export const OFFER_CREATION_RECORD_REPOSITORY_TOKEN = Symbol('OfferCreationRecordRepositoryPort');
 export const CATEGORY_RESOLUTION_SERVICE_TOKEN = Symbol('ICategoryResolutionService');


### PR DESCRIPTION
## Summary

Foundation for outbound offer creation (OL → marketplace). No user-facing behavior yet — this PR establishes the port contract and the persistence layer that downstream issues (#255 Allegro adapter, #256 builder service, #257 worker handler, #259 REST endpoint, #260 seller policies, #261 frontend wizard) build on.

- Extends `MarketplacePort` with optional `createOffer?(cmd)` method and platform-neutral `CreateOfferCommand` / `CreateOfferResult` types. Platform-specific fields (Allegro policy IDs, eBay shipping options, WooCommerce tax classes) flow through `overrides.platformParams` so the core stays marketplace-agnostic.
- New `OfferCreationRecord` domain entity + repository tracking OL-initiated creation lifecycle (`pending` / `draft` / `validating` / `active` / `failed`) plus structured platform validation errors. Kept in its own table rather than extending `identifier_mappings` so the generic mapping table stays free of entity-specific status.
- New port registered via Symbol token only — opts out of the deprecated string-token fallback pattern. Existing string fallbacks are tracked for removal in #264.

## Design decisions

- **`createOffer` (not `createListing`)** — codebase listings domain is 100% offer-centric (`OfferMapping`, `updateOfferFields`, `entityType: 'Offer'`); new method follows the existing verb-noun pattern. Adapters translate to platform vocabulary internally.
- **Separate `OfferCreationRecord` entity** — `OfferMapping` is not a dedicated entity but `IdentifierMapping` scoped to `'Offer'`. Adding creation-lifecycle status to the generic mapping table would pollute it.
- **Two distinct status unions** — `CreateOfferResultStatus` (adapter momentary: `draft`/`validating`/`active`) vs `OfferCreationStatus` (persisted lifecycle: adds `pending` and `failed`). Kept separate by design.

## Test plan

- [x] `pnpm type-check` passes (0 errors)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes — 14 new unit tests added for entity construction and every repository method including not-found exception paths
- [x] Migration verified against ephemeral Postgres: `migration:run` from cold start through the full sequence (including the sibling `AddOrderRecordStatus1783000000000` from #262) and `migration:revert` of `1784000000000`, both clean
- [x] Migration self-bootstraps `uuid-ossp` extension for fresh databases

## Files

- Port + command/result types: `libs/core/src/integrations/domain/{ports,types}/marketplace-*.ts`
- Domain entity + types + port + exception: `libs/core/src/listings/domain/**`
- ORM entity + repository + spec: `libs/core/src/listings/infrastructure/persistence/**`
- Module wiring + barrel exports: `libs/core/src/listings/{listings.module.ts,listings.tokens.ts,index.ts}`
- Migration: `apps/api/src/migrations/1784000000000-add-offer-creation-records-table.ts`
- Plan document: `docs/plans/implementation-plan-offer-creation-foundation.md`

Closes #254
Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)
