### PR TITLE
feat(web): surface OfferCreationRecord on Job detail page for marketplace.offer.create jobs

### DIFF
--- a/apps/web/src/features/listings/components/OfferCreationTracker.test.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationTracker.test.tsx
@@ -146,6 +146,53 @@ describe('OfferCreationTracker', () => {
     await waitFor(() => expect(onDismiss).toHaveBeenCalledTimes(1));
   });
 
+  describe('read-only consumers (no onDismiss)', () => {
+    it('renders the failed-status content without a Dismiss button when onDismiss is omitted', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi.fn().mockResolvedValue(
+            makeRecord('failed', {
+              errors: [{ field: 'parameters.EAN', code: 'MISSING_EAN', message: 'EAN is required.' }],
+            }),
+          ),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker connectionId="conn-1" offerCreationRecordId="rec-1" />,
+        { apiClient: mockApi },
+      );
+
+      // Status, error, and id all render — content is identical to the with-onDismiss path.
+      expect(await screen.findByText('Failed')).toBeInTheDocument();
+      expect(screen.getByText('EAN is required.')).toBeInTheDocument();
+      expect(screen.getByText('rec-1')).toBeInTheDocument();
+      // …but the terminal-status Dismiss button is suppressed.
+      expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument();
+    });
+
+    it('renders nothing when the status fetch errors and onDismiss is omitted', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi.fn().mockRejectedValue(new Error('Boom')),
+        },
+      });
+
+      const { container } = renderWithProviders(
+        <OfferCreationTracker connectionId="conn-1" offerCreationRecordId="rec-1" />,
+        { apiClient: mockApi },
+      );
+
+      // Wait for the query to settle. The component must render no error UI
+      // and no Dismiss button — read-only consumers can't act on errors.
+      await waitFor(() => {
+        expect(screen.queryByText(/unable to load status/i)).not.toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument();
+      expect(container.querySelector('.offer-creation-tracker--error')).toBeNull();
+    });
+  });
+
   describe('retry affordance (#307)', () => {
     it('renders Retry on a failed record when onRetry is provided and a request snapshot exists', async () => {
       const mockApi = createMockApiClient({

--- a/apps/web/src/features/listings/components/OfferCreationTracker.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationTracker.tsx
@@ -28,7 +28,14 @@ import { OfferCreationErrorList } from './OfferCreationErrorList';
 interface OfferCreationTrackerProps {
   connectionId: string;
   offerCreationRecordId: string;
-  onDismiss: () => void;
+  /** Optional. When provided, a Dismiss button appears on terminal statuses
+   *  and the error variant is rendered with a Dismiss action. When omitted,
+   *  the consumer is treated as a static read-only surface (e.g. a page
+   *  panel rather than a session-scoped tracker): no Dismiss button, and
+   *  the error path renders nothing rather than an unactionable error
+   *  message — matches the "gracefully shows nothing" guarantee that
+   *  read-only consumers expect (#391). */
+  onDismiss?: () => void;
   /** Invoked when the operator clicks Retry on a failed record. Only
    *  rendered when the record has a non-null `request` snapshot — without
    *  the snapshot the wizard cannot pre-fill, so we hide the action. */
@@ -58,6 +65,12 @@ export function OfferCreationTracker({
   }
 
   if (query.error) {
+    // Read-only consumers (no onDismiss) are treated as "show nothing on
+    // failure" — they have no way to dismiss the error UI and the surface
+    // is informational, not actionable.
+    if (onDismiss === undefined) {
+      return <></>;
+    }
     return (
       <section className="offer-creation-tracker offer-creation-tracker--error" aria-live="polite">
         <div className="offer-creation-tracker__header">
@@ -88,6 +101,7 @@ export function OfferCreationTracker({
     onRetry !== undefined &&
     record.request != null &&
     canReadCreateOfferRequestSnapshot(record.request);
+  const showDismiss = isTerminal && onDismiss !== undefined;
 
   return (
     <section
@@ -105,7 +119,7 @@ export function OfferCreationTracker({
             Retry
           </Button>
         ) : null}
-        {isTerminal ? (
+        {showDismiss ? (
           <Button tone="ghost" onClick={onDismiss}>
             Dismiss
           </Button>

--- a/apps/web/src/features/sync-jobs/api/sync-jobs.types.ts
+++ b/apps/web/src/features/sync-jobs/api/sync-jobs.types.ts
@@ -28,6 +28,7 @@ export const JOB_TYPE_VALUES = [
   'marketplace.offers.sync',
   'marketplace.offerQuantity.update',
   'marketplace.offer.updateFields', // Internal job — not user-triggerable; listed here for status display only.
+  'marketplace.offer.create',
   'master.product.syncAll',
   'master.product.syncByExternalId',
   'master.inventory.syncAll',

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
@@ -119,4 +119,118 @@ describe('SyncJobDetailPage', () => {
     await screen.findByText('marketplace.orders.poll');
     expect(screen.queryByText(/Job failed/)).toBeNull();
   });
+
+  describe('OfferCreationRecord panel for marketplace.offer.create jobs (#391)', () => {
+    const offerCreateJob: SyncJob = {
+      ...sampleJob,
+      jobType: 'marketplace.offer.create',
+      payloadJson: {
+        connectionId: 'conn_allegro_1',
+        internalVariantId: 'ol_variant_abc',
+        offerCreationRecordId: 'rec-1',
+      },
+    };
+
+    it('fetches and renders the linked OfferCreationRecord with status and validation errors when failed', async () => {
+      const getOfferCreationStatus = vi.fn().mockResolvedValue({
+        id: 'rec-1',
+        connectionId: 'conn_allegro_1',
+        internalVariantId: 'ol_variant_abc',
+        externalOfferId: null,
+        status: 'failed',
+        errors: [
+          { field: 'parameters.EAN', code: 'MISSING_EAN', message: 'EAN is required.' },
+        ],
+        publishImmediately: false,
+        createdAt: '2026-04-25T10:00:00Z',
+        updatedAt: '2026-04-25T10:01:00Z',
+        request: null,
+      });
+      const mockApi = createMockApiClient({
+        syncJobs: { getById: vi.fn().mockResolvedValue(offerCreateJob) },
+        listings: { getOfferCreationStatus },
+      });
+
+      renderDetailPage(mockApi);
+
+      // Status surfaces the failed badge and the structured error, not just the green job badge.
+      expect(await screen.findByText('Failed')).toBeInTheDocument();
+      expect(screen.getByText('parameters.EAN')).toBeInTheDocument();
+      expect(screen.getByText('EAN is required.')).toBeInTheDocument();
+      expect(getOfferCreationStatus).toHaveBeenCalledWith('conn_allegro_1', 'rec-1');
+    });
+
+    it('renders no panel when the payload omits offerCreationRecordId', async () => {
+      const job: SyncJob = {
+        ...offerCreateJob,
+        payloadJson: { connectionId: 'conn_allegro_1', internalVariantId: 'ol_variant_abc' },
+      };
+      const getOfferCreationStatus = vi.fn();
+      const mockApi = createMockApiClient({
+        syncJobs: { getById: vi.fn().mockResolvedValue(job) },
+        listings: { getOfferCreationStatus },
+      });
+
+      renderDetailPage(mockApi);
+
+      await screen.findByText('marketplace.offer.create');
+      expect(getOfferCreationStatus).not.toHaveBeenCalled();
+      expect(screen.queryByText(/^Offer creation$/)).toBeNull();
+    });
+
+    it('renders no panel when payloadJson is null (orchestrator threw before record creation)', async () => {
+      const job: SyncJob = { ...offerCreateJob, payloadJson: null };
+      const getOfferCreationStatus = vi.fn();
+      const mockApi = createMockApiClient({
+        syncJobs: { getById: vi.fn().mockResolvedValue(job) },
+        listings: { getOfferCreationStatus },
+      });
+
+      renderDetailPage(mockApi);
+
+      await screen.findByText('marketplace.offer.create');
+      expect(getOfferCreationStatus).not.toHaveBeenCalled();
+      expect(screen.queryByText(/^Offer creation$/)).toBeNull();
+    });
+
+    it('renders no panel when offerCreationRecordId is present but not a string', async () => {
+      const job: SyncJob = {
+        ...offerCreateJob,
+        // Defensive: a future schema drift or a corrupt payload could carry a non-string here.
+        // The type-guard rejects it; the page must not crash and must not call the API.
+        payloadJson: { ...offerCreateJob.payloadJson, offerCreationRecordId: 42 },
+      };
+      const getOfferCreationStatus = vi.fn();
+      const mockApi = createMockApiClient({
+        syncJobs: { getById: vi.fn().mockResolvedValue(job) },
+        listings: { getOfferCreationStatus },
+      });
+
+      renderDetailPage(mockApi);
+
+      await screen.findByText('marketplace.offer.create');
+      expect(getOfferCreationStatus).not.toHaveBeenCalled();
+      expect(screen.queryByText(/^Offer creation$/)).toBeNull();
+    });
+
+    it('renders no panel for non-marketplace.offer.create job types even when payload happens to carry the field', async () => {
+      // Defensive: the type-guard is keyed on jobType. If a future job type accidentally
+      // adds an offerCreationRecordId field to its payload, the panel must not appear.
+      const job: SyncJob = {
+        ...sampleJob,
+        jobType: 'marketplace.orders.poll',
+        payloadJson: { offerCreationRecordId: 'rec-1' },
+      };
+      const getOfferCreationStatus = vi.fn();
+      const mockApi = createMockApiClient({
+        syncJobs: { getById: vi.fn().mockResolvedValue(job) },
+        listings: { getOfferCreationStatus },
+      });
+
+      renderDetailPage(mockApi);
+
+      await screen.findByText('marketplace.orders.poll');
+      expect(getOfferCreationStatus).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -13,6 +13,23 @@ import { useSyncJobQuery } from '../../features/sync-jobs/hooks/use-sync-job-que
 import { useRetrySyncJobMutation } from '../../features/sync-jobs/hooks/use-retry-sync-job-mutation';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+import { OfferCreationTracker } from '../../features/listings/components/OfferCreationTracker';
+
+/**
+ * Extracts the offer-creation record ID from a `marketplace.offer.create`
+ * job payload. The worker enqueue path (`POST /listings/connections/:id/offers`)
+ * pre-creates the OfferCreationRecord and threads its id through the job
+ * payload so downstream consumers can correlate the job with the business
+ * outcome. Returns null when the field is absent or has a non-string shape
+ * — both cases render no panel (#391 AC3 "gracefully shows nothing").
+ */
+function extractOfferCreationRecordId(job: SyncJob): string | null {
+  if (job.jobType !== 'marketplace.offer.create' || job.payloadJson === null) {
+    return null;
+  }
+  const candidate = (job.payloadJson as Record<string, unknown>).offerCreationRecordId;
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+}
 
 function buildSyncJobItems(job: SyncJob): KeyValueItem[] {
   const items: KeyValueItem[] = [
@@ -75,6 +92,7 @@ export function SyncJobDetailPage(): ReactElement {
 
   const job = query.data;
   const isDead = job.status === 'dead';
+  const offerCreationRecordId = extractOfferCreationRecordId(job);
 
   function handleRetry(): void {
     retry.mutate(job.id, {
@@ -120,6 +138,15 @@ export function SyncJobDetailPage(): ReactElement {
       <section className="detail-section">
         <KeyValueList items={buildSyncJobItems(job)} />
       </section>
+
+      {offerCreationRecordId !== null ? (
+        <section className="detail-section">
+          <OfferCreationTracker
+            connectionId={job.connectionId}
+            offerCreationRecordId={offerCreationRecordId}
+          />
+        </section>
+      ) : null}
 
       {job.lastError ? (
         <section className="detail-section">

--- a/docs/plans/implementation-plan-391-job-detail-offer-creation-record.md
+++ b/docs/plans/implementation-plan-391-job-detail-offer-creation-record.md
@@ -1,0 +1,154 @@
+# Implementation Plan — #391 Part A: Surface `OfferCreationRecord` on the Job detail page
+
+## Goal
+
+When a `marketplace.offer.create` sync job is rendered on the Job detail page,
+load and display the linked `OfferCreationRecord` so the operator can see the
+actual business outcome — rather than just the green "succeeded" badge that
+hides terminal platform rejections (e.g. validation errors from Allegro).
+
+This is **Part A only** per the issue body. Part B (changing what
+`succeeded` means at the job-runner level) is an explicit non-goal here —
+the issue body recommends "ship A first; align on B before changing runner
+contract."
+
+## Layer classification
+
+Frontend only. No BE/CORE/DB work.
+
+## Discovery — what already exists (don't rebuild)
+
+The investigation showed the entire stack is already in place:
+
+| Layer | What | Where |
+|---|---|---|
+| BE endpoint | `GET /listings/connections/:connectionId/offers/creation/:recordId` returning `OfferCreationStatusResponseDto` | `apps/api/src/listings/http/listings.controller.ts:221-239` |
+| FE API wrapper | `getOfferCreationStatus(connectionId, recordId)` | `apps/web/src/features/listings/api/listings.api.ts:91-95` |
+| FE types | `OfferCreationStatusResponse`, `OfferCreationStatus`, `TERMINAL_OFFER_CREATION_STATUSES`, `OfferCreationError` | `apps/web/src/features/listings/api/listings.types.ts:82-145` |
+| FE query hook | `useOfferCreationStatusQuery(connectionId, recordId)` (polls until terminal) | `apps/web/src/features/listings/hooks/use-offer-creation-status-query.ts` |
+| FE panel | `OfferCreationTracker` — header (label + status badge + ID + optional Retry/Dismiss), body text per status, error list on `failed` | `apps/web/src/features/listings/components/OfferCreationTracker.tsx` |
+| FE pieces | `OfferCreationStatusBadge`, `OfferCreationErrorList` | `apps/web/src/features/listings/components/` |
+
+**The only thing missing is the wiring on the Job detail page**, plus one
+tiny gap in the `JobType` union and a small affordance on the existing
+Tracker so it can be rendered without session-scoped Dismiss/Retry actions.
+
+## Non-goals
+
+- **Part B** of #391 — changing job runner success/failure semantics. Explicitly deferred.
+- **A new dedicated panel component** mirroring `OfferCreationTracker`. The existing Tracker covers the layout the issue body asks for; rebuilding would duplicate the rendering logic and the test surface. Reuse > parallel build.
+- **A retry-from-job-detail flow.** Retrying offer creation already lives on the listings list-page session tracker. Adding it here mixes lifecycle concerns and is out of scope per the issue body's Part A.
+- **A "view created listing" deep link** when status is `active`. The Tracker shows the external offer ID as text today; that matches how it renders on the listings page. A linked variant can ship later.
+
+## Implementation steps
+
+### 1. Add `marketplace.offer.create` to the `JobType` union
+
+**File:** `apps/web/src/features/sync-jobs/api/sync-jobs.types.ts:25-37`
+
+Currently `JOB_TYPE_VALUES` lists five values; `'marketplace.offer.create'`
+is missing. Add it. The existing `'marketplace.offer.updateFields'` entry
+has a comment marking it as "internal job, not user-triggerable, listed for
+status display only" — same applies here. No new comment needed since
+the new type *is* user-triggerable from the Create-Offer wizard.
+
+**Acceptance:** `JobType` union now includes `'marketplace.offer.create'`. Build passes.
+
+### 2. Make `onDismiss` optional on `OfferCreationTracker`
+
+**File:** `apps/web/src/features/listings/components/OfferCreationTracker.tsx`
+
+Two changes:
+- `onDismiss: () => void` → `onDismiss?: () => void`
+- The two `<Button onClick={onDismiss}>Dismiss</Button>` sites (lines 65-67 and 108-112) become conditional on `onDismiss !== undefined`, mirroring the existing `canRetry` pattern.
+
+This is a backward-compatible refactor. The single existing call site on
+the listings list-page passes `onDismiss` and continues to work. The new
+Job-detail call site omits it.
+
+**Acceptance:** Tracker renders with no Dismiss button when `onDismiss` is undefined. Existing call site still gets the button. Co-located test (`OfferCreationTracker.test.tsx`) extended with one case asserting button absence when prop is undefined.
+
+### 3. Render the Tracker on the Job detail page when applicable
+
+**File:** `apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx`
+
+When `job.jobType === 'marketplace.offer.create'`:
+1. Safely parse `job.payloadJson` for the `offerCreationRecordId` field. The payload is a JSON string serialized by the worker enqueue path. Wrap `JSON.parse` in try/catch — return `null` on any parse error or if the field is absent / not a string.
+2. Use `job.connectionId` (already on the `SyncJob` entity) for the API call. Don't trust the payload's `connectionId` for this — the job entity is canonical.
+3. If the record ID is present, render the Tracker without `onDismiss`/`onRetry`:
+   ```tsx
+   <section className="detail-section">
+     <OfferCreationTracker
+       connectionId={job.connectionId}
+       offerCreationRecordId={recordId}
+     />
+   </section>
+   ```
+4. If the record ID is absent (orchestrator threw before record creation, or older payload schema, or non-JSON payload), render nothing — matches AC3 ("gracefully shows nothing rather than crashing").
+
+Place the new section between the existing key-value list (line 122) and the "Last error" / "Payload" sections (line 124+), so the offer-creation status sits next to the job metadata and above the raw debugging surfaces.
+
+**Helper:** Extract `extractOfferCreationRecordId(job: SyncJob): string | null` as a small pure function in the same file (or a colocated `*.utils.ts` if the file gets unwieldy — a single helper inline is fine for now). Keeps the JSON-parse + type-guard logic out of the JSX and unit-testable.
+
+**Acceptance:**
+- For a `marketplace.offer.create` job whose payload contains `offerCreationRecordId`, the page renders the Tracker section.
+- For the same job type with a payload missing the field, the page renders without the Tracker section and without throwing.
+- For any other `jobType`, the page renders unchanged.
+- For a payload that is not valid JSON, the page renders without the Tracker and without throwing.
+
+### 4. Tests
+
+**File:** `apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx`
+
+Three new cases (all using `renderWithProviders` + `createMockApiClient` per the FE testing convention):
+
+- `marketplace.offer.create` job + payload with `offerCreationRecordId` → Tracker renders, mock `getOfferCreationStatus` returns a `failed` record, `OfferCreationErrorList` content appears on the page.
+- `marketplace.offer.create` job + payload missing the field → Tracker section not rendered.
+- `marketplace.offer.create` job + payload that is invalid JSON → Tracker section not rendered, no throw.
+
+**File:** `apps/web/src/features/listings/components/OfferCreationTracker.test.tsx`
+
+One new case:
+- Tracker renders without Dismiss button when `onDismiss` is omitted.
+
+The existing OfferCreationTracker tests cover the with-Dismiss path; the new case asserts the optional-prop branch.
+
+## Edge cases to confirm in tests
+
+- **Payload is `null` / empty string** — already covered by AC3.
+- **Record ID is a non-string value** (e.g. a number, accidentally) — type guard rejects it.
+- **`connectionId` on the job is empty / falsy** — possible? Unlikely (the SyncJob entity requires it), but the API call simply 404s if invalid; the Tracker's existing error path already handles this without crashing.
+
+## Validation
+
+- **Architecture:** stays inside FE; no BE/CORE work; no port contracts touched. Frontend dependency direction obeyed: pages → features → shared. The Job detail page imports the Tracker from `features/listings/components/`, which is a cross-feature import — already permitted by the codebase convention (`ListingDetailPage` already imports `ConnectionEntityLabel` from `features/connections/`).
+- **State ownership:** Tracker's existing query hook lives in `features/listings/hooks/`. URL state, form state, and session state are not involved.
+- **Naming:** existing files; no new ones unless the helper extraction in step 3 grows.
+- **No `any`, no `console.log`, no hardcoded secrets, no migration**. ✅
+- **Testing convention:** colocated `*.test.tsx`, `renderWithProviders`, `createMockApiClient` (per `.claude/rules/fe-pages.md`).
+
+## Risks
+
+- **Tracker repurposing has a polling side-effect.** The existing `useOfferCreationStatusQuery` polls until terminal status. Rendering it on the Job detail page means as long as the user keeps the page open, it'll keep polling for non-terminal records. This is consistent with the existing tracker behaviour on the listings page and is not a regression — but worth noting. If a stop-when-page-not-focused optimisation is wanted later, that's a follow-up to the hook, not this issue.
+- **`payloadJson` schema drift.** If a future change to the `marketplace.offer.create` payload renames `offerCreationRecordId`, the Tracker silently disappears from the Job detail page. Acceptable for this issue (graceful degrade matches AC3); the type-safety story for FE access to the payload is its own backlog item.
+
+## Files expected to change
+
+**Production (3):**
+- `apps/web/src/features/sync-jobs/api/sync-jobs.types.ts` — extend `JOB_TYPE_VALUES`
+- `apps/web/src/features/listings/components/OfferCreationTracker.tsx` — make `onDismiss` optional
+- `apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx` — render Tracker conditionally
+
+**Tests (2):**
+- `apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx` — three new cases
+- `apps/web/src/features/listings/components/OfferCreationTracker.test.tsx` — one new case
+
+## Quality gate
+
+```
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All three must pass. No backend changes → no migration check needed.


### PR DESCRIPTION
Closes #391 (Part A only — Part B, changing job runner success/failure semantics, is explicitly deferred per the issue body).

## Why

Operators on the Job detail page see a green ✅ "succeeded" badge for `marketplace.offer.create` jobs even when the offer was rejected by the marketplace. The platform error is recorded in the linked `OfferCreationRecord` but currently invisible in the UI — closing this gap is what Part A was scoped for.

## What

The whole stack (BE endpoint, FE API wrapper, query hook, panel component) already existed. The implementation is wiring + a small backward-compatible refactor:

| File | Change |
|---|---|
| `apps/web/src/features/sync-jobs/api/sync-jobs.types.ts` | Add `'marketplace.offer.create'` to `JOB_TYPE_VALUES` (was missing). |
| `apps/web/src/features/listings/components/OfferCreationTracker.tsx` | Make `onDismiss` optional. When omitted: (a) suppress the terminal-status Dismiss button, (b) render nothing on the error path. Read-only consumers can't act on errors and shouldn't be saddled with stuck error UI. |
| `apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx` | When `jobType === 'marketplace.offer.create'`, extract `offerCreationRecordId` from `payloadJson` (already deserialised on the FE), type-guard as non-empty string, and render the Tracker fed by `job.connectionId`. Renders nothing when the field is missing, payload is null, or the value isn't a string — matches AC3. |

The existing listings list-page consumer of the Tracker continues to pass `onDismiss` and gets the full Dismiss/error behaviour. The Job-detail surface omits it and gets the read-only behaviour.

## Tests

7 new cases (web tests now 673, was 666):

**`OfferCreationTracker.test.tsx`** (2 new):
- Renders the failed-status content without a Dismiss button when `onDismiss` is omitted.
- Renders nothing when the status fetch errors and `onDismiss` is omitted.

**`sync-job-detail-page.test.tsx`** (5 new, in a `#391` describe block):
- Fetches and renders the linked record with status badge + validation errors when failed (asserts API called with `(connectionId, recordId)`).
- Renders no panel when payload omits `offerCreationRecordId`.
- Renders no panel when `payloadJson` is null (orchestrator threw before record creation).
- Renders no panel when `offerCreationRecordId` is present but not a string (defensive).
- Renders no panel for non-`marketplace.offer.create` job types even if the field appears in their payload.

## Test plan

- [x] `pnpm lint` (0 errors across all packages)
- [x] `pnpm type-check` (clean)
- [x] `pnpm test` (673/673 web tests, full root sweep green)
- [ ] Manual: open a `marketplace.offer.create` job whose record is `status='failed'` on `/jobs-logs/<id>` and confirm the validation errors appear above the "Last error" / "Payload" panels.
- [ ] Manual: open a non-offer-create job (e.g. `marketplace.orders.poll`) and confirm no Offer-creation panel appears.

## Out of scope (per the issue body)

- **Part B** — reconsidering what `succeeded` means at the runner level when the orchestrator records a terminal `OfferCreationRecord.status='failed'`. Tracked separately.
- A retry-from-job-detail flow. Retry already lives on the listings list-page session tracker.
- A "view created listing" deep link when status is `active`. Tracker shows the external offer ID as text today; matches the existing surface.

No BE work, no migration, no port-contract changes, no env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)