### PR TITLE
fix(prestashop): handle JSON flat-array shape for product associations

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
@@ -457,7 +457,9 @@ describe('PrestashopProductMapper', () => {
       ]);
     });
 
-    it('should return undefined for an empty JSON-shape images array', () => {
+    it('should map images to null when JSON-shape images array is empty', () => {
+      // mapProduct normalises extractImages' `undefined` to `null` so the
+      // public contract exposes `null` for "no images".
       const prestashopProduct = makeProductWithImages([]);
 
       const result = mapper.mapProduct(prestashopProduct, 1);

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
@@ -443,6 +443,88 @@ describe('PrestashopProductMapper', () => {
       const result = mapper.mapProduct(prestashopProduct, 1);
       expect(result.images).toEqual(['https://shop.test/img/p/5/5/55-home_default.jpg']);
     });
+
+    it('should extract images from JSON shape (flat array, no image wrapper)', () => {
+      // PS JSON endpoint (`output_format=JSON`) collapses `<images><image>…` into
+      // a flat array at `associations.images`. This is the shape that regressed
+      // before the fix and caused every synced product to store `images=null`.
+      const prestashopProduct = makeProductWithImages([{ id: 1 }, { id: 2 }]);
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual([
+        'https://shop.test/img/p/1/1-home_default.jpg',
+        'https://shop.test/img/p/2/2-home_default.jpg',
+      ]);
+    });
+
+    it('should return undefined for an empty JSON-shape images array', () => {
+      const prestashopProduct = makeProductWithImages([]);
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toBeNull();
+    });
+  });
+
+  describe('extractCategories (via mapProduct)', () => {
+    it('should extract categories from XML shape ({ category: [...] })', () => {
+      const prestashopProduct: PrestashopProduct = {
+        id: '1',
+        name: 'Test',
+        reference: 'TEST-001',
+        price: '19.99',
+        associations: {
+          categories: { category: [{ id: '2' }, { id: '3' }] },
+        },
+      };
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.categories).toEqual(['2', '3']);
+    });
+
+    it('should extract categories from XML single-object shape ({ category: {...} })', () => {
+      const prestashopProduct: PrestashopProduct = {
+        id: '1',
+        name: 'Test',
+        reference: 'TEST-001',
+        price: '19.99',
+        associations: {
+          categories: { category: { id: '2' } },
+        },
+      };
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.categories).toEqual(['2']);
+    });
+
+    it('should extract categories from JSON shape (flat array)', () => {
+      // Same PS JSON-endpoint quirk as images — the `<category>` wrapper is
+      // collapsed into a flat array at `associations.categories`.
+      const prestashopProduct: PrestashopProduct = {
+        id: '1',
+        name: 'Test',
+        reference: 'TEST-001',
+        price: '19.99',
+        associations: {
+          categories: [{ id: 2 }, { id: 3 }, { id: 4 }],
+        },
+      };
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.categories).toEqual(['2', '3', '4']);
+    });
+
+    it('should return undefined when categories are absent', () => {
+      const prestashopProduct: PrestashopProduct = {
+        id: '1',
+        name: 'Test',
+        reference: 'TEST-001',
+        price: '19.99',
+        associations: {},
+      };
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+      expect(result.categories).toBeUndefined();
+    });
   });
 
   describe('mapVariant', () => {
@@ -463,7 +545,7 @@ describe('PrestashopProductMapper', () => {
       expect(result.weight).toBe(0.1);
     });
 
-    it('should extract attributes from product_option_values', () => {
+    it('should extract attributes from product_option_values (XML shape with array)', () => {
       const combination: PrestashopCombination = {
         id: '100',
         id_product: '1',
@@ -479,8 +561,50 @@ describe('PrestashopProductMapper', () => {
       };
 
       const result = mapper.mapVariant(combination, 'internal-product-id');
-      expect(result.attributes).toBeDefined();
-      expect(Object.keys(result.attributes || {}).length).toBeGreaterThan(0);
+      expect(result.attributes).toEqual({ option_0: '20', option_1: '30' });
+    });
+
+    it('should extract attributes from product_option_values (XML shape with single object)', () => {
+      const combination: PrestashopCombination = {
+        id: '100',
+        id_product: '1',
+        reference: 'TEST-001-RED',
+        associations: {
+          product_option_values: {
+            product_option_value: { id: '20' },
+          },
+        },
+      };
+
+      const result = mapper.mapVariant(combination, 'internal-product-id');
+      expect(result.attributes).toEqual({ option_0: '20' });
+    });
+
+    it('should extract attributes from product_option_values (JSON shape, flat array)', () => {
+      // PS JSON endpoint collapses the `<product_option_value>` wrapper into
+      // a flat array at `associations.product_option_values`.
+      const combination: PrestashopCombination = {
+        id: '100',
+        id_product: '1',
+        reference: 'TEST-001-RED',
+        associations: {
+          product_option_values: [{ id: 1 }, { id: 8 }],
+        },
+      };
+
+      const result = mapper.mapVariant(combination, 'internal-product-id');
+      expect(result.attributes).toEqual({ option_0: '1', option_1: '8' });
+    });
+
+    it('should return null attributes when product_option_values is absent', () => {
+      const combination: PrestashopCombination = {
+        id: '100',
+        id_product: '1',
+        reference: 'TEST-001-RED',
+      };
+
+      const result = mapper.mapVariant(combination, 'internal-product-id');
+      expect(result.attributes).toBeNull();
     });
 
     it('should map ean13 and upc to ean/gtin', () => {

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
@@ -44,18 +44,22 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
     const ean = normalizeToEan13(combination.ean13 ?? null);
     const gtin = normalizeBarcode(combination.upc ?? null);
 
-    // Extract attributes from product_option_values
-    if (combination.associations?.product_option_values?.product_option_value) {
-      const optionValues = Array.isArray(combination.associations.product_option_values.product_option_value)
-        ? combination.associations.product_option_values.product_option_value
-        : [combination.associations.product_option_values.product_option_value];
-
-      // Note: In a full implementation, we'd need to fetch option value names
-      // For MVP, we'll use the IDs as attribute keys
-      optionValues.forEach((ov, index) => {
-        attributes[`option_${index}`] = String(ov.id);
-      });
-    }
+    // Extract attributes from product_option_values.
+    // Handles both XML-parsed shape ({ product_option_value: [...] | {...} })
+    // and JSON shape ([...] directly) — see unwrapAssociationEntries.
+    const optionValues = this.unwrapAssociationEntries(
+      combination.associations?.product_option_values,
+      'product_option_value',
+    );
+    optionValues.forEach((ov, index) => {
+      if (ov && typeof ov === 'object') {
+        const node = ov as Record<string, unknown>;
+        const id = node.id ?? node['@_id'] ?? node['@id'];
+        if (id !== null && id !== undefined) {
+          attributes[`option_${index}`] = String(id);
+        }
+      }
+    });
 
     return {
       productId,
@@ -275,12 +279,14 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
   /**
    * Extract public image URLs from a PrestaShop product response.
    *
-   * PrestaShop serializes `associations.images.image` as either a single object
-   * (when the product has one image) or an array (when it has many). Each image
-   * node carries its numeric id under either `id` or `@_id` depending on the
-   * response format (JSON vs XML). We normalise both shapes, skip entries that
-   * don't yield a usable id, and build one URL per remaining entry. Preserves
-   * PrestaShop's order — the first element is treated as the cover.
+   * PrestaShop serializes `associations.images` in one of two shapes depending
+   * on the response format:
+   *   - XML (parsed by fast-xml-parser): `{ image: [...] | {...} }`
+   *   - JSON (`output_format=JSON`):     `[...]` directly (the `<image>` wrapper
+   *     is collapsed into a flat array)
+   * `unwrapAssociationEntries` normalises both into a single list. Each entry
+   * carries its numeric id under either `id` or `@_id`. Preserves PrestaShop's
+   * order — the first element is treated as the cover.
    *
    * Returns `undefined` when no images can be extracted (no associations, empty
    * collection, or every entry malformed). `undefined` — not `null` — matches
@@ -293,17 +299,7 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
     }
 
     const associations = product.associations as Record<string, unknown>;
-    const imagesNode = associations.images;
-    if (!imagesNode || typeof imagesNode !== 'object') {
-      return undefined;
-    }
-
-    const imageField = (imagesNode as Record<string, unknown>).image;
-    if (imageField === undefined || imageField === null) {
-      return undefined;
-    }
-
-    const entries = Array.isArray(imageField) ? imageField : [imageField];
+    const entries = this.unwrapAssociationEntries(associations.images, 'image');
 
     const urls: string[] = [];
     for (const entry of entries) {
@@ -315,6 +311,41 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
     }
 
     return urls.length > 0 ? urls : undefined;
+  }
+
+  /**
+   * Normalise a PrestaShop association node into a flat list of entries.
+   *
+   * PrestaShop serializes associations in two different shapes depending on the
+   * response format requested:
+   *   - XML (parsed by fast-xml-parser) preserves the `<singularKey>` wrapper:
+   *     `{ [singularKey]: [...] | {...} }`
+   *   - JSON (`output_format=JSON`) collapses the wrapper into a flat array at
+   *     the plural node: `[...]`
+   *
+   * This helper accepts either shape and always returns an array (possibly
+   * empty). Callers can then iterate uniformly.
+   */
+  private unwrapAssociationEntries(node: unknown, singularKey: string): unknown[] {
+    if (node === null || node === undefined) {
+      return [];
+    }
+
+    // JSON shape: the plural node is already a flat array of entries.
+    if (Array.isArray(node)) {
+      return node;
+    }
+
+    // XML shape: the plural node is an object with the singular key inside.
+    if (typeof node === 'object') {
+      const inner = (node as Record<string, unknown>)[singularKey];
+      if (inner === null || inner === undefined) {
+        return [];
+      }
+      return Array.isArray(inner) ? inner : [inner];
+    }
+
+    return [];
   }
 
   /**
@@ -381,31 +412,28 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
   }
 
   /**
-   * Extract categories from PrestaShop product
+   * Extract categories from PrestaShop product.
+   *
+   * Handles both response shapes via `unwrapAssociationEntries`:
+   *   - XML: `associations.categories = { category: [...] | {...} }`
+   *   - JSON: `associations.categories = [...]`
    */
   private extractCategories(product: PrestashopProduct): string[] | undefined {
-    // PrestaShop categories are in associations.categories
-    if (product.associations && typeof product.associations === 'object') {
-      const associations = product.associations as Record<string, unknown>;
-      if (associations.categories) {
-        const categories = associations.categories as Record<string, unknown>;
-        const categoryList = categories.category;
-
-        if (Array.isArray(categoryList)) {
-          return categoryList.map((cat) => {
-            if (cat && typeof cat === 'object') {
-              const catObj = cat as Record<string, unknown>;
-              return String(catObj.id || catObj['@_id'] || '');
-            }
-            return String(cat);
-          });
-        } else if (categoryList && typeof categoryList === 'object') {
-          const catObj = categoryList as Record<string, unknown>;
-          return [String(catObj.id || catObj['@_id'] || '')];
-        }
-      }
+    if (!product.associations || typeof product.associations !== 'object') {
+      return undefined;
     }
-    return undefined;
+    const associations = product.associations as Record<string, unknown>;
+    const entries = this.unwrapAssociationEntries(associations.categories, 'category');
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return entries.map((cat) => {
+      if (cat && typeof cat === 'object') {
+        const catObj = cat as Record<string, unknown>;
+        return String(catObj.id ?? catObj['@_id'] ?? '');
+      }
+      return String(cat);
+    });
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
@@ -52,12 +52,9 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
       'product_option_value',
     );
     optionValues.forEach((ov, index) => {
-      if (ov && typeof ov === 'object') {
-        const node = ov as Record<string, unknown>;
-        const id = node.id ?? node['@_id'] ?? node['@id'];
-        if (id !== null && id !== undefined) {
-          attributes[`option_${index}`] = String(id);
-        }
+      const id = this.readAssociationId(ov);
+      if (id !== null) {
+        attributes[`option_${index}`] = id;
       }
     });
 
@@ -303,7 +300,7 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
 
     const urls: string[] = [];
     for (const entry of entries) {
-      const id = this.extractImageId(entry);
+      const id = this.readAssociationId(entry);
       if (id === null) {
         continue;
       }
@@ -349,15 +346,18 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
   }
 
   /**
-   * Extract the numeric image id from a single `associations.images.image` entry.
+   * Extract a string id from a single association entry.
    *
-   * PrestaShop returns ids under `id` (JSON) or `@_id` (XML parsed by
-   * `fast-xml-parser`). Defensive against primitive entries (the node itself a
-   * string), object entries with either key, and anything else (returns null so
-   * the caller can skip). String/number ids are accepted; other types are
-   * rejected.
+   * PrestaShop returns ids under `id` (JSON) or `@_id` / `@id` (XML parsed by
+   * `fast-xml-parser`, depending on attribute-prefix config). Defensive against
+   * primitive entries (the node itself a string/number), object entries with
+   * any of the id keys, and anything else (returns null so the caller can
+   * skip). String/number ids are accepted; other types are rejected.
+   *
+   * Shared across `extractImages`, `extractCategories`, and `mapVariant` so the
+   * set of accepted id keys stays in one place.
    */
-  private extractImageId(entry: unknown): string | null {
+  private readAssociationId(entry: unknown): string | null {
     if (entry === null || entry === undefined) {
       return null;
     }
@@ -403,7 +403,7 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
    * Examples: `'1'` → `'1'`, `'42'` → `'4/2'`, `'123'` → `'1/2/3'`.
    *
    * Caller is responsible for supplying numeric ids — PrestaShop image ids
-   * are numeric in practice, and `extractImageId` rejects anything that
+   * are numeric in practice, and `readAssociationId` rejects anything that
    * isn't `string | number` before reaching this helper. Non-digit input
    * would still be split character-by-character rather than stripped.
    */
@@ -427,13 +427,14 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
     if (entries.length === 0) {
       return undefined;
     }
-    return entries.map((cat) => {
-      if (cat && typeof cat === 'object') {
-        const catObj = cat as Record<string, unknown>;
-        return String(catObj.id ?? catObj['@_id'] ?? '');
+    const ids: string[] = [];
+    for (const entry of entries) {
+      const id = this.readAssociationId(entry);
+      if (id !== null) {
+        ids.push(id);
       }
-      return String(cat);
-    });
+    }
+    return ids.length > 0 ? ids : undefined;
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
@@ -39,9 +39,16 @@ export interface PrestashopCombination {
   price?: string | number;
   weight?: string | number;
   associations?: {
-    product_option_values?: {
-      product_option_value?: Array<{ id: string | number }> | { id: string | number };
-    };
+    // PrestaShop serializes associations in one of two shapes depending on the
+    // response format:
+    //   - XML (parsed by fast-xml-parser): { product_option_values: { product_option_value: [...] | {...} } }
+    //   - JSON (`output_format=JSON`):     { product_option_values: [...] }
+    // Both must be accepted by the mapper.
+    product_option_values?:
+      | Array<{ id: string | number }>
+      | {
+          product_option_value?: Array<{ id: string | number }> | { id: string | number };
+        };
   };
   [key: string]: unknown;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- PrestaShop's JSON endpoint (`output_format=JSON`) collapses association wrappers into flat arrays (e.g. `associations.images = [{id:1},{id:2}]`), while the XML-parsed shape preserves the element wrapper (`{image:[...]}`). The mapper only handled the XML shape, causing `images`, `categories`, and variant `product_option_values` to always be `null`.
- Added `unwrapAssociationEntries` private helper that normalises both shapes into a plain array — used by `extractImages`, `extractCategories`, and `mapVariant`.
- Widened `PrestashopCombination.associations.product_option_values` type in the mapper interface to accept both shapes.
- Added 7 new unit tests covering JSON flat-array, XML single-object, XML array, and absent association cases.

> **Note**: existing products already synced will have `images: null` in the DB. They need to be re-synced (trigger a product sync job) to backfill the images column.

## Test plan

- [ ] `pnpm test` passes (38/38 in prestashop mapper suite)
- [ ] `pnpm lint` passes with zero errors
- [ ] `pnpm type-check` passes with zero errors
- [ ] After merge, trigger a product sync for a PrestaShop connection and verify `images` is no longer null on the products endpoint

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)