### PR TITLE
feat(web): add optional storefrontBaseUrl field to PrestaShop connection forms

### DIFF
--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -120,9 +120,10 @@ describe('EditConnectionForm', () => {
   });
 
   describe('structured PrestaShop inputs + raw JSON toggle', () => {
-    it('renders Shop URL / Shop ID inputs for a PrestaShop connection', () => {
+    it('renders Shop URL / Storefront URL / Shop ID inputs for a PrestaShop connection', () => {
       renderWithProviders(<EditConnectionForm connection={sampleConnection} />);
       expect(screen.getByLabelText('Shop URL')).toHaveValue('https://example.com');
+      expect(screen.getByLabelText('Storefront URL (optional)')).toHaveValue('');
       expect(screen.getByLabelText('Shop ID (optional)')).toHaveValue('');
     });
 
@@ -134,6 +135,57 @@ describe('EditConnectionForm', () => {
 
       expect(screen.getByLabelText('Config JSON')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Hide raw config JSON' })).toBeInTheDocument();
+    });
+
+    it('syncs structured Storefront URL edits into the underlying Config JSON payload', async () => {
+      const connectionWithStorefront: Connection = {
+        ...sampleConnection,
+        config: { baseUrl: 'https://api.example.com', storefrontBaseUrl: 'https://example.com' },
+      };
+      const updateFn = vi.fn().mockResolvedValue(connectionWithStorefront);
+      const apiClient = createMockApiClient({ connections: { update: updateFn } });
+      renderWithProviders(<EditConnectionForm connection={connectionWithStorefront} />, { apiClient });
+
+      expect(screen.getByLabelText('Storefront URL (optional)')).toHaveValue('https://example.com');
+
+      fireEvent.change(screen.getByLabelText('Storefront URL (optional)'), {
+        target: { value: 'https://new-storefront.example.com' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+      await waitFor(() => {
+        expect(updateFn).toHaveBeenCalledWith(
+          connectionWithStorefront.id,
+          expect.objectContaining({
+            config: {
+              baseUrl: 'https://api.example.com',
+              storefrontBaseUrl: 'https://new-storefront.example.com',
+            },
+          }),
+        );
+      });
+    });
+
+    it('removes storefrontBaseUrl from config when the field is cleared', async () => {
+      const connectionWithStorefront: Connection = {
+        ...sampleConnection,
+        config: { baseUrl: 'https://api.example.com', storefrontBaseUrl: 'https://example.com' },
+      };
+      const updateFn = vi.fn().mockResolvedValue(connectionWithStorefront);
+      const apiClient = createMockApiClient({ connections: { update: updateFn } });
+      renderWithProviders(<EditConnectionForm connection={connectionWithStorefront} />, { apiClient });
+
+      fireEvent.change(screen.getByLabelText('Storefront URL (optional)'), {
+        target: { value: '' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+      await waitFor(() => {
+        expect(updateFn).toHaveBeenCalled();
+      });
+      const [, payload] = updateFn.mock.calls[0] as [string, { config: Record<string, unknown> }];
+      expect(payload.config).toEqual({ baseUrl: 'https://api.example.com' });
+      expect('storefrontBaseUrl' in payload.config).toBe(false);
     });
 
     it('syncs structured Shop URL edits into the underlying Config JSON payload', async () => {
@@ -197,6 +249,7 @@ describe('EditConnectionForm', () => {
 
       expect(screen.getByText('Raw JSON is invalid')).toBeInTheDocument();
       expect(screen.getByLabelText('Shop URL')).toBeDisabled();
+      expect(screen.getByLabelText('Storefront URL (optional)')).toBeDisabled();
       expect(screen.getByLabelText('Shop ID (optional)')).toBeDisabled();
     });
   });

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -26,7 +26,7 @@ interface EditConnectionFormProps {
   connection: Connection;
 }
 
-type StructuredField = 'baseUrl' | 'shopId' | 'masterCatalogConnectionId';
+type StructuredField = 'baseUrl' | 'shopId' | 'storefrontBaseUrl' | 'masterCatalogConnectionId';
 type PlatformBranch = 'prestashop' | 'marketplace' | 'raw';
 
 function readString(config: Record<string, unknown>, key: string): string {
@@ -54,6 +54,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
       name: connection.name,
       baseUrl: readString(connection.config, 'baseUrl'),
       shopId: readString(connection.config, 'shopId'),
+      storefrontBaseUrl: readString(connection.config, 'storefrontBaseUrl'),
       masterCatalogConnectionId: readString(connection.config, 'masterCatalogConnectionId'),
       configText: JSON.stringify(connection.config, null, 2),
       adapterKey: connection.adapterKey ?? '',
@@ -227,6 +228,21 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
               placeholder="https://shop.example.com"
               disabled={!configIsParseable}
               invalid={Boolean(form.formState.errors.baseUrl)}
+            />
+          </FormField>
+
+          <FormField
+            label="Storefront URL (optional)"
+            name="storefrontBaseUrl"
+            error={form.formState.errors.storefrontBaseUrl?.message}
+            description="Override only if your public storefront URL is different from the webservice URL. Leave blank if they're the same — defaults to Shop URL."
+          >
+            <Input
+              value={form.watch('storefrontBaseUrl') ?? ''}
+              onChange={(event) => syncStructuredToJson('storefrontBaseUrl', event.target.value)}
+              placeholder="https://shop.example.com"
+              disabled={!configIsParseable}
+              invalid={Boolean(form.formState.errors.storefrontBaseUrl)}
             />
           </FormField>
 

--- a/apps/web/src/features/connections/components/edit-connection.schema.test.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mergeStructuredIntoConfig } from './edit-connection.schema';
+import { editConnectionSchema, mergeStructuredIntoConfig } from './edit-connection.schema';
 
 describe('mergeStructuredIntoConfig', () => {
   it('writes a new baseUrl into an empty config', () => {
@@ -45,5 +45,63 @@ describe('mergeStructuredIntoConfig', () => {
     const snapshot = { ...base };
     mergeStructuredIntoConfig(base, { baseUrl: 'https://new.example.com' });
     expect(base).toEqual(snapshot);
+  });
+
+  it('writes storefrontBaseUrl into an empty config', () => {
+    const result = mergeStructuredIntoConfig(
+      {},
+      { storefrontBaseUrl: 'https://shop.example.com' },
+    );
+    expect(result).toEqual({ storefrontBaseUrl: 'https://shop.example.com' });
+  });
+
+  it('deletes storefrontBaseUrl when cleared to empty string', () => {
+    const base = {
+      baseUrl: 'https://api.shop.example.com',
+      storefrontBaseUrl: 'https://shop.example.com',
+    };
+    const result = mergeStructuredIntoConfig(base, { storefrontBaseUrl: '' });
+    expect(result).toEqual({ baseUrl: 'https://api.shop.example.com' });
+    expect('storefrontBaseUrl' in result).toBe(false);
+  });
+});
+
+// Direct-schema tests live here alongside the helper tests for symmetry with
+// the existing file. Only the fields changed by #283 are covered today —
+// extend as additional fields gain validation rules.
+describe('editConnectionSchema — storefrontBaseUrl', () => {
+  const validRest = {
+    name: 'Shop',
+    configText: '{}',
+  };
+
+  it('accepts an absent storefrontBaseUrl', () => {
+    const result = editConnectionSchema.safeParse(validRest);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an empty string (unset signal)', () => {
+    const result = editConnectionSchema.safeParse({ ...validRest, storefrontBaseUrl: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid https URL', () => {
+    const result = editConnectionSchema.safeParse({
+      ...validRest,
+      storefrontBaseUrl: 'https://shop.example.com',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a garbage value with the expected message', () => {
+    const result = editConnectionSchema.safeParse({
+      ...validRest,
+      storefrontBaseUrl: 'not-a-url',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path.includes('storefrontBaseUrl'));
+      expect(issue?.message).toBe('Storefront URL must be a valid URL');
+    }
   });
 });

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -5,6 +5,19 @@ export const editConnectionSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
   baseUrl: z.string().trim().optional(),
   shopId: z.string().trim().optional(),
+  // Optional override for the split-host case (webservice host ≠ public storefront).
+  // Accepts a validated URL or an empty string (to unset). See #271 / #283.
+  storefrontBaseUrl: z
+    .union([
+      z
+        .url('Storefront URL must be a valid URL')
+        .refine(
+          (value) => value.startsWith('http://') || value.startsWith('https://'),
+          'Storefront URL must use http:// or https://',
+        ),
+      z.literal(''),
+    ])
+    .optional(),
   masterCatalogConnectionId: z
     .union([z.string().uuid('Product catalog must be a valid connection ID'), z.literal('')])
     .optional(),
@@ -44,6 +57,7 @@ export function mergeStructuredIntoConfig(
   structured: {
     baseUrl?: string;
     shopId?: string;
+    storefrontBaseUrl?: string;
     masterCatalogConnectionId?: string;
   },
 ): Record<string, unknown> {
@@ -60,6 +74,13 @@ export function mergeStructuredIntoConfig(
       delete next.shopId;
     } else {
       next.shopId = structured.shopId;
+    }
+  }
+  if (structured.storefrontBaseUrl !== undefined) {
+    if (structured.storefrontBaseUrl.length === 0) {
+      delete next.storefrontBaseUrl;
+    } else {
+      next.storefrontBaseUrl = structured.storefrontBaseUrl;
     }
   }
   // Unlike baseUrl/shopId, masterCatalogConnectionId uses `""` as an explicit

--- a/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.test.tsx
@@ -134,6 +134,80 @@ describe('PrestashopSetupForm', () => {
     );
   });
 
+  it('persists storefrontBaseUrl in config when provided', async () => {
+    const create = vi.fn().mockResolvedValue(sampleConnection);
+    const apiClient = createMockApiClient({ connections: { create } });
+    const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
+
+    fillCredentialsStep(view.container, {
+      name: 'Split host shop',
+      url: 'https://api.shop.example.com',
+      key: 'WSKEY',
+    });
+    fireEvent.change(within(view.container).getByLabelText('Storefront URL (optional)'), {
+      target: { value: 'https://shop.example.com' },
+    });
+
+    await advanceToStep(view.container, 3);
+
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    await screen.findByText('Connection created');
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {
+          baseUrl: 'https://api.shop.example.com',
+          storefrontBaseUrl: 'https://shop.example.com',
+        },
+      }),
+    );
+  });
+
+  it('omits storefrontBaseUrl from config when left blank', async () => {
+    const create = vi.fn().mockResolvedValue(sampleConnection);
+    const apiClient = createMockApiClient({ connections: { create } });
+    const view = renderWithProviders(<PrestashopSetupForm />, { apiClient });
+
+    fillCredentialsStep(view.container, {
+      name: 'Same-host shop',
+      url: 'https://shop.example.com',
+      key: 'WSKEY',
+    });
+
+    await advanceToStep(view.container, 3);
+
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Create connection' }));
+
+    await screen.findByText('Connection created');
+    // Blank input must not persist `""` — backend falls back to baseUrl when the key is absent.
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: { baseUrl: 'https://shop.example.com' },
+      }),
+    );
+    const payload = create.mock.calls[0]?.[0] as { config: Record<string, unknown> };
+    expect('storefrontBaseUrl' in payload.config).toBe(false);
+  });
+
+  it('blocks advancing from the credentials step when the storefront URL is invalid', async () => {
+    const view = renderWithProviders(<PrestashopSetupForm />);
+
+    fillCredentialsStep(view.container, {
+      name: 'Shop',
+      url: 'https://shop.example.com',
+      key: 'WSKEY',
+    });
+    fireEvent.change(within(view.container).getByLabelText('Storefront URL (optional)'), {
+      target: { value: 'not-a-url' },
+    });
+
+    fireEvent.click(within(view.container).getByRole('button', { name: 'Next' }));
+
+    expect((await screen.findAllByText('Storefront URL must be a valid URL')).length).toBeGreaterThan(0);
+    expect(within(view.container).getByLabelText('Connection name')).toBeInTheDocument();
+    expect(screen.queryByText('Verify the credentials')).toBeNull();
+  });
+
   it('surfaces API errors in a form-level alert on the review step', async () => {
     const apiClient = createMockApiClient({
       connections: {

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -51,7 +51,7 @@ const CAPABILITY_HELP: Record<Capability, string> = {
 const STEP_LABELS = ['Credentials', 'Verify credentials', 'Capabilities', 'Review & connect'] as const;
 
 const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<PrestashopSetupFormValues>>> = [
-  ['name', 'baseUrl', 'webserviceKey', 'shopId'],
+  ['name', 'baseUrl', 'webserviceKey', 'shopId', 'storefrontBaseUrl'],
   [],
   ['enabledCapabilities'],
   [],
@@ -173,6 +173,19 @@ export function PrestashopSetupForm(): ReactElement {
           </FormField>
 
           <FormField
+            label="Storefront URL (optional)"
+            name="storefrontBaseUrl"
+            error={form.formState.errors.storefrontBaseUrl?.message}
+            description="Override only if your public storefront URL is different from the webservice URL. Leave blank if they're the same — defaults to Shop URL."
+          >
+            <Input
+              {...form.register('storefrontBaseUrl')}
+              placeholder="https://shop.example.com"
+              invalid={Boolean(form.formState.errors.storefrontBaseUrl)}
+            />
+          </FormField>
+
+          <FormField
             label="Webservice key"
             name="webserviceKey"
             error={form.formState.errors.webserviceKey?.message}
@@ -212,6 +225,12 @@ export function PrestashopSetupForm(): ReactElement {
           <dl className="wizard-review-list">
             <dt>Shop URL</dt>
             <dd className="mono-text">{values.baseUrl || '—'}</dd>
+            {values.storefrontBaseUrl ? (
+              <>
+                <dt>Storefront URL</dt>
+                <dd className="mono-text">{values.storefrontBaseUrl}</dd>
+              </>
+            ) : null}
             <dt>Webservice key</dt>
             <dd className="mono-text">{values.webserviceKey ? maskKey(values.webserviceKey) : '—'}</dd>
             {values.shopId ? (
@@ -259,6 +278,12 @@ export function PrestashopSetupForm(): ReactElement {
           <dd>{values.name || '—'}</dd>
           <dt>Shop URL</dt>
           <dd className="mono-text">{values.baseUrl || '—'}</dd>
+          {values.storefrontBaseUrl ? (
+            <>
+              <dt>Storefront URL</dt>
+              <dd className="mono-text">{values.storefrontBaseUrl}</dd>
+            </>
+          ) : null}
           <dt>Webservice key</dt>
           <dd className="mono-text">{values.webserviceKey ? maskKey(values.webserviceKey) : '—'}</dd>
           {values.shopId ? (

--- a/apps/web/src/features/connections/components/prestashop-setup.schema.ts
+++ b/apps/web/src/features/connections/components/prestashop-setup.schema.ts
@@ -35,6 +35,21 @@ export const prestashopSetupSchema = z.object({
     ),
   webserviceKey: z.string().trim().min(1, 'Webservice key is required'),
   shopId: z.string().trim().optional(),
+  // Optional override for the split-host case (webservice host ≠ public storefront).
+  // Empty string is accepted alongside absent so the form can round-trip a blank input
+  // without surfacing a validation error; the create payload filters `""` out so the
+  // backend falls back to `baseUrl` per #271.
+  storefrontBaseUrl: z
+    .union([
+      z
+        .url('Storefront URL must be a valid URL')
+        .refine(
+          (value) => value.startsWith('http://') || value.startsWith('https://'),
+          'Storefront URL must use http:// or https://',
+        ),
+      z.literal(''),
+    ])
+    .optional(),
   enabledCapabilities: z
     .array(
       z.enum([
@@ -56,6 +71,7 @@ export const PRESTASHOP_SETUP_DEFAULT_VALUES: PrestashopSetupFormValues = {
   baseUrl: '',
   webserviceKey: '',
   shopId: '',
+  storefrontBaseUrl: '',
   enabledCapabilities: PRESTASHOP_FALLBACK_CAPABILITIES,
 };
 
@@ -65,6 +81,9 @@ export function toCreateConnectionInput(
   const config: Record<string, unknown> = { baseUrl: values.baseUrl };
   if (values.shopId && values.shopId.length > 0) {
     config.shopId = values.shopId;
+  }
+  if (values.storefrontBaseUrl && values.storefrontBaseUrl.length > 0) {
+    config.storefrontBaseUrl = values.storefrontBaseUrl;
   }
   return {
     name: values.name,

--- a/docs/plans/implementation-plan-283-prestashop-storefront-url-wizard.md
+++ b/docs/plans/implementation-plan-283-prestashop-storefront-url-wizard.md
@@ -1,0 +1,109 @@
+# Implementation Plan — #283 storefrontBaseUrl FE wizard field
+
+## 1. Goal
+
+Add the optional `storefrontBaseUrl` field to both the PrestaShop create-connection wizard and the edit-connection form. The backend field shipped in #271 — the API is forgiving (absent/empty → adapter falls back to `baseUrl`), so this is purely the operator UX affordance for the split-host case (webservice URL ≠ public storefront URL).
+
+**Layer:** Frontend
+**Scope:** two schemas, two form components, two test files
+**Non-goals:**
+- Live validation that the storefront URL actually serves PrestaShop image paths (out of scope per issue).
+- Adding the pattern to non-PrestaShop connection types.
+- Any backend work — the config field, factory fallback, and credentials plumbing are already live in `main` (see `c5891bb`).
+
+## 2. What's already true
+
+**Create wizard** — `apps/web/src/features/connections/components/`
+- `prestashop-setup.schema.ts` defines `prestashopSetupSchema` (Zod) plus `toCreateConnectionInput()` and `PRESTASHOP_SETUP_DEFAULT_VALUES`. `shopId` is the existing precedent for an optional PrestaShop-specific config field that is only persisted when non-empty.
+- `prestashop-setup-form.tsx` drives a 4-step wizard. Step 0 fields are in `STEP_FIELDS[0]`; Steps 1 and 3 show review lists using a `wizard-review-list` `dl`. `shopId` is conditionally rendered there (only when set).
+
+**Edit form** — same directory
+- `edit-connection.schema.ts` has `editConnectionSchema` + `mergeStructuredIntoConfig()`. `StructuredField` type union lives inline in `EditConnectionForm.tsx` and currently has three members: `baseUrl | shopId | masterCatalogConnectionId`. The "delete on empty string" behaviour is explicit in `mergeStructuredIntoConfig`.
+- `EditConnectionForm.tsx` gates the PrestaShop-structured inputs under `platformBranch === 'prestashop'`. The pattern for each structured field is: `form.watch(field)` + `syncStructuredToJson(field, value)` + `FormField` with `disabled={!configIsParseable}`.
+
+**Tests**
+- `prestashop-setup-form.test.tsx` — 5 component tests, advances through the wizard with `fillCredentialsStep` + `advanceToStep` helpers. The `shopId` happy-path is the nearest template.
+- `edit-connection.schema.test.ts` — covers `mergeStructuredIntoConfig` only. Schema-level Zod validation is currently exercised only indirectly through the component. The issue asks for direct schema tests — we'll add them here and keep the style consistent with the helper tests.
+
+## 3. Changes
+
+### 3.1 `prestashop-setup.schema.ts`
+
+- Add `storefrontBaseUrl` to the Zod schema using the same `union([z.url(...), z.literal('')]).optional()` pattern as the issue spec. Keep the error messages verbatim from the issue so we don't drift from the acceptance criteria:
+  ```ts
+  storefrontBaseUrl: z
+    .union([
+      z.url('Storefront URL must be a valid URL').refine(
+        (v) => v.startsWith('http://') || v.startsWith('https://'),
+        'Storefront URL must use http:// or https://',
+      ),
+      z.literal(''),
+    ])
+    .optional(),
+  ```
+- Extend `PRESTASHOP_SETUP_DEFAULT_VALUES` with `storefrontBaseUrl: ''`.
+- In `toCreateConnectionInput`, mirror the `shopId` branch: only set `config.storefrontBaseUrl` when the trimmed value is non-empty. Keep the existing `baseUrl`-first ordering so the API payload reads naturally.
+
+### 3.2 `prestashop-setup-form.tsx`
+
+- Extend `STEP_FIELDS[0]` to include `'storefrontBaseUrl'` so the Zod error surfaces on Next (not only on final submit).
+- Add a `FormField` in Step 0 directly below the Shop URL field, with the helper text the issue specifies: *"Override only if your public storefront URL is different from the webservice URL. Leave blank if they're the same — defaults to Shop URL."*
+- Conditionally render the value in Step 1 (`Verify credentials` `dl`) and Step 3 (final review `dl`) using the same pattern as `shopId` — only when the value is non-empty.
+
+### 3.3 `edit-connection.schema.ts`
+
+- Add `storefrontBaseUrl` to `editConnectionSchema` with the same Zod pattern (union of validated URL + empty string, optional).
+- Extend `mergeStructuredIntoConfig`'s `structured` parameter type with `storefrontBaseUrl?: string` and add a parallel branch that deletes on `""` and writes otherwise (identical to the `baseUrl`/`shopId` branches).
+
+### 3.4 `EditConnectionForm.tsx`
+
+- Extend the inline `StructuredField` type union to include `'storefrontBaseUrl'`.
+- Add to the form's `defaultValues`: `storefrontBaseUrl: readString(connection.config, 'storefrontBaseUrl')` — `readString` already returns `''` for missing/non-string values, which is what we want.
+- In the `platformBranch === 'prestashop'` block, add a `FormField` right below Shop URL with the same helper text as the create wizard. Wire it through `syncStructuredToJson('storefrontBaseUrl', ...)` just like `baseUrl` and `shopId`.
+- No `mergeStructuredIntoConfig` caller change needed — `syncStructuredToJson` already passes through the field name.
+
+### 3.5 `prestashop-setup-form.test.tsx`
+
+Three new tests after the existing `shopId` test:
+
+1. **Persists a valid `storefrontBaseUrl`** — when provided, it appears verbatim in the created `config.storefrontBaseUrl`.
+2. **Omits the key when blank** — no `storefrontBaseUrl` property in the final `config` (asserts via `expect.not.objectContaining`).
+3. **Blocks advancing on invalid URL** — `storefrontBaseUrl: 'not-a-url'` keeps the wizard on Step 0 and surfaces the Zod error (mirror the existing `baseUrl` invalid-URL test).
+
+### 3.6 `edit-connection.schema.test.ts`
+
+Two new `describe` blocks:
+
+1. **`editConnectionSchema`** — direct Zod tests: empty string passes, omitted passes, valid URL passes, garbage (e.g. `'not-a-url'`) fails with the specified message.
+2. **`mergeStructuredIntoConfig` + `storefrontBaseUrl`** — add two cases to the existing describe block: writes on non-empty, deletes on empty string. Follows the existing `baseUrl`/`shopId` precedent to a T.
+
+## 4. Acceptance (from the issue)
+
+- [x] Operator can set `Storefront URL (optional)` in both create and edit forms for PrestaShop connections.
+- [x] Blank field → config has no `storefrontBaseUrl` key.
+- [x] Invalid URL blocks Step 1 advance (create) and form submit (edit).
+- [x] Existing connections without the field continue to work; the input renders empty (via `readString`).
+- [x] `pnpm lint && pnpm type-check && pnpm test` pass.
+
+## 5. Quality gate
+
+```bash
+pnpm --filter @openlinker/web test -- prestashop-setup-form.test
+pnpm --filter @openlinker/web test -- edit-connection.schema.test
+pnpm lint
+pnpm type-check
+pnpm test  # full web + backend unit suites to confirm nothing collateral broke
+```
+
+## 6. Risks
+
+- **Zod v4 `z.url()`** — already in use in this schema for `baseUrl`, so no version concern. The `union([z.url(), z.literal('')])` pattern matches the existing `masterCatalogConnectionId` precedent.
+- **Review `dl` rendering** — The wizard's Step 1/3 `dl` uses `<dt>/<dd>` pairs inside a single `<dl>`. Adding a conditional pair mirrors the existing `shopId` conditional exactly. Low risk.
+- **`configText` round-trip in edit form** — `syncStructuredToJson` already merges through `mergeStructuredIntoConfig` and re-serializes. As long as we extend the helper consistently, raw-JSON-view users never lose the new key. Covered by the schema test.
+- **Schema error message exact-matching** — The issue spec quotes `'Storefront URL must be a valid URL'` and `'Storefront URL must use http:// or https://'`. We'll preserve these strings verbatim so future test copy-paste from the issue still works.
+
+## 7. Out of scope
+
+- Per issue: no probe of the storefront URL (the `/test` endpoint only checks webservice auth).
+- Per issue: field is PrestaShop-specific — no generalisation to other platforms.
+- Not extracting a shared "optional URL" Zod helper — the pattern recurs only twice in this file, three times after this PR. Extraction belongs in a focused refactor if a 4th instance appears.


### PR DESCRIPTION

Body:
  Closes #283.

  #271 shipped the backend plumbing: `storefrontBaseUrl` on the PrestaShop connection config is optional, and the integration factory falls
  back to `baseUrl` when unset. The common case (webservice and storefront share a host) works with zero operator action. This PR adds the
  operator-facing override field to both the create-connection wizard and the edit form for the split-host case (e.g., webservice at
  `api.shop.com`, public storefront at `shop.com`).

  ## Scope

  Frontend only — no backend changes. Six source files + two test files touched, all under `apps/web/src/features/connections/components/`.

  **Create wizard** (`prestashop-setup.schema.ts`, `prestashop-setup-form.tsx`):
  - Zod schema gains an optional `storefrontBaseUrl` field (validated URL or empty string)
  - `toCreateConnectionInput` omits the key when blank — backend falls back to `baseUrl`
  - Step 0 renders `Storefront URL (optional)` below `Shop URL` with helper text
  - `STEP_FIELDS[0]` extended so Zod errors surface on Next
  - Steps 1 and 3 conditionally render the value when non-empty

  **Edit form** (`edit-connection.schema.ts`, `EditConnectionForm.tsx`):
  - Schema mirrors the wizard's optional URL shape
  - `mergeStructuredIntoConfig` gets delete-on-empty semantics for `storefrontBaseUrl`
  - `StructuredField` union extended; defaultValue read via `readString(...)`
  - New FormField wired through `syncStructuredToJson` so raw-JSON users don't lose custom keys

  ## Tests

  - `prestashop-setup-form.test.tsx` (+3): persists valid URL; omits key when blank; invalid URL blocks Step 0
  - `edit-connection.schema.test.ts` (+6): merge helper writes/deletes; direct Zod tests for absent/empty/valid/garbage
  - `EditConnectionForm.test.tsx` (+3): render asserts field present; sync-edits round-trips into payload; clear-field confirms
  delete-on-empty; locks test asserts field disabled under invalid JSON

  ## Quality gate

  - `pnpm lint` — 0 errors
  - `pnpm type-check` — 0 errors across 7 packages
  - `pnpm test` — full monorepo suite green
