### PR TITLE
fix(allegro): send images[] as string[] for POST /sale/product-offers

### DIFF
--- a/docs/plans/implementation-plan-allegro-offer-create-images-shape.md
+++ b/docs/plans/implementation-plan-allegro-offer-create-images-shape.md
@@ -1,0 +1,76 @@
+# Implementation Plan — Fix Allegro `POST /sale/product-offers` images[] shape (#387)
+
+## 1. Understand the task
+
+**Goal:** Stop Allegro from rejecting every offer create with 422 `JsonMappingException` on `images[0]`. The adapter sends `images: [{ url }]`, Allegro's current `POST /sale/product-offers` expects `images: string[]`.
+
+**Classification:** Integration layer, bug fix. Single adapter + single type + one test assertion.
+
+**Non-goals:**
+- No changes to the `updateOfferFields` capability (doesn't write images today).
+- No changes to image validation (size/count/format) — Allegro still owns that and returns `validation.errors`.
+- No migration, no new port, no new API surface, no FE changes.
+- Do not revisit the legacy `POST /sale/offers` endpoint — the shape `{ url }` came from there but is dead code for the current adapter.
+
+## 2. Research — what already exists
+
+- `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts:745-747` — wraps URLs in `{ url }`.
+- `libs/integrations/allegro/src/domain/types/allegro-api.types.ts:334` — type encodes the wrong shape `Array<{ url: string }>`.
+- `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts`:
+  - `:516–529` — `baseCmd` already includes `imageUrls: ['https://example.com/img.jpg']`.
+  - `:537–560` — the "draft status" path asserts the body via `toMatchObject` but never touches `images`. Every body-shape assertion in the suite omits `images` — that's how the bug slipped through.
+  - `:689–706` — the "omits images" path is green and must stay green.
+- Input contract: `CreateOfferCommand.overrides.imageUrls?: string[] | null` (core, already a string array).
+
+No other adapter, service, or test references `images` with the wrapped shape.
+
+## 3. Design
+
+**Change 1 — type:** `AllegroProductOfferCreateRequest.images?: string[]` (was `Array<{ url: string }>`).
+
+**Change 2 — adapter:** emit the array as-is.
+```ts
+if (cmd.overrides?.imageUrls && cmd.overrides.imageUrls.length > 0) {
+  body.images = cmd.overrides.imageUrls;
+}
+```
+No defensive copy — `body` is built once, serialised straight into the HTTP request, never mutated. The rest of `buildCreateOfferRequest` and `applyPlatformParams` already pass arrays through without copying.
+
+**Change 3 — test:** add two positive assertions in the existing `createOffer` suite:
+- single-URL `baseCmd` produces `body.images: ['https://example.com/img.jpg']` (catches the original bug)
+- multi-URL fixture produces `body.images` equal to the input array verbatim (locks in order-preservation against future "improvements")
+
+The "no images" path at `:689` already locks in the omission case — leave it untouched.
+
+No other files need editing. No module rewiring, no DI changes.
+
+## 4. Step-by-step
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| 1 | `libs/integrations/allegro/src/domain/types/allegro-api.types.ts:334` | `images?: string[];` | `pnpm type-check` green |
+| 2 | `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts:745-747` | `body.images = [...cmd.overrides.imageUrls];` | adapter compiles against new type |
+| 3 | `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts` — add one `it(...)` inside `describe('createOffer', …)` | Assert `expect(body).toEqual(expect.objectContaining({ images: ['https://example.com/img.jpg'] }))` for `baseCmd` | new test fails on current code, passes after steps 1-2; `:689` still green |
+| 4 | Quality gate | `pnpm lint && pnpm type-check && pnpm test` | all green |
+
+## 5. Validate
+
+- **Architecture:** type + adapter only; no domain or application changes — no hexagonal boundary crossings.
+- **Naming:** unchanged file names, unchanged class names.
+- **Testing:** unit test at the adapter boundary, mocks the HTTP client (per `backend.md`: "mock ports and interfaces"). No integration-test impact.
+- **Security:** image URLs are already caller-supplied; serialising them as strings instead of `{ url }` objects changes no trust boundary.
+- **Migration / DB:** none.
+- **Backwards compat:** `images` is an internal adapter-to-Allegro detail; no consumer outside the adapter reads it.
+
+## Risks & open questions
+
+- Allegro's docs could theoretically accept both shapes; error text strongly suggests they don't. Manual sandbox check after merge: POST an offer with at least one image URL and confirm 201/202 instead of 422.
+- No concerns around multi-image payloads — the same transformation applies to every element.
+
+## Verification
+
+1. `pnpm --filter @openlinker/integrations-allegro test` — unit tests green.
+2. `pnpm lint && pnpm type-check && pnpm test` — full quality gate.
+3. Sandbox: trigger a `marketplace.offer.create` job on a connection with a variant that has images; confirm Allegro returns 201/202 and the adapter logs `status=active|draft` instead of `rejected`.
+
+**Note:** `libs/integrations/allegro/dist/` carries the wrong type from the previous build. Anyone running locally against pre-built artifacts must `pnpm --filter @openlinker/integrations-allegro build` (or `pnpm build` at root) before manual sandbox testing, otherwise the bug appears to persist after the source is fixed. CI rebuilds from source, so this only affects local dev.

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -331,7 +331,7 @@ export interface AllegroProductOfferCreateRequest extends Record<string, unknown
       items: Array<{ type: 'TEXT'; content: string }>;
     }>;
   };
-  images?: Array<{ url: string }>;
+  images?: string[];
   parameters?: Array<{ id: string; values?: string[]; valuesIds?: string[] }>;
   delivery?: { shippingRates?: { id: string }; handlingTime?: string };
   afterSalesServices?: {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -736,6 +736,20 @@ describe('AllegroOfferManagerAdapter', () => {
       expect(body.images).toEqual(imageUrls);
     });
 
+    it('omits images from the body when overrides.imageUrls is an empty array', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-img-empty', publication: { status: 'INACTIVE' } }),
+      );
+
+      await adapter.createOffer({
+        ...baseCmd,
+        overrides: { ...baseCmd.overrides, imageUrls: [] },
+      });
+
+      const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body).not.toHaveProperty('images');
+    });
+
     it('throws OfferCreateRejectedException when overrides.categoryId is missing (precondition)', async () => {
       const cmd: CreateOfferCommand = {
         ...baseCmd,

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -705,6 +705,37 @@ describe('AllegroOfferManagerAdapter', () => {
       expect(body).not.toHaveProperty('images');
     });
 
+    it('emits images as a flat string[] (Allegro POST /sale/product-offers wire shape)', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-img', publication: { status: 'INACTIVE' } }),
+      );
+
+      await adapter.createOffer(baseCmd);
+
+      const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.images).toEqual(['https://example.com/img.jpg']);
+    });
+
+    it('preserves image URL order when multiple images are supplied', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-img-multi', publication: { status: 'INACTIVE' } }),
+      );
+
+      const imageUrls = [
+        'https://example.com/a.jpg',
+        'https://example.com/b.jpg',
+        'https://example.com/c.jpg',
+      ];
+
+      await adapter.createOffer({
+        ...baseCmd,
+        overrides: { ...baseCmd.overrides, imageUrls },
+      });
+
+      const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.images).toEqual(imageUrls);
+    });
+
     it('throws OfferCreateRejectedException when overrides.categoryId is missing (precondition)', async () => {
       const cmd: CreateOfferCommand = {
         ...baseCmd,

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -743,7 +743,7 @@ export class AllegroOfferManagerAdapter
     }
 
     if (cmd.overrides?.imageUrls && cmd.overrides.imageUrls.length > 0) {
-      body.images = cmd.overrides.imageUrls.map((url) => ({ url }));
+      body.images = cmd.overrides.imageUrls;
     }
 
     this.applyPlatformParams(body, platformParams);


### PR DESCRIPTION
## Summary

- Allegro's `POST /sale/product-offers` rejected every offer-create with **422 `JsonMappingException`** on `images[0]` because the adapter wrapped each URL in `{ url }` while the endpoint expects an array of URL strings.
- Drop the wrap, tighten `AllegroProductOfferCreateRequest.images` from `Array<{ url: string }>` to `string[]`, and lock the wire shape with three new unit-test assertions in the existing `createOffer` suite (single URL, multi-URL order preservation, empty-array omission). The pre-existing `imageUrls: null` omission case stays untouched.
- Pure integration-layer change — no CORE, application, or FE impact; no migration.

## Why the bug existed

The `{ url }` shape is the contract of the legacy `POST /sale/offers` endpoint. It was carried into `AllegroOfferManagerAdapter` when the port was split (`977fe5a` / #328) and never exercised end-to-end on sandbox until today. The existing `createOffer` test suite asserts the body shape with `toMatchObject` and never touches the `images` key — that's how it slipped through.

## Test plan

- [x] `pnpm --filter @openlinker/integrations-allegro test` — Allegro suite: 93 → 96 tests, all green
- [x] `pnpm test` — full unit-test suite green across all packages
- [x] `pnpm lint` — 0 errors (warnings are pre-existing, untouched)
- [x] `pnpm type-check` — 0 errors
- [ ] **Sandbox verification (post-merge):** trigger a `marketplace.offer.create` job on a connection with a variant that has at least one image; confirm Allegro returns 201/202 instead of 422 and the adapter logs `status=active|draft` instead of `rejected`. Local stale `dist/` rebuild also required for any pre-built worker artifacts (`pnpm --filter @openlinker/integrations-allegro build`).

Plan doc: `docs/plans/implementation-plan-allegro-offer-create-images-shape.md`

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)