### PR TITLE
fix(ux,dx): products currency display, failed-orders triage UX, dev admin password

### DIFF
--- a/apps/api/src/auth/bootstrap-admin.service.spec.ts
+++ b/apps/api/src/auth/bootstrap-admin.service.spec.ts
@@ -49,12 +49,15 @@ describe('BootstrapAdminService', () => {
 
   afterEach(() => jest.restoreAllMocks());
 
-  it('seeds an admin and logs a generated password when none is provided', async () => {
+  it('seeds admin/admin in non-production when no password is provided', async () => {
     const repo = makeRepo();
     repo.findByUsername.mockResolvedValue(null);
     repo.save.mockImplementation((u) => Promise.resolve(makeUser(u.username)));
 
-    const service = new BootstrapAdminService(makeConfig(), repo);
+    const service = new BootstrapAdminService(
+      makeConfig({ NODE_ENV: 'development' }),
+      repo,
+    );
     await service.bootstrap();
 
     expect(repo.save).toHaveBeenCalledTimes(1);
@@ -63,10 +66,36 @@ describe('BootstrapAdminService', () => {
     expect(saved.email).toBe('admin@openlinker.local');
     expect(saved.role).toBe('admin');
     const hash: string = saved.passwordHash;
+    expect(await bcrypt.compare('admin', hash)).toBe(true);
     expect(await bcrypt.compare('wrong', hash)).toBe(false);
     expect(warnMessages).toHaveLength(1);
+    expect(warnMessages[0]).toMatch(/literal password `admin`/);
+    expect(warnMessages[0]).toMatch(/password=admin/);
+    expect(warnMessages[0]).toMatch(/before promoting this instance/);
+  });
+
+  it('seeds a random password in production when none is provided', async () => {
+    const repo = makeRepo();
+    repo.findByUsername.mockResolvedValue(null);
+    repo.save.mockImplementation((u) => Promise.resolve(makeUser(u.username)));
+
+    const service = new BootstrapAdminService(
+      makeConfig({ NODE_ENV: 'production' }),
+      repo,
+    );
+    await service.bootstrap();
+
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    const saved = repo.save.mock.calls[0][0];
+    const hash: string = saved.passwordHash;
+    // Random password: must NOT match the dev literal
+    expect(await bcrypt.compare('admin', hash)).toBe(false);
+    expect(warnMessages).toHaveLength(1);
+    expect(warnMessages[0]).toMatch(/store these credentials now/);
     expect(warnMessages[0]).toMatch(/username=admin/);
     expect(warnMessages[0]).toMatch(/password=/);
+    // Banner must NOT contain the default-admin wording
+    expect(warnMessages[0]).not.toMatch(/literal password `admin`/);
   });
 
   it('seeds with provided password and does NOT log it', async () => {

--- a/apps/api/src/auth/bootstrap-admin.service.ts
+++ b/apps/api/src/auth/bootstrap-admin.service.ts
@@ -9,8 +9,13 @@
  *   - OL_BOOTSTRAP_ADMIN_ENABLED (default: true)
  *   - OL_BOOTSTRAP_ADMIN_USERNAME (default: admin)
  *   - OL_BOOTSTRAP_ADMIN_EMAIL (default: admin@openlinker.local)
- *   - OL_BOOTSTRAP_ADMIN_PASSWORD (optional; if unset, a random one is
- *     generated and printed once to the API log)
+ *   - OL_BOOTSTRAP_ADMIN_PASSWORD (optional). Fallback behaviour when unset:
+ *       • NODE_ENV=production → random 18-byte password, printed once in the
+ *         API log banner (must be captured and rotated).
+ *       • Any other NODE_ENV → literal `admin`, so local/dev/staging boots
+ *         are predictable. Production deployments must set
+ *         OL_BOOTSTRAP_ADMIN_PASSWORD explicitly or disable seeding via
+ *         OL_BOOTSTRAP_ADMIN_ENABLED=false.
  *
  * @module apps/api/src/auth
  */
@@ -22,6 +27,7 @@ import { Logger } from '@openlinker/shared/logging';
 import { UserRepositoryPort, USER_REPOSITORY_TOKEN } from '@openlinker/core/users';
 
 const BCRYPT_COST = 10;
+const NON_PROD_DEFAULT_PASSWORD = 'admin';
 
 @Injectable()
 export class BootstrapAdminService implements OnApplicationBootstrap {
@@ -49,14 +55,23 @@ export class BootstrapAdminService implements OnApplicationBootstrap {
       'admin@openlinker.local',
     );
     const providedPassword = this.configService.get<string>('OL_BOOTSTRAP_ADMIN_PASSWORD');
+    const nodeEnv = this.configService.get<string>('NODE_ENV', 'development');
+    const isProduction = nodeEnv === 'production';
 
     const existing = await this.userRepository.findByUsername(username);
     if (existing) {
       return;
     }
 
-    const passwordWasGenerated = !providedPassword;
-    const password = providedPassword ?? this.generatePassword();
+    // Fallback policy: non-prod gets the predictable `admin` literal for
+    // dev-loop friction; prod stays secure-by-default with a random password.
+    const fallbackPassword = isProduction ? this.generatePassword() : NON_PROD_DEFAULT_PASSWORD;
+    const password = providedPassword ?? fallbackPassword;
+    const passwordSource: 'provided' | 'default-admin' | 'generated' = providedPassword
+      ? 'provided'
+      : isProduction
+        ? 'generated'
+        : 'default-admin';
     const passwordHash = await bcrypt.hash(password, BCRYPT_COST);
 
     try {
@@ -77,10 +92,10 @@ export class BootstrapAdminService implements OnApplicationBootstrap {
       throw error;
     }
 
-    if (passwordWasGenerated) {
-      this.logBootstrapBanner(username, password);
-    } else {
+    if (passwordSource === 'provided') {
       this.logger.log(`Seeded default admin user '${username}' with provided password`);
+    } else {
+      this.logBootstrapBanner(username, password, passwordSource);
     }
   }
 
@@ -88,15 +103,27 @@ export class BootstrapAdminService implements OnApplicationBootstrap {
     return randomBytes(18).toString('base64url');
   }
 
-  private logBootstrapBanner(username: string, password: string): void {
+  private logBootstrapBanner(
+    username: string,
+    password: string,
+    source: 'default-admin' | 'generated',
+  ): void {
     const line = '='.repeat(72);
+    const preamble =
+      source === 'default-admin'
+        ? 'OpenLinker seeded the default admin with the literal password `admin` (non-production default):'
+        : 'OpenLinker default admin user seeded — store these credentials now:';
+    const postamble =
+      source === 'default-admin'
+        ? 'Set OL_BOOTSTRAP_ADMIN_PASSWORD before promoting this instance out of development,'
+        : 'Set OL_BOOTSTRAP_ADMIN_PASSWORD or disable seeding via';
     this.logger.warn(
       [
         line,
-        'OpenLinker default admin user seeded — store these credentials now:',
+        preamble,
         `  username=${username}`,
         `  password=${password}`,
-        'Set OL_BOOTSTRAP_ADMIN_PASSWORD or disable seeding via',
+        postamble,
         'OL_BOOTSTRAP_ADMIN_ENABLED=false in production environments.',
         line,
       ].join('\n'),

--- a/apps/api/src/products/http/dto/product-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-response.dto.ts
@@ -23,6 +23,13 @@ export class ProductResponseDto {
   @ApiPropertyOptional({ nullable: true, description: 'Product price' })
   price!: number | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'ISO 4217 currency code (e.g., PLN, EUR). Currently always null pending product-level currency persistence; once the follow-up lands, this carries the code resolved from the master catalog.',
+  })
+  currency!: string | null;
+
   @ApiPropertyOptional({ nullable: true, description: 'Product description' })
   description!: string | null;
 

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -19,14 +19,15 @@ import type { IdentifierMappingPort } from '@openlinker/core/identifier-mapping'
 
 function makeProduct(overrides: Partial<Product> = {}): Product {
   return {
-    id: overrides.id ?? 'ol_product_1',
-    name: overrides.name ?? 'Test Product',
-    sku: overrides.sku ?? 'SKU-001',
-    price: overrides.price ?? 29.99,
-    description: overrides.description ?? 'A test product',
-    images: overrides.images ?? null,
-    createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
-    updatedAt: overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
+    id: 'ol_product_1',
+    name: 'Test Product',
+    sku: 'SKU-001',
+    price: 29.99,
+    description: 'A test product',
+    images: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
   };
 }
 
@@ -139,6 +140,7 @@ describe('ProductsController', () => {
       const result = await controller.getProduct('ol_product_1');
 
       expect(result.id).toBe('ol_product_1');
+      expect(result.currency).toBeNull();
       expect(result.variants).toHaveLength(1);
       expect(result.variants![0].id).toBe('ol_product_v1');
       expect(result.externalIds).toHaveLength(1);
@@ -146,6 +148,16 @@ describe('ProductsController', () => {
       // Verify correct entity type passed for product and variant
       expect(identifierMapping.getExternalIds).toHaveBeenCalledWith('Product', 'ol_product_1');
       expect(identifierMapping.getExternalIds).toHaveBeenCalledWith('Product', 'ol_product_v1');
+    });
+
+    it('should surface currency when the domain entity carries one', async () => {
+      productsService.getProduct.mockResolvedValue(makeProduct({ currency: 'PLN' }));
+      productsService.listVariants.mockResolvedValue({ items: [], total: 0 });
+      identifierMapping.getExternalIds.mockResolvedValue([]);
+
+      const result = await controller.getProduct('ol_product_1');
+
+      expect(result.currency).toBe('PLN');
     });
 
     it('should throw NotFoundException when product not found', async () => {

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -179,6 +179,7 @@ export class ProductsController {
       name: product.name,
       sku: product.sku,
       price: product.price,
+      currency: product.currency ?? null,
       description: product.description,
       images: product.images,
       createdAt: product.createdAt!.toISOString(),

--- a/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
@@ -30,6 +30,7 @@ const product: Product = {
   name: 'Test Shirt',
   sku: 'TS-1',
   price: 49.5,
+  currency: null,
   description: null,
   images: null,
   createdAt: '2026-01-01T00:00:00Z',

--- a/apps/web/src/features/products/api/products.types.ts
+++ b/apps/web/src/features/products/api/products.types.ts
@@ -31,6 +31,8 @@ export interface Product {
   name: string;
   sku: string | null;
   price: number | null;
+  /** ISO 4217 currency code (e.g., 'PLN', 'EUR'). Null when the backend has not populated a currency for this product. */
+  currency: string | null;
   description: string | null;
   images: string[] | null;
   createdAt: string;

--- a/apps/web/src/pages/orders/failed-orders-page.test.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.test.tsx
@@ -1,8 +1,9 @@
-import { screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { FailedOrdersPage } from './failed-orders-page';
 import type { PaginatedOrders, OrderRecord } from '../../features/orders/api/orders.types';
+import type { Connection } from '../../features/connections/api/connections.types';
 
 function makeOrderRecord(overrides: Partial<OrderRecord> = {}): OrderRecord {
   return {
@@ -22,6 +23,22 @@ function makeOrderRecord(overrides: Partial<OrderRecord> = {}): OrderRecord {
   };
 }
 
+function makeConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-1111-2222-3333-444444444444',
+    name: 'Allegro Europe',
+    platformType: 'allegro',
+    status: 'active',
+    config: {},
+    credentialsBacked: true,
+    enabledCapabilities: [],
+    supportedCapabilities: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
 const sampleData: PaginatedOrders = {
   items: [makeOrderRecord()],
   total: 1,
@@ -30,6 +47,8 @@ const sampleData: PaginatedOrders = {
 };
 
 describe('FailedOrdersPage', () => {
+  afterEach(cleanup);
+
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       orders: {
@@ -70,7 +89,47 @@ describe('FailedOrdersPage', () => {
 
     renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
 
-    expect(await screen.findByText(/ol_order_aabbccd/)).toBeInTheDocument();
+    // Full internal order ID now rendered (no manual .slice truncation).
+    expect(await screen.findByText('ol_order_aabbccdd1122334455')).toBeInTheDocument();
+  });
+
+  it('should link each row to the order detail page', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(sampleData) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    const link = await screen.findByRole('link', { name: /ol_order_aabbccdd1122334455/ });
+    expect(link).toHaveAttribute('href', '/orders/ol_order_aabbccdd1122334455');
+  });
+
+  it('should render the Operations eyebrow to match sibling pages', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(sampleData) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    await screen.findByText('ol_order_aabbccdd1122334455');
+    expect(screen.getByText('Operations')).toBeInTheDocument();
+  });
+
+  it('should resolve the connection name via ConnectionEntityLabel', async () => {
+    const connection = makeConnection();
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(sampleData) },
+      connections: {
+        list: vi.fn().mockResolvedValue([connection]),
+        getById: vi.fn().mockResolvedValue(connection),
+      },
+    });
+
+    renderWithProviders(<FailedOrdersPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Allegro Europe')).toBeInTheDocument();
   });
 
   it('should show error state when fetch fails', async () => {

--- a/apps/web/src/pages/orders/failed-orders-page.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.tsx
@@ -18,6 +18,7 @@ import { Select } from '../../shared/ui/select';
 import { StatusBadge } from '../../shared/ui/status-badge';
 import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import type { OrderRecord } from '../../features/orders/api/orders.types';
 
@@ -33,12 +34,22 @@ const COLUMNS: DataTableColumn<OrderRecord>[] = [
   {
     id: 'internalOrderId',
     header: 'Order ID',
-    cell: (order) => <span className="mono-text">{order.internalOrderId.slice(0, 16)}…</span>,
+    cell: (order) => (
+      <span className="mono-text" title={order.internalOrderId}>
+        {order.internalOrderId}
+      </span>
+    ),
   },
   {
     id: 'sourceConnectionId',
     header: 'Connection',
-    cell: (order) => <span className="mono-text">{order.sourceConnectionId.slice(0, 8)}…</span>,
+    cell: (order) => (
+      <ConnectionEntityLabel
+        connectionId={order.sourceConnectionId}
+        linkToDetail={false}
+        showId
+      />
+    ),
     hideBelow: 1024,
   },
   {
@@ -102,7 +113,7 @@ export function FailedOrdersPage(): ReactElement {
 
   return (
     <PageLayout
-      eyebrow="Orders"
+      eyebrow="Operations"
       title="Awaiting Mapping"
       description="Orders with unresolved offer→variant mappings. These retry automatically once the mapping is created."
       actions={
@@ -161,11 +172,26 @@ export function FailedOrdersPage(): ReactElement {
             columns={COLUMNS}
             rows={query.data?.items ?? []}
             rowKey={(order) => order.internalOrderId}
+            rowHref={(order) => `/orders/${order.internalOrderId}`}
             sort={sort}
             onSortChange={setSort}
             cardView={{
-              title: (order) => `${order.internalOrderId.slice(0, 16)}…`,
-              subtitle: (order) => `${snapshotItemCount(order.orderSnapshot)} item(s)`,
+              title: (order) => (
+                <span className="mono-text" title={order.internalOrderId}>
+                  {order.internalOrderId}
+                </span>
+              ),
+              subtitle: (order) => (
+                <>
+                  <ConnectionEntityLabel
+                    connectionId={order.sourceConnectionId}
+                    linkToDetail={false}
+                    showId={false}
+                  />
+                  {' · '}
+                  {snapshotItemCount(order.orderSnapshot)} item(s)
+                </>
+              ),
             }}
           />
 

--- a/apps/web/src/pages/products/product-detail-page.test.tsx
+++ b/apps/web/src/pages/products/product-detail-page.test.tsx
@@ -10,6 +10,7 @@ const sampleProduct: Product = {
   name: 'Test Product',
   sku: 'SKU-001',
   price: 29.99,
+  currency: null,
   description: 'A test product',
   images: null,
   createdAt: '2026-01-15T10:00:00.000Z',

--- a/apps/web/src/pages/products/products-list-page.test.tsx
+++ b/apps/web/src/pages/products/products-list-page.test.tsx
@@ -12,6 +12,7 @@ const sampleProducts: PaginatedProducts = {
       name: 'Test Product',
       sku: 'SKU-001',
       price: 29.99,
+      currency: 'PLN',
       description: null,
       images: ['https://cdn.example.com/test-product.jpg'],
       createdAt: '2026-01-15T10:00:00.000Z',
@@ -22,6 +23,7 @@ const sampleProducts: PaginatedProducts = {
       name: 'Another Product',
       sku: null,
       price: null,
+      currency: null,
       description: null,
       images: null,
       createdAt: '2026-02-01T10:00:00.000Z',
@@ -71,8 +73,38 @@ describe('ProductsListPage', () => {
 
     expect(await screen.findByText('Test Product')).toBeInTheDocument();
     expect(screen.getByText('SKU-001')).toBeInTheDocument();
-    expect(screen.getByText('29.99')).toBeInTheDocument();
+    // Intl.NumberFormat glyphs vary between runtimes — match amount + ISO code.
+    expect(screen.getByText(/29[.,]99/)).toBeInTheDocument();
+    expect(screen.getByText(/PLN/)).toBeInTheDocument();
     expect(screen.getByText('Another Product')).toBeInTheDocument();
+  });
+
+  it('should show muted price with hover explanation when currency is absent', async () => {
+    const mockApi = createMockApiClient({
+      products: {
+        list: vi.fn().mockResolvedValue({
+          items: [
+            {
+              ...sampleProducts.items[0],
+              id: 'ol_product_nocur',
+              name: 'Currencyless Product',
+              price: 19.99,
+              currency: null,
+            },
+          ],
+          total: 1,
+          limit: 20,
+          offset: 0,
+        }),
+      },
+    });
+
+    const { container } = renderWithProviders(<ProductsListPage />, { apiClient: mockApi });
+
+    await within(container).findByText('Currencyless Product');
+    const amount = container.querySelector<HTMLElement>('span[title="Currency unknown"]');
+    expect(amount).not.toBeNull();
+    expect(amount?.textContent).toBe('19.99');
   });
 
   it('should show error state when fetch fails', async () => {

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useState, type ReactElement, type ReactNode } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
@@ -15,6 +15,22 @@ import type { Product, ProductFilters } from '../../features/products/api/produc
 
 const PAGE_SIZE = 20;
 const SEARCH_DEBOUNCE_MS = 300;
+
+// When currency is missing, the raw amount is shown muted with a hover-reveal
+// rather than silently emitting a bare decimal — explicit ambiguity is safer.
+function formatPrice(price: number | null, currency: string | null): ReactNode {
+  if (price === null) {
+    return <span className="text-muted">—</span>;
+  }
+  if (currency) {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(price);
+  }
+  return (
+    <span className="text-muted" title="Currency unknown">
+      {price.toFixed(2)}
+    </span>
+  );
+}
 
 const COLUMNS: DataTableColumn<Product>[] = [
   {
@@ -46,8 +62,7 @@ const COLUMNS: DataTableColumn<Product>[] = [
     id: 'price',
     header: 'Price',
     align: 'right',
-    cell: (product) =>
-      product.price !== null ? product.price.toFixed(2) : <span className="text-muted">—</span>,
+    cell: (product) => formatPrice(product.price, product.currency),
     accessor: (product) => product.price,
     sortable: true,
     hideBelow: 480,
@@ -182,7 +197,8 @@ export function ProductsListPage(): ReactElement {
                 </span>
               ),
               subtitle: (product) => product.sku ?? '—',
-              meta: (product) => (product.price !== null ? product.price.toFixed(2) : null),
+              meta: (product) =>
+                product.price !== null ? formatPrice(product.price, product.currency) : null,
             }}
           />
 

--- a/docs/plans/implementation-plan-326-327-329-ux-dx-fixes.md
+++ b/docs/plans/implementation-plan-326-327-329-ux-dx-fixes.md
@@ -1,0 +1,239 @@
+# Implementation Plan — UX/DX Fixes Bundle (#326 + #327 + #329)
+
+Small, independent fixes bundled into one PR:
+
+- **#326** — Products list: render price with currency glyph (Intl.NumberFormat), muted fallback when currency is absent
+- **#327** — Failed Orders page: row click-through, full internal order ID w/ tooltip, connection-name resolution, eyebrow "Operations", card subtitle cleanup
+- **#329** — Bootstrap admin service: default password to `admin` in non-production, keep random fallback in production
+
+---
+
+## 1. Goals
+
+One-liners per issue:
+
+- **#326**: operators must never see a bare decimal price without currency context.
+- **#327**: `/orders/failed` must be usable as a triage surface — click rows to drill in, see full IDs, see connection names, use the right eyebrow.
+- **#329**: fresh dev DB + missing `OL_BOOTSTRAP_ADMIN_PASSWORD` should yield a predictable `admin` login; prod must stay secure-by-default.
+
+## 2. Layer classification
+
+- **#326**: FE (page composition + feature types) + BE (DTO contract only — no migration; persistence is a follow-up)
+- **#327**: FE only (page composition)
+- **#329**: BE only (apps/api auth bootstrap, NODE_ENV-gated)
+
+## 3. Non-goals
+
+- **Not** persisting `currency` on the `products` table. Requires a schema migration + repo mapping + adapter wiring; a separate follow-up issue will be opened. The DTO will expose `currency: string | null` today (always `null` for repo-sourced products) so the FE contract is ready.
+- **Not** resolving connection-name in a shared hook across pages. #321 tracks that — here we inline-resolve via `useConnectionsQuery()` matching the pattern already used by `failed-orders-page`.
+- **Not** changing any CSS tokens or shared UI primitives.
+- **Not** changing the random-password entropy or bcrypt cost.
+
+---
+
+## 4. Research notes (what already exists)
+
+- `libs/core/src/products/domain/entities/product.entity.ts:30` — `Product.currency?: string` is already on the domain entity but marked "Master-derived, not persisted on the products table".
+- `libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts:74-85` — `toDomain` does **not** read currency from the ORM entity.
+- `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts:33` — currency is hardcoded to `'EUR'` in the adapter but discarded on upsert because the ORM entity has no currency column.
+- `apps/api/src/products/http/dto/product-response.dto.ts` — no `currency` field.
+- `apps/api/src/products/http/products.controller.ts:171-187` — `toProductDto` does not expose `currency`.
+- `apps/web/src/features/orders/components/order-line-items-panel.tsx:20-25` — existing `formatAmount(amount, currency)` precedent: uses `Intl.NumberFormat` when currency present, formatted decimal when absent. We'll diverge slightly for products: when currency is absent, render the amount muted with a `title="Currency unknown"` — explicit, not silent.
+- `apps/web/src/pages/orders/orders-list-page.tsx:198` — uses `rowHref={(order) => order.internalOrderId}` (relative). Failed-orders lives at `/orders/failed`, so relative would resolve to `/orders/failed/:id`. Use an absolute `/orders/${order.internalOrderId}` here.
+- `apps/web/src/shared/ui/data-table.tsx:161-184` — `rowHref` renders a wrapping `<Link>` on the first cell and makes the row clickable. No change needed.
+- `apps/api/src/auth/bootstrap-admin.service.ts:58-60,87-89` — current generator uses `randomBytes(18).toString('base64url')`.
+
+---
+
+## 5. Design
+
+### 5.1 #326 — Products currency formatting
+
+**Backend contract (minimal):**
+
+- Add `currency: string | null` to `ProductResponseDto` (ApiPropertyOptional, nullable).
+- In `ProductsController.toProductDto`, pass `currency: product.currency ?? null`. Today this is always `null` (repo doesn't persist it); contract is forward-compatible.
+
+**Frontend types:**
+
+- Add `currency: string | null` to `apps/web/src/features/products/api/products.types.ts:Product`.
+
+**Frontend rendering:**
+
+- New helper co-located with the page (private, no shared-module churn): `formatPrice(price: number | null, currency: string | null): ReactNode`.
+  - `price === null` → muted em-dash (existing pattern).
+  - `price !== null && currency` → `Intl.NumberFormat(undefined, { style: 'currency', currency }).format(price)` wrapped in plain text.
+  - `price !== null && !currency` → `<span className="text-muted" title="Currency unknown">{price.toFixed(2)}</span>` — muted colouring + hover-reveal + screen-reader-accessible explanation.
+- Replace the price column's `cell` in `COLUMNS`.
+- Replace `cardView.meta` with the same helper.
+
+**Tests:**
+
+- Existing test already asserts `29.99` is in the document. Update to expect `'PLN 29.99'` (or whatever `Intl` emits — match via regex or substring since browsers differ slightly in glyph).
+- Add a case: product with `price` set and `currency: null` → muted element with `title="Currency unknown"` present.
+
+### 5.2 #327 — Failed Orders UX
+
+Five localized edits to `apps/web/src/pages/orders/failed-orders-page.tsx`:
+
+1. `COLUMNS[0].cell` — render full `order.internalOrderId` inside `<span className="mono-text" title={order.internalOrderId}>`. Remove manual `.slice(0, 16)…`. **Not** using `EntityLabel` here: (a) this cell sits at column index 0, which `DataTable` wraps in its own `<Link>` — nesting `EntityLabel`'s internal link/copy button inside another `<a>` would emit invalid HTML; (b) the full internal ID is already the user-facing identifier for orders (no separate human name) — `EntityLabel`'s name-first design would render "Unknown" beside every ID, which is noise.
+2. `COLUMNS[1].cell` — use the existing **`ConnectionEntityLabel`** primitive (`apps/web/src/features/connections/components/ConnectionEntityLabel.tsx`) with `linkToDetail={false}` (the row itself navigates to the order; we don't want a secondary jump to the connection) and `showId={true}`. This is the prescribed pattern per `frontend-ui-style-guide.md` ("used on every list row where an internal UUID would otherwise leak") and handles loading / unknown-name states natively — no manual `connectionNameById` map, no flash of raw UUID while `useConnectionsQuery()` is still resolving. `DataTable.shouldIgnoreRowClick` already skips nested anchors/buttons, so the copy button won't hijack row navigation.
+3. `PageLayout.eyebrow` — change `"Orders"` → `"Operations"`.
+4. `DataTable.rowHref` — add `rowHref={(order) => \`/orders/${order.internalOrderId}\`}` (absolute path because we're not at `/orders`).
+5. `cardView.title` — drop the manual `.slice`, use full internal order id. `cardView.subtitle` — use `ConnectionEntityLabel` followed by the item count, so mobile cards match the table's connection resolution.
+
+**Tests** (`failed-orders-page.test.tsx`):
+
+- Add case: row anchor links to `/orders/<internalOrderId>` (query by `role=link, name: /ol_order_aabbccdd.../` and assert `href`).
+- Add case: connection name renders when `connections.list` returns a matching connection; falls back to mono-text ID otherwise.
+- Update existing "shows table" expectation so it checks the full order ID text (not the chopped `ol_order_aabbccd` substring).
+- Assert `eyebrow="Operations"` is rendered (via `data-eyebrow` or just the literal text if `PageLayout` renders it).
+
+### 5.3 #329 — Bootstrap admin default password
+
+Change `BootstrapAdminService.bootstrap()`:
+
+- After `providedPassword` read, compute:
+  ```ts
+  const nodeEnv = this.configService.get<string>('NODE_ENV', 'development');
+  const isProduction = nodeEnv === 'production';
+  const fallbackPassword = isProduction ? this.generatePassword() : 'admin';
+  const password = providedPassword ?? fallbackPassword;
+  const passwordSource: 'provided' | 'default-admin' | 'generated' =
+    providedPassword ? 'provided' : isProduction ? 'generated' : 'default-admin';
+  ```
+  `ConfigService.get(key, defaultValue)` is the idiom already used elsewhere in this file (see line 41 / 46); reuse it for consistency.
+- Adjust the log branching:
+  - `passwordSource === 'provided'` → current log (unchanged copy).
+  - Otherwise → `logBootstrapBanner(username, password, passwordSource)` with a `source` parameter branching the banner copy internally. A single banner method keeps warning wording in lock-step and avoids drift between two near-identical private methods.
+  - `generated` copy: current message (random password, store it now).
+  - `default-admin` copy: distinct wording calling out the literal `admin` password + reminder that `OL_BOOTSTRAP_ADMIN_PASSWORD` must be set (or `OL_BOOTSTRAP_ADMIN_ENABLED=false`) for non-dev environments.
+- Update file-header JSDoc (lines 12-13) to describe the new behaviour.
+
+**Tests** (`bootstrap-admin.service.spec.ts`):
+
+- Update existing "seeds an admin and logs a generated password when none is provided" → split into two:
+  - non-prod default (no `NODE_ENV` or any non-`production`): seeds `admin`, logs a distinct default-admin banner.
+  - prod default (`NODE_ENV=production`): keeps random behaviour (current assertions).
+- Existing "provided password wins" stays unchanged.
+- Existing "skips when disabled", "skips when exists", concurrency/rethrow tests all stay unchanged.
+
+---
+
+## 6. Step-by-step implementation
+
+### Step 1 — #326 BE DTO contract
+
+- File: `apps/api/src/products/http/dto/product-response.dto.ts`
+  - Add `@ApiPropertyOptional({ nullable: true, description: 'ISO 4217 currency code' })` + `currency!: string | null;`
+- File: `apps/api/src/products/http/products.controller.ts`
+  - `toProductDto` → add `currency: product.currency ?? null,`
+- File: `apps/api/src/products/http/products.controller.spec.ts`
+  - If the fixture asserts the full DTO shape, add `currency: null` expectation. Otherwise, no-op.
+
+**Acceptance:** `pnpm lint && pnpm type-check` passes. The DTO JSON now includes `"currency": null` (today).
+
+### Step 2 — #326 FE type
+
+- File: `apps/web/src/features/products/api/products.types.ts`
+  - Add `currency: string | null;` to `Product`.
+
+**Acceptance:** type-check passes in `apps/web`.
+
+### Step 3 — #326 FE rendering
+
+- File: `apps/web/src/pages/products/products-list-page.tsx`
+  - Add private helper `formatPrice(price, currency)` returning `ReactNode`.
+  - Replace `cell` for price column.
+  - Replace `cardView.meta`.
+
+**Acceptance:** manually eyeball the page in dev mode; tests updated below.
+
+### Step 4 — #326 FE tests
+
+- File: `apps/web/src/pages/products/products-list-page.test.tsx`
+  - Add `currency: 'PLN'` to the first sample product, keep `currency: null` for the second.
+  - Update the `29.99` expectation to a regex match on the formatted string.
+  - Add an assertion that the second product's price renders with `title="Currency unknown"`.
+
+**Acceptance:** `pnpm --filter @openlinker/web test` passes.
+
+### Step 5 — #327 FE page
+
+- File: `apps/web/src/pages/orders/failed-orders-page.tsx`
+  - Move `COLUMNS` construction inside the component (needs `connections` data).
+  - Build a `connectionNameById = new Map(connections.map(c => [c.id, c.name]))`.
+  - Update 5 edits listed in 5.2.
+  - `rowHref={(order) => \`/orders/${order.internalOrderId}\`}`.
+
+**Acceptance:** type-check passes.
+
+### Step 6 — #327 FE tests
+
+- File: `apps/web/src/pages/orders/failed-orders-page.test.tsx`
+  - Add test: row renders as a link to `/orders/ol_order_aabbccdd1122334455`.
+  - Add test: connection name shown when `connections.list` returns a matching connection.
+  - Add test: eyebrow `Operations` present (via `renderWithProviders` + text query).
+  - Existing tests stay green (update the substring match for order ID if now rendering full ID).
+
+**Acceptance:** `pnpm --filter @openlinker/web test` passes.
+
+### Step 7 — #329 BE bootstrap
+
+- File: `apps/api/src/auth/bootstrap-admin.service.ts`
+  - Update `bootstrap()` per 5.3.
+  - Add `logDefaultAdminBanner()` private method (mirrors `logBootstrapBanner` shape but says "literal `admin` password in use").
+  - Update header JSDoc (lines 12-13).
+
+**Acceptance:** type-check passes.
+
+### Step 8 — #329 BE tests
+
+- File: `apps/api/src/auth/bootstrap-admin.service.spec.ts`
+  - Adjust the "logs a generated password when none is provided" test to set `NODE_ENV=production` in the config.
+  - Add a new test "seeds admin/admin in non-production when no password is provided" that verifies:
+    - `bcrypt.compare('admin', hash)` is true
+    - a distinct warning banner is emitted (not the same as the random-password banner).
+  - Confirm existing tests still pass.
+
+**Acceptance:** `pnpm --filter @openlinker/api test` passes.
+
+### Step 9 — Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All three green; no new warnings.
+
+### Step 10 — Open follow-up issue
+
+Open `#??? — Persist Product.currency on products table` referencing this PR. Scope:
+
+- Migration adding `currency varchar(3) null` to `products`.
+- Update `ProductOrmEntity`, `ProductRepository.toDomain/toOrmEntity`.
+- Ensure adapters (PrestaShop product mapper) flow currency through to upsert.
+- Update DTO docstring to clarify currency is now sourced from persistence.
+
+---
+
+## 7. Architecture compliance check
+
+- **#326**: FE feature type change + BE DTO field both stay at their respective interface layers. No domain/application changes. ✅
+- **#327**: page-composition only. No new shared primitives. ✅
+- **#329**: confined to `apps/api/src/auth/bootstrap-admin.service.ts` + its spec. No port/adapter additions. Reads `NODE_ENV` via `ConfigService` like the rest of the file. ✅
+- No `any`, no `console.log`, no hardcoded secrets (literal `admin` password is the explicit fix — gated by `NODE_ENV !== 'production'` and documented; called out loudly in logs). ✅
+
+## 8. Risks and open questions
+
+- **Currency `null` for all repo-sourced products** — the FE will always hit the muted fallback until the persistence follow-up lands. That's the correct bug-fix semantics (don't lie about the currency), and it's explicitly allowed by the AC ("A muted fallback is shown when currency is absent").
+- **`admin/admin` footgun** — mitigated by `NODE_ENV !== 'production'` gate + loud warn banner + existing `OL_BOOTSTRAP_ADMIN_ENABLED=false` escape hatch. If the security team wants a stricter default (e.g., `staging` also random), we'll need an explicit `OL_ENVIRONMENT` enum rather than leaning on `NODE_ENV`. Out of scope here.
+- **`COLUMNS` move inside component** on #327 — marginally re-allocates the column array per render. Page is tiny; no perf concern. Matches the style already used by many other pages that inline column arrays.
+
+## 9. Test strategy summary
+
+- BE unit tests: 1 new (`bootstrap-admin.service.spec.ts`), 1 modified.
+- FE unit tests: 3 new (1 in products-list, 2 in failed-orders), 2 modified (assertion updates).
+- No integration tests needed — these are all pure display/logic changes at an existing integration-test-covered surface.


### PR DESCRIPTION
## Summary

Bundle of three small independent UX/DX fixes, scoped tightly enough to ship together.

### #326 — Products list currency display

The price column used to render as a bare decimal (`19.99`) with no currency context, unsafe for a catalog that spans PLN shops and EUR marketplaces.

- Frontend `Product` type gains `currency: string | null`. When present, price is formatted via `Intl.NumberFormat(locale, { style: 'currency', currency })`. When absent, the amount renders muted with `title="Currency unknown"` — explicit ambiguity instead of a silent bare number.
- `ProductResponseDto` exposes `currency: string | null` and `ProductsController.toProductDto` maps from the domain entity's master-derived `currency` field.
- Today the DTO always emits `null` because `currency` is not yet persisted on the `products` table. Follow-up issue will land migration + repo mapping + adapter wiring so the field flows end-to-end.

### #327 — Failed Orders (`/orders/failed`) triage UX

The triage surface for orders stuck on missing offer→variant mappings had three papercuts:

- Rows are now clickable — they navigate to `/orders/:internalOrderId`.
- Internal order IDs render in full with a `title=` tooltip for hover-reveal (no more manual `.slice(0, 16)…`).
- Connection column uses the existing `ConnectionEntityLabel` primitive (name-first, handles loading + unknown states, per the style guide's "EntityLabel on every list row" rule). `linkToDetail={false}` prevents secondary navigation since the row itself links to the order.
- Eyebrow changed from `Orders` to `Operations` to match sibling pages + the sidebar group.
- Card view (mobile) mirrors the same resolutions.
- Also added `afterEach(cleanup)` to the test file — partial progress on #331 (test isolation).

### #329 — Bootstrap admin password default

Fresh dev DBs no longer require scraping the log for the one-time generated password.

| NODE_ENV | `OL_BOOTSTRAP_ADMIN_PASSWORD` set | Resulting password |
|---|---|---|
| any | yes | provided value |
| `production` | no | random 18-byte (unchanged) |
| anything else | no | literal `admin` |

A distinct loud `warn` banner fires for the `default-admin` case, reminding operators to set `OL_BOOTSTRAP_ADMIN_PASSWORD` before promoting out of development. `OL_BOOTSTRAP_ADMIN_ENABLED=false` remains the escape hatch.

## Test plan

- [ ] `pnpm lint` — zero errors
- [ ] `pnpm type-check` — zero errors
- [ ] `pnpm test` — all unit tests pass (545 FE, 253 API, 107 worker, 365 core, 192 PrestaShop, 93 Allegro, 19 AI, 7 shared)
- [ ] Start API with fresh DB and no `OL_BOOTSTRAP_ADMIN_PASSWORD` → login with `admin` / `admin`
- [ ] Start API with `NODE_ENV=production` and no password → random password in log banner (existing behaviour)
- [ ] `/products` — rows with currency show glyph; rows without currency show muted amount with hover tooltip
- [ ] `/orders/failed` — rows click through, order IDs hover-reveal full value, Connection column shows name
- [ ] Mobile card view on `/orders/failed` — same values resolve

Closes #326
Closes #327
Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)