### PR TITLE
feat(web): promote AI to a top-level nav section (#377)

### DIFF
--- a/apps/web/src/app/app-shell.test.tsx
+++ b/apps/web/src/app/app-shell.test.tsx
@@ -27,14 +27,16 @@ import {
 interface RenderShellOptions {
   apiClient?: ApiClient;
   pathname?: string;
+  sessionAdapter?: ReturnType<typeof createAuthenticatedSessionAdapter>;
 }
 
 function renderShell({
   apiClient = createMockApiClient(),
   pathname = '/',
+  sessionAdapter,
 }: RenderShellOptions = {}): ReturnType<typeof render> {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const adapter = createAuthenticatedSessionAdapter();
+  const adapter = sessionAdapter ?? createAuthenticatedSessionAdapter();
 
   return render(
     <ThemeProvider>
@@ -84,6 +86,33 @@ describe('AppShell', () => {
     expect(automations).toHaveAttribute('aria-disabled', 'true');
     expect(automations).toHaveAttribute('tabindex', '-1');
     expect(automations).toHaveAttribute('title', 'Coming in a future release');
+  });
+
+  it('renders the AI group with a Prompt templates link for admin sessions (#377)', async () => {
+    renderShell({ pathname: '/' });
+    const primary = screen.getByRole('navigation', { name: 'Primary' });
+    // AI group renders only once the session resolves to admin, so use `find`.
+    const promptTemplates = await within(primary).findByText('Prompt templates');
+    expect(within(primary).getByText('AI')).toBeInTheDocument();
+    expect(promptTemplates.closest('a')).toHaveAttribute('href', '/ai/prompt-templates');
+  });
+
+  it('hides the AI nav group from non-admin sessions (#377)', async () => {
+    const viewerAdapter = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: 'viewer@example.com',
+      role: 'viewer',
+      permissions: [],
+    });
+    renderShell({ pathname: '/', sessionAdapter: viewerAdapter });
+    // Wait for the user chip to surface the viewer username — a reliable
+    // signal the session has resolved. Only then is the absence assertion
+    // meaningful.
+    await screen.findByRole('button', { name: /Account menu for viewer/i });
+    const primary = screen.getByRole('navigation', { name: 'Primary' });
+    expect(within(primary).queryByText('AI')).toBeNull();
+    expect(within(primary).queryByText('Prompt templates')).toBeNull();
   });
 
   it('uses "Connections" as the nav label (not "Integrations")', () => {

--- a/apps/web/src/app/app-shell.test.tsx
+++ b/apps/web/src/app/app-shell.test.tsx
@@ -15,6 +15,7 @@ import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './app-shell';
 import { SessionProvider } from '../shared/auth/session-provider';
+import type { SessionAdapter } from '../shared/auth/session-adapter';
 import { ToastProvider } from '../shared/ui/toast-provider';
 import { ApiClientProvider } from './api/api-client-provider';
 import type { ApiClient } from './api/api-client';
@@ -27,7 +28,7 @@ import {
 interface RenderShellOptions {
   apiClient?: ApiClient;
   pathname?: string;
-  sessionAdapter?: ReturnType<typeof createAuthenticatedSessionAdapter>;
+  sessionAdapter?: SessionAdapter;
 }
 
 function renderShell({
@@ -106,10 +107,11 @@ describe('AppShell', () => {
       permissions: [],
     });
     renderShell({ pathname: '/', sessionAdapter: viewerAdapter });
-    // Wait for the user chip to surface the viewer username — a reliable
-    // signal the session has resolved. Only then is the absence assertion
+    // Wait for the viewer username to land in the DOM — a reliable signal
+    // that the session has resolved, without depending on a specific
+    // component's aria-label wording. Only then is the absence assertion
     // meaningful.
-    await screen.findByRole('button', { name: /Account menu for viewer/i });
+    await screen.findAllByText('viewer');
     const primary = screen.getByRole('navigation', { name: 'Primary' });
     expect(within(primary).queryByText('AI')).toBeNull();
     expect(within(primary).queryByText('Prompt templates')).toBeNull();

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -15,6 +15,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   type PropsWithChildren,
   type ReactElement,
@@ -63,38 +64,58 @@ interface PlannedNavGroup {
 
 type NavGroup = LiveNavGroup | PlannedNavGroup;
 
-const navGroups: NavGroup[] = [
-  {
-    kind: 'live',
-    label: 'Operations',
-    items: [
-      { to: '/', label: 'Dashboard', end: true },
-      { to: '/orders', label: 'Orders', countKey: 'orders' },
-      { to: '/products', label: 'Products' },
-      { to: '/inventory', label: 'Inventory', countKey: 'inventory' },
-      { to: '/customers', label: 'Customers', countKey: 'customers' },
-      { to: '/listings', label: 'Listings', countKey: 'listings' },
-    ],
-  },
-  {
-    kind: 'live',
-    label: 'Diagnostics',
-    items: [
-      { to: '/jobs-logs', label: 'Jobs & Logs', countKey: 'jobsFailed' },
-      { to: '/webhook-deliveries', label: 'Webhooks', countKey: 'webhooksFailed' },
-      { to: '/cursors', label: 'Cursors' },
-    ],
-  },
-  {
-    kind: 'live',
-    label: 'Platform',
-    items: [
-      { to: '/connections', label: 'Connections', countKey: 'connections' },
-      { to: '/adapters', label: 'Adapters' },
-      { to: '/settings', label: 'Settings' },
-    ],
-  },
-  {
+interface NavGroupOptions {
+  isAdmin: boolean;
+}
+
+/**
+ * Build the sidebar nav composition for the current session. Admin-only
+ * groups (AI) are spliced in at build time so non-admin sessions never see
+ * them in the DOM — no client-side permission filtering at render.
+ */
+function buildNavGroups({ isAdmin }: NavGroupOptions): NavGroup[] {
+  const groups: NavGroup[] = [
+    {
+      kind: 'live',
+      label: 'Operations',
+      items: [
+        { to: '/', label: 'Dashboard', end: true },
+        { to: '/orders', label: 'Orders', countKey: 'orders' },
+        { to: '/products', label: 'Products' },
+        { to: '/inventory', label: 'Inventory', countKey: 'inventory' },
+        { to: '/customers', label: 'Customers', countKey: 'customers' },
+        { to: '/listings', label: 'Listings', countKey: 'listings' },
+      ],
+    },
+    {
+      kind: 'live',
+      label: 'Diagnostics',
+      items: [
+        { to: '/jobs-logs', label: 'Jobs & Logs', countKey: 'jobsFailed' },
+        { to: '/webhook-deliveries', label: 'Webhooks', countKey: 'webhooksFailed' },
+        { to: '/cursors', label: 'Cursors' },
+      ],
+    },
+    {
+      kind: 'live',
+      label: 'Platform',
+      items: [
+        { to: '/connections', label: 'Connections', countKey: 'connections' },
+        { to: '/adapters', label: 'Adapters' },
+        { to: '/settings', label: 'Settings' },
+      ],
+    },
+  ];
+
+  if (isAdmin) {
+    groups.push({
+      kind: 'live',
+      label: 'AI',
+      items: [{ to: '/ai/prompt-templates', label: 'Prompt templates' }],
+    });
+  }
+
+  groups.push({
     kind: 'planned',
     label: 'Planned',
     items: [
@@ -102,8 +123,10 @@ const navGroups: NavGroup[] = [
       { label: 'Shipping', reason: 'Coming in a future release' },
       { label: 'Invoices', reason: 'Coming in a future release' },
     ],
-  },
-];
+  });
+
+  return groups;
+}
 
 const staticCrumbs: Record<string, { group: string; title: string }> = {
   '/': { group: 'Operations', title: 'Dashboard' },
@@ -123,7 +146,7 @@ const staticCrumbs: Record<string, { group: string; title: string }> = {
   '/connections/new/advanced': { group: 'Platform', title: 'Advanced setup' },
   '/adapters': { group: 'Platform', title: 'Adapters' },
   '/settings': { group: 'Platform', title: 'Settings' },
-  '/settings/prompt-templates': { group: 'Platform', title: 'Prompt templates' },
+  '/ai/prompt-templates': { group: 'AI', title: 'Prompt templates' },
 };
 
 function resolveCrumbs(pathname: string): { group: string; title: string } {
@@ -137,6 +160,7 @@ function resolveCrumbs(pathname: string): { group: string; title: string } {
   if (pathname.startsWith('/listings/')) return { group: 'Operations', title: 'Listing' };
   if (pathname.startsWith('/jobs-logs/')) return { group: 'Diagnostics', title: 'Job' };
   if (pathname.startsWith('/connections/')) return { group: 'Platform', title: 'Connection' };
+  if (pathname.startsWith('/ai/prompt-templates/')) return { group: 'AI', title: 'Prompt template' };
 
   return { group: 'OpenLinker', title: '' };
 }
@@ -151,13 +175,14 @@ function formatCount(value: number | null): string | null {
 interface SidebarNavProps {
   ariaLabel: string;
   counts: NavCounts;
+  groups: NavGroup[];
   onNavigate?: () => void;
 }
 
-function SidebarNav({ ariaLabel, counts, onNavigate }: SidebarNavProps): ReactElement {
+function SidebarNav({ ariaLabel, counts, groups, onNavigate }: SidebarNavProps): ReactElement {
   return (
     <nav className="shell-nav" aria-label={ariaLabel}>
-      {navGroups.map((group) => (
+      {groups.map((group) => (
         <section key={group.label} className="shell-nav__group">
           <p className="shell-nav__label">{group.label}</p>
           <ul className="shell-nav__list">
@@ -304,13 +329,16 @@ function UserChip({ email, onLogout, username }: UserChipProps): ReactElement {
 }
 
 export function AppShell({ children }: PropsWithChildren): ReactElement {
-  const { session, clearSession } = useSession();
+  const { isReady, session, clearSession } = useSession();
   const { showToast } = useToast();
   const location = useLocation();
   const drawerRef = useRef<HTMLDialogElement>(null);
   const username = session.user?.username;
   const email = session.user?.email ?? null;
   const counts = useNavCounts();
+  const isAdmin =
+    isReady && session.status === 'authenticated' && session.user?.role === 'admin';
+  const groups = useMemo(() => buildNavGroups({ isAdmin }), [isAdmin]);
 
   const closeDrawer = useCallback((): void => {
     drawerRef.current?.close();
@@ -337,7 +365,7 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
     <div className="shell">
       <div className="shell-sidebar">
         <SidebarBrand />
-        <SidebarNav ariaLabel="Primary" counts={counts} />
+        <SidebarNav ariaLabel="Primary" counts={counts} groups={groups} />
         <WorkspaceFooter
           username={username}
           onLogout={username ? handleLogout : undefined}
@@ -357,7 +385,12 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
               ✕
             </Button>
           </div>
-          <SidebarNav ariaLabel="Primary (mobile)" counts={counts} onNavigate={closeDrawer} />
+          <SidebarNav
+            ariaLabel="Primary (mobile)"
+            counts={counts}
+            groups={groups}
+            onNavigate={closeDrawer}
+          />
           <WorkspaceFooter
             username={username}
             onLogout={username ? handleLogout : undefined}

--- a/apps/web/src/app/app.test.tsx
+++ b/apps/web/src/app/app.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
@@ -8,15 +8,22 @@ import { rootRoute } from './routes/root.route';
 import { SessionProvider } from '../shared/auth/session-provider';
 import { ToastProvider } from '../shared/ui/toast-provider';
 
-function renderApp(initialEntries: string[]): ReturnType<typeof render> {
+interface RenderAppResult {
+  router: ReturnType<typeof createMemoryRouter>;
+  view: ReturnType<typeof render>;
+}
+
+function renderApp(
+  initialEntries: string[],
+  sessionAdapter = createAuthenticatedSessionAdapter(),
+): RenderAppResult {
   const router = createMemoryRouter([rootRoute], { initialEntries });
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  const sessionAdapter = createAuthenticatedSessionAdapter();
   const apiClient = createMockApiClient();
 
-  return render(
+  const view = render(
     <SessionProvider adapter={sessionAdapter}>
       <ToastProvider>
         <ApiClientProvider client={apiClient}>
@@ -27,11 +34,13 @@ function renderApp(initialEntries: string[]): ReturnType<typeof render> {
       </ToastProvider>
     </SessionProvider>,
   );
+
+  return { router, view };
 }
 
 describe('App', () => {
   it('renders the authenticated shell for live routes', async () => {
-    const view = renderApp(['/']);
+    const { view } = renderApp(['/']);
 
     expect(
       await screen.findByRole('heading', { name: 'Operations overview' }, { timeout: 10000 }),
@@ -47,7 +56,7 @@ describe('App', () => {
   });
 
   it('renders orders list page from the primary navigation', async () => {
-    const view = renderApp(['/orders']);
+    const { view } = renderApp(['/orders']);
 
     expect(await screen.findByRole('heading', { name: 'Orders' })).toBeInTheDocument();
     const primaryNavigation = within(view.container).getByRole('navigation', {
@@ -57,5 +66,23 @@ describe('App', () => {
       'href',
       '/orders',
     );
+  });
+
+  it('redirects legacy /settings/prompt-templates to /ai/prompt-templates (#377)', async () => {
+    const { router } = renderApp(['/settings/prompt-templates']);
+
+    // `<Navigate replace>` fires on first render; wait for the router's
+    // location to reflect the target path.
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/ai/prompt-templates');
+    });
+  });
+
+  it('redirects legacy /settings/prompt-templates/:id to /ai/prompt-templates/:id (#377)', async () => {
+    const { router } = renderApp(['/settings/prompt-templates/tmpl-42']);
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/ai/prompt-templates/tmpl-42');
+    });
   });
 });

--- a/apps/web/src/app/routes/prompt-template-detail.route.tsx
+++ b/apps/web/src/app/routes/prompt-template-detail.route.tsx
@@ -2,6 +2,6 @@ import type { RouteObject } from 'react-router-dom';
 import { PromptTemplateDetailPage } from '../../pages/prompt-templates/prompt-template-detail-page';
 
 export const promptTemplateDetailRoute: RouteObject = {
-  path: 'settings/prompt-templates/:id',
+  path: 'ai/prompt-templates/:id',
   element: <PromptTemplateDetailPage />,
 };

--- a/apps/web/src/app/routes/prompt-templates-legacy-redirects.route.tsx
+++ b/apps/web/src/app/routes/prompt-templates-legacy-redirects.route.tsx
@@ -1,0 +1,32 @@
+/**
+ * Prompt Templates — Legacy Path Redirects
+ *
+ * Prompt templates moved from Settings to a dedicated AI section (#377).
+ * Old URLs stay reachable via these `<Navigate replace>` shims so bookmarks
+ * and shared links resolve. Both redirects sit inside `AuthenticatedAppLayout`
+ * and therefore inherit the auth gate — anonymous users bounce to `/login`
+ * instead of hitting a dead redirect.
+ *
+ * Retire window: TBD. See follow-ups in #377 — this file is a single-file
+ * delete once the deprecation period ends.
+ *
+ * @module app/routes
+ */
+import type { ReactElement } from 'react';
+import { Navigate, useParams, type RouteObject } from 'react-router-dom';
+
+export const promptTemplatesLegacyListRedirectRoute: RouteObject = {
+  path: 'settings/prompt-templates',
+  element: <Navigate to="/ai/prompt-templates" replace />,
+};
+
+function PromptTemplateLegacyDetailRedirect(): ReactElement {
+  const { id } = useParams<{ id: string }>();
+  if (!id) return <Navigate to="/ai/prompt-templates" replace />;
+  return <Navigate to={`/ai/prompt-templates/${id}`} replace />;
+}
+
+export const promptTemplateLegacyDetailRedirectRoute: RouteObject = {
+  path: 'settings/prompt-templates/:id',
+  element: <PromptTemplateLegacyDetailRedirect />,
+};

--- a/apps/web/src/app/routes/prompt-templates-list.route.tsx
+++ b/apps/web/src/app/routes/prompt-templates-list.route.tsx
@@ -2,6 +2,6 @@ import type { RouteObject } from 'react-router-dom';
 import { PromptTemplatesListPage } from '../../pages/prompt-templates/prompt-templates-list-page';
 
 export const promptTemplatesListRoute: RouteObject = {
-  path: 'settings/prompt-templates',
+  path: 'ai/prompt-templates',
   element: <PromptTemplatesListPage />,
 };

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -21,6 +21,10 @@ import { ordersRoute } from './orders.route';
 import { productsRoute } from './products.route';
 import { promptTemplateDetailRoute } from './prompt-template-detail.route';
 import { promptTemplatesListRoute } from './prompt-templates-list.route';
+import {
+  promptTemplateLegacyDetailRedirectRoute,
+  promptTemplatesLegacyListRedirectRoute,
+} from './prompt-templates-legacy-redirects.route';
 import { settingsRoute } from './settings.route';
 import { webhookDeliveriesRoute } from './webhook-deliveries.route';
 
@@ -51,5 +55,7 @@ export const rootRoute: RouteObject = {
     settingsRoute,
     promptTemplatesListRoute,
     promptTemplateDetailRoute,
+    promptTemplatesLegacyListRedirectRoute,
+    promptTemplateLegacyDetailRedirectRoute,
   ],
 };

--- a/apps/web/src/pages/prompt-templates/prompt-template-detail-page.test.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-template-detail-page.test.tsx
@@ -56,11 +56,11 @@ function renderPage(
   const apiClient = createMockApiClient(apiOverrides);
   return renderWithProviders(
     <Routes>
-      <Route path="/settings/prompt-templates/:id" element={<PromptTemplateDetailPage />} />
+      <Route path="/ai/prompt-templates/:id" element={<PromptTemplateDetailPage />} />
     </Routes>,
     {
       apiClient,
-      route: '/settings/prompt-templates/tmpl-1',
+      route: '/ai/prompt-templates/tmpl-1',
       sessionAdapter,
     },
   );

--- a/apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx
@@ -126,7 +126,7 @@ export function PromptTemplateDetailPage(): ReactElement {
     try {
       await deleteMutation.mutateAsync(template.id);
       showToast({ tone: 'success', description: 'Draft discarded' });
-      void navigate('/settings/prompt-templates');
+      void navigate('/ai/prompt-templates');
     } catch {
       /* surfaced via deleteMutation.error */
     }
@@ -143,7 +143,7 @@ export function PromptTemplateDetailPage(): ReactElement {
         variables: template.variables,
       });
       showToast({ tone: 'success', description: `Draft v${draft.version} created` });
-      void navigate(`/settings/prompt-templates/${draft.id}`);
+      void navigate(`/ai/prompt-templates/${draft.id}`);
     } catch {
       /* surfaced via createMutation.error */
     }
@@ -162,7 +162,7 @@ export function PromptTemplateDetailPage(): ReactElement {
           tone: 'success',
           description: `Draft v${draft.version} created from v${version}`,
         });
-        void navigate(`/settings/prompt-templates/${draft.id}`);
+        void navigate(`/ai/prompt-templates/${draft.id}`);
       } catch {
         /* surfaced via revertMutation.error */
       }
@@ -380,7 +380,7 @@ export function PromptTemplateDetailPage(): ReactElement {
               currentId={template.id}
               isLoading={versionsQuery.isLoading}
               onOpen={(version) => {
-                void navigate(`/settings/prompt-templates/${version.id}`);
+                void navigate(`/ai/prompt-templates/${version.id}`);
               }}
               onRevert={(version) => void handleRevertTo(version.version)}
               revertPending={revertMutation.isPending}

--- a/apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx
@@ -200,7 +200,7 @@ export function PromptTemplatesListPage(): ReactElement {
           rows={rows}
           columns={columns}
           rowKey={(row) => row.latestId}
-          rowHref={(row) => `/settings/prompt-templates/${row.latestId}`}
+          rowHref={(row) => `/ai/prompt-templates/${row.latestId}`}
           cardView={CARD_VIEW}
         />
       )}

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -1,13 +1,10 @@
 import type { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
 import { env } from '../../shared/config/env';
 import { useSession } from '../../shared/auth/use-session';
 import { PageLayout } from '../../shared/ui/page-layout';
 
 export function SettingsPage(): ReactElement {
   const { isReady, session } = useSession();
-  const isAdmin =
-    isReady && session.status === 'authenticated' && session.user?.role === 'admin';
 
   return (
     <PageLayout
@@ -124,24 +121,6 @@ export function SettingsPage(): ReactElement {
           </p>
         </article>
 
-        {/* ── Prompt templates (admin-only) ───────────────────────────── */}
-        {isAdmin ? (
-          <article className="panel panel--dense">
-            <div className="panel__header">
-              <div>
-                <p className="eyebrow">AI</p>
-                <h3 className="section-title">Prompt templates</h3>
-              </div>
-              <span className="panel__meta">Admin</span>
-            </div>
-            <p className="panel-copy">
-              Author and version the prompts used to suggest product copy. Changes take effect on the next suggestion request.
-            </p>
-            <Link className="button button--secondary" to="/settings/prompt-templates">
-              Open
-            </Link>
-          </article>
-        ) : null}
       </div>
     </PageLayout>
   );

--- a/docs/plans/implementation-plan-377-ai-nav-section.md
+++ b/docs/plans/implementation-plan-377-ai-nav-section.md
@@ -1,0 +1,211 @@
+# Implementation Plan — #377 Promote AI to a Top-Level Nav Section
+
+## 1. Understand the task
+
+**Goal.** Move the prompt-templates surfaces out of Settings and into a new admin-gated `AI` top-level nav group. Routes move from `/settings/prompt-templates[/:id]` to `/ai/prompt-templates[/:id]`, with redirects so bookmarked URLs keep working. Zero backend changes; zero new primitives.
+
+**Layer.** Frontend (`apps/web`) — route wiring, shell nav composition, one page cleanup.
+
+**Non-goals (explicit).**
+- No backend changes. `PromptTemplatesController` at `/api/prompt-templates` is untouched; the core `@openlinker/core/ai` module is untouched.
+- No new AI features (telemetry, provider config, suggestion history). Those belong to a separate roadmap issue the PR description will flag.
+- No `/ai` landing page. If `/ai` ever needs content beyond the nav entry, that's a follow-up.
+- No cross-page visual restyling or token changes. The style guide is settled; this issue is structural IA only.
+
+## 2. Research the codebase
+
+- **Nav structure.** `apps/web/src/app/app-shell.tsx:66-106` declares a module-level `navGroups` array with `live` and `planned` kinds, rendered by `SidebarNav` (same file, lines 157-203). Each live item can optionally carry a `countKey` fed by `useNavCounts`. `SidebarNav` currently reads the module-level constant directly — adding an admin-gated group means threading `groups` through as a prop, because admin-ness is session-scoped and only known at render time.
+- **Breadcrumbs.** `staticCrumbs` (lines 108-127) maps exact paths → `{ group, title }`; `resolveCrumbs` (129-142) adds prefix-based fallbacks for detail routes like `/orders/:id`.
+- **Route module pattern.** Every route in `apps/web/src/app/routes/*.route.tsx` exports a `RouteObject` and is aggregated into `root.route.tsx`. No route uses `loader`; all use `element`. Redirects are done via `<Navigate to="..." replace />` at the layout level — see `authenticated-app-layout.tsx:29` and `guest-layout.tsx:18`.
+- **Admin gating pattern.** `settings-page.tsx:9-10` already uses `useSession()` + `session.user?.role === 'admin'` to conditionally render the prompt-templates panel. This is the established pattern; reuse it for the nav group.
+- **React Router v7.13.** Named imports from `react-router-dom`; `<Navigate>`, `<Outlet>`, `useParams`, `useNavigate` available.
+- **References to `/settings/prompt-templates` in the tree** (11 hits, grep-verified):
+  - `app-shell.tsx:126` — `staticCrumbs` entry (remove + add new AI entry)
+  - `app/routes/prompt-templates-list.route.tsx:5` — path (rename)
+  - `app/routes/prompt-template-detail.route.tsx:5` — path (rename)
+  - `pages/settings/settings-page.tsx:140` — `<Link>` inside the AI panel (removed with the panel)
+  - `pages/prompt-templates/prompt-template-detail-page.tsx:129,146,165,383` — 4 `navigate()` calls (rewrite to `/ai/...`)
+  - `pages/prompt-templates/prompt-templates-list-page.tsx:203` — `rowHref` callback (rewrite)
+  - `pages/prompt-templates/prompt-template-detail-page.test.tsx:59,63` — Route path + initial pathname (rewrite)
+- **Existing tests to touch.** `settings-page.test.tsx` has zero references to `prompt` (grep-verified) — nothing to remove there. `app-shell.test.tsx` has 14 tests and will gain two new ones (admin sees AI, non-admin does not). The existing test "renders the three live nav groups plus a disabled Planned footer" asserts individual group labels, not group *count*, so adding AI in admin-context won't break it — but I must not over-specify the new admin test as "exactly these 5 groups" either.
+
+## 3. Design the solution
+
+### Nav group placement
+
+**Decision: `AI` as its own live group**, admin-gated, positioned between `Platform` and `Planned`:
+
+```
+Operations   (6 items)
+Diagnostics  (3 items)
+Platform     (3 items: Connections, Adapters, Settings)
+AI           (1 item: Prompt templates)    ← new, admin-only
+Planned      (3 items)
+```
+
+**Why its own group.** The arch doc (`docs/architecture-overview.md` §13) already anticipates AI growth — `AiCompletionPort`, provider selection via `OL_AI_PROVIDER`, per-completion telemetry (`{ requestId, model, latencyMs, inputTokens, outputTokens, cachedInputTokens }`), and publish/revert audit logging. A dedicated group lands the shape before the shape matters. The alternative — nesting prompt templates under Platform — bakes in a rename cost the moment we add a second AI surface.
+
+**Visual-weight concern** (the issue flags this as the one open design question). With only one child, the `AI` group is thinner than its siblings. Mitigations:
+1. The existing `Planned` group renders with 3 items in muted styling — the shell already tolerates variable group density.
+2. Admin-only gating means non-admins don't see the asymmetry at all.
+3. The group header (`p.shell-nav__label`, 10 px / 600 / uppercase tracking in `--text-muted`) is decoupled from item count — a one-item group reads as intentional rather than empty.
+
+If the one-child group reads poorly in QA, the cheap fallback is to demote AI into Platform as a second entry. I'll flag this in the PR description as a reviewable choice.
+
+### Admin gating implementation
+
+Lift `navGroups` from a module constant into a per-render value computed inside `AppShell`, because admin-ness is session-scoped:
+
+```tsx
+// Inside AppShell, before render:
+const isAdmin = session.status === 'authenticated' && session.user?.role === 'admin';
+const groups = useMemo(() => buildNavGroups({ isAdmin }), [isAdmin]);
+```
+
+`buildNavGroups({ isAdmin })` is a pure helper at module scope that returns the array, conditionally splicing the AI group in before `Planned`. `SidebarNav` receives `groups` as a new required prop (replacing the direct module-constant read).
+
+Non-admins never see the AI group at all — not greyed out, not disabled. This matches the issue's "admin-gate the entire group" requirement.
+
+### Redirects
+
+Add two route entries in `root.route.tsx`, keyed at the existing legacy paths, whose `element` uses `<Navigate replace>`. For the `:id` variant, a tiny named component reads `useParams` and forwards to the new path:
+
+```tsx
+// apps/web/src/app/routes/prompt-templates-legacy-redirects.tsx
+export const promptTemplatesLegacyListRedirectRoute: RouteObject = {
+  path: 'settings/prompt-templates',
+  element: <Navigate to="/ai/prompt-templates" replace />,
+};
+
+function PromptTemplateLegacyDetailRedirect(): ReactElement {
+  const { id } = useParams();
+  if (!id) return <Navigate to="/ai/prompt-templates" replace />;
+  return <Navigate to={`/ai/prompt-templates/${id}`} replace />;
+}
+export const promptTemplateLegacyDetailRedirectRoute: RouteObject = {
+  path: 'settings/prompt-templates/:id',
+  element: <PromptTemplateLegacyDetailRedirect />,
+};
+```
+
+Both redirects sit under `AuthenticatedAppLayout`, inheriting the existing auth gate. Anonymous users hitting the old URL get bounced to `/login` (current behavior), not a broken redirect.
+
+File placement: one new file `apps/web/src/app/routes/prompt-templates-legacy-redirects.route.tsx` — the stem `*-legacy-redirects.route.tsx` names its purpose clearly; future removal is a single-file delete.
+
+### Breadcrumbs
+
+In `staticCrumbs` (drop one, add one):
+- remove `'/settings/prompt-templates': { group: 'Platform', title: 'Prompt templates' }`
+- add `'/ai/prompt-templates': { group: 'AI', title: 'Prompt templates' }`
+
+In `resolveCrumbs` prefix branches, add before the final fallback:
+- `if (pathname.startsWith('/ai/prompt-templates/')) return { group: 'AI', title: 'Prompt template' };` (singular for detail view, matching how Orders / Connections detail routes already do it)
+
+### Settings page cleanup
+
+Remove the entire AI panel block (`settings-page.tsx:127-144`) and drop the now-unused `Link` import if no longer referenced. The `isAdmin` computation above it becomes dead — remove it too to avoid eslint `noUnusedLocals` noise.
+
+### Internal navigation inside prompt-template pages
+
+Four `navigate()` calls in `prompt-template-detail-page.tsx` + one `rowHref` in `prompt-templates-list-page.tsx` — simple string swap `'/settings/prompt-templates'` → `'/ai/prompt-templates'`. All five stay inside the same templated URL shape, so the edit is mechanical.
+
+### Data flow (unchanged)
+
+- Query keys, API endpoints, and mutations stay put.
+- `useApiClient()` calls `/api/prompt-templates/*` — unaffected.
+- `PromptTemplateService` in `libs/core/src/ai/` — unaffected.
+
+## 4. Step-by-step implementation plan
+
+### Step 1 — Route path renames
+
+- `apps/web/src/app/routes/prompt-templates-list.route.tsx` → `path: 'ai/prompt-templates'`
+- `apps/web/src/app/routes/prompt-template-detail.route.tsx` → `path: 'ai/prompt-templates/:id'`
+
+**Acceptance:** path strings updated; nothing else changes in these files.
+
+### Step 2 — Legacy redirect routes
+
+- Create `apps/web/src/app/routes/prompt-templates-legacy-redirects.route.tsx` exporting `promptTemplatesLegacyListRedirectRoute` and `promptTemplateLegacyDetailRedirectRoute` as described in §3.
+- Register both in `root.route.tsx` alongside the renamed routes.
+
+**Acceptance:** visiting `/settings/prompt-templates` lands on `/ai/prompt-templates`; visiting `/settings/prompt-templates/tmpl-42` lands on `/ai/prompt-templates/tmpl-42`. Browser back button does not loop (ensured by `replace`).
+
+### Step 3 — AppShell: AI nav group + breadcrumbs
+
+- Extract `buildNavGroups({ isAdmin })` as a module-level pure helper in `app-shell.tsx`.
+- Inside `AppShell`, compute `isAdmin` from `useSession()` and pass `groups` through to both `SidebarNav` calls (sidebar + drawer).
+- `SidebarNav` gains a required `groups: NavGroup[]` prop, replacing the module-constant read.
+- Update `staticCrumbs` and `resolveCrumbs` per §3.
+
+**Acceptance:** admin session sees all 5 groups in order (Operations → Diagnostics → Platform → AI → Planned); non-admin sees 4 (no AI). Breadcrumb on `/ai/prompt-templates` reads `AI / Prompt templates`; on `/ai/prompt-templates/:id` reads `AI / Prompt template`.
+
+### Step 4 — Settings page cleanup
+
+- `apps/web/src/pages/settings/settings-page.tsx`: delete lines 127-144 (the admin-only AI panel), drop the unused `useSession` import and `isAdmin` local (they're used only by the deleted panel per `settings-page.tsx` read).
+
+**Acceptance:** `/settings` no longer renders the Prompt Templates panel for any role. No TS "unused" warnings.
+
+### Step 5 — Internal link updates
+
+- `pages/prompt-templates/prompt-template-detail-page.tsx`: rewrite the 4 `navigate('/settings/prompt-templates...')` → `'/ai/prompt-templates...'`.
+- `pages/prompt-templates/prompt-templates-list-page.tsx`: rewrite `rowHref` → `/ai/prompt-templates/${row.latestId}`.
+
+**Acceptance:** grep for `/settings/prompt-templates` in `apps/web/src` returns only the two legacy redirect route entries.
+
+### Step 6 — Test updates + new tests
+
+- `pages/prompt-templates/prompt-template-detail-page.test.tsx`: flip the `Route path` and the initial `route:` option to `/ai/prompt-templates/:id` and `/ai/prompt-templates/tmpl-1`.
+- `app-shell.test.tsx`: add two tests
+  - `renders the AI nav group for admin sessions` — default `createAuthenticatedSessionAdapter()` in the existing helper already defaults to admin, so an explicit admin assertion + label check is sufficient.
+  - `hides the AI nav group for non-admin sessions` — render with a `viewer` role adapter; assert `queryByText('AI')` within the Primary nav returns `null`.
+- New test file `app/routes/prompt-templates-legacy-redirects.test.tsx` (or a section in `app.test.tsx`) — render with `initialEntries: ['/settings/prompt-templates']`, assert landing on `/ai/prompt-templates`; repeat for the `:id` variant.
+
+**Acceptance:** all three tests pass. Existing prompt-template tests pass with the updated paths.
+
+### Step 7 — Quality gate
+
+```bash
+pnpm --filter @openlinker/web lint
+pnpm --filter @openlinker/web type-check
+pnpm --filter @openlinker/web test
+```
+
+Followed by the workspace-wide gate:
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+## 5. Validate
+
+- **Architecture compliance.** All changes inside `apps/web/src/app` and `apps/web/src/pages` — layer direction preserved (`app` → `pages` → `features` → `shared`). No `features` → `features` imports introduced. No `shared` touched.
+- **Naming.** New file `prompt-templates-legacy-redirects.route.tsx` follows `*.route.tsx` convention. Named export `promptTemplates…RedirectRoute` matches the existing `settingsRoute` / `ordersRoute` shape. Kebab-case stem + PascalCase export per frontend rules.
+- **State ownership.** Session state continues to flow through `SessionProvider`; the new `isAdmin` check is a local derivation, not a new store. URL state for the redirects is handled by React Router, not re-created.
+- **Testing strategy.** Matches the page-rules doc: happy path (admin sees group), edge (non-admin does not see it), redirect (old URLs resolve). No backend work → no integration tests needed.
+- **Security.** Admin gating is **UI-only** — hiding the nav entry does not protect the prompt-templates endpoints; that's the backend's job (`PromptTemplatesController` uses `@Roles('admin')` per the arch doc). A non-admin who types `/ai/prompt-templates` into the URL bar will get a 403 from the API, which the existing page already handles with an inline error state (confirmed in `prompt-template-detail-page.test.tsx` — "blocks viewer sessions with an inline error").
+- **A11y.** Redirects use `replace` so the browser history doesn't trap users in a back-button loop. The AI group header is a `<p class="shell-nav__label">` matching every other group; no new a11y semantics introduced.
+
+## 6. Risks / open questions
+
+- **Visual weight of a one-child AI group.** Flagged in the issue itself and in §3 above. I'll include before/after screenshots of the admin sidebar in the PR description and mark this as a reviewable design choice. If the reviewer prefers Platform-nested, the revert is a 10-line diff in `app-shell.tsx`.
+- **`isAdmin` check consistency.** The settings page currently uses `isReady && session.status === 'authenticated' && session.user?.role === 'admin'`. The shell doesn't currently have `isReady`. For the nav gate I'll use the simpler `session.user?.role === 'admin'` because `useSession()` in the shell is already past the auth gate (`AuthenticatedAppLayout` redirects anonymous users to `/login` before `AppShell` renders). A non-ready session inside `AppShell` would be a bug elsewhere, not a concern here.
+- **Deprecation window for old URLs.** The redirect is indefinite for now; the issue explicitly lists "Decide whether to retire the redirect after a deprecation window" as a follow-up, not part of this PR. Fine as-is.
+
+## Files expected to change
+
+| File | Change |
+|---|---|
+| `apps/web/src/app/routes/prompt-templates-list.route.tsx` | path string |
+| `apps/web/src/app/routes/prompt-template-detail.route.tsx` | path string |
+| `apps/web/src/app/routes/prompt-templates-legacy-redirects.route.tsx` | **new** — 2 `RouteObject` exports |
+| `apps/web/src/app/routes/root.route.tsx` | register 2 redirect routes |
+| `apps/web/src/app/app-shell.tsx` | `buildNavGroups({ isAdmin })` helper, `SidebarNav` takes `groups` prop, breadcrumbs updated |
+| `apps/web/src/app/app-shell.test.tsx` | +2 tests (admin visibility, non-admin absence) |
+| `apps/web/src/pages/settings/settings-page.tsx` | drop AI panel + unused `useSession` / `isAdmin` / `Link` if now unused |
+| `apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx` | 4 `navigate()` path rewrites |
+| `apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx` | `rowHref` path rewrite |
+| `apps/web/src/pages/prompt-templates/prompt-template-detail-page.test.tsx` | Route path + initial `route:` rewrite |
+| `apps/web/src/app/routes/prompt-templates-legacy-redirects.test.tsx` | **new** — redirect smoke tests |


### PR DESCRIPTION
## Summary

- Move prompt templates out of Settings into a dedicated admin-gated **AI** nav group; routes move from `/settings/prompt-templates[/:id]` to `/ai/prompt-templates[/:id]`, with permanent `<Navigate replace>` redirects from the old URLs so bookmarked links keep resolving.
- `AppShell` gains a `buildNavGroups({ isAdmin })` helper that splices the AI group in before `Planned` for admin sessions — non-admins never see the group in the DOM. The admin check matches the settings-page pattern (`isReady && authenticated && role === 'admin'`) to avoid a flash during session hydration.
- Settings page drops its AI panel and the now-unused `isAdmin` / `Link` imports. All internal `navigate()` callsites and the list-page `rowHref` rewired to `/ai/prompt-templates`.
- Architecture doc (§13) already treats AI as a first-class bounded context with planned surfaces (telemetry, provider config, suggestion history, evals); this change aligns the FE structure with what the backend already looks like (`/api/prompt-templates`, `libs/core/src/ai/`, `apps/api/src/ai/`).

## Design note — single-child AI group

The AI group renders with one child (`Prompt templates`) initially. The visual-weight tradeoff is intentional: group labels are semantic clusters (Operations, Diagnostics, Platform, AI, Planned), not density metrics, and the shell already tolerates variable density (Diagnostics has 3 items, Operations has 6). Admin-only gating means non-admins never see the asymmetry. If reviewers prefer nesting prompt templates inside `Platform` instead, the revert is a small diff in `buildNavGroups`.

## Adjacent to #377 scope

Zero backend changes. Zero new tokens, primitives, or components. Pure FE IA reorganisation.

## Test plan

- [x] `/ai/prompt-templates` renders the list page; `/ai/prompt-templates/:id` renders the detail page (existing tests + path-updated detail-page test)
- [x] `/settings/prompt-templates[/:id]` redirects to the new paths (2 new tests in `app.test.tsx` asserting on `router.state.location.pathname` — robust against transient page render state)
- [x] Admin sees `AI` group with `Prompt templates` linking to `/ai/prompt-templates` (new test in `app-shell.test.tsx`)
- [x] Non-admin (`role: 'viewer'`) sees neither `AI` label nor `Prompt templates` in the primary nav (new test)
- [x] Settings page no longer renders the Prompt Templates panel for any role (existing settings test unchanged — panel was never asserted)
- [x] No production code paths still reference `/settings/prompt-templates` (verified by grep — only the 2 legacy redirect route entries + 4 test assertions that intentionally exercise them remain)
- [x] `pnpm lint`, `pnpm type-check`, `pnpm test` all green (1750 total tests pass across the workspace)

## Security

Admin gating is UI-only. Backend `@Roles('admin')` on `PromptTemplatesController` remains the authoritative guard; a non-admin typing `/ai/prompt-templates` still hits the existing viewer-block error path, which stays covered by the detail page's "blocks viewer sessions with an inline error" test.

## Follow-ups (not this PR)

- Scope the rest of the AI section (telemetry, provider config, suggestion history, evals) as a separate roadmap issue.
- Decide whether to retire the `/settings/prompt-templates` redirect after a deprecation window.

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)