### PR TITLE
feat(web): detail-page polish — rebuild inventory (#381) + enrich order (#382)

### DIFF
--- a/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { parseOrderSnapshot } from './order-snapshot.schema';
 
 describe('parseOrderSnapshot', () => {
-  it('parses a well-formed snapshot into typed view-model data', () => {
+  it('parses a well-formed snapshot with empty warnings', () => {
     const snapshot = {
       id: 'ol_order_abc',
       orderNumber: '1024',
@@ -34,32 +34,136 @@ describe('parseOrderSnapshot', () => {
 
     const parsed = parseOrderSnapshot(snapshot);
 
-    expect(parsed).not.toBeNull();
-    expect(parsed?.orderNumber).toBe('1024');
-    expect(parsed?.items).toHaveLength(1);
-    expect(parsed?.items[0].name).toBe('Widget');
-    expect(parsed?.totals?.total).toBe(44.98);
-    expect(parsed?.shippingAddress?.city).toBe('Warszawa');
+    expect(parsed.orderNumber).toBe('1024');
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0]?.name).toBe('Widget');
+    expect(parsed.totals?.total).toBe(44.98);
+    expect(parsed.shippingAddress?.city).toBe('Warszawa');
+    expect(parsed.parseWarnings).toHaveLength(0);
   });
 
-  it('returns null when the snapshot is missing required fields', () => {
-    const garbage = { orderNumber: 'only-this', somethingElse: true };
-    expect(parseOrderSnapshot(garbage)).toBeNull();
+  it('returns a ParsedOrderSnapshot (never null) even when the top-level `id` is missing', () => {
+    const parsed = parseOrderSnapshot({ orderNumber: '1024' });
+
+    expect(parsed.id).toBeUndefined();
+    expect(parsed.orderNumber).toBe('1024');
+    expect(parsed.items).toEqual([]);
+    expect(parsed.parseWarnings).toHaveLength(0);
   });
 
-  it('defaults items to an empty array when omitted', () => {
-    const snapshot = { id: 'ol_order_abc' };
+  it('defaults items to an empty array when the key is omitted', () => {
+    const parsed = parseOrderSnapshot({ id: 'ol_order_abc' });
+
+    expect(parsed.items).toEqual([]);
+    expect(parsed.parseWarnings).toHaveLength(0);
+  });
+
+  it('keeps valid items and warns about malformed ones, without dropping the rest', () => {
+    const snapshot = {
+      id: 'ol_order_abc',
+      items: [
+        {
+          id: 'ol_orderitem_1',
+          productId: 'ol_product_xyz',
+          quantity: 1,
+          price: 10,
+        },
+        {
+          // missing `id`, `quantity`, `price` — should be rejected
+          sku: 'SKU-bad',
+        },
+        {
+          id: 'ol_orderitem_3',
+          productId: 'ol_product_abc',
+          quantity: 3,
+          price: 4.5,
+          name: 'Third',
+        },
+      ],
+    };
+
     const parsed = parseOrderSnapshot(snapshot);
-    expect(parsed?.items).toEqual([]);
+
+    expect(parsed.items).toHaveLength(2);
+    expect(parsed.items[0]?.id).toBe('ol_orderitem_1');
+    expect(parsed.items[1]?.id).toBe('ol_orderitem_3');
+    expect(parsed.parseWarnings).toHaveLength(1);
+    expect(parsed.parseWarnings[0]?.field).toBe('items[1]');
   });
 
-  it('accepts a minimal snapshot with no optional fields', () => {
-    const snapshot = { id: 'ol_order_abc' };
+  it('tolerates items without productId (loosened for legacy/partial snapshots)', () => {
+    const snapshot = {
+      id: 'ol_order_abc',
+      items: [
+        {
+          id: 'ol_orderitem_1',
+          quantity: 1,
+          price: 10,
+          sku: 'SKU-A',
+          name: 'No-product-id item',
+        },
+      ],
+    };
+
     const parsed = parseOrderSnapshot(snapshot);
 
-    expect(parsed).not.toBeNull();
-    expect(parsed?.orderNumber).toBeUndefined();
-    expect(parsed?.totals).toBeUndefined();
-    expect(parsed?.shippingAddress).toBeUndefined();
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0]?.productId).toBeUndefined();
+    expect(parsed.parseWarnings).toHaveLength(0);
+  });
+
+  it('keeps items when totals are malformed, and warns about totals', () => {
+    const snapshot = {
+      id: 'ol_order_abc',
+      items: [
+        { id: 'ol_orderitem_1', quantity: 1, price: 10 },
+      ],
+      totals: { subtotal: 10 }, // missing tax/shipping/total/currency
+    };
+
+    const parsed = parseOrderSnapshot(snapshot);
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.totals).toBeUndefined();
+    expect(parsed.parseWarnings).toHaveLength(1);
+    expect(parsed.parseWarnings[0]?.field).toBe('totals');
+  });
+
+  it('warns when shippingAddress is present-but-malformed and leaves billing intact', () => {
+    const snapshot = {
+      id: 'ol_order_abc',
+      shippingAddress: { address1: 'ul. Testowa 1' }, // missing city/postalCode/country
+      billingAddress: {
+        address1: 'ul. Billing 2',
+        city: 'Kraków',
+        postalCode: '30-001',
+        country: 'PL',
+      },
+    };
+
+    const parsed = parseOrderSnapshot(snapshot);
+
+    expect(parsed.shippingAddress).toBeUndefined();
+    expect(parsed.billingAddress?.city).toBe('Kraków');
+    expect(parsed.parseWarnings.some((w) => w.field === 'shippingAddress')).toBe(true);
+    expect(parsed.parseWarnings.some((w) => w.field === 'billingAddress')).toBe(false);
+  });
+
+  it('accepts a completely empty snapshot as valid-but-empty', () => {
+    const parsed = parseOrderSnapshot({});
+
+    expect(parsed.id).toBeUndefined();
+    expect(parsed.items).toEqual([]);
+    expect(parsed.totals).toBeUndefined();
+    expect(parsed.shippingAddress).toBeUndefined();
+    expect(parsed.billingAddress).toBeUndefined();
+    expect(parsed.parseWarnings).toHaveLength(0);
+  });
+
+  it('warns when items is present-but-wrong-type', () => {
+    const parsed = parseOrderSnapshot({ id: 'ol_order_abc', items: 'not-an-array' });
+
+    expect(parsed.items).toEqual([]);
+    expect(parsed.parseWarnings.some((w) => w.field === 'items')).toBe(true);
   });
 });

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -1,9 +1,12 @@
 /**
  * Order Snapshot Schema
  *
- * Zod schemas for safely parsing the `orderSnapshot` field of an `OrderRecord`.
- * The snapshot is an opaque `Record<string, unknown>` on the wire; these schemas
- * extract typed view-model data without crashing on partial or legacy payloads.
+ * Zod schemas for extracting typed view-model data from an OrderRecord's
+ * opaque `orderSnapshot` field. Parses each sub-tree (items, totals,
+ * shipping/billing address) independently so that a single malformed
+ * section never blanks the whole detail page. Non-fatal parse failures
+ * are surfaced via `parseWarnings` so the page can show a "why is this
+ * empty?" breadcrumb rather than failing silently.
  *
  * @module apps/web/src/features/orders/api
  */
@@ -24,7 +27,7 @@ const addressSchema = z.object({
 
 const orderItemSchema = z.object({
   id: z.string(),
-  productId: z.string(),
+  productId: z.string().optional(),
   variantId: z.string().optional(),
   quantity: z.number(),
   price: z.number(),
@@ -41,24 +44,118 @@ const orderTotalsSchema = z.object({
   currency: z.string(),
 });
 
-export const orderSnapshotSchema = z.object({
-  id: z.string(),
-  orderNumber: z.string().optional(),
-  status: z.string().optional(),
-  items: z.array(orderItemSchema).optional().default([]),
-  totals: orderTotalsSchema.optional(),
-  shippingAddress: addressSchema.optional(),
-  billingAddress: addressSchema.optional(),
-});
-
-export type ParsedOrderSnapshot = z.infer<typeof orderSnapshotSchema>;
 export type ParsedOrderItem = z.infer<typeof orderItemSchema>;
 export type ParsedAddress = z.infer<typeof addressSchema>;
 export type ParsedOrderTotals = z.infer<typeof orderTotalsSchema>;
 
-export function parseOrderSnapshot(
-  snapshot: Record<string, unknown>,
-): ParsedOrderSnapshot | null {
-  const result = orderSnapshotSchema.safeParse(snapshot);
-  return result.success ? result.data : null;
+export interface ParseWarning {
+  field: string;
+  message: string;
+}
+
+export interface ParsedOrderSnapshot {
+  id?: string;
+  orderNumber?: string;
+  status?: string;
+  items: ParsedOrderItem[];
+  totals?: ParsedOrderTotals;
+  shippingAddress?: ParsedAddress;
+  billingAddress?: ParsedAddress;
+  parseWarnings: ParseWarning[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function firstZodMessage(error: z.ZodError): string {
+  return error.issues[0]?.message ?? 'invalid value';
+}
+
+/**
+ * Soft-parse an order snapshot: each sub-tree is validated independently
+ * via `safeParse`, failures are pushed to `parseWarnings`, and the caller
+ * gets back whatever could be parsed. Never throws, never returns null.
+ */
+export function parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrderSnapshot {
+  const warnings: ParseWarning[] = [];
+
+  // Top-level scalar fields — tolerate missing / wrong-typed silently.
+  const id = typeof snapshot.id === 'string' ? snapshot.id : undefined;
+  const orderNumber =
+    typeof snapshot.orderNumber === 'string' ? snapshot.orderNumber : undefined;
+  const status = typeof snapshot.status === 'string' ? snapshot.status : undefined;
+
+  // Items — parse each element independently so one bad row doesn't drop the rest.
+  const items: ParsedOrderItem[] = [];
+  if (Array.isArray(snapshot.items)) {
+    snapshot.items.forEach((raw, index) => {
+      const result = orderItemSchema.safeParse(raw);
+      if (result.success) {
+        items.push(result.data);
+      } else {
+        warnings.push({
+          field: `items[${index}]`,
+          message: firstZodMessage(result.error),
+        });
+      }
+    });
+  } else if (snapshot.items !== undefined) {
+    warnings.push({ field: 'items', message: 'expected an array' });
+  }
+
+  // Totals — optional; only warn when present-but-wrong.
+  let totals: ParsedOrderTotals | undefined;
+  if (snapshot.totals !== undefined) {
+    const result = orderTotalsSchema.safeParse(snapshot.totals);
+    if (result.success) {
+      totals = result.data;
+    } else {
+      warnings.push({ field: 'totals', message: firstZodMessage(result.error) });
+    }
+  }
+
+  // Shipping + billing addresses — same pattern as totals.
+  let shippingAddress: ParsedAddress | undefined;
+  if (snapshot.shippingAddress !== undefined) {
+    const candidate = asRecord(snapshot.shippingAddress);
+    if (candidate === null) {
+      warnings.push({ field: 'shippingAddress', message: 'expected an object' });
+    } else {
+      const result = addressSchema.safeParse(candidate);
+      if (result.success) {
+        shippingAddress = result.data;
+      } else {
+        warnings.push({ field: 'shippingAddress', message: firstZodMessage(result.error) });
+      }
+    }
+  }
+
+  let billingAddress: ParsedAddress | undefined;
+  if (snapshot.billingAddress !== undefined) {
+    const candidate = asRecord(snapshot.billingAddress);
+    if (candidate === null) {
+      warnings.push({ field: 'billingAddress', message: 'expected an object' });
+    } else {
+      const result = addressSchema.safeParse(candidate);
+      if (result.success) {
+        billingAddress = result.data;
+      } else {
+        warnings.push({ field: 'billingAddress', message: firstZodMessage(result.error) });
+      }
+    }
+  }
+
+  return {
+    id,
+    orderNumber,
+    status,
+    items,
+    totals,
+    shippingAddress,
+    billingAddress,
+    parseWarnings: warnings,
+  };
 }

--- a/apps/web/src/features/orders/components/order-customer-card.test.tsx
+++ b/apps/web/src/features/orders/components/order-customer-card.test.tsx
@@ -1,0 +1,185 @@
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OrderCustomerCard } from './order-customer-card';
+import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import type { CustomerProjectionDetail } from '../../customers/api/customers.types';
+
+const customerWithPii: CustomerProjectionDetail = {
+  internalCustomerId: 'ol_customer_abc',
+  emailHash: 'sha256_8awgqyk6a5xxxxxxx',
+  normalizedEmail: 'jane.doe@example.com',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  lastSeenAt: '2026-04-20T10:00:00.000Z',
+  lastSourceConnectionId: 'conn_allegro_1',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2026-04-20T10:00:00.000Z',
+  addresses: [],
+};
+
+const customerHashOnly: CustomerProjectionDetail = {
+  ...customerWithPii,
+  internalCustomerId: 'ol_customer_hash',
+  normalizedEmail: null,
+  firstName: null,
+  lastName: null,
+};
+
+describe('OrderCustomerCard', () => {
+  afterEach(cleanup);
+
+  it('renders a muted empty state when customerId is null and never queries the API', () => {
+    const getById = vi.fn();
+    const list = vi.fn();
+    const apiClient = createMockApiClient({
+      customers: { list: vi.fn(), getById },
+      orders: { list, getById: vi.fn() },
+    });
+
+    renderWithProviders(<OrderCustomerCard customerId={null} />, { apiClient });
+
+    expect(
+      screen.getByText(/No customer linked/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /View failed orders/ })).toBeNull();
+    expect(getById).not.toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('adds a "View failed orders" link to the empty state when sourceConnectionId is provided', () => {
+    const apiClient = createMockApiClient({
+      customers: { list: vi.fn(), getById: vi.fn() },
+      orders: { list: vi.fn(), getById: vi.fn() },
+    });
+
+    renderWithProviders(
+      <OrderCustomerCard customerId={null} sourceConnectionId="conn_allegro_1" />,
+      { apiClient },
+    );
+
+    const link = screen.getByRole('link', { name: /View failed orders/ });
+    expect(link).toHaveAttribute('href', '/orders/failed?connectionId=conn_allegro_1');
+  });
+
+  it('renders the loading skeleton shell while the customer query is pending', () => {
+    const apiClient = createMockApiClient({
+      customers: {
+        list: vi.fn(),
+        getById: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    });
+
+    renderWithProviders(<OrderCustomerCard customerId="ol_customer_abc" />, { apiClient });
+
+    const card = screen.getByLabelText('Customer');
+    expect(card).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('renders the error state with a Retry action when the customer query fails', async () => {
+    const user = userEvent.setup();
+    const getById = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(customerWithPii);
+    const apiClient = createMockApiClient({
+      customers: { list: vi.fn(), getById },
+    });
+
+    renderWithProviders(<OrderCustomerCard customerId="ol_customer_abc" />, { apiClient });
+
+    expect(await screen.findByText(/Couldn’t load customer details/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(getById).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders full name and normalized email under raw PII mode', async () => {
+    const apiClient = createMockApiClient({
+      customers: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(customerWithPii),
+      },
+      orders: {
+        list: vi.fn().mockResolvedValue({ items: [], total: 1, limit: 1, offset: 0 }),
+        getById: vi.fn(),
+      },
+    });
+
+    renderWithProviders(<OrderCustomerCard customerId="ol_customer_abc" />, { apiClient });
+
+    expect(await screen.findByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('jane.doe@example.com')).toBeInTheDocument();
+    const viewCustomer = screen.getByRole('link', { name: 'View customer' });
+    expect(viewCustomer).toHaveAttribute('href', '/customers/ol_customer_abc');
+  });
+
+  it('falls back to an email-hash chip + "Unknown name" under PII hash-only mode', async () => {
+    const apiClient = createMockApiClient({
+      customers: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(customerHashOnly),
+      },
+      orders: {
+        list: vi.fn().mockResolvedValue({ items: [], total: 1, limit: 1, offset: 0 }),
+        getById: vi.fn(),
+      },
+    });
+
+    renderWithProviders(<OrderCustomerCard customerId="ol_customer_hash" />, { apiClient });
+
+    expect(await screen.findByText('Unknown name')).toBeInTheDocument();
+    // Hash chip renders first N chars + ellipsis
+    expect(screen.getByText(/^sha256_8aw/)).toBeInTheDocument();
+    expect(screen.queryByText('jane.doe@example.com')).toBeNull();
+  });
+
+  it('shows the "Previous orders" row when the customer has more than one order', async () => {
+    const apiClient = createMockApiClient({
+      customers: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(customerWithPii),
+      },
+      orders: {
+        list: vi.fn().mockResolvedValue({ items: [], total: 4, limit: 1, offset: 0 }),
+        getById: vi.fn(),
+      },
+    });
+
+    renderWithProviders(<OrderCustomerCard customerId="ol_customer_abc" />, { apiClient });
+
+    expect(await screen.findByText('Previous orders')).toBeInTheDocument();
+    // total = 4 including this order → 3 previous
+    expect(screen.getByRole('link', { name: '3' })).toBeInTheDocument();
+  });
+
+  it('omits the "Previous orders" row when the customer has exactly one order', async () => {
+    const apiClient = createMockApiClient({
+      customers: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(customerWithPii),
+      },
+      orders: {
+        list: vi.fn().mockResolvedValue({ items: [], total: 1, limit: 1, offset: 0 }),
+        getById: vi.fn(),
+      },
+    });
+
+    renderWithProviders(<OrderCustomerCard customerId="ol_customer_abc" />, { apiClient });
+
+    expect(await screen.findByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.queryByText('Previous orders')).toBeNull();
+  });
+
+  it('shows a "record not found" muted message when the customer query resolves null', async () => {
+    const apiClient = createMockApiClient({
+      customers: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(null),
+      },
+    });
+
+    renderWithProviders(<OrderCustomerCard customerId="ol_customer_missing" />, { apiClient });
+
+    expect(await screen.findByText(/Customer record not found/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/orders/components/order-customer-card.tsx
+++ b/apps/web/src/features/orders/components/order-customer-card.tsx
@@ -1,0 +1,175 @@
+/**
+ * Order Customer Card
+ *
+ * Third column of the order detail primary grid. Renders a quick customer
+ * summary for the current order — name, email (or email-hash chip under
+ * PII hash-only mode), last-seen, previous-order count, and a link out
+ * to the customer detail page. When the order has no linked customer,
+ * shows a muted inline explanation rather than an empty card; when a
+ * `sourceConnectionId` is supplied, the empty state offers a jump to the
+ * connection's failed-orders view so the operator has somewhere to go.
+ *
+ * Handles the full four-state pattern (`fe-pages.md`) — loading, error,
+ * empty/null, data — without blocking the rest of the order page when
+ * the customer query fails.
+ */
+import { Link } from 'react-router-dom';
+import type { ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { TimeDisplay } from '../../../shared/ui/time-display';
+import { useCustomerQuery } from '../../customers/hooks/use-customer-query';
+import { useOrdersQuery } from '../hooks/use-orders-query';
+
+interface OrderCustomerCardProps {
+  customerId: string | null;
+  /**
+   * When provided on the null-customer path, the empty-state offers a link
+   * to the failed-orders view filtered to this connection — matching the
+   * wayfinding surface described in #382 §1.
+   */
+  sourceConnectionId?: string | null;
+}
+
+const ORDERS_COUNT_STALE_MS = 30_000;
+const EMAIL_HASH_CHIP_LENGTH = 10;
+
+export function OrderCustomerCard({
+  customerId,
+  sourceConnectionId,
+}: OrderCustomerCardProps): ReactElement {
+  if (customerId === null) {
+    return (
+      <section className="order-customer-card order-customer-card--empty" aria-label="Customer">
+        <p className="order-customer-card__empty-body text-muted">
+          No customer linked — order may be a guest checkout or customer resolution failed.
+        </p>
+        {sourceConnectionId ? (
+          <Link
+            to={`/orders/failed?connectionId=${encodeURIComponent(sourceConnectionId)}`}
+            className="order-customer-card__empty-link"
+          >
+            View failed orders →
+          </Link>
+        ) : null}
+      </section>
+    );
+  }
+  return <OrderCustomerCardLinked customerId={customerId} />;
+}
+
+function OrderCustomerCardLinked({ customerId }: { customerId: string }): ReactElement {
+  const customerQuery = useCustomerQuery(customerId);
+  // Staletime pinned so sibling-order nav within the same customer doesn't
+  // refetch this count on every mount — see #382 tech review.
+  const ordersCountQuery = useOrdersQuery(
+    { customerId },
+    { limit: 1, offset: 0 },
+    { staleTime: ORDERS_COUNT_STALE_MS },
+  );
+
+  if (customerQuery.isLoading) {
+    return (
+      <section className="order-customer-card" aria-label="Customer" aria-busy="true">
+        <header className="order-customer-card__header">
+          <span className="order-customer-card__label">Customer</span>
+        </header>
+        <p className="order-customer-card__name order-customer-card__name--loading">…</p>
+        <p className="order-customer-card__email order-customer-card__email--loading">…</p>
+      </section>
+    );
+  }
+
+  if (customerQuery.error) {
+    return (
+      <section className="order-customer-card" aria-label="Customer">
+        <header className="order-customer-card__header">
+          <span className="order-customer-card__label">Customer</span>
+        </header>
+        <p className="order-customer-card__error text-muted">
+          Couldn&rsquo;t load customer details.
+        </p>
+        <Button
+          tone="secondary"
+          onClick={() => {
+            void customerQuery.refetch();
+          }}
+        >
+          Retry
+        </Button>
+      </section>
+    );
+  }
+
+  const customer = customerQuery.data;
+  // The API returns 200 + null body when a customer isn't found (see api
+  // client). Treat that as a not-found state, same as the mock client's
+  // default `null` resolution.
+  if (!customer) {
+    return (
+      <section className="order-customer-card" aria-label="Customer">
+        <header className="order-customer-card__header">
+          <span className="order-customer-card__label">Customer</span>
+        </header>
+        <p className="order-customer-card__error text-muted">Customer record not found.</p>
+      </section>
+    );
+  }
+
+  const displayName =
+    [customer.firstName, customer.lastName].filter(Boolean).join(' ').trim() || null;
+  // Only subtract the current order from the count once the list has actually
+  // been fetched, otherwise the "Previous orders" row can briefly flash -1→0
+  // during the eventual-consistency window right after order creation.
+  const previousOrdersCount =
+    ordersCountQuery.isFetched && ordersCountQuery.data
+      ? Math.max(ordersCountQuery.data.total - 1, 0)
+      : 0;
+
+  return (
+    <section className="order-customer-card" aria-label="Customer">
+      <header className="order-customer-card__header">
+        <span className="order-customer-card__label">Customer</span>
+        <Link
+          to={`/customers/${customerId}`}
+          className="order-customer-card__view"
+          aria-label="View customer"
+        >
+          View customer →
+        </Link>
+      </header>
+
+      <p className="order-customer-card__name">
+        {displayName ?? <span className="text-muted">Unknown name</span>}
+      </p>
+
+      <p className="order-customer-card__email">
+        {customer.normalizedEmail ? (
+          <span>{customer.normalizedEmail}</span>
+        ) : (
+          <code className="order-customer-card__hash mono-text" title={customer.emailHash}>
+            {customer.emailHash.slice(0, EMAIL_HASH_CHIP_LENGTH)}…
+          </code>
+        )}
+      </p>
+
+      <dl className="order-customer-card__meta">
+        <div className="order-customer-card__meta-row">
+          <dt>Last seen</dt>
+          <dd>
+            <TimeDisplay iso={customer.lastSeenAt} />
+          </dd>
+        </div>
+        {previousOrdersCount > 0 ? (
+          <div className="order-customer-card__meta-row">
+            <dt>Previous orders</dt>
+            <dd>
+              <Link to={`/customers/${customerId}`} className="order-customer-card__meta-link">
+                {previousOrdersCount}
+              </Link>
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+    </section>
+  );
+}

--- a/apps/web/src/features/orders/components/order-line-items-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-line-items-panel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, screen, within } from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { OrderLineItemsPanel } from './order-line-items-panel';
 import { renderWithProviders } from '../../../test/test-utils';
@@ -50,26 +50,21 @@ describe('OrderLineItemsPanel', () => {
     expect(rows).toHaveLength(3);
   });
 
-  it('renders the totals rollup with subtotal, shipping, and total', () => {
-    renderWithProviders(<OrderLineItemsPanel items={items} totals={totals} />);
+  it('does not render a totals rollup (moved to OrderTotalsPanel)', () => {
+    const { container } = renderWithProviders(
+      <OrderLineItemsPanel items={items} totals={totals} />,
+    );
 
-    const rollup = screen.getByText('Subtotal').closest('dl');
-    expect(rollup).not.toBeNull();
-    const rollupEl = within(rollup!);
-    expect(rollupEl.getByText('Subtotal')).toBeInTheDocument();
-    expect(rollupEl.getByText('Shipping')).toBeInTheDocument();
-    expect(rollupEl.getByText('Total')).toBeInTheDocument();
-    // Tax is zero so should NOT render a Tax row
-    expect(rollupEl.queryByText('Tax')).toBeNull();
+    // The `Total` column header still exists inside the table. The rollup — a
+    // sibling <dl class="order-totals"> — must not.
+    expect(screen.queryByText('Subtotal')).toBeNull();
+    expect(container.querySelector('.order-totals')).toBeNull();
   });
 
   it('renders line items without assuming a currency when totals are absent', () => {
     renderWithProviders(<OrderLineItemsPanel items={items} />);
 
     expect(screen.getByText('Widget A')).toBeInTheDocument();
-    // No totals rollup
-    expect(screen.queryByText('Subtotal')).toBeNull();
-    // No PLN or other currency code should appear
     expect(screen.queryByText(/PLN/)).toBeNull();
     expect(screen.queryByText(/\$/)).toBeNull();
     expect(screen.queryByText(/€/)).toBeNull();
@@ -78,5 +73,16 @@ describe('OrderLineItemsPanel', () => {
   it('renders the empty state when there are no items', () => {
     renderWithProviders(<OrderLineItemsPanel items={[]} />);
     expect(screen.getByText('No line items')).toBeInTheDocument();
+  });
+
+  it('falls back to productId then item id for the SKU line when SKU is absent', () => {
+    const itemsMissingSku: ParsedOrderItem[] = [
+      { id: 'ol_orderitem_noSku', productId: 'ol_product_x', quantity: 1, price: 5 },
+      { id: 'ol_orderitem_noProduct', quantity: 1, price: 5 },
+    ];
+    renderWithProviders(<OrderLineItemsPanel items={itemsMissingSku} />);
+
+    expect(screen.getByText('ol_product_x')).toBeInTheDocument();
+    expect(screen.getByText('ol_orderitem_noProduct')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/orders/components/order-line-items-panel.tsx
+++ b/apps/web/src/features/orders/components/order-line-items-panel.tsx
@@ -1,33 +1,28 @@
 /**
  * Order Line Items Panel
  *
- * Renders an order's parsed line items as a DataTable (product thumbnail + name/SKU,
- * qty, unit price, line total) with a subtotal/shipping/tax/total rollup. Currency
- * comes from the order totals; when totals are absent, prices render as plain
- * decimals rather than assuming a default currency.
+ * Renders an order's parsed line items as a DataTable (product thumbnail +
+ * name/SKU, qty, unit price, line total). The financial rollup lives in a
+ * sibling `OrderTotalsPanel` (split in #382) so the summary stays visible
+ * when items fail to parse.
  */
 import type { ReactElement } from 'react';
 import { DataTable, type DataTableColumn } from '../../../shared/ui/data-table';
 import { EmptyState } from '../../../shared/ui/feedback-state';
 import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
+import { formatAmount } from '../../../shared/format/format-amount';
 import type { ParsedOrderItem, ParsedOrderTotals } from '../api/order-snapshot.schema';
 
 interface OrderLineItemsPanelProps {
   items: ParsedOrderItem[];
+  /**
+   * Only used for per-line price formatting. Totals are rendered separately
+   * by `OrderTotalsPanel`.
+   */
   totals?: ParsedOrderTotals;
 }
 
-function formatAmount(amount: number, currency: string | undefined): string {
-  if (currency) {
-    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount);
-  }
-  return new Intl.NumberFormat(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(amount);
-}
-
-export function OrderLineItemsPanel({
-  items,
-  totals,
-}: OrderLineItemsPanelProps): ReactElement {
+export function OrderLineItemsPanel({ items, totals }: OrderLineItemsPanelProps): ReactElement {
   const currency = totals?.currency;
 
   const columns: DataTableColumn<ParsedOrderItem>[] = [
@@ -37,7 +32,7 @@ export function OrderLineItemsPanel({
       cell: (item) => (
         <span className="order-line-item__product">
           <ProductThumbnail
-            name={item.name ?? item.sku ?? item.productId}
+            name={item.name ?? item.sku ?? item.productId ?? item.id}
             src={item.imageUrl}
             size="sm"
           />
@@ -47,8 +42,10 @@ export function OrderLineItemsPanel({
             ) : null}
             {item.sku ? (
               <span className="order-line-item__sku mono-text">{item.sku}</span>
-            ) : (
+            ) : item.productId ? (
               <span className="order-line-item__sku mono-text text-muted">{item.productId}</span>
+            ) : (
+              <span className="order-line-item__sku mono-text text-muted">{item.id}</span>
             )}
           </span>
         </span>
@@ -96,30 +93,6 @@ export function OrderLineItemsPanel({
         rows={items}
         rowKey={(item) => item.id}
       />
-      {totals ? (
-        <dl className="order-totals">
-          <div className="order-totals__row">
-            <dt>Subtotal</dt>
-            <dd className="mono-text">{formatAmount(totals.subtotal, currency)}</dd>
-          </div>
-          {totals.shipping > 0 ? (
-            <div className="order-totals__row">
-              <dt>Shipping</dt>
-              <dd className="mono-text">{formatAmount(totals.shipping, currency)}</dd>
-            </div>
-          ) : null}
-          {totals.tax > 0 ? (
-            <div className="order-totals__row">
-              <dt>Tax</dt>
-              <dd className="mono-text">{formatAmount(totals.tax, currency)}</dd>
-            </div>
-          ) : null}
-          <div className="order-totals__row order-totals__row--total">
-            <dt>Total</dt>
-            <dd className="mono-text">{formatAmount(totals.total, currency)}</dd>
-          </div>
-        </dl>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/orders/components/order-totals-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-totals-panel.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { OrderTotalsPanel } from './order-totals-panel';
+import type { ParsedOrderTotals } from '../api/order-snapshot.schema';
+
+const fullTotals: ParsedOrderTotals = {
+  subtotal: 39.98,
+  tax: 9.2,
+  shipping: 5,
+  total: 54.18,
+  currency: 'PLN',
+};
+
+describe('OrderTotalsPanel', () => {
+  afterEach(cleanup);
+
+  it('renders subtotal, shipping, tax, and a grand-total row marked as total', () => {
+    render(<OrderTotalsPanel totals={fullTotals} />);
+
+    expect(screen.getByText('Subtotal')).toBeInTheDocument();
+    expect(screen.getByText('Shipping')).toBeInTheDocument();
+    expect(screen.getByText('Tax')).toBeInTheDocument();
+    expect(screen.getByText('Total')).toBeInTheDocument();
+
+    const totalRow = screen.getByText('Total').closest('.order-totals__row');
+    expect(totalRow).toHaveClass('order-totals__row--total');
+  });
+
+  it('omits shipping and tax rows when their value is zero', () => {
+    render(
+      <OrderTotalsPanel
+        totals={{ subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' }}
+      />,
+    );
+
+    expect(screen.queryByText('Shipping')).toBeNull();
+    expect(screen.queryByText('Tax')).toBeNull();
+    expect(screen.getByText('Total')).toBeInTheDocument();
+  });
+
+  it('falls back to bare numeric formatting when currency is an empty string', () => {
+    // Schema requires currency as string, so we use '' to simulate missing
+    // formatting info without widening the type.
+    render(
+      <OrderTotalsPanel
+        totals={{ subtotal: 10, tax: 0, shipping: 0, total: 10, currency: '' }}
+      />,
+    );
+
+    // No currency symbols rendered
+    expect(screen.queryByText(/PLN/)).toBeNull();
+    expect(screen.queryByText(/\$/)).toBeNull();
+    expect(screen.queryByText(/€/)).toBeNull();
+    // Still renders the numeric value with fixed fraction digits
+    expect(screen.getAllByText('10.00').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/features/orders/components/order-totals-panel.tsx
+++ b/apps/web/src/features/orders/components/order-totals-panel.tsx
@@ -1,0 +1,43 @@
+/**
+ * Order Totals Panel
+ *
+ * Financial rollup for an order — subtotal, shipping, tax, grand total.
+ * Extracted out of `OrderLineItemsPanel` in #382 so the summary stays
+ * visible when items fail to parse, and so the grand total can act as a
+ * typographic anchor rather than living below a table.
+ */
+import type { ReactElement } from 'react';
+import { formatAmount } from '../../../shared/format/format-amount';
+import type { ParsedOrderTotals } from '../api/order-snapshot.schema';
+
+interface OrderTotalsPanelProps {
+  totals: ParsedOrderTotals;
+}
+
+export function OrderTotalsPanel({ totals }: OrderTotalsPanelProps): ReactElement {
+  const currency = totals.currency;
+  return (
+    <dl className="order-totals">
+      <div className="order-totals__row">
+        <dt>Subtotal</dt>
+        <dd className="mono-text">{formatAmount(totals.subtotal, currency)}</dd>
+      </div>
+      {totals.shipping > 0 ? (
+        <div className="order-totals__row">
+          <dt>Shipping</dt>
+          <dd className="mono-text">{formatAmount(totals.shipping, currency)}</dd>
+        </div>
+      ) : null}
+      {totals.tax > 0 ? (
+        <div className="order-totals__row">
+          <dt>Tax</dt>
+          <dd className="mono-text">{formatAmount(totals.tax, currency)}</dd>
+        </div>
+      ) : null}
+      <div className="order-totals__row order-totals__row--total">
+        <dt>Total</dt>
+        <dd className="mono-text">{formatAmount(totals.total, currency)}</dd>
+      </div>
+    </dl>
+  );
+}

--- a/apps/web/src/features/orders/hooks/use-orders-query.ts
+++ b/apps/web/src/features/orders/hooks/use-orders-query.ts
@@ -3,14 +3,25 @@ import { ordersQueryKeys } from '../api/orders.query-keys';
 import type { PaginatedOrders, OrderFilters, OrderPagination } from '../api/orders.types';
 import { useApiClient } from '../../../app/api/api-client-provider';
 
+/**
+ * Optional query tuning. Currently only `staleTime` is exposed — consumers
+ * that need full TanStack control should call `useQuery` with
+ * `ordersQueryKeys.list(...)` directly.
+ */
+interface UseOrdersQueryOptions {
+  staleTime?: number;
+}
+
 export function useOrdersQuery(
   filters?: OrderFilters,
   pagination?: OrderPagination,
+  options?: UseOrdersQueryOptions,
 ): UseQueryResult<PaginatedOrders> {
   const apiClient = useApiClient();
 
   return useQuery({
     queryKey: ordersQueryKeys.list(filters, pagination),
     queryFn: () => apiClient.orders.list(filters, pagination),
+    staleTime: options?.staleTime,
   });
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4598,6 +4598,24 @@ a.kpi-card:focus-visible {
   }
 }
 
+/* Three-column variant (#382): summary | sync status | customer */
+@media (min-width: 768px) and (max-width: 1023px) {
+  .order-detail__primary-grid--three {
+    /* Tablet: fall back to two columns and let the customer card wrap underneath. */
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
+  }
+
+  .order-detail__primary-grid--three > :last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (min-width: 1024px) {
+  .order-detail__primary-grid--three {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr) minmax(0, 0.85fr);
+  }
+}
+
 /* Address grid: shipping + billing side-by-side (desktop) */
 .order-detail__address-grid {
   display: grid;
@@ -4643,7 +4661,179 @@ a.kpi-card:focus-visible {
   color: var(--text-muted);
 }
 
-/* Order totals summary below line items table */
+/* Raw-snapshot anchor (#382): parse-warning chip scroll-links here. Offset the
+   scroll so the section heading clears the sticky topbar on jump. */
+#order-raw-snapshot {
+  scroll-margin-top: 4rem;
+}
+
+/* Items + totals grid (#382): items on the left, totals panel on the right at >=1024px. */
+.order-detail__items-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 1024px) {
+  .order-detail__items-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.45fr);
+    align-items: start;
+  }
+}
+
+.order-detail__totals-section {
+  min-width: 0;
+}
+
+/* Standalone warning breadcrumb row — quiet, diagnostic, links to raw snapshot. */
+.order-detail__parse-warning-row {
+  margin: 0;
+}
+
+.order-detail__parse-warning {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--status-warning-strong);
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--status-warning-border);
+  padding-bottom: 1px;
+}
+
+.order-detail__parse-warning:hover,
+.order-detail__parse-warning:focus-visible {
+  color: var(--text-primary);
+  border-bottom-color: var(--text-primary);
+  outline: none;
+}
+
+/* Order customer card (#382) — quieter treatment than .detail-section chrome. */
+.order-customer-card {
+  display: grid;
+  gap: 0.375rem;
+  padding: 0.75rem 0 0.75rem 1rem;
+  border-left: 2px solid var(--border-subtle);
+  min-width: 0;
+}
+
+.order-customer-card--empty {
+  border-left-color: var(--border-subtle);
+}
+
+.order-customer-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.order-customer-card__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.order-customer-card__view {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.order-customer-card__view:hover,
+.order-customer-card__view:focus-visible {
+  color: var(--text-primary);
+  outline: none;
+}
+
+.order-customer-card__name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.order-customer-card__name--loading,
+.order-customer-card__email--loading {
+  color: var(--text-disabled);
+}
+
+.order-customer-card__email {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.order-customer-card__hash {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.order-customer-card__meta {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0.25rem 0 0;
+}
+
+.order-customer-card__meta-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.order-customer-card__meta-row dt {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.order-customer-card__meta-row dd {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.order-customer-card__meta-link {
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.order-customer-card__error {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.order-customer-card__empty-body {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.order-customer-card__empty-link {
+  display: inline-flex;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--border-default);
+  padding-bottom: 1px;
+  align-self: flex-start;
+}
+
+.order-customer-card__empty-link:hover,
+.order-customer-card__empty-link:focus-visible {
+  color: var(--text-primary);
+  border-bottom-color: var(--text-primary);
+  outline: none;
+}
+
+/* Order totals summary (moved to OrderTotalsPanel in #382) */
 .order-totals {
   display: grid;
   gap: 0.25rem;
@@ -4665,15 +4855,28 @@ a.kpi-card:focus-visible {
 }
 
 .order-totals__row--total {
+  align-items: baseline;
   font-weight: 600;
   color: var(--text-primary);
   border-top: 1px solid var(--border-subtle);
-  padding-top: 0.375rem;
-  margin-top: 0.125rem;
+  padding-top: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 .order-totals__row--total dt {
   color: var(--text-secondary);
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+/* Grand-total amount as typographic anchor — larger tabular-mono numeral
+   pulls the eye to the bottom of the rollup without using colour. */
+.order-totals__row--total dd {
+  font-size: 1.25rem;
+  line-height: 1.25;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
 }
 
 /* Activity timeline */
@@ -4774,6 +4977,91 @@ a.kpi-card:focus-visible {
     grid-column: 2;
     margin-top: -0.375rem;
   }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Inventory detail page (#381)                                             */
+/* ------------------------------------------------------------------------ */
+
+/* Hero: thumb + product identity + status badge + meta + id chip */
+.inventory-hero {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+  padding: 1rem 1.125rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.inventory-hero__thumb {
+  width: 3rem;
+  height: 3rem;
+  font-size: 1.125rem;
+  border-radius: 0.5rem;
+}
+
+.inventory-hero__body {
+  display: grid;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.inventory-hero__title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.inventory-hero__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--text-primary);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.inventory-hero__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.inventory-hero__sep {
+  color: var(--text-disabled);
+}
+
+.inventory-hero__id {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+/* KPI: single compound card (Available primary + reserved/on-hand description) */
+.inventory-detail__kpi {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 600px) {
+  .inventory-detail__kpi {
+    grid-template-columns: minmax(0, 18rem);
+  }
+}
+
+/* Action cluster in PageLayout.actions slot — back (ghost) + view-product (primary) */
+.inventory-detail__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/apps/web/src/pages/inventory/inventory-detail-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.test.tsx
@@ -1,66 +1,303 @@
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
-import { afterEach, describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { InventoryDetailPage } from './inventory-detail-page';
 import type { InventoryItem } from '../../features/inventory/api/inventory.types';
+import type {
+  OfferMapping,
+  PaginatedOfferMappings,
+} from '../../features/listings/api/listings.types';
 
-const sampleItem: InventoryItem = {
-  id: 'ol_inv_abc123',
-  productId: 'ol_product_abc123',
-  productVariantId: 'ol_variant_xyz',
-  availableQuantity: 10,
-  reservedQuantity: 2,
-  locationId: 'warehouse-1',
-  updatedAt: '2026-01-15T10:00:00.000Z',
-  productName: 'Test Product',
-  productSku: 'SKU-001',
+const baseItem: InventoryItem = {
+  id: 'ol_inventory_item_12345678-90ab-cdef-1234-567890abcdef',
+  productId: 'ol_product_4d2d57a59b44400d83cb8ccd720aa723',
+  productVariantId: null,
+  availableQuantity: 100,
+  reservedQuantity: 0,
+  locationId: null,
+  updatedAt: '2026-04-24T16:30:00.000Z',
+  productName: 'Aparat cyfrowy CANON PowerShot SX740 Lite Edition — srebrny',
+  productSku: 'Aparat_cyfrowy',
   productImageUrl: null,
 };
 
-function renderDetailPage(apiClient: ReturnType<typeof createMockApiClient>): void {
+const sampleListing: OfferMapping = {
+  id: 'map_1',
+  entityType: 'ProductVariant',
+  internalId: 'ol_variant_abc',
+  externalId: '1111',
+  platformType: 'allegro',
+  connectionId: 'conn_allegro_1',
+  context: null,
+  createdAt: '2026-04-01T00:00:00.000Z',
+  updatedAt: '2026-04-20T00:00:00.000Z',
+};
+
+const emptyListingsPage: PaginatedOfferMappings = {
+  items: [],
+  total: 0,
+  limit: 50,
+  offset: 0,
+};
+
+function renderDetail(apiClient: ReturnType<typeof createMockApiClient>): void {
   renderWithProviders(
     <Routes>
       <Route path="/inventory/:id" element={<InventoryDetailPage />} />
     </Routes>,
-    { apiClient, route: '/inventory/ol_inv_abc123' },
+    { apiClient, route: `/inventory/${baseItem.id}` },
   );
 }
 
 describe('InventoryDetailPage', () => {
   afterEach(cleanup);
 
-  it('should show loading state initially', () => {
-    const mockApi = createMockApiClient({
-      inventory: { getById: vi.fn().mockReturnValue(new Promise(() => {})) },
+  it('shows the loading state while the inventory item is fetching', () => {
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
     });
 
-    renderDetailPage(mockApi);
+    renderDetail(apiClient);
 
     expect(screen.getByText('Loading inventory item')).toBeInTheDocument();
   });
 
-  it('should show inventory item detail when data loads', async () => {
-    const mockApi = createMockApiClient({
-      inventory: { getById: vi.fn().mockResolvedValue(sampleItem) },
+  it('shows the error state with a Retry action when fetch fails', async () => {
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockRejectedValue(new Error('Not found')),
+      },
     });
 
-    renderDetailPage(mockApi);
-
-    expect(await screen.findByText('ol_inv_abc123')).toBeInTheDocument();
-    expect(screen.getByText('Test Product')).toBeInTheDocument();
-    expect(screen.getByText('SKU-001')).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
-    expect(screen.getByText('warehouse-1')).toBeInTheDocument();
-  });
-
-  it('should show error state when fetch fails', async () => {
-    const mockApi = createMockApiClient({
-      inventory: { getById: vi.fn().mockRejectedValue(new Error('Not found')) },
-    });
-
-    renderDetailPage(mockApi);
+    renderDetail(apiClient);
 
     expect(await screen.findByText('Unable to load inventory item')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('renders hero with product name, status badge, meta, UUID chip and View product action', async () => {
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(baseItem),
+      },
+      listings: {
+        list: vi.fn().mockResolvedValue(emptyListingsPage),
+        getById: vi.fn().mockResolvedValue(null),
+        updateOfferFields: vi.fn(),
+        createOffer: vi.fn(),
+        getOfferCreationStatus: vi.fn(),
+        getSellerPolicies: vi.fn(),
+      },
+    });
+
+    renderDetail(apiClient);
+
+    // Product name appears as both PageLayout title (h2) and hero heading (h3)
+    const heroTitles = await screen.findAllByText(baseItem.productName as string);
+    expect(heroTitles.length).toBeGreaterThanOrEqual(1);
+
+    expect(screen.getByText('In stock')).toBeInTheDocument();
+    // SKU appears in the hero meta and again in the Item Details row
+    expect(screen.getAllByText(baseItem.productSku as string).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Simple product')).toBeInTheDocument();
+    expect(screen.getByText(baseItem.id)).toBeInTheDocument();
+
+    const viewProduct = screen.getByRole('link', { name: 'View product' });
+    expect(viewProduct).toHaveAttribute('href', `/products/${baseItem.productId}`);
+  });
+
+  it('shows compound Available KPI with reserved / on-hand description', async () => {
+    const item: InventoryItem = { ...baseItem, availableQuantity: 100, reservedQuantity: 7 };
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(item),
+      },
+      listings: {
+        list: vi.fn().mockResolvedValue(emptyListingsPage),
+        getById: vi.fn().mockResolvedValue(null),
+        updateOfferFields: vi.fn(),
+        createOffer: vi.fn(),
+        getOfferCreationStatus: vi.fn(),
+        getSellerPolicies: vi.fn(),
+      },
+    });
+
+    renderDetail(apiClient);
+
+    const kpi = await screen.findByLabelText('Stock levels');
+    expect(within(kpi).getByText('Available')).toBeInTheDocument();
+    expect(within(kpi).getByText('100')).toBeInTheDocument();
+    expect(within(kpi).getByText(/7 reserved/)).toBeInTheDocument();
+    expect(within(kpi).getByText(/107 on hand/)).toBeInTheDocument();
+  });
+
+  it('reflects the out-of-stock tone when availableQuantity is zero', async () => {
+    const item: InventoryItem = { ...baseItem, availableQuantity: 0 };
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(item),
+      },
+      listings: {
+        list: vi.fn().mockResolvedValue(emptyListingsPage),
+        getById: vi.fn().mockResolvedValue(null),
+        updateOfferFields: vi.fn(),
+        createOffer: vi.fn(),
+        getOfferCreationStatus: vi.fn(),
+        getSellerPolicies: vi.fn(),
+      },
+    });
+
+    renderDetail(apiClient);
+
+    expect(await screen.findByText('Out of stock')).toBeInTheDocument();
+  });
+
+  it('reflects the low-stock tone when availableQuantity is within the threshold', async () => {
+    const item: InventoryItem = { ...baseItem, availableQuantity: 3 };
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(item),
+      },
+      listings: {
+        list: vi.fn().mockResolvedValue(emptyListingsPage),
+        getById: vi.fn().mockResolvedValue(null),
+        updateOfferFields: vi.fn(),
+        createOffer: vi.fn(),
+        getOfferCreationStatus: vi.fn(),
+        getSellerPolicies: vi.fn(),
+      },
+    });
+
+    renderDetail(apiClient);
+
+    expect(await screen.findByText('Low stock')).toBeInTheDocument();
+  });
+
+  it('falls back to "Simple product — no variants" and "Default location" in item details', async () => {
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(baseItem),
+      },
+      listings: {
+        list: vi.fn().mockResolvedValue(emptyListingsPage),
+        getById: vi.fn().mockResolvedValue(null),
+        updateOfferFields: vi.fn(),
+        createOffer: vi.fn(),
+        getOfferCreationStatus: vi.fn(),
+        getSellerPolicies: vi.fn(),
+      },
+    });
+
+    renderDetail(apiClient);
+
+    expect(await screen.findByText('Simple product — no variants')).toBeInTheDocument();
+    expect(screen.getByText('Default location')).toBeInTheDocument();
+  });
+
+  it('queries listings by variant id when available, else by product id', async () => {
+    const listItem: InventoryItem = {
+      ...baseItem,
+      productVariantId: 'ol_variant_xyz',
+    };
+    const listMock = vi.fn().mockResolvedValue(emptyListingsPage);
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(listItem),
+      },
+      listings: {
+        list: listMock,
+        getById: vi.fn().mockResolvedValue(null),
+        updateOfferFields: vi.fn(),
+        createOffer: vi.fn(),
+        getOfferCreationStatus: vi.fn(),
+        getSellerPolicies: vi.fn(),
+      },
+    });
+
+    renderDetail(apiClient);
+
+    await screen.findAllByText(listItem.productName as string);
+    expect(listMock).toHaveBeenCalledWith(
+      { internalId: 'ol_variant_xyz' },
+      { limit: 50, offset: 0 },
+    );
+  });
+
+  it('renders the listings table when offer mappings reference this stock', async () => {
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(baseItem),
+      },
+      listings: {
+        list: vi.fn().mockResolvedValue({
+          items: [sampleListing],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        }),
+        getById: vi.fn().mockResolvedValue(null),
+        updateOfferFields: vi.fn(),
+        createOffer: vi.fn(),
+        getOfferCreationStatus: vi.fn(),
+        getSellerPolicies: vi.fn(),
+      },
+    });
+
+    renderDetail(apiClient);
+
+    expect(await screen.findByText('allegro')).toBeInTheDocument();
+    expect(screen.getByText(sampleListing.externalId)).toBeInTheDocument();
+  });
+
+  it('shows the "no listings" empty copy when no offers reference the stock', async () => {
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById: vi.fn().mockResolvedValue(baseItem),
+      },
+      listings: {
+        list: vi.fn().mockResolvedValue(emptyListingsPage),
+        getById: vi.fn().mockResolvedValue(null),
+        updateOfferFields: vi.fn(),
+        createOffer: vi.fn(),
+        getOfferCreationStatus: vi.fn(),
+        getSellerPolicies: vi.fn(),
+      },
+    });
+
+    renderDetail(apiClient);
+
+    expect(await screen.findByText('No listings reference this stock yet.')).toBeInTheDocument();
+  });
+
+  it('refetches the inventory item when Retry is clicked on the error state', async () => {
+    const user = userEvent.setup();
+    const getById = vi.fn().mockRejectedValue(new Error('Network error'));
+    const apiClient = createMockApiClient({
+      inventory: {
+        list: vi.fn(),
+        getById,
+      },
+    });
+
+    renderDetail(apiClient);
+
+    const retry = await screen.findByRole('button', { name: 'Retry' });
+    await user.click(retry);
+
+    expect(getById).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/pages/inventory/inventory-detail-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-detail-page.tsx
@@ -3,39 +3,94 @@ import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { Button } from '../../shared/ui/button';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { EmptyValue } from '../../shared/ui/empty-value';
+import { EntityLabel } from '../../shared/ui/entity-label';
 import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list';
+import { KpiCard } from '../../shared/ui/kpi-card';
+import { ProductThumbnail } from '../../shared/ui/product-thumbnail';
+import { StatusBadge } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
+import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import { useInventoryItemQuery } from '../../features/inventory/hooks/use-inventory-item-query';
+import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
 import type { InventoryItem } from '../../features/inventory/api/inventory.types';
+import type { OfferMapping } from '../../features/listings/api/listings.types';
+import {
+  deriveStockStatus,
+  STOCK_STATUS_BADGE_TONE,
+  STOCK_STATUS_KPI_TONE,
+  STOCK_STATUS_LABEL,
+} from './inventory-stock-status';
 
-function buildInventoryItems(item: InventoryItem): KeyValueItem[] {
-  const items: KeyValueItem[] = [{ id: 'itemId', label: 'Item ID', value: item.id, mono: true }];
-  if (item.productName) {
-    items.push({ id: 'productName', label: 'Product', value: item.productName });
-  }
-  if (item.productSku) {
-    items.push({ id: 'productSku', label: 'Product SKU', value: item.productSku, mono: true });
-  }
-  items.push(
-    { id: 'productId', label: 'Product ID', value: item.productId, mono: true },
+const LISTINGS_COLUMNS: DataTableColumn<OfferMapping>[] = [
+  {
+    id: 'platform',
+    header: 'Platform',
+    cell: (row) => <span>{row.platformType}</span>,
+  },
+  {
+    id: 'connection',
+    header: 'Connection',
+    cell: (row) => <ConnectionEntityLabel connectionId={row.connectionId} showId={false} />,
+  },
+  {
+    id: 'externalId',
+    header: 'External ID',
+    cell: (row) => <span className="mono-text">{row.externalId}</span>,
+    hideBelow: 768,
+  },
+  {
+    id: 'updatedAt',
+    header: 'Updated',
+    cell: (row) => <TimeDisplay iso={row.updatedAt} />,
+    hideBelow: 1024,
+  },
+];
+
+function buildDetailItems(item: InventoryItem): KeyValueItem[] {
+  return [
     {
-      id: 'variantId',
-      label: 'Variant ID',
-      value: item.productVariantId ?? <EmptyValue />,
-      mono: Boolean(item.productVariantId),
+      id: 'variant',
+      label: 'Variant',
+      value: item.productVariantId ? (
+        <span className="mono-text">{item.productVariantId}</span>
+      ) : (
+        <span className="text-muted">Simple product — no variants</span>
+      ),
     },
-    { id: 'available', label: 'Available Quantity', value: item.availableQuantity },
-    { id: 'reserved', label: 'Reserved Quantity', value: item.reservedQuantity },
+    {
+      id: 'sku',
+      label: 'SKU',
+      value: item.productSku ?? <EmptyValue />,
+      mono: Boolean(item.productSku),
+    },
     {
       id: 'location',
       label: 'Location',
-      value: item.locationId ?? <EmptyValue label="Default location" />,
-      mono: Boolean(item.locationId),
+      value: item.locationId ? (
+        <span className="mono-text">{item.locationId}</span>
+      ) : (
+        <span className="text-muted">Default location</span>
+      ),
     },
-    { id: 'updatedAt', label: 'Updated', value: <TimeDisplay iso={item.updatedAt} /> },
-  );
-  return items;
+    {
+      id: 'updatedAt',
+      label: 'Updated',
+      value: <TimeDisplay iso={item.updatedAt} format="datetime" />,
+    },
+    {
+      id: 'product',
+      label: 'Product',
+      value: (
+        <EntityLabel
+          id={item.productId}
+          name={item.productName}
+          to={`/products/${item.productId}`}
+        />
+      ),
+    },
+  ];
 }
 
 export function InventoryDetailPage(): ReactElement {
@@ -45,7 +100,11 @@ export function InventoryDetailPage(): ReactElement {
   if (query.isLoading) {
     return (
       <PageLayout eyebrow="Inventory" title="Inventory item">
-        <LoadingState liveRegion="off" title="Loading inventory item" message="Fetching item details…" />
+        <LoadingState
+          liveRegion="off"
+          title="Loading inventory item"
+          message="Fetching item details…"
+        />
       </PageLayout>
     );
   }
@@ -57,27 +116,123 @@ export function InventoryDetailPage(): ReactElement {
           title="Unable to load inventory item"
           message={query.error?.message ?? 'Item not found'}
           action={
-            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+            <Button
+              onClick={() => {
+                void query.refetch();
+              }}
+            >
+              Retry
+            </Button>
           }
         />
       </PageLayout>
     );
   }
 
-  const item = query.data;
+  return <InventoryDetailContent item={query.data} />;
+}
+
+function InventoryDetailContent({ item }: { item: InventoryItem }): ReactElement {
+  const status = deriveStockStatus(item.availableQuantity);
+  const onHand = item.availableQuantity + item.reservedQuantity;
+  const productHeading = item.productName ?? 'Inventory item';
+  const variantLabel = item.productVariantId ? 'Variant' : 'Simple product';
+
+  const listingsQuery = useListingsQuery(
+    { internalId: item.productVariantId ?? item.productId },
+    { limit: 50, offset: 0 },
+  );
+  const listings = listingsQuery.data?.items ?? [];
 
   return (
     <PageLayout
       eyebrow="Inventory"
-      title={`Inventory — ${item.id}`}
+      title={productHeading}
       actions={
-        <Link to=".." relative="path" className="button button--ghost">
-          ← Back to inventory
-        </Link>
+        <div className="inventory-detail__actions">
+          <Link to=".." relative="path" className="button button--ghost">
+            ← Back to inventory
+          </Link>
+          <Link to={`/products/${item.productId}`} className="button button--primary">
+            View product
+          </Link>
+        </div>
       }
     >
+      <section className="inventory-hero" aria-label="Inventory item summary">
+        <ProductThumbnail
+          className="inventory-hero__thumb"
+          src={item.productImageUrl}
+          name={productHeading}
+          size="md"
+        />
+        <div className="inventory-hero__body">
+          <div className="inventory-hero__title-row">
+            <h3 className="inventory-hero__title">{productHeading}</h3>
+            <StatusBadge compact withDot tone={STOCK_STATUS_BADGE_TONE[status]}>
+              {STOCK_STATUS_LABEL[status]}
+            </StatusBadge>
+          </div>
+          <div className="inventory-hero__meta">
+            {item.productSku ? (
+              <span className="mono-text">{item.productSku}</span>
+            ) : (
+              <span className="text-muted">No SKU</span>
+            )}
+            <span aria-hidden="true" className="inventory-hero__sep">
+              ·
+            </span>
+            <span className="text-muted">{variantLabel}</span>
+            <span aria-hidden="true" className="inventory-hero__sep">
+              ·
+            </span>
+            <span className="text-muted">
+              Updated <TimeDisplay iso={item.updatedAt} />
+            </span>
+          </div>
+          <code className="inventory-hero__id mono-text" title={item.id}>
+            {item.id}
+          </code>
+        </div>
+      </section>
+
+      <section className="inventory-detail__kpi" aria-label="Stock levels">
+        <KpiCard
+          label="Available"
+          tone={STOCK_STATUS_KPI_TONE[status]}
+          value={item.availableQuantity}
+          description={
+            <>
+              {item.reservedQuantity} reserved · {onHand} on hand
+            </>
+          }
+        />
+      </section>
+
       <section className="detail-section">
-        <KeyValueList items={buildInventoryItems(item)} />
+        <h3 className="detail-section__title">Item details</h3>
+        <KeyValueList items={buildDetailItems(item)} />
+      </section>
+
+      <section className="detail-section">
+        <h3 className="detail-section__title">
+          Listings using this stock
+          {listings.length > 0 ? ` (${listings.length})` : ''}
+        </h3>
+        {listingsQuery.isLoading ? (
+          <p className="text-muted">Loading listings…</p>
+        ) : listingsQuery.error ? (
+          <p className="text-muted">Couldn&rsquo;t load listings.</p>
+        ) : listings.length === 0 ? (
+          <p className="text-muted">No listings reference this stock yet.</p>
+        ) : (
+          <DataTable
+            caption="Listings that reference this inventory item"
+            columns={LISTINGS_COLUMNS}
+            rows={listings}
+            rowKey={(row) => row.id}
+          />
+        )}
       </section>
     </PageLayout>
   );

--- a/apps/web/src/pages/inventory/inventory-stock-status.test.ts
+++ b/apps/web/src/pages/inventory/inventory-stock-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_LOW_STOCK_THRESHOLD,
+  deriveStockStatus,
+  STOCK_STATUS_BADGE_TONE,
+  STOCK_STATUS_KPI_TONE,
+  STOCK_STATUS_LABEL,
+} from './inventory-stock-status';
+
+describe('deriveStockStatus', () => {
+  it('returns out-of-stock when availableQuantity is zero', () => {
+    expect(deriveStockStatus(0)).toBe('out-of-stock');
+  });
+
+  it('treats negative quantities as out-of-stock (defensive)', () => {
+    expect(deriveStockStatus(-3)).toBe('out-of-stock');
+  });
+
+  it('returns low-stock at the default threshold boundary (inclusive)', () => {
+    expect(deriveStockStatus(DEFAULT_LOW_STOCK_THRESHOLD)).toBe('low-stock');
+    expect(deriveStockStatus(1)).toBe('low-stock');
+  });
+
+  it('returns in-stock one above the default threshold', () => {
+    expect(deriveStockStatus(DEFAULT_LOW_STOCK_THRESHOLD + 1)).toBe('in-stock');
+    expect(deriveStockStatus(100)).toBe('in-stock');
+  });
+
+  it('respects a custom lowThreshold override', () => {
+    expect(deriveStockStatus(10, 20)).toBe('low-stock');
+    expect(deriveStockStatus(20, 20)).toBe('low-stock');
+    expect(deriveStockStatus(25, 20)).toBe('in-stock');
+  });
+});
+
+describe('stock status lookups', () => {
+  it('provides a user-facing label for each status', () => {
+    expect(STOCK_STATUS_LABEL['out-of-stock']).toBe('Out of stock');
+    expect(STOCK_STATUS_LABEL['low-stock']).toBe('Low stock');
+    expect(STOCK_STATUS_LABEL['in-stock']).toBe('In stock');
+  });
+
+  it('maps each status to a semantic StatusBadge tone', () => {
+    expect(STOCK_STATUS_BADGE_TONE['out-of-stock']).toBe('error');
+    expect(STOCK_STATUS_BADGE_TONE['low-stock']).toBe('warning');
+    expect(STOCK_STATUS_BADGE_TONE['in-stock']).toBe('success');
+  });
+
+  it('maps each status to a semantic KpiCard tone', () => {
+    expect(STOCK_STATUS_KPI_TONE['out-of-stock']).toBe('error');
+    expect(STOCK_STATUS_KPI_TONE['low-stock']).toBe('warning');
+    expect(STOCK_STATUS_KPI_TONE['in-stock']).toBe('success');
+  });
+});

--- a/apps/web/src/pages/inventory/inventory-stock-status.ts
+++ b/apps/web/src/pages/inventory/inventory-stock-status.ts
@@ -1,0 +1,51 @@
+/**
+ * Inventory Stock Status
+ *
+ * Pure helper + lookup tables for deriving a qualitative stock status from
+ * an available-quantity value, and mapping it to the StatusBadge and KpiCard
+ * tones used in the detail-page hero and KPI block.
+ *
+ * Page-local logic (not shared across features), so colocated under
+ * `pages/inventory/`.
+ *
+ * @module pages/inventory
+ */
+import type { KpiCardTone } from '../../shared/ui/kpi-card';
+import type { StatusBadgeTone } from '../../shared/ui/status-badge';
+
+export type StockStatus = 'out-of-stock' | 'low-stock' | 'in-stock';
+
+/**
+ * Default threshold for the "low stock" boundary (inclusive). Per-variant
+ * overrides are not modelled yet — tracked as a follow-up issue after #381.
+ * Exported as a named constant so every caller (helper default, tests, any
+ * future consumer) references one grep-able value instead of a magic 5.
+ */
+export const DEFAULT_LOW_STOCK_THRESHOLD = 5;
+
+export function deriveStockStatus(
+  availableQuantity: number,
+  lowThreshold: number = DEFAULT_LOW_STOCK_THRESHOLD,
+): StockStatus {
+  if (availableQuantity <= 0) return 'out-of-stock';
+  if (availableQuantity <= lowThreshold) return 'low-stock';
+  return 'in-stock';
+}
+
+export const STOCK_STATUS_LABEL: Record<StockStatus, string> = {
+  'out-of-stock': 'Out of stock',
+  'low-stock': 'Low stock',
+  'in-stock': 'In stock',
+};
+
+export const STOCK_STATUS_BADGE_TONE: Record<StockStatus, StatusBadgeTone> = {
+  'out-of-stock': 'error',
+  'low-stock': 'warning',
+  'in-stock': 'success',
+};
+
+export const STOCK_STATUS_KPI_TONE: Record<StockStatus, KpiCardTone> = {
+  'out-of-stock': 'error',
+  'low-stock': 'warning',
+  'in-stock': 'success',
+};

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -14,10 +14,14 @@ import { useOrderQuery } from '../../features/orders/hooks/use-order-query';
 import type { OrderSyncStatus, OrderSyncStatusValue } from '../../features/orders/api/orders.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import { CustomerEntityLabel } from '../../features/customers/components/CustomerEntityLabel';
+import { OrderCustomerCard } from '../../features/orders/components/order-customer-card';
 import { OrderLineItemsPanel } from '../../features/orders/components/order-line-items-panel';
+import { OrderTotalsPanel } from '../../features/orders/components/order-totals-panel';
 import { OrderActivityTimeline } from '../../features/orders/components/order-activity-timeline';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
 import type { ParsedAddress } from '../../features/orders/api/order-snapshot.schema';
+
+const RAW_SNAPSHOT_ANCHOR_ID = 'order-raw-snapshot';
 
 const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
   pending: 'info',
@@ -115,7 +119,13 @@ export function OrderDetailPage(): ReactElement {
           title="Unable to load order"
           message={query.error?.message ?? 'Order not found'}
           action={
-            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+            <Button
+              onClick={() => {
+                void query.refetch();
+              }}
+            >
+              Retry
+            </Button>
           }
         />
       </PageLayout>
@@ -125,8 +135,9 @@ export function OrderDetailPage(): ReactElement {
   const order = query.data;
   const failedDestinations = order.syncStatus.filter((s) => s.status === 'failed');
   const snapshot = parseOrderSnapshot(order.orderSnapshot);
+  const hasAnyAddress = Boolean(snapshot.shippingAddress ?? snapshot.billingAddress);
 
-  const shippingLine = snapshot?.shippingAddress
+  const shippingLine = snapshot.shippingAddress
     ? [
         snapshot.shippingAddress.address1,
         snapshot.shippingAddress.city,
@@ -143,12 +154,10 @@ export function OrderDetailPage(): ReactElement {
       value: order.internalOrderId,
       mono: true,
     },
-    ...(snapshot?.orderNumber
+    ...(snapshot.orderNumber
       ? [{ id: 'orderNumber', label: 'Order #', value: snapshot.orderNumber, mono: true }]
       : []),
-    ...(snapshot?.status
-      ? [{ id: 'status', label: 'Status', value: snapshot.status }]
-      : []),
+    ...(snapshot.status ? [{ id: 'status', label: 'Status', value: snapshot.status }] : []),
     {
       id: 'sourceConnection',
       label: 'Source',
@@ -177,7 +186,7 @@ export function OrderDetailPage(): ReactElement {
     <PageLayout
       eyebrow="Orders"
       title={
-        snapshot?.orderNumber
+        snapshot.orderNumber
           ? `Order #${snapshot.orderNumber}`
           : `Order — ${order.internalOrderId}`
       }
@@ -222,8 +231,8 @@ export function OrderDetailPage(): ReactElement {
         </Alert>
       ) : null}
 
-      {/* Summary + Sync Status — two-column on desktop */}
-      <div className="order-detail__primary-grid">
+      {/* Primary grid: Summary | Sync Status | Customer (three columns on wide viewports) */}
+      <div className="order-detail__primary-grid order-detail__primary-grid--three">
         <section className="detail-section">
           <h3 className="detail-section__title">Summary</h3>
           <KeyValueList items={summaryItems} />
@@ -244,28 +253,59 @@ export function OrderDetailPage(): ReactElement {
             <p className="text-muted">No sync destinations configured.</p>
           )}
         </section>
+
+        <OrderCustomerCard
+          customerId={order.customerId}
+          sourceConnectionId={order.sourceConnectionId}
+        />
       </div>
 
-      {/* Line items */}
-      {snapshot ? (
-        <section className="detail-section">
-          <h3 className="detail-section__title">
-            Line Items{snapshot.items.length > 0 ? ` (${snapshot.items.length})` : ''}
-          </h3>
-          <OrderLineItemsPanel items={snapshot.items} totals={snapshot.totals} />
-        </section>
+      {/* Parse-warnings breadcrumb — quiet, diagnostic, links to the raw snapshot.
+          Stays page-level so it remains visible even when every enriched section
+          below is empty because everything failed to parse. */}
+      {snapshot.parseWarnings.length > 0 ? (
+        <p className="order-detail__parse-warning-row">
+          <a
+            href={`#${RAW_SNAPSHOT_ANCHOR_ID}`}
+            className="order-detail__parse-warning"
+            title="Some fields couldn't be parsed — see raw snapshot"
+          >
+            <span aria-hidden="true">⚠</span> {snapshot.parseWarnings.length} field
+            {snapshot.parseWarnings.length > 1 ? 's' : ''} couldn&rsquo;t be parsed · view raw
+          </a>
+        </p>
       ) : null}
 
-      {/* Addresses */}
-      {(snapshot?.shippingAddress ?? snapshot?.billingAddress) ? (
+      {/* Line items + totals — each renders independently so one failure doesn't blank both.
+          When items are empty but totals exist, skip the Line Items column entirely rather
+          than showing a "Line Items" heading over an explanatory paragraph. */}
+      {snapshot.items.length > 0 || snapshot.totals ? (
+        <div className="order-detail__items-grid">
+          {snapshot.items.length > 0 ? (
+            <section className="detail-section">
+              <h3 className="detail-section__title">Line Items ({snapshot.items.length})</h3>
+              <OrderLineItemsPanel items={snapshot.items} totals={snapshot.totals} />
+            </section>
+          ) : null}
+          {snapshot.totals ? (
+            <section className="detail-section order-detail__totals-section">
+              <h3 className="detail-section__title">Totals</h3>
+              <OrderTotalsPanel totals={snapshot.totals} />
+            </section>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* Addresses — render each independently whenever its own sub-tree parsed */}
+      {hasAnyAddress ? (
         <div className="order-detail__address-grid">
-          {snapshot?.shippingAddress ? (
+          {snapshot.shippingAddress ? (
             <section className="detail-section">
               <h3 className="detail-section__title">Shipping Address</h3>
               <KeyValueList items={buildAddressItems(snapshot.shippingAddress, 'Address')} />
             </section>
           ) : null}
-          {snapshot?.billingAddress ? (
+          {snapshot.billingAddress ? (
             <section className="detail-section">
               <h3 className="detail-section__title">Billing Address</h3>
               <KeyValueList items={buildAddressItems(snapshot.billingAddress, 'Address')} />
@@ -284,8 +324,8 @@ export function OrderDetailPage(): ReactElement {
         />
       </section>
 
-      {/* Raw snapshot — collapsed by default */}
-      <section className="detail-section">
+      {/* Raw snapshot — collapsed by default; warning chip above links here */}
+      <section className="detail-section" id={RAW_SNAPSHOT_ANCHOR_ID}>
         <RawPayloadPanel title="Order Snapshot" payload={order.orderSnapshot} />
       </section>
     </PageLayout>

--- a/apps/web/src/shared/format/format-amount.ts
+++ b/apps/web/src/shared/format/format-amount.ts
@@ -1,0 +1,21 @@
+/**
+ * Amount Formatter
+ *
+ * Currency-aware number formatting. When `currency` is a non-empty ISO-4217
+ * code, formats as localised currency; otherwise falls back to a bare numeric
+ * representation with two fraction digits. Centralised so every surface that
+ * renders money (order totals, line-item unit/line prices, offer prices)
+ * produces the same output for the same input.
+ *
+ * @module apps/web/src/shared/format
+ */
+
+export function formatAmount(amount: number, currency: string | undefined): string {
+  if (currency) {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount);
+  }
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}

--- a/docs/plans/implementation-plan-381-382-detail-page-polish.md
+++ b/docs/plans/implementation-plan-381-382-detail-page-polish.md
@@ -1,0 +1,285 @@
+# Implementation Plan — #381 + #382 Detail-Page Polish
+
+**Branch:** `381-382-detail-page-polish`
+**Scope:** FE-only. Rebuild inventory detail page (#381) + enrich order detail page §1–§3 (#382).
+**Deferred:** #382 §4 (BE item display info) — requires domain extension; filed as a follow-up BE issue after this PR lands.
+
+---
+
+## 1 · Goal & classification
+
+**Layer:** Frontend (`apps/web/src/`). No API, core, worker, or migration changes.
+
+**Goal:** Two detail pages currently useless-for-operators get rebuilt with the data already available in the API, using existing shared primitives. Voice stays refined-minimal per `docs/frontend-ui-style-guide.md` (Shopify admin clarity + Linear polish).
+
+**Explicit non-goals** (out of scope — filed as follow-ups):
+
+- Inventory "Adjust stock" action (needs BE endpoint — follow-up)
+- Inventory movement / adjustment history (needs BE — follow-up)
+- Per-inventory-item sync activity feed (needs BE — follow-up)
+- Per-variant low-stock threshold configuration (BE + FE — follow-up)
+- **#382 §4a/§4b — item `name`/`imageUrl` propagation through Allegro adapter + `OrderRecordService`** — requires extending unified `OrderItem` domain type; filed as a follow-up BE issue. FE schema already treats these fields as optional so nothing regresses.
+- Product-image enrichment for marketplace items (separate issue)
+- Customer merge/split, order status-transition UI, item-level sync diagnostics
+
+**Dependency on #380 (BackLink primitive):** non-blocking. Keep current ad-hoc back-link in place; migrate in #380's own PR.
+
+---
+
+## 2 · Design decisions (with rationale)
+
+### 2.1 Single branch, two commits, one PR closing both issues
+
+Both issues are FE-only, touch non-conflicting file sets, and share the same design voice. Reviewing them together is cheaper than two separate PRs. Commit structure:
+
+- Commit 1: `feat(web): rebuild inventory detail page — hero, KPIs, cross-links, listings (#381)`
+- Commit 2: `feat(web): enrich order detail page — customer card, resilient snapshot, totals block (#382)`
+
+PR body uses `Closes #381` and `Closes #382`.
+
+### 2.2 `ProductThumbnail` gets an `lg` size variant
+
+`ProductThumbnail` currently has `sm` / `md`. The inventory hero needs a bigger image. The right move is extending the shared primitive, not inventing a one-off image renderer in `pages/inventory/`. Cost: one entry in the size union, one CSS rule. No consumer breakage — default stays `md`.
+
+### 2.3 Inventory status derivation is a pure helper, not a hook
+
+`deriveStockStatus(available, lowThreshold?)` lives as a pure function at `pages/inventory/inventory-stock-status.ts`. Pure → easy to unit-test without mocking React. Co-located because it's page-local logic, not shared across features. `lowThreshold` defaults to `5` (constant); per-variant thresholds are deferred.
+
+### 2.4 Soft-parse `parseOrderSnapshot` via independent sub-tree `safeParse`
+
+Today `parseOrderSnapshot` returns `null` on any failure, which binary-gates every enriched section. The fix is to `safeParse` each sub-tree (items, totals, shippingAddress, billingAddress) independently and surface failures through a new `parseIssues` array on the result. Callers stop gating on a single parsed value.
+
+Key design note: the top-level `orderSnapshotSchema.id` is required today, which is the most common failure point. Loosen it to optional on the top-level read — the UI tolerates missing `id` because it keys off `order.internalOrderId` (the outer record's ID), not the snapshot's. The schema's `id` was never load-bearing.
+
+### 2.5 Customer card always renders (with a null-state branch)
+
+When `order.customerId` is null, render a muted inline message — same card chrome, different content — rather than suppressing the column. This keeps the three-column grid stable across orders and makes the null case discoverable ("why is this empty?" gets an inline answer).
+
+### 2.6 Totals panel extracted from line-items panel
+
+The totals rollup currently lives inside `OrderLineItemsPanel`. Extracting it means totals remain visible when items fail to parse, and the financial summary gets its own visual anchor (grand-total emphasised via weight + size, not colour). `OrderLineItemsPanel` loses its `totals` prop.
+
+### 2.7 Inventory hero layout: `grid-template-columns: auto 1fr` on wide, stacks on narrow
+
+No new tokens. Uses existing `var(--space-*)`, `var(--bg-surface)`, `var(--border-subtle)` from the monochrome palette shipped in #371.
+
+---
+
+## 3 · Files changed
+
+### 3.1 #381 — Inventory detail (commit 1)
+
+**Modify**
+- `apps/web/src/pages/inventory/inventory-detail-page.tsx` — full rewrite against new layout
+- `apps/web/src/shared/ui/product-thumbnail.tsx` — add `'lg'` to size union
+- `apps/web/src/index.css` — add `.inventory-detail__hero`, `.inventory-detail__kpi-row`, `.inventory-detail__section`, `.product-thumbnail--lg`
+
+**New**
+- `apps/web/src/pages/inventory/inventory-stock-status.ts` — `deriveStockStatus`, `StockStatus` union
+- `apps/web/src/pages/inventory/inventory-stock-status.test.ts` — three-branch coverage + threshold edge cases
+- `apps/web/src/pages/inventory/inventory-detail-page.test.tsx` — hero renders, KPI row values, status badge reflects thresholds, cross-links render, listings section renders + empty, loading/error states
+
+### 3.2 #382 — Order detail enrichment §1–§3 (commit 2)
+
+**Modify**
+- `apps/web/src/features/orders/api/order-snapshot.schema.ts` — soft-parse, `parseIssues`, top-level `id` loosened
+- `apps/web/src/pages/orders/order-detail-page.tsx` — ungate sections, add customer column, totals block, parse-issues alert, three-column primary grid
+- `apps/web/src/features/orders/components/order-line-items-panel.tsx` — drop totals prop + rollup
+- `apps/web/src/features/orders/components/order-line-items-panel.test.tsx` — drop totals assertions
+- `apps/web/src/index.css` — `.order-customer-card`, `.order-totals-panel`, extend `.order-detail__primary-grid` to three columns on wide viewports
+
+**New**
+- `apps/web/src/features/orders/components/order-customer-card.tsx`
+- `apps/web/src/features/orders/components/order-customer-card.test.tsx`
+- `apps/web/src/features/orders/components/order-totals-panel.tsx`
+- `apps/web/src/features/orders/components/order-totals-panel.test.tsx`
+- `apps/web/src/features/orders/api/order-snapshot.schema.test.ts` — if not already present; covers full-parse, missing `id`, items with missing `productId`, invalid `totals` + valid `items`, empty object
+
+---
+
+## 4 · Step-by-step implementation
+
+### Phase A · Shared primitive extension (foundation for #381)
+
+**A.1** · Extend `ProductThumbnail` with `'lg'` size.
+- File: `apps/web/src/shared/ui/product-thumbnail.tsx`
+- Change: `type ProductThumbnailSize = 'md' | 'sm'` → `'md' | 'sm' | 'lg'`
+- Change: `const size = props.size ?? 'md'` → unchanged
+- CSS: new rule `.product-thumbnail--lg` with 96px square, `font-size: 2rem` for initial fallback
+
+**A.2** · Test: `product-thumbnail.test.tsx` — add an `lg` size test if the file exists; otherwise skip (not a regression risk).
+
+### Phase B · #381 Inventory detail rebuild
+
+**B.1** · Create `inventory-stock-status.ts` with pure helper:
+```ts
+export type StockStatus = 'out-of-stock' | 'low-stock' | 'in-stock';
+export function deriveStockStatus(available: number, lowThreshold = 5): StockStatus {
+  if (available <= 0) return 'out-of-stock';
+  if (available <= lowThreshold) return 'low-stock';
+  return 'in-stock';
+}
+```
+Map each status to `{ label, tone: StatusBadgeTone }` in the same file.
+
+**B.2** · Create `inventory-stock-status.test.ts` — unit-test three branches + threshold boundary (0, 1, `lowThreshold`, `lowThreshold + 1`, custom threshold).
+
+**B.3** · Rewrite `inventory-detail-page.tsx`:
+- Keep loading/error states (unchanged from current).
+- Drop the single `KeyValueList` layout.
+- Render hero: `ProductThumbnail size="lg" src={item.productImageUrl} name={item.productName ?? 'Inventory item'}` + headline (product name) + SKU line + `StatusBadge` (tone from `deriveStockStatus`) + copyable inventory UUID chip.
+- `PageLayout.title` = `item.productName ?? 'Inventory item'` (not the UUID).
+- `PageLayout.actions` = `<Link className="button button--primary" to={`/products/${item.productId}`}>View product</Link>` + keep existing back link (migrate to `BackLink` when #380 lands).
+- Three-column KPI row (`KpiCard` ×3): Available (tone from status), Reserved (neutral), On hand (neutral).
+- "Item details" section: `KeyValueList` with variant (with `"Simple product — no variants"` fallback when `productVariantId` is null), SKU, location (`"Default location"` when null), updated (`TimeDisplay` — existing component), product ID as `EntityLabel` linking to `/products/${item.productId}`.
+- "Listings using this stock" section: `useListingsQuery({ internalId: item.productVariantId ?? item.productId })` → `DataTable`. Inline-empty message when no rows.
+
+**B.4** · CSS in `index.css`:
+```css
+.inventory-detail__hero {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.25rem;
+  align-items: start;
+  padding: 1.25rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.75rem;
+}
+.inventory-detail__hero-body { display: grid; gap: 0.5rem; }
+.inventory-detail__hero-title { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; }
+.inventory-detail__hero-meta { display: flex; gap: 1rem; color: var(--text-muted); font-size: 0.875rem; }
+.inventory-detail__kpi-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+.inventory-detail__section { display: grid; gap: 0.75rem; }
+@media (max-width: 768px) {
+  .inventory-detail__hero { grid-template-columns: 1fr; }
+  .inventory-detail__kpi-row { grid-template-columns: 1fr; }
+}
+```
+
+**B.5** · Test: `inventory-detail-page.test.tsx`.
+- Mock `InventoryApi.getById` via `createMockApiClient`.
+- Assertions:
+  - Renders hero with product name, image (via `src` attribute), SKU chip.
+  - Stock-status badge label corresponds to quantity: 0 → "Out of stock", 3 → "Low stock", 100 → "In stock".
+  - KPI row shows three values: Available, Reserved, On hand (= sum).
+  - "View product" link points to `/products/${productId}`.
+  - Variant shows "Simple product — no variants" when `productVariantId` is null.
+  - Location shows "Default location" when `locationId` is null.
+  - "Listings using this stock" section renders listings or the inline empty message.
+  - Loading state renders `LoadingState`, error state renders `ErrorState` with Retry button.
+
+### Phase C · #382 Order detail enrichment
+
+**C.1** · Rewrite `order-snapshot.schema.ts`:
+- Add sub-schema exports: `orderItemsSchema`, `orderTotalsSchema`, `addressSchema` (already defined internally — promote to exports).
+- Change top-level `orderSnapshotSchema.id` from `z.string()` to `z.string().optional()`.
+- Add new `ParsedOrderSnapshot` shape with `parseIssues: Array<{ field: string; message: string }>`.
+- Rewrite `parseOrderSnapshot(snapshot: Record<string, unknown>): ParsedOrderSnapshot` to never return null; parse each sub-tree independently via `safeParse` and collect issues.
+- Export `ParsedOrderItem`, `ParsedOrderTotals`, `ParsedAddress` as before.
+
+**C.2** · Create `order-snapshot.schema.test.ts`:
+- Full-valid snapshot → all fields populated, `parseIssues` empty.
+- Missing top-level `id` → returns result without `id`, no `parseIssues` entries for it (since we loosened).
+- Items with missing `productId` → item omitted from `items` array, `parseIssues` contains an entry pointing at the offending index.
+- Invalid `totals` but valid `items` → `totals` is `undefined`, `items` populated, `parseIssues` contains `{ field: 'totals', ... }`.
+- Completely empty object `{}` → `items: []`, no other fields, `parseIssues` empty (everything is optional).
+
+**C.3** · Extract `OrderTotalsPanel`:
+- New file `apps/web/src/features/orders/components/order-totals-panel.tsx`.
+- Props: `{ totals: ParsedOrderTotals }` (caller guards on presence).
+- Reuses the existing `.order-totals` / `.order-totals__row` / `.order-totals__row--total` CSS classes — don't duplicate; update `index.css` only if the extraction requires class renames (it shouldn't).
+- Currency formatting via `Intl.NumberFormat(undefined, { style: 'currency', currency: totals.currency })` with a fallback to bare numeric formatting when `currency` is missing.
+
+**C.4** · Create `order-totals-panel.test.tsx`:
+- All fields present → renders subtotal, shipping, tax, total.
+- `shipping === 0` / `tax === 0` → rows omitted (preserves current behaviour).
+- Missing currency → numeric-only formatting without throwing.
+
+**C.5** · Drop totals from `OrderLineItemsPanel`:
+- Remove `totals` prop + rollup JSX.
+- Update its test file to drop totals assertions — assertions for the table itself remain.
+
+**C.6** · Create `OrderCustomerCard`:
+- New file `apps/web/src/features/orders/components/order-customer-card.tsx`.
+- Props: `{ customerId: string | null }` — component handles all the plumbing (query, loading/error/empty/data).
+- When `customerId === null`: render muted inline message "No customer linked — order may be a guest checkout or customer resolution failed." (no card outline).
+- When loading: render card shell with skeleton-light placeholders (one line for name, one for email).
+- When error: muted inline "Couldn't load customer details" + Retry button.
+- When data present:
+  - Display name: `firstName + lastName` joined, fallback "Unknown name".
+  - Email: `normalizedEmail` if present; else `emailHash` rendered as a short `mono-text` chip (use `substring(0, 12) + '…'`).
+  - Last seen: `TimeDisplay iso={customer.lastSeenAt}`.
+  - Previous orders count: `useOrdersQuery({ customerId }).data?.total` — render "N previous orders" as a link to `/customers/${customerId}` when > 0.
+  - "View customer →" link at bottom.
+
+**C.7** · Create `order-customer-card.test.tsx`:
+- Raw PII mode (normalizedEmail + firstName + lastName present) → full name + email rendered.
+- Hash-only mode (normalizedEmail null, firstName/lastName null) → "Unknown name" + emailHash chip.
+- `customerId === null` → muted message, no customer query triggered (assert `apiClient.customers.getById` not called).
+- Loading → skeleton shell visible.
+- Error → "Couldn't load customer details" + Retry.
+- Orders query result → "N previous orders" link renders with correct count.
+
+**C.8** · Wire up `order-detail-page.tsx`:
+- Replace `const snapshot = parseOrderSnapshot(order.orderSnapshot)` — new return shape is never null.
+- Extend `.order-detail__primary-grid` to three columns on wide viewports via CSS media query; add `<OrderCustomerCard customerId={order.customerId} />` as third column.
+- Ungate line items: render when `snapshot.items.length > 0` (not on `snapshot` truthiness).
+- Ungate addresses: render each when its own sub-tree is present.
+- Add `<OrderTotalsPanel totals={snapshot.totals} />` next to line items (or below on narrow viewports) — render when `snapshot.totals` present.
+- Parse-issues alert: when `snapshot.parseIssues.length > 0`, render `<Alert tone="warning">Some order fields couldn't be parsed — see raw snapshot below.</Alert>` above line items with an anchor link to the raw snapshot section's id.
+
+**C.9** · CSS updates in `index.css`:
+- Extend `.order-detail__primary-grid` to `grid-template-columns: 1.2fr 1fr 1fr` on `min-width: 1024px`, `1fr 1fr` on tablet, `1fr` on narrow.
+- Add `.order-customer-card` block matching the existing `.detail-section` card chrome — same border, background, padding, radius.
+- Reuse existing `.order-totals*` classes for `OrderTotalsPanel` (class names unchanged from extraction).
+
+---
+
+## 5 · Test strategy
+
+Unit + component tests only; no integration tests needed for FE-only changes.
+
+**Coverage deltas:**
+- Pure helpers (`deriveStockStatus`, `parseOrderSnapshot`): 100% branch coverage.
+- Components: happy path, loading, error, empty, per the FE rules.
+
+**Command:** `pnpm test` in worktree root runs all vitest suites across the monorepo (unit tests only; no Docker needed).
+
+---
+
+## 6 · Validation checklist (pre-commit)
+
+For each commit:
+
+- [ ] Architecture compliance: `shared` doesn't import from `features` or `pages`; `pages` doesn't cross-feature-import; no core boundary violations.
+- [ ] Naming: `kebab-case.tsx` components, `use-*.ts` hooks, `*.test.tsx` tests, `*.schema.ts` zod schemas, `*.types.ts` types.
+- [ ] No `any`, no `console.log`, no hardcoded secrets.
+- [ ] All four states handled on every page/component that fetches.
+- [ ] Pure vanilla CSS using existing tokens only — no new custom properties introduced.
+- [ ] `tone` (not `variant` / `color`) for variant props; class construction with `.filter(Boolean).join(' ')`.
+- [ ] `pnpm lint`, `pnpm type-check`, `pnpm test` pass with zero errors.
+
+---
+
+## 7 · Risks & open questions
+
+| Risk | Mitigation |
+|---|---|
+| Extending `ProductThumbnail` with `lg` breaks existing snapshot tests | Tests assert tone + src; size is a modifier class, not part of assertions. Audit at implementation time. |
+| `useOrdersQuery({ customerId })` may return full page (expensive) just for count | Use `pagination: { limit: 1 }` — backend returns `total` in payload regardless. Low cost. |
+| Three-column grid breaks the order detail at ~1024px tablet | Explicit media-query breakpoints: 3-col ≥1024px, 2-col 768–1023px, 1-col <768px. Matches existing tablet anchor from memory. |
+| #382 §4 deferral leaves line items with SKU-only rendering | Accepted — existing fallback chain `name ?? sku ?? productId` already handles it; no regression from current behaviour. Follow-up BE issue tracks the enrichment. |
+| `parseOrderSnapshot` behavioural change could silently regress callers | Only one caller (the page). Schema tests plus page tests cover the new contract. |
+
+**No open questions requiring user input** — the issue specs are prescriptive enough.
+
+---
+
+## 8 · Follow-ups to file after merge
+
+1. **BE — Propagate item `name`/`imageUrl` end-to-end.** Extend `OrderItem` on the unified domain (`libs/core/src/orders/domain/types/order.types.ts`) with optional `name`/`imageUrl`; propagate through `OrderRecordService.persistOrder`; map `lineItem.offer.name` in `AllegroOrderSourceAdapter`. Updates specs in both locations. This is exactly §4 of #382, deferred per the issue's own guidance.
+2. **BE — `InventoryAdjustment` HTTP endpoint.** Domain type already exists; add controller + use case; then FE dialog + mutation hook.
+3. **BE — Inventory movement / adjustment history read model.** Needs persistence of adjustment events.
+4. **FE — Per-inventory sync activity feed.** Needs sync-jobs endpoint filter by affected inventory ID.
+5. **FE — Product-image enrichment for marketplace items** (resolve internal Product via `productId` to show images on Allegro orders where `imageUrl` is blank).


### PR DESCRIPTION
## Summary

Two coupled FE-only improvements to the inventory and order detail pages — both were operator-hostile today. Inventory detail was a single `KeyValueList` of 8 IDs on an empty viewport. Order detail blanked every enriched section on a single malformed snapshot field. Both now use existing API fields and shared UI primitives with no backend work.

Plan: `docs/plans/implementation-plan-381-382-detail-page-polish.md`.

### #381 — Inventory detail page

- Hero with `ProductThumbnail`, product name as page title (UUID demoted to a chip), compact `StatusBadge withDot` status lockup, SKU/variant/updated meta row.
- Single compound `KpiCard` — `Available` as the primary number, `N reserved · M on hand` as supporting stats, tone keyed off `deriveStockStatus`.
- Item details KVL with smarter empty-copy (*"Simple product — no variants"*, *"Default location"*) and an `EntityLabel` linking back to the parent product.
- "Listings using this stock" section via `useListingsQuery({ internalId: productVariantId ?? productId })` — reuses the existing offer-mapping filter, no BE work.
- `DEFAULT_LOW_STOCK_THRESHOLD` and status-tone lookups extracted as a pure helper (`inventory-stock-status.ts`) with its own unit test.

### #382 — Order detail enrichment (§1–§3)

- `parseOrderSnapshot` now soft-parses: each sub-tree (items, totals, shipping/billing) validates independently and failures are surfaced via `parseWarnings` instead of returning `null` and blanking every enriched section.
- New `OrderCustomerCard` as the third column of `.order-detail__primary-grid` — handles null-customer / loading / error / data, works under PII hash-only mode (`normalizedEmail` ↔ `emailHash` chip), shows last-seen and previous-orders count. When no customer is linked, offers a "View failed orders" link scoped to the source connection.
- `OrderTotalsPanel` extracted from `OrderLineItemsPanel` so the financial summary stays visible when items fail to parse. Grand total is a typographic anchor (larger tabular-mono numeral) — not a colour change.
- Quiet inline parse-warning breadcrumb linking to the raw-snapshot section. Stays visible even when every enriched section is empty.

### §4 deferred

`OrderItem` on the unified domain doesn't carry `name` / `imageUrl` yet. Per the issue's own guidance, that's a separate BE issue (to be filed) rather than scope creep here. The FE schema already treats both fields as optional, so nothing regresses when they start flowing through.

### Tech-review polish applied

- Extracted `formatAmount` to `apps/web/src/shared/format/format-amount.ts` — was duplicated across `OrderLineItemsPanel` and `OrderTotalsPanel`.
- Extended `useOrdersQuery` with an optional `{ staleTime }` bag so `OrderCustomerCard` doesn't need an in-component `useQuery`.
- Grand-total row promoted to anchor-typography (larger tabular-mono `dd`, uppercase `dt`).
- `scroll-margin-top` on `#order-raw-snapshot` so the parse-warning anchor clears the sticky topbar.
- Gated previous-orders count on `ordersCountQuery.isFetched` to avoid an off-by-one flash during the post-create eventual-consistency window.
- Skip the "Line Items" heading when items are empty-but-totals-present (keeps the section clean).

## Test plan

- [x] `pnpm lint` — 0 errors (16 pre-existing warnings unrelated)
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1,787 tests passing across all packages (web 656, core 443, api 262, worker 107, allegro 93, prestashop 200, ai 19, shared 7)
- [ ] Manual: open `/inventory/:id` on a real record with no image — confirm fallback thumbnail, status badge, KPI, cross-link to `/products/:id`, and listings table (or empty copy).
- [ ] Manual: open `/orders/:internalOrderId` for the failing-Allegro-order case — confirm customer card shows (or null-state with View-failed-orders link), items or totals render independently, parse-warning chip links to raw snapshot and scrolls clear of the topbar.
- [ ] Visual check at 1440, 1024, 768, 360 widths — no horizontal scroll, three-column grid reflows to 2-col at 1023 and 1-col below 768.

Closes #381
Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)
