### PR TITLE
refactor(core): remove legacy string-token DI fallbacks

### DIFF
--- a/docs/plans/implementation-plan-264-remove-string-token-di.md
+++ b/docs/plans/implementation-plan-264-remove-string-token-di.md
@@ -1,0 +1,76 @@
+# Implementation Plan: #264 — Remove legacy string-token DI fallbacks
+
+## 1. Task Understanding
+
+**Goal**: Delete the `{ provide: 'StringTokenName', useExisting: SYMBOL_TOKEN }` fallback providers (and matching `exports` entries) from the 7 listed core modules, so Symbol tokens become the only supported DI binding — as engineering-standards "Repository Ports Pattern" requires.
+
+**Layer**: CORE — module metadata only. No domain/application/infrastructure logic changes.
+
+**Non-goals**:
+- Test `TestingModule` bindings (out of scope per issue).
+- `'REDIS_CLIENT'` and similar external-provider bindings — not port fallbacks.
+- Symbol-token naming migrations or other renames.
+
+## 2. Research findings
+
+Three greps establish zero consumers:
+
+| Query | Purpose | Hits (in scope) |
+|---|---|---|
+| `@Inject\('[A-Z]` | decorator-style injection | 0 (only `'REDIS_CLIENT'`) |
+| `inject: \[.*'[A-Z]` | factory-style `useFactory` injection | 0 (only `'REDIS_CLIENT'`) |
+| `provide: '[A-Z][A-Za-z]+(Port\|Service)'` | test mocks of the same tokens | 0 |
+
+- **30 string-token providers** in 7 core `*.module.ts` files.
+- **Zero in-repo call sites** consume any of them.
+- **No `*.spec.ts` mocks** reference these string tokens.
+- Conclusion: the fallbacks are pure dead code with zero consumers. Delete freely.
+
+## 3. Solution
+
+Per module: remove the `{ provide: 'X', useExisting: X_TOKEN }` provider entry *and* the `'X'` entry in that module's `exports` array. Leave the Symbol provider + export intact.
+
+No production code or tests need updating.
+
+## 4. Step-by-step
+
+One commit per module would be overkill for a delete-only change. Do all 7 in one pass, with the quality gate as the single verification step.
+
+| # | File | Providers to remove | Exports to remove |
+|---|---|---|---|
+| 1 | `libs/core/src/identifier-mapping/identifier-mapping.module.ts` | `'ConnectionPort'`, `'IIdentifierMappingService'`, `'IdentifierMappingPort'`, `'IdentifierMappingRepositoryPort'` | same 4 |
+| 2 | `libs/core/src/sync/sync.module.ts` | `'JobEnqueuePort'`, `'SyncJobRepositoryPort'`, `'ConnectionCursorRepositoryPort'`, `'SyncJobQueuePort'`, `'SyncLockPort'` | same 5 |
+| 3 | `libs/core/src/listings/listings.module.ts` | `'OfferLinkingService'`, `'IOfferMappingSyncService'`, `'ICategoryResolutionService'`, `'OfferMappingRepositoryPort'` | same 4 |
+| 4 | `libs/core/src/products/products.module.ts` | `'ProductRepositoryPort'`, `'ProductVariantRepositoryPort'`, `'IProductsService'`, `'IMasterProductSyncService'`, `'IAutoMatchVariantOffersService'` | same 5 |
+| 5 | `libs/core/src/customers/customers.module.ts` | `'CustomerProjectionRepositoryPort'`, `'ICustomerProjectionService'`, `'ICustomerIdentityResolverService'`, `'CustomerIdentityResolverPort'` | same 4 |
+| 6 | `libs/core/src/inventory/inventory.module.ts` | `'InventoryRepositoryPort'`, `'IInventoryService'`, `'IInventorySyncService'`, `'IMasterInventorySyncService'` | same 4 |
+| 7 | `libs/core/src/orders/orders.module.ts` | `'IOrderSyncService'`, `'IOrderIngestionService'`, `'OrderRecordRepositoryPort'`, `'IOrderRecordService'` | same 4 |
+
+**Step 8 — Unit quality gate**:
+```
+pnpm lint && pnpm type-check && pnpm test
+```
+
+**Step 9 — Integration tests**:
+```
+pnpm test:integration
+```
+
+Both must pass with zero errors. If anything fails, there's a hidden string-token consumer the grep missed — track it down and migrate to Symbol.
+
+**Step 10 — Commit body** should record the three grep queries + their results so a future archaeologist can reconstruct the safety reasoning without re-running the analysis.
+
+## 5. Validation
+
+- **Architecture**: Module metadata only; no layer boundaries touched.
+- **Grep coverage**: Two greps establish zero consumers (`@Inject\\('[A-Z]`, `provide: '[A-Z]...(Port|Service)'`). If the quality gate passes, no consumer exists.
+- **Risk**: Very low. Delete-only diff on module files.
+- **Integration tests**: Issue acceptance requires `pnpm test:integration` to pass. Docker is up in this session — run locally as part of the quality gate (Step 9).
+
+## 6. Open questions resolved
+
+| Question | Decision |
+|---|---|
+| Per-module commits or one commit? | One commit — delete-only, same mechanical change, easier to revert atomically if needed. |
+| Keep the Symbol provider? | Yes — that's the supported pattern. Only the string fallback goes. |
+| Rename any Symbols? | No — out of scope. |

--- a/docs/plans/implementation-plan-264-remove-string-token-di.md
+++ b/docs/plans/implementation-plan-264-remove-string-token-di.md
@@ -63,7 +63,7 @@ Both must pass with zero errors. If anything fails, there's a hidden string-toke
 ## 5. Validation
 
 - **Architecture**: Module metadata only; no layer boundaries touched.
-- **Grep coverage**: Two greps establish zero consumers (`@Inject\\('[A-Z]`, `provide: '[A-Z]...(Port|Service)'`). If the quality gate passes, no consumer exists.
+- **Grep coverage**: Three greps establish zero consumers (`@Inject\\('[A-Z]`, `inject: \\[.*'[A-Z]`, `provide: '[A-Z]...(Port|Service)'`) — see §2 for details. If the quality gate passes, no consumer exists.
 - **Risk**: Very low. Delete-only diff on module files.
 - **Integration tests**: Issue acceptance requires `pnpm test:integration` to pass. Docker is up in this session — run locally as part of the quality gate (Step 9).
 

--- a/libs/core/src/customers/customers.module.ts
+++ b/libs/core/src/customers/customers.module.ts
@@ -56,23 +56,6 @@ import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
       provide: CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN,
       useExisting: CustomerIdentityResolverService,
     },
-    // Also provide as string tokens for convenience
-    {
-      provide: 'CustomerProjectionRepositoryPort',
-      useExisting: CUSTOMER_PROJECTION_REPOSITORY_TOKEN,
-    },
-    {
-      provide: 'ICustomerProjectionService',
-      useExisting: CUSTOMER_PROJECTION_SERVICE_TOKEN,
-    },
-    {
-      provide: 'ICustomerIdentityResolverService',
-      useExisting: CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN,
-    },
-    {
-      provide: 'CustomerIdentityResolverPort',
-      useExisting: CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN,
-    },
   ],
   exports: [
     OrderCustomerProjectionUpdaterService, // Export service class for direct injection
@@ -80,10 +63,6 @@ import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
     CUSTOMER_PROJECTION_SERVICE_TOKEN,
     CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN,
     CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN,
-    'CustomerProjectionRepositoryPort',
-    'ICustomerProjectionService',
-    'ICustomerIdentityResolverService',
-    'CustomerIdentityResolverPort',
   ],
 })
 export class CustomersModule {}

--- a/libs/core/src/identifier-mapping/identifier-mapping.module.ts
+++ b/libs/core/src/identifier-mapping/identifier-mapping.module.ts
@@ -55,33 +55,12 @@ export {
       provide: CONNECTION_PORT_TOKEN,
       useExisting: ConnectionRepository,
     },
-    {
-      provide: 'ConnectionPort',
-      useExisting: CONNECTION_PORT_TOKEN,
-    },
-    // Also provide as string tokens for convenience
-    {
-      provide: 'IIdentifierMappingService',
-      useExisting: IDENTIFIER_MAPPING_SERVICE_TOKEN,
-    },
-    {
-      provide: 'IdentifierMappingPort',
-      useExisting: IDENTIFIER_MAPPING_SERVICE_TOKEN,
-    },
-    {
-      provide: 'IdentifierMappingRepositoryPort',
-      useExisting: IDENTIFIER_MAPPING_REPOSITORY_TOKEN,
-    },
   ],
   exports: [
     IDENTIFIER_MAPPING_SERVICE_TOKEN,
     IDENTIFIER_MAPPING_PORT_TOKEN,
     IDENTIFIER_MAPPING_REPOSITORY_TOKEN,
     CONNECTION_PORT_TOKEN,
-    'IIdentifierMappingService',
-    'IdentifierMappingPort',
-    'IdentifierMappingRepositoryPort',
-    'ConnectionPort',
   ],
 })
 export class IdentifierMappingModule {}

--- a/libs/core/src/inventory/inventory.module.ts
+++ b/libs/core/src/inventory/inventory.module.ts
@@ -64,33 +64,12 @@ export {
       provide: MASTER_INVENTORY_SYNC_SERVICE_TOKEN,
       useExisting: MasterInventorySyncService,
     },
-    // Also provide as string tokens for convenience
-    {
-      provide: 'InventoryRepositoryPort',
-      useExisting: INVENTORY_REPOSITORY_TOKEN,
-    },
-    {
-      provide: 'IInventoryService',
-      useExisting: INVENTORY_SERVICE_TOKEN,
-    },
-    {
-      provide: 'IInventorySyncService',
-      useExisting: INVENTORY_SYNC_SERVICE_TOKEN,
-    },
-    {
-      provide: 'IMasterInventorySyncService',
-      useExisting: MASTER_INVENTORY_SYNC_SERVICE_TOKEN,
-    },
   ],
   exports: [
     INVENTORY_REPOSITORY_TOKEN,
     INVENTORY_SERVICE_TOKEN,
     INVENTORY_SYNC_SERVICE_TOKEN,
     MASTER_INVENTORY_SYNC_SERVICE_TOKEN,
-    'InventoryRepositoryPort',
-    'IInventoryService',
-    'IInventorySyncService',
-    'IMasterInventorySyncService',
   ],
 })
 export class InventoryModule {}

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -65,29 +65,9 @@ export {
       useExisting: OfferCreationRecordRepository,
     },
     {
-      provide: 'OfferLinkingService',
-      useExisting: OFFER_LINKING_SERVICE_TOKEN,
-    },
-    {
-      provide: 'IOfferMappingSyncService',
-      useExisting: OFFER_MAPPING_SYNC_SERVICE_TOKEN,
-    },
-    {
       provide: CATEGORY_RESOLUTION_SERVICE_TOKEN,
       useExisting: CategoryResolutionService,
     },
-    {
-      provide: 'ICategoryResolutionService',
-      useExisting: CATEGORY_RESOLUTION_SERVICE_TOKEN,
-    },
-    {
-      provide: 'OfferMappingRepositoryPort',
-      useExisting: OFFER_MAPPING_REPOSITORY_TOKEN,
-    },
-    // Note: no string-token fallback for OfferCreationRecordRepositoryPort.
-    // Engineering Standards §Repository Ports Pattern deprecates string tokens
-    // as fragile; new ports opt into Symbol-only DI. Existing string fallbacks
-    // (above) are kept for compatibility and tracked for removal in #264.
   ],
   exports: [
     OFFER_LINKING_SERVICE_TOKEN,
@@ -95,10 +75,6 @@ export {
     OFFER_MAPPING_REPOSITORY_TOKEN,
     OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
     CATEGORY_RESOLUTION_SERVICE_TOKEN,
-    'ICategoryResolutionService',
-    'OfferLinkingService',
-    'IOfferMappingSyncService',
-    'OfferMappingRepositoryPort',
   ],
 })
 export class ListingsModule {}

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -64,23 +64,6 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
       provide: ORDER_RECORD_SERVICE_TOKEN,
       useExisting: OrderRecordService,
     },
-    // Also provide as string tokens for convenience
-    {
-      provide: 'IOrderSyncService',
-      useExisting: ORDER_SYNC_SERVICE_TOKEN,
-    },
-    {
-      provide: 'IOrderIngestionService',
-      useExisting: ORDER_INGESTION_SERVICE_TOKEN,
-    },
-    {
-      provide: 'OrderRecordRepositoryPort',
-      useExisting: ORDER_RECORD_REPOSITORY_TOKEN,
-    },
-    {
-      provide: 'IOrderRecordService',
-      useExisting: ORDER_RECORD_SERVICE_TOKEN,
-    },
   ],
   exports: [
     OrderRecordService, // Export service class for direct injection
@@ -88,10 +71,6 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     ORDER_INGESTION_SERVICE_TOKEN,
     ORDER_RECORD_REPOSITORY_TOKEN,
     ORDER_RECORD_SERVICE_TOKEN,
-    'IOrderSyncService',
-    'IOrderIngestionService',
-    'OrderRecordRepositoryPort',
-    'IOrderRecordService',
   ],
 })
 export class OrdersModule {}

--- a/libs/core/src/products/products.module.ts
+++ b/libs/core/src/products/products.module.ts
@@ -68,27 +68,6 @@ export {
       provide: AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
       useExisting: AutoMatchVariantOffersService,
     },
-    // Also provide as string tokens for convenience
-    {
-      provide: 'ProductRepositoryPort',
-      useExisting: PRODUCT_REPOSITORY_TOKEN,
-    },
-    {
-      provide: 'ProductVariantRepositoryPort',
-      useExisting: PRODUCT_VARIANT_REPOSITORY_TOKEN,
-    },
-    {
-      provide: 'IProductsService',
-      useExisting: PRODUCTS_SERVICE_TOKEN,
-    },
-    {
-      provide: 'IMasterProductSyncService',
-      useExisting: MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
-    },
-    {
-      provide: 'IAutoMatchVariantOffersService',
-      useExisting: AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
-    },
   ],
   exports: [
     PRODUCT_REPOSITORY_TOKEN,
@@ -96,11 +75,6 @@ export {
     PRODUCTS_SERVICE_TOKEN,
     MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
     AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
-    'ProductRepositoryPort',
-    'ProductVariantRepositoryPort',
-    'IProductsService',
-    'IMasterProductSyncService',
-    'IAutoMatchVariantOffersService',
   ],
 })
 export class ProductsModule {}

--- a/libs/core/src/sync/sync.module.ts
+++ b/libs/core/src/sync/sync.module.ts
@@ -59,29 +59,12 @@ export {
       provide: CONNECTION_CURSOR_REPOSITORY_TOKEN,
       useExisting: ConnectionCursorRepository,
     },
-    // Also provide as string tokens for convenience
-    {
-      provide: 'JobEnqueuePort',
-      useExisting: JOB_ENQUEUE_TOKEN,
-    },
-    {
-      provide: 'SyncJobRepositoryPort',
-      useExisting: SYNC_JOB_REPOSITORY_TOKEN,
-    },
-    {
-      provide: 'ConnectionCursorRepositoryPort',
-      useExisting: CONNECTION_CURSOR_REPOSITORY_TOKEN,
-    },
 
     // Sync job queue abstraction (application-level)
     SyncJobQueueService,
     {
       provide: SYNC_JOB_QUEUE_TOKEN,
       useExisting: SyncJobQueueService,
-    },
-    {
-      provide: 'SyncJobQueuePort',
-      useExisting: SYNC_JOB_QUEUE_TOKEN,
     },
 
     // Retry service (application-level)
@@ -97,10 +80,6 @@ export {
       provide: SYNC_LOCK_TOKEN,
       useExisting: RedisSyncLockService,
     },
-    {
-      provide: 'SyncLockPort',
-      useExisting: SYNC_LOCK_TOKEN,
-    },
   ],
   exports: [
     JOB_ENQUEUE_TOKEN,
@@ -109,15 +88,10 @@ export {
     RedisStreamsJobEnqueueService,
     SyncJobRepository,
     ConnectionCursorRepository,
-    'JobEnqueuePort',
-    'SyncJobRepositoryPort',
-    'ConnectionCursorRepositoryPort',
     SYNC_JOB_QUEUE_TOKEN,
     SyncJobQueueService,
-    'SyncJobQueuePort',
     SYNC_LOCK_TOKEN,
     RedisSyncLockService,
-    'SyncLockPort',
     SYNC_JOB_RETRY_SERVICE_TOKEN,
     SyncJobRetryService,
   ],


### PR DESCRIPTION
## Summary

- Deletes the 30 `{ provide: 'StringTokenName', useExisting: SYMBOL_TOKEN }` fallback providers and their `exports` entries from the 7 core modules listed in #264.
- Symbol tokens are now the only supported DI binding per `docs/engineering-standards.md` "Repository Ports Pattern", which explicitly deprecates string tokens as fragile and hard to refactor.
- Delete-only change: 7 files, 160 lines removed, 0 added.

## Safety reasoning

Zero consumers confirmed by three greps:

| Query | Purpose | Hits (in scope) |
|---|---|---|
| `@Inject\('[A-Z]` | decorator-style injection | 0 (only `'REDIS_CLIENT'`, oos) |
| `inject: \[.*'[A-Z]` | factory-style `useFactory` injection | 0 (only `'REDIS_CLIENT'`, oos) |
| `provide: '[A-Z][A-Za-z]+(Port\|Service)'` | test mocks of the same tokens | 0 |

After the diff, the second grep above returns zero hits anywhere under `libs/core/src/**/*.module.ts`.

## Test plan

- [x] `pnpm lint` — clean across all packages
- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm test` — all 1168 unit tests pass across 7 packages
- [x] `pnpm test:integration` — 7 failed / 60 passed. **Identical failure set on clean `main`** (verified by stashing this branch and re-running). Pre-existing test-harness isolation bug in `loginAsAdmin` (duplicate-key on `users` table between suites), unrelated to this refactor. Should be tracked as a separate issue.

## Out of scope

- Test `TestingModule` bindings (explicitly out of scope per issue).
- `'REDIS_CLIENT'` and similar external-provider bindings (not core port fallbacks).

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)