### PR TITLE
refactor(web): extract CategoryTreeBrowser shared primitive

### DIFF
--- a/apps/web/src/features/listings/components/CategoryPicker.test.tsx
+++ b/apps/web/src/features/listings/components/CategoryPicker.test.tsx
@@ -259,7 +259,9 @@ describe('CategoryPicker', () => {
     );
 
     await screen.findByText('Electronics');
-    const root = container.querySelector('.category-picker');
+    // In the non-prefill (browser) path, the root is the shared
+    // CategoryTreeBrowser primitive — ARIA wiring is forwarded to it.
+    const root = container.querySelector('.category-tree-browser');
     expect(root).toHaveAttribute('role', 'group');
     expect(root).toHaveAttribute('aria-labelledby', 'external-label');
     expect(root).toHaveAttribute('aria-describedby', 'external-description');

--- a/apps/web/src/features/listings/components/CategoryPicker.tsx
+++ b/apps/web/src/features/listings/components/CategoryPicker.tsx
@@ -2,32 +2,28 @@
  * CategoryPicker
  *
  * Leaf-only Allegro category picker for the create-offer wizard (#305).
- * Browses the Allegro category tree level-by-level with a breadcrumb trail;
- * clicking a leaf fires `onChange(id)` — no staged/save intermediate.
+ * Thin wrapper around the shared `CategoryTreeBrowser` primitive — adds
+ * the pre-fill fallback row, wires leaf-only selection via `canSelect`,
+ * and fires `onChange(id)` immediately on leaf click (no staging).
  *
  * Designed to be used inside an RHF `<Controller>` (not `register()`); see
  * usage in `CreateOfferWizard.tsx` Step 2.
  *
- * Data source: reuses `useAllegroCategoriesQuery` from the mappings feature
- * — this is a cross-feature import. It is intentional: the wizard already
- * imports from `products/` and `connections/`, and duplicating the hook
- * under listings would be worse. A future refactor (#304) will extract a
- * shared `CategoryTreeBrowser` primitive into `shared/ui/` once the
- * existing `AllegroCategorySearch` (mappings) and this picker are refactored
- * onto it together.
+ * Data source: reuses `useAllegroCategoriesQuery` from the mappings
+ * feature. The primitive itself is domain-agnostic; only this wrapper
+ * knows about Allegro.
  *
  * Pre-fill fallback: when `value` is non-null and the operator hasn't
- * browsed yet, the picker shows the raw ID + a "Change" button instead of
- * trying to rehydrate the breadcrumb. Real ancestor-walk rehydration is a
- * follow-up tied to #307's retry flow.
+ * browsed yet, the wrapper shows the raw ID + a "Change" button instead
+ * of trying to rehydrate the breadcrumb. Real ancestor-walk rehydration
+ * is a follow-up tied to #307's retry flow.
  *
  * @module apps/web/src/features/listings/components
  */
 import { useState, type ReactElement } from 'react';
 import { Button } from '../../../shared/ui/button';
-import { LoadingState, ErrorState, EmptyState } from '../../../shared/ui/feedback-state';
+import { CategoryTreeBrowser } from '../../../shared/ui/category-tree-browser';
 import { useAllegroCategoriesQuery } from '../../mappings/hooks/use-allegro-categories';
-import type { AllegroCategory } from '../../mappings/api/mappings.types';
 
 interface CategoryPickerProps {
   connectionId: string;
@@ -50,11 +46,6 @@ interface CategoryPickerProps {
   'aria-invalid'?: boolean;
 }
 
-interface BreadcrumbItem {
-  id: string;
-  name: string;
-}
-
 export function CategoryPicker({
   connectionId,
   value,
@@ -66,13 +57,12 @@ export function CategoryPicker({
   'aria-describedby': ariaDescribedBy,
   'aria-invalid': ariaInvalid,
 }: CategoryPickerProps): ReactElement {
-  const [breadcrumb, setBreadcrumb] = useState<BreadcrumbItem[]>([]);
+  const [parentId, setParentId] = useState<string | undefined>(undefined);
   // `showBrowser` flips on when: (a) no value is set (always browse), or
   // (b) the operator clicks "Change" on the pre-fill fallback row.
   const [showBrowser, setShowBrowser] = useState<boolean>(value === null);
 
-  const currentParentId = breadcrumb.length > 0 ? breadcrumb[breadcrumb.length - 1].id : undefined;
-  const categoriesQuery = useAllegroCategoriesQuery(connectionId, currentParentId, showBrowser);
+  const categoriesQuery = useAllegroCategoriesQuery(connectionId, parentId, showBrowser);
 
   const isInvalid = Boolean(invalid) || Boolean(ariaInvalid);
 
@@ -105,134 +95,27 @@ export function CategoryPicker({
     );
   }
 
-  function navigateInto(category: AllegroCategory): void {
-    setBreadcrumb((prev) => [...prev, { id: category.id, name: category.name }]);
-  }
-
-  function navigateToRoot(): void {
-    setBreadcrumb([]);
-  }
-
-  function navigateToCrumb(index: number): void {
-    // Keep crumbs 0..index inclusive; drop anything deeper.
-    setBreadcrumb((prev) => prev.slice(0, index + 1));
-  }
-
-  function selectLeaf(category: AllegroCategory): void {
-    onChange(category.id);
-  }
-
-  const pickerClasses = [
-    'category-picker',
-    isInvalid ? 'category-picker--invalid' : '',
-    disabled ? 'category-picker--disabled' : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
-
+  // The `key={connectionId}` honors the primitive's breadcrumb-reset contract:
+  // if the wizard ever lets the operator switch connections without remounting
+  // the picker, React key forces a fresh mount so stale breadcrumb state can't
+  // linger. Today's wizard unmounts per open so this is defensive wiring.
   return (
-    <div
-      className={pickerClasses}
-      role="group"
+    <CategoryTreeBrowser
+      key={connectionId}
+      nodes={categoriesQuery.data}
+      isLoading={categoriesQuery.isLoading}
+      error={categoriesQuery.error}
+      onRetry={() => void categoriesQuery.refetch()}
+      onSelect={(node) => onChange(node.id)}
+      onNavigate={(pid) => setParentId(pid)}
+      selectedId={value}
+      canSelect={(node) => node.leaf}
+      density="compact"
+      disabled={disabled}
+      invalid={isInvalid}
       id={id}
       aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}
-      aria-invalid={isInvalid || undefined}
-    >
-      <nav className="category-picker__breadcrumb" aria-label="Category path">
-        <button
-          type="button"
-          className="category-picker__crumb"
-          onClick={navigateToRoot}
-          disabled={disabled || breadcrumb.length === 0}
-        >
-          Root
-        </button>
-        {breadcrumb.map((crumb, i) => (
-          <span key={crumb.id} className="category-picker__crumb-group">
-            <span className="category-picker__separator" aria-hidden="true">
-              ›
-            </span>
-            <button
-              type="button"
-              className="category-picker__crumb"
-              onClick={() => navigateToCrumb(i)}
-              disabled={disabled || i === breadcrumb.length - 1}
-            >
-              {crumb.name}
-            </button>
-          </span>
-        ))}
-      </nav>
-
-      <div className="category-picker__list-container">
-        {categoriesQuery.isLoading && (
-          <LoadingState
-            liveRegion="off"
-            title="Loading categories"
-            message="Fetching Allegro categories…"
-          />
-        )}
-
-        {categoriesQuery.error && (
-          <ErrorState
-            title="Unable to load categories"
-            message={categoriesQuery.error.message}
-            action={
-              <Button onClick={() => void categoriesQuery.refetch()}>Retry</Button>
-            }
-          />
-        )}
-
-        {categoriesQuery.data && categoriesQuery.data.length === 0 && (
-          <EmptyState
-            liveRegion="off"
-            title="No subcategories"
-            message="This level has no children. Step back and pick a different branch."
-          />
-        )}
-
-        {categoriesQuery.data && categoriesQuery.data.length > 0 && (
-          <ul className="category-picker__list" role="list">
-            {categoriesQuery.data.map((cat) => {
-              const isSelected = cat.leaf && cat.id === value;
-              const itemClasses = [
-                'category-picker__item',
-                cat.leaf ? 'category-picker__item--leaf' : 'category-picker__item--non-leaf',
-                isSelected ? 'category-picker__item--selected' : '',
-              ]
-                .filter(Boolean)
-                .join(' ');
-              return (
-                <li key={cat.id} className={itemClasses}>
-                  <span className="category-picker__name">{cat.name}</span>
-                  {cat.leaf ? (
-                    <Button
-                      tone={isSelected ? 'secondary' : 'primary'}
-                      type="button"
-                      onClick={() => selectLeaf(cat)}
-                      disabled={disabled}
-                      aria-pressed={isSelected}
-                    >
-                      {isSelected ? 'Selected' : 'Select'}
-                    </Button>
-                  ) : (
-                    <Button
-                      tone="ghost"
-                      type="button"
-                      onClick={() => navigateInto(cat)}
-                      disabled={disabled}
-                      aria-label={`Browse into ${cat.name}`}
-                    >
-                      Browse →
-                    </Button>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </div>
-    </div>
+    />
   );
 }

--- a/apps/web/src/features/mappings/components/AllegroCategorySearch.test.tsx
+++ b/apps/web/src/features/mappings/components/AllegroCategorySearch.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * AllegroCategorySearch — regression guard
+ *
+ * 5-case smoke suite pinning the component's current behavior before the
+ * #304 CategoryTreeBrowser refactor. These assertions should stay green
+ * after swapping the internals to use the shared primitive — otherwise the
+ * refactor changed user-visible behavior that it shouldn't have.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AllegroCategorySearch } from './AllegroCategorySearch';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import type { AllegroCategory } from '../api/mappings.types';
+
+function mockCategoriesEndpoint(
+  byParent: Record<string, AllegroCategory[]>,
+): (connectionId: string, parentId?: string) => Promise<AllegroCategory[]> {
+  return async (_connectionId, parentId) => {
+    const key = parentId ?? 'root';
+    return byParent[key] ?? [];
+  };
+}
+
+const connectionId = 'conn-allegro-1';
+
+describe('AllegroCategorySearch', () => {
+  afterEach(cleanup);
+
+  it('renders the root list from the mocked query', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [
+              { id: 'cat-1', name: 'Electronics', parentId: null, leaf: false },
+              { id: 'cat-2', name: 'Books', parentId: null, leaf: true },
+            ],
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <AllegroCategorySearch
+        marketplaceConnectionId={connectionId}
+        currentMapping={undefined}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+        isSaving={false}
+      />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText('Electronics')).toBeInTheDocument();
+    expect(screen.getByText('Books')).toBeInTheDocument();
+  });
+
+  it('drills into a non-leaf and loads the drilled level', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-electronics', name: 'Electronics', parentId: null, leaf: false }],
+            'cat-electronics': [
+              { id: 'cat-phones', name: 'Phones', parentId: 'cat-electronics', leaf: true },
+            ],
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <AllegroCategorySearch
+        marketplaceConnectionId={connectionId}
+        currentMapping={undefined}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+        isSaving={false}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText('Electronics');
+    fireEvent.click(screen.getByRole('button', { name: /browse into electronics/i }));
+    await screen.findByText('Phones');
+  });
+
+  it('stages a pick when Select is clicked and shows the built path', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-electronics', name: 'Electronics', parentId: null, leaf: false }],
+            'cat-electronics': [
+              { id: 'cat-phones', name: 'Phones', parentId: 'cat-electronics', leaf: true },
+            ],
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <AllegroCategorySearch
+        marketplaceConnectionId={connectionId}
+        currentMapping={undefined}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+        isSaving={false}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText('Electronics');
+    fireEvent.click(screen.getByRole('button', { name: /browse into electronics/i }));
+    await screen.findByText('Phones');
+
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }));
+
+    // Staged row renders with "Selected:" label and the full path
+    expect(screen.getByText('Selected:')).toBeInTheDocument();
+    expect(screen.getByText('Electronics > Phones')).toBeInTheDocument();
+    // Save + Cancel actions are available
+    expect(screen.getByRole('button', { name: /save mapping/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('fires onSelect with the built path when Save is clicked', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-electronics', name: 'Electronics', parentId: null, leaf: false }],
+            'cat-electronics': [
+              { id: 'cat-phones', name: 'Phones', parentId: 'cat-electronics', leaf: true },
+            ],
+          }),
+        ),
+      },
+    });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <AllegroCategorySearch
+        marketplaceConnectionId={connectionId}
+        currentMapping={undefined}
+        onSelect={onSelect}
+        onClear={vi.fn()}
+        isSaving={false}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText('Electronics');
+    fireEvent.click(screen.getByRole('button', { name: /browse into electronics/i }));
+    await screen.findByText('Phones');
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save mapping/i }));
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'cat-phones', name: 'Phones', leaf: true }),
+      'Electronics > Phones',
+    );
+  });
+
+  it('dismisses the staged pick without firing onSelect when Cancel is clicked', async () => {
+    const apiClient = createMockApiClient({
+      mappings: {
+        getAllegroCategories: vi.fn(
+          mockCategoriesEndpoint({
+            root: [{ id: 'cat-books', name: 'Books', parentId: null, leaf: true }],
+          }),
+        ),
+      },
+    });
+    const onSelect = vi.fn();
+
+    renderWithProviders(
+      <AllegroCategorySearch
+        marketplaceConnectionId={connectionId}
+        currentMapping={undefined}
+        onSelect={onSelect}
+        onClear={vi.fn()}
+        isSaving={false}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText('Books');
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }));
+    expect(screen.getByText('Selected:')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    // Staged row is gone; onSelect was never called
+    expect(screen.queryByText('Selected:')).not.toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/mappings/components/AllegroCategorySearch.tsx
+++ b/apps/web/src/features/mappings/components/AllegroCategorySearch.tsx
@@ -18,6 +18,7 @@ import { useState, type ReactElement } from 'react';
 import { useAllegroCategoriesQuery } from '../hooks/use-allegro-categories';
 import { Button } from '../../../shared/ui/button';
 import {
+  buildCategoryPath,
   CategoryTreeBrowser,
   type CategoryTreeCrumb,
   type CategoryTreeNode,
@@ -37,10 +38,6 @@ interface StagedPick {
   path: string;
 }
 
-function buildPath(breadcrumb: readonly CategoryTreeCrumb[], node: CategoryTreeNode): string {
-  return [...breadcrumb.map((c) => c.name), node.name].join(' > ');
-}
-
 export function AllegroCategorySearch({
   marketplaceConnectionId,
   currentMapping,
@@ -58,7 +55,7 @@ export function AllegroCategorySearch({
     breadcrumb: readonly CategoryTreeCrumb[],
   ): void {
     // Node shape from primitive is structurally compatible with AllegroCategory.
-    setStaged({ category: node as AllegroCategory, path: buildPath(breadcrumb, node) });
+    setStaged({ category: node as AllegroCategory, path: buildCategoryPath(breadcrumb, node) });
   }
 
   function handleSave(): void {

--- a/apps/web/src/features/mappings/components/AllegroCategorySearch.tsx
+++ b/apps/web/src/features/mappings/components/AllegroCategorySearch.tsx
@@ -1,12 +1,15 @@
 /**
  * AllegroCategorySearch
  *
- * Browseable Allegro category tree with lazy-loaded children.
- * Shows breadcrumb path, allows selecting a category for mapping,
- * and clearing an existing mapping.
+ * Browseable Allegro category tree with lazy-loaded children for the
+ * PrestaShop↔Allegro category mapping editor. Thin wrapper around the
+ * shared `CategoryTreeBrowser` primitive — adds the current-mapping
+ * row, the staged-pick preview, and the "Save mapping" / "Cancel"
+ * confirmation flow.
  *
- * Selection is staged — clicking "Select" previews the pick. The caller
- * receives the final choice only when the user confirms with "Save mapping".
+ * Selection is staged — clicking Select (at any tree level) previews
+ * the pick. The caller receives the final choice only when the user
+ * confirms with "Save mapping".
  *
  * @module apps/web/src/features/mappings/components
  */
@@ -14,7 +17,11 @@
 import { useState, type ReactElement } from 'react';
 import { useAllegroCategoriesQuery } from '../hooks/use-allegro-categories';
 import { Button } from '../../../shared/ui/button';
-import { LoadingState, ErrorState, EmptyState } from '../../../shared/ui/feedback-state';
+import {
+  CategoryTreeBrowser,
+  type CategoryTreeCrumb,
+  type CategoryTreeNode,
+} from '../../../shared/ui/category-tree-browser';
 import type { AllegroCategory, CategoryMapping } from '../api/mappings.types';
 
 interface AllegroCategorySearchProps {
@@ -25,14 +32,13 @@ interface AllegroCategorySearchProps {
   isSaving: boolean;
 }
 
-interface BreadcrumbItem {
-  id: string;
-  name: string;
-}
-
 interface StagedPick {
   category: AllegroCategory;
   path: string;
+}
+
+function buildPath(breadcrumb: readonly CategoryTreeCrumb[], node: CategoryTreeNode): string {
+  return [...breadcrumb.map((c) => c.name), node.name].join(' > ');
 }
 
 export function AllegroCategorySearch({
@@ -42,28 +48,17 @@ export function AllegroCategorySearch({
   onClear,
   isSaving,
 }: AllegroCategorySearchProps): ReactElement {
-  const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([]);
+  const [parentId, setParentId] = useState<string | undefined>(undefined);
   const [staged, setStaged] = useState<StagedPick | null>(null);
-  const currentParentId = breadcrumbs.length > 0 ? breadcrumbs[breadcrumbs.length - 1].id : undefined;
 
-  const categoriesQuery = useAllegroCategoriesQuery(marketplaceConnectionId, currentParentId);
+  const categoriesQuery = useAllegroCategoriesQuery(marketplaceConnectionId, parentId);
 
-  function navigateInto(category: AllegroCategory): void {
-    setBreadcrumbs((prev) => [...prev, { id: category.id, name: category.name }]);
-  }
-
-  function navigateTo(index: number): void {
-    setBreadcrumbs((prev) => prev.slice(0, index));
-  }
-
-  function buildPath(category: AllegroCategory): string {
-    const parts = breadcrumbs.map((b) => b.name);
-    parts.push(category.name);
-    return parts.join(' > ');
-  }
-
-  function handleStage(category: AllegroCategory): void {
-    setStaged({ category, path: buildPath(category) });
+  function handlePrimitiveSelect(
+    node: CategoryTreeNode,
+    breadcrumb: readonly CategoryTreeCrumb[],
+  ): void {
+    // Node shape from primitive is structurally compatible with AllegroCategory.
+    setStaged({ category: node as AllegroCategory, path: buildPath(breadcrumb, node) });
   }
 
   function handleSave(): void {
@@ -85,11 +80,7 @@ export function AllegroCategorySearch({
           {currentMapping.allegroCategoryPath && (
             <span className="allegro-category-search__path">{currentMapping.allegroCategoryPath}</span>
           )}
-          <Button
-            className="button--ghost button--sm"
-            onClick={onClear}
-            disabled={isSaving}
-          >
+          <Button className="button--ghost button--sm" onClick={onClear} disabled={isSaving}>
             Clear mapping
           </Button>
         </div>
@@ -122,79 +113,21 @@ export function AllegroCategorySearch({
         </div>
       )}
 
-      {/* Breadcrumb navigation */}
-      <nav className="allegro-category-search__breadcrumbs" aria-label="Category breadcrumbs">
-        <button
-          type="button"
-          className="allegro-category-search__crumb"
-          onClick={() => { navigateTo(0); }}
-        >
-          Root
-        </button>
-        {breadcrumbs.map((crumb, i) => (
-          <span key={crumb.id}>
-            <span className="allegro-category-search__separator"> / </span>
-            <button
-              type="button"
-              className="allegro-category-search__crumb"
-              onClick={() => { navigateTo(i + 1); }}
-            >
-              {crumb.name}
-            </button>
-          </span>
-        ))}
-      </nav>
-
-      {/* Category list */}
-      {categoriesQuery.isLoading && (
-        <LoadingState liveRegion="off" title="Loading categories" message="Fetching Allegro categories..." />
-      )}
-
-      {categoriesQuery.error && (
-        <ErrorState
-          title="Unable to load categories"
-          message={categoriesQuery.error.message}
-          action={<Button onClick={() => { void categoriesQuery.refetch(); }}>Retry</Button>}
-        />
-      )}
-
-      {categoriesQuery.data && categoriesQuery.data.length === 0 && (
-        <EmptyState title="No subcategories" message="This category has no children." />
-      )}
-
-      {categoriesQuery.data && categoriesQuery.data.length > 0 && (
-        <ul className="allegro-category-search__list" role="list">
-          {categoriesQuery.data.map((cat) => (
-            <li
-              key={cat.id}
-              className={[
-                'allegro-category-search__item',
-                staged?.category.id === cat.id ? 'allegro-category-search__item--staged' : '',
-              ].filter(Boolean).join(' ')}
-            >
-              <span className="allegro-category-search__name">{cat.name}</span>
-              <span className="allegro-category-search__actions">
-                {!cat.leaf && (
-                  <button
-                    type="button"
-                    className="button button--ghost button--sm"
-                    onClick={() => { navigateInto(cat); }}
-                  >
-                    Browse
-                  </button>
-                )}
-                <Button
-                  className={staged?.category.id === cat.id ? 'button--secondary button--sm' : 'button--primary button--sm'}
-                  onClick={() => { handleStage(cat); }}
-                  disabled={isSaving}
-                >
-                  {staged?.category.id === cat.id ? 'Selected' : 'Select'}
-                </Button>
-              </span>
-            </li>
-          ))}
-        </ul>
-      )}
+      {/* Browse / navigate / select — shared primitive. `key` honors the
+          breadcrumb-reset contract if the caller ever swaps connections
+          without remounting this wrapper. */}
+      <CategoryTreeBrowser
+        key={marketplaceConnectionId}
+        nodes={categoriesQuery.data}
+        isLoading={categoriesQuery.isLoading}
+        error={categoriesQuery.error}
+        onRetry={() => void categoriesQuery.refetch()}
+        onSelect={handlePrimitiveSelect}
+        onNavigate={(pid) => setParentId(pid)}
+        selectedId={staged?.category.id ?? null}
+        canSelect={() => true}
+        disabled={isSaving}
+      />
     </div>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2199,75 +2199,11 @@ textarea {
   margin-left: auto;
 }
 
-.allegro-category-search__item--staged {
-  background: var(--accent-primary-soft);
-  border-radius: 0.375rem;
-}
-
-.allegro-category-search__breadcrumbs {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.125rem;
-  padding: 0.375rem 0;
-  margin-bottom: 0.5rem;
-  font-size: 0.75rem;
-  border-bottom: 1px solid var(--border-default);
-}
-
-.allegro-category-search__crumb {
-  border: none;
-  background: none;
-  cursor: pointer;
-  color: var(--accent-primary);
-  padding: 0.125rem 0.25rem;
-  border-radius: 0.25rem;
-  font-size: 0.75rem;
-}
-
-.allegro-category-search__crumb:hover {
-  background: var(--accent-primary-soft);
-}
-
-.allegro-category-search__separator {
-  color: var(--text-muted);
-}
-
-.allegro-category-search__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.allegro-category-search__item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
-  border-bottom: 1px solid var(--border-subtle);
-  font-size: 0.8125rem;
-}
-
-.allegro-category-search__item:last-child {
-  border-bottom: none;
-}
-
-.allegro-category-search__name {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.allegro-category-search__actions {
-  display: flex;
-  gap: 0.25rem;
-  flex-shrink: 0;
-}
+/* Browse / selection surface is now the shared `.category-tree-browser`
+ * primitive (see `shared/ui/category-tree-browser.tsx`). Classes moved
+ * there: `__breadcrumbs`, `__crumb`, `__separator`, `__list`, `__item`,
+ * `__item--staged`, `__name`, `__actions`. Wrapper-specific surfaces
+ * (current mapping, staged preview) remain here. */
 
 @media (max-width: 900px) {
   .category-mappings-layout {
@@ -3585,24 +3521,57 @@ textarea {
   letter-spacing: 0.09em;
 }
 
-.category-picker__breadcrumb {
+/* Browse / list / breadcrumb surface lives in the shared
+ * `.category-tree-browser` primitive (see `shared/ui/category-tree-browser.tsx`).
+ * Only the pre-fill fallback row remains wrapper-specific here. */
+
+/*
+ * ── Category Tree Browser (shared primitive, #304) ───────────────
+ * Hierarchical tree navigation with breadcrumb + per-row Select/Browse
+ * actions. Consumed by `CategoryPicker` (listings, leaf-only mode) and
+ * `AllegroCategorySearch` (mappings, any-level staged mode). Density
+ * `compact` enables overflow-x scroll + tighter spacing for
+ * dialog-bounded usage.
+ */
+.category-tree-browser {
+  display: grid;
+  gap: 0.375rem;
+}
+
+.category-tree-browser--invalid {
+  border-color: var(--status-error-border);
+  background: var(--status-error-soft);
+}
+
+.category-tree-browser--disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.category-tree-browser__breadcrumb {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 0.125rem;
-  padding: 0.25rem 0;
-  border-bottom: 1px solid var(--border-subtle);
+  padding: 0.375rem 0;
+  margin-bottom: 0.25rem;
   font-size: 0.75rem;
-  overflow-x: auto;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
-.category-picker__crumb-group {
+.category-tree-browser--density-compact .category-tree-browser__breadcrumb {
+  overflow-x: auto;
+  padding: 0.25rem 0;
+  flex-wrap: nowrap;
+}
+
+.category-tree-browser__crumb-group {
   display: inline-flex;
   align-items: center;
   gap: 0.125rem;
 }
 
-.category-picker__crumb {
+.category-tree-browser__crumb {
   border: none;
   background: none;
   cursor: pointer;
@@ -3613,27 +3582,27 @@ textarea {
   white-space: nowrap;
 }
 
-.category-picker__crumb:hover:not(:disabled) {
+.category-tree-browser__crumb:hover:not(:disabled) {
   background: var(--accent-primary-soft);
 }
 
-.category-picker__crumb:disabled {
+.category-tree-browser__crumb:disabled {
   color: var(--text-primary);
   cursor: default;
   font-weight: 600;
 }
 
-.category-picker__separator {
+.category-tree-browser__separator {
   color: var(--text-muted);
   padding: 0 0.125rem;
 }
 
-.category-picker__list-container {
+.category-tree-browser__list-container {
   max-height: 20rem;
   overflow-y: auto;
 }
 
-.category-picker__list {
+.category-tree-browser__list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -3641,7 +3610,7 @@ textarea {
   flex-direction: column;
 }
 
-.category-picker__item {
+.category-tree-browser__item {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -3651,27 +3620,32 @@ textarea {
   font-size: 0.8125rem;
 }
 
-.category-picker__item:last-child {
+.category-tree-browser__item:last-child {
   border-bottom: none;
 }
 
-.category-picker__item--selected {
+.category-tree-browser__item--selected {
   background: var(--accent-primary-soft);
   border-radius: 0.375rem;
 }
 
 /*
- * The `.category-picker__item--leaf` and `--non-leaf` modifiers are emitted
- * by CategoryPicker.tsx as intentional styling hooks but currently have no
- * rules — the base `.category-picker__item` handles both visual states via
- * the Select / Browse buttons inside. Kept so future differentiated styling
- * (icons, subtle dividers, indent) can attach without markup changes.
+ * `__item--leaf` and `__item--non-leaf` modifiers are emitted as
+ * intentional styling hooks but currently have no rules. Kept so future
+ * differentiated styling (icons, indent, dividers) can attach without
+ * markup changes.
  */
 
-.category-picker__name {
+.category-tree-browser__name {
   flex: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.category-tree-browser__actions {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
 }

--- a/apps/web/src/shared/ui/category-tree-browser.test.tsx
+++ b/apps/web/src/shared/ui/category-tree-browser.test.tsx
@@ -1,7 +1,11 @@
 import { createRef } from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { CategoryTreeBrowser, type CategoryTreeNode } from './category-tree-browser';
+import {
+  buildCategoryPath,
+  CategoryTreeBrowser,
+  type CategoryTreeNode,
+} from './category-tree-browser';
 
 const electronics: CategoryTreeNode = {
   id: 'cat-electronics',
@@ -229,5 +233,29 @@ describe('CategoryTreeBrowser', () => {
     expect(root).toHaveClass('category-tree-browser');
     expect(root).toHaveClass('category-tree-browser--density-compact');
     expect(root).toHaveClass('my-custom-class');
+  });
+});
+
+describe('buildCategoryPath', () => {
+  it('joins a breadcrumb with the selected node using the default separator', () => {
+    expect(
+      buildCategoryPath(
+        [
+          { id: 'cat-electronics', name: 'Electronics' },
+          { id: 'cat-audio', name: 'Audio' },
+        ],
+        phones,
+      ),
+    ).toBe('Electronics > Audio > Phones');
+  });
+
+  it('returns just the node name when the breadcrumb is empty', () => {
+    expect(buildCategoryPath([], books)).toBe('Books');
+  });
+
+  it('honors a custom separator', () => {
+    expect(
+      buildCategoryPath([{ id: 'cat-electronics', name: 'Electronics' }], phones, ' / '),
+    ).toBe('Electronics / Phones');
   });
 });

--- a/apps/web/src/shared/ui/category-tree-browser.test.tsx
+++ b/apps/web/src/shared/ui/category-tree-browser.test.tsx
@@ -1,0 +1,233 @@
+import { createRef } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CategoryTreeBrowser, type CategoryTreeNode } from './category-tree-browser';
+
+const electronics: CategoryTreeNode = {
+  id: 'cat-electronics',
+  name: 'Electronics',
+  parentId: null,
+  leaf: false,
+};
+const books: CategoryTreeNode = { id: 'cat-books', name: 'Books', parentId: null, leaf: true };
+const phones: CategoryTreeNode = {
+  id: 'cat-phones',
+  name: 'Phones',
+  parentId: 'cat-electronics',
+  leaf: true,
+};
+
+describe('CategoryTreeBrowser', () => {
+  afterEach(cleanup);
+
+  it('renders the provided nodes at the root level', () => {
+    render(
+      <CategoryTreeBrowser
+        nodes={[electronics, books]}
+        isLoading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Electronics')).toBeInTheDocument();
+    expect(screen.getByText('Books')).toBeInTheDocument();
+  });
+
+  it('drilling a non-leaf fires onNavigate with the updated breadcrumb', () => {
+    const onNavigate = vi.fn();
+    render(
+      <CategoryTreeBrowser
+        nodes={[electronics]}
+        isLoading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /browse into electronics/i }));
+    expect(onNavigate).toHaveBeenCalledWith('cat-electronics', [
+      { id: 'cat-electronics', name: 'Electronics' },
+    ]);
+    // Breadcrumb now shows Electronics as the current level (disabled crumb)
+    expect(screen.getByRole('button', { name: 'Electronics' })).toBeDisabled();
+  });
+
+  it('clicking Select on a leaf fires onSelect with node + current breadcrumb', () => {
+    const onSelect = vi.fn();
+    render(
+      <CategoryTreeBrowser
+        nodes={[books]}
+        isLoading={false}
+        error={null}
+        onSelect={onSelect}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }));
+    // Called at root, so breadcrumb is empty.
+    expect(onSelect).toHaveBeenCalledWith(books, []);
+  });
+
+  it('clicking a previous crumb truncates breadcrumb and fires onNavigate', () => {
+    const onNavigate = vi.fn();
+    const { rerender } = render(
+      <CategoryTreeBrowser
+        nodes={[electronics]}
+        isLoading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    // Drill into Electronics first.
+    fireEvent.click(screen.getByRole('button', { name: /browse into electronics/i }));
+    onNavigate.mockClear();
+
+    // Simulate the consumer re-rendering with the drilled-level's nodes.
+    rerender(
+      <CategoryTreeBrowser
+        nodes={[phones]}
+        isLoading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    // Click Root to jump back.
+    fireEvent.click(screen.getByRole('button', { name: 'Root' }));
+    expect(onNavigate).toHaveBeenCalledWith(undefined, []);
+  });
+
+  it('renders LoadingState / ErrorState (with Retry) / EmptyState based on props', () => {
+    const onRetry = vi.fn();
+
+    // Loading
+    const { rerender } = render(
+      <CategoryTreeBrowser
+        nodes={undefined}
+        isLoading={true}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Loading categories')).toBeInTheDocument();
+
+    // Error with Retry
+    rerender(
+      <CategoryTreeBrowser
+        nodes={undefined}
+        isLoading={false}
+        error={new Error('boom')}
+        onRetry={onRetry}
+        onSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Unable to load categories')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    // Empty
+    rerender(
+      <CategoryTreeBrowser
+        nodes={[]}
+        isLoading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('No subcategories')).toBeInTheDocument();
+  });
+
+  it('canSelect={() => true} makes non-leaves selectable (any-level mode)', () => {
+    const onSelect = vi.fn();
+    render(
+      <CategoryTreeBrowser
+        nodes={[electronics]}
+        isLoading={false}
+        error={null}
+        onSelect={onSelect}
+        onNavigate={vi.fn()}
+        canSelect={() => true}
+      />,
+    );
+
+    // Non-leaf Electronics now has both Browse and Select
+    expect(screen.getByRole('button', { name: /browse into electronics/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^select$/i }));
+    expect(onSelect).toHaveBeenCalledWith(electronics, []);
+  });
+
+  it('disabled propagates to all interactive controls; invalid + ARIA forward to root', () => {
+    const { container } = render(
+      <CategoryTreeBrowser
+        nodes={[electronics, books]}
+        isLoading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={vi.fn()}
+        disabled
+        invalid
+        aria-labelledby="external-label"
+        aria-describedby="external-description"
+      />,
+    );
+
+    // Root crumb is always disabled when at root (nothing to navigate back to),
+    // so verify via the list buttons.
+    expect(screen.getByRole('button', { name: /browse into electronics/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^select$/i })).toBeDisabled();
+
+    const root = container.querySelector('.category-tree-browser');
+    expect(root).toHaveAttribute('role', 'group');
+    expect(root).toHaveAttribute('aria-labelledby', 'external-label');
+    expect(root).toHaveAttribute('aria-describedby', 'external-description');
+    expect(root).toHaveAttribute('aria-invalid', 'true');
+    expect(root).toHaveClass('category-tree-browser--invalid');
+    expect(root).toHaveClass('category-tree-browser--disabled');
+  });
+
+  it('forwards ref to the root div', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <CategoryTreeBrowser
+        ref={ref}
+        nodes={[books]}
+        isLoading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toHaveClass('category-tree-browser');
+  });
+
+  it('merges custom className with internal classes on the root', () => {
+    const { container } = render(
+      <CategoryTreeBrowser
+        nodes={[books]}
+        isLoading={false}
+        error={null}
+        onSelect={vi.fn()}
+        onNavigate={vi.fn()}
+        className="my-custom-class"
+        density="compact"
+      />,
+    );
+
+    const root = container.querySelector('.category-tree-browser');
+    expect(root).toHaveClass('category-tree-browser');
+    expect(root).toHaveClass('category-tree-browser--density-compact');
+    expect(root).toHaveClass('my-custom-class');
+  });
+});

--- a/apps/web/src/shared/ui/category-tree-browser.tsx
+++ b/apps/web/src/shared/ui/category-tree-browser.tsx
@@ -52,6 +52,19 @@ export interface CategoryTreeCrumb {
   name: string;
 }
 
+/**
+ * Joins a breadcrumb + a selected node into a display path like `"A > B > C"`.
+ * Exported so consumers don't drift on separator or ordering when composing
+ * the path from `onSelect`'s callback args.
+ */
+export function buildCategoryPath(
+  breadcrumb: readonly CategoryTreeCrumb[],
+  node: CategoryTreeNode,
+  separator = ' > ',
+): string {
+  return [...breadcrumb.map((c) => c.name), node.name].join(separator);
+}
+
 export interface CategoryTreeBrowserProps {
   /** Current level's nodes; `undefined` while the consumer's query is loading. */
   nodes: readonly CategoryTreeNode[] | undefined;

--- a/apps/web/src/shared/ui/category-tree-browser.tsx
+++ b/apps/web/src/shared/ui/category-tree-browser.tsx
@@ -1,0 +1,276 @@
+/**
+ * CategoryTreeBrowser
+ *
+ * Shared primitive for browseable hierarchical category trees. Owns the
+ * breadcrumb-navigation UX, per-row Select/Browse actions, and the
+ * loading/error/empty feedback states. Domain-agnostic by design — does
+ * not know about Allegro or any other platform.
+ *
+ * Controlled data flow: callers pass pre-fetched `nodes` + query state;
+ * primitive owns only the breadcrumb (transient navigation state). On
+ * every breadcrumb change the primitive calls `onNavigate(parentId,
+ * breadcrumb)` so the caller can refetch children for the new level.
+ *
+ * ## Breadcrumb reset contract
+ *
+ * The primitive owns breadcrumb state internally. If a caller's identity
+ * context changes mid-mount (e.g., a wizard's `connectionId` flips from
+ * A to B), the existing breadcrumb would still hold A-connection IDs and
+ * the next fetch would likely return empty. Callers must force a remount
+ * via React `key` when identity changes:
+ *
+ * ```tsx
+ * <CategoryTreeBrowser key={connectionId} ... />
+ * ```
+ *
+ * Today's two consumers (CategoryPicker in listings, AllegroCategorySearch
+ * in mappings) both live inside modals that unmount+remount per open, so
+ * they don't hit this in practice — but the contract is explicit so a
+ * future third consumer doesn't silently trip on it.
+ *
+ * @module apps/web/src/shared/ui
+ */
+import { forwardRef, useState, type ReactElement } from 'react';
+import { Button } from './button';
+import { LoadingState, ErrorState, EmptyState } from './feedback-state';
+
+/**
+ * Minimal node shape the primitive needs. Structurally compatible with
+ * `AllegroCategory` from `features/mappings/api/mappings.types`, but
+ * deliberately defined here so `shared/ui/` stays free of `features/`
+ * imports (frontend-architecture.md §Dependency Rules).
+ */
+export interface CategoryTreeNode {
+  id: string;
+  name: string;
+  leaf: boolean;
+  parentId: string | null;
+}
+
+export interface CategoryTreeCrumb {
+  id: string;
+  name: string;
+}
+
+export interface CategoryTreeBrowserProps {
+  /** Current level's nodes; `undefined` while the consumer's query is loading. */
+  nodes: readonly CategoryTreeNode[] | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  /** Optional retry handler for the error-state Retry button. */
+  onRetry?: () => void;
+
+  /**
+   * Fired when the operator selects a node (clicks its Select button).
+   * `breadcrumb` is the path from root at the time of selection, excluding
+   * the selected node itself — callers that need the full path string
+   * should compose `[...breadcrumb.map(c => c.name), node.name].join(' > ')`.
+   */
+  onSelect: (node: CategoryTreeNode, breadcrumb: readonly CategoryTreeCrumb[]) => void;
+
+  /**
+   * Fired whenever the breadcrumb depth changes — drilling into a non-leaf,
+   * jumping back via a crumb, or clicking Root. `parentId` is `undefined`
+   * at the root level. Callers use this to change their query's parentId arg.
+   */
+  onNavigate: (parentId: string | undefined, breadcrumb: readonly CategoryTreeCrumb[]) => void;
+
+  /** Highlights the matching node in the list; toggles its Select button to "Selected". */
+  selectedId?: string | null;
+
+  /**
+   * Predicate controlling which nodes render a Select button. Default:
+   * `(node) => node.leaf`. AllegroCategorySearch passes `() => true` to
+   * allow any-level selection.
+   */
+  canSelect?: (node: CategoryTreeNode) => boolean;
+
+  /**
+   * Visual density. `compact` enables `overflow-x: auto` on the breadcrumb
+   * and tightens spacing — used by the dialog-bounded wizard picker.
+   */
+  density?: 'default' | 'compact';
+
+  disabled?: boolean;
+  invalid?: boolean;
+
+  /** Forwarded to the root `<div role="group">` for form-field integration. */
+  id?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean;
+
+  /** Merged with the primitive's own classes (never overrides). */
+  className?: string;
+}
+
+export const CategoryTreeBrowser = forwardRef<HTMLDivElement, CategoryTreeBrowserProps>(
+  function CategoryTreeBrowser(
+    {
+      nodes,
+      isLoading,
+      error,
+      onRetry,
+      onSelect,
+      onNavigate,
+      selectedId,
+      canSelect = (node) => node.leaf,
+      density = 'default',
+      disabled,
+      invalid,
+      id,
+      'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
+      'aria-invalid': ariaInvalid,
+      className = '',
+    },
+    ref,
+  ): ReactElement {
+    const [breadcrumb, setBreadcrumb] = useState<CategoryTreeCrumb[]>([]);
+
+    const isInvalid = Boolean(invalid) || Boolean(ariaInvalid);
+
+    function navigateInto(node: CategoryTreeNode): void {
+      const next: CategoryTreeCrumb[] = [...breadcrumb, { id: node.id, name: node.name }];
+      setBreadcrumb(next);
+      onNavigate(node.id, next);
+    }
+
+    function navigateToRoot(): void {
+      setBreadcrumb([]);
+      onNavigate(undefined, []);
+    }
+
+    function navigateToCrumb(index: number): void {
+      // Keep crumbs 0..index inclusive; drop anything deeper.
+      const next = breadcrumb.slice(0, index + 1);
+      setBreadcrumb(next);
+      onNavigate(next[next.length - 1]?.id, next);
+    }
+
+    function handleSelect(node: CategoryTreeNode): void {
+      onSelect(node, breadcrumb);
+    }
+
+    const rootClasses = [
+      'category-tree-browser',
+      `category-tree-browser--density-${density}`,
+      isInvalid ? 'category-tree-browser--invalid' : '',
+      disabled ? 'category-tree-browser--disabled' : '',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <div
+        ref={ref}
+        className={rootClasses}
+        role="group"
+        id={id}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={isInvalid || undefined}
+      >
+        <nav className="category-tree-browser__breadcrumb" aria-label="Category path">
+          <button
+            type="button"
+            className="category-tree-browser__crumb"
+            onClick={navigateToRoot}
+            disabled={disabled || breadcrumb.length === 0}
+          >
+            Root
+          </button>
+          {breadcrumb.map((crumb, i) => (
+            <span key={crumb.id} className="category-tree-browser__crumb-group">
+              <span className="category-tree-browser__separator" aria-hidden="true">
+                ›
+              </span>
+              <button
+                type="button"
+                className="category-tree-browser__crumb"
+                onClick={() => navigateToCrumb(i)}
+                disabled={disabled || i === breadcrumb.length - 1}
+              >
+                {crumb.name}
+              </button>
+            </span>
+          ))}
+        </nav>
+
+        <div className="category-tree-browser__list-container">
+          {isLoading && (
+            <LoadingState
+              liveRegion="off"
+              title="Loading categories"
+              message="Fetching categories…"
+            />
+          )}
+
+          {error && (
+            <ErrorState
+              title="Unable to load categories"
+              message={error.message}
+              action={onRetry ? <Button onClick={onRetry}>Retry</Button> : undefined}
+            />
+          )}
+
+          {nodes && nodes.length === 0 && !isLoading && !error && (
+            <EmptyState
+              liveRegion="off"
+              title="No subcategories"
+              message="This level has no children. Step back and pick a different branch."
+            />
+          )}
+
+          {nodes && nodes.length > 0 && (
+            <ul className="category-tree-browser__list" role="list">
+              {nodes.map((node) => {
+                const selectable = canSelect(node);
+                const isSelected = selectable && node.id === selectedId;
+                const itemClasses = [
+                  'category-tree-browser__item',
+                  node.leaf
+                    ? 'category-tree-browser__item--leaf'
+                    : 'category-tree-browser__item--non-leaf',
+                  isSelected ? 'category-tree-browser__item--selected' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ');
+                return (
+                  <li key={node.id} className={itemClasses}>
+                    <span className="category-tree-browser__name">{node.name}</span>
+                    <span className="category-tree-browser__actions">
+                      {!node.leaf && (
+                        <Button
+                          tone="ghost"
+                          type="button"
+                          onClick={() => navigateInto(node)}
+                          disabled={disabled}
+                          aria-label={`Browse into ${node.name}`}
+                        >
+                          Browse
+                        </Button>
+                      )}
+                      {selectable && (
+                        <Button
+                          tone={isSelected ? 'secondary' : 'primary'}
+                          type="button"
+                          onClick={() => handleSelect(node)}
+                          disabled={disabled}
+                          aria-pressed={isSelected}
+                        >
+                          {isSelected ? 'Selected' : 'Select'}
+                        </Button>
+                      )}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    );
+  },
+);

--- a/docs/plans/implementation-plan-category-tree-browser-primitive.md
+++ b/docs/plans/implementation-plan-category-tree-browser-primitive.md
@@ -1,0 +1,332 @@
+# Implementation Plan — `CategoryTreeBrowser` Primitive (#304)
+
+**Issue**: #304 (partial close — `VariantPicker`/`ConnectionPicker` extraction stays open)
+**Branch**: `304-category-tree-browser-primitive`
+**Layer**: Frontend only
+
+---
+
+## 1. Goal
+
+Extract the shared navigation + list + feedback-states machinery from the two existing category browsers into a new **`CategoryTreeBrowser`** primitive in `apps/web/src/shared/ui/`. Refactor both current consumers onto it:
+
+1. `apps/web/src/features/mappings/components/AllegroCategorySearch.tsx` (mapping editor: staged pick → Save, any-level selection)
+2. `apps/web/src/features/listings/components/CategoryPicker.tsx` (create-offer wizard: immediate onChange, leaf-only selection, pre-fill fallback)
+
+The two components share ~80% of their JSX and CSS (breadcrumb row, category list, loading/error/empty states). Extraction closes the "cross-feature coupling" concern flagged in PR #313's tech-review and honors the `frontend-architecture.md` rule that shared primitives stay domain-agnostic.
+
+### Non-goals
+
+- **`VariantPicker` / `ConnectionPicker` extraction.** #304 lists both as candidates, but the variant picker today has only one consumer (the wizard) — extracting it still trips the "no one-consumer abstractions" rule. #304 stays partially open with a follow-up. This PR's `Part of #304`.
+- **Any behavioral change to either wrapper.** Mapping's staged-pick UX stays identical. Listings' leaf-only + pre-fill + form-control wiring stays identical. Pure refactor.
+- **Backend / query-hook changes.** `useAllegroCategoriesQuery` stays where it is. The primitive is a presentation component; consumers call their own query hook and pass data in as props.
+- **Search-as-you-type.** Still deferred to #305.
+
+---
+
+## 2. Architecture
+
+```
+features/mappings/components                     features/listings/components
+  AllegroCategorySearch.tsx (slim wrapper)         CategoryPicker.tsx (slim wrapper)
+  ├── useAllegroCategoriesQuery                    ├── useAllegroCategoriesQuery
+  ├── staged-pick state                            ├── pre-fill fallback state
+  ├── "Save mapping" flow                          ├── form-control a11y wiring
+  └─────────────────┬──────────────────────────────┴─────────────────┐
+                    ▼                                                ▼
+                           shared/ui/category-tree-browser.tsx (NEW)
+                           └── breadcrumb state (internal)
+                           └── loading / error / empty surfaces
+                           └── category list + per-row actions
+                           └── `role="group"` + forwarded a11y props
+```
+
+**Dependency-rule compliance:** the primitive **does not** import from `features/`. The consumers pass their own query results in as props. Per `frontend-architecture.md` §Dependency Rules — "`shared` must not import `features` or `pages`."
+
+**Type reuse:** the primitive defines its own minimal `CategoryTreeNode` interface (`{ id, name, leaf, parentId }`). The `AllegroCategory` type from `features/mappings/api/mappings.types` is structurally compatible, so consumers just pass their arrays through without mapping.
+
+---
+
+## 3. Primitive API
+
+### `CategoryTreeBrowser`
+
+```typescript
+// apps/web/src/shared/ui/category-tree-browser.tsx
+
+export interface CategoryTreeNode {
+  id: string;
+  name: string;
+  leaf: boolean;
+  parentId: string | null;
+}
+
+export interface CategoryTreeCrumb {
+  id: string;
+  name: string;
+}
+
+export interface CategoryTreeBrowserProps {
+  /** Current level's nodes (from the consumer's query). */
+  nodes: readonly CategoryTreeNode[] | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  onRetry?: () => void;
+
+  /**
+   * Fired when the operator clicks the Select button on a node. Primitive
+   * decides whether a node is selectable via `canSelect`; non-selectable
+   * non-leaf nodes show only the Browse action.
+   */
+  onSelect: (node: CategoryTreeNode, breadcrumb: readonly CategoryTreeCrumb[]) => void;
+
+  /**
+   * Fired every time the breadcrumb depth changes — either by drilling into a
+   * non-leaf or by clicking a previous crumb. `parentId` is undefined at root.
+   * Consumers use this to change their query's parentId arg.
+   */
+  onNavigate: (parentId: string | undefined, breadcrumb: readonly CategoryTreeCrumb[]) => void;
+
+  /** Highlight a selected node (leaf-only UI cue). */
+  selectedId?: string | null;
+
+  /**
+   * Controls which nodes render a Select button. Default: `(n) => n.leaf`.
+   * AllegroCategorySearch overrides to `() => true` for any-level selection.
+   */
+  canSelect?: (node: CategoryTreeNode) => boolean;
+
+  /**
+   * Visual density. `compact` enables `overflow-x: auto` on the breadcrumb
+   * and tightens spacing — used by the dialog-bounded wizard picker.
+   * Default: `'default'`.
+   */
+  density?: 'default' | 'compact';
+
+  disabled?: boolean;
+  invalid?: boolean;
+
+  /** A11y — forwarded to the root `<div role="group">`. */
+  id?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean;
+
+  className?: string;
+}
+
+export const CategoryTreeBrowser: ForwardRefExoticComponent<
+  CategoryTreeBrowserProps & RefAttributes<HTMLDivElement>
+>;
+```
+
+**`forwardRef` is required** per `ui-components.md` §Component Structure ("All shared UI components use `forwardRef`"). Implementation uses the named-function-inside-forwardRef convention:
+
+```typescript
+export const CategoryTreeBrowser = forwardRef<HTMLDivElement, CategoryTreeBrowserProps>(
+  function CategoryTreeBrowser(props, ref) { /* ... */ }
+);
+```
+
+**Per-row button labels** are fixed defaults (`Select` / `Selected` / `Browse`). Both current consumers use these — per `ui-components.md` §Implementation rules ("Avoid over-generalized APIs; build only the surface the current product needs"), the three label-override props are deferred until a consumer asks for non-defaults.
+
+### Behavior
+
+- Owns the **breadcrumb state** internally (`useState<CategoryTreeCrumb[]>`). Why: the breadcrumb is pure navigation state, and the two consumers don't need it for anything except rendering + path-string building (handled via the `breadcrumb` callback argument).
+- Fires `onNavigate(undefined, [])` when "Root" is clicked; fires `onNavigate(node.id, [...breadcrumb, node])` when drilling into a non-leaf; fires `onNavigate(prev[i].id, prev.slice(0, i+1))` when clicking a crumb.
+- Renders `<LoadingState>` / `<ErrorState>` (with Retry button if `onRetry` provided) / `<EmptyState>` / list — in that order based on query state.
+- Root element is a `<div role="group">` with forwarded `id`, `aria-labelledby`, `aria-describedby`, `aria-invalid`. This matches `CategoryPicker`'s existing a11y contract.
+- `selectedId` highlights the matching leaf row and toggles the Select button label to `Selected` + `aria-pressed`.
+
+### Breadcrumb reset contract
+
+The primitive owns breadcrumb state. If a consumer's identity context changes mid-mount — e.g., a wizard's `connectionId` switches from A to B — the existing breadcrumb would still hold A-connection category IDs, and the next query for B-connection nodes at one of those parent IDs would return empty. **Consumers must force a remount via React `key` when the identity context changes.**
+
+```tsx
+// Correct — primitive remounts whenever connectionId changes, discarding stale breadcrumb
+<CategoryTreeBrowser key={connectionId} ... />
+```
+
+Documented on the component's JSDoc block and exercised in the primitive's tests. Today's two consumers both live inside modals that unmount+remount per open, so they don't need the `key` trick in practice — but the contract is explicit so a future third consumer doesn't silently trip on it.
+
+### What the primitive does **not** do
+
+- Does **not** manage pre-fill fallback (wrapper-specific).
+- Does **not** manage staged pick / "Save mapping" UX (wrapper-specific).
+- Does **not** call a query hook (controlled component).
+- Does **not** build path strings (wrapper does it from the `breadcrumb` callback arg).
+
+---
+
+## 4. Implementation steps
+
+**File headers** on every new `.tsx`/`.ts` file per `engineering-standards.md` §File Headers.
+
+### Step 1 — Build `CategoryTreeBrowser`
+**New file**: `apps/web/src/shared/ui/category-tree-browser.tsx`
+
+- Implements the API in §3 — wrapped in `forwardRef<HTMLDivElement, CategoryTreeBrowserProps>` per `ui-components.md` §Component Structure.
+- Merges incoming `className` with internal classes (never overrides) per shared-UI convention.
+- Internal `breadcrumb` state via `useState`.
+- Class structure: `.category-tree-browser`, `__breadcrumb`, `__crumb`, `__crumb-group`, `__separator`, `__list`, `__item`, `__item--leaf`, `__item--non-leaf`, `__item--selected`, `__name`.
+- Modifiers: `--density-compact` (wraps `overflow-x: auto` + tighter padding for the wizard's dialog-bounded usage), `--invalid`, `--disabled`.
+- JSDoc on the component block documents the §3 breadcrumb-reset contract (consumer uses `key={identityContext}` to force remount when switching connections).
+
+### Step 2 — Tests for the primitive
+**New file**: `apps/web/src/shared/ui/category-tree-browser.test.tsx`
+
+9 cases:
+1. Renders root nodes from `nodes` prop.
+2. Drilling a non-leaf fires `onNavigate(node.id, [...])` with the updated breadcrumb.
+3. Clicking a leaf's Select button fires `onSelect(node, breadcrumb)`.
+4. Clicking a crumb jumps back and fires `onNavigate` with the truncated breadcrumb.
+5. Loading / error (with Retry) / empty states render based on props.
+6. `canSelect={() => true}` makes **non-leaves** also show Select (any-level selection mode — exercises the mappings wrapper's use case).
+7. `disabled` propagates to all interactive controls; `invalid` + ARIA props forward to the root group.
+8. **forwardRef target** — `ref.current` points to the root `<div>` (standard shared-UI test per `ui-components.md` §Testing).
+9. **className merge** — custom `className` coexists with internal classes on the root (standard shared-UI test).
+
+### Step 3 — New CSS for the primitive
+**Edit**: `apps/web/src/index.css`
+
+Add a `.category-tree-browser__*` block under the existing shared-primitive section. Token-driven. Rules are the union of the two existing near-duplicate class sets:
+
+```css
+.category-tree-browser { ... }
+.category-tree-browser--invalid { border-color: var(--status-error-border); background: var(--status-error-soft); }
+.category-tree-browser--disabled { opacity: 0.6; pointer-events: none; }
+.category-tree-browser--density-compact .category-tree-browser__breadcrumb {
+  overflow-x: auto;
+  padding: 0.25rem 0;
+}
+.category-tree-browser__breadcrumb { ... }
+.category-tree-browser__crumb { ... }
+.category-tree-browser__crumb-group { ... }
+.category-tree-browser__separator { ... }
+.category-tree-browser__list-container { max-height: 20rem; overflow-y: auto; }
+.category-tree-browser__list { ... }
+.category-tree-browser__item { ... }
+.category-tree-browser__item--leaf, .__item--non-leaf { /* styling hooks */ }
+.category-tree-browser__item--selected { background: var(--accent-primary-soft); }
+.category-tree-browser__name { ... }
+```
+
+### Step 4 — Refactor `CategoryPicker` onto the primitive
+**Edit**: `apps/web/src/features/listings/components/CategoryPicker.tsx`
+
+- Keep the public prop surface identical (`connectionId`, `value`, `onChange`, `invalid`, `disabled`, `id`, `aria-*`).
+- Keep the `showBrowser` pre-fill state + `.category-picker__prefill` fallback row — wrapper-specific.
+- Manage a local `parentId` state (mirrored from the primitive's `onNavigate` callback) so the query hook can refetch.
+- Call `useAllegroCategoriesQuery(connectionId, parentId, showBrowser)`.
+- Render `<CategoryTreeBrowser key={connectionId} density="compact" canSelect={(n) => n.leaf} selectedId={value} onSelect={(node) => onChange(node.id)} onNavigate={(pid) => setParentId(pid)} ... />`.
+- The `key={connectionId}` honors the §3 breadcrumb-reset contract — if the wizard ever lets the operator switch connections mid-session, the primitive remounts cleanly.
+- Forward all a11y props through.
+- Wrapper JSX shrinks from ~200 → ~80 lines.
+
+### Step 5 — Refactor `AllegroCategorySearch` onto the primitive
+**Edit**: `apps/web/src/features/mappings/components/AllegroCategorySearch.tsx`
+
+- Keep the public prop surface identical (`marketplaceConnectionId`, `currentMapping`, `onSelect`, `onClear`, `isSaving`).
+- Keep `.allegro-category-search__current` + `.allegro-category-search__staged` + staged-pick UX — wrapper-specific.
+- Manage local `parentId` state; query hook uses it.
+- Wrap `<CategoryTreeBrowser key={marketplaceConnectionId} canSelect={() => true} onSelect={(node, breadcrumb) => setStaged({ category: node, path: buildPath(breadcrumb, node) })} disabled={isSaving} ... />`.
+- Build the path string from the `breadcrumb` callback arg: `[...breadcrumb.map((b) => b.name), node.name].join(' > ')`.
+- Wrapper JSX shrinks.
+
+### Step 6 — Purge duplicate CSS
+**Edit**: `apps/web/src/index.css`
+
+Remove the now-dead rules from both old class sets (keep only the wrapper-specific parts):
+
+**Delete** from `.allegro-category-search__*`:
+- `__breadcrumbs`, `__crumb`, `__separator`, `__list`, `__item`, `__item--staged`, `__name`, `__actions`
+- `__item:last-child` (primitive's `__item:last-child` covers it)
+
+**Keep** in `.allegro-category-search__*`:
+- `__current`, `__staged`, `__staged-label`, `__staged-actions`, `__path` (wrapper-owned surfaces)
+
+**Delete** from `.category-picker__*`:
+- `__breadcrumb`, `__crumb`, `__crumb-group`, `__separator`, `__list-container`, `__list`, `__item`, `__item--leaf`, `__item--non-leaf`, `__item--selected`, `__name`
+- Dead-hook comment for `--leaf`/`--non-leaf` (primitive owns those now)
+
+**Keep** in `.category-picker__*`:
+- `.category-picker` (root wrapper — now used only for the pre-fill variant)
+- `.category-picker--prefill`, `__prefill`, `__prefill-label`
+
+Expected line delta: `+~140` from the new primitive block, `−~80` from the purged duplicates → net `+~60` lines of CSS.
+
+### Step 7 — Update tests
+
+- **`category-tree-browser.test.tsx`** (new) — per Step 2.
+- **`CategoryPicker.test.tsx`** (edit) — 9 existing cases. All should still pass since the wrapper's public surface is unchanged. Likely tweaks:
+  - Selectors that match primitive-owned markup (`.category-picker__breadcrumb`) may need to switch to the new `.category-tree-browser__breadcrumb` — prefer role-based queries (`role="group"`, `aria-label="Category path"`) where possible.
+  - The "forwards aria-labelledby…" test currently inspects `.category-picker` root; after refactor the primitive's root inherits those props, so the test queries the primitive's root instead. Same assertion, different DOM target.
+- **`CreateOfferWizard.test.tsx`** — no change expected; all tests use role/name-based queries.
+- **`AllegroCategorySearch`** has no existing tests. **Add a 5-case smoke test suite *before* the refactor** so the assertions encode the current behavior — the test then catches regressions from the primitive swap. Cases:
+  1. Renders the root list from the mocked query.
+  2. Drilling a non-leaf updates the breadcrumb and loads the drilled level.
+  3. Clicking Select on a leaf stages the pick and shows the `__staged` row with the built path (e.g., "Electronics > Phones").
+  4. Clicking Save fires `onSelect(category, "Electronics > Phones")` with the correct path string built from the breadcrumb.
+  5. Clicking Cancel dismisses the staged pick without firing `onSelect`.
+
+### Step 8 — Quality gate
+`pnpm lint && pnpm type-check && pnpm test` from the worktree root.
+
+---
+
+## 5. File inventory
+
+### New files (3)
+- `apps/web/src/shared/ui/category-tree-browser.tsx`
+- `apps/web/src/shared/ui/category-tree-browser.test.tsx`
+- `apps/web/src/features/mappings/components/AllegroCategorySearch.test.tsx` *(new smoke test)*
+
+### Edited files (4)
+- `apps/web/src/features/listings/components/CategoryPicker.tsx` *(refactored)*
+- `apps/web/src/features/listings/components/CategoryPicker.test.tsx` *(selector updates if any)*
+- `apps/web/src/features/mappings/components/AllegroCategorySearch.tsx` *(refactored)*
+- `apps/web/src/index.css` *(new primitive block + dead-rule purge)*
+
+---
+
+## 6. Risks & open questions
+
+| Risk | Mitigation |
+|---|---|
+| Refactoring `AllegroCategorySearch` without existing tests is risky. | Add a smoke test covering the drill → stage → save round-trip before refactoring, so we have a regression guard. |
+| Primitive API over-fits to today's two consumers. | Keep it minimal — no features that aren't used by either wrapper. `canSelect` + label overrides cover both shapes. If a third consumer surfaces with different needs, iterate then. |
+| Breadcrumb state owned internally could make pre-fill rehydration harder later (for #307's retry flow). | When #307 needs it, add an `initialBreadcrumb?` prop. Out of scope here. |
+| CSS rule shuffling causes visual regressions. | Run both consuming pages (`/listings`, `/connections/:id/mappings`) in the dev server after the refactor. Token-only CSS so no hex drift. |
+| `AllegroCategory` type lives in `features/mappings` — new primitive can't import it. | Primitive defines its own `CategoryTreeNode` interface (structural match). Consumers pass their arrays through; TS narrowing handles compatibility. Documented in step 1. |
+
+---
+
+## 7. Global rules
+
+- File headers on every new `.tsx`/`.ts` file.
+- No `any`. No `console.log`.
+- Token-driven CSS only.
+- Primitive wrapped in `forwardRef<HTMLDivElement, ...>` per `ui-components.md` §Component Structure ("All shared UI components use `forwardRef`"). Uses the named-function-inside-forwardRef convention for DevTools clarity.
+- Primitive merges incoming `className` with internal classes (never overrides) — standard `shared/ui/` convention.
+- Primitive uses `density` (not `tone`) for the default/compact variant. `tone` stays reserved for color/status axes per `ui-components.md` §Prop Naming.
+
+---
+
+## 8. Acceptance checklist
+
+- [ ] `CategoryTreeBrowser` primitive in `shared/ui/` — no imports from `features/` or `pages/`
+- [ ] Primitive is wrapped in `forwardRef` with named inner function
+- [ ] `density` prop (not `tone`) for default/compact variant
+- [ ] Breadcrumb-reset contract documented in JSDoc; both consumers pass `key={connectionId}`
+- [ ] Both `CategoryPicker` and `AllegroCategorySearch` refactored to compose it
+- [ ] No public-surface changes to either wrapper
+- [ ] 9 new primitive tests pass (includes ref-forwarding + className-merge)
+- [ ] Existing `CategoryPicker.test.tsx` (9 cases) still pass
+- [ ] New `AllegroCategorySearch.test.tsx` 5-case smoke suite written **before** the refactor; passes after
+- [ ] `pnpm lint` — 0 errors
+- [ ] `pnpm type-check` — 0 errors
+- [ ] `pnpm test` — all green
+- [ ] CSS block: new `.category-tree-browser__*` rules added; duplicates purged from both wrapper blocks; net diff ~+60 lines
+- [ ] **Visual verification**: before/after screenshots of `/connections/:id/mappings` at desktop (1440×900) per `frontend-ui-style-guide.md` §Responsive
+- [ ] **Visual verification**: before/after screenshots of the create-offer wizard Step 2 at desktop (1440×900)
+- [ ] PR body: `Part of #304` (not `Closes`) — `VariantPicker` still awaiting a second consumer


### PR DESCRIPTION
## Summary
- Extract the browseable category tree UI (breadcrumb navigation, per-row Browse/Select, loading/error/empty states) into a domain-agnostic `CategoryTreeBrowser` primitive in `shared/ui/`.
- Refactor both existing consumers onto the primitive: `CategoryPicker` (listings, leaf-only) and `AllegroCategorySearch` (mappings, any-level with staged-pick confirmation).
- Export a `buildCategoryPath(breadcrumb, node, separator?)` helper from the primitive so consumers don't drift on separator or ordering when composing the display path.

Part of #304 — `VariantPicker` extraction still pending a second consumer.

## Design notes
- **Primitive owns the breadcrumb** (transient nav state). Consumers own query state and pass `nodes` + `isLoading` + `error`. Every breadcrumb change fires `onNavigate(parentId, breadcrumb)` so the caller can refetch at the new level.
- **Breadcrumb-reset contract** is a documented React `key={identityContext}` idiom — no `resetKey` prop on the API. Today's two consumers live inside modals that unmount+remount per open, so the contract is defensive wiring for a future third consumer.
- **`canSelect` predicate** cleanly expresses the single behavioral axis that differed between consumers — leaf-only (default) vs any-level — with no mode flag.
- **No cross-boundary imports**: primitive defines a local `CategoryTreeNode` interface (structurally compatible with `AllegroCategory`) so `shared/ui/` stays free of `features/` imports.
- **A11y**: `role="group"` root with forwarded `aria-labelledby` / `aria-describedby` / `aria-invalid`. `aria-label="Browse into {name}"` on browse buttons and `aria-pressed` on Select buttons are legitimate a11y wins surfaced by the extraction.

## Tests
- New: 9 primitive tests + 3 `buildCategoryPath` helper tests.
- New: 5-case regression smoke suite for `AllegroCategorySearch` (previously untested) — written *before* the refactor as a guard, green after.
- Updated: 1 selector in `CategoryPicker.test.tsx` to match the primitive's root class.
- Net: 456 → 462 web tests, all passing. 0 lint errors, 0 type errors.

## Test plan
- [ ] Manual: Allegro category mapping flow (drill → stage pick → Save + Cancel) works as before
- [ ] Manual: Create-offer wizard category picker (drill → leaf select → onChange fires) works as before
- [ ] Manual: Pre-fill fallback in `CategoryPicker` (non-null value) still shows raw id + Change affordance
- [ ] Manual: Keyboard focus flows correctly across Root / crumbs / Browse / Select buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)