### PR TITLE
feat(listings): retry affordance for failed offer-creation records

### DIFF
--- a/apps/api/src/listings/http/dto/offer-creation-request-payload-response.dto.ts
+++ b/apps/api/src/listings/http/dto/offer-creation-request-payload-response.dto.ts
@@ -1,0 +1,75 @@
+/**
+ * Offer Creation Request Payload Response DTO
+ *
+ * Debug-only response-shape sibling of `CreateOfferDto`. Rendered on the
+ * status response (`GET /listings/connections/:connectionId/offers/creation/:id`)
+ * so the frontend can pre-fill the wizard on retry (#307).
+ *
+ * Separate from the request DTO so `class-validator` decorators don't leak
+ * onto the response path where they're dead weight. Pure `@ApiProperty` /
+ * `@ApiPropertyOptional` annotations here — responses describe shape for
+ * Swagger, not validate inbound input.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class OfferCreationRequestPriceResponseDto {
+  @ApiProperty({ example: 99.99 })
+  amount!: number;
+
+  @ApiProperty({ example: 'PLN' })
+  currency!: string;
+}
+
+export class OfferCreationRequestOverridesResponseDto {
+  @ApiPropertyOptional({ description: 'Offer title override the operator submitted' })
+  title?: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Offer description override; `null` means "no override" was supplied',
+  })
+  description?: string | null;
+
+  @ApiPropertyOptional({ description: 'Platform-specific category id the operator selected' })
+  categoryId?: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    isArray: true,
+    type: String,
+    description: 'Image URLs the operator submitted',
+  })
+  imageUrls?: string[] | null;
+
+  @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: true,
+    description: 'Platform-specific params (e.g. `deliveryPolicyId`, `warrantyId` for Allegro)',
+  })
+  platformParams?: Record<string, unknown>;
+}
+
+export class OfferCreationRequestPayloadDto {
+  @ApiProperty({
+    description: 'Snapshot schema version. Readers route on this value; unknown versions degrade to null.',
+    example: 1,
+  })
+  schemaVersion!: number;
+
+  @ApiProperty({ description: 'OpenLinker internal variant id this create-attempt targeted' })
+  internalVariantId!: string;
+
+  @ApiProperty({ description: 'Stock quantity the operator submitted' })
+  stock!: number;
+
+  @ApiProperty({ description: 'Whether the operator asked to publish immediately' })
+  publishImmediately!: boolean;
+
+  @ApiPropertyOptional({ type: OfferCreationRequestPriceResponseDto })
+  price?: OfferCreationRequestPriceResponseDto;
+
+  @ApiPropertyOptional({ type: OfferCreationRequestOverridesResponseDto })
+  overrides?: OfferCreationRequestOverridesResponseDto;
+}

--- a/apps/api/src/listings/http/dto/offer-creation-status-response.dto.ts
+++ b/apps/api/src/listings/http/dto/offer-creation-status-response.dto.ts
@@ -14,6 +14,8 @@ import {
   OfferCreationStatusValues,
 } from '@openlinker/core/listings';
 
+import { OfferCreationRequestPayloadDto } from './offer-creation-request-payload-response.dto';
+
 export class OfferCreationErrorDto {
   @ApiPropertyOptional({ description: 'Dotted field path reported by the platform' })
   field?: string;
@@ -59,4 +61,12 @@ export class OfferCreationStatusResponseDto {
 
   @ApiProperty({ description: 'ISO 8601 timestamp of the last update' })
   updatedAt!: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    type: OfferCreationRequestPayloadDto,
+    description:
+      'Debug-only: snapshot of the original create-offer request payload. Drives the wizard retry pre-fill. Null for records predating this change or for records created through code paths that do not capture the snapshot.',
+  })
+  request?: OfferCreationRequestPayloadDto | null;
 }

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -188,6 +188,7 @@ describe('ListingsController', () => {
         publishImmediately: true,
         createdAt: '2026-04-20T10:00:00.000Z',
         updatedAt: '2026-04-20T11:00:00.000Z',
+        request: null,
       });
     });
 
@@ -301,7 +302,41 @@ describe('ListingsController', () => {
         publishImmediately: false,
         createdAt: '2026-04-20T10:00:00.000Z',
         updatedAt: '2026-04-20T10:00:00.000Z',
+        request: null,
       });
+    });
+
+    it('surfaces the request snapshot when the record carries one', async () => {
+      const request = {
+        schemaVersion: 1 as const,
+        internalVariantId: 'ol_variant_abc123',
+        stock: 3,
+        publishImmediately: true,
+        price: { amount: 19.99, currency: 'PLN' },
+        overrides: {
+          title: 'Retry pre-fill title',
+          categoryId: 'allegro-cat-1',
+          platformParams: { deliveryPolicyId: 'del-1' },
+        },
+      };
+      const recordWithRequest = new OfferCreationRecord(
+        'record-2',
+        'ol_variant_abc123',
+        'conn-1',
+        null,
+        'failed',
+        [{ code: 'VALIDATION', message: 'Invalid category' }],
+        true,
+        new Date('2026-04-22T10:00:00Z'),
+        new Date('2026-04-22T10:00:01Z'),
+        request,
+      );
+      offerCreationRecords.findById.mockResolvedValue(recordWithRequest);
+
+      const result = await controller.getOfferCreationStatus('conn-1', 'record-2');
+
+      expect(result.request).toEqual(request);
+      expect(result.request?.schemaVersion).toBe(1);
     });
 
     it('throws NotFoundException when record does not exist', async () => {

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -292,6 +292,9 @@ export class ListingsController {
       publishImmediately: record.publishImmediately,
       createdAt: record.createdAt instanceof Date ? record.createdAt.toISOString() : record.createdAt,
       updatedAt: record.updatedAt instanceof Date ? record.updatedAt.toISOString() : record.updatedAt,
+      // Pass the snapshot through untouched. It's already the on-wire shape
+      // (plain object in jsonb); no date fields or instance conversions to run.
+      request: record.request,
     };
   }
 }

--- a/apps/api/src/migrations/1787000000000-add-offer-creation-record-request-payload.ts
+++ b/apps/api/src/migrations/1787000000000-add-offer-creation-record-request-payload.ts
@@ -1,0 +1,36 @@
+/**
+ * Add Offer-Creation-Record Request Payload Column
+ *
+ * Adds a nullable `request` jsonb column to `offer_creation_records` that
+ * persists a snapshot of the original create-offer request payload (#307).
+ * Enables the wizard's retry-prefill path: on a failed record, operators
+ * click Retry and re-open the wizard with the prior fields pre-populated
+ * plus a fresh idempotency key.
+ *
+ * Additive and null-for-old-rows by design. Records predating this change
+ * have `request IS NULL` and degrade gracefully on the FE (retry still
+ * opens the wizard, pre-filling only `connectionId` and `internalVariantId`
+ * from columns already on the record).
+ *
+ * Generated manually: Docker was not available at generation time, so the
+ * SQL is hand-written here rather than going through `migration:generate`.
+ *
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOfferCreationRecordRequestPayload1787000000000 implements MigrationInterface {
+  name = 'AddOfferCreationRecordRequestPayload1787000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "offer_creation_records" ADD COLUMN IF NOT EXISTS "request" jsonb`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "offer_creation_records" DROP COLUMN IF EXISTS "request"`,
+    );
+  }
+}

--- a/apps/api/test/integration/fixtures/offer-creation-record.fixtures.ts
+++ b/apps/api/test/integration/fixtures/offer-creation-record.fixtures.ts
@@ -14,6 +14,8 @@ export interface TestOfferCreationRecordOverrides {
   externalOfferId?: string | null;
   status?: 'pending' | 'draft' | 'validating' | 'active' | 'failed';
   publishImmediately?: boolean;
+  /** Seeds the jsonb `request` column. `null` to omit the snapshot. */
+  request?: Record<string, unknown> | null;
 }
 
 /**
@@ -28,10 +30,11 @@ export async function createTestOfferCreationRecord(
   dataSource: DataSource,
   overrides?: TestOfferCreationRecordOverrides,
 ): Promise<string> {
+  const requestValue = overrides?.request === undefined ? null : overrides.request;
   const result = (await dataSource.query(
     `INSERT INTO offer_creation_records
-       ("internalVariantId", "connectionId", "externalOfferId", "status", "errors", "publishImmediately")
-     VALUES ($1, $2, $3, $4, $5, $6)
+       ("internalVariantId", "connectionId", "externalOfferId", "status", "errors", "publishImmediately", "request")
+     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
      RETURNING id`,
     [
       overrides?.internalVariantId ?? 'ol_variant_abc123',
@@ -40,6 +43,7 @@ export async function createTestOfferCreationRecord(
       overrides?.status ?? 'pending',
       null,
       overrides?.publishImmediately ?? false,
+      requestValue === null ? null : JSON.stringify(requestValue),
     ],
   )) as Array<{ id: string }>;
 

--- a/apps/api/test/integration/listings-create-offer.int-spec.ts
+++ b/apps/api/test/integration/listings-create-offer.int-spec.ts
@@ -77,6 +77,57 @@ describe('Listings Create-Offer API Integration', () => {
         .expect(404);
     });
 
+    it('round-trips the request snapshot from the jsonb column through to the response', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const snapshot = {
+        schemaVersion: 1,
+        internalVariantId: 'ol_variant_abc123',
+        stock: 7,
+        publishImmediately: true,
+        price: { amount: 49.5, currency: 'PLN' },
+        overrides: {
+          title: 'Shipped title',
+          categoryId: 'allegro-cat-1',
+          description: 'desc',
+          platformParams: { deliveryPolicyId: 'del-1', warrantyId: 'war-1' },
+        },
+      };
+
+      const recordId = await createTestOfferCreationRecord(dataSource, {
+        connectionId: CONN_A,
+        status: 'failed',
+        request: snapshot,
+      });
+
+      const response = await http
+        .get(`/listings/connections/${CONN_A}/offers/creation/${recordId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(response.body.request).toEqual(snapshot);
+    });
+
+    it('returns a null request when the record predates the snapshot column', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const recordId = await createTestOfferCreationRecord(dataSource, {
+        connectionId: CONN_A,
+        request: null,
+      });
+
+      const response = await http
+        .get(`/listings/connections/${CONN_A}/offers/creation/${recordId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(response.body.request).toBeNull();
+    });
+
     it('returns 404 when the record exists but belongs to a different connection', async () => {
       const http = harness.getHttp();
       const dataSource = harness.getDataSource();

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -115,7 +115,18 @@ export interface CreateOfferRequest {
   publishImmediately: boolean;
   price?: CreateOfferPrice;
   overrides?: CreateOfferOverrides;
+  /**
+   * Snapshot schema version. Absent on request submits (the wizard does
+   * not populate it — the backend stamps it at persist time). Present on
+   * the `request` field embedded in `OfferCreationStatusResponse`. FE
+   * consumers must treat any unknown version as "cannot safely pre-fill"
+   * and fall back to an empty wizard.
+   */
+  schemaVersion?: number;
 }
+
+/** The only snapshot schema version this client knows how to read. */
+export const SUPPORTED_OFFER_CREATION_REQUEST_SCHEMA_VERSION = 1;
 
 export interface CreateOfferResponse {
   jobId: string;
@@ -132,6 +143,13 @@ export interface OfferCreationStatusResponse {
   publishImmediately: boolean;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Snapshot of the original create-offer request payload. Drives the
+   * wizard retry pre-fill on a failed record. Null when the record
+   * predates this field or when the snapshot schema version is unknown
+   * to this client — consumers must tolerate null and degrade gracefully.
+   */
+  request?: CreateOfferRequest | null;
 }
 
 export interface SellerPolicy {

--- a/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
@@ -9,7 +9,7 @@ import { renderWithProviders, createMockApiClient } from '../../../test/test-uti
 import { CreateOfferWizard } from './CreateOfferWizard';
 import type { Connection } from '../../connections/api/connections.types';
 import type { Product } from '../../products/api/products.types';
-import type { SellerPoliciesResponse } from '../api/listings.types';
+import type { CreateOfferRequest, SellerPoliciesResponse } from '../api/listings.types';
 
 const allegroConnection: Connection = {
   id: 'conn_allegro_1',
@@ -411,6 +411,148 @@ describe('CreateOfferWizard', () => {
     expect(await screen.findByText(/offer creation failed/i)).toBeInTheDocument();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  describe('retry with initialValues (#307)', () => {
+    const initialRequest: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_aaaaaaaa',
+      stock: 5,
+      publishImmediately: false,
+      price: { amount: 99.99, currency: 'PLN' },
+      overrides: {
+        title: 'Original Title',
+        categoryId: '12345',
+        description: null,
+        platformParams: {
+          deliveryPolicyId: 'del-1',
+          returnPolicyId: 'ret-1',
+        },
+      },
+    };
+
+    it('renders the retry hint on Step 1 after Back when opened with initialValues', async () => {
+      const mockApi = defaultMocks();
+      renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          initialValues={initialRequest}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      // Lands on Step 2; no hint yet since Step 1 is not rendered.
+      await screen.findByLabelText(/^title$/i);
+      // Step back to 1 — the hint should now be visible.
+      fireEvent.click(screen.getByRole('button', { name: /back/i }));
+      expect(await screen.findByText(/prior attempt re-loaded/i)).toBeInTheDocument();
+    });
+
+    it('does not render the retry hint on a fresh open', async () => {
+      const mockApi = defaultMocks();
+      renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await screen.findByLabelText(/search products/i);
+      expect(screen.queryByText(/prior attempt re-loaded/i)).not.toBeInTheDocument();
+    });
+
+    it('opens on step 2 with fields pre-filled from initialValues', async () => {
+      const mockApi = defaultMocks();
+      renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          initialValues={initialRequest}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      // Step 2 is visible (not Step 1's search products field).
+      expect(await screen.findByLabelText(/^title$/i)).toHaveValue('Original Title');
+      expect(screen.getByLabelText(/allegro category/i)).toHaveValue('12345');
+      expect(screen.getByLabelText<HTMLInputElement>(/^price$/i).value).toBe('99.99');
+      expect(screen.getByLabelText<HTMLInputElement>(/^stock$/i).value).toBe('5');
+      expect(screen.queryByLabelText(/search products/i)).not.toBeInTheDocument();
+    });
+
+    it('mints a fresh idempotency key on retry open (old failed record untouched)', async () => {
+      const createOffer = vi
+        .fn()
+        .mockResolvedValueOnce({ jobId: 'job-a', offerCreationRecordId: 'rec-a' })
+        .mockResolvedValueOnce({ jobId: 'job-b', offerCreationRecordId: 'rec-b' });
+      const mockApi = defaultMocks({
+        listings: { createOffer, getSellerPolicies: vi.fn().mockResolvedValue(policies) },
+      });
+
+      // First wizard session: normal flow through all four steps.
+      const { rerender } = renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await advanceToStep2();
+      fireEvent.change(screen.getByLabelText(/allegro category/i), { target: { value: '12345' } });
+      fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
+      fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      fireEvent.change(await screen.findByLabelText(/delivery policy/i), {
+        target: { value: 'del-1' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      fireEvent.click(await screen.findByRole('button', { name: /create offer/i }));
+      await waitFor(() => expect(createOffer).toHaveBeenCalledTimes(1));
+      const firstKey = createOffer.mock.calls[0][2].idempotencyKey;
+
+      // Close the wizard, then reopen it with initialValues (the retry path).
+      rerender(
+        <CreateOfferWizard
+          isOpen={false}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          onSubmitted={vi.fn()}
+        />,
+      );
+      rerender(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          initialValues={initialRequest}
+          onSubmitted={vi.fn()}
+        />,
+      );
+
+      // We land on Step 2 pre-filled; advance through Step 3 → submit.
+      await screen.findByLabelText(/^title$/i);
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      // Delivery policy pre-fills from initialValues; just advance.
+      await screen.findByLabelText(/delivery policy/i);
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      fireEvent.click(await screen.findByRole('button', { name: /create offer/i }));
+      await waitFor(() => expect(createOffer).toHaveBeenCalledTimes(2));
+
+      const secondKey = createOffer.mock.calls[1][2].idempotencyKey;
+      expect(firstKey).toBeTruthy();
+      expect(secondKey).toBeTruthy();
+      expect(secondKey).not.toBe(firstKey);
+    });
   });
 
   describe('variant picker pagination (#308)', () => {

--- a/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
@@ -481,7 +481,10 @@ describe('CreateOfferWizard', () => {
 
       // Step 2 is visible (not Step 1's search products field).
       expect(await screen.findByLabelText(/^title$/i)).toHaveValue('Original Title');
-      expect(screen.getByLabelText(/allegro category/i)).toHaveValue('12345');
+      // The CategoryPicker renders the pre-filled categoryId in its
+      // "Current category ID" fallback view rather than as an input value.
+      expect(screen.getByText('Current category ID')).toBeInTheDocument();
+      expect(screen.getByText('12345')).toBeInTheDocument();
       expect(screen.getByLabelText<HTMLInputElement>(/^price$/i).value).toBe('99.99');
       expect(screen.getByLabelText<HTMLInputElement>(/^stock$/i).value).toBe('5');
       expect(screen.queryByLabelText(/search products/i)).not.toBeInTheDocument();
@@ -508,7 +511,7 @@ describe('CreateOfferWizard', () => {
       );
 
       await advanceToStep2();
-      fireEvent.change(screen.getByLabelText(/allegro category/i), { target: { value: '12345' } });
+      await pickFirstLeafCategory();
       fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
       fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
       fireEvent.click(screen.getByRole('button', { name: /next/i }));

--- a/apps/web/src/features/listings/components/CreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.tsx
@@ -51,6 +51,7 @@ import {
   type CreateOfferFieldsSubmission,
   type CreateOfferFieldsValues,
 } from './create-offer-fields.schema';
+import { createOfferRequestToFormValues } from './create-offer-request-to-form-values';
 
 const STEP_LABELS = ['Connection & Variant', 'Offer details', 'Policies', 'Review'] as const;
 
@@ -70,6 +71,10 @@ interface CreateOfferWizardProps {
   /** Pre-fill hint from the listings list filter; the picker is always
    *  visible so the operator can change it. */
   defaultConnectionId?: string;
+  /** Snapshot of a prior request, used by the retry path to reopen the
+   *  wizard pre-populated. Consumed on each open transition; changing it
+   *  while the wizard is already open has no effect. */
+  initialValues?: CreateOfferRequest;
   onSubmitted: (offerCreationRecordId: string, connectionId: string) => void;
 }
 
@@ -88,6 +93,7 @@ export function CreateOfferWizard({
   isOpen,
   onClose,
   defaultConnectionId,
+  initialValues,
   onSubmitted,
 }: CreateOfferWizardProps): ReactElement {
   const mutation = useCreateOfferMutation();
@@ -105,23 +111,51 @@ export function CreateOfferWizard({
   const [productSearchInput, setProductSearchInput] = useState('');
   const [productOffset, setProductOffset] = useState(0);
   const [selectedProductId, setSelectedProductId] = useState<string | null>(null);
+  // True when the current session was opened via Retry with a snapshot.
+  // Lets Step 1 render a hint explaining why the picker looks empty
+  // despite the form carrying a variant id from the prior attempt.
+  const [wasPrefilled, setWasPrefilled] = useState(false);
   const debouncedProductSearch = useDebouncedValue(productSearchInput, VARIANT_SEARCH_DEBOUNCE_MS);
 
-  // Reset wizard state on open.
+  // Reset wizard state on open. A fresh idempotency key is minted every
+  // time the wizard opens — including the retry flow — so a failed record
+  // stays on the previous key and a retry creates a new OfferCreationRecord
+  // rather than colliding with the old one (issue #307 acceptance).
   const prevIsOpenRef = useRef(false);
   useEffect(() => {
     if (isOpen && !prevIsOpenRef.current) {
       idempotencyKeyRef.current = crypto.randomUUID();
-      form.reset({ ...CREATE_OFFER_DEFAULT_VALUES, connectionId: defaultConnectionId ?? '' });
-      setStepIndex(0);
-      setCompletedSteps(new Set());
+      if (initialValues) {
+        const prefilled = createOfferRequestToFormValues(
+          initialValues,
+          defaultConnectionId ?? '',
+        );
+        form.reset(prefilled);
+        // Jump to Step 2 with Steps 0 and 1 marked as completed so the
+        // operator lands directly on the offer-details form with the
+        // prior values visible. Step 0 is re-traversable via Back.
+        setStepIndex(1);
+        setCompletedSteps(new Set([0, 1]));
+        // Pre-select the product panel so Step 0 shows the correct
+        // expansion if the operator steps back. The variant id format
+        // is `ol_variant_*`; product id cannot be derived from it, so
+        // the picker simply opens empty on Back until the operator
+        // re-searches.
+        setSelectedProductId(null);
+        setWasPrefilled(true);
+      } else {
+        form.reset({ ...CREATE_OFFER_DEFAULT_VALUES, connectionId: defaultConnectionId ?? '' });
+        setStepIndex(0);
+        setCompletedSteps(new Set());
+        setSelectedProductId(null);
+        setWasPrefilled(false);
+      }
       setProductSearchInput('');
       setProductOffset(0);
-      setSelectedProductId(null);
       mutation.reset();
     }
     prevIsOpenRef.current = isOpen;
-  }, [isOpen, defaultConnectionId, form, mutation]);
+  }, [isOpen, defaultConnectionId, initialValues, form, mutation]);
 
   // Abandon-prevention: warn if the operator closes the tab mid-flow.
   useEffect(() => {
@@ -279,6 +313,12 @@ export function CreateOfferWizard({
         >
           {stepIndex === 0 ? (
             <>
+              {wasPrefilled ? (
+                <Alert tone="info" title="Prior attempt re-loaded">
+                  Connection and variant were copied from the failed attempt. Search to change
+                  the variant if the original selection was wrong.
+                </Alert>
+              ) : null}
               <FormField
                 label="Connection"
                 name="connectionId"

--- a/apps/web/src/features/listings/components/OfferCreationTracker.test.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationTracker.test.tsx
@@ -7,7 +7,19 @@ import { screen, waitFor, cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
 import { OfferCreationTracker } from './OfferCreationTracker';
-import type { OfferCreationStatus, OfferCreationStatusResponse } from '../api/listings.types';
+import type {
+  CreateOfferRequest,
+  OfferCreationStatus,
+  OfferCreationStatusResponse,
+} from '../api/listings.types';
+
+const sampleRequest: CreateOfferRequest = {
+  internalVariantId: 'ol_variant_abc',
+  stock: 5,
+  publishImmediately: false,
+  price: { amount: 99.99, currency: 'PLN' },
+  overrides: { title: 'T', categoryId: '12345' },
+};
 
 function makeRecord(status: OfferCreationStatus, overrides: Partial<OfferCreationStatusResponse> = {}): OfferCreationStatusResponse {
   return {
@@ -20,6 +32,7 @@ function makeRecord(status: OfferCreationStatus, overrides: Partial<OfferCreatio
     publishImmediately: false,
     createdAt: '2026-04-22T10:00:00Z',
     updatedAt: '2026-04-22T10:00:00Z',
+    request: null,
     ...overrides,
   };
 }
@@ -131,5 +144,145 @@ describe('OfferCreationTracker', () => {
     const dismiss = await screen.findByRole('button', { name: /dismiss/i });
     dismiss.click();
     await waitFor(() => expect(onDismiss).toHaveBeenCalledTimes(1));
+  });
+
+  describe('retry affordance (#307)', () => {
+    it('renders Retry on a failed record when onRetry is provided and a request snapshot exists', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi
+            .fn()
+            .mockResolvedValue(makeRecord('failed', { request: sampleRequest })),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          onDismiss={vi.fn()}
+          onRetry={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      expect(await screen.findByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    it('invokes onRetry with the record when Retry is clicked', async () => {
+      const onRetry = vi.fn();
+      const record = makeRecord('failed', { request: sampleRequest });
+      const mockApi = createMockApiClient({
+        listings: { getOfferCreationStatus: vi.fn().mockResolvedValue(record) },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          onDismiss={vi.fn()}
+          onRetry={onRetry}
+        />,
+        { apiClient: mockApi },
+      );
+
+      const retry = await screen.findByRole('button', { name: /retry/i });
+      retry.click();
+      await waitFor(() => expect(onRetry).toHaveBeenCalledTimes(1));
+      expect(onRetry).toHaveBeenCalledWith(record);
+    });
+
+    it('hides Retry when onRetry is not provided', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi
+            .fn()
+            .mockResolvedValue(makeRecord('failed', { request: sampleRequest })),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          onDismiss={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await screen.findByText('Failed');
+      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+    });
+
+    it('hides Retry when the failed record has no request snapshot', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi
+            .fn()
+            .mockResolvedValue(makeRecord('failed', { request: null })),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          onDismiss={vi.fn()}
+          onRetry={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await screen.findByText('Failed');
+      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+    });
+
+    it('hides Retry when the snapshot carries an unknown schemaVersion', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi.fn().mockResolvedValue(
+            makeRecord('failed', {
+              request: { ...sampleRequest, schemaVersion: 99 },
+            }),
+          ),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          onDismiss={vi.fn()}
+          onRetry={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await screen.findByText('Failed');
+      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render Retry on a non-failed status', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi
+            .fn()
+            .mockResolvedValue(makeRecord('active', { request: sampleRequest })),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          onDismiss={vi.fn()}
+          onRetry={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await screen.findByText('Active');
+      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/listings/components/OfferCreationTracker.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationTracker.tsx
@@ -17,7 +17,11 @@
 import { type ReactElement } from 'react';
 import { Button } from '../../../shared/ui/button';
 import { useOfferCreationStatusQuery } from '../hooks/use-offer-creation-status-query';
-import { TERMINAL_OFFER_CREATION_STATUSES } from '../api/listings.types';
+import {
+  TERMINAL_OFFER_CREATION_STATUSES,
+  type OfferCreationStatusResponse,
+} from '../api/listings.types';
+import { canReadCreateOfferRequestSnapshot } from './create-offer-request-to-form-values';
 import { OfferCreationStatusBadge } from './OfferCreationStatusBadge';
 import { OfferCreationErrorList } from './OfferCreationErrorList';
 
@@ -25,12 +29,17 @@ interface OfferCreationTrackerProps {
   connectionId: string;
   offerCreationRecordId: string;
   onDismiss: () => void;
+  /** Invoked when the operator clicks Retry on a failed record. Only
+   *  rendered when the record has a non-null `request` snapshot — without
+   *  the snapshot the wizard cannot pre-fill, so we hide the action. */
+  onRetry?: (record: OfferCreationStatusResponse) => void;
 }
 
 export function OfferCreationTracker({
   connectionId,
   offerCreationRecordId,
   onDismiss,
+  onRetry,
 }: OfferCreationTrackerProps): ReactElement {
   const query = useOfferCreationStatusQuery(connectionId, offerCreationRecordId);
 
@@ -70,6 +79,15 @@ export function OfferCreationTracker({
   }
 
   const isTerminal = TERMINAL_OFFER_CREATION_STATUSES.includes(record.status);
+  // Hide Retry when the snapshot is absent (old records) or carries a
+  // schemaVersion this client does not know how to read. A server newer
+  // than the client can persist v2+ snapshots; we must not silently
+  // map them with v1 semantics.
+  const canRetry =
+    record.status === 'failed' &&
+    onRetry !== undefined &&
+    record.request != null &&
+    canReadCreateOfferRequestSnapshot(record.request);
 
   return (
     <section
@@ -82,6 +100,11 @@ export function OfferCreationTracker({
         <span className="mono-text offer-creation-tracker__id" title={record.id}>
           {record.id}
         </span>
+        {canRetry ? (
+          <Button tone="secondary" onClick={() => onRetry?.(record)}>
+            Retry
+          </Button>
+        ) : null}
         {isTerminal ? (
           <Button tone="ghost" onClick={onDismiss}>
             Dismiss

--- a/apps/web/src/features/listings/components/create-offer-request-to-form-values.test.ts
+++ b/apps/web/src/features/listings/components/create-offer-request-to-form-values.test.ts
@@ -1,0 +1,161 @@
+/**
+ * createOfferRequestToFormValues Tests
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  canReadCreateOfferRequestSnapshot,
+  createOfferRequestToFormValues,
+} from './create-offer-request-to-form-values';
+import { CREATE_OFFER_DEFAULT_VALUES } from './create-offer-fields.schema';
+import {
+  SUPPORTED_OFFER_CREATION_REQUEST_SCHEMA_VERSION,
+  type CreateOfferRequest,
+} from '../api/listings.types';
+
+describe('createOfferRequestToFormValues', () => {
+  it('maps a fully-populated request onto form values', () => {
+    const request: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_abcdef',
+      stock: 7,
+      publishImmediately: true,
+      price: { amount: 99.9, currency: 'PLN' },
+      overrides: {
+        title: 'Nice shirt',
+        categoryId: '12345',
+        description: 'Cotton, black, crew neck.',
+        platformParams: {
+          deliveryPolicyId: 'del-1',
+          returnPolicyId: 'ret-1',
+          warrantyId: 'war-1',
+          impliedWarrantyId: 'iw-1',
+        },
+      },
+    };
+
+    const values = createOfferRequestToFormValues(request, 'conn_1');
+
+    expect(values).toEqual({
+      ...CREATE_OFFER_DEFAULT_VALUES,
+      connectionId: 'conn_1',
+      internalVariantId: 'ol_variant_abcdef',
+      variantLabel: '',
+      title: 'Nice shirt',
+      categoryId: '12345',
+      priceAmount: '99.90',
+      priceCurrency: 'PLN',
+      stock: 7,
+      description: 'Cotton, black, crew neck.',
+      publishImmediately: true,
+      deliveryPolicyId: 'del-1',
+      returnPolicyId: 'ret-1',
+      warrantyId: 'war-1',
+      impliedWarrantyId: 'iw-1',
+    });
+  });
+
+  it('falls back to defaults when optional fields are missing', () => {
+    const request: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_xyz',
+      stock: 0,
+      publishImmediately: false,
+    };
+
+    const values = createOfferRequestToFormValues(request, 'conn_1');
+
+    expect(values.connectionId).toBe('conn_1');
+    expect(values.internalVariantId).toBe('ol_variant_xyz');
+    expect(values.title).toBe('');
+    expect(values.categoryId).toBe('');
+    expect(values.priceAmount).toBe('');
+    expect(values.priceCurrency).toBe(CREATE_OFFER_DEFAULT_VALUES.priceCurrency);
+    expect(values.stock).toBe(0);
+    expect(values.description).toBe('');
+    expect(values.publishImmediately).toBe(false);
+    expect(values.deliveryPolicyId).toBe('');
+    expect(values.returnPolicyId).toBe('');
+    expect(values.warrantyId).toBe('');
+    expect(values.impliedWarrantyId).toBe('');
+  });
+
+  it('coerces a null description to an empty string', () => {
+    const request: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_xyz',
+      stock: 1,
+      publishImmediately: false,
+      overrides: { title: 't', categoryId: 'c', description: null },
+    };
+
+    const values = createOfferRequestToFormValues(request, 'conn_1');
+    expect(values.description).toBe('');
+  });
+
+  it('formats the price amount with exactly two decimals', () => {
+    const request: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_xyz',
+      stock: 1,
+      publishImmediately: false,
+      price: { amount: 42, currency: 'EUR' },
+    };
+
+    const values = createOfferRequestToFormValues(request, 'conn_1');
+    expect(values.priceAmount).toBe('42.00');
+    expect(values.priceCurrency).toBe('EUR');
+  });
+
+  describe('canReadCreateOfferRequestSnapshot', () => {
+    it('accepts the supported version', () => {
+      const request: CreateOfferRequest = {
+        internalVariantId: 'ol_variant_xyz',
+        stock: 1,
+        publishImmediately: false,
+        schemaVersion: SUPPORTED_OFFER_CREATION_REQUEST_SCHEMA_VERSION,
+      };
+      expect(canReadCreateOfferRequestSnapshot(request)).toBe(true);
+    });
+
+    it('accepts an undefined version (pre-versioning records)', () => {
+      const request: CreateOfferRequest = {
+        internalVariantId: 'ol_variant_xyz',
+        stock: 1,
+        publishImmediately: false,
+      };
+      expect(canReadCreateOfferRequestSnapshot(request)).toBe(true);
+    });
+
+    it('rejects an unknown future version', () => {
+      const request: CreateOfferRequest = {
+        internalVariantId: 'ol_variant_xyz',
+        stock: 1,
+        publishImmediately: false,
+        schemaVersion: 99,
+      };
+      expect(canReadCreateOfferRequestSnapshot(request)).toBe(false);
+    });
+  });
+
+  it('ignores non-string platformParams entries', () => {
+    const request: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_xyz',
+      stock: 1,
+      publishImmediately: false,
+      overrides: {
+        title: 't',
+        categoryId: 'c',
+        platformParams: {
+          deliveryPolicyId: 'del-1',
+          returnPolicyId: 123,
+          warrantyId: null,
+          impliedWarrantyId: { nested: 'value' },
+        },
+      },
+    };
+
+    const values = createOfferRequestToFormValues(request, 'conn_1');
+    expect(values.deliveryPolicyId).toBe('del-1');
+    expect(values.returnPolicyId).toBe('');
+    expect(values.warrantyId).toBe('');
+    expect(values.impliedWarrantyId).toBe('');
+  });
+});

--- a/apps/web/src/features/listings/components/create-offer-request-to-form-values.ts
+++ b/apps/web/src/features/listings/components/create-offer-request-to-form-values.ts
@@ -1,0 +1,72 @@
+/**
+ * CreateOfferRequest → form-values mapper
+ *
+ * Maps a persisted `CreateOfferRequest` snapshot (from a failed
+ * `OfferCreationRecord.request`) into the wizard's form shape so Retry
+ * can re-open with every field pre-populated. Kept pure so it's trivially
+ * testable and usable outside the wizard.
+ *
+ * Wire → form deltas handled here:
+ * - `price.amount` is `number` on the wire but the wizard's Input types
+ *   it as `string` (so the operator can edit freely and Zod validates
+ *   the decimal pattern at submit).
+ * - `overrides.description` is `string | null | undefined` on the wire;
+ *   the form treats any missing/null as empty string.
+ * - `overrides.platformParams` is the escape hatch where Allegro policy
+ *   IDs live. Pull the four known keys into first-class form fields.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import {
+  SUPPORTED_OFFER_CREATION_REQUEST_SCHEMA_VERSION,
+  type CreateOfferRequest,
+} from '../api/listings.types';
+import {
+  CREATE_OFFER_DEFAULT_VALUES,
+  type CreateOfferFieldsValues,
+} from './create-offer-fields.schema';
+
+function readString(params: Record<string, unknown> | undefined, key: string): string {
+  const value = params?.[key];
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Guard against reading a snapshot persisted by a server newer than the
+ * client. `undefined` is tolerated for records persisted before the
+ * schema version field landed — those are structurally identical to v1
+ * so the mapping is safe.
+ */
+export function canReadCreateOfferRequestSnapshot(request: CreateOfferRequest): boolean {
+  const version = request.schemaVersion;
+  return version === undefined || version === SUPPORTED_OFFER_CREATION_REQUEST_SCHEMA_VERSION;
+}
+
+export function createOfferRequestToFormValues(
+  request: CreateOfferRequest,
+  connectionId: string,
+): CreateOfferFieldsValues {
+  const overrides = request.overrides;
+  const platformParams = overrides?.platformParams;
+
+  return {
+    ...CREATE_OFFER_DEFAULT_VALUES,
+    connectionId,
+    internalVariantId: request.internalVariantId,
+    // Variant label is not part of the wire shape; left blank — Review step
+    // falls back to the raw id, which is acceptable on a retry where the
+    // operator is re-confirming known values.
+    variantLabel: '',
+    title: overrides?.title ?? '',
+    categoryId: overrides?.categoryId ?? '',
+    priceAmount: request.price ? request.price.amount.toFixed(2) : '',
+    priceCurrency: request.price?.currency ?? CREATE_OFFER_DEFAULT_VALUES.priceCurrency,
+    stock: request.stock,
+    description: overrides?.description ?? '',
+    publishImmediately: request.publishImmediately,
+    deliveryPolicyId: readString(platformParams, 'deliveryPolicyId'),
+    returnPolicyId: readString(platformParams, 'returnPolicyId'),
+    warrantyId: readString(platformParams, 'warrantyId'),
+    impliedWarrantyId: readString(platformParams, 'impliedWarrantyId'),
+  };
+}

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -218,7 +218,10 @@ describe('ListingsListPage', () => {
     // Wizard opens on Step 2 with values drawn from the failed record.
     const title = await screen.findByLabelText<HTMLInputElement>(/^title$/i);
     await waitFor(() => expect(title.value).toBe('Prior Title'));
-    expect(screen.getByLabelText<HTMLInputElement>(/allegro category/i).value).toBe('98765');
+    // CategoryPicker pre-fill fallback: renders the raw id + a Change button
+    // rather than a text input with a value.
+    expect(screen.getByText('Current category ID')).toBeInTheDocument();
+    expect(screen.getByText('98765')).toBeInTheDocument();
     expect(screen.getByLabelText<HTMLInputElement>(/^price$/i).value).toBe('120.50');
     expect(screen.getByLabelText<HTMLInputElement>(/^stock$/i).value).toBe('7');
 

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -1,9 +1,12 @@
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { ListingsListPage } from './listings-list-page';
-import type { PaginatedOfferMappings } from '../../features/listings/api/listings.types';
+import type {
+  CreateOfferRequest,
+  PaginatedOfferMappings,
+} from '../../features/listings/api/listings.types';
 
 const sampleMappings: PaginatedOfferMappings = {
   items: [
@@ -147,6 +150,80 @@ describe('ListingsListPage', () => {
 
     expect(await screen.findByText(/offer creation/i)).toBeInTheDocument();
     expect(await screen.findByText('Pending')).toBeInTheDocument();
+  });
+
+  it('should reopen the wizard pre-filled from the failed record when Retry is clicked', async () => {
+    const user = userEvent.setup();
+    const sampleRequest: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_abc',
+      stock: 7,
+      publishImmediately: false,
+      price: { amount: 120.5, currency: 'PLN' },
+      overrides: {
+        title: 'Prior Title',
+        categoryId: '98765',
+        description: null,
+        platformParams: { deliveryPolicyId: 'del-1' },
+      },
+    };
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockResolvedValue(sampleMappings),
+        getOfferCreationStatus: vi.fn().mockResolvedValue({
+          id: 'rec-1',
+          connectionId: 'conn_allegro_1',
+          internalVariantId: 'ol_variant_abc',
+          externalOfferId: null,
+          status: 'failed',
+          errors: [{ code: 'X', message: 'boom' }],
+          publishImmediately: false,
+          createdAt: '2026-04-22T10:00:00Z',
+          updatedAt: '2026-04-22T10:00:00Z',
+          request: sampleRequest,
+        }),
+        getSellerPolicies: vi.fn().mockResolvedValue({
+          deliveryPolicies: [{ id: 'del-1', name: 'Free shipping' }],
+          returnPolicies: [],
+          warranties: [],
+          impliedWarranties: [],
+        }),
+      },
+      connections: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: 'conn_allegro_1',
+            name: 'Allegro sandbox',
+            platformType: 'allegro',
+            status: 'active',
+            config: {},
+            credentialsBacked: true,
+            adapterKey: 'allegro.publicapi.v1',
+            enabledCapabilities: ['Marketplace'],
+            supportedCapabilities: ['Marketplace'],
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ]),
+      },
+    });
+
+    renderWithProviders(<ListingsListPage />, {
+      apiClient: mockApi,
+      route: '/listings?offerCreationRecordId=rec-1&trackedConnectionId=conn_allegro_1',
+    });
+
+    const retry = await screen.findByRole('button', { name: /retry/i });
+    await user.click(retry);
+
+    // Wizard opens on Step 2 with values drawn from the failed record.
+    const title = await screen.findByLabelText<HTMLInputElement>(/^title$/i);
+    await waitFor(() => expect(title.value).toBe('Prior Title'));
+    expect(screen.getByLabelText<HTMLInputElement>(/allegro category/i).value).toBe('98765');
+    expect(screen.getByLabelText<HTMLInputElement>(/^price$/i).value).toBe('120.50');
+    expect(screen.getByLabelText<HTMLInputElement>(/^stock$/i).value).toBe('7');
+
+    // The tracker URL params are dropped once Retry is pressed.
+    expect(screen.queryByText(/offer creation/i)).not.toBeInTheDocument();
   });
 
   it('should not render OfferCreationTracker when only one URL param is present', async () => {

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -11,7 +11,12 @@ import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
 import { CreateOfferWizard } from '../../features/listings/components/CreateOfferWizard';
 import { OfferCreationTracker } from '../../features/listings/components/OfferCreationTracker';
-import type { ListingsFilters, OfferMapping } from '../../features/listings/api/listings.types';
+import type {
+  CreateOfferRequest,
+  ListingsFilters,
+  OfferCreationStatusResponse,
+  OfferMapping,
+} from '../../features/listings/api/listings.types';
 
 const PAGE_SIZE = 20;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -134,6 +139,15 @@ export function ListingsListPage(): ReactElement {
   const hasTracker = Boolean(trackedRecordId && trackedConnectionId);
 
   const [isWizardOpen, setIsWizardOpen] = useState(false);
+  // Retry-path hints passed to the wizard when the operator clicks Retry
+  // on a failed OfferCreationTracker. These mirror the record's snapshot
+  // so the wizard can pre-fill on open and land directly on Step 2.
+  const [retryInitialValues, setRetryInitialValues] = useState<CreateOfferRequest | undefined>(
+    undefined,
+  );
+  const [retryDefaultConnectionId, setRetryDefaultConnectionId] = useState<string | undefined>(
+    undefined,
+  );
 
   function dismissTracker(): void {
     setSearchParams((prev) => {
@@ -153,6 +167,22 @@ export function ListingsListPage(): ReactElement {
     });
   }
 
+  function handleRetry(record: OfferCreationStatusResponse): void {
+    if (!record.request) return;
+    setRetryInitialValues(record.request);
+    setRetryDefaultConnectionId(record.connectionId);
+    setIsWizardOpen(true);
+    // Drop the old tracker from the URL — the new submit will re-install
+    // a fresh tracker for the new OfferCreationRecord via onSubmitted.
+    dismissTracker();
+  }
+
+  function closeWizard(): void {
+    setIsWizardOpen(false);
+    setRetryInitialValues(undefined);
+    setRetryDefaultConnectionId(undefined);
+  }
+
   return (
     <PageLayout
       eyebrow="Operations"
@@ -165,6 +195,7 @@ export function ListingsListPage(): ReactElement {
           connectionId={trackedConnectionId}
           offerCreationRecordId={trackedRecordId}
           onDismiss={dismissTracker}
+          onRetry={handleRetry}
         />
       ) : null}
 
@@ -253,8 +284,9 @@ export function ListingsListPage(): ReactElement {
 
       <CreateOfferWizard
         isOpen={isWizardOpen}
-        onClose={() => setIsWizardOpen(false)}
-        defaultConnectionId={debouncedConnectionId || undefined}
+        onClose={closeWizard}
+        defaultConnectionId={retryDefaultConnectionId ?? (debouncedConnectionId || undefined)}
+        initialValues={retryInitialValues}
         onSubmitted={handleOfferSubmitted}
       />
     </PageLayout>

--- a/docs/plans/implementation-plan-offer-retry-affordance.md
+++ b/docs/plans/implementation-plan-offer-retry-affordance.md
@@ -1,0 +1,220 @@
+# Implementation Plan — Retry affordance on failed OfferCreationTracker (#307)
+
+## 1. Task restatement
+
+When an OL-initiated offer creation lands in `failed`, the `OfferCreationTracker` surfaces structured errors and a "Dismiss" button. Today, the operator's only next step is to re-open `CreateOfferWizard` and re-type every field from scratch. Issue #307 proposes a **"Retry"** button that:
+
+1. Opens `CreateOfferWizard` with `defaultConnectionId` set to the failed record's `connectionId`.
+2. Pre-fills the form from the **original request payload** stored on the record.
+3. Jumps the operator past Step 1 so they don't re-pick connection + variant.
+4. Generates a **new idempotency key** — retry is a genuinely new creation attempt, not a re-run of the old record.
+
+**Layer:** full-stack vertical slice.
+- CORE / listings: persist `request` on `OfferCreationRecord` (ORM column + domain field + DTO field).
+- Migration: add `request` jsonb column to `offer_creation_records`.
+- Frontend: Retry button in tracker, wizard pre-fill from the persisted request, list-page wiring.
+
+**Explicit non-goals**
+- **Not** re-running the same job. The old record's sync job is terminal; retry enqueues a fresh one.
+- **Not** linking the new record to the old. If that becomes valuable for audit later, it's a separate issue.
+- **Not** partial pre-fill. Full request payload goes back into the form; the operator edits whatever was wrong.
+- **Not** the Allegro category picker (#305 separately). If `categoryId` was the failure, operator edits the free-text as today.
+
+## 2. Codebase research
+
+- `libs/core/src/listings/domain/entities/offer-creation-record.entity.ts` — domain entity, readonly shape.
+- `libs/core/src/listings/domain/types/offer-creation-record.types.ts` — `OfferCreationStatus`, `CreateOfferCreationRecordInput`, `OfferCreationError`.
+- `libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts` — TypeORM entity.
+- `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts` — private `toDomain` / `buildOrmEntity` mappers.
+- `libs/core/src/listings/application/services/offer-creation-enqueue.service.ts` — already passes `internalVariantId`, `connectionId`, `publishImmediately` to the record. Needs to also pass the full request.
+- `apps/api/src/listings/http/dto/offer-creation-status-response.dto.ts` — response DTO to extend.
+- `apps/api/src/listings/http/dto/create-offer.dto.ts` — the canonical `CreateOfferRequest` shape on the wire.
+- `apps/api/src/migrations/1784000000000-add-offer-creation-records-table.ts` — reference migration pattern for this table.
+- Frontend: `apps/web/src/features/listings/components/OfferCreationTracker.tsx`, `CreateOfferWizard.tsx`, `create-offer-fields.schema.ts`, `api/listings.types.ts`, `hooks/use-offer-creation-status-query.ts`, `pages/listings/listings-list-page.tsx`.
+
+Existing idempotency behaviour in `CreateOfferWizard.tsx:94,113`: a stable `idempotencyKeyRef` is generated on every wizard open via `crypto.randomUUID()` and reused until close. Because **Retry opens the wizard fresh**, this already satisfies acceptance bullet 4 ("fresh idempotency key") for free — no wizard changes needed on that axis.
+
+## 3. Design
+
+### Backend
+
+**3.1 New domain snapshot type (not the wire type)**
+Introduce a **domain-owned** `OfferCreationRequestSnapshot` in `libs/core/src/listings/domain/types/offer-creation-request-snapshot.types.ts`. Structurally identical to the wire `CreateOfferRequest` today, but owned by the listings domain so wire-shape drift (new `class-validator` decorators on the controller DTO, request-shape renames, etc.) stops at the DTO boundary unless the domain explicitly adopts the change.
+
+The domain entity gains `request: OfferCreationRequestSnapshot | null`. The HTTP DTO (`CreateOfferRequestDto`) and the FE transport type stay where they are; the enqueue service builds a `Snapshot` from its existing `EnqueueOfferCreationInput` fields before handing it to the repo.
+
+*Why not move `CreateOfferOverrides` / `CreateOfferPrice` with it?* They already live in `@openlinker/core/integrations` and are used by `MarketplaceOfferCreatePayloadV1` in `@openlinker/core/sync`. Moving them into `listings` would create a reverse dependency (`integrations` → `listings`), which violates layer direction. The snapshot type imports `CreateOfferOverrides` from integrations (one-way, fine) rather than owning it.
+
+*Why a blob, not first-class columns?* Two defensible options: (a) jsonb blob that mirrors the wire aggregate; (b) promote `stock` / `title` / `categoryId` / `description` / `price` / platform-param IDs to first-class columns on `offer_creation_records`. Picking (a) for three reasons — lower migration cost (one column, one additive migration, not seven), wire-shape flexibility (FE wizard / API DTO can evolve without schema churn since it's "debug-only"), no operational query against these fields planned. The downside (no ad-hoc querying on inner fields, no column-level nullability constraints) is acceptable for a retry-prefill payload that's treated as opaque debug state.
+
+**3.2 Schema versioning**
+The stored blob includes `schemaVersion: 1` as its first field, matching the precedent set by `MarketplaceOfferCreatePayloadV1` in `@openlinker/core/sync`. Readers (the retry-prefill path) check the version and treat unknown versions as "unknown shape; degrade to minimal pre-fill". Cheap to add now, retroactively hard. The `OfferCreationRequestSnapshot` type declares `schemaVersion: 1 as const` so TS catches bumps at compile time.
+
+**3.3 Persistence**
+- Add `request` jsonb nullable column to `offer_creation_records`.
+- Migration: additive, no backfill. Existing rows have `request IS NULL`. Retry button degrades gracefully when the record predates this change (still opens the wizard, pre-fills only `connectionId` + `internalVariantId` from the record itself).
+- Repository `buildOrmEntity` writes `input.request ?? null`. `toDomain` reads it back. No new queries.
+
+**3.4 Application**
+- `OfferCreationEnqueueService.enqueueCreation(input)` — `EnqueueOfferCreationInput` already carries `stock`, `price`, `overrides`, `publishImmediately`, `internalVariantId`. Assemble a `OfferCreationRequestSnapshot` (with `schemaVersion: 1`) from those fields and pass it to `offerCreationRecords.create({ ...existingFields, request })`. No new inputs on the controller side.
+
+**3.5 Interface**
+- `OfferCreationStatusResponseDto` gains `request?: OfferCreationRequestPayloadDto | null` — a **new response-shape DTO** colocated with the response DTO, with `@ApiProperty` annotations but **no `class-validator` decorators** (responses don't validate inbound input). Reusing `CreateOfferRequestDto` (the request DTO with `@IsString` / `@IsNotEmpty` etc.) on a response is mildly awkward because those decorators are dead weight on the outbound path. Separate response DTO keeps the two roles tidy. Swagger description: "debug-only; original request payload when available; may be omitted for records predating 2026-04-22".
+
+### Frontend
+
+**3.6 Tracker**
+`OfferCreationTracker` takes a new optional `onRetry?: (record: OfferCreationStatusResponse) => void` prop. When `status === 'failed'` **and** `onRetry` is provided, render a "Retry" Button next to "Dismiss". Click → `onRetry(record)`. If `onRetry` is absent, behaviour is unchanged (backward-compatible). The prop is intentionally designed to work on **any tracker consumer** — the listing-detail page's offer-creation surface shipped in #306 is a deliberately-deferred second consumer (covered in §7, not in this PR's scope).
+
+**3.7 Wizard**
+`CreateOfferWizard` gains one optional prop: `initialValues?: CreateOfferRequest`. When present, the existing open-reset effect (which already sets `idempotencyKeyRef.current = crypto.randomUUID()` and resets the form) also maps `initialValues` into `CreateOfferFieldsValues` and uses that as the form's reset target instead of `CREATE_OFFER_DEFAULT_VALUES`. Start at `stepIndex = 1` (Step 2 "Offer details") when `initialValues` is provided, with Steps 0 and 1 marked completed — the operator can still click back.
+
+*Step-choice trade-off.* Two defensible landing points:
+- **Step 2** (picked): most failures today are field-validation errors on title/category/price, all of which live on Step 2. Operator lands on the fixable surface. Steps 3–4 stay incomplete (operator clicks Next through them).
+- **Step 4 Review** (alternative): every field is pre-filled and valid per the schema, so the payload is by definition in "about to resubmit" state. Opening on Review lets the operator inspect and hit Save in one click.
+
+Step 2 wins for the common case — the reason they're here is *something needs to change*, and Review isn't a fixing surface. If real operator data later shows that wasn't the issue (e.g., failures cluster on Step 3 policy mismatches), revisit. Marking Step 3 not-completed is an honest signal that the policy fields haven't been re-confirmed.
+
+Mapping `CreateOfferRequest` → `CreateOfferFieldsValues` lives in a small pure function `createOfferRequestToFormValues(request)` next to the wizard. Unit-tested. Handles price (number → string), `overrides.platformParams.{deliveryPolicyId,returnPolicyId,warrantyId,impliedWarrantyId}`, and nullable description.
+
+**3.8 List page wiring**
+`ListingsListPage` owns the retry glue:
+- `handleRetry(record)`: set local state `retryInitialValues = record.request`, `retryDefaultConnectionId = record.connectionId`, `setIsWizardOpen(true)`, and `dismissTracker()` (the old failed record is done with — the new tracker will take its place on success).
+- Pass those as wizard props.
+- On successful submit, the new record pushes a fresh `offerCreationRecordId` into search params via existing `handleOfferSubmitted`.
+
+## 4. Step-by-step plan
+
+### Step 1 — Domain snapshot type (backend)
+- **File:** `libs/core/src/listings/domain/types/offer-creation-request-snapshot.types.ts` (new)
+- Declare `OfferCreationRequestSnapshot` with a `schemaVersion: 1` literal as its first field and fields mirroring the current `CreateOfferRequest` wire aggregate. Imports `CreateOfferOverrides` from `@openlinker/core/integrations` (stays where it is).
+- Re-export from `libs/core/src/listings/index.ts`.
+- **Acceptance:** type-check passes; no changes to `@openlinker/core/integrations`.
+
+### Step 2 — Domain entity + input type
+- **Files:**
+  - `libs/core/src/listings/domain/entities/offer-creation-record.entity.ts`
+  - `libs/core/src/listings/domain/types/offer-creation-record.types.ts`
+- Add readonly `request: OfferCreationRequestSnapshot | null` to the constructor.
+- Add optional `request?: OfferCreationRequestSnapshot | null` to `CreateOfferCreationRecordInput`.
+- **Acceptance:** entity constructor accepts the new field; input type accepts it optionally.
+
+### Step 3 — ORM entity + migration
+- **Files:**
+  - `libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts`
+  - `apps/api/src/migrations/{timestamp}-add-offer-creation-record-request-payload.ts` (new, generated via `pnpm --filter @openlinker/api migration:generate`)
+- Add `@Column({ type: 'jsonb', nullable: true }) request!: CreateOfferRequest | null`.
+- Migration: `ALTER TABLE "offer_creation_records" ADD COLUMN "request" jsonb`. No index.
+- **Acceptance:** `pnpm --filter @openlinker/api migration:generate` produces the migration; `migration:run` + `migration:revert` round-trip cleanly.
+
+### Step 4 — Repository round-trip
+- **Files:**
+  - `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts`
+  - `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts`
+- `buildOrmEntity` assigns `entity.request = input.request ?? null`.
+- `toDomain` passes `entity.request` through.
+- Add a spec case: `create({ ...input, request })` → `findById` returns the same snapshot including `schemaVersion`.
+- **Acceptance:** repo spec passes.
+
+### Step 5 — Enqueue service stores the snapshot
+- **Files:**
+  - `libs/core/src/listings/application/services/offer-creation-enqueue.service.ts`
+  - `libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts`
+- Construct `request: OfferCreationRequestSnapshot` (with `schemaVersion: 1`) from the existing `EnqueueOfferCreationInput` fields and pass it to `offerCreationRecords.create({ ...existing, request })`.
+- Update spec: assert the repo's `create` receives the full snapshot payload with the correct `schemaVersion`.
+- **Acceptance:** spec passes.
+
+### Step 6 — Response DTO + controller mapping
+- **Files:**
+  - `apps/api/src/listings/http/dto/offer-creation-request-payload-response.dto.ts` (new — response-shape sibling of `CreateOfferRequestDto`, without `class-validator` decorators)
+  - `apps/api/src/listings/http/dto/offer-creation-status-response.dto.ts`
+  - `apps/api/src/listings/http/listings.controller.ts` (the mapper from domain record → response DTO)
+  - `apps/api/src/listings/http/listings.controller.spec.ts`
+- Define `OfferCreationRequestPayloadDto` with `@ApiProperty` / `@ApiPropertyOptional` only (no validators — responses don't validate).
+- Add optional `request?: OfferCreationRequestPayloadDto | null` to `OfferCreationStatusResponseDto`, Swagger-annotated as "debug-only; original request payload when available; may be omitted for records predating this change".
+- Controller mapper passes `record.request` through.
+- Controller spec asserts the field round-trips, including `schemaVersion`.
+- **Acceptance:** controller spec passes; Swagger renders the new field as nullable.
+
+### Step 7 — Frontend API types
+- **File:** `apps/web/src/features/listings/api/listings.types.ts`
+- Add `request?: CreateOfferRequest | null` to `OfferCreationStatusResponse`. The FE type keeps its existing `CreateOfferRequest` structural shape (no `schemaVersion` surfaced to the FE — the FE treats unknown-version payloads identically to null, see §3.2).
+- **Acceptance:** type-check passes; existing consumers (tracker, detail page, etc.) unaffected.
+
+### Step 8 — Wizard accepts `initialValues` + jumps to Step 2
+- **Files:**
+  - `apps/web/src/features/listings/components/CreateOfferWizard.tsx`
+  - `apps/web/src/features/listings/components/CreateOfferWizard.test.tsx`
+  - `apps/web/src/features/listings/components/create-offer-request-to-form-values.ts` (new small pure helper) + `.test.ts`
+- Add `initialValues?: CreateOfferRequest` prop.
+- In the open-reset effect, when `initialValues` is set:
+  - Compute `values = createOfferRequestToFormValues(initialValues)` merged with `connectionId` from `defaultConnectionId`.
+  - `form.reset(values)`, `setStepIndex(1)`, `setCompletedSteps(new Set([0, 1]))`.
+  - Also pre-select the product panel (`selectedProductId`) from the variant id so Step 1 shows the correct state if the operator steps back.
+- **Acceptance:**
+  - Helper spec round-trips a minimal request and a fully-populated one.
+  - Wizard spec: opening with `initialValues` renders Step 2 with title/price/category/stock populated from the payload and delivery policy selected on Step 3.
+  - **Explicit idempotency-key regression test** (per issue acceptance bullet 4): render the wizard, submit once (mutation fires with key-A), close, reopen with `initialValues` and submit again → assert the second submit's `idempotencyKey` differs from key-A. Guards against a future refactor silently reusing the ref across opens.
+  - Existing wizard tests still pass.
+
+### Step 9 — Tracker Retry button
+- **Files:**
+  - `apps/web/src/features/listings/components/OfferCreationTracker.tsx`
+  - `apps/web/src/features/listings/components/OfferCreationTracker.test.tsx`
+- Add optional `onRetry?: (record: OfferCreationStatusResponse) => void` prop.
+- Render a secondary Button labelled "Retry" next to "Dismiss" only when `record.status === 'failed'` **and** `onRetry` is provided.
+- Click → `onRetry(record)`.
+- **Acceptance:**
+  - Spec: failed + `onRetry` set → Retry button present, clicking invokes `onRetry(record)`.
+  - Spec: failed + `onRetry` absent → no Retry button (backward compat).
+  - Spec: active/pending → no Retry button.
+
+### Step 10 — List page wiring
+- **Files:**
+  - `apps/web/src/pages/listings/listings-list-page.tsx`
+  - `apps/web/src/pages/listings/listings-list-page.test.tsx` (if present; otherwise a minimal test alongside, following the existing pattern in the file)
+- Add local state `retryInitialValues` + `retryDefaultConnectionId`.
+- `handleRetry(record)`: set the two state fields, `setIsWizardOpen(true)`, `dismissTracker()`.
+- Pass `onRetry={handleRetry}` to the tracker and `initialValues={retryInitialValues} defaultConnectionId={retryDefaultConnectionId ?? connectionIdInput}` to the wizard.
+- Clear `retryInitialValues` / `retryDefaultConnectionId` on wizard close.
+- **Acceptance:** integration-style test: render page → inject a failed record via the mock API → click Retry → wizard opens with Step 2 visible and title pre-filled from the record's request.
+
+### Step 11 — Quality gate + ship
+- `pnpm lint` (repo-wide, zero errors)
+- `pnpm type-check` (zero errors)
+- `pnpm test` (all unit tests)
+- `pnpm --filter @openlinker/api migration:show` — confirms only this migration is pending
+- Commit (`feat(listings):`), push, PR with `Closes #307`.
+
+## 5. Testing strategy
+
+**Coverage per layer**:
+- Domain: entity constructor trivially holds the new field (implicit).
+- Application: enqueue service spec asserts the request is forwarded to the repo.
+- Infrastructure (repo): round-trip spec persists + reads the request.
+- Interface (controller): response includes the request field; Swagger includes it.
+- FE helper (`createOfferRequestToFormValues`): pure-function spec.
+- FE tracker: renders/omits Retry button per status + prop.
+- FE wizard: pre-fills form and lands on Step 2 when `initialValues` is provided.
+- FE list page: clicking Retry opens a pre-filled wizard.
+
+Integration tests: **not required**. This is a schema addition with no new query paths; the existing Testcontainer harness covers the table already. If we wanted paranoid confidence we could add an `offer-creation-record.int-spec.ts`, but the unit-level round-trip spec plus the migration's up/down paths cover the risk.
+
+## 6. Validation (architecture + standards)
+
+- **Hexagonal:** new `request` field sits in a domain snapshot type → ORM entity → repo mapping → enqueue service. No port exposes infrastructure error types. No cross-layer shortcuts. `CreateOfferOverrides` stays in `@openlinker/core/integrations` (listings imports from integrations, never the reverse).
+- **Naming:** new file `offer-creation-request-snapshot.types.ts` (domain types), new response DTO `offer-creation-request-payload-response.dto.ts`, new FE helper `create-offer-request-to-form-values.ts` (colocated with the wizard; small enough to skip a folder). All match convention.
+- **TS strict mode:** `request` is `OfferCreationRequestSnapshot | null` on the domain side; `CreateOfferRequest | null` on the FE. Never `any`. `schemaVersion: 1 as const` enforces version awareness at the type level.
+- **No new framework coupling in the domain layer:** the snapshot type is a plain interface; zero NestJS/TypeORM imports.
+- **FE dependency direction:** unchanged. Tracker + wizard + list-page all stay within their existing layers.
+- **Migration:** additive, nullable, down-safe (drops the column). Follows `docs/migrations.md`.
+- **Security:** `CreateOfferRequest` carries offer content (title, description, price, stock) — no credentials or PII. Safe to store in jsonb.
+
+## 7. Risks / trade-offs
+
+- **Pre-existing records have `request = null`.** Retry button still renders and still opens the wizard, but with only `connectionId` and `internalVariantId` pre-filled. Graceful degradation; no code path errors. Once the new column is populated on all fresh records, this fades.
+- **Schema-version evolution.** `schemaVersion: 1` gives us a clean migration path for future wire-shape changes: a future `v2` can ship alongside `v1` and the retry-prefill reader picks the right mapper. Readers that see an unknown `schemaVersion` degrade to null-like behaviour (minimal pre-fill) rather than crashing. This is the same contract as `MarketplaceOfferCreatePayloadV1` in `@openlinker/core/sync` — we're following, not inventing.
+- **Domain snapshot vs wire type.** We chose a separate `OfferCreationRequestSnapshot` (domain-owned) instead of re-purposing the wire `CreateOfferRequest` directly on the entity. The two are structurally identical today; the separation enforces that a future wire-shape rename (new `class-validator` decorators, field additions) stops at the DTO boundary unless the domain explicitly adopts. Tiny up-front cost (one more type), large future-proofing upside.
+- **Jsonb blob vs first-class columns.** Jsonb wins for migration cost + wire-shape flexibility; loses on queryability + column-level constraints. Payload is treated as opaque debug state — no ad-hoc queries planned — so jsonb is the right pick today. Revisit if operational needs emerge.
+- **Start step on retry.** Step 2 (Offer details) is the MVP choice because most failures are field-validation errors on that step. Step 4 (Review) is the alternative — defensible if retries are a "nothing to change, resubmit" path, but that contradicts the premise of landing here from a failure. If operator data later shows Step-3 (policy) failures dominate, we'll revisit.
+- **Deferred consumer: detail-page tracker.** #306 shipped an offer-creation status surface on the listing detail page. The `onRetry` prop on `OfferCreationTracker` is intentionally designed so it works on **any** consumer — but this PR wires the callback only on the list page to keep the change reviewable. A follow-up PR can pass `onRetry` from the detail page with no component changes. Called out in the PR description so reviewers don't read the gap as an oversight.

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts
@@ -90,6 +90,13 @@ describe('OfferCreationEnqueueService', () => {
       status: 'pending',
       errors: null,
       publishImmediately: false,
+      request: {
+        schemaVersion: 1,
+        internalVariantId: variantId,
+        stock: 5,
+        publishImmediately: false,
+        price: { amount: 99.99, currency: 'PLN' },
+      },
     });
     expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith({
       jobType: 'marketplace.offer.create',
@@ -187,5 +194,55 @@ describe('OfferCreationEnqueueService', () => {
 
     const payload = jobEnqueue.enqueueJob.mock.calls[0][0].payload;
     expect(payload.overrides).toEqual(overrides);
+  });
+
+  it('persists the full request snapshot including overrides and schemaVersion', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(jest.fn()));
+    const overrides = {
+      title: 'Shipped title',
+      categoryId: 'allegro-cat-1',
+      description: 'desc',
+      platformParams: { deliveryPolicyId: 'del-1', warrantyId: 'war-1' },
+    };
+
+    await service.enqueueCreation({
+      internalVariantId: variantId,
+      connectionId,
+      stock: 7,
+      publishImmediately: true,
+      price: { amount: 49.5, currency: 'PLN' },
+      overrides,
+    });
+
+    const createdWith = records.create.mock.calls[0][0];
+    expect(createdWith.request).toEqual({
+      schemaVersion: 1,
+      internalVariantId: variantId,
+      stock: 7,
+      publishImmediately: true,
+      price: { amount: 49.5, currency: 'PLN' },
+      overrides,
+    });
+  });
+
+  it('omits price and overrides from the request snapshot when the caller does not supply them', async () => {
+    integrations.getCapabilityAdapter.mockResolvedValue(adapterWith(jest.fn()));
+
+    await service.enqueueCreation({
+      internalVariantId: variantId,
+      connectionId,
+      stock: 1,
+      publishImmediately: false,
+    });
+
+    const createdWith = records.create.mock.calls[0][0];
+    expect(createdWith.request).toEqual({
+      schemaVersion: 1,
+      internalVariantId: variantId,
+      stock: 1,
+      publishImmediately: false,
+    });
+    expect(createdWith.request).not.toHaveProperty('price');
+    expect(createdWith.request).not.toHaveProperty('overrides');
   });
 });

--- a/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
@@ -30,6 +30,10 @@ import {
 } from '@openlinker/core/sync';
 
 import { OfferCreationRecordRepositoryPort } from '../../domain/ports/offer-creation-record-repository.port';
+import {
+  OFFER_CREATION_REQUEST_SNAPSHOT_SCHEMA_VERSION,
+  type OfferCreationRequestSnapshot,
+} from '../../domain/types/offer-creation-request-snapshot.types';
 import { OFFER_CREATION_RECORD_REPOSITORY_TOKEN } from '../../listings.tokens';
 import { IOfferCreationEnqueueService } from '../interfaces/offer-creation-enqueue.service.interface';
 import type {
@@ -66,7 +70,20 @@ export class OfferCreationEnqueueService implements IOfferCreationEnqueueService
       );
     }
 
-    // 3. Pre-create the record so the HTTP response carries an id clients
+    // 3. Capture a snapshot of the request payload so a failed record can be
+    //    re-opened in the wizard pre-filled. Schema-versioned so a future
+    //    wire-shape change can ship a `v2` mapper without breaking readers of
+    //    old records (#307).
+    const requestSnapshot: OfferCreationRequestSnapshot = {
+      schemaVersion: OFFER_CREATION_REQUEST_SNAPSHOT_SCHEMA_VERSION,
+      internalVariantId: input.internalVariantId,
+      stock: input.stock,
+      publishImmediately: input.publishImmediately,
+      ...(input.price !== undefined && { price: input.price }),
+      ...(input.overrides !== undefined && { overrides: input.overrides }),
+    };
+
+    // 4. Pre-create the record so the HTTP response carries an id clients
     //    can poll immediately.
     const record = await this.offerCreationRecords.create({
       internalVariantId: input.internalVariantId,
@@ -75,9 +92,10 @@ export class OfferCreationEnqueueService implements IOfferCreationEnqueueService
       status: 'pending',
       errors: null,
       publishImmediately: input.publishImmediately,
+      request: requestSnapshot,
     });
 
-    // 4. Enqueue. Default idempotency key is per-call-unique (the fresh
+    // 5. Enqueue. Default idempotency key is per-call-unique (the fresh
     //    record id) — a client that wants cross-retry dedupe passes
     //    `input.idempotencyKey`.
     const payload = {

--- a/libs/core/src/listings/domain/entities/offer-creation-record.entity.ts
+++ b/libs/core/src/listings/domain/entities/offer-creation-record.entity.ts
@@ -15,6 +15,7 @@ import {
   OfferCreationError,
   OfferCreationStatus,
 } from '../types/offer-creation-record.types';
+import { OfferCreationRequestSnapshot } from '../types/offer-creation-request-snapshot.types';
 
 export class OfferCreationRecord {
   constructor(
@@ -27,5 +28,12 @@ export class OfferCreationRecord {
     public readonly publishImmediately: boolean,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
+    /**
+     * Persisted snapshot of the original create-offer request. Null for records
+     * predating this change and for records created through code paths that do
+     * not pass the snapshot. Surfaced on the status response for retry
+     * pre-fill on the wizard.
+     */
+    public readonly request: OfferCreationRequestSnapshot | null = null,
   ) {}
 }

--- a/libs/core/src/listings/domain/types/offer-creation-record.types.ts
+++ b/libs/core/src/listings/domain/types/offer-creation-record.types.ts
@@ -13,6 +13,8 @@
  * @module libs/core/src/listings/domain/types
  */
 
+import type { OfferCreationRequestSnapshot } from './offer-creation-request-snapshot.types';
+
 /**
  * Persisted lifecycle status for OL-initiated offer creation.
  *
@@ -65,4 +67,11 @@ export interface CreateOfferCreationRecordInput {
   externalOfferId?: string | null;
   /** Structured errors when the initial status is already `'failed'`. Null otherwise. */
   errors?: OfferCreationError[] | null;
+  /**
+   * Persisted snapshot of the original create-offer request payload. Enables
+   * retry pre-fill on the wizard when a record is `'failed'`. Omitted or
+   * `null` for callers that cannot or do not need to supply it; readers must
+   * tolerate null.
+   */
+  request?: OfferCreationRequestSnapshot | null;
 }

--- a/libs/core/src/listings/domain/types/offer-creation-request-snapshot.types.ts
+++ b/libs/core/src/listings/domain/types/offer-creation-request-snapshot.types.ts
@@ -1,0 +1,50 @@
+/**
+ * Offer Creation Request Snapshot Types
+ *
+ * Domain-owned snapshot of the `CreateOfferRequest` wire aggregate, persisted on
+ * `OfferCreationRecord.request` so a failed record can be re-opened in the
+ * wizard with its original fields pre-filled. Kept structurally identical to
+ * the wire type today, but decoupled so future wire-shape drift stops at the
+ * DTO boundary unless the domain explicitly adopts the change.
+ *
+ * Versioning follows the `MarketplaceOfferCreatePayloadV1` precedent in
+ * `@openlinker/core/sync`: readers check `schemaVersion` and degrade to
+ * null-like behaviour on unknown versions.
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+import type { CreateOfferOverrides } from '@openlinker/core/integrations';
+
+/**
+ * Current snapshot schema version. Bump when the shape changes incompatibly;
+ * readers (retry-prefill on the FE) should route on this value.
+ */
+export const OFFER_CREATION_REQUEST_SNAPSHOT_SCHEMA_VERSION = 1;
+
+/**
+ * Price shape as captured in the wizard submission.
+ *
+ * Distinct from domain-layer `Money` value objects — this is the raw form
+ * input shape, so retry pre-fill restores exactly what the operator typed.
+ */
+export interface OfferCreationRequestPriceSnapshot {
+  amount: number;
+  currency: string;
+}
+
+/**
+ * Persisted snapshot of the wizard's `CreateOfferRequest` payload.
+ *
+ * Stored in `offer_creation_records.request` as jsonb. Optional fields mirror
+ * the wire aggregate — the snapshot treats everything the operator didn't
+ * provide as `undefined` (not `null`).
+ */
+export interface OfferCreationRequestSnapshot {
+  schemaVersion: 1;
+  internalVariantId: string;
+  stock: number;
+  publishImmediately: boolean;
+  price?: OfferCreationRequestPriceSnapshot;
+  overrides?: CreateOfferOverrides;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -52,6 +52,11 @@ export type {
   OfferCreationError,
   CreateOfferCreationRecordInput,
 } from './domain/types/offer-creation-record.types';
+export { OFFER_CREATION_REQUEST_SNAPSHOT_SCHEMA_VERSION } from './domain/types/offer-creation-request-snapshot.types';
+export type {
+  OfferCreationRequestSnapshot,
+  OfferCreationRequestPriceSnapshot,
+} from './domain/types/offer-creation-request-snapshot.types';
 export type { OfferCreationRecordRepositoryPort } from './domain/ports/offer-creation-record-repository.port';
 export { OfferCreationRecordNotFoundException } from './domain/exceptions/offer-creation-record-not-found.exception';
 export { OfferBuilderService } from './application/services/offer-builder.service';

--- a/libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts
@@ -20,6 +20,7 @@ import type {
   OfferCreationError,
   OfferCreationStatus,
 } from '../../../domain/types/offer-creation-record.types';
+import type { OfferCreationRequestSnapshot } from '../../../domain/types/offer-creation-request-snapshot.types';
 
 @Entity('offer_creation_records')
 @Index(['internalVariantId', 'connectionId'])
@@ -53,6 +54,14 @@ export class OfferCreationRecordOrmEntity {
 
   @Column({ type: 'boolean', default: false })
   publishImmediately!: boolean;
+
+  /**
+   * Snapshot of the original create-offer request payload. Nullable because
+   * records predating the 2026-04-22 schema change carry no payload; the
+   * retry-prefill path on the FE degrades gracefully when null.
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  request!: OfferCreationRequestSnapshot | null;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
@@ -17,6 +17,7 @@ import type {
   CreateOfferCreationRecordInput,
   OfferCreationError,
 } from '../../../domain/types/offer-creation-record.types';
+import type { OfferCreationRequestSnapshot } from '../../../domain/types/offer-creation-request-snapshot.types';
 
 describe('OfferCreationRecordRepository', () => {
   let repository: OfferCreationRecordRepository;
@@ -34,8 +35,26 @@ describe('OfferCreationRecordRepository', () => {
     status: 'pending',
     errors: null,
     publishImmediately: false,
+    request: null,
     createdAt: now,
     updatedAt: now,
+    ...overrides,
+  });
+
+  const buildRequestSnapshot = (
+    overrides: Partial<OfferCreationRequestSnapshot> = {},
+  ): OfferCreationRequestSnapshot => ({
+    schemaVersion: 1,
+    internalVariantId: 'ol_variant_123',
+    stock: 5,
+    publishImmediately: true,
+    price: { amount: 99.99, currency: 'PLN' },
+    overrides: {
+      title: 'Shipped title',
+      categoryId: 'allegro-cat-1',
+      description: 'desc',
+      platformParams: { deliveryPolicyId: 'del-1' },
+    },
     ...overrides,
   });
 
@@ -84,6 +103,41 @@ describe('OfferCreationRecordRepository', () => {
       expect(result).toBeInstanceOf(OfferCreationRecord);
       expect(result.id).toBe('rec-uuid');
       expect(result.publishImmediately).toBe(true);
+    });
+
+    it('should persist and round-trip the request snapshot including schemaVersion', async () => {
+      const request = buildRequestSnapshot();
+      const input: CreateOfferCreationRecordInput = {
+        internalVariantId: 'ol_variant_123',
+        connectionId: 'conn-uuid',
+        status: 'pending',
+        publishImmediately: true,
+        request,
+      };
+      ormRepository.save.mockResolvedValue(buildOrm({ publishImmediately: true, request }));
+
+      const result = await repository.create(input);
+
+      const savedArg = ormRepository.save.mock.calls[0][0] as OfferCreationRecordOrmEntity;
+      expect(savedArg.request).toEqual(request);
+      expect(savedArg.request?.schemaVersion).toBe(1);
+      expect(result.request).toEqual(request);
+    });
+
+    it('should default request to null when omitted', async () => {
+      const input: CreateOfferCreationRecordInput = {
+        internalVariantId: 'ol_variant_123',
+        connectionId: 'conn-uuid',
+        status: 'pending',
+        publishImmediately: false,
+      };
+      ormRepository.save.mockResolvedValue(buildOrm());
+
+      const result = await repository.create(input);
+
+      const savedArg = ormRepository.save.mock.calls[0][0] as OfferCreationRecordOrmEntity;
+      expect(savedArg.request).toBeNull();
+      expect(result.request).toBeNull();
     });
 
     it('should accept optional externalOfferId and errors on create', async () => {
@@ -352,12 +406,14 @@ describe('OfferCreationRecordRepository', () => {
   describe('toDomain mapping', () => {
     it('should preserve all fields round-trip', async () => {
       const errors: OfferCreationError[] = [{ code: 'X', message: 'y' }];
+      const request = buildRequestSnapshot();
       ormRepository.findOne.mockResolvedValue(
         buildOrm({
           externalOfferId: 'external-1',
           status: 'validating',
           errors,
           publishImmediately: true,
+          request,
         }),
       );
 
@@ -374,6 +430,7 @@ describe('OfferCreationRecordRepository', () => {
           true,
           now,
           now,
+          request,
         ),
       );
     });

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts
@@ -116,6 +116,7 @@ export class OfferCreationRecordRepository implements OfferCreationRecordReposit
     entity.publishImmediately = input.publishImmediately;
     entity.externalOfferId = input.externalOfferId ?? null;
     entity.errors = input.errors ?? null;
+    entity.request = input.request ?? null;
     return entity;
   }
 
@@ -130,6 +131,7 @@ export class OfferCreationRecordRepository implements OfferCreationRecordReposit
       entity.publishImmediately,
       entity.createdAt,
       entity.updatedAt,
+      entity.request,
     );
   }
 }


### PR DESCRIPTION
## Summary

- Persists a schema-versioned snapshot of the create-offer request on `OfferCreationRecord` (new nullable jsonb column, additive migration).
- Inline `OfferCreationTracker` renders a **Retry** button on `failed` records when the snapshot is present and the client knows the `schemaVersion`.
- Retry reopens the `CreateOfferWizard` pre-filled from the snapshot, landing on Step 2 with a Step-1 hint explaining the re-load. Every open mints a fresh idempotency key, so the retry creates a new `OfferCreationRecord` and leaves the failed one untouched.

## Changes

### Backend
- Domain: `OfferCreationRequestSnapshot` type (`schemaVersion: 1` discriminator) + field on `OfferCreationRecord`.
- Persistence: `request jsonb NULL` column, migration `1787000000000-add-offer-creation-record-request-payload`, round-trip in the repository.
- Application: `OfferCreationEnqueueService` builds and persists the snapshot at enqueue time.
- Interface: new `OfferCreationRequestPayloadDto` (response-shape only, no `class-validator`), plumbed through `OfferCreationStatusResponseDto`.

### Frontend
- `CreateOfferRequest.schemaVersion?: number` + `SUPPORTED_OFFER_CREATION_REQUEST_SCHEMA_VERSION` constant.
- Pure helper `createOfferRequestToFormValues` with a `canReadCreateOfferRequestSnapshot` guard — unknown future versions hide Retry rather than silently mis-mapping.
- `CreateOfferWizard` gains an optional `initialValues` prop; on open it pre-fills, jumps to Step 2, marks Steps 0–1 complete, and surfaces an info alert if the operator steps back.
- `OfferCreationTracker` gains an optional `onRetry(record)` callback; Retry appears next to Dismiss only when `failed` + snapshot + readable version + callback.
- `ListingsListPage` wires `handleRetry`, dismisses the stale tracker, reopens the wizard with the snapshot, and clears retry hints on close.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 165/165 unit suites pass (7 new FE tests: helper + version guard + wizard retry path including fresh-idempotency-key regression + tracker button conditions including unknown-version + list-page integration)
- [x] `pnpm --filter @openlinker/api migration:show` — new migration surfaced as pending
- [x] `pnpm --filter @openlinker/api test:integration listings-create-offer` — 5/5 pass, including new cases covering `request: snapshot` round-trip and `request: null` (pre-existing records)
- [ ] Manual smoke on the listings page: trigger a failed create, confirm Retry reopens the wizard pre-filled, re-submit, confirm a new `OfferCreationRecord` is created (distinct `offerCreationRecordId`) and the old record remains `failed`.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)