### PR TITLE
feat(allegro): proactive access-token refresh using credentials expiresAt

### DIFF
--- a/docs/plans/implementation-plan-336-allegro-proactive-token-refresh.md
+++ b/docs/plans/implementation-plan-336-allegro-proactive-token-refresh.md
@@ -1,0 +1,280 @@
+# Implementation Plan — #336 Proactive Allegro access-token refresh
+
+**Issue:** [#336](https://github.com/SilkSoftwareHouse/openlinker/issues/336) — Proactive Allegro access-token refresh using `expiresAt` (avoid first-request 401)
+**Layer:** Integration (`libs/integrations/allegro`)
+**Branch:** `336-allegro-proactive-token-refresh`
+
+---
+
+## 1. Goal
+
+Make `AllegroHttpClient` refresh the access token *before* it hits an Allegro API request, using the `expiresAt` already persisted on `AllegroCredentials`. Today the client only refreshes reactively on a 401 — every first request after idle eats an extra round-trip. Keep the reactive 401 path as a safety net.
+
+### In scope
+- Thread `expiresAt` into `AllegroHttpClient` (already on `AllegroCredentials`).
+- Proactively refresh when `Date.now() >= expiresAt - 60_000`.
+- Serialize concurrent refresh attempts inside one client instance (single-flight).
+- Update the cached `expiresAt` after a successful refresh so the next request sees fresh expiry.
+- Unit test coverage for: near-expiry refreshes, valid token doesn't refresh, concurrent single-flight, reactive fallback preserved, missing-expiry = no-op.
+
+### Non-goals
+- Distributed single-flight across processes — already handled by `AllegroTokenRefreshService`'s Redis lock. Per-instance single-flight here is an additional guard against thundering herd inside a single Node process.
+- Changing the token refresh mechanism itself (`AllegroTokenRefreshService`).
+- Background refresh worker. Pre-request check is enough for the target workloads.
+- Changing credential storage shape.
+
+---
+
+## 2. Current behaviour (from the issue)
+
+- `AllegroHttpClient` constructor (`libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts:67-81`) reads `credentials.accessToken` only; `credentials.expiresAt` is ignored.
+- `handleError` (lines 332-382) is the sole refresh path — runs only on 401 with "token"-ish body text.
+- `AllegroCredentials.expiresAt` (`domain/types/allegro-credentials.types.ts:32`) is `Date | string | undefined`. Populated by `allegro-oauth.service.ts` and `allegro-token-refresh.service.ts`.
+- Factory (`application/allegro-adapter.factory.ts:55-73`) builds `tokenRefreshCallback: (connectionId) => Promise<string>` from `AllegroTokenRefreshService.refreshToken()` — the service actually returns `TokenRefreshResponse { accessToken, refreshToken?, expiresAt? }`, but the callback currently throws away everything except `accessToken`.
+
+Callsites of `new AllegroHttpClient(...)`:
+1. `application/allegro-adapter.factory.ts:67` — production path (sync/runtime), passes the refresh callback.
+2. `infrastructure/adapters/allegro-connection-tester.adapter.ts:45` — short-lived, one-shot probe against `/me`. No refresh callback. Must stay unchanged behaviorally.
+
+---
+
+## 3. Design
+
+### 3.1 Cached expiry
+
+Store `expiresAt` inside `AllegroHttpClient` as a normalized epoch-ms number:
+
+```ts
+private tokenExpiresAt: number | undefined;
+```
+
+Normalize in the constructor:
+
+```ts
+this.tokenExpiresAt = this.normalizeExpiresAt(credentials.expiresAt);
+```
+
+- `Date` → `.getTime()` (check `Number.isFinite` in case of an Invalid Date)
+- `string` → `Date.parse(v)`, then `Number.isFinite(n)` — if not finite, return `undefined`
+- `undefined` → `undefined` (proactive refresh becomes a no-op — preserves backward compat for connections without `expiresAt`)
+
+**Invalid-value handling:** `Date.parse('garbage')` returns `NaN`. An un-guarded `tokenExpiresAt = NaN` would make every `Date.now() >= NaN - 60_000` comparison evaluate to `false`, silently disabling proactive refresh. Worse, if we ever flipped the comparison, `NaN` could make it always true. So: **always reduce NaN / Invalid Date to `undefined`** and let the backward-compat no-op handle it. Test coverage includes a garbage-string case.
+
+### 3.2 Single-flight refresh promise
+
+```ts
+private refreshInFlight: Promise<void> | null = null;
+```
+
+One in-flight refresh at a time per client instance. Callers await the same promise; they don't start new ones.
+
+**Scope note:** this is **per-instance** single-flight. Cross-process / cross-instance protection is already provided by `AllegroTokenRefreshService`'s Redis `SET NX EX` lock (`allegro-token-refresh.service.ts:252-272`). Per-instance single-flight only matters if one `AllegroHttpClient` lives long enough to see truly-parallel requests (e.g., a sync worker running `Promise.all([...])` over a list of offer updates). Verify during Phase 4 whether `IntegrationsService` / `AdapterRegistryService` caches adapters per-connection or constructs a new one per operation:
+
+- **If cached per-connection**: per-instance single-flight is a real latency win on bursty workloads.
+- **If one-adapter-per-operation**: the guard is still cheap & correct but does little beyond what the Redis lock already does. In that case the PR description should frame it as "defense-in-depth" rather than "no thundering herd".
+
+Either way the implementation is unchanged — only the PR narrative adjusts to what's true.
+
+### 3.2.1 Negative cache on proactive-refresh failure
+
+When `performProactiveRefresh` throws, `refreshInFlight` clears in `.finally()`. If the token is already past `expiresAt - 60s` and the refresh endpoint is consistently failing, every subsequent request re-attempts the proactive refresh before falling through to the reactive 401 path. Not a correctness problem — the reactive path is still the ceiling — but it creates N-times the call volume on the refresh endpoint during an outage.
+
+Add a small negative cache:
+```ts
+private proactiveRefreshCooldownUntil: number | undefined;
+private static readonly PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS = 5_000;
+```
+
+On failure, set `proactiveRefreshCooldownUntil = Date.now() + PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS`. In `ensureFreshToken`, short-circuit if `Date.now() < proactiveRefreshCooldownUntil`. This caps proactive attempts at one every 5 seconds during an endpoint outage while keeping the reactive 401 path fully functional.
+
+### 3.3 Widen the refresh callback return type
+
+Today:
+```ts
+tokenRefreshCallback?: (connectionId: string) => Promise<string>;
+```
+
+New: introduce a dedicated types file `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.types.ts` (per Engineering Standards "Type Definitions in Separate Files" — types don't belong in the implementation file):
+
+```ts
+// allegro-http-client.types.ts
+export interface TokenRefreshResult {
+  accessToken: string;
+  expiresAt?: Date | string;
+}
+
+export type TokenRefreshCallback = (connectionId: string) => Promise<TokenRefreshResult>;
+```
+
+Then in the HTTP client:
+```ts
+import { TokenRefreshCallback } from './allegro-http-client.types';
+
+tokenRefreshCallback?: TokenRefreshCallback;
+```
+
+**Why:** proactive refresh must also update `tokenExpiresAt`, otherwise the client keeps thinking the (now-refreshed) token is expiring and re-refreshes every request. The factory already has this data — `AllegroTokenRefreshService.refreshToken()` returns `TokenRefreshResponse` which includes `expiresAt`. We just stop discarding it.
+
+**Type placement note:** `AllegroHttpRequestOptions` / `AllegroHttpResponse` currently sit inside `allegro-http-client.interface.ts` — pre-existing deviation from the `.types.ts` rule. Out of scope for this issue; we don't reshuffle unrelated code. The new types go in `allegro-http-client.types.ts` and we stop adding to the interface file.
+
+### 3.4 Pre-request `ensureFreshToken()`
+
+Called at the top of `executeRequest` *before* the `Authorization` header is built:
+
+```ts
+private async ensureFreshToken(traceId: string): Promise<void> {
+  if (!this.tokenRefreshCallback || this.tokenExpiresAt === undefined) {
+    return; // no callback or no expiry → nothing to do (reactive path still applies)
+  }
+  if (
+    this.proactiveRefreshCooldownUntil !== undefined &&
+    Date.now() < this.proactiveRefreshCooldownUntil
+  ) {
+    return; // recent proactive refresh failed; wait out the cooldown and let reactive 401 handle it
+  }
+  const refreshAt = this.tokenExpiresAt - TOKEN_REFRESH_WINDOW_MS;
+  if (Date.now() < refreshAt) {
+    return; // well within validity
+  }
+  if (this.refreshInFlight) {
+    await this.refreshInFlight; // piggyback on in-flight refresh
+    return;
+  }
+  this.refreshInFlight = this.performProactiveRefresh(traceId)
+    .finally(() => { this.refreshInFlight = null; });
+  await this.refreshInFlight;
+}
+
+private async performProactiveRefresh(traceId: string): Promise<void> {
+  try {
+    this.logger.debug(
+      `[${traceId}] Proactive token refresh (connection: ${this.connectionId})`,
+    );
+    const { accessToken, expiresAt } = await this.tokenRefreshCallback!(this.connectionId);
+    this.accessToken = accessToken;
+    this.tokenExpiresAt = this.normalizeExpiresAt(expiresAt);
+    this.proactiveRefreshCooldownUntil = undefined; // success clears any cooldown
+  } catch (error) {
+    // Swallow: reactive 401 path is the fallback (per AC).
+    this.proactiveRefreshCooldownUntil =
+      Date.now() + AllegroHttpClient.PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS;
+    this.logger.warn(
+      `[${traceId}] Proactive token refresh failed, will fall back to reactive 401 path: ${(error as Error).message}`,
+    );
+  }
+}
+```
+
+**Constant:** `const TOKEN_REFRESH_WINDOW_MS = 60_000;` top-of-file alongside other constants.
+
+**Trace-id caveat:** under single-flight, concurrent requests B and C await the refresh started by A and so the refresh log line carries A's traceId. Downstream logs for B/C still carry their own traceIds. Correlation stays sensible because B and C log their own request lines separately; the shared refresh just shows up under A's trace. Matches the reactive-path semantics. Not worth minting a dedicated refresh traceId.
+
+### 3.5 Reactive 401 path update
+
+In `handleError`, when a reactive refresh succeeds, also update `tokenExpiresAt` using the same widened callback. This keeps the two paths consistent — after *any* refresh, the cached expiry reflects the new token.
+
+```ts
+const { accessToken, expiresAt } = await this.tokenRefreshCallback(this.connectionId);
+this.accessToken = accessToken;
+this.tokenExpiresAt = this.normalizeExpiresAt(expiresAt);
+```
+
+### 3.6 Factory callback widening
+
+`allegro-adapter.factory.ts` — simplify to just return the full response:
+
+```ts
+const tokenRefreshCallback = this.tokenRefreshService
+  ? async (_connectionId: string): Promise<TokenRefreshResult> => {
+      const res = await this.tokenRefreshService!.refreshToken(connection, credentialsResolver);
+      return { accessToken: res.accessToken, expiresAt: res.expiresAt };
+    }
+  : undefined;
+```
+
+Also pass the full `credentials` (already does — just making sure `expiresAt` flows).
+
+### 3.7 Connection tester adapter
+
+No change needed. It constructs the client without a refresh callback; `ensureFreshToken()` short-circuits in that case. Signature-wise, the new `credentials.expiresAt` is already accepted.
+
+---
+
+## 4. Step-by-step
+
+### File: `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.types.ts` (new)
+
+1. Export `interface TokenRefreshResult { accessToken: string; expiresAt?: Date | string }`.
+2. Export `type TokenRefreshCallback = (connectionId: string) => Promise<TokenRefreshResult>`.
+
+### File: `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts`
+
+3. Import `TokenRefreshCallback` from `./allegro-http-client.types`.
+4. Add `TOKEN_REFRESH_WINDOW_MS = 60_000` module-level constant.
+5. Add `static readonly PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS = 5_000` on the class.
+6. Change `tokenRefreshCallback` parameter & field type from `(connectionId: string) => Promise<string>` to `TokenRefreshCallback`.
+7. Add `private tokenExpiresAt: number | undefined`, initialize from `credentials.expiresAt` via new private `normalizeExpiresAt`.
+8. Add `private refreshInFlight: Promise<void> | null = null`.
+9. Add `private proactiveRefreshCooldownUntil: number | undefined`.
+10. Add `private async ensureFreshToken(traceId: string)` (logic in §3.4).
+11. Add `private async performProactiveRefresh(traceId: string)` (logic in §3.4).
+12. Add `private normalizeExpiresAt(v: Date | string | undefined): number | undefined` — guard NaN / Invalid Date to `undefined` (§3.1).
+13. Call `await this.ensureFreshToken(traceId)` at the top of `executeRequest` (just after `traceId` is created, before building headers).
+14. Update the reactive 401 branch in `handleError` to unpack `{ accessToken, expiresAt }` and update both `this.accessToken` and `this.tokenExpiresAt` (and clear `proactiveRefreshCooldownUntil` on success, for symmetry).
+
+**AC for this file:**
+- No behavior change when `credentials.expiresAt` is absent or when no `tokenRefreshCallback` is provided (backward compat).
+- Proactive refresh fires only once per expiry window even under concurrent `request()` calls.
+- Reactive 401 path still works.
+
+### File: `libs/integrations/allegro/src/application/allegro-adapter.factory.ts`
+
+15. Import `TokenRefreshResult` from `../infrastructure/http/allegro-http-client.types`.
+16. Update the `tokenRefreshCallback` definition to return the full result (accessToken + expiresAt).
+
+### File: `libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts`
+
+17. Add a new `describe('proactive token refresh')` block with the following tests:
+    - `does not trigger proactive refresh when no expiresAt is set (backward compat)`
+    - `does not trigger proactive refresh when no refresh callback is provided`
+    - `treats a garbage expiresAt string as no expiry (no-op, no refresh)` — covers the NaN guard from §3.1
+    - `does not trigger refresh when token is well within validity`
+    - `triggers proactive refresh when token is within 60s of expiry`
+    - `uses refreshed accessToken on subsequent requests`
+    - `updates cached expiresAt from refresh result so it does not re-refresh immediately`
+    - `serializes concurrent refresh attempts (single-flight)` — 3 parallel `get()` calls with an expiring token and a slow refresh should result in exactly 1 refresh callback invocation and 3 fetches with the new token
+    - `falls through to reactive 401 path when proactive refresh throws`
+    - `honours proactive-refresh cooldown after a failure` — two quick requests after a failed proactive refresh trigger exactly 1 callback invocation (the second hits the cooldown short-circuit), and advancing time past `PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS` allows a new proactive attempt
+
+   Fake timers + `jest.setSystemTime()` to control `Date.now()`. Existing suite uses fake timers already.
+
+18. Update the existing reactive 401 tests (if any) to the new widened callback shape. A quick grep of the current file shows the reactive path is not unit tested today — only the 401 *rejection without callback* case is tested (`'should not retry on authentication errors'`). Good: the widened signature doesn't break anything that already exists. No edits needed in the existing tests.
+
+---
+
+## 5. Architecture & standards check
+
+- ✅ Integration boundary preserved — all changes in `libs/integrations/allegro`, CORE untouched.
+- ✅ `AllegroHttpClient` already has file header, matches naming (`*-http-client.ts`, not a port).
+- ✅ No `any`, no `console.log`, no hardcoded secrets.
+- ✅ Types: new `TokenRefreshResult` exported from the http client module (co-located with the callback signature it describes; small interface used only there).
+- ✅ Logging: reuse existing `Logger`, include `traceId` and `connectionId` in messages.
+- ✅ Tests use fake timers pattern already established in the spec (see file header comment, #287 history).
+
+## 6. Risks & open questions
+
+- **Callback signature widening is a micro-breaking change** for anyone constructing `AllegroHttpClient` with a custom refresh callback. Only one production callsite (the factory) and zero in tests — low blast radius.
+- **Proactive refresh error handling**: swallowing the error means the request continues with the old token and may 401, which then triggers the reactive path. This matches the AC ("Reactive 401 refresh path is preserved as a fallback"). I'm intentionally *not* re-throwing from `performProactiveRefresh` so a transient refresh-endpoint hiccup doesn't block requests that might still have a valid token (clock skew, etc.). The 5s negative cache (§3.2.1) caps re-attempts during a sustained refresh-endpoint outage.
+- **Clock skew**: the 60s window gives enough buffer for typical clock drift. Not worth making configurable for now.
+- **Adapter caching scope for single-flight** (verify in Phase 4): `IntegrationsService` / `AdapterRegistryService` caching determines whether per-instance single-flight is a real latency win or defense-in-depth. Either outcome leaves the implementation unchanged — only the PR description adjusts (see §3.2).
+
+## 7. Quality gate
+
+Before commit:
+```
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All three must be green. Integration tests not needed — no DB/Redis changes.

--- a/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
+++ b/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
@@ -15,6 +15,7 @@ import { AllegroConnectionConfig, AllegroEnvironmentValues } from '../domain/typ
 import { AllegroCredentials } from '../domain/types/allegro-credentials.types';
 import { AllegroConfigException } from '../domain/exceptions/allegro-config.exception';
 import { AllegroHttpClient } from '../infrastructure/http/allegro-http-client';
+import { TokenRefreshResult } from '../infrastructure/http/allegro-http-client.types';
 import { AllegroMarketplaceAdapter, QuantityPollConfig } from '../infrastructure/adapters/allegro-marketplace.adapter';
 import { AllegroTokenRefreshService } from '../infrastructure/token-refresh/allegro-token-refresh.service';
 import { Logger } from '@openlinker/shared/logging';
@@ -51,15 +52,20 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
     // Determine API base URL
     const apiBaseUrl = config.apiBaseUrl || this.getDefaultApiBaseUrl(config.environment);
 
-    // Create token refresh callback if token refresh service is available
+    // Create token refresh callback if token refresh service is available.
+    // We forward both accessToken and expiresAt so the HTTP client can update
+    // its cached expiry and avoid immediately re-triggering a proactive
+    // refresh on the next request.
     const tokenRefreshCallback = this.tokenRefreshService
-      ? async (_connectionId: string): Promise<string> => {
-          // Token refresh service uses the connection we have in scope
+      ? async (_connectionId: string): Promise<TokenRefreshResult> => {
           const refreshResponse = await this.tokenRefreshService!.refreshToken(
             connection,
             credentialsResolver,
           );
-          return refreshResponse.accessToken;
+          return {
+            accessToken: refreshResponse.accessToken,
+            expiresAt: refreshResponse.expiresAt,
+          };
         }
       : undefined;
 

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts
@@ -482,4 +482,243 @@ describe('AllegroHttpClient', () => {
       expect(global.fetch).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('proactive token refresh', () => {
+    const NOW = new Date('2026-04-22T10:00:00.000Z').getTime();
+    // Cooldown constant mirrors AllegroHttpClient.PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS.
+    const COOLDOWN_MS = 5_000;
+    let refreshCallback: jest.Mock;
+
+    beforeEach(() => {
+      jest.setSystemTime(NOW);
+      refreshCallback = jest.fn();
+    });
+
+    // Build a no-retry client with controllable credentials. Skipping retries
+    // keeps the bulk of the suite single-attempt — the reactive-fallback test
+    // below opts into the default retry config explicitly.
+    const buildClient = (opts: {
+      expiresAt?: Date | string;
+      callback?: (connectionId: string) => Promise<{ accessToken: string; expiresAt?: Date | string }>;
+      accessToken?: string;
+    } = {}): AllegroHttpClient => {
+      return new AllegroHttpClient(
+        connectionId,
+        baseUrl,
+        { accessToken: opts.accessToken ?? 'initial-token', expiresAt: opts.expiresAt },
+        config,
+        { maxRetries: 0, initialDelayMs: 0, maxDelayMs: 0, backoffMultiplier: 1 },
+        opts.callback,
+      );
+    };
+
+    const mockAlways200 = (): void => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve('{}'),
+      });
+    };
+
+    it('should not trigger proactive refresh when no expiresAt is set (backward compat)', async () => {
+      mockAlways200();
+      const client = buildClient({ callback: refreshCallback });
+
+      await client.get('/test');
+
+      expect(refreshCallback).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger proactive refresh when no refresh callback is provided', async () => {
+      mockAlways200();
+      const client = buildClient({ expiresAt: new Date(NOW - 1_000) });
+
+      await client.get('/test');
+
+      // Can't assert on a callback that doesn't exist — we assert the request
+      // still went through on the initial token.
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should treat a garbage expiresAt string as no expiry (no-op, no refresh)', async () => {
+      mockAlways200();
+      const client = buildClient({ expiresAt: 'not-a-date', callback: refreshCallback });
+
+      await client.get('/test');
+
+      expect(refreshCallback).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger refresh when token is well within validity', async () => {
+      mockAlways200();
+      const client = buildClient({
+        expiresAt: new Date(NOW + 10 * 60_000), // 10 min out
+        callback: refreshCallback,
+      });
+
+      await client.get('/test');
+
+      expect(refreshCallback).not.toHaveBeenCalled();
+    });
+
+    it('should trigger proactive refresh when token is within 60s of expiry', async () => {
+      mockAlways200();
+      refreshCallback.mockResolvedValue({
+        accessToken: 'refreshed-token',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      const client = buildClient({
+        expiresAt: new Date(NOW + 30_000), // inside the 60s window
+        callback: refreshCallback,
+      });
+
+      await client.get('/test');
+
+      expect(refreshCallback).toHaveBeenCalledTimes(1);
+      expect(refreshCallback).toHaveBeenCalledWith(connectionId);
+    });
+
+    it('should use refreshed access token on the outgoing request', async () => {
+      mockAlways200();
+      refreshCallback.mockResolvedValue({
+        accessToken: 'refreshed-token',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      const client = buildClient({
+        expiresAt: new Date(NOW + 30_000),
+        callback: refreshCallback,
+      });
+
+      await client.get('/test');
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      const headers = (fetchCall[1]?.headers as Record<string, string>) ?? {};
+      expect(headers.authorization).toBe('Bearer refreshed-token');
+    });
+
+    it('should update cached expiresAt from the refresh result so it does not re-refresh immediately', async () => {
+      mockAlways200();
+      refreshCallback.mockResolvedValue({
+        accessToken: 'refreshed-token',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      const client = buildClient({
+        expiresAt: new Date(NOW + 30_000),
+        callback: refreshCallback,
+      });
+
+      await client.get('/test1');
+      await client.get('/test2');
+
+      expect(refreshCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should serialize concurrent refresh attempts (single-flight)', async () => {
+      mockAlways200();
+      // Hold the refresh pending until the three requests are suspended on it.
+      let resolveRefresh!: (v: { accessToken: string; expiresAt: string }) => void;
+      refreshCallback.mockReturnValue(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+      const client = buildClient({
+        expiresAt: new Date(NOW + 30_000),
+        callback: refreshCallback,
+      });
+
+      const p1 = client.get('/test1');
+      const p2 = client.get('/test2');
+      const p3 = client.get('/test3');
+
+      // All three requests are now parked on the same in-flight refresh.
+      expect(refreshCallback).toHaveBeenCalledTimes(1);
+
+      resolveRefresh({
+        accessToken: 'refreshed-token',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+
+      await Promise.all([p1, p2, p3]);
+
+      expect(refreshCallback).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      for (const call of (global.fetch as jest.Mock).mock.calls as Array<[string, RequestInit]>) {
+        const headers = (call[1]?.headers as Record<string, string>) ?? {};
+        expect(headers.authorization).toBe('Bearer refreshed-token');
+      }
+    });
+
+    it('should fall through to reactive 401 path when proactive refresh throws', async () => {
+      // First callback invocation (proactive): fails → swallowed + cooldown set.
+      // Second invocation (reactive on 401): succeeds → request retries.
+      refreshCallback.mockRejectedValueOnce(new Error('refresh endpoint down'));
+      refreshCallback.mockResolvedValueOnce({
+        accessToken: 'recovered-token',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          headers: new Headers(),
+          text: () => Promise.resolve('{"error":"expired_token"}'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () => Promise.resolve('{}'),
+        });
+
+      // Need default retry config for the TokenRefreshedError → retry loop.
+      const client = new AllegroHttpClient(
+        connectionId,
+        baseUrl,
+        { accessToken: 'initial-token', expiresAt: new Date(NOW + 30_000) },
+        config,
+        undefined,
+        refreshCallback,
+      );
+
+      const response = await client.get('/test');
+
+      expect(response.status).toBe(200);
+      expect(refreshCallback).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      // The retry attempt carries the recovered token from the reactive path.
+      const retryCall = (global.fetch as jest.Mock).mock.calls[1] as [string, RequestInit];
+      const retryHeaders = (retryCall[1]?.headers as Record<string, string>) ?? {};
+      expect(retryHeaders.authorization).toBe('Bearer recovered-token');
+    });
+
+    it('should honour proactive-refresh cooldown after a failure', async () => {
+      mockAlways200();
+      refreshCallback.mockRejectedValueOnce(new Error('transient failure'));
+      const client = buildClient({
+        expiresAt: new Date(NOW + 30_000),
+        callback: refreshCallback,
+      });
+
+      // First request: proactive refresh attempt fails (swallowed), request
+      // proceeds with the old token, server returns 200 — one callback invocation.
+      await client.get('/test1');
+      expect(refreshCallback).toHaveBeenCalledTimes(1);
+
+      // Still inside the 5s cooldown: no second proactive attempt.
+      jest.setSystemTime(NOW + 1_000);
+      await client.get('/test2');
+      expect(refreshCallback).toHaveBeenCalledTimes(1);
+
+      // Past the cooldown: proactive path resumes, this time it succeeds.
+      refreshCallback.mockResolvedValueOnce({
+        accessToken: 'recovered-token',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      jest.setSystemTime(NOW + COOLDOWN_MS + 1_000);
+      await client.get('/test3');
+      expect(refreshCallback).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
@@ -10,6 +10,7 @@
  * @implements {IAllegroHttpClient}
  */
 import { IAllegroHttpClient, AllegroHttpRequestOptions, AllegroHttpResponse } from './allegro-http-client.interface';
+import { TokenRefreshCallback, TokenRefreshResult } from './allegro-http-client.types';
 import { AllegroConnectionConfig } from '../../domain/types/allegro-config.types';
 import { AllegroCredentials } from '../../domain/types/allegro-credentials.types';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
@@ -39,6 +40,15 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
 };
 
 /**
+ * Proactive token-refresh window.
+ *
+ * Refresh proactively when the current access token is within this many
+ * milliseconds of its expiresAt timestamp, so we don't pay a wasted 401
+ * round-trip on the next request after an idle period.
+ */
+const TOKEN_REFRESH_WINDOW_MS = 60_000;
+
+/**
  * Token refreshed error
  *
  * Internal error used to signal that token was refreshed and request should be retried.
@@ -57,12 +67,22 @@ class TokenRefreshedError extends Error {
  * Implements HTTP client for Allegro Public API using native fetch.
  */
 export class AllegroHttpClient implements IAllegroHttpClient {
+  /**
+   * Cooldown after a failed proactive refresh. During this window pre-request
+   * checks short-circuit and rely on the reactive 401 path, preventing a
+   * refresh storm when the refresh endpoint is unhealthy.
+   */
+  private static readonly PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS = 5_000;
+
   private readonly logger = new Logger(AllegroHttpClient.name);
   private readonly baseUrl: string;
   private accessToken: string; // Mutable to support token refresh
+  private tokenExpiresAt: number | undefined; // Epoch ms; undefined disables proactive refresh
+  private refreshInFlight: Promise<void> | null = null; // Per-instance single-flight
+  private proactiveRefreshCooldownUntil: number | undefined; // Epoch ms; set on failure
   private readonly retryConfig: RetryConfig;
   private readonly connectionId: string;
-  private readonly tokenRefreshCallback?: (connectionId: string) => Promise<string>;
+  private readonly tokenRefreshCallback?: TokenRefreshCallback;
 
   constructor(
     connectionId: string,
@@ -70,12 +90,13 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     credentials: AllegroCredentials,
     _config: AllegroConnectionConfig,
     retryConfig?: Partial<RetryConfig>,
-    tokenRefreshCallback?: (connectionId: string) => Promise<string>,
+    tokenRefreshCallback?: TokenRefreshCallback,
   ) {
     this.connectionId = connectionId;
     // Normalize baseUrl (remove trailing slash)
     this.baseUrl = baseUrl.replace(/\/$/, '');
     this.accessToken = credentials.accessToken;
+    this.tokenExpiresAt = this.normalizeExpiresAt(credentials.expiresAt);
     this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
     this.tokenRefreshCallback = tokenRefreshCallback;
   }
@@ -201,6 +222,11 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     const startTime = Date.now();
     const traceId = randomUUID();
 
+    // Proactively refresh the token before building Authorization if we're
+    // inside the refresh window. No-op when no callback or no expiresAt,
+    // preserving behavior for connections without expiry metadata.
+    await this.ensureFreshToken(traceId);
+
     // Build URL with query parameters
     const url = new URL(path, this.baseUrl);
     if (options?.queryParams) {
@@ -307,7 +333,12 @@ export class AllegroHttpClient implements IAllegroHttpClient {
       if (
         error instanceof AllegroApiException ||
         error instanceof AllegroAuthenticationException ||
-        error instanceof AllegroRateLimitException
+        error instanceof AllegroRateLimitException ||
+        // TokenRefreshedError is an internal control-flow signal for request()
+        // to retry immediately with the new access token. Without this re-throw
+        // it would get wrapped in AllegroApiException("Network error: ...") and
+        // the `continue` branch in request() would never match.
+        error instanceof TokenRefreshedError
       ) {
         throw error;
       }
@@ -351,8 +382,8 @@ export class AllegroHttpClient implements IAllegroHttpClient {
           this.logger.warn(
             `[${traceId}] Access token expired, attempting refresh (connection: ${this.connectionId})`,
           );
-          const newAccessToken = await this.tokenRefreshCallback(this.connectionId);
-          this.accessToken = newAccessToken;
+          const refreshResult = await this.tokenRefreshCallback(this.connectionId);
+          this.applyRefreshResult(refreshResult);
           this.logger.log(
             `[${traceId}] Access token refreshed successfully (connection: ${this.connectionId})`,
           );
@@ -415,6 +446,101 @@ export class AllegroHttpClient implements IAllegroHttpClient {
       body.substring(0, 500),
       url,
     );
+  }
+
+  /**
+   * Ensure the access token is fresh before sending a request.
+   *
+   * No-op when the client has no refresh callback or no expiresAt (backward
+   * compat for connections that were created before expiry was persisted).
+   * Short-circuits during the post-failure cooldown so a sick refresh endpoint
+   * can't trigger a refresh storm — the reactive 401 path stays as the
+   * fallback.
+   *
+   * Uses per-instance single-flight: concurrent callers await the same
+   * in-flight refresh promise instead of each triggering their own. Cross-
+   * process / cross-instance serialization is handled by
+   * `AllegroTokenRefreshService`'s Redis lock.
+   */
+  private async ensureFreshToken(traceId: string): Promise<void> {
+    if (!this.tokenRefreshCallback || this.tokenExpiresAt === undefined) {
+      return;
+    }
+    if (
+      this.proactiveRefreshCooldownUntil !== undefined &&
+      Date.now() < this.proactiveRefreshCooldownUntil
+    ) {
+      return;
+    }
+    if (Date.now() < this.tokenExpiresAt - TOKEN_REFRESH_WINDOW_MS) {
+      return;
+    }
+    if (this.refreshInFlight) {
+      await this.refreshInFlight;
+      return;
+    }
+    this.refreshInFlight = this.performProactiveRefresh(traceId).finally(() => {
+      this.refreshInFlight = null;
+    });
+    await this.refreshInFlight;
+  }
+
+  /**
+   * Perform the actual proactive refresh. Updates cached access token and
+   * expiry on success; records a cooldown on failure so subsequent requests
+   * skip the proactive path and rely on the reactive 401 path.
+   */
+  private async performProactiveRefresh(traceId: string): Promise<void> {
+    if (!this.tokenRefreshCallback) {
+      return;
+    }
+    try {
+      this.logger.debug(
+        `[${traceId}] Proactive token refresh (connection: ${this.connectionId})`,
+      );
+      const refreshResult = await this.tokenRefreshCallback(this.connectionId);
+      this.applyRefreshResult(refreshResult);
+      this.logger.log(
+        `[${traceId}] Proactive token refresh succeeded (connection: ${this.connectionId})`,
+      );
+    } catch (error) {
+      // Deliberately swallowed: the reactive 401 path is the documented
+      // fallback (see issue #336 AC). Record a short cooldown so we don't
+      // re-attempt on every request while the endpoint is unhealthy.
+      this.proactiveRefreshCooldownUntil =
+        Date.now() + AllegroHttpClient.PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS;
+      this.logger.warn(
+        `[${traceId}] Proactive token refresh failed, falling back to reactive 401 path: ${(error as Error).message} (connection: ${this.connectionId})`,
+      );
+    }
+  }
+
+  /**
+   * Apply a successful refresh result to cached client state.
+   *
+   * Single place where the access token and cached expiry get updated, so
+   * the proactive and reactive refresh paths can't drift (e.g., one forgetting
+   * to clear the cooldown or update the expiry).
+   */
+  private applyRefreshResult(result: TokenRefreshResult): void {
+    this.accessToken = result.accessToken;
+    this.tokenExpiresAt = this.normalizeExpiresAt(result.expiresAt);
+    this.proactiveRefreshCooldownUntil = undefined;
+  }
+
+  /**
+   * Normalize an `expiresAt` value (Date | string | undefined) to epoch ms.
+   *
+   * Returns `undefined` for absent values, invalid Date objects, or strings
+   * that don't parse — which disables proactive refresh for that client
+   * instance rather than letting NaN silently poison the comparison.
+   */
+  private normalizeExpiresAt(value: Date | string | undefined): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+    return Number.isFinite(ms) ? ms : undefined;
   }
 
   /**

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.types.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.types.ts
@@ -1,0 +1,32 @@
+/**
+ * Allegro HTTP Client Types
+ *
+ * Type definitions for the Allegro HTTP client's token-refresh contract.
+ * Kept in a dedicated `.types.ts` file per Engineering Standards "Type
+ * Definitions in Separate Files".
+ *
+ * @module libs/integrations/allegro/src/infrastructure/http
+ */
+
+/**
+ * Token Refresh Result
+ *
+ * Returned by a `TokenRefreshCallback` to the HTTP client after an
+ * OAuth refresh. Carries the new access token and, when available, the
+ * updated expiration so the client can cache it and avoid triggering
+ * another proactive refresh immediately.
+ */
+export interface TokenRefreshResult {
+  accessToken: string;
+  expiresAt?: Date | string;
+}
+
+/**
+ * Token Refresh Callback
+ *
+ * Invoked by `AllegroHttpClient` on both proactive and reactive (401)
+ * refresh paths. Implementations are responsible for serializing refresh
+ * attempts across processes (e.g., via Redis lock in
+ * `AllegroTokenRefreshService`).
+ */
+export type TokenRefreshCallback = (connectionId: string) => Promise<TokenRefreshResult>;


### PR DESCRIPTION
## Summary

Before this change, `AllegroHttpClient` only refreshed the OAuth access token **reactively** on a 401. Every request made after an idle period (e.g., the first request of a sync job after a webhook wake-up) silently 401'd first, triggered a refresh, then retried — wasted latency on workloads that are naturally bursty.

This PR adds **proactive** refresh: before each request, if the cached `expiresAt` is within 60 seconds, refresh first. The reactive 401 path is preserved as a fallback.

Closes #336

## What changed

- **Cached expiry on the client**: `AllegroHttpClient` now threads `credentials.expiresAt` in at construction and normalizes it to epoch ms. Invalid `Date` objects and unparseable strings collapse to `undefined`, which disables proactive refresh for that instance rather than letting `NaN` silently poison the comparison.
- **Pre-request `ensureFreshToken()`** called at the top of `executeRequest()`. No-op when no callback or no `expiresAt` (backward compat for connections that predate expiry persistence).
- **Per-instance single-flight** via `refreshInFlight: Promise<void> | null`. Concurrent requests through the same adapter reference share one refresh invocation. Cross-process / cross-instance serialization is still handled by `AllegroTokenRefreshService`'s Redis lock — this is defense-in-depth for parallel calls *within* one adapter instance.
- **5-second failure cooldown**: if proactive refresh throws, subsequent requests skip the proactive path during the cooldown window and let the reactive 401 path take over. Prevents a refresh storm when the refresh endpoint itself is unhealthy. Cleared on any successful refresh (either path).
- **Widened callback shape**: `TokenRefreshCallback` now returns `{ accessToken, expiresAt? }` so both paths update the cached expiry via a shared `applyRefreshResult()` helper. `AllegroAdapterFactory` stops discarding the `expiresAt` that `AllegroTokenRefreshService.refreshToken()` already returns.
- **New `allegro-http-client.types.ts`** file — types live in `*.types.ts` per engineering standards.

## Bundled bug fix (flagging explicitly)

While writing an end-to-end test for the "reactive path still works after proactive failure" case, I discovered `TokenRefreshedError` — an internal control-flow signal from `handleError()` to `request()`'s retry loop — was being **wrapped** by `executeRequest()`'s outer catch as `AllegroApiException("Network error: ...")`. The `if (error instanceof TokenRefreshedError) continue` branch in `request()` therefore never matched, and the reactive 401 path only "worked" by fallthrough to the generic 5xx retry (with a 1s sleep).

One-line fix: added `TokenRefreshedError` to the re-throw list in `executeRequest()`'s catch block, with an inline comment explaining why. Without this, the AC *"Reactive 401 refresh path is preserved as a fallback"* would have been technically a half-truth. Keeping the fix here rather than as a separate PR because splitting it would have broken the type-check across commits (the factory and tests in this PR already reference the widened callback shape).

## Backward compatibility

- Connections without `expiresAt` (or adapters constructed without a refresh callback): proactive path is a no-op, reactive 401 path is the only path. No behavior change.
- `AllegroConnectionTesterAdapter` constructs the client without a refresh callback — unaffected.
- One production callsite of the widened callback (`AllegroAdapterFactory`), updated in this PR. Zero existing tests depended on the old `Promise<string>` shape.

## Test plan

- [x] `pnpm lint` — 0 errors (warnings are pre-existing in untouched files)
- [x] `pnpm type-check` — clean across all 7 workspaces
- [x] `pnpm test` — 1,456/1,456 passing (allegro package: 92 total, +10 new)
- [x] New `describe('proactive token refresh')` block covers every AC bullet plus edge cases:
  - [x] no `expiresAt` → no-op (backward compat)
  - [x] no refresh callback → no-op
  - [x] garbage `expiresAt` string → no-op (NaN guard)
  - [x] token well within validity → no refresh
  - [x] token within 60s of expiry → proactive refresh fires
  - [x] refreshed access token is used on the outgoing request
  - [x] cached `expiresAt` updates so subsequent requests don't re-refresh
  - [x] 3 parallel `get()` calls share one refresh invocation (single-flight)
  - [x] proactive failure → reactive 401 path completes the request
  - [x] proactive failure → subsequent requests respect the 5s cooldown

## Implementation plan

Full design rationale and design alternatives considered live at `docs/plans/implementation-plan-336-allegro-proactive-token-refresh.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
