### PR TITLE
fix(web): resolve connection names on Sync Jobs and Webhook Deliveries

### DIFF
--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
@@ -9,6 +9,23 @@ import type {
   SyncJobPagination,
 } from '../../features/sync-jobs/api/sync-jobs.types';
 import { SYNC_JOBS_MAX_LIMIT } from '../../features/sync-jobs/api/sync-jobs.types';
+import type { Connection } from '../../features/connections/api/connections.types';
+
+function makeConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn_allegro_1',
+    name: 'Allegro Europe',
+    platformType: 'allegro',
+    status: 'active',
+    config: {},
+    credentialsBacked: true,
+    enabledCapabilities: [],
+    supportedCapabilities: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 const sampleJobs: PaginatedSyncJobs = {
   items: [
@@ -39,6 +56,7 @@ describe('SyncJobsPage', () => {
   it('should show loading state initially', () => {
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
@@ -49,6 +67,7 @@ describe('SyncJobsPage', () => {
   it('should show jobs table when data loads', async () => {
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockResolvedValue(sampleJobs) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
@@ -60,6 +79,7 @@ describe('SyncJobsPage', () => {
   it('renders the Diagnostics eyebrow so the header matches the sidebar group and breadcrumb', async () => {
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockResolvedValue(sampleJobs) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
@@ -70,6 +90,7 @@ describe('SyncJobsPage', () => {
   it('should show error state when fetch fails', async () => {
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockRejectedValue(new Error('Service unavailable')) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
@@ -81,6 +102,7 @@ describe('SyncJobsPage', () => {
   it('should show empty state without an action when no jobs exist and no filter is active', async () => {
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
@@ -97,6 +119,7 @@ describe('SyncJobsPage', () => {
     const user = userEvent.setup();
     const mockApi = createMockApiClient({
       syncJobs: { list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<SyncJobsPage />, {
@@ -119,7 +142,10 @@ describe('SyncJobsPage', () => {
   // and broke every load.
   it('requests sync jobs with limit capped at SYNC_JOBS_MAX_LIMIT', async () => {
     const listMock = vi.fn().mockResolvedValue(sampleJobs);
-    const mockApi = createMockApiClient({ syncJobs: { list: listMock } });
+    const mockApi = createMockApiClient({
+      syncJobs: { list: listMock },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
 
     renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
 
@@ -129,5 +155,43 @@ describe('SyncJobsPage', () => {
     const [, pagination] = listMock.mock.calls[0] as [SyncJobFilters, SyncJobPagination];
     expect(pagination.limit).toBeLessThanOrEqual(SYNC_JOBS_MAX_LIMIT);
     expect(pagination.limit).toBe(SYNC_JOBS_MAX_LIMIT);
+  });
+
+  it('should resolve the connection name via ConnectionEntityLabel in the Connection column', async () => {
+    const connection = makeConnection();
+    const mockApi = createMockApiClient({
+      syncJobs: { list: vi.fn().mockResolvedValue(sampleJobs) },
+      connections: {
+        list: vi.fn().mockResolvedValue([connection]),
+        getById: vi.fn().mockResolvedValue(connection),
+      },
+    });
+
+    renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Allegro Europe')).toBeInTheDocument();
+  });
+
+  it('filters sync jobs by the selected connection when changing the dropdown', async () => {
+    const user = userEvent.setup();
+    const connection = makeConnection();
+    const listMock = vi.fn().mockResolvedValue(sampleJobs);
+    const mockApi = createMockApiClient({
+      syncJobs: { list: listMock },
+      connections: { list: vi.fn().mockResolvedValue([connection]) },
+    });
+
+    renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+    await screen.findByRole('option', { name: 'Allegro Europe' });
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: /filter by connection/i }),
+      connection.id,
+    );
+
+    await waitFor(() => {
+      const lastCall = listMock.mock.calls.at(-1) as [SyncJobFilters, SyncJobPagination];
+      expect(lastCall[0].connectionId).toBe(connection.id);
+    });
   });
 });

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
@@ -6,11 +6,12 @@ import { useTableSort } from '../../shared/ui/use-table-sort';
 import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
 import { Button } from '../../shared/ui/button';
-import { Input } from '../../shared/ui/input';
 import { Select } from '../../shared/ui/select';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobStatusBadge';
 import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
+import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import type { SyncJob, SyncJobFilters, JobStatus, JobType } from '../../features/sync-jobs/api/sync-jobs.types';
 import {
   JOB_STATUS_VALUES,
@@ -44,9 +45,7 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
     id: 'connectionId',
     header: 'Connection',
     cell: (job) => (
-      <span className="mono-text" title={job.connectionId}>
-        {job.connectionId}
-      </span>
+      <ConnectionEntityLabel connectionId={job.connectionId} linkToDetail={false} showId />
     ),
     hideBelow: 1024,
   },
@@ -94,6 +93,8 @@ export function SyncJobsPage(): ReactElement {
   const pagination = { limit: PAGE_SIZE, offset };
 
   const query = useSyncJobsQuery(filters, pagination);
+  const connectionsQuery = useConnectionsQuery();
+  const connections = connectionsQuery.data ?? [];
 
   function setFilter(key: string, value: string): void {
     setSearchParams((prev) => {
@@ -170,12 +171,18 @@ export function SyncJobsPage(): ReactElement {
           ))}
         </Select>
 
-        <Input
-          aria-label="Filter by connection ID"
-          placeholder="Connection ID"
+        <Select
+          aria-label="Filter by connection"
           value={connectionId ?? ''}
           onChange={(e) => { setFilter('connectionId', e.target.value); }}
-        />
+        >
+          <option value="">All connections</option>
+          {connections.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </Select>
       </div>
 
       {/* Table */}
@@ -218,7 +225,13 @@ export function SyncJobsPage(): ReactElement {
             containerHeight={600}
             cardView={{
               title: (job) => job.jobType,
-              subtitle: (job) => job.connectionId,
+              subtitle: (job) => (
+                <ConnectionEntityLabel
+                  connectionId={job.connectionId}
+                  linkToDetail={false}
+                  showId={false}
+                />
+              ),
               meta: (job) => <SyncJobStatusBadge status={job.status} />,
             }}
           />

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx
@@ -1,8 +1,26 @@
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { WebhookDeliveriesPage } from './webhook-deliveries-page';
 import type { WebhookDeliverySummary } from '../../features/webhook-deliveries/api/webhook-deliveries.types';
+import type { Connection } from '../../features/connections/api/connections.types';
+
+function makeConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn_1',
+    name: 'PrestaShop Main',
+    platformType: 'prestashop',
+    status: 'active',
+    config: {},
+    credentialsBacked: true,
+    enabledCapabilities: [],
+    supportedCapabilities: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 const sampleDelivery: WebhookDeliverySummary = {
   id: 'del_1',
@@ -33,6 +51,7 @@ describe('WebhookDeliveriesPage', () => {
       webhookDeliveries: {
         list: vi.fn().mockReturnValue(new Promise(() => undefined)),
       },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
@@ -45,6 +64,7 @@ describe('WebhookDeliveriesPage', () => {
       webhookDeliveries: {
         list: vi.fn().mockResolvedValue({ items: [sampleDelivery], total: 1 }),
       },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
@@ -58,6 +78,7 @@ describe('WebhookDeliveriesPage', () => {
       webhookDeliveries: {
         list: vi.fn().mockResolvedValue({ items: [sampleDelivery], total: 1 }),
       },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
@@ -70,6 +91,7 @@ describe('WebhookDeliveriesPage', () => {
       webhookDeliveries: {
         list: vi.fn().mockResolvedValue({ items: [], total: 0 }),
       },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
@@ -82,10 +104,51 @@ describe('WebhookDeliveriesPage', () => {
       webhookDeliveries: {
         list: vi.fn().mockRejectedValue(new Error('Network error')),
       },
+      connections: { list: vi.fn().mockResolvedValue([]) },
     });
 
     renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('Unable to load webhook deliveries')).toBeInTheDocument();
+  });
+
+  it('should resolve the connection name via ConnectionEntityLabel in the Connection column', async () => {
+    const connection = makeConnection();
+    const mockApi = createMockApiClient({
+      webhookDeliveries: {
+        list: vi.fn().mockResolvedValue({ items: [sampleDelivery], total: 1 }),
+      },
+      connections: {
+        list: vi.fn().mockResolvedValue([connection]),
+        getById: vi.fn().mockResolvedValue(connection),
+      },
+    });
+
+    renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('PrestaShop Main')).toBeInTheDocument();
+  });
+
+  it('filters deliveries by the selected connection when changing the dropdown', async () => {
+    const user = userEvent.setup();
+    const connection = makeConnection();
+    const listMock = vi.fn().mockResolvedValue({ items: [sampleDelivery], total: 1 });
+    const mockApi = createMockApiClient({
+      webhookDeliveries: { list: listMock },
+      connections: { list: vi.fn().mockResolvedValue([connection]) },
+    });
+
+    renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
+
+    await screen.findByRole('option', { name: 'PrestaShop Main' });
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: /filter by connection/i }),
+      connection.id,
+    );
+
+    await waitFor(() => {
+      const lastCall = listMock.mock.calls.at(-1);
+      expect(lastCall?.[0]).toMatchObject({ connectionId: connection.id });
+    });
   });
 });

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx
@@ -11,6 +11,8 @@ import { Select } from '../../shared/ui/select';
 import { StatusBadge } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useWebhookDeliveriesQuery } from '../../features/webhook-deliveries/hooks/use-webhook-deliveries-query';
+import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import {
   WEBHOOK_DELIVERY_STATUS_VALUES,
   type WebhookDeliveryFilters,
@@ -69,9 +71,7 @@ const COLUMNS: DataTableColumn<WebhookDeliverySummary>[] = [
     id: 'connectionId',
     header: 'Connection',
     cell: (d) => (
-      <span className="mono-text" title={d.connectionId}>
-        {d.connectionId}
-      </span>
+      <ConnectionEntityLabel connectionId={d.connectionId} linkToDetail={false} showId />
     ),
     hideBelow: 1024,
   },
@@ -109,6 +109,8 @@ export function WebhookDeliveriesPage(): ReactElement {
 
   const filters: WebhookDeliveryFilters = { provider, connectionId, status };
   const query = useWebhookDeliveriesQuery(filters, { limit: PAGE_SIZE, offset });
+  const connectionsQuery = useConnectionsQuery();
+  const connections = connectionsQuery.data ?? [];
 
   function setFilter(key: string, value: string): void {
     setSearchParams((prev) => {
@@ -160,12 +162,18 @@ export function WebhookDeliveriesPage(): ReactElement {
           onChange={(e) => { setFilter('provider', e.target.value); }}
         />
 
-        <Input
-          aria-label="Filter by connection ID"
-          placeholder="Connection ID"
+        <Select
+          aria-label="Filter by connection"
           value={connectionId ?? ''}
           onChange={(e) => { setFilter('connectionId', e.target.value); }}
-        />
+        >
+          <option value="">All connections</option>
+          {connections.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </Select>
       </div>
 
       {query.isLoading ? (

--- a/docs/plans/implementation-plan-321-sync-jobs-webhooks-connection-picker.md
+++ b/docs/plans/implementation-plan-321-sync-jobs-webhooks-connection-picker.md
@@ -1,0 +1,215 @@
+# Implementation Plan — #321 Sync Jobs & Webhook Deliveries connection resolution + picker
+
+## Scope
+
+Two triage pages (`/jobs-logs`, `/webhook-deliveries`) currently render raw connection UUIDs in the `Connection` column and filter by a free-text `<Input>`. Operators have no way to triage without round-tripping through the Connections list to look up or copy IDs.
+
+Mirror the pattern that already ships on `/orders/failed` (PR #357):
+- Column → `<ConnectionEntityLabel>` (name + shortened ID badge + copy button + "Unknown" fallback)
+- Filter → `<Select>` populated from `useConnectionsQuery()`, "All connections" as the empty option
+
+Both changes are interface-layer frontend only. Classification:
+- Layer: Frontend — Interface (page composition + feature hook reuse)
+- Files: 2 pages + 2 colocated tests
+- No backend, no API, no DB
+
+## Decision log
+
+**Column rendering — ConnectionEntityLabel (Option A) vs. Map lookup from useConnectionsQuery (Option B).**
+Chose **A**. Rationale: consistency with the Failed Orders triage page (#357) — same copy-ID button, same "Unknown" fallback, same loading affordance. The cost is N+1 detail fetches (one `GET /connections/:id` per unique connectionId on-screen, bounded by TanStack Query dedup). The list query the page already issues for the filter dropdown is not shared with `useConnectionQuery`'s detail cache — different query keys. This N+1 is a pre-existing pattern Failed Orders already ships; repeating it here keeps all three triage pages consistent, and the fix (prime `useConnectionQuery` cache from `useConnectionsQuery` list results) is a small follow-up that retroactively benefits every page at once. **Follow-up commitment:** file an issue after this PR merges to prime the detail cache from the list query.
+
+## Non-goals
+
+- **Not** converting the Webhook Deliveries `provider` free-text filter to a `<Select>`. The issue explicitly permits this as a follow-up ("Fold into this task if trivial; otherwise leave for a follow-up"). Providers aren't a fixed enum at the FE layer today (backend can accept any string), and adding a hardcoded `['prestashop', 'allegro']` option list is a separate judgment call. Leaving free-text.
+- **Not** changing the `DataTable` row-link behavior. Both pages already use `rowHref` which wraps each row in a link — so `ConnectionEntityLabel` must use `linkToDetail={false}` to avoid nested `<a>` tags (same reason Failed Orders uses `linkToDetail={false}`).
+- **Not** rendering an "orphan" option when the URL contains a `connectionId` that doesn't match any active connection. Filter still fires (URL param is passed through); the `<Select>` just shows its default. Matches Failed Orders behavior. Can be addressed in a follow-up if operators report confusion.
+- **Not** populating the `useConnectionQuery` (detail) cache from `useConnectionsQuery` (list) to eliminate N+1 detail fetches. Failed Orders already ships this N+1 pattern; a fix here would help all three triage pages at once and is a separate, cross-cutting concern.
+- **Not** renaming `sync-jobs-page.tsx`'s URL from `/jobs-logs` (that's a separate routing cleanup).
+
+## Step 1 — Sync Jobs: Connection column → `ConnectionEntityLabel`
+
+**File:** `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx`
+
+1. Add imports at the top (alphabetical where relevant):
+   ```ts
+   import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
+   import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+   ```
+2. Replace the current `connectionId` column cell:
+   ```ts
+   // Before
+   cell: (job) => (
+     <span className="mono-text" title={job.connectionId}>{job.connectionId}</span>
+   ),
+   // After
+   cell: (job) => (
+     <ConnectionEntityLabel connectionId={job.connectionId} linkToDetail={false} showId />
+   ),
+   ```
+3. Update the `cardView.subtitle` to render the same label compactly (`showId={false}` for the denser card view, matching Failed Orders' card pattern):
+   ```ts
+   cardView={{
+     title: (job) => job.jobType,
+     subtitle: (job) => (
+       <ConnectionEntityLabel connectionId={job.connectionId} linkToDetail={false} showId={false} />
+     ),
+     meta: (job) => <SyncJobStatusBadge status={job.status} />,
+   }}
+   ```
+
+**Untruncated-ID acceptance:** `EntityLabel` renders the ID inside a `<code className="entity-label__id mono-text" title={id}>` span. Hovering reveals the full ID; a Copy button copies it verbatim. Unknown-connection fallback renders `<span title={id}>Unknown</span>`. Satisfies the issue's "title attribute with the untruncated connection ID" requirement.
+
+## Step 2 — Sync Jobs: Connection filter → `<Select>`
+
+**File:** `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx`
+
+1. Invoke `const connectionsQuery = useConnectionsQuery();` inside the component body (after the existing `useSyncJobsQuery`). Destructure `const connections = connectionsQuery.data ?? [];`.
+2. Replace the free-text connection filter:
+   ```tsx
+   // Before
+   <Input
+     aria-label="Filter by connection ID"
+     placeholder="Connection ID"
+     value={connectionId ?? ''}
+     onChange={(e) => { setFilter('connectionId', e.target.value); }}
+   />
+   // After
+   <Select
+     aria-label="Filter by connection"
+     value={connectionId ?? ''}
+     onChange={(e) => { setFilter('connectionId', e.target.value); }}
+   >
+     <option value="">All connections</option>
+     {connections.map((c) => (
+       <option key={c.id} value={c.id}>{c.name}</option>
+     ))}
+   </Select>
+   ```
+3. Remove the now-unused `Input` import if no other filter uses it. (The page doesn't import `Input` for anything else on post-change state, so drop the line.)
+
+URL param name (`connectionId`) is preserved, so existing bookmarks/deep links remain valid.
+
+## Step 3 — Webhook Deliveries: Connection column → `ConnectionEntityLabel`
+
+**File:** `apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx`
+
+Same change as Step 1, adapted:
+1. Add the two imports (`useConnectionsQuery`, `ConnectionEntityLabel`).
+2. Replace the `connectionId` column cell with `<ConnectionEntityLabel connectionId={d.connectionId} linkToDetail={false} showId />`.
+3. The `cardView` here does NOT currently surface the connection (subtitle is `eventType`), so no card-view change.
+
+## Step 4 — Webhook Deliveries: Connection filter → `<Select>`
+
+**File:** `apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx`
+
+Same as Step 2, adapted: call `useConnectionsQuery()` in the component, swap the connection-filter `<Input>` for `<Select>`. Keep the separate provider `<Input>` — deferred per Non-goals. The `Input` import remains necessary for the provider filter.
+
+## Step 5 — Tests
+
+### `apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx`
+
+Update the existing `createMockApiClient` calls to provide a `connections.list` mock (otherwise the new `useConnectionsQuery` call will throw a mock-missing error). Do this once near the test-setup block or per test as needed — the existing test mocks `syncJobs.list` only.
+
+Add two new tests:
+
+```ts
+it('renders the connection name in the Connection column when a matching connection exists', async () => {
+  const mockApi = createMockApiClient({
+    syncJobs: { list: vi.fn().mockResolvedValue(sampleJobs) },
+    connections: {
+      list: vi.fn().mockResolvedValue([
+        { id: 'conn_allegro_1', name: 'Allegro PL (main)', platformType: 'allegro', status: 'active',
+          config: {}, credentialsBacked: true, enabledCapabilities: [], supportedCapabilities: [],
+          createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+      ]),
+      get: vi.fn().mockResolvedValue({ /* same shape */ }),
+    },
+  });
+
+  renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+  expect(await screen.findByText('Allegro PL (main)')).toBeInTheDocument();
+});
+
+it('filters sync jobs by the selected connection in the dropdown', async () => {
+  const user = userEvent.setup();
+  const listMock = vi.fn().mockResolvedValue(sampleJobs);
+  const mockApi = createMockApiClient({
+    syncJobs: { list: listMock },
+    connections: {
+      list: vi.fn().mockResolvedValue([
+        { id: 'conn_allegro_1', name: 'Allegro PL (main)', /* ... minimal shape */ },
+      ]),
+    },
+  });
+
+  renderWithProviders(<SyncJobsPage />, { apiClient: mockApi });
+
+  await screen.findByRole('option', { name: 'Allegro PL (main)' });
+  await user.selectOptions(
+    screen.getByRole('combobox', { name: /filter by connection/i }),
+    'conn_allegro_1',
+  );
+
+  await waitFor(() => {
+    const call = listMock.mock.calls.at(-1) as [SyncJobFilters, SyncJobPagination];
+    expect(call[0].connectionId).toBe('conn_allegro_1');
+  });
+});
+```
+
+Update the existing "Clear filters" test only if it breaks due to the new connections mock — no behavior change otherwise.
+
+### `apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx`
+
+Same shape: connection-name render test + connection-dropdown filter test. Existing mocks only cover `webhookDeliveries.list`, so they need `connections.list` added too.
+
+### Mirror ConnectionEntityLabel's internal fetch
+
+`ConnectionEntityLabel` internally calls `useConnectionQuery(connectionId)` (detail fetch, different query key from list). The backing API client method is `connections.getById` (verified in `failed-orders-page.test.tsx:126`, not `connections.get`). Tests that render and assert a connection name must mock both `connections.list` and `connections.getById`. Tests that don't care about the connection label (loading, error, empty, filter-fire) only need `connections.list: () => Promise.resolve([])` to keep ConnectionEntityLabel's list-provider happy. Mirror the `makeConnection()` factory helper from `failed-orders-page.test.tsx:26-40` to avoid inline `Connection` shapes diverging from the type.
+
+## Step 6 — Quality gate
+
+From the worktree root:
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm --filter @openlinker/web test -- --run
+```
+
+All three must pass with zero errors. If the backend mock shape drifts from `Connection` type (e.g., missing `adapterKey` makes type-check fail) I'll either broaden the mock or cast `as Connection` inside the test file. Pattern already used in sibling tests.
+
+## Validation
+
+- **Architecture compliance:** frontend dependency direction preserved — pages import from `features/connections`. No API client is imported directly; hooks use `useApiClient()` internally. No new `shared/ui/` primitives introduced.
+- **Naming conventions:** no file renames. Pre-existing `ConnectionEntityLabel.tsx` filename is PascalCase (frontend rule mandates kebab-case), same pre-existing violation as the rest of `features/connections/components/` — out of scope here, same call I made on #316.
+- **Testing:** two new tests per page (rendering + filtering). Existing tests remain green once `connections.list` / `connections.get` mocks are added.
+- **Security:** no new input handling; URL param shape is unchanged.
+- **A11y:** new `<Select>` carries an `aria-label="Filter by connection"` matching the Failed Orders pattern.
+- **Risk:** Low. The only code path that risks behavior change is the mock surface in tests — a missing `connections.list` mock could break existing tests. Addressed in Step 5.
+
+## Commit plan
+
+Single commit, conventional format:
+
+```
+fix(web): resolve connection names and swap free-text filter for Select on triage pages
+
+Sync Jobs and Webhook Deliveries rendered raw connection UUIDs in the
+Connection column and offered a free-text connectionId filter — making
+triage useless without round-tripping through the Connections list.
+Align with the pattern shipped on Failed Orders (#357): render
+ConnectionEntityLabel for the column, populate the filter from
+useConnectionsQuery() as a Select with "All connections" as the empty
+option. Untruncated IDs remain accessible via the EntityLabel copy
+button and title attribute.
+
+Closes #321
+```
+
+## Out of scope / follow-up
+
+- Webhook Deliveries `provider` filter as `<Select>` with `['prestashop', 'allegro']` options — allowed deferral per the issue.
+- Shared hook to populate `useConnectionQuery` detail cache from `useConnectionsQuery` list to remove N+1 detail fetches across all three triage pages.
+- Orphan-connection option in the `<Select>` when URL `connectionId` references a deleted connection.


### PR DESCRIPTION
## Summary

- Both triage pages rendered raw connection UUIDs (`ol_connection_*`) in the Connection column and filtered by a free-text `<Input>` — operators couldn't triage without round-tripping through the Connections list to copy an ID.
- Aligns with the pattern shipped on Failed Orders (#357): Connection column → `ConnectionEntityLabel` (name + shortened-ID badge + copy button + "Unknown" fallback); connection filter → `<Select>` populated from `useConnectionsQuery()` with "All connections" as the empty option.
- URL param shape (`connectionId`) preserved so existing bookmarks still work. Webhook Deliveries' free-text `provider` filter is intentionally left alone (providers aren't enum-enforced at the FE layer today).

## Files changed

- `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx` — column + filter + cardView subtitle
- `apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.tsx` — column + filter
- Colocated tests for both pages — broadened existing mocks with `connections.list`, added 2 new tests per page (name-resolution, filter-fire)
- `docs/plans/implementation-plan-321-sync-jobs-webhooks-connection-picker.md` — full plan + decision log

## Decision log

**Column rendering:** Option A (`ConnectionEntityLabel`) over Option B (bespoke `Map<connectionId, Connection>` lookup from the list query). Rationale: consistency with Failed Orders, copy-ID affordance, Unknown-connection fallback. Cost: N+1 detail fetches (`useConnectionQuery` per unique row, deduped by TanStack). Follow-up commitment: prime detail cache from list query — a one-line fix that retroactively removes the N+1 on all three triage pages at once.

## Test plan

- [ ] `pnpm --filter @openlinker/web test -- --run` — all 550 tests pass (pre-commit hook verified this)
- [ ] `pnpm lint` — zero errors
- [ ] `pnpm type-check` — zero errors
- [ ] Manual: `/jobs-logs` Connection column shows connection names; filter dropdown lists active connections; selecting a connection fires a new query with `connectionId=<id>` in the URL
- [ ] Manual: `/webhook-deliveries` same as above
- [ ] Mobile/card view (≤ 767 px) on Sync Jobs: subtitle renders `ConnectionEntityLabel` compactly (no ID badge)

Closes #321