### PR TITLE
fix(web): add actionable CTAs to empty states on list pages

### DIFF
--- a/apps/web/src/pages/adapters/adapters-catalog-page.tsx
+++ b/apps/web/src/pages/adapters/adapters-catalog-page.tsx
@@ -75,6 +75,7 @@ export function AdaptersCatalogPage(): ReactElement {
           }
         />
       ) : (query.data ?? []).length === 0 ? (
+        // No action: adapters are system-registered at build time; operators cannot add them from the UI.
         <EmptyState
           title="No adapters available"
           message="No integration adapters are registered in the system."

--- a/apps/web/src/pages/connections/connections-list-page.test.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { ConnectionsListPage } from './connections-list-page';
@@ -35,12 +36,30 @@ describe('ConnectionsListPage', () => {
     expect(await screen.findByRole('heading', { name: 'Unable to load connections' })).toBeInTheDocument();
   });
 
-  it('shows empty state when no connections exist', async () => {
+  it('shows empty state with the Add the first connection CTA when no connections exist', async () => {
     const apiClient = createMockApiClient({
       connections: { list: vi.fn().mockResolvedValue([]) },
     });
     renderWithProviders(<ConnectionsListPage />, { apiClient });
     expect(await screen.findByRole('heading', { name: 'No connections found' })).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'Add the first connection' });
+    expect(cta).toHaveAttribute('href', '/connections/new');
+  });
+
+  it('shows a Clear filters button that clears platform and status params when filters are active', async () => {
+    const user = userEvent.setup();
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+    renderWithProviders(<ConnectionsListPage />, {
+      apiClient,
+      route: '/connections?platformType=allegro&status=active',
+    });
+
+    expect(await screen.findByText('No connections match the current filters.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(await screen.findByRole('link', { name: 'Add the first connection' })).toBeInTheDocument();
   });
 
   it('renders platform and status filter dropdowns', () => {

--- a/apps/web/src/pages/connections/connections-list-page.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.tsx
@@ -88,6 +88,17 @@ export function ConnectionsListPage(): ReactElement {
     });
   }
 
+  function clearFilters(): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('platformType');
+      next.delete('status');
+      return next;
+    });
+  }
+
+  const filtersActive = Boolean(filters.platformType ?? filters.status);
+
   return (
     <PageLayout
       eyebrow="Integrations"
@@ -143,16 +154,18 @@ export function ConnectionsListPage(): ReactElement {
         <EmptyState
           title="No connections found"
           message={
-            filters.platformType || filters.status
-              ? 'No connections match the current filters. Try adjusting your selection.'
+            filtersActive
+              ? 'No connections match the current filters.'
               : 'Create the first connection to start configuring integrations.'
           }
           action={
-            !filters.platformType && !filters.status ? (
-              <Link className="button" to="/connections/new">
+            filtersActive ? (
+              <Button onClick={clearFilters}>Clear filters</Button>
+            ) : (
+              <Link className="button button--primary" to="/connections/new">
                 Add the first connection
               </Link>
-            ) : undefined
+            )
           }
         />
       ) : (

--- a/apps/web/src/pages/connections/connections-list-page.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.tsx
@@ -97,7 +97,7 @@ export function ConnectionsListPage(): ReactElement {
     });
   }
 
-  const filtersActive = Boolean(filters.platformType ?? filters.status);
+  const filtersActive = Boolean(filters.platformType || filters.status);
 
   return (
     <PageLayout

--- a/apps/web/src/pages/customers/customers-list-page.test.tsx
+++ b/apps/web/src/pages/customers/customers-list-page.test.tsx
@@ -1,5 +1,6 @@
-import { screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { CustomersListPage } from './customers-list-page';
 import type { PaginatedCustomers } from '../../features/customers/api/customers.types';
@@ -35,6 +36,7 @@ const sampleCustomers: PaginatedCustomers = {
 };
 
 describe('CustomersListPage', () => {
+  afterEach(cleanup);
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       customers: {
@@ -75,32 +77,25 @@ describe('CustomersListPage', () => {
     expect(screen.getByText('Network error')).toBeInTheDocument();
   });
 
-  it('should show empty state when no customers exist', async () => {
+  it('should show empty state with a Browse orders CTA when no customers exist', async () => {
     const mockApi = createMockApiClient({
       customers: {
-        list: vi.fn().mockResolvedValue({
-          items: [],
-          total: 0,
-          limit: 20,
-          offset: 0,
-        }),
+        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
       },
     });
 
     renderWithProviders(<CustomersListPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('No customers found')).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'Browse orders' });
+    expect(cta).toHaveAttribute('href', '/orders');
   });
 
-  it('should show empty state with filter message when filters are active', async () => {
+  it('should show a Clear filters button that clears filters when filters are active', async () => {
+    const user = userEvent.setup();
     const mockApi = createMockApiClient({
       customers: {
-        list: vi.fn().mockResolvedValue({
-          items: [],
-          total: 0,
-          limit: 20,
-          offset: 0,
-        }),
+        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
       },
     });
 
@@ -110,5 +105,8 @@ describe('CustomersListPage', () => {
     });
 
     expect(await screen.findByText('No customer projections match the current filters.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(await screen.findByRole('link', { name: 'Browse orders' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/customers/customers-list-page.tsx
+++ b/apps/web/src/pages/customers/customers-list-page.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement, type ReactNode } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { useTableSort } from '../../shared/ui/use-table-sort';
@@ -104,6 +104,19 @@ export function CustomersListPage(): ReactElement {
     });
   }
 
+  function clearFilters(): void {
+    setSearchInput('');
+    setConnectionIdInput('');
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('search');
+      next.delete('lastSourceConnectionId');
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  const filtersActive = Boolean(debouncedSearch || debouncedConnectionId);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
@@ -144,9 +157,18 @@ export function CustomersListPage(): ReactElement {
           liveRegion="off"
           title="No customers found"
           message={
-            debouncedSearch || debouncedConnectionId
+            filtersActive
               ? 'No customer projections match the current filters.'
               : 'No customer projections have been recorded yet.'
+          }
+          action={
+            filtersActive ? (
+              <Button onClick={clearFilters}>Clear filters</Button>
+            ) : (
+              <Link className="button button--primary" to="/orders">
+                Browse orders
+              </Link>
+            )
           }
         />
       ) : (

--- a/apps/web/src/pages/inventory/inventory-list-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.test.tsx
@@ -1,4 +1,5 @@
-import { screen, within } from '@testing-library/react';
+import { cleanup, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { InventoryListPage } from './inventory-list-page';
@@ -44,6 +45,7 @@ describe('InventoryListPage', () => {
   afterEach(() => {
     vi.runAllTimers();
     vi.useRealTimers();
+    cleanup();
   });
 
   it('should show loading state initially', () => {
@@ -123,7 +125,7 @@ describe('InventoryListPage', () => {
     expect(within(container).getByText('SKU-NO-IMG')).toBeInTheDocument();
   });
 
-  it('should show empty state when no inventory items exist', async () => {
+  it('should show empty state with a Browse products CTA when no inventory items exist', async () => {
     const mockApi = createMockApiClient({
       inventory: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
     });
@@ -131,5 +133,24 @@ describe('InventoryListPage', () => {
     renderWithProviders(<InventoryListPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('No inventory items found')).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'Browse products' });
+    expect(cta).toHaveAttribute('href', '/products');
+  });
+
+  it('should show a Clear filters button that clears filters when they are active', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const mockApi = createMockApiClient({
+      inventory: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+    });
+
+    renderWithProviders(<InventoryListPage />, {
+      apiClient: mockApi,
+      route: '/inventory?productId=missing',
+    });
+
+    expect(await screen.findByText('No inventory items match the current filters.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(await screen.findByRole('link', { name: 'Browse products' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/inventory/inventory-list-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement, type ReactNode } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { useTableSort } from '../../shared/ui/use-table-sort';
@@ -164,6 +164,19 @@ export function InventoryListPage(): ReactElement {
     });
   }
 
+  function clearFilters(): void {
+    setProductIdInput('');
+    setVariantIdInput('');
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('productId');
+      next.delete('productVariantId');
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  const filtersActive = Boolean(debouncedProductId || debouncedVariantId);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
@@ -205,9 +218,18 @@ export function InventoryListPage(): ReactElement {
           liveRegion="off"
           title="No inventory items found"
           message={
-            debouncedProductId || debouncedVariantId
+            filtersActive
               ? 'No inventory items match the current filters.'
               : 'No inventory records have been synced yet.'
+          }
+          action={
+            filtersActive ? (
+              <Button onClick={clearFilters}>Clear filters</Button>
+            ) : (
+              <Link className="button button--primary" to="/products">
+                Browse products
+              </Link>
+            )
           }
         />
       ) : (

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { ListingsListPage } from './listings-list-page';
@@ -76,32 +77,25 @@ describe('ListingsListPage', () => {
     expect(screen.getByText('Network error')).toBeInTheDocument();
   });
 
-  it('should show empty state when no mappings exist', async () => {
+  it('should show empty state with a Manage connections CTA when no mappings exist', async () => {
     const mockApi = createMockApiClient({
       listings: {
-        list: vi.fn().mockResolvedValue({
-          items: [],
-          total: 0,
-          limit: 20,
-          offset: 0,
-        }),
+        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
       },
     });
 
     renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('No offer mappings found')).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'Manage connections' });
+    expect(cta).toHaveAttribute('href', '/connections');
   });
 
-  it('should show empty state with filter message when filters are active', async () => {
+  it('should show a Clear filters button that clears filters when filters are active', async () => {
+    const user = userEvent.setup();
     const mockApi = createMockApiClient({
       listings: {
-        list: vi.fn().mockResolvedValue({
-          items: [],
-          total: 0,
-          limit: 20,
-          offset: 0,
-        }),
+        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
       },
     });
 
@@ -111,5 +105,8 @@ describe('ListingsListPage', () => {
     });
 
     expect(await screen.findByText('No offer mappings match the current filters.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(await screen.findByRole('link', { name: 'Manage connections' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement, type ReactNode } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { useTableSort } from '../../shared/ui/use-table-sort';
@@ -108,6 +108,20 @@ export function ListingsListPage(): ReactElement {
     });
   }
 
+  function clearFilters(): void {
+    setSearchInput('');
+    setConnectionIdInput('');
+    setPlatformTypeInput('');
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('search');
+      next.delete('connectionId');
+      next.delete('platformType');
+      next.delete('offset');
+      return next;
+    });
+  }
+
   const hasFilters = !!(debouncedSearch || debouncedConnectionId || debouncedPlatformType);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
@@ -158,6 +172,15 @@ export function ListingsListPage(): ReactElement {
             hasFilters
               ? 'No offer mappings match the current filters.'
               : 'No offer mappings have been synced yet.'
+          }
+          action={
+            hasFilters ? (
+              <Button onClick={clearFilters}>Clear filters</Button>
+            ) : (
+              <Link className="button button--primary" to="/connections">
+                Manage connections
+              </Link>
+            )
           }
         />
       ) : (

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -1,5 +1,6 @@
-import { screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { OrdersListPage } from './orders-list-page';
 import type { PaginatedOrders } from '../../features/orders/api/orders.types';
@@ -24,6 +25,8 @@ const sampleOrders: PaginatedOrders = {
 };
 
 describe('OrdersListPage', () => {
+  afterEach(cleanup);
+
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       orders: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
@@ -57,7 +60,7 @@ describe('OrdersListPage', () => {
     expect(screen.getByText('Network error')).toBeInTheDocument();
   });
 
-  it('should show empty state when no orders exist', async () => {
+  it('should show empty state with a Manage connections CTA when no orders exist and no filters are active', async () => {
     const mockApi = createMockApiClient({
       orders: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
     });
@@ -65,5 +68,25 @@ describe('OrdersListPage', () => {
     renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('No orders found')).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'Manage connections' });
+    expect(cta).toHaveAttribute('href', '/connections');
+  });
+
+  it('should show a Clear filters button that clears syncStatus from the URL when a filter is active', async () => {
+    const user = userEvent.setup();
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+    });
+
+    renderWithProviders(<OrdersListPage />, {
+      apiClient: mockApi,
+      route: '/orders?syncStatus=failed',
+    });
+
+    expect(await screen.findByText('No orders match the current filters.')).toBeInTheDocument();
+    const clearButton = screen.getByRole('button', { name: 'Clear filters' });
+    await user.click(clearButton);
+
+    expect(await screen.findByRole('link', { name: 'Manage connections' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -117,6 +117,17 @@ export function OrdersListPage(): ReactElement {
     });
   }
 
+  function clearFilters(): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('syncStatus');
+      next.delete('sourceConnectionId');
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  const filtersActive = Boolean(syncStatus ?? sourceConnectionId);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
@@ -163,9 +174,18 @@ export function OrdersListPage(): ReactElement {
           liveRegion="off"
           title="No orders found"
           message={
-            syncStatus
-              ? 'No orders match the selected status filter.'
+            filtersActive
+              ? 'No orders match the current filters.'
               : 'No order records have been synced yet.'
+          }
+          action={
+            filtersActive ? (
+              <Button onClick={clearFilters}>Clear filters</Button>
+            ) : (
+              <Link className="button button--primary" to="/connections">
+                Manage connections
+              </Link>
+            )
           }
         />
       ) : (

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -127,7 +127,7 @@ export function OrdersListPage(): ReactElement {
     });
   }
 
-  const filtersActive = Boolean(syncStatus ?? sourceConnectionId);
+  const filtersActive = Boolean(syncStatus || sourceConnectionId);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -228,6 +228,7 @@ export function ProductDetailPage(): ReactElement {
             }
           />
         ) : (inventoryQuery.data?.items.length ?? 0) === 0 ? (
+          // No action: stock is sourced from the product master and not editable here.
           <EmptyState liveRegion="off" title="No stock records" message="No inventory records found for this product." />
         ) : (
           <DataTable

--- a/apps/web/src/pages/products/products-list-page.test.tsx
+++ b/apps/web/src/pages/products/products-list-page.test.tsx
@@ -1,4 +1,5 @@
-import { screen, within } from '@testing-library/react';
+import { cleanup, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { ProductsListPage } from './products-list-page';
@@ -44,6 +45,7 @@ describe('ProductsListPage', () => {
     // "window is not defined" unhandled errors from useDebouncedValue.
     vi.runAllTimers();
     vi.useRealTimers();
+    cleanup();
   });
 
   it('should show loading state initially', () => {
@@ -121,20 +123,36 @@ describe('ProductsListPage', () => {
     expect(placeholderRow?.textContent).toBe('A');
   });
 
-  it('should show empty state when no products exist', async () => {
+  it('should show empty state with a Manage connections CTA when no products exist', async () => {
     const mockApi = createMockApiClient({
       products: {
-        list: vi.fn().mockResolvedValue({
-          items: [],
-          total: 0,
-          limit: 20,
-          offset: 0,
-        }),
+        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
       },
     });
 
     renderWithProviders(<ProductsListPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('No products found')).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'Manage connections' });
+    expect(cta).toHaveAttribute('href', '/connections');
+  });
+
+  it('should show a Clear search button that clears the search param when a query is active', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const mockApi = createMockApiClient({
+      products: {
+        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
+      },
+    });
+
+    renderWithProviders(<ProductsListPage />, {
+      apiClient: mockApi,
+      route: '/products?search=nope',
+    });
+
+    expect(await screen.findByText('No products match the current search.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Clear search' }));
+
+    expect(await screen.findByRole('link', { name: 'Manage connections' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { useTableSort } from '../../shared/ui/use-table-sort';
@@ -103,6 +103,16 @@ export function ProductsListPage(): ReactElement {
     });
   }
 
+  function clearSearch(): void {
+    setSearchInput('');
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('search');
+      next.delete('offset');
+      return next;
+    });
+  }
+
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
@@ -140,8 +150,17 @@ export function ProductsListPage(): ReactElement {
           title="No products found"
           message={
             debouncedSearch
-              ? 'No products match the current search. Try a different query.'
+              ? 'No products match the current search.'
               : 'No products have been synced yet.'
+          }
+          action={
+            debouncedSearch ? (
+              <Button onClick={clearSearch}>Clear search</Button>
+            ) : (
+              <Link className="button button--primary" to="/connections">
+                Manage connections
+              </Link>
+            )
           }
         />
       ) : (

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
@@ -1,5 +1,6 @@
-import { screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { SyncJobsPage } from './sync-jobs-page';
 import type {
@@ -34,6 +35,7 @@ const sampleJobs: PaginatedSyncJobs = {
 };
 
 describe('SyncJobsPage', () => {
+  afterEach(cleanup);
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
@@ -66,7 +68,7 @@ describe('SyncJobsPage', () => {
     expect(screen.getByText('Service unavailable')).toBeInTheDocument();
   });
 
-  it('should show empty state when no jobs exist', async () => {
+  it('should show empty state without an action when no jobs exist and no filter is active', async () => {
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
     });
@@ -74,6 +76,30 @@ describe('SyncJobsPage', () => {
     renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('No jobs found')).toBeInTheDocument();
+    // Jobs are system-populated — no CTA for the no-filter branch.
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should show a Clear filters button that clears all filter params when filters are active', async () => {
+    const user = userEvent.setup();
+    const mockApi = createMockApiClient({
+      syncJobs: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+    });
+
+    renderWithProviders(<SyncJobsPage />, {
+      apiClient: mockApi,
+      route: '/sync-jobs?status=failed&jobType=order.sync',
+    });
+
+    expect(await screen.findByText('No jobs match the current filters.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    // After clearing, we're back to the informational empty state — no button.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Clear filters' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('No sync jobs have been enqueued yet.')).toBeInTheDocument();
   });
 
   // Regression guard for #270: the backend rejects `limit > 100` with HTTP 400

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
@@ -77,8 +77,10 @@ describe('SyncJobsPage', () => {
 
     expect(await screen.findByText('No jobs found')).toBeInTheDocument();
     // Jobs are system-populated — no CTA for the no-filter branch.
-    expect(screen.queryByRole('button', { name: 'Clear filters' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /manage connections|browse|add the first/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('should show a Clear filters button that clears all filter params when filters are active', async () => {

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
@@ -121,7 +121,7 @@ export function SyncJobsPage(): ReactElement {
     });
   }
 
-  const filtersActive = Boolean(status ?? jobType ?? connectionId);
+  const filtersActive = Boolean(status || jobType || connectionId);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
@@ -110,6 +110,18 @@ export function SyncJobsPage(): ReactElement {
     });
   }
 
+  function clearFilters(): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('status');
+      next.delete('jobType');
+      next.delete('connectionId');
+      next.delete('offset');
+      return next;
+    });
+  }
+
+  const filtersActive = Boolean(status ?? jobType ?? connectionId);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
@@ -172,9 +184,14 @@ export function SyncJobsPage(): ReactElement {
           liveRegion="off"
           title="No jobs found"
           message={
-            status || jobType || connectionId
-              ? 'No jobs match the current filters. Try clearing some filters.'
+            filtersActive
+              ? 'No jobs match the current filters.'
               : 'No sync jobs have been enqueued yet.'
+          }
+          action={
+            filtersActive ? (
+              <Button onClick={clearFilters}>Clear filters</Button>
+            ) : undefined
           }
         />
       ) : (

--- a/docs/plans/implementation-plan-empty-state-ctas.md
+++ b/docs/plans/implementation-plan-empty-state-ctas.md
@@ -1,0 +1,186 @@
+# Implementation Plan — Empty-state CTAs on list pages (#219)
+
+## Goal
+
+Every list-page `EmptyState` should offer a clear next step. Operators who land on an empty screen today hit a dead end — this adds actionable CTAs to guide them forward, and adds a "Clear filters" button when an empty result is the product of active filters.
+
+**Issue:** #219 — `fix(web): add actionable CTAs to empty states on list pages`
+
+## Non-goals
+
+- No new shared components — the existing `EmptyState` `action` prop does the work.
+- Pages *not* listed in the issue (webhook-deliveries, cursors, failed-orders, customer/order/connection detail drawers) stay untouched — avoid scope creep.
+- No copy changes to titles/messages beyond what's necessary to support the new CTA.
+- No changes to the `EmptyState` component API.
+
+## Layer classification
+
+**Frontend — page composition only.** No `shared/ui/` changes, no new hooks, no feature/API work.
+
+## Research summary
+
+- `apps/web/src/shared/ui/feedback-state.tsx:40` — `EmptyState` already accepts an optional `action: ReactNode`; renders it inside `.state-card__actions`.
+- `.claude/rules/fe-pages.md` requires "Provide CTA on empty — guide the user toward the next action". The issue is closing a known gap against this rule.
+- Two existing patterns for the action slot:
+  - Navigation CTA: `<Link className="button button--primary" to="/target">Label</Link>` (used at `connection-category-mappings-page.tsx:174`)
+  - Inline Button: existing pattern in error states — `<Button onClick={handler}>Retry</Button>`.
+- Filter-clearing handlers: each affected page already owns `setSearchParams` — clearing is a local concern that maps to existing search-param resets.
+- `connections-list-page.tsx:150` already ships a navigation CTA for the no-filter empty state, but no CTA for the filter-active branch. Consistent treatment is the goal.
+
+## Design
+
+### CTA matrix (from the issue, refined by code inspection)
+
+| Page | No data (no filter) | Filter-active empty |
+|---|---|---|
+| `orders-list-page` | `Link → /connections` ("Manage connections") | Button: "Clear filters" (removes `syncStatus` + `sourceConnectionId`) |
+| `products-list-page` | `Link → /connections` ("Manage connections") | Button: "Clear search" (removes `search`) |
+| `inventory-list-page` | `Link → /products` ("Browse products") | Button: "Clear filters" (removes `productId`, `productVariantId`) |
+| `listings-list-page` | `Link → /connections` ("Manage connections") | Button: "Clear filters" (removes `search`, `connectionId`, `platformType`) |
+| `customers-list-page` | `Link → /orders` ("Browse orders") | Button: "Clear filters" (removes `search`, `lastSourceConnectionId`) |
+| `connections-list-page` | **Already has** `Link → /connections/new` — no change | Button: "Clear filters" (removes `platformType`, `status`) |
+| `sync-jobs-page` | No CTA (informational — jobs are populated by the system) | Button: "Clear filters" (removes `status`, `jobType`, `connectionId`) |
+| `adapters-catalog-page` | No CTA (system-managed registry — user cannot add adapters from UI) | N/A |
+| `product-detail-page` stock section | No CTA (informational — stock is sourced from the master, not editable here) | N/A |
+
+**Rationale for exclusions:**
+- `sync-jobs` no-filter branch, `adapters-catalog`, and `product-detail` stock section have no meaningful user action; the issue itself flags `sync-jobs` as "Informational only" and offering a fake CTA would be noise.
+
+### Implementation sketch
+
+For each list page, replace
+
+```tsx
+<EmptyState
+  liveRegion="off"
+  title="No X found"
+  message={filterActive ? 'filter msg' : 'empty msg'}
+/>
+```
+
+with
+
+```tsx
+<EmptyState
+  liveRegion="off"
+  title="No X found"
+  message={filterActive ? 'filter msg' : 'empty msg'}
+  action={
+    filterActive ? (
+      <Button onClick={clearFilters}>Clear filter(s)</Button>
+    ) : (
+      <Link className="button button--primary" to="/target">Label</Link>
+    )
+  }
+/>
+```
+
+Where `clearFilters` is a small local function that calls `setSearchParams` with the filter keys removed and `offset` dropped, plus — for pages that keep a debounced local input state (products, inventory, listings, customers) — resets the `useState` input mirrors so the toolbar reflects the cleared filter.
+
+**On duplication:** four pages (products / inventory / listings / customers) end up with near-identical `clearFilters` implementations (reset useState mirrors + drop URL params + reset offset). This is accepted as intentional in-page duplication, not a deferred extraction. Rationale: a generic `useClearableSearchParams` hook would need to juggle per-page `useState` mirrors via callbacks, which adds more complexity than it saves for four call sites. Revisit if a fifth page joins the pattern.
+
+For `connections-list-page`, the no-filter branch already has a CTA. Add the filter-active branch; keep the existing CTA intact.
+
+For `sync-jobs-page`, only the filter-active branch gets a button.
+
+## Files to modify
+
+- `apps/web/src/pages/orders/orders-list-page.tsx`
+- `apps/web/src/pages/products/products-list-page.tsx`
+- `apps/web/src/pages/inventory/inventory-list-page.tsx`
+- `apps/web/src/pages/listings/listings-list-page.tsx`
+- `apps/web/src/pages/customers/customers-list-page.tsx`
+- `apps/web/src/pages/connections/connections-list-page.tsx`
+- `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx`
+
+And their corresponding `*.test.tsx` files to add/extend empty-state tests covering both branches.
+
+## Step-by-step implementation
+
+Each page follows the same shape: extract a local `clearFilters` function, pass an `action` node to the existing `EmptyState`, make sure `Link` is imported where needed. One acceptance criterion per page below.
+
+### Step 1 — `orders-list-page.tsx`
+
+- Add `clearFilters()` that calls `setSearchParams` clearing `syncStatus` + `sourceConnectionId` + `offset`.
+- Filter-active branch is `Boolean(syncStatus ?? sourceConnectionId)` so the button also appears for URL-driven `sourceConnectionId` filters even though the toolbar doesn't expose an input for it yet.
+- `action`: `filterActive ? <Button onClick={clearFilters}>Clear filters</Button> : <Link className="button button--primary" to="/connections">Manage connections</Link>`
+
+Acceptance: with `?syncStatus=failed` and no results → "Clear filters" clears the URL param. With `?sourceConnectionId=X` and no results → same button clears the URL param. Without any filter → a primary-styled link navigates to `/connections`.
+
+### Step 2 — `products-list-page.tsx`
+
+- Add `clearFilters()` that resets the debounced `searchInput` state and calls `setSearchParams` clearing `search` + `offset`.
+- `action`: `debouncedSearch ? <Button onClick={clearFilters}>Clear search</Button> : <Link className="button button--primary" to="/connections">Manage connections</Link>`
+
+Acceptance: search with no match → "Clear search" clears both URL param and toolbar input. Empty state with no search → link to `/connections`.
+
+### Step 3 — `inventory-list-page.tsx`
+
+- Add `clearFilters()` that resets `productIdInput`, `variantIdInput` and clears URL params.
+- `action`: filters-active → "Clear filters" button; otherwise → `Link → /products` ("Browse products").
+
+Acceptance: filter-active empty → single click clears both filters and toolbar inputs. No-filter empty → link navigates to `/products`.
+
+### Step 4 — `listings-list-page.tsx`
+
+- Add `clearFilters()` covering `searchInput`, `connectionIdInput`, `platformTypeInput` and URL params.
+- `action`: filters-active → "Clear filters"; otherwise → `Link → /connections` ("Manage connections").
+
+Acceptance: matches Step 3 pattern.
+
+### Step 5 — `customers-list-page.tsx`
+
+- Add `clearFilters()` covering `searchInput`, `connectionIdInput` and URL params.
+- `action`: filters-active → "Clear filters"; otherwise → `Link → /orders` ("Browse orders").
+
+Acceptance: matches Step 3 pattern; primary-link destination is `/orders`.
+
+### Step 6 — `connections-list-page.tsx`
+
+- Existing no-filter CTA stays in place but is upgraded from `className="button"` to `className="button button--primary"` so it matches every other navigation CTA introduced in this PR.
+- Add filter-active CTA: `<Button onClick={clearFilters}>Clear filters</Button>` clearing `platformType`/`status` from the URL.
+
+Acceptance: two branches each render a CTA; the "Add the first connection" link is primary-styled; the filter-active button clears both filter params.
+
+### Step 7 — `sync-jobs-page.tsx`
+
+- Add `clearFilters()` that removes `status`, `jobType`, `connectionId`, `offset`.
+- `action`: filters-active → "Clear filters" button; no-filter branch → no `action` (informational).
+- Trim the trailing "Try clearing some filters." sentence in the filter-active message since a button now provides the action. Grep `sync-jobs-page.test.tsx` for that exact sentence before the change so any test assertion on it is updated in lockstep (Step 8).
+
+Acceptance: filter-active empty → button clears all three filter params. No-filter empty is text-only (unchanged behavior aside from slightly tightened copy).
+
+### Step 8 — Tests
+
+For each of the 7 pages, extend the empty-state test(s) to assert the new CTA. Where there is an existing "empty state with filter message when filters are active" test (customers, listings), add a role-based assertion that a "Clear filters" button (or "Clear search"/"Clear filter") is present. Where only a single "empty state" test exists (orders, products, inventory, sync-jobs), add a second test for the filter-active branch.
+
+For `connections-list-page`, add a filter-active test alongside the existing "empty state" test.
+
+Acceptance: `pnpm --filter @openlinker/web test` passes with new assertions green; no regressions in existing tests.
+
+### Step 9 — Quality gate
+
+```bash
+pnpm lint         # zero errors
+pnpm type-check   # zero errors
+pnpm --filter @openlinker/web test
+```
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Clearing filters leaves stale debounced input in local state | Explicitly reset the `useState` mirrors in `clearFilters()` for each affected page. |
+| Pages that navigate to a suggested target land on another empty screen | Accept as MVP — the link gives the operator a concrete next move instead of a dead end. The downstream empty state (per this same work) will also have a CTA. |
+| CTA wording inconsistency across pages | Standardise: "Clear filters" when N > 1 filters, "Clear filter" / "Clear search" when exactly one scalar param. Use `button button--primary` for navigation links across the board. |
+| Adding `action` changes the ARIA live region's text and may re-announce | `EmptyState` already sets `liveRegion="off"` on these pages; unchanged. |
+
+## Open questions
+
+None — issue is prescriptive.
+
+## Out of scope (documented for the PR description)
+
+- `webhook-deliveries-page`, `cursors-list-page`, `failed-orders-page` — outside the issue's scope list; left untouched.
+- `product-detail-page` stock section and `adapters-catalog-page` — inside the issue's scope list but have no meaningful user CTA (stock is sourced from the master; adapters are system-registered). Leave as text-only empty states and add a one-line `// No action: …` comment above each `EmptyState` so future readers don't quietly add a CTA without re-checking the rationale.
+- No changes to `EmptyState` component itself.


### PR DESCRIPTION
## Summary

- Every list-page `EmptyState` now offers a clear next step — either a primary-styled navigation link when there's no data yet, or a "Clear filters"/"Clear search" button when the empty result is the product of active filters.
- Clearing a filter resets both the URL param and the page-local debounced input state so the toolbar input reflects the cleared filter immediately.
- Scope covers the 7 list pages called out in the issue (orders, products, inventory, listings, customers, connections, sync-jobs).

## CTA matrix

| Page | No-filter empty | Filter-active empty |
|---|---|---|
| Orders | Link → `/connections` ("Manage connections") | "Clear filters" |
| Products | Link → `/connections` ("Manage connections") | "Clear search" |
| Inventory | Link → `/products` ("Browse products") | "Clear filters" |
| Listings | Link → `/connections` ("Manage connections") | "Clear filters" |
| Customers | Link → `/orders` ("Browse orders") | "Clear filters" |
| Connections | Link → `/connections/new` ("Add the first connection", existing, upgraded to primary style) | "Clear filters" (new) |
| Sync-jobs | — (system-populated, informational) | "Clear filters" |

## Excluded (with inline `// No action:` comments in the code)

- `adapters-catalog-page` — adapters are system-registered at build time; operators cannot add them from the UI.
- `product-detail-page` stock section — stock is sourced from the product master and not editable here.
- `webhook-deliveries`, `cursors-list`, `failed-orders` — outside the issue's scope list.

## Follow-up tech debt

Five pages (products / inventory / listings / customers / sync-jobs) ship near-identical inline `clearFilters()` helpers. This is the 5th page — the threshold noted in the implementation plan for revisiting extraction. Tracked as a follow-up so it doesn't get forgotten when a 6th page joins the pattern.

## Test plan

- [ ] `pnpm --filter @openlinker/web test` — 392/392 green locally
- [ ] `pnpm lint` — zero errors
- [ ] `pnpm type-check` — zero errors
- [ ] Manual: visit each of the 7 list pages with no data → verify the correct navigation CTA
- [ ] Manual: apply a filter that returns zero results → click "Clear filters"/"Clear search" → verify the toolbar resets and the page returns to either the table (if data exists unfiltered) or the no-filter empty state
- [ ] Manual: connections list — confirm the existing "Add the first connection" link is now primary-styled (matches the other new CTAs)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)