### PR TITLE
feat(core): content draft buffer + AI completion port foundation

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -15,6 +15,8 @@ module.exports = {
   moduleNameMapper: {
     '^@openlinker/integrations-allegro$': path.resolve(__dirname, '../../libs/integrations/allegro/src/index.ts'),
     '^@openlinker/integrations-allegro/(.*)$': path.resolve(__dirname, '../../libs/integrations/allegro/src/$1'),
+    '^@openlinker/integrations-ai$': path.resolve(__dirname, '../../libs/integrations/ai/src/index.ts'),
+    '^@openlinker/integrations-ai/(.*)$': path.resolve(__dirname, '../../libs/integrations/ai/src/$1'),
     '^@openlinker/core/(.*)$': path.resolve(__dirname, '../../libs/core/src/$1'),
     '^@openlinker/shared/(.*)$': path.resolve(__dirname, '../../libs/shared/src/$1'),
   },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,6 +36,7 @@
     "@nestjs/swagger": "^7.3.0",
     "@nestjs/typeorm": "10.0.2",
     "@openlinker/core": "workspace:*",
+    "@openlinker/integrations-ai": "workspace:*",
     "@openlinker/integrations-allegro": "workspace:*",
     "@openlinker/integrations-prestashop": "workspace:*",
     "bcryptjs": "^3.0.3",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { RedisConfigModule } from '@openlinker/shared/redis';
 import { HealthModule } from './health/health.module';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { CustomersModule } from '@openlinker/core/customers';
+import { ContentModule } from '@openlinker/core/content';
 import { AuthModule } from './auth/auth.module';
 import { IntegrationsModule } from './integrations/integrations.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
@@ -52,6 +53,7 @@ import { MappingsApiModule } from './mappings/mappings.module';
     ListingsApiModule,
     CursorsModule,
     MappingsApiModule,
+    ContentModule, // Product content draft buffer + reconcile + publish (#338)
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -13,6 +13,7 @@ import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { SyncModule } from '@openlinker/core/sync';
 import { PrestashopIntegrationModule } from '@openlinker/integrations-prestashop';
 import { AllegroIntegrationModule } from '@openlinker/integrations-allegro';
+import { AiIntegrationModule } from '@openlinker/integrations-ai';
 import { RedisConfigModule } from '@openlinker/shared/redis';
 import { ConnectionController } from './http/connection.controller';
 import { AdapterController } from './http/adapter.controller';
@@ -29,6 +30,7 @@ import { ALLEGRO_OAUTH_SERVICE_TOKEN } from './application/interfaces/allegro-oa
     RedisConfigModule, // Required for OAuth state storage
     PrestashopIntegrationModule, // Register PrestaShop adapter factory
     AllegroIntegrationModule, // Register Allegro adapter factory
+    AiIntegrationModule.register(), // Register AI completion adapter (Anthropic via Vercel AI SDK; Fake when OL_AI_PROVIDER=fake)
   ],
   controllers: [ConnectionController, AdapterController, AllegroController],
   providers: [

--- a/apps/api/src/migrations/1789000000000-add-product-content-field-table.ts
+++ b/apps/api/src/migrations/1789000000000-add-product-content-field-table.ts
@@ -1,0 +1,66 @@
+/**
+ * Migration: add `product_content_field` table
+ *
+ * Creates the draft/base storage for per-product, per-channel (or master)
+ * content fields used by the new content/ bounded context (#338).
+ *
+ * Index design: Postgres treats NULL ≠ NULL in unique indexes, so we ship
+ * two partial unique indexes — one constraining the master row uniqueness
+ * (`connection_id IS NULL`), one constraining the channel rows
+ * (`connection_id IS NOT NULL`). A third non-unique index supports
+ * `findByKey`-style lookups by `product_id`.
+ *
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductContentFieldTable1789000000000 implements MigrationInterface {
+  name = 'AddProductContentFieldTable1789000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "product_content_field" (
+        "id"            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+        "product_id"    TEXT        NOT NULL,
+        "connection_id" UUID        NULL,
+        "field_key"     TEXT        NOT NULL,
+        "draft_value"   TEXT        NULL,
+        "base_value"    TEXT        NULL,
+        "base_version"  TEXT        NULL,
+        "has_conflict"  BOOLEAN     NOT NULL DEFAULT FALSE,
+        "created_at"    TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_at"    TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updated_by"    TEXT        NULL,
+        CONSTRAINT "fk_pcf_product"    FOREIGN KEY ("product_id")    REFERENCES "products"("id")    ON DELETE CASCADE,
+        CONSTRAINT "fk_pcf_connection" FOREIGN KEY ("connection_id") REFERENCES "connections"("id") ON DELETE CASCADE
+      )
+    `);
+
+    // Master uniqueness: at most one row per (product_id, field_key) when connection_id is NULL.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "ux_pcf_master"
+        ON "product_content_field" ("product_id", "field_key")
+        WHERE "connection_id" IS NULL
+    `);
+
+    // Channel uniqueness: at most one row per (product_id, connection_id, field_key) when connection_id is set.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "ux_pcf_channel"
+        ON "product_content_field" ("product_id", "connection_id", "field_key")
+        WHERE "connection_id" IS NOT NULL
+    `);
+
+    // Lookup index for the productId-only scan (used by future "show all field rows for a product" reads).
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "ix_pcf_product"
+        ON "product_content_field" ("product_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "ix_pcf_product"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "ux_pcf_channel"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "ux_pcf_master"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "product_content_field"`);
+  }
+}

--- a/apps/api/src/migrations/1789000000000-add-product-content-field-table.ts
+++ b/apps/api/src/migrations/1789000000000-add-product-content-field-table.ts
@@ -18,6 +18,9 @@ export class AddProductContentFieldTable1789000000000 implements MigrationInterf
   name = 'AddProductContentFieldTable1789000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // gen_random_uuid() is built-in on Postgres ≥ 13. On PG ≤ 12 it requires
+    // `CREATE EXTENSION IF NOT EXISTS pgcrypto`. Testcontainers uses PG 16
+    // and prod is PG 16+, so we rely on the built-in here.
     await queryRunner.query(`
       CREATE TABLE IF NOT EXISTS "product_content_field" (
         "id"            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/apps/api/test/integration/content-draft.int-spec.ts
+++ b/apps/api/test/integration/content-draft.int-spec.ts
@@ -1,0 +1,336 @@
+/**
+ * Content Draft — Integration Tests
+ *
+ * Exercises ContentDraftService against a real Postgres via the shared
+ * Testcontainers harness. Verifies:
+ *  - Storage round-trip (insert / update via the upsert path).
+ *  - Reconcile semantics (silent vs conflict-marking branches).
+ *  - The two partial unique indexes — master and channel rows for the same
+ *    (productId, fieldKey) coexist without collision.
+ *  - Read-side resolution with channel→master fallback.
+ *
+ * Publish path is covered in unit tests only — real publishing requires the
+ * PrestaShop integration container, which is out of scope for this harness.
+ *
+ * @module apps/api/test/integration
+ */
+import { DataSource } from 'typeorm';
+import {
+  CONTENT_DRAFT_SERVICE_TOKEN,
+  ContentConflictException,
+  type IContentDraftService,
+  type ProductContentField,
+} from '@openlinker/core/content';
+import { ProductOrmEntity } from '@openlinker/core/products';
+import { ProductContentFieldOrmEntity } from '@openlinker/core/content/infrastructure/persistence/entities/product-content-field.orm-entity';
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+
+const seedProduct = async (ds: DataSource, suffix: string): Promise<string> => {
+  const productId = `ol_product_int_${suffix}`;
+  const repo = ds.getRepository(ProductOrmEntity);
+  await repo.save(
+    repo.create({
+      id: productId,
+      name: `Integration test product ${suffix}`,
+      sku: null,
+      price: null,
+    }),
+  );
+  return productId;
+};
+
+const findRow = async (
+  ds: DataSource,
+  productId: string,
+  connectionId: string | null,
+): Promise<ProductContentFieldOrmEntity | null> => {
+  const where: Record<string, unknown> = { productId, fieldKey: 'description' };
+  // typeorm find treats undefined as missing condition; use a raw query to handle null vs uuid uniformly.
+  const rows = (await ds.query(
+    `SELECT * FROM product_content_field WHERE product_id = $1 AND field_key = $2 AND ${
+      connectionId === null ? 'connection_id IS NULL' : 'connection_id = $3'
+    }`,
+    connectionId === null ? [productId, where.fieldKey] : [productId, where.fieldKey, connectionId],
+  )) as Array<Record<string, unknown>>;
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  const orm = new ProductContentFieldOrmEntity();
+  orm.id = r.id as string;
+  orm.productId = r.product_id as string;
+  orm.connectionId = r.connection_id as string | null;
+  orm.fieldKey = r.field_key as string;
+  orm.draftValue = r.draft_value as string | null;
+  orm.baseValue = r.base_value as string | null;
+  orm.baseVersion = r.base_version as string | null;
+  orm.hasConflict = r.has_conflict as boolean;
+  orm.createdAt = new Date(r.created_at as string);
+  orm.updatedAt = new Date(r.updated_at as string);
+  orm.updatedBy = r.updated_by as string | null;
+  return orm;
+};
+
+describe('Content Draft Integration', () => {
+  let dataSource: DataSource;
+  let service: IContentDraftService;
+
+  beforeAll(async () => {
+    const harness = await getTestHarness();
+    dataSource = harness.getDataSource();
+    service = harness.getApp().get<IContentDraftService>(CONTENT_DRAFT_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('persists a fresh master draft on saveDraft', async () => {
+    const productId = await seedProduct(dataSource, 'save-1');
+
+    const saved: ProductContentField = await service.saveDraft({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      value: 'fresh draft',
+      userId: 'user-1',
+    });
+
+    expect(saved.draftValue).toBe('fresh draft');
+    expect(saved.baseValue).toBeNull();
+    expect(saved.hasConflict).toBe(false);
+
+    const row = await findRow(dataSource, productId, null);
+    expect(row?.draftValue).toBe('fresh draft');
+    expect(row?.updatedBy).toBe('user-1');
+  });
+
+  it('silently refreshes base on reconcileExternal when no draft exists', async () => {
+    const productId = await seedProduct(dataSource, 'rec-silent');
+
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'platform value',
+      externalVersion: 'v1',
+    });
+
+    const row = await findRow(dataSource, productId, null);
+    expect(row?.baseValue).toBe('platform value');
+    expect(row?.baseVersion).toBe('v1');
+    expect(row?.draftValue).toBeNull();
+    expect(row?.hasConflict).toBe(false);
+  });
+
+  it('marks hasConflict=true when reconcile sees a divergent external version while a draft is pending', async () => {
+    const productId = await seedProduct(dataSource, 'rec-conflict');
+
+    // Establish a base via reconcile, then save a draft, then reconcile with a new external version.
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'original',
+      externalVersion: 'v1',
+    });
+    await service.saveDraft({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      value: 'pending edit',
+      userId: 'user-1',
+    });
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'someone else changed it',
+      externalVersion: 'v2',
+    });
+
+    const row = await findRow(dataSource, productId, null);
+    expect(row?.draftValue).toBe('pending edit');
+    expect(row?.baseValue).toBe('someone else changed it');
+    expect(row?.baseVersion).toBe('v2');
+    expect(row?.hasConflict).toBe(true);
+  });
+
+  it('clears hasConflict when the user re-saves the draft (implicit acknowledgement)', async () => {
+    const productId = await seedProduct(dataSource, 'rec-ack');
+
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'orig',
+      externalVersion: 'v1',
+    });
+    await service.saveDraft({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      value: 'first draft',
+      userId: 'user-1',
+    });
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'remote',
+      externalVersion: 'v2',
+    });
+
+    const conflicted = await findRow(dataSource, productId, null);
+    expect(conflicted?.hasConflict).toBe(true);
+
+    await service.saveDraft({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      value: 'reconciled draft',
+      userId: 'user-1',
+    });
+
+    const after = await findRow(dataSource, productId, null);
+    expect(after?.hasConflict).toBe(false);
+    expect(after?.draftValue).toBe('reconciled draft');
+  });
+
+  it('throws ContentConflictException when publishDraft is called on a conflicted row', async () => {
+    const productId = await seedProduct(dataSource, 'pub-conflict');
+
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'orig',
+      externalVersion: 'v1',
+    });
+    await service.saveDraft({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      value: 'pending',
+      userId: 'user-1',
+    });
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'remote update',
+      externalVersion: 'v2',
+    });
+
+    await expect(
+      service.publishDraft({
+        productId,
+        connectionId: null,
+        fieldKey: 'description',
+      }),
+    ).rejects.toBeInstanceOf(ContentConflictException);
+  });
+
+  it('discards a draft and leaves the base intact', async () => {
+    const productId = await seedProduct(dataSource, 'discard');
+
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'base',
+      externalVersion: 'v1',
+    });
+    await service.saveDraft({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      value: 'oops',
+      userId: 'user-1',
+    });
+    await service.discardDraft({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+    });
+
+    const row = await findRow(dataSource, productId, null);
+    expect(row?.draftValue).toBeNull();
+    expect(row?.baseValue).toBe('base');
+    expect(row?.baseVersion).toBe('v1');
+  });
+
+  it('lets a master row and a channel-scoped row coexist for the same (productId, fieldKey) under the partial unique indexes', async () => {
+    const productId = await seedProduct(dataSource, 'partial-unique');
+    const conn = await createTestConnection(dataSource, { name: 'channel-conn' });
+
+    await service.saveDraft({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      value: 'master draft',
+      userId: 'user-1',
+    });
+    await service.saveDraft({
+      productId,
+      connectionId: conn.id,
+      fieldKey: 'description',
+      value: 'channel draft',
+      userId: 'user-1',
+    });
+
+    const master = await findRow(dataSource, productId, null);
+    const channel = await findRow(dataSource, productId, conn.id);
+    expect(master?.draftValue).toBe('master draft');
+    expect(channel?.draftValue).toBe('channel draft');
+    expect(master?.id).not.toBe(channel?.id);
+  });
+
+  it('resolves channel value when present, falling back to master otherwise', async () => {
+    const productId = await seedProduct(dataSource, 'resolve');
+    const conn = await createTestConnection(dataSource, { name: 'resolve-conn' });
+
+    await service.reconcileExternal({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+      externalValue: 'master base',
+      externalVersion: 'v1',
+    });
+
+    // No channel row yet → resolve(channel) falls back to master.
+    const beforeChannelOverride = await service.resolveValue({
+      productId,
+      connectionId: conn.id,
+      fieldKey: 'description',
+    });
+    expect(beforeChannelOverride).toBe('master base');
+
+    // Channel override saved → resolve(channel) returns channel draft.
+    await service.saveDraft({
+      productId,
+      connectionId: conn.id,
+      fieldKey: 'description',
+      value: 'channel override',
+      userId: 'user-1',
+    });
+
+    const afterChannelOverride = await service.resolveValue({
+      productId,
+      connectionId: conn.id,
+      fieldKey: 'description',
+    });
+    expect(afterChannelOverride).toBe('channel override');
+
+    // Master resolution still sees master base.
+    const masterResolved = await service.resolveValue({
+      productId,
+      connectionId: null,
+      fieldKey: 'description',
+    });
+    expect(masterResolved).toBe('master base');
+  });
+});

--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -124,6 +124,8 @@ export class IntegrationTestHarness {
     await this.dataSource.query('TRUNCATE TABLE sync_jobs CASCADE');
     await this.dataSource.query('TRUNCATE TABLE inventory_items CASCADE');
     await this.dataSource.query('TRUNCATE TABLE order_records CASCADE');
+    // product_content_field FKs to both products + connections, so it goes before them.
+    await this.dataSource.query('TRUNCATE TABLE product_content_field CASCADE');
     await this.dataSource.query('TRUNCATE TABLE product_variants CASCADE');
     await this.dataSource.query('TRUNCATE TABLE products CASCADE');
     await this.dataSource.query('TRUNCATE TABLE connections CASCADE');

--- a/apps/api/test/jest-integration.cjs
+++ b/apps/api/test/jest-integration.cjs
@@ -35,5 +35,13 @@ module.exports = {
       __dirname,
       '../../../libs/integrations/prestashop/src/$1',
     ),
+    '^@openlinker/integrations-ai$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/ai/src/index.ts',
+    ),
+    '^@openlinker/integrations-ai/(.*)$': path.resolve(
+      __dirname,
+      '../../../libs/integrations/ai/src/$1',
+    ),
   },
 };

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -14,7 +14,9 @@
       "@openlinker/shared": ["../../libs/shared/src/index.ts"],
       "@openlinker/shared/*": ["../../libs/shared/src/*"],
       "@openlinker/integrations-allegro": ["../../libs/integrations/allegro/src/index.ts"],
-      "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"]
+      "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"],
+      "@openlinker/integrations-ai": ["../../libs/integrations/ai/src/index.ts"],
+      "@openlinker/integrations-ai/*": ["../../libs/integrations/ai/src/*"]
     }
   },
   "include": ["src/**/*.ts"],

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -17,7 +17,9 @@
       "@openlinker/shared": ["../../libs/shared/src/index.ts"],
       "@openlinker/shared/*": ["../../libs/shared/src/*"],
       "@openlinker/integrations-allegro": ["../../libs/integrations/allegro/src/index.ts"],
-      "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"]
+      "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"],
+      "@openlinker/integrations-ai": ["../../libs/integrations/ai/src/index.ts"],
+      "@openlinker/integrations-ai/*": ["../../libs/integrations/ai/src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -175,17 +175,17 @@ The system is organized into the following core bounded contexts:
 - Allegro offer sync uses `GET /sale/offer-events` with persisted cursor key `allegro.offers.lastEventId`.
 - Offer linking by barcode uses master-catalog scoping and links only on unique matches.
 
-### 6. Sync Manager
+### 7. Sync Manager
 - **Responsibility**: Job scheduling and retry logic; workers execute jobs. **Sync orchestration policies live in core application services** (e.g., order ingestion, inventory propagation), not in worker handlers.
 - **Key Services**: SyncJobService, RetryService, SchedulerService
 - **Location**: `libs/core/src/sync/` (core sync infrastructure), `apps/worker/src/sync/` (job runners/handlers)
 
-### 7. Event Bus / Messaging
+### 8. Event Bus / Messaging
 - **Responsibility**: Event-driven communication between modules
 - **Technology**: Redis Streams (initial), RabbitMQ/Kafka (future)
 - **Location**: `libs/core/src/events/`
 
-### 8. Identifier Mapping Service
+### 9. Identifier Mapping Service
 - **Responsibility**: Centralized identifier mapping between external platform IDs and internal OpenLinker IDs
 - **Key Services**: IdentifierMappingService
 - **Location**: `libs/core/src/identifier-mapping/`
@@ -196,17 +196,17 @@ The system is organized into the following core bounded contexts:
   - Used by adapters to replace external IDs with internal IDs during data transformation
 - **Architecture**: Core infrastructure service used by all adapters
 
-### 9. Plugin Manager / Integrations
+### 10. Plugin Manager / Integrations
 - **Responsibility**: Adapter registry, per-connection adapter resolution, capability validation
 - **Key Services**: IntegrationsService, AdapterRegistryService, ConnectionService
 - **Location**: `apps/api/src/integrations/` (API layer), `libs/core/src/integrations/` (core domain)
 
-### 10. Logging & Monitoring
+### 11. Logging & Monitoring
 - **Responsibility**: Structured logging, metrics, tracing
 - **Technology**: NestJS Logger, OpenTelemetry (future)
 - **Location**: `libs/shared/src/logging/`
 
-### 11. Content
+### 12. Content
 - **Responsibility**: Per-product, per-channel (or master) content fields with draft write-through and conflict detection. First field key: `description`.
 - **Key Entities**: `ProductContentField`
 - **Location**: `libs/core/src/content/`
@@ -214,7 +214,7 @@ The system is organized into the following core bounded contexts:
 - **Storage**: `product_content_field` table with two partial unique indexes (master vs channel) to honour Postgres' NULL-distinct uniqueness for the nullable `connection_id` column.
 - **Conflict model**: optimistic — inbound reconcile sets `has_conflict=true` when an external version diverges while a draft is pending; re-saving the draft is treated as implicit acknowledgement and clears the flag.
 
-### 12. AI
+### 13. AI
 - **Responsibility**: Provider-agnostic LLM completions for content generation. No application services live here — the bounded context is a single capability port + types + exceptions.
 - **Key Port**: `AiCompletionPort` (`complete(input) → result`)
 - **Location**: `libs/core/src/ai/`

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -206,6 +206,23 @@ The system is organized into the following core bounded contexts:
 - **Technology**: NestJS Logger, OpenTelemetry (future)
 - **Location**: `libs/shared/src/logging/`
 
+### 11. Content
+- **Responsibility**: Per-product, per-channel (or master) content fields with draft write-through and conflict detection. First field key: `description`.
+- **Key Entities**: `ProductContentField`
+- **Location**: `libs/core/src/content/`
+- **Capability**: Uses `ContentPublisherPort` for outbound publishing (master path resolves `ProductMasterPort` via the integrations registry; channel path is deferred to #339/#342).
+- **Storage**: `product_content_field` table with two partial unique indexes (master vs channel) to honour Postgres' NULL-distinct uniqueness for the nullable `connection_id` column.
+- **Conflict model**: optimistic — inbound reconcile sets `has_conflict=true` when an external version diverges while a draft is pending; re-saving the draft is treated as implicit acknowledgement and clears the flag.
+
+### 12. AI
+- **Responsibility**: Provider-agnostic LLM completions for content generation. No application services live here — the bounded context is a single capability port + types + exceptions.
+- **Key Port**: `AiCompletionPort` (`complete(input) → result`)
+- **Location**: `libs/core/src/ai/`
+- **Adapter package**: `libs/integrations/ai/` (workspace `@openlinker/integrations-ai`) — ships `VercelAiCompletionAdapter` (Anthropic via `ai` + `@ai-sdk/anthropic`, with system-prompt cache control) and `FakeAiCompletionAdapter` for tests / offline dev.
+- **Selection**: `OL_AI_PROVIDER` env (`anthropic` default; `fake` for tests). `AiIntegrationModule` is registered inside `apps/api/src/integrations/integrations.module.ts` alongside the other `@openlinker/integrations-*` modules.
+- **Telemetry**: per-call structured log carrying `{ requestId, model, latencyMs, inputTokens, outputTokens, cachedInputTokens }`.
+- **Worker registration**: deferred — no consumer of `AiCompletionPort` lives in `apps/worker/` yet; wiring lands with #341 / #342.
+
 ---
 
 ## Capability Abstractions (Business Roles)

--- a/docs/plans/implementation-plan-338-340-content-and-ai-foundation.md
+++ b/docs/plans/implementation-plan-338-340-content-and-ai-foundation.md
@@ -1,0 +1,483 @@
+# Implementation Plan: Content & AI Foundation (#338 + #340)
+
+**Date**: 2026-04-22
+**Status**: Ready for Review
+**Estimated Effort**: ~8–10 hours (backend-only: two new bounded contexts + one new integrations package + migration + tests)
+
+**Issues**:
+- [#338 feat(core): product content storage with draft write-through semantics](https://github.com/SilkSoftwareHouse/openlinker/issues/338)
+- [#340 feat(core): AI engine foundation — AiCompletionPort + Vercel AI SDK adapter](https://github.com/SilkSoftwareHouse/openlinker/issues/340)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Lay down the two independent foundations of the Content & AI epic (#6):
+
+1. **#338** — A `content/` bounded context with a `product_content_field` table and `ContentDraftService` providing draft-buffered writes, optimistic-concurrency reconcile, and publish-through for product content fields (master + per-connection overrides). First `fieldKey`: `description`.
+2. **#340** — An `ai/` bounded context exposing a neutral `AiCompletionPort`, plus a new `libs/integrations/ai/` package containing a `VercelAiCompletionAdapter` (Anthropic via `ai` + `@ai-sdk/anthropic`) with system-prompt caching and a `FakeAiCompletionAdapter` for tests / offline dev.
+
+**Why bundled**: Both are greenfield foundations of the same epic with no file overlap and no runtime interaction yet (the description-suggestion wiring in #342 joins them). Shipping together amortises the review overhead, locks consistent env-var naming (`OL_*`), and avoids an awkward half-epic intermediate state in `main`.
+
+**Classification**: Pure **CORE + Integration** backend work. No frontend, no API controller surface in this PR (that arrives in #339 / #342).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope — #338 (Content)
+- New bounded context `libs/core/src/content/` following the standard hexagonal layout.
+- Domain entity `ProductContentField`, types (`FieldKey` `as const` union, `ContentConflictInfo`), domain exceptions (`ContentConflictException`, `ContentFieldNotFoundException`, `ChannelContentPublishNotSupportedException`).
+- Repository port + TypeORM implementation (`product_content_field` table).
+- Migration `1789000000000-add-product-content-field-table.ts` with working `down()`.
+- `IContentDraftService` interface + `ContentDraftService` implementation covering:
+  - `saveDraft`, `discardDraft`, `publishDraft` (master path only for MVP — see §Out of scope for channel rationale), `reconcileExternal`, `resolveValue`.
+- A small domain-layer helper service `ContentPublisher` (domain service, platform-agnostic) that the app service delegates publishing to. Concrete publish wiring uses `IntegrationsService.listCapabilityAdapters<ProductMasterPort>`.
+- Exhaustive unit tests for the service (save/discard/publish/reconcile/resolve paths including conflict branches).
+- One integration test proving the end-to-end write-through cycle against the Testcontainers harness.
+- `ContentModule` wired into `AppModule`.
+
+### In Scope — #340 (AI)
+- New bounded context `libs/core/src/ai/` containing only domain surface (no application service — the port is consumed directly).
+- `AiCompletionPort` interface (`ai-completion.port.ts`).
+- Types in `ai-completion.types.ts`: `AiCompletionInput`, `AiCompletionResult`, `AiCompletionUsage`, `AiProviderValues`, `AiProvider`.
+- Domain exceptions: `AiCompletionError`, `AiRateLimitError`, `AiInvalidResponseError`, `AiTimeoutError`.
+- New workspace package `libs/integrations/ai/` mirroring the `integrations-allegro` layout (package.json, tsconfig.json, tsconfig.spec.json, jest.config.mjs, sequencer).
+- `VercelAiCompletionAdapter` (`ai` + `@ai-sdk/anthropic`) applying `cache_control` on the system prompt when `cacheSystemPrompt !== false`.
+- `FakeAiCompletionAdapter` used when `OL_AI_PROVIDER=fake`.
+- `AiIntegrationModule` (NestJS) selecting the adapter based on env and binding `AI_COMPLETION_PORT_TOKEN` via `useExisting`.
+- Structured logging via `@openlinker/shared/logging`: `{ requestId, model, latencyMs, inputTokens, outputTokens, cachedInputTokens }` per call.
+- Unit tests for both adapters (Vercel adapter uses `generateText` mock; Fake adapter asserts deterministic returns + usage payload).
+- Register `AiIntegrationModule` inside `apps/api/src/integrations/integrations.module.ts` (next to `AllegroIntegrationModule` + `PrestashopIntegrationModule`) — that's where every `@openlinker/integrations-*` module already lands. **Not** in `AppModule` directly.
+- Add path aliases `@openlinker/integrations-ai` / `@openlinker/integrations-ai/*` to `tsconfig.base.json`, `apps/api/tsconfig.json`, `apps/api/tsconfig.build.json`, `apps/api/jest.config.js`, `apps/api/test/jest-integration.cjs`.
+
+### Out of Scope (deferred to follow-up issues)
+- **Channel-path `publishDraft`** (writing per-marketplace overrides via `MarketplacePort.updateOfferFields`): requires offer-discovery from (productId, connectionId) and variant-to-offer mapping resolution, which is properly the listings bounded context's responsibility. For MVP we implement `connectionId=null` (master) fully and throw `ChannelContentPublishNotSupportedException` for `connectionId !== null`. The surface is correct; the wire is short. Explicit follow-up comment + TODO pointer to #339/#342.
+- **Editing UI** (#339) and **AI description suggestion flow** (#342) — this PR is strictly backend scaffolding.
+- **Additional field keys** beyond `description`: extension-point only (the `FieldKey` union is ready to grow).
+- **Version history** beyond `(draftValue, baseValue)`.
+- **Merge-resolution UI** — the conflict is surfaced as a persisted boolean + a domain event slot (event bus integration deferred until a consumer exists).
+- **Per-user cost caps / rate limiting / streaming / tool use / RAG** for AI — flagged in #340.
+- **Multi-provider AI adapter coexistence** — one Vercel SDK adapter + Fake adapter. Swap target remains the port.
+
+### Constraints
+- No `any`, no `console.log`, no framework imports inside `libs/core/src/**/domain/`.
+- Env vars follow the existing `OL_*` convention (`OL_AI_PROVIDER`, `OL_AI_DEFAULT_MODEL`, `OL_AI_DEFAULT_MAX_TOKENS`, `OL_AI_TIMEOUT_MS`). `ANTHROPIC_API_KEY` keeps its vendor name (industry standard).
+- No provider SDK types (`ai`, `@ai-sdk/*`) leak out of `libs/integrations/ai/`.
+- All core + integration tests must pass `pnpm lint && pnpm type-check && pnpm test` at the end.
+- Unique constraint on `(productId, connectionId, fieldKey)` must handle the nullable `connectionId` correctly (Postgres treats `NULL ≠ NULL` in uniques) → **two partial unique indexes** (one `WHERE connectionId IS NULL`, one `WHERE connectionId IS NOT NULL`) per the standard Postgres idiom. The `down()` drops both.
+
+---
+
+## 3. Research Summary
+
+### Existing patterns located (authoritative file paths)
+| Concern | File / Path |
+|---|---|
+| Bounded-context layout reference | `libs/core/src/products/` (domain/application/infrastructure folders + `products.module.ts` + `products.tokens.ts`) |
+| Symbol-token + `useExisting` idiom | `libs/core/src/products/products.module.ts`, `libs/core/src/products/products.tokens.ts` |
+| Migrations folder | `apps/api/src/migrations/` — latest is `1788000000000-promote-product-variant-entity-type.ts`; next slot is `1789000000000` |
+| Entity auto-discovery glob | `apps/api/src/database/data-source.ts` — `libs/core/src/**/*.orm-entity{.ts,.js}` — new ORM entity will be discovered automatically |
+| Integrations package exemplar | `libs/integrations/allegro/` — `package.json`, `tsconfig.json`, `tsconfig.spec.json`, `jest.config.mjs`, `test/openlinker.sequencer.cjs`, `src/allegro-integration.module.ts` (OnModuleInit factory registration pattern) |
+| Adapter registration for `apps/api` | `apps/api/src/integrations/integrations.module.ts` imports `AllegroIntegrationModule` + `PrestashopIntegrationModule` |
+| `tsconfig.base.json` alias list | path aliases currently wire `core`, `shared`, `integrations-allegro` — we add `integrations-ai` |
+| Logger | `@openlinker/shared/logging` → `new Logger(ClassName.name)` |
+| Env helpers (framework-free) | `@openlinker/shared/config` → `getEnv`, `getEnvNumber`, `getEnvBoolean` |
+| NestJS env helper | `@nestjs/config` `ConfigService.get<T>()` pattern used in `apps/api/src/auth/bootstrap-admin.service.ts` |
+| Integration test harness | `apps/api/test/integration/setup.ts` — `IntegrationTestHarness.reset()` truncates: `identifier_mappings`, `sync_jobs`, `inventory_items`, `order_records`, `product_variants`, `products`, `connections`, `users`. **We add `product_content_field` to that TRUNCATE list.** |
+| Jest config for apps/api | `apps/api/jest.config.js` + `apps/api/test/jest-integration.cjs` both need the new `integrations-ai` alias |
+| MarketplacePort / UpdateOfferFieldsCommand (for future channel publishing reference only) | `libs/core/src/integrations/domain/ports/marketplace.port.ts:70` + `libs/core/src/integrations/domain/types/marketplace-offer-update.types.ts` |
+| ProductMasterPort.updateProduct + ProductUpdate type | `libs/core/src/products/domain/ports/product-master.port.ts` + `libs/core/src/products/domain/types/product.types.ts:67` — `ProductUpdate` already has `description?: string`, so the publish write is a one-field patch |
+| Connection entity | `libs/core/src/identifier-mapping/domain/entities/connection.entity.ts` — `connectionId: string` |
+| IntegrationsService API | `libs/core/src/integrations/…` — `listCapabilityAdapters<T>({ capability: 'ProductMaster' })` returns `{ connectionId, connection, adapter }[]` |
+
+### What this unlocks
+- Clean publish hook — `ContentDraftService.publishDraft()` → `ContentPublisher.publishMaster(productId, fieldKey, value)` → `IntegrationsService.listCapabilityAdapters<ProductMasterPort>({ capability: 'ProductMaster' })` → `adapter.updateProduct(productId, { [fieldKey]: value })`.
+- AI port consumption — application services in #341/#342 will inject `AI_COMPLETION_PORT_TOKEN` and call `.complete(...)`.
+
+### Dependencies added
+- `ai` (Vercel AI SDK core) and `@ai-sdk/anthropic` — **only in `libs/integrations/ai/package.json`**. We pin to concrete versions (latest stable as of implementation) to keep the lockfile deterministic.
+- No changes to root `package.json`.
+
+---
+
+## 4. Design
+
+### 4.1 Bounded contexts after this PR
+
+```
+libs/core/src/
+├── ai/                                    (NEW — domain-only)
+│   ├── domain/
+│   │   ├── ports/
+│   │   │   └── ai-completion.port.ts
+│   │   ├── types/
+│   │   │   └── ai-completion.types.ts
+│   │   └── exceptions/
+│   │       ├── ai-completion.exception.ts
+│   │       ├── ai-rate-limit.exception.ts
+│   │       ├── ai-invalid-response.exception.ts
+│   │       └── ai-timeout.exception.ts
+│   ├── ai.tokens.ts                       (AI_COMPLETION_PORT_TOKEN)
+│   └── index.ts
+│
+├── content/                               (NEW)
+│   ├── domain/
+│   │   ├── entities/
+│   │   │   └── product-content-field.entity.ts
+│   │   ├── ports/
+│   │   │   ├── product-content-field-repository.port.ts
+│   │   │   └── content-publisher.port.ts
+│   │   ├── types/
+│   │   │   └── content.types.ts           (FieldKey union, ContentConflictInfo)
+│   │   └── exceptions/
+│   │       ├── content-conflict.exception.ts
+│   │       ├── content-field-not-found.exception.ts
+│   │       └── channel-content-publish-not-supported.exception.ts
+│   ├── application/
+│   │   ├── services/
+│   │   │   ├── content-draft.service.interface.ts            (interface lives next to its impl, per existing products convention)
+│   │   │   ├── content-draft.service.ts
+│   │   │   ├── content-draft.service.spec.ts
+│   │   │   ├── integrations-content-publisher.service.ts     (implements ContentPublisherPort)
+│   │   │   └── integrations-content-publisher.service.spec.ts
+│   │   └── types/
+│   │       └── content-draft.types.ts     (command DTOs)
+│   ├── infrastructure/
+│   │   └── persistence/
+│   │       ├── entities/
+│   │       │   └── product-content-field.orm-entity.ts
+│   │       └── repositories/
+│   │           ├── product-content-field.repository.ts
+│   │           └── product-content-field.repository.spec.ts  (private mapping methods coverage via service-level tests is enough; spec omitted unless mapping edge case appears)
+│   ├── content.module.ts
+│   ├── content.tokens.ts                  (CONTENT_*_TOKEN family)
+│   └── index.ts
+```
+
+```
+libs/integrations/ai/                     (NEW — package)
+├── package.json
+├── tsconfig.json
+├── tsconfig.spec.json
+├── jest.config.mjs
+├── test/openlinker.sequencer.cjs
+└── src/
+    ├── infrastructure/
+    │   └── adapters/
+    │       ├── vercel-ai-completion.adapter.ts
+    │       ├── vercel-ai-completion.adapter.spec.ts
+    │       ├── fake-ai-completion.adapter.ts
+    │       └── fake-ai-completion.adapter.spec.ts
+    ├── ai-integration.module.ts
+    ├── ai.tokens.ts                       (re-exports core token for convenience; keep in core)
+    └── index.ts
+```
+
+### 4.2 Data model
+
+```sql
+CREATE TABLE product_content_field (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),  -- OL-internal entity, not in identifier-mapping
+  product_id    TEXT        NOT NULL
+    REFERENCES products(id) ON DELETE CASCADE,
+  connection_id UUID        NULL
+    REFERENCES connections(id) ON DELETE CASCADE,        -- NULL = master
+  field_key     TEXT        NOT NULL,                    -- MVP: 'description'
+  draft_value   TEXT        NULL,
+  base_value    TEXT        NULL,
+  base_version  TEXT        NULL,                        -- opaque, platform-specific
+  has_conflict  BOOLEAN     NOT NULL DEFAULT FALSE,
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by    TEXT        NULL                         -- user id (string), nullable for system-driven reconcile
+);
+
+-- Postgres NULL-distinct uniqueness idiom: two partial indexes
+CREATE UNIQUE INDEX ux_pcf_master
+  ON product_content_field (product_id, field_key)
+  WHERE connection_id IS NULL;
+
+CREATE UNIQUE INDEX ux_pcf_channel
+  ON product_content_field (product_id, connection_id, field_key)
+  WHERE connection_id IS NOT NULL;
+
+CREATE INDEX ix_pcf_product ON product_content_field (product_id);
+```
+
+### 4.3 Key interface shapes
+
+```typescript
+// libs/core/src/content/domain/types/content.types.ts
+export const FieldKeyValues = ['description'] as const;
+export type FieldKey = (typeof FieldKeyValues)[number];
+
+export interface ContentConflictInfo {
+  fieldKey: FieldKey;
+  baseVersion: string | null;
+  externalVersion: string;
+}
+
+// libs/core/src/content/application/types/content-draft.types.ts
+export interface SaveDraftCommand {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+  value: string;
+  userId: string;
+}
+export interface DiscardDraftCommand {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+}
+export interface PublishDraftCommand {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+}
+export interface ReconcileExternalCommand {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+  externalValue: string;
+  externalVersion: string;
+}
+export interface ResolveValueQuery {
+  productId: string;
+  connectionId: string | null;      // null resolves master only
+  fieldKey: FieldKey;
+}
+
+// libs/core/src/content/application/interfaces/content-draft.service.interface.ts
+export interface IContentDraftService {
+  saveDraft(cmd: SaveDraftCommand): Promise<ProductContentField>;
+  discardDraft(cmd: DiscardDraftCommand): Promise<void>;
+  publishDraft(cmd: PublishDraftCommand): Promise<ProductContentField>;
+  reconcileExternal(cmd: ReconcileExternalCommand): Promise<ProductContentField>;
+  resolveValue(q: ResolveValueQuery): Promise<string | null>;
+}
+```
+
+```typescript
+// libs/core/src/ai/domain/types/ai-completion.types.ts
+export const AiProviderValues = ['anthropic', 'fake'] as const;
+export type AiProvider = (typeof AiProviderValues)[number];
+
+export interface AiCompletionInput {
+  systemPrompt: string;
+  userPrompt: string;
+  model?: string;
+  maxOutputTokens?: number;
+  temperature?: number;
+  cacheSystemPrompt?: boolean;   // default true in adapter
+  requestId?: string;
+}
+export interface AiCompletionUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+}
+export interface AiCompletionResult {
+  text: string;
+  usage: AiCompletionUsage;
+  modelUsed: string;
+  latencyMs: number;
+}
+
+// libs/core/src/ai/domain/ports/ai-completion.port.ts
+export interface AiCompletionPort {
+  complete(input: AiCompletionInput): Promise<AiCompletionResult>;
+}
+```
+
+### 4.4 Publish routing logic
+
+```
+ContentDraftService.publishDraft(cmd)
+  1. Load row (productId, connectionId, fieldKey). If draftValue == null → return row (no-op).
+  2. If hasConflict → throw ContentConflictException (caller must reconcile + resaveDraft).
+  3. Delegate to ContentPublisherPort.publish({ productId, connectionId, fieldKey, value: draftValue }).
+  4. On success:
+       baseValue = draftValue
+       baseVersion = result.baseVersion   (returned by publisher)
+       draftValue = null
+       hasConflict = false
+       updatedAt = now
+       updatedBy = caller (reuse from last save) OR system marker
+  5. Persist + return.
+
+IntegrationsContentPublisher.publish(req)
+  - connectionId == null → resolve ProductMaster adapter from IntegrationsService, call adapter.updateProduct(productId, { [fieldKey]: value }), read `updatedAt` or version-like field from returned Product as baseVersion.
+  - connectionId != null → throw ChannelContentPublishNotSupportedException (deferred scope).
+```
+
+### 4.5 Reconcile logic
+
+```
+reconcileExternal(cmd)
+  Find row. If not found → insert with baseValue=externalValue, baseVersion=externalVersion.
+  If found:
+    - draftValue == null → silent update: baseValue=externalValue, baseVersion=externalVersion, hasConflict=false.
+    - draftValue != null && externalVersion > baseVersion → hasConflict=true, update baseValue+baseVersion to external (FE will render diff). Draft preserved.
+    - draftValue != null && externalVersion == baseVersion → no-op (same origin).
+```
+
+`externalVersion > baseVersion` is a **string compare**: since we store platform-specific opaque markers, we don't perform ordering arithmetic — we treat any change from the stored `baseVersion` to a different `externalVersion` as a divergence. The `>` semantics in the issue is a simplification; the implementation is "divergence when strings differ" (documented in code comments).
+
+### 4.6 AI adapter behaviour
+
+- `VercelAiCompletionAdapter.complete(input)`:
+  - Defaults: `model = OL_AI_DEFAULT_MODEL (claude-opus-4-7)`, `maxOutputTokens = OL_AI_DEFAULT_MAX_TOKENS (2048)`, `temperature = 0.2`, `cacheSystemPrompt = true`, timeout = `OL_AI_TIMEOUT_MS (60000)`.
+  - Calls `generateText({ model: anthropic(model), system: systemPrompt, prompt: userPrompt, maxOutputTokens, temperature, providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } } })` when `cacheSystemPrompt`.
+  - Wraps in `AbortController` for timeout → on timeout → `AiTimeoutError`.
+  - Maps provider errors by shape (rate-limit 429 → `AiRateLimitError`; other → `AiCompletionError`). Uses duck-typed detection (`error.statusCode === 429` or string match) to avoid importing provider error types into the adapter boundary check.
+  - Logs `{ requestId, model, latencyMs, inputTokens, outputTokens, cachedInputTokens }`.
+  - **Anthropic cache threshold note (in adapter file header):** the Anthropic prompt cache silently no-ops `cache_control` when the cached prefix is below ~1024 input tokens. The adapter applies the marker unconditionally when `cacheSystemPrompt` is true; `cachedInputTokens === 0` on first call is **expected behaviour**, not a bug. Repeated calls with a sufficiently long system prompt should observe `cachedInputTokens > 0` after the first warm-up.
+- `FakeAiCompletionAdapter.complete(input)`:
+  - Returns `text = \`fake: \${input.userPrompt.slice(0, 120)}\`` (deterministic from input).
+  - `usage.inputTokens = Math.ceil(systemPrompt.length / 4)`, `outputTokens = Math.ceil(text.length / 4)`, `cachedInputTokens = 0`.
+  - `modelUsed = 'fake-model'`, `latencyMs = 1`.
+  - Useful for unit tests consuming the port without touching the network.
+
+### 4.7 Module wiring
+
+- `ContentModule` (core): providers = `ProductContentFieldRepository`, `ContentDraftService`, `IntegrationsContentPublisher`, plus token bindings; exports token bindings + `ContentDraftService` via token.
+- `AiIntegrationModule` (integrations): reads `OL_AI_PROVIDER` (default `'anthropic'`; `'fake'` selects the fake adapter). Provides the chosen adapter as concrete class + binds `AI_COMPLETION_PORT_TOKEN` via `useExisting`.
+- `AppModule`: add `ContentModule` + `AiIntegrationModule` to imports.
+
+### 4.8 Env vars introduced
+| Var | Default | Consumer |
+|---|---|---|
+| `OL_AI_PROVIDER` | `anthropic` | `AiIntegrationModule` (adapter selection) |
+| `OL_AI_DEFAULT_MODEL` | `claude-opus-4-7` | `VercelAiCompletionAdapter` |
+| `OL_AI_DEFAULT_MAX_TOKENS` | `2048` | `VercelAiCompletionAdapter` |
+| `OL_AI_TIMEOUT_MS` | `60000` | `VercelAiCompletionAdapter` |
+| `OL_AI_LOG_PROMPT` | `false` | `VercelAiCompletionAdapter` (debug-only — when true, logs raw prompt + response text in addition to metadata) |
+| `ANTHROPIC_API_KEY` | — (required when provider=anthropic) | `VercelAiCompletionAdapter` |
+
+`.env.example` is updated.
+
+---
+
+## 5. Step-by-step Implementation Plan
+
+### Phase A — Plumbing (path aliases, scaffold empty package)
+- **A1.** Add `@openlinker/integrations-ai` alias pairs to `tsconfig.base.json`, `apps/api/tsconfig.json`, `apps/api/tsconfig.build.json`, `apps/api/jest.config.js`, `apps/api/test/jest-integration.cjs`. **AC**: `pnpm type-check` still green from the repo root.
+- **A2.** Create `libs/integrations/ai/` skeleton: `package.json` (name: `@openlinker/integrations-ai`, deps `@openlinker/core`, `@openlinker/shared`, `ai@latest-stable`, `@ai-sdk/anthropic@latest-stable`; peerDep `@nestjs/common`), `tsconfig.json`, `tsconfig.spec.json`, `jest.config.mjs`, `test/openlinker.sequencer.cjs` — all mirrored from the allegro package. **AC**: `pnpm install` resolves the new workspace package without error.
+- **A3.** Add `@openlinker/integrations-ai` to `apps/api/package.json` dependencies (workspace:*). **AC**: `pnpm install` linked.
+
+### Phase B — AI core (#340)
+- **B1.** `libs/core/src/ai/domain/types/ai-completion.types.ts` + `…/ports/ai-completion.port.ts` + 4 exception files + `ai.tokens.ts` (exports `AI_COMPLETION_PORT_TOKEN = Symbol('AiCompletionPort')`). `index.ts` re-exports. **AC**: files compile; domain has zero framework imports.
+- **B2.** `libs/integrations/ai/src/infrastructure/adapters/fake-ai-completion.adapter.ts` + its `.spec.ts`. **AC**: spec asserts deterministic return payload for a fixed input.
+- **B3.** `libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.ts`. Uses `generateText` from `ai` + `anthropic` from `@ai-sdk/anthropic`. Reads env via `ConfigService`. Structured logs via `Logger`. Timeout + error mapping. **AC**: spec mocks `ai.generateText` (via `jest.mock('ai')`) and asserts the adapter forwards model + maxOutputTokens, applies cache-control when `cacheSystemPrompt` is true (default), surfaces timeout as `AiTimeoutError`, and maps `statusCode 429` → `AiRateLimitError`.
+- **B4.** `libs/integrations/ai/src/ai-integration.module.ts` — NestJS module selecting the adapter via `OL_AI_PROVIDER`. Binds `AI_COMPLETION_PORT_TOKEN` with `useExisting`. **AC**: module file compiles, exports `AI_COMPLETION_PORT_TOKEN` via `useExisting`.
+- **B5.** `libs/integrations/ai/src/index.ts` exports module + adapters (adapters exported only for testing — callers consume the port via token).
+- **B6.** Register `AiIntegrationModule` in `apps/api/src/integrations/integrations.module.ts` (next to `AllegroIntegrationModule` + `PrestashopIntegrationModule`). **Not** `AppModule` — every other `@openlinker/integrations-*` module sits in the api-level `IntegrationsModule`.
+
+### Phase C — Content core (#338)
+- **C1.** Domain surface: `libs/core/src/content/domain/types/content.types.ts`, `…/entities/product-content-field.entity.ts`, `…/ports/product-content-field-repository.port.ts`, `…/ports/content-publisher.port.ts`, 3 exception files. **AC**: domain has zero framework imports.
+- **C2.** ORM entity `libs/core/src/content/infrastructure/persistence/entities/product-content-field.orm-entity.ts` with the columns from §4.2 and correct indexes via `@Index(...)` decorators. **Note**: the two partial-unique indexes must be created in the migration (TypeORM decorator support for partial/filtered indexes is fragile — safer to define them in migration SQL).
+- **C3.** Migration `apps/api/src/migrations/1789000000000-add-product-content-field-table.ts` with `up()` creating table + indexes and `down()` dropping them cleanly.
+- **C4.** Repository `…/infrastructure/persistence/repositories/product-content-field.repository.ts` implementing the port (`findByKey`, `upsert`, `delete`). Private `toDomain` / `toOrm`. **PK is a plain UUID** generated by Postgres `gen_random_uuid()` (default on the column) — `ProductContentField` is an OL-internal entity with no external-ID counterpart, so it intentionally does not participate in `IdentifierMappingService` and does not carry an `ol_*` prefix. Avoids the visual ambiguity of mixing `ol_*` IDs with rows that have no identifier-mapping presence.
+- **C5.** Application service `ContentDraftService` implementing `IContentDraftService` (§4.3). All methods. Publishes via injected `ContentPublisherPort` (token: `CONTENT_PUBLISHER_PORT_TOKEN`).
+- **C6.** Concrete publisher `IntegrationsContentPublisher` implements `ContentPublisherPort`. Depends on `IntegrationsService` to resolve the `ProductMasterPort` adapter. Handles master path. Throws `ChannelContentPublishNotSupportedException` for non-null `connectionId` with a clear message pointing at #339/#342.
+- **C7.** `content.tokens.ts` (`PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN`, `CONTENT_DRAFT_SERVICE_TOKEN`, `CONTENT_PUBLISHER_PORT_TOKEN`) + `content.module.ts` wiring everything + `index.ts` re-exports.
+- **C8.** Register `ContentModule` in `apps/api/src/app.module.ts` imports. (Core bounded context, sits at app-level alongside `ProductsApiModule`, `OrdersModule`, etc.)
+- **C9.** Add `product_content_field` to the integration-harness TRUNCATE list in `apps/api/test/integration/setup.ts`. Since the entity has FKs to `products` and `connections`, put it **before** those in the truncate order.
+- **C10.** Worker registration (`apps/worker/`) is **deferred**. `ContentDraftService.reconcileExternal` is the natural call site for inbound sync handlers, but no consumer exists yet — wiring it before #339/#342 land would create a dead provider in the worker module. Tracked as a follow-up note in the AI/Content sections of architecture-overview.md.
+
+### Phase D — Tests
+- **D1.** Unit tests `content-draft.service.spec.ts`:
+  - `should create row with draftValue when no row exists` (saveDraft fresh).
+  - `should update draftValue and preserve baseValue/baseVersion when row exists` (saveDraft on existing row).
+  - `should clear hasConflict when a new draft is saved over a previously-conflicted row (implicit acknowledgement)` — explicitly documents the policy that re-saving acts as user acknowledgement of the divergence; future `acknowledgeConflict` action could split this if the FE needs separate semantics.
+  - `should null draftValue on discardDraft` and `should be a no-op when no row exists`.
+  - `should be a no-op when publishDraft is called with no pending draft`.
+  - `should throw ContentConflictException when publishDraft is called on a conflicted row`.
+  - `should call ContentPublisherPort.publish, set baseValue=draftValue, null draftValue, and update baseVersion on successful publish`.
+  - `should silently update baseValue and baseVersion on reconcileExternal when no draft exists`.
+  - `should mark hasConflict=true on reconcileExternal when draft exists and external version differs from base`.
+  - `should be a no-op on reconcileExternal when external version equals base version` (same-origin replay).
+  - `should resolve master draftValue, then master baseValue, then null when connectionId=null`.
+  - `should resolve channel draft, channel base, master draft, master base, then null when connectionId is provided`.
+- **D2.** Unit test `integrations-content-publisher.service.spec.ts`: master path resolves `ProductMaster` and calls `updateProduct(productId, { description: 'new' })`; channel path throws `ChannelContentPublishNotSupportedException`.
+- **D3.** Adapter unit tests for AI (B2, B3 above).
+- **D4.** Integration test `apps/api/test/integration/content-draft.int-spec.ts`:
+  - Seed a connection + a product (via harness helpers or direct SQL inserts if helpers missing).
+  - Save draft → assert row exists with `draftValue`.
+  - Reconcile with same-version external → no-op.
+  - Reconcile with different external version → row has `hasConflict=true`.
+  - Save a new draft → `hasConflict=false`.
+  - Publish draft path: stub the `ContentPublisherPort` (not the underlying `IntegrationsService`) via `Test.createTestingModule().overrideProvider(CONTENT_PUBLISHER_PORT_TOKEN).useValue({ publish: jest.fn().mockResolvedValue({ baseVersion: '...' }) })` — this is the lowest-blast-radius override, avoids touching adapter-factory test helpers (whose surface for arbitrary capability overrides isn't established yet), and keeps the publish path testable end-to-end at the row level. After the call, assert `draftValue=null`, `baseValue=draft`, `baseVersion=stub-version`.
+  - Use `resetTestHarness()` between tests per `docs/testing-guide.md`.
+
+### Phase E — Docs + env
+- **E1.** Update `.env.example` (or equivalent) with the five new env vars and comments.
+- **E2.** Extend `docs/architecture-overview.md` — add a short Content bounded context section (the table already has slots 1–10; add §11 Content) + a short AI section (§12). One paragraph each + the public port surface.
+- **E3.** No changes to `engineering-standards.md` — patterns followed, no new standard introduced.
+
+### Phase F — Quality gate
+- **F1.** `pnpm lint` — zero errors.
+- **F2.** `pnpm type-check` — zero errors.
+- **F3.** `pnpm test` — all unit suites green.
+- **F4.** `pnpm test:integration --testPathPattern=content-draft.int-spec` — new suite green (only run the content one to validate the addition; the rest run in CI).
+- **F5.** `pnpm --filter @openlinker/api migration:show` — confirms the new migration is detected + unapplied on a clean DB.
+
+---
+
+## 6. Validation Checklist (before commit)
+
+Architecture
+- [ ] Domain folders (`libs/core/src/{ai,content}/domain/**`) import only from `@openlinker/core/**/domain/**` and `@openlinker/shared/**` (no NestJS, no TypeORM).
+- [ ] Adapters implement ports, not vice-versa.
+- [ ] Service → repository **port** (not concrete class); module binds via symbol token + `useExisting`.
+- [ ] No provider SDK type (`ai`, `@ai-sdk/*`) appears outside `libs/integrations/ai/src/infrastructure/adapters/`.
+- [ ] `ContentDraftService` depends on `ContentPublisherPort` (not on `IntegrationsService` directly).
+
+Naming + file conventions
+- [ ] Ports: `*.port.ts` → `{Capability}Port`. Adapters: `*-adapter.ts` → `{Platform}{Capability}Adapter`.
+- [ ] Service interface in `*.service.interface.ts`; implementation in `*.service.ts`.
+- [ ] Types in `*.types.ts`. Exceptions in `domain/exceptions/*.exception.ts`.
+- [ ] File-header block on every new source file (purpose + `@module` tag).
+
+TS / lint
+- [ ] No `any`. `unknown` + narrowing where necessary.
+- [ ] No `console.log`. Logger everywhere.
+- [ ] Explicit return types on public methods.
+
+Migrations
+- [ ] `up()` idempotent with `IF NOT EXISTS` guards.
+- [ ] `down()` drops the two partial unique indexes + the table in reverse order.
+- [ ] Migration timestamp is monotonic. **Re-confirm at commit time** by running `ls apps/api/src/migrations/ | sort | tail -1`; bump the new migration's timestamp if a later migration has merged from `main` since this plan was written.
+
+Tests
+- [ ] Unit test files sit next to their subject (`*.spec.ts`).
+- [ ] Integration test added to `apps/api/test/integration/` as `*.int-spec.ts`.
+- [ ] `resetTestHarness()` is called between integration test cases.
+- [ ] `product_content_field` is truncated in `IntegrationTestHarness.reset()`.
+
+Security
+- [ ] `ANTHROPIC_API_KEY` is read from env, never logged.
+- [ ] No secrets checked into `.env.example` (only var names + placeholder comments).
+- [ ] No raw prompt or response body logged (we log metadata + token counts only; actual prompt text is debug-only gated by `OL_AI_LOG_PROMPT=true` env flag).
+
+Docs
+- [ ] `docs/architecture-overview.md` updated with Content + AI sections.
+- [ ] `.env.example` updated.
+
+---
+
+## 7. Risks & Open Questions
+
+| Risk | Mitigation |
+|---|---|
+| Two partial-unique indexes may surprise future contributors accustomed to a single unique constraint. | One-line comment in the migration + a note in the ORM entity header. |
+| `base_version` semantics are platform-specific. The `>` comparison in the issue is informal. | Explicit code comment: "divergence = string inequality"; adapters pass whatever opaque version marker they have (`date_upd` for PS, `revision` for Allegro). |
+| Vercel AI SDK major-version churn could break us. | Pin to a specific minor in the `integrations-ai` package.json. Version bumps are a deliberate PR. |
+| Fake adapter responses might accidentally satisfy real-adapter tests. | Fake adapter always prefixes `fake:` and real-adapter tests mock `generateText` rather than using the Fake. |
+| Channel-path publish is deferred — if a caller wires `connectionId != null` today they'll get an exception. | Exception message explicitly references follow-up issues. Integration test covers both branches. |
+| Prompt-cache hit rate isn't validated in this PR (requires live Anthropic call). | Caching is applied at the call site; the first consumer (#342) will observe `cachedInputTokens > 0` in logs. Acceptance for #340 only requires the adapter applies cache control correctly (unit-testable via mocked SDK call arguments). |
+
+### Open questions (non-blocking)
+- Do we want `updated_by` to FK to `users.id`? For MVP it's a free-text string to keep the table self-contained and to allow system-driven reconciles (`updatedBy = 'system'`). Cheap to tighten later if needed.
+- Should `OL_AI_LOG_PROMPT` default to `false` (privacy) or `true` in dev? Defaulting to `false` — only the metadata logs fire by default. Devs can opt in for debugging.

--- a/libs/core/src/ai/ai.tokens.ts
+++ b/libs/core/src/ai/ai.tokens.ts
@@ -1,0 +1,9 @@
+/**
+ * AI Module Dependency Injection Tokens
+ *
+ * Symbol tokens for AI module providers. AI_COMPLETION_PORT_TOKEN is bound
+ * to the configured adapter (Vercel/Anthropic or Fake) by AiIntegrationModule.
+ *
+ * @module libs/core/src/ai
+ */
+export const AI_COMPLETION_PORT_TOKEN = Symbol('AiCompletionPort');

--- a/libs/core/src/ai/domain/exceptions/ai-completion.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/ai-completion.exception.ts
@@ -1,0 +1,17 @@
+/**
+ * AI Completion Exception
+ *
+ * Generic domain exception for AI completion failures that do not fall into
+ * a more specific category (rate limit, timeout, invalid response). Adapters
+ * convert provider-specific errors into this (or one of the subclasses) at
+ * the adapter boundary so application code never sees provider error types.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+export class AiCompletionError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'AiCompletionError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/ai/domain/exceptions/ai-invalid-response.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/ai-invalid-response.exception.ts
@@ -1,0 +1,19 @@
+/**
+ * AI Invalid Response Exception
+ *
+ * Thrown when the provider returns a response that doesn't conform to the
+ * expected shape (e.g. empty `text`, missing usage fields, malformed payload).
+ * Indicates a bug in the adapter's response parsing or an unexpected provider
+ * change — distinct from a transport-level failure.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+import { AiCompletionError } from './ai-completion.exception';
+
+export class AiInvalidResponseError extends AiCompletionError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'AiInvalidResponseError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/ai/domain/exceptions/ai-rate-limit.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/ai-rate-limit.exception.ts
@@ -1,0 +1,18 @@
+/**
+ * AI Rate Limit Exception
+ *
+ * Thrown when the upstream AI provider signals a rate-limit (HTTP 429 or
+ * provider-specific equivalent). Callers may decide to back off, queue, or
+ * surface a user-visible "try again later" message.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+import { AiCompletionError } from './ai-completion.exception';
+
+export class AiRateLimitError extends AiCompletionError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'AiRateLimitError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/ai/domain/exceptions/ai-timeout.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/ai-timeout.exception.ts
@@ -1,0 +1,18 @@
+/**
+ * AI Timeout Exception
+ *
+ * Thrown when the adapter's per-call timeout (`OL_AI_TIMEOUT_MS`) elapses
+ * before the provider returns. Distinct from generic completion errors so
+ * callers can implement timeout-specific retry policies.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+import { AiCompletionError } from './ai-completion.exception';
+
+export class AiTimeoutError extends AiCompletionError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'AiTimeoutError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/ai/domain/ports/ai-completion.port.ts
+++ b/libs/core/src/ai/domain/ports/ai-completion.port.ts
@@ -1,0 +1,14 @@
+/**
+ * AI Completion Port
+ *
+ * Capability port for requesting AI text completions. Application services
+ * inject this via AI_COMPLETION_PORT_TOKEN and call `complete(...)` without
+ * coupling to any provider SDK.
+ *
+ * @module libs/core/src/ai/domain/ports
+ */
+import type { AiCompletionInput, AiCompletionResult } from '../types/ai-completion.types';
+
+export interface AiCompletionPort {
+  complete(input: AiCompletionInput): Promise<AiCompletionResult>;
+}

--- a/libs/core/src/ai/domain/types/ai-completion.types.ts
+++ b/libs/core/src/ai/domain/types/ai-completion.types.ts
@@ -1,0 +1,47 @@
+/**
+ * AI Completion Types
+ *
+ * Domain types for AI completion requests and responses. Provider-agnostic —
+ * no SDK shapes from the underlying provider leak through these types.
+ *
+ * @module libs/core/src/ai/domain/types
+ */
+
+/**
+ * Runtime array of supported AI provider keys. Used by AiIntegrationModule
+ * to select an adapter at boot. `'fake'` is the deterministic offline adapter
+ * used in tests and `OL_AI_PROVIDER=fake` local dev.
+ */
+export const AiProviderValues = ['anthropic', 'fake'] as const;
+export type AiProvider = (typeof AiProviderValues)[number];
+
+/**
+ * Input payload for a single completion call.
+ *
+ * `cacheSystemPrompt` defaults to `true` in the adapter; set `false` only when
+ * the system prompt is genuinely per-call (no reuse across requests). Anthropic's
+ * cache silently no-ops below ~1024 input tokens, so a `cachedInputTokens === 0`
+ * result on a short prompt is expected, not a failure.
+ */
+export interface AiCompletionInput {
+  systemPrompt: string;
+  userPrompt: string;
+  model?: string;
+  maxOutputTokens?: number;
+  temperature?: number;
+  cacheSystemPrompt?: boolean;
+  requestId?: string;
+}
+
+export interface AiCompletionUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+}
+
+export interface AiCompletionResult {
+  text: string;
+  usage: AiCompletionUsage;
+  modelUsed: string;
+  latencyMs: number;
+}

--- a/libs/core/src/ai/index.ts
+++ b/libs/core/src/ai/index.ts
@@ -1,0 +1,16 @@
+/**
+ * AI Bounded Context — Public Surface
+ *
+ * Exports the capability port, types, exceptions, and DI token. Implemented
+ * by adapters in libs/integrations/ai. The bounded context intentionally has
+ * no application services — the port is the surface application code consumes.
+ *
+ * @module libs/core/src/ai
+ */
+export * from './domain/ports/ai-completion.port';
+export * from './domain/types/ai-completion.types';
+export * from './domain/exceptions/ai-completion.exception';
+export * from './domain/exceptions/ai-rate-limit.exception';
+export * from './domain/exceptions/ai-timeout.exception';
+export * from './domain/exceptions/ai-invalid-response.exception';
+export * from './ai.tokens';

--- a/libs/core/src/content/application/services/content-draft.service.interface.ts
+++ b/libs/core/src/content/application/services/content-draft.service.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Content Draft Service Interface
+ *
+ * Application-layer contract for managing the draft lifecycle of product
+ * content fields: save, discard, publish, inbound-reconcile, and resolve.
+ *
+ * @module libs/core/src/content/application/services
+ */
+import type { ProductContentField } from '../../domain/entities/product-content-field.entity';
+import type {
+  DiscardDraftCommand,
+  PublishDraftCommand,
+  ReconcileExternalCommand,
+  ResolveValueQuery,
+  SaveDraftCommand,
+} from '../types/content-draft.types';
+
+export interface IContentDraftService {
+  /** Upsert the row's `draftValue`. Implicitly clears `hasConflict` (re-saving acknowledges the divergence). */
+  saveDraft(cmd: SaveDraftCommand): Promise<ProductContentField>;
+
+  /** Null out `draftValue` on the row. No-op when the row does not exist. */
+  discardDraft(cmd: DiscardDraftCommand): Promise<void>;
+
+  /** Push the draft to the platform via `ContentPublisherPort`, then clear the draft and update the base. */
+  publishDraft(cmd: PublishDraftCommand): Promise<ProductContentField>;
+
+  /** Inbound sync hook: silently update base when no draft; mark conflict when draft + divergence. */
+  reconcileExternal(cmd: ReconcileExternalCommand): Promise<ProductContentField>;
+
+  /** Read-side resolution: returns the value the application should display / use, with channel→master fallback. */
+  resolveValue(query: ResolveValueQuery): Promise<string | null>;
+}

--- a/libs/core/src/content/application/services/content-draft.service.spec.ts
+++ b/libs/core/src/content/application/services/content-draft.service.spec.ts
@@ -1,0 +1,414 @@
+/**
+ * Content Draft Service — Unit Tests
+ *
+ * Covers all branches of the save / discard / publish / reconcile / resolve
+ * lifecycle defined in §4.4 / §4.5 of the implementation plan. The repository
+ * port is mocked; the publisher port is mocked.
+ *
+ * @module libs/core/src/content/application/services
+ */
+import { ContentDraftService } from './content-draft.service';
+import { ProductContentField } from '../../domain/entities/product-content-field.entity';
+import { ContentConflictException } from '../../domain/exceptions/content-conflict.exception';
+import type { ContentPublisherPort } from '../../domain/ports/content-publisher.port';
+import type { ProductContentFieldRepositoryPort } from '../../domain/ports/product-content-field-repository.port';
+
+const buildField = (overrides: Partial<ProductContentField> = {}): ProductContentField => {
+  const base = {
+    id: 'fld-1',
+    productId: 'ol_product_abc',
+    connectionId: null as string | null,
+    fieldKey: 'description' as const,
+    draftValue: null as string | null,
+    baseValue: null as string | null,
+    baseVersion: null as string | null,
+    hasConflict: false,
+    updatedAt: new Date('2026-04-22T10:00:00Z'),
+    updatedBy: null as string | null,
+    ...overrides,
+  };
+  return new ProductContentField(
+    base.id,
+    base.productId,
+    base.connectionId,
+    base.fieldKey,
+    base.draftValue,
+    base.baseValue,
+    base.baseVersion,
+    base.hasConflict,
+    base.updatedAt,
+    base.updatedBy,
+  );
+};
+
+const buildRepoMock = (): jest.Mocked<ProductContentFieldRepositoryPort> => ({
+  findByKey: jest.fn(),
+  upsert: jest.fn(),
+  delete: jest.fn(),
+});
+
+const buildPublisherMock = (): jest.Mocked<ContentPublisherPort> => ({
+  publish: jest.fn(),
+});
+
+describe('ContentDraftService', () => {
+  let repo: jest.Mocked<ProductContentFieldRepositoryPort>;
+  let publisher: jest.Mocked<ContentPublisherPort>;
+  let service: ContentDraftService;
+
+  beforeEach(() => {
+    repo = buildRepoMock();
+    publisher = buildPublisherMock();
+    service = new ContentDraftService(repo, publisher);
+  });
+
+  describe('saveDraft', () => {
+    it('should create a row with draftValue when no row exists', async () => {
+      repo.findByKey.mockResolvedValue(null);
+      repo.upsert.mockImplementation((p) =>
+        Promise.resolve(buildField({ draftValue: p.draftValue, updatedBy: p.updatedBy })),
+      );
+
+      await service.saveDraft({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        value: 'new draft',
+        userId: 'user-1',
+      });
+
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draftValue: 'new draft',
+          baseValue: null,
+          baseVersion: null,
+          hasConflict: false,
+          updatedBy: 'user-1',
+        }),
+      );
+    });
+
+    it('should update draftValue and preserve baseValue/baseVersion when row exists', async () => {
+      repo.findByKey.mockResolvedValue(
+        buildField({ baseValue: 'old base', baseVersion: 'v1', draftValue: 'old draft' }),
+      );
+      repo.upsert.mockImplementation((p) =>
+        Promise.resolve(buildField({ ...p, baseValue: p.baseValue, baseVersion: p.baseVersion })),
+      );
+
+      await service.saveDraft({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        value: 'new draft',
+        userId: 'user-2',
+      });
+
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draftValue: 'new draft',
+          baseValue: 'old base',
+          baseVersion: 'v1',
+        }),
+      );
+    });
+
+    it('should clear hasConflict when a new draft is saved over a previously-conflicted row (implicit acknowledgement)', async () => {
+      repo.findByKey.mockResolvedValue(
+        buildField({ baseValue: 'newer base', baseVersion: 'v2', draftValue: 'stale draft', hasConflict: true }),
+      );
+      repo.upsert.mockImplementation((p) => Promise.resolve(buildField(p)));
+
+      await service.saveDraft({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        value: 'reconciled draft',
+        userId: 'user-1',
+      });
+
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ hasConflict: false }),
+      );
+    });
+  });
+
+  describe('discardDraft', () => {
+    it('should null draftValue when a row with a draft exists', async () => {
+      repo.findByKey.mockResolvedValue(
+        buildField({ baseValue: 'b', baseVersion: 'v1', draftValue: 'd' }),
+      );
+
+      await service.discardDraft({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+      });
+
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draftValue: null,
+          baseValue: 'b',
+          baseVersion: 'v1',
+        }),
+      );
+    });
+
+    it('should be a no-op when no row exists', async () => {
+      repo.findByKey.mockResolvedValue(null);
+
+      await service.discardDraft({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+      });
+
+      expect(repo.upsert).not.toHaveBeenCalled();
+    });
+
+    it('should be a no-op when the row has no draft', async () => {
+      repo.findByKey.mockResolvedValue(buildField({ baseValue: 'b', draftValue: null }));
+
+      await service.discardDraft({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+      });
+
+      expect(repo.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('publishDraft', () => {
+    it('should be a no-op when there is no draft to publish', async () => {
+      repo.findByKey.mockResolvedValue(buildField({ baseValue: 'b', draftValue: null }));
+
+      await service.publishDraft({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+      });
+
+      expect(publisher.publish).not.toHaveBeenCalled();
+      expect(repo.upsert).not.toHaveBeenCalled();
+    });
+
+    it('should throw ContentConflictException when the row is conflicted', async () => {
+      repo.findByKey.mockResolvedValue(
+        buildField({ baseValue: 'newer', baseVersion: 'v2', draftValue: 'd', hasConflict: true }),
+      );
+
+      await expect(
+        service.publishDraft({
+          productId: 'ol_product_abc',
+          connectionId: null,
+          fieldKey: 'description',
+        }),
+      ).rejects.toBeInstanceOf(ContentConflictException);
+      expect(publisher.publish).not.toHaveBeenCalled();
+    });
+
+    it('should call ContentPublisherPort.publish, set baseValue=draftValue, null draftValue, and update baseVersion on success', async () => {
+      repo.findByKey.mockResolvedValue(
+        buildField({ baseValue: 'old', baseVersion: 'v1', draftValue: 'new draft' }),
+      );
+      publisher.publish.mockResolvedValue({ baseVersion: 'v2-after-publish' });
+      repo.upsert.mockImplementation((p) => Promise.resolve(buildField(p)));
+
+      await service.publishDraft({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+      });
+
+      expect(publisher.publish).toHaveBeenCalledWith({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        value: 'new draft',
+      });
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          draftValue: null,
+          baseValue: 'new draft',
+          baseVersion: 'v2-after-publish',
+          hasConflict: false,
+        }),
+      );
+    });
+  });
+
+  describe('reconcileExternal', () => {
+    it('should silently update baseValue and baseVersion when no draft exists', async () => {
+      repo.findByKey.mockResolvedValue(buildField({ baseValue: 'old', baseVersion: 'v1' }));
+      repo.upsert.mockImplementation((p) => Promise.resolve(buildField(p)));
+
+      await service.reconcileExternal({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        externalValue: 'platform value',
+        externalVersion: 'v2',
+      });
+
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseValue: 'platform value',
+          baseVersion: 'v2',
+          draftValue: null,
+          hasConflict: false,
+        }),
+      );
+    });
+
+    it('should mark hasConflict=true when draft exists and external version differs from base', async () => {
+      repo.findByKey.mockResolvedValue(
+        buildField({ baseValue: 'old', baseVersion: 'v1', draftValue: 'pending draft' }),
+      );
+      repo.upsert.mockImplementation((p) => Promise.resolve(buildField(p)));
+
+      await service.reconcileExternal({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        externalValue: 'someone else changed it',
+        externalVersion: 'v2',
+      });
+
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseValue: 'someone else changed it',
+          baseVersion: 'v2',
+          draftValue: 'pending draft',
+          hasConflict: true,
+        }),
+      );
+    });
+
+    it('should be a no-op when external version equals base version (same-origin replay)', async () => {
+      repo.findByKey.mockResolvedValue(
+        buildField({ baseValue: 'b', baseVersion: 'v1', draftValue: 'd' }),
+      );
+
+      await service.reconcileExternal({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        externalValue: 'b',
+        externalVersion: 'v1',
+      });
+
+      expect(repo.upsert).not.toHaveBeenCalled();
+    });
+
+    it('should insert a fresh row on first-touch when no row exists', async () => {
+      repo.findByKey.mockResolvedValue(null);
+      repo.upsert.mockImplementation((p) => Promise.resolve(buildField(p)));
+
+      await service.reconcileExternal({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        externalValue: 'first value',
+        externalVersion: 'v0',
+      });
+
+      expect(repo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseValue: 'first value',
+          baseVersion: 'v0',
+          draftValue: null,
+          hasConflict: false,
+          updatedBy: null,
+        }),
+      );
+    });
+  });
+
+  describe('resolveValue', () => {
+    it('should return master draft when connectionId is null and a draft exists', async () => {
+      repo.findByKey.mockResolvedValue(buildField({ baseValue: 'b', draftValue: 'master draft' }));
+
+      const value = await service.resolveValue({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+      });
+
+      expect(value).toBe('master draft');
+    });
+
+    it('should return master baseValue when no draft and connectionId is null', async () => {
+      repo.findByKey.mockResolvedValue(buildField({ baseValue: 'master base', draftValue: null }));
+
+      const value = await service.resolveValue({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+      });
+
+      expect(value).toBe('master base');
+    });
+
+    it('should return null when no master row exists and connectionId is null', async () => {
+      repo.findByKey.mockResolvedValue(null);
+
+      const value = await service.resolveValue({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+      });
+
+      expect(value).toBeNull();
+    });
+
+    it('should prefer channel draft over channel base over master values when connectionId is set', async () => {
+      // First call (channel) returns a draft.
+      repo.findByKey.mockImplementation(({ connectionId }) =>
+        Promise.resolve(
+          connectionId === null
+            ? buildField({ baseValue: 'master base' })
+            : buildField({ connectionId: 'conn-1', draftValue: 'channel draft', baseValue: 'channel base' }),
+        ),
+      );
+
+      const value = await service.resolveValue({
+        productId: 'ol_product_abc',
+        connectionId: 'conn-1',
+        fieldKey: 'description',
+      });
+
+      expect(value).toBe('channel draft');
+    });
+
+    it('should fall back from channel base to master draft to master base when channel has no value', async () => {
+      repo.findByKey.mockImplementation(({ connectionId }) =>
+        Promise.resolve(
+          connectionId === null
+            ? buildField({ draftValue: 'master draft', baseValue: 'master base' })
+            : null, // no channel row
+        ),
+      );
+
+      const value = await service.resolveValue({
+        productId: 'ol_product_abc',
+        connectionId: 'conn-1',
+        fieldKey: 'description',
+      });
+
+      expect(value).toBe('master draft');
+    });
+
+    it('should return null when neither channel nor master have any value', async () => {
+      repo.findByKey.mockResolvedValue(null);
+
+      const value = await service.resolveValue({
+        productId: 'ol_product_abc',
+        connectionId: 'conn-1',
+        fieldKey: 'description',
+      });
+
+      expect(value).toBeNull();
+    });
+  });
+});

--- a/libs/core/src/content/application/services/content-draft.service.spec.ts
+++ b/libs/core/src/content/application/services/content-draft.service.spec.ts
@@ -10,6 +10,7 @@
 import { ContentDraftService } from './content-draft.service';
 import { ProductContentField } from '../../domain/entities/product-content-field.entity';
 import { ContentConflictException } from '../../domain/exceptions/content-conflict.exception';
+import { ContentFieldNotFoundException } from '../../domain/exceptions/content-field-not-found.exception';
 import type { ContentPublisherPort } from '../../domain/ports/content-publisher.port';
 import type { ProductContentFieldRepositoryPort } from '../../domain/ports/product-content-field-repository.port';
 
@@ -180,7 +181,21 @@ describe('ContentDraftService', () => {
   });
 
   describe('publishDraft', () => {
-    it('should be a no-op when there is no draft to publish', async () => {
+    it('should throw ContentFieldNotFoundException when no row exists', async () => {
+      repo.findByKey.mockResolvedValue(null);
+
+      await expect(
+        service.publishDraft({
+          productId: 'ol_product_abc',
+          connectionId: null,
+          fieldKey: 'description',
+        }),
+      ).rejects.toBeInstanceOf(ContentFieldNotFoundException);
+      expect(publisher.publish).not.toHaveBeenCalled();
+      expect(repo.upsert).not.toHaveBeenCalled();
+    });
+
+    it('should be a no-op when the row exists but has no draft to publish', async () => {
       repo.findByKey.mockResolvedValue(buildField({ baseValue: 'b', draftValue: null }));
 
       await service.publishDraft({

--- a/libs/core/src/content/application/services/content-draft.service.ts
+++ b/libs/core/src/content/application/services/content-draft.service.ts
@@ -10,8 +10,9 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
-import { ProductContentField } from '../../domain/entities/product-content-field.entity';
+import type { ProductContentField } from '../../domain/entities/product-content-field.entity';
 import { ContentConflictException } from '../../domain/exceptions/content-conflict.exception';
+import { ContentFieldNotFoundException } from '../../domain/exceptions/content-field-not-found.exception';
 import {
   CONTENT_PUBLISHER_PORT_TOKEN,
   PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN,
@@ -94,34 +95,19 @@ export class ContentDraftService implements IContentDraftService {
       fieldKey: cmd.fieldKey,
     });
 
-    if (!existing || existing.draftValue === null) {
-      // No-op publish: nothing to push. Return whatever the row currently looks like
-      // (or fabricate an empty representation if absent — but absent + publish is unusual,
-      // so we return the existing row to keep the contract simple).
-      if (!existing) {
-        // Not throwing here keeps publishDraft idempotent w.r.t. callers that don't
-        // pre-check; if a stricter "must exist" semantic is wanted later, swap to
-        // ContentFieldNotFoundException. For MVP, silently no-op preserves the
-        // "draft buffer is the truth" mental model.
-        this.logger.debug(
-          `[content] publishDraft no-op (no row): productId=${cmd.productId} connectionId=${cmd.connectionId ?? 'master'} fieldKey=${cmd.fieldKey}`,
-        );
-      }
-      return (
-        existing ??
-        new ProductContentField(
-          'no-op',
-          cmd.productId,
-          cmd.connectionId,
-          cmd.fieldKey,
-          null,
-          null,
-          null,
-          false,
-          new Date(),
-          null,
-        )
+    if (!existing) {
+      // Publishing requires a row to exist. Callers should saveDraft first.
+      // We throw rather than silently no-op so a misuse (publish-before-save)
+      // is surfaced rather than swallowed.
+      throw new ContentFieldNotFoundException(cmd.productId, cmd.connectionId, cmd.fieldKey);
+    }
+
+    if (existing.draftValue === null) {
+      // Row exists but no draft to publish — idempotent no-op, return as-is.
+      this.logger.debug(
+        `[content] publishDraft no-op (no draft): productId=${cmd.productId} connectionId=${cmd.connectionId ?? 'master'} fieldKey=${cmd.fieldKey}`,
       );
+      return existing;
     }
 
     if (existing.hasConflict) {

--- a/libs/core/src/content/application/services/content-draft.service.ts
+++ b/libs/core/src/content/application/services/content-draft.service.ts
@@ -1,0 +1,237 @@
+/**
+ * Content Draft Service
+ *
+ * Implements the draft write-through lifecycle for product content fields.
+ * See `docs/plans/implementation-plan-338-340-content-and-ai-foundation.md`
+ * §4.4 for the publish algorithm and §4.5 for the reconcile algorithm.
+ *
+ * @module libs/core/src/content/application/services
+ * @implements {IContentDraftService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { ProductContentField } from '../../domain/entities/product-content-field.entity';
+import { ContentConflictException } from '../../domain/exceptions/content-conflict.exception';
+import {
+  CONTENT_PUBLISHER_PORT_TOKEN,
+  PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN,
+} from '../../content.tokens';
+import type { ContentPublisherPort } from '../../domain/ports/content-publisher.port';
+import type { ProductContentFieldRepositoryPort } from '../../domain/ports/product-content-field-repository.port';
+import type {
+  DiscardDraftCommand,
+  PublishDraftCommand,
+  ReconcileExternalCommand,
+  ResolveValueQuery,
+  SaveDraftCommand,
+} from '../types/content-draft.types';
+import type { IContentDraftService } from './content-draft.service.interface';
+
+@Injectable()
+export class ContentDraftService implements IContentDraftService {
+  private readonly logger = new Logger(ContentDraftService.name);
+
+  constructor(
+    @Inject(PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN)
+    private readonly repository: ProductContentFieldRepositoryPort,
+    @Inject(CONTENT_PUBLISHER_PORT_TOKEN)
+    private readonly publisher: ContentPublisherPort,
+  ) {}
+
+  async saveDraft(cmd: SaveDraftCommand): Promise<ProductContentField> {
+    const existing = await this.repository.findByKey({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+    });
+
+    return this.repository.upsert({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+      draftValue: cmd.value,
+      baseValue: existing?.baseValue ?? null,
+      baseVersion: existing?.baseVersion ?? null,
+      // Saving a draft implicitly acknowledges any prior conflict — the user is taking ownership.
+      hasConflict: false,
+      updatedBy: cmd.userId,
+    });
+  }
+
+  async discardDraft(cmd: DiscardDraftCommand): Promise<void> {
+    const existing = await this.repository.findByKey({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+    });
+
+    if (!existing) {
+      // No row → nothing to discard. Idempotent no-op.
+      return;
+    }
+
+    if (existing.draftValue === null) {
+      // Already no draft.
+      return;
+    }
+
+    await this.repository.upsert({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+      draftValue: null,
+      baseValue: existing.baseValue,
+      baseVersion: existing.baseVersion,
+      hasConflict: existing.hasConflict,
+      updatedBy: existing.updatedBy,
+    });
+  }
+
+  async publishDraft(cmd: PublishDraftCommand): Promise<ProductContentField> {
+    const existing = await this.repository.findByKey({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+    });
+
+    if (!existing || existing.draftValue === null) {
+      // No-op publish: nothing to push. Return whatever the row currently looks like
+      // (or fabricate an empty representation if absent — but absent + publish is unusual,
+      // so we return the existing row to keep the contract simple).
+      if (!existing) {
+        // Not throwing here keeps publishDraft idempotent w.r.t. callers that don't
+        // pre-check; if a stricter "must exist" semantic is wanted later, swap to
+        // ContentFieldNotFoundException. For MVP, silently no-op preserves the
+        // "draft buffer is the truth" mental model.
+        this.logger.debug(
+          `[content] publishDraft no-op (no row): productId=${cmd.productId} connectionId=${cmd.connectionId ?? 'master'} fieldKey=${cmd.fieldKey}`,
+        );
+      }
+      return (
+        existing ??
+        new ProductContentField(
+          'no-op',
+          cmd.productId,
+          cmd.connectionId,
+          cmd.fieldKey,
+          null,
+          null,
+          null,
+          false,
+          new Date(),
+          null,
+        )
+      );
+    }
+
+    if (existing.hasConflict) {
+      throw new ContentConflictException(cmd.productId, cmd.connectionId, cmd.fieldKey);
+    }
+
+    const publishResult = await this.publisher.publish({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+      value: existing.draftValue,
+    });
+
+    return this.repository.upsert({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+      draftValue: null,
+      baseValue: existing.draftValue,
+      baseVersion: publishResult.baseVersion,
+      hasConflict: false,
+      updatedBy: existing.updatedBy,
+    });
+  }
+
+  async reconcileExternal(cmd: ReconcileExternalCommand): Promise<ProductContentField> {
+    const existing = await this.repository.findByKey({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+    });
+
+    if (!existing) {
+      // First-touch: insert the base values silently, no draft, no conflict.
+      return this.repository.upsert({
+        productId: cmd.productId,
+        connectionId: cmd.connectionId,
+        fieldKey: cmd.fieldKey,
+        draftValue: null,
+        baseValue: cmd.externalValue,
+        baseVersion: cmd.externalVersion,
+        hasConflict: false,
+        updatedBy: null, // system-driven
+      });
+    }
+
+    const versionsMatch = existing.baseVersion === cmd.externalVersion;
+    if (versionsMatch) {
+      // Same-origin replay; nothing to do.
+      return existing;
+    }
+
+    if (existing.draftValue === null) {
+      // No draft pending → silent base refresh.
+      return this.repository.upsert({
+        productId: cmd.productId,
+        connectionId: cmd.connectionId,
+        fieldKey: cmd.fieldKey,
+        draftValue: null,
+        baseValue: cmd.externalValue,
+        baseVersion: cmd.externalVersion,
+        hasConflict: false,
+        updatedBy: null,
+      });
+    }
+
+    // Draft + divergence → mark conflict, advance the base, preserve the draft.
+    this.logger.warn(
+      `[content] conflict detected: productId=${cmd.productId} connectionId=${cmd.connectionId ?? 'master'} fieldKey=${cmd.fieldKey} ` +
+        `baseVersion=${existing.baseVersion ?? '-'} externalVersion=${cmd.externalVersion}`,
+    );
+    return this.repository.upsert({
+      productId: cmd.productId,
+      connectionId: cmd.connectionId,
+      fieldKey: cmd.fieldKey,
+      draftValue: existing.draftValue,
+      baseValue: cmd.externalValue,
+      baseVersion: cmd.externalVersion,
+      hasConflict: true,
+      updatedBy: existing.updatedBy,
+    });
+  }
+
+  async resolveValue(query: ResolveValueQuery): Promise<string | null> {
+    if (query.connectionId === null) {
+      // Master-only resolution: master draft → master base → null.
+      const master = await this.repository.findByKey({
+        productId: query.productId,
+        connectionId: null,
+        fieldKey: query.fieldKey,
+      });
+      return master?.draftValue ?? master?.baseValue ?? null;
+    }
+
+    // Channel resolution with master fallback.
+    const channel = await this.repository.findByKey({
+      productId: query.productId,
+      connectionId: query.connectionId,
+      fieldKey: query.fieldKey,
+    });
+    const channelValue = channel?.draftValue ?? channel?.baseValue ?? null;
+    if (channelValue !== null) {
+      return channelValue;
+    }
+
+    const master = await this.repository.findByKey({
+      productId: query.productId,
+      connectionId: null,
+      fieldKey: query.fieldKey,
+    });
+    return master?.draftValue ?? master?.baseValue ?? null;
+  }
+}

--- a/libs/core/src/content/application/services/integrations-content-publisher.service.spec.ts
+++ b/libs/core/src/content/application/services/integrations-content-publisher.service.spec.ts
@@ -9,6 +9,8 @@
  */
 import { IntegrationsContentPublisher } from './integrations-content-publisher.service';
 import { ChannelContentPublishNotSupportedException } from '../../domain/exceptions/channel-content-publish-not-supported.exception';
+import { ContentPublishMissingVersionException } from '../../domain/exceptions/content-publish-missing-version.exception';
+import { NoProductMasterAdapterException } from '../../domain/exceptions/no-product-master-adapter.exception';
 import type { IIntegrationsService } from '@openlinker/core/integrations/application/interfaces/integrations.service.interface';
 import type { ProductMasterPort } from '@openlinker/core/products/domain/ports/product-master.port';
 import type { Product } from '@openlinker/core/products/domain/entities/product.entity';
@@ -52,38 +54,6 @@ describe('IntegrationsContentPublisher', () => {
       expect(result.baseVersion).toBe('2026-04-22T10:30:00.000Z');
     });
 
-    it('should fall back to a current ISO timestamp as baseVersion when the adapter returns no updatedAt', async () => {
-      const adapterUpdateProduct = jest
-        .fn<Promise<Product>, Parameters<ProductMasterPort['updateProduct']>>()
-        .mockResolvedValue({
-          id: 'ol_product_abc',
-          name: 'irrelevant',
-          sku: null,
-          price: null,
-          description: 'v',
-          images: null,
-        } as Product);
-      const integrationsService = {
-        listCapabilityAdapters: jest.fn().mockResolvedValue([
-          {
-            connectionId: 'conn-master',
-            connection: {},
-            adapter: { updateProduct: adapterUpdateProduct } as unknown as ProductMasterPort,
-            metadata: {},
-          },
-        ]),
-      } as unknown as IIntegrationsService;
-      const publisher = new IntegrationsContentPublisher(integrationsService);
-
-      const result = await publisher.publish({
-        productId: 'ol_product_abc',
-        connectionId: null,
-        fieldKey: 'description',
-        value: 'v',
-      });
-
-      expect(result.baseVersion).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-    });
 
     it('should throw ChannelContentPublishNotSupportedException for non-null connectionId', async () => {
       const integrationsService = {
@@ -101,7 +71,7 @@ describe('IntegrationsContentPublisher', () => {
       ).rejects.toBeInstanceOf(ChannelContentPublishNotSupportedException);
     });
 
-    it('should throw a clear error when no ProductMaster adapter is registered', async () => {
+    it('should throw NoProductMasterAdapterException when no ProductMaster adapter is registered', async () => {
       const integrationsService = {
         listCapabilityAdapters: jest.fn().mockResolvedValue([]),
       } as unknown as IIntegrationsService;
@@ -114,7 +84,41 @@ describe('IntegrationsContentPublisher', () => {
           fieldKey: 'description',
           value: 'v',
         }),
-      ).rejects.toThrow(/No active ProductMaster adapter/);
+      ).rejects.toBeInstanceOf(NoProductMasterAdapterException);
+    });
+
+    it('should throw ContentPublishMissingVersionException when adapter returns a product with no updatedAt', async () => {
+      const adapterUpdateProduct = jest
+        .fn<Promise<Product>, Parameters<ProductMasterPort['updateProduct']>>()
+        .mockResolvedValue({
+          id: 'ol_product_abc',
+          name: 'irrelevant',
+          sku: null,
+          price: null,
+          description: 'v',
+          images: null,
+          updatedAt: undefined as unknown as Date,
+        } as Product);
+      const integrationsService = {
+        listCapabilityAdapters: jest.fn().mockResolvedValue([
+          {
+            connectionId: 'conn-master',
+            connection: {},
+            adapter: { updateProduct: adapterUpdateProduct } as unknown as ProductMasterPort,
+            metadata: {},
+          },
+        ]),
+      } as unknown as IIntegrationsService;
+      const publisher = new IntegrationsContentPublisher(integrationsService);
+
+      await expect(
+        publisher.publish({
+          productId: 'ol_product_abc',
+          connectionId: null,
+          fieldKey: 'description',
+          value: 'v',
+        }),
+      ).rejects.toBeInstanceOf(ContentPublishMissingVersionException);
     });
   });
 });

--- a/libs/core/src/content/application/services/integrations-content-publisher.service.spec.ts
+++ b/libs/core/src/content/application/services/integrations-content-publisher.service.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Integrations Content Publisher — Unit Tests
+ *
+ * Asserts: master path resolves the ProductMaster adapter and calls
+ * `updateProduct` with a single-field patch keyed by `fieldKey`; channel
+ * path throws ChannelContentPublishNotSupportedException.
+ *
+ * @module libs/core/src/content/application/services
+ */
+import { IntegrationsContentPublisher } from './integrations-content-publisher.service';
+import { ChannelContentPublishNotSupportedException } from '../../domain/exceptions/channel-content-publish-not-supported.exception';
+import type { IIntegrationsService } from '@openlinker/core/integrations/application/interfaces/integrations.service.interface';
+import type { ProductMasterPort } from '@openlinker/core/products/domain/ports/product-master.port';
+import type { Product } from '@openlinker/core/products/domain/entities/product.entity';
+
+describe('IntegrationsContentPublisher', () => {
+  describe('publish', () => {
+    it('should resolve ProductMaster and call updateProduct with the keyed patch on master path', async () => {
+      const adapterUpdateProduct = jest.fn<Promise<Product>, Parameters<ProductMasterPort['updateProduct']>>(
+        () =>
+          Promise.resolve({
+            id: 'ol_product_abc',
+            name: 'irrelevant',
+            sku: null,
+            price: null,
+            description: 'new value',
+            images: null,
+            updatedAt: new Date('2026-04-22T10:30:00.000Z'),
+          } as Product),
+      );
+      const integrationsService: jest.Mocked<Pick<IIntegrationsService, 'listCapabilityAdapters'>> = {
+        listCapabilityAdapters: jest.fn().mockResolvedValue([
+          {
+            connectionId: 'conn-master',
+            connection: {} as unknown,
+            adapter: { updateProduct: adapterUpdateProduct } as unknown as ProductMasterPort,
+            metadata: {} as unknown,
+          },
+        ]),
+      };
+      const publisher = new IntegrationsContentPublisher(integrationsService as unknown as IIntegrationsService);
+
+      const result = await publisher.publish({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        value: 'new value',
+      });
+
+      expect(integrationsService.listCapabilityAdapters).toHaveBeenCalledWith({ capability: 'ProductMaster' });
+      expect(adapterUpdateProduct).toHaveBeenCalledWith('ol_product_abc', { description: 'new value' });
+      expect(result.baseVersion).toBe('2026-04-22T10:30:00.000Z');
+    });
+
+    it('should fall back to a current ISO timestamp as baseVersion when the adapter returns no updatedAt', async () => {
+      const adapterUpdateProduct = jest
+        .fn<Promise<Product>, Parameters<ProductMasterPort['updateProduct']>>()
+        .mockResolvedValue({
+          id: 'ol_product_abc',
+          name: 'irrelevant',
+          sku: null,
+          price: null,
+          description: 'v',
+          images: null,
+        } as Product);
+      const integrationsService = {
+        listCapabilityAdapters: jest.fn().mockResolvedValue([
+          {
+            connectionId: 'conn-master',
+            connection: {},
+            adapter: { updateProduct: adapterUpdateProduct } as unknown as ProductMasterPort,
+            metadata: {},
+          },
+        ]),
+      } as unknown as IIntegrationsService;
+      const publisher = new IntegrationsContentPublisher(integrationsService);
+
+      const result = await publisher.publish({
+        productId: 'ol_product_abc',
+        connectionId: null,
+        fieldKey: 'description',
+        value: 'v',
+      });
+
+      expect(result.baseVersion).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('should throw ChannelContentPublishNotSupportedException for non-null connectionId', async () => {
+      const integrationsService = {
+        listCapabilityAdapters: jest.fn(),
+      } as unknown as IIntegrationsService;
+      const publisher = new IntegrationsContentPublisher(integrationsService);
+
+      await expect(
+        publisher.publish({
+          productId: 'ol_product_abc',
+          connectionId: 'conn-allegro-1',
+          fieldKey: 'description',
+          value: 'channel-only value',
+        }),
+      ).rejects.toBeInstanceOf(ChannelContentPublishNotSupportedException);
+    });
+
+    it('should throw a clear error when no ProductMaster adapter is registered', async () => {
+      const integrationsService = {
+        listCapabilityAdapters: jest.fn().mockResolvedValue([]),
+      } as unknown as IIntegrationsService;
+      const publisher = new IntegrationsContentPublisher(integrationsService);
+
+      await expect(
+        publisher.publish({
+          productId: 'ol_product_abc',
+          connectionId: null,
+          fieldKey: 'description',
+          value: 'v',
+        }),
+      ).rejects.toThrow(/No active ProductMaster adapter/);
+    });
+  });
+});

--- a/libs/core/src/content/application/services/integrations-content-publisher.service.ts
+++ b/libs/core/src/content/application/services/integrations-content-publisher.service.ts
@@ -20,6 +20,8 @@ import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations/integr
 import type { IIntegrationsService } from '@openlinker/core/integrations/application/interfaces/integrations.service.interface';
 import type { ProductMasterPort } from '@openlinker/core/products/domain/ports/product-master.port';
 import { ChannelContentPublishNotSupportedException } from '../../domain/exceptions/channel-content-publish-not-supported.exception';
+import { ContentPublishMissingVersionException } from '../../domain/exceptions/content-publish-missing-version.exception';
+import { NoProductMasterAdapterException } from '../../domain/exceptions/no-product-master-adapter.exception';
 import type {
   ContentPublishRequest,
   ContentPublishResult,
@@ -49,9 +51,7 @@ export class IntegrationsContentPublisher implements ContentPublisherPort {
     });
 
     if (masters.length === 0) {
-      throw new Error(
-        `No active ProductMaster adapter available to publish content for productId=${request.productId} fieldKey=${request.fieldKey}.`,
-      );
+      throw new NoProductMasterAdapterException(request.productId, request.fieldKey);
     }
 
     if (masters.length > 1) {
@@ -76,11 +76,15 @@ export class IntegrationsContentPublisher implements ContentPublisherPort {
 
     // Use the platform-derived `updatedAt` as the opaque baseVersion. ISO string
     // keeps the comparison purely lexical (we never order versions, only test
-    // equality for divergence detection).
-    const baseVersion = updated.updatedAt
-      ? updated.updatedAt.toISOString()
-      : new Date().toISOString();
+    // equality for divergence detection). Synthesising a local timestamp when
+    // the adapter omits `updatedAt` would corrupt the conflict-detection
+    // invariant — the next inbound reconcile would compare the platform's real
+    // `updatedAt` against our fabricated value and falsely flag a conflict —
+    // so we fail loud here. Adapters MUST populate Product.updatedAt on update.
+    if (!updated.updatedAt) {
+      throw new ContentPublishMissingVersionException(request.productId, request.fieldKey);
+    }
 
-    return { baseVersion };
+    return { baseVersion: updated.updatedAt.toISOString() };
   }
 }

--- a/libs/core/src/content/application/services/integrations-content-publisher.service.ts
+++ b/libs/core/src/content/application/services/integrations-content-publisher.service.ts
@@ -1,0 +1,86 @@
+/**
+ * Integrations Content Publisher
+ *
+ * Default `ContentPublisherPort` implementation. Routes master publishes
+ * (`connectionId === null`) through `IntegrationsService.listCapabilityAdapters`
+ * to the active `ProductMaster` adapter and calls `updateProduct(productId, { [fieldKey]: value })`.
+ *
+ * Channel publishes (`connectionId !== null`) throw
+ * `ChannelContentPublishNotSupportedException` until #339 / #342 wire offer
+ * discovery + `MarketplacePort.updateOfferFields`. The exception message
+ * carries the follow-up issue references so the gap is self-documenting at
+ * call sites.
+ *
+ * @module libs/core/src/content/application/services
+ * @implements {ContentPublisherPort}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations/integrations.tokens';
+import type { IIntegrationsService } from '@openlinker/core/integrations/application/interfaces/integrations.service.interface';
+import type { ProductMasterPort } from '@openlinker/core/products/domain/ports/product-master.port';
+import { ChannelContentPublishNotSupportedException } from '../../domain/exceptions/channel-content-publish-not-supported.exception';
+import type {
+  ContentPublishRequest,
+  ContentPublishResult,
+  ContentPublisherPort,
+} from '../../domain/ports/content-publisher.port';
+
+@Injectable()
+export class IntegrationsContentPublisher implements ContentPublisherPort {
+  private readonly logger = new Logger(IntegrationsContentPublisher.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+  ) {}
+
+  async publish(request: ContentPublishRequest): Promise<ContentPublishResult> {
+    if (request.connectionId !== null) {
+      throw new ChannelContentPublishNotSupportedException(
+        request.productId,
+        request.connectionId,
+        request.fieldKey,
+      );
+    }
+
+    const masters = await this.integrationsService.listCapabilityAdapters<ProductMasterPort>({
+      capability: 'ProductMaster',
+    });
+
+    if (masters.length === 0) {
+      throw new Error(
+        `No active ProductMaster adapter available to publish content for productId=${request.productId} fieldKey=${request.fieldKey}.`,
+      );
+    }
+
+    if (masters.length > 1) {
+      // Today there is at most one ProductMaster connection in practice, but the contract
+      // returns an array. Log + pick the first; refine to an explicit selection rule
+      // (e.g. the connection that owns the product) when multi-master is real.
+      this.logger.warn(
+        `[content] Multiple ProductMaster adapters resolved (${masters.length}); using the first. ` +
+          `Refine selection when multi-master is wired.`,
+      );
+    }
+
+    const { adapter } = masters[0];
+
+    // Patch only the requested field — `ProductUpdate` accepts arbitrary string keys
+    // via its index signature (`[key: string]: unknown`). Adapters that don't know
+    // a particular field key simply ignore it; for `description` (the MVP key),
+    // `PrestashopProductMasterAdapter` writes it through to PrestaShop.
+    const updated = await adapter.updateProduct(request.productId, {
+      [request.fieldKey]: request.value,
+    });
+
+    // Use the platform-derived `updatedAt` as the opaque baseVersion. ISO string
+    // keeps the comparison purely lexical (we never order versions, only test
+    // equality for divergence detection).
+    const baseVersion = updated.updatedAt
+      ? updated.updatedAt.toISOString()
+      : new Date().toISOString();
+
+    return { baseVersion };
+  }
+}

--- a/libs/core/src/content/application/types/content-draft.types.ts
+++ b/libs/core/src/content/application/types/content-draft.types.ts
@@ -1,0 +1,49 @@
+/**
+ * Content Draft Application-Layer Types
+ *
+ * Command and query DTOs for `ContentDraftService`. Kept separate from the
+ * domain types because they describe the application surface (caller intent)
+ * rather than domain invariants.
+ *
+ * @module libs/core/src/content/application/types
+ */
+import type { FieldKey } from '../../domain/types/content.types';
+
+export interface SaveDraftCommand {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+  value: string;
+  /** Acting user id (string) for audit. `null` is reserved for system writers; user-driven save commands always carry a user id. */
+  userId: string;
+}
+
+export interface DiscardDraftCommand {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+}
+
+export interface PublishDraftCommand {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+}
+
+export interface ReconcileExternalCommand {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+  externalValue: string;
+  externalVersion: string;
+}
+
+export interface ResolveValueQuery {
+  productId: string;
+  /**
+   * `null` resolves the master value only. A non-null connectionId resolves
+   * channel-with-master-fallback (channel draft → channel base → master draft → master base → null).
+   */
+  connectionId: string | null;
+  fieldKey: FieldKey;
+}

--- a/libs/core/src/content/content.module.ts
+++ b/libs/core/src/content/content.module.ts
@@ -1,0 +1,59 @@
+/**
+ * Content Module
+ *
+ * NestJS module for the content bounded context. Wires the
+ * `product_content_field` ORM entity into TypeORM, registers the repository,
+ * the `ContentDraftService` (bound to `IContentDraftService` via token), and
+ * the default `IntegrationsContentPublisher` (bound to `ContentPublisherPort`
+ * via token).
+ *
+ * Imports `IntegrationsModule` so the publisher can resolve the
+ * `ProductMaster` capability adapter at publish time.
+ *
+ * @module libs/core/src/content
+ */
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IntegrationsModule } from '@openlinker/core/integrations';
+import { ContentDraftService } from './application/services/content-draft.service';
+import { IntegrationsContentPublisher } from './application/services/integrations-content-publisher.service';
+import {
+  CONTENT_DRAFT_SERVICE_TOKEN,
+  CONTENT_PUBLISHER_PORT_TOKEN,
+  PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN,
+} from './content.tokens';
+import { ProductContentFieldOrmEntity } from './infrastructure/persistence/entities/product-content-field.orm-entity';
+import { ProductContentFieldRepository } from './infrastructure/persistence/repositories/product-content-field.repository';
+
+export {
+  CONTENT_DRAFT_SERVICE_TOKEN,
+  CONTENT_PUBLISHER_PORT_TOKEN,
+  PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN,
+} from './content.tokens';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ProductContentFieldOrmEntity]), IntegrationsModule],
+  providers: [
+    ProductContentFieldRepository,
+    IntegrationsContentPublisher,
+    ContentDraftService,
+    {
+      provide: PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN,
+      useExisting: ProductContentFieldRepository,
+    },
+    {
+      provide: CONTENT_PUBLISHER_PORT_TOKEN,
+      useExisting: IntegrationsContentPublisher,
+    },
+    {
+      provide: CONTENT_DRAFT_SERVICE_TOKEN,
+      useExisting: ContentDraftService,
+    },
+  ],
+  exports: [
+    PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN,
+    CONTENT_PUBLISHER_PORT_TOKEN,
+    CONTENT_DRAFT_SERVICE_TOKEN,
+  ],
+})
+export class ContentModule {}

--- a/libs/core/src/content/content.tokens.ts
+++ b/libs/core/src/content/content.tokens.ts
@@ -1,0 +1,14 @@
+/**
+ * Content Module Dependency Injection Tokens
+ *
+ * Symbol tokens for the content bounded context. Used to inject the
+ * repository port, the publisher port, and the application service via
+ * NestJS DI without leaking concrete classes.
+ *
+ * @module libs/core/src/content
+ */
+export const PRODUCT_CONTENT_FIELD_REPOSITORY_TOKEN = Symbol(
+  'ProductContentFieldRepositoryPort',
+);
+export const CONTENT_PUBLISHER_PORT_TOKEN = Symbol('ContentPublisherPort');
+export const CONTENT_DRAFT_SERVICE_TOKEN = Symbol('IContentDraftService');

--- a/libs/core/src/content/domain/entities/product-content-field.entity.ts
+++ b/libs/core/src/content/domain/entities/product-content-field.entity.ts
@@ -1,0 +1,43 @@
+/**
+ * Product Content Field — Domain Entity
+ *
+ * Per-product, per-channel (or master) draft buffer for a single content
+ * field (e.g. `description`). Implements the "draft write-through with
+ * conflict detection" model documented in #338: a draft sits in front of
+ * the last-known platform value (`baseValue`/`baseVersion`); publishing
+ * pushes through to the platform; inbound reconcile updates the base
+ * silently when no draft exists, or marks `hasConflict` when a draft and
+ * an external divergence collide.
+ *
+ * The entity is plain — no NestJS/TypeORM decorators. ORM mapping lives
+ * in `infrastructure/persistence/entities/product-content-field.orm-entity.ts`.
+ *
+ * @module libs/core/src/content/domain/entities
+ */
+import type { FieldKey } from '../types/content.types';
+
+export class ProductContentField {
+  constructor(
+    public readonly id: string,
+    public readonly productId: string,
+    /** `null` means master (platform-agnostic). Non-null = channel override scoped to that connection. */
+    public readonly connectionId: string | null,
+    public readonly fieldKey: FieldKey,
+    public readonly draftValue: string | null,
+    public readonly baseValue: string | null,
+    public readonly baseVersion: string | null,
+    public readonly hasConflict: boolean,
+    public readonly updatedAt: Date,
+    public readonly updatedBy: string | null,
+  ) {}
+
+  /**
+   * Derived: a row "has a pending draft" when draftValue is set AND it differs
+   * from baseValue. A draftValue equal to baseValue is meaningless and treated
+   * as no-draft; callers shouldn't construct such rows but this guard makes
+   * publish/discard idempotent against accidental same-value writes.
+   */
+  get hasPendingDraft(): boolean {
+    return this.draftValue !== null && this.draftValue !== this.baseValue;
+  }
+}

--- a/libs/core/src/content/domain/exceptions/channel-content-publish-not-supported.exception.ts
+++ b/libs/core/src/content/domain/exceptions/channel-content-publish-not-supported.exception.ts
@@ -1,0 +1,25 @@
+/**
+ * Channel Content Publish Not Supported Exception
+ *
+ * Thrown by the MVP `IntegrationsContentPublisher` when a publish is requested
+ * for a channel-scoped row (`connectionId !== null`). The channel publish
+ * path requires offer discovery from `(productId, connectionId)` and
+ * marketplace `updateOfferFields` wiring — both deferred to follow-up
+ * issues #339 (editor UI) and #342 (AI suggestion flow). This PR ships the
+ * surface; the wire is short and intentional.
+ *
+ * @module libs/core/src/content/domain/exceptions
+ */
+export class ChannelContentPublishNotSupportedException extends Error {
+  constructor(
+    public readonly productId: string,
+    public readonly connectionId: string,
+    public readonly fieldKey: string,
+  ) {
+    super(
+      `Channel-scoped content publish is not yet wired (productId=${productId} connectionId=${connectionId} fieldKey=${fieldKey}). Tracked in #339 / #342.`,
+    );
+    this.name = 'ChannelContentPublishNotSupportedException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/content/domain/exceptions/content-conflict.exception.ts
+++ b/libs/core/src/content/domain/exceptions/content-conflict.exception.ts
@@ -1,0 +1,23 @@
+/**
+ * Content Conflict Exception
+ *
+ * Thrown by `ContentDraftService.publishDraft` when the row carries
+ * `hasConflict=true`. Signals that the inbound reconcile observed an
+ * external divergence while the user's draft was pending — the draft must
+ * be re-saved (acknowledging the new base) before publish is allowed.
+ *
+ * @module libs/core/src/content/domain/exceptions
+ */
+export class ContentConflictException extends Error {
+  constructor(
+    public readonly productId: string,
+    public readonly connectionId: string | null,
+    public readonly fieldKey: string,
+  ) {
+    super(
+      `Content conflict for productId=${productId} connectionId=${connectionId ?? 'master'} fieldKey=${fieldKey}; resave the draft to acknowledge the divergence before publishing.`,
+    );
+    this.name = 'ContentConflictException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/content/domain/exceptions/content-field-not-found.exception.ts
+++ b/libs/core/src/content/domain/exceptions/content-field-not-found.exception.ts
@@ -1,0 +1,21 @@
+/**
+ * Content Field Not Found Exception
+ *
+ * Thrown by `ContentDraftService` operations that require an existing row
+ * (e.g. publishing or discarding a draft on a row that never existed).
+ *
+ * @module libs/core/src/content/domain/exceptions
+ */
+export class ContentFieldNotFoundException extends Error {
+  constructor(
+    public readonly productId: string,
+    public readonly connectionId: string | null,
+    public readonly fieldKey: string,
+  ) {
+    super(
+      `No content field row for productId=${productId} connectionId=${connectionId ?? 'master'} fieldKey=${fieldKey}.`,
+    );
+    this.name = 'ContentFieldNotFoundException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/content/domain/exceptions/content-publish-missing-version.exception.ts
+++ b/libs/core/src/content/domain/exceptions/content-publish-missing-version.exception.ts
@@ -1,0 +1,27 @@
+/**
+ * Content Publish Missing Version Exception
+ *
+ * Thrown by `IntegrationsContentPublisher` when the underlying ProductMaster
+ * adapter returns a successful update response but does not include an
+ * `updatedAt` field that can be recorded as `baseVersion`. Without a real
+ * platform-derived version marker, the next inbound reconcile would compare
+ * the platform's actual `updatedAt` against a synthetic local timestamp and
+ * spuriously flag a conflict — corrupting the conflict-detection invariant.
+ *
+ * Adapters implementing `ProductMasterPort` MUST return a `Product` with
+ * `updatedAt` populated after a successful `updateProduct` call.
+ *
+ * @module libs/core/src/content/domain/exceptions
+ */
+export class ContentPublishMissingVersionException extends Error {
+  constructor(
+    public readonly productId: string,
+    public readonly fieldKey: string,
+  ) {
+    super(
+      `ProductMaster adapter returned no updatedAt after publishing content (productId=${productId} fieldKey=${fieldKey}). The adapter must populate Product.updatedAt so a baseVersion can be recorded; otherwise the next reconcile would falsely report a conflict.`,
+    );
+    this.name = 'ContentPublishMissingVersionException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/content/domain/exceptions/no-product-master-adapter.exception.ts
+++ b/libs/core/src/content/domain/exceptions/no-product-master-adapter.exception.ts
@@ -1,0 +1,23 @@
+/**
+ * No Product Master Adapter Exception
+ *
+ * Thrown by `IntegrationsContentPublisher` when a master-path publish is
+ * requested but the integrations registry has no active `ProductMaster`
+ * capability adapter to route through. Indicates a configuration gap
+ * (no PrestaShop / OpenLinker / Shopify connection registered as the
+ * master) rather than a runtime failure of the underlying adapter.
+ *
+ * @module libs/core/src/content/domain/exceptions
+ */
+export class NoProductMasterAdapterException extends Error {
+  constructor(
+    public readonly productId: string,
+    public readonly fieldKey: string,
+  ) {
+    super(
+      `No active ProductMaster adapter is registered; cannot publish content (productId=${productId} fieldKey=${fieldKey}). Configure a connection that supports the ProductMaster capability.`,
+    );
+    this.name = 'NoProductMasterAdapterException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/content/domain/ports/content-publisher.port.ts
+++ b/libs/core/src/content/domain/ports/content-publisher.port.ts
@@ -1,0 +1,36 @@
+/**
+ * Content Publisher Port
+ *
+ * Abstraction over "where does this content value get pushed to". Lets
+ * `ContentDraftService` stay platform-agnostic — it asks the publisher to
+ * push a (productId, connectionId, fieldKey, value) tuple and gets back an
+ * opaque `baseVersion` to record on the row.
+ *
+ * The MVP `IntegrationsContentPublisher` resolves master rows
+ * (`connectionId === null`) via `ProductMasterPort.updateProduct`. Channel
+ * rows throw `ChannelContentPublishNotSupportedException` until #339/#342
+ * wire offer discovery + `MarketplacePort.updateOfferFields`.
+ *
+ * @module libs/core/src/content/domain/ports
+ */
+import type { FieldKey } from '../types/content.types';
+
+export interface ContentPublishRequest {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+  value: string;
+}
+
+export interface ContentPublishResult {
+  /**
+   * Opaque platform-specific version marker (e.g. PrestaShop `date_upd`,
+   * Allegro `revision`). Recorded as `baseVersion` on the row so the next
+   * inbound reconcile can detect divergence by string inequality.
+   */
+  baseVersion: string;
+}
+
+export interface ContentPublisherPort {
+  publish(request: ContentPublishRequest): Promise<ContentPublishResult>;
+}

--- a/libs/core/src/content/domain/ports/product-content-field-repository.port.ts
+++ b/libs/core/src/content/domain/ports/product-content-field-repository.port.ts
@@ -1,0 +1,43 @@
+/**
+ * Product Content Field Repository Port
+ *
+ * Persistence contract for `ProductContentField` rows. Methods cover the
+ * read/write shapes the application service needs — no broader CRUD surface
+ * (no findAll, no pagination) until a real consumer asks for it.
+ *
+ * @module libs/core/src/content/domain/ports
+ */
+import type { ProductContentField } from '../entities/product-content-field.entity';
+import type { FieldKey } from '../types/content.types';
+
+/**
+ * Lookup key for a single content field row. `connectionId === null` means
+ * the master (platform-agnostic) row.
+ */
+export interface ProductContentFieldKey {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+}
+
+/**
+ * Upsert payload — a complete row state. The repository is responsible for
+ * inserting when no row matches the key, or updating in place when one does.
+ * Callers always pass the post-mutation state, never partial diffs.
+ */
+export interface ProductContentFieldUpsert {
+  productId: string;
+  connectionId: string | null;
+  fieldKey: FieldKey;
+  draftValue: string | null;
+  baseValue: string | null;
+  baseVersion: string | null;
+  hasConflict: boolean;
+  updatedBy: string | null;
+}
+
+export interface ProductContentFieldRepositoryPort {
+  findByKey(key: ProductContentFieldKey): Promise<ProductContentField | null>;
+  upsert(payload: ProductContentFieldUpsert): Promise<ProductContentField>;
+  delete(key: ProductContentFieldKey): Promise<void>;
+}

--- a/libs/core/src/content/domain/types/content.types.ts
+++ b/libs/core/src/content/domain/types/content.types.ts
@@ -1,0 +1,31 @@
+/**
+ * Content Domain Types
+ *
+ * Type definitions for product content fields. `FieldKey` is the extension
+ * point — MVP supports `description`; future keys (title, short description,
+ * SEO meta) can be added without schema changes.
+ *
+ * @module libs/core/src/content/domain/types
+ */
+
+/**
+ * Runtime array of supported content field keys.
+ *
+ * Add a new field key here, then no further migration is needed — the
+ * `product_content_field` table is keyed on `(productId, connectionId, fieldKey)`
+ * and accepts any string. The union exists only to keep callers honest.
+ */
+export const FieldKeyValues = ['description'] as const;
+export type FieldKey = (typeof FieldKeyValues)[number];
+
+/**
+ * Information about a divergence detected during inbound reconcile while a
+ * pending draft existed. Surfaced via the `hasConflict` flag on the row;
+ * future iterations may emit a domain event with this payload so a
+ * resolution UI can render side-by-side diffs.
+ */
+export interface ContentConflictInfo {
+  fieldKey: FieldKey;
+  baseVersion: string | null;
+  externalVersion: string;
+}

--- a/libs/core/src/content/index.ts
+++ b/libs/core/src/content/index.ts
@@ -14,6 +14,8 @@ export * from './domain/ports/content-publisher.port';
 export * from './domain/exceptions/content-conflict.exception';
 export * from './domain/exceptions/content-field-not-found.exception';
 export * from './domain/exceptions/channel-content-publish-not-supported.exception';
+export * from './domain/exceptions/no-product-master-adapter.exception';
+export * from './domain/exceptions/content-publish-missing-version.exception';
 export * from './application/services/content-draft.service.interface';
 export * from './application/types/content-draft.types';
 export * from './content.tokens';

--- a/libs/core/src/content/index.ts
+++ b/libs/core/src/content/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Content Bounded Context — Public Surface
+ *
+ * Exports domain types/entities/exceptions/ports, the application service
+ * interface, and the NestJS module. Consumers should depend on the port +
+ * service-interface tokens via `@Inject(...)`, never on concrete classes.
+ *
+ * @module libs/core/src/content
+ */
+export * from './domain/entities/product-content-field.entity';
+export * from './domain/types/content.types';
+export * from './domain/ports/product-content-field-repository.port';
+export * from './domain/ports/content-publisher.port';
+export * from './domain/exceptions/content-conflict.exception';
+export * from './domain/exceptions/content-field-not-found.exception';
+export * from './domain/exceptions/channel-content-publish-not-supported.exception';
+export * from './application/services/content-draft.service.interface';
+export * from './application/types/content-draft.types';
+export * from './content.tokens';
+export { ContentModule } from './content.module';

--- a/libs/core/src/content/infrastructure/persistence/entities/product-content-field.orm-entity.ts
+++ b/libs/core/src/content/infrastructure/persistence/entities/product-content-field.orm-entity.ts
@@ -1,0 +1,61 @@
+/**
+ * Product Content Field ORM Entity
+ *
+ * TypeORM mapping for the `product_content_field` table — the draft buffer
+ * plus last-known platform value for a single product field, optionally
+ * scoped to a connection (channel override) or master (`connectionId IS NULL`).
+ *
+ * Index design note: the unique constraint on `(productId, connectionId, fieldKey)`
+ * is implemented as **two partial unique indexes** (one for `connectionId IS NULL`,
+ * one for `connectionId IS NOT NULL`) to handle Postgres' `NULL ≠ NULL`
+ * uniqueness semantics. Those indexes are created in the migration (TypeORM
+ * decorator support for partial indexes is fragile across versions). The
+ * decorator below only declares the non-unique lookup index on `productId`.
+ *
+ * @module libs/core/src/content/infrastructure/persistence/entities
+ */
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('product_content_field')
+@Index('ix_pcf_product', ['productId'])
+export class ProductContentFieldOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'product_id', type: 'text' })
+  productId!: string;
+
+  @Column({ name: 'connection_id', type: 'uuid', nullable: true })
+  connectionId!: string | null;
+
+  @Column({ name: 'field_key', type: 'text' })
+  fieldKey!: string;
+
+  @Column({ name: 'draft_value', type: 'text', nullable: true })
+  draftValue!: string | null;
+
+  @Column({ name: 'base_value', type: 'text', nullable: true })
+  baseValue!: string | null;
+
+  @Column({ name: 'base_version', type: 'text', nullable: true })
+  baseVersion!: string | null;
+
+  @Column({ name: 'has_conflict', type: 'boolean', default: false })
+  hasConflict!: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt!: Date;
+
+  @Column({ name: 'updated_by', type: 'text', nullable: true })
+  updatedBy!: string | null;
+}

--- a/libs/core/src/content/infrastructure/persistence/entities/product-content-field.orm-entity.ts
+++ b/libs/core/src/content/infrastructure/persistence/entities/product-content-field.orm-entity.ts
@@ -8,9 +8,11 @@
  * Index design note: the unique constraint on `(productId, connectionId, fieldKey)`
  * is implemented as **two partial unique indexes** (one for `connectionId IS NULL`,
  * one for `connectionId IS NOT NULL`) to handle Postgres' `NULL ≠ NULL`
- * uniqueness semantics. Those indexes are created in the migration (TypeORM
- * decorator support for partial indexes is fragile across versions). The
- * decorator below only declares the non-unique lookup index on `productId`.
+ * uniqueness semantics. The decorators declare them here so `synchronize: true`
+ * (used only by the integration-test harness) materialises them; production DBs
+ * get the identical indexes via the migration, which remains the source of truth.
+ * They must also exist at runtime because the repository's upsert relies on the
+ * `ON CONFLICT (...) WHERE ...` inference clause matching these partial indexes.
  *
  * @module libs/core/src/content/infrastructure/persistence/entities
  */
@@ -25,6 +27,14 @@ import {
 
 @Entity('product_content_field')
 @Index('ix_pcf_product', ['productId'])
+@Index('ux_pcf_master', ['productId', 'fieldKey'], {
+  unique: true,
+  where: '"connection_id" IS NULL',
+})
+@Index('ux_pcf_channel', ['productId', 'connectionId', 'fieldKey'], {
+  unique: true,
+  where: '"connection_id" IS NOT NULL',
+})
 export class ProductContentFieldOrmEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;

--- a/libs/core/src/content/infrastructure/persistence/repositories/product-content-field.repository.ts
+++ b/libs/core/src/content/infrastructure/persistence/repositories/product-content-field.repository.ts
@@ -1,0 +1,99 @@
+/**
+ * Product Content Field Repository
+ *
+ * TypeORM-backed implementation of `ProductContentFieldRepositoryPort`.
+ * Handles the upsert path manually because the unique key spans a nullable
+ * column (`connection_id`); TypeORM's `upsert()` helper doesn't compose well
+ * with NULL-aware uniqueness, so we do find-then-insert/update inside a
+ * single repository call.
+ *
+ * Mapping between ORM and domain entities is private to this class.
+ *
+ * @module libs/core/src/content/infrastructure/persistence/repositories
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { ProductContentField } from '../../../domain/entities/product-content-field.entity';
+import type {
+  ProductContentFieldKey,
+  ProductContentFieldRepositoryPort,
+  ProductContentFieldUpsert,
+} from '../../../domain/ports/product-content-field-repository.port';
+import type { FieldKey } from '../../../domain/types/content.types';
+import { ProductContentFieldOrmEntity } from '../entities/product-content-field.orm-entity';
+
+@Injectable()
+export class ProductContentFieldRepository implements ProductContentFieldRepositoryPort {
+  constructor(
+    @InjectRepository(ProductContentFieldOrmEntity)
+    private readonly ormRepository: Repository<ProductContentFieldOrmEntity>,
+  ) {}
+
+  async findByKey(key: ProductContentFieldKey): Promise<ProductContentField | null> {
+    const entity = await this.ormRepository.findOne({
+      where: {
+        productId: key.productId,
+        connectionId: key.connectionId === null ? IsNull() : key.connectionId,
+        fieldKey: key.fieldKey,
+      },
+    });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async upsert(payload: ProductContentFieldUpsert): Promise<ProductContentField> {
+    const existing = await this.ormRepository.findOne({
+      where: {
+        productId: payload.productId,
+        connectionId: payload.connectionId === null ? IsNull() : payload.connectionId,
+        fieldKey: payload.fieldKey,
+      },
+    });
+
+    if (existing) {
+      existing.draftValue = payload.draftValue;
+      existing.baseValue = payload.baseValue;
+      existing.baseVersion = payload.baseVersion;
+      existing.hasConflict = payload.hasConflict;
+      existing.updatedBy = payload.updatedBy;
+      const saved = await this.ormRepository.save(existing);
+      return this.toDomain(saved);
+    }
+
+    const fresh = this.ormRepository.create({
+      productId: payload.productId,
+      connectionId: payload.connectionId,
+      fieldKey: payload.fieldKey,
+      draftValue: payload.draftValue,
+      baseValue: payload.baseValue,
+      baseVersion: payload.baseVersion,
+      hasConflict: payload.hasConflict,
+      updatedBy: payload.updatedBy,
+    });
+    const saved = await this.ormRepository.save(fresh);
+    return this.toDomain(saved);
+  }
+
+  async delete(key: ProductContentFieldKey): Promise<void> {
+    await this.ormRepository.delete({
+      productId: key.productId,
+      connectionId: key.connectionId === null ? IsNull() : key.connectionId,
+      fieldKey: key.fieldKey,
+    });
+  }
+
+  private toDomain(entity: ProductContentFieldOrmEntity): ProductContentField {
+    return new ProductContentField(
+      entity.id,
+      entity.productId,
+      entity.connectionId,
+      entity.fieldKey as FieldKey,
+      entity.draftValue,
+      entity.baseValue,
+      entity.baseVersion,
+      entity.hasConflict,
+      entity.updatedAt,
+      entity.updatedBy,
+    );
+  }
+}

--- a/libs/core/src/content/infrastructure/persistence/repositories/product-content-field.repository.ts
+++ b/libs/core/src/content/infrastructure/persistence/repositories/product-content-field.repository.ts
@@ -2,10 +2,17 @@
  * Product Content Field Repository
  *
  * TypeORM-backed implementation of `ProductContentFieldRepositoryPort`.
- * Handles the upsert path manually because the unique key spans a nullable
- * column (`connection_id`); TypeORM's `upsert()` helper doesn't compose well
- * with NULL-aware uniqueness, so we do find-then-insert/update inside a
- * single repository call.
+ *
+ * Upsert design: the unique key spans a nullable column (`connection_id`)
+ * via two partial unique indexes (one `WHERE connection_id IS NULL`, one
+ * `WHERE connection_id IS NOT NULL`). A naive find-then-save would race —
+ * two concurrent callers can both observe "no row" and both attempt insert,
+ * and the second insert would explode with a `QueryFailedError` from the
+ * partial unique index. We use Postgres `INSERT ... ON CONFLICT WHERE
+ * <index_predicate> DO UPDATE` so the upsert collapses to a single
+ * round-trip and is concurrency-safe by construction. The conflict target
+ * is branched by `connection_id IS NULL` because the two partial indexes
+ * have different predicates.
  *
  * Mapping between ORM and domain entities is private to this class.
  *
@@ -22,6 +29,49 @@ import type {
 } from '../../../domain/ports/product-content-field-repository.port';
 import type { FieldKey } from '../../../domain/types/content.types';
 import { ProductContentFieldOrmEntity } from '../entities/product-content-field.orm-entity';
+
+interface UpsertReturningRow {
+  id: string;
+  product_id: string;
+  connection_id: string | null;
+  field_key: string;
+  draft_value: string | null;
+  base_value: string | null;
+  base_version: string | null;
+  has_conflict: boolean;
+  updated_at: string | Date;
+  updated_by: string | null;
+}
+
+const MASTER_UPSERT_SQL = `
+  INSERT INTO product_content_field
+    (product_id, connection_id, field_key, draft_value, base_value, base_version, has_conflict, updated_by)
+  VALUES ($1, NULL, $2, $3, $4, $5, $6, $7)
+  ON CONFLICT (product_id, field_key) WHERE connection_id IS NULL
+  DO UPDATE SET
+    draft_value  = EXCLUDED.draft_value,
+    base_value   = EXCLUDED.base_value,
+    base_version = EXCLUDED.base_version,
+    has_conflict = EXCLUDED.has_conflict,
+    updated_by   = EXCLUDED.updated_by,
+    updated_at   = now()
+  RETURNING id, product_id, connection_id, field_key, draft_value, base_value, base_version, has_conflict, updated_at, updated_by
+`;
+
+const CHANNEL_UPSERT_SQL = `
+  INSERT INTO product_content_field
+    (product_id, connection_id, field_key, draft_value, base_value, base_version, has_conflict, updated_by)
+  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+  ON CONFLICT (product_id, connection_id, field_key) WHERE connection_id IS NOT NULL
+  DO UPDATE SET
+    draft_value  = EXCLUDED.draft_value,
+    base_value   = EXCLUDED.base_value,
+    base_version = EXCLUDED.base_version,
+    has_conflict = EXCLUDED.has_conflict,
+    updated_by   = EXCLUDED.updated_by,
+    updated_at   = now()
+  RETURNING id, product_id, connection_id, field_key, draft_value, base_value, base_version, has_conflict, updated_at, updated_by
+`;
 
 @Injectable()
 export class ProductContentFieldRepository implements ProductContentFieldRepositoryPort {
@@ -42,36 +92,29 @@ export class ProductContentFieldRepository implements ProductContentFieldReposit
   }
 
   async upsert(payload: ProductContentFieldUpsert): Promise<ProductContentField> {
-    const existing = await this.ormRepository.findOne({
-      where: {
-        productId: payload.productId,
-        connectionId: payload.connectionId === null ? IsNull() : payload.connectionId,
-        fieldKey: payload.fieldKey,
-      },
-    });
+    const rows: UpsertReturningRow[] =
+      payload.connectionId === null
+        ? ((await this.ormRepository.query(MASTER_UPSERT_SQL, [
+            payload.productId,
+            payload.fieldKey,
+            payload.draftValue,
+            payload.baseValue,
+            payload.baseVersion,
+            payload.hasConflict,
+            payload.updatedBy,
+          ])) as UpsertReturningRow[])
+        : ((await this.ormRepository.query(CHANNEL_UPSERT_SQL, [
+            payload.productId,
+            payload.connectionId,
+            payload.fieldKey,
+            payload.draftValue,
+            payload.baseValue,
+            payload.baseVersion,
+            payload.hasConflict,
+            payload.updatedBy,
+          ])) as UpsertReturningRow[]);
 
-    if (existing) {
-      existing.draftValue = payload.draftValue;
-      existing.baseValue = payload.baseValue;
-      existing.baseVersion = payload.baseVersion;
-      existing.hasConflict = payload.hasConflict;
-      existing.updatedBy = payload.updatedBy;
-      const saved = await this.ormRepository.save(existing);
-      return this.toDomain(saved);
-    }
-
-    const fresh = this.ormRepository.create({
-      productId: payload.productId,
-      connectionId: payload.connectionId,
-      fieldKey: payload.fieldKey,
-      draftValue: payload.draftValue,
-      baseValue: payload.baseValue,
-      baseVersion: payload.baseVersion,
-      hasConflict: payload.hasConflict,
-      updatedBy: payload.updatedBy,
-    });
-    const saved = await this.ormRepository.save(fresh);
-    return this.toDomain(saved);
+    return this.toDomainFromRow(rows[0]);
   }
 
   async delete(key: ProductContentFieldKey): Promise<void> {
@@ -94,6 +137,21 @@ export class ProductContentFieldRepository implements ProductContentFieldReposit
       entity.hasConflict,
       entity.updatedAt,
       entity.updatedBy,
+    );
+  }
+
+  private toDomainFromRow(row: UpsertReturningRow): ProductContentField {
+    return new ProductContentField(
+      row.id,
+      row.product_id,
+      row.connection_id,
+      row.field_key as FieldKey,
+      row.draft_value,
+      row.base_value,
+      row.base_version,
+      row.has_conflict,
+      row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at),
+      row.updated_by,
     );
   }
 }

--- a/libs/integrations/ai/jest.config.mjs
+++ b/libs/integrations/ai/jest.config.mjs
@@ -1,0 +1,35 @@
+export default {
+  testEnvironment: 'node',
+  rootDir: '.',
+  testSequencer: '<rootDir>/test/openlinker.sequencer.cjs',
+
+  // IMPORTANT: avoid running fixtures/mocks as "tests"
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+
+  // ESM + TS support for Node16 module resolution
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+
+  // Helps when TS/Node16 emits/assumes .js in import paths
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@openlinker/integrations-ai$': '<rootDir>/src/index.ts',
+    '^@openlinker/integrations-ai/(.*)$': '<rootDir>/src/$1',
+    '^@openlinker/core/(.*)$': '<rootDir>/../../core/src/$1',
+    '^@openlinker/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+  },
+
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '<rootDir>/coverage',
+  clearMocks: true,
+  testTimeout: 30000,
+};

--- a/libs/integrations/ai/package.json
+++ b/libs/integrations/ai/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@openlinker/integrations-ai",
+  "version": "0.1.0",
+  "description": "AI completion adapter for OpenLinker (Vercel AI SDK + Anthropic)",
+  "private": true,
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --config ./jest.config.mjs",
+    "test:watch": "jest --watch --config ./jest.config.mjs",
+    "test:cov": "jest --coverage --config ./jest.config.mjs",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.71",
+    "@openlinker/core": "workspace:*",
+    "@openlinker/shared": "workspace:*",
+    "ai": "^6.0.168"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "20.11.30",
+    "@typescript-eslint/eslint-plugin": "7.3.1",
+    "@typescript-eslint/parser": "7.3.1",
+    "eslint": "8.57.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.2",
+    "typescript": "5.4.3"
+  }
+}

--- a/libs/integrations/ai/src/ai-integration.module.ts
+++ b/libs/integrations/ai/src/ai-integration.module.ts
@@ -1,0 +1,61 @@
+/**
+ * AI Integration Module
+ *
+ * NestJS module that selects an AiCompletionPort adapter based on
+ * `OL_AI_PROVIDER` (default: `anthropic`; `fake` for tests / offline dev) and
+ * binds the chosen instance to `AI_COMPLETION_PORT_TOKEN` via `useExisting`.
+ *
+ * Registered inside `apps/api/src/integrations/integrations.module.ts`
+ * alongside `AllegroIntegrationModule` + `PrestashopIntegrationModule` —
+ * not in `AppModule` directly — to keep all `@openlinker/integrations-*`
+ * modules under one umbrella.
+ *
+ * @module libs/integrations/ai
+ */
+import { Module, type DynamicModule, type Provider } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AI_COMPLETION_PORT_TOKEN } from '@openlinker/core/ai/ai.tokens';
+import { AiProviderValues, type AiProvider } from '@openlinker/core/ai/domain/types/ai-completion.types';
+import { Logger } from '@openlinker/shared/logging';
+import { FakeAiCompletionAdapter } from './infrastructure/adapters/fake-ai-completion.adapter';
+import { VercelAiCompletionAdapter } from './infrastructure/adapters/vercel-ai-completion.adapter';
+
+const DEFAULT_PROVIDER: AiProvider = 'anthropic';
+
+const isAiProvider = (value: string): value is AiProvider =>
+  (AiProviderValues as readonly string[]).includes(value);
+
+@Module({})
+export class AiIntegrationModule {
+  static register(): DynamicModule {
+    const logger = new Logger(AiIntegrationModule.name);
+    const rawProvider = process.env.OL_AI_PROVIDER ?? DEFAULT_PROVIDER;
+    const provider: AiProvider = isAiProvider(rawProvider) ? rawProvider : DEFAULT_PROVIDER;
+
+    if (rawProvider !== provider) {
+      logger.warn(
+        `Invalid OL_AI_PROVIDER value "${rawProvider}"; falling back to "${DEFAULT_PROVIDER}". Allowed values: ${AiProviderValues.join(', ')}.`,
+      );
+    } else {
+      logger.log(`AiIntegrationModule using provider: ${provider}`);
+    }
+
+    const providers: Provider[] =
+      provider === 'fake'
+        ? [
+            FakeAiCompletionAdapter,
+            { provide: AI_COMPLETION_PORT_TOKEN, useExisting: FakeAiCompletionAdapter },
+          ]
+        : [
+            VercelAiCompletionAdapter,
+            { provide: AI_COMPLETION_PORT_TOKEN, useExisting: VercelAiCompletionAdapter },
+          ];
+
+    return {
+      module: AiIntegrationModule,
+      imports: [ConfigModule],
+      providers: [ConfigService, ...providers],
+      exports: [AI_COMPLETION_PORT_TOKEN],
+    };
+  }
+}

--- a/libs/integrations/ai/src/index.ts
+++ b/libs/integrations/ai/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * AI Integration Package — Public Surface
+ *
+ * Exports the dynamic NestJS module + concrete adapters. Consumers should
+ * inject AI_COMPLETION_PORT_TOKEN (re-exported via @openlinker/core/ai)
+ * rather than depending on the concrete adapter classes.
+ *
+ * @module libs/integrations/ai
+ */
+export { AiIntegrationModule } from './ai-integration.module';
+export { FakeAiCompletionAdapter } from './infrastructure/adapters/fake-ai-completion.adapter';
+export {
+  VercelAiCompletionAdapter,
+  VERCEL_GENERATE_TEXT_FN_TOKEN,
+  type VercelGenerateTextFn,
+} from './infrastructure/adapters/vercel-ai-completion.adapter';

--- a/libs/integrations/ai/src/infrastructure/adapters/fake-ai-completion.adapter.spec.ts
+++ b/libs/integrations/ai/src/infrastructure/adapters/fake-ai-completion.adapter.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Fake AI Completion Adapter — Unit Tests
+ *
+ * Asserts deterministic output shape: prefix marker, prompt-derived text,
+ * length-based token estimates, and propagated model override.
+ *
+ * @module libs/integrations/ai/infrastructure/adapters
+ */
+import { FakeAiCompletionAdapter } from './fake-ai-completion.adapter';
+
+describe('FakeAiCompletionAdapter', () => {
+  let adapter: FakeAiCompletionAdapter;
+
+  beforeEach(() => {
+    adapter = new FakeAiCompletionAdapter();
+  });
+
+  describe('complete', () => {
+    it('should return text prefixed with "fake:" and derived from the user prompt', async () => {
+      const result = await adapter.complete({
+        systemPrompt: 'You are a helpful assistant.',
+        userPrompt: 'Generate a short product description for a leather wallet.',
+      });
+
+      expect(result.text).toBe(
+        'fake: Generate a short product description for a leather wallet.',
+      );
+    });
+
+    it('should truncate the user prompt slice at 120 characters', async () => {
+      const longPrompt = 'a'.repeat(200);
+
+      const result = await adapter.complete({
+        systemPrompt: 'system',
+        userPrompt: longPrompt,
+      });
+
+      expect(result.text).toBe(`fake: ${'a'.repeat(120)}`);
+    });
+
+    it('should report length-based token estimates and zero cached tokens', async () => {
+      const result = await adapter.complete({
+        systemPrompt: '12345678', // 8 chars → ceil(8/4) = 2 tokens
+        userPrompt: 'hello',
+      });
+
+      expect(result.usage.inputTokens).toBe(2);
+      expect(result.usage.cachedInputTokens).toBe(0);
+      expect(result.usage.outputTokens).toBeGreaterThan(0);
+    });
+
+    it('should propagate the requested model when provided', async () => {
+      const result = await adapter.complete({
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        model: 'claude-haiku-4-5-20251001',
+      });
+
+      expect(result.modelUsed).toBe('claude-haiku-4-5-20251001');
+    });
+
+    it('should default modelUsed to "fake-model" when no override is given', async () => {
+      const result = await adapter.complete({
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+      });
+
+      expect(result.modelUsed).toBe('fake-model');
+    });
+
+    it('should report a non-zero latency', async () => {
+      const result = await adapter.complete({
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+      });
+
+      expect(result.latencyMs).toBeGreaterThan(0);
+    });
+  });
+});

--- a/libs/integrations/ai/src/infrastructure/adapters/fake-ai-completion.adapter.ts
+++ b/libs/integrations/ai/src/infrastructure/adapters/fake-ai-completion.adapter.ts
@@ -1,0 +1,45 @@
+/**
+ * Fake AI Completion Adapter
+ *
+ * Deterministic, network-free AiCompletionPort implementation. Selected by
+ * AiIntegrationModule when `OL_AI_PROVIDER=fake`. Used by integration tests
+ * and offline local dev so the rest of the stack can exercise the port without
+ * an Anthropic API key.
+ *
+ * The output text is derived from the userPrompt prefix so assertions can pin
+ * the exact response. Token counts are length/4 estimates — not literally
+ * tokenised, but stable enough for tests that check usage propagation.
+ *
+ * @module libs/integrations/ai/infrastructure/adapters
+ */
+import { Injectable } from '@nestjs/common';
+import type {
+  AiCompletionInput,
+  AiCompletionResult,
+} from '@openlinker/core/ai/domain/types/ai-completion.types';
+import type { AiCompletionPort } from '@openlinker/core/ai/domain/ports/ai-completion.port';
+
+const FAKE_MODEL = 'fake-model';
+const FAKE_PREFIX = 'fake:';
+const FAKE_USER_PROMPT_SLICE = 120;
+const FAKE_LATENCY_MS = 1;
+
+@Injectable()
+export class FakeAiCompletionAdapter implements AiCompletionPort {
+  async complete(input: AiCompletionInput): Promise<AiCompletionResult> {
+    const text = `${FAKE_PREFIX} ${input.userPrompt.slice(0, FAKE_USER_PROMPT_SLICE)}`;
+    const inputTokens = Math.ceil(input.systemPrompt.length / 4);
+    const outputTokens = Math.ceil(text.length / 4);
+
+    return Promise.resolve({
+      text,
+      usage: {
+        inputTokens,
+        outputTokens,
+        cachedInputTokens: 0,
+      },
+      modelUsed: input.model ?? FAKE_MODEL,
+      latencyMs: FAKE_LATENCY_MS,
+    });
+  }
+}

--- a/libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.spec.ts
+++ b/libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Vercel AI Completion Adapter — Unit Tests
+ *
+ * Mocks the Vercel AI SDK's `generateText` via the optional override token.
+ * Asserts: argument forwarding (model, prompts, max tokens, cache control),
+ * usage propagation (cacheReadTokens preference, deprecated fallback), and
+ * error mapping to domain exceptions.
+ *
+ * @module libs/integrations/ai/infrastructure/adapters
+ */
+import { ConfigService } from '@nestjs/config';
+import {
+  VercelAiCompletionAdapter,
+  type VercelGenerateTextFn,
+} from './vercel-ai-completion.adapter';
+import { AiRateLimitError } from '@openlinker/core/ai/domain/exceptions/ai-rate-limit.exception';
+import { AiTimeoutError } from '@openlinker/core/ai/domain/exceptions/ai-timeout.exception';
+import { AiCompletionError } from '@openlinker/core/ai/domain/exceptions/ai-completion.exception';
+import { AiInvalidResponseError } from '@openlinker/core/ai/domain/exceptions/ai-invalid-response.exception';
+
+/**
+ * Subset of args we care about asserting in the test. Mirrors the keys passed
+ * to `generateText` so we can avoid `any` propagating from `.mock.calls[0][0]`.
+ */
+interface CapturedGenerateArgs {
+  prompt: unknown;
+  maxOutputTokens: unknown;
+  timeout: unknown;
+  maxRetries: unknown;
+  system: unknown;
+}
+
+const captureFirstCallArgs = (fn: jest.Mock): CapturedGenerateArgs => {
+  const calls = fn.mock.calls as unknown as CapturedGenerateArgs[][];
+  if (calls.length === 0) {
+    throw new Error('generateText was not called');
+  }
+  return calls[0][0];
+};
+
+const buildConfigService = (overrides: Record<string, string | undefined> = {}): ConfigService =>
+  ({
+    get: <T = string>(key: string, defaultValue?: T): T => {
+      const v = overrides[key];
+      return (v ?? defaultValue) as T;
+    },
+  }) as unknown as ConfigService;
+
+const buildSuccessResult = (
+  overrides: Partial<{
+    text: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cachedInputTokensDeprecated: number;
+  }> = {},
+): Awaited<ReturnType<VercelGenerateTextFn>> =>
+  ({
+    text: overrides.text ?? 'generated text',
+    usage: {
+      inputTokens: overrides.inputTokens ?? 100,
+      outputTokens: overrides.outputTokens ?? 50,
+      inputTokenDetails: { cacheReadTokens: overrides.cacheReadTokens, noCacheTokens: undefined, cacheWriteTokens: undefined },
+      outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+      totalTokens: undefined,
+      cachedInputTokens: overrides.cachedInputTokensDeprecated,
+    },
+  }) as unknown as Awaited<ReturnType<VercelGenerateTextFn>>;
+
+describe('VercelAiCompletionAdapter', () => {
+  describe('complete', () => {
+    it('should forward model, system, prompt, and cache control to generateText when cacheSystemPrompt is true (default)', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      await adapter.complete({
+        systemPrompt: 'system instructions',
+        userPrompt: 'user input',
+        requestId: 'req-1',
+      });
+
+      expect(generateTextFn).toHaveBeenCalledTimes(1);
+      const args = captureFirstCallArgs(generateTextFn);
+      expect(args.prompt).toBe('user input');
+      expect(args.maxOutputTokens).toBe(2048); // default
+      expect(args.timeout).toBe(60000); // default
+      expect(args.maxRetries).toBe(0);
+      expect(args.system).toEqual({
+        role: 'system',
+        content: 'system instructions',
+        providerOptions: {
+          anthropic: { cacheControl: { type: 'ephemeral' } },
+        },
+      });
+    });
+
+    it('should pass the system prompt as a plain string when cacheSystemPrompt is false', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      await adapter.complete({
+        systemPrompt: 'sys',
+        userPrompt: 'usr',
+        cacheSystemPrompt: false,
+      });
+
+      expect(captureFirstCallArgs(generateTextFn).system).toBe('sys');
+    });
+
+    it('should honour per-call model and maxOutputTokens overrides', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      await adapter.complete({
+        systemPrompt: 's',
+        userPrompt: 'u',
+        model: 'claude-haiku-4-5-20251001',
+        maxOutputTokens: 256,
+      });
+
+      const args = captureFirstCallArgs(generateTextFn);
+      expect(args.maxOutputTokens).toBe(256);
+      // model is wrapped by the anthropic() factory; we can't assert on the wrapped object,
+      // but modelUsed in the result reflects what the adapter passed.
+    });
+
+    it('should report the requested model in modelUsed', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      const result = await adapter.complete({
+        systemPrompt: 's',
+        userPrompt: 'u',
+        model: 'custom-model-id',
+      });
+
+      expect(result.modelUsed).toBe('custom-model-id');
+    });
+
+    it('should prefer usage.inputTokenDetails.cacheReadTokens over deprecated usage.cachedInputTokens', async () => {
+      const generateTextFn = jest
+        .fn()
+        .mockResolvedValue(buildSuccessResult({ cacheReadTokens: 42, cachedInputTokensDeprecated: 7 }));
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      const result = await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
+
+      expect(result.usage.cachedInputTokens).toBe(42);
+    });
+
+    it('should fall back to deprecated usage.cachedInputTokens when cacheReadTokens is missing', async () => {
+      const generateTextFn = jest
+        .fn()
+        .mockResolvedValue(buildSuccessResult({ cachedInputTokensDeprecated: 11 }));
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      const result = await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
+
+      expect(result.usage.cachedInputTokens).toBe(11);
+    });
+
+    it('should default cachedInputTokens to 0 when both signals are absent', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      const result = await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
+
+      expect(result.usage.cachedInputTokens).toBe(0);
+    });
+
+    it('should map abort/timeout-shaped errors to AiTimeoutError', async () => {
+      const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' });
+      const generateTextFn = jest.fn().mockRejectedValue(abortError);
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
+        AiTimeoutError,
+      );
+    });
+
+    it('should map a 429 statusCode to AiRateLimitError', async () => {
+      const rateLimitError = Object.assign(new Error('rate limited'), { statusCode: 429 });
+      const generateTextFn = jest.fn().mockRejectedValue(rateLimitError);
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
+        AiRateLimitError,
+      );
+    });
+
+    it('should map an unknown failure to AiCompletionError', async () => {
+      const generateTextFn = jest.fn().mockRejectedValue(new Error('boom'));
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
+        AiCompletionError,
+      );
+    });
+
+    it('should throw AiInvalidResponseError when the provider returns empty text', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult({ text: '' }));
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
+        AiInvalidResponseError,
+      );
+    });
+
+    it('should report a non-negative latency', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
+      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+
+      const result = await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
+
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should respect env-driven defaults for max tokens and timeout', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService({ OL_AI_DEFAULT_MAX_TOKENS: '512', OL_AI_TIMEOUT_MS: '15000' }),
+        generateTextFn,
+      );
+
+      await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
+
+      const args = captureFirstCallArgs(generateTextFn);
+      expect(args.maxOutputTokens).toBe(512);
+      expect(args.timeout).toBe(15000);
+    });
+  });
+});

--- a/libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.ts
+++ b/libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.ts
@@ -1,0 +1,195 @@
+/**
+ * Vercel AI Completion Adapter (Anthropic)
+ *
+ * AiCompletionPort implementation backed by Vercel AI SDK Core (`ai`) and the
+ * `@ai-sdk/anthropic` provider. Selected by AiIntegrationModule when
+ * `OL_AI_PROVIDER=anthropic` (the default).
+ *
+ * Anthropic prompt-cache note: when `cacheSystemPrompt` is true (default), this
+ * adapter attaches `providerOptions.anthropic.cacheControl = { type: 'ephemeral' }`
+ * to the system message. The Anthropic API silently no-ops cache_control when
+ * the cached prefix is below ~1024 input tokens, so `cachedInputTokens === 0`
+ * on a short system prompt is **expected behaviour**, not a bug. Repeat calls
+ * with a sufficiently long, stable system prompt should observe
+ * `cachedInputTokens > 0` after the first warm-up.
+ *
+ * Provider error mapping happens at this boundary — no `ai` / `@ai-sdk/*`
+ * types leak into the application layer. Rate-limits map to AiRateLimitError,
+ * timeouts to AiTimeoutError, parse failures to AiInvalidResponseError, and
+ * everything else to AiCompletionError.
+ *
+ * @module libs/integrations/ai/infrastructure/adapters
+ */
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { generateText } from 'ai';
+import { anthropic } from '@ai-sdk/anthropic';
+import { Logger } from '@openlinker/shared/logging';
+import type { AiCompletionPort } from '@openlinker/core/ai/domain/ports/ai-completion.port';
+import type {
+  AiCompletionInput,
+  AiCompletionResult,
+} from '@openlinker/core/ai/domain/types/ai-completion.types';
+import { AiCompletionError } from '@openlinker/core/ai/domain/exceptions/ai-completion.exception';
+import { AiInvalidResponseError } from '@openlinker/core/ai/domain/exceptions/ai-invalid-response.exception';
+import { AiRateLimitError } from '@openlinker/core/ai/domain/exceptions/ai-rate-limit.exception';
+import { AiTimeoutError } from '@openlinker/core/ai/domain/exceptions/ai-timeout.exception';
+
+const DEFAULT_MODEL = 'claude-opus-4-7';
+const DEFAULT_MAX_OUTPUT_TOKENS = 2048;
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_TEMPERATURE = 0.2;
+
+/**
+ * Optional override hook for tests — allows specs to substitute a stub for
+ * the `generateText` function without mocking the entire `ai` module. When
+ * not provided, the adapter calls the real SDK function.
+ */
+export const VERCEL_GENERATE_TEXT_FN_TOKEN = Symbol('VercelGenerateTextFn');
+export type VercelGenerateTextFn = typeof generateText;
+
+@Injectable()
+export class VercelAiCompletionAdapter implements AiCompletionPort {
+  private readonly logger = new Logger(VercelAiCompletionAdapter.name);
+  private readonly defaultModel: string;
+  private readonly defaultMaxOutputTokens: number;
+  private readonly defaultTimeoutMs: number;
+  private readonly logPrompt: boolean;
+  private readonly generateTextFn: VercelGenerateTextFn;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @Optional()
+    @Inject(VERCEL_GENERATE_TEXT_FN_TOKEN)
+    generateTextOverride?: VercelGenerateTextFn,
+  ) {
+    this.defaultModel = this.configService.get<string>('OL_AI_DEFAULT_MODEL', DEFAULT_MODEL);
+    this.defaultMaxOutputTokens = Number(
+      this.configService.get<string | number>(
+        'OL_AI_DEFAULT_MAX_TOKENS',
+        DEFAULT_MAX_OUTPUT_TOKENS,
+      ),
+    );
+    this.defaultTimeoutMs = Number(
+      this.configService.get<string | number>('OL_AI_TIMEOUT_MS', DEFAULT_TIMEOUT_MS),
+    );
+    this.logPrompt =
+      String(this.configService.get<string>('OL_AI_LOG_PROMPT', 'false')).toLowerCase() === 'true';
+    this.generateTextFn = generateTextOverride ?? generateText;
+  }
+
+  async complete(input: AiCompletionInput): Promise<AiCompletionResult> {
+    const model = input.model ?? this.defaultModel;
+    const maxOutputTokens = input.maxOutputTokens ?? this.defaultMaxOutputTokens;
+    const temperature = input.temperature ?? DEFAULT_TEMPERATURE;
+    const cacheSystemPrompt = input.cacheSystemPrompt ?? true;
+    const requestId = input.requestId;
+    const startedAt = Date.now();
+
+    const systemMessage = cacheSystemPrompt
+      ? ({
+          role: 'system' as const,
+          content: input.systemPrompt,
+          providerOptions: {
+            anthropic: { cacheControl: { type: 'ephemeral' as const } },
+          },
+        })
+      : input.systemPrompt;
+
+    if (this.logPrompt) {
+      this.logger.debug(
+        `[ai] prompt requestId=${requestId ?? '-'} system=${input.systemPrompt} user=${input.userPrompt}`,
+      );
+    }
+
+    let result: Awaited<ReturnType<typeof generateText>>;
+    try {
+      result = await this.generateTextFn({
+        model: anthropic(model),
+        system: systemMessage,
+        prompt: input.userPrompt,
+        maxOutputTokens,
+        temperature,
+        timeout: this.defaultTimeoutMs,
+        maxRetries: 0,
+      });
+    } catch (error: unknown) {
+      throw this.mapProviderError(error, requestId);
+    }
+
+    if (typeof result.text !== 'string' || result.text.length === 0) {
+      throw new AiInvalidResponseError(
+        `AI provider returned an empty or non-string response (requestId=${requestId ?? '-'})`,
+      );
+    }
+
+    const inputTokens = result.usage.inputTokens ?? 0;
+    const outputTokens = result.usage.outputTokens ?? 0;
+    const cachedInputTokens =
+      result.usage.inputTokenDetails?.cacheReadTokens ?? result.usage.cachedInputTokens ?? 0;
+    const latencyMs = Date.now() - startedAt;
+
+    this.logger.log(
+      `[ai] completion requestId=${requestId ?? '-'} model=${model} latencyMs=${latencyMs} ` +
+        `inputTokens=${inputTokens} outputTokens=${outputTokens} cachedInputTokens=${cachedInputTokens}`,
+    );
+
+    if (this.logPrompt) {
+      this.logger.debug(`[ai] response requestId=${requestId ?? '-'} text=${result.text}`);
+    }
+
+    return {
+      text: result.text,
+      usage: { inputTokens, outputTokens, cachedInputTokens },
+      modelUsed: model,
+      latencyMs,
+    };
+  }
+
+  /**
+   * Maps any thrown value from the SDK / provider into the closest domain
+   * exception. Duck-typed so we never import provider error classes here —
+   * those would re-introduce the coupling the port exists to prevent.
+   */
+  private mapProviderError(error: unknown, requestId: string | undefined): AiCompletionError {
+    const ctx = `requestId=${requestId ?? '-'}`;
+
+    if (this.isAbortLikeError(error)) {
+      return new AiTimeoutError(`AI completion timed out (${ctx})`, { cause: error });
+    }
+
+    if (this.isRateLimitError(error)) {
+      return new AiRateLimitError(`AI provider rate limited (${ctx})`, { cause: error });
+    }
+
+    const message = this.extractMessage(error);
+    return new AiCompletionError(`AI completion failed (${ctx}): ${message}`, { cause: error });
+  }
+
+  private isAbortLikeError(error: unknown): boolean {
+    if (error instanceof Error) {
+      if (error.name === 'AbortError' || error.name === 'TimeoutError') return true;
+      const m = error.message.toLowerCase();
+      if (m.includes('abort') || m.includes('timeout') || m.includes('timed out')) return true;
+    }
+    return false;
+  }
+
+  private isRateLimitError(error: unknown): boolean {
+    if (error && typeof error === 'object') {
+      const candidate = error as { statusCode?: unknown; status?: unknown; message?: unknown };
+      if (candidate.statusCode === 429 || candidate.status === 429) return true;
+      if (typeof candidate.message === 'string') {
+        const m = candidate.message.toLowerCase();
+        if (m.includes('rate limit') || m.includes('429')) return true;
+      }
+    }
+    return false;
+  }
+
+  private extractMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === 'string') return error;
+    return 'unknown provider error';
+  }
+}

--- a/libs/integrations/ai/test/openlinker.sequencer.cjs
+++ b/libs/integrations/ai/test/openlinker.sequencer.cjs
@@ -1,0 +1,22 @@
+// Minimal deterministic Jest test sequencer.
+// Avoids pnpm workspace resolution issues with '@jest/test-sequencer'.
+
+class OpenLinkerSequencer {
+  /**
+   * @param {Array<{path: string}>} tests
+   */
+  sort(tests) {
+    return Array.from(tests).sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  /**
+   * Jest calls this after a run to allow the sequencer to persist results.
+   * We don't need this, but we must implement it to satisfy Jest's expectations.
+   */
+  cacheResults() {
+    // no-op
+  }
+}
+
+module.exports = OpenLinkerSequencer;
+

--- a/libs/integrations/ai/tsconfig.json
+++ b/libs/integrations/ai/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../../core" },
+    { "path": "../../shared" }
+  ]
+}

--- a/libs/integrations/ai/tsconfig.spec.json
+++ b/libs/integrations/ai/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/__tests__/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@openlinker/core':
         specifier: workspace:*
         version: link:../../libs/core
+      '@openlinker/integrations-ai':
+        specifier: workspace:*
+        version: link:../../libs/integrations/ai
       '@openlinker/integrations-allegro':
         specifier: workspace:*
         version: link:../../libs/integrations/allegro
@@ -289,7 +292,7 @@ importers:
         version: 6.0.1(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)))
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)))
       happy-dom:
         specifier: ^20.8.9
         version: 20.8.9
@@ -301,7 +304,7 @@ importers:
         version: 8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2))
 
   apps/worker:
     dependencies:
@@ -399,6 +402,49 @@ importers:
       typeorm:
         specifier: 0.3.17
         version: 0.3.17(pg@8.11.3)(redis@4.6.12)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3))
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.12
+        version: 29.5.12
+      '@types/node':
+        specifier: 20.11.30
+        version: 20.11.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: 7.3.1
+        version: 7.3.1(@typescript-eslint/parser@7.3.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/parser':
+        specifier: 7.3.1
+        version: 7.3.1(eslint@8.57.0)(typescript@5.4.3)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.11.30)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3))
+      ts-jest:
+        specifier: 29.1.2
+        version: 29.1.2(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@20.11.30)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3)))(typescript@5.4.3)
+      typescript:
+        specifier: 5.4.3
+        version: 5.4.3
+
+  libs/integrations/ai:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.71
+        version: 3.0.71(zod@4.3.6)
+      '@nestjs/common':
+        specifier: ^10.0.0
+        version: 10.3.0(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.1)(rxjs@7.8.1)
+      '@openlinker/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@openlinker/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      ai:
+        specifier: ^6.0.168
+        version: 6.0.168(zod@4.3.6)
     devDependencies:
       '@types/jest':
         specifier: 29.5.12
@@ -550,6 +596,28 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/anthropic@3.0.71':
+    resolution: {integrity: sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.104':
+    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
+
   '@angular-devkit/core@17.0.9':
     resolution: {integrity: sha512-r5jqwpWOgowqe9KSDqJ3iSbmsEt2XPjSvRG4DSI2T9s31bReoMtreo8b7wkRa2B3hbcDnstFbn8q27VvJDqRaQ==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -631,11 +699,6 @@ packages:
   '@babel/helpers@7.28.4':
     resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
@@ -743,10 +806,6 @@ packages:
 
   '@babel/traverse@7.28.5':
     resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -1211,6 +1270,10 @@ packages:
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/runtime@0.115.0':
     resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
@@ -2080,6 +2143,10 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2213,6 +2280,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@6.0.168:
+    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -3060,6 +3133,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -3701,6 +3778,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -5468,6 +5548,30 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/anthropic@3.0.71(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/gateway@3.0.104(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
   '@angular-devkit/core@17.0.9(chokidar@3.5.3)':
     dependencies:
       ajv: 8.12.0
@@ -5536,10 +5640,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -5551,8 +5655,8 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -5570,7 +5674,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5594,11 +5698,7 @@ snapshots:
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.0':
     dependencies:
@@ -5694,25 +5794,20 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
   '@babel/traverse@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:
@@ -6307,6 +6402,8 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/runtime@0.115.0': {}
 
@@ -6918,24 +7015,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -7212,12 +7309,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -7229,7 +7328,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -7377,6 +7476,14 @@ snapshots:
 
   agent-base@7.1.4:
     optional: true
+
+  ai@6.0.168(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
 
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
@@ -7552,7 +7659,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
@@ -8269,6 +8376,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.8: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8770,7 +8879,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -8780,7 +8889,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.3
@@ -9087,7 +9196,7 @@ snapshots:
       '@babel/generator': 7.28.5
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -9214,6 +9323,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -10693,7 +10804,7 @@ snapshots:
       terser: 5.44.1
       yaml: 2.8.2
 
-  vitest@4.1.0(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2))
@@ -10716,6 +10827,7 @@ snapshots:
       vite: 8.0.0(@types/node@24.12.0)(terser@5.44.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 24.12.0
       happy-dom: 20.8.9
       jsdom: 28.1.0(@noble/hashes@1.8.0)

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,7 +34,9 @@
       "@openlinker/shared": ["libs/shared/src/index.ts"],
       "@openlinker/shared/*": ["libs/shared/src/*"],
       "@openlinker/integrations-allegro": ["libs/integrations/allegro/src/index.ts"],
-      "@openlinker/integrations-allegro/*": ["libs/integrations/allegro/src/*"]
+      "@openlinker/integrations-allegro/*": ["libs/integrations/allegro/src/*"],
+      "@openlinker/integrations-ai": ["libs/integrations/ai/src/index.ts"],
+      "@openlinker/integrations-ai/*": ["libs/integrations/ai/src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- **#338 — Product content storage with draft write-through semantics**: New `content` bounded context with `ProductContentField` entity, `ContentDraftService` (save/discard/publish/reconcile/resolveValue), `IntegrationsContentPublisher` (routes master publishes via `ProductMasterPort`), concurrency-safe upsert repository using `INSERT ... ON CONFLICT WHERE <partial-index-predicate> DO UPDATE RETURNING`, and a migration adding `product_content_field` with two partial unique indexes for NULL-distinct `connection_id` uniqueness.
- **#340 — AI engine foundation**: New `ai` bounded context (port-only: `AiCompletionPort` + types + exceptions) and `@openlinker/integrations-ai` package shipping `VercelAiCompletionAdapter` (Anthropic via Vercel AI SDK with system-prompt cache control) and `FakeAiCompletionAdapter` (deterministic, offline). `OL_AI_PROVIDER` env selects the adapter; `AiIntegrationModule` wired into `integrations.module.ts`.

## Test plan

- [ ] `pnpm test` — all 1012 unit tests pass across all packages
- [ ] `pnpm type-check` — zero errors
- [ ] `pnpm lint` — zero errors
- [ ] `pnpm test:integration` — `content-draft.int-spec.ts` exercises the full SQL upsert path against a real Postgres container
- [ ] Manual smoke: set `OL_AI_PROVIDER=fake` and call the content draft endpoints once the HTTP layer is wired (#341)

Closes #338
Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)