### PR TITLE
feat(orders,allegro): propagate line-item name + imageUrl through the order pipeline

### DIFF
--- a/docs/plans/implementation-plan-388-order-item-name-image-url.md
+++ b/docs/plans/implementation-plan-388-order-item-name-image-url.md
@@ -1,0 +1,178 @@
+# Implementation Plan — #388: Propagate line-item `name` + `imageUrl` through the order pipeline
+
+## Goal
+
+End-to-end propagation of `name` and `imageUrl` for order line items, so the
+order-detail page (FE already accepts these as optional via #386) renders real
+product names instead of *"unnamed SKU row"* for Allegro orders.
+
+## Layer classification
+
+CORE + Integration. No interface/UI work, no migration, no env vars, no FE
+change.
+
+## Non-goals
+
+- PrestaShop order-source `name` enrichment (separate adapter, different shape — defer).
+- Internal-catalog `imageUrl` enrichment for Allegro (Allegro's checkout-form
+  endpoint does not expose product images — defer to a follow-up).
+- Translation / locale handling for `name` (multi-locale is a separate workstream).
+- Any change to the persisted `orderSnapshot` schema contract (it's `Record<string, unknown>`; new keys are additive).
+
+## Discovery — files the issue body did not call out
+
+The issue lists 3 production files. The propagation chain actually crosses 5,
+because there are two distinct item types:
+
+| Layer | Type | Where |
+|---|---|---|
+| Adapter return | `IncomingOrderItem` | `libs/core/src/orders/domain/types/incoming-order.types.ts` |
+| Unified order  | `OrderItem`        | `libs/core/src/orders/domain/types/order.types.ts` |
+
+Conversion happens in `OrderIngestionService.buildUnifiedOrder` —
+specifically the resolved-items loop at `order-ingestion.service.ts:203-217`,
+which today does `{ id, productId, variantId, quantity, price, sku }` and drops
+everything else.
+
+Without extending `IncomingOrderItem` and propagating through the conversion,
+the adapter mapping `name: lineItem.offer.name` won't typecheck, and even if it
+did the field would evaporate in `buildUnifiedOrder` before reaching
+`persistOrder`. So the honest minimum diff is **5 production files + 2 specs**,
+not the 3+2 the issue body lists.
+
+## Implementation steps
+
+### 1. Extend `IncomingOrderItem` (domain types — incoming side)
+
+**File:** `libs/core/src/orders/domain/types/incoming-order.types.ts`
+
+Add two optional fields to `IncomingOrderItem`:
+
+```ts
+name?: string;       // Source-reported display label (no translation)
+imageUrl?: string;   // Absolute URL when the source provides one
+```
+
+**Acceptance:** type compiles; existing consumers unaffected (fields optional).
+
+### 2. Extend `OrderItem` (domain types — unified side)
+
+**File:** `libs/core/src/orders/domain/types/order.types.ts:94-101`
+
+Same two optional fields on `OrderItem`. Issue spec already shows the exact
+shape.
+
+**Acceptance:** type compiles.
+
+### 3. Populate `name` in `AllegroOrderSourceAdapter.getOrder`
+
+**File:** `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts:158-164`
+
+Add `name: lineItem.offer.name` to the items mapping. **Do not** set
+`imageUrl` — Allegro's checkout-form endpoint does not expose one. Document
+the omission inline.
+
+**Acceptance:** type compiles; an existing well-formed checkout-form fixture
+produces an `IncomingOrder` whose items carry the offer name.
+
+### 4. Propagate through `OrderIngestionService.buildUnifiedOrder`
+
+**File:** `libs/core/src/orders/application/services/order-ingestion.service.ts:203-217`
+
+In the resolved-items push, pass `name: item.name` and `imageUrl: item.imageUrl`
+through alongside the other fields.
+
+**Acceptance:** type compiles. No new test required — this is direct
+pass-through plumbing; the end-to-end behavior is exercised by the
+`OrderRecordService` spec (step 7) and would be redundant to retest at this
+layer with mocked dependencies.
+
+### 5. Propagate through `OrderRecordService.persistOrder`
+
+**File:** `libs/core/src/orders/application/services/order-record.service.ts:52-59`
+
+Add `name: item.name` and `imageUrl: item.imageUrl` to the snapshot items
+mapping. Keys are present-only (a missing `name` becomes `name: undefined`,
+which `JSON.stringify` drops — no extra conditional needed). Document this
+behavior in the existing snapshot-mapping site.
+
+**Acceptance:** type compiles; snapshot items carry `name`/`imageUrl` when the
+domain order had them, omit the keys when serialised otherwise.
+
+### 6. Spec — Allegro adapter
+
+**File:** `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts`
+
+The existing `'should hydrate a full IncomingOrder from the checkout-form
+endpoint'` test (line 186) already uses a fixture with
+`offer: { id: 'offer-1', name: 'Offer 1' }`. Extend its existing
+`incoming.items[0]` `toMatchObject` assertion (line 226) with `name: 'Offer 1'`,
+and add an explicit `expect(incoming.items[0].imageUrl).toBeUndefined()` to
+lock in the documented omission.
+
+**Acceptance:** test passes; if `name` is later dropped or `imageUrl` is set
+without justification, the test fails.
+
+### 7. Spec — `OrderRecordService.persistOrder`
+
+**File:** `libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts`
+
+Two new assertions (added to the existing PII-enabled `describe` block at
+line 133, since neither concerns PII handling):
+
+(a) When a domain `OrderItem` carries `name` and `imageUrl`, the persisted
+    `orderSnapshot.items[0]` carries them verbatim.
+
+(b) When neither field is set on the domain `OrderItem`, the persisted
+    `orderSnapshot.items[0]` does not have the keys (use
+    `expect(snapshotItem).not.toHaveProperty('name')` after a JSON round-trip,
+    or assert the items array equals the expected literal without those keys).
+
+The existing `createMockOrder` fixture has one item (`item-1`); extend it
+inline in the new tests rather than mutating the helper.
+
+**Acceptance:** both assertions pass; spec covers presence and omission cases.
+
+## Validation
+
+Architecture: domain types stay framework-free; the adapter remains the only
+place that knows about Allegro's wire shape; no port contract changes; no
+ORM/migration work. Naming: existing `OrderItem` extension follows the file's
+own convention; no new types file warranted (per issue body). Testing: extends
+two existing specs as the issue instructs — no new spec files. Security: none
+of the new fields are PII; `name` is the merchant-facing offer title and
+`imageUrl` is a public CDN URL when set.
+
+## Risks
+
+- **Empty-string `offer.name`** — issue body declines to pre-empt this. If
+  production data later shows empty strings, add a `.trim() || undefined`
+  guard at that point. Not a blocker.
+- **PrestaShop order source still omits `name`** — out of scope. PS order
+  ingestion will keep showing the SKU/productId fallback until a separate
+  follow-up enriches it from the internal catalog. The FE fallback chain
+  (#386) handles this gracefully.
+
+## Files expected to change
+
+**Production (5):**
+- `libs/core/src/orders/domain/types/order.types.ts`
+- `libs/core/src/orders/domain/types/incoming-order.types.ts`
+- `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts`
+- `libs/core/src/orders/application/services/order-ingestion.service.ts`
+- `libs/core/src/orders/application/services/order-record.service.ts`
+
+**Tests (2):**
+- `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts`
+- `libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts`
+
+## Quality gate
+
+```
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All three must pass before commit. No migration check needed (no ORM entity
+changes).

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -402,7 +402,14 @@ describe('OrderIngestionService', () => {
       orderNumber: externalOrderId,
       status: 'BOUGHT',
       items: [
-        { id: 'item-1', productRef: { type: 'offer' as const, externalId: 'offer-a' }, quantity: 1, price: 9.99 },
+        {
+          id: 'item-1',
+          productRef: { type: 'offer' as const, externalId: 'offer-a' },
+          quantity: 1,
+          price: 9.99,
+          name: 'Offer A',
+          imageUrl: 'https://cdn.example/a.jpg',
+        },
         { id: 'item-2', productRef: { type: 'offer' as const, externalId: 'offer-b' }, quantity: 2, price: 4.99 },
       ],
       totals: { subtotal: 19.97, tax: 0, shipping: 0, total: 19.97, currency: 'PLN' },
@@ -427,6 +434,20 @@ describe('OrderIngestionService', () => {
       expect(orderRecordService.persistIncomingSnapshot).toHaveBeenCalledTimes(1);
       expect(orderRecordService.persistOrder).toHaveBeenCalledTimes(1);
       expect(orderSyncService.syncOrder).toHaveBeenCalledTimes(1);
+
+      // buildUnifiedOrder must propagate IncomingOrderItem.name / imageUrl
+      // onto the resolved OrderItem so persistOrder can persist them. This
+      // is the only test that exercises the IncomingOrderItem → OrderItem
+      // conversion; the persistOrder spec works with Order directly.
+      const persistedOrder = orderRecordService.persistOrder.mock.calls[0][0];
+      expect(persistedOrder.items).toHaveLength(2);
+      expect(persistedOrder.items[0]).toMatchObject({
+        id: 'item-1',
+        name: 'Offer A',
+        imageUrl: 'https://cdn.example/a.jpg',
+      });
+      expect(persistedOrder.items[1].name).toBeUndefined();
+      expect(persistedOrder.items[1].imageUrl).toBeUndefined();
     });
 
     it('partial unresolved: persistIncomingSnapshot called, MissingOrderItemMappingError thrown, persistOrder NOT called', async () => {

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -169,6 +169,42 @@ describe('OrderRecordService', () => {
       expect(callArg.orderSnapshot.billingAddress).toEqual(order.billingAddress);
       expect(callArg.recordStatus).toBe('ready');
     });
+
+    it('should serialise OrderItem.name and imageUrl into the snapshot when present', async () => {
+      const order = createMockOrder();
+      order.items[0].name = 'Widget';
+      order.items[0].imageUrl = 'https://cdn.example/widget.jpg';
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      const snapshotItems = (callArg.orderSnapshot as { items: Array<Record<string, unknown>> }).items;
+      expect(snapshotItems[0]).toMatchObject({
+        id: 'item-1',
+        name: 'Widget',
+        imageUrl: 'https://cdn.example/widget.jpg',
+      });
+    });
+
+    it('should omit name and imageUrl from the snapshot when the OrderItem does not carry them', async () => {
+      const order = createMockOrder();
+      // createMockOrder() leaves name/imageUrl unset; this asserts conditional
+      // serialisation in persistOrder keeps the keys absent rather than emitting
+      // explicit `undefined` (the snapshot is a stable JSON contract).
+      expect(order.items[0].name).toBeUndefined();
+      expect(order.items[0].imageUrl).toBeUndefined();
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      const snapshotItems = (callArg.orderSnapshot as { items: Array<Record<string, unknown>> }).items;
+      expect(snapshotItems[0]).not.toHaveProperty('name');
+      expect(snapshotItems[0]).not.toHaveProperty('imageUrl');
+    });
   });
 
   describe('persistOrder - PII disabled', () => {

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -210,6 +210,8 @@ export class OrderIngestionService implements IOrderIngestionService {
           quantity: item.quantity,
           price: item.price,
           sku: item.sku,
+          name: item.name,
+          imageUrl: item.imageUrl,
         });
       } else {
         unresolvedRefs.push({ itemId: item.id, reason: result.reason });

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -56,6 +56,12 @@ export class OrderRecordService implements IOrderRecordService {
         quantity: item.quantity,
         price: item.price,
         sku: item.sku,
+        // Conditional spread keeps the snapshot key absent (not `undefined`)
+        // when the source did not supply the field — the snapshot is a
+        // stable JSON contract surfaced to the FE, so present-only keys keep
+        // the wire shape clean and let consumers tell "missing" from "blank".
+        ...(item.name !== undefined && { name: item.name }),
+        ...(item.imageUrl !== undefined && { imageUrl: item.imageUrl }),
       })),
       totals: order.totals,
       shippingAddress: piiConfig.storePii

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -107,6 +107,11 @@ export class OrderRecordService implements IOrderRecordService {
       orderNumber: incoming.orderNumber,
       status: incoming.status,
       customerExternalId: incoming.customerExternalId,
+      // Items are passed through verbatim — this snapshot captures the raw
+      // pre-mapping incoming order for debugging and retry. Optional fields
+      // (name, imageUrl) propagate automatically; when an adapter omits one,
+      // the property is absent and `JSON.stringify` drops it, matching the
+      // present-only wire shape `persistOrder` emits below.
       items: incoming.items,
       totals: incoming.totals,
       shippingAddress: piiConfig.storePii

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -77,6 +77,22 @@ export interface IncomingOrderItem {
   quantity: number;
   price: number;
   sku?: string;
+
+  /**
+   * Source-reported display label (e.g. Allegro `lineItem.offer.name`).
+   * Optional because not every adapter has it — PrestaShop's order-source
+   * doesn't expose a free per-line product name and would need catalog
+   * enrichment to populate this.
+   */
+  name?: string;
+
+  /**
+   * Absolute URL to a representative product image when the source provides
+   * one. Optional and forward-compatible: today no order-source endpoint we
+   * consume returns this (Allegro's checkout-form does not), so it's reserved
+   * for future enrichment.
+   */
+  imageUrl?: string;
 }
 
 /**

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -98,6 +98,19 @@ export interface OrderItem {
   quantity: number;
   price: number;
   sku?: string;
+
+  /**
+   * Source-reported display label, propagated from `IncomingOrderItem.name`
+   * by `OrderIngestionService.buildUnifiedOrder`. Optional because not every
+   * order-source adapter populates it.
+   */
+  name?: string;
+
+  /**
+   * Absolute product-image URL when the source supplies one. Reserved for
+   * future enrichment — no current adapter sets this on ingestion.
+   */
+  imageUrl?: string;
 }
 
 export interface OrderTotals {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -227,6 +227,7 @@ describe('AllegroOrderSourceAdapter', () => {
         productRef: { type: 'offer', externalId: 'offer-1' },
         quantity: 2,
         price: 19.99,
+        name: 'Offer 1',
       });
       expect(incoming.totals).toMatchObject({ total: 39.98, currency: 'PLN' });
       expect(incoming.shippingAddress?.city).toBe('Warsaw');

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -161,6 +161,10 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort {
           quantity: lineItem.quantity,
           price: Number.parseFloat(lineItem.price.amount),
           sku: lineItem.offer.id,
+          name: lineItem.offer.name,
+          // imageUrl intentionally omitted — Allegro's checkout-form endpoint
+          // does not expose a product image URL. Future enrichment from the
+          // internal product catalog is tracked as a separate follow-up.
         })),
         totals: {
           subtotal: Number.parseFloat(checkoutForm.summary.totalToPay.amount),


### PR DESCRIPTION
Closes #388

## Summary

Extends the unified order pipeline so the order-detail page renders real product names for Allegro orders instead of *"unnamed SKU row"*. PR #386 already shipped the FE-side schema loosening (`ParsedOrderItem.name?` / `imageUrl?` with the `name ?? sku ?? productId ?? id` fallback chain), so once this lands the line-items panel picks up real names automatically — no FE follow-up needed.

## What changed

The propagation chain crosses three hops; the issue body called out three files but the honest minimum is five, because the chain crosses two distinct domain types:

| Hop | File | Change |
|---|---|---|
| 1. wire → `IncomingOrderItem` | `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts` | `getOrder` now emits `name: lineItem.offer.name`. `imageUrl` intentionally omitted with an inline comment — Allegro's checkout-form endpoint does not expose product images. |
| 2. `IncomingOrderItem` → `OrderItem` | `libs/core/src/orders/application/services/order-ingestion.service.ts` | `buildUnifiedOrder`'s resolved-items push now copies `name` / `imageUrl` across the boundary. |
| 3. `OrderItem` → snapshot | `libs/core/src/orders/application/services/order-record.service.ts` | `persistOrder` serialises both via conditional spread (`...(item.name !== undefined && { name: item.name })`) so keys are absent (not `undefined`) when the source omits them — keeps the snapshot wire shape stable. |

Domain types extended:
- `libs/core/src/orders/domain/types/incoming-order.types.ts` — optional `name?` / `imageUrl?` on `IncomingOrderItem`
- `libs/core/src/orders/domain/types/order.types.ts` — same on `OrderItem`

A second commit adds a comment to `persistIncomingSnapshot` documenting the deliberate snapshot-shape asymmetry it has with `persistOrder` — they produce equivalent JSON in practice, but the asymmetry could surprise a future reader.

## Tests

Three-hop chain fully covered:
- `allegro-order-source.adapter.spec.ts` — asserts `name: 'Offer 1'` arrives on `IncomingOrder`
- `order-ingestion.service.spec.ts` — extends the happy-path test to assert `buildUnifiedOrder` propagates `name` / `imageUrl` onto the `Order` passed to `persistOrder` (presence on item-1, absence on item-2)
- `order-record.service.spec.ts` — two new cases: snapshot carries the fields when the domain `OrderItem` has them, and `not.toHaveProperty('name')` / `not.toHaveProperty('imageUrl')` when it doesn't

## Test plan

- [x] `pnpm lint` (zero errors)
- [x] `pnpm type-check` (clean)
- [x] `pnpm test` (1601/1601 across all packages)
- [ ] Manual: ingest a real Allegro order through the dev stack, open its detail page, confirm the line-items table shows the offer name (carried by PR #386's FE).

## Out of scope (per issue body)

- PrestaShop order-source `name` enrichment (different shape — separate follow-up).
- `imageUrl` enrichment for Allegro orders from the internal product catalog (decision needed: denormalise at `persistOrder` time or enrich at read time).
- Multi-locale handling for `name` (e.g. Allegro's `localizedOfferName`).

No DB migration, no port contract changes, no env vars, no FE work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)