### PR TITLE
refactor(listings): split OfferManagerPort optional methods into capability interfaces

### DIFF
--- a/apps/api/src/categories/categories-cache.service.ts
+++ b/apps/api/src/categories/categories-cache.service.ts
@@ -14,7 +14,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ICategoriesCacheService, PrestashopCategoryDto } from './categories-cache.service.interface';
 import { AllegroCategoryCacheOrmEntity } from './persistence/allegro-category-cache.orm-entity';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, isCategoryBrowser } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { OfferCategory } from '@openlinker/core/listings';
 import type { ProductMasterPort } from '@openlinker/core/products';
@@ -50,7 +50,7 @@ export class CategoriesCacheService implements ICategoriesCacheService {
       'OfferManager',
     );
 
-    if (!adapter.fetchCategories) {
+    if (!isCategoryBrowser(adapter)) {
       this.logger.warn(`Marketplace adapter for connection ${connectionId} does not support fetchCategories`);
       return [];
     }

--- a/apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts
@@ -18,7 +18,7 @@ import {
   IIdentifierMappingService,
   IDENTIFIER_MAPPING_SERVICE_TOKEN,
 } from '@openlinker/core/identifier-mapping';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, isOfferFieldUpdater } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -60,7 +60,7 @@ export class MarketplaceOfferFieldUpdateHandler implements SyncJobHandler {
       'OfferManager',
     );
 
-    if (!adapter.updateOfferFields) {
+    if (!isOfferFieldUpdater(adapter)) {
       throw new SyncJobExecutionError(
         `Adapter for connection ${job.connectionId} does not support updateOfferFields`,
         job.id,

--- a/apps/worker/test/integration/marketplace-offers-sync-e2e.int-spec.ts
+++ b/apps/worker/test/integration/marketplace-offers-sync-e2e.int-spec.ts
@@ -9,7 +9,7 @@ import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
 import { WorkerIntegrationTestHarness } from './setup';
 import { createTestConnection } from './helpers/test-connection.helper';
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations/integrations.tokens';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, OfferLister } from '@openlinker/core/listings';
 import { IIntegrationsService } from '@openlinker/core/integrations';
 import { JOB_ENQUEUE_TOKEN, SyncJobRepositoryPort } from '@openlinker/core/sync';
 import { JobEnqueuePort } from '@openlinker/core/sync/domain/ports/job-enqueue.port';
@@ -71,7 +71,7 @@ describe('Marketplace Offers Sync End-to-End Integration', () => {
     });
     await variantRepo.save(variant);
 
-    const mockMarketplaceAdapter: OfferManagerPort = {
+    const mockMarketplaceAdapter: OfferManagerPort & OfferLister = {
       updateOfferQuantity: jest.fn(),
       listOffers: jest.fn().mockResolvedValue({
         items: [{ offerId: 'offer-1', externalRef: 'SKU-1' }],

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -436,26 +436,33 @@ interface OrderSourcePort {
 
 ### OfferManagerPort
 
-**Purpose**: Canonical capability contract for marketplace offer/listing management — offer feed, quantity + field updates, offer creation, category directory, barcode-to-category matching, and seller-policy discovery. Split out of the legacy `MarketplacePort` (#328).
+**Purpose**: Base capability contract for marketplace offer/listing management. Split out of the legacy `MarketplacePort` (#328); the previously-optional methods were extracted into distinct capability interfaces (#337). The base port carries only the single method every marketplace adapter must implement.
 
-**Interface** (abbreviated — all methods except `updateOfferQuantity` are optional):
+**Interface**:
 ```typescript
 interface OfferManagerPort {
-  listOffers?(input: OfferFeedInput): Promise<OfferFeedOutput>;
-  listOfferEvents?(input: OfferFeedInput): Promise<OfferFeedOutput>;
   updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void>;
-  updateOfferQuantitiesBatch?(cmd: UpdateOfferQuantitiesBatchCommand): Promise<UpdateOfferQuantitiesBatchResult>;
-  updateOfferFields?(cmd: UpdateOfferFieldsCommand): Promise<void>;
-  fetchCategories?(parentId?: string): Promise<MarketplaceCategory[]>;
-  matchCategoryByBarcode?(barcode: string): Promise<string | null>;
-  createOffer?(cmd: CreateOfferCommand): Promise<CreateOfferResult>;
-  fetchSellerPolicies?(): Promise<SellerPolicies>;
 }
 ```
 
-**Current Implementation**: `AllegroOfferManagerAdapter`
+**Sub-capabilities** (in `libs/core/src/listings/domain/ports/capabilities/`):
 
-**Future Implementations**: `ShopifyOfferManagerAdapter`, `WooCommerceOfferManagerAdapter`, `EbayOfferManagerAdapter`
+Each is an independent interface + co-located `is{Capability}(adapter)` type guard. Adapters declare the capabilities they support via `implements OfferManagerPort, OfferLister, OfferCreator, …`; call sites narrow via the guard before invoking the method — after the guard TypeScript knows the method is present.
+
+| Capability | Method |
+|---|---|
+| `OfferLister` | `listOffers(input)` |
+| `OfferEventReader` | `listOfferEvents(input)` |
+| `OfferQuantityBatchUpdater` | `updateOfferQuantitiesBatch(cmd)` |
+| `OfferFieldUpdater` | `updateOfferFields(cmd)` |
+| `CategoryBrowser` | `fetchCategories(parentId?)` |
+| `CategoryBarcodeMatcher` | `matchCategoryByBarcode(barcode)` |
+| `OfferCreator` | `createOffer(cmd)` |
+| `SellerPoliciesReader` | `fetchSellerPolicies()` |
+
+**Current Implementation**: `AllegroOfferManagerAdapter` (implements every capability except `OfferQuantityBatchUpdater`).
+
+**Future Implementations**: `ShopifyOfferManagerAdapter`, `WooCommerceOfferManagerAdapter`, `EbayOfferManagerAdapter`.
 
 ### Future Capability Ports
 

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -60,6 +60,7 @@ All TypeScript projects must use strict mode:
 - **Domain Services**: `*.domain-service.ts` (e.g., `product-mapping.domain-service.ts`)
 - **Domain Events**: `*.event.ts` (e.g., `product-created.event.ts`)
 - **Ports (Interfaces)**: `*.port.ts` (e.g., `inventory-master.port.ts`) - interface definition only
+- **Port sub-capabilities**: `*.capability.ts` (e.g., `offer-creator.capability.ts`) - optional capability interface + co-located `is{Capability}` type-guard. Used when a port has optional methods that can be extracted as distinct composable capabilities; lives under `domain/ports/capabilities/`.
 - **Types**: `*.types.ts` (e.g., `product.types.ts`) - type definitions only
 
 #### Application Layer Files

--- a/docs/plans/implementation-plan-337-offer-manager-capability-split.md
+++ b/docs/plans/implementation-plan-337-offer-manager-capability-split.md
@@ -1,0 +1,455 @@
+# Implementation Plan — #337 — OfferManagerPort capability split
+
+**Branch:** `337-offer-manager-capability-split`
+**Layer:** CORE (domain refactor) + Integration (adapter declaration) + Application (call-site migration) + Docs
+**Scope:** Type-level refactor — no runtime behaviour change
+**Risk:** Low — behaviour-preserving, boundaries clearly defined
+
+---
+
+## 1. Understand the task
+
+### Goal
+
+Replace the 8 optional methods on `OfferManagerPort` with distinct **capability interfaces** + co-located **type guards**. Call sites switch from `if (!adapter.method)` (presence check) to `if (!isCapability(adapter))` (type-narrowing guard). Purely a type-level / code-shape refactor.
+
+### Why
+
+Today an adapter "supports a capability" is expressed only by method presence. Consequences:
+
+- A handler that forgets the `if (!adapter.method)` guard crashes at runtime.
+- `OfferManagerPort` balloons as new optional capabilities accrete.
+- Test doubles must carry every optional slot, even unused ones.
+- No compile-time rejection of "passed an adapter to a handler that needs capability X".
+
+Capability interfaces + type guards give us:
+- Compile-time narrowing: after the guard, the method is guaranteed callable.
+- Smaller, composable port — adding capabilities no longer edits the base interface.
+- Minimal test doubles — only implement the capabilities needed.
+- Mirrors the existing capability-registry model (`Capability` union) with a finer-grained layer suitable for future per-sub-capability routing.
+
+### Non-goals
+
+- Changing which adapters support which capabilities (Allegro still supports all eight).
+- Changing the string `Capability` union (`'OfferManager'` stays) or the adapter registry (`supportedCapabilities`).
+- Splitting `OrderSourcePort` (its methods are both required — not a target).
+- Renaming `updateOfferQuantity` or otherwise touching the required base method.
+- Any DB migration (none needed).
+- PrestaShop: doesn't advertise `OfferManager` — nothing to change there.
+
+### Layer classification
+
+- Domain refactor in `libs/core/src/listings/domain/ports/` — primary work.
+- Application service edits — mechanical replacement of null checks with guards.
+- One integration adapter edit (`AllegroOfferManagerAdapter`) — add `implements` clauses.
+- One API service + one worker handler touched (outside `libs/`). No infra changes.
+- Doc updates: `docs/architecture-overview.md` §"OfferManagerPort" + one-line suffix registration in `docs/engineering-standards.md`.
+
+---
+
+## 2. Research — current state
+
+**Port file:** `libs/core/src/listings/domain/ports/offer-manager.port.ts`
+- 1 required: `updateOfferQuantity`
+- 8 optional: `listOffers`, `listOfferEvents`, `updateOfferQuantitiesBatch`, `updateOfferFields`, `fetchCategories`, `matchCategoryByBarcode`, `createOffer`, `fetchSellerPolicies`
+
+**Index re-export:** `libs/core/src/listings/index.ts:92` already re-exports `OfferManagerPort`. The new capability exports will join the same block.
+
+**Adapters:**
+- `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts:89` — `implements OfferManagerPort` (implements all 9 methods).
+- No other implementors.
+
+**Null-check call sites — full inventory (9):**
+
+| # | File | Line | Method |
+|---|---|---|---|
+| 1 | `libs/core/src/listings/application/services/offer-mapping-sync.service.ts` | 119 | `listOfferEvents` |
+| 2 | `libs/core/src/listings/application/services/offer-mapping-sync.service.ts` | 128 | `listOffers` |
+| 3 | `libs/core/src/listings/application/services/offer-creation-enqueue.service.ts` | 64 | `createOffer` |
+| 4 | `libs/core/src/listings/application/services/offer-creation-execution.service.ts` | 100 | `createOffer` |
+| 5 | `libs/core/src/listings/application/services/category-resolution.service.ts` | 73 | `matchCategoryByBarcode` |
+| 6 | `libs/core/src/listings/application/services/seller-policies.service.ts` | 54 | `fetchSellerPolicies` |
+| 7 | `libs/core/src/products/application/services/auto-match-variant-offers.service.ts` | 143 | `listOffers` |
+| 8 | `apps/api/src/categories/categories-cache.service.ts` | 53 | `fetchCategories` |
+| 9 | `apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts` | 63 | `updateOfferFields` |
+
+`updateOfferQuantitiesBatch` has **no consumer** today — still included in the split because the Allegro adapter implements it; removing it would be a behavioural loss.
+
+**Unit tests that touch OfferManagerPort mocks:**
+- `libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts`
+- `libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts`
+- `libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts`
+- `libs/core/src/listings/application/services/__tests__/category-resolution.service.spec.ts`
+- `libs/core/src/listings/application/services/__tests__/seller-policies.service.spec.ts`
+
+**Integration-test helper:** `apps/worker/test/integration/helpers/mock-allegro-adapters.helper.ts` — annotation updates required; consumed by `apps/worker/test/integration/marketplace-offers-sync-e2e.int-spec.ts`.
+
+**Capability registry (string-level):** `libs/core/src/integrations/domain/types/adapter.types.ts:18-24` — `'OfferManager'` is in `CapabilityValues`. Untouched by this refactor.
+
+**Existing docs to update:**
+- `docs/architecture-overview.md` lines 441–454 — the `OfferManagerPort` interface sketch with 8 optional methods.
+- `docs/engineering-standards.md` §"Domain Layer Files" — register the new `*.capability.ts` suffix.
+
+---
+
+## 3. Design
+
+### Capability interfaces — one per optional method
+
+Eight capabilities, one method each. Per-method interfaces give maximum composability (a future adapter that supports `listOffers` but not events declares only `OfferLister`).
+
+| Capability interface | Method | File |
+|---|---|---|
+| `OfferLister` | `listOffers` | `offer-lister.capability.ts` |
+| `OfferEventReader` | `listOfferEvents` | `offer-event-reader.capability.ts` |
+| `OfferQuantityBatchUpdater` | `updateOfferQuantitiesBatch` | `offer-quantity-batch-updater.capability.ts` |
+| `OfferFieldUpdater` | `updateOfferFields` | `offer-field-updater.capability.ts` |
+| `CategoryBrowser` | `fetchCategories` | `category-browser.capability.ts` |
+| `CategoryBarcodeMatcher` | `matchCategoryByBarcode` | `category-barcode-matcher.capability.ts` |
+| `OfferCreator` | `createOffer` | `offer-creator.capability.ts` |
+| `SellerPoliciesReader` | `fetchSellerPolicies` | `seller-policies-reader.capability.ts` |
+
+### Naming decision — no `Port` suffix (conscious)
+
+Engineering standards specify `{Capability}Port` for top-level ports. These interfaces are *sub-capabilities* layered onto `OfferManagerPort`, not independent top-level ports — the issue's own proposal drops the suffix (`isOfferFieldUpdater`, not `isOfferFieldUpdaterPort`). Reads naturally as a role (`OfferCreator`, `CategoryBrowser`). The capability files' header comments will call this out explicitly so a future contributor doesn't "fix" them by renaming.
+
+### Directory
+
+```
+libs/core/src/listings/domain/ports/
+├── offer-manager.port.ts          # base: only updateOfferQuantity
+└── capabilities/
+    ├── offer-lister.capability.ts
+    ├── offer-event-reader.capability.ts
+    ├── offer-quantity-batch-updater.capability.ts
+    ├── offer-field-updater.capability.ts
+    ├── category-browser.capability.ts
+    ├── category-barcode-matcher.capability.ts
+    ├── offer-creator.capability.ts
+    ├── seller-policies-reader.capability.ts
+    └── __tests__/
+        └── offer-manager-capabilities.spec.ts
+```
+
+### File naming — `*.capability.ts`
+
+Engineering standards reserve `*.port.ts` for "interface definition only". These capability files bundle an interface **and** a runtime type-guard function. I considered the stricter alternative — `*.port.ts` + companion `*.guard.ts` (16 files total, mirroring the service-interface/implementation split). Rejected: the guard is meaningless without its interface, and splitting would double the file count for zero architectural gain. The runtime+type co-location precedent already exists in `adapter.types.ts` (`CapabilityValues` runtime array + `Capability` type in one file).
+
+To prevent this convention from looking like unannounced drift, Step 10 adds a one-line suffix registration to `docs/engineering-standards.md` "Domain Layer Files":
+
+> - **Port sub-capabilities**: `*.capability.ts` (e.g. `offer-creator.capability.ts`) — optional capability interface + co-located `is{Capability}` type-guard. Used when a port has optional methods that can be extracted as distinct composable capabilities.
+
+### Shape — each capability file
+
+```typescript
+/**
+ * Offer Lister Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can page
+ * through the marketplace's current offer catalogue declare `implements OfferLister`.
+ *
+ * Call sites narrow support via `isOfferLister(adapter)`.
+ *
+ * Naming: sub-capabilities deliberately drop the `Port` suffix — they layer
+ * onto `OfferManagerPort`, they are not independent top-level ports. Do not
+ * rename to `OfferListerPort`.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+
+import type { OfferFeedInput, OfferFeedOutput } from '../../types/offer-feed.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface OfferLister {
+  listOffers(input: OfferFeedInput): Promise<OfferFeedOutput>;
+}
+
+export function isOfferLister(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferLister {
+  return typeof (adapter as Partial<OfferLister>).listOffers === 'function';
+}
+```
+
+The guard uses `typeof X === 'function'` — matches the existing null-check behaviour semantically (`!adapter.x` was false for both `undefined` and non-function falsies, but in practice every consumer stored a function or nothing; the stronger check is safer and prevents accidental field-name collisions).
+
+Only the first file (`offer-lister.capability.ts`) carries the long "Naming:" paragraph; subsequent files get a short one-liner that references it.
+
+### Base port — trimmed (last code step)
+
+After refactor, `offer-manager.port.ts` contains only:
+
+```typescript
+export interface OfferManagerPort {
+  updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void>;
+}
+```
+
+The port's file-level doc comment is updated to point at `capabilities/` for optional sub-capabilities. All other method signatures + their JSDoc move to their capability files.
+
+### Adapter — `AllegroOfferManagerAdapter`
+
+Class declaration changes from:
+
+```typescript
+export class AllegroOfferManagerAdapter implements OfferManagerPort { ... }
+```
+
+to:
+
+```typescript
+export class AllegroOfferManagerAdapter
+  implements
+    OfferManagerPort,
+    OfferLister,
+    OfferEventReader,
+    OfferQuantityBatchUpdater,
+    OfferFieldUpdater,
+    CategoryBrowser,
+    CategoryBarcodeMatcher,
+    OfferCreator,
+    SellerPoliciesReader { ... }
+```
+
+Method bodies unchanged. The `?` modifiers on methods are irrelevant to an adapter that always implements them.
+
+### Call-site migration — template
+
+Before:
+```typescript
+if (!adapter.createOffer) {
+  throw new UnprocessableEntityException('…');
+}
+await adapter.createOffer(command);
+```
+
+After:
+```typescript
+if (!isOfferCreator(adapter)) {
+  throw new UnprocessableEntityException('…');
+}
+await adapter.createOffer(command); // now type-narrowed to OfferCreator
+```
+
+Same runtime behaviour. Every call site: swap the condition, keep the error/message, keep the subsequent method call.
+
+One wrinkle — `offer-mapping-sync.service.ts` does **two** optional checks in the same function. Both migrate independently; the fallback logic (prefer events, fall back to lister) stays identical.
+
+### Exports — `libs/core/src/listings/index.ts`
+
+`OfferManagerPort` is already re-exported at line 92. Add the 8 capability interfaces + their type guards in the same block so application services can `import { isOfferCreator, OfferCreator } from '@openlinker/core/listings'`.
+
+### Testing
+
+**Unit tests — keep green without edits where possible.**
+Existing service specs mock `OfferManagerPort` as `{ listOffers: jest.fn(), … }`. Since jest mocks are functions, the new `typeof X === 'function'` guards return `true` for the same mock shape → tests continue to pass unchanged.
+
+Test shapes that mock a partial port (e.g. omit `createOffer` to assert the "not supported" branch) also continue to work — omitting the field returns `undefined`, guard returns `false`, same behaviour.
+
+Only likely adjustment: the type of the mock variable (`Partial<OfferManagerPort>` or explicit object-literal) may need an updated annotation (e.g. `Partial<OfferManagerPort & OfferCreator>`) to keep TS happy. Localised fix per file.
+
+**New test — `offer-manager-capabilities.spec.ts`** (one file covering all 8 guards):
+- For each guard: asserts `true` when the relevant method is a function; `false` when absent; `false` when present but non-function.
+
+**Integration tests — required, not conditional.**
+Step 6 modifies `apps/worker/test/integration/helpers/mock-allegro-adapters.helper.ts`, consumed by `apps/worker/test/integration/marketplace-offers-sync-e2e.int-spec.ts`. Even if the mock change is annotation-only, the helper's consumers must exercise the new type shapes end-to-end against the Testcontainer stack before merge.
+
+---
+
+## 4. Step-by-step implementation
+
+**Ordering principle:** every intermediate commit type-checks. The port is trimmed **last** (after all capability consumers exist and all call sites use guards) so the tree never enters a broken state.
+
+### Step 1 — Add capability directory + eight capability files
+
+**Files (new):**
+- `libs/core/src/listings/domain/ports/capabilities/offer-lister.capability.ts`
+- `.../capabilities/offer-event-reader.capability.ts`
+- `.../capabilities/offer-quantity-batch-updater.capability.ts`
+- `.../capabilities/offer-field-updater.capability.ts`
+- `.../capabilities/category-browser.capability.ts`
+- `.../capabilities/category-barcode-matcher.capability.ts`
+- `.../capabilities/offer-creator.capability.ts`
+- `.../capabilities/seller-policies-reader.capability.ts`
+
+**Each file:** header comment (with naming rationale only on the first file; short one-liner on the rest), typed import of the domain types it references, `import type { OfferManagerPort } from '../offer-manager.port'`, the capability interface, the `is{Capability}` guard.
+
+**Acceptance:** `pnpm type-check` passes — nothing else consumes these yet.
+
+### Step 2 — Re-export capabilities from listings index
+
+**File (edit):** `libs/core/src/listings/index.ts`
+
+Confirmed: `OfferManagerPort` is already exported at line 92. Add an adjacent block re-exporting all 8 capability interfaces + guards.
+
+**Acceptance:** `pnpm type-check` passes; `import { isOfferCreator } from '@openlinker/core/listings'` resolves.
+
+### Step 3 — Update `AllegroOfferManagerAdapter` with capability declarations
+
+**File (edit):** `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts`
+
+- Change `implements OfferManagerPort` to the 9-interface list (base + 8 capabilities).
+- Add imports for the 8 capability interfaces from `@openlinker/core/listings`.
+- No method-body changes.
+
+Note: the base `OfferManagerPort` still carries all 8 optional methods at this point — the adapter satisfies both the old shape and the new capabilities simultaneously. The tree stays green.
+
+**Acceptance:** Adapter type-checks. The `implements` list exercises every capability → compiler asserts each method signature matches the new interfaces.
+
+### Step 4 — Migrate the 9 null-check call sites to type guards
+
+**Files (edit):**
+
+| File | Line | Guard |
+|---|---|---|
+| `libs/core/src/listings/application/services/offer-mapping-sync.service.ts` | 119 | `isOfferEventReader` |
+| `libs/core/src/listings/application/services/offer-mapping-sync.service.ts` | 128 | `isOfferLister` |
+| `libs/core/src/listings/application/services/offer-creation-enqueue.service.ts` | 64 | `isOfferCreator` |
+| `libs/core/src/listings/application/services/offer-creation-execution.service.ts` | 100 | `isOfferCreator` |
+| `libs/core/src/listings/application/services/category-resolution.service.ts` | 73 | `isCategoryBarcodeMatcher` |
+| `libs/core/src/listings/application/services/seller-policies.service.ts` | 54 | `isSellerPoliciesReader` |
+| `libs/core/src/products/application/services/auto-match-variant-offers.service.ts` | 143 | `isOfferLister` |
+| `apps/api/src/categories/categories-cache.service.ts` | 53 | `isCategoryBrowser` |
+| `apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts` | 63 | `isOfferFieldUpdater` |
+
+**For each:** add the guard import from `@openlinker/core/listings`; replace `if (!x.method)` with `if (!isCapability(x))`; leave error message and downstream call unchanged.
+
+Special case — `offer-mapping-sync.service.ts`: the `loadOfferFeed` helper has the "prefer events, fall back to lister" branch. Both guards applied independently; logic preserved.
+
+The port still has optional methods at this point, so both the old presence checks and the new guards type-check. Only after all 9 sites migrate does Step 6 tighten the base port.
+
+**Acceptance:** Each service/handler type-checks. The code inside each `if`-branch now has a narrowed `adapter` type — TS rejects any call that doesn't match the guard.
+
+### Step 5 — Update integration-test adapter mock
+
+**File (edit):** `apps/worker/test/integration/helpers/mock-allegro-adapters.helper.ts`
+
+Update the mock's type annotation (and any `as OfferManagerPort` casts) to reflect the new capability split. Expected: a simple annotation tweak or a small helper-class `implements` list update. Runtime shape unchanged.
+
+**Acceptance:** `pnpm type-check` passes; the mock still provides the same methods at runtime.
+
+### Step 6 — Trim `OfferManagerPort` to the required base method
+
+**File (edit):** `libs/core/src/listings/domain/ports/offer-manager.port.ts`
+
+- Remove the 8 optional methods.
+- Remove now-unused type imports (only `UpdateOfferQuantityCommand` remains).
+- Update header doc to point at `capabilities/` for optional sub-capabilities.
+
+Because all call sites now use capability guards (Step 4) and the adapter declares all capabilities explicitly (Step 3), this step is type-safe: nothing still reads `adapter.createOffer` without first narrowing via a guard.
+
+**Acceptance:** `pnpm type-check` passes for the whole repo. Fail-forward — if any call site was missed in Step 4, TS surfaces it here.
+
+### Step 7 — Add `offer-manager-capabilities.spec.ts` for the 8 type guards
+
+**File (new):** `libs/core/src/listings/domain/ports/capabilities/__tests__/offer-manager-capabilities.spec.ts`
+
+Table-driven: for each `{guard, methodName}` pair, assert:
+- `guard({ [methodName]: jest.fn() } as unknown as OfferManagerPort)` → `true`
+- `guard({} as unknown as OfferManagerPort)` → `false` (and also `guard({ updateOfferQuantity: jest.fn() } as OfferManagerPort)` — a valid-but-minimal adapter → `false` for every sub-capability)
+- `guard({ [methodName]: 'not a function' } as unknown as OfferManagerPort)` → `false`
+
+**Acceptance:** `pnpm test` — new spec passes; 8 guards × 3 cases green.
+
+### Step 8 — Update architecture-overview docs
+
+**File (edit):** `docs/architecture-overview.md` §"OfferManagerPort" (lines 441–454)
+
+- Replace the inline interface sketch with the trimmed base port (only `updateOfferQuantity`).
+- Add a short paragraph (2–4 sentences) introducing the `capabilities/` sub-directory, listing the 8 capability interfaces, and noting the type-guard pattern (`is{Capability}(adapter)`).
+- Keep the "Current Implementation" and "Future Implementations" lines as-is.
+
+**Acceptance:** Docs describe the new shape accurately. A contributor reading only `architecture-overview.md` understands what lives on the base port vs what lives in `capabilities/`.
+
+### Step 9 — Register the `*.capability.ts` suffix in engineering standards
+
+**File (edit):** `docs/engineering-standards.md` §"Files and Folders → Domain Layer Files"
+
+Add a single bullet after "Ports (Interfaces)":
+
+> - **Port sub-capabilities**: `*.capability.ts` (e.g. `offer-creator.capability.ts`) — optional capability interface + co-located `is{Capability}` type-guard. Used when a port has optional methods that can be extracted as distinct composable capabilities.
+
+**Acceptance:** The new file-suffix convention is registered so the next reviewer doesn't treat it as drift.
+
+### Step 10 — Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+pnpm test:integration
+```
+
+All four are required. The integration run is non-negotiable because Step 5 touches an integration helper. Fix any fallout before commit.
+
+### Step 11 — Review + commit
+
+Self-review against `docs/code-review-guide.md`. Commit message:
+
+```
+refactor(listings): split OfferManagerPort optional methods into capability interfaces
+
+Extract the 8 optional methods on OfferManagerPort into per-method
+capability interfaces with co-located type guards under
+libs/core/src/listings/domain/ports/capabilities/. Call sites switch
+from presence checks (if (!adapter.method)) to type-narrowing guards
+(if (!isCapability(adapter))) — same runtime behaviour, now the method
+call inside the branch is type-checked.
+
+Register the new *.capability.ts suffix in engineering-standards.md and
+update the OfferManagerPort section in architecture-overview.md to
+reflect the new shape.
+
+Closes #337
+```
+
+---
+
+## 5. Validation
+
+### Architecture compliance
+
+- ✅ Capability interfaces live in the domain layer — no framework imports.
+- ✅ Each interface co-located with its guard — not scattered.
+- ✅ No new DI wiring (pure type-level refactor at the boundary).
+- ✅ `OfferManagerPort` stays as the single injection point (`integrationsService.getCapabilityAdapter<OfferManagerPort>(…)`); guards narrow the type locally.
+- ✅ Docs updated to match code (architecture-overview + engineering-standards).
+
+### Naming
+
+- `OfferLister`, `OfferCreator`, `CategoryBrowser`, etc. — noun-phrase capability roles. Drops `Port` suffix deliberately (sub-capabilities, not independent top-level ports); rationale in each capability file's header.
+- Guards: `is{Capability}` — idiomatic TS, matches project convention.
+- Files: `*.capability.ts` — deviation from `*.port.ts` registered in engineering-standards in Step 9.
+
+### Testing
+
+- Behaviour preserved — every existing service spec stays green (jest mocks are functions → `typeof === 'function'` guards pass).
+- New `offer-manager-capabilities.spec.ts` adds direct coverage for the 8 guards (24+ assertions).
+- Integration tests mandatory because Step 5 touches an integration helper.
+
+### Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| A call site is missed in Step 4 | Step 6 surfaces it as a type error (port no longer has the method); `pnpm type-check` in the quality gate catches any remaining site. |
+| Integration-test mock annotation needs more work than expected | Step 5 is isolated; `pnpm test:integration` in the quality gate validates before merge. |
+| Guard strictness (`typeof === 'function'`) differs from the old `!method` | In practice the old `!method` already returned `false` only for function values; no behavioural regression expected. If any test fails unexpectedly, inspect the mock shape — that's the signal. |
+| A fresh call site lands between plan and PR | Final-step re-grep: `grep -rn "if (!.*\.\(listOffers\|listOfferEvents\|updateOfferQuantitiesBatch\|updateOfferFields\|fetchCategories\|matchCategoryByBarcode\|createOffer\|fetchSellerPolicies\))" libs apps` should return zero hits. |
+
+### Open questions — none
+
+The plan deviates from the issue's proposal in one spot (splitting `listOffers` + `listOfferEvents` into two capabilities instead of bundling them into `OfferFeedReader`), because the call sites use them independently. Confirmed with user.
+
+---
+
+## 6. Estimate
+
+~90 min end-to-end:
+- 15 min — Steps 1–2 (capability files + re-exports)
+- 10 min — Step 3 (adapter declarations)
+- 20 min — Step 4 (9 call-site migrations + import plumbing)
+- 10 min — Step 5 (integration-test mock annotation)
+- 5 min — Step 6 (port trim, guarded by TS)
+- 10 min — Step 7 (new guard spec)
+- 10 min — Steps 8–9 (doc updates)
+- 10 min — Steps 10–11 (quality gate incl. integration tests + commit + self-review)

--- a/libs/core/src/inventory/application/services/__tests__/inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory-sync.service.spec.ts
@@ -7,13 +7,13 @@
  */
 
 import { InventorySyncService } from '../inventory-sync.service';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, OfferQuantityBatchUpdater } from '@openlinker/core/listings';
 import { IIntegrationsService } from '@openlinker/core/integrations';
 
 describe('InventorySyncService', () => {
   let service: InventorySyncService;
   let integrationsService: jest.Mocked<IIntegrationsService>;
-  let marketplace: jest.Mocked<OfferManagerPort>;
+  let marketplace: jest.Mocked<OfferManagerPort & OfferQuantityBatchUpdater>;
 
   const connectionId = 'connection-123';
 
@@ -23,7 +23,7 @@ describe('InventorySyncService', () => {
       getOrder: jest.fn(),
       updateOfferQuantity: jest.fn(),
       updateOfferQuantitiesBatch: jest.fn(),
-    } as unknown as jest.Mocked<OfferManagerPort>;
+    } as unknown as jest.Mocked<OfferManagerPort & OfferQuantityBatchUpdater>;
 
     integrationsService = {
       getCapabilityAdapter: jest.fn().mockResolvedValue(marketplace),

--- a/libs/core/src/inventory/application/services/inventory-sync.service.ts
+++ b/libs/core/src/inventory/application/services/inventory-sync.service.ts
@@ -8,7 +8,7 @@
 
 import { Injectable, Inject } from '@nestjs/common';
 import { createHash } from 'crypto';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, isOfferQuantityBatchUpdater } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { UpdateOfferQuantityCommand, UpdateOfferQuantitiesBatchCommand, UpdateOfferQuantitiesBatchResult } from '@openlinker/core/listings';
 import { IInventorySyncService } from './inventory-sync.service.interface';
@@ -52,7 +52,7 @@ export class InventorySyncService implements IInventorySyncService {
     };
 
     // Prefer adapter batch API when available and we have more than one item.
-    if (marketplace.updateOfferQuantitiesBatch && normalized.items.length > 1) {
+    if (isOfferQuantityBatchUpdater(marketplace) && normalized.items.length > 1) {
       try {
         return await marketplace.updateOfferQuantitiesBatch(normalized);
       } catch (error) {

--- a/libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts
@@ -5,7 +5,7 @@
  */
 import { OfferMappingSyncService } from '../offer-mapping-sync.service';
 import { OfferLinkingService } from '../offer-linking.service';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, OfferLister, OfferEventReader } from '@openlinker/core/listings';
 import { IIntegrationsService } from '@openlinker/core/integrations';
 import { IIdentifierMappingService, IdentifierMappingConflictException } from '@openlinker/core/identifier-mapping';
 import { ProductVariantRepositoryPort } from '@openlinker/core/products/domain/ports/product-variant-repository.port';
@@ -29,7 +29,7 @@ describe('OfferMappingSyncService', () => {
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let identifierMapping: jest.Mocked<IIdentifierMappingService>;
   let variantRepository: jest.Mocked<ProductVariantRepositoryPort>;
-  let marketplace: jest.Mocked<OfferManagerPort>;
+  let marketplace: jest.Mocked<OfferManagerPort & OfferLister & OfferEventReader>;
 
   beforeEach(() => {
     marketplace = {
@@ -38,7 +38,7 @@ describe('OfferMappingSyncService', () => {
       updateOfferQuantity: jest.fn(),
       listOffers: jest.fn(),
       listOfferEvents: jest.fn(),
-    } as unknown as jest.Mocked<OfferManagerPort>;
+    } as unknown as jest.Mocked<OfferManagerPort & OfferLister & OfferEventReader>;
 
     integrationsService = {
       getCapabilityAdapter: jest.fn().mockResolvedValue(marketplace),

--- a/libs/core/src/listings/application/services/category-resolution.service.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.ts
@@ -12,7 +12,7 @@
 
 import { Injectable, Inject } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, isCategoryBarcodeMatcher } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
 import { ICategoryResolutionService } from '../interfaces/category-resolution.service.interface';
@@ -70,7 +70,7 @@ export class CategoryResolutionService implements ICategoryResolutionService {
         connectionId,
         'OfferManager',
       );
-      if (!marketplace.matchCategoryByBarcode) {
+      if (!isCategoryBarcodeMatcher(marketplace)) {
         this.logger.debug(
           `Marketplace adapter does not support matchCategoryByBarcode (connection=${connectionId})`,
         );

--- a/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
@@ -18,7 +18,7 @@
 
 import { Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
 
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, isOfferCreator } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import {
   JobEnqueuePort,
@@ -61,7 +61,7 @@ export class OfferCreationEnqueueService implements IOfferCreationEnqueueService
     // 2. `Marketplace` is supported, but `createOffer` is an optional
     //    sub-capability. Distinct 422 so clients can distinguish
     //    "unknown connection" from "this adapter reads but can't create".
-    if (!adapter.createOffer) {
+    if (!isOfferCreator(adapter)) {
       throw new UnprocessableEntityException(
         `Adapter for connection ${input.connectionId} does not support offer creation`,
       );

--- a/libs/core/src/listings/application/services/offer-creation-execution.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-execution.service.ts
@@ -30,7 +30,7 @@ import {
   IDENTIFIER_MAPPING_SERVICE_TOKEN,
   IIdentifierMappingService,
 } from '@openlinker/core/identifier-mapping';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, isOfferCreator } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { CreateOfferCommand, CreateOfferResult, CreateOfferValidationError, OfferCreateRejectedException } from '@openlinker/core/listings';
 import { Logger } from '@openlinker/shared/logging';
@@ -97,7 +97,7 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
       input.connectionId,
       'OfferManager',
     );
-    if (!adapter.createOffer) {
+    if (!isOfferCreator(adapter)) {
       throw new Error(
         `Adapter for connection ${input.connectionId} does not support Marketplace.createOffer`,
       );

--- a/libs/core/src/listings/application/services/offer-mapping-sync.service.ts
+++ b/libs/core/src/listings/application/services/offer-mapping-sync.service.ts
@@ -6,7 +6,7 @@
  * @module libs/core/src/listings/application/services
  */
 import { Injectable, Inject } from '@nestjs/common';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, isOfferEventReader, isOfferLister } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { OfferFeedItem } from '@openlinker/core/listings';
 import {
@@ -116,7 +116,7 @@ export class OfferMappingSyncService implements IOfferMappingSyncService {
     input: { cursor: string | null; limit: number; feedType: 'offers' | 'events' },
   ): Promise<{ items: OfferFeedItem[]; nextCursor: string | null }> {
     if (input.feedType === 'events') {
-      if (!marketplace.listOfferEvents) {
+      if (!isOfferEventReader(marketplace)) {
         this.logger.warn(
           'Marketplace adapter does not support listOfferEvents; falling back to listOffers',
         );
@@ -125,7 +125,7 @@ export class OfferMappingSyncService implements IOfferMappingSyncService {
       }
     }
 
-    if (!marketplace.listOffers) {
+    if (!isOfferLister(marketplace)) {
       throw new Error('Marketplace adapter does not support listOffers');
     }
 

--- a/libs/core/src/listings/application/services/seller-policies.service.ts
+++ b/libs/core/src/listings/application/services/seller-policies.service.ts
@@ -14,7 +14,7 @@
 
 import { Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
 
-import { OfferManagerPort } from '@openlinker/core/listings';
+import { OfferManagerPort, isSellerPoliciesReader } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { SellerPolicies } from '@openlinker/core/listings';
 import { Logger } from '@openlinker/shared/logging';
@@ -51,7 +51,7 @@ export class SellerPoliciesService implements ISellerPoliciesService {
       'OfferManager',
     );
 
-    if (!adapter.fetchSellerPolicies) {
+    if (!isSellerPoliciesReader(adapter)) {
       throw new UnprocessableEntityException(
         `Adapter for connection ${connectionId} does not support seller-policy listing`,
       );

--- a/libs/core/src/listings/domain/ports/capabilities/__tests__/offer-manager-capabilities.spec.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/__tests__/offer-manager-capabilities.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Offer Manager Capabilities — type guards spec
+ *
+ * Table-driven coverage for every `is{Capability}(adapter)` type guard exposed
+ * under `libs/core/src/listings/domain/ports/capabilities/`. Each guard must
+ * return true when the matching method is a function on the adapter, false
+ * when the method is absent, and false when the method slot exists but is
+ * not callable.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities/__tests__
+ */
+
+import type { OfferManagerPort } from '../../offer-manager.port';
+import { isOfferLister } from '../offer-lister.capability';
+import { isOfferEventReader } from '../offer-event-reader.capability';
+import { isOfferQuantityBatchUpdater } from '../offer-quantity-batch-updater.capability';
+import { isOfferFieldUpdater } from '../offer-field-updater.capability';
+import { isCategoryBrowser } from '../category-browser.capability';
+import { isCategoryBarcodeMatcher } from '../category-barcode-matcher.capability';
+import { isOfferCreator } from '../offer-creator.capability';
+import { isSellerPoliciesReader } from '../seller-policies-reader.capability';
+
+type Guard = (adapter: OfferManagerPort) => boolean;
+
+const cases: ReadonlyArray<readonly [string, Guard, string]> = [
+  ['OfferLister', isOfferLister, 'listOffers'],
+  ['OfferEventReader', isOfferEventReader, 'listOfferEvents'],
+  ['OfferQuantityBatchUpdater', isOfferQuantityBatchUpdater, 'updateOfferQuantitiesBatch'],
+  ['OfferFieldUpdater', isOfferFieldUpdater, 'updateOfferFields'],
+  ['CategoryBrowser', isCategoryBrowser, 'fetchCategories'],
+  ['CategoryBarcodeMatcher', isCategoryBarcodeMatcher, 'matchCategoryByBarcode'],
+  ['OfferCreator', isOfferCreator, 'createOffer'],
+  ['SellerPoliciesReader', isSellerPoliciesReader, 'fetchSellerPolicies'],
+];
+
+function makeAdapter(extra: Record<string, unknown> = {}): OfferManagerPort {
+  return { updateOfferQuantity: jest.fn(), ...extra } as unknown as OfferManagerPort;
+}
+
+describe('Offer Manager capability type guards', () => {
+  describe.each(cases)('%s', (_name, guard, methodName) => {
+    it(`returns true when \`${methodName}\` is a function`, () => {
+      expect(guard(makeAdapter({ [methodName]: jest.fn() }))).toBe(true);
+    });
+
+    it(`returns false when \`${methodName}\` is absent`, () => {
+      expect(guard(makeAdapter())).toBe(false);
+    });
+
+    it(`returns false when \`${methodName}\` is present but non-function`, () => {
+      expect(guard(makeAdapter({ [methodName]: 'not a function' }))).toBe(false);
+    });
+  });
+});

--- a/libs/core/src/listings/domain/ports/capabilities/category-barcode-matcher.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/category-barcode-matcher.capability.ts
@@ -1,0 +1,25 @@
+/**
+ * Category Barcode Matcher Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can auto-detect
+ * a marketplace category for a given product barcode declare
+ * `implements CategoryBarcodeMatcher`. Returns null when the marketplace cannot
+ * resolve or the match is ambiguous.
+ *
+ * See `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface CategoryBarcodeMatcher {
+  matchCategoryByBarcode(barcode: string): Promise<string | null>;
+}
+
+export function isCategoryBarcodeMatcher(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & CategoryBarcodeMatcher {
+  return (
+    typeof (adapter as Partial<CategoryBarcodeMatcher>).matchCategoryByBarcode === 'function'
+  );
+}

--- a/libs/core/src/listings/domain/ports/capabilities/category-browser.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/category-browser.capability.ts
@@ -1,0 +1,23 @@
+/**
+ * Category Browser Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that expose the
+ * marketplace's category directory declare `implements CategoryBrowser`.
+ * Used by the category-resolution / mapping-editor flows.
+ *
+ * See `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { OfferCategory } from '../../types/category.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface CategoryBrowser {
+  fetchCategories(parentId?: string): Promise<OfferCategory[]>;
+}
+
+export function isCategoryBrowser(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & CategoryBrowser {
+  return typeof (adapter as Partial<CategoryBrowser>).fetchCategories === 'function';
+}

--- a/libs/core/src/listings/domain/ports/capabilities/offer-creator.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/offer-creator.capability.ts
@@ -1,0 +1,25 @@
+/**
+ * Offer Creator Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can create new
+ * offers outbound (OL → marketplace) declare `implements OfferCreator`.
+ * Platform-specific fields travel inside `cmd.overrides.platformParams`.
+ * For marketplaces that validate asynchronously (Allegro), callers must poll
+ * to observe the final status.
+ *
+ * See `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { CreateOfferCommand, CreateOfferResult } from '../../types/offer-create.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface OfferCreator {
+  createOffer(cmd: CreateOfferCommand): Promise<CreateOfferResult>;
+}
+
+export function isOfferCreator(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferCreator {
+  return typeof (adapter as Partial<OfferCreator>).createOffer === 'function';
+}

--- a/libs/core/src/listings/domain/ports/capabilities/offer-event-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/offer-event-reader.capability.ts
@@ -1,0 +1,23 @@
+/**
+ * Offer Event Reader Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters backed by an
+ * incremental event journal (e.g. Allegro) declare `implements OfferEventReader`.
+ * Cursor-based; preferred over `OfferLister` when both are available.
+ *
+ * See `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { OfferFeedInput, OfferFeedOutput } from '../../types/offer-feed.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface OfferEventReader {
+  listOfferEvents(input: OfferFeedInput): Promise<OfferFeedOutput>;
+}
+
+export function isOfferEventReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferEventReader {
+  return typeof (adapter as Partial<OfferEventReader>).listOfferEvents === 'function';
+}

--- a/libs/core/src/listings/domain/ports/capabilities/offer-field-updater.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/offer-field-updater.capability.ts
@@ -1,0 +1,24 @@
+/**
+ * Offer Field Updater Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that support partial
+ * field updates (price, title, description, …) declare `implements OfferFieldUpdater`.
+ * Partial-update semantics: only fields present in `cmd.fields` are sent to the
+ * marketplace.
+ *
+ * See `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { UpdateOfferFieldsCommand } from '../../types/offer-fields-update.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface OfferFieldUpdater {
+  updateOfferFields(cmd: UpdateOfferFieldsCommand): Promise<void>;
+}
+
+export function isOfferFieldUpdater(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferFieldUpdater {
+  return typeof (adapter as Partial<OfferFieldUpdater>).updateOfferFields === 'function';
+}

--- a/libs/core/src/listings/domain/ports/capabilities/offer-lister.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/offer-lister.capability.ts
@@ -1,0 +1,26 @@
+/**
+ * Offer Lister Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can page through
+ * the marketplace's current offer catalogue declare `implements OfferLister`.
+ * Call sites narrow support via `isOfferLister(adapter)`; after the guard the
+ * `listOffers` method is compile-time-guaranteed to be present and callable.
+ *
+ * Naming: sub-capabilities deliberately drop the `Port` suffix — they layer onto
+ * `OfferManagerPort`, they are not independent top-level ports. Do not rename to
+ * `OfferListerPort`. This convention is shared by every file in this directory.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { OfferFeedInput, OfferFeedOutput } from '../../types/offer-feed.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface OfferLister {
+  listOffers(input: OfferFeedInput): Promise<OfferFeedOutput>;
+}
+
+export function isOfferLister(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferLister {
+  return typeof (adapter as Partial<OfferLister>).listOffers === 'function';
+}

--- a/libs/core/src/listings/domain/ports/capabilities/offer-quantity-batch-updater.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/offer-quantity-batch-updater.capability.ts
@@ -1,0 +1,31 @@
+/**
+ * Offer Quantity Batch Updater Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that expose a bulk
+ * quantity-update API declare `implements OfferQuantityBatchUpdater`. Core
+ * orchestration falls back to per-offer `updateOfferQuantity` when not supported.
+ *
+ * See `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type {
+  UpdateOfferQuantitiesBatchCommand,
+  UpdateOfferQuantitiesBatchResult,
+} from '../../types/offer-quantity-update.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface OfferQuantityBatchUpdater {
+  updateOfferQuantitiesBatch(
+    cmd: UpdateOfferQuantitiesBatchCommand,
+  ): Promise<UpdateOfferQuantitiesBatchResult>;
+}
+
+export function isOfferQuantityBatchUpdater(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferQuantityBatchUpdater {
+  return (
+    typeof (adapter as Partial<OfferQuantityBatchUpdater>).updateOfferQuantitiesBatch ===
+    'function'
+  );
+}

--- a/libs/core/src/listings/domain/ports/capabilities/seller-policies-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/seller-policies-reader.capability.ts
@@ -1,0 +1,27 @@
+/**
+ * Seller Policies Reader Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can surface the
+ * seller-configured policies required when creating an offer (delivery, return,
+ * warranty, implied-warranty) declare `implements SellerPoliciesReader`. The FE
+ * offer-creation wizard renders these so the operator can attach them via
+ * `CreateOfferCommand.overrides.platformParams`.
+ *
+ * See `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { SellerPolicies } from '../../types/seller-policies.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface SellerPoliciesReader {
+  fetchSellerPolicies(): Promise<SellerPolicies>;
+}
+
+export function isSellerPoliciesReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & SellerPoliciesReader {
+  return (
+    typeof (adapter as Partial<SellerPoliciesReader>).fetchSellerPolicies === 'function'
+  );
+}

--- a/libs/core/src/listings/domain/ports/offer-manager.port.ts
+++ b/libs/core/src/listings/domain/ports/offer-manager.port.ts
@@ -1,99 +1,31 @@
 /**
  * Offer Manager Port
  *
- * Canonical capability contract for marketplace offer / listing management —
- * offer feed, quantity + field updates, offer creation, category directory,
- * and seller-policy discovery. Implemented by marketplace integration adapters
- * (Allegro today; eBay / WooCommerce / Shopify future).
+ * Canonical capability contract for marketplace offer / listing management.
+ * The base port carries only the one method every marketplace adapter must
+ * implement: `updateOfferQuantity`. All other previously-optional methods
+ * (feed, events, field updates, offer creation, category directory, policies)
+ * now live as distinct capability interfaces under `./capabilities/`.
  *
- * Split out of the legacy `MarketplacePort` (#328). Order-ingestion methods
- * previously on the same port now live on `OrderSourcePort` in
- * `@openlinker/core/orders`.
+ * Adapters declare the extra capabilities they support via `implements`
+ * (e.g. `implements OfferManagerPort, OfferLister, OfferCreator, …`).
+ * Call sites narrow support via the co-located type guards
+ * (`isOfferLister`, `isOfferCreator`, …) instead of presence checks on
+ * optional methods.
+ *
+ * Split out of the legacy `MarketplacePort` (#328); optional methods split
+ * out into capability interfaces (#337).
  *
  * Domain-only: no framework dependencies, no import from `@openlinker/core/orders`.
  *
  * @module libs/core/src/listings/domain/ports
  */
 
-import type { OfferFeedInput, OfferFeedOutput } from '../types/offer-feed.types';
-import type {
-  UpdateOfferQuantityCommand,
-  UpdateOfferQuantitiesBatchCommand,
-  UpdateOfferQuantitiesBatchResult,
-} from '../types/offer-quantity-update.types';
-import type { UpdateOfferFieldsCommand } from '../types/offer-fields-update.types';
-import type { OfferCategory } from '../types/category.types';
-import type { CreateOfferCommand, CreateOfferResult } from '../types/offer-create.types';
-import type { SellerPolicies } from '../types/seller-policies.types';
+import type { UpdateOfferQuantityCommand } from '../types/offer-quantity-update.types';
 
 export interface OfferManagerPort {
-  /**
-   * List marketplace offers (optional).
-   */
-  listOffers?(input: OfferFeedInput): Promise<OfferFeedOutput>;
-
-  /**
-   * List incremental marketplace offer events (optional).
-   *
-   * Uses a cursor-based event journal when supported by the marketplace.
-   */
-  listOfferEvents?(input: OfferFeedInput): Promise<OfferFeedOutput>;
-
   /**
    * Update a single offer quantity.
    */
   updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void>;
-
-  /**
-   * Optional batch update API. Core orchestration will fall back to single updates.
-   */
-  updateOfferQuantitiesBatch?(
-    cmd: UpdateOfferQuantitiesBatchCommand,
-  ): Promise<UpdateOfferQuantitiesBatchResult>;
-
-  /**
-   * Update offer fields (price, title, description) — optional capability.
-   *
-   * Partial update semantics: only fields present in cmd.fields are sent to the marketplace.
-   */
-  updateOfferFields?(cmd: UpdateOfferFieldsCommand): Promise<void>;
-
-  /**
-   * Fetch marketplace categories (optional).
-   */
-  fetchCategories?(parentId?: string): Promise<OfferCategory[]>;
-
-  /**
-   * Match a marketplace category by product barcode (EAN/GTIN) — optional capability.
-   *
-   * Returns the category ID if the marketplace can auto-detect a category for the
-   * given barcode, or null if no match / ambiguous.
-   */
-  matchCategoryByBarcode?(barcode: string): Promise<string | null>;
-
-  /**
-   * Create a new offer on the marketplace — optional capability (outbound, OL → marketplace).
-   *
-   * Adapters that implement this translate the neutral `CreateOfferCommand` into
-   * their platform-specific create-offer API call (e.g. Allegro POST /sale/product-offers).
-   * Platform-specific fields (policy IDs, shipping classes, etc.) are carried in
-   * `cmd.overrides.platformParams`.
-   *
-   * Returns momentary status (`draft` / `validating` / `active`). For marketplaces that
-   * validate asynchronously (Allegro), callers must poll to observe the final outcome.
-   */
-  createOffer?(cmd: CreateOfferCommand): Promise<CreateOfferResult>;
-
-  /**
-   * Return the seller-configured policies the marketplace requires when
-   * creating an offer (delivery, return, warranty, implied-warranty) — optional capability.
-   *
-   * Adapters that implement this fetch the operator's platform-native policies
-   * and map them to the neutral `SellerPolicies` shape. Callers (e.g. the FE
-   * offer-creation wizard) surface these in dropdowns so the operator can
-   * choose which policies to attach to the new offer via
-   * `CreateOfferCommand.overrides.platformParams`. Adapters that do not need
-   * policy IDs for offer creation omit this method.
-   */
-  fetchSellerPolicies?(): Promise<SellerPolicies>;
 }

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -113,3 +113,24 @@ export type {
 } from './domain/types/offer-create.types';
 export type { SellerPolicy, SellerPolicies } from './domain/types/seller-policies.types';
 export { OfferCreateRejectedException } from './domain/exceptions/offer-create-rejected.exception';
+
+// OfferManagerPort sub-capabilities (#337): optional capabilities extracted into
+// distinct interfaces + co-located type guards. Call sites narrow support via
+// `is{Capability}(adapter)`; see capabilities/offer-lister.capability.ts for the
+// shared naming convention.
+export type { OfferLister } from './domain/ports/capabilities/offer-lister.capability';
+export { isOfferLister } from './domain/ports/capabilities/offer-lister.capability';
+export type { OfferEventReader } from './domain/ports/capabilities/offer-event-reader.capability';
+export { isOfferEventReader } from './domain/ports/capabilities/offer-event-reader.capability';
+export type { OfferQuantityBatchUpdater } from './domain/ports/capabilities/offer-quantity-batch-updater.capability';
+export { isOfferQuantityBatchUpdater } from './domain/ports/capabilities/offer-quantity-batch-updater.capability';
+export type { OfferFieldUpdater } from './domain/ports/capabilities/offer-field-updater.capability';
+export { isOfferFieldUpdater } from './domain/ports/capabilities/offer-field-updater.capability';
+export type { CategoryBrowser } from './domain/ports/capabilities/category-browser.capability';
+export { isCategoryBrowser } from './domain/ports/capabilities/category-browser.capability';
+export type { CategoryBarcodeMatcher } from './domain/ports/capabilities/category-barcode-matcher.capability';
+export { isCategoryBarcodeMatcher } from './domain/ports/capabilities/category-barcode-matcher.capability';
+export type { OfferCreator } from './domain/ports/capabilities/offer-creator.capability';
+export { isOfferCreator } from './domain/ports/capabilities/offer-creator.capability';
+export type { SellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';
+export { isSellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';

--- a/libs/core/src/products/application/services/auto-match-variant-offers.service.ts
+++ b/libs/core/src/products/application/services/auto-match-variant-offers.service.ts
@@ -9,7 +9,12 @@
  * @implements {IAutoMatchVariantOffersService}
  */
 import { Injectable, Inject } from '@nestjs/common';
-import { OfferManagerPort } from '@openlinker/core/listings';
+import type { OfferManagerPort, OfferFeedOutput } from '@openlinker/core/listings';
+// Direct subpath import bypasses the `@openlinker/core/listings` barrel — the
+// barrel re-exports services whose transitive imports loop back through
+// `@openlinker/core/products`, creating a runtime circular require. Importing
+// the guard from its capability file keeps the dependency graph acyclic.
+import { isOfferLister } from '@openlinker/core/listings/domain/ports/capabilities/offer-lister.capability';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import {
   IIdentifierMappingService,
@@ -140,7 +145,7 @@ export class AutoMatchVariantOffersService implements IAutoMatchVariantOffersSer
   }
 
   private async loadAllOffers(marketplace: OfferManagerPort): Promise<OfferIdentifiers[]> {
-    if (!marketplace.listOffers) {
+    if (!isOfferLister(marketplace)) {
       throw new Error('Marketplace adapter does not support listOffers');
     }
 
@@ -148,7 +153,10 @@ export class AutoMatchVariantOffersService implements IAutoMatchVariantOffersSer
     let cursor: string | null = null;
 
     do {
-      const feed = await marketplace.listOffers({ cursor, limit: OFFER_FEED_PAGE_SIZE });
+      const feed: OfferFeedOutput = await marketplace.listOffers({
+        cursor,
+        limit: OFFER_FEED_PAGE_SIZE,
+      });
       for (const item of feed.items) {
         allOffers.push({
           offerId: item.offerId,

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -18,9 +18,18 @@ import type {
   CategoryBarcodeMatcher,
   OfferCreator,
   SellerPoliciesReader,
+  OfferFeedInput,
+  OfferFeedOutput,
+  UpdateOfferQuantityCommand,
+  UpdateOfferFieldsCommand,
+  CreateOfferCommand,
+  CreateOfferResult,
+  CreateOfferResultStatus,
+  CreateOfferValidationError,
+  OfferCategory,
+  SellerPolicies,
 } from '@openlinker/core/listings';
-import { OfferFeedInput, OfferFeedOutput, OfferCreateRejectedException, UpdateOfferQuantityCommand, UpdateOfferFieldsCommand } from '@openlinker/core/listings';
-import type { CreateOfferCommand, CreateOfferResult, CreateOfferResultStatus, CreateOfferValidationError, OfferCategory, SellerPolicies } from '@openlinker/core/listings';
+import { OfferCreateRejectedException } from '@openlinker/core/listings';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { IAllegroHttpClient } from '../http/allegro-http-client.interface';
 import {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -9,7 +9,16 @@
  * @module libs/integrations/allegro/src/infrastructure/adapters
  * @implements {OfferManagerPort}
  */
-import type { OfferManagerPort } from '@openlinker/core/listings';
+import type {
+  OfferManagerPort,
+  OfferLister,
+  OfferEventReader,
+  OfferFieldUpdater,
+  CategoryBrowser,
+  CategoryBarcodeMatcher,
+  OfferCreator,
+  SellerPoliciesReader,
+} from '@openlinker/core/listings';
 import { OfferFeedInput, OfferFeedOutput, OfferCreateRejectedException, UpdateOfferQuantityCommand, UpdateOfferFieldsCommand } from '@openlinker/core/listings';
 import type { CreateOfferCommand, CreateOfferResult, CreateOfferResultStatus, CreateOfferValidationError, OfferCategory, SellerPolicies } from '@openlinker/core/listings';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
@@ -86,7 +95,16 @@ export interface QuantityPollConfig {
  * Shares the Allegro HTTP client + identifier-mapping instance with its
  * sibling `AllegroOrderSourceAdapter` through the per-connection factory.
  */
-export class AllegroOfferManagerAdapter implements OfferManagerPort {
+export class AllegroOfferManagerAdapter
+  implements
+    OfferManagerPort,
+    OfferLister,
+    OfferEventReader,
+    OfferFieldUpdater,
+    CategoryBrowser,
+    CategoryBarcodeMatcher,
+    OfferCreator,
+    SellerPoliciesReader {
   private readonly logger = new Logger(AllegroOfferManagerAdapter.name);
 
   private readonly quantityPollConfig: QuantityPollConfig;


### PR DESCRIPTION
## Summary

- Extract the 8 optional methods on `OfferManagerPort` into per-method **capability interfaces** with co-located type guards under `libs/core/src/listings/domain/ports/capabilities/`.
- Call sites switch from presence checks (`if (!adapter.method)`) to type-narrowing guards (`if (!isCapability(adapter))`) — same runtime behaviour, now the method call inside the branch is compile-time-verified.
- `AllegroOfferManagerAdapter` declares the 7 capabilities it supports (everything except the unimplemented `OfferQuantityBatchUpdater`); `OfferManagerPort` shrinks to the single required `updateOfferQuantity`.

Closes #337

## What changed

**New capability interfaces + guards** (8 files under `libs/core/src/listings/domain/ports/capabilities/`):

| Capability | Method |
|---|---|
| `OfferLister` | `listOffers(input)` |
| `OfferEventReader` | `listOfferEvents(input)` |
| `OfferQuantityBatchUpdater` | `updateOfferQuantitiesBatch(cmd)` |
| `OfferFieldUpdater` | `updateOfferFields(cmd)` |
| `CategoryBrowser` | `fetchCategories(parentId?)` |
| `CategoryBarcodeMatcher` | `matchCategoryByBarcode(barcode)` |
| `OfferCreator` | `createOffer(cmd)` |
| `SellerPoliciesReader` | `fetchSellerPolicies()` |

Each ships with an `is{Capability}(adapter)` guard co-located in the same file.

**9 call-sites migrated** across:
- `libs/core/src/listings/application/services/` (5 sites: offer-mapping-sync, offer-creation-enqueue, offer-creation-execution, category-resolution, seller-policies)
- `libs/core/src/products/application/services/auto-match-variant-offers.service.ts` (1)
- `libs/core/src/inventory/application/services/inventory-sync.service.ts` (1)
- `apps/api/src/categories/categories-cache.service.ts` (1)
- `apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts` (1)

**Docs**
- `docs/architecture-overview.md` §OfferManagerPort rewritten to reflect the new shape + capabilities table.
- `docs/engineering-standards.md` registers the `*.capability.ts` suffix under Domain Layer Files.
- Implementation plan at `docs/plans/implementation-plan-337-offer-manager-capability-split.md`.

**Tests**
- New `libs/core/src/listings/domain/ports/capabilities/__tests__/offer-manager-capabilities.spec.ts` — 24 assertions (8 guards × 3 cases each: function present / absent / non-function).
- Two unit-test mocks and one integration-test mock get widened type annotations (`OfferManagerPort & OfferLister`, etc.) since the methods moved off the base port.

**Naming decision** — capability interfaces deliberately drop the `Port` suffix (they layer onto `OfferManagerPort`, they are not independent top-level ports). Documented inline in every capability file's header so it isn't "fixed" by a later contributor.

## Known follow-up

⚠️ **Circular-require workaround** in `libs/core/src/products/application/services/auto-match-variant-offers.service.ts:14-16` — the new value import of `isOfferLister` through the `@openlinker/core/listings` barrel triggers a runtime cycle (barrel re-exports Injectable service classes that transitively pull `@openlinker/core/products`). Fixed locally in this PR with a deep subpath import + inline explanation. The structural fix — splitting the listings barrel — is tracked in a separate tech-debt issue.

## Test plan

- [x] `pnpm lint` — 0 errors (4 pre-existing unrelated warnings)
- [x] `pnpm type-check` — green across all packages
- [x] `pnpm test` — **1,034/1,034 unit tests pass** (96 suites)
- [x] `pnpm test:integration` (api) — 96/96 pass
- [x] `pnpm --filter @openlinker/worker test:integration` — 20/21 pass; the 1 failure (`allegro-order-sync-e2e.int-spec.ts → should sync orders from poll to order processor`) **is pre-existing on main**, independently verified by stashing this branch's changes and re-running the spec.
- [x] The integration spec touched by this PR (`marketplace-offers-sync-e2e.int-spec.ts`) passes.
- [x] No runtime behaviour change — every existing unit + integration test that exercises the old null-check pattern keeps passing unchanged (jest mocks are functions → new `typeof === 'function'` guards return the same result as the old truthy checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
