### PR TITLE
feat(listings): offer-creation status on detail page + variant-picker pagination (#306, #308)

### DIFF
--- a/apps/api/src/listings/http/dto/offer-mapping-response.dto.ts
+++ b/apps/api/src/listings/http/dto/offer-mapping-response.dto.ts
@@ -7,6 +7,8 @@
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+import { OfferCreationStatusResponseDto } from './offer-creation-status-response.dto';
+
 export class OfferMappingResponseDto {
   @ApiProperty({ description: 'Mapping row ID' })
   id!: string;
@@ -34,4 +36,16 @@ export class OfferMappingResponseDto {
 
   @ApiProperty({ description: 'Last update timestamp (ISO 8601)' })
   updatedAt!: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    type: OfferCreationStatusResponseDto,
+    description:
+      'Populated only by `GET /listings/:id` (detail endpoint) for Offer-type ' +
+      'mappings that originated from an OL-initiated create. Always absent on ' +
+      'list responses (`GET /listings`) regardless of creation history — the ' +
+      'list does not fan-out lookups per row. Absent on synced-in offers and ' +
+      'on non-Offer entity types (Product, Inventory, etc.).',
+  })
+  offerCreation?: OfferCreationStatusResponseDto | null;
 }

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -68,6 +68,7 @@ describe('ListingsController', () => {
       create: jest.fn(),
       findById: jest.fn(),
       findLatestByVariantAndConnection: jest.fn(),
+      findByExternalOfferIdAndConnectionId: jest.fn(),
       updateStatus: jest.fn(),
       updateExternalOfferId: jest.fn(),
       updateExternalIdAndStatus: jest.fn(),
@@ -140,6 +141,7 @@ describe('ListingsController', () => {
   describe('getOfferMapping', () => {
     it('should return offer mapping when found', async () => {
       repository.findById.mockResolvedValue(mockMapping);
+      offerCreationRecords.findByExternalOfferIdAndConnectionId.mockResolvedValue(null);
 
       const result = await controller.getOfferMapping('uuid-1');
 
@@ -153,6 +155,71 @@ describe('ListingsController', () => {
       repository.findById.mockResolvedValue(null);
 
       await expect(controller.getOfferMapping('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should embed offerCreation when an Offer mapping has a matching record', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+      const linkedRecord = new OfferCreationRecord(
+        'record-42',
+        'ol_variant_abc123',
+        'conn-1',
+        'allegro-offer-456',
+        'active',
+        null,
+        true,
+        new Date('2026-04-20T10:00:00Z'),
+        new Date('2026-04-20T11:00:00Z'),
+      );
+      offerCreationRecords.findByExternalOfferIdAndConnectionId.mockResolvedValue(linkedRecord);
+
+      const result = await controller.getOfferMapping('uuid-1');
+
+      expect(offerCreationRecords.findByExternalOfferIdAndConnectionId).toHaveBeenCalledWith(
+        'allegro-offer-456',
+        'conn-1',
+      );
+      expect(result.offerCreation).toEqual({
+        id: 'record-42',
+        internalVariantId: 'ol_variant_abc123',
+        connectionId: 'conn-1',
+        externalOfferId: 'allegro-offer-456',
+        status: 'active',
+        errors: null,
+        publishImmediately: true,
+        createdAt: '2026-04-20T10:00:00.000Z',
+        updatedAt: '2026-04-20T11:00:00.000Z',
+      });
+    });
+
+    it('should omit offerCreation when an Offer mapping has no matching record (synced-in)', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+      offerCreationRecords.findByExternalOfferIdAndConnectionId.mockResolvedValue(null);
+
+      const result = await controller.getOfferMapping('uuid-1');
+
+      expect(offerCreationRecords.findByExternalOfferIdAndConnectionId).toHaveBeenCalledTimes(1);
+      expect(result.offerCreation).toBeUndefined();
+    });
+
+    it('should skip the creation-record lookup entirely for non-Offer entity types', async () => {
+      const productMapping = new IdentifierMapping(
+        'uuid-2',
+        'Product',
+        'ol_product_abc',
+        'prestashop-product-7',
+        'prestashop',
+        'conn-2',
+        null,
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-01-01T00:00:00Z'),
+      );
+      repository.findById.mockResolvedValue(productMapping);
+
+      const result = await controller.getOfferMapping('uuid-2');
+
+      expect(offerCreationRecords.findByExternalOfferIdAndConnectionId).not.toHaveBeenCalled();
+      expect(result.offerCreation).toBeUndefined();
+      expect(result.entityType).toBe('Product');
     });
   });
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -110,7 +110,22 @@ export class ListingsController {
     if (!mapping) {
       throw new NotFoundException(`Offer mapping not found: ${id}`);
     }
-    return this.toDto(mapping);
+
+    const dto = this.toDto(mapping);
+    // Enrich Offer-type mappings with the matching OfferCreationRecord so the
+    // detail page can show creation status + errors for OL-initiated offers
+    // without a second round-trip. Synced-in offers (no matching record) and
+    // non-Offer entity types fall through to a plain DTO.
+    if (mapping.entityType === 'Offer') {
+      const record = await this.offerCreationRecords.findByExternalOfferIdAndConnectionId(
+        mapping.externalId,
+        mapping.connectionId,
+      );
+      if (record) {
+        dto.offerCreation = this.toOfferCreationStatusDto(record);
+      }
+    }
+    return dto;
   }
 
   @Post('connections/:connectionId/offers/:offerId/fields')

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -39,7 +39,7 @@ import type {
   OfferCreationRecordRepositoryPort,
   OfferMappingRepositoryPort,
 } from '@openlinker/core/listings';
-import type { IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import type { EntityType, IdentifierMapping } from '@openlinker/core/identifier-mapping';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { JobEnqueuePort } from '@openlinker/core/sync';
 
@@ -116,7 +116,7 @@ export class ListingsController {
     // detail page can show creation status + errors for OL-initiated offers
     // without a second round-trip. Synced-in offers (no matching record) and
     // non-Offer entity types fall through to a plain DTO.
-    if (mapping.entityType === 'Offer') {
+    if (mapping.entityType === ('Offer' satisfies EntityType)) {
       const record = await this.offerCreationRecords.findByExternalOfferIdAndConnectionId(
         mapping.externalId,
         mapping.connectionId,

--- a/apps/api/src/migrations/1786000000000-add-offer-creation-record-external-offer-index.ts
+++ b/apps/api/src/migrations/1786000000000-add-offer-creation-record-external-offer-index.ts
@@ -1,0 +1,39 @@
+/**
+ * Add Offer-Creation-Record External-Offer Partial Index
+ *
+ * Adds a partial composite index on `offer_creation_records
+ * (externalOfferId, connectionId) WHERE externalOfferId IS NOT NULL`. Powers
+ * the `findByExternalOfferIdAndConnectionId` lookup used by the listings
+ * detail endpoint to embed creation status alongside an offer mapping
+ * (issue #306 follow-up to #261).
+ *
+ * Partial by design: pre-creation rows (status `pending` before the adapter
+ * returns) always have null `externalOfferId` and never hit this index path,
+ * so indexing them wastes space. The `WHERE` predicate keeps the index
+ * narrow and selective.
+ *
+ * Generated manually: Docker was not available at generation time, so the
+ * partial-index SQL is hand-written here rather than going through
+ * `migration:generate`.
+ *
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOfferCreationRecordExternalOfferIndex1786000000000 implements MigrationInterface {
+  name = 'AddOfferCreationRecordExternalOfferIndex1786000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX "IDX_offer_creation_records_external_offer_connection"
+        ON "offer_creation_records" ("externalOfferId", "connectionId")
+        WHERE "externalOfferId" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_offer_creation_records_external_offer_connection"`,
+    );
+  }
+}

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -26,6 +26,13 @@ export interface OfferMapping {
   context: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Populated only by the detail endpoint (`GET /listings/:id`) for Offer-type
+   * mappings that originated from an OL-initiated create. Always absent on
+   * list responses — the list endpoint does not fan out lookups per row.
+   * Absent on synced-in offers and on non-Offer entity types.
+   */
+  offerCreation?: OfferCreationStatusResponse | null;
 }
 
 export interface ListingsFilters {

--- a/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
@@ -366,4 +366,117 @@ describe('CreateOfferWizard', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  describe('variant picker pagination (#308)', () => {
+    const page1Product = { ...product, id: 'ol_product_abc', name: 'Test Shirt' };
+    const page2Product = { ...product, id: 'ol_product_def', name: 'Page Two Shirt' };
+
+    it('does not render Prev/Next when total <= page size', async () => {
+      const list = vi.fn().mockResolvedValue({ items: [page1Product], total: 1, limit: 10, offset: 0 });
+      const mockApi = defaultMocks({ products: { list, getById: vi.fn().mockResolvedValue(page1Product) } });
+      renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await waitFor(() => expect(screen.getByText('Test Shirt')).toBeInTheDocument());
+      expect(screen.queryByRole('button', { name: /previous page of products/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /next page of products/i })).not.toBeInTheDocument();
+    });
+
+    it('paginates forward and disables Next on the last page', async () => {
+      const list = vi
+        .fn()
+        .mockImplementation((_filters, pagination: { limit?: number; offset?: number } = {}) =>
+          Promise.resolve(
+            (pagination.offset ?? 0) === 0
+              ? { items: [page1Product], total: 15, limit: 10, offset: 0 }
+              : { items: [page2Product], total: 15, limit: 10, offset: 10 },
+          ),
+        );
+      const mockApi = defaultMocks({
+        products: { list, getById: vi.fn().mockResolvedValue(page1Product) },
+      });
+      renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      // Page 1: Prev disabled, Next enabled
+      await waitFor(() => expect(screen.getByText('Test Shirt')).toBeInTheDocument());
+      const prev = await screen.findByRole('button', { name: /previous page of products/i });
+      const next = await screen.findByRole('button', { name: /next page of products/i });
+      expect(prev).toBeDisabled();
+      expect(next).not.toBeDisabled();
+
+      // Click Next → page 2
+      fireEvent.click(next);
+      await waitFor(() => expect(screen.getByText('Page Two Shirt')).toBeInTheDocument());
+      expect(list).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({ offset: 10 }),
+      );
+
+      // Page 2 of 15: Prev enabled, Next disabled (10 + 10 >= 15)
+      const prevAfter = screen.getByRole('button', { name: /previous page of products/i });
+      const nextAfter = screen.getByRole('button', { name: /next page of products/i });
+      expect(prevAfter).not.toBeDisabled();
+      expect(nextAfter).toBeDisabled();
+    });
+
+    it('resets offset to 0 when the search input changes', async () => {
+      const list = vi
+        .fn()
+        .mockImplementation((filters: { search?: string } = {}, pagination: { offset?: number } = {}) =>
+          Promise.resolve(
+            filters.search
+              ? { items: [page2Product], total: 1, limit: 10, offset: 0 }
+              : (pagination.offset ?? 0) === 0
+                ? { items: [page1Product], total: 15, limit: 10, offset: 0 }
+                : { items: [], total: 15, limit: 10, offset: 10 },
+          ),
+        );
+      const mockApi = defaultMocks({
+        products: { list, getById: vi.fn().mockResolvedValue(page1Product) },
+      });
+      renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      // Advance to page 2
+      await waitFor(() => expect(screen.getByText('Test Shirt')).toBeInTheDocument());
+      fireEvent.click(await screen.findByRole('button', { name: /next page of products/i }));
+      await waitFor(() =>
+        expect(list).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ offset: 10 })),
+      );
+
+      // Type in search — offset must reset to 0 (last call after debounce)
+      const searchInput = screen.getByLabelText(/search products/i);
+      fireEvent.change(searchInput, { target: { value: 'page two' } });
+      await waitFor(
+        () => {
+          const lastCall = list.mock.calls[list.mock.calls.length - 1];
+          expect(lastCall[0]).toEqual(expect.objectContaining({ search: 'page two' }));
+          expect(lastCall[1]).toEqual(expect.objectContaining({ offset: 0 }));
+        },
+        { timeout: 1000 },
+      );
+    });
+  });
 });

--- a/apps/web/src/features/listings/components/CreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.tsx
@@ -61,6 +61,7 @@ const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<CreateOfferFieldsValues>>> =
 ];
 
 const VARIANT_SEARCH_DEBOUNCE_MS = 300;
+const VARIANT_PICKER_PAGE_SIZE = 10;
 
 interface CreateOfferWizardProps {
   isOpen: boolean;
@@ -101,6 +102,7 @@ export function CreateOfferWizard({
   const [stepIndex, setStepIndex] = useState(0);
   const [completedSteps, setCompletedSteps] = useState<ReadonlySet<number>>(new Set());
   const [productSearchInput, setProductSearchInput] = useState('');
+  const [productOffset, setProductOffset] = useState(0);
   const [selectedProductId, setSelectedProductId] = useState<string | null>(null);
   const debouncedProductSearch = useDebouncedValue(productSearchInput, VARIANT_SEARCH_DEBOUNCE_MS);
 
@@ -113,6 +115,7 @@ export function CreateOfferWizard({
       setStepIndex(0);
       setCompletedSteps(new Set());
       setProductSearchInput('');
+      setProductOffset(0);
       setSelectedProductId(null);
       mutation.reset();
     }
@@ -161,7 +164,7 @@ export function CreateOfferWizard({
 
   const productsQuery = useProductsQuery(
     { search: debouncedProductSearch || undefined },
-    { limit: 10, offset: 0 },
+    { limit: VARIANT_PICKER_PAGE_SIZE, offset: productOffset },
   );
   const productDetailQuery = useProductQuery(selectedProductId ?? '');
 
@@ -301,7 +304,14 @@ export function CreateOfferWizard({
               >
                 <Input
                   value={productSearchInput}
-                  onChange={(e) => setProductSearchInput(e.target.value)}
+                  onChange={(e) => {
+                    setProductSearchInput(e.target.value);
+                    // Reset offset synchronously here (not via a useEffect on the
+                    // debounced value) so the debounced query always fires with a
+                    // fresh offset — narrowing a search can otherwise leave the
+                    // picker on a now-empty page.
+                    setProductOffset(0);
+                  }}
                   placeholder="e.g. T-shirt, SKU-123, 5901234567890"
                 />
               </FormField>
@@ -382,6 +392,43 @@ export function CreateOfferWizard({
                   <p className="form-field__error" role="alert">
                     {form.formState.errors.internalVariantId.message}
                   </p>
+                ) : null}
+                {(productsQuery.data?.total ?? 0) > VARIANT_PICKER_PAGE_SIZE ? (
+                  <div className="create-offer-variant-picker__pagination">
+                    <span className="muted-text">
+                      {productOffset + 1}–
+                      {Math.min(
+                        productOffset + VARIANT_PICKER_PAGE_SIZE,
+                        productsQuery.data?.total ?? 0,
+                      )}{' '}
+                      of {productsQuery.data?.total ?? 0}
+                    </span>
+                    <div className="create-offer-variant-picker__pagination-actions">
+                      <Button
+                        tone="secondary"
+                        type="button"
+                        aria-label="Previous page of products"
+                        disabled={productOffset === 0}
+                        onClick={() =>
+                          setProductOffset((o) => Math.max(0, o - VARIANT_PICKER_PAGE_SIZE))
+                        }
+                      >
+                        Previous
+                      </Button>
+                      <Button
+                        tone="secondary"
+                        type="button"
+                        aria-label="Next page of products"
+                        disabled={
+                          productOffset + VARIANT_PICKER_PAGE_SIZE >=
+                          (productsQuery.data?.total ?? 0)
+                        }
+                        onClick={() => setProductOffset((o) => o + VARIANT_PICKER_PAGE_SIZE)}
+                      >
+                        Next
+                      </Button>
+                    </div>
+                  </div>
                 ) : null}
               </div>
             </>

--- a/apps/web/src/features/listings/components/CreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.tsx
@@ -393,43 +393,40 @@ export function CreateOfferWizard({
                     {form.formState.errors.internalVariantId.message}
                   </p>
                 ) : null}
-                {(productsQuery.data?.total ?? 0) > VARIANT_PICKER_PAGE_SIZE ? (
-                  <div className="create-offer-variant-picker__pagination">
-                    <span className="muted-text">
-                      {productOffset + 1}–
-                      {Math.min(
-                        productOffset + VARIANT_PICKER_PAGE_SIZE,
-                        productsQuery.data?.total ?? 0,
-                      )}{' '}
-                      of {productsQuery.data?.total ?? 0}
-                    </span>
-                    <div className="create-offer-variant-picker__pagination-actions">
-                      <Button
-                        tone="secondary"
-                        type="button"
-                        aria-label="Previous page of products"
-                        disabled={productOffset === 0}
-                        onClick={() =>
-                          setProductOffset((o) => Math.max(0, o - VARIANT_PICKER_PAGE_SIZE))
-                        }
-                      >
-                        Previous
-                      </Button>
-                      <Button
-                        tone="secondary"
-                        type="button"
-                        aria-label="Next page of products"
-                        disabled={
-                          productOffset + VARIANT_PICKER_PAGE_SIZE >=
-                          (productsQuery.data?.total ?? 0)
-                        }
-                        onClick={() => setProductOffset((o) => o + VARIANT_PICKER_PAGE_SIZE)}
-                      >
-                        Next
-                      </Button>
+                {(() => {
+                  const total = productsQuery.data?.total ?? 0;
+                  if (total <= VARIANT_PICKER_PAGE_SIZE) return null;
+                  const pageEnd = Math.min(productOffset + VARIANT_PICKER_PAGE_SIZE, total);
+                  return (
+                    <div className="create-offer-variant-picker__pagination">
+                      <span className="muted-text">
+                        {productOffset + 1}–{pageEnd} of {total}
+                      </span>
+                      <div className="create-offer-variant-picker__pagination-actions">
+                        <Button
+                          tone="secondary"
+                          type="button"
+                          aria-label="Previous page of products"
+                          disabled={productOffset === 0}
+                          onClick={() =>
+                            setProductOffset((o) => Math.max(0, o - VARIANT_PICKER_PAGE_SIZE))
+                          }
+                        >
+                          Previous
+                        </Button>
+                        <Button
+                          tone="secondary"
+                          type="button"
+                          aria-label="Next page of products"
+                          disabled={productOffset + VARIANT_PICKER_PAGE_SIZE >= total}
+                          onClick={() => setProductOffset((o) => o + VARIANT_PICKER_PAGE_SIZE)}
+                        >
+                          Next
+                        </Button>
+                      </div>
                     </div>
-                  </div>
-                ) : null}
+                  );
+                })()}
               </div>
             </>
           ) : null}

--- a/apps/web/src/features/listings/hooks/use-listing-query.ts
+++ b/apps/web/src/features/listings/hooks/use-listing-query.ts
@@ -1,7 +1,9 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { listingsQueryKeys } from '../api/listings.query-keys';
-import type { OfferMapping } from '../api/listings.types';
+import { TERMINAL_OFFER_CREATION_STATUSES, type OfferMapping } from '../api/listings.types';
 import { useApiClient } from '../../../app/api/api-client-provider';
+
+const OFFER_CREATION_POLL_MS = 5000;
 
 export function useListingQuery(id: string): UseQueryResult<OfferMapping> {
   const apiClient = useApiClient();
@@ -10,5 +12,13 @@ export function useListingQuery(id: string): UseQueryResult<OfferMapping> {
     queryKey: listingsQueryKeys.detail(id),
     queryFn: () => apiClient.listings.getById(id),
     enabled: id.length > 0,
+    // Poll the detail while a non-terminal offer-creation is attached.
+    // Stops automatically once `status` reaches `active` or `failed`, or
+    // when the record is absent (non-Offer entity / synced-in offer).
+    refetchInterval: (query) => {
+      const status = query.state.data?.offerCreation?.status;
+      if (!status) return false;
+      return TERMINAL_OFFER_CREATION_STATUSES.includes(status) ? false : OFFER_CREATION_POLL_MS;
+    },
   });
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3500,3 +3500,53 @@ textarea {
   font-size: 0.875rem;
   color: var(--text-secondary);
 }
+
+/*
+ * ── Listing detail — Offer creation section (#306) ────────────────
+ * Surfaces the OfferCreationStatus badge (+ errors on failed) next to
+ * the mapping's key-value list. Only renders when the backend embeds
+ * `offerCreation` on the detail response (OL-created offers).
+ */
+.listing-detail-offer-creation {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.5rem;
+  background: var(--bg-surface);
+}
+
+.listing-detail-offer-creation__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.listing-detail-offer-creation__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/*
+ * ── Variant-picker pagination (#308) ──────────────────────────────
+ * Prev/Next footer inside the variant-picker scroll box. Renders only
+ * when total > VARIANT_PICKER_PAGE_SIZE.
+ */
+.create-offer-variant-picker__pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.125rem 0.125rem;
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+}
+
+.create-offer-variant-picker__pagination-actions {
+  display: flex;
+  gap: 0.375rem;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3503,24 +3503,17 @@ textarea {
 
 /*
  * ── Listing detail — Offer creation section (#306) ────────────────
- * Surfaces the OfferCreationStatus badge (+ errors on failed) next to
- * the mapping's key-value list. Only renders when the backend embeds
- * `offerCreation` on the detail response (OL-created offers).
+ * Header row (title + status badge) for the embedded OfferCreation
+ * surface. Visual parity with sibling detail sections — the outer
+ * `.detail-section` already owns spacing, so this only styles the
+ * header row itself plus its sibling gap.
  */
-.listing-detail-offer-creation {
-  display: grid;
-  gap: 0.5rem;
-  padding: 0.875rem 1rem;
-  border: 1px solid var(--border-subtle);
-  border-radius: 0.5rem;
-  background: var(--bg-surface);
-}
-
 .listing-detail-offer-creation__header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .listing-detail-offer-creation__title {

--- a/apps/web/src/pages/listings/listing-detail-page.test.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.test.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { ListingDetailPage } from './listing-detail-page';
-import type { OfferMapping } from '../../features/listings/api/listings.types';
+import type { OfferCreationStatusResponse, OfferMapping } from '../../features/listings/api/listings.types';
 
 function buildMapping(overrides: Partial<OfferMapping>): OfferMapping {
   return {
@@ -61,5 +61,54 @@ describe('ListingDetailPage', () => {
 
     await screen.findByText('ol_opaque_42');
     expect(screen.queryByRole('link', { name: 'ol_opaque_42' })).toBeNull();
+  });
+
+  it('renders the offer-creation section with an Active badge when offerCreation is present', async () => {
+    const offerCreation: OfferCreationStatusResponse = {
+      id: 'rec-1',
+      internalVariantId: 'ol_variant_abc',
+      connectionId: sampleConnection.id,
+      externalOfferId: 'ext-42',
+      status: 'active',
+      errors: null,
+      publishImmediately: true,
+      createdAt: '2026-04-22T10:00:00.000Z',
+      updatedAt: '2026-04-22T10:05:00.000Z',
+    };
+    renderDetail(buildMapping({ entityType: 'Offer', offerCreation }));
+
+    expect(await screen.findByRole('heading', { name: /offer creation/i })).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    // Not failed → no error list
+    expect(screen.queryByRole('list', { name: /offer creation errors/i })).toBeNull();
+  });
+
+  it('renders the error list when offerCreation.status is failed', async () => {
+    const offerCreation: OfferCreationStatusResponse = {
+      id: 'rec-2',
+      internalVariantId: 'ol_variant_abc',
+      connectionId: sampleConnection.id,
+      externalOfferId: null,
+      status: 'failed',
+      errors: [
+        { field: 'parameters.EAN', code: 'MISSING_EAN', message: 'EAN is required.' },
+      ],
+      publishImmediately: false,
+      createdAt: '2026-04-22T10:00:00.000Z',
+      updatedAt: '2026-04-22T10:05:00.000Z',
+    };
+    renderDetail(buildMapping({ entityType: 'Offer', offerCreation }));
+
+    expect(await screen.findByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText('parameters.EAN')).toBeInTheDocument();
+    expect(screen.getByText('EAN is required.')).toBeInTheDocument();
+  });
+
+  it('does not render the offer-creation section when offerCreation is absent', async () => {
+    renderDetail(buildMapping({ entityType: 'Offer' }));
+
+    // Wait for the page to fully render by asserting on a known element first
+    await screen.findByText('mapping_1');
+    expect(screen.queryByRole('heading', { name: /offer creation/i })).toBeNull();
   });
 });

--- a/apps/web/src/pages/listings/listing-detail-page.test.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.test.tsx
@@ -63,7 +63,7 @@ describe('ListingDetailPage', () => {
     expect(screen.queryByRole('link', { name: 'ol_opaque_42' })).toBeNull();
   });
 
-  it('renders the offer-creation section with an Active badge when offerCreation is present', async () => {
+  it('renders the offer-creation section with an Active badge and metadata when offerCreation is present', async () => {
     const offerCreation: OfferCreationStatusResponse = {
       id: 'rec-1',
       internalVariantId: 'ol_variant_abc',
@@ -79,8 +79,29 @@ describe('ListingDetailPage', () => {
 
     expect(await screen.findByRole('heading', { name: /offer creation/i })).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
+    // Metadata rendered in KeyValueList
+    expect(screen.getByText('rec-1')).toBeInTheDocument();
+    expect(screen.getAllByText('ext-42').length).toBeGreaterThan(0);
     // Not failed → no error list
     expect(screen.queryByRole('list', { name: /offer creation errors/i })).toBeNull();
+  });
+
+  it('renders an em-dash for externalOfferId when the record has none (pre-creation)', async () => {
+    const offerCreation: OfferCreationStatusResponse = {
+      id: 'rec-pending',
+      internalVariantId: 'ol_variant_abc',
+      connectionId: sampleConnection.id,
+      externalOfferId: null,
+      status: 'pending',
+      errors: null,
+      publishImmediately: true,
+      createdAt: '2026-04-22T10:00:00.000Z',
+      updatedAt: '2026-04-22T10:05:00.000Z',
+    };
+    renderDetail(buildMapping({ entityType: 'Offer', offerCreation }));
+
+    expect(await screen.findByText('rec-pending')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('renders the error list when offerCreation.status is failed', async () => {

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -106,15 +106,39 @@ export function ListingDetailPage(): ReactElement {
 
       {mapping.offerCreation ? (
         <section className="detail-section">
-          <div className="listing-detail-offer-creation">
-            <div className="listing-detail-offer-creation__header">
-              <h3 className="listing-detail-offer-creation__title">Offer creation</h3>
-              <OfferCreationStatusBadge status={mapping.offerCreation.status} />
-            </div>
-            {mapping.offerCreation.status === 'failed' ? (
-              <OfferCreationErrorList errors={mapping.offerCreation.errors} />
-            ) : null}
+          <div className="listing-detail-offer-creation__header">
+            <h3 className="listing-detail-offer-creation__title">Offer creation</h3>
+            <OfferCreationStatusBadge status={mapping.offerCreation.status} />
           </div>
+          <KeyValueList
+            items={[
+              {
+                id: 'offerCreationId',
+                label: 'Record ID',
+                value: mapping.offerCreation.id,
+                mono: true,
+              },
+              {
+                id: 'externalOfferId',
+                label: 'External Offer ID',
+                value: mapping.offerCreation.externalOfferId ?? '—',
+                mono: true,
+              },
+              {
+                id: 'offerCreationCreatedAt',
+                label: 'Created',
+                value: <TimeDisplay iso={mapping.offerCreation.createdAt} />,
+              },
+              {
+                id: 'offerCreationUpdatedAt',
+                label: 'Updated',
+                value: <TimeDisplay iso={mapping.offerCreation.updatedAt} />,
+              },
+            ]}
+          />
+          {mapping.offerCreation.status === 'failed' ? (
+            <OfferCreationErrorList errors={mapping.offerCreation.errors} />
+          ) : null}
         </section>
       ) : null}
 

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -8,6 +8,8 @@ import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
 import { EditOfferDrawer } from '../../features/listings/components/EditOfferDrawer';
+import { OfferCreationStatusBadge } from '../../features/listings/components/OfferCreationStatusBadge';
+import { OfferCreationErrorList } from '../../features/listings/components/OfferCreationErrorList';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import {
   KNOWN_MAPPING_ENTITY_TYPES,
@@ -101,6 +103,20 @@ export function ListingDetailPage(): ReactElement {
           ]}
         />
       </section>
+
+      {mapping.offerCreation ? (
+        <section className="detail-section">
+          <div className="listing-detail-offer-creation">
+            <div className="listing-detail-offer-creation__header">
+              <h3 className="listing-detail-offer-creation__title">Offer creation</h3>
+              <OfferCreationStatusBadge status={mapping.offerCreation.status} />
+            </div>
+            {mapping.offerCreation.status === 'failed' ? (
+              <OfferCreationErrorList errors={mapping.offerCreation.errors} />
+            ) : null}
+          </div>
+        </section>
+      ) : null}
 
       {mapping.context !== null ? (
         <section className="detail-section">

--- a/docs/plans/implementation-plan-offer-creation-detail-and-pagination.md
+++ b/docs/plans/implementation-plan-offer-creation-detail-and-pagination.md
@@ -1,0 +1,476 @@
+# Implementation Plan: Offer-creation detail-page surface + variant-picker pagination (#306 + #308)
+
+**Date**: 2026-04-22
+**Status**: Ready for implementation (v2 — tech-review applied)
+**Estimated Effort**: ~4 hours total (~3 h for #306, ~1 h for #308)
+
+---
+
+## 1. Task Summary
+
+Two follow-ups from the create-offer-wizard PR (#303, Closes #261), bundled because they close the loop on the same feature:
+
+- **#306** — Surface `OfferCreationStatus` on `listing-detail-page.tsx` for OL-created offers. Adds a backend lookup from `(connectionId, externalOfferId)` → `OfferCreationRecord`, extends `GET /listings/:id` to embed the record when present, and renders the status badge + errors on the detail page.
+- **#308** — Paginate the variant picker inside the wizard (currently capped at 10 products).
+
+**Classification**: Mixed — #306 touches CORE (new repository method), Infrastructure (new DB index + migration), Interface (controller + DTO), and Frontend (detail page + type). #308 is Frontend-only.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- **Backend**:
+  - New port method: `OfferCreationRecordRepositoryPort.findByExternalOfferIdAndConnectionId(externalOfferId, connectionId)` → returns `OfferCreationRecord | null`
+  - Implement in `OfferCreationRecordRepository` using TypeORM `findOne` with `{ where: { externalOfferId, connectionId } }`
+  - Add a partial composite index `@Index(['externalOfferId', 'connectionId'])` on the ORM entity (only where `externalOfferId IS NOT NULL` via a migration `WHERE` clause so we don't index the many pending/failed rows without an external id)
+  - Generate TypeORM migration for the new index
+  - Extend `OfferMappingResponseDto` with optional `offerCreation?: OfferCreationStatusResponseDto`
+  - Update `ListingsController.getOfferMapping` to call the new repository method when `mapping.entityType === 'Offer'` and embed the record
+  - Unit test coverage for new repo method (repository `.spec.ts`) + integration test for the extended controller response (listings integration test)
+- **Frontend (#306 half)**:
+  - Extend `OfferMapping` FE wire type with optional `offerCreation?: OfferCreationStatusResponse` (reuse the existing type from listings.types.ts)
+  - Add `OfferCreationSection` to `listing-detail-page.tsx`: renders the `StatusBadge` + `OfferCreationErrorList` when `mapping.offerCreation` is present; renders nothing otherwise
+  - Updates to `listing-detail-page.test.tsx` covering both the "has record" and "no record" paths
+- **Frontend (#308 half)**:
+  - Add offset state (local `useState`) to `CreateOfferWizard` Step 1
+  - Pass offset to `useProductsQuery`; render Prev/Next buttons using existing `.pagination` class
+  - Reset offset to 0 when the search input changes (avoid landing on an empty page after narrowing)
+  - Update `CreateOfferWizard.test.tsx` with a mock where `total > limit` to cover Prev/Next disable logic
+
+### Out of Scope
+- **Extending the listings LIST endpoint to embed `offerCreation`** — the list renders many rows and an N+1 lookup per row is wasteful. The detail page is where the status is expected; the list page already has the post-submit tracker for OL-created offers.
+- **Filtering/sorting by creation status on the list** — separate feature.
+- **Backfilling `[externalOfferId, connectionId]` tuples for historical rows** — the index is partial and new rows will populate naturally. No data migration needed.
+- **URL-persisted offset for the wizard picker** — local `useState` is sufficient since the picker is modal-local (per `docs/frontend-architecture.md` §State Management: "local UI state → component-local useState"). Pagination state resets with the wizard.
+
+### Constraints
+- No breaking changes to public API shapes (new DTO field is optional)
+- Migration must have both `up()` and `down()` and be runnable via `pnpm --filter @openlinker/api migration:run`
+- `pnpm lint` / `pnpm type-check` / `pnpm test` all pass
+- `pnpm --filter @openlinker/api migration:show` shows no pending migrations after the run
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: CORE (listings domain port + repository) + Infrastructure (ORM index + migration) + Interface (controller + DTO) + Frontend
+
+**Capabilities Involved**: None new — the OfferCreationRecord persistence already exists from #261. The new repository method is additive.
+
+**Existing Services Reused**:
+- `OfferCreationRecordRepositoryPort` (adding one method)
+- `OfferMappingRepositoryPort` (unchanged)
+- FE: `OfferCreationStatusBadge`, `OfferCreationErrorList`, `OfferCreationStatus` types (all from PR #303)
+
+**New Components Required**:
+- 1 new port method + implementation + test
+- 1 TypeORM migration
+- 1 DTO field on `OfferMappingResponseDto`
+- FE wire-type extension
+- FE detail-page section
+- Wizard pagination controls
+
+**Core vs Integration Justification**: CORE owns the OfferCreationRecord domain and its persistence port. The new lookup is a pure CORE concern (look up a domain entity by a domain-level key). Infrastructure changes (the DB index) are an implementation detail of the port. No adapter / integration code touched.
+
+---
+
+## 4. External / Domain Research
+
+### Internal Patterns (researched in this session)
+
+- **`OfferCreationRecordRepositoryPort`** (`libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts`) already has: `create`, `findById`, `findLatestByVariantAndConnection`, `updateStatus`, `updateExternalOfferId`, `updateExternalIdAndStatus`. The new method fits the existing `findBy*` style.
+- **ORM entity** (`libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts`) already has indexes on `[internalVariantId, connectionId]`, `[connectionId]`, `[status]`. Adding `[externalOfferId, connectionId]` (partial, `WHERE externalOfferId IS NOT NULL`) is the natural place to add the new index.
+- **Controller** (`apps/api/src/listings/http/listings.controller.ts:101-114`): `getOfferMapping(id)` already injects `OFFER_CREATION_RECORD_REPOSITORY_TOKEN`. The call site has both `mapping.externalId` and `mapping.connectionId` in hand, so looking up the creation record is a one-line addition with zero extra round-trips.
+- **`toOfferCreationStatusDto(record)`** helper already exists on the controller (lines 269-281). Reuse it to build the nested DTO.
+- **Test harness**: FE tests use `renderWithProviders` + `createMockApiClient`; the `listing-detail-page.test.tsx` already mocks `listings.getById`. Adding a test for the new surface is a natural extension.
+- **Pagination pattern** (`apps/web/src/pages/listings/listings-list-page.tsx:110-113, 183-195`): `hasPrev = offset > 0`, `hasNext = offset + PAGE_SIZE < total`, Prev/Next buttons in a `.pagination` div. Modal-local `useState` is the right scope (not URL params — wizard is transient).
+
+### Documentation Gaps
+- None material. Existing docs cover the hexagonal layers, naming conventions, migration workflow, and FE patterns relevant to this change.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+1. **Should the lookup only run when `entityType === 'Offer'`?** Answer: yes — `OfferCreationRecord` only exists for offers. Guarding the call avoids a pointless query for `Product`/`Inventory`/etc. mapping rows. Documented in the plan; enforced in the controller.
+2. **Partial vs full index on `[externalOfferId, connectionId]`?** Answer: partial (`WHERE externalOfferId IS NOT NULL`). Rationale: every `pending`/`failed` record before the adapter returns has `externalOfferId = NULL`. A full index would bloat with these non-queryable rows.
+
+### Assumptions
+- The `OfferMapping.externalId` field (on `IdentifierMapping` rows with `entityType = 'Offer'`) is the same value as `OfferCreationRecord.externalOfferId` for OL-created offers. Verified via `offer-creation-execution.service` in the worker — the service writes the adapter's returned id both to the record and to the mapping. So the join condition is clean.
+- A single `OfferMapping` can only match zero or one `OfferCreationRecord` because external IDs are unique per connection within a marketplace. Multiple creation attempts that retried before an external id was assigned share the same `internalVariantId + connectionId` but don't share an `externalOfferId`. Only the successful attempt writes the id. This justifies using `findOne` rather than `findLatest`.
+- The FE wire type `OfferCreationStatusResponse` already exists in `listings.types.ts`; the extended `OfferMapping` type just adds an optional field of that shape. No FE API-client changes required beyond the type.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Backend: port + repository + migration
+
+1. **Extend `OfferCreationRecordRepositoryPort`** with the new lookup method.
+   - **File**: `libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts`
+   - **Action**: Add
+     ```ts
+     /**
+      * Look up the record that produced a given marketplace offer. Matches by
+      * (externalOfferId, connectionId) so cross-connection collisions do not
+      * return a false positive. Returns null when no record has been linked to
+      * the offer (i.e. the mapping was synced-in, not OL-created).
+      */
+     findByExternalOfferIdAndConnectionId(
+       externalOfferId: string,
+       connectionId: string,
+     ): Promise<OfferCreationRecord | null>;
+     ```
+   - **Acceptance**: Port interface exports the new method; `pnpm type-check` passes.
+
+2. **Implement in repository.**
+   - **File**: `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts`
+   - **Action**: Add method mirroring the existing `findOne` style:
+     ```ts
+     async findByExternalOfferIdAndConnectionId(
+       externalOfferId: string,
+       connectionId: string,
+     ): Promise<OfferCreationRecord | null> {
+       const entity = await this.repository.findOne({
+         where: { externalOfferId, connectionId },
+       });
+       return entity ? this.toDomain(entity) : null;
+     }
+     ```
+   - **Acceptance**: Existing `*.spec.ts` (or new coverage) exercises the method; returns `null` for no-match, domain entity for match.
+
+3. **Add partial composite index on the ORM entity.**
+   - **File**: `libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts`
+   - **Action**: Add the decorator with an **explicit index name** so the migration's `down()` can target it deterministically:
+     ```ts
+     @Index('IDX_offer_creation_records_external_offer_connection', ['externalOfferId', 'connectionId'], {
+       where: '"externalOfferId" IS NOT NULL',
+     })
+     ```
+     alongside the existing `@Index` decorators. The `where` clause makes it partial so pending/failed records (null external id) don't bloat the index. The explicit name avoids TypeORM-generated hash-based names that break when columns are later renamed.
+   - **Acceptance**: `pnpm --filter @openlinker/api migration:generate` produces a migration that creates this index with the explicit name.
+
+4. **Generate + verify migration.**
+   - **File**: `apps/api/src/migrations/{timestamp}-add-offer-creation-record-external-id-index.ts`
+   - **Action**:
+     1. Run `pnpm --filter @openlinker/api migration:generate -- src/migrations/AddOfferCreationRecordExternalIdIndex`
+     2. `grep -i 'WHERE.*externalOfferId' apps/api/src/migrations/*-add-offer-creation-record-external-id-index.ts` — if no match, TypeORM dropped the partial clause from its diff. Hand-edit the generated `up()` to use a raw `await queryRunner.query(\`CREATE INDEX "IDX_offer_creation_records_external_offer_connection" ON "offer_creation_records" ("externalOfferId", "connectionId") WHERE "externalOfferId" IS NOT NULL\`)`. Matching `down()` becomes `await queryRunner.query(\`DROP INDEX "IDX_offer_creation_records_external_offer_connection"\`)`.
+     3. **Verify up/down/up cycle works:** run `pnpm --filter @openlinker/api migration:run`, then `migration:revert`, then `migration:run` again. Each must succeed without error. Then `migration:show` must report no pending.
+   - **Acceptance**: Partial `WHERE` clause is present in the committed migration; up-down-up cycle completes cleanly locally.
+
+5. **Unit test the new repository method.**
+   - **File**: `libs/core/src/listings/infrastructure/persistence/repositories/__tests__/offer-creation-record.repository.spec.ts` (create if missing, extend if present)
+   - **Action**: Mock the TypeORM `Repository` and assert:
+     - Returns a domain entity when `findOne` resolves with a match
+     - Returns `null` when `findOne` resolves with `undefined`/`null`
+     - Passes the correct `where` clause to `findOne`
+   - **Acceptance**: 3 new tests pass; method has 100% coverage.
+
+### Phase 2 — Backend: DTO + controller
+
+6. **Extend `OfferMappingResponseDto`.**
+   - **File**: `apps/api/src/listings/http/dto/offer-mapping-response.dto.ts`
+   - **Action**: Add optional field
+     ```ts
+     @ApiPropertyOptional({
+       nullable: true,
+       type: OfferCreationStatusResponseDto,
+       description:
+         'Populated only by `GET /listings/:id` (detail endpoint) for Offer-type ' +
+         'mappings that originated from an OL-initiated create. Always absent on ' +
+         'list responses (`GET /listings`) regardless of creation history — the ' +
+         'list does not fan-out lookups per row. Absent on synced-in offers and ' +
+         'on non-Offer entity types (Product, Inventory, etc.).',
+     })
+     offerCreation?: OfferCreationStatusResponseDto | null;
+     ```
+   - Import the existing `OfferCreationStatusResponseDto` from the sibling DTO file.
+   - **Acceptance**: Swagger renders the optional nested schema with the "detail-only" behaviour clearly documented; compiled TS accepts `undefined`/`null`/object values.
+
+7. **Update `ListingsController.getOfferMapping`.**
+   - **File**: `apps/api/src/listings/http/listings.controller.ts`
+   - **Action**: After `findById`, add a conditional lookup:
+     ```ts
+     const dto = this.toDto(mapping);
+     if (mapping.entityType === 'Offer') {
+       const record = await this.offerCreationRecords.findByExternalOfferIdAndConnectionId(
+         mapping.externalId,
+         mapping.connectionId,
+       );
+       if (record) {
+         dto.offerCreation = this.toOfferCreationStatusDto(record);
+       }
+     }
+     return dto;
+     ```
+   - **Note on architecture**: The listings controller already calls repository ports directly for reads (the existing `getOfferMapping` does `findById` + `toDto` inline). Per `docs/architecture-overview.md` §Layer Dependencies, the strict form is "interfaces → application → domain", but the codebase has chosen to skip the application layer for trivial reads. This PR follows the existing pattern rather than introducing a new use-case wrapper just for this change. When a third read-enrichment lands on this controller, extract a `GetOfferMappingUseCase` to the application layer — tracked as follow-up.
+   - **Acceptance**: Detail response includes `offerCreation` for OL-created Allegro offer mappings and omits it for synced-in mappings + non-Offer entity types.
+
+8. **Controller unit spec.**
+   - **File**: `apps/api/src/listings/http/listings.controller.spec.ts` (create if missing)
+   - **Rationale**: The change is a trivial conditional lookup guarded by `entityType === 'Offer'`. A unit spec that mocks both repository ports gives full coverage of all three branches for milliseconds of runtime. A new integration test file would duplicate coverage the repository spec already provides and does not match `docs/testing-guide.md` §Test Organization: "Integration tests — targeted, focus on critical vertical slices." This is not a critical vertical slice; it's a conditional read-enrichment.
+   - **Action**: Mock `OfferMappingRepositoryPort.findById` and `OfferCreationRecordRepositoryPort.findByExternalOfferIdAndConnectionId`. Three cases:
+     1. `entityType === 'Offer'` + record present → response includes `offerCreation` with correct shape (asserts `toOfferCreationStatusDto` is applied)
+     2. `entityType === 'Offer'` + record absent → response omits `offerCreation`; assert the lookup **was** called
+     3. `entityType !== 'Offer'` (e.g., `'Product'`) → response omits `offerCreation`; assert the lookup was **not** called (no wasted query)
+   - **Acceptance**: Three new tests pass; the controller has coverage for the branching logic added in step 7.
+
+### Phase 3 — Frontend: detail-page surface (#306 half)
+
+9. **Extend FE wire type.**
+   - **File**: `apps/web/src/features/listings/api/listings.types.ts`
+   - **Action**: Add to the existing `OfferMapping` interface:
+     ```ts
+     offerCreation?: OfferCreationStatusResponse | null;
+     ```
+     Note: `OfferCreationStatusResponse` already exists in this file.
+   - **Acceptance**: TypeScript compiles; existing consumers unaffected (optional field).
+
+10. **Update detail page.**
+    - **File**: `apps/web/src/pages/listings/listing-detail-page.tsx`
+    - **Action**: Add a new section between the `KeyValueList` section and the optional `RawPayloadPanel` context section:
+      ```tsx
+      {mapping.offerCreation ? (
+        <section className="detail-section">
+          <div className="listing-detail-offer-creation">
+            <div className="listing-detail-offer-creation__header">
+              <h3>Offer creation</h3>
+              <OfferCreationStatusBadge status={mapping.offerCreation.status} />
+            </div>
+            {mapping.offerCreation.status === 'failed' ? (
+              <OfferCreationErrorList errors={mapping.offerCreation.errors} />
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+      ```
+    - Import `OfferCreationStatusBadge` + `OfferCreationErrorList` from `features/listings/components/`.
+    - **Acceptance**: Section renders for mappings with `offerCreation` present; renders nothing for mappings without it.
+
+11. **CSS (minimal).**
+    - **File**: `apps/web/src/index.css`
+    - **Action**: Add a small block for `.listing-detail-offer-creation` (header flex with badge, `h3` in section-title scale). Reuses existing `--bg-surface`/`--border-subtle` tokens. Under 15 lines.
+    - **Acceptance**: Section is visually consistent with other detail sections.
+
+12. **Test the detail page.**
+    - **File**: `apps/web/src/pages/listings/listing-detail-page.test.tsx`
+    - **Action**: Add two cases:
+      - **"renders offer-creation status badge when `offerCreation` is present"** — mock `listings.getById` to return a mapping with `offerCreation: { status: 'active', ... }`. Assert the badge label renders and no error list is shown.
+      - **"renders the error list when `offerCreation.status === 'failed'`"** — same shape but `status: 'failed'` with a populated `errors` array. Assert field + message render.
+      - **"does not render offer-creation section when `offerCreation` is absent"** — mock with no `offerCreation`. Assert the heading is absent.
+    - **Acceptance**: Three new tests pass; existing tests unchanged.
+
+### Phase 4 — Frontend: variant-picker pagination (#308)
+
+13. **Add offset state to the wizard.**
+    - **File**: `apps/web/src/features/listings/components/CreateOfferWizard.tsx`
+    - **Note on state ownership**: Modal-local `useState`, **not** URL search params. This intentionally diverges from `listings-list-page.tsx` which uses URL params for `offset` — the wizard is transient (a refresh closes it), so URL state would be stale-by-design. Per `docs/frontend-architecture.md` §State Management: "local UI state → component-local `useState`" fits this case (wizard step state + modal-scoped pagination are the same concern).
+    - **Action**:
+      - Add `const [productOffset, setProductOffset] = useState(0)` alongside the existing `productSearchInput` state
+      - Add a constant `const VARIANT_PICKER_PAGE_SIZE = 10;` near the other constants
+      - Pass through: `useProductsQuery({ search: debouncedProductSearch || undefined }, { limit: VARIANT_PICKER_PAGE_SIZE, offset: productOffset })`
+      - **Reset offset to 0 synchronously from the search `onChange`** (not via a `useEffect` on the debounced value) — the synchronous reset eliminates a race where the debounced search fires with a stale offset before the reset effect runs. The existing search input's `onChange` already updates `productSearchInput`; extend it to also `setProductOffset(0)`.
+      - Also reset offset on wizard re-open (the existing reset `useEffect` — add `setProductOffset(0)` there)
+    - **Acceptance**: Pagination state is local and resets on search change + wizard re-open; no race between debounce and offset reset.
+
+14. **Render Prev/Next controls.**
+    - **File**: same
+    - **Action**: Add a footer inside `.create-offer-variant-picker` (below the `ul.create-offer-variant-picker__list`):
+      ```tsx
+      {(productsQuery.data?.total ?? 0) > VARIANT_PICKER_PAGE_SIZE ? (
+        <div className="create-offer-variant-picker__pagination">
+          <span className="muted-text">
+            {productOffset + 1}–{Math.min(productOffset + VARIANT_PICKER_PAGE_SIZE, productsQuery.data.total)} of {productsQuery.data.total}
+          </span>
+          <div>
+            <Button
+              tone="secondary"
+              type="button"
+              disabled={productOffset === 0}
+              onClick={() => setProductOffset((o) => Math.max(0, o - VARIANT_PICKER_PAGE_SIZE))}
+            >
+              Previous
+            </Button>
+            <Button
+              tone="secondary"
+              type="button"
+              disabled={productOffset + VARIANT_PICKER_PAGE_SIZE >= (productsQuery.data?.total ?? 0)}
+              onClick={() => setProductOffset((o) => o + VARIANT_PICKER_PAGE_SIZE)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
+      ```
+    - **Acceptance**: Controls only render when total > page size; Prev disabled on first page, Next on last page; clicking either re-runs the query.
+
+15. **CSS for the pagination footer.**
+    - **File**: `apps/web/src/index.css`
+    - **Action**: Add `.create-offer-variant-picker__pagination` (flex `space-between`, 0.5rem gap, top border in `--border-subtle`, small font). ~10 lines.
+    - **Acceptance**: Fits cleanly at the bottom of the existing variant-picker box.
+
+16. **Test pagination.**
+    - **File**: `apps/web/src/features/listings/components/CreateOfferWizard.test.tsx`
+    - **Action**: Add one test (plus light edits to existing mocks so the default does not trip the pagination assertions):
+      - **"paginates through products when total > limit"** — mock `products.list` to return `{ items: [product], total: 15, limit: 10, offset: 0 }` for the first call and `{ items: [product2], total: 15, limit: 10, offset: 10 }` for the second. Click Next. Assert `products.list` was called with `{ offset: 10 }` on the second invocation. Assert Prev is enabled after clicking Next; Next becomes disabled (total 15, offset 10 + 10 >= 15).
+    - **Acceptance**: One new test passes; existing tests continue to pass (the mock default of `total: 1, limit: 10` means pagination controls don't render, so older tests are unaffected).
+
+### Implementation Details
+
+**New files** (5 new, 8 modified):
+
+- **New (backend)**:
+  - `apps/api/src/migrations/{timestamp}-add-offer-creation-record-external-id-index.ts`
+  - `libs/core/src/listings/infrastructure/persistence/repositories/__tests__/offer-creation-record.repository.spec.ts` (or extend existing)
+  - Integration test file OR controller spec file (pick one per step 8)
+
+- **Modified (backend)**:
+  - `libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts`
+  - `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts`
+  - `libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts`
+  - `apps/api/src/listings/http/dto/offer-mapping-response.dto.ts`
+  - `apps/api/src/listings/http/listings.controller.ts`
+
+- **Modified (frontend)**:
+  - `apps/web/src/features/listings/api/listings.types.ts`
+  - `apps/web/src/pages/listings/listing-detail-page.tsx`
+  - `apps/web/src/pages/listings/listing-detail-page.test.tsx`
+  - `apps/web/src/features/listings/components/CreateOfferWizard.tsx`
+  - `apps/web/src/features/listings/components/CreateOfferWizard.test.tsx`
+  - `apps/web/src/index.css`
+
+**Database Migrations**: 1 — adds a partial composite index. Tested up + down locally.
+
+**Events**: None.
+
+**Configuration Changes**: None.
+
+**Error Handling**:
+- The new repository method returns `null` on no-match (matches existing `findBy*` style — no exception)
+- Controller silently omits the `offerCreation` field when lookup returns null — this is the expected "synced-in offer" path
+- If the lookup fails (DB error), NestJS's default error handler returns 5xx; the detail page already handles this via `query.error` → `ErrorState`
+
+**Reference**: [Engineering Standards — Repository Ports Pattern](../engineering-standards.md#repository-ports-pattern), [Migrations Guide](../migrations.md), [Frontend Architecture — State Management](../frontend-architecture.md#state-management)
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1 (for #306): Separate endpoint `GET /listings/connections/:connectionId/offers/:externalOfferId/creation-record`
+- **Description**: Option A from the issue body
+- **Why Rejected**: Adds a round-trip on every detail-page load for no gain. The controller already has both `externalId` and `connectionId` from the mapping lookup, so embedding the record is one extra local query. A separate endpoint would require the FE to do the coordination.
+- **Trade-offs**: Cleaner "one concept per endpoint" separation. But the OfferMapping + OfferCreationRecord are tightly related (a mapping either was OL-created or not), so bundling is honest.
+
+### Alternative 2 (for #306): Extend the LIST endpoint `GET /listings` to include `offerCreation` per row
+- **Description**: Show the status on the list without drilling in
+- **Why Rejected**: N+1 lookup per row on the list. The list already has the post-submit tracker for in-flight OL-created offers; the detail page is the right place for historical context.
+- **Trade-offs**: Would enable filtering/sorting by creation status from the list, but that's a bigger feature.
+
+### Alternative 3 (for #308): Bump `limit` to 50
+- **Description**: Cheapest fix
+- **Why Rejected**: Silently moves the ceiling without giving operators a way past it. Pagination matches the existing list-page pattern and handles arbitrary catalog sizes.
+- **Trade-offs**: Zero-effort fix vs ~30 lines for proper pagination. Proper pagination wins on longevity.
+
+### Alternative 4 (for #308): Infinite scroll via `useInfiniteQuery` + `@tanstack/react-virtual`
+- **Description**: Nicer UX with no pagination controls
+- **Why Rejected**: Added complexity (scroll handler, observer, virtualization config) for a modal picker that typically resolves to < 20 rows after a search. Pagination is simpler and the operator's mental model already maps to Prev/Next from the listings list.
+- **Trade-offs**: Smoother UX on very large catalogs. Acceptable to defer.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Port method lives in `domain/ports/`, implementation in `infrastructure/persistence/repositories/` — repository ports pattern
+- ✅ Domain layer has no framework deps; the new method uses only TypeScript types
+- ✅ No CORE ↔ Integration boundary touched (pure CORE extension)
+- ✅ DTO extension is additive + optional → backwards compatible
+
+### Naming Conventions
+- ✅ `findByExternalOfferIdAndConnectionId` matches the existing `findLatestByVariantAndConnection` style
+- ✅ Migration file follows `{timestamp}-{description}.ts`
+- ✅ FE file names unchanged
+
+### Existing Patterns
+- ✅ Controller embeds data via a single lookup (same pattern as the existing `toDto` path)
+- ✅ FE pagination mirrors `listings-list-page.tsx`
+- ✅ FE detail-page section follows the existing `<section className="detail-section">` pattern
+
+### Risks
+- **Migration correctness** — a partial index needs hand-verification after TypeORM generation (TypeORM may drop the `WHERE` clause). Mitigation: review generated SQL; adjust manually if needed.
+- **Index selectivity** — the partial index only covers rows with a non-null `externalOfferId`, which is a strong filter. Query plans should use it. If not, `EXPLAIN ANALYZE` in dev.
+- **Stale test fixtures** — existing listings controller tests may snapshot the DTO shape. Any snapshot needs updating for the new optional field. Verified during implementation.
+- **Pagination: race between search change and offset reset** — if the operator types fast and the debounced search updates before the `useEffect` resets offset, the query fires with a stale offset. Mitigation: reset offset synchronously from the `onChange` of the search input (not via debounced value), so the offset is always 0 by the time the debounce fires.
+
+### Edge Cases
+- **Mapping has entity type other than `Offer`** — the guard `if (mapping.entityType === 'Offer')` skips the lookup. Covered by controller test.
+- **Mapping with no external id** — `IdentifierMapping.externalId` is never null by schema, so this doesn't apply.
+- **OfferCreationRecord has `externalOfferId` but connection mismatch** — the `connectionId` filter eliminates false positives across connections.
+- **No products match search after narrowing** — pagination reset to 0 handles this; the picker shows "No products match."
+
+### Backward Compatibility
+- ✅ Additive DTO field (optional, nullable)
+- ✅ New migration is forward-compatible; `down()` drops the index cleanly
+- ✅ No changes to existing endpoints' request shapes
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- **Repository spec** — `offer-creation-record.repository.spec.ts`: 3 new cases for `findByExternalOfferIdAndConnectionId` (match, no-match, correct `where` clause)
+- **Frontend detail page** — `listing-detail-page.test.tsx`: 3 new cases (active status, failed status with errors, absent)
+- **Frontend wizard** — `CreateOfferWizard.test.tsx`: 1 new case (paginate forward, verify offset changes + disable logic)
+
+### Integration Tests
+- **Listings detail** — `listing-detail-offer-creation.int-spec.ts` (or controller unit spec): validates the controller embeds the record when present + skips for non-Offer entity types. One test file, three cases.
+
+### Mocking Strategy
+- Repository spec: mock the TypeORM `Repository<OfferCreationRecordOrmEntity>` with `.findOne` mock
+- Frontend tests: `createMockApiClient` with `listings.getById` returning fixtures that include/exclude `offerCreation`
+- Integration test: real Postgres via Testcontainers; seed both tables directly, then `supertest` the endpoint
+
+### Acceptance Criteria
+- [ ] **#306 AC-1**: `GET /listings/:id` returns `offerCreation` for an OL-created Allegro offer mapping
+- [ ] **#306 AC-2**: `GET /listings/:id` does **not** return `offerCreation` for a synced-in mapping (no matching record)
+- [ ] **#306 AC-3**: The listing detail page renders `OfferCreationStatusBadge` when `offerCreation` is present
+- [ ] **#306 AC-4**: The listing detail page renders `OfferCreationErrorList` when the status is `failed`
+- [ ] **#306 AC-5**: The listing detail page renders nothing extra when `offerCreation` is absent
+- [ ] **#306 AC-6**: Migration `up → down → up` cycle completes cleanly locally; after the final `up`, `migration:show` reports no pending
+- [ ] **#306 AC-7**: Generated SQL contains `WHERE "externalOfferId" IS NOT NULL` (verified via grep on the committed migration file)
+- [ ] **#308 AC-1**: Operator can page forward past the first 10 products
+- [ ] **#308 AC-2**: Prev disabled on page 1; Next disabled on the last page
+- [ ] **#308 AC-3**: Changing the search input resets offset to 0
+- [ ] **Quality gate**: `pnpm lint` + `pnpm type-check` + `pnpm test` all pass; explicit up/down/up migration cycle succeeds; `pnpm --filter @openlinker/api migration:show` reports no pending
+
+**Reference**: [Testing Guide](../testing-guide.md)
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture (port in domain, impl in infrastructure)
+- [x] Respects CORE vs Integration boundaries
+- [x] Uses existing patterns (no unnecessary abstractions)
+- [x] Idempotency considered — the GET endpoint is naturally idempotent; the lookup is read-only
+- [x] Rate limits & retries addressed — the new DB lookup is O(1) with the index
+- [x] Error handling comprehensive — null-returns on the repository, standard NestJS error mapping on failures
+- [x] Testing strategy complete — unit + integration + FE
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Migration follows `docs/migrations.md` (partial index with both up/down)
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Migrations Guide](../migrations.md)
+- [Frontend Architecture](../frontend-architecture.md)
+- [Testing Guide](../testing-guide.md)

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts
@@ -58,6 +58,7 @@ describe('OfferCreationEnqueueService', () => {
       create: jest.fn().mockResolvedValue(mockRecord),
       findById: jest.fn(),
       findLatestByVariantAndConnection: jest.fn(),
+      findByExternalOfferIdAndConnectionId: jest.fn(),
       updateStatus: jest.fn(),
       updateExternalOfferId: jest.fn(),
       updateExternalIdAndStatus: jest.fn(),

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
@@ -74,6 +74,7 @@ describe('OfferCreationExecutionService', () => {
       create: jest.fn().mockResolvedValue(buildRecord()),
       findById: jest.fn(),
       findLatestByVariantAndConnection: jest.fn(),
+      findByExternalOfferIdAndConnectionId: jest.fn(),
       updateStatus: jest
         .fn()
         .mockImplementation((id, status, errors) =>

--- a/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
@@ -42,6 +42,22 @@ export interface OfferCreationRecordRepositoryPort {
   ): Promise<OfferCreationRecord | null>;
 
   /**
+   * Look up the record that produced a given marketplace offer. Matches by
+   * (externalOfferId, connectionId) so cross-connection collisions do not
+   * return a false positive. Returns null when no record has been linked to
+   * the offer — i.e. the mapping was synced-in rather than OL-created, or the
+   * offer's creation record was never written.
+   *
+   * External offer ids are only assigned once the adapter returns successfully,
+   * so pre-creation rows (status `pending` with null externalOfferId) are
+   * never returned by this method.
+   */
+  findByExternalOfferIdAndConnectionId(
+    externalOfferId: string,
+    connectionId: string,
+  ): Promise<OfferCreationRecord | null>;
+
+  /**
    * Update status (and optionally errors) for an existing record.
    *
    * `errors` semantics:

--- a/libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts
@@ -25,6 +25,13 @@ import type {
 @Index(['internalVariantId', 'connectionId'])
 @Index(['connectionId'])
 @Index(['status'])
+// Partial composite index for the `findByExternalOfferIdAndConnectionId` lookup.
+// `WHERE "externalOfferId" IS NOT NULL` keeps pre-creation pending rows (which
+// always have a null external id) out of the index. Explicit name so the
+// migration's `down()` can target it deterministically.
+@Index('IDX_offer_creation_records_external_offer_connection', ['externalOfferId', 'connectionId'], {
+  where: '"externalOfferId" IS NOT NULL',
+})
 export class OfferCreationRecordOrmEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
@@ -180,6 +180,35 @@ describe('OfferCreationRecordRepository', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should pass connectionId to where clause so same externalOfferId on a different connection is not returned', async () => {
+      // Shared externalOfferId across two connections is valid (different
+      // marketplace tenants can reuse marketplace-side ids). The lookup must
+      // scope by connectionId — only the current connection's record should
+      // come back. Simulate that by returning null when the wrong connection
+      // is queried.
+      ormRepository.findOne.mockResolvedValueOnce(null);
+      const missForWrongConn = await repository.findByExternalOfferIdAndConnectionId(
+        'shared-offer-1',
+        'conn-wrong',
+      );
+      expect(ormRepository.findOne).toHaveBeenLastCalledWith({
+        where: { externalOfferId: 'shared-offer-1', connectionId: 'conn-wrong' },
+      });
+      expect(missForWrongConn).toBeNull();
+
+      ormRepository.findOne.mockResolvedValueOnce(
+        buildOrm({ externalOfferId: 'shared-offer-1', connectionId: 'conn-right' }),
+      );
+      const hit = await repository.findByExternalOfferIdAndConnectionId(
+        'shared-offer-1',
+        'conn-right',
+      );
+      expect(ormRepository.findOne).toHaveBeenLastCalledWith({
+        where: { externalOfferId: 'shared-offer-1', connectionId: 'conn-right' },
+      });
+      expect(hit?.connectionId).toBe('conn-right');
+    });
   });
 
   describe('updateStatus', () => {

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
@@ -154,6 +154,34 @@ describe('OfferCreationRecordRepository', () => {
     });
   });
 
+  describe('findByExternalOfferIdAndConnectionId', () => {
+    it('should scope the lookup by both externalOfferId and connectionId', async () => {
+      ormRepository.findOne.mockResolvedValue(buildOrm({ externalOfferId: 'allegro-999' }));
+
+      const result = await repository.findByExternalOfferIdAndConnectionId(
+        'allegro-999',
+        'conn-uuid',
+      );
+
+      expect(ormRepository.findOne).toHaveBeenCalledWith({
+        where: { externalOfferId: 'allegro-999', connectionId: 'conn-uuid' },
+      });
+      expect(result).toBeInstanceOf(OfferCreationRecord);
+      expect(result?.externalOfferId).toBe('allegro-999');
+    });
+
+    it('should return null when no record is linked to the external offer', async () => {
+      ormRepository.findOne.mockResolvedValue(null);
+
+      const result = await repository.findByExternalOfferIdAndConnectionId(
+        'allegro-unknown',
+        'conn-uuid',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('updateStatus', () => {
     it('should update status and errors and return the updated domain entity', async () => {
       const existing = buildOrm();

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts
@@ -52,6 +52,16 @@ export class OfferCreationRecordRepository implements OfferCreationRecordReposit
     return entity ? this.toDomain(entity) : null;
   }
 
+  async findByExternalOfferIdAndConnectionId(
+    externalOfferId: string,
+    connectionId: string,
+  ): Promise<OfferCreationRecord | null> {
+    const entity = await this.repository.findOne({
+      where: { externalOfferId, connectionId },
+    });
+    return entity ? this.toDomain(entity) : null;
+  }
+
   async updateStatus(
     id: string,
     status: OfferCreationStatus,


### PR DESCRIPTION
## Summary

Two follow-ups from PR #303 (the create-offer wizard), bundled because they polish the same feature's edges:

- **#306** — `GET /listings/:id` now embeds the matching `OfferCreationRecord` as `offerCreation?: OfferCreationStatusResponseDto` when the mapping is an Offer type and a record exists. Detail page renders the status badge (+ error list on `failed`) right under the `KeyValueList`. Synced-in offers and non-Offer entity types pass through unchanged.
- **#308** — Variant picker in the wizard paginates via local `useState(offset)` with Prev/Next controls inside the picker footer. Matches the existing `listings-list-page.tsx` pattern; page size stays at 10.

## Implementation highlights

### Backend (#306)
- New port method `OfferCreationRecordRepositoryPort.findByExternalOfferIdAndConnectionId(externalOfferId, connectionId)` — scoped by both values so cross-connection collisions can't false-match
- Partial composite DB index: `CREATE INDEX ... ON offer_creation_records (externalOfferId, connectionId) WHERE externalOfferId IS NOT NULL` — keeps pre-creation `pending` rows (null externalOfferId) out of the index
- Explicit index name (`IDX_offer_creation_records_external_offer_connection`) so the migration's `down()` can target it deterministically
- Migration hand-written (Docker was down during generation; partial `WHERE` clauses are often dropped by TypeORM's diff-based generator anyway). Verified locally via an up → down → up cycle against a clean Postgres volume — see "Test plan" below.
- `ListingsController.getOfferMapping` guards the lookup with `if (mapping.entityType === 'Offer')` so non-Offer reads skip the query entirely

### Frontend
- **#306**: `OfferMapping` FE type extended with optional `offerCreation?: OfferCreationStatusResponse | null`. Detail page renders `<OfferCreationStatusBadge>` + conditional `<OfferCreationErrorList>` on failed — reuses the primitives shipped in PR #303 verbatim. Minimal CSS (`.listing-detail-offer-creation*`, ~20 lines) against existing tokens.
- **#308**: Modal-local offset state (not URL params — wizard is transient; `docs/frontend-architecture.md` §State Management). Reset-to-0 is **synchronous** inside the search input's `onChange` (not a `useEffect` on the debounced value) to eliminate the race where stale offset can fire through the debounce window. Prev/Next buttons disambiguated from the wizard's step-advance Next via explicit `aria-label="Next page of products"`.

## Test plan

- [ ] **Backend unit tests** pass: 333/333 libs/core (includes 2 new `findByExternalOfferIdAndConnectionId` cases), 250/250 apps/api (includes 3 new controller cases: record present / absent / non-Offer skip)
- [ ] **Frontend tests** pass: 430/430 apps/web (includes 3 new detail-page cases + 3 new wizard pagination cases)
- [ ] **Migration up → down → up cycle** verified locally against a clean `openlinker_postgres_data` volume:
  ```
  pnpm --filter @openlinker/api migration:run     # 28/28 applied
  pnpm --filter @openlinker/api migration:revert  # reverts IDX_offer_creation_records_external_offer_connection
  pnpm --filter @openlinker/api migration:run     # re-applies, migration:show reports 28/28 again
  ```
- [ ] **Partial index verified in Postgres** via `pg_indexes`:
  ```
  indexdef: CREATE INDEX "IDX_offer_creation_records_external_offer_connection"
            ON public.offer_creation_records
            USING btree ("externalOfferId", "connectionId")
            WHERE ("externalOfferId" IS NOT NULL)
  ```
- [ ] **Manual happy-path** (requires a local Allegro connection with a recently OL-created offer):
  - Navigate to `/listings/:id` for an OL-created Allegro mapping → "Offer creation" section appears with status badge
  - Trigger a deliberate failure (invalid category ID in the wizard) → detail page shows `Failed` badge + error list
  - Navigate to `/listings/:id` for a synced-in Allegro offer (no matching record) → no section rendered
  - Open the wizard with > 10 products matching a search → Prev/Next appear, total/range counter reads correctly, Next disabled on the last page
  - Type in the search box while on page 2 → query fires with `offset: 0`

## Pre-existing flakiness note

The full-workspace test run occasionally (~25%) fails on `DashboardPage > shows an honest "nothing re-queued" toast` or `EditOfferDrawer > should show success toast and close drawer on successful submit` — both pre-existing per issue #309 (toast test isolation) and not related to this PR. Re-running passes consistently.

Closes #306
Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)