### PR TITLE
feat(allegro): re-host PrestaShop images on Allegro CDN before offer creation

### DIFF
--- a/docs/plans/implementation-plan-397-allegro-image-url-preflight.md
+++ b/docs/plans/implementation-plan-397-allegro-image-url-preflight.md
@@ -1,0 +1,580 @@
+# Implementation Plan — #397 Allegro `createOffer` image-binary upload (Solution B, no-cache)
+
+## 1. Goal
+
+Make `marketplace.offer.create` actually work end-to-end against Allegro for
+operators whose PrestaShop image URLs are not publicly reachable from
+Allegro's servers (localhost, private IPs, basic-auth, hardened `.htaccess`,
+expired tunnels, etc.) — by **downloading bytes from PrestaShop OL-side and
+re-uploading them to Allegro's image CDN**, then passing the Allegro CDN URLs
+to `POST /sale/product-offers`.
+
+This is Solution B from the issue, in the simplest viable form: **no
+caching**. Each `createOffer` call re-downloads from PrestaShop and re-uploads
+to Allegro. The "Allegro GCs unattached images" concern that motivates a
+cache only arises *if* you cache; without one, every uploaded image is used
+in the same call, so GC never opens a window we'd hit.
+
+This subsumes Solution A's operator-clarity win for free: when the OL→PS
+download fails (the same conditions that cause the original 422), we surface
+a clear `IMAGE_DOWNLOAD_FAILED` error instead of an opaque Allegro 422.
+
+Solution A (HEAD pre-flight) is **discarded**: redundant with the GET we now
+have to do anyway.
+
+## 2. Classification
+
+- **Layer:** Integration (Allegro adapter + HTTP client). No CORE, no FE, no
+  DB changes, no migration.
+- **Files (5 new / 6 edited):**
+  - **NEW** `libs/integrations/allegro/src/infrastructure/http/allegro-connection-token-state.ts`
+  - **NEW** `libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-connection-token-state.spec.ts`
+  - **NEW** `libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.ts`
+  - **NEW** `libs/integrations/allegro/src/infrastructure/util/__tests__/upload-images-via-allegro.spec.ts`
+  - **EDIT** `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.interface.ts` — add `postBinary`
+  - **EDIT** `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts` — refactor to use `AllegroConnectionTokenState`, add `postBinary`
+  - **EDIT** `libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts` — update existing constructor calls, add `postBinary` specs
+  - **EDIT** `libs/integrations/allegro/src/domain/types/allegro-config.types.ts` — add `uploadBaseUrl?: string`
+  - **EDIT** `libs/integrations/allegro/src/application/allegro-adapter.factory.ts` — build shared token state + 2 HTTP clients
+  - **EDIT** `libs/integrations/allegro/src/infrastructure/adapters/allegro-connection-tester.adapter.ts` — update `AllegroHttpClient` construction
+  - **EDIT** `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts` — accept `uploadHttpClient`, wire upload step in `createOffer`
+  - **EDIT** `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts` — two HTTP-client mocks, fetch spy, update 2 image specs, add 5 new specs
+
+## 3. Design decisions reached during /grill-me
+
+| # | Decision |
+|---|---|
+| 1 | Two `AllegroHttpClient` instances per connection — one for `api.*`, one for `upload.*`. Both reference a shared `AllegroConnectionTokenState` so a refresh by one is visible to the other. |
+| 2 | Partial upload failure → throw `OfferCreateRejectedException`. No skip-and-continue. Allegro GCs the leaked uploads. |
+| 3 | Token state: shared mutable state holder (option (a) from Q3). `AllegroHttpClient` no longer owns `accessToken`. |
+| 4 | Upload step lives **between** `buildCreateOfferRequest` and the POST. `buildCreateOfferRequest` stays sync + pure. `createOffer` mutates `body.images` after the orchestrator returns. |
+| 5 | Strict Content-Type whitelist on PS download: `image/jpeg \| image/png \| image/gif \| image/webp` after stripping params. `image/jpg → image/jpeg` is the only normalization. No magic-byte sniffing, no URL extension fallback. |
+| 6 | `AllegroConnectionConfig.uploadBaseUrl?: string` symmetric to existing `apiBaseUrl?`. Default from `environment` (`production → upload.allegro.pl`, `sandbox → upload.allegro.pl.allegrosandbox.pl`). |
+| 7 | Buffer (`Uint8Array`), not stream. Parallel `Promise.all` over images. No early-abort via `AbortController` — failures of in-flight peers are discarded silently after the first throw. |
+| 8 | Tests: two `jest.Mocked<IAllegroHttpClient>` instances + `jest.spyOn(globalThis, 'fetch')`. Single `IAllegroHttpClient` interface; `postBinary` lives on it. |
+| 9 | Three error codes, all `field: 'images'`: `IMAGE_DOWNLOAD_FAILED`, `IMAGE_DOWNLOAD_INVALID_TYPE`, `IMAGE_UPLOAD_FAILED`. No sub-codes for download failure modes (HTTP/timeout/network) — cause goes in `message`. |
+| 10 | Standalone util `upload-images-via-allegro.ts` with one exported orchestrator. Internal helpers file-private. |
+| 11 | Logging: 1 `debug` at upload start, 1 `debug` at success, 1 `warn` on failure (count + connection only). No per-image chatter. |
+
+## 4. Architecture in 4 boxes
+
+```
+                                                                                
+┌─────────────────────────────────┐                                            
+│ AllegroAdapterFactory           │  builds:                                   
+│   per Connection:               │  ┌──────────────────────────────┐          
+│   1. AllegroConnectionTokenState│──▶│ AllegroConnectionTokenState  │          
+│   2. apiHttpClient (api host)   │  │   accessToken                 │          
+│   3. uploadHttpClient (upload)  │  │   tokenExpiresAt              │          
+│      ↑both reference (1)↑       │  │   refreshInFlight             │          
+└─────────────────────────────────┘  │   cooldownUntil               │          
+                                     │   ensureFreshToken()          │          
+                                     │   refreshOnUnauthorized()     │          
+                                     └──────────────────────────────┘          
+                                                                               
+┌──────────────────────────────────┐ ┌────────────────────────────────────┐    
+│ AllegroOfferManagerAdapter       │ │ upload-images-via-allegro.ts (util)│    
+│ ctor(apiClient, uploadClient,…)  │ │  exports: uploadImagesViaAllegro() │    
+│                                  │ │                                    │    
+│ createOffer(cmd) {               │ │  for each url (parallel):          │    
+│   body = buildCreateOfferReq()   │ │    1. fetch(url) — global fetch    │    
+│   if (body.images?.length)       │ │       check 2xx, content-type      │    
+│     body.images = await          │─▶│    2. uploadClient.postBinary(    │    
+│       uploadImagesViaAllegro(    │ │       '/sale/images', contentType, │    
+│       this.uploadClient,         │ │       bytes)                       │    
+│       body.images)               │ │    3. return location              │    
+│   apiClient.post('/sale/...')    │ │                                    │    
+│ }                                │ │  any failure → throw               │    
+└──────────────────────────────────┘ │  OfferCreateRejectedException      │    
+                                     └────────────────────────────────────┘    
+```
+
+## 5. Detailed design
+
+### 5.1 `AllegroConnectionTokenState` (new)
+
+Owns the per-connection token state currently scattered on
+`AllegroHttpClient`. Both `api` and `upload` HTTP clients reference the same
+instance, so a refresh by either is immediately visible to the other.
+
+```ts
+export class AllegroConnectionTokenState {
+  private accessToken: string;
+  private tokenExpiresAt: number | undefined;
+  private refreshInFlight: Promise<void> | null = null;
+  private proactiveRefreshCooldownUntil: number | undefined;
+
+  constructor(
+    private readonly connectionId: string,
+    initial: AllegroCredentials,
+    private readonly tokenRefreshCallback?: TokenRefreshCallback,
+  ) {
+    this.accessToken = initial.accessToken;
+    this.tokenExpiresAt = AllegroConnectionTokenState.normalizeExpiresAt(initial.expiresAt);
+  }
+
+  getAccessToken(): string { return this.accessToken; }
+
+  /** Pre-request hook. Single-flight via `refreshInFlight`. No-op if no callback / no expiresAt / inside cooldown / outside refresh window. */
+  async ensureFreshToken(traceId: string, logger: Logger): Promise<void>;
+
+  /** Reactive 401 path. Returns true if refreshed (caller should retry). False if no callback. */
+  async refreshOnUnauthorized(traceId: string, logger: Logger): Promise<boolean>;
+
+  // Internal
+  private applyRefreshResult(result: TokenRefreshResult): void;
+  private static normalizeExpiresAt(value: Date | string | undefined): number | undefined;
+}
+```
+
+The `ensureFreshToken` and `refreshOnUnauthorized` methods carry the same
+behaviour `AllegroHttpClient` has today (5s post-failure cooldown, 60s
+refresh window, single-flight) — they're moved verbatim.
+
+### 5.2 `AllegroHttpClient` (refactored)
+
+Constructor signature changes:
+
+**Before:**
+```ts
+constructor(
+  connectionId: string,
+  baseUrl: string,
+  credentials: AllegroCredentials,
+  _config: AllegroConnectionConfig,        // unused
+  retryConfig?: Partial<RetryConfig>,
+  tokenRefreshCallback?: TokenRefreshCallback,
+)
+```
+
+**After:**
+```ts
+constructor(
+  connectionId: string,
+  baseUrl: string,
+  tokenState: AllegroConnectionTokenState,
+  retryConfig?: Partial<RetryConfig>,
+)
+```
+
+Everywhere the existing client reads `this.accessToken`, it now reads
+`this.tokenState.getAccessToken()`. `this.ensureFreshToken` delegates to
+`this.tokenState.ensureFreshToken`. The 401 reactive path delegates to
+`this.tokenState.refreshOnUnauthorized` and uses its boolean return to drive
+the existing `TokenRefreshedError` retry mechanism.
+
+The unused `_config` parameter is removed in this refactor — it's not
+referenced anywhere except its own destructuring.
+
+**New method — `postBinary`:**
+
+```ts
+async postBinary<T = unknown>(
+  path: string,
+  contentType: string,    // e.g. 'image/jpeg'
+  body: Uint8Array,
+  options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+): Promise<AllegroHttpResponse<T>>;
+```
+
+Routes through the existing `request()` so retry + token-refresh behaviour
+are inherited unchanged. The only difference from `post()` is the request
+build step: `Content-Type` comes from the parameter (not the JSON default)
+and `body` is passed straight through to `fetch()` as a `Uint8Array` (the
+Node fetch implementation accepts `BodyInit`, which includes Uint8Array, so
+no `JSON.stringify`).
+
+Internally we add one branch in `executeRequest` to skip JSON serialization
+when the body is `Uint8Array`. The `Content-Type` for binary callers is set
+directly from the argument; for the existing JSON path nothing changes.
+
+### 5.3 Interface (`IAllegroHttpClient`)
+
+Add:
+
+```ts
+postBinary<T = unknown>(
+  path: string,
+  contentType: string,
+  body: Uint8Array,
+  options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+): Promise<AllegroHttpResponse<T>>;
+```
+
+Single shared interface — both `apiHttpClient` and `uploadHttpClient`
+implement it. The adapter chooses which client to call. Convention enforces
+which host gets binary uploads, not the type system.
+
+### 5.4 `AllegroConnectionConfig`
+
+```ts
+export interface AllegroConnectionConfig {
+  environment: AllegroEnvironment;
+  apiBaseUrl?: string;     // existing
+  uploadBaseUrl?: string;  // NEW — defaults from environment if absent
+}
+```
+
+`AllegroAdapterFactory.getDefaultUploadBaseUrl(env)` mirrors the existing
+`getDefaultApiBaseUrl`:
+
+| environment | default `uploadBaseUrl` |
+|---|---|
+| `production` | `https://upload.allegro.pl` |
+| `sandbox` | `https://upload.allegro.pl.allegrosandbox.pl` |
+
+### 5.5 `AllegroAdapterFactory.createAdapters` (edited)
+
+```ts
+const tokenState = new AllegroConnectionTokenState(
+  connection.id,
+  credentials,
+  tokenRefreshCallback,
+);
+
+const apiHttpClient = new AllegroHttpClient(
+  connection.id,
+  apiBaseUrl,
+  tokenState,
+);
+
+const uploadHttpClient = new AllegroHttpClient(
+  connection.id,
+  config.uploadBaseUrl ?? this.getDefaultUploadBaseUrl(config.environment),
+  tokenState, // ✅ same instance
+);
+
+const offerManagerAdapter = new AllegroOfferManagerAdapter(
+  connection.id,
+  apiHttpClient,
+  uploadHttpClient,
+  identifierMapping,
+  connection,
+  this.commandRepository,
+  this.quantityPollConfig,
+);
+const orderSourceAdapter = new AllegroOrderSourceAdapter(
+  connection.id,
+  apiHttpClient, // unchanged — still only needs api host
+  connection,
+);
+```
+
+### 5.6 `AllegroConnectionTesterAdapter` (edited)
+
+The probe creates its own throwaway `AllegroHttpClient` and now needs a
+throwaway token state too. No refresh callback — it's a probe; if the token
+is bad we want it to fail clearly.
+
+```ts
+const tokenState = new AllegroConnectionTokenState(
+  connection.id,
+  credentials,
+  undefined, // no refresh — probe
+);
+const client = new AllegroHttpClient(
+  connection.id,
+  apiBaseUrl,
+  tokenState,
+  { maxRetries: 0, initialDelayMs: 0, maxDelayMs: 0, backoffMultiplier: 1 },
+);
+```
+
+### 5.7 `upload-images-via-allegro.ts` (new util)
+
+Public surface — one function. Returns a discriminated result; the adapter
+constructs the `OfferCreateRejectedException` with its own `ALLEGRO_ADAPTER_KEY`
+constant so the util stays adapter-agnostic.
+
+```ts
+export type UploadImagesResult =
+  | { ok: true; locations: string[] }     // input order preserved
+  | { ok: false; failures: CreateOfferValidationError[] };
+
+export async function uploadImagesViaAllegro(
+  uploadHttpClient: IAllegroHttpClient,
+  imageUrls: string[],
+  options?: {
+    fetchImpl?: typeof fetch;
+    downloadTimeoutMs?: number;  // default 30_000
+  },
+): Promise<UploadImagesResult>;
+```
+
+Internal flow:
+
+```ts
+1. If imageUrls.length === 0 → return { ok: true, locations: [] }.
+2. const fetchImpl = options?.fetchImpl ?? globalThis.fetch;
+3. const failures: CreateOfferValidationError[] = [];
+4. const results = await Promise.all(imageUrls.map(async (url) => {
+     // 4a. download
+     const download = await downloadImage(url, fetchImpl, downloadTimeoutMs);
+     if (download.error) { failures.push(download.error); return null; }
+     // 4b. upload
+     const upload = await uploadOneImage(uploadHttpClient, download.contentType, download.bytes, url);
+     if (upload.error) { failures.push(upload.error); return null; }
+     return upload.location;
+   }));
+5. if (failures.length > 0) return { ok: false, failures };
+6. return { ok: true, locations: results as string[] };
+```
+
+The util **never throws** for image-related failures — it returns a result.
+This keeps the adapter-key string out of the util entirely and gives
+`createOffer` one place to decide how to surface the failure.
+
+Internal helpers (file-private):
+
+- `downloadImage(url, fetchImpl, timeoutMs)`:
+  - `AbortController` with `setTimeout(timeoutMs)`
+  - `await fetchImpl(url, { method: 'GET', signal })`
+  - On `AbortError` → return error `{ field: 'images', code: 'IMAGE_DOWNLOAD_FAILED', message: \`Image URL '${url}' timed out after ${timeoutMs}ms\` }`
+  - On non-`AbortError` exception → return error with `IMAGE_DOWNLOAD_FAILED` and the message
+  - On non-2xx → return error with `IMAGE_DOWNLOAD_FAILED` and `\`Image URL '${url}' returned HTTP ${status}\``
+  - Read `response.headers.get('content-type')` → strip `;`-params → `normalizeImageContentType()`
+  - If not in whitelist → return error with `IMAGE_DOWNLOAD_INVALID_TYPE` and `\`Image URL '${url}' returned content-type '${ct}', expected image/jpeg|png|gif|webp\``
+  - `bytes = new Uint8Array(await response.arrayBuffer())`
+  - Return `{ contentType, bytes }`
+- `uploadOneImage(client, contentType, bytes, sourceUrl)`:
+  - `await client.postBinary<{ location: string }>('/sale/images', contentType, bytes)`
+  - On `AllegroApiException` → return error with `IMAGE_UPLOAD_FAILED` and message including `sourceUrl` + status
+  - On any other exception → wrap as `IMAGE_UPLOAD_FAILED` with the message
+  - Read `response.data.location` — if missing or non-string → error `IMAGE_UPLOAD_FAILED` `\`Allegro upload response missing 'location' for image '${sourceUrl}'\``
+  - Return `{ location }`
+- `normalizeImageContentType(raw: string | null): string | null`:
+  - Strip everything after `;` and trim
+  - lowercase
+  - `image/jpg → image/jpeg`
+  - Return value if in `{image/jpeg, image/png, image/gif, image/webp}`, else null
+
+### 5.8 `AllegroOfferManagerAdapter` — `createOffer` (edited)
+
+Constructor signature:
+
+**Before:**
+```ts
+constructor(
+  connectionId: string,
+  httpClient: IAllegroHttpClient,
+  identifierMapping: IdentifierMappingPort,
+  _connection: Connection,
+  commandRepository?: AllegroQuantityCommandRepositoryPort,
+  quantityPollConfig?: Partial<QuantityPollConfig>,
+)
+```
+
+**After:**
+```ts
+constructor(
+  connectionId: string,
+  httpClient: IAllegroHttpClient,        // ← api host (unchanged role)
+  uploadHttpClient: IAllegroHttpClient,  // ← NEW, upload host
+  identifierMapping: IdentifierMappingPort,
+  _connection: Connection,
+  commandRepository?: AllegroQuantityCommandRepositoryPort,
+  quantityPollConfig?: Partial<QuantityPollConfig>,
+)
+```
+
+`createOffer` body insertion (between `buildCreateOfferRequest` and `httpClient.post`):
+
+```ts
+const body = this.buildCreateOfferRequest(cmd);
+
+if (body.images && body.images.length > 0) {
+  const originalCount = body.images.length;
+  this.logger.debug(
+    `Allegro image upload starting: connection=${this.connectionId} count=${originalCount}`,
+  );
+
+  const result = await uploadImagesViaAllegro(this.uploadHttpClient, body.images);
+
+  if (!result.ok) {
+    const codes = Array.from(new Set(result.failures.map((f) => f.code))).join(',');
+    this.logger.warn(
+      `Allegro image upload rejected create: connection=${this.connectionId} ` +
+        `failed=${result.failures.length}/${originalCount} codes=${codes}`,
+    );
+    throw new OfferCreateRejectedException(ALLEGRO_ADAPTER_KEY, 0, result.failures);
+  }
+
+  body.images = result.locations;
+  this.logger.debug(
+    `Allegro image upload complete: connection=${this.connectionId} count=${body.images.length}`,
+  );
+}
+
+// existing httpClient.post('/sale/product-offers', body, …) unchanged below
+```
+
+## 6. Testing
+
+### 6.1 New util tests (`upload-images-via-allegro.spec.ts`)
+
+9 specs (all assert on the `UploadImagesResult` shape — never on a thrown
+exception, since the util never throws for image failures):
+
+1. Empty input → `{ ok: true, locations: [] }`; `fetch` never called, `postBinary` never called
+2. Single happy path: 200 + `image/jpeg` + 1 byte → `{ ok: true, locations: ['https://...allegrostatic...'] }`
+3. Order preservation: 3 inputs → 3 outputs in input order
+4. Download HTTP failure (status 403) → `{ ok: false, failures: [{ code: 'IMAGE_DOWNLOAD_FAILED', message contains URL + '403' }] }`; `postBinary` never called
+5. Download timeout (mock fetch rejects with `AbortError`) → `IMAGE_DOWNLOAD_FAILED` with timeout language
+6. Wrong content-type (200 + `text/html`) → `IMAGE_DOWNLOAD_INVALID_TYPE`
+7. `image/jpg` normalization: PS sends `image/jpg`, util sends `image/jpeg` to Allegro `postBinary` (assert on `postBinary` mock call args)
+8. Upload failure (`postBinary` rejects with `AllegroApiException(422)`) → `IMAGE_UPLOAD_FAILED`
+9. Mixed (one OK, one 403 download) → `{ ok: false, failures }` with one entry citing only the failing URL
+
+### 6.2 New token-state tests (`allegro-connection-token-state.spec.ts`)
+
+6 specs:
+
+1. **Happy path: `ensureFreshToken` inside refresh window calls the callback, updates `accessToken`, clears cooldown** (the canonical behavior)
+2. `ensureFreshToken` no-ops when no callback
+3. `ensureFreshToken` no-ops when outside refresh window
+4. `ensureFreshToken` calls callback once even under concurrent callers (single-flight via `refreshInFlight`)
+5. `ensureFreshToken` records cooldown after callback throws; subsequent calls within cooldown skip the callback
+6. `refreshOnUnauthorized`: returns true on success, false when no callback, false when callback throws (and accessToken stays unchanged)
+
+### 6.3 Existing http-client tests (edits)
+
+All `new AllegroHttpClient(...)` constructions update to build a token state
+first. Existing behaviour assertions don't change. ~10–15 lines of churn.
+
+**New `postBinary` specs** (added to `allegro-http-client.spec.ts`):
+
+1. Sends raw `Uint8Array` body without JSON-stringifying
+2. Sets `Content-Type` from the parameter, overriding the default `application/vnd.allegro.public.v1+json`
+3. Still attaches `Authorization: Bearer <token>` from token state (regression guard for the extraction)
+4. Inherits 5xx retry from `request()` (one 500 then 200 → succeeds)
+5. Inherits 401 reactive refresh from `request()` (one 401 with refresh callback → token refreshes, request retries with new token)
+
+### 6.4 Existing offer-manager adapter tests (edits)
+
+In `describe('createOffer')`'s `beforeEach`:
+
+```ts
+let uploadHttpClient: jest.Mocked<IAllegroHttpClient>;
+let fetchSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  // existing httpClient/identifierMapping/connection setup,
+  // PLUS update the api-host mock to include postBinary: jest.fn()
+  // so jest.Mocked<IAllegroHttpClient> stays type-correct.
+  uploadHttpClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    postBinary: jest.fn(),
+  } as unknown as jest.Mocked<IAllegroHttpClient>;
+
+  fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    }),
+  );
+
+  let i = 0;
+  uploadHttpClient.postBinary.mockImplementation(() =>
+    Promise.resolve({
+      data: { location: `https://images.allegrostatic.com/test/uploaded-${++i}.jpg` },
+      status: 201,
+      headers: {},
+    }),
+  );
+
+  adapter = new AllegroOfferManagerAdapter(
+    connectionId, httpClient, uploadHttpClient, identifierMapping, connection,
+  );
+});
+
+afterEach(() => fetchSpy.mockRestore());
+```
+
+Two existing specs need updating:
+
+- `"emits images as a flat string[] (Allegro POST /sale/product-offers wire shape)"` —
+  expectation flips from `['https://example.com/img.jpg']` to
+  `['https://images.allegrostatic.com/test/uploaded-1.jpg']`. Test name stays
+  accurate; the wire shape is still `string[]`.
+- `"preserves image URL order when multiple images are supplied"` — expect
+  `['uploaded-1.jpg', 'uploaded-2.jpg', 'uploaded-3.jpg']` (paths abbreviated).
+
+5 new specs:
+
+1. `"throws OfferCreateRejectedException with IMAGE_DOWNLOAD_FAILED when PrestaShop returns 403"`
+2. `"throws OfferCreateRejectedException with IMAGE_DOWNLOAD_INVALID_TYPE when PrestaShop returns text/html with 200"`
+3. `"throws OfferCreateRejectedException with IMAGE_UPLOAD_FAILED when Allegro upload returns 422"`
+4. `"does not call POST /sale/product-offers when image upload step fails"`
+5. `"calls upload host /sale/images with image/jpeg content-type"` (assert on `uploadHttpClient.postBinary` mock call args)
+
+## 7. Step-by-step
+
+| # | Task | File(s) |
+|---|---|---|
+| 1 | Create `AllegroConnectionTokenState` + spec — **with file headers per `engineering-standards.md` §"File Headers"** | 2 new files in `infrastructure/http/` |
+| 2 | Refactor `AllegroHttpClient` to use token state; add `postBinary` — preserve the existing file header | 1 edit (impl), 1 edit (interface), 1 edit (spec) |
+| 3 | Update `AllegroConnectionTesterAdapter` ctor call — **inline comment explaining why `tokenRefreshCallback` is intentionally `undefined`** (probe must surface stale tokens, not silently rotate) | 1 edit |
+| 4 | Add `uploadBaseUrl?` to config types; update factory to build 2 clients + shared token state | 2 edits |
+| 5 | Create `upload-images-via-allegro.ts` util + spec — **with file headers; util never throws for image failures, returns `UploadImagesResult`** | 2 new files in `infrastructure/util/` |
+| 6 | Wire upload step into `AllegroOfferManagerAdapter.createOffer`; update its constructor signature; warn-line includes failure codes for at-a-glance triage | 1 edit |
+| 7 | Update offer-manager adapter spec: `beforeEach` (two mocks + fetch spy, both mocks include `postBinary: jest.fn()`), update 2 existing image specs, add 5 new specs | 1 edit |
+| 8 | `pnpm lint && pnpm type-check && pnpm test` — fix any drift | — |
+
+## 8. Validation against engineering standards
+
+- ✅ **Architecture:** orchestrator util lives under `libs/integrations/allegro/src/infrastructure/util/`. Token state under `infrastructure/http/`. No CORE pollution. The neutral `OfferCreateRejectedException` (CORE) is the only domain type the util references.
+- ✅ **Interface separation:** `IAllegroHttpClient` is the interface; `AllegroHttpClient` is the impl. New token-state class is implementation-internal; not exposed as a port.
+- ✅ **No `any`** — `Uint8Array`, typed responses, typed validation errors throughout.
+- ✅ **Single interface for HTTP clients** — `postBinary` lives on `IAllegroHttpClient`; both api/upload clients implement it.
+- ✅ **Naming** — `*-via-allegro.ts` follows the existing `sanitize-allegro-description.ts` util pattern.
+- ✅ **No DB / migration impact.**
+- ✅ **No new deps** — native fetch only.
+- ✅ **Logging** — uses existing `Logger` shared lib; structured fields only; no PII (image URLs are operator-owned PrestaShop URLs).
+- ✅ **Backward compat** — `cmd.overrides.imageUrls` empty/null path unchanged. The `uploadBaseUrl?` config field is optional with a sensible default; existing connection rows need no migration.
+
+## 9. Manual sandbox verification (per issue AC)
+
+Post-merge, on connection `eecbdcd2-862a-4f77-acb7-f764592ed3d5`, variant
+`ol_variant_0c6eeb1b522144339b0882a225597859`:
+
+- Verify offer creation now **succeeds** (instead of failing with the
+  documented `status=422 errors=0`) for variants whose PrestaShop image URLs
+  are localhost-only.
+- Verify the `upload.allegro.pl.allegrosandbox.pl` host is the one that
+  receives the image POSTs (via OL trace logs).
+- Verify a deliberately misconfigured PS image (e.g., a URL that 403s) now
+  surfaces as `IMAGE_DOWNLOAD_FAILED` with the URL + status in the operator-
+  visible error, not as opaque Allegro 422.
+
+## 10. Risks & known limitations
+
+- **Per-create bandwidth.** Every retry re-downloads + re-uploads. Acceptable
+  for the typical 1–8 images per variant. If a single seller hits this often
+  with many images, caching becomes the next obvious follow-up. **Out of
+  scope; track as a separate issue if/when measured.**
+- **Allegro upload sandbox host not 100% confirmed** in public docs. The
+  default I'm shipping (`upload.allegro.pl.allegrosandbox.pl`) follows
+  Allegro's existing `*.allegrosandbox.pl` pattern; the manual verification
+  step above will confirm. Operators can override via the new
+  `uploadBaseUrl` config field if needed.
+- **HEAD vs GET-from-Allegro asymmetry no longer applies** — Solution B
+  takes Allegro fully out of the operator-host fetch path.
+- **Allegro CDN URL stability.** Once an image is attached to a published
+  offer, the CDN URL is stable per Allegro's docs. We don't persist these
+  URLs anywhere, so the GC concern (only relevant for unattached uploads) is
+  moot for the no-cache flow.
+- **Not bundled here:** the `errors=0` diagnostic tangent (the
+  `AllegroApiException.responseBody` 500-char truncation that swallows the
+  real Allegro error code). It's marked optional in the issue. Solution B
+  largely sidesteps the symptom (we no longer reach that code path on the
+  reachability case), but the underlying logging bug still exists for any
+  Allegro response > 500 chars. Track as a separate small issue/PR.
+
+## 11. Effort
+
+~1.5–2 days of focused work. The biggest item is the token-state extraction
++ the existing `AllegroHttpClient` test churn; everything else is additive
+and follows established patterns.

--- a/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
+++ b/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
@@ -21,6 +21,7 @@ import {
 import { AllegroCredentials } from '../domain/types/allegro-credentials.types';
 import { AllegroConfigException } from '../domain/exceptions/allegro-config.exception';
 import { AllegroHttpClient } from '../infrastructure/http/allegro-http-client';
+import { AllegroConnectionTokenState } from '../infrastructure/http/allegro-connection-token-state';
 import {
   AllegroOfferManagerAdapter,
   QuantityPollConfig,
@@ -64,8 +65,9 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
     // Resolve credentials
     const credentials = await this.resolveCredentials(connection, credentialsResolver);
 
-    // Determine API base URL
+    // Determine API + upload base URLs
     const apiBaseUrl = config.apiBaseUrl || this.getDefaultApiBaseUrl(config.environment);
+    const uploadBaseUrl = config.uploadBaseUrl || this.getDefaultUploadBaseUrl(config.environment);
 
     // Create token refresh callback if token refresh service is available.
     // We forward both accessToken and expiresAt so the HTTP client can update
@@ -84,22 +86,27 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
         }
       : undefined;
 
-    // Create HTTP client
-    const httpClient = new AllegroHttpClient(
+    // One token state shared between both HTTP clients so a refresh triggered
+    // by either client is immediately visible to the other (no wasted 401
+    // round-trip on the sibling client after rotation).
+    const tokenState = new AllegroConnectionTokenState(
       connection.id,
-      apiBaseUrl,
       credentials,
-      config,
-      undefined, // retryConfig
-      tokenRefreshCallback
+      tokenRefreshCallback,
     );
 
-    // Both adapters receive the single per-connection HTTP client + identifier-mapping
-    // instance constructed above. This keeps token-refresh + rate-limit coordination
-    // coherent across the offer-side and order-ingestion paths.
+    // Two HTTP clients per connection — one for api.allegro.pl, one for
+    // upload.allegro.pl. They share the token state above.
+    const httpClient = new AllegroHttpClient(connection.id, apiBaseUrl, tokenState);
+    const uploadHttpClient = new AllegroHttpClient(connection.id, uploadBaseUrl, tokenState);
+
+    // The offer-manager adapter needs both clients (api for offer CRUD,
+    // upload for `POST /sale/images`). The order-source adapter only ever
+    // talks to the api host.
     const offerManagerAdapter = new AllegroOfferManagerAdapter(
       connection.id,
       httpClient,
+      uploadHttpClient,
       identifierMapping,
       connection,
       this.commandRepository,
@@ -127,6 +134,25 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
       default:
         this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
         return 'https://api.allegro.pl.allegrosandbox.pl';
+    }
+  }
+
+  /**
+   * Get default image-upload base URL for environment.
+   *
+   * Allegro hosts image uploads on a separate domain (`upload.allegro.pl`)
+   * from the rest of the API; the sandbox follows the same `*.allegrosandbox.pl`
+   * naming pattern as the api host.
+   */
+  private getDefaultUploadBaseUrl(environment: string): string {
+    switch (environment) {
+      case 'sandbox':
+        return 'https://upload.allegro.pl.allegrosandbox.pl';
+      case 'production':
+        return 'https://upload.allegro.pl';
+      default:
+        this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
+        return 'https://upload.allegro.pl.allegrosandbox.pl';
     }
   }
 

--- a/libs/integrations/allegro/src/domain/types/allegro-config.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-config.types.ts
@@ -37,6 +37,15 @@ export interface AllegroConnectionConfig {
    * - Production: https://api.allegro.pl
    */
   apiBaseUrl?: string;
+
+  /**
+   * Allegro image-upload base URL (optional, defaults based on environment).
+   * The image-binary endpoint lives on a different host from the rest of the
+   * Allegro API, so each connection holds two host configurations.
+   * - Sandbox: https://upload.allegro.pl.allegrosandbox.pl
+   * - Production: https://upload.allegro.pl
+   */
+  uploadBaseUrl?: string;
 }
 
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -21,6 +21,7 @@ import { OfferCreateRejectedException, type CreateOfferCommand } from '@openlink
 describe('AllegroOfferManagerAdapter', () => {
   let adapter: AllegroOfferManagerAdapter;
   let httpClient: jest.Mocked<IAllegroHttpClient>;
+  let uploadHttpClient: jest.Mocked<IAllegroHttpClient>;
   let identifierMapping: jest.Mocked<IdentifierMappingPort>;
   let connection: Connection;
 
@@ -32,6 +33,15 @@ describe('AllegroOfferManagerAdapter', () => {
       post: jest.fn(),
       put: jest.fn(),
       patch: jest.fn(),
+      postBinary: jest.fn(),
+    } as unknown as jest.Mocked<IAllegroHttpClient>;
+
+    uploadHttpClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      patch: jest.fn(),
+      postBinary: jest.fn(),
     } as unknown as jest.Mocked<IAllegroHttpClient>;
 
     identifierMapping = {
@@ -58,7 +68,13 @@ describe('AllegroOfferManagerAdapter', () => {
       ['OfferManager', 'OrderSource'],
     );
 
-    adapter = new AllegroOfferManagerAdapter(connectionId, httpClient, identifierMapping, connection);
+    adapter = new AllegroOfferManagerAdapter(
+      connectionId,
+      httpClient,
+      uploadHttpClient,
+      identifierMapping,
+      connection,
+    );
   });
 
   describe('updateOfferQuantity', () => {
@@ -283,6 +299,7 @@ describe('AllegroOfferManagerAdapter', () => {
       const adapterWithRepo = new AllegroOfferManagerAdapter(
         connectionId,
         httpClient,
+        uploadHttpClient,
         identifierMapping,
         connection,
         commandRepository,
@@ -560,6 +577,38 @@ describe('AllegroOfferManagerAdapter', () => {
       headers: {},
     });
 
+    let fetchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // Default fetch: 200 + image/jpeg + minimal JPEG bytes — keeps existing
+      // specs that don't care about the upload step green.
+      fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockImplementation(() =>
+          Promise.resolve(
+            new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+              status: 200,
+              headers: { 'content-type': 'image/jpeg' },
+            }),
+          ),
+        );
+
+      // Default upload: returns deterministic Allegro CDN URLs per call so
+      // multi-image specs can pin order.
+      let i = 0;
+      uploadHttpClient.postBinary.mockImplementation(() =>
+        Promise.resolve({
+          data: { location: `https://images.allegrostatic.com/test/uploaded-${++i}.jpg` },
+          status: 201,
+          headers: {},
+        }),
+      );
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
     it('returns draft status when INACTIVE without validation errors', async () => {
       httpClient.post.mockResolvedValue(
         mockHttpResponse({
@@ -731,7 +780,7 @@ describe('AllegroOfferManagerAdapter', () => {
       expect(body).not.toHaveProperty('images');
     });
 
-    it('emits images as a flat string[] (Allegro POST /sale/product-offers wire shape)', async () => {
+    it('emits images as a flat string[] of Allegro CDN locations (after upload step)', async () => {
       httpClient.post.mockResolvedValue(
         mockHttpResponse({ id: 'allegro-offer-img', publication: { status: 'INACTIVE' } }),
       );
@@ -739,10 +788,10 @@ describe('AllegroOfferManagerAdapter', () => {
       await adapter.createOffer(baseCmd);
 
       const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
-      expect(body.images).toEqual(['https://example.com/img.jpg']);
+      expect(body.images).toEqual(['https://images.allegrostatic.com/test/uploaded-1.jpg']);
     });
 
-    it('preserves image URL order when multiple images are supplied', async () => {
+    it('preserves image order through the upload step when multiple images are supplied', async () => {
       httpClient.post.mockResolvedValue(
         mockHttpResponse({ id: 'allegro-offer-img-multi', publication: { status: 'INACTIVE' } }),
       );
@@ -759,7 +808,11 @@ describe('AllegroOfferManagerAdapter', () => {
       });
 
       const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
-      expect(body.images).toEqual(imageUrls);
+      expect(body.images).toEqual([
+        'https://images.allegrostatic.com/test/uploaded-1.jpg',
+        'https://images.allegrostatic.com/test/uploaded-2.jpg',
+        'https://images.allegrostatic.com/test/uploaded-3.jpg',
+      ]);
     });
 
     it('omits images from the body when overrides.imageUrls is an empty array', async () => {
@@ -871,6 +924,98 @@ describe('AllegroOfferManagerAdapter', () => {
 
       const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
       expect(body.external).toEqual({ id: 'ol_variant_abc' });
+    });
+
+    it('throws OfferCreateRejectedException with IMAGE_DOWNLOAD_FAILED when PrestaShop returns 403', async () => {
+      fetchSpy.mockResolvedValue(new Response('Forbidden', { status: 403 }));
+
+      await expect(adapter.createOffer(baseCmd)).rejects.toMatchObject({
+        name: 'OfferCreateRejectedException',
+        statusCode: 0,
+        errors: [
+          expect.objectContaining({
+            field: 'images',
+            code: 'IMAGE_DOWNLOAD_FAILED',
+            message: expect.stringMatching(/403/),
+          }),
+        ],
+      });
+      expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('throws OfferCreateRejectedException with IMAGE_DOWNLOAD_INVALID_TYPE when PrestaShop returns 200 + text/html', async () => {
+      fetchSpy.mockResolvedValue(
+        new Response('<html>Blocked</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }),
+      );
+
+      await expect(adapter.createOffer(baseCmd)).rejects.toMatchObject({
+        name: 'OfferCreateRejectedException',
+        statusCode: 0,
+        errors: [
+          expect.objectContaining({
+            field: 'images',
+            code: 'IMAGE_DOWNLOAD_INVALID_TYPE',
+          }),
+        ],
+      });
+      expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('throws OfferCreateRejectedException with IMAGE_UPLOAD_FAILED when Allegro upload returns 422', async () => {
+      uploadHttpClient.postBinary.mockReset();
+      uploadHttpClient.postBinary.mockRejectedValue(
+        new AllegroApiException(
+          'Unprocessable entity',
+          422,
+          '{"errors":[{"code":"INVALID_IMAGE"}]}',
+          'https://upload.allegro.pl/sale/images',
+        ),
+      );
+
+      await expect(adapter.createOffer(baseCmd)).rejects.toMatchObject({
+        name: 'OfferCreateRejectedException',
+        statusCode: 0,
+        errors: [
+          expect.objectContaining({
+            field: 'images',
+            code: 'IMAGE_UPLOAD_FAILED',
+            message: expect.stringMatching(/HTTP 422/),
+          }),
+        ],
+      });
+      expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('does not call POST /sale/product-offers when the image upload step fails', async () => {
+      // Reuses the IMAGE_DOWNLOAD_FAILED setup; explicit assertion that no
+      // offer-create attempt was made (regression guard against silently
+      // proceeding with the original PrestaShop URLs).
+      fetchSpy.mockResolvedValue(new Response('Forbidden', { status: 403 }));
+
+      await expect(adapter.createOffer(baseCmd)).rejects.toBeInstanceOf(
+        OfferCreateRejectedException,
+      );
+
+      expect(httpClient.post).not.toHaveBeenCalled();
+      expect(uploadHttpClient.postBinary).not.toHaveBeenCalled();
+    });
+
+    it('calls upload host /sale/images with the normalized image content-type', async () => {
+      httpClient.post.mockResolvedValue(
+        mockHttpResponse({ id: 'allegro-offer-ct', publication: { status: 'INACTIVE' } }),
+      );
+
+      await adapter.createOffer(baseCmd);
+
+      expect(uploadHttpClient.postBinary).toHaveBeenCalledTimes(1);
+      expect(uploadHttpClient.postBinary).toHaveBeenCalledWith(
+        '/sale/images',
+        'image/jpeg',
+        expect.any(Uint8Array),
+      );
     });
   });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-connection-tester.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-connection-tester.adapter.ts
@@ -14,6 +14,7 @@
 import { ConnectionTesterPort, ConnectionTestResult, CredentialsResolverPort } from '@openlinker/core/integrations';
 import { Connection } from '@openlinker/core/identifier-mapping';
 import { AllegroHttpClient } from '../http/allegro-http-client';
+import { AllegroConnectionTokenState } from '../http/allegro-connection-token-state';
 import { AllegroCredentials } from '../../domain/types/allegro-credentials.types';
 import { AllegroConnectionConfig } from '../../domain/types/allegro-config.types';
 
@@ -38,13 +39,16 @@ export class AllegroConnectionTesterAdapter implements ConnectionTesterPort {
         connection.credentialsRef,
       );
 
-      const client = new AllegroHttpClient(
-        connection.id,
-        apiBaseUrl,
-        credentials,
-        config as AllegroConnectionConfig,
-        { maxRetries: 0, initialDelayMs: 0, maxDelayMs: 0, backoffMultiplier: 1 },
-      );
+      // Probe deliberately runs without a token-refresh callback: a stale or
+      // invalid token must surface as a clear failure (caller can prompt the
+      // operator to reconnect), not silently rotate behind the operator's back.
+      const tokenState = new AllegroConnectionTokenState(connection.id, credentials);
+      const client = new AllegroHttpClient(connection.id, apiBaseUrl, tokenState, {
+        maxRetries: 0,
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        backoffMultiplier: 1,
+      });
 
       const response = await client.get('/me');
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -56,6 +56,7 @@ import { AllegroApiException } from '../../domain/exceptions/allegro-api.excepti
 import { Logger } from '@openlinker/shared/logging';
 import { createHash } from 'crypto';
 import { sanitizeAllegroDescription } from '../util/sanitize-allegro-description';
+import { uploadImagesViaAllegro } from '../util/upload-images-via-allegro';
 import {
   AllegroQuantityCommandRepositoryPort,
   AllegroQuantityCommand,
@@ -122,6 +123,13 @@ export class AllegroOfferManagerAdapter
   constructor(
     private readonly connectionId: string,
     private readonly httpClient: IAllegroHttpClient,
+    /**
+     * Sibling HTTP client pointed at `upload.allegro.pl[.allegrosandbox.pl]`.
+     * Allegro's image-binary endpoint lives on a different host from the
+     * rest of the API; the factory builds both clients with shared token
+     * state (see `AllegroAdapterFactory`).
+     */
+    private readonly uploadHttpClient: IAllegroHttpClient,
     private readonly identifierMapping: IdentifierMappingPort,
     _connection: Connection,
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
@@ -617,6 +625,33 @@ export class AllegroOfferManagerAdapter
    */
   async createOffer(cmd: CreateOfferCommand): Promise<CreateOfferResult> {
     const body = this.buildCreateOfferRequest(cmd);
+
+    // Pre-step: re-host any operator image URLs onto Allegro's CDN. Allegro
+    // resolves URLs in `images[]` server-side and rejects offer creation when
+    // it can't fetch them — so for operators whose PS lives behind localhost,
+    // private IPs, basic-auth, or hardened .htaccess, we proxy bytes via OL.
+    // The util returns a result object (never throws for image failures); we
+    // map it to the neutral `OfferCreateRejectedException` here, where the
+    // adapter-key constant lives.
+    if (body.images && body.images.length > 0) {
+      const originalCount = body.images.length;
+      this.logger.debug(
+        `Allegro image upload starting: connection=${this.connectionId} count=${originalCount}`,
+      );
+      const uploadResult = await uploadImagesViaAllegro(this.uploadHttpClient, body.images);
+      if (!uploadResult.ok) {
+        const codes = Array.from(new Set(uploadResult.failures.map((f) => f.code))).join(',');
+        this.logger.warn(
+          `Allegro image upload rejected create: connection=${this.connectionId} ` +
+            `failed=${uploadResult.failures.length}/${originalCount} codes=${codes}`,
+        );
+        throw new OfferCreateRejectedException(ALLEGRO_ADAPTER_KEY, 0, uploadResult.failures);
+      }
+      body.images = uploadResult.locations;
+      this.logger.debug(
+        `Allegro image upload complete: connection=${this.connectionId} count=${body.images.length}`,
+      );
+    }
 
     this.logger.debug(
       `Creating Allegro offer: connection=${this.connectionId} externalRef=${body.external?.id ?? 'n/a'} publishImmediately=${cmd.publishImmediately}`,

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-connection-token-state.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-connection-token-state.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * Allegro Connection Token State Tests
+ *
+ * Unit tests for the per-connection token-state holder. Covers proactive
+ * refresh (single-flight + cooldown) and reactive 401 refresh return-value
+ * paths. The end-to-end interplay with the HTTP client request loop is
+ * already exercised in `allegro-http-client.spec.ts` — these specs target
+ * the state class in isolation.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/http/__tests__
+ */
+import { Logger } from '@openlinker/shared/logging';
+import { AllegroConnectionTokenState } from '../allegro-connection-token-state';
+
+describe('AllegroConnectionTokenState', () => {
+  const NOW = new Date('2026-04-26T10:00:00.000Z').getTime();
+  const COOLDOWN_MS = 5_000;
+  const TRACE = 'trace-test';
+  const connectionId = 'connection-test';
+
+  let logger: Logger;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    logger = new Logger('AllegroConnectionTokenStateTest');
+    jest.spyOn(logger, 'debug').mockImplementation();
+    jest.spyOn(logger, 'log').mockImplementation();
+    jest.spyOn(logger, 'warn').mockImplementation();
+    jest.spyOn(logger, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('ensureFreshToken — happy path', () => {
+    it('refreshes inside the window, updates accessToken, clears any prior cooldown', async () => {
+      const callback = jest.fn().mockResolvedValue({
+        accessToken: 'fresh-token',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      const state = new AllegroConnectionTokenState(
+        connectionId,
+        { accessToken: 'stale-token', expiresAt: new Date(NOW + 30_000) },
+        callback,
+      );
+
+      await state.ensureFreshToken(TRACE, logger);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(connectionId);
+      expect(state.getAccessToken()).toBe('fresh-token');
+
+      // Subsequent call inside the new validity window must NOT refresh again.
+      await state.ensureFreshToken(TRACE, logger);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ensureFreshToken — no-op paths', () => {
+    it('no-ops when no callback is registered', async () => {
+      const state = new AllegroConnectionTokenState(connectionId, {
+        accessToken: 'token',
+        expiresAt: new Date(NOW + 30_000),
+      });
+
+      await state.ensureFreshToken(TRACE, logger);
+
+      expect(state.getAccessToken()).toBe('token');
+    });
+
+    it('no-ops when expiresAt is absent (backward compat)', async () => {
+      const callback = jest.fn();
+      const state = new AllegroConnectionTokenState(
+        connectionId,
+        { accessToken: 'token' },
+        callback,
+      );
+
+      await state.ensureFreshToken(TRACE, logger);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('no-ops when current token is well outside the refresh window', async () => {
+      const callback = jest.fn();
+      const state = new AllegroConnectionTokenState(
+        connectionId,
+        { accessToken: 'token', expiresAt: new Date(NOW + 10 * 60_000) },
+        callback,
+      );
+
+      await state.ensureFreshToken(TRACE, logger);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ensureFreshToken — single-flight', () => {
+    it('serializes concurrent callers onto a single in-flight refresh', async () => {
+      let resolveRefresh!: (v: { accessToken: string; expiresAt: string }) => void;
+      const callback = jest.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+      const state = new AllegroConnectionTokenState(
+        connectionId,
+        { accessToken: 'stale', expiresAt: new Date(NOW + 30_000) },
+        callback,
+      );
+
+      const p1 = state.ensureFreshToken(TRACE, logger);
+      const p2 = state.ensureFreshToken(TRACE, logger);
+      const p3 = state.ensureFreshToken(TRACE, logger);
+
+      // All three callers parked on the same refresh promise.
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      resolveRefresh({
+        accessToken: 'fresh',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      await Promise.all([p1, p2, p3]);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(state.getAccessToken()).toBe('fresh');
+    });
+  });
+
+  describe('ensureFreshToken — cooldown', () => {
+    it('records cooldown after a failure and skips proactive attempts inside it', async () => {
+      const callback = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('refresh endpoint down'))
+        .mockResolvedValueOnce({
+          accessToken: 'recovered',
+          expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+        });
+      const state = new AllegroConnectionTokenState(
+        connectionId,
+        { accessToken: 'stale', expiresAt: new Date(NOW + 30_000) },
+        callback,
+      );
+
+      // 1st call: refresh attempt fails (swallowed) — cooldown set.
+      await state.ensureFreshToken(TRACE, logger);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(state.getAccessToken()).toBe('stale');
+
+      // Inside the cooldown: no second proactive attempt.
+      jest.setSystemTime(NOW + 1_000);
+      await state.ensureFreshToken(TRACE, logger);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // Past the cooldown: proactive resumes; this time it succeeds.
+      jest.setSystemTime(NOW + COOLDOWN_MS + 1_000);
+      await state.ensureFreshToken(TRACE, logger);
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(state.getAccessToken()).toBe('recovered');
+    });
+  });
+
+  describe('refreshOnUnauthorized', () => {
+    it('returns true on success and updates accessToken', async () => {
+      const callback = jest.fn().mockResolvedValue({
+        accessToken: 'recovered',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      const state = new AllegroConnectionTokenState(
+        connectionId,
+        { accessToken: 'stale' },
+        callback,
+      );
+
+      await expect(state.refreshOnUnauthorized(TRACE, logger)).resolves.toBe(true);
+      expect(state.getAccessToken()).toBe('recovered');
+    });
+
+    it('returns false (without throwing) when no callback is registered', async () => {
+      const state = new AllegroConnectionTokenState(connectionId, { accessToken: 'token' });
+
+      await expect(state.refreshOnUnauthorized(TRACE, logger)).resolves.toBe(false);
+      expect(state.getAccessToken()).toBe('token');
+    });
+
+    it('returns false (without throwing) when the refresh callback throws', async () => {
+      const callback = jest.fn().mockRejectedValue(new Error('refresh endpoint down'));
+      const state = new AllegroConnectionTokenState(
+        connectionId,
+        { accessToken: 'stale' },
+        callback,
+      );
+
+      await expect(state.refreshOnUnauthorized(TRACE, logger)).resolves.toBe(false);
+      expect(state.getAccessToken()).toBe('stale');
+    });
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts
@@ -11,8 +11,8 @@
  * @module libs/integrations/allegro/src/infrastructure/http/__tests__
  */
 import { AllegroHttpClient } from '../allegro-http-client';
+import { AllegroConnectionTokenState } from '../allegro-connection-token-state';
 import {
-  AllegroConnectionConfig,
   AllegroCredentials,
   AllegroApiException,
   AllegroAuthenticationException,
@@ -30,7 +30,6 @@ describe('AllegroHttpClient', () => {
   let connectionId: string;
   let baseUrl: string;
   let credentials: AllegroCredentials;
-  let config: AllegroConnectionConfig;
 
   beforeEach(() => {
     connectionId = 'connection-123';
@@ -38,14 +37,18 @@ describe('AllegroHttpClient', () => {
     credentials = {
       accessToken: 'test-access-token-12345',
     };
-    config = {
-      environment: 'production',
-    };
 
-    client = new AllegroHttpClient(connectionId, baseUrl, credentials, config);
-    noRetryClient = new AllegroHttpClient(connectionId, baseUrl, credentials, config, {
-      maxRetries: 0,
-    });
+    client = new AllegroHttpClient(
+      connectionId,
+      baseUrl,
+      new AllegroConnectionTokenState(connectionId, credentials),
+    );
+    noRetryClient = new AllegroHttpClient(
+      connectionId,
+      baseUrl,
+      new AllegroConnectionTokenState(connectionId, credentials),
+      { maxRetries: 0 },
+    );
     jest.useFakeTimers();
   });
 
@@ -59,8 +62,7 @@ describe('AllegroHttpClient', () => {
       const clientWithSlash = new AllegroHttpClient(
         connectionId,
         'https://api.allegro.pl/',
-        credentials,
-        config,
+        new AllegroConnectionTokenState(connectionId, credentials),
       );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       expect((clientWithSlash as any).baseUrl).toBe('https://api.allegro.pl');
@@ -90,8 +92,7 @@ describe('AllegroHttpClient', () => {
       const clientWithCustom = new AllegroHttpClient(
         connectionId,
         baseUrl,
-        credentials,
-        config,
+        new AllegroConnectionTokenState(connectionId, credentials),
         customRetryConfig,
       );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
@@ -180,6 +181,120 @@ describe('AllegroHttpClient', () => {
           body: JSON.stringify(requestBody),
         }),
       );
+    });
+  });
+
+  describe('postBinary', () => {
+    it('sends raw Uint8Array body without JSON-stringifying it', async () => {
+      const responseData = { location: 'https://images.allegrostatic.com/abc.jpg' };
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify(responseData)),
+      });
+
+      const bytes = new Uint8Array([0xff, 0xd8, 0xff]); // JPEG magic bytes
+      const response = await client.postBinary('/sale/images', 'image/jpeg', bytes);
+
+      expect(response.data).toEqual(responseData);
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      expect(fetchCall[1]?.method).toBe('POST');
+      expect(fetchCall[1]?.body).toBe(bytes);
+    });
+
+    it('sets Content-Type from the parameter, overriding the JSON default', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve('{}'),
+      });
+
+      await client.postBinary('/sale/images', 'image/png', new Uint8Array([1, 2, 3]));
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      const headers = (fetchCall[1]?.headers as Record<string, string>) ?? {};
+      expect(headers['content-type']).toBe('image/png');
+    });
+
+    it('still attaches Authorization: Bearer <token> from the token state', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve('{}'),
+      });
+
+      await client.postBinary('/sale/images', 'image/jpeg', new Uint8Array([0xff]));
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit];
+      const headers = (fetchCall[1]?.headers as Record<string, string>) ?? {};
+      expect(headers.authorization).toBe('Bearer test-access-token-12345');
+    });
+
+    it('inherits 5xx retry from the request loop', async () => {
+      const responseData = { location: 'https://images.allegrostatic.com/ok.jpg' };
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          headers: new Headers(),
+          text: () => Promise.resolve('Internal Server Error'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () => Promise.resolve(JSON.stringify(responseData)),
+        });
+
+      const promise = client.postBinary('/sale/images', 'image/jpeg', new Uint8Array([0xff]));
+      await jest.advanceTimersByTimeAsync(1_000);
+      const response = await promise;
+
+      expect(response.data).toEqual(responseData);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('inherits 401 reactive token-refresh from the request loop', async () => {
+      const NOW = Date.now();
+      const refreshCallback = jest.fn().mockResolvedValue({
+        accessToken: 'recovered-token',
+        expiresAt: new Date(NOW + 60 * 60_000).toISOString(),
+      });
+      const tokenState = new AllegroConnectionTokenState(
+        connectionId,
+        { accessToken: 'stale-token' },
+        refreshCallback,
+      );
+      const refreshClient = new AllegroHttpClient(connectionId, baseUrl, tokenState);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          headers: new Headers(),
+          text: () => Promise.resolve('{"error":"expired_token"}'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 201,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () => Promise.resolve('{"location":"https://images.allegrostatic.com/x.jpg"}'),
+        });
+
+      const response = await refreshClient.postBinary(
+        '/sale/images',
+        'image/jpeg',
+        new Uint8Array([0xff]),
+      );
+
+      expect(response.status).toBe(201);
+      expect(refreshCallback).toHaveBeenCalledTimes(1);
+      const retryCall = (global.fetch as jest.Mock).mock.calls[1] as [string, RequestInit];
+      const retryHeaders = (retryCall[1]?.headers as Record<string, string>) ?? {};
+      expect(retryHeaders.authorization).toBe('Bearer recovered-token');
     });
   });
 
@@ -502,14 +617,17 @@ describe('AllegroHttpClient', () => {
       callback?: (connectionId: string) => Promise<{ accessToken: string; expiresAt?: Date | string }>;
       accessToken?: string;
     } = {}): AllegroHttpClient => {
-      return new AllegroHttpClient(
+      const tokenState = new AllegroConnectionTokenState(
         connectionId,
-        baseUrl,
         { accessToken: opts.accessToken ?? 'initial-token', expiresAt: opts.expiresAt },
-        config,
-        { maxRetries: 0, initialDelayMs: 0, maxDelayMs: 0, backoffMultiplier: 1 },
         opts.callback,
       );
+      return new AllegroHttpClient(connectionId, baseUrl, tokenState, {
+        maxRetries: 0,
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        backoffMultiplier: 1,
+      });
     };
 
     const mockAlways200 = (): void => {
@@ -676,10 +794,11 @@ describe('AllegroHttpClient', () => {
       const client = new AllegroHttpClient(
         connectionId,
         baseUrl,
-        { accessToken: 'initial-token', expiresAt: new Date(NOW + 30_000) },
-        config,
-        undefined,
-        refreshCallback,
+        new AllegroConnectionTokenState(
+          connectionId,
+          { accessToken: 'initial-token', expiresAt: new Date(NOW + 30_000) },
+          refreshCallback,
+        ),
       );
 
       const response = await client.get('/test');

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-connection-token-state.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-connection-token-state.ts
@@ -1,0 +1,181 @@
+/**
+ * Allegro Connection Token State
+ *
+ * Per-connection mutable holder for OAuth access-token state shared by every
+ * `AllegroHttpClient` that talks to Allegro on behalf of one connection.
+ * The factory builds two HTTP clients per connection — one pointed at
+ * `api.allegro.pl`, one at `upload.allegro.pl` — and both reference the same
+ * `AllegroConnectionTokenState` instance so a refresh triggered by either
+ * client is immediately visible to the other (no wasted 401 round-trip).
+ *
+ * Owns three responsibilities previously scattered on `AllegroHttpClient`:
+ *
+ *  1. The current `accessToken` + cached `tokenExpiresAt`.
+ *  2. The proactive-refresh path (`ensureFreshToken`) — single-flight via
+ *     `refreshInFlight`, with a post-failure cooldown so a sick refresh
+ *     endpoint can't trigger a refresh storm.
+ *  3. The reactive 401 path (`refreshOnUnauthorized`) — returns whether a
+ *     refresh actually happened so the caller can decide to retry.
+ *
+ * Cross-process coordination (e.g., serializing refresh attempts across
+ * worker pods) is the `AllegroTokenRefreshService` callback's job, not this
+ * class — the Redis lock lives there.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/http
+ * @see {@link AllegroHttpClient} — sole consumer (constructed twice per
+ *   connection, both instances sharing one `AllegroConnectionTokenState`)
+ * @see {@link AllegroAdapterFactory} — constructs the shared token state
+ */
+import { Logger } from '@openlinker/shared/logging';
+import { AllegroCredentials } from '../../domain/types/allegro-credentials.types';
+import { TokenRefreshCallback, TokenRefreshResult } from './allegro-http-client.types';
+
+/**
+ * Proactive token-refresh window.
+ *
+ * Refresh proactively when the current access token is within this many
+ * milliseconds of its expiresAt timestamp, so we don't pay a wasted 401
+ * round-trip on the next request after an idle period.
+ */
+const TOKEN_REFRESH_WINDOW_MS = 60_000;
+
+/**
+ * Cooldown after a failed proactive refresh. During this window pre-request
+ * checks short-circuit and rely on the reactive 401 path, preventing a
+ * refresh storm when the refresh endpoint is unhealthy.
+ */
+const PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS = 5_000;
+
+export class AllegroConnectionTokenState {
+  private accessToken: string;
+  private tokenExpiresAt: number | undefined;
+  private refreshInFlight: Promise<void> | null = null;
+  private proactiveRefreshCooldownUntil: number | undefined;
+
+  constructor(
+    private readonly connectionId: string,
+    initial: AllegroCredentials,
+    private readonly tokenRefreshCallback?: TokenRefreshCallback,
+  ) {
+    this.accessToken = initial.accessToken;
+    this.tokenExpiresAt = AllegroConnectionTokenState.normalizeExpiresAt(initial.expiresAt);
+  }
+
+  getAccessToken(): string {
+    return this.accessToken;
+  }
+
+  /**
+   * Pre-request hook: refresh proactively if the current token is within
+   * the refresh window. No-op when no callback / no expiresAt / inside the
+   * post-failure cooldown / outside the refresh window.
+   *
+   * Per-instance single-flight via `refreshInFlight`: concurrent callers
+   * await the same in-flight refresh promise.
+   */
+  async ensureFreshToken(traceId: string, logger: Logger): Promise<void> {
+    if (!this.tokenRefreshCallback || this.tokenExpiresAt === undefined) {
+      return;
+    }
+    if (
+      this.proactiveRefreshCooldownUntil !== undefined &&
+      Date.now() < this.proactiveRefreshCooldownUntil
+    ) {
+      return;
+    }
+    if (Date.now() < this.tokenExpiresAt - TOKEN_REFRESH_WINDOW_MS) {
+      return;
+    }
+    if (this.refreshInFlight) {
+      await this.refreshInFlight;
+      return;
+    }
+    this.refreshInFlight = this.performProactiveRefresh(traceId, logger).finally(() => {
+      this.refreshInFlight = null;
+    });
+    await this.refreshInFlight;
+  }
+
+  /**
+   * Reactive 401 path. Invokes the refresh callback and returns whether
+   * the refresh succeeded — the caller decides whether to retry.
+   *
+   * Returns `false` (without throwing) when:
+   *  - no refresh callback is registered, OR
+   *  - the refresh callback throws (the original 401 path stays as the
+   *    authoritative failure).
+   */
+  async refreshOnUnauthorized(traceId: string, logger: Logger): Promise<boolean> {
+    if (!this.tokenRefreshCallback) {
+      return false;
+    }
+    try {
+      logger.warn(
+        `[${traceId}] Access token expired, attempting refresh (connection: ${this.connectionId})`,
+      );
+      const refreshResult = await this.tokenRefreshCallback(this.connectionId);
+      this.applyRefreshResult(refreshResult);
+      logger.log(
+        `[${traceId}] Access token refreshed successfully (connection: ${this.connectionId})`,
+      );
+      return true;
+    } catch (error) {
+      logger.error(
+        `[${traceId}] Token refresh failed: ${(error as Error).message} (connection: ${this.connectionId})`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Perform the actual proactive refresh. Updates cached access token and
+   * expiry on success; records a cooldown on failure so subsequent requests
+   * skip the proactive path and rely on the reactive 401 path.
+   */
+  private async performProactiveRefresh(traceId: string, logger: Logger): Promise<void> {
+    if (!this.tokenRefreshCallback) {
+      return;
+    }
+    try {
+      logger.debug(
+        `[${traceId}] Proactive token refresh (connection: ${this.connectionId})`,
+      );
+      const refreshResult = await this.tokenRefreshCallback(this.connectionId);
+      this.applyRefreshResult(refreshResult);
+      logger.log(
+        `[${traceId}] Proactive token refresh succeeded (connection: ${this.connectionId})`,
+      );
+    } catch (error) {
+      this.proactiveRefreshCooldownUntil = Date.now() + PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS;
+      logger.warn(
+        `[${traceId}] Proactive token refresh failed, falling back to reactive 401 path: ${(error as Error).message} (connection: ${this.connectionId})`,
+      );
+    }
+  }
+
+  /**
+   * Single place where the access token + cached expiry get updated, so
+   * the proactive and reactive refresh paths can't drift (e.g., one
+   * forgetting to clear the cooldown or update the expiry).
+   */
+  private applyRefreshResult(result: TokenRefreshResult): void {
+    this.accessToken = result.accessToken;
+    this.tokenExpiresAt = AllegroConnectionTokenState.normalizeExpiresAt(result.expiresAt);
+    this.proactiveRefreshCooldownUntil = undefined;
+  }
+
+  /**
+   * Normalize an `expiresAt` value (Date | string | undefined) to epoch ms.
+   *
+   * Returns `undefined` for absent values, invalid Date objects, or strings
+   * that don't parse — which disables proactive refresh for that token state
+   * rather than letting NaN silently poison the comparison.
+   */
+  private static normalizeExpiresAt(value: Date | string | undefined): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+    return Number.isFinite(ms) ? ms : undefined;
+  }
+}

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.interface.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.interface.ts
@@ -83,6 +83,28 @@ export interface IAllegroHttpClient {
     body?: Record<string, unknown> | string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>>;
+
+  /**
+   * Make POST request with a raw binary body.
+   *
+   * Used for endpoints that accept image / file bytes (`upload.allegro.pl/sale/images`)
+   * — `Content-Type` comes from the parameter, not the JSON default. The body
+   * is passed straight to fetch as `Uint8Array`; no JSON serialization happens.
+   * Otherwise behaves identically to `post`: same auth header, same retry +
+   * token-refresh machinery.
+   *
+   * @param path - API path (e.g., '/sale/images')
+   * @param contentType - MIME type of the body (e.g., 'image/jpeg')
+   * @param body - Raw bytes
+   * @param options - Request options (headers, query params)
+   * @returns Response data
+   */
+  postBinary<T = unknown>(
+    path: string,
+    contentType: string,
+    body: Uint8Array,
+    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+  ): Promise<AllegroHttpResponse<T>>;
 }
 
 

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
@@ -6,13 +6,16 @@
  * request building, response parsing, retries with backoff, rate limiting,
  * and error handling.
  *
+ * Token state (accessToken, expiresAt, single-flight refresh, cooldown) is
+ * owned by `AllegroConnectionTokenState` so multiple clients per connection
+ * (e.g., the api host + the upload host) can share one refresh path.
+ *
  * @module libs/integrations/allegro/src/infrastructure/http
  * @implements {IAllegroHttpClient}
+ * @see {@link AllegroConnectionTokenState} — owns the per-connection token
  */
 import { IAllegroHttpClient, AllegroHttpRequestOptions, AllegroHttpResponse } from './allegro-http-client.interface';
-import { TokenRefreshCallback, TokenRefreshResult } from './allegro-http-client.types';
-import { AllegroConnectionConfig } from '../../domain/types/allegro-config.types';
-import { AllegroCredentials } from '../../domain/types/allegro-credentials.types';
+import { AllegroConnectionTokenState } from './allegro-connection-token-state';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
 import { AllegroAuthenticationException } from '../../domain/exceptions/allegro-authentication.exception';
 import { AllegroRateLimitException } from '../../domain/exceptions/allegro-rate-limit.exception';
@@ -40,15 +43,6 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
 };
 
 /**
- * Proactive token-refresh window.
- *
- * Refresh proactively when the current access token is within this many
- * milliseconds of its expiresAt timestamp, so we don't pay a wasted 401
- * round-trip on the next request after an idle period.
- */
-const TOKEN_REFRESH_WINDOW_MS = 60_000;
-
-/**
  * Token refreshed error
  *
  * Internal error used to signal that token was refreshed and request should be retried.
@@ -67,45 +61,30 @@ class TokenRefreshedError extends Error {
  * Implements HTTP client for Allegro Public API using native fetch.
  */
 export class AllegroHttpClient implements IAllegroHttpClient {
-  /**
-   * Cooldown after a failed proactive refresh. During this window pre-request
-   * checks short-circuit and rely on the reactive 401 path, preventing a
-   * refresh storm when the refresh endpoint is unhealthy.
-   */
-  private static readonly PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS = 5_000;
-
   private readonly logger = new Logger(AllegroHttpClient.name);
   private readonly baseUrl: string;
-  private accessToken: string; // Mutable to support token refresh
-  private tokenExpiresAt: number | undefined; // Epoch ms; undefined disables proactive refresh
-  private refreshInFlight: Promise<void> | null = null; // Per-instance single-flight
-  private proactiveRefreshCooldownUntil: number | undefined; // Epoch ms; set on failure
   private readonly retryConfig: RetryConfig;
   private readonly connectionId: string;
-  private readonly tokenRefreshCallback?: TokenRefreshCallback;
+  private readonly tokenState: AllegroConnectionTokenState;
 
   constructor(
     connectionId: string,
     baseUrl: string,
-    credentials: AllegroCredentials,
-    _config: AllegroConnectionConfig,
+    tokenState: AllegroConnectionTokenState,
     retryConfig?: Partial<RetryConfig>,
-    tokenRefreshCallback?: TokenRefreshCallback,
   ) {
     this.connectionId = connectionId;
     // Normalize baseUrl (remove trailing slash)
     this.baseUrl = baseUrl.replace(/\/$/, '');
-    this.accessToken = credentials.accessToken;
-    this.tokenExpiresAt = this.normalizeExpiresAt(credentials.expiresAt);
+    this.tokenState = tokenState;
     this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
-    this.tokenRefreshCallback = tokenRefreshCallback;
   }
 
   async get<T = unknown>(
     path: string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('GET', path, undefined, options);
+    return this.request<T>('GET', path, undefined, undefined, options);
   }
 
   async post<T = unknown>(
@@ -113,7 +92,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     body?: Record<string, unknown> | string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('POST', path, body, options);
+    return this.request<T>('POST', path, body, undefined, options);
   }
 
   async put<T = unknown>(
@@ -121,7 +100,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     body?: Record<string, unknown> | string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('PUT', path, body, options);
+    return this.request<T>('PUT', path, body, undefined, options);
   }
 
   async patch<T = unknown>(
@@ -129,7 +108,16 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     body?: Record<string, unknown> | string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>> {
-    return this.request<T>('PATCH', path, body, options);
+    return this.request<T>('PATCH', path, body, undefined, options);
+  }
+
+  async postBinary<T = unknown>(
+    path: string,
+    contentType: string,
+    body: Uint8Array,
+    options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
+  ): Promise<AllegroHttpResponse<T>> {
+    return this.request<T>('POST', path, body, contentType, options);
   }
 
   /**
@@ -137,14 +125,18 @@ export class AllegroHttpClient implements IAllegroHttpClient {
    *
    * @param method - HTTP method
    * @param path - API path
-   * @param body - Request body (optional)
+   * @param body - Request body (optional). When `Uint8Array`, the request is
+   *   binary and `binaryContentType` must be supplied.
+   * @param binaryContentType - When body is binary, the MIME type to send.
+   *   When undefined the request takes the JSON default.
    * @param options - Request options
    * @returns Response data
    */
   private async request<T = unknown>(
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     path: string,
-    body?: Record<string, unknown> | string,
+    body?: Record<string, unknown> | string | Uint8Array,
+    binaryContentType?: string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>> {
     let lastError: Error | null = null;
@@ -152,7 +144,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
 
     for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
       try {
-        return await this.executeRequest<T>(method, path, body, options);
+        return await this.executeRequest<T>(method, path, body, binaryContentType, options);
       } catch (error: unknown) {
         lastError = error instanceof Error ? error : new Error(String(error));
 
@@ -210,13 +202,15 @@ export class AllegroHttpClient implements IAllegroHttpClient {
    * @param method - HTTP method
    * @param path - API path
    * @param body - Request body (optional)
+   * @param binaryContentType - MIME for raw binary body; undefined for JSON
    * @param options - Request options
    * @returns Response data
    */
   private async executeRequest<T = unknown>(
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     path: string,
-    body?: Record<string, unknown> | string,
+    body?: Record<string, unknown> | string | Uint8Array,
+    binaryContentType?: string,
     options?: Omit<AllegroHttpRequestOptions, 'method' | 'body'>,
   ): Promise<AllegroHttpResponse<T>> {
     const startTime = Date.now();
@@ -225,7 +219,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     // Proactively refresh the token before building Authorization if we're
     // inside the refresh window. No-op when no callback or no expiresAt,
     // preserving behavior for connections without expiry metadata.
-    await this.ensureFreshToken(traceId);
+    await this.tokenState.ensureFreshToken(traceId, this.logger);
 
     // Build URL with query parameters
     const url = new URL(path, this.baseUrl);
@@ -240,7 +234,11 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     // Structural headers land last because Authorization is owned by the token-refresh
     // flow and X-Trace-Id must match the log correlation ID — neither is a caller concern.
     const headers = new Headers();
-    headers.set('Content-Type', 'application/vnd.allegro.public.v1+json');
+    if (binaryContentType !== undefined) {
+      headers.set('Content-Type', binaryContentType);
+    } else {
+      headers.set('Content-Type', 'application/vnd.allegro.public.v1+json');
+    }
     headers.set('Accept', 'application/vnd.allegro.public.v1+json');
 
     if (options?.headers) {
@@ -249,7 +247,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
       }
     }
 
-    headers.set('Authorization', `Bearer ${this.accessToken}`);
+    headers.set('Authorization', `Bearer ${this.tokenState.getAccessToken()}`);
     headers.set('X-Trace-Id', traceId);
 
     // Convert Headers to plain object for fetch (Node.js fetch may have issues with Headers object)
@@ -258,10 +256,16 @@ export class AllegroHttpClient implements IAllegroHttpClient {
       headersObject[key] = value;
     });
 
-    // Prepare request body
-    let requestBody: string | undefined;
-    if (body) {
-      requestBody = typeof body === 'string' ? body : JSON.stringify(body);
+    // Prepare request body. Binary bodies (Uint8Array) flow through to fetch
+    // unchanged; the JSON path stringifies plain objects.
+    let requestBody: string | Uint8Array | undefined;
+    if (body !== undefined) {
+      if (binaryContentType !== undefined) {
+        // Caller supplied a Content-Type — body must be raw bytes.
+        requestBody = body as Uint8Array;
+      } else {
+        requestBody = typeof body === 'string' ? body : JSON.stringify(body);
+      }
     }
 
     // Create AbortController for timeout
@@ -357,7 +361,7 @@ export class AllegroHttpClient implements IAllegroHttpClient {
   /**
    * Handle HTTP error responses
    *
-   * For 401 errors, attempts token refresh if a refresh callback is available.
+   * For 401 errors, attempts token refresh via `tokenState.refreshOnUnauthorized`.
    * Otherwise, throws AllegroAuthenticationException.
    */
   private async handleError(
@@ -375,36 +379,16 @@ export class AllegroHttpClient implements IAllegroHttpClient {
         bodyLower.includes('token') ||
         bodyLower.includes('invalid_token') ||
         bodyLower.includes('access_token');
-      
-      if (isTokenExpired && this.tokenRefreshCallback) {
-        // Attempt token refresh
-        try {
-          this.logger.warn(
-            `[${traceId}] Access token expired, attempting refresh (connection: ${this.connectionId})`,
-          );
-          const refreshResult = await this.tokenRefreshCallback(this.connectionId);
-          this.applyRefreshResult(refreshResult);
-          this.logger.log(
-            `[${traceId}] Access token refreshed successfully (connection: ${this.connectionId})`,
-          );
-          // Return a special error that indicates refresh succeeded (caller should retry)
+
+      if (isTokenExpired) {
+        const refreshed = await this.tokenState.refreshOnUnauthorized(traceId, this.logger);
+        if (refreshed) {
+          // Signal caller to retry with the freshly-rotated token.
           throw new TokenRefreshedError('Token refreshed, retry request');
-        } catch (error) {
-          if (error instanceof TokenRefreshedError) {
-            // Re-throw to signal caller to retry
-            throw error;
-          }
-          // Refresh failed - log and fall through to throw authentication exception
-          this.logger.error(
-            `[${traceId}] Token refresh failed: ${(error as Error).message} (connection: ${this.connectionId})`,
-          );
         }
-      } else if (isTokenExpired) {
-        this.logger.warn(
-          `[${traceId}] Access token expired or invalid, refresh required but no refresh callback available (connection: ${this.connectionId})`,
-        );
+        // Refresh path didn't help — fall through to authentication exception.
       }
-      
+
       this.logger.error(`[${traceId}] Authentication failed: Invalid or expired access token`);
       throw new AllegroAuthenticationException(
         `Authentication failed: Invalid or expired access token for ${url}`,
@@ -449,105 +433,9 @@ export class AllegroHttpClient implements IAllegroHttpClient {
   }
 
   /**
-   * Ensure the access token is fresh before sending a request.
-   *
-   * No-op when the client has no refresh callback or no expiresAt (backward
-   * compat for connections that were created before expiry was persisted).
-   * Short-circuits during the post-failure cooldown so a sick refresh endpoint
-   * can't trigger a refresh storm — the reactive 401 path stays as the
-   * fallback.
-   *
-   * Uses per-instance single-flight: concurrent callers await the same
-   * in-flight refresh promise instead of each triggering their own. Cross-
-   * process / cross-instance serialization is handled by
-   * `AllegroTokenRefreshService`'s Redis lock.
-   */
-  private async ensureFreshToken(traceId: string): Promise<void> {
-    if (!this.tokenRefreshCallback || this.tokenExpiresAt === undefined) {
-      return;
-    }
-    if (
-      this.proactiveRefreshCooldownUntil !== undefined &&
-      Date.now() < this.proactiveRefreshCooldownUntil
-    ) {
-      return;
-    }
-    if (Date.now() < this.tokenExpiresAt - TOKEN_REFRESH_WINDOW_MS) {
-      return;
-    }
-    if (this.refreshInFlight) {
-      await this.refreshInFlight;
-      return;
-    }
-    this.refreshInFlight = this.performProactiveRefresh(traceId).finally(() => {
-      this.refreshInFlight = null;
-    });
-    await this.refreshInFlight;
-  }
-
-  /**
-   * Perform the actual proactive refresh. Updates cached access token and
-   * expiry on success; records a cooldown on failure so subsequent requests
-   * skip the proactive path and rely on the reactive 401 path.
-   */
-  private async performProactiveRefresh(traceId: string): Promise<void> {
-    if (!this.tokenRefreshCallback) {
-      return;
-    }
-    try {
-      this.logger.debug(
-        `[${traceId}] Proactive token refresh (connection: ${this.connectionId})`,
-      );
-      const refreshResult = await this.tokenRefreshCallback(this.connectionId);
-      this.applyRefreshResult(refreshResult);
-      this.logger.log(
-        `[${traceId}] Proactive token refresh succeeded (connection: ${this.connectionId})`,
-      );
-    } catch (error) {
-      // Deliberately swallowed: the reactive 401 path is the documented
-      // fallback (see issue #336 AC). Record a short cooldown so we don't
-      // re-attempt on every request while the endpoint is unhealthy.
-      this.proactiveRefreshCooldownUntil =
-        Date.now() + AllegroHttpClient.PROACTIVE_REFRESH_FAILURE_COOLDOWN_MS;
-      this.logger.warn(
-        `[${traceId}] Proactive token refresh failed, falling back to reactive 401 path: ${(error as Error).message} (connection: ${this.connectionId})`,
-      );
-    }
-  }
-
-  /**
-   * Apply a successful refresh result to cached client state.
-   *
-   * Single place where the access token and cached expiry get updated, so
-   * the proactive and reactive refresh paths can't drift (e.g., one forgetting
-   * to clear the cooldown or update the expiry).
-   */
-  private applyRefreshResult(result: TokenRefreshResult): void {
-    this.accessToken = result.accessToken;
-    this.tokenExpiresAt = this.normalizeExpiresAt(result.expiresAt);
-    this.proactiveRefreshCooldownUntil = undefined;
-  }
-
-  /**
-   * Normalize an `expiresAt` value (Date | string | undefined) to epoch ms.
-   *
-   * Returns `undefined` for absent values, invalid Date objects, or strings
-   * that don't parse — which disables proactive refresh for that client
-   * instance rather than letting NaN silently poison the comparison.
-   */
-  private normalizeExpiresAt(value: Date | string | undefined): number | undefined {
-    if (value === undefined) {
-      return undefined;
-    }
-    const ms = value instanceof Date ? value.getTime() : Date.parse(value);
-    return Number.isFinite(ms) ? ms : undefined;
-  }
-
-  /**
    * Sleep utility for retry delays
    */
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
-

--- a/libs/integrations/allegro/src/infrastructure/util/__tests__/upload-images-via-allegro.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/__tests__/upload-images-via-allegro.spec.ts
@@ -1,0 +1,268 @@
+/**
+ * Upload Images Via Allegro Tests
+ *
+ * Unit tests for the no-cache image-pipeline orchestrator. Exercises the
+ * download → validate → upload path with a mocked `fetchImpl` (operator-
+ * host downloads) and a mocked `IAllegroHttpClient.postBinary` (Allegro
+ * upload).
+ *
+ * @module libs/integrations/allegro/src/infrastructure/util/__tests__
+ */
+import { IAllegroHttpClient } from '../../http/allegro-http-client.interface';
+import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
+import { uploadImagesViaAllegro } from '../upload-images-via-allegro';
+
+describe('uploadImagesViaAllegro', () => {
+  let uploadHttpClient: jest.Mocked<IAllegroHttpClient>;
+
+  const okFetchResponse = (body: Uint8Array, contentType = 'image/jpeg'): Response =>
+    new Response(body, { status: 200, headers: { 'content-type': contentType } });
+
+  const errFetchResponse = (status: number, body = ''): Response =>
+    new Response(body, { status });
+
+  beforeEach(() => {
+    uploadHttpClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      patch: jest.fn(),
+      postBinary: jest.fn(),
+    } as unknown as jest.Mocked<IAllegroHttpClient>;
+  });
+
+  it('returns ok=true with empty array when input is empty (fetch and upload never called)', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+
+    const result = await uploadImagesViaAllegro(uploadHttpClient, [], { fetchImpl });
+
+    expect(result).toEqual({ ok: true, locations: [] });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(uploadHttpClient.postBinary).not.toHaveBeenCalled();
+  });
+
+  it('happy path — single 200 jpeg returns one Allegro CDN location', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(new Uint8Array([0xff, 0xd8, 0xff])));
+    uploadHttpClient.postBinary.mockResolvedValue({
+      data: { location: 'https://images.allegrostatic.com/uploaded-1.jpg' },
+      status: 201,
+      headers: {},
+    });
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/img/1.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      locations: ['https://images.allegrostatic.com/uploaded-1.jpg'],
+    });
+    expect(uploadHttpClient.postBinary).toHaveBeenCalledTimes(1);
+    expect(uploadHttpClient.postBinary).toHaveBeenCalledWith(
+      '/sale/images',
+      'image/jpeg',
+      expect.any(Uint8Array),
+    );
+  });
+
+  it('preserves input order across N images', async () => {
+    // Fresh Response per call — Response bodies can only be consumed once.
+    const fetchImpl = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(okFetchResponse(new Uint8Array([1]))));
+    let counter = 0;
+    uploadHttpClient.postBinary.mockImplementation(() =>
+      Promise.resolve({
+        data: { location: `https://images.allegrostatic.com/u-${++counter}.jpg` },
+        status: 201,
+        headers: {},
+      }),
+    );
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://a/1.jpg', 'http://a/2.jpg', 'http://a/3.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.locations).toHaveLength(3);
+    // Each input URL was downloaded.
+    expect(fetchImpl).toHaveBeenCalledWith('http://a/1.jpg', expect.any(Object));
+    expect(fetchImpl).toHaveBeenCalledWith('http://a/2.jpg', expect.any(Object));
+    expect(fetchImpl).toHaveBeenCalledWith('http://a/3.jpg', expect.any(Object));
+  });
+
+  it('IMAGE_DOWNLOAD_FAILED when PrestaShop returns 403 — postBinary never called', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(errFetchResponse(403, 'Forbidden'));
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/locked.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toEqual({
+      field: 'images',
+      code: 'IMAGE_DOWNLOAD_FAILED',
+      message: expect.stringMatching(/http:\/\/shop\.local\/locked\.jpg.*403/),
+    });
+    expect(uploadHttpClient.postBinary).not.toHaveBeenCalled();
+  });
+
+  it('IMAGE_DOWNLOAD_FAILED with timeout language when fetch rejects with AbortError', async () => {
+    const fetchImpl = jest.fn().mockImplementation(() => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      return Promise.reject(err);
+    });
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://slow.local/x.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch, downloadTimeoutMs: 5_000 },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failures[0]).toEqual({
+      field: 'images',
+      code: 'IMAGE_DOWNLOAD_FAILED',
+      message: expect.stringMatching(/timed out after 5000ms/),
+    });
+  });
+
+  it('IMAGE_DOWNLOAD_INVALID_TYPE when PrestaShop returns 200 + text/html (error page)', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(
+        new Response('<html>Not authorized</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        }),
+      );
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/blocked.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failures[0]).toEqual({
+      field: 'images',
+      code: 'IMAGE_DOWNLOAD_INVALID_TYPE',
+      message: expect.stringMatching(/text\/html/),
+    });
+    expect(uploadHttpClient.postBinary).not.toHaveBeenCalled();
+  });
+
+  it('normalizes image/jpg to image/jpeg when forwarding to Allegro', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+        status: 200,
+        headers: { 'content-type': 'image/jpg' }, // non-standard but ubiquitous
+      }),
+    );
+    uploadHttpClient.postBinary.mockResolvedValue({
+      data: { location: 'https://images.allegrostatic.com/n.jpg' },
+      status: 201,
+      headers: {},
+    });
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/jpg-mime.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(uploadHttpClient.postBinary).toHaveBeenCalledWith(
+      '/sale/images',
+      'image/jpeg', // not 'image/jpg'
+      expect.any(Uint8Array),
+    );
+  });
+
+  it('IMAGE_UPLOAD_FAILED when Allegro postBinary rejects with 4xx', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(new Uint8Array([0xff])));
+    uploadHttpClient.postBinary.mockRejectedValue(
+      new AllegroApiException(
+        'Unprocessable entity',
+        422,
+        '{"errors":[{"code":"INVALID_IMAGE"}]}',
+        'https://upload.allegro.pl/sale/images',
+      ),
+    );
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/x.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failures[0]).toEqual({
+      field: 'images',
+      code: 'IMAGE_UPLOAD_FAILED',
+      message: expect.stringMatching(/Allegro rejected image upload.*HTTP 422/),
+    });
+  });
+
+  it('IMAGE_UPLOAD_FAILED when Allegro response is missing the location field', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(new Uint8Array([0xff])));
+    uploadHttpClient.postBinary.mockResolvedValue({
+      data: {},
+      status: 201,
+      headers: {},
+    });
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/x.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failures[0]).toEqual({
+      field: 'images',
+      code: 'IMAGE_UPLOAD_FAILED',
+      message: expect.stringMatching(/missing 'location'/),
+    });
+  });
+
+  it('mixed (one OK, one 403 download) returns failures listing only the failing URL', async () => {
+    const fetchImpl = jest.fn().mockImplementation((url: string) => {
+      if (url.includes('bad')) {
+        return Promise.resolve(errFetchResponse(403));
+      }
+      return Promise.resolve(okFetchResponse(new Uint8Array([0xff])));
+    });
+    uploadHttpClient.postBinary.mockResolvedValue({
+      data: { location: 'https://images.allegrostatic.com/ok.jpg' },
+      status: 201,
+      headers: {},
+    });
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/good.jpg', 'http://shop.local/bad.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].message).toContain('http://shop.local/bad.jpg');
+    expect(result.failures[0].message).not.toContain('http://shop.local/good.jpg');
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.ts
@@ -1,0 +1,207 @@
+/**
+ * Upload Images Via Allegro
+ *
+ * Orchestrator that takes a list of operator-supplied image URLs (typically
+ * PrestaShop product images), downloads each one, validates the response
+ * shape, and re-uploads the bytes to Allegro's image CDN
+ * (`POST /sale/images`). Returns the list of Allegro-hosted CDN URLs in the
+ * same order as the input so callers can drop them straight into
+ * `body.images` for `POST /sale/product-offers`.
+ *
+ * The util **never throws** for image-related failures — it returns a
+ * discriminated `UploadImagesResult`. Failure surfaces as a list of
+ * `CreateOfferValidationError` carrying:
+ *
+ * - `IMAGE_DOWNLOAD_FAILED`        — non-2xx, network error, or timeout when
+ *                                    GETting the operator's image URL
+ * - `IMAGE_DOWNLOAD_INVALID_TYPE`  — GET succeeded but Content-Type is not
+ *                                    `image/jpeg|png|gif|webp`
+ * - `IMAGE_UPLOAD_FAILED`          — Allegro's `POST /sale/images` rejected
+ *                                    the upload, or its response is missing
+ *                                    the `location` field
+ *
+ * Adapter-key context (e.g. `'allegro.publicapi.v1'`) lives in the calling
+ * adapter, not here — the util stays adapter-agnostic.
+ *
+ * Implementation notes:
+ * - Downloads run in parallel via `Promise.all` (typical N is 1–8).
+ * - On any failure, the **other** in-flight pipelines run to completion and
+ *   their results are discarded; the wasted work is bounded and Allegro GCs
+ *   any uploads that don't end up attached to an offer.
+ * - Bytes are buffered in `Uint8Array`. Streaming would be premature — typical
+ *   product images are < 5MB, and buffering keeps the HTTP-client interface
+ *   simple.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/util
+ * @see {@link AllegroOfferManagerAdapter.createOffer} — sole consumer
+ */
+import { CreateOfferValidationError } from '@openlinker/core/listings';
+import { IAllegroHttpClient } from '../http/allegro-http-client.interface';
+import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
+import { UploadImagesResult, UploadImagesViaAllegroOptions } from './upload-images-via-allegro.types';
+
+export type { UploadImagesResult, UploadImagesViaAllegroOptions } from './upload-images-via-allegro.types';
+
+const DEFAULT_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+const ACCEPTED_IMAGE_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+
+export async function uploadImagesViaAllegro(
+  uploadHttpClient: IAllegroHttpClient,
+  imageUrls: string[],
+  options?: UploadImagesViaAllegroOptions,
+): Promise<UploadImagesResult> {
+  if (imageUrls.length === 0) {
+    return { ok: true, locations: [] };
+  }
+
+  const fetchImpl = options?.fetchImpl ?? globalThis.fetch;
+  const downloadTimeoutMs = options?.downloadTimeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS;
+
+  const results = await Promise.all(
+    imageUrls.map(async (url) => {
+      const download = await downloadImage(url, fetchImpl, downloadTimeoutMs);
+      if (!download.ok) {
+        return { ok: false as const, failure: download.failure };
+      }
+      const upload = await uploadOneImage(
+        uploadHttpClient,
+        download.contentType,
+        download.bytes,
+        url,
+      );
+      if (!upload.ok) {
+        return { ok: false as const, failure: upload.failure };
+      }
+      return { ok: true as const, location: upload.location };
+    }),
+  );
+
+  const failures: CreateOfferValidationError[] = [];
+  const locations: string[] = [];
+  for (const r of results) {
+    if (r.ok) {
+      locations.push(r.location);
+    } else {
+      failures.push(r.failure);
+    }
+  }
+
+  if (failures.length > 0) {
+    return { ok: false, failures };
+  }
+  return { ok: true, locations };
+}
+
+// ---------- internal helpers (file-private) ----------
+
+type DownloadOk = { ok: true; contentType: string; bytes: Uint8Array };
+type DownloadErr = { ok: false; failure: CreateOfferValidationError };
+
+async function downloadImage(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+): Promise<DownloadOk | DownloadErr> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, { method: 'GET', signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return downloadFailure('IMAGE_DOWNLOAD_FAILED', `Image URL '${url}' timed out after ${timeoutMs}ms`);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return downloadFailure('IMAGE_DOWNLOAD_FAILED', `Image URL '${url}': ${message}`);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    return downloadFailure(
+      'IMAGE_DOWNLOAD_FAILED',
+      `Image URL '${url}' returned HTTP ${response.status}`,
+    );
+  }
+
+  const rawContentType = response.headers.get('content-type');
+  const contentType = normalizeImageContentType(rawContentType);
+  if (!contentType) {
+    return downloadFailure(
+      'IMAGE_DOWNLOAD_INVALID_TYPE',
+      `Image URL '${url}' returned content-type '${rawContentType ?? 'missing'}', expected one of image/jpeg, image/png, image/gif, image/webp`,
+    );
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = new Uint8Array(await response.arrayBuffer());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return downloadFailure('IMAGE_DOWNLOAD_FAILED', `Image URL '${url}': failed to read body — ${message}`);
+  }
+
+  return { ok: true, contentType, bytes };
+}
+
+type UploadOk = { ok: true; location: string };
+type UploadErr = { ok: false; failure: CreateOfferValidationError };
+
+async function uploadOneImage(
+  uploadHttpClient: IAllegroHttpClient,
+  contentType: string,
+  bytes: Uint8Array,
+  sourceUrl: string,
+): Promise<UploadOk | UploadErr> {
+  let response;
+  try {
+    response = await uploadHttpClient.postBinary<{ location?: unknown }>(
+      '/sale/images',
+      contentType,
+      bytes,
+    );
+  } catch (error) {
+    const status = error instanceof AllegroApiException ? error.statusCode : undefined;
+    const message = error instanceof Error ? error.message : String(error);
+    const detail = status !== undefined ? `HTTP ${status}` : message;
+    return uploadFailure(`Allegro rejected image upload for '${sourceUrl}': ${detail}`);
+  }
+
+  const location = response.data?.location;
+  if (typeof location !== 'string' || location.length === 0) {
+    return uploadFailure(`Allegro upload response missing 'location' for image '${sourceUrl}'`);
+  }
+
+  return { ok: true, location };
+}
+
+function normalizeImageContentType(raw: string | null): string | null {
+  if (!raw) return null;
+  // Strip parameters (e.g. `; charset=utf-8`) and lowercase.
+  const head = raw.split(';')[0]?.trim().toLowerCase();
+  if (!head) return null;
+  // The only normalization the spec calls out: `image/jpg` → `image/jpeg`.
+  const normalized = head === 'image/jpg' ? 'image/jpeg' : head;
+  return ACCEPTED_IMAGE_CONTENT_TYPES.has(normalized) ? normalized : null;
+}
+
+function downloadFailure(
+  code: 'IMAGE_DOWNLOAD_FAILED' | 'IMAGE_DOWNLOAD_INVALID_TYPE',
+  message: string,
+): DownloadErr {
+  return { ok: false, failure: { field: 'images', code, message } };
+}
+
+function uploadFailure(message: string): UploadErr {
+  return {
+    ok: false,
+    failure: { field: 'images', code: 'IMAGE_UPLOAD_FAILED', message },
+  };
+}

--- a/libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.types.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.types.ts
@@ -1,0 +1,32 @@
+/**
+ * Upload Images Via Allegro Types
+ *
+ * Public type surface for the `upload-images-via-allegro` orchestrator.
+ * Kept in a dedicated `.types.ts` file per Engineering Standards
+ * "Type Definitions in Separate Files".
+ *
+ * @module libs/integrations/allegro/src/infrastructure/util
+ */
+import { CreateOfferValidationError } from '@openlinker/core/listings';
+
+/**
+ * Discriminated result of `uploadImagesViaAllegro`.
+ *
+ * The util never throws for image-related failures — failures surface as
+ * a list of neutral `CreateOfferValidationError` so the calling adapter
+ * can wrap them into the appropriate platform-specific exception
+ * (`OfferCreateRejectedException` for Allegro).
+ */
+export type UploadImagesResult =
+  | { ok: true; locations: string[] }
+  | { ok: false; failures: CreateOfferValidationError[] };
+
+/**
+ * Options for `uploadImagesViaAllegro`.
+ */
+export interface UploadImagesViaAllegroOptions {
+  /** Override fetch (tests). Defaults to `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Per-URL download timeout. Default 30 000 ms. */
+  downloadTimeoutMs?: number;
+}


### PR DESCRIPTION
Closes #397

## Problem

Operators whose PrestaShop image URLs aren't publicly reachable from Allegro's servers (localhost, private IPs, basic-auth, hardened `.htaccess`, expired tunnels) couldn't create offers — Allegro fetches `images[]` URLs server-side and rejected the create with an opaque `status=422 errors=0` and `DownloadError.Forbidden` from the captured logs.

This was the last bug in the #387 → #389 → #392 → #393 chain.

## Solution

Solution **B** from #397 (no-cache): `createOffer` now downloads each image from the operator's URL and re-uploads the bytes to Allegro's image CDN (`POST upload.allegro.pl/sale/images`), then passes the resulting Allegro CDN URLs to `POST /sale/product-offers`. No caching layer — each create round-trips the bytes, which keeps the design footprint small and dodges Allegro's GC of unused uploads.

Why not Solution A (HEAD pre-flight)? It only improves the error message; operators with localhost / private-IP PS configs still couldn't list. B actually fixes the underlying problem and subsumes A's clarity win for free (a download failure surfaces as a clear `IMAGE_DOWNLOAD_FAILED` with the URL + HTTP status).

## Architectural changes

- **New `AllegroConnectionTokenState`** extracts per-connection access-token state out of `AllegroHttpClient` so two HTTP clients per connection (api + upload host) can share one refresh path. A refresh triggered by either client is immediately visible to the other — no wasted 401 round-trip on the sibling after rotation.
- `AllegroHttpClient` constructor now takes a `tokenState` instead of raw credentials + refresh callback; gains a `postBinary` method for raw-bytes uploads with a caller-supplied `Content-Type`. JSON path is unchanged.
- `AllegroConnectionConfig.uploadBaseUrl?` (symmetric to existing `apiBaseUrl?`) with environment-based defaults: `production → upload.allegro.pl`; `sandbox → upload.allegro.pl.allegrosandbox.pl`.
- `AllegroAdapterFactory` builds a shared token state and two clients per connection. `AllegroOrderSourceAdapter` still receives only the api client; `AllegroOfferManagerAdapter` receives both.
- `AllegroConnectionTesterAdapter` deliberately constructs token state **without** a refresh callback — a probe must surface stale tokens as a clear failure, not silently rotate.

## Image pipeline (`upload-images-via-allegro` util)

- Pure orchestrator that returns a discriminated `UploadImagesResult` rather than throwing. Keeps the util adapter-agnostic; the offer-manager adapter owns the platform-specific `OfferCreateRejectedException` construction.
- Downloads in parallel via `Promise.all`, buffers bytes in `Uint8Array` (typical 1–8 images, ≤ ~15 MB transient).
- **Strict Content-Type whitelist** on PrestaShop responses (`{image/jpeg, image/png, image/gif, image/webp}`, with `image/jpg → image/jpeg` normalization). Catches the 200 + `text/html` error-page trap before wasting an Allegro upload.
- **Three distinct error codes**, all `field: 'images'`, surfaced through `OfferCreateRejectedException`:
  | Code | Triggers when | Operator fix |
  |---|---|---|
  | `IMAGE_DOWNLOAD_FAILED` | non-2xx, network error, or 30 s timeout fetching the operator URL | fix PS hosting / network reachability |
  | `IMAGE_DOWNLOAD_INVALID_TYPE` | 200 but Content-Type isn't an accepted image MIME | fix the URL or PS server config |
  | `IMAGE_UPLOAD_FAILED` | Allegro `/sale/images` rejects the upload, or response missing `location` | likely transient Allegro issue; retry |
- On any failure the whole create aborts. Other in-flight pipelines run to completion silently and Allegro GCs the orphan uploads (no compensation logic).

## Files (5 new / 8 edited)

**New:**
- `libs/integrations/allegro/src/infrastructure/http/allegro-connection-token-state.ts`
- `libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-connection-token-state.spec.ts`
- `libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.ts`
- `libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.types.ts`
- `libs/integrations/allegro/src/infrastructure/util/__tests__/upload-images-via-allegro.spec.ts`
- `docs/plans/implementation-plan-397-allegro-image-url-preflight.md`

**Edited:**
- `allegro-http-client.{ts,interface.ts}` (+ spec) — token-state refactor, `postBinary`
- `allegro-adapter.factory.ts` — shared token state + two clients per connection
- `allegro-config.types.ts` — `uploadBaseUrl?`
- `allegro-connection-tester.adapter.ts` — token-state construction (no refresh callback)
- `allegro-offer-manager.adapter.ts` (+ spec) — accept upload client, wire upload step

## Out of scope (deliberate)

- **Image caching** — would matter for re-listing the same variant repeatedly; defer until measured. Current bandwidth cost is ~1–8 image round-trips per `createOffer`, which is not a hot path.
- **The `errors=0` diagnostic tangent** from #397 (responseBody truncation + silent JSON.parse failure). Solution B sidesteps the symptom on the reachability case; the underlying logging bug for any Allegro response > 500 chars is a separate small follow-up.
- **HEAD pre-flight (Solution A)** — discarded; redundant with the GET we now do anyway.

## Test plan

- [x] `pnpm lint` — zero errors (1 pre-existing warning in unrelated file)
- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm -r test` — all 8 workspace packages green: `core (45) / shared (1) / integrations-ai (2) / integrations-prestashop (13) / integrations-allegro (8) / apps/api (28) / apps/worker (8)` + `apps/web (104 vitest files)`
- [x] 9 new specs for `AllegroConnectionTokenState`
- [x] 5 new `postBinary` specs on `AllegroHttpClient`
- [x] 10 specs for the upload util
- [x] 5 new specs on the offer-manager adapter (3 error codes, no-POST-on-failure regression guard, content-type forwarding)
- [ ] **Manual sandbox verification** on connection `eecbdcd2-862a-4f77-acb7-f764592ed3d5`, variant `ol_variant_0c6eeb1b522144339b0882a225597859`: confirm offer creation now succeeds (instead of `status=422 errors=0`) and that `upload.allegro.pl.allegrosandbox.pl` is the host receiving the image POSTs (sandbox upload host is high-confidence-by-pattern but not 100% verified in public docs).
- [ ] Manual: deliberately misconfigure a PS image (e.g. URL that 403s) and confirm operator now sees `IMAGE_DOWNLOAD_FAILED` with the URL + status inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)