### PR TITLE
feat: populate product images end-to-end (#271 + #272)

### DIFF
--- a/apps/api/src/inventory/http/dto/inventory-item-response.dto.ts
+++ b/apps/api/src/inventory/http/dto/inventory-item-response.dto.ts
@@ -35,4 +35,10 @@ export class InventoryItemResponseDto {
 
   @ApiPropertyOptional({ nullable: true, description: 'Product SKU from the master catalog (null if product not found or no SKU)' })
   productSku!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Cover image URL from the master catalog (null if product has no images or not found)',
+  })
+  productImageUrl!: string | null;
 }

--- a/apps/api/src/inventory/http/inventory.controller.spec.ts
+++ b/apps/api/src/inventory/http/inventory.controller.spec.ts
@@ -38,6 +38,17 @@ describe('InventoryController', () => {
     'SKU-001',
     99.99,
     null,
+    ['https://shop.test/img/p/1/1-home_default.jpg', 'https://shop.test/img/p/1/1-medium.jpg'],
+    new Date('2026-01-01T00:00:00Z'),
+    new Date('2026-04-01T00:00:00Z'),
+  );
+
+  const mockProductWithoutImages = new Product(
+    'prod-001',
+    'Test Product',
+    'SKU-001',
+    99.99,
+    null,
     null,
     new Date('2026-01-01T00:00:00Z'),
     new Date('2026-04-01T00:00:00Z'),
@@ -77,7 +88,7 @@ describe('InventoryController', () => {
   });
 
   describe('listInventory', () => {
-    it('should return paginated inventory items with product name and SKU', async () => {
+    it('should return paginated inventory items with product name, SKU, and cover image', async () => {
       repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
       productRepository.findById.mockResolvedValue(mockProduct);
 
@@ -91,9 +102,10 @@ describe('InventoryController', () => {
       expect(result.items[0].updatedAt).toBe('2026-04-01T00:00:00.000Z');
       expect(result.items[0].productName).toBe('Test Product');
       expect(result.items[0].productSku).toBe('SKU-001');
+      expect(result.items[0].productImageUrl).toBe('https://shop.test/img/p/1/1-home_default.jpg');
     });
 
-    it('should return null productName and productSku when product not found', async () => {
+    it('should return null product fields when product not found', async () => {
       repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
       productRepository.findById.mockResolvedValue(null);
 
@@ -101,6 +113,17 @@ describe('InventoryController', () => {
 
       expect(result.items[0].productName).toBeNull();
       expect(result.items[0].productSku).toBeNull();
+      expect(result.items[0].productImageUrl).toBeNull();
+    });
+
+    it('should return null productImageUrl when product has no images', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
+      productRepository.findById.mockResolvedValue(mockProductWithoutImages);
+
+      const result = await controller.listInventory({ limit: 20, offset: 0 });
+
+      expect(result.items[0].productName).toBe('Test Product');
+      expect(result.items[0].productImageUrl).toBeNull();
     });
 
     it('should pass filters to repository', async () => {
@@ -142,7 +165,7 @@ describe('InventoryController', () => {
   });
 
   describe('getInventoryItem', () => {
-    it('should return inventory item with product name and SKU when found', async () => {
+    it('should return inventory item with product name, SKU, and cover image when found', async () => {
       repository.findById.mockResolvedValue(mockItem);
       productRepository.findById.mockResolvedValue(mockProduct);
 
@@ -154,6 +177,7 @@ describe('InventoryController', () => {
       expect(result.reservedQuantity).toBe(5);
       expect(result.productName).toBe('Test Product');
       expect(result.productSku).toBe('SKU-001');
+      expect(result.productImageUrl).toBe('https://shop.test/img/p/1/1-home_default.jpg');
     });
 
     it('should throw NotFoundException when item not found', async () => {

--- a/apps/api/src/inventory/http/inventory.controller.ts
+++ b/apps/api/src/inventory/http/inventory.controller.ts
@@ -113,6 +113,9 @@ export class InventoryController {
       updatedAt: item.updatedAt instanceof Date ? item.updatedAt.toISOString() : item.updatedAt,
       productName: product?.name ?? null,
       productSku: product?.sku ?? null,
+      // Cover-image rule lives on the Product entity (`coverImageUrl` getter);
+      // the inventory layer does not replicate it.
+      productImageUrl: product?.coverImageUrl ?? null,
     };
   }
 }

--- a/apps/api/test/integration/fixtures/inventory.fixtures.ts
+++ b/apps/api/test/integration/fixtures/inventory.fixtures.ts
@@ -14,10 +14,14 @@ import { InventoryItemOrmEntity } from '@openlinker/core/inventory';
  * Seed a product + inventory item row.
  *
  * Returns the seeded inventory item.
+ *
+ * @param productOverrides Optional overrides applied to the seeded parent
+ * product (e.g. `images`) — defaults keep the product minimal.
  */
 export async function createTestInventoryItem(
   dataSource: DataSource,
   overrides?: Partial<InventoryItemOrmEntity>,
+  productOverrides?: Partial<ProductOrmEntity>,
 ): Promise<InventoryItemOrmEntity> {
   const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
   const productId = `ol_product_fixture_${suffix}`;
@@ -25,7 +29,13 @@ export async function createTestInventoryItem(
   // Seed parent product (inventory_items has FK to products)
   const productRepo = dataSource.getRepository(ProductOrmEntity);
   await productRepo.save(
-    productRepo.create({ id: productId, name: `Test Product ${suffix}`, sku: null, price: null }),
+    productRepo.create({
+      id: productId,
+      name: `Test Product ${suffix}`,
+      sku: null,
+      price: null,
+      ...productOverrides,
+    }),
   );
 
   const repo = dataSource.getRepository(InventoryItemOrmEntity);

--- a/apps/api/test/integration/inventory-read.int-spec.ts
+++ b/apps/api/test/integration/inventory-read.int-spec.ts
@@ -140,6 +140,49 @@ describe('Inventory Read API Integration', () => {
       const http = harness.getHttp();
       await http.get('/inventory').expect(401);
     });
+
+    it('should surface the cover image URL from the parent product', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const item = await createTestInventoryItem(
+        dataSource,
+        undefined,
+        {
+          images: [
+            'https://shop.test/img/p/1/1-home_default.jpg',
+            'https://shop.test/img/p/1/1-medium_default.jpg',
+          ],
+        },
+      );
+
+      const response = await http
+        .get('/inventory')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      const body = response.body.items.find((row: { id: string }) => row.id === item.id);
+      expect(body).toBeDefined();
+      expect(body.productImageUrl).toBe('https://shop.test/img/p/1/1-home_default.jpg');
+    });
+
+    it('should return null productImageUrl when the parent product has no images', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const item = await createTestInventoryItem(dataSource, undefined, { images: null });
+
+      const response = await http
+        .get('/inventory')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      const body = response.body.items.find((row: { id: string }) => row.id === item.id);
+      expect(body).toBeDefined();
+      expect(body.productImageUrl).toBeNull();
+    });
   });
 
   describe('GET /inventory/:id', () => {

--- a/apps/web/src/features/inventory/api/inventory.types.ts
+++ b/apps/web/src/features/inventory/api/inventory.types.ts
@@ -18,6 +18,7 @@ export interface InventoryItem {
   updatedAt: string;
   productName: string | null;
   productSku: string | null;
+  productImageUrl: string | null;
 }
 
 export interface InventoryFilters {

--- a/apps/web/src/pages/inventory/inventory-detail-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.test.tsx
@@ -15,6 +15,7 @@ const sampleItem: InventoryItem = {
   updatedAt: '2026-01-15T10:00:00.000Z',
   productName: 'Test Product',
   productSku: 'SKU-001',
+  productImageUrl: null,
 };
 
 function renderDetailPage(apiClient: ReturnType<typeof createMockApiClient>): void {

--- a/apps/web/src/pages/inventory/inventory-list-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.test.tsx
@@ -16,6 +16,7 @@ const sampleInventory: PaginatedInventory = {
       updatedAt: '2026-01-15T10:00:00.000Z',
       productName: 'Test Product',
       productSku: 'SKU-001',
+      productImageUrl: null,
     },
   ],
   total: 1,

--- a/docs/plans/implementation-plan-product-images-backend.md
+++ b/docs/plans/implementation-plan-product-images-backend.md
@@ -1,0 +1,232 @@
+# Implementation Plan — Product Images Backend Slice (#271 + #272)
+
+**Branch:** `271-272-product-images-backend`
+**Issues:** Closes #271, closes #272
+**Scope:** Backend only. Consumers ship separately: `ProductThumbnail` primitive (#273), Products-list thumbnails (#274), Inventory-list thumbnails (#275), FE wizard storefront-URL override field (#283).
+
+---
+
+## 1. Goal
+
+Populate `Product.images` end-to-end for PrestaShop connections, and expose `productImageUrl` on the Inventory list response so the frontend can render product thumbnails on `/products` and `/inventory`.
+
+### Non-goals
+- Image storage/upload/proxy infrastructure — we only emit URLs that point at PrestaShop's storefront.
+- Variant-level images (`ProductVariant` has no image field).
+- Authenticated image proxy for private storefronts — degraded behaviour is `images: undefined` (persisted as `null`) when storefront URL resolution fails.
+- FE rendering work.
+- FE wizard UX for the storefront-URL override (tracked in #283) — this PR uses the `baseUrl` fallback so the common case still works with zero operator action.
+- Reconciling the two `Product` type declarations — see "Known limitations" below.
+
+## 2. Layer classification
+
+- **CORE** — `Product.coverImageUrl` getter (domain entity).
+- **Integration** — PrestaShop mapper + config schema changes.
+- **Interface** — Inventory DTO + controller mapping.
+
+## 3. Research findings
+
+- `Product` is overloaded across the codebase: the **domain entity class** lives at `libs/core/src/products/domain/entities/product.entity.ts` (re-exported as `ProductEntity` from `@openlinker/core/products`); the **port interface** lives at `libs/core/src/products/domain/ports/product-master.port.ts` (re-exported as `Product`). The inventory controller already imports the entity class via `ProductEntity as Product` — the `coverImageUrl` getter goes on the entity class.
+- Mapper is framework-free, instantiated once per connection in `PrestashopAdapterFactory.createAdapters()` with no args. Cheapest extension is to pass `storefrontBaseUrl` via constructor — per-connection factory creates per-connection mapper, so no cross-request state leaks.
+- Inventory controller (`apps/api/src/inventory/http/inventory.controller.ts:92-103`) already builds a `productMap` from `ProductRepositoryPort.findById` and maps `productName`/`productSku` in `toDto()`. Adding `productImageUrl` is one line.
+- `PrestashopConnectionConfig` already validates `baseUrl` as a URL. We add optional `storefrontBaseUrl` with the same validation and the ergonomic default of falling back to `baseUrl` when absent (webservice and storefront share a hostname in the common case).
+- PrestaShop image URL format used: `{storefrontBaseUrl}/img/p/{split}/{imageId}-home_default.jpg`, where `split` is the image id with digits separated by `/` (e.g. `123` → `1/2/3`). Numeric path works regardless of "Friendly URL" config. `home_default` is PrestaShop's standard thumbnail size (~250×250) — safe default for list rows and detail pages.
+- `PrestashopProduct.associations.images` shape (per PrestaShop XML/JSON serialization): `{ image: { id: '1' } }` or `{ image: [{ id: '1' }, { id: '2' }] }` (single-element collections can collapse to a bare object).
+- Engineering standards require types to live in `*.types.ts` files — the mapper options type goes in a colocated types file, not inline.
+
+## 4. Design
+
+### Data flow (unchanged structurally)
+
+```
+PrestaShop API → PrestashopProductMasterAdapter
+              → PrestashopProductMapper.mapProduct() — now emits real image URLs
+              → MasterProductSyncService → ProductRepository.save()
+              → Product.images jsonb in Postgres
+
+GET /inventory → InventoryController → ProductRepositoryPort.findById (batched)
+             → Product (domain entity) — exposes .coverImageUrl getter
+             → InventoryItemResponseDto { ..., productImageUrl }
+```
+
+### Port ownership
+
+The rule "the cover image is the first element of `images`" belongs to the Products domain. Inventory does not replicate that rule — it calls `product.coverImageUrl`. This is the core architectural intent of the PR (mirrored in #272's body).
+
+### Connection config
+
+`storefrontBaseUrl` is optional. If present, use it. If absent, fall back to `baseUrl` at the factory layer — the mapper never sees `null`. This covers the common case (webservice + storefront at the same host) without requiring any operator action. The operator-facing override field (wizard UX) ships in #283.
+
+### Mapper construction
+
+```ts
+// factory
+const productMapper = new PrestashopProductMapper({
+  storefrontBaseUrl: config.storefrontBaseUrl ?? config.baseUrl, // always a valid URL
+});
+```
+
+Constructor takes an options object so we can add mapper config in the future without churning call sites. The options type is **non-nullable** (`string`, not `string | null`) because the factory is the only call site and always passes a valid URL — no dead branches in the mapper.
+
+### Null/undefined handling convention (existing)
+
+`mapProduct` converts `null → undefined` for fields destined for the port interface (see existing lines 28, 32). The new `extractImages` returns `string[] | undefined` to match that convention. Downstream the domain entity persists as `string[] | null` — the port↔entity impedance is existing and out of scope here.
+
+## 5. Implementation steps
+
+### Step 1 — `Product.coverImageUrl` getter
+
+**File:** `libs/core/src/products/domain/entities/product.entity.ts`
+
+- Add `get coverImageUrl(): string | null { return this.images?.[0] ?? null; }`
+- JSDoc: "First image URL by convention — the cover. Null if the product has no images."
+
+### Step 2 — `Product` entity unit spec
+
+**File (new):** `libs/core/src/products/domain/entities/product.entity.spec.ts`
+
+- File header per `docs/engineering-standards.md#file-headers`.
+- Cover the getter: `null` (null images), `null` (empty array), first element (populated).
+
+### Step 3 — Extend `PrestashopConnectionConfig`
+
+**File:** `libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts`
+
+- Add `storefrontBaseUrl?: string` with JSDoc explaining purpose, default-to-`baseUrl` fallback, and the split-host use case.
+
+### Step 4 — Validate `storefrontBaseUrl` in factory
+
+**File:** `libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts`
+
+- In `validateAndParseConfig`: when `storefrontBaseUrl` is present, validate it's a string + valid URL (same pattern as `baseUrl`). Throw `PrestashopConfigException` otherwise.
+- Include it in the returned `PrestashopConnectionConfig` object.
+
+### Step 5 — Mapper options type (separate file)
+
+**File (new):** `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.types.ts`
+
+- File header.
+- Export `PrestashopProductMapperOptions`:
+  ```ts
+  export interface PrestashopProductMapperOptions {
+    /**
+     * Base URL used to build public product-image URLs.
+     * Always a valid URL at runtime — the adapter factory falls back
+     * to PrestaShop's webservice baseUrl when storefrontBaseUrl is unset.
+     * Never null.
+     */
+    storefrontBaseUrl: string;
+  }
+  ```
+
+Per `docs/engineering-standards.md#type-definitions-in-separate-files`: types must not be inline.
+
+### Step 6 — `PrestashopProductMapper` constructor + URL helper
+
+**File:** `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts`
+
+- Add `constructor(private readonly options: PrestashopProductMapperOptions)`.
+- Add a pure private helper `splitImageId(id: string): string` (digits separated by `/`: `123` → `1/2/3`, `42` → `4/2`, `7` → `7`).
+- Add a private `buildImageUrl(imageId: string): string`:
+  - Strips trailing slash from `options.storefrontBaseUrl` defensively.
+  - Returns `${base}/img/p/${split}/${imageId}-home_default.jpg`.
+  - `// TODO: image type ('home_default') is fixed for v1. Expose via options when detail-page or retina sizes land.`
+
+### Step 7 — Real `extractImages()` implementation
+
+Same file as Step 6.
+
+- Replace the stubbed method. Inputs: `PrestashopProduct`. Output: `string[] | undefined` (**not** `null` — matches existing `null → undefined` convention in this file).
+- Read `associations.images.image`; normalize object → single-element array.
+- For each entry, extract `id` tolerating both `id` and `@_id` attribute key variants (mirror the `extractLanguageId` pattern).
+- Build URLs via `buildImageUrl`. Skip entries with missing/invalid id (don't throw, don't short-circuit — one bad image shouldn't kill the whole product).
+- Preserve PrestaShop order (first element = cover).
+- No null-branch — `storefrontBaseUrl` is always a valid URL by type.
+
+### Step 8 — Update factory call site
+
+**File:** `libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts`
+
+- `new PrestashopProductMapper({ storefrontBaseUrl: config.storefrontBaseUrl ?? config.baseUrl })`.
+
+### Step 9 — Mapper unit tests
+
+**File:** `libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts`
+
+All existing tests must pass after updating `new PrestashopProductMapper()` to `new PrestashopProductMapper({ storefrontBaseUrl: 'https://shop.test' })` (a shared fixture constant reduces churn).
+
+New cases:
+- `extractImages`: single image object → 1-element array with correctly built URL.
+- `extractImages`: multi-image array → multi-element array, cover first.
+- `extractImages`: attribute-style id (`@_id`) → URL built correctly.
+- `extractImages`: no `associations.images` → `undefined`.
+- `extractImages`: entry with missing id → skipped, other entries still processed.
+- `buildImageUrl` via observable output: `1` → `.../img/p/1/1-home_default.jpg`, `42` → `.../img/p/4/2/42-home_default.jpg`, `123` → `.../img/p/1/2/3/123-home_default.jpg`, `1234` → `.../img/p/1/2/3/4/1234-home_default.jpg`.
+- `storefrontBaseUrl` with trailing slash → URL has exactly one slash between host and path.
+
+### Step 10 — Inventory DTO field
+
+**File:** `apps/api/src/inventory/http/dto/inventory-item-response.dto.ts`
+
+- Add `productImageUrl!: string | null` with `@ApiPropertyOptional({ nullable: true, description: 'Cover image URL from the master catalog (null if product has no images or not found)' })`.
+
+### Step 11 — Inventory controller mapping
+
+**File:** `apps/api/src/inventory/http/inventory.controller.ts`
+
+- In `toDto()` (around line 105-117): add `productImageUrl: product?.coverImageUrl ?? null`.
+- **Do not** write `product?.images?.[0] ?? null` in the controller — ownership stays on the entity.
+
+### Step 12 — Inventory controller spec update
+
+**File:** `apps/api/src/inventory/http/inventory.controller.spec.ts`
+
+- Extend the two "Test Product" cases (lines 92, 155): add `images: ['https://shop.test/img/p/1/1-home_default.jpg']` on the mock Product fixture; assert `productImageUrl === 'https://shop.test/img/p/1/1-home_default.jpg'` in both list and detail.
+- Extend the "product not found" case (line 96): assert `productImageUrl === null`.
+- Add a case where product has `images: null` → `productImageUrl` is `null`.
+
+### Step 13 — Inventory integration test
+
+**File:** `apps/api/test/integration/inventory-read.int-spec.ts`
+
+- Extend the happy-path fixture: seed a product with `images: ['https://shop.test/img/p/1/1-home_default.jpg', 'https://shop.test/img/p/1/1-medium_default.jpg']`, hit `GET /inventory`, assert `productImageUrl` equals the first element.
+- Seed a product with `images: null` → `productImageUrl` is `null`.
+
+### Step 14 — Frontend type sync (contract only, no UI wiring)
+
+**File:** `apps/web/src/features/inventory/api/inventory.types.ts`
+
+- Add `productImageUrl: string | null;` to the `InventoryItem` interface so the FE contract stays in lockstep. Not consumed in this PR — #275 picks it up.
+
+## 6. Validation checklist
+
+- [ ] Domain layer has no framework deps (`product.entity.ts` still a plain class).
+- [ ] Mapper has no framework deps (no `@Injectable()`, no NestJS imports).
+- [ ] `ProductRepositoryPort` unchanged — getter is derived data, not a port-shape change.
+- [ ] No `any` types introduced; narrow `unknown` with type guards for `associations.images` parsing.
+- [ ] No `console.log` — use `Logger`.
+- [ ] Mapper options type lives in a `*.types.ts` file (not inline).
+- [ ] No schema migration needed (ORM column unchanged).
+- [ ] Inventory DTO change is additive (nullable field); no breaking change to existing consumers.
+- [ ] FE type sync keeps FE–BE contract in lockstep.
+
+## 7. Known limitations / deliberate out-of-scope
+
+- **`Product` port interface vs domain entity class drift.** `@openlinker/core/products` re-exports both: the port interface (`images?: string[]`) and the entity class (`images: string[] | null`). This PR adds `coverImageUrl` only to the entity class — correct for the inventory controller's use case (reads via `ProductRepositoryPort` → entity class), but widens the drift that #281 already flags for `ProductVariant`. **Proposed follow-up:** file a Product-equivalent of #281 to reconcile the two `Product` types. Not required for this PR to be correct.
+- **Custom PrestaShop URL paths.** Stores with heavy front-office customization (CDNs, rewritten image paths) may 404 the canonical `/img/p/…` URL. `ProductThumbnail`'s `onError` fallback (#273) handles this gracefully.
+- **Connection `/test` endpoint doesn't probe the storefront URL.** The field is best-effort; URL shape is validated at submit time, not live.
+
+## 8. Commit plan
+
+Two logical commits on one branch:
+
+1. `feat(products): add Product.coverImageUrl getter for display convention` — Steps 1–2.
+2. `feat(prestashop): populate Product.images via storefront URLs; feat(api): expose productImageUrl on inventory list response` — Steps 3–14.
+
+## 9. PR body outline
+
+- What: one-liner per issue.
+- Why: unlocks product thumbnail UI (#273/#274/#275) and FE wizard override field (#283).
+- Key design call: port ownership — `coverImageUrl` on Product entity, not in the inventory layer.
+- Follow-ups flagged: #283 (FE wizard override), and new Product port/entity reconciliation issue to be filed.
+- Closes #271, closes #272.

--- a/libs/core/src/products/domain/entities/product.entity.spec.ts
+++ b/libs/core/src/products/domain/entities/product.entity.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Product Domain Entity — Unit Spec
+ *
+ * Covers the derived getters on the Product entity. The entity itself is a
+ * plain data class, so the surface area under test is minimal; the key
+ * invariant verified here is the cover-image rule (first-element-or-null).
+ *
+ * @module libs/core/src/products/domain/entities
+ */
+import { Product } from './product.entity';
+
+describe('Product', () => {
+  const baseArgs = {
+    id: 'ol_product_1',
+    name: 'Test Product',
+    sku: 'TEST-001' as string | null,
+    price: 19.99 as number | null,
+    description: null as string | null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+  };
+
+  function makeProduct(images: string[] | null): Product {
+    return new Product(
+      baseArgs.id,
+      baseArgs.name,
+      baseArgs.sku,
+      baseArgs.price,
+      baseArgs.description,
+      images,
+      baseArgs.createdAt,
+      baseArgs.updatedAt,
+    );
+  }
+
+  describe('coverImageUrl', () => {
+    it('should return null when images is null', () => {
+      const product = makeProduct(null);
+      expect(product.coverImageUrl).toBeNull();
+    });
+
+    it('should return null when images is an empty array', () => {
+      const product = makeProduct([]);
+      expect(product.coverImageUrl).toBeNull();
+    });
+
+    it('should return the first image when images is populated', () => {
+      const product = makeProduct([
+        'https://shop.test/img/p/1/1-home_default.jpg',
+        'https://shop.test/img/p/1/2/1-medium_default.jpg',
+      ]);
+      expect(product.coverImageUrl).toBe('https://shop.test/img/p/1/1-home_default.jpg');
+    });
+
+    it('should return the first image when the array has a single element', () => {
+      const product = makeProduct(['https://shop.test/img/p/7/7-home_default.jpg']);
+      expect(product.coverImageUrl).toBe('https://shop.test/img/p/7/7-home_default.jpg');
+    });
+  });
+});

--- a/libs/core/src/products/domain/entities/product.entity.ts
+++ b/libs/core/src/products/domain/entities/product.entity.ts
@@ -19,5 +19,16 @@ export class Product {
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
   ) {}
+
+  /**
+   * First image URL by convention — the cover. Null if the product has no images.
+   *
+   * This is the canonical "which image represents the product" rule for the
+   * Products bounded context. Consumers (e.g. inventory read endpoints) should
+   * call this getter rather than replicating `images?.[0] ?? null` themselves.
+   */
+  get coverImageUrl(): string | null {
+    return this.images?.[0] ?? null;
+  }
 }
 

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -66,8 +66,12 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       config,
     );
 
-    // Create mappers
-    const productMapper = new PrestashopProductMapper();
+    // Create mappers. `storefrontBaseUrl` falls back to the webservice `baseUrl`
+    // when unset — works for the common case where webservice and storefront
+    // share a host. Operators override it via connection config when they differ.
+    const productMapper = new PrestashopProductMapper({
+      storefrontBaseUrl: config.storefrontBaseUrl ?? config.baseUrl,
+    });
     const inventoryMapper = new PrestashopInventoryMapper();
     const orderMapper = new PrestashopOrderMapper();
 
@@ -158,6 +162,26 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       );
     }
 
+    // Validate storefrontBaseUrl (optional — falls back to baseUrl at use site)
+    if (config.storefrontBaseUrl !== undefined) {
+      if (typeof config.storefrontBaseUrl !== 'string') {
+        throw new PrestashopConfigException(
+          'storefrontBaseUrl must be a string',
+          'storefrontBaseUrl',
+          config.storefrontBaseUrl,
+        );
+      }
+      try {
+        new URL(config.storefrontBaseUrl);
+      } catch (error) {
+        throw new PrestashopConfigException(
+          `Invalid storefrontBaseUrl format: ${config.storefrontBaseUrl}`,
+          'storefrontBaseUrl',
+          config.storefrontBaseUrl,
+        );
+      }
+    }
+
     // Validate shopId (if provided)
     if (config.shopId !== undefined) {
       const shopId = typeof config.shopId === 'number' ? config.shopId : parseInt(String(config.shopId), 10);
@@ -225,6 +249,7 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
     // Build validated config with defaults
     const validatedConfig: PrestashopConnectionConfig = {
       baseUrl: config.baseUrl,
+      storefrontBaseUrl: config.storefrontBaseUrl,
       shopId: config.shopId as number | undefined,
       langId: (config.langId as number | undefined) ?? 1,
       timeoutMs: (config.timeoutMs as number | undefined) ?? 30000,

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -249,7 +249,7 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
     // Build validated config with defaults
     const validatedConfig: PrestashopConnectionConfig = {
       baseUrl: config.baseUrl,
-      storefrontBaseUrl: config.storefrontBaseUrl,
+      storefrontBaseUrl: config.storefrontBaseUrl as string | undefined,
       shopId: config.shopId as number | undefined,
       langId: (config.langId as number | undefined) ?? 1,
       timeoutMs: (config.timeoutMs as number | undefined) ?? 30000,

--- a/libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts
+++ b/libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts
@@ -21,6 +21,23 @@ export interface PrestashopConnectionConfig {
   baseUrl: string;
 
   /**
+   * Public storefront URL used to build product-image URLs (optional).
+   *
+   * PrestaShop webservice image endpoints (`/images/products/{id}/{image_id}`)
+   * require an API key and cannot be loaded by a browser. Public storefront
+   * image paths (`{storefrontBaseUrl}/img/p/…`) are unauthenticated and work
+   * for any public PrestaShop storefront.
+   *
+   * If unset, the adapter factory falls back to `baseUrl` — correct for the
+   * common case where the webservice and the storefront share a host.
+   * Provide this override only when they differ (e.g. webservice at
+   * `api.shop.com`, storefront at `shop.com`).
+   *
+   * Example: `'https://shop.example.com'` (no trailing slash).
+   */
+  storefrontBaseUrl?: string;
+
+  /**
    * Shop ID for multi-store PrestaShop installations (optional)
    * Maps to `id_shop` query parameter in PrestaShop API requests
    * If not provided, uses default shop (ID 1)

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
@@ -31,7 +31,7 @@ describe('PrestashopProductMasterAdapter', () => {
     mockHttpClient = createMockHttpClient();
     mockIdentifierMapping = createMockIdentifierMapping();
     connection = createTestConnection();
-    productMapper = new PrestashopProductMapper();
+    productMapper = new PrestashopProductMapper({ storefrontBaseUrl: 'https://shop.test' });
 
     adapter = new PrestashopProductMasterAdapter(
       mockHttpClient,

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
@@ -9,11 +9,13 @@
 import { PrestashopProductMapper } from '../prestashop-product.mapper';
 import { PrestashopProduct, PrestashopCombination } from '../prestashop.mapper.interface';
 
+const STOREFRONT_BASE_URL = 'https://shop.test';
+
 describe('PrestashopProductMapper', () => {
   let mapper: PrestashopProductMapper;
 
   beforeEach(() => {
-    mapper = new PrestashopProductMapper();
+    mapper = new PrestashopProductMapper({ storefrontBaseUrl: STOREFRONT_BASE_URL });
   });
 
   describe('mapProduct', () => {
@@ -317,6 +319,129 @@ describe('PrestashopProductMapper', () => {
 
       const result = mapper.mapProduct(prestashopProduct, 1);
       expect(result.categories).toEqual(['5', '10']);
+    });
+  });
+
+  describe('extractImages (via mapProduct)', () => {
+    function makeProductWithImages(images: unknown): PrestashopProduct {
+      return {
+        id: '1',
+        name: 'Test',
+        reference: 'TEST-001',
+        price: '19.99',
+        associations: {
+          images,
+        },
+      } as unknown as PrestashopProduct;
+    }
+
+    it('should return undefined when associations has no images key', () => {
+      const prestashopProduct: PrestashopProduct = {
+        id: '1',
+        name: 'Test',
+        reference: 'TEST-001',
+        price: '19.99',
+        associations: {},
+      };
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toBeUndefined();
+    });
+
+    it('should return undefined when associations is absent entirely', () => {
+      const prestashopProduct: PrestashopProduct = {
+        id: '1',
+        name: 'Test',
+        reference: 'TEST-001',
+        price: '19.99',
+      };
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toBeUndefined();
+    });
+
+    it('should extract a single-image object association (PrestaShop collapses solo collections)', () => {
+      const prestashopProduct = makeProductWithImages({ image: { id: '7' } });
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual(['https://shop.test/img/p/7/7-home_default.jpg']);
+    });
+
+    it('should extract a multi-image array and preserve order (cover first)', () => {
+      const prestashopProduct = makeProductWithImages({
+        image: [{ id: '1' }, { id: '2' }, { id: '3' }],
+      });
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual([
+        'https://shop.test/img/p/1/1-home_default.jpg',
+        'https://shop.test/img/p/2/2-home_default.jpg',
+        'https://shop.test/img/p/3/3-home_default.jpg',
+      ]);
+    });
+
+    it('should accept attribute-style @_id keys from XML parser output', () => {
+      const prestashopProduct = makeProductWithImages({
+        image: [{ '@_id': '42' }, { '@_id': '123' }],
+      });
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual([
+        'https://shop.test/img/p/4/2/42-home_default.jpg',
+        'https://shop.test/img/p/1/2/3/123-home_default.jpg',
+      ]);
+    });
+
+    it('should split image ids by digit for deep directories', () => {
+      const prestashopProduct = makeProductWithImages({
+        image: [{ id: '1' }, { id: '42' }, { id: '123' }, { id: '1234' }],
+      });
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual([
+        'https://shop.test/img/p/1/1-home_default.jpg',
+        'https://shop.test/img/p/4/2/42-home_default.jpg',
+        'https://shop.test/img/p/1/2/3/123-home_default.jpg',
+        'https://shop.test/img/p/1/2/3/4/1234-home_default.jpg',
+      ]);
+    });
+
+    it('should tolerate a trailing slash on storefrontBaseUrl', () => {
+      const localMapper = new PrestashopProductMapper({
+        storefrontBaseUrl: 'https://shop.test/',
+      });
+      const prestashopProduct = makeProductWithImages({ image: { id: '1' } });
+
+      const result = localMapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual(['https://shop.test/img/p/1/1-home_default.jpg']);
+    });
+
+    it('should skip entries without a usable id and still return the rest', () => {
+      const prestashopProduct = makeProductWithImages({
+        image: [{ id: '1' }, { notAnId: 'x' }, { id: '' }, { id: '  ' }, { id: '3' }],
+      });
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual([
+        'https://shop.test/img/p/1/1-home_default.jpg',
+        'https://shop.test/img/p/3/3-home_default.jpg',
+      ]);
+    });
+
+    it('should return undefined when every entry is unusable', () => {
+      const prestashopProduct = makeProductWithImages({
+        image: [{ notAnId: 'x' }, { id: '' }, null],
+      });
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toBeUndefined();
+    });
+
+    it('should accept a numeric id', () => {
+      const prestashopProduct = makeProductWithImages({ image: { id: 55 } });
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual(['https://shop.test/img/p/5/5/55-home_default.jpg']);
     });
   });
 

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
@@ -8,6 +8,7 @@
  * @implements {IPrestashopProductMapper}
  */
 import { IPrestashopProductMapper, PrestashopProduct, PrestashopCombination } from './prestashop.mapper.interface';
+import { PrestashopProductMapperOptions } from './prestashop-product.mapper.types';
 import { Product, ProductVariant, normalizeBarcode, normalizeToEan13 } from '@openlinker/core/products';
 
 /**
@@ -16,6 +17,8 @@ import { Product, ProductVariant, normalizeBarcode, normalizeToEan13 } from '@op
  * Transforms PrestaShop product data to OpenLinker Product schema.
  */
 export class PrestashopProductMapper implements IPrestashopProductMapper {
+  constructor(private readonly options: PrestashopProductMapperOptions) {}
+
   mapProduct(prestashopProduct: PrestashopProduct, langId: number = 1): Omit<Product, 'id'> {
     // Extract localized fields with fallback to empty string for name (required field)
     const name = this.getLocalizedField(prestashopProduct.name, langId) || '';
@@ -270,20 +273,107 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
   }
 
   /**
-   * Extract images from PrestaShop product
+   * Extract public image URLs from a PrestaShop product response.
+   *
+   * PrestaShop serializes `associations.images.image` as either a single object
+   * (when the product has one image) or an array (when it has many). Each image
+   * node carries its numeric id under either `id` or `@_id` depending on the
+   * response format (JSON vs XML). We normalise both shapes, skip entries that
+   * don't yield a usable id, and build one URL per remaining entry. Preserves
+   * PrestaShop's order — the first element is treated as the cover.
+   *
+   * Returns `undefined` when no images can be extracted (no associations, empty
+   * collection, or every entry malformed). `undefined` — not `null` — matches
+   * the rest of this mapper, which relies on downstream consumers to convert
+   * `undefined → null` at persistence boundaries.
    */
   private extractImages(product: PrestashopProduct): string[] | undefined {
-    // PrestaShop images are typically in associations.images
-    // For MVP, we'll handle basic cases
-    if (product.associations && typeof product.associations === 'object') {
-      const associations = product.associations as Record<string, unknown>;
-      if (associations.images) {
-        // Handle image associations if present
-        // Full implementation would fetch image URLs
-        return undefined; // Placeholder
+    if (!product.associations || typeof product.associations !== 'object') {
+      return undefined;
+    }
+
+    const associations = product.associations as Record<string, unknown>;
+    const imagesNode = associations.images;
+    if (!imagesNode || typeof imagesNode !== 'object') {
+      return undefined;
+    }
+
+    const imageField = (imagesNode as Record<string, unknown>).image;
+    if (imageField === undefined || imageField === null) {
+      return undefined;
+    }
+
+    const entries = Array.isArray(imageField) ? imageField : [imageField];
+
+    const urls: string[] = [];
+    for (const entry of entries) {
+      const id = this.extractImageId(entry);
+      if (id === null) {
+        continue;
+      }
+      urls.push(this.buildImageUrl(id));
+    }
+
+    return urls.length > 0 ? urls : undefined;
+  }
+
+  /**
+   * Extract the numeric image id from a single `associations.images.image` entry.
+   *
+   * PrestaShop returns ids under `id` (JSON) or `@_id` (XML parsed by
+   * `fast-xml-parser`). Defensive against primitive entries (the node itself a
+   * string), object entries with either key, and anything else (returns null so
+   * the caller can skip). String/number ids are accepted; other types are
+   * rejected.
+   */
+  private extractImageId(entry: unknown): string | null {
+    if (entry === null || entry === undefined) {
+      return null;
+    }
+
+    if (typeof entry === 'string' || typeof entry === 'number') {
+      const asString = String(entry).trim();
+      return asString.length > 0 ? asString : null;
+    }
+
+    if (typeof entry === 'object') {
+      const node = entry as Record<string, unknown>;
+      const rawId = node.id ?? node['@_id'] ?? node['@id'];
+      if (typeof rawId === 'string' || typeof rawId === 'number') {
+        const asString = String(rawId).trim();
+        return asString.length > 0 ? asString : null;
       }
     }
-    return undefined;
+
+    return null;
+  }
+
+  /**
+   * Build a public front-office image URL for a given PrestaShop image id.
+   *
+   * Uses the numeric path format (`/img/p/{split}/{id}-{type}.jpg`) which
+   * PrestaShop serves regardless of "Friendly URL" configuration. `split` is
+   * the image id with digits separated by `/` (e.g. `123` → `1/2/3`). Digit
+   * splitting handles arbitrarily long ids.
+   *
+   * TODO: image type ('home_default') is fixed for v1. Expose via options
+   * when detail-page or retina sizes land.
+   */
+  private buildImageUrl(imageId: string): string {
+    const base = this.options.storefrontBaseUrl.replace(/\/+$/, '');
+    const split = this.splitImageId(imageId);
+    return `${base}/img/p/${split}/${imageId}-home_default.jpg`;
+  }
+
+  /**
+   * Split a numeric id into a `/`-separated digit path.
+   *
+   * Examples: `'1'` → `'1'`, `'42'` → `'4/2'`, `'123'` → `'1/2/3'`.
+   * Non-digit characters are preserved as-is (PrestaShop ids are numeric in
+   * practice, but this keeps the helper defensive).
+   */
+  private splitImageId(id: string): string {
+    return id.split('').join('/');
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
@@ -7,9 +7,9 @@
  * @module libs/integrations/prestashop/src/infrastructure/mappers
  * @implements {IPrestashopProductMapper}
  */
+import { Product, ProductVariant, normalizeBarcode, normalizeToEan13 } from '@openlinker/core/products';
 import { IPrestashopProductMapper, PrestashopProduct, PrestashopCombination } from './prestashop.mapper.interface';
 import { PrestashopProductMapperOptions } from './prestashop-product.mapper.types';
-import { Product, ProductVariant, normalizeBarcode, normalizeToEan13 } from '@openlinker/core/products';
 
 /**
  * PrestaShop Product Mapper
@@ -366,11 +366,15 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
   }
 
   /**
-   * Split a numeric id into a `/`-separated digit path.
+   * Split a numeric id into a `/`-separated character path.
    *
+   * Every character of the input becomes one path segment, separated by `/`.
    * Examples: `'1'` → `'1'`, `'42'` → `'4/2'`, `'123'` → `'1/2/3'`.
-   * Non-digit characters are preserved as-is (PrestaShop ids are numeric in
-   * practice, but this keeps the helper defensive).
+   *
+   * Caller is responsible for supplying numeric ids — PrestaShop image ids
+   * are numeric in practice, and `extractImageId` rejects anything that
+   * isn't `string | number` before reaching this helper. Non-digit input
+   * would still be split character-by-character rather than stripped.
    */
   private splitImageId(id: string): string {
     return id.split('').join('/');

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.types.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.types.ts
@@ -1,0 +1,26 @@
+/**
+ * PrestaShop Product Mapper Types
+ *
+ * Options consumed by `PrestashopProductMapper` at construction time. Kept in
+ * a separate file per `docs/engineering-standards.md#type-definitions-in-separate-files`.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/mappers
+ */
+
+/**
+ * Construction-time options for `PrestashopProductMapper`.
+ *
+ * The mapper is instantiated once per connection by
+ * `PrestashopAdapterFactory.createAdapters()`, so these options are effectively
+ * per-connection configuration frozen at adapter-creation time.
+ */
+export interface PrestashopProductMapperOptions {
+  /**
+   * Base URL used to build public product-image URLs.
+   *
+   * Always a valid URL at runtime — the adapter factory falls back to the
+   * connection's webservice `baseUrl` when `storefrontBaseUrl` is unset.
+   * Never null. Trailing slashes are tolerated by the mapper.
+   */
+  storefrontBaseUrl: string;
+}


### PR DESCRIPTION
## Summary

Closes #271. Closes #272.

Populates `Product.images` for PrestaShop connections and exposes `productImageUrl` on the inventory list response. Unlocks product-thumbnail rendering on `/products` and `/inventory` (frontend wiring ships in #273 / #274 / #275).

## Key design call — port ownership

The "cover image is the first element of `images`" rule lives on the **Product** domain entity as a `coverImageUrl` getter. The inventory layer does **not** replicate the rule — `toDto()` reads `product.coverImageUrl` directly. This keeps product-display knowledge inside the Products bounded context. (Discussed in #272.)

## What changed

### `Product.coverImageUrl` getter — `fa66b1e`

- `libs/core/src/products/domain/entities/product.entity.ts`: new `get coverImageUrl(): string | null` returning `images?.[0] ?? null`.
- `product.entity.spec.ts`: 4 cases (null images, empty array, populated, single element).

### PrestaShop: real image URL extraction — `0581a70`

- `PrestashopProductMapper.extractImages()` was a stubbed no-op returning `undefined` unconditionally. Now emits public front-office URLs: `{storefrontBaseUrl}/img/p/{split}/{imageId}-home_default.jpg`, where `split` is the id with digits separated by `/` (e.g. `123` → `1/2/3`). This is PrestaShop's numeric path, which serves regardless of "Friendly URL" config.
- **New optional config field** `PrestashopConnectionConfig.storefrontBaseUrl`. If unset, the factory falls back to the webservice `baseUrl` — works for the common case (webservice + storefront at same host) with zero operator action. Operator-facing override field in the wizard is split out to #283.
- `PrestashopProductMapperOptions` lives in its own `*.types.ts` file per engineering-standards §Type Definitions in Separate Files.
- Mapper options are non-nullable `string` — the factory is the only call site and always supplies a valid URL. No dead null-branch in the mapper.

### Inventory API: `productImageUrl` on list response — `0581a70`

- `InventoryItemResponseDto` gains `productImageUrl: string | null`. Controller `toDto()` maps `product?.coverImageUrl ?? null`. Reuses the existing batch `buildProductMap` lookup — no new repository queries.
- `apps/web/src/features/inventory/api/inventory.types.ts`: `InventoryItem.productImageUrl` added to keep the FE/BE contract in lockstep (not consumed yet — #275 picks it up).

### Tech-review fixes — `3369beb`

- Reordered mapper imports to follow engineering-standards §Import Order (external → cross-boundary → local).
- Rewrote the `splitImageId` doc comment — actual behaviour is "split every character"; old comment said "non-digit characters are preserved as-is" which was ambiguous.
- Added `as string | undefined` cast on `storefrontBaseUrl` in the factory's `validatedConfig` for symmetry with sibling fields.

## Known limitations / follow-ups

- **Port vs entity `Product` drift.** `@openlinker/core/products` re-exports both the port interface (`images?: string[]`) and the domain entity class (`images: string[] | null`). `coverImageUrl` only lives on the entity class — correct for inventory's use case, but widens drift that #281 already flags for `ProductVariant`. Worth filing a Product-equivalent of #281.
- `home_default` image size is hardcoded; TODO comment in `buildImageUrl` marks it for options exposure when detail-page or retina sizes land.
- #283 tracks the FE wizard override field for `storefrontBaseUrl`.

## Test plan

- [x] `pnpm lint` — 0 errors (only pre-existing warnings in untouched files)
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — all packages green: libs/core 273/273, prestashop 181/181, api 242/242, web 335/335
- [x] `pnpm test:integration inventory-read` — both new cases (`productImageUrl` round-trip + null case) pass; one unrelated pre-existing flake in the same suite (#278, `loginAsAdmin` duplicate-key)
- [x] `pnpm --filter @openlinker/api migration:show` — no pending migrations (ORM `images` column unchanged)
- [x] Pre-commit hooks passed on all three commits

Manual verification recommended post-merge: confirm front-office URLs load against a live PrestaShop demo store once a thumbnail-consuming FE surface (#274 or #275) lands.

## Unrelated observation

Filed #287 to track an `AllegroHttpClient` retry-test flake that surfaced during this branch's pre-commit hook — tests use real `setTimeout` retry delays and time out under concurrent jest load. Not caused by this diff; worth a follow-up.
