### PR TITLE
refactor(products): reconcile the two ProductVariant type definitions

### DIFF
--- a/apps/api/src/categories/categories-cache.service.ts
+++ b/apps/api/src/categories/categories-cache.service.ts
@@ -85,8 +85,8 @@ export class CategoriesCacheService implements ICategoriesCacheService {
       id: cat.id,
       name: cat.name,
       parentId: cat.parentId ?? null,
-      depth: typeof cat['depth'] === 'number' ? cat['depth'] : 0,
-      active: cat['active'] !== false,
+      depth: cat.depth ?? 0,
+      active: cat.active !== false,
     }));
   }
 

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -11,7 +11,7 @@ import { ProductsController, VariantsController } from './products.controller';
 import {
   PRODUCTS_SERVICE_TOKEN,
   ProductEntity,
-  ProductVariantEntity,
+  ProductVariant,
 } from '@openlinker/core/products';
 import type { IProductsService } from '@openlinker/core/products';
 import { IDENTIFIER_MAPPING_SERVICE_TOKEN } from '@openlinker/core/identifier-mapping';
@@ -30,17 +30,17 @@ function makeProduct(overrides: Partial<ProductEntity> = {}): ProductEntity {
   );
 }
 
-function makeVariant(overrides: Partial<ProductVariantEntity> = {}): ProductVariantEntity {
-  return new ProductVariantEntity(
-    overrides.id ?? 'ol_product_v1',
-    overrides.productId ?? 'ol_product_1',
-    overrides.sku ?? 'SKU-001-S',
-    overrides.attributes ?? { size: 'S' },
-    overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
-    overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
-    overrides.ean ?? '1234567890123',
-    overrides.gtin ?? null,
-  );
+function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
+  return {
+    id: overrides.id ?? 'ol_product_v1',
+    productId: overrides.productId ?? 'ol_product_1',
+    sku: overrides.sku ?? 'SKU-001-S',
+    attributes: overrides.attributes ?? { size: 'S' },
+    ean: overrides.ean ?? '1234567890123',
+    gtin: overrides.gtin ?? null,
+    createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
+  };
 }
 
 function createMockProductsService(): jest.Mocked<IProductsService> {

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -37,6 +37,28 @@ import { ExternalIdMappingDto } from './dto/external-id-mapping.dto';
 
 const MAX_VARIANTS_IN_DETAIL = 100;
 
+/**
+ * Shared variant-to-DTO mapper.
+ *
+ * Timestamps are optional on the ProductVariant interface because adapters
+ * produce pre-persistence variants. In these controllers the variant is always
+ * repository-sourced (see ProductVariantRepository#toDomain), so timestamps are
+ * guaranteed present — non-null assertion crashes loudly if the invariant ever
+ * breaks, which is preferable to silently emitting a 1970 epoch date.
+ */
+function variantToDto(variant: ProductVariant): ProductVariantResponseDto {
+  return {
+    id: variant.id,
+    productId: variant.productId,
+    sku: variant.sku,
+    attributes: variant.attributes,
+    ean: variant.ean ?? null,
+    gtin: variant.gtin ?? null,
+    createdAt: variant.createdAt!.toISOString(),
+    updatedAt: variant.updatedAt!.toISOString(),
+  };
+}
+
 @Roles('admin')
 @ApiBearerAuth()
 @ApiTags('products')
@@ -160,20 +182,7 @@ export class ProductsController {
   }
 
   private toVariantDto(variant: ProductVariant): ProductVariantResponseDto {
-    // Timestamps are optional on the ProductVariant interface because adapters
-    // produce pre-persistence variants. In this controller the variant is always
-    // repository-sourced (see ProductVariantRepository#toDomain), so they are
-    // guaranteed present — fall back to epoch for compiler's benefit only.
-    return {
-      id: variant.id,
-      productId: variant.productId,
-      sku: variant.sku,
-      attributes: variant.attributes,
-      ean: variant.ean ?? null,
-      gtin: variant.gtin ?? null,
-      createdAt: (variant.createdAt ?? new Date(0)).toISOString(),
-      updatedAt: (variant.updatedAt ?? new Date(0)).toISOString(),
-    };
+    return variantToDto(variant);
   }
 
   private toExternalIdDto(mapping: { externalId: string; platformType: string; connectionId: string }): ExternalIdMappingDto {
@@ -226,19 +235,6 @@ export class VariantsController {
   }
 
   private toVariantDto(variant: ProductVariant): ProductVariantResponseDto {
-    // Timestamps are optional on the ProductVariant interface because adapters
-    // produce pre-persistence variants. In this controller the variant is always
-    // repository-sourced (see ProductVariantRepository#toDomain), so they are
-    // guaranteed present — fall back to epoch for compiler's benefit only.
-    return {
-      id: variant.id,
-      productId: variant.productId,
-      sku: variant.sku,
-      attributes: variant.attributes,
-      ean: variant.ean ?? null,
-      gtin: variant.gtin ?? null,
-      createdAt: (variant.createdAt ?? new Date(0)).toISOString(),
-      updatedAt: (variant.updatedAt ?? new Date(0)).toISOString(),
-    };
+    return variantToDto(variant);
   }
 }

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -22,7 +22,7 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
-import { PRODUCTS_SERVICE_TOKEN, ProductEntity, ProductVariantEntity } from '@openlinker/core/products';
+import { PRODUCTS_SERVICE_TOKEN, ProductEntity, ProductVariant } from '@openlinker/core/products';
 import { IDENTIFIER_MAPPING_SERVICE_TOKEN } from '@openlinker/core/identifier-mapping';
 import type { IProductsService } from '@openlinker/core/products';
 import type { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
@@ -159,7 +159,11 @@ export class ProductsController {
     };
   }
 
-  private toVariantDto(variant: ProductVariantEntity): ProductVariantResponseDto {
+  private toVariantDto(variant: ProductVariant): ProductVariantResponseDto {
+    // Timestamps are optional on the ProductVariant interface because adapters
+    // produce pre-persistence variants. In this controller the variant is always
+    // repository-sourced (see ProductVariantRepository#toDomain), so they are
+    // guaranteed present — fall back to epoch for compiler's benefit only.
     return {
       id: variant.id,
       productId: variant.productId,
@@ -167,8 +171,8 @@ export class ProductsController {
       attributes: variant.attributes,
       ean: variant.ean ?? null,
       gtin: variant.gtin ?? null,
-      createdAt: variant.createdAt.toISOString(),
-      updatedAt: variant.updatedAt.toISOString(),
+      createdAt: (variant.createdAt ?? new Date(0)).toISOString(),
+      updatedAt: (variant.updatedAt ?? new Date(0)).toISOString(),
     };
   }
 
@@ -221,7 +225,11 @@ export class VariantsController {
     };
   }
 
-  private toVariantDto(variant: ProductVariantEntity): ProductVariantResponseDto {
+  private toVariantDto(variant: ProductVariant): ProductVariantResponseDto {
+    // Timestamps are optional on the ProductVariant interface because adapters
+    // produce pre-persistence variants. In this controller the variant is always
+    // repository-sourced (see ProductVariantRepository#toDomain), so they are
+    // guaranteed present — fall back to epoch for compiler's benefit only.
     return {
       id: variant.id,
       productId: variant.productId,
@@ -229,8 +237,8 @@ export class VariantsController {
       attributes: variant.attributes,
       ean: variant.ean ?? null,
       gtin: variant.gtin ?? null,
-      createdAt: variant.createdAt.toISOString(),
-      updatedAt: variant.updatedAt.toISOString(),
+      createdAt: (variant.createdAt ?? new Date(0)).toISOString(),
+      updatedAt: (variant.updatedAt ?? new Date(0)).toISOString(),
     };
   }
 }

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
@@ -248,8 +248,15 @@ describe('TriggerSyncDialog', () => {
         expect(onOpenChange).toHaveBeenCalledWith(false);
       });
 
-      expect(screen.getByText(/sync job enqueued/i)).toBeInTheDocument();
-      expect(screen.getByText(/job_42/i)).toBeInTheDocument();
+      // Radix Toast renders the title and description twice — once in the
+      // visible `.toast__title`/`.toast__description` and once inside an
+      // `aria-live` announcement span. Scope to the visible toast title/body.
+      expect(
+        screen.getByText(/sync job enqueued/i, { selector: '.toast__title' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/job_42/i, { selector: '.toast__description' }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/worker/test/integration/helpers/mock-adapters.helper.ts
+++ b/apps/worker/test/integration/helpers/mock-adapters.helper.ts
@@ -37,6 +37,8 @@ export function createMockPrestashopProductAdapter(): ProductMasterPort {
           productId,
           sku: 'TEST-VARIANT-SKU-001',
           attributes: { size: 'M', color: 'Blue' },
+          ean: null,
+          gtin: null,
           createdAt: new Date(),
           updatedAt: new Date(),
         },

--- a/docs/plans/implementation-plan-281-reconcile-product-variant.md
+++ b/docs/plans/implementation-plan-281-reconcile-product-variant.md
@@ -168,7 +168,7 @@ Will file a follow-up issue after this PR lands so the reviewer can see the shap
 | Question | Decision |
 |---|---|
 | Keep class or use interface? | Interface. Issue recommends it; repositories build plain objects. |
-| Required or optional timestamps? | **Required.** Adapters stamp `new Date()` placeholders; TypeORM handles persistence timestamps. |
+| Required or optional timestamps? | **Optional.** Adapters produce pre-persistence variants without timestamps; TypeORM `@CreateDateColumn`/`@UpdateDateColumn` fills them in on save; repositories populate on load. Required would force adapters to fabricate `new Date()` placeholders that TypeORM discards. Controllers that serialize repository-sourced variants use a non-null assertion (see `apps/api/src/products/http/products.controller.ts`). |
 | `ean`/`gtin` null vs undefined? | **`string \| null`.** Aligns with DB columns; consumers do truthy check in practice. |
 | Keep the `[key: string]: unknown` index signature? | **No.** Issue explicitly calls it out as a bug-hiding escape hatch. |
 | Keep `ProductVariantEntity` alias in the barrel? | **No.** After migrating three test files, it has zero consumers. |

--- a/docs/plans/implementation-plan-281-reconcile-product-variant.md
+++ b/docs/plans/implementation-plan-281-reconcile-product-variant.md
@@ -1,0 +1,175 @@
+# Implementation Plan: #281 — Reconcile the two `ProductVariant` type definitions
+
+## 1. Task Understanding
+
+**Goal**: Collapse the two `ProductVariant` exports from `@openlinker/core/products` — the port interface (in `domain/ports/product-master.port.ts`) and the domain entity class (in `domain/entities/product-variant.entity.ts`) — into a single interface exported from one place. Repositories build plain objects, callers import one type, adapters produce the same shape as what the repo returns.
+
+**Layer**: CORE (products domain) + integrations/tests that currently straddle both shapes.
+
+**Non-goals**:
+- Same duality for `Product` and `Category` — the issue explicitly says to file a separate issue if found. See §7 below: confirmed both have it, will file as a follow-up.
+- Fixing the `products.service.ts:62` bug that drops `ean`/`gtin` when rebuilding variants to re-stamp `productId` — incidentally resolved by switching from `new ProductVariant(...)` to object-spread, but not a scope goal.
+
+## 2. Research findings
+
+**Current state:**
+- Port interface `ProductVariant` (`product-master.port.ts:36-46`): optional `ean`/`gtin` (`string | undefined`), no `createdAt`/`updatedAt`, has `[key: string]: unknown` escape hatch.
+- Entity class `ProductVariant` (`product-variant.entity.ts:10-21`): required `createdAt`/`updatedAt`, nullable `ean`/`gtin` (`string | null`), nullable `sku` and `attributes`.
+- Barrel exports: `ProductVariant` (port interface) + alias `ProductVariantEntity` (class).
+- Repository `toDomain` returns the **class**, typed as the **interface** (via the port).
+- Consumers of `new ProductVariant(...)`: 3 files (`product-variant.repository.ts`, `products.service.ts`, `products.service.spec.ts`).
+- Consumers of `new ProductVariantEntity(...)`: 3 test files (API controller spec, offer-mapping-sync spec, order-item-ref-resolver spec).
+- **No `as unknown as ProductVariant` casts** in the current codebase — the issue's example was forward-looking. Zero casts to remove.
+- PrestaShop adapter returns plain object literals without `createdAt`/`updatedAt` or `attributes` (`prestashop-product-master.adapter.ts:198-206` and `237-259`). These compile today only because the port interface has those fields optional.
+
+**The structural tension:**
+Adapters produce variants *before* persistence → no timestamps yet. Repositories produce variants *after* persistence → timestamps always present. Forcing required timestamps means adapters fabricate `new Date()`; leaving them optional means the type allows unsafe states at runtime.
+
+## 3. Solution
+
+**Canonical shape** — single interface, keep it in `domain/entities/product-variant.entity.ts` (the standard location for domain entities). Port re-imports from there, barrel exports it:
+
+```ts
+// domain/entities/product-variant.entity.ts
+export interface ProductVariant {
+  id: string;
+  productId: string;
+  sku: string | null;
+  attributes: Record<string, string> | null;
+  ean: string | null;
+  gtin: string | null;
+  createdAt?: Date;  // populated by repo on load; adapters/drafts omit
+  updatedAt?: Date;  // same
+  price?: number;    // master-derived, not persisted
+  weight?: number;   // same
+}
+```
+
+Decisions, referenced against the issue and the tech-review of this plan:
+- **Optional `createdAt`/`updatedAt`** — **push back on the issue's "required" recommendation**. The real data flow is bidirectional: adapters produce pre-persistence variants (no timestamps exist yet); repositories produce post-persistence variants (timestamps always present). Forcing "required" means adapters fabricate `new Date()` placeholders that TypeORM discards on save — semantic noise that propagates into logs and test assertions. Optional matches reality; the narrow cost is that the type allows a theoretically invalid state ("persisted variant without timestamps") that never actually occurs. Documented in §8.
+- **`ean` / `gtin` as `string | null`** — per the issue, aligns with DB nullability. PrestaShop adapter currently emits `string | undefined`; convert with `?? null`. Grep confirmed **zero strict-undefined checks** on these fields — all consumers use truthy checks, so the shift is safe.
+- **`sku` as `string | null`** — matches the existing class + DB; PrestaShop adapter emits a fallback string so it's non-null in practice.
+- **`attributes` as `Record<string, string> | null`** — matches the existing class + DB. Adapter synthetic-variant case currently omits it; will add `attributes: null`.
+- **Optional `price` / `weight`** — per the issue, derived/transient fields not persisted on the variants table.
+- **No index signature `[key: string]: unknown`** — per the issue, hides bugs.
+- **Interface, not class.** Repositories build plain objects. Interface chosen explicitly per the issue — file header will carry a short note ("shape crosses adapter/repo/ui boundaries; structural typing avoids `instanceof` false negatives across import paths") so future readers don't "correct" it back to a class.
+
+**Port/barrel:**
+- `product-master.port.ts`: remove the inline `ProductVariant` interface. Import from `../entities/product-variant.entity`.
+- `products/index.ts`: export `ProductVariant` from the entity file. Remove the `ProductVariantEntity` alias (backwards-compat shim with no consumers after step 4).
+
+## 4. Step-by-step
+
+### Step 1 — Rewrite `domain/entities/product-variant.entity.ts`
+
+Replace the class with the canonical interface (shape above). Keep the JSDoc module comment. File header stays.
+
+### Step 2 — Port interface deduplication
+
+**File**: `libs/core/src/products/domain/ports/product-master.port.ts`
+
+- Remove the local `ProductVariant` interface (lines 34-46).
+- Import from entity: `import type { ProductVariant } from '../entities/product-variant.entity';`
+- **Re-export is required**: `libs/core/src/products/application/services/master-product-sync.service.ts:21` deep-imports `ProductVariant` from this port path. Add `export type { ProductVariant } from '../entities/product-variant.entity';` to preserve that import (and fix the service in Step 5 below to drop the now-redundant alias).
+- **Also drop `[key: string]: unknown` from `Category`** (line ~55) — same one-line cleanup while we're already in this file. Consumers use known keys only (would have surfaced as a compile error with strict mode otherwise).
+
+### Step 3 — Barrel cleanup
+
+**File**: `libs/core/src/products/index.ts`
+
+- Replace `export { ProductVariant } from './domain/ports/product-master.port';` with `export { ProductVariant } from './domain/entities/product-variant.entity';`
+- Remove `export { ProductVariant as ProductVariantEntity } from './domain/entities/product-variant.entity';` — alias no longer needed once call sites are migrated.
+
+### Step 4 — Repository: switch to object literal
+
+**File**: `libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts`
+
+- `toDomain`: replace `new ProductVariant(entity.id, ...)` with an object literal matching the interface.
+- Imports: drop the class import; the repo already imports the type via the port (which re-exports).
+
+### Step 5 — Services: drop constructor calls and type aliases
+
+**File**: `libs/core/src/products/application/services/products.service.ts`
+
+- `upsertVariants` (line ~62): replace the `new ProductVariant(...)` rebuild with object spread `{ ...variant, productId }`. This incidentally fixes the silent `ean`/`gtin` drop bug (not a scope goal, but a free win).
+
+**File**: `libs/core/src/products/application/services/master-product-sync.service.ts`
+
+- Collapse the two aliased imports (`ProductVariantPortInterface` + `ProductVariantDomainEntity`) into one: `import { ProductVariant } from '../../domain/entities/product-variant.entity';` (or via the barrel).
+- The private `toDomainVariant` mapper (line ~104-114) becomes a pass-through: port shape == entity shape. Delete the mapper and pass variants through unchanged. (Keep `toDomainProduct` untouched — Product duality is out of scope for this PR.)
+
+### Step 6 — Service spec: drop the constructor call
+
+**File**: `libs/core/src/products/application/services/products.service.spec.ts`
+
+- Replace test `new ProductVariant(...)` factory calls with plain object literals.
+
+### Step 7 — Migrate `ProductVariantEntity` test imports
+
+Three test files currently use `ProductVariantEntity`:
+- `apps/api/src/products/http/products.controller.spec.ts`
+- `libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts`
+- `libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts`
+
+In each: replace `new ProductVariantEntity(...)` with an object literal matching the new interface. Import `ProductVariant` from `@openlinker/core/products` (same barrel, different name).
+
+### Step 8 — PrestaShop adapter: add `attributes: null`, coerce ean/gtin to null
+
+With optional timestamps, adapters don't need to stamp `new Date()` placeholders. Changes are minimal:
+
+**Files**:
+- `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts`
+  - Synthetic-variant literal (line ~198): add `attributes: null`; coerce `ean`/`gtin` to `?? null` instead of `?? undefined`.
+  - Normal-variant branch at line ~255: ensure the spread produces `attributes: null` and `ean|gtin: string | null`. The mapper returns `Omit<ProductVariant, 'id'>` so the mapper output drives the shape.
+- `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts`
+  - `mapVariant` return shape: add `attributes: null`, `ean` and `gtin` as `string | null`.
+
+### Step 9 — Worker test helper
+
+**File**: `apps/worker/test/integration/helpers/mock-adapters.helper.ts`
+
+If it constructs variants, update the literal shape. (Noted in the grep; confirm content during implementation.)
+
+### Step 10 — Quality gate
+
+```
+pnpm lint && pnpm type-check && pnpm test
+```
+
+Expected impact on tests: mock factories change signature (object literal vs class constructor); mocked call-site behaviour identical. No integration DB schema changes.
+
+### Step 11 — Confirm no regression in existing prestashop adapter spec
+
+`prestashop-product-master.adapter.spec.ts` asserts the shape of returned variants — update expected objects if they check `ean: undefined` vs `ean: null`, or if they check `createdAt`/`updatedAt` are omitted (they shouldn't if the current interface's optional fields).
+
+## 5. Validation
+
+- **Architecture**: Domain entity lives in `domain/entities/` (correct per engineering-standards "Files and Folders"). No NestJS/TypeORM imports in that file. ✅
+- **Naming**: File stays `product-variant.entity.ts` per domain-entity convention. ✅
+- **Union/interface rules**: Interface is PascalCase in its own `*.entity.ts` file. Engineering-standards §"Type Definitions in Separate Files" allows entity types in `*.entity.ts` (not `*.types.ts`) since it's the canonical entity shape.
+- **Barrel hygiene**: single export per name, no `As Alias` shim after migration.
+- **Tests**: all unit tests must pass; no new tests required (reshape-only).
+
+## 6. Risk
+
+- **Type-error blast radius**: any consumer that relies on `ProductVariant` being a class (e.g. `instanceof ProductVariant`) will break. Grep confirmed zero `instanceof ProductVariant` in the codebase. ✅
+- **Silent behaviour changes**: the `ean ?? undefined` → `ean ?? null` shift in the adapter could surface downstream code that does `if (variant.ean)` (truthy check is still correct) vs `if (variant.ean === undefined)` (becomes always-false). Grep for strict-undefined checks on barcode fields before committing.
+
+## 7. Out of scope (new follow-up issues)
+
+Confirmed via grep:
+- `Product` has the same duality (port interface at `product-master.port.ts:19` + class entity at `domain/entities/product.entity.ts`, alias `ProductEntity` in the barrel).
+- `Category` has a port-interface-only form (no corresponding class entity today) — no duality, but the `[key: string]: unknown` index signature should be dropped in the same spirit.
+
+Will file a follow-up issue after this PR lands so the reviewer can see the shape this PR adopts first.
+
+## 8. Open questions resolved
+
+| Question | Decision |
+|---|---|
+| Keep class or use interface? | Interface. Issue recommends it; repositories build plain objects. |
+| Required or optional timestamps? | **Required.** Adapters stamp `new Date()` placeholders; TypeORM handles persistence timestamps. |
+| `ean`/`gtin` null vs undefined? | **`string \| null`.** Aligns with DB columns; consumers do truthy check in practice. |
+| Keep the `[key: string]: unknown` index signature? | **No.** Issue explicitly calls it out as a bug-hiding escape hatch. |
+| Keep `ProductVariantEntity` alias in the barrel? | **No.** After migrating three test files, it has zero consumers. |
+| Address `Product` / `Category` duality? | **Out of scope.** Follow-up issue filed after merge. |

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -10,10 +10,7 @@ import type { ConnectionPort, Connection } from '@openlinker/core/identifier-map
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { IIntegrationsService, MarketplacePort } from '@openlinker/core/integrations';
 import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
-import type { ProductVariantRepositoryPort } from '@openlinker/core/products';
-import { ProductVariantEntity as ProductVariantDomain } from '@openlinker/core/products';
-
-type ProductVariant = ProductVariantDomain;
+import type { ProductVariant, ProductVariantRepositoryPort } from '@openlinker/core/products';
 
 import { OfferBuilderService } from '../offer-builder.service';
 import { CATEGORY_RESOLUTION_SERVICE_TOKEN } from '../../../listings.tokens';

--- a/libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts
@@ -8,7 +8,20 @@ import { OfferLinkingService } from '../offer-linking.service';
 import { IIntegrationsService, MarketplacePort } from '@openlinker/core/integrations';
 import { IIdentifierMappingService, IdentifierMappingConflictException } from '@openlinker/core/identifier-mapping';
 import { ProductVariantRepositoryPort } from '@openlinker/core/products/domain/ports/product-variant-repository.port';
-import { ProductVariantEntity } from '@openlinker/core/products';
+import { ProductVariant } from '@openlinker/core/products';
+
+function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
+  return {
+    id: overrides.id ?? 'variant-1',
+    productId: overrides.productId ?? 'product-1',
+    sku: overrides.sku ?? 'SKU-1',
+    attributes: overrides.attributes ?? null,
+    ean: overrides.ean ?? null,
+    gtin: overrides.gtin ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date(),
+  };
+}
 
 describe('OfferMappingSyncService', () => {
   let service: OfferMappingSyncService;
@@ -87,8 +100,8 @@ describe('OfferMappingSyncService', () => {
     });
 
     variantRepository.findBySkuIn.mockResolvedValue([
-      new ProductVariantEntity('variant-1', 'product-1', 'SKU-1', null, new Date(), new Date()),
-      new ProductVariantEntity('variant-2', 'product-2', 'SKU-2', null, new Date(), new Date()),
+      makeVariant({ id: 'variant-1', productId: 'product-1', sku: 'SKU-1' }),
+      makeVariant({ id: 'variant-2', productId: 'product-2', sku: 'SKU-2' }),
     ]);
 
     variantRepository.findByEanOrGtinIn.mockResolvedValue([]);
@@ -106,7 +119,7 @@ describe('OfferMappingSyncService', () => {
     });
 
     variantRepository.findBySkuIn.mockResolvedValue([
-      new ProductVariantEntity('variant-1', 'product-1', 'SKU-1', null, new Date(), new Date()),
+      makeVariant({ id: 'variant-1', productId: 'product-1', sku: 'SKU-1' }),
     ]);
     variantRepository.findByEanOrGtinIn.mockResolvedValue([]);
 
@@ -163,16 +176,12 @@ describe('OfferMappingSyncService', () => {
 
     variantRepository.findBySkuIn.mockResolvedValue([]);
     variantRepository.findByEanOrGtinIn.mockResolvedValue([
-      new ProductVariantEntity(
-        'variant-1',
-        'product-1',
-        'SKU-1',
-        null,
-        new Date(),
-        new Date(),
-        '5901234123457',
-        null,
-      ),
+      makeVariant({
+        id: 'variant-1',
+        productId: 'product-1',
+        sku: 'SKU-1',
+        ean: '5901234123457',
+      }),
     ]);
 
     const result = await service.sync('connection-1', { limit: 50, cursor: null });

--- a/libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts
@@ -1,8 +1,21 @@
 import { OrderItemRefResolverService } from '../order-item-ref-resolver.service';
 import { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
-import { ProductVariantEntity } from '@openlinker/core/products';
+import { ProductVariant } from '@openlinker/core/products';
 import { ProductVariantRepositoryPort } from '@openlinker/core/products/domain/ports/product-variant-repository.port';
+
+function makeVariant(id: string, productId: string): ProductVariant {
+  return {
+    id,
+    productId,
+    sku: null,
+    attributes: null,
+    ean: null,
+    gtin: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
 
 describe('OrderItemRefResolverService', () => {
   const connectionId = 'connection-123';
@@ -38,7 +51,7 @@ describe('OrderItemRefResolverService', () => {
   it('resolves offer refs via IdentifierMappingService(Offer)', async () => {
     identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
     variantRepository.findById.mockResolvedValueOnce(
-      new ProductVariantEntity('ol_variant_1', 'ol_product_1', null, null, new Date(), new Date()),
+      makeVariant('ol_variant_1', 'ol_product_1'),
     );
 
     await expect(
@@ -72,7 +85,7 @@ describe('OrderItemRefResolverService', () => {
   it('resolves variant refs via IdentifierMappingService(ProductVariant)', async () => {
     identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
     variantRepository.findById.mockResolvedValueOnce(
-      new ProductVariantEntity('ol_variant_1', 'ol_product_1', null, null, new Date(), new Date()),
+      makeVariant('ol_variant_1', 'ol_product_1'),
     );
 
     await expect(
@@ -85,7 +98,7 @@ describe('OrderItemRefResolverService', () => {
   it('resolves sku refs via IdentifierMappingService(Sku) and variant lookup', async () => {
     identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
     variantRepository.findById.mockResolvedValueOnce(
-      new ProductVariantEntity('ol_variant_1', 'ol_product_1', null, null, new Date(), new Date()),
+      makeVariant('ol_variant_1', 'ol_product_1'),
     );
 
     await expect(
@@ -108,7 +121,7 @@ describe('OrderItemRefResolverService', () => {
     it('should return resolved=true with IDs when offer mapping exists', async () => {
       identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
       variantRepository.findById.mockResolvedValueOnce(
-        new ProductVariantEntity('ol_variant_1', 'ol_product_1', null, null, new Date(), new Date()),
+        makeVariant('ol_variant_1', 'ol_product_1'),
       );
 
       const result = await service.tryResolve(connectionId, { type: 'offer', externalId: 'offer-1' });

--- a/libs/core/src/products/application/services/master-product-sync.service.ts
+++ b/libs/core/src/products/application/services/master-product-sync.service.ts
@@ -18,9 +18,9 @@ import {
 } from '@openlinker/core/identifier-mapping';
 import { PRODUCTS_SERVICE_TOKEN } from '../../products.tokens';
 import { IProductsService } from './products.service.interface';
-import { ProductMasterPort, Product as ProductPortInterface, ProductVariant as ProductVariantPortInterface } from '../../domain/ports/product-master.port';
+import { ProductMasterPort, Product as ProductPortInterface } from '../../domain/ports/product-master.port';
 import { Product as ProductDomainEntity } from '../../domain/entities/product.entity';
-import { ProductVariant as ProductVariantDomainEntity } from '../../domain/entities/product-variant.entity';
+import { ProductVariant } from '../../domain/entities/product-variant.entity';
 import { normalizeBarcode, normalizeToEan13 } from '../../domain/utils/barcode-normalization';
 import { IMasterProductSyncService, MasterProductSyncResult } from './master-product-sync.service.interface';
 import { Logger } from '@openlinker/shared/logging';
@@ -98,25 +98,20 @@ export class MasterProductSyncService implements IMasterProductSyncService {
   }
 
   /**
-   * Convert port ProductVariant to domain ProductVariant entity.
+   * Normalize adapter-produced variant: coerce barcode fields and pin productId.
+   *
+   * Adapters may omit createdAt/updatedAt — the repository populates them on
+   * save via TypeORM's @CreateDateColumn/@UpdateDateColumn.
    */
-  private toDomainVariant(
-    variant: ProductVariantPortInterface,
-    productId: string,
-  ): ProductVariantDomainEntity {
-    const ean = normalizeToEan13(variant.ean ?? null);
-    const gtin = normalizeBarcode(variant.gtin ?? null);
-
-    return new ProductVariantDomainEntity(
-      variant.id,
+  private toDomainVariant(variant: ProductVariant, productId: string): ProductVariant {
+    return {
+      ...variant,
       productId,
-      variant.sku ?? null,
-      variant.attributes ?? null,
-      new Date(),
-      new Date(),
-      ean,
-      gtin,
-    );
+      sku: variant.sku ?? null,
+      attributes: variant.attributes ?? null,
+      ean: normalizeToEan13(variant.ean ?? null),
+      gtin: normalizeBarcode(variant.gtin ?? null),
+    };
   }
 }
 

--- a/libs/core/src/products/application/services/products.service.spec.ts
+++ b/libs/core/src/products/application/services/products.service.spec.ts
@@ -27,16 +27,16 @@ function makeProduct(overrides: Partial<Product> = {}): Product {
 }
 
 function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
-  return new ProductVariant(
-    overrides.id ?? 'ol_product_v1',
-    overrides.productId ?? 'ol_product_1',
-    overrides.sku ?? 'SKU-001-S',
-    overrides.attributes ?? { size: 'S' },
-    overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
-    overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
-    overrides.ean ?? '1234567890123',
-    overrides.gtin ?? null,
-  );
+  return {
+    id: overrides.id ?? 'ol_product_v1',
+    productId: overrides.productId ?? 'ol_product_1',
+    sku: overrides.sku ?? 'SKU-001-S',
+    attributes: overrides.attributes ?? { size: 'S' },
+    ean: overrides.ean ?? '1234567890123',
+    gtin: overrides.gtin ?? null,
+    createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
+  };
 }
 
 describe('ProductsService', () => {

--- a/libs/core/src/products/application/services/products.service.ts
+++ b/libs/core/src/products/application/services/products.service.ts
@@ -59,14 +59,7 @@ export class ProductsService implements IProductsService {
         this.logger.warn(
           `Variant ${variant.id} has productId ${variant.productId}, expected ${productId}. Updating.`,
         );
-        return new ProductVariant(
-          variant.id,
-          productId,
-          variant.sku,
-          variant.attributes,
-          variant.createdAt,
-          variant.updatedAt,
-        );
+        return { ...variant, productId };
       }
       return variant;
     });

--- a/libs/core/src/products/domain/entities/product-variant.entity.ts
+++ b/libs/core/src/products/domain/entities/product-variant.entity.ts
@@ -5,18 +5,28 @@
  * system. Variants are stored with internal IDs only; external identifiers live
  * in IdentifierMapping. Variants are linked to their parent product via productId.
  *
+ * Shape note: this is an `interface` (not a `class`) deliberately. Variants cross
+ * adapter → repository → application → UI boundaries and are constructed in
+ * several places (adapter mappers, repo `toDomain`, test factories). Structural
+ * typing avoids `instanceof` false negatives across import paths and lets
+ * repositories build plain objects without a constructor call. Adapters and
+ * drafts may omit `createdAt`/`updatedAt` — the repo fills them on load.
+ *
  * @module libs/core/src/products/domain/entities
  */
-export class ProductVariant {
-  constructor(
-    public readonly id: string,
-    public readonly productId: string,
-    public readonly sku: string | null,
-    public readonly attributes: Record<string, string> | null,
-    public readonly createdAt: Date,
-    public readonly updatedAt: Date,
-    public readonly ean: string | null = null,
-    public readonly gtin: string | null = null,
-  ) {}
+export interface ProductVariant {
+  id: string;
+  productId: string;
+  sku: string | null;
+  attributes: Record<string, string> | null;
+  ean: string | null;
+  gtin: string | null;
+  /** Populated by the repository on load; adapters/drafts may omit. */
+  createdAt?: Date;
+  /** Populated by the repository on load; adapters/drafts may omit. */
+  updatedAt?: Date;
+  /** Master-derived, not persisted on the variants table. */
+  price?: number;
+  /** Master-derived, not persisted on the variants table. */
+  weight?: number;
 }
-

--- a/libs/core/src/products/domain/ports/product-master.port.ts
+++ b/libs/core/src/products/domain/ports/product-master.port.ts
@@ -11,6 +11,10 @@
  * @module libs/core/src/products/domain/ports
  */
 import { ProductFilters, ProductCreate, ProductUpdate, ProductVariantCreate } from '../types/product.types';
+import type { ProductVariant } from '../entities/product-variant.entity';
+
+// Re-exported so existing deep imports from this path keep working.
+export type { ProductVariant } from '../entities/product-variant.entity';
 
 /**
  * Product domain entity (minimal interface for port)
@@ -31,28 +35,16 @@ export interface Product {
 }
 
 /**
- * Product variant domain entity
- */
-export interface ProductVariant {
-  id: string;
-  productId: string;
-  sku: string;
-  attributes?: Record<string, string>;
-  ean?: string;
-  gtin?: string;
-  price?: number;
-  weight?: number;
-  [key: string]: unknown;
-}
-
-/**
  * Category domain entity
  */
 export interface Category {
   id: string;
   name: string;
   parentId?: string;
-  [key: string]: unknown;
+  /** Tree depth, if the source platform exposes one (PrestaShop, Allegro). */
+  depth?: number;
+  /** Whether the category is active in the source catalog. Defaults to true when absent. */
+  active?: boolean;
 }
 
 /**

--- a/libs/core/src/products/index.ts
+++ b/libs/core/src/products/index.ts
@@ -23,7 +23,6 @@ export {
 export {
   ProductMasterPort,
   Product,
-  ProductVariant,
   Category,
 } from './domain/ports/product-master.port';
 export { ProductRepositoryPort } from './domain/ports/product-repository.port';
@@ -31,7 +30,7 @@ export { ProductVariantRepositoryPort } from './domain/ports/product-variant-rep
 
 // Domain Entities
 export { Product as ProductEntity } from './domain/entities/product.entity';
-export { ProductVariant as ProductVariantEntity } from './domain/entities/product-variant.entity';
+export { ProductVariant } from './domain/entities/product-variant.entity';
 
 // Domain Utils
 export { normalizeBarcode, normalizeToEan13 } from './domain/utils/barcode-normalization';

--- a/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
@@ -215,16 +215,16 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
    * Map ORM entity to domain entity
    */
   private toDomain(entity: ProductVariantOrmEntity): ProductVariant {
-    return new ProductVariant(
-      entity.id,
-      entity.productId,
-      entity.sku,
-      entity.attributes,
-      entity.createdAt,
-      entity.updatedAt,
-      entity.ean,
-      entity.gtin,
-    );
+    return {
+      id: entity.id,
+      productId: entity.productId,
+      sku: entity.sku,
+      attributes: entity.attributes,
+      ean: entity.ean,
+      gtin: entity.gtin,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+    };
   }
 
   /**
@@ -238,8 +238,10 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
     entity.attributes = variant.attributes;
     entity.ean = variant.ean;
     entity.gtin = variant.gtin;
-    entity.createdAt = variant.createdAt;
-    entity.updatedAt = variant.updatedAt;
+    // Adapters may omit timestamps on first insert; TypeORM's @CreateDateColumn
+    // and @UpdateDateColumn populate them in that case.
+    if (variant.createdAt) entity.createdAt = variant.createdAt;
+    if (variant.updatedAt) entity.updatedAt = variant.updatedAt;
     return entity;
   }
 }

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
@@ -368,10 +368,10 @@ describe('PrestashopProductMasterAdapter', () => {
       const result = await adapter.getProductVariants(productId);
 
       expect(result).toHaveLength(2);
-      expect(result[0].ean).toBeUndefined();
-      expect(result[0].gtin).toBeUndefined();
-      expect(result[1].ean).toBeUndefined();
-      expect(result[1].gtin).toBeUndefined();
+      expect(result[0].ean).toBeNull();
+      expect(result[0].gtin).toBeNull();
+      expect(result[1].ean).toBeNull();
+      expect(result[1].gtin).toBeNull();
     });
 
     it('should return synthetic variant when no combinations found', async () => {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -200,8 +200,9 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
           id: internalId,
           productId,
           sku,
-          ean: productEan ?? undefined,
-          gtin: productGtin ?? undefined,
+          attributes: null,
+          ean: productEan ?? null,
+          gtin: productGtin ?? null,
         },
       ];
     }

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
@@ -509,8 +509,8 @@ describe('PrestashopProductMapper', () => {
 
       const result = mapper.mapVariant(combination, 'internal-product-id');
 
-      expect(result.ean).toBeUndefined();
-      expect(result.gtin).toBeUndefined();
+      expect(result.ean).toBeNull();
+      expect(result.gtin).toBeNull();
     });
   });
 });

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
@@ -41,8 +41,8 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
 
   mapVariant(combination: PrestashopCombination, productId: string): Omit<ProductVariant, 'id'> {
     const attributes: Record<string, string> = {};
-    const ean = normalizeToEan13(combination.ean13 ?? null) ?? undefined;
-    const gtin = normalizeBarcode(combination.upc ?? null) ?? undefined;
+    const ean = normalizeToEan13(combination.ean13 ?? null);
+    const gtin = normalizeBarcode(combination.upc ?? null);
 
     // Extract attributes from product_option_values
     if (combination.associations?.product_option_values?.product_option_value) {
@@ -59,8 +59,8 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
 
     return {
       productId,
-      sku: this.getStringField(combination.reference) || '',
-      attributes: Object.keys(attributes).length > 0 ? attributes : undefined,
+      sku: this.getStringField(combination.reference) || null,
+      attributes: Object.keys(attributes).length > 0 ? attributes : null,
       ean,
       gtin,
       price: this.parseNumber(combination.price),


### PR DESCRIPTION
## Summary

`@openlinker/core/products` previously exported **two incompatible** `ProductVariant` shapes: the port interface (optional `ean`/`gtin`, no timestamps, `[key: string]: unknown` escape hatch) and a domain entity class (nullable `ean`/`gtin`, required timestamps). The barrel re-exported both as `ProductVariant` and `ProductVariantEntity`, leaving callers to pick by import path.

Replaces both with a **single interface** at `domain/entities/product-variant.entity.ts`:

- `sku` / `attributes` / `ean` / `gtin` as `string | null` (aligns with DB nullability)
- Optional `createdAt` / `updatedAt` (see trade-off below)
- No `[key: string]: unknown` escape hatch
- Interface, not class — structural typing across adapter/repo/UI boundaries

## Trade-off: optional timestamps

Issue #281 recommended **required** timestamps ("domain entities always have them after persistence"). Pushed back: adapters produce pre-persistence variants (no timestamps yet); repositories produce post-persistence variants (timestamps always present). Required would force adapters to fabricate `new Date()` placeholders that TypeORM discards on save — semantic noise that propagates into logs and tests.

**Optional** matches the real bidirectional data flow. Narrow cost: the type allows a theoretically invalid state ("persisted variant without timestamps") that never actually occurs. Trade-off documented in the plan's §8.

## Also bundled in

- Dropped `[key: string]: unknown` on `Category` (same file). Replaced with explicit optional `depth?: number` / `active?: boolean` fields that `categories-cache.service.ts` was already using via the escape hatch — now typed properly.

## Test plan

- [x] `pnpm lint` — 0 errors across all packages
- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm test` — all 1184 unit tests pass across 7 packages
- [x] `pnpm test:integration` — 7 failed / 60 passed. **Same failure set as clean `main`** (all `loginAsAdmin` duplicate-key from #278). Unrelated to this refactor.

## Out of scope / follow-up

- **`Product` has the same duality** — port interface at `product-master.port.ts:19` + class entity at `domain/entities/product.entity.ts`, aliased as `ProductEntity` in the barrel. Needs a separate issue to apply the same pattern (likely with the `Product` entity keeping a class form since it's constructed in more places). Will file a follow-up.

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)