### PR TITLE
fix(web): stable idempotency key for manual sync job triggers (#369)

### DIFF
--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx
@@ -205,7 +205,12 @@ describe('TriggerSyncDialog', () => {
             jobType: 'master.product.syncAll',
             payload: { schemaVersion: 1 },
             idempotencyKey: expect.stringMatching(
-              new RegExp(`^manual:${sampleConnection.id}:master\\.product\\.syncAll:\\d+$`),
+              // Suffix is a crypto.randomUUID() value — stable per dialog
+              // open cycle so the backend dedup can collapse double-clicks.
+              // See #369.
+              new RegExp(
+                `^manual:${sampleConnection.id}:master\\.product\\.syncAll:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+              ),
             ),
           }),
         );
@@ -310,6 +315,104 @@ describe('TriggerSyncDialog', () => {
       const { onOpenChange } = renderDialog();
       fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
       expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('idempotency key (#369)', () => {
+    it('should reuse the same idempotency key across retries after a failed submit', async () => {
+      const enqueue = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('Connection refused'))
+        .mockResolvedValueOnce({ jobId: 'job_retry', status: 'queued' });
+      const mockApi = createMockApiClient({ syncJobs: { enqueue } });
+      renderWithProviders(
+        <TriggerSyncDialog connection={sampleConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+
+      // First click — rejects
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+      await waitFor(() => {
+        expect(screen.getByText(/connection refused/i)).toBeInTheDocument();
+      });
+
+      // Second click — succeeds (operator retries)
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+      await waitFor(() => {
+        expect(enqueue).toHaveBeenCalledTimes(2);
+      });
+
+      const firstKey = (enqueue.mock.calls[0][0] as { idempotencyKey: string }).idempotencyKey;
+      const secondKey = (enqueue.mock.calls[1][0] as { idempotencyKey: string }).idempotencyKey;
+      expect(firstKey).toBe(secondKey); // stable across retries within the same dialog open cycle
+    });
+
+    it('should mint a fresh idempotency key on each dialog open cycle', async () => {
+      const enqueue = vi.fn().mockResolvedValue({ jobId: 'job_x', status: 'queued' });
+      const mockApi = createMockApiClient({ syncJobs: { enqueue } });
+
+      const { rerender } = renderWithProviders(
+        <TriggerSyncDialog connection={sampleConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+
+      // First open + submit
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+      await waitFor(() => {
+        expect(enqueue).toHaveBeenCalledTimes(1);
+      });
+
+      // Close then reopen
+      rerender(
+        <TriggerSyncDialog connection={sampleConnection} open={false} onOpenChange={vi.fn()} />,
+      );
+      rerender(
+        <TriggerSyncDialog connection={sampleConnection} open onOpenChange={vi.fn()} />,
+      );
+
+      // Second open + submit
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+      await waitFor(() => {
+        expect(enqueue).toHaveBeenCalledTimes(2);
+      });
+
+      const firstKey = (enqueue.mock.calls[0][0] as { idempotencyKey: string }).idempotencyKey;
+      const secondKey = (enqueue.mock.calls[1][0] as { idempotencyKey: string }).idempotencyKey;
+      expect(firstKey).not.toBe(secondKey); // distinct intents across dialog sessions
+    });
+
+    it('should yield a distinct key when switching job types within the same open cycle', async () => {
+      const enqueue = vi.fn().mockResolvedValue({ jobId: 'job_x', status: 'queued' });
+      const mockApi = createMockApiClient({ syncJobs: { enqueue } });
+      renderWithProviders(
+        <TriggerSyncDialog connection={sampleConnection} open onOpenChange={vi.fn()} />,
+        { apiClient: mockApi },
+      );
+
+      // First submit — default job (master.product.syncAll)
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+      await waitFor(() => {
+        expect(enqueue).toHaveBeenCalledTimes(1);
+      });
+
+      // Switch job type and submit again — different jobType segment in the key
+      const select = screen.getByRole('combobox', { name: /job type/i });
+      fireEvent.change(select, { target: { value: 'master.inventory.syncAll' } });
+      fireEvent.click(screen.getByRole('button', { name: /trigger/i }));
+      await waitFor(() => {
+        expect(enqueue).toHaveBeenCalledTimes(2);
+      });
+
+      const firstKey = (enqueue.mock.calls[0][0] as { idempotencyKey: string }).idempotencyKey;
+      const secondKey = (enqueue.mock.calls[1][0] as { idempotencyKey: string }).idempotencyKey;
+      // Full keys differ because the jobType segment differs (master.product vs master.inventory)
+      expect(firstKey).not.toBe(secondKey);
+      expect(firstKey).toContain(':master.product.syncAll:');
+      expect(secondKey).toContain(':master.inventory.syncAll:');
+      // UUID suffix is stable across the session
+      const firstSuffix = firstKey.split(':').at(-1);
+      const secondSuffix = secondKey.split(':').at(-1);
+      expect(firstSuffix).toBe(secondSuffix);
     });
   });
 });

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
@@ -155,6 +155,12 @@ export function TriggerSyncDialog({
   const [selectedJobType, setSelectedJobType] = useState(triggerableJobs[0]?.jobType ?? '');
   const [payloadValues, setPayloadValues] = useState<Record<string, string>>({});
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  // Stable idempotency-key suffix for this dialog open cycle. Reused across
+  // retries after a failed submit so the backend dedup (Redis SET NX + DB
+  // unique index on idempotency_key) collapses rapid double-clicks into a
+  // single sync_jobs row. Re-minted each time the dialog is reopened so
+  // genuinely distinct triggers remain distinct. See #369.
+  const [intentKey, setIntentKey] = useState<string | null>(null);
 
   const enqueueSyncJob = useEnqueueSyncJobMutation();
   const { showToast } = useToast();
@@ -169,6 +175,7 @@ export function TriggerSyncDialog({
         firstJob ? buildDefaultValues(firstJob.payloadFields, connection) : {},
       );
       setFieldErrors({});
+      setIntentKey(crypto.randomUUID());
       enqueueSyncJob.reset();
     }
   }, [open]); // enqueueSyncJob.reset and triggerableJobs are intentionally excluded — stable on open only
@@ -194,7 +201,7 @@ export function TriggerSyncDialog({
   };
 
   const handleSubmit = async (): Promise<void> => {
-    if (!selectedJob || !validate()) return;
+    if (!selectedJob || !validate() || intentKey === null) return;
 
     const payload: Record<string, unknown> = { schemaVersion: 1 };
     for (const field of selectedJob.payloadFields) {
@@ -209,7 +216,7 @@ export function TriggerSyncDialog({
         connectionId: connection.id,
         jobType: selectedJob.jobType,
         payload,
-        idempotencyKey: `manual:${connection.id}:${selectedJob.jobType}:${Date.now()}`,
+        idempotencyKey: `manual:${connection.id}:${selectedJob.jobType}:${intentKey}`,
       });
 
       onOpenChange(false);

--- a/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
+++ b/apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx
@@ -293,7 +293,7 @@ export function TriggerSyncDialog({
           <Button
             tone="primary"
             onClick={() => void handleSubmit()}
-            disabled={enqueueSyncJob.isPending}
+            disabled={enqueueSyncJob.isPending || intentKey === null}
           >
             {enqueueSyncJob.isPending ? 'Enqueuing…' : 'Trigger'}
           </Button>

--- a/docs/plans/implementation-plan-369-stable-sync-job-idempotency-key.md
+++ b/docs/plans/implementation-plan-369-stable-sync-job-idempotency-key.md
@@ -120,7 +120,7 @@ Acceptance: diff touches only three regions of the file; no other behaviour chan
 
 ### Step 2 — `TriggerSyncDialog.test.tsx` test additions
 
-Add two new `it()` blocks under the existing `describe` that covers submission:
+Three new `it()` blocks in a new `describe('idempotency key (#369)')` block, plus one update to the existing key-format assertion (the pre-existing test at the "submission" describe asserts the suffix matches `\d+` — the regex must be updated to the UUID shape, or it would silently keep matching a narrow subset of UUIDs that happen to start with digits).
 
 **Test A — "reuses the same idempotency key when resubmitting after a failed enqueue"**
 
@@ -176,7 +176,11 @@ it('mints a fresh idempotency key on each dialog open cycle', async () => {
 });
 ```
 
-Acceptance: both tests pass with the patched component; at least one fails against the unpatched component (the pre-fix `Date.now()` would let both keys differ even within one open cycle, breaking Test A).
+**Test C — "yields a distinct full key when switching job types within the same open cycle"**
+
+Asserts that switching job types within one open cycle produces a different full key (because the `jobType` segment changes) while the UUID suffix stays stable. This closes the loop on the "option 2 vs option 3" scoping decision from §5.1 — proving that scoping to (dialog open) is sufficient without also re-minting on jobType change.
+
+Acceptance: all three tests pass with the patched component; Test A fails against the unpatched component (the pre-fix `Date.now()` would let both keys differ even within one open cycle).
 
 ### Step 3 — Quality gate
 

--- a/docs/plans/implementation-plan-369-stable-sync-job-idempotency-key.md
+++ b/docs/plans/implementation-plan-369-stable-sync-job-idempotency-key.md
@@ -1,0 +1,210 @@
+# Implementation plan — #369 Stable idempotency key for manual sync job triggers
+
+## 1. Goal
+
+The `TriggerSyncDialog` client-generates its idempotency key by embedding `Date.now()` into the suffix. Because `Date.now()` changes on every call, the backend dedup infrastructure (Redis `SET NX` on `idempotencyKey`, Postgres unique index on `sync_jobs.idempotency_key`) cannot ever collapse rapid double-submits into a single `sync_jobs` row. A fast double-click or a retry-after-failure currently produces N distinct keys → N distinct jobs.
+
+Fix: generate **one stable idempotency key per dialog open cycle** and reuse it across every submit attempt inside that cycle (including retries after a failed enqueue). A fresh key is minted each time the dialog is reopened, so genuinely distinct user intents remain distinct.
+
+## 2. Classification
+
+- **Type**: Frontend (bug fix)
+- **Layer**: `features/sync-jobs` — feature component + colocated test
+- **Surface area**: 1 component file + 1 test file
+- **Scope size**: tiny. Roughly 10 lines changed + 2 new tests.
+
+## 3. Non-goals
+
+- **No backend changes.** `sync.controller.ts`, `redis-streams-job-enqueue.service.ts`, `sync-job.repository.ts` all work correctly when given a stable key; the broken contract is entirely on the client.
+- **No server-side enforcement** of "only server may generate idempotency keys." The issue mentions this as a possible future second-line defence; it's out of scope for this PR.
+- **No changes to the `isPending` disable guard** on the Trigger button. That guard is correct — the bug is the timing window where the state flip isn't instantaneous. The stable key fixes that window directly at the key layer.
+- **No changes to `useEnqueueSyncJobMutation`** — the hook is fine; the bug is at the call site.
+- **No changes to the idempotency key format beyond the suffix.** Still `manual:{connectionId}:{jobType}:{stable-suffix}` per the issue's explicit readability request.
+
+## 4. Files in scope
+
+| File | Change |
+|---|---|
+| `apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx` | Add `intentKey` state, mint via `crypto.randomUUID()` in the existing `useEffect(open)`, use it in `handleSubmit` instead of `Date.now()`. |
+| `apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx` | Add two tests: (a) retry-after-failure reuses the key; (b) reopening the dialog mints a fresh key. |
+
+## 5. Design
+
+### 5.1 Why "per dialog open cycle" is the right scoping unit
+
+Three candidate scopings for "one intent":
+
+1. **Per mutateAsync call** — current, broken. Defeats dedup.
+2. **Per dialog open cycle** — mint on open, reset on close. What I'm proposing.
+3. **Per (dialog open + job type) tuple** — mint on open, re-mint when user switches job type.
+
+Option 3 is slightly more conservative: if the user opens the dialog, picks job A, submits (succeeds), then picks job B and submits, you want those to be distinct jobs. But in practice, option 2 already handles that correctly because the idempotency key is `manual:{connId}:{jobType}:{uuid}` — the `jobType` segment changes when the user switches, so the full key changes even with a stable UUID. So option 2 is sufficient and simpler.
+
+Option 2 collapses:
+- Rapid double-click on the Trigger button → same key, one job
+- Retry after network failure → same key, backend returns existing job
+- Keyboard enter-mashing → same key, one job
+
+Option 2 keeps distinct:
+- Submit job A → close dialog → reopen → submit job A again → new UUID, new key, new job
+- Submit job A → switch to B → submit → different `jobType` segment, different key, new job
+
+### 5.2 Mint timing
+
+The component already has a `useEffect(() => { if (open) { ... } }, [open])` that resets `selectedJobType`, `payloadValues`, `fieldErrors`, and the mutation state on open. The `intentKey` belongs in that same effect — it's part of the "fresh dialog session" initialization.
+
+```tsx
+const [intentKey, setIntentKey] = useState<string | null>(null);
+
+useEffect(() => {
+  if (open) {
+    // ... existing resets
+    setIntentKey(crypto.randomUUID());
+  }
+}, [open]);
+```
+
+Setting to `null` on close is unnecessary — the next open always overwrites, and reading `intentKey` only happens inside `handleSubmit` which is only reachable when the dialog is open.
+
+### 5.3 Consumption
+
+```tsx
+// handleSubmit
+if (!selectedJob || !validate() || intentKey === null) return;
+// ...
+await enqueueSyncJob.mutateAsync({
+  connectionId: connection.id,
+  jobType: selectedJob.jobType,
+  payload,
+  idempotencyKey: `manual:${connection.id}:${selectedJob.jobType}:${intentKey}`,
+});
+```
+
+The `intentKey === null` guard is defensive — it should never hold when the dialog is visible, since the effect runs synchronously when `open` flips to `true`. But the type is `string | null`, and narrowing at the use site keeps TypeScript happy without a non-null assertion.
+
+### 5.4 `crypto.randomUUID()` availability
+
+- Browsers: shipped in all evergreen browsers since 2022.
+- `happy-dom` (the vitest environment for `apps/web`, see `apps/web/vite.config.ts`): `crypto.randomUUID()` is supported since happy-dom v6; the repo is on v19 at time of writing. Safe.
+- No polyfill needed.
+
+### 5.5 Key format preserved
+
+Issue explicitly asked for readability: `manual:{connId}:{jobType}:{stable-suffix}`. The new format matches: only the suffix changes from a mutable epoch millisecond to a stable UUID. Job-log readers still see `manual:ol_connection_...:master.product.syncAll:f47ac10b-...`.
+
+## 6. Step-by-step implementation
+
+### Step 1 — `TriggerSyncDialog.tsx` component change
+
+1. Add `intentKey` state after the existing `fieldErrors` state (line ~158):
+
+   ```tsx
+   const [intentKey, setIntentKey] = useState<string | null>(null);
+   ```
+
+2. Extend the existing `useEffect(() => { if (open) { ... } }, [open])` (line ~164) to also mint the key:
+
+   ```tsx
+   setIntentKey(crypto.randomUUID());
+   ```
+
+3. In `handleSubmit` (line ~196), add `intentKey === null` to the early-return guard, and replace the inline `Date.now()` with `intentKey`:
+
+   ```tsx
+   if (!selectedJob || !validate() || intentKey === null) return;
+   // ...
+   idempotencyKey: `manual:${connection.id}:${selectedJob.jobType}:${intentKey}`,
+   ```
+
+Acceptance: diff touches only three regions of the file; no other behaviour changed.
+
+### Step 2 — `TriggerSyncDialog.test.tsx` test additions
+
+Add two new `it()` blocks under the existing `describe` that covers submission:
+
+**Test A — "reuses the same idempotency key when resubmitting after a failed enqueue"**
+
+```tsx
+it('reuses the same idempotency key across retries after a failed submit', async () => {
+  const enqueue = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('enqueue failed'))
+    .mockResolvedValueOnce({ jobId: 'job-123', isExisting: false });
+  const apiClient = createMockApiClient({ syncJobs: { enqueue } });
+
+  renderWithProviders(<TriggerSyncDialog {...baseProps} />, { apiClient });
+
+  // First click → fails
+  await userEvent.click(screen.getByRole('button', { name: /trigger/i }));
+  await screen.findByText(/failed to enqueue job/i);
+
+  // Second click (user retries) → succeeds
+  await userEvent.click(screen.getByRole('button', { name: /trigger/i }));
+
+  expect(enqueue).toHaveBeenCalledTimes(2);
+  const firstKey = enqueue.mock.calls[0][0].idempotencyKey;
+  const secondKey = enqueue.mock.calls[1][0].idempotencyKey;
+  expect(firstKey).toBe(secondKey); // stable across retries within the same dialog open cycle
+  expect(firstKey).toMatch(/^manual:[^:]+:[^:]+:[0-9a-f]{8}-[0-9a-f]{4}/); // format guard
+});
+```
+
+**Test B — "mints a fresh idempotency key when the dialog is closed and reopened"**
+
+```tsx
+it('mints a fresh idempotency key on each dialog open cycle', async () => {
+  const enqueue = vi.fn().mockResolvedValue({ jobId: 'job-123', isExisting: false });
+  const apiClient = createMockApiClient({ syncJobs: { enqueue } });
+
+  const { rerender } = renderWithProviders(
+    <TriggerSyncDialog {...baseProps} open={true} />,
+    { apiClient },
+  );
+  await userEvent.click(screen.getByRole('button', { name: /trigger/i }));
+
+  // Close
+  rerender(<TriggerSyncDialog {...baseProps} open={false} />);
+  // Reopen
+  rerender(<TriggerSyncDialog {...baseProps} open={true} />);
+
+  await userEvent.click(screen.getByRole('button', { name: /trigger/i }));
+
+  expect(enqueue).toHaveBeenCalledTimes(2);
+  const firstKey = enqueue.mock.calls[0][0].idempotencyKey;
+  const secondKey = enqueue.mock.calls[1][0].idempotencyKey;
+  expect(firstKey).not.toBe(secondKey); // distinct intents across dialog sessions
+});
+```
+
+Acceptance: both tests pass with the patched component; at least one fails against the unpatched component (the pre-fix `Date.now()` would let both keys differ even within one open cycle, breaking Test A).
+
+### Step 3 — Quality gate
+
+```bash
+pnpm lint        # zero errors
+pnpm type-check  # zero errors
+pnpm test        # all tests pass
+```
+
+Pre-commit hook runs the same gate.
+
+## 7. Validation
+
+- **Architecture**: pure FE component change, no new abstractions, state ownership rules unchanged (local component state for `intentKey` is correct per `docs/frontend-architecture.md` — "short-lived interaction state" lives in component-local `useState`).
+- **Naming / conventions**: `intentKey` matches `camelCase`; no new files; no new exports.
+- **No `any`, no `console.log`, no secrets**: change is one `useState<string | null>` and a `crypto.randomUUID()` call.
+- **Accessibility**: no markup change, no a11y impact.
+- **Security**: idempotency keys are not authentication tokens; the random UUID is just a dedup nonce. No risk introduced.
+- **Testing strategy**: two new focused component tests in the existing spec file; mocks use the established `createMockApiClient()` + `renderWithProviders()` pattern per `.claude/rules/fe-pages.md`.
+
+## 8. Risks & open questions
+
+- **Risk — none material.** Worst case if `crypto.randomUUID()` were unavailable (it isn't, but hypothetically): a static fallback like `String(Math.random()).slice(2) + String(Date.now())` would still give a stable per-intent key. Not implementing a fallback because happy-dom v19 and all supported browsers cover it.
+- **Open question — none.** The issue is prescriptive about scope, the fix is single-call-site, and there's no ambiguity about what "one intent" means for this dialog (= one open cycle).
+
+## 9. Acceptance checklist (from the issue)
+
+- [ ] Rapid double-click on the *Trigger* button produces at most one `sync_jobs` row (via backend dedup on the stable key).
+- [ ] Unit/component test covering duplicate-submit prevention (Test A — retry reuses key).
+- [ ] No regression for genuinely distinct triggers (Test B — reopen mints a fresh key).
+- [ ] `pnpm lint`, `pnpm type-check`, `pnpm test` pass.


### PR DESCRIPTION
## Summary

`TriggerSyncDialog` was embedding `Date.now()` in the idempotency-key suffix, so every `mutateAsync` call produced a distinct key. The backend dedup layer (Redis `SET NX` + Postgres unique index on `idempotency_key`) could never collapse a rapid double-click into a single `sync_jobs` row — and a network-failure retry enqueued a second job instead of idempotently returning the first.

Fix: mint one `crypto.randomUUID()` **per dialog open cycle**, store it in component state, and reuse it across every submit inside that cycle (including retries after a failed enqueue). The dialog's existing `useEffect(open)` already handles "fresh session" resets — the intent key goes there alongside the other per-session state.

## Scope

### What changed
- `apps/web/src/features/sync-jobs/components/TriggerSyncDialog.tsx`
  - New `intentKey: string | null` component state
  - Minted in the existing `useEffect(open)` alongside the other per-session resets
  - Consumed in `handleSubmit` — replacing `Date.now()` in the idempotency-key suffix
  - Trigger button `disabled` tightened to include `|| intentKey === null` so the narrow "render-before-effect" window can't silently no-op
- `apps/web/src/features/sync-jobs/components/TriggerSyncDialog.test.tsx`
  - Updated the existing key-format assertion from `\d+$` to a UUID regex (it would have broken silently otherwise)
  - **Test A** — retry after a failed enqueue reuses the same key
  - **Test B** — closing and reopening the dialog mints a fresh key
  - **Test C** — switching job types within one open cycle yields a distinct full key while the UUID suffix stays stable (closes the "option 2 vs option 3" scoping decision — `jobType` is already a separate segment in the key, so scoping to dialog-open is sufficient)

### What didn't change
- **Key format is preserved** per the issue's explicit readability request: `manual:{connId}:{jobType}:{suffix}`. Only the suffix semantics change.
- Backend — dedup at `sync-job.repository.ts` + `redis-streams-job-enqueue.service.ts` already works correctly when given a stable key. No backend changes.
- `useEnqueueSyncJobMutation` — hook is fine; the bug was at the call site.
- The mutation's `isPending` disable on the Trigger button — correct, just insufficient on its own. The stable key + the `intentKey === null` guard close the remaining timing windows.

## Why "one intent = one dialog open cycle"

Scoping alternatives considered:

1. **Per `mutateAsync` call** — the broken status quo.
2. **Per dialog open cycle** — what this PR implements.
3. **Per (dialog open + jobType) tuple** — re-mint on jobType change too.

Option 2 is simpler and equivalent in effect: `jobType` is already a segment in the key, so switching job types produces a distinct full key even with a stable UUID. Test C asserts this explicitly.

## Test plan

- [x] `pnpm lint` — 0 errors (warnings pre-existing)
- [x] `pnpm type-check` — clean
- [x] `pnpm --filter @openlinker/web test` — 618/618 pass locally (up from 615 — the 3 new tests)
- [x] Pre-commit hook (lint + type-check + apps/web vitest) — passed on both commits
- [ ] Reviewer spot-check: rapid double-click on the Trigger button in the Connections UI produces exactly one `sync_jobs` row (observable in Jobs & Logs)
- [ ] Reviewer spot-check: after a transient network error during Trigger, clicking Trigger again returns the existing job via backend dedup (inspect with `docker exec` or the API logs)

## Out of scope (intentional) — flagged for follow-up

- **Toast copy on `result.isExisting === true`**: the success toast says "Sync job enqueued" regardless of whether the backend dedup'd. After this fix, `isExisting: true` becomes a more likely outcome (any retry collapses to it) rather than a rare race. A small copy refinement ("Sync job already running" when `isExisting`) would make the dedup visible to the operator. Pre-existing UX quirk; not touched here.
- **Mid-session payload edit vs stable key**: a user who submits with job A, hits a transient failure, edits a payload field (e.g., `limit` 100 → 50), and resubmits will reuse the same key. If the first submit succeeded on the backend but failed to deliver the response, the retry gets the original job back and the new payload values are ignored. The workaround today is "close + reopen the dialog to reset." A future refinement could re-mint on payload-field change; acceptable to defer until a real operator report.

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)