### PR TITLE
chore(prestashop): drop unnecessary storefrontBaseUrl type assertion

### DIFF
--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -249,7 +249,11 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
     // Build validated config with defaults
     const validatedConfig: PrestashopConnectionConfig = {
       baseUrl: config.baseUrl,
-      storefrontBaseUrl: config.storefrontBaseUrl as string | undefined,
+      // No cast needed: TypeScript narrows `config.storefrontBaseUrl` to
+      // `string | undefined` via the preceding `typeof` guard + throw branch.
+      // `@typescript-eslint/no-unnecessary-type-assertion` flags the redundant
+      // assertion that symmetry with sibling fields would otherwise suggest.
+      storefrontBaseUrl: config.storefrontBaseUrl,
       shopId: config.shopId as number | undefined,
       langId: (config.langId as number | undefined) ?? 1,
       timeoutMs: (config.timeoutMs as number | undefined) ?? 30000,


### PR DESCRIPTION
## Summary

Follow-up from #288. Drops the `as string | undefined` cast on `storefrontBaseUrl` in `validateAndParseConfig` so `pnpm lint` stays clean.

## Why

In #288 I added the cast for visual symmetry with the sibling fields (`shopId`, `langId`, `timeoutMs`, `pageSize`, `responseFormat`) during tech-review. Turns out `@typescript-eslint/no-unnecessary-type-assertion` auto-fixes it out because TypeScript narrows `config.storefrontBaseUrl` to `string | undefined` via the preceding `typeof !== 'string'` + throw guard — the cast is redundant.

This got past the pre-commit hook in #288 because `pnpm lint` runs with `--fix` *after* git stages the file — the unfixed version got committed, then ESLint auto-fixed the working-tree copy post-commit. The merged PR shipped the cast; the worktree flagged the diff on my way out.

Left a short comment where the cast used to be so the next reviewer doesn't re-add it out of symmetry instinct.

## Test plan

- [x] `pnpm lint` — clean, no auto-fix needed
- [x] `pnpm type-check` — clean (narrowing still valid without the cast)
- [x] `pnpm test` — all green (pre-commit hook ran full suite)

No behavioural change.
