### PR TITLE
feat(offer-create): OfferBuilderService + Allegro createOffer adapter

### DIFF
--- a/docs/plans/implementation-plan-offer-creation-core.md
+++ b/docs/plans/implementation-plan-offer-creation-core.md
@@ -1,0 +1,294 @@
+# Implementation Plan — Offer Creation Core Logic (#255 + #256)
+
+**Branch:** `255-256-allegro-create-offer-and-builder`
+**Scope:** Implement `AllegroMarketplaceAdapter.createOffer` + core `OfferBuilderService` that assembles a `CreateOfferCommand` from an OL variant.
+
+---
+
+## 1. Understand the Task
+
+### Goal
+Make it possible to turn an OL variant id + marketplace connection id into a posted Allegro offer, going through two composable pieces:
+
+- **#256** — `OfferBuilderService` (core application): fetches variant + parent product + resolved Allegro category, and produces a platform-neutral `CreateOfferCommand`.
+- **#255** — `AllegroMarketplaceAdapter.createOffer` (integration): translates the neutral command into Allegro's POST `/sale/product-offers` API call and returns `CreateOfferResult`.
+
+### Layers
+- **#256**: CORE / application layer.
+- **#255**: Integration layer (Allegro adapter), pure platform translation.
+
+### Explicit non-goals (deferred)
+- Worker job handler + lifecycle orchestration → #257
+- REST endpoint → #259
+- Seller policy listing endpoint → #260
+- Frontend wizard → #261
+- Publication follow-up (`PUT /sale/product-offers/{id}/publication`) for `publishImmediately=true` — **NOT** in this PR. Publication semantics need their own spec (Allegro returns an async publication command id); `publishImmediately` is persisted on the record and honored by a later worker handler. For this PR, `publishImmediately` is accepted on the command and threaded to the Allegro payload's `publication.status = 'ACTIVE' | 'INACTIVE'` *if* that field works inline; otherwise we log-warn and treat it as advisory.
+  - **Decision up front**: per the [Allegro docs](https://developer.allegro.pl/documentation) `POST /sale/product-offers` accepts `publication.status = 'INACTIVE' | 'ACTIVE'` inline. Default is `INACTIVE`. We pass `'ACTIVE'` iff `publishImmediately: true`. Allegro itself resolves whether the offer actually goes live (may stay in validation). Adapter returns status based on the response's `publication.status` + `validation.errors` array.
+- Offer parameter auto-population from variant attributes — **NOT** in this PR. Parameters are required per category, resolved via `fetchCategories`. For the MVP, parameters are only what the caller provides via `overrides.platformParams.parameters`. Offers without required parameters will be rejected by Allegro's validation — that's acceptable and surfaces as domain errors. A later issue can add attribute→parameter auto-mapping.
+
+---
+
+## 2. Research Findings (codebase-grounded)
+
+### #255 — Allegro adapter surface
+
+- `AllegroMarketplaceAdapter` (`libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts`) constructor takes `connectionId`, `httpClient: IAllegroHttpClient`, `identifierMapping`, `_connection: Connection`, plus optional customer/command repos.
+- HTTP pattern: `this.httpClient.post<TResponse>(path, body)`, `.patch<T>()`, `.put<T>()`.
+- Closest reference for a mutation: `updateOfferFields` (lines 657–712) — build partial body, call `patch`, log, rethrow.
+- Token refresh is handled by the HTTP client interceptor — adapter code doesn't deal with it.
+- Allegro-specific exceptions live in `libs/integrations/allegro/src/domain/exceptions/` (pattern: `allegro-*.exception.ts` or `-.error.ts`). I'll add `allegro-offer-create.exception.ts` for validation / category errors surfaced from Allegro's response.
+- Spec pattern: `__tests__/allegro-marketplace.adapter.spec.ts` — mocks `httpClient` (all HTTP methods as jest.fn), constructs adapter directly.
+- Existing Allegro API types live in `libs/integrations/allegro/src/domain/types/allegro-api.types.ts` (not `infrastructure/types/` — research had this slightly off). All new types go there.
+
+### #256 — Core builder surface
+
+- `ProductVariantRepositoryPort.findById(id)` returns `ProductVariant | null` — gives `{ id, productId, sku, ean, gtin, attributes, createdAt, updatedAt }`. No price / name / description / images on the variant entity.
+- `Product` interface (via `ProductMasterPort.getProduct(productId)`) carries `name, description?, price, currency?, images?`. **This is where name/description/images/price come from.**
+- Master catalog connection is read from the marketplace connection's `config.masterCatalogConnectionId` — established pattern in `AutoMatchVariantOffersService` (`libs/core/src/products/application/services/auto-match-variant-offers.service.ts:266`).
+- `ProductMasterPort` for a master connection is resolved via `IntegrationsService.getCapabilityAdapter(masterConnectionId, 'ProductMaster')`.
+- `ICategoryResolutionService.resolveCategory({ connectionId, barcode?, sourceCategoryIds? })` → `{ allegroCategoryId: string | null, method }`. Already exists and handles the full barcode → mapping → manual fallback chain. **Reuse, don't duplicate.**
+- Connection lookup: `ConnectionPort.get(connectionId)` returns connection with `config` blob.
+- Service structure: interface in `application/interfaces/*.service.interface.ts`, impl in `application/services/*.service.ts`, types in `application/types/*.types.ts`, Symbol token in module tokens file. See `CategoryResolutionService` for the template.
+- No existing `offer-builder*` files — greenfield.
+
+---
+
+## 3. Design
+
+### File map
+
+**Issue #255 (Allegro `createOffer`)**
+- `libs/core/src/integrations/domain/types/marketplace-offer-create.types.ts` — **extend** the foundation types with `CreateOfferValidationError` (neutral shape) and add optional `validationErrors?: CreateOfferValidationError[]` to `CreateOfferResult`. Adapters that don't validate leave it empty/omit.
+- `libs/integrations/allegro/src/domain/types/allegro-api.types.ts` — add `AllegroProductOfferCreateRequest`, `AllegroProductOfferCreateResponse`, `AllegroOfferPublicationStatusValues` (mirror of Allegro's response enum)
+- `libs/integrations/allegro/src/domain/exceptions/allegro-offer-create.exception.ts` — `AllegroOfferCreateException` raised **only on non-2xx** responses; carries structured Allegro errors
+- `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts` — implement `createOffer(cmd): Promise<CreateOfferResult>`
+- `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts` — extend with `createOffer` tests (happy path, `publishImmediately` threading, 2xx-with-validation-errors, 422 error, `idempotencyKey` → `external.id` preference)
+- `libs/integrations/allegro/src/index.ts` — re-export new exception type
+
+**Issue #256 (`OfferBuilderService`)**
+- `libs/core/src/listings/application/types/offer-builder.types.ts` — `BuildCreateOfferCommandInput`, `OfferBuilderValidationIssue`
+- `libs/core/src/listings/application/interfaces/offer-builder.service.interface.ts` — `IOfferBuilderService`
+- `libs/core/src/listings/application/services/offer-builder.service.ts` — `OfferBuilderService`
+- `libs/core/src/listings/application/services/offer-builder.service.spec.ts`
+- `libs/core/src/listings/domain/exceptions/offer-builder-validation.exception.ts` — `OfferBuilderValidationException` (list of field-level issues)
+- `libs/core/src/listings/domain/exceptions/master-catalog-connection-not-configured.exception.ts` — thrown when connection lacks `masterCatalogConnectionId`
+- `libs/core/src/listings/listings.tokens.ts` — add `OFFER_BUILDER_SERVICE_TOKEN`
+- `libs/core/src/listings/listings.module.ts` — register provider (Symbol token only; no string fallback, per #264)
+- `libs/core/src/listings/index.ts` — barrel exports
+
+### `createOffer` adapter design (#255)
+
+**Allegro request body shape** (minimal viable for `POST /sale/product-offers`):
+
+```ts
+interface AllegroProductOfferCreateRequest {
+  name: string;                              // cmd.overrides.title or variant-derived
+  category: { id: string };                  // cmd.overrides.categoryId (required)
+  sellingMode: {
+    price: { amount: string; currency: string };
+    format: 'BUY_NOW';
+  };
+  stock: { available: number; unit: 'UNIT' };
+  description?: {
+    sections: Array<{
+      items: Array<{ type: 'TEXT'; content: string }>;
+    }>;
+  };
+  images?: Array<{ url: string }>;
+  parameters?: Array<{ id: string; values?: string[]; valuesIds?: string[] }>;
+  delivery?: { shippingRates?: { id: string }; handlingTime?: string };
+  afterSalesServices?: {
+    impliedWarranty?: { id: string };
+    returnPolicy?: { id: string };
+    warranty?: { id: string };
+  };
+  payments?: { invoice?: 'VAT' | 'NO_INVOICE' | 'VAT_MARGIN' };
+  publication?: { status: 'INACTIVE' | 'ACTIVE' };
+  external?: { id: string };                 // our internal variant id for traceability
+}
+```
+
+**Platform-specific params read from `cmd.overrides.platformParams` (Allegro keys):**
+- `deliveryPolicyId?: string` → `delivery.shippingRates.id`
+- `handlingTime?: string` (ISO8601 duration) → `delivery.handlingTime`
+- `returnPolicyId?: string` → `afterSalesServices.returnPolicy.id`
+- `warrantyId?: string` → `afterSalesServices.warranty.id`
+- `impliedWarrantyId?: string` → `afterSalesServices.impliedWarranty.id`
+- `invoice?: 'VAT' | 'NO_INVOICE' | 'VAT_MARGIN'` → `payments.invoice`
+- `parameters?: Array<{ id, values?, valuesIds? }>` → `parameters` passthrough
+- Any unknown keys are ignored (with a debug log).
+
+**Response → `CreateOfferResult` mapping:**
+- Allegro response has `id`, `publication.status`, `validation.errors[]`.
+- `status: 'active'` if `publication.status === 'ACTIVE'` and no validation errors
+- `status: 'validating'` if `validation.errors` is empty but `publication.status === 'INACTIVE'` AND caller asked for publish (validation in progress)
+- `status: 'draft'` if `publication.status === 'INACTIVE'` and caller did not ask for publish
+
+**Error mapping:**
+- On HTTP 422 (validation errors from Allegro) → throw `AllegroOfferCreateException` carrying the structured `validation.errors` list from the response body so downstream handlers can map into `OfferCreationError[]` on the record.
+- On HTTP 400 (malformed request) → same exception with the 400 body; debug-log the request body.
+- On HTTP 401/403 → let the existing `allegro-authentication.exception` path handle it (bubbles through the HTTP client).
+- No silent swallowing — adapter always throws a domain exception on non-2xx.
+
+### `OfferBuilderService` design (#256)
+
+**Interface:**
+```ts
+export interface IOfferBuilderService {
+  buildCreateOfferCommand(input: BuildCreateOfferCommandInput): Promise<CreateOfferCommand>;
+}
+
+export interface BuildCreateOfferCommandInput {
+  internalVariantId: string;
+  connectionId: string;                    // marketplace connection (e.g. Allegro)
+  price?: { amount: number; currency: string };
+  stock: number;                           // always required — caller decides inventory
+  publishImmediately?: boolean;
+  overrides?: CreateOfferOverrides;
+  idempotencyKey?: string;
+}
+```
+
+**Dependencies (constructor-injected via Symbol tokens):**
+- `ProductVariantRepositoryPort` (via `PRODUCT_VARIANT_REPOSITORY_TOKEN`) — `findById(variantId)`
+- `ConnectionPort` (via the existing symbol token) — `get(connectionId)` to read `config.masterCatalogConnectionId`
+- `IntegrationsService` (via `INTEGRATIONS_SERVICE_TOKEN`) — resolves `ProductMasterPort` per master-catalog connection
+- `ICategoryResolutionService` (via `CATEGORY_RESOLUTION_SERVICE_TOKEN`) — category resolution
+
+**Flow:**
+1. `variant = variantRepo.findById(input.internalVariantId)` → if null, throw `OfferBuilderValidationException({ field: 'internalVariantId', code: 'NOT_FOUND' })`.
+2. `connection = connectionPort.get(input.connectionId)` → if null, throw `ConnectionNotFoundException` (existing).
+3. `masterConnectionId = connection.config.masterCatalogConnectionId` → if missing, throw `MasterCatalogConnectionNotConfiguredException(input.connectionId)`.
+4. `productMaster = integrationsService.getCapabilityAdapter<ProductMasterPort>(masterConnectionId, 'ProductMaster')`.
+5. `product = await productMaster.getProduct(variant.productId)` — gives name, description, price (fallback), images.
+6. Resolve category: if `overrides.categoryId` is provided, use it as-is; otherwise call `CategoryResolutionService.resolveCategory({ connectionId, barcode: variant.ean ?? variant.gtin })`. If result's `allegroCategoryId` is null, throw `OfferBuilderValidationException({ field: 'overrides.categoryId', code: 'REQUIRED', message: 'No automatic category match; provide overrides.categoryId' })`.
+7. Determine `price`: if `input.price` is provided, use it. Else if `product.price` is set and `product.currency` is set → use both. Else throw `OfferBuilderValidationException({ field: 'price.currency', code: 'REQUIRED', message: 'Currency could not be resolved from input or master product; provide input.price explicitly' })`. No hardcoded currency defaults — the builder stays marketplace-neutral.
+8. Determine `title`: `overrides.title ?? product.name`.
+9. Determine `description`: `overrides.description ?? product.description` (optional).
+10. Determine `imageUrls`: `overrides.imageUrls ?? product.images ?? []`.
+11. Return `CreateOfferCommand` with `publishImmediately: input.publishImmediately ?? false`, merged overrides, and `platformParams` passed through untouched.
+
+**Validation:** all missing-required checks collected into a single `OfferBuilderValidationException` with an array of `OfferBuilderValidationIssue` so the caller can show all problems at once. This matches the tone of existing domain exceptions in the codebase.
+
+### Which status values does the adapter return vs which does the builder produce?
+
+- Builder produces `CreateOfferCommand` (no status — that's adapter-returned).
+- Adapter returns `CreateOfferResult.status: 'draft' | 'validating' | 'active'` per the existing `CreateOfferResultStatusValues` already defined in foundation PR.
+
+---
+
+## 4. Step-by-Step Implementation
+
+### Part A — Issue #256 (OfferBuilderService)
+
+#### A1. Builder types + exceptions
+- Create `offer-builder.types.ts` with `BuildCreateOfferCommandInput` and `OfferBuilderValidationIssue`.
+- Create `offer-builder-validation.exception.ts` with `OfferBuilderValidationException extends Error` carrying `issues: OfferBuilderValidationIssue[]`.
+- Create `master-catalog-connection-not-configured.exception.ts`.
+
+#### A2. Service interface
+- `offer-builder.service.interface.ts` exports `IOfferBuilderService` with single `build(input)` method.
+
+#### A3. Service implementation
+- `offer-builder.service.ts` — full flow from Section 3. Uses `@openlinker/shared/logging` Logger.
+- Error handling: catches nothing it doesn't know how to map; lets downstream exceptions bubble (e.g. `ConnectionNotFoundException` passes through).
+
+#### A4. Token + module wiring
+- Add `OFFER_BUILDER_SERVICE_TOKEN = Symbol('OfferBuilderService')` to `listings.tokens.ts`.
+- Register in `listings.module.ts`: provider `{ provide: OFFER_BUILDER_SERVICE_TOKEN, useExisting: OfferBuilderService }` and add `OfferBuilderService` to providers. Export token. **No string fallback** (new port per #264).
+- Barrel export from `listings/index.ts`: `IOfferBuilderService`, `OfferBuilderService`, types, exceptions, token.
+
+#### A5. Unit tests
+File: `offer-builder.service.spec.ts` — mock all four injected ports.
+- Happy path: all data resolved from variant + product, category auto-detected
+- `overrides.categoryId` present → skips `CategoryResolutionService`
+- Variant not found → `OfferBuilderValidationException` with `NOT_FOUND` on `internalVariantId`
+- Missing `masterCatalogConnectionId` → `MasterCatalogConnectionNotConfiguredException`
+- No EAN/GTIN + no `overrides.categoryId` and resolution returns null → `OfferBuilderValidationException` on `overrides.categoryId`
+- Missing price on variant and no `input.price` and `product.price == 0/undefined` → validation issue on `price`
+- `platformParams` passed through unchanged
+
+### Part B — Issue #255 (Allegro `createOffer`)
+
+#### B1. API types
+Add to `allegro-api.types.ts`:
+- `AllegroProductOfferCreateRequest`
+- `AllegroProductOfferCreateResponse` — `{ id, name, publication: { status }, validation?: { errors: AllegroValidationError[] } }`
+- `AllegroValidationError` — `{ code: string; message: string; details?: string; path?: string; userMessage?: string }`
+- `AllegroOfferPublicationStatusValues = ['INACTIVE','ACTIVE','ENDED','ACTIVATING','INACTIVATING'] as const`
+
+#### B2. Domain exception
+`allegro-offer-create.exception.ts`:
+```ts
+export class AllegroOfferCreateException extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly errors: AllegroValidationError[],
+  ) {
+    super(`Allegro rejected offer creation (HTTP ${statusCode}, ${errors.length} errors)`);
+    this.name = 'AllegroOfferCreateException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+```
+
+#### B3. Adapter implementation
+In `allegro-marketplace.adapter.ts`, add `createOffer(cmd: CreateOfferCommand): Promise<CreateOfferResult>`:
+1. Build `AllegroProductOfferCreateRequest` body from `cmd`, pulling platform-specific fields from `cmd.overrides.platformParams`.
+2. `publication.status = cmd.publishImmediately ? 'ACTIVE' : 'INACTIVE'`.
+3. `external.id = cmd.idempotencyKey ?? cmd.internalVariantId` — prefers the per-attempt idempotency key (if set by the caller) for retry uniqueness, falls back to the internal variant id for first-attempt traceability in Allegro's admin UI.
+4. Call `this.httpClient.post<AllegroProductOfferCreateResponse>('/sale/product-offers', body)`.
+5. Catch HTTP errors: if 400/422 and response has `errors` → throw `AllegroOfferCreateException`. Let other errors bubble (auth, rate-limit exceptions already exist).
+6. Map response → `CreateOfferResult`:
+   - Any validation errors → throw (even on 2xx Allegro sometimes reports validation issues inline; for safety treat non-empty `validation.errors` as failure)
+   - `publication.status === 'ACTIVE'` → `'active'`
+   - `publication.status === 'INACTIVE'` and `cmd.publishImmediately === true` → `'validating'`
+   - `publication.status === 'INACTIVE'` and `cmd.publishImmediately === false` → `'draft'`
+   - Else (ACTIVATING/etc) → `'validating'` (async in progress)
+7. Log success with offer id + status at `log` level.
+
+#### B4. Adapter spec
+In `allegro-marketplace.adapter.spec.ts`, add `describe('createOffer')` block:
+- Happy path (draft): returns `status: 'draft'`, `externalOfferId` populated
+- `publishImmediately: true` → request body has `publication.status = 'ACTIVE'`; response with `'ACTIVE'` → `status: 'active'`
+- `publishImmediately: true` + response `publication.status = 'INACTIVE'` → `status: 'validating'`
+- HTTP 422 with validation errors → throws `AllegroOfferCreateException` with the errors list
+- `platformParams` → verify delivery/return/warranty IDs are correctly placed in request body
+- `external.id` precedence: `cmd.idempotencyKey ?? cmd.internalVariantId` — both branches covered in tests
+
+#### B5. Barrel export
+Add `AllegroOfferCreateException` and `AllegroValidationError` (type) to `libs/integrations/allegro/src/index.ts`.
+
+### Part C — Quality gate
+```bash
+pnpm lint && pnpm type-check && pnpm test
+```
+
+---
+
+## 5. Validation
+
+### Architecture compliance
+- ✅ Builder in core application layer; depends only on ports (no infrastructure imports)
+- ✅ Adapter in integration layer; uses existing `IAllegroHttpClient` pattern
+- ✅ Neutral port command → adapter translates; reused Allegro `platformParams` for platform-specific IDs
+- ✅ Domain exceptions live in `domain/exceptions/` (both modules)
+- ✅ Repository/port injection via Symbol tokens only (no new string-fallback providers, per #264)
+- ✅ No new capability value needed; adapters implement existing `Marketplace` capability
+- ✅ Every new source file carries a module-path `@module` header per Engineering Standards §File Headers
+
+### Testing strategy
+- Unit tests for both pieces (builder + adapter).
+- #256 does change module wiring (new provider + token in `ListingsModule`). The existing `app-boot.int-spec.ts` loads the full app module and will surface any DI misconfiguration — no new int-spec required for this round, but a DI failure there would block merge. Integration tests covering the request path arrive with #257 / #259.
+
+### Risks / open questions
+- **Allegro publication semantics** — the Allegro public-API docs state `publication.status = 'ACTIVE'` is accepted inline on POST `/sale/product-offers` but final publication is asynchronous (status transitions through `ACTIVATING`). This plan assumes the inline field is accepted and honored. If sandbox testing during #255 reveals `'ACTIVE'` is rejected inline or silently ignored, fall back to POST-with-INACTIVE + follow-up `PUT /sale/product-offers/{id}/publication` call inside the same adapter method. This is an implementation detail of `createOffer`, not a contract change — `CreateOfferResult` already exposes `'validating'` for async publication.
+- **Stock unit handling** — hardcoded to `'UNIT'`. Other units (KG, PIECES) are a future concern.
+- **Currency resolution** — builder now throws when currency can't be resolved from input or master product (see Step 7). No platform-specific default. `Connection.config.defaultCurrency` may be added in a follow-up to unblock callers that want a per-connection fallback.
+
+### Commit plan
+Two logical commits on this branch:
+1. `feat(listings): OfferBuilderService — resolve variant into CreateOfferCommand` (#256)
+2. `feat(allegro): implement MarketplacePort.createOffer in AllegroMarketplaceAdapter` (#255)
+
+PR body: `Closes #255`, `Closes #256`.

--- a/libs/core/src/integrations/domain/types/marketplace-offer-create.types.ts
+++ b/libs/core/src/integrations/domain/types/marketplace-offer-create.types.ts
@@ -75,11 +75,38 @@ export const CreateOfferResultStatusValues = ['draft', 'validating', 'active'] a
 export type CreateOfferResultStatus = (typeof CreateOfferResultStatusValues)[number];
 
 /**
+ * Validation error reported by the marketplace during offer creation.
+ *
+ * Neutral shape mapped from platform-specific error formats by the adapter.
+ * Adapters that do not surface validation errors (WooCommerce, direct-API
+ * platforms) leave `validationErrors` unset on the result.
+ */
+export interface CreateOfferValidationError {
+  /** Dotted field path reported by the platform, when available (e.g. `parameters.EAN`). */
+  field?: string;
+  /** Platform-specific or OL-normalized error code (e.g. `PARAMETER_REQUIRED`). */
+  code: string;
+  /** Human-readable message suitable for displaying to an operator. */
+  message: string;
+}
+
+/**
  * Result returned by `MarketplacePort.createOffer`.
+ *
+ * A non-throwing response means the offer was successfully *created* on the
+ * platform (the `externalOfferId` exists) even if `validationErrors` is
+ * populated — that represents "created as draft but with issues blocking
+ * publication," which is a valid, recoverable state. Adapters only throw on
+ * non-2xx responses where no offer was created.
  */
 export interface CreateOfferResult {
   /** Marketplace-native id of the newly created offer. */
   externalOfferId: string;
   /** Adapter-reported status immediately after the create call. */
   status: CreateOfferResultStatus;
+  /**
+   * Structured validation errors the platform reported inline (2xx response
+   * with validation issues). Omitted when empty.
+   */
+  validationErrors?: CreateOfferValidationError[];
 }

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -60,6 +60,7 @@ export type {
   CreateOfferOverrides,
   CreateOfferResult,
   CreateOfferResultStatus,
+  CreateOfferValidationError,
 } from './domain/types/marketplace-offer-create.types';
 
 // Exceptions

--- a/libs/core/src/listings/application/interfaces/offer-builder.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/offer-builder.service.interface.ts
@@ -1,0 +1,31 @@
+/**
+ * Offer Builder Service Interface
+ *
+ * Contract for assembling a platform-neutral `CreateOfferCommand` from an OL
+ * internal variant id plus optional overrides. Implementations resolve the
+ * parent master product (for name/description/images/price), the target
+ * marketplace category (via the existing category resolution chain), and
+ * assemble the final command consumed by `MarketplacePort.createOffer`.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import type { CreateOfferCommand } from '@openlinker/core/integrations';
+import type { BuildCreateOfferCommandInput } from '../types/offer-builder.types';
+
+export interface IOfferBuilderService {
+  /**
+   * Resolve and assemble a `CreateOfferCommand` for the given variant and
+   * marketplace connection.
+   *
+   * Failure modes:
+   * - Unknown variant → `OfferBuilderValidationException` (`internalVariantId`, `NOT_FOUND`)
+   * - Unknown marketplace connection → `ConnectionNotFoundException`
+   * - Marketplace connection missing `masterCatalogConnectionId` in config →
+   *   `MasterCatalogConnectionNotConfiguredException`
+   * - Cannot resolve category (no EAN/GTIN, no override, resolution returned null) →
+   *   `OfferBuilderValidationException` (`overrides.categoryId`, `REQUIRED`)
+   * - Cannot resolve price/currency → `OfferBuilderValidationException` (`price.currency`, `REQUIRED`)
+   */
+  buildCreateOfferCommand(input: BuildCreateOfferCommandInput): Promise<CreateOfferCommand>;
+}

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -1,0 +1,311 @@
+/**
+ * Offer Builder Service Tests
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { CONNECTION_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
+import type { ConnectionPort, Connection } from '@openlinker/core/identifier-mapping';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type { IIntegrationsService, MarketplacePort } from '@openlinker/core/integrations';
+import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
+import type { ProductVariantRepositoryPort } from '@openlinker/core/products';
+import { ProductVariantEntity as ProductVariantDomain } from '@openlinker/core/products';
+
+type ProductVariant = ProductVariantDomain;
+
+import { OfferBuilderService } from '../offer-builder.service';
+import { CATEGORY_RESOLUTION_SERVICE_TOKEN } from '../../../listings.tokens';
+import type { ICategoryResolutionService } from '../../interfaces/category-resolution.service.interface';
+import { OfferBuilderValidationException } from '../../../domain/exceptions/offer-builder-validation.exception';
+import { MasterCatalogConnectionNotConfiguredException } from '../../../domain/exceptions/master-catalog-connection-not-configured.exception';
+
+describe('OfferBuilderService', () => {
+  let service: OfferBuilderService;
+  let variantRepo: jest.Mocked<Pick<ProductVariantRepositoryPort, 'findById'>>;
+  let connectionPort: jest.Mocked<Pick<ConnectionPort, 'get'>>;
+  let integrationsService: jest.Mocked<Pick<IIntegrationsService, 'getCapabilityAdapter'>>;
+  let categoryResolution: jest.Mocked<Pick<ICategoryResolutionService, 'resolveCategory'>>;
+  let productMaster: { getProduct: jest.Mock };
+
+  const VARIANT_ID = 'ol_variant_123';
+  const MARKETPLACE_CONN_ID = 'conn-allegro';
+  const MASTER_CONN_ID = 'conn-prestashop';
+
+  const defaultVariant = {
+    id: VARIANT_ID,
+    productId: 'ol_product_456',
+    sku: 'SKU-1',
+    ean: '5901234123457',
+    gtin: undefined,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  } as unknown as ProductVariant;
+
+  const defaultConnection: Partial<Connection> = {
+    id: MARKETPLACE_CONN_ID,
+    platformType: 'allegro',
+    config: { masterCatalogConnectionId: MASTER_CONN_ID },
+  };
+
+  beforeEach(async () => {
+    variantRepo = { findById: jest.fn().mockResolvedValue(defaultVariant) };
+    connectionPort = {
+      get: jest.fn().mockResolvedValue(defaultConnection as Connection),
+    };
+    productMaster = {
+      getProduct: jest.fn().mockResolvedValue({
+        id: 'ol_product_456',
+        name: 'Test Product',
+        sku: 'SKU-1',
+        description: 'A test product description.',
+        price: 49.99,
+        currency: 'PLN',
+        images: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
+      }),
+    };
+    integrationsService = {
+      getCapabilityAdapter: jest.fn().mockResolvedValue(productMaster as unknown as MarketplacePort),
+    };
+    categoryResolution = {
+      resolveCategory: jest
+        .fn()
+        .mockResolvedValue({ allegroCategoryId: 'allegro-cat-999', method: 'auto_detect' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OfferBuilderService,
+        { provide: PRODUCT_VARIANT_REPOSITORY_TOKEN, useValue: variantRepo },
+        { provide: CONNECTION_PORT_TOKEN, useValue: connectionPort },
+        { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
+        { provide: CATEGORY_RESOLUTION_SERVICE_TOKEN, useValue: categoryResolution },
+      ],
+    }).compile();
+
+    service = module.get(OfferBuilderService);
+  });
+
+  describe('happy path', () => {
+    it('resolves product, category, price and builds a neutral CreateOfferCommand', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 10,
+        publishImmediately: true,
+      });
+
+      expect(variantRepo.findById).toHaveBeenCalledWith(VARIANT_ID);
+      expect(connectionPort.get).toHaveBeenCalledWith(MARKETPLACE_CONN_ID);
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+        MASTER_CONN_ID,
+        'ProductMaster',
+      );
+      expect(categoryResolution.resolveCategory).toHaveBeenCalledWith({
+        connectionId: MARKETPLACE_CONN_ID,
+        barcode: '5901234123457',
+      });
+
+      expect(result).toEqual({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        price: { amount: 49.99, currency: 'PLN' },
+        stock: 10,
+        publishImmediately: true,
+        overrides: {
+          title: 'Test Product',
+          description: 'A test product description.',
+          categoryId: 'allegro-cat-999',
+          imageUrls: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
+        },
+        idempotencyKey: undefined,
+      });
+    });
+  });
+
+  describe('category resolution', () => {
+    it('skips CategoryResolutionService when overrides.categoryId is provided', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        overrides: { categoryId: 'explicit-cat' },
+      });
+
+      expect(categoryResolution.resolveCategory).not.toHaveBeenCalled();
+      expect(result.overrides?.categoryId).toBe('explicit-cat');
+    });
+
+    it('throws OfferBuilderValidationException when no barcode and no override', async () => {
+      variantRepo.findById.mockResolvedValue({
+        ...(defaultVariant as unknown as Record<string, unknown>),
+        ean: undefined,
+        gtin: undefined,
+      } as unknown as ProductVariant);
+
+      await expect(
+        service.buildCreateOfferCommand({
+          internalVariantId: VARIANT_ID,
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        }),
+      ).rejects.toBeInstanceOf(OfferBuilderValidationException);
+      expect(categoryResolution.resolveCategory).not.toHaveBeenCalled();
+    });
+
+    it('throws OfferBuilderValidationException when resolution returns null', async () => {
+      categoryResolution.resolveCategory.mockResolvedValue({
+        allegroCategoryId: null,
+        method: 'manual',
+      });
+
+      await expect(
+        service.buildCreateOfferCommand({
+          internalVariantId: VARIANT_ID,
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        }),
+      ).rejects.toBeInstanceOf(OfferBuilderValidationException);
+    });
+  });
+
+  describe('variant and connection lookup', () => {
+    it('throws OfferBuilderValidationException when variant is missing', async () => {
+      variantRepo.findById.mockResolvedValue(null);
+
+      await expect(
+        service.buildCreateOfferCommand({
+          internalVariantId: 'missing',
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        }),
+      ).rejects.toBeInstanceOf(OfferBuilderValidationException);
+      expect(connectionPort.get).not.toHaveBeenCalled();
+    });
+
+    it('throws MasterCatalogConnectionNotConfiguredException when config missing the key', async () => {
+      connectionPort.get.mockResolvedValue({
+        ...defaultConnection,
+        config: {},
+      } as Connection);
+
+      await expect(
+        service.buildCreateOfferCommand({
+          internalVariantId: VARIANT_ID,
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        }),
+      ).rejects.toBeInstanceOf(MasterCatalogConnectionNotConfiguredException);
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('price and currency resolution', () => {
+    it('uses input.price when provided, ignoring master product price', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        price: { amount: 99.99, currency: 'EUR' },
+      });
+
+      expect(result.price).toEqual({ amount: 99.99, currency: 'EUR' });
+    });
+
+    it('throws when no input.price and master product has no currency', async () => {
+      productMaster.getProduct.mockResolvedValue({
+        id: 'ol_product_456',
+        name: 'Test',
+        sku: 'SKU-1',
+        price: 49.99,
+        // no currency
+      });
+
+      await expect(
+        service.buildCreateOfferCommand({
+          internalVariantId: VARIANT_ID,
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        }),
+      ).rejects.toBeInstanceOf(OfferBuilderValidationException);
+    });
+
+    it('throws when no input.price and master product has no positive price', async () => {
+      productMaster.getProduct.mockResolvedValue({
+        id: 'ol_product_456',
+        name: 'Test',
+        sku: 'SKU-1',
+        price: 0,
+        currency: 'PLN',
+      });
+
+      await expect(
+        service.buildCreateOfferCommand({
+          internalVariantId: VARIANT_ID,
+          connectionId: MARKETPLACE_CONN_ID,
+          stock: 1,
+        }),
+      ).rejects.toBeInstanceOf(OfferBuilderValidationException);
+    });
+  });
+
+  describe('passthrough fields', () => {
+    it('forwards overrides.platformParams untouched', async () => {
+      const platformParams = {
+        deliveryPolicyId: 'deliv-1',
+        returnPolicyId: 'ret-1',
+        warrantyId: 'war-1',
+      };
+
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        overrides: { platformParams },
+      });
+
+      expect(result.overrides?.platformParams).toBe(platformParams);
+    });
+
+    it('forwards idempotencyKey untouched', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        idempotencyKey: 'idem-abc',
+      });
+
+      expect(result.idempotencyKey).toBe('idem-abc');
+    });
+
+    it('defaults publishImmediately to false when not set', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+
+      expect(result.publishImmediately).toBe(false);
+    });
+  });
+
+  describe('title/description/imageUrls overrides', () => {
+    it('prefers overrides.title/description/imageUrls over master product values', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        overrides: {
+          title: 'Custom Title',
+          description: 'Custom desc',
+          imageUrls: ['https://example.com/custom.jpg'],
+        },
+      });
+
+      expect(result.overrides?.title).toBe('Custom Title');
+      expect(result.overrides?.description).toBe('Custom desc');
+      expect(result.overrides?.imageUrls).toEqual(['https://example.com/custom.jpg']);
+    });
+  });
+});

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -1,0 +1,193 @@
+/**
+ * Offer Builder Service
+ *
+ * Assembles a platform-neutral `CreateOfferCommand` from an OL internal variant
+ * id. Fetches variant metadata from the local repository, resolves the parent
+ * master product via `ProductMasterPort` (for name/description/images/price),
+ * resolves the marketplace category via `ICategoryResolutionService`, and
+ * validates required fields. Throws `OfferBuilderValidationException` with a
+ * list of issues when anything is missing so callers can surface all problems
+ * at once.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IOfferBuilderService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+
+import { Logger } from '@openlinker/shared/logging';
+import {
+  CONNECTION_PORT_TOKEN,
+  ConnectionPort,
+} from '@openlinker/core/identifier-mapping';
+import {
+  CreateOfferCommand,
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+} from '@openlinker/core/integrations';
+import {
+  PRODUCT_VARIANT_REPOSITORY_TOKEN,
+  ProductMasterPort,
+  ProductVariantRepositoryPort,
+} from '@openlinker/core/products';
+
+import { MasterCatalogConnectionNotConfiguredException } from '../../domain/exceptions/master-catalog-connection-not-configured.exception';
+import {
+  OfferBuilderValidationException,
+  OfferBuilderValidationIssue,
+} from '../../domain/exceptions/offer-builder-validation.exception';
+import { CATEGORY_RESOLUTION_SERVICE_TOKEN } from '../../listings.tokens';
+import { ICategoryResolutionService } from '../interfaces/category-resolution.service.interface';
+import { IOfferBuilderService } from '../interfaces/offer-builder.service.interface';
+import { BuildCreateOfferCommandInput } from '../types/offer-builder.types';
+
+@Injectable()
+export class OfferBuilderService implements IOfferBuilderService {
+  private readonly logger = new Logger(OfferBuilderService.name);
+
+  constructor(
+    @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
+    private readonly variantRepository: ProductVariantRepositoryPort,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(CATEGORY_RESOLUTION_SERVICE_TOKEN)
+    private readonly categoryResolution: ICategoryResolutionService,
+  ) {}
+
+  async buildCreateOfferCommand(input: BuildCreateOfferCommandInput): Promise<CreateOfferCommand> {
+    const issues: OfferBuilderValidationIssue[] = [];
+
+    const variant = await this.variantRepository.findById(input.internalVariantId);
+    if (!variant) {
+      throw new OfferBuilderValidationException([
+        {
+          field: 'internalVariantId',
+          code: 'NOT_FOUND',
+          message: `Variant ${input.internalVariantId} not found`,
+        },
+      ]);
+    }
+
+    const connection = await this.connectionPort.get(input.connectionId);
+    const masterConnectionId = this.readMasterCatalogConnectionId(connection.config);
+    if (!masterConnectionId) {
+      throw new MasterCatalogConnectionNotConfiguredException(input.connectionId);
+    }
+
+    const productMaster = await this.integrationsService.getCapabilityAdapter<ProductMasterPort>(
+      masterConnectionId,
+      'ProductMaster',
+    );
+    const product = await productMaster.getProduct(variant.productId);
+
+    const categoryId = await this.resolveCategory(input, variant.ean ?? variant.gtin ?? null);
+    if (!categoryId) {
+      issues.push({
+        field: 'overrides.categoryId',
+        code: 'REQUIRED',
+        message:
+          'No automatic category match for variant barcode and no override provided; supply overrides.categoryId',
+      });
+    }
+
+    const price = this.resolvePrice(input, product, issues);
+
+    if (issues.length > 0) {
+      throw new OfferBuilderValidationException(issues);
+    }
+
+    const title = input.overrides?.title ?? product.name;
+    const description = input.overrides?.description ?? product.description;
+    const imageUrls = input.overrides?.imageUrls ?? product.images;
+
+    const overrides = {
+      title,
+      description,
+      categoryId: categoryId ?? undefined,
+      imageUrls,
+      platformParams: input.overrides?.platformParams,
+    };
+
+    // Drop undefined so serialization stays tidy.
+    const cleanedOverrides: CreateOfferCommand['overrides'] = {};
+    if (overrides.title !== undefined) cleanedOverrides.title = overrides.title;
+    if (overrides.description !== undefined) cleanedOverrides.description = overrides.description;
+    if (overrides.categoryId !== undefined) cleanedOverrides.categoryId = overrides.categoryId;
+    if (overrides.imageUrls !== undefined) cleanedOverrides.imageUrls = overrides.imageUrls;
+    if (overrides.platformParams !== undefined) {
+      cleanedOverrides.platformParams = overrides.platformParams;
+    }
+
+    const command: CreateOfferCommand = {
+      internalVariantId: input.internalVariantId,
+      connectionId: input.connectionId,
+      // `price` is guaranteed defined here because `issues` would have caught it above.
+      price: price as { amount: number; currency: string },
+      stock: input.stock,
+      publishImmediately: input.publishImmediately ?? false,
+      overrides: Object.keys(cleanedOverrides).length > 0 ? cleanedOverrides : undefined,
+      idempotencyKey: input.idempotencyKey,
+    };
+
+    this.logger.debug(
+      `Built CreateOfferCommand for variant=${input.internalVariantId} connection=${input.connectionId} categoryId=${categoryId ?? 'null'}`,
+    );
+
+    return command;
+  }
+
+  private async resolveCategory(
+    input: BuildCreateOfferCommandInput,
+    barcode: string | null,
+  ): Promise<string | null> {
+    if (input.overrides?.categoryId) {
+      return input.overrides.categoryId;
+    }
+    if (!barcode) {
+      return null;
+    }
+    const result = await this.categoryResolution.resolveCategory({
+      connectionId: input.connectionId,
+      barcode,
+    });
+    return result.allegroCategoryId;
+  }
+
+  private resolvePrice(
+    input: BuildCreateOfferCommandInput,
+    product: { price?: number; currency?: string },
+    issues: OfferBuilderValidationIssue[],
+  ): { amount: number; currency: string } | null {
+    if (input.price) {
+      return input.price;
+    }
+    const amount = product.price;
+    const currency = product.currency;
+    if (typeof amount !== 'number' || amount <= 0) {
+      issues.push({
+        field: 'price.amount',
+        code: 'REQUIRED',
+        message: 'No positive price available from input or master product',
+      });
+      return null;
+    }
+    if (!currency) {
+      issues.push({
+        field: 'price.currency',
+        code: 'REQUIRED',
+        message:
+          'Currency could not be resolved from input or master product; provide input.price explicitly',
+      });
+      return null;
+    }
+    return { amount, currency };
+  }
+
+  private readMasterCatalogConnectionId(config: Record<string, unknown> | null | undefined): string | null {
+    if (!config) return null;
+    const value = config['masterCatalogConnectionId'];
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+}

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -165,11 +165,22 @@ export class OfferBuilderService implements IOfferBuilderService {
     }
     const amount = product.price;
     const currency = product.currency;
-    if (typeof amount !== 'number' || amount <= 0) {
+    if (typeof amount !== 'number') {
       issues.push({
         field: 'price.amount',
         code: 'REQUIRED',
-        message: 'No positive price available from input or master product',
+        message:
+          'Price amount could not be resolved from input or master product; provide input.price explicitly',
+      });
+      return null;
+    }
+    // Marketplaces reject non-positive prices; distinguish "missing" from "zero/negative"
+    // so the caller can see which fix is needed.
+    if (amount <= 0) {
+      issues.push({
+        field: 'price.amount',
+        code: 'NON_POSITIVE',
+        message: `Master product price (${amount}) is not a positive value; provide input.price explicitly`,
       });
       return null;
     }

--- a/libs/core/src/listings/application/types/offer-builder.types.ts
+++ b/libs/core/src/listings/application/types/offer-builder.types.ts
@@ -1,0 +1,39 @@
+/**
+ * Offer Builder Types
+ *
+ * Input shape for `IOfferBuilderService.buildCreateOfferCommand`. The service
+ * resolves the OL variant + parent master product, resolves the Allegro
+ * category, and produces a neutral `CreateOfferCommand` consumed by any
+ * marketplace adapter implementing `MarketplacePort.createOffer`.
+ *
+ * @module libs/core/src/listings/application/types
+ */
+
+import type { CreateOfferOverrides } from '@openlinker/core/integrations';
+
+export interface BuildCreateOfferCommandInput {
+  /** OL internal variant id being listed. */
+  internalVariantId: string;
+  /** Target marketplace connection id (e.g. Allegro). */
+  connectionId: string;
+  /**
+   * Optional explicit price. When omitted, the builder tries to resolve a
+   * price from the master product (requires both amount and currency).
+   */
+  price?: { amount: number; currency: string };
+  /**
+   * Offered quantity. Always required — the builder does not read inventory;
+   * the caller decides how much stock to expose per offer.
+   */
+  stock: number;
+  /** Whether the resulting command should ask the adapter to publish immediately. */
+  publishImmediately?: boolean;
+  /** Overrides and platform-specific fields passed through to the command. */
+  overrides?: CreateOfferOverrides;
+  /**
+   * Optional idempotency key forwarded to the produced `CreateOfferCommand`.
+   * Adapters may use it for unique external references on the marketplace
+   * (see Allegro's `external.id` handling).
+   */
+  idempotencyKey?: string;
+}

--- a/libs/core/src/listings/domain/exceptions/master-catalog-connection-not-configured.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/master-catalog-connection-not-configured.exception.ts
@@ -1,0 +1,19 @@
+/**
+ * Master Catalog Connection Not Configured Exception
+ *
+ * Raised when building a marketplace offer requires resolving master-catalog
+ * product data (name, description, images, price) but the marketplace
+ * connection has no `masterCatalogConnectionId` set in its config.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+
+export class MasterCatalogConnectionNotConfiguredException extends Error {
+  constructor(public readonly marketplaceConnectionId: string) {
+    super(
+      `Marketplace connection ${marketplaceConnectionId} has no masterCatalogConnectionId configured; cannot resolve master product data for offer creation`,
+    );
+    this.name = 'MasterCatalogConnectionNotConfiguredException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/domain/exceptions/offer-builder-validation.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/offer-builder-validation.exception.ts
@@ -1,0 +1,31 @@
+/**
+ * Offer Builder Validation Exception
+ *
+ * Domain exception raised by OfferBuilderService when one or more required
+ * fields for creating an offer cannot be resolved from the variant, master
+ * product, or caller-provided overrides. Carries a list of field-level issues
+ * so callers can surface all problems at once instead of iterating.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+
+export interface OfferBuilderValidationIssue {
+  /** Dotted path of the field the issue applies to (e.g. `overrides.categoryId`). */
+  field: string;
+  /** Machine-readable code (e.g. `NOT_FOUND`, `REQUIRED`). */
+  code: string;
+  /** Human-readable message suitable for operator display. */
+  message: string;
+}
+
+export class OfferBuilderValidationException extends Error {
+  constructor(public readonly issues: OfferBuilderValidationIssue[]) {
+    super(
+      `Offer builder validation failed (${issues.length} issue${
+        issues.length === 1 ? '' : 's'
+      }): ${issues.map((i) => `${i.field}:${i.code}`).join(', ')}`,
+    );
+    this.name = 'OfferBuilderValidationException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -11,6 +11,7 @@ export {
   OFFER_MAPPING_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
+  OFFER_BUILDER_SERVICE_TOKEN,
 } from './listings.tokens';
 export { OfferLinkingService } from './application/services/offer-linking.service';
 export { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
@@ -49,3 +50,13 @@ export type {
 } from './domain/types/offer-creation-record.types';
 export type { OfferCreationRecordRepositoryPort } from './domain/ports/offer-creation-record-repository.port';
 export { OfferCreationRecordNotFoundException } from './domain/exceptions/offer-creation-record-not-found.exception';
+export { OfferBuilderService } from './application/services/offer-builder.service';
+export type { IOfferBuilderService } from './application/interfaces/offer-builder.service.interface';
+export type { BuildCreateOfferCommandInput } from './application/types/offer-builder.types';
+export {
+  OfferBuilderValidationException,
+} from './domain/exceptions/offer-builder-validation.exception';
+export type {
+  OfferBuilderValidationIssue,
+} from './domain/exceptions/offer-builder-validation.exception';
+export { MasterCatalogConnectionNotConfiguredException } from './domain/exceptions/master-catalog-connection-not-configured.exception';

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -17,12 +17,14 @@ import { CategoryResolutionService } from './application/services/category-resol
 import { OfferMappingRepository } from './infrastructure/persistence/repositories/offer-mapping.repository';
 import { OfferCreationRecordOrmEntity } from './infrastructure/persistence/entities/offer-creation-record.orm-entity';
 import { OfferCreationRecordRepository } from './infrastructure/persistence/repositories/offer-creation-record.repository';
+import { OfferBuilderService } from './application/services/offer-builder.service';
 import {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
+  OFFER_BUILDER_SERVICE_TOKEN,
 } from './listings.tokens';
 
 // Re-export tokens for convenience
@@ -32,6 +34,7 @@ export {
   OFFER_MAPPING_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
+  OFFER_BUILDER_SERVICE_TOKEN,
 } from './listings.tokens';
 
 @Module({
@@ -48,6 +51,7 @@ export {
     CategoryResolutionService,
     OfferMappingRepository,
     OfferCreationRecordRepository,
+    OfferBuilderService,
     {
       provide: OFFER_LINKING_SERVICE_TOKEN,
       useExisting: OfferLinkingService,
@@ -68,6 +72,10 @@ export {
       provide: CATEGORY_RESOLUTION_SERVICE_TOKEN,
       useExisting: CategoryResolutionService,
     },
+    {
+      provide: OFFER_BUILDER_SERVICE_TOKEN,
+      useExisting: OfferBuilderService,
+    },
   ],
   exports: [
     OFFER_LINKING_SERVICE_TOKEN,
@@ -75,6 +83,7 @@ export {
     OFFER_MAPPING_REPOSITORY_TOKEN,
     OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
     CATEGORY_RESOLUTION_SERVICE_TOKEN,
+    OFFER_BUILDER_SERVICE_TOKEN,
   ],
 })
 export class ListingsModule {}

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -9,3 +9,4 @@ export const OFFER_MAPPING_SYNC_SERVICE_TOKEN = Symbol('OfferMappingSyncService'
 export const OFFER_MAPPING_REPOSITORY_TOKEN = Symbol('OfferMappingRepositoryPort');
 export const OFFER_CREATION_RECORD_REPOSITORY_TOKEN = Symbol('OfferCreationRecordRepositoryPort');
 export const CATEGORY_RESOLUTION_SERVICE_TOKEN = Symbol('ICategoryResolutionService');
+export const OFFER_BUILDER_SERVICE_TOKEN = Symbol('IOfferBuilderService');

--- a/libs/integrations/allegro/src/domain/exceptions/allegro-offer-create.exception.ts
+++ b/libs/integrations/allegro/src/domain/exceptions/allegro-offer-create.exception.ts
@@ -1,0 +1,32 @@
+/**
+ * Allegro Offer Create Exception
+ *
+ * Raised by `AllegroMarketplaceAdapter.createOffer` when Allegro rejects the
+ * creation with a non-2xx response — no offer was created, there is no
+ * marketplace-side id. Carries structured Allegro validation errors so
+ * callers (worker handlers) can persist them on the `OfferCreationRecord`.
+ *
+ * 2xx responses with inline validation errors do NOT throw this — the offer
+ * exists as a draft and the errors flow through `CreateOfferResult.validationErrors`.
+ *
+ * @module libs/integrations/allegro/src/domain/exceptions
+ */
+
+import type { AllegroValidationError } from '../types/allegro-api.types';
+
+export class AllegroOfferCreateException extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly errors: AllegroValidationError[],
+  ) {
+    super(
+      `Allegro rejected offer creation (HTTP ${statusCode}, ${errors.length} error${
+        errors.length === 1 ? '' : 's'
+      })`,
+    );
+    this.name = 'AllegroOfferCreateException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AllegroOfferCreateException);
+    }
+  }
+}

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -278,3 +278,80 @@ export interface AllegroMatchingCategoriesResponse {
   }>;
 }
 
+/**
+ * Allegro offer publication status — Allegro's string enum from the
+ * `publication.status` field on the product-offer resource.
+ *
+ * `INACTIVE` — draft, not visible to buyers.
+ * `ACTIVE` — published and visible.
+ * `ACTIVATING` / `INACTIVATING` — transient async state during publication changes.
+ * `ENDED` — publication has ended (historical).
+ */
+export const AllegroOfferPublicationStatusValues = [
+  'INACTIVE',
+  'ACTIVE',
+  'ACTIVATING',
+  'INACTIVATING',
+  'ENDED',
+] as const;
+export type AllegroOfferPublicationStatus = (typeof AllegroOfferPublicationStatusValues)[number];
+
+/**
+ * Validation error returned by Allegro when creating or updating an offer.
+ * Can appear on 2xx responses (offer created but has issues blocking publication)
+ * as well as on 422 responses (offer not created).
+ */
+export interface AllegroValidationError {
+  code: string;
+  message: string;
+  details?: string;
+  path?: string;
+  userMessage?: string;
+}
+
+/**
+ * Minimal body accepted by `POST /sale/product-offers`.
+ *
+ * Many fields are optional for the API itself but may be required by the
+ * target category's validation — Allegro surfaces those as 2xx validation
+ * errors in the response's `validation.errors` array. The adapter lets
+ * callers provide such platform-specific fields through
+ * `CreateOfferCommand.overrides.platformParams` and passes them through here.
+ */
+export interface AllegroProductOfferCreateRequest extends Record<string, unknown> {
+  name: string;
+  category: { id: string };
+  sellingMode: {
+    price: { amount: string; currency: string };
+    format: 'BUY_NOW';
+  };
+  stock: { available: number; unit: 'UNIT' };
+  description?: {
+    sections: Array<{
+      items: Array<{ type: 'TEXT'; content: string }>;
+    }>;
+  };
+  images?: Array<{ url: string }>;
+  parameters?: Array<{ id: string; values?: string[]; valuesIds?: string[] }>;
+  delivery?: { shippingRates?: { id: string }; handlingTime?: string };
+  afterSalesServices?: {
+    impliedWarranty?: { id: string };
+    returnPolicy?: { id: string };
+    warranty?: { id: string };
+  };
+  payments?: { invoice?: 'VAT' | 'NO_INVOICE' | 'VAT_MARGIN' };
+  publication?: { status: 'INACTIVE' | 'ACTIVE' };
+  external?: { id: string };
+}
+
+/**
+ * Response from `POST /sale/product-offers`.
+ */
+export interface AllegroProductOfferCreateResponse {
+  id: string;
+  name?: string;
+  publication?: { status?: AllegroOfferPublicationStatus };
+  validation?: { errors?: AllegroValidationError[] };
+  external?: { id?: string };
+}
+

--- a/libs/integrations/allegro/src/index.ts
+++ b/libs/integrations/allegro/src/index.ts
@@ -28,6 +28,8 @@ export { AllegroAuthenticationException } from './domain/exceptions/allegro-auth
 export { AllegroRateLimitException } from './domain/exceptions/allegro-rate-limit.exception';
 export { DuplicateAllegroQuantityCommandError } from './domain/exceptions/duplicate-allegro-quantity-command.error';
 export { AllegroQuantityCommandNotFoundException } from './domain/exceptions/allegro-quantity-command-not-found.error';
+export { AllegroOfferCreateException } from './domain/exceptions/allegro-offer-create.exception';
+export type { AllegroValidationError } from './domain/types/allegro-api.types';
 
 // Entities
 export { AllegroQuantityCommand, AllegroQuantityCommandStatus, AllegroQuantityCommandStatusValues } from './domain/entities/allegro-quantity-command.entity';

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
@@ -15,7 +15,11 @@ import {
   AllegroCheckoutForm,
   AllegroOrderEventsResponse,
   AllegroOfferQuantityChangeCommandResponse,
+  AllegroProductOfferCreateResponse,
 } from '../../../domain/types/allegro-api.types';
+import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
+import { AllegroOfferCreateException } from '../../../domain/exceptions/allegro-offer-create.exception';
+import type { CreateOfferCommand } from '@openlinker/core/integrations';
 
 describe('AllegroMarketplaceAdapter', () => {
   let adapter: AllegroMarketplaceAdapter;
@@ -719,6 +723,190 @@ describe('AllegroMarketplaceAdapter', () => {
       const result = await adapter.matchCategoryByBarcode('5901234123457');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('createOffer', () => {
+    const baseCmd: CreateOfferCommand = {
+      internalVariantId: 'ol_variant_abc',
+      connectionId,
+      price: { amount: 49.99, currency: 'PLN' },
+      stock: 5,
+      publishImmediately: false,
+      overrides: {
+        title: 'Test Offer Title',
+        description: 'Test description',
+        categoryId: 'allegro-cat-100',
+        imageUrls: ['https://example.com/img.jpg'],
+      },
+    };
+
+    const mockHttpResponse = (data: AllegroProductOfferCreateResponse) => ({
+      data,
+      status: 201,
+      headers: {},
+    });
+
+    it('returns draft status when INACTIVE without validation errors', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({
+          id: 'allegro-offer-1',
+          publication: { status: 'INACTIVE' },
+        }),
+      );
+
+      const result = await adapter.createOffer(baseCmd);
+
+      expect(result).toEqual({ externalOfferId: 'allegro-offer-1', status: 'draft' });
+      const [path, body] = httpClient.post.mock.calls[0];
+      expect(path).toBe('/sale/product-offers');
+      expect(body).toMatchObject({
+        name: 'Test Offer Title',
+        category: { id: 'allegro-cat-100' },
+        sellingMode: {
+          price: { amount: '49.99', currency: 'PLN' },
+          format: 'BUY_NOW',
+        },
+        stock: { available: 5, unit: 'UNIT' },
+        publication: { status: 'INACTIVE' },
+      });
+    });
+
+    it('requests publication.status=ACTIVE when publishImmediately=true and returns active when response is ACTIVE', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({
+          id: 'allegro-offer-2',
+          publication: { status: 'ACTIVE' },
+        }),
+      );
+
+      const result = await adapter.createOffer({ ...baseCmd, publishImmediately: true });
+
+      expect(result.status).toBe('active');
+      const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.publication).toEqual({ status: 'ACTIVE' });
+    });
+
+    it('returns validating when publishImmediately=true but response is INACTIVE with no validation errors', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({
+          id: 'allegro-offer-3',
+          publication: { status: 'INACTIVE' },
+        }),
+      );
+
+      const result = await adapter.createOffer({ ...baseCmd, publishImmediately: true });
+
+      expect(result.status).toBe('validating');
+    });
+
+    it('returns draft + validationErrors on 2xx with inline validation errors (does NOT throw)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({
+          id: 'allegro-offer-4',
+          publication: { status: 'INACTIVE' },
+          validation: {
+            errors: [
+              {
+                code: 'VALIDATION_REQUIRED',
+                message: 'Parameter EAN is required',
+                path: 'parameters.EAN',
+                userMessage: 'Supply EAN',
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await adapter.createOffer(baseCmd);
+
+      expect(result.externalOfferId).toBe('allegro-offer-4');
+      expect(result.status).toBe('draft');
+      expect(result.validationErrors).toEqual([
+        {
+          field: 'parameters.EAN',
+          code: 'VALIDATION_REQUIRED',
+          message: 'Supply EAN',
+        },
+      ]);
+    });
+
+    it('throws AllegroOfferCreateException on 422 with structured errors', async () => {
+      httpClient.post.mockRejectedValue(
+        new AllegroApiException(
+          'Unprocessable entity',
+          422,
+          JSON.stringify({
+            errors: [
+              { code: 'BAD_CATEGORY', message: 'Category does not exist' },
+            ],
+          }),
+          'https://api.allegro.pl/sale/product-offers',
+        ),
+      );
+
+      await expect(adapter.createOffer(baseCmd)).rejects.toBeInstanceOf(
+        AllegroOfferCreateException,
+      );
+    });
+
+    it('maps platformParams to delivery/return/warranty/invoice/parameters', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-5', publication: { status: 'INACTIVE' } }),
+      );
+
+      await adapter.createOffer({
+        ...baseCmd,
+        overrides: {
+          ...baseCmd.overrides,
+          platformParams: {
+            deliveryPolicyId: 'deliv-1',
+            handlingTime: 'PT72H',
+            returnPolicyId: 'ret-1',
+            warrantyId: 'war-1',
+            impliedWarrantyId: 'iwar-1',
+            invoice: 'VAT',
+            parameters: [{ id: 'ean-param', values: ['5901234123457'] }],
+            unknownField: 'should be ignored',
+          },
+        },
+      });
+
+      const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.delivery).toEqual({
+        shippingRates: { id: 'deliv-1' },
+        handlingTime: 'PT72H',
+      });
+      expect(body.afterSalesServices).toEqual({
+        returnPolicy: { id: 'ret-1' },
+        warranty: { id: 'war-1' },
+        impliedWarranty: { id: 'iwar-1' },
+      });
+      expect(body.payments).toEqual({ invoice: 'VAT' });
+      expect(body.parameters).toEqual([{ id: 'ean-param', values: ['5901234123457'] }]);
+      expect(body).not.toHaveProperty('unknownField');
+    });
+
+    it('uses cmd.idempotencyKey for external.id when provided', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-6', publication: { status: 'INACTIVE' } }),
+      );
+
+      await adapter.createOffer({ ...baseCmd, idempotencyKey: 'idem-xyz' });
+
+      const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.external).toEqual({ id: 'idem-xyz' });
+    });
+
+    it('falls back to cmd.internalVariantId for external.id when no idempotencyKey', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-7', publication: { status: 'INACTIVE' } }),
+      );
+
+      await adapter.createOffer(baseCmd);
+
+      const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.external).toEqual({ id: 'ol_variant_abc' });
     });
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
@@ -887,6 +887,55 @@ describe('AllegroMarketplaceAdapter', () => {
       expect(body).not.toHaveProperty('unknownField');
     });
 
+    it('throws AllegroOfferCreateException when overrides.title is missing (precondition)', async () => {
+      const cmd: CreateOfferCommand = {
+        ...baseCmd,
+        overrides: { ...baseCmd.overrides, title: undefined },
+      };
+
+      await expect(adapter.createOffer(cmd)).rejects.toBeInstanceOf(AllegroOfferCreateException);
+      expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('throws AllegroOfferCreateException when overrides.categoryId is missing (precondition)', async () => {
+      const cmd: CreateOfferCommand = {
+        ...baseCmd,
+        overrides: { ...baseCmd.overrides, categoryId: undefined },
+      };
+
+      await expect(adapter.createOffer(cmd)).rejects.toBeInstanceOf(AllegroOfferCreateException);
+      expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('drops malformed parameter entries from platformParams.parameters', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-params', publication: { status: 'INACTIVE' } }),
+      );
+
+      await adapter.createOffer({
+        ...baseCmd,
+        overrides: {
+          ...baseCmd.overrides,
+          platformParams: {
+            parameters: [
+              { id: 'valid', values: ['a', 'b'] },
+              { id: 'bad-values', values: [1, 2] }, // values must be strings
+              { id: '', values: ['x'] }, // empty id
+              { values: ['y'] }, // missing id
+              { id: 'bad-valuesIds', valuesIds: 'not-an-array' },
+              { id: 'also-valid', valuesIds: ['123'] },
+            ],
+          },
+        },
+      });
+
+      const body = httpClient.post.mock.calls[0][1] as { parameters?: Array<{ id: string }> };
+      expect(body.parameters).toEqual([
+        { id: 'valid', values: ['a', 'b'] },
+        { id: 'also-valid', valuesIds: ['123'] },
+      ]);
+    });
+
     it('uses cmd.idempotencyKey for external.id when provided', async () => {
       httpClient.post.mockResolvedValue(
         mockHttpResponse({ id: 'allegro-offer-6', publication: { status: 'INACTIVE' } }),

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
@@ -18,7 +18,13 @@ import {
   UpdateOfferQuantityCommand,
   UpdateOfferFieldsCommand,
 } from '@openlinker/core/integrations';
-import type { MarketplaceCategory } from '@openlinker/core/integrations';
+import type {
+  CreateOfferCommand,
+  CreateOfferResult,
+  CreateOfferResultStatus,
+  CreateOfferValidationError,
+  MarketplaceCategory,
+} from '@openlinker/core/integrations';
 import type { IncomingOrder } from '@openlinker/core/orders';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CustomerIdentityResolverPort } from '@openlinker/core/customers';
@@ -36,7 +42,12 @@ import {
   AllegroOfferEventsResponse,
   AllegroOfferFieldsPatchBody,
   AllegroMatchingCategoriesResponse,
+  AllegroProductOfferCreateRequest,
+  AllegroProductOfferCreateResponse,
+  AllegroValidationError,
 } from '../../domain/types/allegro-api.types';
+import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
+import { AllegroOfferCreateException } from '../../domain/exceptions/allegro-offer-create.exception';
 import { Logger } from '@openlinker/shared/logging';
 import { createHash } from 'crypto';
 import {
@@ -709,6 +720,211 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
       );
       throw error;
     }
+  }
+
+  /**
+   * Create a new Allegro offer (outbound OL → Allegro).
+   *
+   * Translates the neutral `CreateOfferCommand` into Allegro's
+   * `POST /sale/product-offers` request. Platform-specific fields flow
+   * through `cmd.overrides.platformParams`:
+   * - `deliveryPolicyId` → `delivery.shippingRates.id`
+   * - `handlingTime` → `delivery.handlingTime`
+   * - `returnPolicyId` → `afterSalesServices.returnPolicy.id`
+   * - `warrantyId` → `afterSalesServices.warranty.id`
+   * - `impliedWarrantyId` → `afterSalesServices.impliedWarranty.id`
+   * - `invoice` → `payments.invoice`
+   * - `parameters` → passthrough to request `parameters`
+   * Unknown keys are ignored.
+   *
+   * `external.id` precedence: `cmd.idempotencyKey ?? cmd.internalVariantId` —
+   * callers set the idempotency key per creation attempt so retries get a
+   * unique reference. Allegro's public API does not accept an `Idempotency-Key`
+   * header, so this is the adapter's only use of `cmd.idempotencyKey`.
+   *
+   * Non-2xx responses with structured errors are translated to
+   * `AllegroOfferCreateException`. 2xx responses with inline validation errors
+   * are **not** thrown — the offer exists as a draft on Allegro and the errors
+   * are surfaced through `CreateOfferResult.validationErrors`.
+   */
+  async createOffer(cmd: CreateOfferCommand): Promise<CreateOfferResult> {
+    const body = this.buildCreateOfferRequest(cmd);
+
+    this.logger.debug(
+      `Creating Allegro offer: connection=${this.connectionId} externalRef=${body.external?.id ?? 'n/a'} publishImmediately=${cmd.publishImmediately}`,
+    );
+
+    let response: AllegroProductOfferCreateResponse;
+    try {
+      const httpResponse = await this.httpClient.post<AllegroProductOfferCreateResponse>(
+        '/sale/product-offers',
+        body as unknown as Record<string, unknown>,
+      );
+      response = httpResponse.data;
+    } catch (error) {
+      if (error instanceof AllegroApiException && error.statusCode !== undefined) {
+        const parsedErrors = this.parseAllegroErrors(error.responseBody);
+        this.logger.error(
+          `Allegro rejected offer creation: connection=${this.connectionId} status=${error.statusCode} errors=${parsedErrors.length}`,
+          error,
+        );
+        throw new AllegroOfferCreateException(error.statusCode, parsedErrors);
+      }
+      throw error;
+    }
+
+    const validationErrors = this.mapValidationErrors(response.validation?.errors ?? []);
+    const status = this.resolveCreateOfferStatus(
+      response.publication?.status,
+      validationErrors.length > 0,
+      cmd.publishImmediately,
+    );
+
+    this.logger.log(
+      `Allegro offer created: connection=${this.connectionId} offerId=${response.id} status=${status} validationErrors=${validationErrors.length}`,
+    );
+
+    const result: CreateOfferResult = {
+      externalOfferId: response.id,
+      status,
+    };
+    if (validationErrors.length > 0) {
+      result.validationErrors = validationErrors;
+    }
+    return result;
+  }
+
+  private buildCreateOfferRequest(cmd: CreateOfferCommand): AllegroProductOfferCreateRequest {
+    const platformParams = (cmd.overrides?.platformParams ?? {});
+
+    const name = cmd.overrides?.title ?? '';
+    const categoryId = cmd.overrides?.categoryId ?? '';
+    const externalRef = cmd.idempotencyKey ?? cmd.internalVariantId;
+
+    const body: AllegroProductOfferCreateRequest = {
+      name,
+      category: { id: categoryId },
+      sellingMode: {
+        price: {
+          amount: cmd.price.amount.toFixed(2),
+          currency: cmd.price.currency,
+        },
+        format: 'BUY_NOW',
+      },
+      stock: { available: cmd.stock, unit: 'UNIT' },
+      publication: { status: cmd.publishImmediately ? 'ACTIVE' : 'INACTIVE' },
+      external: { id: externalRef },
+    };
+
+    if (cmd.overrides?.description) {
+      body.description = {
+        sections: [
+          {
+            items: [{ type: 'TEXT', content: cmd.overrides.description }],
+          },
+        ],
+      };
+    }
+
+    if (cmd.overrides?.imageUrls && cmd.overrides.imageUrls.length > 0) {
+      body.images = cmd.overrides.imageUrls.map((url) => ({ url }));
+    }
+
+    this.applyPlatformParams(body, platformParams);
+
+    return body;
+  }
+
+  private applyPlatformParams(
+    body: AllegroProductOfferCreateRequest,
+    platformParams: Record<string, unknown>,
+  ): void {
+    const deliveryPolicyId = platformParams['deliveryPolicyId'];
+    const handlingTime = platformParams['handlingTime'];
+    if (typeof deliveryPolicyId === 'string' || typeof handlingTime === 'string') {
+      body.delivery = {};
+      if (typeof deliveryPolicyId === 'string') {
+        body.delivery.shippingRates = { id: deliveryPolicyId };
+      }
+      if (typeof handlingTime === 'string') {
+        body.delivery.handlingTime = handlingTime;
+      }
+    }
+
+    const returnPolicyId = platformParams['returnPolicyId'];
+    const warrantyId = platformParams['warrantyId'];
+    const impliedWarrantyId = platformParams['impliedWarrantyId'];
+    if (
+      typeof returnPolicyId === 'string' ||
+      typeof warrantyId === 'string' ||
+      typeof impliedWarrantyId === 'string'
+    ) {
+      body.afterSalesServices = {};
+      if (typeof returnPolicyId === 'string') {
+        body.afterSalesServices.returnPolicy = { id: returnPolicyId };
+      }
+      if (typeof warrantyId === 'string') {
+        body.afterSalesServices.warranty = { id: warrantyId };
+      }
+      if (typeof impliedWarrantyId === 'string') {
+        body.afterSalesServices.impliedWarranty = { id: impliedWarrantyId };
+      }
+    }
+
+    const invoice = platformParams['invoice'];
+    if (invoice === 'VAT' || invoice === 'NO_INVOICE' || invoice === 'VAT_MARGIN') {
+      body.payments = { invoice };
+    }
+
+    const parameters = platformParams['parameters'];
+    if (Array.isArray(parameters)) {
+      body.parameters = parameters.filter(
+        (p): p is { id: string; values?: string[]; valuesIds?: string[] } =>
+          typeof p === 'object' && p !== null && typeof (p as { id?: unknown }).id === 'string',
+      );
+    }
+  }
+
+  private resolveCreateOfferStatus(
+    publicationStatus: string | undefined,
+    hasValidationErrors: boolean,
+    publishImmediately: boolean,
+  ): CreateOfferResultStatus {
+    if (hasValidationErrors) {
+      return 'draft';
+    }
+    if (publicationStatus === 'ACTIVE') {
+      return 'active';
+    }
+    if (publicationStatus === 'ACTIVATING') {
+      return 'validating';
+    }
+    // INACTIVE or unknown
+    if (publishImmediately) {
+      return 'validating';
+    }
+    return 'draft';
+  }
+
+  private mapValidationErrors(errors: AllegroValidationError[]): CreateOfferValidationError[] {
+    return errors.map((err) => ({
+      field: err.path,
+      code: err.code,
+      message: err.userMessage ?? err.message,
+    }));
+  }
+
+  private parseAllegroErrors(responseBody: string | undefined): AllegroValidationError[] {
+    if (!responseBody) return [];
+    try {
+      const parsed = JSON.parse(responseBody) as { errors?: AllegroValidationError[] };
+      if (Array.isArray(parsed.errors)) {
+        return parsed.errors;
+      }
+    } catch {
+      // Response wasn't JSON or didn't match the expected shape.
+    }
+    return [];
   }
 
   /**

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
@@ -58,6 +58,28 @@ import {
 type MarketplaceOrderFeedItem = MarketplaceOrderFeedOutput['items'][number];
 
 /**
+ * Type guard used when filtering untyped `platformParams.parameters` into the
+ * Allegro-accepted shape. Requires `id: string` and, when present, `values` /
+ * `valuesIds` must be arrays of strings. Anything that fails this check is
+ * silently dropped — Allegro would reject it anyway, and keeping the guard
+ * strict means invalid shapes fail fast at the request-build step.
+ */
+function isAllegroOfferParameterShape(
+  candidate: unknown,
+): candidate is { id: string; values?: string[]; valuesIds?: string[] } {
+  if (typeof candidate !== 'object' || candidate === null) return false;
+  const c = candidate as { id?: unknown; values?: unknown; valuesIds?: unknown };
+  if (typeof c.id !== 'string' || c.id.length === 0) return false;
+  if (c.values !== undefined) {
+    if (!Array.isArray(c.values) || !c.values.every((v) => typeof v === 'string')) return false;
+  }
+  if (c.valuesIds !== undefined) {
+    if (!Array.isArray(c.valuesIds) || !c.valuesIds.every((v) => typeof v === 'string')) return false;
+  }
+  return true;
+}
+
+/**
  * Polling configuration for Allegro async quantity change commands.
  *
  * Defaults: 5 attempts, 2s initial delay, 30s max delay, 2x backoff multiplier
@@ -797,8 +819,22 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
   private buildCreateOfferRequest(cmd: CreateOfferCommand): AllegroProductOfferCreateRequest {
     const platformParams = (cmd.overrides?.platformParams ?? {});
 
-    const name = cmd.overrides?.title ?? '';
-    const categoryId = cmd.overrides?.categoryId ?? '';
+    // Preconditions: the core `OfferBuilderService` is expected to have resolved
+    // these, but callers *may* bypass the builder. Fail fast with a structured
+    // domain error rather than sending `name: ''` / `category: { id: '' }` to
+    // Allegro and getting a cryptic 400 back.
+    const name = cmd.overrides?.title;
+    const categoryId = cmd.overrides?.categoryId;
+    if (!name || name.trim().length === 0) {
+      throw new AllegroOfferCreateException(0, [
+        { code: 'PRECONDITION_TITLE_REQUIRED', message: 'overrides.title is required for Allegro offer creation' },
+      ]);
+    }
+    if (!categoryId || categoryId.trim().length === 0) {
+      throw new AllegroOfferCreateException(0, [
+        { code: 'PRECONDITION_CATEGORY_REQUIRED', message: 'overrides.categoryId is required for Allegro offer creation' },
+      ]);
+    }
     const externalRef = cmd.idempotencyKey ?? cmd.internalVariantId;
 
     const body: AllegroProductOfferCreateRequest = {
@@ -878,10 +914,7 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
 
     const parameters = platformParams['parameters'];
     if (Array.isArray(parameters)) {
-      body.parameters = parameters.filter(
-        (p): p is { id: string; values?: string[]; valuesIds?: string[] } =>
-          typeof p === 'object' && p !== null && typeof (p as { id?: unknown }).id === 'string',
-      );
+      body.parameters = parameters.filter(isAllegroOfferParameterShape);
     }
   }
 


### PR DESCRIPTION
## Summary

Second slice of the offer creation capability (foundation landed in #267). This PR implements the two pieces a caller needs to turn an OL variant id into a posted Allegro offer:

- **#256 — `OfferBuilderService`** (core application layer): resolves an internal variant id + marketplace connection into a platform-neutral `CreateOfferCommand`. Fetches the master product via `ProductMasterPort` (through the established `config.masterCatalogConnectionId` pattern), reuses the existing `CategoryResolutionService` for the barcode → Allegro category chain, and aggregates missing-field problems into a single `OfferBuilderValidationException` so callers see everything wrong at once.
- **#255 — `AllegroMarketplaceAdapter.createOffer`** (integration): translates the neutral command into `POST /sale/product-offers`. Platform-specific fields (delivery / return / warranty policies, invoice, parameters, handling time) flow through `overrides.platformParams` — unknown keys are silently dropped.

## Design decisions

- **`CreateOfferResult.validationErrors`** added to the foundation types. 2xx responses from Allegro with inline `validation.errors` no longer throw — the offer was created as a draft and we preserve the `externalOfferId` so retry / fix / republish workflows stay intact. Only non-2xx throws (`AllegroOfferCreateException`).
- **`external.id` precedence**: `cmd.idempotencyKey ?? cmd.internalVariantId`. Per-attempt idempotency keys give retries a unique external reference; `internalVariantId` preserves traceability on first attempts. Allegro's public API does not accept an `Idempotency-Key` header, so this is the adapter's only use of `idempotencyKey` — documented, not silently dropped.
- **No hardcoded currency default** in the builder. Missing amount or currency → structured validation issue. Keeps the builder marketplace-neutral across WooCommerce / eBay futures.
- **Adapter preconditions** fail fast when `overrides.title` / `overrides.categoryId` are missing, rather than sending empty strings to Allegro. Callers routing through the builder get this for free; callers bypassing it now see clean error messages.
- **Parameter-shape guard** on `overrides.platformParams.parameters` validates `id` + array-of-strings for `values` / `valuesIds`. Malformed entries are dropped.
- **Symbol-only DI** for the new `OFFER_BUILDER_SERVICE_TOKEN` — no string-token fallback, per #264.

## Test plan

- [x] `pnpm type-check` (workspace) — 0 errors
- [x] `pnpm lint` — 0 errors (only pre-existing warnings)
- [x] `pnpm test` — 338+ tests, all green
- [x] New unit tests: 13 for `OfferBuilderService`, 11 for `createOffer` on the adapter (covering happy path, publish immediacy, 2xx-with-validation-errors, 422, platformParams mapping, external.id precedence, preconditions, malformed parameters)
- [x] No integration tests this round — the existing `app-boot.int-spec.ts` already boots `ListingsModule` and would fail on DI wiring mistakes

## Follow-ups filed

- **#281** — reconcile the two `ProductVariant` type definitions in `@openlinker/core/products` (port interface vs domain entity class). Pre-existing tech debt surfaced by the builder spec's type casts.

## Risks

- Adapter assumes Allegro accepts `publication.status='ACTIVE'` inline on POST `/sale/product-offers`. If sandbox testing during integration reveals it doesn't, the adapter can fall back to POST-with-INACTIVE + follow-up `PUT /sale/product-offers/{id}/publication` inside the same method without touching the public contract — `CreateOfferResult.status = 'validating'` already covers the async publication case.

Closes #255
Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
