### PR TITLE
fix(web): FE polish bundle — diagnostics eyebrow, state-card CTA width, DataTable tooltips

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -858,6 +858,10 @@ textarea {
   justify-items: end;
 }
 
+.state-card__actions {
+  justify-items: start;
+}
+
 .page-summary {
   align-items: center;
 }

--- a/apps/web/src/pages/connections/connections-list-page.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.tsx
@@ -50,7 +50,11 @@ const COLUMNS: DataTableColumn<Connection>[] = [
   {
     id: 'identifier',
     header: 'Identifier',
-    cell: (connection) => <span className="mono-text">{connection.id}</span>,
+    cell: (connection) => (
+      <span className="mono-text" title={connection.id}>
+        {connection.id}
+      </span>
+    ),
     hideBelow: 1024,
   },
   {

--- a/apps/web/src/pages/cursors/cursors-list-page.tsx
+++ b/apps/web/src/pages/cursors/cursors-list-page.tsx
@@ -100,7 +100,7 @@ export function CursorsListPage(): ReactElement {
 
   return (
     <PageLayout
-      eyebrow="Operations"
+      eyebrow="Diagnostics"
       title="Cursors"
       description="Sync cursor state per connection — track incremental sync positions."
     >

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
@@ -57,6 +57,16 @@ describe('SyncJobsPage', () => {
     expect(screen.getAllByText('marketplace.orders.poll').length).toBeGreaterThan(1);
   });
 
+  it('renders the Diagnostics eyebrow so the header matches the sidebar group and breadcrumb', async () => {
+    const mockApi = createMockApiClient({
+      syncJobs: { list: vi.fn().mockResolvedValue(sampleJobs) },
+    });
+
+    renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Diagnostics')).toBeInTheDocument();
+  });
+
   it('should show error state when fetch fails', async () => {
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockRejectedValue(new Error('Service unavailable')) },

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
@@ -30,14 +30,22 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
   {
     id: 'jobType',
     header: 'Job type',
-    cell: (job) => <span className="mono-text">{job.jobType}</span>,
+    cell: (job) => (
+      <span className="mono-text" title={job.jobType}>
+        {job.jobType}
+      </span>
+    ),
     accessor: (job) => job.jobType,
     sortable: true,
   },
   {
     id: 'connectionId',
     header: 'Connection',
-    cell: (job) => <span className="mono-text">{job.connectionId}</span>,
+    cell: (job) => (
+      <span className="mono-text" title={job.connectionId}>
+        {job.connectionId}
+      </span>
+    ),
     hideBelow: 1024,
   },
   {
@@ -128,7 +136,7 @@ export function SyncJobsPage(): ReactElement {
 
   return (
     <PageLayout
-      eyebrow="Operations"
+      eyebrow="Diagnostics"
       title="Sync Jobs"
       description="Background processing visibility — filter by status, job type, or connection."
     >

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { WebhookDeliveriesPage } from './webhook-deliveries-page';
 import type { WebhookDeliverySummary } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
@@ -26,6 +26,8 @@ const sampleDelivery: WebhookDeliverySummary = {
 };
 
 describe('WebhookDeliveriesPage', () => {
+  afterEach(cleanup);
+
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       webhookDeliveries: {
@@ -49,6 +51,18 @@ describe('WebhookDeliveriesPage', () => {
 
     expect(await screen.findByText('prestashop')).toBeInTheDocument();
     expect(await screen.findByText('order.created')).toBeInTheDocument();
+  });
+
+  it('renders the Diagnostics eyebrow so the header matches the sidebar group and breadcrumb', async () => {
+    const mockApi = createMockApiClient({
+      webhookDeliveries: {
+        list: vi.fn().mockResolvedValue({ items: [sampleDelivery], total: 1 }),
+      },
+    });
+
+    renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Diagnostics')).toBeInTheDocument();
   });
 
   it('should show empty state when no deliveries', async () => {

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
@@ -45,20 +45,32 @@ const COLUMNS: DataTableColumn<WebhookDeliverySummary>[] = [
   {
     id: 'provider',
     header: 'Provider',
-    cell: (d) => <span className="mono-text">{d.provider}</span>,
+    cell: (d) => (
+      <span className="mono-text" title={d.provider}>
+        {d.provider}
+      </span>
+    ),
     accessor: (d) => d.provider,
     sortable: true,
   },
   {
     id: 'eventType',
     header: 'Event type',
-    cell: (d) => <span className="mono-text">{d.eventType ?? '—'}</span>,
+    cell: (d) => (
+      <span className="mono-text" title={d.eventType ?? undefined}>
+        {d.eventType ?? '—'}
+      </span>
+    ),
     hideBelow: 768,
   },
   {
     id: 'connectionId',
     header: 'Connection',
-    cell: (d) => <span className="mono-text">{d.connectionId}</span>,
+    cell: (d) => (
+      <span className="mono-text" title={d.connectionId}>
+        {d.connectionId}
+      </span>
+    ),
     hideBelow: 1024,
   },
   {
@@ -121,7 +133,7 @@ export function WebhookDeliveriesPage(): ReactElement {
 
   return (
     <PageLayout
-      eyebrow="Operations"
+      eyebrow="Diagnostics"
       title="Webhook Deliveries"
       description="Inbound webhook visibility — signature, dedup, publish, and downstream job linkage."
     >

--- a/docs/plans/implementation-plan-317-319-320-fe-polish-bundle.md
+++ b/docs/plans/implementation-plan-317-319-320-fe-polish-bundle.md
@@ -1,0 +1,95 @@
+# Implementation Plan — FE Polish Bundle (#317 + #319 + #320)
+
+## 1. Goal
+
+Bundle three small, independent frontend bugs into a single PR:
+
+- **#317** — Diagnostics pages show `eyebrow="Operations"` while the sidebar group and breadcrumb read `Diagnostics`. Fix the eyebrow to match.
+- **#319** — `EmptyState` / `ErrorState` CTAs stretch to full card width on desktop because `.state-card__actions` is a grid without `justify-items`. Fix the CSS.
+- **#320** — DataTable `mono-text` cells truncate at 20ch with no tooltip or accessible full value on identifier columns. Add `title={value}` to the affected spans.
+
+**Layer:** Interface (pages) + Shared UI (CSS tokens). Frontend only.
+
+**Non-goals:**
+- Not introducing a new `IdentifierCell` with clipboard-copy (explicitly deferred in #320).
+- Not migrating the connection-identifier columns to `EntityLabel`. `EntityLabel` is the canonical primitive for "internal UUID rendered next to a human name" per `frontend-ui-style-guide.md` §MVP Primitives, and is the right long-term home for these cells — but issue #320 explicitly scopes that follow-up out. The `title={value}` patch here is the MVP fix, not the final shape. The next polish pass should migrate the connection-id columns to `EntityLabel` rather than propagating more `title=` onto new columns.
+- Not migrating `.state-card__actions` to flex (explicitly rejected in #319).
+- Not touching the Operations pages for #317 (the Operations labeling there is correct).
+- Not touching the lastError / rejectionReason columns for #320 (they already use `title=`).
+
+## 2. Research notes
+
+- `apps/web/src/shared/ui/app-shell.tsx:48-88` defines the sidebar groups: **Operations** and **Diagnostics**. Breadcrumb mapping at lines 98-100 correctly lists `/jobs-logs`, `/webhook-deliveries`, `/cursors` under `Diagnostics`.
+- `apps/web/src/shared/ui/feedback-state.tsx:49,62` are the only two call sites that render `.state-card__actions` — one inside `EmptyState`, one inside `ErrorState`. A single CSS fix covers both.
+- `apps/web/src/index.css:848-855` groups `.state-card__actions` in a shared declaration with other grid containers; `.page-header__actions` already has an explicit `justify-items: end` override at line 857-859. The fix mirrors that pattern.
+- `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx:57` and `webhook-deliveries-page.tsx:71` already show the intended pattern for `.mono-text` + `title={value}`. The bug columns are missing it.
+- No existing tests assert on the eyebrow string or on `title` attributes for these cells — so no test rewrites required.
+
+## 3. Changes
+
+### #317 — Diagnostics eyebrow
+
+Three one-line edits:
+
+| File | Line | Change |
+|---|---|---|
+| `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx` | 131 | `eyebrow="Operations"` → `eyebrow="Diagnostics"` |
+| `apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx` | 124 | `eyebrow="Operations"` → `eyebrow="Diagnostics"` |
+| `apps/web/src/pages/cursors/cursors-list-page.tsx` | 103 | `eyebrow="Operations"` → `eyebrow="Diagnostics"` |
+
+### #319 — state-card actions width
+
+In `apps/web/src/index.css`, add a new rule block right after `.page-header__actions { justify-items: end; }` (line 857-859):
+
+```css
+.state-card__actions {
+  justify-items: start;
+}
+```
+
+Rationale: mirrors the `.page-header__actions` pattern in the same file; no change to the shared declaration at 848-855; opts state-card CTAs into natural-width behavior while leaving all other grid containers untouched. Start-aligned (not end) because CTAs in empty/error states are conceptually part of the content, not an action bar.
+
+### #320 — DataTable mono-text tooltips
+
+Add `title={value}` on the following `<span className="mono-text">` elements:
+
+| File | Line | Span value |
+|---|---|---|
+| `apps/web/src/pages/connections/connections-list-page.tsx` | 53 | `connection.id` |
+| `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx` | 33 | `job.jobType` |
+| `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx` | 40 | `job.connectionId` |
+| `apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx` | 48 | `d.provider` |
+| `apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx` | 55 | `d.eventType ?? '—'` → keep span, set `title={d.eventType ?? undefined}` (avoid tooltip of `—`) |
+| `apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx` | 61 | `d.connectionId` |
+
+For the nullable `eventType` row, use `title={d.eventType ?? undefined}` so the em-dash fallback doesn't become a tooltip (screen readers and hover both degrade cleanly to no-title).
+
+Skipped:
+- `sync-jobs-page.tsx:57` and `webhook-deliveries-page.tsx:71` — already have `title=`.
+
+**Scope decision — include short-value columns:** `jobType` and `provider` carry short values today, and #320 itself flags them as "less painful". They are still included in this patch because uniform behavior ("every mono-text identifier in a DataTable carries its full value") is easier to reason about than a column-by-column threshold, and future long-tailed values (e.g., a new job type introduced by an integration) get the tooltip for free.
+
+## 4. Tests
+
+- **Eyebrow regression guards (#317):** add one `expect(await screen.findByText('Diagnostics')).toBeInTheDocument()` assertion in `sync-jobs-page.test.tsx` and `webhook-deliveries-page.test.tsx`. Near-zero cost, prevents the exact bug from creeping back if a future copy-pass sweeps "Operations" labels back across diagnostics pages. No matching test file exists for the Cursors page, so skip it there.
+- **No tests for `title=` or CSS (#319, #320):** attribute-only changes and a single CSS rule aren't behaviors the existing test suite asserts on; adding DOM-attribute assertions for every cell would be noise. The test harness renders components without CSS anyway, so `.state-card__actions` width can't be asserted meaningfully in Vitest.
+- Existing `sync-jobs-page.test.tsx`, `webhook-deliveries-page.test.tsx`, `connections-list-page.test.tsx` must still pass.
+- Manual verification (done in review, not wired into CI):
+  - All three diagnostics pages show `DIAGNOSTICS` eyebrow matching the sidebar group and breadcrumb.
+  - Orders / Connections empty states render a natural-width CTA on ≥1440px viewports.
+  - **Also check EmptyState/ErrorState CTAs at 360 × 812 (mobile) and 768 × 1024 (tablet)** — `justify-items: start` is applied at all breakpoints, so confirm tap targets remain comfortable on mobile. `.button--sm` is 28px on desktop and 36px on touch per the style guide, so this should already be handled at the button layer; the check is just to confirm no adverse interaction with the new grid rule.
+  - Hovering any truncated identifier in Connections / Sync Jobs / Webhook Deliveries tables reveals the full value.
+
+## 5. Validation
+
+- **Hexagonal boundaries:** all changes are in `apps/web/src/pages/` and `apps/web/src/index.css` — Interface + shared CSS only. No CORE or domain touches.
+- **Dependency rules:** no new imports, no cross-layer violations.
+- **A11y:** `title` is acceptable per issue #320 ("`title` already satisfies hover + screen-reader disclosure"). Eyebrow string change restores taxonomy consistency for assistive tech.
+- **Security:** none (no data flow changes).
+- **Quality gate:** `pnpm lint && pnpm type-check && pnpm test` must pass.
+
+## 6. Risks / open questions
+
+- Eyebrow assumption (#317): docs explicitly call out that `Diagnostics` is the correct taxonomy per sidebar + breadcrumb, so no product decision needed.
+- `justify-items: start` vs `end` (#319): issue lists start as the preferred default; easy to flip later if product disagrees.
+- Nothing requires a migration, backend change, or follow-up issue.


### PR DESCRIPTION
Bundles three small, independent frontend bugs that all touch shared UI primitives and page-level composition.

## Summary

- **#317** — Diagnostics pages (Sync Jobs, Webhook Deliveries, Cursors) now render `eyebrow="Diagnostics"` so the page-header eyebrow matches the sidebar group label and breadcrumb instead of the stale `"Operations"` copy.
- **#319** — `.state-card__actions` now sets `justify-items: start`, matching the sibling `.page-header__actions` pattern in the same CSS block. Fixes `EmptyState` / `ErrorState` CTAs stretching to full card width on desktop across every list page that uses the feedback primitives.
- **#320** — `.mono-text` cells in the Connections, Sync Jobs, and Webhook Deliveries tables now carry `title={value}` so truncated identifiers disclose the full value on hover and to assistive tech. Nullable `eventType` uses `title={d.eventType ?? undefined}` so the em-dash fallback doesn't surface as a tooltip.

## Scope callout — extra change worth flagging

`apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx` gains `afterEach(cleanup)` alongside its new eyebrow regression assertion. Without it, the new test hits a latent DOM-pollution bug where prior tests' headers stay mounted and `findByText('Diagnostics')` matches multiple elements and times out. This wasn't in the plan — it was an unblocker for the new test.

A grep-sweep against `apps/web/src/pages/**/*.test.tsx` found 8 sibling files with the same gap; they pass today because none of their assertions currently target strings that repeat across tests. Tracked separately as **#331** — intentionally kept out of this polish bundle.

## Implementation plan

`docs/plans/implementation-plan-317-319-320-fe-polish-bundle.md` — includes the scope decision re including the short-value `jobType` / `provider` columns, the nullable-`eventType` edge case, the EntityLabel note as the proper long-term home for connection-id columns, and the verification widths.

## Test plan

Quality gate run locally before push:

- [x] `pnpm lint` — 0 errors (pre-existing warnings untouched)
- [x] `pnpm type-check` — clean across all workspaces
- [x] `pnpm test` — 1,440 tests passing (480 web + 338 core + 251 api + 181 prestashop + 104 worker + 79 allegro + 7 shared)
- [x] 2 new Vitest regression guards (one per diagnostics page test file) assert the `Diagnostics` eyebrow renders, so #317 can't silently regress via a future copy sweep.

Manual visual verification (not wired into CI):

- [ ] `/sync-jobs`, `/webhook-deliveries`, `/cursors` — page-header eyebrow reads `DIAGNOSTICS`, matching the sidebar group and breadcrumb.
- [ ] Connections list empty state (and any `ErrorState` with a Retry button) — CTA renders at natural button width on desktop (≥ 1440 px), not stretched to the full card.
- [ ] Hovering any truncated identifier in the Connections / Sync Jobs / Webhook Deliveries tables reveals the full value via native tooltip.
- [ ] Cross-check at 360 × 812 (mobile) and 768 × 1024 (tablet) per `docs/frontend-ui-style-guide.md` §Responsive — `justify-items: start` applies at all breakpoints; tap targets remain comfortable because `.button--sm` already enforces a 36 px touch floor at the button layer.

Screenshots deliberately not attached — the behavior is fully described in the three issues with pixel-level reproduction steps, and the diff is small enough to eyeball without a visual reference. Happy to capture a before/after pair if it would help review.

Closes #317
Closes #319
Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)