### PR TITLE
feat(products): persist Product.currency to the products table

### DIFF
--- a/apps/api/src/migrations/1790000000000-AddCurrencyToProducts.ts
+++ b/apps/api/src/migrations/1790000000000-AddCurrencyToProducts.ts
@@ -1,0 +1,21 @@
+/**
+ * Add Currency To Products
+ *
+ * Adds a `currency` column to the `products` table so the ISO 4217 currency code
+ * resolved by the master adapter at sync time survives persistence. Nullable —
+ * existing rows stay null until their next sync populates the field, and
+ * adapters that don't know the shop's currency emit `null` rather than a guess.
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCurrencyToProducts1790000000000 implements MigrationInterface {
+  name = 'AddCurrencyToProducts1790000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "products" ADD "currency" character varying(3)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "products" DROP COLUMN "currency"`);
+  }
+}

--- a/apps/api/src/products/http/dto/product-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-response.dto.ts
@@ -26,7 +26,7 @@ export class ProductResponseDto {
   @ApiPropertyOptional({
     nullable: true,
     description:
-      'ISO 4217 currency code (e.g., PLN, EUR). Currently always null pending product-level currency persistence; once the follow-up lands, this carries the code resolved from the master catalog.',
+      'ISO 4217 currency code (e.g., PLN, EUR), resolved from the master catalog at sync time. Null when the adapter did not provide a currency.',
   })
   currency!: string | null;
 

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -23,6 +23,7 @@ function makeProduct(overrides: Partial<Product> = {}): Product {
     name: 'Test Product',
     sku: 'SKU-001',
     price: 29.99,
+    currency: null,
     description: 'A test product',
     images: null,
     createdAt: new Date('2026-01-01T00:00:00Z'),

--- a/apps/api/test/integration/products-read.int-spec.ts
+++ b/apps/api/test/integration/products-read.int-spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Products Read API Integration Test
+ *
+ * Vertical slice covering `currency` persistence round-trip for #358:
+ * seed → `GET /products` → assert the field survives ORM ↔ domain ↔ DTO mapping
+ * without loss (both a populated ISO 4217 code and the null case).
+ *
+ * Uses real Postgres via Testcontainers.
+ *
+ * @module apps/api/test/integration
+ */
+import { DataSource } from 'typeorm';
+import {
+  Product,
+  ProductOrmEntity,
+  ProductRepositoryPort,
+  PRODUCT_REPOSITORY_TOKEN,
+} from '@openlinker/core/products';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+
+interface SeedProductOverrides {
+  id?: string;
+  name?: string;
+  sku?: string | null;
+  price?: number | null;
+  currency?: string | null;
+}
+
+async function seedProduct(
+  dataSource: DataSource,
+  overrides: SeedProductOverrides = {},
+): Promise<ProductOrmEntity> {
+  const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+  const repo = dataSource.getRepository(ProductOrmEntity);
+  const entity = repo.create({
+    id: `ol_product_fixture_${suffix}`,
+    name: 'Test Product',
+    sku: 'SKU-FIX',
+    price: 29.99,
+    currency: null,
+    description: null,
+    images: null,
+    ...overrides,
+  });
+  return repo.save(entity);
+}
+
+describe('Products Read API Integration — currency persistence', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('should surface persisted currency through GET /products', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const seeded = await seedProduct(dataSource, { currency: 'PLN' });
+
+    const response = await http
+      .get('/products')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const item = response.body.items.find(
+      (p: { id: string; currency: string | null }) => p.id === seeded.id,
+    );
+    expect(item).toBeDefined();
+    expect(item.currency).toBe('PLN');
+  });
+
+  it('should return null currency when the column is null', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const seeded = await seedProduct(dataSource, { currency: null });
+
+    const response = await http
+      .get('/products')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const item = response.body.items.find(
+      (p: { id: string; currency: string | null }) => p.id === seeded.id,
+    );
+    expect(item).toBeDefined();
+    expect(item.currency).toBeNull();
+  });
+
+  it('should persist currency via ProductRepository.upsert (domain → ORM)', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const repo = harness
+      .getApp()
+      .get<ProductRepositoryPort>(PRODUCT_REPOSITORY_TOKEN);
+    const domainProduct: Product = {
+      id: `ol_product_upsert_${Date.now()}`,
+      name: 'Upsert Roundtrip',
+      sku: 'SKU-UPSERT',
+      price: 42.5,
+      currency: 'PLN',
+      description: null,
+      images: null,
+    };
+
+    await repo.upsert(domainProduct);
+
+    const response = await http
+      .get('/products')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const item = response.body.items.find(
+      (p: { id: string; currency: string | null }) => p.id === domainProduct.id,
+    );
+    expect(item).toBeDefined();
+    expect(item.currency).toBe('PLN');
+  });
+});

--- a/docs/plans/implementation-plan-358-persist-product-currency.md
+++ b/docs/plans/implementation-plan-358-persist-product-currency.md
@@ -1,0 +1,169 @@
+# Implementation Plan — #358 Persist `Product.currency`
+
+Follow-up from PR #357. The `currency` field travels from the PrestaShop mapper → adapter → `ProductsService.upsertProduct` → `ProductRepository.upsert`, but dies at the `toOrmEntity` boundary because the ORM entity has no currency column. This plan closes the loop.
+
+---
+
+## 1. Goal
+
+End-to-end: `GET /products` returns `currency` non-null for products synced from a connection whose adapter populates it. Products list in the web UI renders the currency glyph instead of the muted "Currency unknown" fallback.
+
+## 2. Layer classification
+
+- **CORE** — ORM entity + repository mapping (no port or service changes)
+- **Infrastructure (persistence)** — schema migration
+- **Interface** — DTO docstring cleanup
+- **Integration (PrestaShop)** — decision point on the hardcoded `'EUR'`
+
+No domain/application contract changes; the domain `Product.currency` field and the repository port signature already support `string | undefined`.
+
+## 3. Non-goals
+
+- Multi-currency price lists per product (one currency per product is the product-table semantic)
+- Currency on `ProductVariant` (variants inherit from the parent product)
+- Backfill for pre-migration products — the next sync repopulates currency; until then existing rows keep the muted fallback
+- Frontend changes — FE already consumes `currency` from PR #357
+
+## 4. Research notes
+
+- `ProductOrmEntity` (`libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts`) — six columns today: `id`, `name`, `sku`, `price`, `description`, `images`, `createdAt`, `updatedAt`. No `currency`.
+- `ProductRepository.toDomain` (line 74) reads six fields + timestamps; `toOrmEntity` (line 93) writes the same six. `currency` is never touched.
+- Domain `Product.currency?: string` (`product.entity.ts:30`) — already there, commented "Master-derived, not persisted on the products table." Comment becomes stale after this PR.
+- `PrestashopProductMapper.mapProduct` (`prestashop-product.mapper.ts:33`) hardcodes `currency: 'EUR'`. The mapper is already constructed per-connection via `PrestashopAdapterFactory` (`libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts:72-74`), so per-connection currency is a viable extension point if we want it later.
+- `PrestashopCurrencyResolver` (`libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-currency-resolver.ts`) goes the *wrong direction* — ISO code → PrestaShop currency ID. Not reusable here.
+- Migration pattern (e.g., `1783000000000-add-order-record-status.ts`) is plain `ALTER TABLE ... ADD COLUMN`. No index needed — currency is descriptive, not queried.
+- `ProductsController` + its unit spec were updated in PR #357 to map and assert `currency`. That coverage stays valid.
+- No existing products integration test. Need a new `products-read.int-spec.ts` per the issue AC.
+
+## 5. Design
+
+### 5.1 Schema — add `currency varchar(3) NULL`
+
+- Column type: `varchar(3)` nullable. ISO 4217 is always 3 letters; a `CHAR(3)` would be equivalent but TypeORM defaults to `varchar` for string fields — stay consistent with `sku`.
+- No index: currency is a display field, not a query predicate.
+- Nullable: existing rows stay null until their next sync.
+
+### 5.2 ORM entity
+
+Add one field:
+
+```typescript
+@Column({ type: 'varchar', length: 3, nullable: true })
+currency!: string | null;
+```
+
+### 5.3 Domain nullability alignment
+
+The existing domain `Product.currency?: string` (optional, `undefined`-shaped) is inconsistent with `sku`, `price`, `description` — all of which use `string | null`. The FE `Product` type and `ProductResponseDto` are both already `currency: string | null`. Align the domain to match before wiring the ORM column, so both mapping methods become straight pass-throughs (no null↔undefined coercion at the repo boundary).
+
+- Change `product.entity.ts:30` from `currency?: string` → `currency: string | null`.
+- Fix any adapters that return partial products to include `currency: null` explicitly — this is a `strictNullChecks` enforcement that `pnpm type-check` will flag.
+
+### 5.4 Repository mapping
+
+With the domain aligned, mapping is trivial:
+
+- `toDomain`: `currency: entity.currency` (both `string | null`, direct pass-through).
+- `toOrmEntity`: `entity.currency = product.currency` (direct pass-through).
+
+### 5.5 DTO docstring
+
+Remove the "Currently always null pending ..." hedge added in PR #357. Replace with:
+
+```text
+ISO 4217 currency code (e.g., PLN, EUR), resolved from the master catalog at sync time. Null when the adapter did not provide a currency.
+```
+
+### 5.6 PrestaShop mapper currency source — decision
+
+**Decision: Option D — drop the hardcoded `'EUR'` in `PrestashopProductMapper.mapProduct` and emit `currency: null`. Persist-plumbing only; no wrong-data regression. File a follow-up issue for a real source (Option B or C).**
+
+Why:
+- The current hardcode is safe today because persistence drops it. Once we wire the column through, every PS-synced product would persist `currency='EUR'` — **wrong for the primary operator cohort (PL shops on PLN)** and regressing the FE from an honest muted "Currency unknown" fallback to a confident but incorrect "EUR" glyph. Violates "status first, debuggable by design" (`docs/frontend-ui-style-guide.md`).
+- Option D keeps the PR minimal (no config field, no webservice endpoint) while not introducing a data-quality regression: `currency` stays `null` in the DB until a proper source lands, FE still renders the muted fallback, and the plumbing is ready for B/C to drop in without another migration.
+
+Alternatives considered:
+- **Option A (keep hardcoded `'EUR'`)** — satisfies AC literally but confidently persists wrong currency for PLN shops. Rejected.
+- **Option B (connection config)** — add optional `currency` to `PrestashopConnectionConfig`, flow into mapper options, fall back to `null` when unset. Medium scope (validation + factory wiring + eventual wizard input). Tracked as the follow-up direction.
+- **Option C (auto-detect)** — fetch `PS_CURRENCY_DEFAULT` via `/configurations` at factory time and cache per connection. Largest scope (new resolver, cache, tests). Best UX long-term; possibly the follow-up's final shape.
+
+## 6. Step-by-step implementation
+
+### Step 1 — Align domain nullability
+- `libs/core/src/products/domain/entities/product.entity.ts`:
+  - Change `currency?: string` → `currency: string | null`.
+  - Rewrite the JSDoc from "Master-derived, not persisted on the products table" to something like "ISO 4217 currency code resolved at sync time; null when the adapter did not provide one."
+
+### Step 2 — Drop PrestaShop mapper hardcode
+- `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts:33`:
+  - Change `currency: 'EUR', // Default, can be configured` → `currency: null,` with a short comment referencing the follow-up issue (Step 10) for the real source.
+- Any mapper test / factory that asserts `currency: 'EUR'` gets updated to `currency: null`.
+- If `PrestashopProductMapperOptions` currently exposes no currency field, no options change needed; otherwise keep the option optional and plumb it through later.
+
+### Step 3 — ORM entity
+- `libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts`: add the `currency` column (`varchar(3) NULL`).
+
+### Step 4 — Repository mapping
+- `libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts`:
+  - `toDomain`: include `currency: entity.currency`.
+  - `toOrmEntity`: include `entity.currency = product.currency`.
+  - No null↔undefined coercion needed after Step 1.
+
+### Step 5 — DTO docstring
+- `apps/api/src/products/http/dto/product-response.dto.ts`: replace the "Currently always null" hedge with the final description (see §5.5).
+
+### Step 6 — Migration
+- **Precondition**: `pnpm dev:stack:up` must be running and the DB must be on the last committed migration (`pnpm --filter @openlinker/api migration:show` clean), per `docs/migrations.md#prerequisites`.
+- Run `pnpm --filter @openlinker/api migration:generate -- src/migrations/AddCurrencyToProducts`.
+- Verify the generated `up()`/`down()` — expect simple `ALTER TABLE "products" ADD COLUMN "currency" varchar(3)` up and `DROP COLUMN "currency"` down. Hand-tune header comment if TypeORM emits something more elaborate.
+- Run `pnpm --filter @openlinker/api migration:run`; then `migration:revert` to verify `down()`; then `migration:run` again to leave the dev DB migrated.
+
+### Step 7 — Unit tests
+- `ProductRepository` has no dedicated spec today; skip adding one (covered by integration test in Step 8).
+- `apps/api/src/products/http/products.controller.spec.ts` — existing PR #357 test (`should surface currency when the domain entity carries one`) stays green.
+- Update any existing PrestaShop product mapper spec that asserts `currency: 'EUR'` to assert `currency: null`.
+
+### Step 8 — Integration test
+- New file: `apps/api/test/integration/products-read.int-spec.ts`.
+- Seed a product with `currency='PLN'` via the repository directly (not via the adapter — the mapper returns `null` now by design), hit `GET /products`, assert `body.items[0].currency === 'PLN'`.
+- Also cover the null case: seed a product with `currency: null`, assert the DTO returns `currency: null`.
+- Use the existing `getTestHarness()` / `resetTestHarness()` pattern from other int-specs.
+
+### Step 9 — Quality gate
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+pnpm --filter @openlinker/api migration:show
+pnpm test:integration  # new products-read spec + existing suite, requires Docker
+```
+
+### Step 10 — File follow-up issue
+Open a new issue: "Resolve PrestaShop product currency from shop config or connection setting". Scope (recommended: Option B):
+- Add optional `currency?: string` (ISO 4217) to `PrestashopConnectionConfig` with `class-validator` length/format rules.
+- Flow through `PrestashopAdapterFactory` → `PrestashopProductMapperOptions` → `mapProduct`.
+- Fall back to `null` when unset (keeps current muted-FE behaviour).
+- Optional later: Option C (auto-detect via `/configurations?filter[name]=PS_CURRENCY_DEFAULT`) as a wizard convenience.
+
+### Step 11 — Commit + PR
+- Conventional commit: `feat(products): persist Product.currency to the products table`
+- PR body: `Closes #358`, reference follow-up issue from Step 10, call out the Option D decision + the domain nullability alignment.
+
+## 7. Architecture compliance check
+
+- Change is confined to ORM entity + repo mapping + migration + DTO docstring. No port or service contract shifts. ✅
+- Domain entity's `currency?: string` already existed — no domain-layer change other than a doc-comment cleanup.
+- No framework bleed into domain. ✅
+- Migration co-located correctly in `apps/api/src/migrations/`. ✅
+
+## 8. Risks and open questions
+
+- **Hardcoded 'EUR' on PS adapter** — documented as a known limitation for this PR. Non-PL/EU shops synced today would persist `currency='EUR'` incorrectly. Realistic impact today is near-zero (all current connections are PL/EU shops), but the comment in the mapper should call this out.
+- **Decimal type on `price`** — TypeORM returns strings for `decimal`; the repo already handles this at line 79. No parallel concern for `currency` since `varchar` is returned as a string as expected.
+- **`varchar(3)` vs `text`** — `varchar(3)` hard-caps ISO 4217. If the domain ever needed to carry a non-ISO currency code (e.g., a cryptocurrency ticker, 4+ chars), the migration would need to relax. Cost to revisit is low (single migration). Using `text` is also defensible; chose `varchar(3)` to match schema-level validation.
+
+## 9. Test strategy summary
+
+- Unit tests: no new coverage needed (existing PR #357 controller test + pre-existing repo tests are sufficient).
+- Integration test: 1 new file covering seed → read → assert currency passthrough.
+- No frontend tests — FE already consumes the field, nothing on the UI side has changed.

--- a/libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts
@@ -51,6 +51,7 @@ describe('InventoryQueryService', () => {
     name: 'Product One',
     sku: 'SKU-1',
     price: 99.99,
+    currency: null,
     description: null,
     images: ['https://shop.test/img/1/cover.jpg', 'https://shop.test/img/1/alt.jpg'],
   };
@@ -59,6 +60,7 @@ describe('InventoryQueryService', () => {
     name: 'Product Two',
     sku: null,
     price: null,
+    currency: null,
     description: null,
     images: null,
   };

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -156,7 +156,7 @@ export class OfferBuilderService implements IOfferBuilderService {
 
   private resolvePrice(
     input: BuildCreateOfferCommandInput,
-    product: { price: number | null; currency?: string },
+    product: { price: number | null; currency: string | null },
     issues: OfferBuilderValidationIssue[],
   ): { amount: number; currency: string } | null {
     if (input.price) {

--- a/libs/core/src/products/application/services/products.service.spec.ts
+++ b/libs/core/src/products/application/services/products.service.spec.ts
@@ -15,14 +15,16 @@ import { PRODUCT_REPOSITORY_TOKEN, PRODUCT_VARIANT_REPOSITORY_TOKEN } from '../.
 
 function makeProduct(overrides: Partial<Product> = {}): Product {
   return {
-    id: overrides.id ?? 'ol_product_1',
-    name: overrides.name ?? 'Test Product',
-    sku: overrides.sku ?? 'SKU-001',
-    price: overrides.price ?? 29.99,
-    description: overrides.description ?? 'A test product',
-    images: overrides.images ?? null,
-    createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
-    updatedAt: overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
+    id: 'ol_product_1',
+    name: 'Test Product',
+    sku: 'SKU-001',
+    price: 29.99,
+    currency: null,
+    description: 'A test product',
+    images: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
   };
 }
 

--- a/libs/core/src/products/domain/entities/product.entity.ts
+++ b/libs/core/src/products/domain/entities/product.entity.ts
@@ -22,12 +22,16 @@ export interface Product {
   price: number | null;
   description: string | null;
   images: string[] | null;
+  /**
+   * ISO 4217 currency code resolved at sync time by the master adapter.
+   * Null when the adapter did not provide a currency (e.g., before a per-connection
+   * currency setting is configured). Persisted on the products table.
+   */
+  currency: string | null;
   /** Populated by the repository on load; adapters/drafts may omit. */
   createdAt?: Date;
   /** Populated by the repository on load; adapters/drafts may omit. */
   updatedAt?: Date;
-  /** Master-derived, not persisted on the products table. */
-  currency?: string;
   /** Master-derived, not persisted on the products table. */
   weight?: number;
   /** Master-derived (external category IDs), not persisted on the products table. */

--- a/libs/core/src/products/domain/utils/product-cover-image.spec.ts
+++ b/libs/core/src/products/domain/utils/product-cover-image.spec.ts
@@ -16,6 +16,7 @@ function makeProduct(images: string[] | null): Product {
     name: 'Test Product',
     sku: 'TEST-001',
     price: 19.99,
+    currency: null,
     description: null,
     images,
     createdAt: new Date('2026-01-01T00:00:00Z'),

--- a/libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts
+++ b/libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts
@@ -29,6 +29,9 @@ export class ProductOrmEntity {
   @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
   price!: number | null;
 
+  @Column({ type: 'varchar', length: 3, nullable: true })
+  currency!: string | null;
+
   @Column({ type: 'text', nullable: true })
   description!: string | null;
 

--- a/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
@@ -77,6 +77,7 @@ export class ProductRepository implements ProductRepositoryPort {
       name: entity.name,
       sku: entity.sku,
       price: entity.price !== null ? Number(entity.price) : null,
+      currency: entity.currency,
       description: entity.description,
       images: entity.images,
       createdAt: entity.createdAt,
@@ -96,6 +97,7 @@ export class ProductRepository implements ProductRepositoryPort {
     entity.name = product.name;
     entity.sku = product.sku;
     entity.price = product.price;
+    entity.currency = product.currency;
     entity.description = product.description;
     entity.images = product.images;
     if (product.createdAt) entity.createdAt = product.createdAt;

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
@@ -37,6 +37,19 @@ describe('PrestashopProductMapper', () => {
       expect(result.weight).toBe(0.5);
     });
 
+    it('should emit currency=null until a real source is wired up (#362)', () => {
+      const prestashopProduct: PrestashopProduct = {
+        id: '1',
+        name: 'Test Product',
+        reference: 'TEST-001',
+        price: '19.99',
+      };
+
+      const result = mapper.mapProduct(prestashopProduct, 1);
+
+      expect(result.currency).toBeNull();
+    });
+
     it('should handle localized name field with array of languages', () => {
       const prestashopProduct: PrestashopProduct = {
         id: '1',

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
@@ -30,7 +30,9 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
       sku: this.getStringField(prestashopProduct.reference) || '',
       description,
       price: this.parseNumber(prestashopProduct.price) || 0,
-      currency: 'EUR', // Default, can be configured
+      // Null until a per-connection currency or shop auto-detect lands (#362).
+      // The previous 'EUR' hardcode would persist wrong values for PLN shops.
+      currency: null,
       weight: this.parseNumber(prestashopProduct.weight),
       images,
       categories: this.extractCategories(prestashopProduct),


### PR DESCRIPTION
## Summary

Closes the round-trip from adapter → repository → controller → FE that was opened in #357. `ProductOrmEntity` gains a nullable `varchar(3)` `currency` column; `ProductRepository` maps it through `toDomain` / `toOrmEntity`. The `ProductResponseDto` docstring loses the "currently always null" hedge — after this lands the field carries whatever the master adapter resolved, or `null` when none was resolved.

## Decisions

- **Domain nullability alignment.** `Product.currency?: string` (optional) was inconsistent with every other nullable field on the same entity (`sku/price/description: string | null`). Changed to `currency: string | null`. Removes a null↔undefined coercion at the repo boundary and makes the domain match the already-aligned FE type and DTO. All product fixtures updated.

- **PrestaShop mapper: drop the hardcoded `'EUR'`.** The existing mapper emitted `currency: 'EUR'` for every product; today that value was silently dropped at upsert. With persistence wired up, keeping the hardcode would store EUR for every PS-synced product — wrong for the PL/PLN operator cohort and regressing the FE from a muted "Currency unknown" fallback to a confident-but-incorrect "EUR" glyph. Mapper now emits `currency: null`. Follow-up **#362** will source this from per-connection config or PrestaShop shop auto-detection.

## Migration

`AddCurrencyToProducts1790000000000` — simple `ALTER TABLE ADD COLUMN varchar(3) NULL` with matching `DROP COLUMN` down. Tested up/down/up locally. Existing rows stay `null` until their next sync.

## Test plan

- [x] `pnpm lint` — zero errors
- [x] `pnpm type-check` — zero errors
- [x] `pnpm test` — full suite green (545 FE / 253 API / 107 worker / 365 core / 193 PS / 93 Allegro / 19 AI / 7 shared)
- [x] `pnpm test:integration` — full suite green (18 suites / 101 tests), including three new `products-read.int-spec.ts` cases:
  - ORM → DTO read with currency present
  - ORM → DTO read with null
  - Domain → ORM write via `ProductRepository.upsert`
- [x] `pnpm --filter @openlinker/api migration:run` + `migration:revert` + `migration:run` round-trip verified locally

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)