### PR TITLE
test(web): scope toast-text assertions past Radix a11y announce portal

### DIFF
--- a/apps/web/src/features/connections/components/create-connection-form.test.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.test.tsx
@@ -3,7 +3,12 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { useLocation } from 'react-router-dom';
 import { CreateConnectionForm } from './create-connection-form';
-import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import {
+  createMockApiClient,
+  findToastDescription,
+  findToastTitle,
+  renderWithProviders,
+} from '../../../test/test-utils';
 
 function LocationProbe(): ReactElement {
   const location = useLocation();
@@ -54,9 +59,9 @@ describe('CreateConnectionForm', () => {
     });
     fireEvent.click(within(view.container).getAllByRole('button', { name: 'Create connection' })[0]);
 
-    expect(await screen.findByText('Connection created')).toBeInTheDocument();
+    expect(await findToastTitle('Connection created')).toBeInTheDocument();
     expect(
-      screen.getByText('Connection "Main PrestaShop Store" was created.'),
+      await findToastDescription('Connection "Main PrestaShop Store" was created.'),
     ).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByTestId('location-pathname')).toHaveTextContent('/connections');
@@ -82,7 +87,7 @@ describe('CreateConnectionForm', () => {
     );
 
     expect(within(view.container).getAllByLabelText('Connection name')[0]).toHaveValue('');
-    expect(await screen.findByText('Draft reset')).toBeInTheDocument();
+    expect(await findToastTitle('Draft reset')).toBeInTheDocument();
   });
 
   it('shows a form-level API error alert', async () => {

--- a/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
+++ b/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
@@ -5,7 +5,11 @@
  */
 import { screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import {
+  createMockApiClient,
+  findToastTitle,
+  renderWithProviders,
+} from '../../../test/test-utils';
 import { EditOfferDrawer } from './EditOfferDrawer';
 import type { OfferMapping } from '../api/listings.types';
 
@@ -116,7 +120,7 @@ describe('EditOfferDrawer', () => {
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();
     });
-    expect(await screen.findByText(/update dispatched/i)).toBeInTheDocument();
+    expect(await findToastTitle(/update dispatched/i)).toBeInTheDocument();
   });
 
   it('should show inline error and not close drawer on API failure', async () => {

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
@@ -9,7 +9,13 @@
  */
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import {
+  createMockApiClient,
+  getToastDescription,
+  getToastTitle,
+  renderWithProviders,
+  sampleConnection,
+} from '../../../test/test-utils';
 import { TriggerSyncDialog } from './TriggerSyncDialog';
 
 // jsdom does not implement showModal/close — stub them on HTMLDialogElement
@@ -248,15 +254,8 @@ describe('TriggerSyncDialog', () => {
         expect(onOpenChange).toHaveBeenCalledWith(false);
       });
 
-      // Radix Toast renders the title and description twice — once in the
-      // visible `.toast__title`/`.toast__description` and once inside an
-      // `aria-live` announcement span. Scope to the visible toast title/body.
-      expect(
-        screen.getByText(/sync job enqueued/i, { selector: '.toast__title' }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/job_42/i, { selector: '.toast__description' }),
-      ).toBeInTheDocument();
+      expect(getToastTitle(/sync job enqueued/i)).toBeInTheDocument();
+      expect(getToastDescription(/job_42/i)).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -1,6 +1,12 @@
 import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
+import {
+  createMockApiClient,
+  findToastDescription,
+  findToastTitle,
+  renderWithProviders,
+  sampleConnection,
+} from '../../test/test-utils';
 import { DashboardPage } from './dashboard-page';
 import type { Connection } from '../../features/connections/api/connections.types';
 import type {
@@ -375,7 +381,7 @@ describe('DashboardPage', () => {
       });
       fireEvent.click(retryButton);
 
-      expect(await screen.findByText(/Re-queued 3 jobs/i)).toBeInTheDocument();
+      expect(await findToastTitle(/Re-queued 3 jobs/i)).toBeInTheDocument();
     });
 
     it('mentions skipped jobs in the toast when the bulk endpoint skips some', async () => {
@@ -405,9 +411,7 @@ describe('DashboardPage', () => {
       });
       fireEvent.click(retryButton);
 
-      expect(
-        await screen.findByText(/skipped 2 already running/i),
-      ).toBeInTheDocument();
+      expect(await findToastDescription(/skipped 2 already running/i)).toBeInTheDocument();
     });
 
     it('shows an honest "nothing re-queued" toast when the bulk endpoint returns count=0', async () => {
@@ -439,8 +443,8 @@ describe('DashboardPage', () => {
       });
       fireEvent.click(retryButton);
 
-      expect(await screen.findByText(/Nothing re-queued/i)).toBeInTheDocument();
-      expect(screen.getByText(/no dead jobs remain/i)).toBeInTheDocument();
+      expect(await findToastTitle(/Nothing re-queued/i)).toBeInTheDocument();
+      expect(await findToastDescription(/no dead jobs remain/i)).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
+import { render, screen, type RenderOptions, type RenderResult } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
@@ -249,6 +249,33 @@ export function createAuthenticatedSessionAdapter(
     async persistSession(): Promise<void> {},
     async clearSession(): Promise<void> {},
   };
+}
+
+/**
+ * Toast text helpers.
+ *
+ * `@radix-ui/react-toast` renders every toast twice — once visibly inside the
+ * Viewport (`.toast__title` / `.toast__description` in our wrapper) and once
+ * inside a hidden `ToastAnnounce` portal for screen readers. The announce
+ * portal hides itself ~1000ms after mount, creating a race window where a
+ * plain `screen.getByText(...)` intermittently matches both copies and throws.
+ * Scope toast-text assertions to the visible `.toast__*` elements to skip the
+ * announce portal entirely.
+ */
+export function findToastTitle(text: string | RegExp): Promise<HTMLElement> {
+  return screen.findByText(text, { selector: '.toast__title' });
+}
+
+export function getToastTitle(text: string | RegExp): HTMLElement {
+  return screen.getByText(text, { selector: '.toast__title' });
+}
+
+export function findToastDescription(text: string | RegExp): Promise<HTMLElement> {
+  return screen.findByText(text, { selector: '.toast__description' });
+}
+
+export function getToastDescription(text: string | RegExp): HTMLElement {
+  return screen.getByText(text, { selector: '.toast__description' });
 }
 
 export function renderWithProviders(ui: ReactElement, options: RenderWithProvidersOptions = {}): RenderResult {

--- a/docs/plans/implementation-plan-flaky-toast-tests.md
+++ b/docs/plans/implementation-plan-flaky-toast-tests.md
@@ -1,0 +1,109 @@
+# Implementation Plan — Flaky toast tests (#309)
+
+## 1. Task restatement
+
+Two tests fail ~25% of full-suite runs and 0% in isolation:
+
+1. `apps/web/src/pages/dashboard/dashboard-page.test.tsx` → `DashboardPage > "What's broken right now" triage surface > shows an honest "nothing re-queued" toast when the bulk endpoint returns count=0`
+   - Failure: `Found multiple elements with the text: /no dead jobs remain/i` on line 443.
+2. `apps/web/src/features/listings/components/EditOfferDrawer.test.tsx` → `EditOfferDrawer > should show success toast and close drawer on successful submit`
+   - Failure: `Found multiple elements with the text: /update dispatched/i` on line 119.
+
+**Layer:** Frontend (FE) — test-only.
+
+**Non-goals:**
+- No changes to `apps/web/src/shared/ui/toast-provider.tsx`.
+- No changes to Radix Toast usage or app behavior.
+- No changes to `renderWithProviders` shape.
+
+## 2. Root cause
+
+`@radix-ui/react-toast@1.2.15` renders **two DOM nodes per toast**:
+
+1. The **visible toast** — rendered into `<RadixToast.Viewport>` (our `.toast-region`) via `ReactDOM.createPortal`, containing `.toast__title` and `.toast__description`.
+2. A **screen-reader announce portal** (`ToastAnnounce`) — a separate `@radix-ui/react-portal` wrapping a `VisuallyHidden` span whose text is `context.label + " " + announceTextContent`. `announceTextContent` is populated from the visible toast's DOM by a `useEffect` **after** the first render, and the announce hides itself (`isAnnounced=true → return null`) **1000ms** after mount.
+
+Key source references (`@radix-ui/react-toast@1.2.15/dist/index.js`):
+- `ToastImpl` renders `<ToastAnnounce>` + `createPortal(visibleToast)` as siblings (line ~414–423).
+- `ToastAnnounce` uses `Portal` + `VisuallyHidden` (line ~529).
+- `setIsAnnounced` fires after 1000ms (line ~525).
+
+So any `getByText(...)` that matches the toast body text will intermittently match **both** the visible `.toast__title`/`.toast__description` and the VisuallyHidden announce span. The flake window is the ~1s during which both exist.
+
+For the two failing tests specifically:
+- `findByText(/…/)` polls — it returns once exactly one match exists. It typically wins the race because `announceTextContent` is populated in a `useEffect` **after** the first visible render, so for one or two animation frames only the visible toast is in the DOM.
+- The very next `screen.getByText(/…/)` line runs synchronously after `findByText` resolves. Under parallel-worker load, the microtask/scheduler gap is long enough for React to commit the announce update — resulting in 2 matches → `getByText` throws.
+
+This matches the observed "fails ~25%, isolated 0%" profile and the specific failure line in both tests.
+
+An existing precedent already applies the fix in `apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx:235-260` — with a comment explaining the duplicate.
+
+## 3. Fix
+
+Scope text queries to the **visible** toast elements using the existing class selectors `.toast__title` and `.toast__description`. This bypasses the a11y announce portal entirely. No retries, no waitFor padding, no timing assumptions, no production changes.
+
+Rather than scatter the `{ selector: '.toast__title' }` idiom (plus its explanatory comment) across every new call site, **extract four test helpers into `apps/web/src/test/test-utils.tsx`** — the file that already owns `renderWithProviders`:
+
+```tsx
+// test/test-utils.tsx (new)
+export function findToastTitle(text: string | RegExp): Promise<HTMLElement> { ... }
+export function getToastTitle(text: string | RegExp): HTMLElement { ... }
+export function findToastDescription(text: string | RegExp): Promise<HTMLElement> { ... }
+export function getToastDescription(text: string | RegExp): HTMLElement { ... }
+```
+
+One JSDoc block at the top of the helpers explains the Radix `ToastAnnounce` race once, so future toast-asserting tests don't have to rediscover it.
+
+Apply by replacing call sites with the helpers in:
+1. `apps/web/src/pages/dashboard/dashboard-page.test.tsx` — four toast-body assertions in the triage surface describe block (success, skipped, nothing-requeued).
+2. `apps/web/src/features/listings/components/EditOfferDrawer.test.tsx` — one toast-title assertion.
+3. `apps/web/src/features/connections/components/create-connection-form.test.tsx` — proactive: two assertions in "shows a success toast after creating a connection".
+4. `apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx` — fold the existing `{ selector: … }` pattern (lines 251-259) into the new helpers so the entire codebase converges on one shape.
+
+## 4. Step-by-step plan
+
+### Step 1 — Fix `dashboard-page.test.tsx`
+
+Scope the four toast-text assertions in the `"What's broken right now" triage surface` describe block:
+
+- Line 378: `screen.findByText(/Re-queued 3 jobs/i)` → scope to `.toast__title`.
+- Line 409-410: `screen.findByText(/skipped 2 already running/i)` → scope to `.toast__description`.
+- Line 442: `screen.findByText(/Nothing re-queued/i)` → scope to `.toast__title`.
+- Line 443: `screen.getByText(/no dead jobs remain/i)` → scope to `.toast__description`.
+
+Add a one-line explanatory comment above the block (same as `TriggerSyncDialog.test.tsx`) so future readers don't re-introduce the flake.
+
+**Acceptance:** The affected test file passes 20/20 in a loop.
+
+### Step 2 — Fix `EditOfferDrawer.test.tsx`
+
+- Line 119: `screen.findByText(/update dispatched/i)` → scope to `.toast__title`.
+
+**Acceptance:** File passes 20/20 in a loop.
+
+### Step 3 — Fix `create-connection-form.test.tsx`
+
+- Line 57: `screen.findByText('Connection created')` → scope to `.toast__title`.
+- Line 59: `screen.getByText('Connection "Main PrestaShop Store" was created.')` → scope to `.toast__description`.
+
+**Acceptance:** File passes 20/20 in a loop.
+
+### Step 4 — Stability validation
+
+Run `pnpm --filter @openlinker/web test` 20 consecutive times. All must pass.
+
+Final pre-push quality gate (matches CI, repo-wide):
+- `pnpm lint`
+- `pnpm type-check`
+- `pnpm test`
+
+### Step 5 — Ship
+
+Self-review, commit (`test(web): scope toast-text assertions past Radix a11y announce portal`), push, PR with `Closes #309`.
+
+## 5. Risks / trade-offs
+
+- **Coupling tests to CSS class names.** `.toast__title` and `.toast__description` are already structurally stable (used across `toast-provider.tsx` and CSS tokens in `index.css`). If someone later restructures the toast markup, the failure mode is a loud test miss (`getByText` throws immediately), never a production regression. Cheap risk, contained by the helpers.
+- **Not fixing the Radix announce portal globally.** Tempting to add a teardown hook or wrapper to `ToastProvider`, but the task explicitly forbids production changes. The test-only fix is the cheapest and most targeted.
+- **Scope widened beyond the two failing tests.** Fixing the success/skipped assertions in the same dashboard test file (and proactively touching `create-connection-form.test.tsx`) is intentional: the latent race exists everywhere we assert toast text, and whack-a-mole is its own antipattern. Called out in the PR description so reviewers don't read it as scope creep.
+- **PR #303 wizard tests not touched.** The acceptance says they must still pass 20/20 — they don't use toast-text assertions today, so unaffected.


### PR DESCRIPTION
## Summary

Fixes the ~25% full-suite flake tracked in #309. Two tests (`DashboardPage > … "nothing re-queued" toast` and `EditOfferDrawer > should show success toast and close drawer on successful submit`) intermittently failed with `Found multiple elements with the text: …`. Root cause is in `@radix-ui/react-toast@1.2.15`: every toast renders **twice** — visibly in our `.toast-region` viewport and invisibly inside a `ToastAnnounce` portal (a `VisuallyHidden` span used by screen readers). The announce portal self-removes ~1000 ms after mount, so a `screen.getByText(...)` call can intermittently match both copies.

The fix is test-only: scope toast text assertions to `.toast__title` / `.toast__description` via four new helpers in `test/test-utils.tsx`. A single JSDoc on the helpers explains the Radix race once, so future toast-asserting tests don't have to rediscover it.

- New helpers: `findToastTitle`, `getToastTitle`, `findToastDescription`, `getToastDescription`.
- 9 call sites across 4 test files converted to helpers.
- Folded the pre-existing inline `{ selector: '.toast__title' }` workaround in `TriggerSyncDialog.test.tsx` onto the same helpers so the codebase converges on one pattern.
- **No production file touched** — `toast-provider.tsx`, `renderWithProviders`, and UI components are all untouched (per #309 acceptance).

## Scope notes

- **Widened beyond the two tests named in #309**. The success and skipped dashboard-retry toasts share the same latent race, as do both assertions in `create-connection-form.test.tsx`'s success test plus the "Draft reset" toast. Fixing them in the same PR avoids whack-a-mole. Only the two explicitly reported by #309 were observed failing, but the mechanism is identical.
- **One intentional behaviour tweak** at `dashboard-page.test.tsx:443`: `screen.getByText(...)` → `await findToastDescription(...)`. Radix renders title and description in the same JSX commit, so once `findToastTitle` resolves the description is already in the DOM — the async form is defence-in-depth, not a semantic change.
- **Helpers have transitive coverage** through the 4 consumer files. No dedicated helper tests — a direct test would just re-assert Testing Library's own behaviour, and if the `.toast__*` class names ever change, all 9 call sites break loudly on the next run (correct failure mode).
- **Removed comment in `TriggerSyncDialog.test.tsx`**. The three-line explanatory comment that preceded the two inline selector calls is dropped — the JSDoc on the helpers now owns that context, and keeping the old comment would create drift.

## Test plan

- [x] Reproduce flake on bare `main`: 3/10 failures with the exact `Found multiple elements …` signature on both affected tests.
- [x] Fix applied, full suite re-run: **20/20 consecutive runs pass** (`pnpm --filter @openlinker/web test`).
- [x] Targeted re-run of the 4 edited test files: 49/49 pass.
- [x] Repo-wide `pnpm lint` ✅ (2 pre-existing warnings in `apps/api/src/auth/password-reset.service.spec.ts`, unrelated).
- [x] Repo-wide `pnpm type-check` ✅.
- [x] Repo-wide `pnpm test` ✅ (973 tests across all packages).
- [x] PR #303 wizard tests still pass (no toast-text assertions there; unaffected).

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)