### PR TITLE
fix(web): give RawPayloadPanel vertical scroll + keyboard reachability

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3465,9 +3465,18 @@ a.kpi-card:focus-visible {
   color: var(--text-primary);
   background: var(--bg-canvas);
   overflow-x: auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   max-height: 520px;
   white-space: pre;
   tab-size: 2;
+}
+
+.raw-payload__body:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  /* Negative offset keeps the outline inside the panel so it doesn't
+     collide with the header border on short payloads. */
+  outline-offset: -2px;
 }
 
 .raw-payload__body[hidden] {

--- a/apps/web/src/shared/ui/raw-payload-panel.test.tsx
+++ b/apps/web/src/shared/ui/raw-payload-panel.test.tsx
@@ -36,6 +36,11 @@ describe('RawPayloadPanel', () => {
     expect(screen.getByLabelText('Payload content')).toHaveAttribute('id', controls!);
   });
 
+  it('makes the scrollable body keyboard-reachable via tabIndex', () => {
+    render(<RawPayloadPanel payload={{ a: 1 }} defaultOpen />);
+    expect(screen.getByLabelText('Payload content')).toHaveAttribute('tabindex', '0');
+  });
+
   it('can start expanded via defaultOpen', () => {
     render(<RawPayloadPanel payload={{ a: 1 }} defaultOpen />);
     const body = screen.getByLabelText('Payload content');

--- a/apps/web/src/shared/ui/raw-payload-panel.tsx
+++ b/apps/web/src/shared/ui/raw-payload-panel.tsx
@@ -73,6 +73,7 @@ export const RawPayloadPanel = forwardRef<HTMLElement, RawPayloadPanelProps>(
           id={bodyId}
           className="raw-payload__body mono-text"
           aria-label="Payload content"
+          tabIndex={0}
           hidden={!open}
         >
           {tinted ?? formatted}

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -638,7 +638,7 @@ Parity matrix — what changes across sizes:
 
 Rules:
 
-- **No horizontal scrolling** at any breakpoint except inside `RawPayloadPanel` and virtualized tables' column-overflow area.
+- **No horizontal scrolling** at any breakpoint except inside `RawPayloadPanel` and virtualized tables' column-overflow area. `RawPayloadPanel` also scrolls vertically when content exceeds its `max-height` cap (#390).
 - **Tap targets ≥ 44 px** on mobile for every interactive element (`.btn--sm` grows to 36 px min on touch; icon buttons to 40 px).
 - Text must remain readable at `13 px` body — no shrinking below that on mobile.
 - Status banners stack their action buttons below the body on mobile instead of pushing off-screen.

--- a/docs/plans/implementation-plan-raw-payload-panel-vertical-scroll.md
+++ b/docs/plans/implementation-plan-raw-payload-panel-vertical-scroll.md
@@ -1,0 +1,75 @@
+# Implementation Plan — `RawPayloadPanel` vertical scroll fix (#390)
+
+## 1. Goal
+
+`RawPayloadPanel` clips content taller than its `max-height: 520px` cap because the
+body element only sets `overflow-x`, not `overflow-y`. Five FE pages reuse the
+component (Job detail, Webhook delivery detail, Order detail, Listing detail,
+Connection config), and on each of them long payloads silently lose their bottom
+half with no scrollbar to recover them. Add vertical overflow handling so the
+body becomes scrollable when content exceeds the cap.
+
+**Layer:** Frontend / `shared/ui` styling only.
+
+**Non-goals:**
+- No change to the panel's React component, its API, or its tests.
+- No change to `max-height` (the 520px cap is intentional — we want a scroll, not unbounded growth).
+- No change to consumers of the panel.
+
+## 2. Research
+
+- Component: `apps/web/src/shared/ui/raw-payload-panel.tsx` — renders a `<pre className="raw-payload__body mono-text">`. No styling lives in the TSX; the cap and overflow rules are entirely in `index.css`.
+- Styles: `apps/web/src/index.css:3460-3471` — currently sets `overflow-x: auto` and `max-height: 520px`, but no `overflow-y`. Default `overflow-y: visible` lets content escape the layout box but `max-height` truncates the visible region — hence "clipped, not scrollable".
+- Existing tests: `apps/web/src/shared/ui/raw-payload-panel.test.tsx` exercise behavior (open/close, aria, copy, syntax tinting). They do not import `index.css` or assert computed style — so a CSS-rule smoke test would require non-trivial test-setup changes for negligible value. Issue #390 explicitly flags such a test as optional; skip.
+
+## 3. Design
+
+Three small, coupled changes — the CSS fix, plus a folded-in keyboard-a11y polish that the tech-review surfaced (the `<pre>` becomes a scrollable region under this fix and should be reachable by keyboard, with a visible focus outline matching the rest of the panel's controls).
+
+### CSS
+
+```css
+.raw-payload__body {
+  /* existing rules unchanged */
+  overflow-x: auto;
+  overflow-y: auto;             /* NEW — vertical scroll when content > max-height */
+  overscroll-behavior: contain; /* NEW — prevents wheel/touch chaining to the page */
+  max-height: 520px;
+}
+
+.raw-payload__body:focus-visible {  /* NEW — visible focus when keyboard-scrolling */
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
+}
+```
+
+`auto` (not `scroll`) — no always-present gutter on short payloads. Two-axis lines kept separate for diff intent and to read alongside `max-height`. `outline-offset: -2px` keeps the outline inside the panel border so it doesn't collide with the surrounding panel chrome.
+
+### TSX
+
+```tsx
+<pre
+  id={bodyId}
+  className="raw-payload__body mono-text"
+  aria-label="Payload content"
+  tabIndex={0}                 // NEW — make the scrollable region keyboard-reachable
+  hidden={!open}
+>
+```
+
+`tabIndex={0}` is the standard pattern for a custom scrollable region: once focused, browsers handle Arrow / Page Up / Page Down / Home / End natively, so no extra key handlers are needed.
+
+## 4. Steps
+
+1. **Edit `apps/web/src/index.css`** — add `overflow-y: auto;` and `overscroll-behavior: contain;` to the `.raw-payload__body` rule (around line 3468); add a sibling `.raw-payload__body:focus-visible` rule under it.
+2. **Edit `apps/web/src/shared/ui/raw-payload-panel.tsx`** — add `tabIndex={0}` to the `<pre>`.
+3. **Run quality gate:** `pnpm lint && pnpm type-check && pnpm test`.
+4. **Manual verification:** open any `RawPayloadPanel` instance with content >520px (Job detail with a `marketplace.offer.create` payload is the original repro). Confirm: (a) vertical scroll works; (b) horizontal scroll still works for long lines; (c) Tab moves focus into the body and Arrow/Page keys scroll it; (d) the focus outline is visible against `var(--bg-canvas)`.
+
+## 5. Validation
+
+- **Architecture compliance:** styling-only change in `shared/ui` CSS, no boundary changes.
+- **Naming / standards:** no new identifiers introduced.
+- **Testing strategy:** existing behavior tests still apply; no new test added (JSDOM doesn't reliably exercise stylesheet rules and the issue marks it optional).
+- **Security:** no surface change.
+- **Risk:** zero — purely additive CSS property on an existing rule.


### PR DESCRIPTION
## Summary

`RawPayloadPanel` (`apps/web/src/shared/ui/raw-payload-panel.tsx`) capped content at `max-height: 520px` but only set `overflow-x` — so any payload taller than the cap was silently clipped across all 5 surfaces that reuse the primitive (Job detail, Webhook delivery, Order detail, Listing detail, Connection config). First spotted on a `marketplace.offer.create` Job detail where the payload visibly cut off mid-line.

This PR adds `overflow-y: auto` plus `overscroll-behavior: contain` so the panel scrolls vertically without chaining the wheel/touch scroll up to the surrounding page. Because the body is now a custom scrollable region, it also gets `tabIndex={0}` so keyboard users can reach it (browsers handle Arrow / Page Up·Down / Home / End natively once focused), with a matching `:focus-visible` outline rule using `var(--accent-focus)` and a negative offset that keeps the outline inside the panel border (avoids collision with the header on short payloads).

Closes #390

## Files

- `apps/web/src/index.css` — `overflow-y: auto`, `overscroll-behavior: contain`, sibling `.raw-payload__body:focus-visible` rule with a one-line WHY comment on the negative outline-offset.
- `apps/web/src/shared/ui/raw-payload-panel.tsx` — `tabIndex={0}` on the `<pre>`.
- `apps/web/src/shared/ui/raw-payload-panel.test.tsx` — new assertion locking the `tabindex="0"` contract.
- `docs/frontend-ui-style-guide.md` — Responsive matrix note: the no-horizontal-scrolling exception for `RawPayloadPanel` now also covers vertical scroll.
- `docs/plans/implementation-plan-raw-payload-panel-vertical-scroll.md` — implementation plan for the change.

## Test plan

- [x] `pnpm lint` — 0 errors (only pre-existing warnings)
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1840 unit tests across 8 workspaces all pass; new assertion brings `apps/web` from 666 → 667 tests
- [ ] Manual verification: open any `RawPayloadPanel` instance with content >520px (the original repro is a `marketplace.offer.create` Job detail). Confirm: (a) vertical scroll works; (b) horizontal scroll still works for long lines; (c) Tab moves focus into the body and Arrow / Page keys scroll it; (d) the focus outline is visible against `var(--bg-canvas)` in both light and dark mode; (e) no extra scrollbar gutter on short payloads (`auto`, not `scroll`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)