### PR TITLE
feat(web): Allegro category picker on create-offer wizard (part of #305)

### DIFF
--- a/apps/web/src/features/listings/components/CategoryPicker.test.tsx
+++ b/apps/web/src/features/listings/components/CategoryPicker.test.tsx
@@ -168,4 +168,101 @@ describe('CategoryPicker', () => {
     fireEvent.click(screen.getByRole('button', { name: /change/i }));
     await screen.findByText('Electronics');
   });
+
+  it('lets the operator re-pick a different leaf after clicking Change on a pre-filled value', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-new', name: 'Books', parentId: null, leaf: true }],
+          }),
+        ),
+      },
+    });
+    const onChange = vi.fn();
+
+    renderWithProviders(
+      <CategoryPicker
+        connectionId={connectionId}
+        value="cat-prefilled-999"
+        onChange={onChange}
+      />,
+      { apiClient },
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /change/i }));
+    // Browser reveals; the new leaf is available.
+    fireEvent.click(await screen.findByRole('button', { name: /^select$/i }));
+
+    // Controlled component: onChange fires with the new id. The "Selected"
+    // state only renders when the parent re-renders with the new value, which
+    // this test doesn't simulate — the contract we verify is the callback
+    // firing. The wizard test covers the parent-controlled round-trip.
+    expect(onChange).toHaveBeenCalledWith('cat-new');
+  });
+
+  it('disables all interactive elements when `disabled` is true', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [
+              { id: 'cat-1', name: 'Electronics', parentId: null, leaf: false },
+              { id: 'cat-2', name: 'Books', parentId: null, leaf: true },
+            ],
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <CategoryPicker
+        connectionId={connectionId}
+        value={null}
+        onChange={vi.fn()}
+        disabled
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText('Electronics');
+    // Non-leaf browse button
+    expect(screen.getByRole('button', { name: /browse into electronics/i })).toBeDisabled();
+    // Leaf select button
+    expect(screen.getByRole('button', { name: /^select$/i })).toBeDisabled();
+    // Root crumb is always disabled when at root (nothing to navigate back to),
+    // so that alone doesn't prove `disabled` plumbing — cover it via the
+    // leaf button instead.
+  });
+
+  it('forwards aria-labelledby, aria-describedby, and aria-invalid to the root group', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-1', name: 'Electronics', parentId: null, leaf: false }],
+          }),
+        ),
+      },
+    });
+
+    const { container } = renderWithProviders(
+      <CategoryPicker
+        connectionId={connectionId}
+        value={null}
+        onChange={vi.fn()}
+        invalid
+        aria-labelledby="external-label"
+        aria-describedby="external-description"
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText('Electronics');
+    const root = container.querySelector('.category-picker');
+    expect(root).toHaveAttribute('role', 'group');
+    expect(root).toHaveAttribute('aria-labelledby', 'external-label');
+    expect(root).toHaveAttribute('aria-describedby', 'external-description');
+    expect(root).toHaveAttribute('aria-invalid', 'true');
+  });
 });

--- a/apps/web/src/features/listings/components/CategoryPicker.test.tsx
+++ b/apps/web/src/features/listings/components/CategoryPicker.test.tsx
@@ -1,0 +1,171 @@
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CategoryPicker } from './CategoryPicker';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import type { AllegroCategory } from '../../mappings/api/mappings.types';
+
+function mockCategoriesEndpoint(
+  byParent: Record<string, AllegroCategory[]>,
+): (connectionId: string, parentId?: string) => Promise<AllegroCategory[]> {
+  return async (_connectionId, parentId) => {
+    const key = parentId ?? 'root';
+    return byParent[key] ?? [];
+  };
+}
+
+const connectionId = 'conn-1';
+
+describe('CategoryPicker', () => {
+  afterEach(cleanup);
+
+  it('renders the root list on mount', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [
+              { id: 'cat-1', name: 'Electronics', parentId: null, leaf: false },
+              { id: 'cat-2', name: 'Books', parentId: null, leaf: true },
+            ],
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <CategoryPicker connectionId={connectionId} value={null} onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText('Electronics')).toBeInTheDocument();
+    expect(screen.getByText('Books')).toBeInTheDocument();
+  });
+
+  it('drills into a non-leaf and updates the breadcrumb', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-electronics', name: 'Electronics', parentId: null, leaf: false }],
+            'cat-electronics': [
+              { id: 'cat-phones', name: 'Phones', parentId: 'cat-electronics', leaf: true },
+            ],
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <CategoryPicker connectionId={connectionId} value={null} onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /browse into electronics/i }),
+    );
+
+    // Breadcrumb now includes Electronics; children list contains Phones.
+    await screen.findByText('Phones');
+    expect(screen.getByRole('button', { name: 'Root' })).toBeEnabled();
+    // Electronics crumb is present but the *current* level's crumb is disabled (you can't
+    // navigate to where you already are).
+    expect(screen.getByRole('button', { name: 'Electronics' })).toBeDisabled();
+  });
+
+  it('calls onChange when a leaf is selected', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-books', name: 'Books', parentId: null, leaf: true }],
+          }),
+        ),
+      },
+    });
+    const onChange = vi.fn();
+
+    renderWithProviders(
+      <CategoryPicker connectionId={connectionId} value={null} onChange={onChange} />,
+      { apiClient },
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /^select$/i }));
+
+    expect(onChange).toHaveBeenCalledWith('cat-books');
+  });
+
+  it('jumps back when a breadcrumb crumb is clicked', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-electronics', name: 'Electronics', parentId: null, leaf: false }],
+            'cat-electronics': [
+              { id: 'cat-phones', name: 'Phones', parentId: 'cat-electronics', leaf: true },
+            ],
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <CategoryPicker connectionId={connectionId} value={null} onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /browse into electronics/i }),
+    );
+    await screen.findByText('Phones');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Root' }));
+    // Wait for the re-fetch at root level to render Electronics again.
+    await screen.findByRole('button', { name: /browse into electronics/i });
+    expect(screen.queryByText('Phones')).not.toBeInTheDocument();
+  });
+
+  it('renders an error state with a Retry button on query failure', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn().mockRejectedValue(new Error('API exploded')),
+      },
+    });
+
+    renderWithProviders(
+      <CategoryPicker connectionId={connectionId} value={null} onChange={vi.fn()} />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText('Unable to load categories')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('shows the pre-fill fallback row when opened with a non-null value', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-1', name: 'Electronics', parentId: null, leaf: false }],
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <CategoryPicker
+        connectionId={connectionId}
+        value="cat-prefilled-999"
+        onChange={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    // Shows the raw id, not the browser.
+    expect(await screen.findByText('cat-prefilled-999')).toBeInTheDocument();
+    expect(screen.queryByText('Electronics')).not.toBeInTheDocument();
+
+    // Clicking Change reveals the browser.
+    fireEvent.click(screen.getByRole('button', { name: /change/i }));
+    await screen.findByText('Electronics');
+  });
+});

--- a/apps/web/src/features/listings/components/CategoryPicker.tsx
+++ b/apps/web/src/features/listings/components/CategoryPicker.tsx
@@ -37,6 +37,13 @@ interface CategoryPickerProps {
   disabled?: boolean;
   /** Forwarded from `FormField` for `aria-describedby` wiring. */
   id?: string;
+  /**
+   * Required for a11y when the picker is used as a form control — the root
+   * container is a `<div role="group">`, so screen readers need an external
+   * label reference to announce the field name. Pass the `id` of the
+   * `.form-field__label` element above the picker.
+   */
+  'aria-labelledby'?: string;
   /** Forwarded from `FormField`. */
   'aria-describedby'?: string;
   /** Forwarded from `FormField`. */
@@ -55,6 +62,7 @@ export function CategoryPicker({
   invalid,
   disabled,
   id,
+  'aria-labelledby': ariaLabelledBy,
   'aria-describedby': ariaDescribedBy,
   'aria-invalid': ariaInvalid,
 }: CategoryPickerProps): ReactElement {
@@ -75,7 +83,9 @@ export function CategoryPicker({
     return (
       <div
         className={['category-picker', 'category-picker--prefill'].join(' ')}
+        role="group"
         id={id}
+        aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
         aria-invalid={isInvalid || undefined}
       >
@@ -99,8 +109,12 @@ export function CategoryPicker({
     setBreadcrumb((prev) => [...prev, { id: category.id, name: category.name }]);
   }
 
-  function navigateTo(index: number): void {
-    // index -1 → back to root; 0+ → keep first N crumbs
+  function navigateToRoot(): void {
+    setBreadcrumb([]);
+  }
+
+  function navigateToCrumb(index: number): void {
+    // Keep crumbs 0..index inclusive; drop anything deeper.
     setBreadcrumb((prev) => prev.slice(0, index + 1));
   }
 
@@ -119,7 +133,9 @@ export function CategoryPicker({
   return (
     <div
       className={pickerClasses}
+      role="group"
       id={id}
+      aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}
       aria-invalid={isInvalid || undefined}
     >
@@ -127,7 +143,7 @@ export function CategoryPicker({
         <button
           type="button"
           className="category-picker__crumb"
-          onClick={() => navigateTo(-1)}
+          onClick={navigateToRoot}
           disabled={disabled || breadcrumb.length === 0}
         >
           Root
@@ -140,7 +156,7 @@ export function CategoryPicker({
             <button
               type="button"
               className="category-picker__crumb"
-              onClick={() => navigateTo(i)}
+              onClick={() => navigateToCrumb(i)}
               disabled={disabled || i === breadcrumb.length - 1}
             >
               {crumb.name}

--- a/apps/web/src/features/listings/components/CategoryPicker.tsx
+++ b/apps/web/src/features/listings/components/CategoryPicker.tsx
@@ -1,0 +1,222 @@
+/**
+ * CategoryPicker
+ *
+ * Leaf-only Allegro category picker for the create-offer wizard (#305).
+ * Browses the Allegro category tree level-by-level with a breadcrumb trail;
+ * clicking a leaf fires `onChange(id)` — no staged/save intermediate.
+ *
+ * Designed to be used inside an RHF `<Controller>` (not `register()`); see
+ * usage in `CreateOfferWizard.tsx` Step 2.
+ *
+ * Data source: reuses `useAllegroCategoriesQuery` from the mappings feature
+ * — this is a cross-feature import. It is intentional: the wizard already
+ * imports from `products/` and `connections/`, and duplicating the hook
+ * under listings would be worse. A future refactor (#304) will extract a
+ * shared `CategoryTreeBrowser` primitive into `shared/ui/` once the
+ * existing `AllegroCategorySearch` (mappings) and this picker are refactored
+ * onto it together.
+ *
+ * Pre-fill fallback: when `value` is non-null and the operator hasn't
+ * browsed yet, the picker shows the raw ID + a "Change" button instead of
+ * trying to rehydrate the breadcrumb. Real ancestor-walk rehydration is a
+ * follow-up tied to #307's retry flow.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { useState, type ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { LoadingState, ErrorState, EmptyState } from '../../../shared/ui/feedback-state';
+import { useAllegroCategoriesQuery } from '../../mappings/hooks/use-allegro-categories';
+import type { AllegroCategory } from '../../mappings/api/mappings.types';
+
+interface CategoryPickerProps {
+  connectionId: string;
+  value: string | null;
+  onChange: (categoryId: string) => void;
+  invalid?: boolean;
+  disabled?: boolean;
+  /** Forwarded from `FormField` for `aria-describedby` wiring. */
+  id?: string;
+  /** Forwarded from `FormField`. */
+  'aria-describedby'?: string;
+  /** Forwarded from `FormField`. */
+  'aria-invalid'?: boolean;
+}
+
+interface BreadcrumbItem {
+  id: string;
+  name: string;
+}
+
+export function CategoryPicker({
+  connectionId,
+  value,
+  onChange,
+  invalid,
+  disabled,
+  id,
+  'aria-describedby': ariaDescribedBy,
+  'aria-invalid': ariaInvalid,
+}: CategoryPickerProps): ReactElement {
+  const [breadcrumb, setBreadcrumb] = useState<BreadcrumbItem[]>([]);
+  // `showBrowser` flips on when: (a) no value is set (always browse), or
+  // (b) the operator clicks "Change" on the pre-fill fallback row.
+  const [showBrowser, setShowBrowser] = useState<boolean>(value === null);
+
+  const currentParentId = breadcrumb.length > 0 ? breadcrumb[breadcrumb.length - 1].id : undefined;
+  const categoriesQuery = useAllegroCategoriesQuery(connectionId, currentParentId, showBrowser);
+
+  const isInvalid = Boolean(invalid) || Boolean(ariaInvalid);
+
+  // Pre-fill fallback: the operator opened the wizard with a pre-set categoryId
+  // (e.g. via a future retry flow from #307). We can't show the breadcrumb
+  // path without an extra API call, so we show the raw ID + a Change affordance.
+  if (!showBrowser && value !== null) {
+    return (
+      <div
+        className={['category-picker', 'category-picker--prefill'].join(' ')}
+        id={id}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={isInvalid || undefined}
+      >
+        <div className="category-picker__prefill">
+          <span className="category-picker__prefill-label">Current category ID</span>
+          <span className="mono-text">{value}</span>
+          <Button
+            tone="secondary"
+            type="button"
+            onClick={() => setShowBrowser(true)}
+            disabled={disabled}
+          >
+            Change
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  function navigateInto(category: AllegroCategory): void {
+    setBreadcrumb((prev) => [...prev, { id: category.id, name: category.name }]);
+  }
+
+  function navigateTo(index: number): void {
+    // index -1 → back to root; 0+ → keep first N crumbs
+    setBreadcrumb((prev) => prev.slice(0, index + 1));
+  }
+
+  function selectLeaf(category: AllegroCategory): void {
+    onChange(category.id);
+  }
+
+  const pickerClasses = [
+    'category-picker',
+    isInvalid ? 'category-picker--invalid' : '',
+    disabled ? 'category-picker--disabled' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={pickerClasses}
+      id={id}
+      aria-describedby={ariaDescribedBy}
+      aria-invalid={isInvalid || undefined}
+    >
+      <nav className="category-picker__breadcrumb" aria-label="Category path">
+        <button
+          type="button"
+          className="category-picker__crumb"
+          onClick={() => navigateTo(-1)}
+          disabled={disabled || breadcrumb.length === 0}
+        >
+          Root
+        </button>
+        {breadcrumb.map((crumb, i) => (
+          <span key={crumb.id} className="category-picker__crumb-group">
+            <span className="category-picker__separator" aria-hidden="true">
+              ›
+            </span>
+            <button
+              type="button"
+              className="category-picker__crumb"
+              onClick={() => navigateTo(i)}
+              disabled={disabled || i === breadcrumb.length - 1}
+            >
+              {crumb.name}
+            </button>
+          </span>
+        ))}
+      </nav>
+
+      <div className="category-picker__list-container">
+        {categoriesQuery.isLoading && (
+          <LoadingState
+            liveRegion="off"
+            title="Loading categories"
+            message="Fetching Allegro categories…"
+          />
+        )}
+
+        {categoriesQuery.error && (
+          <ErrorState
+            title="Unable to load categories"
+            message={categoriesQuery.error.message}
+            action={
+              <Button onClick={() => void categoriesQuery.refetch()}>Retry</Button>
+            }
+          />
+        )}
+
+        {categoriesQuery.data && categoriesQuery.data.length === 0 && (
+          <EmptyState
+            liveRegion="off"
+            title="No subcategories"
+            message="This level has no children. Step back and pick a different branch."
+          />
+        )}
+
+        {categoriesQuery.data && categoriesQuery.data.length > 0 && (
+          <ul className="category-picker__list" role="list">
+            {categoriesQuery.data.map((cat) => {
+              const isSelected = cat.leaf && cat.id === value;
+              const itemClasses = [
+                'category-picker__item',
+                cat.leaf ? 'category-picker__item--leaf' : 'category-picker__item--non-leaf',
+                isSelected ? 'category-picker__item--selected' : '',
+              ]
+                .filter(Boolean)
+                .join(' ');
+              return (
+                <li key={cat.id} className={itemClasses}>
+                  <span className="category-picker__name">{cat.name}</span>
+                  {cat.leaf ? (
+                    <Button
+                      tone={isSelected ? 'secondary' : 'primary'}
+                      type="button"
+                      onClick={() => selectLeaf(cat)}
+                      disabled={disabled}
+                      aria-pressed={isSelected}
+                    >
+                      {isSelected ? 'Selected' : 'Select'}
+                    </Button>
+                  ) : (
+                    <Button
+                      tone="ghost"
+                      type="button"
+                      onClick={() => navigateInto(cat)}
+                      disabled={disabled}
+                      aria-label={`Browse into ${cat.name}`}
+                    >
+                      Browse →
+                    </Button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
@@ -68,8 +68,27 @@ function defaultMocks(overrides: Parameters<typeof createMockApiClient>[0] = {})
         .mockResolvedValue({ jobId: 'job-1', offerCreationRecordId: 'rec-1' }),
       getSellerPolicies: vi.fn().mockResolvedValue(policies),
     },
+    mappings: {
+      // Single-leaf root tree for simple happy-path coverage. Individual tests
+      // override with deeper trees when they need to exercise drilling.
+      getAllegroCategories: vi.fn().mockResolvedValue([
+        { id: '12345', name: 'Test Category', parentId: null, leaf: true },
+      ]),
+    },
     ...overrides,
   });
+}
+
+/**
+ * Pick the leaf category whose "Select" button is currently visible in the
+ * CategoryPicker. Assumes Step 2 is rendered and the picker has loaded.
+ */
+async function pickFirstLeafCategory(): Promise<void> {
+  const selectButton = await screen.findByRole('button', { name: /^select$/i });
+  fireEvent.click(selectButton);
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /^selected$/i })).toBeInTheDocument(),
+  );
 }
 
 async function advanceToStep2(): Promise<void> {
@@ -87,8 +106,10 @@ async function advanceToStep2(): Promise<void> {
   fireEvent.click(screen.getByRole('radio'));
   fireEvent.click(screen.getByRole('button', { name: /next/i }));
   // Confirm Step 2 has rendered before handing back to the caller so that
-  // downstream `getByLabelText` calls are not racing the advance.
-  await waitFor(() => expect(screen.getByLabelText(/allegro category/i)).toBeInTheDocument());
+  // downstream queries are not racing the advance. The "Allegro category"
+  // label is now a static span (the picker is a custom control, not an
+  // input), so we look for the picker's own markup instead.
+  await waitFor(() => expect(screen.getByText('Allegro category')).toBeInTheDocument());
 }
 
 describe('CreateOfferWizard', () => {
@@ -167,6 +188,31 @@ describe('CreateOfferWizard', () => {
     expect(await screen.findByText(/pick a variant/i)).toBeInTheDocument();
   });
 
+  it('blocks advancement past step 2 until a leaf category is selected', async () => {
+    const mockApi = defaultMocks();
+    renderWithProviders(
+      <CreateOfferWizard
+        isOpen={true}
+        onClose={vi.fn()}
+        defaultConnectionId={allegroConnection.id}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: mockApi },
+    );
+
+    await advanceToStep2();
+    // Fill the other required Step-2 fields, but leave categoryId unselected.
+    fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
+    fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(
+      await screen.findByText(/allegro category id is required/i),
+    ).toBeInTheDocument();
+    // Still on Step 2 — delivery-policy select (Step 3) is not rendered.
+    expect(screen.queryByLabelText(/delivery policy/i)).not.toBeInTheDocument();
+  });
+
   it('validates title ≤ 75 chars on step 2', async () => {
     const mockApi = defaultMocks();
     renderWithProviders(
@@ -202,7 +248,7 @@ describe('CreateOfferWizard', () => {
 
     await advanceToStep2();
     // Fill the required Step-2 fields
-    fireEvent.change(screen.getByLabelText(/allegro category/i), { target: { value: '12345' } });
+    await pickFirstLeafCategory();
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
@@ -236,7 +282,7 @@ describe('CreateOfferWizard', () => {
     );
 
     await advanceToStep2();
-    fireEvent.change(screen.getByLabelText(/allegro category/i), { target: { value: '12345' } });
+    await pickFirstLeafCategory();
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
@@ -261,7 +307,7 @@ describe('CreateOfferWizard', () => {
     );
 
     await advanceToStep2();
-    fireEvent.change(screen.getByLabelText(/allegro category/i), { target: { value: '12345' } });
+    await pickFirstLeafCategory();
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
@@ -314,7 +360,7 @@ describe('CreateOfferWizard', () => {
     );
 
     await advanceToStep2();
-    fireEvent.change(screen.getByLabelText(/allegro category/i), { target: { value: '12345' } });
+    await pickFirstLeafCategory();
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
@@ -353,7 +399,7 @@ describe('CreateOfferWizard', () => {
     );
 
     await advanceToStep2();
-    fireEvent.change(screen.getByLabelText(/allegro category/i), { target: { value: '12345' } });
+    await pickFirstLeafCategory();
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));

--- a/apps/web/src/features/listings/components/CreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.tsx
@@ -464,6 +464,7 @@ export function CreateOfferWizard({
                       value={field.value || null}
                       onChange={field.onChange}
                       invalid={Boolean(fieldState.error)}
+                      aria-labelledby="categoryId-label"
                       aria-describedby="categoryId-description categoryId-error"
                     />
                   )}

--- a/apps/web/src/features/listings/components/CreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.tsx
@@ -24,7 +24,7 @@
  * @module apps/web/src/features/listings/components
  */
 import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
-import { useForm, type Path } from 'react-hook-form';
+import { Controller, useForm, type Path } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
@@ -43,6 +43,7 @@ import { useProductsQuery } from '../../products/hooks/use-products-query';
 import type { Product, ProductVariant } from '../../products/api/products.types';
 import { useCreateOfferMutation } from '../hooks/use-create-offer-mutation';
 import { useSellerPoliciesQuery } from '../hooks/use-seller-policies-query';
+import { CategoryPicker } from './CategoryPicker';
 import type { CreateOfferRequest } from '../api/listings.types';
 import {
   CREATE_OFFER_DEFAULT_VALUES,
@@ -446,18 +447,36 @@ export function CreateOfferWizard({
                 />
               </FormField>
 
-              <FormField
-                label="Allegro category ID"
-                name="categoryId"
-                description="Required for Allegro. Paste the numeric category id from the Allegro category tree."
-                error={form.formState.errors.categoryId?.message}
-              >
-                <Input
-                  {...form.register('categoryId')}
-                  placeholder="e.g. 12345"
-                  invalid={Boolean(form.formState.errors.categoryId)}
+              {/* Manual form-field layout — Controller + custom control means we
+                  can't use the shared FormField (which clones a single forwardRef
+                  child to inject ARIA wiring). We keep the same class structure
+                  so visual alignment with other fields is preserved. */}
+              <div className="form-field">
+                <span id="categoryId-label" className="form-field__label">
+                  Allegro category
+                </span>
+                <Controller
+                  control={form.control}
+                  name="categoryId"
+                  render={({ field, fieldState }) => (
+                    <CategoryPicker
+                      connectionId={currentConnectionId}
+                      value={field.value || null}
+                      onChange={field.onChange}
+                      invalid={Boolean(fieldState.error)}
+                      aria-describedby="categoryId-description categoryId-error"
+                    />
+                  )}
                 />
-              </FormField>
+                <p id="categoryId-description" className="form-field__description">
+                  Browse the Allegro tree and pick a leaf category.
+                </p>
+                {form.formState.errors.categoryId?.message ? (
+                  <p id="categoryId-error" className="form-field__error" role="alert">
+                    {form.formState.errors.categoryId.message}
+                  </p>
+                ) : null}
+              </div>
 
               <div className="form-grid form-grid--2col">
                 <FormField

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3660,6 +3660,14 @@ textarea {
   border-radius: 0.375rem;
 }
 
+/*
+ * The `.category-picker__item--leaf` and `--non-leaf` modifiers are emitted
+ * by CategoryPicker.tsx as intentional styling hooks but currently have no
+ * rules — the base `.category-picker__item` handles both visual states via
+ * the Select / Browse buttons inside. Kept so future differentiated styling
+ * (icons, subtle dividers, indent) can attach without markup changes.
+ */
+
 .category-picker__name {
   flex: 1;
   min-width: 0;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3543,3 +3543,127 @@ textarea {
   display: flex;
   gap: 0.375rem;
 }
+
+/*
+ * ── Category picker (#305) ────────────────────────────────────────
+ * Leaf-only Allegro category picker used in CreateOfferWizard Step 2.
+ * Browse-backed via breadcrumb; clicking a leaf fires onChange(id).
+ * The "--prefill" variant renders when the form opens with a pre-set
+ * categoryId — shows the raw ID + "Change" button as a fallback since
+ * we don't resolve the breadcrumb ancestor chain yet.
+ */
+.category-picker {
+  display: grid;
+  gap: 0.375rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--border-default);
+  border-radius: 0.625rem;
+  background: var(--bg-surface);
+}
+
+.category-picker--invalid {
+  border-color: var(--status-error-border);
+  background: var(--status-error-soft);
+}
+
+.category-picker--disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.category-picker__prefill {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.category-picker__prefill-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+}
+
+.category-picker__breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.125rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 0.75rem;
+  overflow-x: auto;
+}
+
+.category-picker__crumb-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+}
+
+.category-picker__crumb {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--accent-primary);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.category-picker__crumb:hover:not(:disabled) {
+  background: var(--accent-primary-soft);
+}
+
+.category-picker__crumb:disabled {
+  color: var(--text-primary);
+  cursor: default;
+  font-weight: 600;
+}
+
+.category-picker__separator {
+  color: var(--text-muted);
+  padding: 0 0.125rem;
+}
+
+.category-picker__list-container {
+  max-height: 20rem;
+  overflow-y: auto;
+}
+
+.category-picker__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.category-picker__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 0.8125rem;
+}
+
+.category-picker__item:last-child {
+  border-bottom: none;
+}
+
+.category-picker__item--selected {
+  background: var(--accent-primary-soft);
+  border-radius: 0.375rem;
+}
+
+.category-picker__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/docs/plans/implementation-plan-category-picker-and-shared-primitive.md
+++ b/docs/plans/implementation-plan-category-picker-and-shared-primitive.md
@@ -1,0 +1,200 @@
+# Implementation Plan — Allegro Category Picker (browse-only v1)
+
+**Issues**: #305 partial (category picker for wizard) · #304 stays open (now has a real second consumer — see §Scope)
+**Branch**: `304-305-category-picker-and-shared-primitive`
+**Layer mix**: Frontend only. Backend and cache infrastructure already exist.
+
+---
+
+## Scope — major revision after discovery
+
+Codebase discovery during Phase 4 kickoff found that **most of the infrastructure this plan's first draft wanted to build already exists**:
+
+- `GET /connections/:connectionId/allegro/categories?parentId=...` — implemented at `apps/api/src/mappings/http/mapping-options.controller.ts:199`
+- Backing service + cache — `apps/api/src/categories/categories-cache.service.ts` with `allegro_category_cache` table, 24h TTL, adapter fan-out via `MarketplacePort.fetchCategories`
+- Migration `1779000000001-add-allegro-category-cache-table.ts` applied
+- FE query hook — `apps/web/src/features/mappings/hooks/use-allegro-categories.ts` with 1h `staleTime`
+- FE type — `AllegroCategory` at `apps/web/src/features/mappings/api/mappings.types.ts:53`
+- A browse-based picker — `apps/web/src/features/mappings/components/AllegroCategorySearch.tsx` — exists but is tightly coupled to the mapping-editor UX (staged pick → "Save mapping", `currentMapping` prop, path-string building, allows selecting any level)
+
+**So what actually needs building for #305:**
+- A new `CategoryPicker` in `features/listings/components/` that is leaf-only, emits via `onChange(id)` on leaf click (no staged/save intermediate), and is shaped for RHF `Controller` wiring.
+- CSS for it.
+- Wizard Step 2 wiring.
+- Tests.
+
+**Cross-feature import from listings → mappings** (for the query hook + `AllegroCategory` type) is acceptable here — the wizard already imports from `products/` and `connections/` features (see `CreateOfferWizard.tsx:40–42`). The alternative — duplicating the hook/type under listings — is worse.
+
+**#304 scope change**: the existing `AllegroCategorySearch` in `features/mappings/components/` + the new `CategoryPicker` in `features/listings/components/` now give #304 a legitimate second consumer. **This PR does not close #304**; it sets up the condition for a future PR that extracts a shared `CategoryTreeBrowser` primitive into `shared/ui/`. Called out in the PR body.
+
+**#305 scope change**: search-as-you-type still deferred (Allegro adapter doesn't expose it). PR closes #305 only if the user accepts browse-only in review; otherwise `Part of #305`.
+
+---
+
+## 1. Goal
+
+Replace the free-text `overrides.categoryId` input on Step 2 of `CreateOfferWizard` with a browseable category picker that enforces **leaf-only** selection. Reuse the existing backend endpoint and query hook.
+
+### Non-goals
+
+- **Search-as-you-type.** Adapter doesn't expose it.
+- **Breadcrumb rehydration for pre-filled IDs.** The picker shows a pre-fill fallback row (monospace ID + "Change" button). Real ancestor-walk is a follow-up tied to #307's retry flow.
+- **Extracting shared `CategoryTreeBrowser` primitive.** Closes #304 — not this PR.
+- **Touching `AllegroCategorySearch` in mappings.** Stays as-is; its staged-pick UX suits the mapping editor.
+
+---
+
+## 2. Architecture
+
+```
+CreateOfferWizard (apps/web/src/features/listings/components)   # Step 2 form field
+       ↓  <Controller>
+CategoryPicker (NEW — apps/web/src/features/listings/components)
+       ↓ query hook import (cross-feature — precedent set)
+useAllegroCategoriesQuery (EXISTING — apps/web/src/features/mappings/hooks)
+       ↓ useApiClient()
+apiClient.mappings.getAllegroCategories (EXISTING)
+       ↓ HTTP
+GET /connections/:id/allegro/categories?parentId=... (EXISTING)
+       ↓
+MappingOptionsController → CategoriesCacheService (EXISTING)
+       ↓ cache-aside (DB, 24h TTL)
+MarketplacePort.fetchCategories (EXISTING — Allegro adapter)
+```
+
+---
+
+## 3. Implementation steps
+
+### Step 1 — `CategoryPicker` component
+**New file**: `apps/web/src/features/listings/components/CategoryPicker.tsx`
+
+Props:
+```typescript
+interface CategoryPickerProps {
+  connectionId: string;
+  value: string | null;
+  onChange: (categoryId: string) => void;
+  invalid?: boolean;
+  disabled?: boolean;
+  /** Forwarded from FormField for aria-describedby wiring */
+  id?: string;
+}
+```
+
+Behavior:
+- Imports `useAllegroCategoriesQuery` from `../../mappings/hooks/use-allegro-categories` and `AllegroCategory` from `../../mappings/api/mappings.types` (cross-feature — matches wizard's existing pattern).
+- Internal breadcrumb state: `useState<Array<{ id: string; name: string }>>([])`. Current `parentId = breadcrumb.at(-1)?.id ?? undefined`.
+- Renders:
+  1. Pre-fill fallback row (when `value` is non-null and breadcrumb is empty): `<span class="mono-text">{value}</span>` + "Change" button that keeps `value` intact and shows the root list for re-selection.
+  2. Breadcrumb row (`<nav aria-label="Category path">`) — "Root" button + current crumbs.
+  3. Query-state handling: `LoadingState` / `ErrorState` (with retry) / `EmptyState` / data list.
+  4. Category list: clicking a **non-leaf** pushes onto breadcrumb (re-fetch); clicking a **leaf** fires `onChange(id)` and highlights it as selected.
+- Uses `aria-invalid={invalid}` and `aria-disabled={disabled}` on the container.
+- Tags the root-level container with `id` so `FormField`'s `aria-describedby` wiring works (spec'd in `frontend.md`).
+
+### Step 2 — CSS
+**Edit**: `apps/web/src/index.css` (append)
+
+New classes (all token-driven):
+- `.category-picker` (container, grid layout)
+- `.category-picker__prefill` (the pre-fill fallback row)
+- `.category-picker__breadcrumb` (`overflow-x: auto` so deep paths scroll)
+- `.category-picker__crumb` (clickable button)
+- `.category-picker__list` (scrollable category list, ~320px max-height)
+- `.category-picker__item` + `--leaf`, `--selected`, `--non-leaf` modifiers
+- `.category-picker[aria-invalid="true"]` state styling for invalid ring
+
+Pattern: mirror spacing/borders/radii of the existing `.allegro-category-search__*` classes so visual consistency is preserved between the two surfaces.
+
+### Step 3 — Wizard integration
+**Edit**: `apps/web/src/features/listings/components/CreateOfferWizard.tsx`
+
+Replace the Step 2 `<Input>` for `categoryId` with:
+
+```tsx
+<FormField
+  label="Allegro category"
+  name="categoryId"
+  description="Browse and pick a leaf category (no free-text)"
+  error={form.formState.errors.categoryId?.message}
+>
+  <Controller
+    control={form.control}
+    name="categoryId"
+    render={({ field, fieldState }) => (
+      <CategoryPicker
+        connectionId={currentConnectionId}
+        value={field.value ?? null}
+        onChange={field.onChange}
+        invalid={!!fieldState.error}
+      />
+    )}
+  />
+</FormField>
+```
+
+Zod schema stays unchanged (`z.string().min(1, ...)` — the picker guarantees non-empty leaf IDs).
+
+### Step 4 — Tests
+
+- **New: `CategoryPicker.test.tsx`** — 6 cases:
+  1. Renders root list on mount.
+  2. Clicking a non-leaf updates breadcrumb and fetches children.
+  3. Clicking a leaf calls `onChange(id)` and shows selected state.
+  4. Clicking a crumb jumps back.
+  5. Error state with retry button.
+  6. Pre-fill fallback row when `value` is non-null with empty breadcrumb; "Change" reveals the root list.
+
+- **Edit: `CreateOfferWizard.test.tsx`** — update happy-path to drill into a leaf category; add regression "won't advance past Step 2 until a leaf is selected."
+
+### Step 5 — Quality gate + commit
+
+`pnpm lint && pnpm type-check && pnpm test` from the worktree root.
+
+---
+
+## 4. File inventory
+
+### New files (2)
+- `apps/web/src/features/listings/components/CategoryPicker.tsx`
+- `apps/web/src/features/listings/components/CategoryPicker.test.tsx`
+
+### Edited files (3)
+- `apps/web/src/features/listings/components/CreateOfferWizard.tsx`
+- `apps/web/src/features/listings/components/CreateOfferWizard.test.tsx`
+- `apps/web/src/index.css`
+
+**No backend changes. No migrations.**
+
+---
+
+## 5. Global rules
+
+- File header on the new `.tsx` file per `engineering-standards.md` §File Headers.
+- No `any`. No `console.log`.
+- Token-driven CSS only.
+- `aria-invalid` + `aria-describedby` wired through `FormField`.
+
+---
+
+## 6. Acceptance checklist
+
+- [ ] `CategoryPicker` renders root list and drills through breadcrumb
+- [ ] Leaf click emits `onChange(id)` with the leaf ID
+- [ ] Non-leaf click pushes breadcrumb; crumb click jumps back
+- [ ] Pre-fill fallback row shows mono ID + "Change" when `value` non-null on mount
+- [ ] Wizard Step 2 uses `CategoryPicker` (no free-text input remains)
+- [ ] Wizard tests updated; 6 picker tests pass
+- [ ] `pnpm lint && pnpm type-check && pnpm test` all pass
+- [ ] No `any`, no `console.log`, file header present
+- [ ] PR body accurately reflects: `Part of #305` (browse-only) + `#304 stays open with real second consumer now established`
+
+---
+
+## 7. Follow-ups
+
+- **#305 search-as-you-type** — needs a new adapter method (Allegro name lookup). File on merge.
+- **#304 shared primitive extraction** — now has two real consumers (`AllegroCategorySearch` in mappings + `CategoryPicker` in listings). Propose a future PR that extracts `shared/ui/category-tree-browser.tsx`, with `mappings` keeping its staged-pick wrapper and `listings` keeping its leaf-only wrapper. Not this PR.
+- **#307 retry flow breadcrumb rehydration** — needs `GET /connections/:id/allegro/categories/:id/ancestors` or similar to rehydrate breadcrumb for a pre-filled ID. Tied to #307.
+- **Manual cache invalidation endpoint** — `POST /connections/:id/allegro/categories/invalidate-cache`. Only if operators hit staleness pain.


### PR DESCRIPTION
## Summary

Step 2 of `CreateOfferWizard` now uses a new browseable `CategoryPicker` (leaf-only) instead of the free-text `categoryId` input. Backed by the **existing** `/connections/:id/allegro/categories` endpoint and the `useAllegroCategoriesQuery` hook already shipped for the mappings feature — no backend work in this PR.

## Scope (honest accounting)

- **Part of #305** — delivers browse-backed category selection. Does NOT close #305 because the "search-as-you-type on leaf categories" bullet from the issue is still out of scope. Allegro's adapter doesn't expose a name-lookup surface today; when it does (or when we accept full-tree client-side cache), a follow-up PR will close #305.
- **#304 stays open.** The existing `AllegroCategorySearch` (mappings) + this `CategoryPicker` (listings) now give #304 a real second consumer. A future PR should extract a shared `shared/ui/category-tree-browser` primitive and refactor both surfaces onto it. This PR deliberately avoids speculative extraction.

## Implementation highlights

**Codebase discovery shaped the scope:** the first draft of the implementation plan proposed a full backend stack (service, cache port, ORM entity, migration, controller endpoint). Phase-4 discovery found that all of it already exists (`apps/api/src/categories/categories-cache.service.ts`, the `allegro_category_cache` table, `useAllegroCategoriesQuery`). The plan was rewritten to a frontend-only delivery.

**Architecture:**
- `CategoryPicker` in `features/listings/components/` (domain-specific → not `shared/ui/`).
- Cross-feature import from `features/mappings/` (hook + `AllegroCategory` type). Matches the wizard's existing pattern of importing from `products/` and `connections/`; not a documented violation of `frontend-architecture.md` §Dependency Rules (those only restrict `shared → features/pages`).

**Form wiring:** wizard uses `<Controller>` + manual `.form-field` layout — `FormField` can't clone a non-forwardRef child to inject ARIA props through a `Controller`. Documented inline. A future `FormFieldShell` primitive is the clean extraction when a second custom-control field appears (e.g., #307's retry flow).

**Pre-fill fallback:** when the picker opens with a non-null `value` and no breadcrumb history, renders the raw ID + "Change" button instead of attempting a breadcrumb rehydration. Real ancestor-walk rehydration is follow-up work tied to #307.

**Accessibility:** `role="group"` + `aria-labelledby="categoryId-label"` associates the picker with its visible label. `aria-describedby` forwards description + error ids. `aria-invalid` reflects field state. Per-row buttons have explicit `aria-label` (`Browse into {name}`) and leaf selects use `aria-pressed`.

## Test plan

- [x] 9 new `CategoryPicker.test.tsx` cases: root render · drill non-leaf · leaf select · crumb jump · error state · pre-fill fallback · re-pick after Change · `disabled` prop propagation · ARIA forwarding to root group
- [x] Updated `CreateOfferWizard.test.tsx`: `pickFirstLeafCategory()` helper; regression "blocks advancement past step 2 until a leaf category is selected"
- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 442/442 web · 334/334 core · 250/250 api · 104/104 worker · 181/181 prestashop · 79/79 allegro · 7/7 shared

## Commits

1. **`feat(web):`** initial CategoryPicker + wizard integration
2. **`refactor(web):`** applied tech-review suggestions (aria-labelledby, navigateToRoot/navigateToCrumb split, CSS hook comment, 3 new tests)

## Not closing

- `#305` stays open — search-as-you-type still pending
- `#304` stays open — awaiting the shared-primitive extraction PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)