### PR TITLE
fix(web): remove dead global search input from topbar

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -607,25 +607,6 @@ textarea {
   flex: 1;
 }
 
-.shell-search {
-  display: none;
-}
-
-@media (min-width: 768px) {
-  .shell-search {
-    display: block;
-    flex: 0 1 320px;
-    min-width: 0;
-  }
-
-  .shell-search .control,
-  .shell-search input {
-    height: 32px;
-    padding: 0 10px;
-    font-size: 13px;
-  }
-}
-
 .shell-topbar__alerts {
   padding: 6px 10px;
   font-size: 12.5px;

--- a/apps/web/src/shared/ui/app-shell.test.tsx
+++ b/apps/web/src/shared/ui/app-shell.test.tsx
@@ -1,3 +1,12 @@
+/**
+ * AppShell Tests
+ *
+ * Smoke tests for the authenticated-app chrome: nav-group composition,
+ * breadcrumb resolution, mobile-drawer open/close behaviour, and regression
+ * guards against dead UI in the topbar.
+ *
+ * @module shared/ui
+ */
 import type { ReactElement } from 'react';
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -89,7 +98,7 @@ describe('AppShell', () => {
     expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
   });
 
-  it('does not render a dead global search input in the topbar', () => {
+  it('should not render a global search input in the topbar until search is wired', () => {
     // Regression for #220: the topbar previously rendered an <Input type="search">
     // with no handler. Global search isn't implemented yet — no dead UI until it is.
     renderShell('/');

--- a/apps/web/src/shared/ui/app-shell.test.tsx
+++ b/apps/web/src/shared/ui/app-shell.test.tsx
@@ -89,6 +89,13 @@ describe('AppShell', () => {
     expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
   });
 
+  it('does not render a dead global search input in the topbar', () => {
+    // Regression for #220: the topbar previously rendered an <Input type="search">
+    // with no handler. Global search isn't implemented yet — no dead UI until it is.
+    renderShell('/');
+    expect(screen.queryByRole('searchbox')).toBeNull();
+  });
+
   it('renders the child page content', () => {
     renderShell('/');
     expect(screen.getByTestId('page-content')).toHaveTextContent('Page content');

--- a/apps/web/src/shared/ui/app-shell.tsx
+++ b/apps/web/src/shared/ui/app-shell.tsx
@@ -9,7 +9,6 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { useSession } from '../auth/use-session';
 import { Button } from './button';
 import { EnvironmentBadge } from './environment-badge';
-import { Input } from './input';
 import { useToast } from './toast-provider';
 
 interface LiveNavItem {
@@ -277,10 +276,7 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
 
           <div className="shell-topbar__spacer" />
 
-          <label className="shell-search">
-            <span className="sr-only">Search</span>
-            <Input type="search" placeholder="Search orders, products, jobs…" />
-          </label>
+          {/* Global search — planned. See #220. */}
 
           <Button tone="ghost" className="shell-topbar__alerts">
             Alerts <span aria-hidden="true">0</span>

--- a/apps/web/src/shared/ui/app-shell.tsx
+++ b/apps/web/src/shared/ui/app-shell.tsx
@@ -1,3 +1,12 @@
+/**
+ * AppShell
+ *
+ * Authenticated-app chrome: persistent left nav (240 px sidebar with mobile
+ * drawer fallback), top utility bar (breadcrumb + alerts), and the main
+ * content slot. Every authenticated route renders inside this shell.
+ *
+ * @module shared/ui
+ */
 import {
   useCallback,
   useEffect,

--- a/docs/plans/implementation-plan-topbar-search-removal.md
+++ b/docs/plans/implementation-plan-topbar-search-removal.md
@@ -1,0 +1,54 @@
+# Implementation Plan — Remove dead topbar search input (#220)
+
+## 1. Task restatement
+
+The `AppShell` topbar renders a search `<Input type="search" placeholder="Search orders, products, jobs…" />` with no `onChange`, no routing, and no results UI. It is visibly interactive but functionally dead — typing does nothing, `Enter` does nothing. Issue #220 proposes two resolutions and explicitly recommends **Option A** for MVP: remove the input so the UI stops lying about a feature that doesn't exist. A keyboard shortcut hint (⌘K) can be added later when real search is wired.
+
+**Layer:** Frontend (FE) shell only. No API, no feature module, no routing change.
+
+**Non-goals (deliberately out of scope):**
+- Implementing real global search (Option B). Filed as a future issue; when wired, the UI comes back.
+- Adding a `⌘K` keyboard-shortcut skeleton without a handler — that just recreates the same "UI implies a feature that doesn't exist" problem at smaller scale.
+- Changing `AppShell`'s layout model or breakpoints. The `shell-topbar__spacer` already eats the empty space the search used to occupy; no layout jitter expected.
+
+## 2. Fix
+
+Remove the search `<label>` block and the now-unused `Input` import from `app-shell.tsx`, drop the three `.shell-search` CSS blocks from `index.css`, and add a regression test that asserts no `role="searchbox"` control is rendered in the shell.
+
+Leave a one-line JSX comment at the former location (`{/* Global search — planned. See #220. */}`) as the "marker" the issue's acceptance criteria calls for.
+
+## 3. Step-by-step plan
+
+### Step 1 — `apps/web/src/shared/ui/app-shell.tsx`
+
+- Remove the `<label className="shell-search">…<Input type="search" …/></label>` block (currently lines 280–283).
+- Remove `import { Input } from './input';` on line 12 (this is the only use of `Input` in the file — confirmed via grep).
+- Leave a JSX comment at the removed location so future readers can find the trail: `{/* Global search — planned. See #220. */}`.
+
+### Step 2 — `apps/web/src/index.css`
+
+- Delete the three `.shell-search` rules (base `display: none` + the `@media (min-width: 768px)` block + the nested `.shell-search .control / input` rule, currently lines 610–627).
+- No other rule references `.shell-search` — verified via grep.
+
+### Step 3 — `apps/web/src/shared/ui/app-shell.test.tsx`
+
+- Add one regression test: `it('does not render a dead global search input in the topbar', …)` that asserts `screen.queryByRole('searchbox')` returns `null`. This locks in the removal and will fail loudly if anyone adds an input back without wiring it.
+- Use the existing `renderShell('/')` helper already at the top of the file.
+
+## 4. Acceptance criteria (map to issue)
+
+- [x] Dead input removed → **no silent dead UI**.
+- [x] Marker left at the removed location (`{/* Global search — planned. See #220. */}`) per the issue's "if removed: `<!-- planned -->` comment or `planned` badge" rule.
+- [x] Regression test added — any future re-introduction without wiring will break CI.
+- [x] No `⌘K` / `/` shortcut added — intentionally deferred (bullet in the issue's acceptance is conditional on `input is kept`, which it isn't).
+
+## 5. Validation
+
+- `pnpm lint` — expected clean. Removing the `Input` import clears the only risk (strict `noUnusedLocals`).
+- `pnpm type-check` — expected clean.
+- `pnpm test` — expected clean; the new test should pass, and no other test currently references the search input.
+
+## 6. Risks / trade-offs
+
+- **Visual jitter at desktop width.** The `.shell-search` rule only displays the input at ≥ 768 px with `flex: 0 1 320px`. After removal, the topbar's `shell-topbar__spacer` (currently `flex: 1`, to its left) will absorb the 320 px + gap. Alerts button stays right-aligned; no layout change on mobile. Verified by reading the flex declarations; no visual QA artifact attached to this PR because there's nothing to compare — the "before" was a fake affordance.
+- **"Operators expect search".** Accepted in the issue itself: better to have no search than a lying one. Real search returns when #220 is reopened for Option B (or a successor issue).


### PR DESCRIPTION
## Summary

The `AppShell` topbar rendered an `<Input type="search">` with no `onChange`, no routing, and no results — typing did nothing, `Enter` did nothing. Issue #220 flagged it as misleading UX and proposed **Option A** for MVP: remove the dead input rather than wire half a feature.

### Changes (4 files, +62/−24)

- `app-shell.tsx` — drop the `<label className="shell-search">…<Input/></label>` block and the now-unused `Input` import. Leave a JSX comment marker `{/* Global search — planned. See #220. */}` at the removed location so future grep traffic lands a reader on the trail (per the issue's "leave a planned marker" rule).
- `index.css` — drop the three `.shell-search` rules (base + `@media (min-width: 768px)` override + the nested input-height rule). No other selector references `.shell-search`.
- `app-shell.test.tsx` — add one regression test asserting `queryByRole('searchbox')` is `null`. Any future re-introduction without wiring breaks CI loudly.
- `docs/plans/implementation-plan-topbar-search-removal.md` — the plan (kept for audit trail).

### Notes for reviewers

- **No `⌘K` / "coming soon" hint added, deliberately.** A `⌘K` placeholder with no handler recreates the same "UI implies a feature that doesn't exist" problem at smaller scale. Real search returns when #220 is reopened for Option B (navigate-on-`Enter` to a list page with `?search=` set). Called out in the plan's `## 1 · Non-goals`.
- **Style-guide alignment.** `docs/frontend-ui-style-guide.md` §Top Utility Bar still permits "global search" in the topbar — the guide says "may contain", not "must". This change doesn't violate the shell contract, it just doesn't render an implementation until there is one.
- **No screenshots.** The "before" was a fake affordance; there's nothing meaningful to compare against.

## Test plan

- [x] `pnpm --filter @openlinker/web test` — 425 passed (424 before + 1 new regression)
- [x] `pnpm lint` — 0 errors (pre-existing warnings in `apps/api` + `data-table.tsx` unchanged)
- [x] `pnpm type-check` — 0 errors
- [x] Pre-commit hooks green (full repo-wide lint / type-check / test)
- [x] Regression test added — `queryByRole('searchbox')` returns `null`

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)