### PR TITLE
feat(listings): add create-offer endpoint (#259) and seller-policies endpoint (#260)

### DIFF
--- a/apps/api/src/listings/http/dto/create-offer-response.dto.ts
+++ b/apps/api/src/listings/http/dto/create-offer-response.dto.ts
@@ -1,0 +1,21 @@
+/**
+ * Create Offer Response DTO
+ *
+ * Response shape for `POST /listings/connections/:connectionId/offers` (202).
+ * Exposes both the enqueued job id and the pre-created OfferCreationRecord id
+ * so clients can poll the GET status endpoint without waiting for the worker.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateOfferResponseDto {
+  @ApiProperty({ description: 'Redis Streams message id of the enqueued marketplace.offer.create job' })
+  jobId!: string;
+
+  @ApiProperty({
+    description:
+      'Id of the OfferCreationRecord created synchronously with status=pending. Use this to poll GET /listings/connections/:connectionId/offers/creation/:id.',
+  })
+  offerCreationRecordId!: string;
+}

--- a/apps/api/src/listings/http/dto/create-offer.dto.ts
+++ b/apps/api/src/listings/http/dto/create-offer.dto.ts
@@ -1,0 +1,156 @@
+/**
+ * Create Offer DTOs
+ *
+ * Request DTOs for `POST /listings/connections/:connectionId/offers`. Shape
+ * mirrors `CreateOfferCommand` from `@openlinker/core/integrations`; the
+ * controller maps the validated DTO into the job payload
+ * (`MarketplaceOfferCreatePayloadV1`).
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsPositive,
+  IsString,
+  IsUrl,
+  Matches,
+  MaxLength,
+  Min,
+  Validate,
+  ValidateIf,
+  ValidateNested,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Reject `platformParams` payloads whose JSON-serialised size exceeds 4 KB.
+ *
+ * The field is a `Record<string, unknown>` escape hatch (#254) for adapter-
+ * specific IDs — a handful of short strings in practice. A soft upper bound
+ * keeps a misbehaving client from pushing multi-MB objects into the Redis
+ * Streams job payload. Operational hygiene, not a security boundary.
+ */
+@ValidatorConstraint({ name: 'platformParamsSize', async: false })
+class PlatformParamsSizeValidator implements ValidatorConstraintInterface {
+  private static readonly MAX_BYTES = 4096;
+
+  validate(value: unknown): boolean {
+    if (value === undefined || value === null) return true;
+    if (typeof value !== 'object') return false;
+    try {
+      return Buffer.byteLength(JSON.stringify(value), 'utf8') <= PlatformParamsSizeValidator.MAX_BYTES;
+    } catch {
+      return false;
+    }
+  }
+
+  defaultMessage(_args: ValidationArguments): string {
+    return `platformParams exceeds ${PlatformParamsSizeValidator.MAX_BYTES}-byte size limit`;
+  }
+}
+
+export class CreateOfferPriceDto {
+  @ApiProperty({ example: 99.99 })
+  @IsNumber()
+  @IsPositive()
+  amount!: number;
+
+  @ApiProperty({ example: 'PLN' })
+  @IsString()
+  @IsNotEmpty()
+  currency!: string;
+}
+
+export class CreateOfferOverridesDto {
+  @ApiPropertyOptional({
+    description: 'Offer title (overrides variant name). Capped at 75 chars (Allegro limit).',
+    maxLength: 75,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(75)
+  title?: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Offer description. `null` means "no override" (same as omitting).',
+  })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @ApiPropertyOptional({ description: 'Platform-specific category id' })
+  @IsOptional()
+  @IsString()
+  categoryId?: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    isArray: true,
+    type: String,
+    description: 'Image URLs in display order. `null` means "no override". Each entry must be a valid URL.',
+  })
+  @IsOptional()
+  @ValidateIf((_o, v) => v !== null)
+  @IsArray()
+  @IsUrl({}, { each: true, message: 'imageUrls must be an array of valid URLs' })
+  imageUrls?: string[] | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Platform-specific policy / shipping / tax params the adapter reads directly. Escape hatch — keep small (≤4 KB serialised).',
+    type: 'object',
+    additionalProperties: true,
+  })
+  @IsOptional()
+  @IsObject()
+  @Validate(PlatformParamsSizeValidator)
+  platformParams?: Record<string, unknown>;
+}
+
+export class CreateOfferDto {
+  @ApiProperty({
+    description: 'OpenLinker internal variant id (format: ol_variant_{hex})',
+    example: 'ol_variant_a1b2c3d4e5f6',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^ol_variant_[a-f0-9]+$/, {
+    message: 'internalVariantId must be an OpenLinker internal variant id (ol_variant_{hex})',
+  })
+  internalVariantId!: string;
+
+  @ApiProperty({ example: 10, minimum: 0 })
+  @IsInt()
+  @Min(0)
+  stock!: number;
+
+  @ApiProperty({
+    description: 'Publish immediately after creation (false = create as draft)',
+    example: false,
+  })
+  @IsBoolean()
+  publishImmediately!: boolean;
+
+  @ApiPropertyOptional({ type: CreateOfferPriceDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateOfferPriceDto)
+  price?: CreateOfferPriceDto;
+
+  @ApiPropertyOptional({ type: CreateOfferOverridesDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateOfferOverridesDto)
+  overrides?: CreateOfferOverridesDto;
+}

--- a/apps/api/src/listings/http/dto/offer-creation-status-response.dto.ts
+++ b/apps/api/src/listings/http/dto/offer-creation-status-response.dto.ts
@@ -1,0 +1,62 @@
+/**
+ * Offer Creation Status Response DTO
+ *
+ * Response shape for `GET /listings/connections/:connectionId/offers/creation/:offerCreationRecordId`.
+ * Flat view of the `OfferCreationRecord` with ISO-string timestamps.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import {
+  OfferCreationError,
+  OfferCreationStatus,
+  OfferCreationStatusValues,
+} from '@openlinker/core/listings';
+
+export class OfferCreationErrorDto {
+  @ApiPropertyOptional({ description: 'Dotted field path reported by the platform' })
+  field?: string;
+
+  @ApiProperty({ description: 'Machine-readable error code' })
+  code!: string;
+
+  @ApiProperty({ description: 'Human-readable message' })
+  message!: string;
+}
+
+export class OfferCreationStatusResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({ description: 'OpenLinker internal variant id being listed' })
+  internalVariantId!: string;
+
+  @ApiProperty({ description: 'Connection id this record belongs to' })
+  connectionId!: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Marketplace-native offer id. Null until the adapter returns.',
+  })
+  externalOfferId!: string | null;
+
+  @ApiProperty({ enum: OfferCreationStatusValues })
+  status!: OfferCreationStatus;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    type: [OfferCreationErrorDto],
+    description: 'Structured errors populated when status=failed.',
+  })
+  errors!: OfferCreationError[] | null;
+
+  @ApiProperty()
+  publishImmediately!: boolean;
+
+  @ApiProperty({ description: 'ISO 8601 timestamp of record creation' })
+  createdAt!: string;
+
+  @ApiProperty({ description: 'ISO 8601 timestamp of the last update' })
+  updatedAt!: string;
+}

--- a/apps/api/src/listings/http/dto/seller-policies-response.dto.ts
+++ b/apps/api/src/listings/http/dto/seller-policies-response.dto.ts
@@ -1,0 +1,31 @@
+/**
+ * Seller Policies Response DTO
+ *
+ * Response shape for `GET /listings/connections/:connectionId/seller-policies`.
+ * Swagger-decorated mirror of `SellerPolicies` from `@openlinker/core/integrations`.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SellerPolicyDto {
+  @ApiProperty({ description: 'Platform-native policy id' })
+  id!: string;
+
+  @ApiProperty({ description: 'Operator-facing label' })
+  name!: string;
+}
+
+export class SellerPoliciesResponseDto {
+  @ApiProperty({ type: [SellerPolicyDto] })
+  deliveryPolicies!: SellerPolicyDto[];
+
+  @ApiProperty({ type: [SellerPolicyDto] })
+  returnPolicies!: SellerPolicyDto[];
+
+  @ApiProperty({ type: [SellerPolicyDto] })
+  warranties!: SellerPolicyDto[];
+
+  @ApiProperty({ type: [SellerPolicyDto] })
+  impliedWarranties!: SellerPolicyDto[];
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -3,18 +3,36 @@
  *
  * @module apps/api/src/listings/http
  */
+import { NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
-import { ListingsController } from './listings.controller';
-import { OFFER_MAPPING_REPOSITORY_TOKEN } from '@openlinker/core/listings';
-import type { OfferMappingRepositoryPort } from '@openlinker/core/listings';
+
+import type { SellerPolicies } from '@openlinker/core/integrations';
+import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import {
+  OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
+  OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
+  OFFER_MAPPING_REPOSITORY_TOKEN,
+  OfferCreationRecord,
+  SELLER_POLICIES_SERVICE_TOKEN,
+} from '@openlinker/core/listings';
+import type {
+  IOfferCreationEnqueueService,
+  ISellerPoliciesService,
+  OfferCreationRecordRepositoryPort,
+  OfferMappingRepositoryPort,
+} from '@openlinker/core/listings';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { JobEnqueuePort } from '@openlinker/core/sync';
-import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+
+import { ListingsController } from './listings.controller';
 
 describe('ListingsController', () => {
   let controller: ListingsController;
   let repository: jest.Mocked<OfferMappingRepositoryPort>;
+  let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+  let offerCreationRecords: jest.Mocked<OfferCreationRecordRepositoryPort>;
+  let offerCreationEnqueue: jest.Mocked<IOfferCreationEnqueueService>;
+  let sellerPolicies: jest.Mocked<ISellerPoliciesService>;
 
   const mockMapping = new IdentifierMapping(
     'uuid-1',
@@ -28,28 +46,51 @@ describe('ListingsController', () => {
     new Date('2026-01-01T00:00:00Z'),
   );
 
+  const mockRecord = new OfferCreationRecord(
+    'record-1',
+    'ol_variant_abc123',
+    'conn-1',
+    null,
+    'pending',
+    null,
+    false,
+    new Date('2026-04-20T10:00:00Z'),
+    new Date('2026-04-20T10:00:00Z'),
+  );
+
   beforeEach(async () => {
-    const mockRepository: jest.Mocked<OfferMappingRepositoryPort> = {
+    repository = {
       findById: jest.fn(),
       findMany: jest.fn(),
+    };
+    jobEnqueue = { enqueueJob: jest.fn() } as unknown as jest.Mocked<JobEnqueuePort>;
+    offerCreationRecords = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findLatestByVariantAndConnection: jest.fn(),
+      updateStatus: jest.fn(),
+      updateExternalOfferId: jest.fn(),
+      updateExternalIdAndStatus: jest.fn(),
+    };
+    offerCreationEnqueue = {
+      enqueueCreation: jest.fn(),
+    };
+    sellerPolicies = {
+      getSellerPolicies: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ListingsController],
       providers: [
-        {
-          provide: OFFER_MAPPING_REPOSITORY_TOKEN,
-          useValue: mockRepository,
-        },
-        {
-          provide: JOB_ENQUEUE_TOKEN,
-          useValue: { enqueueJob: jest.fn() } as jest.Mocked<JobEnqueuePort>,
-        },
+        { provide: OFFER_MAPPING_REPOSITORY_TOKEN, useValue: repository },
+        { provide: JOB_ENQUEUE_TOKEN, useValue: jobEnqueue },
+        { provide: OFFER_CREATION_RECORD_REPOSITORY_TOKEN, useValue: offerCreationRecords },
+        { provide: OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, useValue: offerCreationEnqueue },
+        { provide: SELLER_POLICIES_SERVICE_TOKEN, useValue: sellerPolicies },
       ],
     }).compile();
 
     controller = module.get<ListingsController>(ListingsController);
-    repository = module.get(OFFER_MAPPING_REPOSITORY_TOKEN);
   });
 
   describe('listOfferMappings', () => {
@@ -112,6 +153,121 @@ describe('ListingsController', () => {
       repository.findById.mockResolvedValue(null);
 
       await expect(controller.getOfferMapping('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('createOffer', () => {
+    const validDto = {
+      internalVariantId: 'ol_variant_abc123',
+      stock: 5,
+      publishImmediately: false,
+      price: { amount: 99.99, currency: 'PLN' },
+    };
+
+    it('delegates to the enqueue service and flattens the result', async () => {
+      offerCreationEnqueue.enqueueCreation.mockResolvedValue({
+        jobId: 'job-1',
+        offerCreationRecord: mockRecord,
+      });
+
+      const result = await controller.createOffer('conn-1', validDto);
+
+      expect(result).toEqual({ jobId: 'job-1', offerCreationRecordId: 'record-1' });
+      expect(offerCreationEnqueue.enqueueCreation).toHaveBeenCalledWith({
+        internalVariantId: 'ol_variant_abc123',
+        connectionId: 'conn-1',
+        stock: 5,
+        publishImmediately: false,
+        price: { amount: 99.99, currency: 'PLN' },
+        overrides: undefined,
+        idempotencyKey: undefined,
+      });
+    });
+
+    it('forwards x-idempotency-key header to the service', async () => {
+      offerCreationEnqueue.enqueueCreation.mockResolvedValue({
+        jobId: 'job-1',
+        offerCreationRecord: mockRecord,
+      });
+
+      await controller.createOffer('conn-1', validDto, 'client-key-42');
+
+      expect(offerCreationEnqueue.enqueueCreation).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotencyKey: 'client-key-42' }),
+      );
+    });
+
+    it('propagates UnprocessableEntityException from the service (adapter lacks createOffer)', async () => {
+      offerCreationEnqueue.enqueueCreation.mockRejectedValue(
+        new UnprocessableEntityException('adapter does not support offer creation'),
+      );
+
+      await expect(controller.createOffer('conn-1', validDto)).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('propagates connection-level exceptions from the service unchanged', async () => {
+      offerCreationEnqueue.enqueueCreation.mockRejectedValue(
+        new Error('ConnectionDisabledException'),
+      );
+
+      await expect(controller.createOffer('conn-1', validDto)).rejects.toThrow(
+        'ConnectionDisabledException',
+      );
+    });
+  });
+
+  describe('getOfferCreationStatus', () => {
+    it('returns the record on happy path with ISO timestamps', async () => {
+      offerCreationRecords.findById.mockResolvedValue(mockRecord);
+
+      const result = await controller.getOfferCreationStatus('conn-1', 'record-1');
+
+      expect(result).toEqual({
+        id: 'record-1',
+        internalVariantId: 'ol_variant_abc123',
+        connectionId: 'conn-1',
+        externalOfferId: null,
+        status: 'pending',
+        errors: null,
+        publishImmediately: false,
+        createdAt: '2026-04-20T10:00:00.000Z',
+        updatedAt: '2026-04-20T10:00:00.000Z',
+      });
+    });
+
+    it('throws NotFoundException when record does not exist', async () => {
+      offerCreationRecords.findById.mockResolvedValue(null);
+
+      await expect(controller.getOfferCreationStatus('conn-1', 'missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException when record belongs to a different connection', async () => {
+      offerCreationRecords.findById.mockResolvedValue(mockRecord);
+
+      await expect(controller.getOfferCreationStatus('conn-other', 'record-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getSellerPolicies', () => {
+    it('delegates to the seller-policies service and returns its result', async () => {
+      const policies: SellerPolicies = {
+        deliveryPolicies: [{ id: 'd1', name: 'Standard' }],
+        returnPolicies: [{ id: 'r1', name: '14-day' }],
+        warranties: [],
+        impliedWarranties: [{ id: 'iw1', name: 'Consumer rights' }],
+      };
+      sellerPolicies.getSellerPolicies.mockResolvedValue(policies);
+
+      const result = await controller.getSellerPolicies('conn-1');
+
+      expect(result).toEqual(policies);
+      expect(sellerPolicies.getSellerPolicies).toHaveBeenCalledWith('conn-1');
     });
   });
 });

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -1,37 +1,57 @@
 /**
  * Listings Controller
  *
- * HTTP REST API endpoints for offer mapping read operations. Provides endpoints
- * for listing offer-to-variant mappings with filters and retrieving individual
- * offer mapping details.
+ * HTTP REST API endpoints for offer mapping read operations, outbound offer
+ * creation (202-async), offer-creation status polling, and seller-policy
+ * lookup (cached). Validates connection + capability up front for create,
+ * then delegates asynchronous orchestration to the worker via
+ * `marketplace.offer.create`.
  *
  * @module apps/api/src/listings/http
  */
 import {
+  Body,
   Controller,
   Get,
-  Post,
-  Body,
   Headers,
-  Query,
-  Param,
   HttpCode,
   HttpStatus,
-  NotFoundException,
   Inject,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
-import { Roles } from '../../auth/decorators/roles.decorator';
-import { OFFER_MAPPING_REPOSITORY_TOKEN } from '@openlinker/core/listings';
-import type { OfferMappingRepositoryPort } from '@openlinker/core/listings';
-import type { IdentifierMapping } from '@openlinker/core/identifier-mapping';
-import { JobEnqueuePort, JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { randomUUID } from 'crypto';
+
+import { Roles } from '../../auth/decorators/roles.decorator';
+import {
+  OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
+  OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
+  OFFER_MAPPING_REPOSITORY_TOKEN,
+  SELLER_POLICIES_SERVICE_TOKEN,
+} from '@openlinker/core/listings';
+import type {
+  IOfferCreationEnqueueService,
+  ISellerPoliciesService,
+  OfferCreationRecord,
+  OfferCreationRecordRepositoryPort,
+  OfferMappingRepositoryPort,
+} from '@openlinker/core/listings';
+import type { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
+import type { JobEnqueuePort } from '@openlinker/core/sync';
+
 import { ListOfferMappingsQueryDto } from './dto/list-offer-mappings-query.dto';
 import { OfferMappingResponseDto } from './dto/offer-mapping-response.dto';
 import { PaginatedOfferMappingsResponseDto } from './dto/paginated-offer-mappings-response.dto';
 import { UpdateOfferFieldsDto, UpdateOfferFieldsResponseDto } from './dto/update-offer-fields.dto';
 import { AutoMatchVariantsRequestDto, AutoMatchVariantsResponseDto } from './dto/auto-match-variants.dto';
+import { CreateOfferDto } from './dto/create-offer.dto';
+import { CreateOfferResponseDto } from './dto/create-offer-response.dto';
+import { OfferCreationStatusResponseDto } from './dto/offer-creation-status-response.dto';
+import { SellerPoliciesResponseDto } from './dto/seller-policies-response.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -43,6 +63,12 @@ export class ListingsController {
     private readonly offerMappingRepository: OfferMappingRepositoryPort,
     @Inject(JOB_ENQUEUE_TOKEN)
     private readonly jobEnqueue: JobEnqueuePort,
+    @Inject(OFFER_CREATION_RECORD_REPOSITORY_TOKEN)
+    private readonly offerCreationRecords: OfferCreationRecordRepositoryPort,
+    @Inject(OFFER_CREATION_ENQUEUE_SERVICE_TOKEN)
+    private readonly offerCreationEnqueue: IOfferCreationEnqueueService,
+    @Inject(SELLER_POLICIES_SERVICE_TOKEN)
+    private readonly sellerPolicies: ISellerPoliciesService,
   ) {}
 
   @Get()
@@ -151,6 +177,81 @@ export class ListingsController {
     return { jobId };
   }
 
+  @Post('connections/:connectionId/offers')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiOperation({
+    summary: 'Create a marketplace offer from an OpenLinker variant',
+    description:
+      'Validates the connection and adapter capability, pre-creates an OfferCreationRecord (status=pending), and enqueues a marketplace.offer.create job. Poll GET /listings/connections/:connectionId/offers/creation/:offerCreationRecordId for lifecycle updates.',
+  })
+  @ApiResponse({ status: 202, description: 'Creation job dispatched', type: CreateOfferResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
+  @ApiResponse({ status: 409, description: 'Connection disabled' })
+  @ApiResponse({ status: 422, description: 'Adapter does not support offer creation' })
+  async createOffer(
+    @Param('connectionId') connectionId: string,
+    @Body() dto: CreateOfferDto,
+    @Headers('x-idempotency-key') clientIdempotencyKey?: string,
+  ): Promise<CreateOfferResponseDto> {
+    // All orchestration (adapter resolution, capability check, record
+    // creation, job enqueue) lives in the core application service so the
+    // worker's `OfferCreationExecutionService` sibling has a matching
+    // pre-enqueue counterpart. Exceptions propagate unchanged — Nest maps
+    // ConnectionNotFoundException → 404, ConnectionDisabledException → 409,
+    // Capability* → 422, UnprocessableEntityException → 422.
+    const { jobId, offerCreationRecord } = await this.offerCreationEnqueue.enqueueCreation({
+      internalVariantId: dto.internalVariantId,
+      connectionId,
+      stock: dto.stock,
+      publishImmediately: dto.publishImmediately,
+      price: dto.price,
+      overrides: dto.overrides,
+      idempotencyKey: clientIdempotencyKey,
+    });
+
+    return { jobId, offerCreationRecordId: offerCreationRecord.id };
+  }
+
+  @Get('connections/:connectionId/offers/creation/:offerCreationRecordId')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiParam({ name: 'offerCreationRecordId', description: 'OfferCreationRecord id returned by POST /offers' })
+  @ApiOperation({ summary: 'Get offer-creation record status' })
+  @ApiResponse({ status: 200, description: 'Record detail', type: OfferCreationStatusResponseDto })
+  @ApiResponse({ status: 404, description: 'Record not found or belongs to a different connection' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getOfferCreationStatus(
+    @Param('connectionId') connectionId: string,
+    @Param('offerCreationRecordId') offerCreationRecordId: string,
+  ): Promise<OfferCreationStatusResponseDto> {
+    const record = await this.offerCreationRecords.findById(offerCreationRecordId);
+    if (!record || record.connectionId !== connectionId) {
+      // Cross-connection lookups return 404 to avoid leaking record existence.
+      throw new NotFoundException(`Offer creation record not found: ${offerCreationRecordId}`);
+    }
+    return this.toOfferCreationStatusDto(record);
+  }
+
+  @Get('connections/:connectionId/seller-policies')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiOperation({
+    summary: 'List seller-configured marketplace policies',
+    description:
+      'Returns delivery, return, warranty, and implied-warranty policy options for the connection. Cached for 10 minutes.',
+  })
+  @ApiResponse({ status: 200, description: 'Seller policies', type: SellerPoliciesResponseDto })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
+  @ApiResponse({ status: 409, description: 'Connection disabled' })
+  @ApiResponse({ status: 422, description: 'Adapter does not support seller-policy listing' })
+  async getSellerPolicies(
+    @Param('connectionId') connectionId: string,
+  ): Promise<SellerPoliciesResponseDto> {
+    return this.sellerPolicies.getSellerPolicies(connectionId);
+  }
+
   private toDto(mapping: IdentifierMapping): OfferMappingResponseDto {
     return {
       id: mapping.id,
@@ -162,6 +263,20 @@ export class ListingsController {
       context: mapping.context as Record<string, unknown> | null,
       createdAt: mapping.createdAt instanceof Date ? mapping.createdAt.toISOString() : mapping.createdAt,
       updatedAt: mapping.updatedAt instanceof Date ? mapping.updatedAt.toISOString() : mapping.updatedAt,
+    };
+  }
+
+  private toOfferCreationStatusDto(record: OfferCreationRecord): OfferCreationStatusResponseDto {
+    return {
+      id: record.id,
+      internalVariantId: record.internalVariantId,
+      connectionId: record.connectionId,
+      externalOfferId: record.externalOfferId,
+      status: record.status,
+      errors: record.errors,
+      publishImmediately: record.publishImmediately,
+      createdAt: record.createdAt instanceof Date ? record.createdAt.toISOString() : record.createdAt,
+      updatedAt: record.updatedAt instanceof Date ? record.updatedAt.toISOString() : record.updatedAt,
     };
   }
 }

--- a/apps/api/src/migrations/1785000000000-add-seller-policies-cache.ts
+++ b/apps/api/src/migrations/1785000000000-add-seller-policies-cache.ts
@@ -1,0 +1,38 @@
+/**
+ * Add Seller Policies Cache Table Migration
+ *
+ * Creates the `seller_policies_cache` table used by `SellerPoliciesService`
+ * to memoise marketplace seller-policy lookups (delivery / return / warranty /
+ * implied-warranty) for the 10-minute TTL window. One row per connection;
+ * the full `SellerPolicies` document is stored as JSONB and the `fetchedAt`
+ * timestamp drives staleness checks.
+ *
+ * Hand-written: 2026-04-21
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSellerPoliciesCache1785000000000 implements MigrationInterface {
+  name = 'AddSellerPoliciesCache1785000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('seller_policies_cache');
+
+    if (!table) {
+      await queryRunner.query(`
+        CREATE TABLE "seller_policies_cache" (
+          "connectionId" uuid NOT NULL,
+          "policies" jsonb NOT NULL,
+          "fetchedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+          "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+          "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+          CONSTRAINT "PK_seller_policies_cache" PRIMARY KEY ("connectionId")
+        )
+      `);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "seller_policies_cache"`);
+  }
+}

--- a/apps/api/test/integration/fixtures/offer-creation-record.fixtures.ts
+++ b/apps/api/test/integration/fixtures/offer-creation-record.fixtures.ts
@@ -1,0 +1,47 @@
+/**
+ * Offer Creation Record Test Fixtures
+ *
+ * Factory helper for seeding `offer_creation_records` rows in integration
+ * tests. Returns the inserted row's primary key so tests can reference it.
+ *
+ * @module apps/api/test/integration/fixtures
+ */
+import { DataSource } from 'typeorm';
+
+export interface TestOfferCreationRecordOverrides {
+  internalVariantId?: string;
+  connectionId?: string;
+  externalOfferId?: string | null;
+  status?: 'pending' | 'draft' | 'validating' | 'active' | 'failed';
+  publishImmediately?: boolean;
+}
+
+/**
+ * Insert an `offer_creation_records` row directly via SQL and return its id.
+ *
+ * Uses raw SQL (not `DataSource.getRepository(...).save`) because the ORM
+ * entity lives in `@openlinker/core` and integration tests avoid importing
+ * core ORM entities to keep the fixture layer lightweight. The same pattern
+ * is used by connection/user fixtures.
+ */
+export async function createTestOfferCreationRecord(
+  dataSource: DataSource,
+  overrides?: TestOfferCreationRecordOverrides,
+): Promise<string> {
+  const result = (await dataSource.query(
+    `INSERT INTO offer_creation_records
+       ("internalVariantId", "connectionId", "externalOfferId", "status", "errors", "publishImmediately")
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [
+      overrides?.internalVariantId ?? 'ol_variant_abc123',
+      overrides?.connectionId ?? '11111111-1111-4111-8111-111111111111',
+      overrides?.externalOfferId ?? null,
+      overrides?.status ?? 'pending',
+      null,
+      overrides?.publishImmediately ?? false,
+    ],
+  )) as Array<{ id: string }>;
+
+  return result[0].id;
+}

--- a/apps/api/test/integration/fixtures/seller-policies-cache.fixtures.ts
+++ b/apps/api/test/integration/fixtures/seller-policies-cache.fixtures.ts
@@ -1,0 +1,44 @@
+/**
+ * Seller Policies Cache Test Fixtures
+ *
+ * Factory helper for seeding `seller_policies_cache` rows in integration
+ * tests. Useful when testing the read path without exercising the Allegro
+ * HTTP round-trip.
+ *
+ * @module apps/api/test/integration/fixtures
+ */
+import { DataSource } from 'typeorm';
+import type { SellerPolicies } from '@openlinker/core/integrations';
+
+export interface TestSellerPoliciesCacheOverrides {
+  connectionId?: string;
+  policies?: SellerPolicies;
+  /** Staleness override — defaults to `now()` (fresh). */
+  fetchedAt?: Date;
+}
+
+const DEFAULT_POLICIES: SellerPolicies = {
+  deliveryPolicies: [{ id: 'd1', name: 'Standard delivery' }],
+  returnPolicies: [{ id: 'r1', name: '14-day returns' }],
+  warranties: [{ id: 'w1', name: '1-year manufacturer' }],
+  impliedWarranties: [{ id: 'iw1', name: 'Consumer rights' }],
+};
+
+/**
+ * Insert a `seller_policies_cache` row directly via SQL. Returns void
+ * because the primary key is `connectionId` which the caller already has.
+ */
+export async function createTestSellerPoliciesCache(
+  dataSource: DataSource,
+  overrides?: TestSellerPoliciesCacheOverrides,
+): Promise<void> {
+  const connectionId = overrides?.connectionId ?? '33333333-3333-4333-8333-333333333333';
+  const policies = overrides?.policies ?? DEFAULT_POLICIES;
+  const fetchedAt = overrides?.fetchedAt ?? new Date();
+
+  await dataSource.query(
+    `INSERT INTO seller_policies_cache ("connectionId", "policies", "fetchedAt")
+     VALUES ($1, $2, $3)`,
+    [connectionId, JSON.stringify(policies), fetchedAt],
+  );
+}

--- a/apps/api/test/integration/listings-create-offer.int-spec.ts
+++ b/apps/api/test/integration/listings-create-offer.int-spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Listings Create-Offer API Integration Test
+ *
+ * Vertical slice covering:
+ * - GET /listings/connections/:id/offers/creation/:recordId — seeded record path
+ * - GET /listings/connections/:id/offers/creation/:recordId — not-found path
+ * - GET /listings/connections/:id/offers/creation/:recordId — cross-connection
+ *     (exists but belongs to a different connection → 404)
+ *
+ * We do **not** exercise `POST /offers` end-to-end here because a real Allegro
+ * adapter would need live credentials; that path is covered by the controller
+ * unit spec (`ListingsController`), the `OfferCreationEnqueueService` spec
+ * (adapter/capability/record/enqueue orchestration), and the worker-handler
+ * spec (`OfferCreationExecutionService`). The integration test's job is to
+ * prove Nest wiring + DB plumbing for the status-poll endpoint which is the
+ * operator-visible contract the FE will call every few seconds.
+ *
+ * @module apps/api/test/integration
+ */
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestOfferCreationRecord } from './fixtures/offer-creation-record.fixtures';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+
+const CONN_A = '11111111-1111-4111-8111-111111111111';
+const CONN_B = '22222222-2222-4222-8222-222222222222';
+
+describe('Listings Create-Offer API Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  describe('GET /listings/connections/:connectionId/offers/creation/:offerCreationRecordId', () => {
+    it('returns the record for an authenticated operator when the record belongs to the connection', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const recordId = await createTestOfferCreationRecord(dataSource, {
+        connectionId: CONN_A,
+        status: 'validating',
+      });
+
+      const response = await http
+        .get(`/listings/connections/${CONN_A}/offers/creation/${recordId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(response.body.id).toBe(recordId);
+      expect(response.body.connectionId).toBe(CONN_A);
+      expect(response.body.internalVariantId).toBe('ol_variant_abc123');
+      expect(response.body.status).toBe('validating');
+      expect(response.body.externalOfferId).toBeNull();
+      expect(response.body.errors).toBeNull();
+      expect(response.body.publishImmediately).toBe(false);
+      expect(typeof response.body.createdAt).toBe('string');
+      expect(typeof response.body.updatedAt).toBe('string');
+    });
+
+    it('returns 404 when the record does not exist', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      await http
+        .get(`/listings/connections/${CONN_A}/offers/creation/00000000-0000-4000-8000-000000000000`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+
+    it('returns 404 when the record exists but belongs to a different connection', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const recordId = await createTestOfferCreationRecord(dataSource, { connectionId: CONN_B });
+
+      await http
+        .get(`/listings/connections/${CONN_A}/offers/creation/${recordId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+  });
+});

--- a/apps/api/test/integration/listings-seller-policies.int-spec.ts
+++ b/apps/api/test/integration/listings-seller-policies.int-spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Listings Seller-Policies API Integration Test
+ *
+ * Proves the cache + controller + DTO serialization path end-to-end without
+ * needing a live Allegro HTTP round-trip:
+ *   1. Seed a fresh row in `seller_policies_cache` for a test connectionId.
+ *   2. GET /listings/connections/:id/seller-policies.
+ *   3. Expect the seeded policies back, through real Nest wiring + real DB.
+ *
+ * The adapter's `fetchSellerPolicies` is covered by the Allegro unit spec;
+ * the service's cache-hit path is covered by the service unit spec. This
+ * test covers the integration seam those two miss: route registration,
+ * DTO shape on the wire, and the TypeORM read path.
+ *
+ * @module apps/api/test/integration
+ */
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestSellerPoliciesCache } from './fixtures/seller-policies-cache.fixtures';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+
+const CONN = '33333333-3333-4333-8333-333333333333';
+
+describe('Listings Seller-Policies API Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('returns seeded cache contents via GET /listings/connections/:id/seller-policies', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const policies = {
+      deliveryPolicies: [{ id: 'd1', name: 'Standard' }],
+      returnPolicies: [{ id: 'r1', name: '14-day returns' }],
+      warranties: [{ id: 'w1', name: '1-year manufacturer' }],
+      impliedWarranties: [{ id: 'iw1', name: 'Consumer rights' }],
+    };
+
+    await createTestSellerPoliciesCache(dataSource, { connectionId: CONN, policies });
+
+    const response = await http
+      .get(`/listings/connections/${CONN}/seller-policies`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body).toEqual(policies);
+  });
+});

--- a/docs/plans/implementation-plan-create-offer-seller-policies.md
+++ b/docs/plans/implementation-plan-create-offer-seller-policies.md
@@ -1,0 +1,503 @@
+# Implementation Plan — Create-offer endpoint (#259) + Seller policies endpoint (#260)
+
+**Branch:** `259-260-create-offer-seller-policies`
+**Scope:** One PR bundling both endpoints. They share a controller (`ListingsController`) and both unblock the FE offer-creation wizard (#261).
+**Layer:** Core application (seller policies) + Integration (Allegro) + Interface (REST).
+
+The create-offer adapter method, worker handler, `OfferCreationExecutionService`, `OfferCreationRecord` entity/repo/migration, and `MarketplaceOfferCreatePayloadV1` already exist (#254/#257/#258/#289). This PR wires the HTTP endpoints in front of them and adds the seller-policies read path end-to-end.
+
+---
+
+## 1. Goal & non-goals
+
+**Goal (#259):** Add `POST /listings/connections/:connectionId/offers` (202 async) and `GET /listings/connections/:connectionId/offers/creation/:offerCreationRecordId` (status poll).
+
+**Goal (#260):** Add `GET /listings/connections/:connectionId/seller-policies` returning delivery + return + warranty + implied-warranty lists for the connection's marketplace adapter, with a 10-minute cache to absorb repeated wizard loads.
+
+**Non-goals:**
+- Frontend wizard (#261 — separate PR).
+- A `pollCreationStatus` job handler to advance `validating → active` (the worker handler leaves `validating` as a terminal state today with a warn log; follow-up issue territory).
+- Extending `fetchSellerPolicies` to non-Allegro adapters (port method is optional; only Allegro implements it here).
+- Generalising the cache layer into a reusable abstraction. `SellerPoliciesCache` follows the same shape as the existing `AllegroCategoryCache` — single-purpose ORM table.
+- Authorisation beyond the existing `@Roles('admin')` — seller-policies contain no secrets, so no additional guard.
+
+---
+
+## 2. Layer classification & doc alignment
+
+| Component | Layer | Location |
+|---|---|---|
+| `SellerPolicies` / `SellerPolicy` types | Domain (integrations) | `libs/core/src/integrations/domain/types/` |
+| `fetchSellerPolicies` port method | Domain (integrations) | `libs/core/src/integrations/domain/ports/marketplace.port.ts` |
+| Allegro implementation | Integration | `libs/integrations/allegro/src/infrastructure/adapters/` |
+| `SellerPoliciesCacheRepositoryPort` | Domain (listings) | `libs/core/src/listings/domain/ports/` |
+| `SellerPoliciesCacheOrmEntity` + repo impl | Infrastructure (listings) | `libs/core/src/listings/infrastructure/persistence/` |
+| `SellerPoliciesService` | Application (listings) | `libs/core/src/listings/application/services/` |
+| `ListingsController` additions | Interface | `apps/api/src/listings/http/` |
+| Migration | API | `apps/api/src/migrations/` |
+
+**Deviations from issue text (documented here so reviewers can see the reasoning):**
+
+1. **Controller path.** Issue #259 references `apps/api/src/listings/interfaces/http/` — the actual project uses `apps/api/src/listings/http/`. Following the repo.
+2. **Auth decorator.** Issue #259 says `@UseGuards(JwtAuthGuard)`. Codebase uses class-level `@Roles('admin') + @ApiBearerAuth()`. Following the repo.
+3. **Cache backend.** Issue #260 says "Redis cache for 10 minutes". The codebase has **no Redis cache abstraction** — caching is DB-backed via TypeORM tables (e.g., `AllegroCategoryCacheOrmEntity` + `CategoriesCacheService`). I'll follow the codebase convention. Cost/benefit: a DB row read is fine for an operator-triggered lookup (the wizard opens a handful of times per day per connection); the consistency win beats the latency win Redis would give.
+4. **DTO validation.** Issue #259 lists `@IsUUID() internalVariantId`. Internal IDs in OpenLinker use the `ol_{entityType}_{hex}` format — they're `TEXT`, not strict UUIDs (per `architecture-overview.md` §"Internal Identifier Format"). Using `@IsString() @IsNotEmpty() @Matches(/^ol_variant_/)` instead.
+5. **Capability check.** `IIntegrationsService.getCapabilityAdapter` already throws `CapabilityNotSupportedException` at the capability level (`'Marketplace'`). `createOffer` is optional *within* the `MarketplacePort` interface — adapters may support `Marketplace` but not `createOffer`. I'll throw `UnprocessableEntityException` on a missing `createOffer` method to match the issue's 422 expectation.
+6. **No new application service for #259.** `OfferCreationExecutionService` already owns the orchestration; the worker handler already delegates to it. The HTTP endpoint only needs to (a) validate connection/capability, (b) pre-create the `OfferCreationRecord`, (c) enqueue the job with `offerCreationRecordId` in the payload. This is thin enough to live inline in the controller, mirroring `updateOfferFields` which also uses `JobEnqueuePort` directly.
+
+Conventions I'll enforce:
+- Types in separate `*.types.ts` files.
+- Service interface in a separate `*.service.interface.ts` (for `SellerPoliciesService`).
+- Repository port defined in `domain/ports/`, implementation in `infrastructure/persistence/repositories/` (per `docs/engineering-standards.md` → *Repository Ports Pattern*). The cache repo is behind a port like every other application-visible repository in the codebase — service-layer testability is the reason.
+- Ports injected via Symbol tokens; `useExisting` binding in module.
+- No `any`, no `console.log`, no `eslint-disable`.
+- Repository throws domain errors, not infrastructure errors; TypeORM exceptions stay private inside the concrete repo impl.
+
+---
+
+## 3. Design
+
+### 3.1 Seller policies (#260)
+
+#### 3.1.1 Core types
+
+**Location: integrations layer (with the port that returns them).** `libs/core/src/integrations/domain/types/seller-policies.types.ts`:
+
+```typescript
+export interface SellerPolicy {
+  id: string;
+  name: string;
+}
+
+export interface SellerPolicies {
+  deliveryPolicies: SellerPolicy[];
+  returnPolicies: SellerPolicy[];
+  warranties: SellerPolicy[];
+  impliedWarranties: SellerPolicy[];
+}
+```
+
+Framework-free (no `@ApiProperty`). Controller DTOs add Swagger decoration. **Rationale for placement:** the port defines the shape it returns. `CreateOfferCommand` / `CreateOfferResult` / `CreateOfferOverrides` already live in `libs/core/src/integrations/domain/types/` for the same reason. Putting `SellerPolicies` anywhere else (e.g., `libs/core/src/listings/application/types/`) creates an unnecessary import from `integrations/domain/ports/` → `listings/application/types/`, which also risks a circular dependency. The listings barrel re-exports for FE/API convenience (see §3.4) — but the canonical home is integrations.
+
+#### 3.1.2 Port method
+
+Extend `libs/core/src/integrations/domain/ports/marketplace.port.ts`:
+
+```typescript
+/**
+ * Return the seller-configured policies the marketplace requires when
+ * creating an offer (delivery, return, warranty, implied-warranty).
+ * Optional — adapters that do not need policy IDs for offer creation
+ * omit this method; callers must check for presence before invoking.
+ */
+fetchSellerPolicies?(): Promise<SellerPolicies>;
+```
+
+Import path: `SellerPolicies` is colocated with the port in `libs/core/src/integrations/domain/types/` — no cross-layer import needed.
+
+#### 3.1.3 Allegro adapter implementation
+
+`libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts` — add method + 4 API types in `allegro-api.types.ts`:
+
+- `AllegroDeliverySettings` (from `GET /sale/delivery-settings` → array of `settings[].id + name`)
+- `AllegroReturnPolicy`, `AllegroWarranty`, `AllegroImpliedWarranty` (from `GET /after-sales-service-conditions/return-policies` / `/warranties` / `/implied-warranties`)
+
+Method body:
+```typescript
+async fetchSellerPolicies(): Promise<SellerPolicies> {
+  const [delivery, returns, warranties, impliedWarranties] = await Promise.all([
+    this.httpClient.get<{ deliverySettings: AllegroDeliverySettings[] }>('/sale/delivery-settings'),
+    this.httpClient.get<{ returnPolicies: AllegroReturnPolicy[] }>('/after-sales-service-conditions/return-policies'),
+    this.httpClient.get<{ warranties: AllegroWarranty[] }>('/after-sales-service-conditions/warranties'),
+    this.httpClient.get<{ impliedWarranties: AllegroImpliedWarranty[] }>('/after-sales-service-conditions/implied-warranties'),
+  ]);
+  return {
+    deliveryPolicies: delivery.deliverySettings.map((p) => ({ id: p.id, name: p.name })),
+    returnPolicies: returns.returnPolicies.map((p) => ({ id: p.id, name: p.name })),
+    warranties: warranties.warranties.map((p) => ({ id: p.id, name: p.name })),
+    impliedWarranties: impliedWarranties.impliedWarranties.map((p) => ({ id: p.id, name: p.name })),
+  };
+}
+```
+
+Verify the response envelope names against Allegro docs during implementation; adjust mapping if needed. Any HTTP error propagates — the Allegro HTTP client already wraps non-2xx into `AllegroApiException`, which the application service surfaces as a 500 (acceptable — policy fetch failure is rare and recoverable by retry).
+
+#### 3.1.4 Cache ORM entity + migration
+
+`libs/core/src/listings/infrastructure/persistence/entities/seller-policies-cache.orm-entity.ts`:
+
+```typescript
+@Entity('seller_policies_cache')
+export class SellerPoliciesCacheOrmEntity {
+  @PrimaryColumn({ type: 'uuid' }) connectionId!: string;
+  @Column({ type: 'jsonb' }) policies!: SellerPolicies;
+  @Column({ type: 'timestamptz' }) fetchedAt!: Date;
+  @CreateDateColumn({ type: 'timestamptz' }) createdAt!: Date;
+  @UpdateDateColumn({ type: 'timestamptz' }) updatedAt!: Date;
+}
+```
+
+`connectionId` is the primary key (one row per connection is the contract — no surrogate id or unique index needed). Platform is already captured by the connection (`connections.platform_type` is immutable), so adding `platformType` to the key is redundant.
+
+**Migration** (`pnpm --filter @openlinker/api migration:generate -- src/migrations/CreateSellerPoliciesCache`):
+- Table `seller_policies_cache` with those columns
+- Unique index on `connection_id`
+- Verify `up` and `down` both clean (test with `migration:run` then `migration:revert`)
+
+#### 3.1.5 `SellerPoliciesService` + cache port
+
+**Repository port (domain).** `libs/core/src/listings/domain/ports/seller-policies-cache-repository.port.ts`:
+
+```typescript
+import { SellerPolicies } from '@openlinker/core/integrations';
+
+export interface CachedSellerPolicies {
+  connectionId: string;
+  policies: SellerPolicies;
+  fetchedAt: Date;
+}
+
+export interface SellerPoliciesCacheRepositoryPort {
+  findByConnectionId(connectionId: string): Promise<CachedSellerPolicies | null>;
+  upsert(entry: CachedSellerPolicies): Promise<void>;
+}
+```
+
+**Why a port (not a concrete class):** `docs/engineering-standards.md` → *Repository Ports Pattern* is unconditional: "Application services must never depend on concrete infrastructure repositories. They must depend on repository ports (interfaces) defined in the domain layer." This applies even for a thin cache wrapper — the service layer must stay testable with a port mock, not a TypeORM mock. Mirrors `OfferCreationRecordRepositoryPort` in the same module.
+
+**Concrete repo.** `libs/core/src/listings/infrastructure/persistence/repositories/seller-policies-cache.repository.ts` — implements `SellerPoliciesCacheRepositoryPort`, injects `@InjectRepository(SellerPoliciesCacheOrmEntity)`, private ORM ↔ domain mapping methods.
+
+**Service interface.** `application/services/seller-policies.service.interface.ts`:
+```typescript
+export interface ISellerPoliciesService {
+  /**
+   * Get seller policies for a connection. Hits cache if fresh (<10 min),
+   * otherwise fetches from the adapter and repopulates cache. Throws
+   * `UnprocessableEntityException` if adapter does not implement
+   * `fetchSellerPolicies`.
+   */
+  getSellerPolicies(connectionId: string): Promise<SellerPolicies>;
+}
+```
+
+Interface file colocated with the impl in `application/services/` — matching the listings module convention (verified: `offer-creation-execution.service.interface.ts`, `offer-builder.service.interface.ts` all colocate with their impls in `application/interfaces/`; I'll place the new interface in whichever folder the existing listings interfaces use once I open the directory).
+
+**Service impl.** `application/services/seller-policies.service.ts`:
+- Inject `INTEGRATIONS_SERVICE_TOKEN` (for `getCapabilityAdapter<MarketplacePort>`) + `SELLER_POLICIES_CACHE_TOKEN` bound to `SellerPoliciesCacheRepositoryPort`.
+- `SELLER_POLICIES_TTL_MS = 10 * 60 * 1000`
+- Flow:
+  1. Lookup cache row by `connectionId`. If present and `fetchedAt > now - TTL`, return `row.policies`.
+  2. Resolve Marketplace adapter via `integrationsService.getCapabilityAdapter<MarketplacePort>(connectionId, 'Marketplace')`. (This throws `ConnectionNotFoundException` → 404, `ConnectionDisabledException` → 409, `CapabilityNotSupportedException` → 422.)
+  3. If `!adapter.fetchSellerPolicies`, throw `UnprocessableEntityException(\`Adapter for connection \${connectionId} does not support seller-policy listing\`)`.
+  4. Call `adapter.fetchSellerPolicies()`. Upsert into cache — **on upsert failure, log a warning and return the fresh policies anyway** (cache-aside semantics; a transient DB blip must not make the endpoint fail when we already have the data).
+- Tokens `SELLER_POLICIES_SERVICE_TOKEN = Symbol('ISellerPoliciesService')` and `SELLER_POLICIES_CACHE_TOKEN = Symbol('SellerPoliciesCacheRepositoryPort')` in `listings.tokens.ts`. Bind both with `useExisting` in `listings.module.ts`, export both.
+
+#### 3.1.6 Controller endpoint
+
+`apps/api/src/listings/http/listings.controller.ts` — add:
+
+```typescript
+@Get('connections/:connectionId/seller-policies')
+@HttpCode(HttpStatus.OK)
+@ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+@ApiOperation({
+  summary: 'List seller-configured marketplace policies',
+  description: 'Returns delivery, return, warranty, and implied-warranty policy options for the connection.',
+})
+@ApiResponse({ status: 200, type: SellerPoliciesResponseDto })
+@ApiResponse({ status: 404, description: 'Connection not found' })
+@ApiResponse({ status: 409, description: 'Connection disabled' })
+@ApiResponse({ status: 422, description: 'Adapter does not support seller-policy listing' })
+async getSellerPolicies(
+  @Param('connectionId') connectionId: string,
+): Promise<SellerPoliciesResponseDto> {
+  return this.sellerPoliciesService.getSellerPolicies(connectionId);
+}
+```
+
+DTO: `apps/api/src/listings/http/dto/seller-policies-response.dto.ts` — four `@ApiProperty` arrays of `{ id, name }`. Identical structure to `SellerPolicies` but decorated.
+
+Inject `SELLER_POLICIES_SERVICE_TOKEN` into the controller.
+
+### 3.2 Create-offer endpoint (#259)
+
+#### 3.2.1 Request DTO
+
+`apps/api/src/listings/http/dto/create-offer.dto.ts`:
+
+```typescript
+export class CreateOfferPriceDto {
+  @IsNumber() @IsPositive() amount!: number;
+  @IsString() @IsNotEmpty() currency!: string;
+}
+
+export class CreateOfferOverridesDto {
+  @IsOptional() @IsString() title?: string;
+  @IsOptional() @IsString() description?: string | null;
+  @IsOptional() @IsString() categoryId?: string;
+  @IsOptional() @IsArray() @IsString({ each: true }) imageUrls?: string[] | null;
+  @IsOptional() @IsObject() platformParams?: Record<string, unknown>;
+}
+
+export class CreateOfferDto {
+  @IsString() @IsNotEmpty() @Matches(/^ol_variant_/)
+  internalVariantId!: string;
+
+  @IsInt() @Min(0)
+  stock!: number;
+
+  @IsBoolean()
+  publishImmediately!: boolean;
+
+  @IsOptional() @ValidateNested() @Type(() => CreateOfferPriceDto)
+  price?: CreateOfferPriceDto;
+
+  @IsOptional() @ValidateNested() @Type(() => CreateOfferOverridesDto)
+  overrides?: CreateOfferOverridesDto;
+}
+```
+
+**Note on `description`/`imageUrls` accepting `null`:** matches `CreateOfferOverrides` in `@openlinker/core/integrations` after PR #295. Keep the HTTP DTO aligned.
+
+**Note on `@Matches(/^ol_variant_/)`.** Internal IDs follow the `ol_{entityType}_{hex}` format (see `architecture-overview.md` → *Internal Identifier Format*). At implementation time, check whether a shared prefix constant or type guard already exists in `@openlinker/core/products` or `@openlinker/core/identifier-mapping` — if yes, reference it instead of an inline regex. If not, keep the regex and follow the neighbours (don't introduce a new helper purely for this one DTO).
+
+**Note on `platformParams` shape.** `Record<string, unknown>` is the documented escape hatch (#254), so the DTO intentionally lets anything object-shaped through. But `@IsObject()` alone lets a client push multi-MB payloads into the Redis Streams job payload. Add a soft upper bound in the DTO (e.g., `@MaxLength` via a custom `@MaxObjectJsonSize(4096)` validator, or a post-transform byte check). Target: reject anything over ~4 KB serialised — well above the handful of policy-id fields Allegro actually reads, well below anything that could stress the stream. This is operational hygiene, not a security control.
+
+**Note on DTO ↔ `CreateOfferOverrides` drift.** The DTO mirrors `CreateOfferOverrides` field-for-field today. If the core type later gains a field (another PR in the #286/#293/#295 line), this DTO silently misses it. Add a type-level assertion alongside the DTO (e.g., `type _DtoMatchesOverrides = AssertEqual<CreateOfferOverridesDto, Required<CreateOfferOverrides>>;` with a small `AssertEqual<A, B>` utility) so the next drift breaks type-check. Optional — skip if there's no existing `AssertEqual` utility in the repo.
+
+#### 3.2.2 Response DTOs
+
+```typescript
+// create-offer-response.dto.ts
+export class CreateOfferResponseDto {
+  @ApiProperty() jobId!: string;
+  @ApiProperty() offerCreationRecordId!: string;
+}
+
+// offer-creation-status-response.dto.ts
+export class OfferCreationStatusResponseDto {
+  @ApiProperty() id!: string;
+  @ApiProperty() internalVariantId!: string;
+  @ApiProperty() connectionId!: string;
+  @ApiPropertyOptional({ nullable: true }) externalOfferId!: string | null;
+  @ApiProperty({ enum: OfferCreationStatusValues }) status!: OfferCreationStatus;
+  @ApiPropertyOptional({ nullable: true, type: 'array' }) errors!: OfferCreationError[] | null;
+  @ApiProperty() publishImmediately!: boolean;
+  @ApiProperty() createdAt!: string; // ISO string
+  @ApiProperty() updatedAt!: string;
+}
+```
+
+#### 3.2.3 Controller handlers
+
+Add to `ListingsController` — inject two more tokens (`INTEGRATIONS_SERVICE_TOKEN`, `OFFER_CREATION_RECORD_REPOSITORY_TOKEN`):
+
+**POST handler:**
+```typescript
+@Post('connections/:connectionId/offers')
+@HttpCode(HttpStatus.ACCEPTED)
+async createOffer(
+  @Param('connectionId') connectionId: string,
+  @Body() dto: CreateOfferDto,
+  @Headers('x-idempotency-key') clientIdempotencyKey?: string,
+): Promise<CreateOfferResponseDto> {
+  // 1. Validate connection + Marketplace capability.
+  //    getCapabilityAdapter throws ConnectionNotFoundException (404) / ConnectionDisabledException (409) / CapabilityNotSupportedException (422).
+  const adapter = await this.integrationsService.getCapabilityAdapter<MarketplacePort>(
+    connectionId,
+    'Marketplace',
+  );
+  if (!adapter.createOffer) {
+    throw new UnprocessableEntityException(
+      `Adapter for connection ${connectionId} does not support offer creation`,
+    );
+  }
+
+  // 2. Pre-create record so it's visible before the job runs.
+  const record = await this.offerCreationRecords.create({
+    internalVariantId: dto.internalVariantId,
+    connectionId,
+    externalOfferId: null,
+    status: 'pending',
+    errors: null,
+    publishImmediately: dto.publishImmediately,
+  });
+
+  // 3. Enqueue the job.
+  const { jobId } = await this.jobEnqueue.enqueueJob({
+    jobType: 'marketplace.offer.create',
+    connectionId,
+    idempotencyKey: clientIdempotencyKey ?? `offer-create:${record.id}`,
+    payload: {
+      schemaVersion: 1,
+      internalVariantId: dto.internalVariantId,
+      stock: dto.stock,
+      publishImmediately: dto.publishImmediately,
+      ...(dto.price && { price: dto.price }),
+      ...(dto.overrides && { overrides: dto.overrides }),
+      offerCreationRecordId: record.id,
+    } satisfies MarketplaceOfferCreatePayloadV1,
+  });
+
+  return { jobId, offerCreationRecordId: record.id };
+}
+```
+
+**Notes on the idempotency key.** The default `offer-create:${record.id}` is **per-call unique** because the record is freshly created on every POST — so without an `x-idempotency-key` header, two rapid double-submits will create two distinct `OfferCreationRecord` rows and two distinct jobs. That matches the `updateOfferFields` behaviour (which defaults to `randomUUID()`) and is intentional: the record id is the only thing that ties the HTTP response back to a specific creation attempt, so a second submit legitimately represents a second attempt.
+
+**If we wanted client-header-less dedupe** (e.g., collapse two near-simultaneous POSTs for the same variant+connection into one record + one job), the key would need to be deterministic from request inputs — e.g., `offer-create:${connectionId}:${dto.internalVariantId}`. That changes behaviour meaningfully (a client that legitimately wanted to create two offers for the same variant on the same connection would be blocked until the first job's dedupe TTL elapsed), so I'm **not** adopting it. Clients that need dedupe send `x-idempotency-key`; this will be surfaced in the FE wizard (#261).
+
+**GET status handler:**
+```typescript
+@Get('connections/:connectionId/offers/creation/:offerCreationRecordId')
+@HttpCode(HttpStatus.OK)
+async getOfferCreationStatus(
+  @Param('connectionId') connectionId: string,
+  @Param('offerCreationRecordId') recordId: string,
+): Promise<OfferCreationStatusResponseDto> {
+  const record = await this.offerCreationRecords.findById(recordId);
+  if (!record || record.connectionId !== connectionId) {
+    throw new NotFoundException(`Offer creation record not found: ${recordId}`);
+  }
+  return this.toOfferCreationStatusDto(record);
+}
+```
+
+Why the connectionId cross-check: defence against URL-tampering (`GET /.../conn-a/offers/creation/:id` where the record actually belongs to `conn-b`). Cheap belt-and-braces; same pattern the worker handler wouldn't need but the HTTP surface should.
+
+Private `toOfferCreationStatusDto(record: OfferCreationRecord)`: flat mapping, `Date → ISO string`.
+
+**Note on upfront validation cost.** Calling `integrationsService.getCapabilityAdapter<MarketplacePort>(...)` constructs the full adapter (credentials lookup, HTTP client setup) just to check `!adapter.createOffer`, then throws it away — the worker constructs the adapter again when it picks up the job. This is a UX-for-cost tradeoff the issue explicitly asks for: fail-fast 404/409/422 at enqueue time rather than silently enqueuing a job that will fail on the first worker attempt. Acceptable for low-frequency operator-initiated POSTs; revisit if we ever move offer creation to high-volume automation.
+
+### 3.3 Tests
+
+**New service spec** — `libs/core/src/listings/application/services/__tests__/seller-policies.service.spec.ts`:
+1. Cache hit (fresh) → returns cached, does NOT call adapter.
+2. Cache miss (stale) → calls adapter, upserts cache, returns adapter result.
+3. Cache empty → calls adapter, upserts cache, returns.
+4. Adapter resolves but missing `fetchSellerPolicies` method → throws `UnprocessableEntityException`.
+5. `getCapabilityAdapter` throws `ConnectionNotFoundException` → propagates (no swallowing, controller will map to 404).
+6. Adapter returns successfully but cache `upsert` throws → service still returns fresh policies; warning is logged (cache-aside resilience).
+
+Mocks: `jest.Mocked<IIntegrationsService>`, `jest.Mocked<SellerPoliciesCacheRepositoryPort>` (port interface, not the concrete repo). Fake timers for the TTL boundary case (`fetchedAt` exactly at `now - TTL`).
+
+**New controller spec** — extend `apps/api/src/listings/http/listings.controller.spec.ts`:
+- Mock `ISellerPoliciesService`, `IIntegrationsService`, `OfferCreationRecordRepositoryPort`, existing `JobEnqueuePort`.
+- **GET seller-policies**: service called, response shape mirrors `SellerPolicies`.
+- **POST create-offer**, happy path: calls `getCapabilityAdapter`, creates record, enqueues job with `offerCreationRecordId`, returns 202 `{ jobId, offerCreationRecordId }`.
+- **POST create-offer**, adapter without `createOffer` → `UnprocessableEntityException` (422).
+- **POST create-offer**, `ConnectionDisabledException` from `getCapabilityAdapter` → propagates (Nest maps 409).
+- **GET status** happy path: ISO dates, flat DTO.
+- **GET status**, record belongs to different connection → `NotFoundException`.
+- **GET status**, unknown id → `NotFoundException`.
+
+**Allegro adapter spec** — extend `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts`:
+- `fetchSellerPolicies` dispatches 4 GETs in parallel.
+- Maps Allegro response envelopes to `SellerPolicy[]` correctly.
+- Propagates `AllegroApiException` on non-2xx (one failure fails the whole call — `Promise.all`).
+
+**Integration test** — new `apps/api/test/integration/listings-create-offer.int-spec.ts`:
+- POST create-offer with a seeded variant + active Allegro connection (using fixtures) → 202 response shape, row appears in `offer_creation_records` with `status='pending'`, job appears in `sync_jobs` with the right payload.
+- GET status → returns the created record.
+- Cross-connection GET → 404.
+
+**Seller-policies integration test** — new `apps/api/test/integration/listings-seller-policies.int-spec.ts`. Lightweight: does **not** mock Allegro, instead exercises the cache+Nest wiring path by pre-seeding a fresh row in `seller_policies_cache` for a test connection, then hitting `GET /listings/connections/:id/seller-policies` and asserting the shape comes back through Nest. One positive case is enough — unit tests cover the adapter + service logic; this just proves the DB plumbing, route registration, and DTO serialization work end-to-end. Skip the cache-miss + live-Allegro-fetch path in integration (it's flaky and already covered by unit tests).
+
+### 3.4 Module wiring summary
+
+`libs/core/src/listings/listings.module.ts`:
+- Import `SellerPoliciesCacheOrmEntity` via `TypeOrmModule.forFeature(...)`.
+- Register `SellerPoliciesService`, `SellerPoliciesCacheRepository` as providers.
+- Add `SELLER_POLICIES_SERVICE_TOKEN` with `useExisting: SellerPoliciesService`, export.
+- Add `SELLER_POLICIES_CACHE_TOKEN` with `useExisting: SellerPoliciesCacheRepository`, export (so tests and future consumers can mock the port).
+
+`libs/core/src/listings/listings.tokens.ts`:
+- Add `export const SELLER_POLICIES_SERVICE_TOKEN = Symbol('ISellerPoliciesService');`
+- Add `export const SELLER_POLICIES_CACHE_TOKEN = Symbol('SellerPoliciesCacheRepositoryPort');`
+
+`libs/core/src/integrations/index.ts`:
+- Export `SellerPolicies`, `SellerPolicy` from `./domain/types/seller-policies.types`.
+
+`libs/core/src/listings/index.ts`:
+- Export `SellerPoliciesService`, `ISellerPoliciesService`, `SELLER_POLICIES_SERVICE_TOKEN`, `SELLER_POLICIES_CACHE_TOKEN`, `SellerPoliciesCacheRepositoryPort`.
+- **Do not** re-export `SellerPolicies` / `SellerPolicy` — they belong to integrations; consumers import them from `@openlinker/core/integrations` directly.
+
+`apps/api/src/listings/listings.module.ts`:
+- No change (it already imports core listings module — the new providers + token ride in).
+
+`apps/api/src/database/data-source.ts`:
+- Verify the glob picks up the new `.orm-entity.ts`; usually covered by `libs/core/src/**/*.orm-entity.ts`. No code change expected.
+
+---
+
+## 4. Step-by-step
+
+| # | File | Action |
+|---|---|---|
+| 1.1 | `libs/core/src/integrations/domain/types/seller-policies.types.ts` | **New.** `SellerPolicy`, `SellerPolicies` — colocated with `MarketplacePort` which returns them. |
+| 1.2 | `libs/core/src/integrations/index.ts` | Re-export `SellerPolicy`, `SellerPolicies` from the barrel. |
+| 1.3 | `libs/core/src/integrations/domain/ports/marketplace.port.ts` | Add optional `fetchSellerPolicies?(): Promise<SellerPolicies>`. Local import from `../types/seller-policies.types` — no cross-module import. |
+| 1.4 | `libs/integrations/allegro/src/infrastructure/types/allegro-api.types.ts` | Add `AllegroDeliverySettings`, `AllegroReturnPolicy`, `AllegroWarranty`, `AllegroImpliedWarranty` response shapes. |
+| 1.5 | `libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts` | Implement `fetchSellerPolicies` with 4-parallel GETs. |
+| 2.1 | `libs/core/src/listings/infrastructure/persistence/entities/seller-policies-cache.orm-entity.ts` | **New.** ORM entity; `connectionId` as PK. |
+| 2.2 | `libs/core/src/listings/domain/ports/seller-policies-cache-repository.port.ts` | **New.** `SellerPoliciesCacheRepositoryPort` + `CachedSellerPolicies` type (per engineering-standards Repository Ports Pattern). |
+| 2.3 | `libs/core/src/listings/infrastructure/persistence/repositories/seller-policies-cache.repository.ts` | **New.** Implements `SellerPoliciesCacheRepositoryPort`; private ORM ↔ domain mapping. |
+| 2.4 | `apps/api/src/migrations/{timestamp}-CreateSellerPoliciesCache.ts` | **New.** Generated via TypeORM CLI; test `up`/`down`. |
+| 3.1 | `libs/core/src/listings/listings.tokens.ts` | Add `SELLER_POLICIES_SERVICE_TOKEN` + `SELLER_POLICIES_CACHE_TOKEN`. |
+| 3.2 | `libs/core/src/listings/application/services/seller-policies.service.interface.ts` | **New.** `ISellerPoliciesService`. (Place in whichever folder the sibling listings service interfaces use — `application/services/` or `application/interfaces/`; verify on disk.) |
+| 3.3 | `libs/core/src/listings/application/services/seller-policies.service.ts` | **New.** Cache-aware impl; injects via `INTEGRATIONS_SERVICE_TOKEN` + `SELLER_POLICIES_CACHE_TOKEN`; swallows cache-write failure with warn log. |
+| 3.4 | `libs/core/src/listings/listings.module.ts` | Register `SellerPoliciesCacheRepository` + `SellerPoliciesService` as providers; `forFeature(SellerPoliciesCacheOrmEntity)`; `useExisting` bindings for both tokens; export both tokens. |
+| 3.5 | `libs/core/src/listings/index.ts` | Re-export `SellerPoliciesService`, `ISellerPoliciesService`, both tokens, `SellerPoliciesCacheRepositoryPort`. Do NOT re-export `SellerPolicies`/`SellerPolicy` — those live in integrations. |
+| 4.1 | `libs/core/src/listings/application/services/__tests__/seller-policies.service.spec.ts` | **New.** 6 unit tests per §3.3. |
+| 4.2 | `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts` | Add 2–3 tests for `fetchSellerPolicies`. |
+| 5.1 | `apps/api/src/listings/http/dto/seller-policies-response.dto.ts` | **New.** Swagger-decorated mirror of `SellerPolicies`. |
+| 5.2 | `apps/api/src/listings/http/dto/create-offer.dto.ts` | **New.** Request DTOs; include `@MaxObjectJsonSize(4096)` (or equivalent) on `platformParams` if a helper exists, otherwise soft-skip. |
+| 5.3 | `apps/api/src/listings/http/dto/create-offer-response.dto.ts` | **New.** `{ jobId, offerCreationRecordId }`. |
+| 5.4 | `apps/api/src/listings/http/dto/offer-creation-status-response.dto.ts` | **New.** Flat status DTO. |
+| 6.1 | `apps/api/src/listings/http/listings.controller.ts` | Inject 3 new tokens (`SELLER_POLICIES_SERVICE_TOKEN`, `INTEGRATIONS_SERVICE_TOKEN`, `OFFER_CREATION_RECORD_REPOSITORY_TOKEN`); add 3 endpoints (GET policies, POST create, GET status); private `toOfferCreationStatusDto`. |
+| 6.2 | `apps/api/src/listings/http/listings.controller.spec.ts` | Add mocks + 7 new tests per §3.3. |
+| 7.1 | `apps/api/test/integration/listings-create-offer.int-spec.ts` | **New.** 3 integration cases. |
+| 7.2 | `apps/api/test/integration/listings-seller-policies.int-spec.ts` | **New.** 1 integration case: pre-seeded cache row → `GET /listings/connections/:id/seller-policies` returns the policies. |
+| 8 | Quality gate | `pnpm --filter @openlinker/api migration:show` + `pnpm lint && pnpm type-check && pnpm test && pnpm test:integration`. |
+
+---
+
+## 5. Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Allegro response envelopes differ from assumed names (`deliverySettings`, `returnPolicies`, `warranties`, `impliedWarranties`) | Medium | Confirm against Allegro docs during implementation; adapter spec tests pin the shape. |
+| Cache row count grows unbounded (one per connection) | Very low | Connections are low-cardinality (≤ 100s). Primary-keyed by `connectionId`. If cardinality becomes a concern, add a TTL-driven cleanup job — out of scope here. |
+| Cache write transient failure masks successful Allegro fetch | Very low | Service logs a warning and returns the fresh value anyway (cache-aside semantics, §3.1.5). Next request either reads a fresh cache entry or refetches; no operator-visible error. Test #6 in the service spec pins this behaviour. |
+| `platformParams` forwarded unchecked from HTTP → Allegro | Low | The adapter reads only the keys it knows (`deliveryPolicyId`, `returnPolicyId`, `warrantyId`, `impliedWarrantyId`). Extra keys are ignored. DTO validation lets the object through as `Record<string, unknown>` intentionally — this is the documented escape hatch per #254. Soft size cap (§3.2.1) prevents operational abuse. |
+| `offerCreationRecordId` in the payload gets stale if the worker picks up a record whose row was manually deleted | Very low | `OfferCreationExecutionService.loadOrCreateRecord` throws `OfferCreationRecordNotFoundException` in that case; worker surfaces it as a job failure. Acceptable. |
+| 10-minute TTL too aggressive — operator rotates policies and can't see new ones for up to 10 min | Low | Add a follow-up if it becomes a real pain; for MVP, 10 min is the trade-off the issue specified. |
+| Integration test flakes because of Allegro HTTP mocking complexity | Low | Seller-policies integration test seeds cache directly and hits the endpoint (§3.3) — no Allegro HTTP in the loop. Unit tests cover the adapter + service logic. |
+
+---
+
+## 6. Architecture compliance check
+
+- ✅ Domain layer (`libs/core/src/integrations/domain/ports/`) gets one new optional method, no framework imports. `SellerPolicies` / `SellerPolicy` colocated in `integrations/domain/types/` with the port that returns them.
+- ✅ `SellerPoliciesService` depends only on port interfaces (`IIntegrationsService`, `MarketplacePort`, `SellerPoliciesCacheRepositoryPort`) — no concrete repo or adapter classes. Satisfies `docs/engineering-standards.md` → *Repository Ports Pattern* without exceptions.
+- ✅ Repository port `SellerPoliciesCacheRepositoryPort` defined in the domain layer; concrete repo in infrastructure implements it.
+- ✅ Types in separate `*.types.ts`.
+- ✅ Service interface in separate `*.service.interface.ts`.
+- ✅ Symbol token + `useExisting` + barrel export pattern for both service and cache port.
+- ✅ Controller injects via tokens only (`OFFER_CREATION_RECORD_REPOSITORY_TOKEN`, `INTEGRATIONS_SERVICE_TOKEN`, `SELLER_POLICIES_SERVICE_TOKEN`, existing `JOB_ENQUEUE_TOKEN`, existing `OFFER_MAPPING_REPOSITORY_TOKEN`).
+- ✅ No `any`, no `console.log`, no new `synchronize: true`.
+- ✅ Migration for schema change (per `docs/migrations.md`).
+- ✅ Tests mock ports, never concrete classes.
+- ✅ `@Roles('admin') + @ApiBearerAuth()` auth on the controller class — existing endpoints unchanged.
+
+---
+
+## 7. Rollout
+
+Single commit, single PR, closes both issues. Reversible via `git revert`. Migration ships with the PR; CI/CD runs migrations before app start per `docs/migrations.md`. No env var or config changes.
+
+**PR body** lists each endpoint + acceptance from both issues, deviations from spec (§2 above), and a test plan checklist (lint, type-check, test, test:integration, `migration:show` clean).
+
+Follow-ups to open after merge:
+- `marketplace.offer.pollCreationStatus` handler to advance Allegro `validating → active` (referenced by the warn log in `OfferCreationExecutionService`).
+- FE wizard (#261) — now unblocked.

--- a/libs/core/src/integrations/domain/ports/marketplace.port.ts
+++ b/libs/core/src/integrations/domain/ports/marketplace.port.ts
@@ -25,6 +25,7 @@ import {
 import type { UpdateOfferFieldsCommand } from '../types/marketplace-offer-update.types';
 import type { MarketplaceCategory } from '../types/marketplace-category.types';
 import type { CreateOfferCommand, CreateOfferResult } from '../types/marketplace-offer-create.types';
+import type { SellerPolicies } from '../types/seller-policies.types';
 
 export interface MarketplacePort {
   /**
@@ -93,5 +94,18 @@ export interface MarketplacePort {
    * validate asynchronously (Allegro), callers must poll to observe the final outcome.
    */
   createOffer?(cmd: CreateOfferCommand): Promise<CreateOfferResult>;
+
+  /**
+   * Return the seller-configured policies the marketplace requires when
+   * creating an offer (delivery, return, warranty, implied-warranty) — optional capability.
+   *
+   * Adapters that implement this fetch the operator's platform-native policies
+   * and map them to the neutral `SellerPolicies` shape. Callers (e.g. the FE
+   * offer-creation wizard) surface these in dropdowns so the operator can
+   * choose which policies to attach to the new offer via
+   * `CreateOfferCommand.overrides.platformParams`. Adapters that do not need
+   * policy IDs for offer creation omit this method.
+   */
+  fetchSellerPolicies?(): Promise<SellerPolicies>;
 }
 

--- a/libs/core/src/integrations/domain/types/seller-policies.types.ts
+++ b/libs/core/src/integrations/domain/types/seller-policies.types.ts
@@ -1,0 +1,29 @@
+/**
+ * Seller Policies Types
+ *
+ * Canonical shape returned by `MarketplacePort.fetchSellerPolicies?()` —
+ * the neutral view of seller-configured policies (delivery, return,
+ * warranty, implied-warranty) that an operator must reference when
+ * creating a marketplace offer. Allegro-specific IDs today; other
+ * marketplaces that need analogous policies would map their platform
+ * shape into the same structure.
+ *
+ * Framework-free. Interface-layer DTOs decorate these fields with
+ * Swagger annotations separately.
+ *
+ * @module libs/core/src/integrations/domain/types
+ */
+
+export interface SellerPolicy {
+  /** Platform-native policy id passed back through `CreateOfferCommand.overrides.platformParams`. */
+  id: string;
+  /** Operator-facing label for dropdown display. */
+  name: string;
+}
+
+export interface SellerPolicies {
+  deliveryPolicies: SellerPolicy[];
+  returnPolicies: SellerPolicy[];
+  warranties: SellerPolicy[];
+  impliedWarranties: SellerPolicy[];
+}

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -62,6 +62,7 @@ export type {
   CreateOfferResultStatus,
   CreateOfferValidationError,
 } from './domain/types/marketplace-offer-create.types';
+export type { SellerPolicy, SellerPolicies } from './domain/types/seller-policies.types';
 
 // Exceptions
 export { AdapterNotFoundException } from './domain/exceptions/adapter-not-found.exception';

--- a/libs/core/src/listings/application/interfaces/offer-creation-enqueue.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/offer-creation-enqueue.service.interface.ts
@@ -1,0 +1,45 @@
+/**
+ * Offer Creation Enqueue Service Interface
+ *
+ * Contract for the pre-enqueue half of the OL → marketplace offer creation
+ * flow. Mirrors `IOfferCreationExecutionService` (post-enqueue) so the HTTP
+ * endpoint and any future trigger (webhook, automation, batch) share one
+ * orchestration point.
+ *
+ * Responsibilities:
+ *   1. Resolve the Marketplace adapter for the connection (validates
+ *      connection existence, status, and capability support).
+ *   2. Verify the adapter implements `createOffer` — Marketplace is
+ *      supported, but not every marketplace adapter offers outbound create.
+ *   3. Create an `OfferCreationRecord` with status='pending' so the record
+ *      is visible before the worker picks up the job.
+ *   4. Enqueue the `marketplace.offer.create` job carrying the record id.
+ *
+ * Per `architecture-overview.md` §6, sync orchestration policies live in
+ * core application services — not in controllers, not in worker handlers.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import type {
+  EnqueueOfferCreationInput,
+  EnqueueOfferCreationResult,
+} from '../types/offer-creation-enqueue.types';
+
+export interface IOfferCreationEnqueueService {
+  /**
+   * Validate + pre-create record + enqueue job.
+   *
+   * Throws:
+   * - `ConnectionNotFoundException` (→ HTTP 404) when the connection does not exist.
+   * - `ConnectionDisabledException` (→ HTTP 409) when the connection is disabled.
+   * - `CapabilityNotSupportedException` (→ HTTP 422) when the connection's
+   *   adapter does not implement the `Marketplace` capability at all.
+   * - `UnprocessableEntityException` (→ HTTP 422) when the adapter supports
+   *   `Marketplace` but does not implement `createOffer`.
+   *
+   * The connection-resolution exceptions come from `IIntegrationsService`
+   * and are expected to propagate to the controller layer unchanged.
+   */
+  enqueueCreation(input: EnqueueOfferCreationInput): Promise<EnqueueOfferCreationResult>;
+}

--- a/libs/core/src/listings/application/interfaces/seller-policies.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/seller-policies.service.interface.ts
@@ -1,0 +1,37 @@
+/**
+ * Seller Policies Service Interface
+ *
+ * Contract for the core read service that returns marketplace seller-configured
+ * policies (delivery / return / warranty / implied-warranty). Implemented by
+ * `SellerPoliciesService`; consumed by the HTTP layer so the FE offer-creation
+ * wizard (#261) can populate policy dropdowns without re-hitting the
+ * marketplace API on every render.
+ *
+ * @module libs/core/src/listings/application/interfaces
+ */
+
+import type { SellerPolicies } from '@openlinker/core/integrations';
+
+export interface ISellerPoliciesService {
+  /**
+   * Return seller policies for a connection.
+   *
+   * Cache-aside: if the cache row is fresh (`fetchedAt > now - TTL`), returns
+   * it without calling the adapter. On a miss/stale, resolves the Marketplace
+   * adapter for the connection, invokes `fetchSellerPolicies()`, upserts the
+   * cache, and returns the fresh value.
+   *
+   * Throws:
+   * - `ConnectionNotFoundException` (→ HTTP 404) when the connection does not exist.
+   * - `ConnectionDisabledException` (→ HTTP 409) when the connection is disabled.
+   * - `CapabilityNotSupportedException` (→ HTTP 422) when the connection's
+   *   adapter does not implement `Marketplace` at all.
+   * - `UnprocessableEntityException` (→ HTTP 422) when the adapter supports
+   *   `Marketplace` but does not implement `fetchSellerPolicies`.
+   *
+   * A cache-write failure after a successful adapter call is logged and
+   * swallowed — the fresh policies are returned to the caller regardless
+   * (cache-aside resilience).
+   */
+  getSellerPolicies(connectionId: string): Promise<SellerPolicies>;
+}

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Offer Creation Enqueue Service Tests
+ *
+ * Covers the pre-enqueue orchestration: adapter capability check, record
+ * creation, payload construction, idempotency-key handling, and
+ * exception propagation for all connection-failure modes.
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+
+import { UnprocessableEntityException } from '@nestjs/common';
+
+import type {
+  IIntegrationsService,
+  MarketplacePort,
+} from '@openlinker/core/integrations';
+import type { JobEnqueuePort } from '@openlinker/core/sync';
+
+import { OfferCreationRecord } from '../../../domain/entities/offer-creation-record.entity';
+import { OfferCreationRecordRepositoryPort } from '../../../domain/ports/offer-creation-record-repository.port';
+import { OfferCreationEnqueueService } from '../offer-creation-enqueue.service';
+
+describe('OfferCreationEnqueueService', () => {
+  let service: OfferCreationEnqueueService;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let records: jest.Mocked<OfferCreationRecordRepositoryPort>;
+  let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+
+  const connectionId = 'conn-xyz';
+  const variantId = 'ol_variant_abc';
+
+  const mockRecord = new OfferCreationRecord(
+    'record-1',
+    variantId,
+    connectionId,
+    null,
+    'pending',
+    null,
+    false,
+    new Date('2026-04-21T10:00:00Z'),
+    new Date('2026-04-21T10:00:00Z'),
+  );
+
+  const adapterWith = (createOffer: jest.Mock | undefined): MarketplacePort =>
+    ({
+      ...(createOffer ? { createOffer } : {}),
+    } as unknown as MarketplacePort);
+
+  beforeEach(() => {
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      resolveAdapterMetadata: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    records = {
+      create: jest.fn().mockResolvedValue(mockRecord),
+      findById: jest.fn(),
+      findLatestByVariantAndConnection: jest.fn(),
+      updateStatus: jest.fn(),
+      updateExternalOfferId: jest.fn(),
+      updateExternalIdAndStatus: jest.fn(),
+    };
+
+    jobEnqueue = {
+      enqueueJob: jest.fn().mockResolvedValue({ jobId: 'job-1', isExisting: false }),
+    } as unknown as jest.Mocked<JobEnqueuePort>;
+
+    service = new OfferCreationEnqueueService(integrations, records, jobEnqueue);
+  });
+
+  it('happy path: creates a record then enqueues a job with offerCreationRecordId', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(jest.fn()));
+
+    const result = await service.enqueueCreation({
+      internalVariantId: variantId,
+      connectionId,
+      stock: 5,
+      publishImmediately: false,
+      price: { amount: 99.99, currency: 'PLN' },
+    });
+
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(connectionId, 'Marketplace');
+    expect(records.create).toHaveBeenCalledWith({
+      internalVariantId: variantId,
+      connectionId,
+      externalOfferId: null,
+      status: 'pending',
+      errors: null,
+      publishImmediately: false,
+    });
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith({
+      jobType: 'marketplace.offer.create',
+      connectionId,
+      idempotencyKey: 'offer-create:record-1',
+      payload: expect.objectContaining({
+        schemaVersion: 1,
+        internalVariantId: variantId,
+        stock: 5,
+        publishImmediately: false,
+        offerCreationRecordId: 'record-1',
+        price: { amount: 99.99, currency: 'PLN' },
+      }),
+    });
+    expect(result).toEqual({ jobId: 'job-1', offerCreationRecord: mockRecord });
+  });
+
+  it('uses the caller-supplied idempotency key when provided', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(jest.fn()));
+
+    await service.enqueueCreation({
+      internalVariantId: variantId,
+      connectionId,
+      stock: 1,
+      publishImmediately: true,
+      idempotencyKey: 'client-key-42',
+    });
+
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: 'client-key-42' }),
+    );
+  });
+
+  it('throws UnprocessableEntityException without touching repo or queue when adapter lacks createOffer', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(undefined));
+
+    await expect(
+      service.enqueueCreation({
+        internalVariantId: variantId,
+        connectionId,
+        stock: 1,
+        publishImmediately: false,
+      }),
+    ).rejects.toThrow(UnprocessableEntityException);
+
+    expect(records.create).not.toHaveBeenCalled();
+    expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+  });
+
+  it('propagates exceptions from getCapabilityAdapter (e.g. ConnectionDisabledException)', async () => {
+    integrations.getCapabilityAdapter.mockRejectedValue(new Error('ConnectionDisabledException'));
+
+    await expect(
+      service.enqueueCreation({
+        internalVariantId: variantId,
+        connectionId,
+        stock: 1,
+        publishImmediately: false,
+      }),
+    ).rejects.toThrow('ConnectionDisabledException');
+
+    expect(records.create).not.toHaveBeenCalled();
+    expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+  });
+
+  it('omits price/overrides from the payload when not supplied', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(jest.fn()));
+
+    await service.enqueueCreation({
+      internalVariantId: variantId,
+      connectionId,
+      stock: 1,
+      publishImmediately: false,
+    });
+
+    const payload = jobEnqueue.enqueueJob.mock.calls[0][0].payload;
+    expect(payload).not.toHaveProperty('price');
+    expect(payload).not.toHaveProperty('overrides');
+  });
+
+  it('forwards overrides unchanged when supplied', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(jest.fn()));
+    const overrides = {
+      title: 'Custom title',
+      platformParams: { deliveryPolicyId: 'd-1' },
+    };
+
+    await service.enqueueCreation({
+      internalVariantId: variantId,
+      connectionId,
+      stock: 1,
+      publishImmediately: false,
+      overrides,
+    });
+
+    const payload = jobEnqueue.enqueueJob.mock.calls[0][0].payload;
+    expect(payload.overrides).toEqual(overrides);
+  });
+});

--- a/libs/core/src/listings/application/services/__tests__/seller-policies.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/seller-policies.service.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Seller Policies Service Tests
+ *
+ * Unit tests for cache hit / miss / stale behaviour, capability gating,
+ * and cache-aside resilience (upsert failure does not block the response).
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+
+import { UnprocessableEntityException } from '@nestjs/common';
+
+import type {
+  IIntegrationsService,
+  MarketplacePort,
+  SellerPolicies,
+} from '@openlinker/core/integrations';
+
+import type {
+  CachedSellerPolicies,
+  SellerPoliciesCacheRepositoryPort,
+} from '../../../domain/ports/seller-policies-cache-repository.port';
+import { SellerPoliciesService } from '../seller-policies.service';
+
+describe('SellerPoliciesService', () => {
+  let service: SellerPoliciesService;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let cache: jest.Mocked<SellerPoliciesCacheRepositoryPort>;
+
+  const policies: SellerPolicies = {
+    deliveryPolicies: [{ id: 'd1', name: 'Standard' }],
+    returnPolicies: [{ id: 'r1', name: '14-day' }],
+    warranties: [{ id: 'w1', name: '1-year' }],
+    impliedWarranties: [{ id: 'iw1', name: 'Consumer' }],
+  };
+
+  const connectionId = 'conn-abc';
+
+  const adapterWith = (fetchSellerPolicies: jest.Mock | undefined): MarketplacePort => ({
+    ...(fetchSellerPolicies ? { fetchSellerPolicies } : {}),
+  } as unknown as MarketplacePort);
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-21T12:00:00.000Z'));
+
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      resolveAdapterMetadata: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    cache = {
+      findByConnectionId: jest.fn(),
+      upsert: jest.fn().mockResolvedValue(undefined),
+    };
+
+    service = new SellerPoliciesService(integrations, cache);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns cached policies when the cache row is fresh (<10 min old)', async () => {
+    const fetchedAt = new Date('2026-04-21T11:55:00.000Z'); // 5 min old
+    const cached: CachedSellerPolicies = { connectionId, policies, fetchedAt };
+    cache.findByConnectionId.mockResolvedValue(cached);
+
+    const result = await service.getSellerPolicies(connectionId);
+
+    expect(result).toBe(policies);
+    expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    expect(cache.upsert).not.toHaveBeenCalled();
+  });
+
+  it('refetches when the cache row is stale (>10 min old)', async () => {
+    const fetchedAt = new Date('2026-04-21T11:49:00.000Z'); // 11 min old
+    cache.findByConnectionId.mockResolvedValue({ connectionId, policies, fetchedAt });
+    const fetchSellerPolicies = jest.fn().mockResolvedValue(policies);
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(fetchSellerPolicies));
+
+    const result = await service.getSellerPolicies(connectionId);
+
+    expect(result).toBe(policies);
+    expect(fetchSellerPolicies).toHaveBeenCalledTimes(1);
+    expect(cache.upsert).toHaveBeenCalledWith({
+      connectionId,
+      policies,
+      fetchedAt: new Date('2026-04-21T12:00:00.000Z'),
+    });
+  });
+
+  it('fetches + caches on an empty cache (no row)', async () => {
+    cache.findByConnectionId.mockResolvedValue(null);
+    const fetchSellerPolicies = jest.fn().mockResolvedValue(policies);
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(fetchSellerPolicies));
+
+    const result = await service.getSellerPolicies(connectionId);
+
+    expect(result).toBe(policies);
+    expect(fetchSellerPolicies).toHaveBeenCalledTimes(1);
+    expect(cache.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws UnprocessableEntityException when the adapter does not implement fetchSellerPolicies', async () => {
+    cache.findByConnectionId.mockResolvedValue(null);
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(undefined));
+
+    await expect(service.getSellerPolicies(connectionId)).rejects.toThrow(
+      UnprocessableEntityException,
+    );
+    expect(cache.upsert).not.toHaveBeenCalled();
+  });
+
+  it('propagates exceptions from getCapabilityAdapter (connection not found / disabled)', async () => {
+    cache.findByConnectionId.mockResolvedValue(null);
+    integrations.getCapabilityAdapter.mockRejectedValue(new Error('ConnectionNotFoundException'));
+
+    await expect(service.getSellerPolicies(connectionId)).rejects.toThrow(
+      'ConnectionNotFoundException',
+    );
+    expect(cache.upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns fresh policies even when the cache upsert fails', async () => {
+    cache.findByConnectionId.mockResolvedValue(null);
+    const fetchSellerPolicies = jest.fn().mockResolvedValue(policies);
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(fetchSellerPolicies));
+    cache.upsert.mockRejectedValue(new Error('db transient'));
+
+    const result = await service.getSellerPolicies(connectionId);
+
+    expect(result).toBe(policies);
+    // The fetch happened and completed; the upsert error is swallowed
+    expect(fetchSellerPolicies).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
@@ -1,0 +1,102 @@
+/**
+ * Offer Creation Enqueue Service
+ *
+ * Pre-enqueue orchestration for outbound offer creation: resolves adapter,
+ * checks `createOffer` support, pre-creates the `OfferCreationRecord`, and
+ * enqueues the `marketplace.offer.create` sync job. Used by the HTTP
+ * controller (#259) so the controller stays thin.
+ *
+ * Post-enqueue orchestration (adapter call + mapping persistence + status
+ * update) lives in the sibling `OfferCreationExecutionService`, invoked by
+ * the worker handler.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IOfferCreationEnqueueService}
+ * @see {@link IOfferCreationEnqueueService} for the service contract
+ * @see {@link OfferCreationExecutionService} for the post-enqueue half
+ */
+
+import { Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
+
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  MarketplacePort,
+} from '@openlinker/core/integrations';
+import {
+  JobEnqueuePort,
+  JOB_ENQUEUE_TOKEN,
+  type MarketplaceOfferCreatePayloadV1,
+} from '@openlinker/core/sync';
+
+import { OfferCreationRecordRepositoryPort } from '../../domain/ports/offer-creation-record-repository.port';
+import { OFFER_CREATION_RECORD_REPOSITORY_TOKEN } from '../../listings.tokens';
+import { IOfferCreationEnqueueService } from '../interfaces/offer-creation-enqueue.service.interface';
+import type {
+  EnqueueOfferCreationInput,
+  EnqueueOfferCreationResult,
+} from '../types/offer-creation-enqueue.types';
+
+@Injectable()
+export class OfferCreationEnqueueService implements IOfferCreationEnqueueService {
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(OFFER_CREATION_RECORD_REPOSITORY_TOKEN)
+    private readonly offerCreationRecords: OfferCreationRecordRepositoryPort,
+    @Inject(JOB_ENQUEUE_TOKEN)
+    private readonly jobEnqueue: JobEnqueuePort,
+  ) {}
+
+  async enqueueCreation(input: EnqueueOfferCreationInput): Promise<EnqueueOfferCreationResult> {
+    // 1. Resolve the adapter. getCapabilityAdapter handles the connection
+    //    existence / status / capability cascade and surfaces the right
+    //    exception for each failure mode.
+    const adapter = await this.integrationsService.getCapabilityAdapter<MarketplacePort>(
+      input.connectionId,
+      'Marketplace',
+    );
+
+    // 2. `Marketplace` is supported, but `createOffer` is an optional
+    //    sub-capability. Distinct 422 so clients can distinguish
+    //    "unknown connection" from "this adapter reads but can't create".
+    if (!adapter.createOffer) {
+      throw new UnprocessableEntityException(
+        `Adapter for connection ${input.connectionId} does not support offer creation`,
+      );
+    }
+
+    // 3. Pre-create the record so the HTTP response carries an id clients
+    //    can poll immediately.
+    const record = await this.offerCreationRecords.create({
+      internalVariantId: input.internalVariantId,
+      connectionId: input.connectionId,
+      externalOfferId: null,
+      status: 'pending',
+      errors: null,
+      publishImmediately: input.publishImmediately,
+    });
+
+    // 4. Enqueue. Default idempotency key is per-call-unique (the fresh
+    //    record id) — a client that wants cross-retry dedupe passes
+    //    `input.idempotencyKey`.
+    const payload = {
+      schemaVersion: 1 as const,
+      internalVariantId: input.internalVariantId,
+      stock: input.stock,
+      publishImmediately: input.publishImmediately,
+      offerCreationRecordId: record.id,
+      ...(input.price !== undefined && { price: input.price }),
+      ...(input.overrides !== undefined && { overrides: input.overrides }),
+    } satisfies MarketplaceOfferCreatePayloadV1;
+
+    const { jobId } = await this.jobEnqueue.enqueueJob({
+      jobType: 'marketplace.offer.create',
+      connectionId: input.connectionId,
+      idempotencyKey: input.idempotencyKey ?? `offer-create:${record.id}`,
+      payload,
+    });
+
+    return { jobId, offerCreationRecord: record };
+  }
+}

--- a/libs/core/src/listings/application/services/seller-policies.service.ts
+++ b/libs/core/src/listings/application/services/seller-policies.service.ts
@@ -1,0 +1,85 @@
+/**
+ * Seller Policies Service
+ *
+ * Cache-aside read service for marketplace seller policies. Memoises the
+ * adapter's `fetchSellerPolicies()` result in a DB-backed cache table
+ * (`seller_policies_cache`) with a 10-minute TTL so repeated wizard loads
+ * do not hammer the marketplace API.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {ISellerPoliciesService}
+ * @see {@link ISellerPoliciesService} for the service contract
+ * @see {@link SellerPoliciesCacheRepositoryPort} for the cache persistence port
+ */
+
+import { Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
+
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  MarketplacePort,
+} from '@openlinker/core/integrations';
+import type { SellerPolicies } from '@openlinker/core/integrations';
+import { Logger } from '@openlinker/shared/logging';
+
+import type { SellerPoliciesCacheRepositoryPort } from '../../domain/ports/seller-policies-cache-repository.port';
+import {
+  SELLER_POLICIES_CACHE_TOKEN,
+} from '../../listings.tokens';
+import { ISellerPoliciesService } from '../interfaces/seller-policies.service.interface';
+
+const SELLER_POLICIES_TTL_MS = 10 * 60 * 1000;
+
+@Injectable()
+export class SellerPoliciesService implements ISellerPoliciesService {
+  private readonly logger = new Logger(SellerPoliciesService.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(SELLER_POLICIES_CACHE_TOKEN)
+    private readonly cache: SellerPoliciesCacheRepositoryPort,
+  ) {}
+
+  async getSellerPolicies(connectionId: string): Promise<SellerPolicies> {
+    const cached = await this.cache.findByConnectionId(connectionId);
+    if (cached && this.isFresh(cached.fetchedAt)) {
+      return cached.policies;
+    }
+
+    // Throws ConnectionNotFoundException (404) / ConnectionDisabledException (409) /
+    // CapabilityNotSupportedException (422) for upstream connection-level issues.
+    const adapter = await this.integrationsService.getCapabilityAdapter<MarketplacePort>(
+      connectionId,
+      'Marketplace',
+    );
+
+    if (!adapter.fetchSellerPolicies) {
+      throw new UnprocessableEntityException(
+        `Adapter for connection ${connectionId} does not support seller-policy listing`,
+      );
+    }
+
+    const policies = await adapter.fetchSellerPolicies();
+    try {
+      await this.cache.upsert({
+        connectionId,
+        policies,
+        fetchedAt: new Date(),
+      });
+    } catch (error) {
+      // Cache-aside resilience: a transient cache-write failure must not mask
+      // a successful adapter fetch. Log and return the fresh value.
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `seller_policies_cache_upsert_failed connectionId=${connectionId} reason=${message}`,
+      );
+    }
+
+    return policies;
+  }
+
+  private isFresh(fetchedAt: Date): boolean {
+    return Date.now() - fetchedAt.getTime() < SELLER_POLICIES_TTL_MS;
+  }
+}

--- a/libs/core/src/listings/application/types/offer-creation-enqueue.types.ts
+++ b/libs/core/src/listings/application/types/offer-creation-enqueue.types.ts
@@ -1,0 +1,43 @@
+/**
+ * Offer Creation Enqueue Types
+ *
+ * Input / result contracts for the core pre-enqueue orchestration that sits
+ * between the HTTP layer and the sync job queue: validate connection +
+ * capability, pre-create the `OfferCreationRecord`, enqueue the
+ * `marketplace.offer.create` job.
+ *
+ * Symmetric with `offer-creation-execution.types.ts` (the post-enqueue
+ * worker-side orchestration) so both halves of the create flow have
+ * dedicated application-service contracts — per `architecture-overview.md`
+ * §6 (sync orchestration lives in core, not in workers or controllers).
+ *
+ * @module libs/core/src/listings/application/types
+ */
+
+import type { CreateOfferOverrides } from '@openlinker/core/integrations';
+
+import type { OfferCreationRecord } from '../../domain/entities/offer-creation-record.entity';
+
+export interface EnqueueOfferCreationInput {
+  /** OL internal variant id being listed. */
+  internalVariantId: string;
+  /** Target marketplace connection id. */
+  connectionId: string;
+  /** Offered stock quantity. */
+  stock: number;
+  /** Publish immediately after creation (false = create as draft). */
+  publishImmediately: boolean;
+  /** Optional explicit price; when omitted the builder falls back to master product. */
+  price?: { amount: number; currency: string };
+  /** Optional overrides; the builder strips null/undefined on the worker side. */
+  overrides?: CreateOfferOverrides;
+  /** Caller-supplied idempotency key; defaults to `offer-create:{record.id}` (per-call-unique). */
+  idempotencyKey?: string;
+}
+
+export interface EnqueueOfferCreationResult {
+  /** Redis Streams message id of the enqueued job. */
+  jobId: string;
+  /** Pre-created record visible before the worker runs. */
+  offerCreationRecord: OfferCreationRecord;
+}

--- a/libs/core/src/listings/domain/ports/seller-policies-cache-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/seller-policies-cache-repository.port.ts
@@ -1,0 +1,39 @@
+/**
+ * Seller Policies Cache Repository Port
+ *
+ * Persistence contract for cached marketplace seller policies (delivery /
+ * return / warranty / implied-warranty). The cache is keyed by `connectionId`
+ * — one row per connection — and is consulted before the adapter's live
+ * `fetchSellerPolicies` call to absorb repeated wizard loads within the TTL.
+ *
+ * Implemented in the listings infrastructure layer; application services
+ * depend on this port (not the concrete repo) per `docs/engineering-standards.md`
+ * → Repository Ports Pattern.
+ *
+ * @module libs/core/src/listings/domain/ports
+ */
+
+import { SellerPolicies } from '@openlinker/core/integrations';
+
+/**
+ * Cached seller-policies entry. `fetchedAt` is the canonical TTL reference —
+ * callers compare against `now - TTL` to decide whether to refresh.
+ */
+export interface CachedSellerPolicies {
+  connectionId: string;
+  policies: SellerPolicies;
+  fetchedAt: Date;
+}
+
+export interface SellerPoliciesCacheRepositoryPort {
+  /**
+   * Look up the cache row for a connection. Returns null when no row exists.
+   */
+  findByConnectionId(connectionId: string): Promise<CachedSellerPolicies | null>;
+
+  /**
+   * Write a cache entry. Insert-or-update semantics on `connectionId` —
+   * a stale row for the same connection is overwritten.
+   */
+  upsert(entry: CachedSellerPolicies): Promise<void>;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -13,6 +13,9 @@ export {
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
+  OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
+  SELLER_POLICIES_SERVICE_TOKEN,
+  SELLER_POLICIES_CACHE_TOKEN,
 } from './listings.tokens';
 export { OfferLinkingService } from './application/services/offer-linking.service';
 export { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
@@ -67,3 +70,15 @@ export type {
   OfferBuilderValidationIssue,
 } from './domain/exceptions/offer-builder-validation.exception';
 export { MasterCatalogConnectionNotConfiguredException } from './domain/exceptions/master-catalog-connection-not-configured.exception';
+export { SellerPoliciesService } from './application/services/seller-policies.service';
+export type { ISellerPoliciesService } from './application/interfaces/seller-policies.service.interface';
+export type {
+  SellerPoliciesCacheRepositoryPort,
+  CachedSellerPolicies,
+} from './domain/ports/seller-policies-cache-repository.port';
+export { OfferCreationEnqueueService } from './application/services/offer-creation-enqueue.service';
+export type { IOfferCreationEnqueueService } from './application/interfaces/offer-creation-enqueue.service.interface';
+export type {
+  EnqueueOfferCreationInput,
+  EnqueueOfferCreationResult,
+} from './application/types/offer-creation-enqueue.types';

--- a/libs/core/src/listings/infrastructure/persistence/entities/seller-policies-cache.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/seller-policies-cache.orm-entity.ts
@@ -1,0 +1,37 @@
+/**
+ * Seller Policies Cache ORM Entity
+ *
+ * TypeORM entity for `seller_policies_cache` — one row per connection, keyed
+ * by `connectionId`. Stores the full `SellerPolicies` document as JSONB and
+ * the `fetchedAt` timestamp used for TTL checks.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/entities
+ * @see {@link SellerPoliciesCacheRepositoryPort} for the domain port
+ */
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import type { SellerPolicies } from '@openlinker/core/integrations';
+
+@Entity('seller_policies_cache')
+export class SellerPoliciesCacheOrmEntity {
+  @PrimaryColumn({ type: 'uuid' })
+  connectionId!: string;
+
+  @Column({ type: 'jsonb' })
+  policies!: SellerPolicies;
+
+  @Column({ type: 'timestamptz' })
+  fetchedAt!: Date;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/listings/infrastructure/persistence/repositories/seller-policies-cache.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/seller-policies-cache.repository.ts
@@ -1,0 +1,53 @@
+/**
+ * Seller Policies Cache Repository
+ *
+ * TypeORM implementation of `SellerPoliciesCacheRepositoryPort`. Handles all
+ * ORM ↔ domain mapping privately; callers receive plain `CachedSellerPolicies`
+ * values only.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/repositories
+ * @implements {SellerPoliciesCacheRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import type {
+  CachedSellerPolicies,
+  SellerPoliciesCacheRepositoryPort,
+} from '../../../domain/ports/seller-policies-cache-repository.port';
+import { SellerPoliciesCacheOrmEntity } from '../entities/seller-policies-cache.orm-entity';
+
+@Injectable()
+export class SellerPoliciesCacheRepository implements SellerPoliciesCacheRepositoryPort {
+  constructor(
+    @InjectRepository(SellerPoliciesCacheOrmEntity)
+    private readonly repository: Repository<SellerPoliciesCacheOrmEntity>,
+  ) {}
+
+  async findByConnectionId(connectionId: string): Promise<CachedSellerPolicies | null> {
+    const row = await this.repository.findOne({ where: { connectionId } });
+    return row ? this.toDomain(row) : null;
+  }
+
+  async upsert(entry: CachedSellerPolicies): Promise<void> {
+    // Using TypeORM's `upsert` helper keyed on the primary column so concurrent
+    // writers for the same connection collapse into a single row.
+    await this.repository.upsert(
+      {
+        connectionId: entry.connectionId,
+        policies: entry.policies,
+        fetchedAt: entry.fetchedAt,
+      },
+      { conflictPaths: ['connectionId'] },
+    );
+  }
+
+  private toDomain(row: SellerPoliciesCacheOrmEntity): CachedSellerPolicies {
+    return {
+      connectionId: row.connectionId,
+      policies: row.policies,
+      fetchedAt: row.fetchedAt,
+    };
+  }
+}

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -11,6 +11,7 @@ import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule, IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping';
 import { ProductsModule } from '@openlinker/core/products';
 import { MappingsModule } from '@openlinker/core/mappings';
+import { SyncModule } from '@openlinker/core/sync';
 import { OfferLinkingService } from './application/services/offer-linking.service';
 import { OfferMappingSyncService } from './application/services/offer-mapping-sync.service';
 import { CategoryResolutionService } from './application/services/category-resolution.service';
@@ -19,6 +20,10 @@ import { OfferCreationRecordOrmEntity } from './infrastructure/persistence/entit
 import { OfferCreationRecordRepository } from './infrastructure/persistence/repositories/offer-creation-record.repository';
 import { OfferBuilderService } from './application/services/offer-builder.service';
 import { OfferCreationExecutionService } from './application/services/offer-creation-execution.service';
+import { SellerPoliciesCacheOrmEntity } from './infrastructure/persistence/entities/seller-policies-cache.orm-entity';
+import { SellerPoliciesCacheRepository } from './infrastructure/persistence/repositories/seller-policies-cache.repository';
+import { SellerPoliciesService } from './application/services/seller-policies.service';
+import { OfferCreationEnqueueService } from './application/services/offer-creation-enqueue.service';
 import {
   OFFER_LINKING_SERVICE_TOKEN,
   OFFER_MAPPING_SYNC_SERVICE_TOKEN,
@@ -27,6 +32,9 @@ import {
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
+  OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
+  SELLER_POLICIES_SERVICE_TOKEN,
+  SELLER_POLICIES_CACHE_TOKEN,
 } from './listings.tokens';
 
 // Re-export tokens for convenience
@@ -38,15 +46,23 @@ export {
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
+  OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
+  SELLER_POLICIES_SERVICE_TOKEN,
+  SELLER_POLICIES_CACHE_TOKEN,
 } from './listings.tokens';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([IdentifierMappingOrmEntity, OfferCreationRecordOrmEntity]),
+    TypeOrmModule.forFeature([
+      IdentifierMappingOrmEntity,
+      OfferCreationRecordOrmEntity,
+      SellerPoliciesCacheOrmEntity,
+    ]),
     IntegrationsModule,
     IdentifierMappingModule,
     ProductsModule,
     MappingsModule,
+    SyncModule,
   ],
   providers: [
     OfferLinkingService,
@@ -56,6 +72,9 @@ export {
     OfferCreationRecordRepository,
     OfferBuilderService,
     OfferCreationExecutionService,
+    OfferCreationEnqueueService,
+    SellerPoliciesCacheRepository,
+    SellerPoliciesService,
     {
       provide: OFFER_LINKING_SERVICE_TOKEN,
       useExisting: OfferLinkingService,
@@ -84,6 +103,18 @@ export {
       provide: OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
       useExisting: OfferCreationExecutionService,
     },
+    {
+      provide: OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
+      useExisting: OfferCreationEnqueueService,
+    },
+    {
+      provide: SELLER_POLICIES_CACHE_TOKEN,
+      useExisting: SellerPoliciesCacheRepository,
+    },
+    {
+      provide: SELLER_POLICIES_SERVICE_TOKEN,
+      useExisting: SellerPoliciesService,
+    },
   ],
   exports: [
     OFFER_LINKING_SERVICE_TOKEN,
@@ -93,6 +124,9 @@ export {
     CATEGORY_RESOLUTION_SERVICE_TOKEN,
     OFFER_BUILDER_SERVICE_TOKEN,
     OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
+    OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
+    SELLER_POLICIES_SERVICE_TOKEN,
+    SELLER_POLICIES_CACHE_TOKEN,
   ],
 })
 export class ListingsModule {}

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -11,3 +11,6 @@ export const OFFER_CREATION_RECORD_REPOSITORY_TOKEN = Symbol('OfferCreationRecor
 export const CATEGORY_RESOLUTION_SERVICE_TOKEN = Symbol('ICategoryResolutionService');
 export const OFFER_BUILDER_SERVICE_TOKEN = Symbol('IOfferBuilderService');
 export const OFFER_CREATION_EXECUTION_SERVICE_TOKEN = Symbol('IOfferCreationExecutionService');
+export const OFFER_CREATION_ENQUEUE_SERVICE_TOKEN = Symbol('IOfferCreationEnqueueService');
+export const SELLER_POLICIES_SERVICE_TOKEN = Symbol('ISellerPoliciesService');
+export const SELLER_POLICIES_CACHE_TOKEN = Symbol('SellerPoliciesCacheRepositoryPort');

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -355,3 +355,43 @@ export interface AllegroProductOfferCreateResponse {
   external?: { id?: string };
 }
 
+/**
+ * Seller-configured policy entry returned by the four Allegro after-sales /
+ * delivery endpoints. All four endpoints return entries sharing an `id` +
+ * `name` shape (plus platform-specific metadata the adapter does not need).
+ */
+export interface AllegroSellerPolicyEntry {
+  id: string;
+  name: string;
+}
+
+/**
+ * Response from `GET /sale/delivery-settings`.
+ *
+ * Allegro wraps the policy list under the `deliverySettings` key.
+ */
+export interface AllegroDeliverySettingsResponse {
+  deliverySettings: AllegroSellerPolicyEntry[];
+}
+
+/**
+ * Response from `GET /after-sales-service-conditions/return-policies`.
+ */
+export interface AllegroReturnPoliciesResponse {
+  returnPolicies: AllegroSellerPolicyEntry[];
+}
+
+/**
+ * Response from `GET /after-sales-service-conditions/warranties`.
+ */
+export interface AllegroWarrantiesResponse {
+  warranties: AllegroSellerPolicyEntry[];
+}
+
+/**
+ * Response from `GET /after-sales-service-conditions/implied-warranties`.
+ */
+export interface AllegroImpliedWarrantiesResponse {
+  impliedWarranties: AllegroSellerPolicyEntry[];
+}
+

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-marketplace.adapter.spec.ts
@@ -983,5 +983,88 @@ describe('AllegroMarketplaceAdapter', () => {
       expect(body.external).toEqual({ id: 'ol_variant_abc' });
     });
   });
+
+  describe('fetchSellerPolicies', () => {
+    function makeResponse<T>(data: T): { data: T; status: number; headers: Record<string, string> } {
+      return { data, status: 200, headers: {} };
+    }
+
+    it('issues 4 parallel GETs and maps the envelopes to the neutral SellerPolicies shape', async () => {
+      httpClient.get
+        .mockResolvedValueOnce(
+          makeResponse({
+            deliverySettings: [
+              { id: 'd1', name: 'Standard' },
+              { id: 'd2', name: 'Express' },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeResponse({
+            returnPolicies: [{ id: 'r1', name: '14-day returns' }],
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeResponse({
+            warranties: [{ id: 'w1', name: '1-year manufacturer' }],
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeResponse({
+            impliedWarranties: [{ id: 'iw1', name: 'Consumer rights' }],
+          }),
+        );
+
+      const result = await adapter.fetchSellerPolicies();
+
+      expect(result).toEqual({
+        deliveryPolicies: [
+          { id: 'd1', name: 'Standard' },
+          { id: 'd2', name: 'Express' },
+        ],
+        returnPolicies: [{ id: 'r1', name: '14-day returns' }],
+        warranties: [{ id: 'w1', name: '1-year manufacturer' }],
+        impliedWarranties: [{ id: 'iw1', name: 'Consumer rights' }],
+      });
+
+      expect(httpClient.get).toHaveBeenCalledTimes(4);
+      const calledPaths = httpClient.get.mock.calls.map((args) => args[0]).sort();
+      expect(calledPaths).toEqual(
+        [
+          '/after-sales-service-conditions/implied-warranties',
+          '/after-sales-service-conditions/return-policies',
+          '/after-sales-service-conditions/warranties',
+          '/sale/delivery-settings',
+        ].sort(),
+      );
+    });
+
+    it('returns empty arrays when Allegro returns no policies', async () => {
+      httpClient.get
+        .mockResolvedValueOnce(makeResponse({ deliverySettings: [] }))
+        .mockResolvedValueOnce(makeResponse({ returnPolicies: [] }))
+        .mockResolvedValueOnce(makeResponse({ warranties: [] }))
+        .mockResolvedValueOnce(makeResponse({ impliedWarranties: [] }));
+
+      const result = await adapter.fetchSellerPolicies();
+
+      expect(result).toEqual({
+        deliveryPolicies: [],
+        returnPolicies: [],
+        warranties: [],
+        impliedWarranties: [],
+      });
+    });
+
+    it('propagates AllegroApiException when any single endpoint fails', async () => {
+      httpClient.get
+        .mockResolvedValueOnce(makeResponse({ deliverySettings: [] }))
+        .mockRejectedValueOnce(new AllegroApiException('rate limit', 429))
+        .mockResolvedValueOnce(makeResponse({ warranties: [] }))
+        .mockResolvedValueOnce(makeResponse({ impliedWarranties: [] }));
+
+      await expect(adapter.fetchSellerPolicies()).rejects.toBeInstanceOf(AllegroApiException);
+    });
+  });
 });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-marketplace.adapter.ts
@@ -25,6 +25,7 @@ import type {
   CreateOfferResultStatus,
   CreateOfferValidationError,
   MarketplaceCategory,
+  SellerPolicies,
 } from '@openlinker/core/integrations';
 import type { IncomingOrder } from '@openlinker/core/orders';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
@@ -46,6 +47,11 @@ import {
   AllegroProductOfferCreateRequest,
   AllegroProductOfferCreateResponse,
   AllegroValidationError,
+  AllegroDeliverySettingsResponse,
+  AllegroReturnPoliciesResponse,
+  AllegroWarrantiesResponse,
+  AllegroImpliedWarrantiesResponse,
+  AllegroSellerPolicyEntry,
 } from '../../domain/types/allegro-api.types';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
 import { Logger } from '@openlinker/shared/logging';
@@ -822,6 +828,38 @@ export class AllegroMarketplaceAdapter implements MarketplacePort {
       result.validationErrors = validationErrors;
     }
     return result;
+  }
+
+  /**
+   * Fetch seller-configured Allegro policies (delivery + return + warranty +
+   * implied-warranty). All four Allegro endpoints are independent; issued in
+   * parallel via Promise.all so total latency tracks the slowest call. Any
+   * non-2xx propagates as `AllegroApiException` from the HTTP client — the
+   * calling service surfaces that to the HTTP layer as a 5xx.
+   */
+  async fetchSellerPolicies(): Promise<SellerPolicies> {
+    this.logger.debug(
+      `Fetching Allegro seller policies (connection: ${this.connectionId})`,
+    );
+
+    const [delivery, returns, warranties, impliedWarranties] = await Promise.all([
+      this.httpClient.get<AllegroDeliverySettingsResponse>('/sale/delivery-settings'),
+      this.httpClient.get<AllegroReturnPoliciesResponse>('/after-sales-service-conditions/return-policies'),
+      this.httpClient.get<AllegroWarrantiesResponse>('/after-sales-service-conditions/warranties'),
+      this.httpClient.get<AllegroImpliedWarrantiesResponse>('/after-sales-service-conditions/implied-warranties'),
+    ]);
+
+    const mapEntry = (p: AllegroSellerPolicyEntry): { id: string; name: string } => ({
+      id: p.id,
+      name: p.name,
+    });
+
+    return {
+      deliveryPolicies: (delivery.data.deliverySettings ?? []).map(mapEntry),
+      returnPolicies: (returns.data.returnPolicies ?? []).map(mapEntry),
+      warranties: (warranties.data.warranties ?? []).map(mapEntry),
+      impliedWarranties: (impliedWarranties.data.impliedWarranties ?? []).map(mapEntry),
+    };
   }
 
   private buildCreateOfferRequest(cmd: CreateOfferCommand): AllegroProductOfferCreateRequest {


### PR DESCRIPTION
## Summary

Unblocks the FE offer-creation wizard (#261). Three new endpoints on `ListingsController`, a new `seller_policies_cache` table, one new core application service per pre- and post-enqueue half of the create flow.

### #260 — Seller policies

- `SellerPolicy` / `SellerPolicies` types colocated in `libs/core/src/integrations/domain/types/` with the `MarketplacePort` that returns them; optional `fetchSellerPolicies?()` added to the port.
- Allegro adapter implementation: four parallel GETs (`/sale/delivery-settings`, `/after-sales-service-conditions/{return-policies,warranties,implied-warranties}`).
- **DB-backed cache** (`seller_policies_cache`, `connectionId`-keyed, 10-min TTL) — the codebase has no Redis cache abstraction, so this follows the existing `CategoriesCacheService` pattern rather than the issue's "Redis" wording. Cache behind `SellerPoliciesCacheRepositoryPort` per engineering-standards Repository Ports Pattern.
- `SellerPoliciesService` is cache-aside and resilient to transient upsert failures (logs + returns fresh value).
- `GET /listings/connections/:connectionId/seller-policies`.

### #259 — Create-offer endpoint

- **`OfferCreationEnqueueService`** in core owns pre-enqueue orchestration: adapter resolution, `Marketplace` capability check, explicit `createOffer`-present check, `OfferCreationRecord` creation, job enqueue. Symmetric with the existing `OfferCreationExecutionService` (post-enqueue worker path) so both halves of the create flow live in core per `architecture-overview.md` §6.
- `POST /listings/connections/:connectionId/offers` → 202 `{ jobId, offerCreationRecordId }`.
- `GET /listings/connections/:connectionId/offers/creation/:offerCreationRecordId` for status polling, with cross-connection defensive 404.
- DTOs include `title` `@MaxLength(75)` (Allegro cap), `imageUrls` `@IsUrl({}, { each: true })`, and a soft 4KB size cap on `platformParams` (escape-hatch operational hygiene).

### Deviations from issue specs (all in the plan §2)

1. Controller path `http/` not `interfaces/http/` — matches repo convention.
2. `@Roles('admin') + @ApiBearerAuth()` not `@UseGuards(JwtAuthGuard)` — matches repo convention.
3. DB-backed cache, not Redis — no Redis cache abstraction exists in the codebase.
4. `internalVariantId` uses `@Matches(/^ol_variant_[a-f0-9]+$/)` not `@IsUUID()` — OL internal IDs use `ol_{entityType}_{hex}` format per `architecture-overview.md` Internal Identifier Format.

## Files

**New (core):**
- `libs/core/src/integrations/domain/types/seller-policies.types.ts`
- `libs/core/src/listings/domain/ports/seller-policies-cache-repository.port.ts`
- `libs/core/src/listings/application/interfaces/seller-policies.service.interface.ts`
- `libs/core/src/listings/application/services/seller-policies.service.ts`
- `libs/core/src/listings/application/interfaces/offer-creation-enqueue.service.interface.ts`
- `libs/core/src/listings/application/services/offer-creation-enqueue.service.ts`
- `libs/core/src/listings/application/types/offer-creation-enqueue.types.ts`
- `libs/core/src/listings/infrastructure/persistence/entities/seller-policies-cache.orm-entity.ts`
- `libs/core/src/listings/infrastructure/persistence/repositories/seller-policies-cache.repository.ts`

**New (API + tests):**
- 4 DTOs under `apps/api/src/listings/http/dto/`
- Migration `1785000000000-add-seller-policies-cache.ts`
- 2 integration specs + 2 fixture files under `apps/api/test/integration/`
- 2 service unit specs under `libs/core/src/listings/application/services/__tests__/`

**Modified:** `marketplace.port.ts`, Allegro adapter + spec, listings module/tokens/index, API listings controller + spec.

## Test plan

- [x] `pnpm type-check` — clean across all 7 projects.
- [x] `pnpm lint` — 0 errors.
- [x] `pnpm test` — 331 core (6 new enqueue-service tests) + 247 api (5 new controller tests covering the delegation) + 79 allegro (3 new `fetchSellerPolicies` tests) all pass.
- [x] `pnpm test:integration` — 86/86 pass including `listings-create-offer.int-spec.ts` (status-poll path) and `listings-seller-policies.int-spec.ts` (cache-seeded round trip).
- [x] Pre-commit husky hook (full lint + type-check + test) — passed.

## Follow-ups

- `marketplace.offer.pollCreationStatus` handler to advance Allegro `validating → active` (referenced by the warn log in `OfferCreationExecutionService`).
- FE wizard (#261) — now unblocked.
- **Non-blocker noted:** `apps/web/src/pages/dashboard/dashboard-page.test.tsx` is flaky under parallel monorepo test load (passes in isolation). Pre-existing — same class of issue as the fix in commit `0d8e865`. Not touched in this PR.

Closes #259
Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)