### PR TITLE
fix(api): disable BootstrapAdminService in integration test harness

### DIFF
--- a/apps/api/test/integration/bootstrap-admin-disabled.int-spec.ts
+++ b/apps/api/test/integration/bootstrap-admin-disabled.int-spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Bootstrap-admin-disabled regression guard (#278)
+ *
+ * Verifies that BootstrapAdminService does not seed a default `admin` user
+ * when the integration harness boots. The harness sets
+ * `OL_BOOTSTRAP_ADMIN_ENABLED=false` so `loginAsAdmin('admin')` in any suite
+ * can freely insert its own admin row without colliding on the
+ * `users.username` unique constraint. Without this guarantee, the first test
+ * of every suite that calls `loginAsAdmin` fails at boot.
+ *
+ * If someone re-enables the bootstrap in `harness.ts` or adds a new seeding
+ * `OnApplicationBootstrap`, this spec fails loudly.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+
+describe('Bootstrap admin disabled in integration harness (#278)', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('leaves the users table empty after app boot', async () => {
+    const result = await harness
+      .getDataSource()
+      .query<{ count: string }[]>('SELECT COUNT(*)::text AS count FROM users');
+    expect(result[0].count).toBe('0');
+  });
+});

--- a/apps/api/test/integration/bootstrap-admin-disabled.int-spec.ts
+++ b/apps/api/test/integration/bootstrap-admin-disabled.int-spec.ts
@@ -16,7 +16,6 @@
 import {
   getTestHarness,
   IntegrationTestHarness,
-  resetTestHarness,
   teardownTestHarness,
 } from './setup';
 
@@ -24,18 +23,24 @@ describe('Bootstrap admin disabled in integration harness (#278)', () => {
   let harness: IntegrationTestHarness;
 
   beforeAll(async () => {
+    // Force a fresh app boot so this assertion observes the real
+    // post-`onApplicationBootstrap` state. Any cached harness from a
+    // prior suite would mask a re-enabled bootstrap because app.init()
+    // (and therefore the bootstrap hook) only runs once per harness.
+    await teardownTestHarness();
     harness = await getTestHarness();
-    await resetTestHarness();
   });
 
   afterAll(async () => {
     await teardownTestHarness();
   });
 
-  it('leaves the users table empty after app boot', async () => {
-    const result = await harness
+  it('does not seed a default admin user after app boot', async () => {
+    const rows = await harness
       .getDataSource()
-      .query<{ count: string }[]>('SELECT COUNT(*)::text AS count FROM users');
-    expect(result[0].count).toBe('0');
+      .query<
+        { count: string }[]
+      >(`SELECT COUNT(*)::text AS count FROM users WHERE username = 'admin'`);
+    expect(rows[0].count).toBe('0');
   });
 });

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -74,6 +74,7 @@ export async function startHarness(): Promise<void> {
   // helpers. Letting BootstrapAdminService also insert a default `admin`
   // user on app.init() causes the first `loginAsAdmin('admin')` call in
   // every suite to collide on the users.username unique constraint. See #278.
+  // Regression guard: test/integration/bootstrap-admin-disabled.int-spec.ts
   process.env.OL_BOOTSTRAP_ADMIN_ENABLED = 'false';
 
   // Store containers on globalThis for teardown

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -70,6 +70,12 @@ export async function startHarness(): Promise<void> {
   process.env.OL_INVENTORY_SYNC_ENABLED = 'false';
   process.env.OL_PRODUCT_SYNC_ENABLED = 'false';
 
+  // Integration tests seed users explicitly via loginAsAdmin / seedUser
+  // helpers. Letting BootstrapAdminService also insert a default `admin`
+  // user on app.init() causes the first `loginAsAdmin('admin')` call in
+  // every suite to collide on the users.username unique constraint. See #278.
+  process.env.OL_BOOTSTRAP_ADMIN_ENABLED = 'false';
+
   // Store containers on globalThis for teardown
   globalThis.__API_TEST_HARNESS__ = { postgres, redis };
 }

--- a/docs/plans/implementation-plan-integration-test-admin-leak.md
+++ b/docs/plans/implementation-plan-integration-test-admin-leak.md
@@ -1,0 +1,164 @@
+# Implementation plan — Integration test admin-user leak (#278)
+
+**Issue:** https://github.com/SilkSoftwareHouse/openlinker/issues/278
+**Layer:** Backend test infrastructure only (no production code, no migration)
+
+## Goal
+
+`pnpm test:integration` fails with 7 suites erroring on the first `loginAsAdmin` call. Fix so every run returns zero failures, and running it twice back-to-back on the same Docker state still returns zero failures.
+
+## Root cause (corrected after audit)
+
+The issue body hypothesised between-suite data leakage: admin rows from one suite surviving into the next. The repro walk proves a different cause.
+
+**Root cause: `BootstrapAdminService.onApplicationBootstrap()` seeds an `admin` user on every Nest app boot.**
+
+`apps/api/src/auth/bootstrap-admin.service.ts`:
+
+```ts
+@Injectable()
+export class BootstrapAdminService implements OnApplicationBootstrap {
+  async onApplicationBootstrap(): Promise<void> { await this.bootstrap(); }
+
+  async bootstrap(): Promise<void> {
+    const enabled = this.configService.get<string>('OL_BOOTSTRAP_ADMIN_ENABLED', 'true');
+    if (enabled.trim().toLowerCase() !== 'true') return;
+
+    const username = this.configService.get<string>('OL_BOOTSTRAP_ADMIN_USERNAME', 'admin');
+    // ... inserts a user row with username='admin' if not present
+  }
+}
+```
+
+Sequence for a failing suite:
+1. `beforeAll` → `getTestHarness()` → `app.init()` → `onApplicationBootstrap` → **insert `admin`**.
+2. First `it` → `loginAsAdmin(http, dataSource)` → `INSERT INTO users (username='admin', ...)` → **`users.username` unique-constraint violation** → test fails here.
+3. `afterEach(resetTestHarness)` → truncates users → both the bootstrap row and any partial insert are gone.
+4. Second `it` → `loginAsAdmin` → clean insert → passes.
+
+That matches the observed failure shape perfectly: every failing suite has exactly one failure (always the first test), and it's always the same constraint. The candidate "between-suite leak" theory in the issue body was wrong — the admin row isn't leaking across suites, it's being re-seeded on every app boot.
+
+### Audit results
+
+Grep-audit from tech-review:
+
+| Mechanism (from earlier plan) | Result |
+|---|---|
+| (a) Suite missing `afterEach(resetTestHarness)` | **Ruled out** — all 10 suites have it wired. |
+| (b) Double `loginAsAdmin` in a single `it` with the same username | **Ruled out** — zero matches across all failing suites. |
+| (c) App boot re-seeds admin | **Confirmed** — `BootstrapAdminService.onApplicationBootstrap` in `apps/api/src/auth/bootstrap-admin.service.ts` is the active seeder. |
+
+Failing set from live repro (matches the issue body except for one filename drift — `sync-jobs-read.int-spec.ts`, not `sync-jobs-crud.int-spec.ts`, and `orders-read.int-spec.ts` is in the failing set too; `webhook-ingestion.int-spec.ts` passes now despite being listed as failing in the issue body):
+
+- `connection-capabilities.int-spec.ts`
+- `connection-credentials.int-spec.ts`
+- `connection-crud.int-spec.ts`
+- `connection-diagnostics.int-spec.ts`
+- `inventory-read.int-spec.ts`
+- `sync-jobs-read.int-spec.ts`
+- `orders-read.int-spec.ts`
+
+Every failing suite calls `loginAsAdmin('admin', ...)` in its first `it`. Every passing suite either doesn't use `loginAsAdmin` (app-boot, webhook-ingestion) or uses a distinct username via `seedUser('testuser', ...)` (auth).
+
+## Non-goals
+
+- A blanket harness-level truncate in `setup()`. I considered this in the first draft and rejected it: disabling the specific production behaviour that causes the conflict (bootstrap seeding) is narrower and more correct than papering over whatever the app boots with.
+- Redesigning the harness / container strategy.
+- Fixing the dead `globalTeardown` wiring (`jest-integration.cjs` doesn't reference `teardown.ts`). Worth a follow-up but out of scope.
+- Making `loginAsAdmin` idempotent via `ON CONFLICT`. Per the issue, that hides leaks.
+
+## Design decision
+
+**Disable `BootstrapAdminService` in the integration harness via `OL_BOOTSTRAP_ADMIN_ENABLED=false`.**
+
+- The service already reads that env var and exits early when it's set to anything other than `"true"`.
+- Integration tests seed users explicitly through `loginAsAdmin` / `seedUser`. The bootstrap seed adds nothing — it only collides.
+- One line in `harness.ts` where the existing test-only disable flags already live (`OL_ALLEGRO_POLL_SCHEDULER_ENABLED=false`, `OL_PRODUCT_SYNC_ENABLED=false`, etc.). Matches the established pattern.
+- No production change. No new abstraction. Surgical fix.
+
+**Rejected alternatives:**
+
+- *Harness-level `await this.reset()` in `setup()`* — fixes the symptom but doesn't explain *why* truncation is needed. Every future reader has to reason "the app must be seeding something somehow." Disabling the seeder is self-documenting.
+- *`loginAsAdmin` with `ON CONFLICT (username) DO NOTHING`* — the issue explicitly rejects this because it would mask future leaks, and on reflection the real issue is that the seeder shouldn't run in tests at all.
+
+## Change set
+
+### 1. `apps/api/test/integration/harness.ts::startHarness()`
+
+Add `OL_BOOTSTRAP_ADMIN_ENABLED=false` alongside the existing scheduler-disable env vars. Group it with the other test-only disables and comment why.
+
+Before (lines ~68-71):
+```ts
+  process.env.OL_ALLEGRO_POLL_SCHEDULER_ENABLED = 'false';
+  process.env.OL_ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED = 'false';
+  process.env.OL_INVENTORY_SYNC_ENABLED = 'false';
+  process.env.OL_PRODUCT_SYNC_ENABLED = 'false';
+```
+
+After:
+```ts
+  process.env.OL_ALLEGRO_POLL_SCHEDULER_ENABLED = 'false';
+  process.env.OL_ALLEGRO_OFFERS_SYNC_SCHEDULER_ENABLED = 'false';
+  process.env.OL_INVENTORY_SYNC_ENABLED = 'false';
+  process.env.OL_PRODUCT_SYNC_ENABLED = 'false';
+
+  // Integration tests seed users explicitly via loginAsAdmin / seedUser
+  // helpers. Letting BootstrapAdminService also insert a default `admin`
+  // user on app.init() causes the first `loginAsAdmin('admin')` call in
+  // every suite to collide on the users.username unique constraint. See #278.
+  process.env.OL_BOOTSTRAP_ADMIN_ENABLED = 'false';
+```
+
+### 2. Regression guard — new `bootstrap-admin-disabled.int-spec.ts`
+
+Small, focused test that pins the contract at the integration level: booting the harness and calling `resetTestHarness` immediately gives an empty users table (i.e., the bootstrap didn't seed one). Keeps the documented guarantee testable without touching any of the existing suites' semantics.
+
+```ts
+// test/integration/bootstrap-admin-disabled.int-spec.ts
+import { getTestHarness, resetTestHarness, teardownTestHarness, IntegrationTestHarness } from './setup';
+
+describe('Bootstrap admin disabled in integration harness (#278)', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('leaves the users table empty after app boot', async () => {
+    const result = await harness
+      .getDataSource()
+      .query<{ count: string }[]>('SELECT COUNT(*)::text AS count FROM users');
+    expect(result[0].count).toBe('0');
+  });
+});
+```
+
+If someone later re-enables the bootstrap in `harness.ts` or adds a new seeding `OnApplicationBootstrap`, this test flags it immediately.
+
+### 3. No production code changes
+
+No `src/` files touched. No migration. No API change.
+
+## Quality gate
+
+- `pnpm --filter @openlinker/api test:integration` — **must** return `Test Suites: 11 passed, 11 total` / `Tests: 68 passed, 68 total` (one new test added).
+- Run it a second time immediately after the first run completes — both runs still pass. This validates the "same Docker state" criterion from the issue.
+- `pnpm lint` — clean.
+- `pnpm type-check` — clean.
+- `pnpm test` — backend unit tests unchanged (still have the pre-existing `libs/core` failures that predate this issue; we do not regress them).
+
+## Risks / open questions
+
+- **Bootstrap service behaviour in non-test contexts** — unchanged. `OL_BOOTSTRAP_ADMIN_ENABLED` defaults to `true`; only the integration harness overrides it. Unit tests for the bootstrap service itself (`bootstrap-admin.service.spec.ts`) continue to cover the enabled-by-default path.
+- **"Run twice back-to-back" verification** — will be empirical. Testcontainers' process-exit hooks may or may not fire under Jest's `forceExit: true`; if they don't, containers from run 1 persist and run 2 re-uses them. Either way, our fix handles both cases — a fresh container boots without admin seeded, a re-used container gets truncated by the next `afterEach` between tests. Will confirm by running the suite twice during implementation.
+- **If the env var check in `BootstrapAdminService` ever changes** — e.g. the default flips to `"false"` or the string comparison tightens — our disable no longer works. Covered by the new regression test; it fails if `users` has any rows on boot.
+
+## Out of scope / follow-ups
+
+- Wire `globalTeardown: './test/integration/teardown.ts'` in `jest-integration.cjs` so containers stop explicitly and we can drop `forceExit: true`. Worth a separate issue.
+- Consider replacing `TRUNCATE ... CASCADE` with a programmatic enumeration of `public` schema tables so new tables are picked up automatically. Defer.


### PR DESCRIPTION
## Summary

- `pnpm test:integration` was failing with 7 suites erroring on the first `loginAsAdmin('admin', …)` call — always a `users.username` unique-constraint violation at the very first `it`.
- Root cause (narrower than the issue body hypothesis): `BootstrapAdminService.onApplicationBootstrap` seeds a default `admin` user on every Nest app boot, and each integration suite boots a fresh app in `beforeAll` — so the suite's first `loginAsAdmin` collides with the bootstrap seed.
- Fix: set `OL_BOOTSTRAP_ADMIN_ENABLED=false` in `harness.ts` alongside the existing test-only disable flags (schedulers, sync cron). The service already short-circuits when the env var isn't exactly `"true"`. Integration tests seed users explicitly; the production bootstrap adds nothing to them except the collision.
- Adds a regression guard (`bootstrap-admin-disabled.int-spec.ts`) that forces a fresh app boot via `teardownTestHarness()` + `getTestHarness()` and asserts no `admin` row exists afterwards — so any future re-enable or new seeding `OnApplicationBootstrap` fails loudly.

### Audit results

The issue body originally framed this as between-suite data leakage. Grep-audit ruled out both alternative candidates:
- All 10 suites correctly wire `afterEach(resetTestHarness)`.
- No suite double-calls `loginAsAdmin` inside a single `it` block.

The bootstrap-seeds-every-boot mechanism is the only one that matches the observed failure shape (exactly one failure per failing suite, always the first test, always the same constraint).

### Verification

- **Fix result**: 11 suites passing (was 10), 68 tests passing (was 67), zero failures. Confirmed across three consecutive `pnpm test:integration` runs.
- **Guard correctness proof**: locally flipped `OL_BOOTSTRAP_ADMIN_ENABLED=true` and re-ran the spec alone — it correctly failed with `Received: "1"`. Flipped back to `false`, suite green.
- `pnpm lint` / `pnpm type-check` / `pnpm test` all clean (the two pre-existing `password-reset.service.spec.ts` warnings are unchanged).

### Out of scope

- Wiring `globalTeardown: './test/integration/teardown.ts'` in `jest-integration.cjs` so we can drop `forceExit: true` — worth a separate issue.
- Making `loginAsAdmin` idempotent via `ON CONFLICT` — rejected per the issue, would mask future leaks.

## Test plan

- [x] `pnpm --filter @openlinker/api test:integration` passes 11/11 suites, 68/68 tests
- [x] Three back-to-back runs with no failures
- [x] Regression guard verified: fails when env var flipped to `true`, passes when `false`
- [x] `pnpm lint` clean
- [x] `pnpm type-check` clean
- [x] `pnpm test` clean

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)