### PR TITLE
feat(web): structured ProductMaster catalog picker in edit form + smarter unlinked banner

### DIFF
--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -1,7 +1,59 @@
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import type { Connection } from '../api/connections.types';
 import { EditConnectionForm } from './EditConnectionForm';
+
+const PRESTASHOP_UUID_1 = '11111111-1111-4111-8111-111111111111';
+const PRESTASHOP_UUID_2 = '22222222-2222-4222-8222-222222222222';
+const ALLEGRO_UUID = '33333333-3333-4333-8333-333333333333';
+
+// UUID-shaped candidate fixtures — the Zod schema rejects non-UUIDs, so the
+// shared `sampleConnection.id = 'conn_1'` can't be used directly once the
+// marketplace branch mounts.
+const candidatePrestashop: Connection = {
+  ...sampleConnection,
+  id: PRESTASHOP_UUID_1,
+  name: 'Main PrestaShop Store',
+};
+
+const secondPrestashop: Connection = {
+  ...sampleConnection,
+  id: PRESTASHOP_UUID_2,
+  name: 'Second PrestaShop',
+};
+
+const allegroConnection: Connection = {
+  ...sampleConnection,
+  id: ALLEGRO_UUID,
+  name: 'Allegro sandbox',
+  platformType: 'allegro',
+  config: { environment: 'sandbox' },
+  enabledCapabilities: ['Marketplace', 'OrderProcessorManager'],
+  supportedCapabilities: ['Marketplace', 'OrderProcessorManager'],
+  adapterKey: 'allegro.publicapi.v1',
+};
+
+/**
+ * Build an api client mock where `connections.list` returns the given set of
+ * candidates (shapes the ProductMaster dropdown in the marketplace branch).
+ */
+function apiClientWithCandidates(
+  candidates: Connection[],
+  overrides: Parameters<typeof createMockApiClient>[0] = {},
+): ReturnType<typeof createMockApiClient> {
+  // Helper's `list` mock wins over any `overrides.connections.list` — the
+  // helper's purpose is to inject candidates, so callers pass overrides for
+  // other endpoints (`update`, etc.) and don't expect them to silently replace
+  // the candidate list.
+  return createMockApiClient({
+    ...overrides,
+    connections: {
+      ...overrides.connections,
+      list: vi.fn().mockResolvedValue(candidates),
+    },
+  });
+}
 
 describe('EditConnectionForm', () => {
   afterEach(cleanup);
@@ -146,6 +198,228 @@ describe('EditConnectionForm', () => {
       expect(screen.getByText('Raw JSON is invalid')).toBeInTheDocument();
       expect(screen.getByLabelText('Shop URL')).toBeDisabled();
       expect(screen.getByLabelText('Shop ID (optional)')).toBeDisabled();
+    });
+  });
+
+  describe('marketplace branch — Product catalog connection picker', () => {
+    it('renders the catalog picker for an Allegro connection and hides it for PrestaShop', async () => {
+      const apiClient = apiClientWithCandidates([candidatePrestashop]);
+      const { rerender } = renderWithProviders(
+        <EditConnectionForm connection={allegroConnection} />,
+        { apiClient },
+      );
+
+      expect(await screen.findByLabelText('Product catalog connection')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Shop URL')).toBeNull();
+
+      rerender(<EditConnectionForm connection={sampleConnection} />);
+      expect(screen.queryByLabelText('Product catalog connection')).toBeNull();
+      expect(screen.getByLabelText('Shop URL')).toBeInTheDocument();
+    });
+
+    it('auto-selects the only ProductMaster candidate when config has no stored value', async () => {
+      const apiClient = apiClientWithCandidates([candidatePrestashop]);
+      renderWithProviders(<EditConnectionForm connection={allegroConnection} />, { apiClient });
+
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      await waitFor(() => {
+        expect(picker.value).toBe(candidatePrestashop.id);
+      });
+    });
+
+    it('does NOT auto-select when config has an explicit "" opt-out', async () => {
+      const apiClient = apiClientWithCandidates([candidatePrestashop]);
+      const optedOut: Connection = {
+        ...allegroConnection,
+        config: { environment: 'sandbox', masterCatalogConnectionId: '' },
+      };
+      renderWithProviders(<EditConnectionForm connection={optedOut} />, { apiClient });
+
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      // Give the auto-select effect a chance to fire if it incorrectly would.
+      await waitFor(() => {
+        expect(picker).toBeInTheDocument();
+      });
+      expect(picker.value).toBe('');
+    });
+
+    it('does NOT auto-select when 2+ ProductMaster candidates exist', async () => {
+      const apiClient = apiClientWithCandidates([candidatePrestashop, secondPrestashop]);
+      renderWithProviders(<EditConnectionForm connection={allegroConnection} />, { apiClient });
+
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      // Both candidates should be rendered as options, but none pre-selected.
+      await waitFor(() => {
+        expect(picker.querySelectorAll('option').length).toBeGreaterThanOrEqual(3); // None + 2 candidates
+      });
+      expect(picker.value).toBe('');
+    });
+
+    it('auto-select runs at most once: operator clearing after auto-fill stays cleared', async () => {
+      // Realistic operator-override path — the Select is disabled during
+      // `isLoading`, so interaction before candidates resolve isn't physically
+      // possible. The guard we care about is: after auto-select fires once, the
+      // operator can pick "None" (matching the default) and the effect must NOT
+      // re-fire. This exercises both the run-once ref AND the operator-touched
+      // ref, since RHF's `dirtyFields` would clear once value == default.
+      const apiClient = apiClientWithCandidates([candidatePrestashop]);
+      renderWithProviders(<EditConnectionForm connection={allegroConnection} />, { apiClient });
+
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      // Wait for the auto-fill to land.
+      await waitFor(() => {
+        expect(picker.value).toBe(candidatePrestashop.id);
+      });
+      // Operator clears the selection.
+      fireEvent.change(picker, { target: { value: '' } });
+      await waitFor(() => {
+        expect(picker.value).toBe('');
+      });
+      // Give any trailing effects a render cycle.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      // Auto-select MUST NOT re-fire.
+      expect(picker.value).toBe('');
+    });
+
+    it('auto-select does not flip form dirty state (Save changes submits unchanged config)', async () => {
+      const updateFn = vi.fn().mockResolvedValue(allegroConnection);
+      const apiClient = apiClientWithCandidates([candidatePrestashop], {
+        connections: { update: updateFn },
+      });
+      renderWithProviders(<EditConnectionForm connection={allegroConnection} />, { apiClient });
+
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      await waitFor(() => {
+        expect(picker.value).toBe(candidatePrestashop.id);
+      });
+
+      // The Save button stays enabled (not gated on dirty), and the submit handler
+      // fires with the auto-filled value — proving the form committed the value
+      // WITHOUT relying on dirty state being flipped.
+      const saveButton = screen.getByRole('button', { name: 'Save changes' });
+      expect(saveButton).not.toBeDisabled();
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(updateFn).toHaveBeenCalled();
+      });
+      const [, payload] = updateFn.mock.calls[0] as [string, { config: Record<string, unknown> }];
+      expect(payload.config).toEqual({
+        environment: 'sandbox',
+        masterCatalogConnectionId: candidatePrestashop.id,
+      });
+    });
+
+    it('renders a stale-pointer error when config references a missing ProductMaster', async () => {
+      const apiClient = apiClientWithCandidates([]); // No candidates — stored UUID is stale.
+      const staleId = '00000000-0000-4000-8000-000000000000';
+      const stale: Connection = {
+        ...allegroConnection,
+        config: { environment: 'sandbox', masterCatalogConnectionId: staleId },
+      };
+      renderWithProviders(<EditConnectionForm connection={stale} />, { apiClient });
+
+      expect(await screen.findByText('Linked catalog is missing')).toBeInTheDocument();
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      const missingOption = picker.querySelector(`option[value="${staleId}"]`);
+      expect(missingOption).not.toBeNull();
+      expect(missingOption?.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('locks the Select when raw JSON is unparseable', async () => {
+      const apiClient = apiClientWithCandidates([candidatePrestashop]);
+      renderWithProviders(<EditConnectionForm connection={allegroConnection} />, { apiClient });
+
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      await waitFor(() => {
+        expect(picker.value).toBe(candidatePrestashop.id);
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show raw config JSON' }));
+      fireEvent.change(screen.getByLabelText('Config JSON'), {
+        target: { value: '{ not: valid json' },
+      });
+
+      expect(screen.getByText('Raw JSON is invalid')).toBeInTheDocument();
+      expect(picker).toBeDisabled();
+    });
+
+    it('submits the picked value and preserves other config keys', async () => {
+      const updateFn = vi.fn().mockResolvedValue(allegroConnection);
+      const apiClient = apiClientWithCandidates([candidatePrestashop, secondPrestashop], {
+        connections: { update: updateFn },
+      });
+      renderWithProviders(<EditConnectionForm connection={allegroConnection} />, { apiClient });
+
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      await waitFor(() => {
+        expect(picker.querySelectorAll('option').length).toBeGreaterThanOrEqual(3);
+      });
+      fireEvent.change(picker, { target: { value: secondPrestashop.id } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+      await waitFor(() => {
+        expect(updateFn).toHaveBeenCalledWith(
+          allegroConnection.id,
+          expect.objectContaining({
+            config: {
+              environment: 'sandbox',
+              masterCatalogConnectionId: secondPrestashop.id,
+            },
+          }),
+        );
+      });
+    });
+
+    it('persists "" when the operator picks None (preserves explicit opt-out, does not delete the key)', async () => {
+      const updateFn = vi.fn().mockResolvedValue(allegroConnection);
+      const apiClient = apiClientWithCandidates([candidatePrestashop, secondPrestashop], {
+        connections: { update: updateFn },
+      });
+      const linked: Connection = {
+        ...allegroConnection,
+        config: { environment: 'sandbox', masterCatalogConnectionId: candidatePrestashop.id },
+      };
+      renderWithProviders(<EditConnectionForm connection={linked} />, { apiClient });
+
+      const picker = await screen.findByLabelText<HTMLSelectElement>(
+        'Product catalog connection',
+      );
+      // Wait for candidates to render so the None option can actually be picked
+      // against a controlled select whose DOM value is the stored UUID.
+      await waitFor(() => {
+        expect(picker.querySelectorAll('option').length).toBeGreaterThanOrEqual(3);
+      });
+      fireEvent.change(picker, { target: { value: '' } });
+      await waitFor(() => {
+        expect(picker.value).toBe('');
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+      await waitFor(() => {
+        expect(updateFn).toHaveBeenCalled();
+      });
+      const [, payload] = updateFn.mock.calls[0] as [string, { config: Record<string, unknown> }];
+      expect(payload.config).toEqual({
+        environment: 'sandbox',
+        masterCatalogConnectionId: '',
+      });
     });
   });
 });

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -1,10 +1,11 @@
-import { useState, type FormEvent, type ReactElement } from 'react';
+import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import type { Connection } from '../api/connections.types';
 import { useUpdateConnectionMutation } from '../hooks/use-update-connection-mutation';
 import { useUpdateConnectionCredentialsMutation } from '../hooks/use-update-connection-credentials-mutation';
+import { useProductMasterConnections } from '../hooks/use-product-master-connections';
 import {
   editConnectionSchema,
   mergeStructuredIntoConfig,
@@ -17,12 +18,16 @@ import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
 import { Textarea } from '../../../shared/ui/textarea';
 import { useToast } from '../../../shared/ui/toast-provider';
 
 interface EditConnectionFormProps {
   connection: Connection;
 }
+
+type StructuredField = 'baseUrl' | 'shopId' | 'masterCatalogConnectionId';
+type PlatformBranch = 'prestashop' | 'marketplace' | 'raw';
 
 function readString(config: Record<string, unknown>, key: string): string {
   const value = config[key];
@@ -49,6 +54,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
       name: connection.name,
       baseUrl: readString(connection.config, 'baseUrl'),
       shopId: readString(connection.config, 'shopId'),
+      masterCatalogConnectionId: readString(connection.config, 'masterCatalogConnectionId'),
       configText: JSON.stringify(connection.config, null, 2),
       adapterKey: connection.adapterKey ?? '',
     },
@@ -59,7 +65,13 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
     error?.message ? [String(error.message)] : [],
   );
 
-  const hasStructuredInputs = connection.platformType === 'prestashop';
+  const platformBranch: PlatformBranch =
+    connection.platformType === 'prestashop'
+      ? 'prestashop'
+      : connection.enabledCapabilities.includes('Marketplace')
+        ? 'marketplace'
+        : 'raw';
+  const hasStructuredInputs = platformBranch !== 'raw';
 
   // Tracks whether the raw JSON currently parses. When it doesn't, we lock the
   // structured inputs so typing in them can't silently drop custom keys that
@@ -67,17 +79,69 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const configText = form.watch('configText');
   const configIsParseable = isParseableJson(configText);
 
+  const { connectionsQuery, productMasterConnections } = useProductMasterConnections();
+  const candidates = useMemo(
+    () => productMasterConnections.filter((c) => c.id !== connection.id),
+    [productMasterConnections, connection.id],
+  );
+  const localAutoSelectId = candidates.length === 1 ? candidates[0].id : undefined;
+
+  const masterCatalogValue = form.watch('masterCatalogConnectionId') ?? '';
+  const storedMasterRaw = connection.config.masterCatalogConnectionId;
+  const hasStoredMaster = typeof storedMasterRaw === 'string';
+  const isStaleMaster =
+    masterCatalogValue !== '' && !candidates.some((c) => c.id === masterCatalogValue);
+
+  // Operator-touched flag for the catalog picker. Any user-driven change to
+  // `masterCatalogConnectionId` flips this to true so auto-select can skip.
+  // We do NOT rely on RHF's `dirtyFields`, since RHF clears dirty when a field
+  // value matches its default — the operator could legitimately pick "None"
+  // (which is the default for a fresh connection) and RHF would report not-dirty.
+  const operatorTouchedCatalogRef = useRef(false);
+
   // Keep the raw configText in sync with structured inputs so the power-user
   // JSON view always reflects the live form state, and submission goes through
   // a single JSON payload. Refuses to write when the JSON is unparseable so we
   // never discard the user's in-progress raw edits.
-  function syncStructuredToJson(field: 'baseUrl' | 'shopId', value: string): void {
-    form.setValue(field, value, { shouldDirty: true });
+  function syncStructuredToJson(
+    field: StructuredField,
+    value: string,
+    options: { markDirty?: boolean } = {},
+  ): void {
+    const markDirty = options.markDirty ?? true;
+    if (markDirty && field === 'masterCatalogConnectionId') {
+      operatorTouchedCatalogRef.current = true;
+    }
+    form.setValue(field, value, { shouldDirty: markDirty });
     if (!configIsParseable) return;
     const parsed = JSON.parse(form.getValues('configText')) as Record<string, unknown>;
     const merged = mergeStructuredIntoConfig(parsed, { [field]: value });
-    form.setValue('configText', JSON.stringify(merged, null, 2), { shouldDirty: true });
+    form.setValue('configText', JSON.stringify(merged, null, 2), { shouldDirty: markDirty });
   }
+
+  // Auto-select the sole candidate ONCE on mount, only when the server never
+  // stored a value (typeof check distinguishes "unset" from an explicit `""`
+  // opt-out) and the operator hasn't already touched the picker. Never marks
+  // the form dirty so save-without-changes doesn't trigger a confirm-leave.
+  const autoSelectFiredRef = useRef(false);
+  useEffect(() => {
+    if (autoSelectFiredRef.current) return;
+    if (platformBranch !== 'marketplace') return;
+    if (hasStoredMaster) return;
+    if (!localAutoSelectId) return;
+    if (connectionsQuery.isLoading) return;
+    if (connectionsQuery.error) return;
+    if (operatorTouchedCatalogRef.current) return;
+    if (form.getValues('masterCatalogConnectionId')) return;
+    autoSelectFiredRef.current = true;
+    syncStructuredToJson('masterCatalogConnectionId', localAutoSelectId, { markDirty: false });
+  }, [
+    localAutoSelectId,
+    connectionsQuery.isLoading,
+    connectionsQuery.error,
+    platformBranch,
+    hasStoredMaster,
+  ]);
 
   const onSubmit = form.handleSubmit(async (values) => {
     try {
@@ -142,14 +206,15 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
         />
       </FormField>
 
-      {hasStructuredInputs ? (
+      {hasStructuredInputs && !configIsParseable ? (
+        <Alert tone="warning" title="Raw JSON is invalid">
+          Fix the raw config JSON below before editing the structured inputs — they are locked so
+          your custom JSON keys are not silently lost.
+        </Alert>
+      ) : null}
+
+      {platformBranch === 'prestashop' ? (
         <>
-          {!configIsParseable ? (
-            <Alert tone="warning" title="Raw JSON is invalid">
-              Fix the raw config JSON below before editing Shop URL / Shop ID — the structured
-              inputs are locked so your custom JSON keys are not silently lost.
-            </Alert>
-          ) : null}
           <FormField
             label="Shop URL"
             name="baseUrl"
@@ -180,6 +245,20 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
             />
           </FormField>
         </>
+      ) : null}
+
+      {platformBranch === 'marketplace' ? (
+        <MarketplaceCatalogPicker
+          value={masterCatalogValue}
+          candidates={candidates}
+          isLoading={connectionsQuery.isLoading}
+          loadError={connectionsQuery.error}
+          isStale={isStaleMaster}
+          errorMessage={form.formState.errors.masterCatalogConnectionId?.message}
+          disabled={!configIsParseable}
+          onChange={(value) => syncStructuredToJson('masterCatalogConnectionId', value)}
+          onRetry={() => void connectionsQuery.refetch()}
+        />
       ) : null}
 
       <div className="config-panel__toggle">
@@ -217,6 +296,101 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
         </Button>
       </div>
     </form>
+  );
+}
+
+interface MarketplaceCatalogPickerProps {
+  value: string;
+  candidates: Connection[];
+  isLoading: boolean;
+  loadError: Error | null;
+  isStale: boolean;
+  errorMessage: string | undefined;
+  disabled: boolean;
+  onChange: (value: string) => void;
+  onRetry: () => void;
+}
+
+function MarketplaceCatalogPicker({
+  value,
+  candidates,
+  isLoading,
+  loadError,
+  isStale,
+  errorMessage,
+  disabled,
+  onChange,
+  onRetry,
+}: MarketplaceCatalogPickerProps): ReactElement {
+  const noCandidates = !isLoading && !loadError && candidates.length === 0 && !isStale;
+
+  return (
+    <>
+      {loadError ? (
+        <Alert
+          tone="error"
+          title="Could not load ProductMaster connections"
+          action={
+            <Button tone="secondary" type="button" onClick={onRetry}>
+              Retry
+            </Button>
+          }
+        >
+          {loadError.message}
+        </Alert>
+      ) : null}
+
+      {noCandidates ? (
+        <Alert tone="info" title="No ProductMaster connections yet">
+          Barcode linking needs a catalog source.{' '}
+          <Link to="/connections/new?platform=prestashop">Add a PrestaShop connection</Link> to
+          enable offer-to-product linking.
+        </Alert>
+      ) : null}
+
+      {isStale ? (
+        <Alert tone="error" title="Linked catalog is missing">
+          This connection points to a deleted or disabled ProductMaster. Pick a new one below or
+          clear the link.
+        </Alert>
+      ) : null}
+
+      <FormField
+        label="Product catalog connection"
+        name="masterCatalogConnectionId"
+        error={errorMessage}
+        description="OpenLinker uses this ProductMaster connection to resolve offer barcodes (EAN/GTIN) to internal product variants. If left empty and exactly one ProductMaster connection exists, it is used automatically."
+      >
+        {isLoading ? (
+          <Select disabled>
+            <option>Loading connections…</option>
+          </Select>
+        ) : loadError ? (
+          <Select disabled>
+            <option>Failed to load connections</option>
+          </Select>
+        ) : (
+          <Select
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            disabled={disabled}
+            invalid={Boolean(errorMessage) || isStale}
+          >
+            <option value="">None (barcode linking disabled)</option>
+            {candidates.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+            {isStale ? (
+              <option value={value} disabled>
+                Missing: {value}
+              </option>
+            ) : null}
+          </Select>
+        )}
+      </FormField>
+    </>
   );
 }
 

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -5,6 +5,9 @@ export const editConnectionSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
   baseUrl: z.string().trim().optional(),
   shopId: z.string().trim().optional(),
+  masterCatalogConnectionId: z
+    .union([z.string().uuid('Product catalog must be a valid connection ID'), z.literal('')])
+    .optional(),
   configText: z
     .string()
     .trim()
@@ -38,7 +41,11 @@ export function toUpdateConnectionInput(values: EditConnectionFormSubmission): U
  */
 export function mergeStructuredIntoConfig(
   base: Record<string, unknown>,
-  structured: { baseUrl?: string; shopId?: string },
+  structured: {
+    baseUrl?: string;
+    shopId?: string;
+    masterCatalogConnectionId?: string;
+  },
 ): Record<string, unknown> {
   const next: Record<string, unknown> = { ...base };
   if (structured.baseUrl !== undefined) {
@@ -54,6 +61,13 @@ export function mergeStructuredIntoConfig(
     } else {
       next.shopId = structured.shopId;
     }
+  }
+  // Unlike baseUrl/shopId, masterCatalogConnectionId uses `""` as an explicit
+  // opt-out signal (see offer-mapping-sync.service.ts:278 — `""` disables
+  // barcode linking, absent key falls back to auto-resolve). So we persist the
+  // value verbatim instead of deleting on empty.
+  if (structured.masterCatalogConnectionId !== undefined) {
+    next.masterCatalogConnectionId = structured.masterCatalogConnectionId;
   }
   return next;
 }

--- a/apps/web/src/pages/connections/connection-detail-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.test.tsx
@@ -1,9 +1,73 @@
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Connection } from '../../features/connections/api/connections.types';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { ConnectionDetailPage } from './connection-detail-page';
+
+const PRESTASHOP_UUID_1 = '11111111-1111-4111-8111-111111111111';
+const PRESTASHOP_UUID_2 = '22222222-2222-4222-8222-222222222222';
+const ALLEGRO_UUID = '33333333-3333-4333-8333-333333333333';
+
+const candidatePrestashop: Connection = {
+  ...sampleConnection,
+  id: PRESTASHOP_UUID_1,
+  name: 'Main PrestaShop Store',
+};
+
+const secondPrestashop: Connection = {
+  ...sampleConnection,
+  id: PRESTASHOP_UUID_2,
+  name: 'Second PrestaShop',
+};
+
+function makeAllegro(overrides: Partial<Connection> = {}): Connection {
+  return {
+    ...sampleConnection,
+    id: ALLEGRO_UUID,
+    name: 'Allegro sandbox',
+    platformType: 'allegro',
+    config: { environment: 'sandbox' },
+    enabledCapabilities: ['Marketplace', 'OrderProcessorManager'],
+    supportedCapabilities: ['Marketplace', 'OrderProcessorManager'],
+    adapterKey: 'allegro.publicapi.v1',
+    ...overrides,
+  };
+}
+
+/**
+ * Build an api client mock where `connections.getById` returns the connection under
+ * test and `connections.list` returns the given candidate set.
+ */
+function apiClientForBanner(
+  connection: Connection,
+  candidates: Connection[],
+  overrides: Parameters<typeof createMockApiClient>[0] = {},
+): ReturnType<typeof createMockApiClient> {
+  return createMockApiClient({
+    ...overrides,
+    connections: {
+      ...overrides.connections,
+      getById: vi.fn().mockResolvedValue(connection),
+      list: vi.fn().mockResolvedValue(candidates),
+    },
+  });
+}
+
+async function renderDetailPage(
+  connection: Connection,
+  apiClient: ReturnType<typeof createMockApiClient>,
+): Promise<void> {
+  renderWithProviders(
+    <Routes>
+      <Route path="/connections/:connectionId" element={<ConnectionDetailPage />} />
+    </Routes>,
+    { apiClient, route: `/connections/${connection.id}` },
+  );
+  // Wait for the main connection query to settle so banner logic can render.
+  await screen.findByRole('heading', { name: 'Overview' });
+}
 
 // Note: renderWithProviders uses MemoryRouter. The page reads connectionId via
 // useParams which defaults to '' when no route pattern matches. To provide the
@@ -75,5 +139,136 @@ describe('ConnectionDetailPage', () => {
 
     const configTab = await screen.findByRole('tab', { name: 'Config' });
     expect(configTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  describe('ProductCatalogLinkBanner', () => {
+    it('does NOT render the banner for non-Marketplace connections (e.g. PrestaShop)', async () => {
+      const apiClient = apiClientForBanner(sampleConnection, [candidatePrestashop]);
+      await renderDetailPage(sampleConnection, apiClient);
+
+      expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
+      expect(screen.queryByText('Product catalog not linked')).toBeNull();
+      expect(screen.queryByText('Barcode linking disabled')).toBeNull();
+    });
+
+    it('does NOT render the banner when an explicit master catalog is linked', async () => {
+      const connection = makeAllegro({
+        config: { environment: 'sandbox', masterCatalogConnectionId: candidatePrestashop.id },
+      });
+      const apiClient = apiClientForBanner(connection, [candidatePrestashop]);
+      await renderDetailPage(connection, apiClient);
+
+      expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
+      expect(screen.queryByText('Product catalog not linked')).toBeNull();
+      expect(screen.queryByText('Barcode linking disabled')).toBeNull();
+    });
+
+    it('renders the "explicitly disabled" warning when config has an empty master id', async () => {
+      const connection = makeAllegro({
+        config: { environment: 'sandbox', masterCatalogConnectionId: '' },
+      });
+      const apiClient = apiClientForBanner(connection, [candidatePrestashop]);
+      await renderDetailPage(connection, apiClient);
+
+      expect(await screen.findByText('Barcode linking disabled')).toBeInTheDocument();
+      expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
+    });
+
+    it('renders the auto-linked info banner when exactly one ProductMaster candidate exists', async () => {
+      const connection = makeAllegro();
+      const apiClient = apiClientForBanner(connection, [candidatePrestashop]);
+      await renderDetailPage(connection, apiClient);
+
+      const banner = await screen.findByText('Product catalog auto-linked');
+      expect(banner).toBeInTheDocument();
+      // Candidate name is surfaced in the banner body.
+      expect(screen.getByText(candidatePrestashop.name)).toBeInTheDocument();
+      // Linked-state banners should NOT appear simultaneously.
+      expect(screen.queryByText('Product catalog not linked')).toBeNull();
+    });
+
+    it('renders the ambiguous warning when 2+ candidates exist', async () => {
+      const connection = makeAllegro();
+      const apiClient = apiClientForBanner(connection, [candidatePrestashop, secondPrestashop]);
+      await renderDetailPage(connection, apiClient);
+
+      expect(await screen.findByText('Product catalog not linked')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Multiple ProductMaster connections exist/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
+    });
+
+    it('renders the no-candidates warning with a "create PrestaShop" CTA when 0 candidates exist', async () => {
+      const connection = makeAllegro();
+      const apiClient = apiClientForBanner(connection, []);
+      await renderDetailPage(connection, apiClient);
+
+      expect(await screen.findByText('Product catalog not linked')).toBeInTheDocument();
+      const cta = screen.getByRole('link', { name: /add a prestashop connection/i });
+      expect(cta).toHaveAttribute('href', '/connections/new?platform=prestashop');
+    });
+
+    it('renders nothing while the candidates query is still loading', async () => {
+      const connection = makeAllegro();
+      const apiClient = createMockApiClient({
+        connections: {
+          getById: vi.fn().mockResolvedValue(connection),
+          list: vi.fn().mockImplementation(
+            () => new Promise(() => {}), // never resolves — simulate persistent loading
+          ),
+        },
+      });
+      renderWithProviders(
+        <Routes>
+          <Route path="/connections/:connectionId" element={<ConnectionDetailPage />} />
+        </Routes>,
+        { apiClient, route: `/connections/${connection.id}` },
+      );
+      await screen.findByRole('heading', { name: 'Overview' });
+
+      // Neither auto-resolved nor ambiguous banner should flash during loading.
+      expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
+      expect(screen.queryByText('Product catalog not linked')).toBeNull();
+    });
+
+    it('stays silent when the candidates query errors out (advisory, not blocking)', async () => {
+      const connection = makeAllegro();
+      const apiClient = createMockApiClient({
+        connections: {
+          getById: vi.fn().mockResolvedValue(connection),
+          list: vi.fn().mockRejectedValue(new Error('Network error')),
+        },
+      });
+      renderWithProviders(
+        <Routes>
+          <Route path="/connections/:connectionId" element={<ConnectionDetailPage />} />
+        </Routes>,
+        { apiClient, route: `/connections/${connection.id}` },
+      );
+      await screen.findByRole('heading', { name: 'Overview' });
+
+      // Give the query a tick to fail.
+      await waitFor(() => {
+        expect((apiClient.connections.list as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
+      });
+      expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
+      expect(screen.queryByText('Product catalog not linked')).toBeNull();
+    });
+
+    it('excludes the connection under test from its own candidate list', async () => {
+      // Dual-cap hypothetical: the connection under test is itself marked as a
+      // ProductMaster candidate by the hook (which doesn't exclude self). The
+      // banner must filter self out to avoid auto-linking to itself.
+      const dualCap = makeAllegro({
+        enabledCapabilities: ['Marketplace', 'ProductMaster', 'OrderProcessorManager'],
+      });
+      const apiClient = apiClientForBanner(dualCap, [dualCap]);
+      await renderDetailPage(dualCap, apiClient);
+
+      // After filtering self, candidates = 0 → no-candidates warning, not auto-linked.
+      expect(await screen.findByText('Product catalog not linked')).toBeInTheDocument();
+      expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
+    });
   });
 });

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -1,11 +1,12 @@
 import type { ReactElement } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
+import { useProductMasterConnections } from '../../features/connections/hooks/use-product-master-connections';
 import { ConnectionActionsPanel } from '../../features/connections/components/ConnectionActionsPanel';
 import { ConnectionCapabilitiesPanel } from '../../features/connections/components/ConnectionCapabilitiesPanel';
 import { ConnectionConfigPanel } from '../../features/connections/components/ConnectionConfigPanel';
 import { ConnectionDiagnosticsPanel } from '../../features/connections/components/ConnectionDiagnosticsPanel';
-import type { ConnectionStatus } from '../../features/connections/api/connections.types';
+import type { Connection, ConnectionStatus } from '../../features/connections/api/connections.types';
 import { EmptyState, ErrorState, LoadingState } from '../../shared/ui/feedback-state';
 import { EntityLabel } from '../../shared/ui/entity-label';
 import { KeyValueList } from '../../shared/ui/key-value-list';
@@ -33,9 +34,79 @@ function isTabValue(value: string | null): value is TabValue {
   return value !== null && (TAB_VALUES as readonly string[]).includes(value);
 }
 
+interface ProductCatalogLinkBannerProps {
+  connection: Connection;
+  candidates: Connection[];
+  isLoading: boolean;
+  hasError: boolean;
+}
+
+function ProductCatalogLinkBanner({
+  connection,
+  candidates,
+  isLoading,
+  hasError,
+}: ProductCatalogLinkBannerProps): ReactElement | null {
+  if (!connection.enabledCapabilities.includes('Marketplace')) return null;
+
+  const rawMaster = connection.config.masterCatalogConnectionId;
+  const explicitMaster = typeof rawMaster === 'string' ? rawMaster : null;
+  const editHref = `/connections/${connection.id}/edit`;
+
+  if (explicitMaster !== null && explicitMaster.length > 0) {
+    // Linked — no banner.
+    return null;
+  }
+
+  if (explicitMaster === '') {
+    return (
+      <Alert tone="warning" title="Barcode linking disabled">
+        Barcode linking is turned off for this connection. <Link to={editHref}>Edit connection</Link>{' '}
+        to select a catalog.
+      </Alert>
+    );
+  }
+
+  // From here: explicitMaster === null (server never stored the key).
+  // Defer banner render until candidates query settles, and stay silent on
+  // candidate-query errors (advisory banner, not blocking; avoids double
+  // noise when the user already sees global query errors elsewhere).
+  if (isLoading) return null;
+  if (hasError) return null;
+
+  if (candidates.length === 1) {
+    return (
+      <Alert tone="info" title="Product catalog auto-linked">
+        Barcode linking will use <strong>{candidates[0].name}</strong> (the only ProductMaster
+        connection). <Link to={editHref}>Edit connection</Link> to pin this explicitly.
+      </Alert>
+    );
+  }
+
+  if (candidates.length === 0) {
+    return (
+      <Alert tone="warning" title="Product catalog not linked">
+        No active ProductMaster connections to link to.{' '}
+        <Link to="/connections/new?platform=prestashop">Add a PrestaShop connection</Link> first.
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert tone="warning" title="Product catalog not linked">
+      Multiple ProductMaster connections exist — pick one explicitly or barcode sync will be
+      skipped. <Link to={editHref}>Edit connection</Link>.
+    </Alert>
+  );
+}
+
 export function ConnectionDetailPage(): ReactElement {
   const { connectionId = '' } = useParams();
   const connectionQuery = useConnectionQuery(connectionId);
+  const {
+    productMasterConnections,
+    connectionsQuery: productMasterConnectionsQuery,
+  } = useProductMasterConnections();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const tabParam = searchParams.get('tab');
@@ -128,13 +199,13 @@ export function ConnectionDetailPage(): ReactElement {
           message="No connection data was returned for this route. Retry from the integrations list or verify the selected identifier."
         />
       ) : null}
-      {connection &&
-      connection.enabledCapabilities.includes('Marketplace') &&
-      typeof connection.config.masterCatalogConnectionId !== 'string' ? (
-        <Alert tone="warning" title="Product catalog not linked">
-          Offer-to-product barcode linking is disabled. Edit this connection to select a ProductMaster
-          catalog connection, or barcode sync will be skipped.
-        </Alert>
+      {connection ? (
+        <ProductCatalogLinkBanner
+          connection={connection}
+          candidates={productMasterConnections.filter((c) => c.id !== connection.id)}
+          isLoading={productMasterConnectionsQuery.isLoading}
+          hasError={Boolean(productMasterConnectionsQuery.error)}
+        />
       ) : null}
       {connection ? (
         <Tabs value={activeTab} onValueChange={handleTabChange}>


### PR DESCRIPTION
## Summary

Closes #276.

Two frontend fixes, shipped together per the issue:

1. **Edit Connection form — structured ProductMaster picker for marketplace connections.** Before this PR, only PrestaShop connections got structured inputs in `EditConnectionForm`; Allegro (and any future marketplace) fell through to the raw Config JSON textarea, forcing operators to hand-edit JSON to link their catalog. The form now exposes `masterCatalogConnectionId` as a `<Select>` populated from `useProductMasterConnections()`, with loading / error / empty-candidates / stale-pointer states, auto-selection when exactly one ProductMaster candidate exists, and two-way sync with the raw Config JSON textarea. Behavior mirrors `AllegroSetupForm`.

2. **Detail-page banner — five states, not one.** The banner on `/connections/:id` previously fired a warning whenever `masterCatalogConnectionId` was absent, ignoring the backend's `autoResolveMasterConnectionId(excludeConnectionId)` policy (which auto-picks the only ProductMaster candidate). Now it distinguishes:
   - **Linked** (UUID stored) → no banner
   - **Explicitly disabled** (`""` stored) → warning
   - **Auto-resolved** (unset + exactly 1 candidate) → **info** (no more false-positive warning on the happiest path)
   - **Ambiguous** (unset + 2+ candidates) → warning
   - **No candidates** (unset + 0 candidates) → warning with "Add a PrestaShop connection" CTA

State is derived client-side from data the page already fetches (no new backend field), matching `offer-mapping-sync.service.ts` policy exactly (`excludeConnectionId` filter included).

## Design

Implementation plan + tech-review trail: `docs/plans/implementation-plan-edit-connection-catalog-picker.md`.

Two deliberate deviations from the original plan, both improvements:

- **Merge helper persists `""` verbatim** for `masterCatalogConnectionId` instead of deleting on empty (matches the backend opt-out contract at `offer-mapping-sync.service.ts:278`). Inline comment explains the divergence from `baseUrl`/`shopId` semantics.
- **Operator-touched `useRef` guard** replaces RHF's `dirtyFields` check — RHF clears dirty when a field's value matches the default, which breaks the "don't auto-fill over an operator's explicit choice" invariant when the operator's choice is "None" (matching the default).

## Files changed

| Path | Change |
|---|---|
| `edit-connection.schema.ts` | New `masterCatalogConnectionId` field (UUID \| `""`); merge helper persists `""` verbatim |
| `EditConnectionForm.tsx` | `PlatformBranch` discriminant; `MarketplaceCatalogPicker` subcomponent; auto-select effect with run-once + operator-touched refs |
| `connection-detail-page.tsx` | `ProductCatalogLinkBanner` subcomponent (5-state + silent loading/error); consumes `useProductMasterConnections` |
| `EditConnectionForm.test.tsx` | +10 marketplace-branch cases |
| `connection-detail-page.test.tsx` | +9 banner cases (all five states + loading + error + self-exclusion + PrestaShop negative) |

No backend changes, no new shared UI primitives, no new CSS.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` — 0 errors
- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web test` — 352/352 passing (19 new cases)
- [x] Pre-commit hook ran full monorepo lint + type-check + tests (apps/worker 97 green, apps/api clean) — see commit run
- [ ] Manual smoke: open `/connections/:allegroId/edit`, confirm Product catalog dropdown appears, pick a PrestaShop, save, verify the detail-page banner disappears (linked state)
- [ ] Manual smoke: with exactly one PrestaShop connection, open a fresh Allegro detail page; confirm **info** "Product catalog auto-linked" banner appears (not warning)
- [ ] Manual smoke: with zero PrestaShop connections, confirm the no-candidates warning renders with a working "Add a PrestaShop connection" link
- [ ] Manual smoke: confirm inline `<Link>` elements inside `Alert` bodies are visually distinguishable (default bare-anchor underline should apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)