### PR TITLE
refactor(inventory): extract IInventoryQueryService for cross-aggregate read

### DIFF
--- a/apps/api/src/inventory/http/inventory.controller.spec.ts
+++ b/apps/api/src/inventory/http/inventory.controller.spec.ts
@@ -1,113 +1,114 @@
 /**
  * Inventory Controller Unit Tests
  *
+ * Focuses on HTTP-shape concerns: pagination echo, date serialisation,
+ * flattening of the InventoryItemView into the response DTO, and 404
+ * translation on missing items. Composition correctness (dedup, null
+ * product fallback across a list) is covered in the service spec.
+ *
  * @module apps/api/src/inventory/http
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { InventoryController } from './inventory.controller';
 import {
-  INVENTORY_REPOSITORY_TOKEN,
+  INVENTORY_QUERY_SERVICE_TOKEN,
   InventoryItemEntity as InventoryItem,
 } from '@openlinker/core/inventory';
-import type { InventoryRepositoryPort } from '@openlinker/core/inventory';
-import {
-  PRODUCT_REPOSITORY_TOKEN,
-  Product,
-} from '@openlinker/core/products';
-import type { ProductRepositoryPort } from '@openlinker/core/products';
+import type {
+  IInventoryQueryService,
+  InventoryItemView,
+} from '@openlinker/core/inventory';
 
 describe('InventoryController', () => {
   let controller: InventoryController;
-  let repository: jest.Mocked<InventoryRepositoryPort>;
-  let productRepository: jest.Mocked<ProductRepositoryPort>;
+  let queryService: jest.Mocked<IInventoryQueryService>;
 
-  const mockItem = new InventoryItem(
-    'inv-001',
-    'prod-001',
-    'var-001',
+  const itemA = new InventoryItem(
+    'inv-a',
+    'prod-1',
+    'var-a',
     50,
     5,
     null,
     new Date('2026-04-01T00:00:00Z'),
   );
+  const itemB = new InventoryItem(
+    'inv-b',
+    'prod-2',
+    null,
+    10,
+    0,
+    null,
+    new Date('2026-04-02T00:00:00Z'),
+  );
 
-  const mockProduct: Product = {
-    id: 'prod-001',
-    name: 'Test Product',
-    sku: 'SKU-001',
-    price: 99.99,
-    description: null,
-    images: ['https://shop.test/img/p/1/1-home_default.jpg', 'https://shop.test/img/p/1/1-medium.jpg'],
-    createdAt: new Date('2026-01-01T00:00:00Z'),
-    updatedAt: new Date('2026-04-01T00:00:00Z'),
+  const viewWithProduct: InventoryItemView = {
+    item: itemA,
+    product: {
+      name: 'Product One',
+      sku: 'SKU-1',
+      coverImageUrl: 'https://shop.test/img/1/cover.jpg',
+    },
   };
-
-  const mockProductWithoutImages: Product = {
-    id: 'prod-001',
-    name: 'Test Product',
-    sku: 'SKU-001',
-    price: 99.99,
-    description: null,
-    images: null,
-    createdAt: new Date('2026-01-01T00:00:00Z'),
-    updatedAt: new Date('2026-04-01T00:00:00Z'),
+  const viewWithoutProduct: InventoryItemView = {
+    item: itemB,
+    product: null,
   };
 
   beforeEach(async () => {
-    const mockRepository: jest.Mocked<InventoryRepositoryPort> = {
-      findByProductAndVariant: jest.fn(),
-      upsert: jest.fn(),
-      findById: jest.fn(),
-      findMany: jest.fn(),
-    };
-
-    const mockProductRepository: jest.Mocked<ProductRepositoryPort> = {
-      findById: jest.fn(),
-      findMany: jest.fn(),
-      upsert: jest.fn(),
+    const mockQueryService: jest.Mocked<IInventoryQueryService> = {
+      listInventoryItems: jest.fn(),
+      getInventoryItem: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [InventoryController],
       providers: [
         {
-          provide: INVENTORY_REPOSITORY_TOKEN,
-          useValue: mockRepository,
-        },
-        {
-          provide: PRODUCT_REPOSITORY_TOKEN,
-          useValue: mockProductRepository,
+          provide: INVENTORY_QUERY_SERVICE_TOKEN,
+          useValue: mockQueryService,
         },
       ],
     }).compile();
 
     controller = module.get<InventoryController>(InventoryController);
-    repository = module.get(INVENTORY_REPOSITORY_TOKEN);
-    productRepository = module.get(PRODUCT_REPOSITORY_TOKEN);
+    queryService = module.get(INVENTORY_QUERY_SERVICE_TOKEN);
   });
 
   describe('listInventory', () => {
-    it('should return paginated inventory items with product name, SKU, and cover image', async () => {
-      repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
-      productRepository.findById.mockResolvedValue(mockProduct);
+    it('flattens the view into the DTO with pagination echo and ISO-string updatedAt', async () => {
+      queryService.listInventoryItems.mockResolvedValue({
+        items: [viewWithProduct, viewWithoutProduct],
+        total: 2,
+      });
 
       const result = await controller.listInventory({ limit: 20, offset: 0 });
 
-      expect(result.items).toHaveLength(1);
-      expect(result.total).toBe(1);
+      expect(result.total).toBe(2);
       expect(result.limit).toBe(20);
       expect(result.offset).toBe(0);
-      expect(result.items[0].id).toBe('inv-001');
-      expect(result.items[0].updatedAt).toBe('2026-04-01T00:00:00.000Z');
-      expect(result.items[0].productName).toBe('Test Product');
-      expect(result.items[0].productSku).toBe('SKU-001');
-      expect(result.items[0].productImageUrl).toBe('https://shop.test/img/p/1/1-home_default.jpg');
+      expect(result.items).toHaveLength(2);
+
+      expect(result.items[0]).toEqual({
+        id: 'inv-a',
+        productId: 'prod-1',
+        productVariantId: 'var-a',
+        availableQuantity: 50,
+        reservedQuantity: 5,
+        locationId: null,
+        updatedAt: '2026-04-01T00:00:00.000Z',
+        productName: 'Product One',
+        productSku: 'SKU-1',
+        productImageUrl: 'https://shop.test/img/1/cover.jpg',
+      });
     });
 
-    it('should return null product fields when product not found', async () => {
-      repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
-      productRepository.findById.mockResolvedValue(null);
+    it('emits null productName/Sku/ImageUrl when the view has no product', async () => {
+      queryService.listInventoryItems.mockResolvedValue({
+        items: [viewWithoutProduct],
+        total: 1,
+      });
 
       const result = await controller.listInventory({ limit: 20, offset: 0 });
 
@@ -116,74 +117,50 @@ describe('InventoryController', () => {
       expect(result.items[0].productImageUrl).toBeNull();
     });
 
-    it('should return null productImageUrl when product has no images', async () => {
-      repository.findMany.mockResolvedValue({ items: [mockItem], total: 1 });
-      productRepository.findById.mockResolvedValue(mockProductWithoutImages);
-
-      const result = await controller.listInventory({ limit: 20, offset: 0 });
-
-      expect(result.items[0].productName).toBe('Test Product');
-      expect(result.items[0].productImageUrl).toBeNull();
-    });
-
-    it('should pass filters to repository', async () => {
-      repository.findMany.mockResolvedValue({ items: [], total: 0 });
+    it('passes filters and pagination into the query service', async () => {
+      queryService.listInventoryItems.mockResolvedValue({ items: [], total: 0 });
 
       await controller.listInventory({
-        productId: 'prod-001',
-        productVariantId: 'var-001',
-        locationId: 'loc-001',
+        productId: 'prod-1',
+        productVariantId: 'var-a',
+        locationId: 'loc-1',
         limit: 10,
         offset: 5,
       });
 
-      expect(repository.findMany).toHaveBeenCalledWith(
-        { productId: 'prod-001', productVariantId: 'var-001', locationId: 'loc-001' },
+      expect(queryService.listInventoryItems).toHaveBeenCalledWith(
+        { productId: 'prod-1', productVariantId: 'var-a', locationId: 'loc-1' },
         { limit: 10, offset: 5 },
       );
-    });
-
-    it('should deduplicate product lookups when multiple items share the same productId', async () => {
-      const secondItem = new InventoryItem('inv-002', 'prod-001', null, 10, 0, null, new Date('2026-04-01T00:00:00Z'));
-      repository.findMany.mockResolvedValue({ items: [mockItem, secondItem], total: 2 });
-      productRepository.findById.mockResolvedValue(mockProduct);
-
-      await controller.listInventory({ limit: 20, offset: 0 });
-
-      expect(productRepository.findById).toHaveBeenCalledTimes(1);
-      expect(productRepository.findById).toHaveBeenCalledWith('prod-001');
-    });
-
-    it('should return empty list when no items match', async () => {
-      repository.findMany.mockResolvedValue({ items: [], total: 0 });
-
-      const result = await controller.listInventory({ limit: 20, offset: 0 });
-
-      expect(result.items).toHaveLength(0);
-      expect(result.total).toBe(0);
     });
   });
 
   describe('getInventoryItem', () => {
-    it('should return inventory item with product name, SKU, and cover image when found', async () => {
-      repository.findById.mockResolvedValue(mockItem);
-      productRepository.findById.mockResolvedValue(mockProduct);
+    it('flattens the view into the DTO on the happy path', async () => {
+      queryService.getInventoryItem.mockResolvedValue(viewWithProduct);
 
-      const result = await controller.getInventoryItem('inv-001');
+      const result = await controller.getInventoryItem('inv-a');
 
-      expect(result.id).toBe('inv-001');
-      expect(result.productId).toBe('prod-001');
-      expect(result.availableQuantity).toBe(50);
-      expect(result.reservedQuantity).toBe(5);
-      expect(result.productName).toBe('Test Product');
-      expect(result.productSku).toBe('SKU-001');
-      expect(result.productImageUrl).toBe('https://shop.test/img/p/1/1-home_default.jpg');
+      expect(result).toEqual({
+        id: 'inv-a',
+        productId: 'prod-1',
+        productVariantId: 'var-a',
+        availableQuantity: 50,
+        reservedQuantity: 5,
+        locationId: null,
+        updatedAt: '2026-04-01T00:00:00.000Z',
+        productName: 'Product One',
+        productSku: 'SKU-1',
+        productImageUrl: 'https://shop.test/img/1/cover.jpg',
+      });
     });
 
-    it('should throw NotFoundException when item not found', async () => {
-      repository.findById.mockResolvedValue(null);
+    it('throws NotFoundException when the query service returns null', async () => {
+      queryService.getInventoryItem.mockResolvedValue(null);
 
-      await expect(controller.getInventoryItem('inv-999')).rejects.toThrow(NotFoundException);
+      await expect(controller.getInventoryItem('inv-missing')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/apps/api/src/inventory/http/inventory.controller.ts
+++ b/apps/api/src/inventory/http/inventory.controller.ts
@@ -1,8 +1,10 @@
 /**
  * Inventory Controller
  *
- * HTTP REST API endpoints for inventory read operations. Provides endpoints
- * for listing inventory items with filters and retrieving individual items.
+ * HTTP REST API endpoints for inventory read operations. Delegates the
+ * cross-aggregate composition of inventory items with master-catalog product
+ * details to IInventoryQueryService; keeps only transport concerns (pagination
+ * echo, date serialisation, HTTP 404 translation).
  *
  * @module apps/api/src/inventory/http
  */
@@ -19,16 +21,10 @@ import {
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import {
-  InventoryRepositoryPort,
-  INVENTORY_REPOSITORY_TOKEN,
-  InventoryItemEntity as InventoryItem,
+  IInventoryQueryService,
+  INVENTORY_QUERY_SERVICE_TOKEN,
+  InventoryItemView,
 } from '@openlinker/core/inventory';
-import {
-  ProductRepositoryPort,
-  PRODUCT_REPOSITORY_TOKEN,
-  Product,
-  coverImageUrl,
-} from '@openlinker/core/products';
 import { ListInventoryQueryDto } from './dto/list-inventory-query.dto';
 import { InventoryItemResponseDto } from './dto/inventory-item-response.dto';
 import { PaginatedInventoryResponseDto } from './dto/paginated-inventory-response.dto';
@@ -39,10 +35,8 @@ import { PaginatedInventoryResponseDto } from './dto/paginated-inventory-respons
 @Controller('inventory')
 export class InventoryController {
   constructor(
-    @Inject(INVENTORY_REPOSITORY_TOKEN)
-    private readonly inventoryRepository: InventoryRepositoryPort,
-    @Inject(PRODUCT_REPOSITORY_TOKEN)
-    private readonly productRepository: ProductRepositoryPort,
+    @Inject(INVENTORY_QUERY_SERVICE_TOKEN)
+    private readonly queryService: IInventoryQueryService,
   ) {}
 
   @Get()
@@ -57,15 +51,13 @@ export class InventoryController {
   async listInventory(@Query() query: ListInventoryQueryDto): Promise<PaginatedInventoryResponseDto> {
     const { productId, productVariantId, locationId, limit = 20, offset = 0 } = query;
 
-    const { items, total } = await this.inventoryRepository.findMany(
+    const { items, total } = await this.queryService.listInventoryItems(
       { productId, productVariantId, locationId },
       { limit, offset },
     );
 
-    const productMap = await this.buildProductMap(items.map((i) => i.productId));
-
     return {
-      items: items.map((item) => this.toDto(item, productMap.get(item.productId))),
+      items: items.map((view) => this.inventoryViewToDto(view)),
       total,
       limit,
       offset,
@@ -79,31 +71,15 @@ export class InventoryController {
   @ApiResponse({ status: 404, description: 'Inventory item not found' })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async getInventoryItem(@Param('id') id: string): Promise<InventoryItemResponseDto> {
-    const item = await this.inventoryRepository.findById(id);
-    if (!item) {
+    const view = await this.queryService.getInventoryItem(id);
+    if (!view) {
       throw new NotFoundException(`Inventory item not found: ${id}`);
     }
-    const product = await this.productRepository.findById(item.productId);
-    return this.toDto(item, product);
+    return this.inventoryViewToDto(view);
   }
 
-  // TODO: Replace with a single findByIds(ids) call once ProductRepositoryPort supports batch lookup.
-  // Current implementation issues N individual findById calls (one per unique productId).
-  // For typical page sizes (≤20 items) this is acceptable, but a batch method would be more efficient.
-  private async buildProductMap(productIds: string[]): Promise<Map<string, Product>> {
-    const uniqueIds = [...new Set(productIds)];
-    const products = await Promise.all(uniqueIds.map((id) => this.productRepository.findById(id)));
-    const map = new Map<string, Product>();
-    uniqueIds.forEach((id, idx) => {
-      const product = products[idx];
-      if (product) {
-        map.set(id, product);
-      }
-    });
-    return map;
-  }
-
-  private toDto(item: InventoryItem, product?: Product | null): InventoryItemResponseDto {
+  private inventoryViewToDto(view: InventoryItemView): InventoryItemResponseDto {
+    const { item, product } = view;
     return {
       id: item.id,
       productId: item.productId,
@@ -114,8 +90,7 @@ export class InventoryController {
       updatedAt: item.updatedAt instanceof Date ? item.updatedAt.toISOString() : item.updatedAt,
       productName: product?.name ?? null,
       productSku: product?.sku ?? null,
-      // Cover-image rule owned by the Products domain; do not replicate here.
-      productImageUrl: product ? coverImageUrl(product) : null,
+      productImageUrl: product?.coverImageUrl ?? null,
     };
   }
 }

--- a/apps/api/src/inventory/inventory.module.ts
+++ b/apps/api/src/inventory/inventory.module.ts
@@ -8,11 +8,10 @@
  */
 import { Module } from '@nestjs/common';
 import { InventoryModule as CoreInventoryModule } from '@openlinker/core/inventory';
-import { ProductsModule } from '@openlinker/core/products';
 import { InventoryController } from './http/inventory.controller';
 
 @Module({
-  imports: [CoreInventoryModule, ProductsModule],
+  imports: [CoreInventoryModule],
   controllers: [InventoryController],
 })
 export class InventoryModule {}

--- a/docs/plans/implementation-plan-inventory-query-service.md
+++ b/docs/plans/implementation-plan-inventory-query-service.md
@@ -1,0 +1,227 @@
+# Implementation Plan — Extract `IInventoryQueryService` (#280)
+
+**Branch:** `280-inventory-query-service`
+**Layer:** CORE application + API interface
+**Driver:** `InventoryController` injects `ProductRepositoryPort` directly and orchestrates a cross-aggregate read in the HTTP layer (`inventory.controller.ts:40-120`). Extract the composition into an application-layer query service so the controller keeps only HTTP-shape concerns.
+
+---
+
+## 1. Goal & non-goals
+
+**Goal:** Behaviour-preserving refactor. HTTP response shape for `GET /inventory` and `GET /inventory/:id` is byte-identical to main.
+
+**Non-goals:**
+- Changing which product fields are returned (still `productName`, `productSku`, `productImageUrl`).
+- Moving to a batch `GET /products?ids=…` FE pattern.
+- Refactoring other controllers that do similar reads (orders, listings — file separately per domain if needed).
+- Adding a `findByIds` batch method to `ProductRepositoryPort`. The current N individual `findById` pattern moves intact to the service; the TODO stays. Widening the port's read surface is separate architectural work.
+
+---
+
+## 2. Layer classification & doc alignment
+
+Pure CORE + Interface refactor. Two modules touch:
+- `libs/core/src/inventory/` — add `IInventoryQueryService` interface + impl + view-model types + Symbol token + module binding.
+- `apps/api/src/inventory/` — rewrite controller to depend on the new service; rewrite tests.
+
+Conventions enforced (`.claude/rules/backend.md`, `docs/engineering-standards.md`):
+- Application services depend on port interfaces; query service injects `InventoryRepositoryPort` and `ProductRepositoryPort` via Symbol tokens.
+- Interface in a separate `*.service.interface.ts`; impl naming `{Purpose}Service` → `InventoryQueryService` implements `IInventoryQueryService`.
+- Types in a separate `*.types.ts` — view model goes in `application/types/inventory-view.types.ts`.
+- View model is framework-free (no `@ApiProperty`, no ISO-string dates — `Date` stays `Date`). Serialization is a controller concern.
+- Token bound with `useExisting` and exported from `inventory.tokens.ts` + `inventory.module.ts` + `index.ts`.
+
+**Interface file placement.** `docs/engineering-standards.md` examples show `application/interfaces/*.service.interface.ts`, but the inventory module's established convention is to **colocate** interface + impl in `application/services/` (`inventory.service.interface.ts`, `inventory-sync.service.interface.ts`, `master-inventory-sync.service.interface.ts` all sit next to their impls). Following module consistency over doc example: new interface goes in `application/services/`.
+
+---
+
+## 3. Design
+
+### 3.1 View model (framework-free)
+
+`libs/core/src/inventory/application/types/inventory-view.types.ts`:
+
+```typescript
+import { InventoryItem } from '../../domain/entities/inventory-item.entity';
+
+/**
+ * Product details composed onto an inventory view. `null` when the
+ * upstream product lookup returned no row — the inventory item still
+ * exists, we just have no name/SKU/image to surface.
+ */
+export interface InventoryViewProduct {
+  name: string;
+  sku: string | null;
+  coverImageUrl: string | null;
+}
+
+/**
+ * Inventory item + joined product details. Application-layer type;
+ * not decorated for Swagger. Serialization to the HTTP DTO lives in
+ * the interface layer.
+ */
+export interface InventoryItemView {
+  item: InventoryItem;
+  product: InventoryViewProduct | null;
+}
+
+export interface PaginatedInventoryView {
+  items: InventoryItemView[];
+  total: number;
+}
+```
+
+**Design note (nested vs flat).** The issue suggests flattening the view's `product` into three top-level fields. I'm keeping it nested — the controller needs `item.*` **and** `product.*` to build the DTO, so nesting the inventory fields under `item` and the product fields under `product` makes the "product absent" case explicit (it's `null`, not three silent nulls). The DTO stays flat; the view is internal.
+
+**Design note (raw `InventoryItem` on view).** The view exposes the raw domain `InventoryItem` on `item` rather than a narrowed projection. Accepted tradeoff: the controller is the only consumer and maps 1:1 to DTO fields, so narrowing would be ceremony with no payoff. If this view ever grows a second consumer (e.g., worker, another controller), reconsider — exposing the raw entity silently widens the consumer contract whenever `InventoryItem` gains a field.
+
+### 3.2 Service interface
+
+`libs/core/src/inventory/application/services/inventory-query.service.interface.ts`:
+
+```typescript
+import { InventoryFilters, InventoryPagination } from '../../domain/types/inventory.types';
+import { InventoryItemView, PaginatedInventoryView } from '../types/inventory-view.types';
+
+export interface IInventoryQueryService {
+  /**
+   * List inventory items with filters + pagination, composing product details.
+   * `product` on each view is `null` when the upstream product lookup failed.
+   */
+  listInventoryItems(
+    filters: InventoryFilters,
+    pagination: InventoryPagination,
+  ): Promise<PaginatedInventoryView>;
+
+  /**
+   * Get a single inventory item by id with its product details composed.
+   * Returns `null` when the inventory item does not exist. `view.product`
+   * is `null` when the item exists but its product does not.
+   */
+  getInventoryItem(id: string): Promise<InventoryItemView | null>;
+}
+```
+
+**Design note (null vs exception on get).** Returning `InventoryItemView | null` and letting the controller throw `NotFoundException` matches existing pattern in `InventoryRepositoryPort.findById` (returns `T | null`) and the current controller code. The domain doesn't know about HTTP 404s; the interface layer does.
+
+### 3.3 Service implementation
+
+`libs/core/src/inventory/application/services/inventory-query.service.ts`:
+
+- `@Injectable()` class implementing `IInventoryQueryService`
+- Inject both repositories via Symbol tokens
+- Private `buildProductMap` helper (moved verbatim from the controller)
+- `compose(item, product)` helper that produces an `InventoryItemView` with the `{ name, sku, coverImageUrl }` shape via `coverImageUrl(product)`
+- `listInventoryItems` calls `inventoryRepository.findMany` + `buildProductMap`, then maps
+- `getInventoryItem` calls `inventoryRepository.findById`, short-circuits on null, then `productRepository.findById`, then `compose`
+
+### 3.4 Module binding + exports
+
+**`libs/core/src/inventory/inventory.tokens.ts`** — add:
+```typescript
+export const INVENTORY_QUERY_SERVICE_TOKEN = Symbol('IInventoryQueryService');
+```
+
+**`libs/core/src/inventory/inventory.module.ts`** — add import, re-export, provider entry, export entry. Class-first + `useExisting` per established pattern.
+
+**`libs/core/src/inventory/index.ts`** — add:
+```typescript
+export { INVENTORY_QUERY_SERVICE_TOKEN } from './inventory.tokens';
+export { IInventoryQueryService } from './application/services/inventory-query.service.interface';
+export { InventoryQueryService } from './application/services/inventory-query.service';
+export {
+  InventoryItemView,
+  InventoryViewProduct,
+  PaginatedInventoryView,
+} from './application/types/inventory-view.types';
+```
+
+### 3.5 Controller rewrite
+
+`apps/api/src/inventory/http/inventory.controller.ts`:
+
+- Drop imports from `@openlinker/core/products`
+- Replace the two `@Inject` repos with one: `@Inject(INVENTORY_QUERY_SERVICE_TOKEN) queryService: IInventoryQueryService`
+- `listInventory` → delegate, then `items.map(inventoryViewToDto)` + paginate
+- `getInventoryItem` → delegate, null → `NotFoundException`, else `inventoryViewToDto(view)`
+- `inventoryViewToDto(view)` (replaces `toDto`): flattens `view.item.*` + `view.product?.*` into the DTO shape. `updatedAt` → ISO string, `productName`/`productSku`/`productImageUrl` from `view.product ?? { … null }`
+- `buildProductMap` helper deleted (moved into the service)
+
+### 3.6 Tests
+
+**New:** `libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts`. Mirrors the pattern in existing inventory service specs. Covers:
+1. `listInventoryItems` composes product onto each item
+2. `listInventoryItems` deduplicates product lookups (two items, same productId → one `findById`)
+3. `listInventoryItems` returns `product: null` when the product lookup returns null
+4. `listInventoryItems` passes filters + pagination through to the repository unchanged
+5. `listInventoryItems` returns empty items on empty repository result
+6. `getInventoryItem` composes product when both exist
+7. `getInventoryItem` returns `null` when the inventory item doesn't exist (and does NOT call the product repo)
+8. `getInventoryItem` returns a view with `product: null` when the item exists but the product lookup returns null
+9. `listInventoryItems` preserves the order of `repository.findMany` results after composition (dedup via `Set` must not reorder the output array)
+
+Mocks use `jest.Mocked<InventoryRepositoryPort>` and `jest.Mocked<ProductRepositoryPort>` — ports, not concrete classes (per backend rules).
+
+**Update:** `apps/api/src/inventory/http/inventory.controller.spec.ts`. Mocks a single `IInventoryQueryService`:
+- `listInventoryItems: jest.fn()` returning `PaginatedInventoryView`
+- `getInventoryItem: jest.fn()` returning `InventoryItemView | null`
+
+Controller tests shrink to:
+1. `listInventory` — service returns a two-item view; assert DTO shape (pagination echo, ISO string, flattened product fields)
+2. `listInventory` with absent product on one item — assert flattened `productName/Sku/ImageUrl` are all `null`
+3. `listInventory` passes filters + pagination into the service
+4. `getInventoryItem` flattens the view into the DTO (happy path)
+5. `getInventoryItem` — service returns null → `NotFoundException`
+
+Composition-specific cases (deduplication, null product for shared productId) move to the service spec where the composition actually lives.
+
+---
+
+## 4. Step-by-step
+
+| # | File | Action |
+|---|---|---|
+| 1.1 | `libs/core/src/inventory/inventory.tokens.ts` | Add `INVENTORY_QUERY_SERVICE_TOKEN`. |
+| 1.2 | `libs/core/src/inventory/application/types/inventory-view.types.ts` | **New.** `InventoryItemView`, `InventoryViewProduct`, `PaginatedInventoryView`. |
+| 1.3 | `libs/core/src/inventory/application/services/inventory-query.service.interface.ts` | **New.** `IInventoryQueryService` with `listInventoryItems` + `getInventoryItem`. |
+| 1.4 | `libs/core/src/inventory/application/services/inventory-query.service.ts` | **New.** `@Injectable` impl; private `buildProductMap` + `compose`. |
+| 1.5 | `libs/core/src/inventory/inventory.module.ts` | Import new class + token; provider + `useExisting`; add to exports; re-export token. |
+| 1.6 | `libs/core/src/inventory/index.ts` | Export new token, interface, class, view types. |
+| 2.1 | `libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts` | **New.** 9 unit tests per §3.6. |
+| 3.1 | `apps/api/src/inventory/http/inventory.controller.ts` | Replace both repo injections with single service injection; rewrite `list`/`get`; delete `buildProductMap`; `toDto` → `inventoryViewToDto`; drop `@openlinker/core/products` imports. |
+| 3.2 | `apps/api/src/inventory/http/inventory.controller.spec.ts` | Mock single `IInventoryQueryService`; rewrite tests per §3.6. |
+| 4.1 | `apps/api/src/inventory/inventory.module.ts` | **Decision:** remove `ProductsModule` import — no longer needed once the controller stops reading `ProductRepositoryPort` directly. **Before deleting**, run `grep -R "@openlinker/core/products" apps/api/src/inventory/` **from the worktree root** (`.claude/worktrees/280-inventory-query-service/`) to confirm no other file in the module still imports from products. If anything remains, leave the import. |
+| 5.1 | `apps/api/test/integration/inventory-read.int-spec.ts` | **Verify** (no code change expected): file already covers `GET /inventory` and `GET /inventory/:id`. This is the byte-identical safety net per §1. Must stay green after the refactor; if a case is missing, extend it here before shipping. |
+| 5.2 | Quality gate | `pnpm lint && pnpm type-check && pnpm test && pnpm test:integration` per acceptance criteria. |
+
+---
+
+## 5. Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| HTTP response shape drifts (breaking FE / existing integration tests) | Low | Issue's primary acceptance: "byte-identical." Controller's `inventoryViewToDto` is a mechanical rewrite of `toDto`; every field maps 1:1. `pnpm test:integration` must pass. |
+| N+1 regression — `buildProductMap` moves but loses dedup | Very low | Moving the helper verbatim, including `[...new Set(productIds)]`. Dedicated unit test covers the dedup invariant. |
+| Circular DI (inventory module importing products module, both exposing services) | Very low | `inventory.module.ts` already imports `ProductsModule`. No new cycle introduced. |
+| Test drift — controller spec and service spec overlap | Medium | Explicit split: composition correctness lives in the service spec; HTTP-shape correctness lives in the controller spec. Documented in §3.6. |
+| Controller-spec coverage regression on the `inventoryViewToDto` branches (null-vs-populated product) | Low | §3.6 controller test #2 covers the "one item with absent product" branch; combined with test #1 (both items have products) the populated/null pair is exercised. Verify branch coverage on the controller spec after implementation. |
+| Forgotten re-export from `index.ts` (consumers in `apps/api` rely on barrel exports) | Low | Step 1.6 is explicit; verified at type-check. |
+
+---
+
+## 6. Architecture compliance check
+
+- ✅ `InventoryQueryService` is in `application/services/` and implements `I{Purpose}Service` in a separate `.interface.ts` (colocated per module convention — see §2).
+- ✅ Depends only on port interfaces (`InventoryRepositoryPort`, `ProductRepositoryPort`) via Symbol tokens.
+- ✅ View model is framework-free (no `@ApiProperty`, no transport-layer concerns).
+- ✅ Types in a separate `*.types.ts` file.
+- ✅ Controller interfaces → application dependency direction preserved; no infrastructure imports added.
+- ✅ No `any`, no `console.log`, no new `synchronize: true`.
+- ✅ Domain layer untouched.
+- ✅ Unit tests mock ports, not concrete classes.
+
+---
+
+## 7. Rollout
+
+Single commit. Reversible via `git revert`. No migration, no config, no env. Acceptance gate per issue: unit tests + integration tests + byte-identical responses. The integration test on `GET /inventory` and `GET /inventory/:id` is the safety net proving shape preservation end-to-end.

--- a/libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Inventory Query Service Tests
+ *
+ * Unit tests for InventoryQueryService. Covers composition of inventory items
+ * with master-catalog product details, product-lookup deduplication, null
+ * handling, and order preservation.
+ *
+ * @module libs/core/src/inventory/application/services/__tests__
+ */
+
+import { InventoryQueryService } from '../inventory-query.service';
+import { InventoryItem } from '../../../domain/entities/inventory-item.entity';
+import type { InventoryRepositoryPort } from '../../../domain/ports/inventory-repository.port';
+import type { Product, ProductRepositoryPort } from '@openlinker/core/products';
+
+describe('InventoryQueryService', () => {
+  let service: InventoryQueryService;
+  let inventoryRepository: jest.Mocked<InventoryRepositoryPort>;
+  let productRepository: jest.Mocked<ProductRepositoryPort>;
+
+  const itemA = new InventoryItem(
+    'inv-a',
+    'prod-1',
+    'var-a',
+    50,
+    5,
+    null,
+    new Date('2026-04-01T00:00:00Z'),
+  );
+  const itemB = new InventoryItem(
+    'inv-b',
+    'prod-1',
+    null,
+    10,
+    0,
+    null,
+    new Date('2026-04-02T00:00:00Z'),
+  );
+  const itemC = new InventoryItem(
+    'inv-c',
+    'prod-2',
+    null,
+    3,
+    1,
+    null,
+    new Date('2026-04-03T00:00:00Z'),
+  );
+
+  const product1: Product = {
+    id: 'prod-1',
+    name: 'Product One',
+    sku: 'SKU-1',
+    price: 99.99,
+    description: null,
+    images: ['https://shop.test/img/1/cover.jpg', 'https://shop.test/img/1/alt.jpg'],
+  };
+  const product2: Product = {
+    id: 'prod-2',
+    name: 'Product Two',
+    sku: null,
+    price: null,
+    description: null,
+    images: null,
+  };
+
+  beforeEach(() => {
+    inventoryRepository = {
+      findByProductAndVariant: jest.fn(),
+      upsert: jest.fn(),
+      findById: jest.fn(),
+      findMany: jest.fn(),
+    };
+
+    productRepository = {
+      findById: jest.fn(),
+    } as unknown as jest.Mocked<ProductRepositoryPort>;
+
+    service = new InventoryQueryService(inventoryRepository, productRepository);
+  });
+
+  describe('listInventoryItems', () => {
+    it('composes product details onto each item', async () => {
+      inventoryRepository.findMany.mockResolvedValue({ items: [itemA], total: 1 });
+      productRepository.findById.mockResolvedValue(product1);
+
+      const result = await service.listInventoryItems({}, { limit: 20, offset: 0 });
+
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].item).toBe(itemA);
+      expect(result.items[0].product).toEqual({
+        name: 'Product One',
+        sku: 'SKU-1',
+        coverImageUrl: 'https://shop.test/img/1/cover.jpg',
+      });
+    });
+
+    it('deduplicates product lookups when items share a productId', async () => {
+      inventoryRepository.findMany.mockResolvedValue({ items: [itemA, itemB], total: 2 });
+      productRepository.findById.mockResolvedValue(product1);
+
+      await service.listInventoryItems({}, { limit: 20, offset: 0 });
+
+      expect(productRepository.findById).toHaveBeenCalledTimes(1);
+      expect(productRepository.findById).toHaveBeenCalledWith('prod-1');
+    });
+
+    it('returns product: null on each view when the product lookup returns null', async () => {
+      inventoryRepository.findMany.mockResolvedValue({ items: [itemA, itemB], total: 2 });
+      productRepository.findById.mockResolvedValue(null);
+
+      const result = await service.listInventoryItems({}, { limit: 20, offset: 0 });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].product).toBeNull();
+      expect(result.items[1].product).toBeNull();
+    });
+
+    it('passes filters and pagination through to the repository unchanged', async () => {
+      inventoryRepository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      await service.listInventoryItems(
+        { productId: 'prod-1', productVariantId: 'var-a', locationId: 'loc-1' },
+        { limit: 10, offset: 5 },
+      );
+
+      expect(inventoryRepository.findMany).toHaveBeenCalledWith(
+        { productId: 'prod-1', productVariantId: 'var-a', locationId: 'loc-1' },
+        { limit: 10, offset: 5 },
+      );
+    });
+
+    it('returns an empty view when the repository returns no items', async () => {
+      inventoryRepository.findMany.mockResolvedValue({ items: [], total: 0 });
+
+      const result = await service.listInventoryItems({}, { limit: 20, offset: 0 });
+
+      expect(result.items).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(productRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it('preserves repository.findMany ordering after composition', async () => {
+      // Repo returns prod-2 first, prod-1 second; after dedup via Set the
+      // composed output must still reflect the input order.
+      inventoryRepository.findMany.mockResolvedValue({
+        items: [itemC, itemA, itemB],
+        total: 3,
+      });
+      productRepository.findById.mockImplementation((id: string) => {
+        if (id === 'prod-1') return Promise.resolve(product1);
+        if (id === 'prod-2') return Promise.resolve(product2);
+        return Promise.resolve(null);
+      });
+
+      const result = await service.listInventoryItems({}, { limit: 20, offset: 0 });
+
+      expect(result.items.map((v) => v.item.id)).toEqual(['inv-c', 'inv-a', 'inv-b']);
+    });
+  });
+
+  describe('getInventoryItem', () => {
+    it('composes product details when both item and product exist', async () => {
+      inventoryRepository.findById.mockResolvedValue(itemA);
+      productRepository.findById.mockResolvedValue(product1);
+
+      const result = await service.getInventoryItem('inv-a');
+
+      expect(result).not.toBeNull();
+      expect(result!.item).toBe(itemA);
+      expect(result!.product).toEqual({
+        name: 'Product One',
+        sku: 'SKU-1',
+        coverImageUrl: 'https://shop.test/img/1/cover.jpg',
+      });
+    });
+
+    it('returns null when the inventory item does not exist and skips the product lookup', async () => {
+      inventoryRepository.findById.mockResolvedValue(null);
+
+      const result = await service.getInventoryItem('missing');
+
+      expect(result).toBeNull();
+      expect(productRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it('returns a view with product: null when the item exists but the product lookup returns null', async () => {
+      inventoryRepository.findById.mockResolvedValue(itemA);
+      productRepository.findById.mockResolvedValue(null);
+
+      const result = await service.getInventoryItem('inv-a');
+
+      expect(result).not.toBeNull();
+      expect(result!.item).toBe(itemA);
+      expect(result!.product).toBeNull();
+    });
+  });
+});

--- a/libs/core/src/inventory/application/services/inventory-query.service.interface.ts
+++ b/libs/core/src/inventory/application/services/inventory-query.service.interface.ts
@@ -1,0 +1,39 @@
+/**
+ * Inventory Query Service Interface
+ *
+ * Defines the contract for cross-aggregate inventory read operations that
+ * compose canonical inventory items with master-catalog product details.
+ * Implemented by InventoryQueryService; consumed by the HTTP interface
+ * layer in place of direct repository access.
+ *
+ * @module libs/core/src/inventory/application/services
+ * @see {@link InventoryQueryService} for the implementation
+ */
+import type {
+  InventoryFilters,
+  InventoryPagination,
+} from '../../domain/types/inventory.types';
+import type {
+  InventoryItemView,
+  PaginatedInventoryView,
+} from '../types/inventory-view.types';
+
+export interface IInventoryQueryService {
+  /**
+   * List inventory items with filters + pagination, composing product
+   * details onto each item. `view.product` is `null` when the upstream
+   * product lookup returned null for that item's productId.
+   */
+  listInventoryItems(
+    filters: InventoryFilters,
+    pagination: InventoryPagination,
+  ): Promise<PaginatedInventoryView>;
+
+  /**
+   * Get a single inventory item by id, composing product details.
+   * Returns `null` when the inventory item does not exist. `view.product`
+   * is `null` when the item exists but its product lookup returned null.
+   * Callers in the interface layer translate `null` to an HTTP 404.
+   */
+  getInventoryItem(id: string): Promise<InventoryItemView | null>;
+}

--- a/libs/core/src/inventory/application/services/inventory-query.service.ts
+++ b/libs/core/src/inventory/application/services/inventory-query.service.ts
@@ -1,0 +1,98 @@
+/**
+ * Inventory Query Service
+ *
+ * Application service that composes canonical inventory items with their
+ * master-catalog product details. Centralises the cross-aggregate read that
+ * was previously orchestrated in the HTTP controller, keeping the interface
+ * layer responsible only for transport shape.
+ *
+ * @module libs/core/src/inventory/application/services
+ * @implements {IInventoryQueryService}
+ * @see {@link IInventoryQueryService} for the service interface
+ * @see {@link InventoryRepositoryPort} for inventory persistence
+ * @see {@link ProductRepositoryPort} for product persistence
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  coverImageUrl,
+  PRODUCT_REPOSITORY_TOKEN,
+  ProductRepositoryPort,
+} from '@openlinker/core/products';
+import type { Product } from '@openlinker/core/products';
+import { INVENTORY_REPOSITORY_TOKEN } from '../../inventory.tokens';
+import { InventoryRepositoryPort } from '../../domain/ports/inventory-repository.port';
+import type { InventoryItem } from '../../domain/entities/inventory-item.entity';
+import type {
+  InventoryFilters,
+  InventoryPagination,
+} from '../../domain/types/inventory.types';
+import type {
+  InventoryItemView,
+  InventoryViewProduct,
+  PaginatedInventoryView,
+} from '../types/inventory-view.types';
+import { IInventoryQueryService } from './inventory-query.service.interface';
+
+@Injectable()
+export class InventoryQueryService implements IInventoryQueryService {
+  constructor(
+    @Inject(INVENTORY_REPOSITORY_TOKEN)
+    private readonly inventoryRepository: InventoryRepositoryPort,
+    @Inject(PRODUCT_REPOSITORY_TOKEN)
+    private readonly productRepository: ProductRepositoryPort,
+  ) {}
+
+  async listInventoryItems(
+    filters: InventoryFilters,
+    pagination: InventoryPagination,
+  ): Promise<PaginatedInventoryView> {
+    const { items, total } = await this.inventoryRepository.findMany(
+      filters,
+      pagination,
+    );
+    const productMap = await this.buildProductMap(items.map((i) => i.productId));
+    return {
+      items: items.map((item) => this.compose(item, productMap.get(item.productId) ?? null)),
+      total,
+    };
+  }
+
+  async getInventoryItem(id: string): Promise<InventoryItemView | null> {
+    const item = await this.inventoryRepository.findById(id);
+    if (!item) {
+      return null;
+    }
+    const product = await this.productRepository.findById(item.productId);
+    return this.compose(item, product);
+  }
+
+  // TODO: Replace with a single findByIds(ids) call once ProductRepositoryPort supports batch lookup.
+  // Current implementation issues N individual findById calls (one per unique productId).
+  // For typical page sizes (≤20 items) this is acceptable, but a batch method would be more efficient.
+  private async buildProductMap(productIds: string[]): Promise<Map<string, Product>> {
+    const uniqueIds = [...new Set(productIds)];
+    const products = await Promise.all(
+      uniqueIds.map((id) => this.productRepository.findById(id)),
+    );
+    const map = new Map<string, Product>();
+    uniqueIds.forEach((id, idx) => {
+      const product = products[idx];
+      if (product) {
+        map.set(id, product);
+      }
+    });
+    return map;
+  }
+
+  private compose(item: InventoryItem, product: Product | null): InventoryItemView {
+    const viewProduct: InventoryViewProduct | null = product
+      ? {
+          name: product.name,
+          sku: product.sku,
+          // Cover-image rule owned by the Products domain; do not replicate here.
+          coverImageUrl: coverImageUrl(product),
+        }
+      : null;
+    return { item, product: viewProduct };
+  }
+}

--- a/libs/core/src/inventory/application/types/inventory-view.types.ts
+++ b/libs/core/src/inventory/application/types/inventory-view.types.ts
@@ -1,0 +1,42 @@
+/**
+ * Inventory View Types
+ *
+ * Application-layer view models that combine canonical inventory items with
+ * joined product details. Produced by IInventoryQueryService for the HTTP
+ * interface layer; not decorated for Swagger and not coupled to transport
+ * concerns (no ISO-string dates — Date stays Date).
+ *
+ * @module libs/core/src/inventory/application/types
+ */
+import type { InventoryItem } from '../../domain/entities/inventory-item.entity';
+
+/**
+ * Product details composed onto an inventory view. `null` on the parent
+ * `InventoryItemView` when the upstream product lookup returned no row —
+ * the inventory item still exists, we just have no product metadata to
+ * surface.
+ */
+export interface InventoryViewProduct {
+  name: string;
+  sku: string | null;
+  coverImageUrl: string | null;
+}
+
+/**
+ * Inventory item + joined product details. `product` is `null` when the
+ * item exists but its product lookup returned null. The raw `InventoryItem`
+ * domain entity is exposed as `item` because the controller is the only
+ * consumer and maps its fields 1:1 to the HTTP DTO.
+ */
+export interface InventoryItemView {
+  item: InventoryItem;
+  product: InventoryViewProduct | null;
+}
+
+/**
+ * Paginated list result for `IInventoryQueryService.listInventoryItems`.
+ */
+export interface PaginatedInventoryView {
+  items: InventoryItemView[];
+  total: number;
+}

--- a/libs/core/src/inventory/index.ts
+++ b/libs/core/src/inventory/index.ts
@@ -16,6 +16,7 @@ export {
   INVENTORY_SERVICE_TOKEN,
   INVENTORY_SYNC_SERVICE_TOKEN,
   MASTER_INVENTORY_SYNC_SERVICE_TOKEN,
+  INVENTORY_QUERY_SERVICE_TOKEN,
 } from './inventory.tokens';
 
 // Ports
@@ -32,6 +33,15 @@ export { IInventorySyncService } from './application/services/inventory-sync.ser
 export { InventorySyncService } from './application/services/inventory-sync.service';
 export { IMasterInventorySyncService, MasterInventorySyncResult } from './application/services/master-inventory-sync.service.interface';
 export { MasterInventorySyncService } from './application/services/master-inventory-sync.service';
+export { IInventoryQueryService } from './application/services/inventory-query.service.interface';
+export { InventoryQueryService } from './application/services/inventory-query.service';
+
+// Application Types
+export {
+  InventoryItemView,
+  InventoryViewProduct,
+  PaginatedInventoryView,
+} from './application/types/inventory-view.types';
 
 // Types
 export {

--- a/libs/core/src/inventory/inventory.module.ts
+++ b/libs/core/src/inventory/inventory.module.ts
@@ -14,11 +14,13 @@ import { InventoryRepository } from './infrastructure/persistence/repositories/i
 import { InventoryService } from './application/services/inventory.service';
 import { InventorySyncService } from './application/services/inventory-sync.service';
 import { MasterInventorySyncService } from './application/services/master-inventory-sync.service';
+import { InventoryQueryService } from './application/services/inventory-query.service';
 import {
   INVENTORY_REPOSITORY_TOKEN,
   INVENTORY_SERVICE_TOKEN,
   INVENTORY_SYNC_SERVICE_TOKEN,
   MASTER_INVENTORY_SYNC_SERVICE_TOKEN,
+  INVENTORY_QUERY_SERVICE_TOKEN,
 } from './inventory.tokens';
 import { ProductsModule } from '@openlinker/core/products';
 import { IntegrationsModule } from '@openlinker/core/integrations';
@@ -31,6 +33,7 @@ export {
   INVENTORY_SERVICE_TOKEN,
   INVENTORY_SYNC_SERVICE_TOKEN,
   MASTER_INVENTORY_SYNC_SERVICE_TOKEN,
+  INVENTORY_QUERY_SERVICE_TOKEN,
 } from './inventory.tokens';
 
 @Module({
@@ -47,6 +50,7 @@ export {
     InventoryService,
     InventorySyncService,
     MasterInventorySyncService,
+    InventoryQueryService,
     // Then provide token bindings using useExisting
     {
       provide: INVENTORY_REPOSITORY_TOKEN,
@@ -64,12 +68,17 @@ export {
       provide: MASTER_INVENTORY_SYNC_SERVICE_TOKEN,
       useExisting: MasterInventorySyncService,
     },
+    {
+      provide: INVENTORY_QUERY_SERVICE_TOKEN,
+      useExisting: InventoryQueryService,
+    },
   ],
   exports: [
     INVENTORY_REPOSITORY_TOKEN,
     INVENTORY_SERVICE_TOKEN,
     INVENTORY_SYNC_SERVICE_TOKEN,
     MASTER_INVENTORY_SYNC_SERVICE_TOKEN,
+    INVENTORY_QUERY_SERVICE_TOKEN,
   ],
 })
 export class InventoryModule {}

--- a/libs/core/src/inventory/inventory.tokens.ts
+++ b/libs/core/src/inventory/inventory.tokens.ts
@@ -13,4 +13,5 @@ export const INVENTORY_REPOSITORY_TOKEN = Symbol('InventoryRepositoryPort');
 export const INVENTORY_SERVICE_TOKEN = Symbol('IInventoryService');
 export const INVENTORY_SYNC_SERVICE_TOKEN = Symbol('IInventorySyncService');
 export const MASTER_INVENTORY_SYNC_SERVICE_TOKEN = Symbol('IMasterInventorySyncService');
+export const INVENTORY_QUERY_SERVICE_TOKEN = Symbol('IInventoryQueryService');
 


### PR DESCRIPTION
## Summary

- Extract the inventory→product composition out of `InventoryController` into a new application-layer `InventoryQueryService` behind `IInventoryQueryService` (Symbol token, `useExisting` binding, barrel export).
- Controller now depends on a single query service and keeps only transport concerns (pagination echo, ISO serialisation, HTTP 404 translation). Both `ProductRepositoryPort` and the manual `buildProductMap` helper are gone from the HTTP layer.
- Behaviour-preserving: `GET /inventory` and `GET /inventory/:id` return the same shape byte-for-byte, enforced by the existing `test/integration/inventory-read.int-spec.ts`. The N individual product lookups and the `productId` dedup via `Set` move intact; widening `ProductRepositoryPort` with a batch `findByIds` is tracked separately.

## Files

- **New** `libs/core/src/inventory/application/services/inventory-query.service.interface.ts` — `IInventoryQueryService`
- **New** `libs/core/src/inventory/application/services/inventory-query.service.ts` — `@Injectable` impl, private `buildProductMap` + `compose`
- **New** `libs/core/src/inventory/application/types/inventory-view.types.ts` — `InventoryItemView`, `InventoryViewProduct`, `PaginatedInventoryView` (framework-free; `Date` stays `Date`)
- **New** `libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts` — 9 unit tests (composition, dedup, null product handling for list + get, filter/pagination passthrough, empty result, short-circuit on missing item, order preservation after dedup)
- Updated `libs/core/src/inventory/inventory.tokens.ts` — add `INVENTORY_QUERY_SERVICE_TOKEN`
- Updated `libs/core/src/inventory/inventory.module.ts` — register provider + `useExisting` + export token
- Updated `libs/core/src/inventory/index.ts` — barrel exports for token, interface, class, view types
- Rewritten `apps/api/src/inventory/http/inventory.controller.ts` — single service injection, `inventoryViewToDto` (replaces `toDto`)
- Rewritten `apps/api/src/inventory/http/inventory.controller.spec.ts` — 5 tests focused on HTTP shape; composition cases moved to the service spec
- Updated `apps/api/src/inventory/inventory.module.ts` — removes `ProductsModule` import (no longer needed)
- Plan doc `docs/plans/implementation-plan-inventory-query-service.md`

## Design notes (recorded in the plan)

- **Nested view (`product: {...} | null`)** over flattening to three top-level fields — makes "product absent" explicit as a single `null`, not three silent nulls. The HTTP DTO stays flat.
- **`getInventoryItem` returns `null`** rather than throwing — the domain doesn't know about HTTP 404s; the controller translates.
- **Interface colocated in `application/services/`** to match sibling services (`inventory.service.interface.ts`, `inventory-sync.service.interface.ts`). Called out explicitly in the plan vs. the `application/interfaces/` example in `docs/engineering-standards.md`.

## Test plan

- [x] `pnpm lint` — 0 errors (pre-existing warnings in unrelated files only)
- [x] `pnpm type-check` — clean across all 7 projects
- [x] `pnpm test` — 315 core + 239 api + 104 worker + more all green; 9 new service tests + 5 rewritten controller tests included
- [x] `pnpm test:integration` — 70/70 passing; `inventory-read.int-spec.ts` green (byte-identical response shape confirmed end-to-end)
- [x] Pre-commit husky hook (full lint + type-check + test) — passed

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)