### PR TITLE
test+fix(web): page-test cleanup hooks + Allegro wizard "Before you start" callout

### DIFF
--- a/apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
 import { AllegroSetupForm } from './AllegroSetupForm';
@@ -40,6 +40,21 @@ async function advanceOneStep(container: HTMLElement, expectedStepLabel: string)
 describe('AllegroSetupForm', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+  afterEach(cleanup);
+
+  it('renders the "Before you start" info callout on step 1', () => {
+    const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient: defaultApiClient() });
+    const scope = within(container);
+
+    expect(scope.getByText(/before you start/i)).toBeInTheDocument();
+    expect(scope.getByRole('link', { name: /allegro developer portal/i })).toHaveAttribute(
+      'href',
+      'https://developer.allegro.pl/',
+    );
+    // Redirect URI is rendered inside an inline .mono-text span; simplest
+    // cross-node substring assertion is on container.textContent.
+    expect(container.textContent).toContain('/integrations/allegro/connect/callback');
   });
 
   it('renders the credentials step fields first', () => {

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
@@ -128,6 +128,20 @@ export function AllegroSetupForm(): ReactElement {
 
       {stepIndex === 0 ? (
         <>
+          <Alert tone="info" title="Before you start">
+            In the{' '}
+            <a
+              href="https://developer.allegro.pl/"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Allegro developer portal
+            </a>
+            , create a developer app and register{' '}
+            <span className="mono-text">{redirectUri}</span> as an allowed redirect URI. Copy the
+            Client ID and Client Secret from that app into the fields below.
+          </Alert>
+
           <FormField
             label="Connection name"
             name="name"

--- a/apps/web/src/pages/adapters/adapters-catalog-page.test.tsx
+++ b/apps/web/src/pages/adapters/adapters-catalog-page.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
 import { AdaptersCatalogPage } from './adapters-catalog-page';
 import type { AdapterSummary } from '../../features/adapters/api/adapters.types';
@@ -13,6 +13,8 @@ const sampleAdapter: AdapterSummary = {
 };
 
 describe('AdaptersCatalogPage', () => {
+  afterEach(cleanup);
+
   it('renders the page heading', () => {
     renderWithProviders(<AdaptersCatalogPage />);
     expect(screen.getByRole('heading', { name: 'Adapter catalog' })).toBeInTheDocument();
@@ -63,6 +65,9 @@ describe('AdaptersCatalogPage', () => {
       adapters: { list: vi.fn().mockResolvedValue([noDisplayName]) },
     });
     renderWithProviders(<AdaptersCatalogPage />, { apiClient });
-    expect(await screen.findByText('prestashop.webservice.v1')).toBeInTheDocument();
+    // Fallback renders the adapter key in both the strong label and the
+    // mono-text subtitle row — assert the strong label specifically.
+    const matches = await screen.findAllByText('prestashop.webservice.v1');
+    expect(matches.some((el) => el.tagName === 'STRONG')).toBe(true);
   });
 });

--- a/apps/web/src/pages/integrations/allegro-connect-callback-page.test.tsx
+++ b/apps/web/src/pages/integrations/allegro-connect-callback-page.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
 import { ApiError } from '../../shared/api/api-error';
 import { AllegroConnectCallbackPage } from './allegro-connect-callback-page';
@@ -7,6 +7,8 @@ import { AllegroConnectCallbackPage } from './allegro-connect-callback-page';
 const CALLBACK_ROUTE = '/integrations/allegro/connect/callback';
 
 describe('AllegroConnectCallbackPage', () => {
+  afterEach(cleanup);
+
   it('shows error state when Allegro returns ?error param', () => {
     renderWithProviders(<AllegroConnectCallbackPage />, {
       route: `${CALLBACK_ROUTE}?error=access_denied`,

--- a/apps/web/src/pages/inventory/inventory-detail-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.test.tsx
@@ -1,6 +1,6 @@
-import { screen } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { InventoryDetailPage } from './inventory-detail-page';
 import type { InventoryItem } from '../../features/inventory/api/inventory.types';
@@ -28,6 +28,8 @@ function renderDetailPage(apiClient: ReturnType<typeof createMockApiClient>): vo
 }
 
 describe('InventoryDetailPage', () => {
+  afterEach(cleanup);
+
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       inventory: { getById: vi.fn().mockReturnValue(new Promise(() => {})) },

--- a/apps/web/src/pages/inventory/inventory-list-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-list-page.test.tsx
@@ -45,8 +45,8 @@ describe('InventoryListPage', () => {
   afterEach(() => {
     vi.runAllTimers();
     vi.useRealTimers();
-    cleanup();
   });
+  afterEach(cleanup);
 
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({

--- a/apps/web/src/pages/orders/failed-orders-page.test.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { FailedOrdersPage } from './failed-orders-page';
 import type { PaginatedOrders, OrderRecord } from '../../features/orders/api/orders.types';
@@ -30,6 +30,8 @@ const sampleData: PaginatedOrders = {
 };
 
 describe('FailedOrdersPage', () => {
+  afterEach(cleanup);
+
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       orders: {

--- a/apps/web/src/pages/products/product-detail-page.test.tsx
+++ b/apps/web/src/pages/products/product-detail-page.test.tsx
@@ -1,6 +1,6 @@
-import { screen } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { ProductDetailPage } from './product-detail-page';
 import type { Product } from '../../features/products/api/products.types';
@@ -44,6 +44,8 @@ function renderDetailPage(apiClient: ReturnType<typeof createMockApiClient>): vo
 }
 
 describe('ProductDetailPage', () => {
+  afterEach(cleanup);
+
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       products: {

--- a/apps/web/src/pages/products/products-list-page.test.tsx
+++ b/apps/web/src/pages/products/products-list-page.test.tsx
@@ -45,8 +45,8 @@ describe('ProductsListPage', () => {
     // "window is not defined" unhandled errors from useDebouncedValue.
     vi.runAllTimers();
     vi.useRealTimers();
-    cleanup();
   });
+  afterEach(cleanup);
 
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -1,9 +1,11 @@
-import { screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createAuthenticatedSessionAdapter, renderWithProviders } from '../../test/test-utils';
 import { SettingsPage } from './settings-page';
 
 describe('SettingsPage', () => {
+  afterEach(cleanup);
+
   it('shows environment info', () => {
     renderWithProviders(<SettingsPage />);
 

--- a/docs/plans/implementation-plan-331-316-test-cleanup-allegro-callout.md
+++ b/docs/plans/implementation-plan-331-316-test-cleanup-allegro-callout.md
@@ -1,0 +1,141 @@
+# Implementation Plan — #331 + #316 Test cleanup & Allegro "Before you start" callout
+
+## Scope
+
+Two small frontend polish issues bundled into one PR:
+
+- **#331** (tech-debt) — Add `afterEach(cleanup)` to the 8 page test files that are missing it.
+- **#316** (enhancement) — Add a "Before you start" info `Alert` to Step 1 of the Allegro setup wizard, matching the pattern used on the PrestaShop wizard.
+
+Both changes are interface-layer frontend only (no backend, no API, no DB). Classification:
+- Layer: Frontend — Interface (page composition) + Frontend — Test infrastructure
+- Files: 1 component + 1 component test for #316, 8 page tests for #331
+
+## Non-goals
+
+- **Not** moving `afterEach(cleanup)` into a shared `test-setup.ts` via Vitest `setupFiles`. The optional follow-up in #331 is explicitly called out as out-of-scope for the mechanical fix.
+- **Not** changing the sibling PrestaShop callout copy.
+- **Not** introducing a new style for the callout — reuse `<Alert tone="info">` and `.mono-text` primitives already in use on Step 3 of the same wizard.
+- **Not** touching the two canonical files (`sync-jobs-page.test.tsx`, `webhook-deliveries-page.test.tsx`) — they already have `afterEach(cleanup)`.
+
+## Step 1 — Extend Allegro wizard Step 1 with "Before you start" callout
+
+**File:** `apps/web/src/features/allegro/components/AllegroSetupForm.tsx`
+
+Insert an `<Alert tone="info" title="Before you start">` block at the very top of the `stepIndex === 0` branch, above the "Connection name" `FormField`. Content covers the three onboarding prerequisites listed in #316.
+
+**Copy pattern:** match the PrestaShop sibling (`prestashop-setup-form.tsx:148-152`) — **prose with inline `<strong>` and `.mono-text`**, no `<ol>`. No existing `tone="info"` Alert in `apps/web/src/features/**` uses a list child; `.alert__description` isn't audited for list spacing and introducing one risks the callout looking off against the cockpit baseline. Two short sentences cover the three steps cleanly.
+
+`redirectUri` is already computed at component scope and is available to the Step 1 branch — no new variable.
+
+Link opens in a new tab (`target="_blank" rel="noreferrer noopener"`).
+
+**Acceptance:**
+- On load (Step 1), an Alert with title "Before you start" appears above the form fields.
+- The alert names the Allegro developer portal (linked), shows the exact redirect URI in a monospaced span, and points to where Client ID / Client Secret come from.
+- Steps 2 and 3 callouts remain unchanged.
+
+## Step 2 — Add test for the new callout + opportunistic cleanup
+
+**File:** `apps/web/src/features/allegro/components/AllegroSetupForm.test.tsx`
+
+1. Add a single test inside the existing `describe('AllegroSetupForm', ...)`:
+
+   ```ts
+   it('renders the "Before you start" info callout on step 1', () => {
+     const { container } = renderWithProviders(<AllegroSetupForm />, { apiClient: defaultApiClient() });
+     const scope = within(container);
+
+     expect(scope.getByText(/before you start/i)).toBeInTheDocument();
+     expect(scope.getByText(/allegro developer portal/i)).toBeInTheDocument();
+     // Redirect URI is rendered across an inline .mono-text span; simplest
+     // cross-node substring assertion is on container.textContent.
+     expect(container.textContent).toContain('/integrations/allegro/connect/callback');
+   });
+   ```
+
+2. **Opportunistic cleanup** (addresses the same failure mode as #331): this file is out of #331's scope (it's a feature test, not a page test), but since the file is already being edited and every test here uses `renderWithProviders`, add `afterEach(cleanup);` alongside the existing `afterEach(() => { vi.unstubAllGlobals(); })`. Vitest runs all registered hooks. Add `cleanup` to the `@testing-library/react` import.
+
+**Acceptance:** new test passes; the 6 existing tests continue to pass unchanged; the new cleanup hook prevents future tests in this file from inheriting leaked DOMs.
+
+## Step 3 — Add `afterEach(cleanup)` to the 8 page tests
+
+**Files (each gets the same mechanical change):**
+- `apps/web/src/pages/settings/settings-page.test.tsx`
+- `apps/web/src/pages/products/product-detail-page.test.tsx`
+- `apps/web/src/pages/products/products-list-page.test.tsx`
+- `apps/web/src/pages/adapters/adapters-catalog-page.test.tsx`
+- `apps/web/src/pages/integrations/allegro-connect-callback-page.test.tsx`
+- `apps/web/src/pages/orders/failed-orders-page.test.tsx`
+- `apps/web/src/pages/inventory/inventory-detail-page.test.tsx`
+- `apps/web/src/pages/inventory/inventory-list-page.test.tsx`
+
+For each file:
+
+1. Add `cleanup` to the existing `@testing-library/react` import.
+2. Add `afterEach` to the existing `vitest` import.
+3. Inside the top-level `describe(...)` block, register `afterEach(cleanup);` as the first statement, matching the canonical form in `sync-jobs-page.test.tsx`:
+
+```ts
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+describe('SomePage', () => {
+  afterEach(cleanup);
+  // …tests…
+});
+```
+
+If a file already has a different `afterEach(...)` (e.g. for `vi.unstubAllGlobals()`), add `afterEach(cleanup);` as an additional call. Vitest runs all registered `afterEach` callbacks.
+
+**Acceptance:**
+- `grep -rL "afterEach(cleanup)" apps/web/src/pages --include="*.test.tsx"` returns zero results.
+- `pnpm test` still passes.
+
+## Step 4 — Quality gate
+
+Run in sequence from repo root:
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All three must pass with zero errors before commit.
+
+## Validation
+
+- **Architecture compliance:** no cross-boundary changes; no new shared primitives; no new CSS; no backend edits. Frontend dependency direction preserved — edits stay inside `pages/**` tests and a single `features/allegro` component.
+- **Naming conventions:** no file renames; `AllegroSetupForm.tsx` keeps its existing PascalCase name (pre-existing; not in scope to rename per kebab-case rule).
+- **Testing:** #316 adds one passing test; #331 preserves all existing tests while immunising them against a real failure mode (multiple elements matched across leaked DOMs).
+- **Security:** no new input handling; the external link uses `rel="noreferrer noopener"`.
+- **Risk:** Very low. The 8-file `afterEach(cleanup)` change is mechanical and idempotent — if any test was secretly relying on cross-test DOM leakage it will surface as a broken test on first run.
+
+## Commit plan
+
+Two commits on the same branch — types reflect the nature of each change (per Conventional Commits and recent history):
+
+```
+test(web): add afterEach(cleanup) to page and feature tests
+
+Prevent cross-test DOM leakage by registering afterEach(cleanup) in the
+8 page test files that were missing it, plus the AllegroSetupForm feature
+test (opportunistic, since #316 touches it in a follow-up commit).
+
+Closes #331
+```
+
+```
+fix(web): add "Before you start" callout to Allegro wizard step 1
+
+Align Allegro connection wizard with the PrestaShop sibling: render an
+info Alert above the credentials fields telling operators to register a
+developer app, register the redirect URI, and copy Client ID/Secret.
+
+Closes #316
+```
+
+## Out of scope / follow-up
+
+- `AllegroSetupForm.tsx` and `AllegroSetupForm.test.tsx` use PascalCase filenames, while `docs/frontend-architecture.md` § *Components And Pages* mandates kebab-case (`allegro-setup-form.tsx`). Sibling `prestashop-setup-form.tsx` already follows the rule. Pre-existing — handle in a dedicated rename issue.


### PR DESCRIPTION
## Summary

Bundles two small frontend polish issues into a single PR (two commits, one per issue):

- **#331 (tech-debt)** — Register `afterEach(cleanup)` on the 8 page test files that were missing it. Two of them (`products-list`, `inventory-list`) already called `cleanup()` inside bespoke fake-timer `afterEach` wrappers — split cleanup into its own hook so the canonical form is present while preserving the "flush timers before unmount" ordering that avoids `"window is not defined"` errors from `useDebouncedValue`.
- **#316 (enhancement)** — Add a `Before you start` info `Alert` to Step 1 of the Allegro connection wizard, matching the pattern used by the PrestaShop sibling. The callout links the Allegro developer portal, shows the exact OpenLinker redirect URI in a `.mono-text` span (so operators can copy it verbatim), and points to where Client ID / Client Secret come from.

### Bonus (surfaced by the cleanup work)

Adding `afterEach(cleanup)` to `adapters-catalog-page.test.tsx` exposed a latent test fragility that only passed thanks to cross-test DOM leakage: the `shows adapter key when no display name is provided` test used `findByText` for a string the component renders **twice** (in both a `<strong>` label and a `.mono-text` subtitle). Fixed by switching to `findAllByText` with a `tagName === 'STRONG'` assertion — matches the component's actual fallback behaviour and removes the implicit reliance on leakage. This is exactly the class of latent bug #331 was filed to prevent.

### Out of scope / follow-up

- `AllegroSetupForm.tsx` and `AllegroSetupForm.test.tsx` use PascalCase filenames, violating the `kebab-case.tsx` rule from `docs/frontend-architecture.md` § *Components And Pages* (the PrestaShop sibling already follows it). Pre-existing — worth a dedicated rename issue if one doesn't exist.
- `#331` mentions an optional migration to shared `setupFiles` so `afterEach(cleanup)` is registered globally. Left for a follow-up.

Closes #331
Closes #316

## Test plan

- [x] `pnpm lint` — 0 errors (pre-existing warnings unchanged)
- [x] `pnpm type-check` — all packages clean
- [x] `pnpm test` — all ~1,576 tests pass across every workspace (apps/web 542, apps/api 251, apps/worker 107, libs/core 365, libs/shared 7, libs/integrations/ai 19, libs/integrations/allegro 93, libs/integrations/prestashop 192)
- [x] `grep -rL "afterEach(cleanup)" apps/web/src/pages --include="*.test.tsx"` returns zero results (#331 mechanical acceptance criterion)
- [ ] Visual check of the Allegro wizard Step 1 callout at 360 / 768 / 1440 widths per `docs/frontend-ui-style-guide.md` § *Responsive*
- [ ] Click the "Allegro developer portal" link — opens `https://developer.allegro.pl/` in a new tab
- [ ] Copy the monospace redirect URI from the callout — matches the value used in the final Review step

🤖 Generated with [Claude Code](https://claude.com/claude-code)