### PR TITLE
feat(ai): store provider API key encrypted with admin endpoints

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -103,3 +103,24 @@ OL_STORE_PII=true
 # REQUIRED. Org-level salt for deterministic PII hashing.
 # WARNING: changing this breaks existing hash lookups.
 OL_PII_HASH_SALT=your-org-level-salt-change-in-production
+
+# --- AI provider --------------------------------------------------------------
+# Active LLM provider for content suggestions. `anthropic` (default) routes
+# completions through @ai-sdk/anthropic; `fake` is a deterministic offline
+# adapter used by integration tests and local dev when no key is available.
+# OL_AI_PROVIDER=anthropic
+#
+# DEPRECATED env fallback for the Anthropic API key. The supported way to
+# configure the key in any non-dev environment is via the admin UI / API:
+#   PUT /ai-provider-settings  body: { "apiKey": "sk-ant-..." }
+# which stores the key encrypted in `integration_credentials` (same shape as
+# webhook secrets — see the OPENLINKER_WEBHOOK_SECRET deprecation note above).
+# Setting this env var still works in dev for fresh checkouts; the API logs a
+# one-shot deprecation warning the first time it falls back to it.
+# ANTHROPIC_API_KEY=
+#
+# Optional tunables (leave unset for sensible defaults):
+# OL_AI_DEFAULT_MODEL=claude-opus-4-7
+# OL_AI_DEFAULT_MAX_TOKENS=2048
+# OL_AI_TIMEOUT_MS=60000
+# OL_AI_LOG_PROMPT=false   # set to true to log prompt + response at debug level

--- a/apps/api/src/ai/ai.module.ts
+++ b/apps/api/src/ai/ai.module.ts
@@ -1,8 +1,12 @@
 /**
  * AI API Module
  *
- * NestJS module owning the HTTP surface for the AI bounded context. Wires
- * the `PromptTemplatesController` against the core `AiModule` providers.
+ * NestJS module owning the HTTP surface for the AI bounded context. Both
+ * controllers (`PromptTemplatesController` and `AiProviderSettingsController`)
+ * resolve their dependencies from core `AiModule` — prompt-template service
+ * + provider-settings service — so this module's only responsibility is
+ * mounting controllers and importing the core module.
+ *
  * Follows the `{domain}.module.ts` + `{Domain}ApiModule` pattern already
  * used by `ProductsApiModule` / `ListingsApiModule`.
  *
@@ -10,10 +14,11 @@
  */
 import { Module } from '@nestjs/common';
 import { AiModule as CoreAiModule } from '@openlinker/core/ai';
+import { AiProviderSettingsController } from './http/ai-provider-settings.controller';
 import { PromptTemplatesController } from './http/prompt-templates.controller';
 
 @Module({
   imports: [CoreAiModule],
-  controllers: [PromptTemplatesController],
+  controllers: [PromptTemplatesController, AiProviderSettingsController],
 })
 export class AiApiModule {}

--- a/apps/api/src/ai/http/ai-provider-settings.controller.ts
+++ b/apps/api/src/ai/http/ai-provider-settings.controller.ts
@@ -1,0 +1,113 @@
+/**
+ * AI Provider Settings Controller
+ *
+ * Admin-only REST surface for managing the AI provider's API key. Backed by
+ * `IAiProviderSettingsService`, which writes to the encrypted
+ * `integration_credentials` store and invalidates the credentials port's
+ * cache after every write.
+ *
+ * Path is `/ai-provider-settings` — single, top-level resource path
+ * matching the BE convention used by `prompt-templates` and `connections`.
+ * The frontend route lives at `/ai/provider-settings` (FE namespace) and
+ * the API client maps between the two.
+ *
+ * @module apps/api/src/ai/http
+ */
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Put,
+  Res,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { Response } from 'express';
+import {
+  AI_PROVIDER_SETTINGS_SERVICE_TOKEN,
+  AiProviderSettingsNotApplicableError,
+  IAiProviderSettingsService,
+} from '@openlinker/core/ai';
+import { AuthenticatedUser } from '../../auth/auth.types';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { AiProviderSettingsResponseDto } from './dto/ai-provider-settings-response.dto';
+import { UpdateAiProviderSettingsDto } from './dto/update-ai-provider-settings.dto';
+
+@ApiBearerAuth()
+@ApiTags('ai-provider-settings')
+@Controller('ai-provider-settings')
+export class AiProviderSettingsController {
+  constructor(
+    @Inject(AI_PROVIDER_SETTINGS_SERVICE_TOKEN)
+    private readonly service: IAiProviderSettingsService,
+  ) {}
+
+  @Roles('admin')
+  @Get()
+  @ApiOperation({ summary: 'Read AI provider key status (never returns the key)' })
+  @ApiResponse({ status: 200, type: AiProviderSettingsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async get(
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<AiProviderSettingsResponseDto> {
+    res.setHeader('Cache-Control', 'no-store');
+    const view = await this.service.get();
+    return AiProviderSettingsResponseDto.fromView(view);
+  }
+
+  @Roles('admin')
+  @Put()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Set or rotate the AI provider API key' })
+  @ApiResponse({ status: 204, description: 'Key stored encrypted' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Active provider does not require an API key (e.g. OL_AI_PROVIDER=fake), or the request body failed validation',
+  })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async set(
+    @Body() dto: UpdateAiProviderSettingsDto,
+    @CurrentUser() user: AuthenticatedUser,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    res.setHeader('Cache-Control', 'no-store');
+    await this.withDomainExceptionMapping(() => this.service.set(dto.apiKey, user?.id));
+  }
+
+  @Roles('admin')
+  @Delete()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Remove the stored AI provider API key (falls back to env or none)',
+  })
+  @ApiResponse({ status: 204, description: 'Key cleared' })
+  @ApiResponse({
+    status: 400,
+    description: 'Active provider does not require an API key',
+  })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async clear(
+    @CurrentUser() user: AuthenticatedUser,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    res.setHeader('Cache-Control', 'no-store');
+    await this.withDomainExceptionMapping(() => this.service.clear(user?.id));
+  }
+
+  private async withDomainExceptionMapping<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (error) {
+      if (error instanceof AiProviderSettingsNotApplicableError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/ai/http/dto/ai-provider-settings-response.dto.ts
+++ b/apps/api/src/ai/http/dto/ai-provider-settings-response.dto.ts
@@ -1,0 +1,46 @@
+/**
+ * AI Provider Settings Response DTO
+ *
+ * Response body for `GET /ai-provider-settings`. Reports the active
+ * provider, whether a key is currently resolvable, and where the key
+ * resolves from (`db | env | none`). The DTO has no `apiKey` field —
+ * the value never leaves the server.
+ *
+ * @module apps/api/src/ai/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  AiProviderKeySource,
+  AiProviderKeySourceValues,
+  AiProviderSettingsView,
+  AiProvider,
+  AiProviderValues,
+} from '@openlinker/core/ai';
+
+export class AiProviderSettingsResponseDto {
+  @ApiProperty({
+    enum: AiProviderValues,
+    description: 'Active provider read from `OL_AI_PROVIDER` (default: `anthropic`).',
+  })
+  provider!: AiProvider;
+
+  @ApiProperty({
+    description: 'True when an API key is currently resolvable for the active provider.',
+  })
+  configured!: boolean;
+
+  @ApiProperty({
+    enum: AiProviderKeySourceValues,
+    description:
+      'Where the key resolves from. `db` wins over `env` when both are set; `none` when neither is set.',
+  })
+  source!: AiProviderKeySource;
+
+  static fromView(view: AiProviderSettingsView): AiProviderSettingsResponseDto {
+    const dto = new AiProviderSettingsResponseDto();
+    dto.provider = view.provider;
+    dto.configured = view.configured;
+    dto.source = view.source;
+    return dto;
+  }
+}

--- a/apps/api/src/ai/http/dto/update-ai-provider-settings.dto.ts
+++ b/apps/api/src/ai/http/dto/update-ai-provider-settings.dto.ts
@@ -1,0 +1,41 @@
+/**
+ * Update AI Provider Settings DTO
+ *
+ * Request body for `PUT /ai-provider-settings`. The single field carries
+ * the API key the admin pasted into the form. Length bounds are loose on
+ * purpose — Anthropic's `sk-ant-` prefix has changed before, so a brittle
+ * prefix check would invite breakage on a future rotation.
+ *
+ * @module apps/api/src/ai/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+const MIN_KEY_LENGTH = 8;
+const MAX_KEY_LENGTH = 512;
+
+/**
+ * Trim incoming `apiKey` before validation. Pasted secrets often carry
+ * stray newlines or surrounding whitespace from clipboard managers; storing
+ * those verbatim yields a 401 from the upstream provider with no obvious
+ * cause. Trim once at the boundary so length / non-empty assertions reflect
+ * the value we'll actually persist.
+ */
+export class UpdateAiProviderSettingsDto {
+  @ApiProperty({
+    description:
+      'API key for the active AI provider. Stored encrypted; never returned in any response body. ' +
+      'Surrounding whitespace is trimmed before validation and storage.',
+    minLength: MIN_KEY_LENGTH,
+    maxLength: MAX_KEY_LENGTH,
+  })
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(MIN_KEY_LENGTH)
+  @MaxLength(MAX_KEY_LENGTH)
+  apiKey!: string;
+}

--- a/apps/api/test/integration/ai-provider-settings.int-spec.ts
+++ b/apps/api/test/integration/ai-provider-settings.int-spec.ts
@@ -1,0 +1,211 @@
+/**
+ * AI Provider Settings Integration Test
+ *
+ * Vertical slice covering the #398 admin surface plus the storage
+ * round-trip against a real Postgres via Testcontainers.
+ *
+ * The harness boots with `OL_AI_PROVIDER=fake` (matching every other
+ * int-spec), so the wired `CredentialsAiProviderAdapter` instance is
+ * locked to fake mode. That lets us assert two complementary things:
+ *
+ *   1. **HTTP behaviour in fake mode**: `GET` returns the fake-shape view
+ *      without any DB / env lookup; `PUT` and `DELETE` return 400 with the
+ *      `AiProviderSettingsNotApplicableError` message; non-admin callers
+ *      are blocked at the `@Roles('admin')` guard.
+ *
+ *   2. **Storage round-trip (provider-agnostic)**: encrypt → store →
+ *      retrieve → decrypt → equal-to-original, exercised directly against
+ *      `IntegrationCredentialRepositoryPort` + `CryptoService` so the
+ *      result is independent of which provider the booted adapter
+ *      selected. This is the issue's AC.
+ *
+ * @module apps/api/test/integration
+ */
+import * as bcrypt from 'bcryptjs';
+import {
+  CredentialNotFoundException,
+  INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
+  IntegrationCredentialRepositoryPort,
+} from '@openlinker/core/integrations';
+import { aiProviderCredentialsRef } from '@openlinker/core/ai';
+import { CryptoService } from '@openlinker/shared';
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import type { IntegrationTestHarness } from './setup';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+
+async function loginAsViewer(
+  harness: IntegrationTestHarness,
+  username = 'viewer',
+): Promise<string> {
+  const passwordHash = await bcrypt.hash('viewer-pass', 4);
+  await harness.getDataSource().query(
+    `INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, $3, 'viewer')`,
+    [username, `${username}@example.com`, passwordHash],
+  );
+  const response = await harness.getHttp()
+    .post('/auth/login')
+    .send({ username, password: 'viewer-pass' })
+    .expect(200);
+  return response.body.access_token as string;
+}
+
+describe('AI Provider Settings Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  describe('GET /ai-provider-settings', () => {
+    it('returns the fake-mode view when OL_AI_PROVIDER=fake', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+
+      const res = await http
+        .get('/ai-provider-settings')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body).toEqual({
+        provider: 'fake',
+        configured: false,
+        source: 'none',
+      });
+      expect(res.body.apiKey).toBeUndefined();
+      expect(res.headers['cache-control']).toContain('no-store');
+    });
+
+    it('returns 403 to non-admin callers', async () => {
+      const http = harness.getHttp();
+      const viewerToken = await loginAsViewer(harness);
+
+      await http
+        .get('/ai-provider-settings')
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .expect(403);
+    });
+  });
+
+  describe('PUT /ai-provider-settings', () => {
+    it('returns 400 when active provider is fake', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+
+      const res = await http
+        .put('/ai-provider-settings')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ apiKey: 'sk-ant-pretend-key-1234567890' })
+        .expect(400);
+
+      expect(res.body.message).toMatch(/does not require an API key/i);
+    });
+
+    it('rejects empty / too-short API keys with 400', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+
+      await http
+        .put('/ai-provider-settings')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ apiKey: '' })
+        .expect(400);
+
+      await http
+        .put('/ai-provider-settings')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ apiKey: 'short' })
+        .expect(400);
+    });
+
+    it('returns 403 to non-admin callers', async () => {
+      const http = harness.getHttp();
+      const viewerToken = await loginAsViewer(harness);
+
+      await http
+        .put('/ai-provider-settings')
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .send({ apiKey: 'sk-ant-test-key-12345' })
+        .expect(403);
+    });
+  });
+
+  describe('DELETE /ai-provider-settings', () => {
+    it('returns 400 when active provider is fake', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+
+      const res = await http
+        .delete('/ai-provider-settings')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(400);
+
+      expect(res.body.message).toMatch(/does not require an API key/i);
+    });
+
+    it('returns 403 to non-admin callers', async () => {
+      const http = harness.getHttp();
+      const viewerToken = await loginAsViewer(harness);
+
+      await http
+        .delete('/ai-provider-settings')
+        .set('Authorization', `Bearer ${viewerToken}`)
+        .expect(403);
+    });
+  });
+
+  describe('storage round-trip against real Postgres', () => {
+    it('encrypts → stores → retrieves → decrypts to the original key', async () => {
+      const app = harness.getApp();
+      const repository = app.get<IntegrationCredentialRepositoryPort>(
+        INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
+      );
+      const crypto = app.get(CryptoService);
+
+      const ref = aiProviderCredentialsRef('anthropic');
+      const plaintext = 'sk-ant-real-shape-but-fake-value-abc123';
+      const ciphertext = crypto.encrypt(plaintext);
+
+      // Sanity: the cipher is not the plaintext (else encryption is a no-op).
+      expect(ciphertext).not.toBe(plaintext);
+      expect(ciphertext.length).toBeGreaterThan(plaintext.length);
+
+      // Persist via the repository (real Postgres write).
+      const created = await repository.create({
+        ref,
+        platformType: 'anthropic',
+        credentialsJson: { ciphertext },
+        encrypted: true,
+      });
+
+      expect(created.ref).toBe(ref);
+      expect(created.encrypted).toBe(true);
+      expect(created.credentialsJson).toEqual({ ciphertext });
+
+      // Retrieve and decrypt.
+      const retrieved = await repository.getByRef(ref);
+      const retrievedCipher = retrieved.credentialsJson?.ciphertext;
+      expect(typeof retrievedCipher).toBe('string');
+      const decrypted = crypto.decrypt(retrievedCipher as string);
+
+      expect(decrypted).toBe(plaintext);
+
+      // Cleanup leaves the row absent for the next test.
+      await repository.delete(ref);
+      await expect(repository.getByRef(ref)).rejects.toBeInstanceOf(
+        CredentialNotFoundException,
+      );
+    });
+
+    it('persists at ref = ai-provider:{provider} (matches the service contract)', () => {
+      expect(aiProviderCredentialsRef('anthropic')).toBe('ai-provider:anthropic');
+    });
+  });
+});

--- a/docs/plans/implementation-plan-398-ai-provider-key-encrypted-storage.md
+++ b/docs/plans/implementation-plan-398-ai-provider-key-encrypted-storage.md
@@ -1,0 +1,206 @@
+# Implementation Plan — #398 AI provider API key in encrypted credentials store
+
+## 1. Goal
+
+Stop reading `ANTHROPIC_API_KEY` directly from `process.env` inside the AI completion adapter. Instead, resolve it through a port whose default implementation looks the value up in the existing encrypted `integration_credentials` table, falling back to the environment variable for local dev. Surface admin REST endpoints so the key can be pasted / rotated / cleared without a redeploy. Document the env fallback in `apps/api/.env.example`.
+
+**Layer**: CORE (port + service + adapter) + Integration (Vercel adapter refactor) + Interface (admin controller) + DX (env doc).
+
+**Non-goals**:
+- Multi-provider key management (only `anthropic` is wired today; the union is extensible later).
+- Cross-provider pre-staging (writing an `anthropic` key while `OL_AI_PROVIDER=fake` is rejected — see §3 *Behaviour for `OL_AI_PROVIDER=fake`*).
+- A new `ai_provider_settings` table — we reuse `integration_credentials` with `ref = ai-provider:{provider}`.
+- FE work (tracked separately as #399).
+
+## 2. Codebase research
+
+### Precedent to mirror: webhook secret migration
+- Service: `libs/core/src/integrations/application/services/webhook-secret.service.ts`
+- Adapter: `libs/core/src/integrations/infrastructure/adapters/credentials-webhook-secret.adapter.ts` — implements a port with `getSecret` / `invalidate`, has a 60 s FIFO cache, and falls back to an env var with a one-shot deprecation warning.
+- Storage table: `integration_credentials` (`libs/core/src/integrations/infrastructure/persistence/entities/integration-credential.orm-entity.ts`) — keyed by unique `ref`, JSONB `credentialsJson`, `encrypted: boolean`. The webhook-secret rows store `{ ciphertext: '<aes-gcm>' }`.
+- Repo port: `libs/core/src/integrations/domain/ports/integration-credential-repository.port.ts` — exposes `getByRef` / `create` / `update` / `delete`. Throws `CredentialNotFoundException` on miss.
+- Crypto: `libs/shared/src/crypto/crypto.service.ts` — `encrypt(plaintext)` / `decrypt(ciphertext)`, AES-256-GCM keyed off `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY`.
+- DI tokens: `INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN` exported from `libs/core/src/integrations/integrations.tokens.ts` and re-exported from `@openlinker/core/integrations`.
+- Controller pattern (rotate webhook secret): `apps/api/src/integrations/http/connection.controller.ts:202-218` — `@Roles('admin')`, `Cache-Control: no-store`. Top-level resource path (`/connections`), no domain prefix — same convention used by `PromptTemplatesController` (`@Controller('prompt-templates')`).
+
+### Today's AI key handling
+- `libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.ts` imports `{ anthropic } from '@ai-sdk/anthropic'` (the default singleton, which reads `process.env.ANTHROPIC_API_KEY`). The package also exports `createAnthropic({ apiKey })` (`AnthropicProviderSettings.apiKey`, confirmed in the SDK's `dist/index.d.ts:1084`). We will switch to `createAnthropic`.
+- `AiIntegrationModule.register()` (`libs/integrations/ai/src/ai-integration.module.ts`) selects between `VercelAiCompletionAdapter` and `FakeAiCompletionAdapter` based on `OL_AI_PROVIDER` (default `anthropic`). It already imports `ConfigModule` and exports `AI_COMPLETION_PORT_TOKEN`.
+- The completion port is consumed from `apps/api` only (`libs/core/src/content/application/services/content-suggestion.service.ts`), and `AiIntegrationModule` is registered exactly once inside `apps/api/src/integrations/integrations.module.ts:33`. There is no `apps/worker` consumer — single place to wire.
+- `apps/api/.env.example` does not mention `ANTHROPIC_API_KEY` at all today.
+
+### Decision: where the port + service live
+- The port is part of the AI bounded context (it knows about `AiProvider`), so it lives in `libs/core/src/ai/domain/ports/`.
+- The settings service belongs to the same context; it depends on both the credentials port (read) and the credential repository port (write).
+- **Service interface co-located with implementation** under `libs/core/src/ai/application/services/`, mirroring the existing `prompt-template.service.interface.ts` next to `prompt-template.service.ts` in this same module. (`engineering-standards.md` documents `application/interfaces/` as the default; this AI module already deviates and we keep the deviation local rather than introducing a third pattern. The `PromptTemplateService` setup is treated as the local convention for `libs/core/src/ai/`.)
+- Wiring goes into `AiIntegrationModule.register()` (the only place that boots adapter selection), not into the core `AiModule` — this keeps the core module free of the integrations-tokens dependency. `AiIntegrationModule` already imports `ConfigModule`; we add `CoreIntegrationsModule` to its imports so it can resolve `INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN`. The new tokens are exported from `@openlinker/integrations-ai` and consumed by the admin controller through the existing re-export chain (`apps/api/src/integrations/integrations.module.ts:42-45`).
+
+## 3. Design
+
+### Single response shape
+```ts
+// libs/core/src/ai/domain/types/ai-provider-credentials.types.ts
+export const AiProviderKeySourceValues = ['db', 'env', 'none'] as const;
+export type AiProviderKeySource = (typeof AiProviderKeySourceValues)[number];
+
+/**
+ * Single response shape used by both the port (`describe()`) and the
+ * service (`get()`). The service adds nothing the port doesn't already
+ * compute — keeping one type avoids duplication and drifting Swagger /
+ * TanStack Query types.
+ */
+export interface AiProviderSettingsView {
+  /** Active provider read from `OL_AI_PROVIDER` (default: `anthropic`). */
+  provider: AiProvider;
+  /** True when an API key is currently resolvable for the active provider. */
+  configured: boolean;
+  /** Where the key currently resolves from. `'none'` ⇒ neither DB nor env. */
+  source: AiProviderKeySource;
+}
+```
+
+### Port (read side)
+```ts
+// libs/core/src/ai/domain/ports/ai-provider-credentials.port.ts
+export interface AiProviderCredentialsPort {
+  /**
+   * Resolve the API key for the active provider.
+   *
+   * Resolution order (DB wins over env when both are set):
+   *   1. Encrypted row in `integration_credentials` at `ref = ai-provider:{provider}`
+   *   2. `ConfigService.get('ANTHROPIC_API_KEY')` (legacy fallback for local dev)
+   *   3. throws `AiProviderKeyMissingError` if neither is set
+   *
+   * Should never be called for `provider=fake` — `FakeAiCompletionAdapter`
+   * does not invoke the port. Throws if it is called in that mode.
+   */
+  getApiKey(): Promise<string>;
+
+  /** Where the key currently resolves from, without exposing the value. */
+  describe(): Promise<AiProviderSettingsView>;
+
+  /** Drop the cached value (called by the settings service after PUT/DELETE). */
+  invalidate(): void;
+}
+```
+
+The "active provider" is read once at adapter construction from `OL_AI_PROVIDER` (default `anthropic`). The port is provider-agnostic in shape; what it does internally varies by provider. For the singleton-per-deployment model in this issue, no `provider` argument is needed.
+
+### Settings service (write side)
+```ts
+// libs/core/src/ai/application/services/ai-provider-settings.service.interface.ts
+//   (co-located with the implementation, matching prompt-template.service.interface.ts)
+export interface IAiProviderSettingsService {
+  get(): Promise<AiProviderSettingsView>;
+  set(apiKey: string, actorUserId?: string): Promise<void>;
+  clear(actorUserId?: string): Promise<void>;
+}
+```
+
+`set` upserts `integration_credentials` at `ref = ai-provider:{provider}` with `{ ciphertext: encrypt(apiKey) }`, `encrypted: true`. `clear` deletes the row. Both call `port.invalidate()` so the next request re-reads.
+
+### Behaviour for `OL_AI_PROVIDER=fake`
+The admin endpoints stay registered in DI in fake mode (so the FE doesn't 404), but they enforce that fake doesn't accept keys:
+
+| Endpoint | `provider=anthropic` | `provider=fake` |
+|---|---|---|
+| `GET` | `{ provider, configured, source }` per resolution | `{ provider: 'fake', configured: false, source: 'none' }` |
+| `PUT` | upsert + 204 | `400 Bad Request` — *"Active provider 'fake' does not require an API key."* |
+| `DELETE` | delete + 204 | `400 Bad Request` — same message |
+
+This avoids the cross-provider pre-staging complexity (writing an `anthropic` row while `OL_AI_PROVIDER=fake`) while keeping the FE story uniform: it always GETs the same shape and the controller refuses writes when irrelevant. Pre-staging is explicitly out of scope (see §1 *Non-goals*).
+
+### Adapter (DB + env fallback)
+```ts
+// libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.ts
+@Injectable()
+export class CredentialsAiProviderAdapter implements AiProviderCredentialsPort {
+  // Mirrors CredentialsWebhookSecretAdapter:
+  //   - 60s FIFO cache (single entry — there's one provider)
+  //   - getApiKey: DB hit (decrypt) → env (warn once) → throw
+  //   - describe: returns 'db' | 'env' | 'none' without revealing the key
+  //   - invalidate: clear cache
+}
+```
+
+Env-fallback variable name: `ANTHROPIC_API_KEY`, **read via `ConfigService.get<string>('ANTHROPIC_API_KEY')`** — matching `CredentialsWebhookSecretAdapter` (which goes through `ConfigService.get<string>(...)` at `credentials-webhook-secret.adapter.ts:108-111`). No raw `process.env` access.
+
+### Vercel adapter refactor
+Replace the implicit `anthropic(model)` call with:
+```ts
+import { createAnthropic } from '@ai-sdk/anthropic';
+// ...
+const apiKey = await this.credentials.getApiKey();
+const provider = createAnthropic({ apiKey });
+const result = await this.generateTextFn({ model: provider(model), ... });
+```
+Constructor gains an `AiProviderCredentialsPort` injection. The existing `VERCEL_GENERATE_TEXT_FN_TOKEN` override stays for tests; the new spec adds a stub `AiProviderCredentialsPort`.
+
+### HTTP surface
+```
+GET    /ai-provider-settings                 → 200 { provider, configured, source }
+PUT    /ai-provider-settings   body{apiKey}  → 204
+DELETE /ai-provider-settings                 → 204
+```
+Path is `@Controller('ai-provider-settings')` — single, top-level resource path matching the BE convention used by `@Controller('prompt-templates')` and `@Controller('connections')`. The FE issue (#399) keeps `/ai/provider-settings` on the *frontend* route side (mirrors how prompt-templates work today: BE at `/prompt-templates`, FE at `/ai/prompt-templates`).
+
+Admin-only (`@Roles('admin')`), `Cache-Control: no-store` on all three. Response body is an `AiProviderSettingsResponseDto` with **only** `provider`, `configured`, `source` properties — no `apiKey` field exists on the DTO at all (Swagger generation will reflect that).
+
+### Logging contract
+Service logs follow the structured shape established by the webhook-secret service:
+
+```ts
+this.logger.log('ai_provider_settings.set', { provider, actor: actorUserId ?? 'system' });
+this.logger.log('ai_provider_settings.clear', { provider, actor: actorUserId ?? 'system' });
+```
+
+Matches `this.logger.log('webhook_secret.rotated', { ... })` at `webhook-secret.service.ts:74`. Never log the key value.
+
+### Migration?
+None. The `integration_credentials` table already exists and is generic enough; we just write rows with a new `ref` discriminator. `migration:show` will be checked as a sanity step in the quality gate.
+
+## 4. Step-by-step
+
+| # | File | What | AC |
+|---|---|---|---|
+| 1 | `libs/core/src/ai/domain/types/ai-provider-credentials.types.ts` (new) | Define `AiProviderKeySourceValues` (`as const`) + `AiProviderKeySource` + `AiProviderSettingsView` (single response shape used by port + service). | No runtime artifact beyond the values array. |
+| 2 | `libs/core/src/ai/domain/exceptions/ai-provider-key-missing.exception.ts` (new) | Domain exception thrown by `getApiKey()` when neither DB nor env has a key. | Lives in `domain/exceptions/`, no framework imports. |
+| 3 | `libs/core/src/ai/domain/ports/ai-provider-credentials.port.ts` (new) | Port interface. | No NestJS / TypeORM imports. |
+| 4 | `libs/core/src/ai/ai.tokens.ts` | Add `AI_PROVIDER_CREDENTIALS_PORT_TOKEN` and `AI_PROVIDER_SETTINGS_SERVICE_TOKEN`. | Tokens re-exported from `@openlinker/core/ai`. |
+| 5 | `libs/core/src/ai/application/services/ai-provider-settings.service.interface.ts` (new) | `IAiProviderSettingsService` interface — **co-located** with the implementation, matching the `prompt-template.service.interface.ts` placement in the same directory. | Service-interface naming convention. |
+| 6 | `libs/core/src/ai/application/services/ai-provider-settings.service.ts` (new) | Implementation. Depends on `AiProviderCredentialsPort`, `IntegrationCredentialRepositoryPort`, `CryptoService`, `ConfigService` (for active provider name). Rejects writes when `provider=fake` with a 400. Logs `ai_provider_settings.set/clear` with structured `{ provider, actor }`. | Calls `port.invalidate()` after every write; never logs the key. |
+| 7 | `libs/core/src/ai/application/services/ai-provider-settings.service.spec.ts` (new) | Unit tests: get-when-db, get-when-env, get-when-none, set creates row, set updates row, clear deletes row, every write invalidates, set/clear throw on `provider=fake`, logger receives structured event. | Mocks all ports — never touches a real DB. |
+| 8 | `libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.ts` (new) | Port impl: 60 s FIFO cache, DB → env → throw resolution, one-shot env-fallback warning. Env reads go through `ConfigService.get<string>('ANTHROPIC_API_KEY')`, never `process.env`. For `provider=fake`, `describe()` returns `{ provider: 'fake', configured: false, source: 'none' }` without any DB/env lookup, and `getApiKey()` throws (should never be called). | `getApiKey` short-circuits the cache; `describe` does not. |
+| 9 | `libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts` (new) | Unit tests: DB hit, DB row missing → env fallback warns once, both missing → throws `AiProviderKeyMissingError`, cache hit, invalidate clears cache, `provider=fake` short-circuit, env reads happen via `ConfigService` (not `process.env`). | Mocks repo + crypto + config. |
+| 10 | `libs/core/src/ai/index.ts` | Re-export the new port, types, exception, service interface, and tokens. | Public surface stays consistent. |
+| 11 | `libs/integrations/ai/src/ai-integration.module.ts` | Add `CoreIntegrationsModule` to `imports` (for `INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN`) + `CryptoService` to providers. **Wire `CredentialsAiProviderAdapter` and `AiProviderSettingsService` regardless of the selected provider** so the admin endpoints work in both `anthropic` and `fake` modes. Export the two new tokens. | `OL_AI_PROVIDER=fake` boots without a DB / env key; admin GET still returns 200, PUT/DELETE return 400. |
+| 12 | `libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.ts` | Switch to `createAnthropic({ apiKey })`. Inject `AiProviderCredentialsPort`. Resolve key on every `complete()` call (cache lives in the port adapter — good enough). | All existing spec assertions still pass; new spec asserts the resolved key reaches `createAnthropic`. |
+| 13 | `libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.spec.ts` | Add a stub `AiProviderCredentialsPort` to the constructor and a single new test that captures the SDK call site to confirm the key flows through. | All previous tests still green. |
+| 14 | `apps/api/src/ai/http/dto/update-ai-provider-settings.dto.ts` (new) | `class-validator`: `@IsString @IsNotEmpty @MinLength(8) @MaxLength(512) apiKey`. Length bounds only — no `sk-ant-` prefix check (Anthropic prefixes have changed before). | Rejects empty / whitespace strings. |
+| 15 | `apps/api/src/ai/http/dto/ai-provider-settings-response.dto.ts` (new) | Response shape with `@ApiProperty` on `provider`, `configured`, `source` only. The DTO type structurally cannot carry an `apiKey` field — Swagger output will reflect that. | No `apiKey` property exists on the class. |
+| 16 | `apps/api/src/ai/http/ai-provider-settings.controller.ts` (new) | `@Controller('ai-provider-settings')` — three endpoints: GET / PUT (HttpCode 204) / DELETE (HttpCode 204). All `@Roles('admin')`. `Cache-Control: no-store`. Accepts `@CurrentUser()` for actor logging. PUT/DELETE return 400 when active provider is `fake`. | Returns 204 on success; payload never contains key; non-admin → 403. |
+| 17 | `apps/api/src/ai/ai.module.ts` | Register `AiProviderSettingsController`. Import `IntegrationsModule` (apps/api one — already re-exports `AiIntegrationModule`) so the service token is resolvable. Same pattern as `apps/api/src/content/content.module.ts:34`. | DI compiles at boot. |
+| 18 | `apps/api/test/integration/ai-provider-settings.int-spec.ts` (new) | Integration test against the real Postgres harness (`docs/testing-guide.md#integration-tests`). Covers: PUT writes encrypted row, GET returns `source=db` after PUT, GET returns `source=env` when only env is set, GET returns `source=none` on a clean slate, DELETE clears the row and the next GET returns `source=env` (or `none`). One round-trip asserts `decrypt(stored.ciphertext) === originalKey`. | Real `integration_credentials` table; no mocks except outbound HTTP. |
+| 19 | `apps/api/test/integration/content-editor-and-suggest.int-spec.ts` | Verify still passes after the Vercel adapter constructor change (the test runs with `OL_AI_PROVIDER=fake` so `FakeAiCompletionAdapter` is selected and the new port wiring is unused on the hot path; this is a sanity check, not a behaviour change). | Test suite green. |
+| 20 | `apps/api/.env.example` | Add a `# --- AI provider --------------------` block. Documents `OL_AI_PROVIDER` and `ANTHROPIC_API_KEY` (marked as a dev-only fallback that the admin UI overrides — mirrors the webhook-secret deprecation note at lines 58–64). | Documented end-to-end. |
+
+## 5. Risks / open questions
+
+- **Resolution timing**: Resolving the API key on every `complete()` call adds one async lookup per LLM request, but the cache is in-memory and 60 s TTL — measured cost is negligible compared to the LLM round-trip itself. Confirmed by webhook-secret precedent which does the same on every webhook.
+- **`OL_AI_PROVIDER=fake`**: `FakeAiCompletionAdapter` never calls `port.getApiKey()`. The port + service + admin controller are wired regardless of provider so the FE doesn't 404 on `/ai-provider-settings` in fake mode; PUT/DELETE refuse with 400 to make the "fake doesn't need a key" semantics explicit. Cross-provider pre-staging is intentionally out of scope.
+- **Resolution priority**: DB always wins over env, even when both are set. Documented on the port and surfaced in the response (`source` reflects the *effective* origin, not the *available* origins). The FE will surface "key currently set via env, save here to override" only when `source === 'env'`.
+- **Key shape validation**: We deliberately do *not* validate that `apiKey` starts with `sk-ant-` — Anthropic's prefix has changed before, and a brittle prefix check would break next time. Length bounds (`8..512`) + non-empty are enough.
+- **Concurrent writes**: Two admins hitting PUT at once would race; last-write-wins via `update`-then-`create`-on-miss matches the webhook-secret pattern. Acceptable for an admin endpoint with low concurrency.
+- **Telemetry**: Service logs `ai_provider_settings.set` / `.clear` with structured `{ actor, provider }` (no key value). Aligns with `webhook_secret.rotated`.
+
+## 6. Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+pnpm test:integration              # new ai-provider-settings.int-spec.ts must pass
+pnpm --filter @openlinker/api migration:show   # confirms zero new migrations needed
+```
+
+All must pass with zero errors before commit.

--- a/libs/core/src/ai/ai.module.ts
+++ b/libs/core/src/ai/ai.module.ts
@@ -1,28 +1,54 @@
 /**
  * AI Module (core)
  *
- * NestJS module for the AI bounded context — wires the `prompt_templates`
- * ORM entity, the TypeORM repository, and the `PromptTemplateService` into
- * DI. Bound via Symbol tokens so consumers depend only on the port + service
- * interface, never on the concrete classes.
+ * NestJS module for the AI bounded context. Wires:
+ *   - The `prompt_templates` ORM entity, TypeORM repository, and
+ *     `PromptTemplateService` (#341).
+ *   - The provider-key resolver (`CredentialsAiProviderAdapter` →
+ *     `AI_PROVIDER_CREDENTIALS_PORT_TOKEN`) and the admin write-side service
+ *     (`AiProviderSettingsService` → `AI_PROVIDER_SETTINGS_SERVICE_TOKEN`)
+ *     (#398). Both are core code, so DI registration lives here — mirroring
+ *     the webhook-secret split (`WebhookSecretService` +
+ *     `CredentialsWebhookSecretAdapter` are wired by core
+ *     `IntegrationsModule`, not by the integrations package).
  *
- * The AI adapter (Vercel / Anthropic / Fake) lives in
- * `libs/integrations/ai/` and is registered separately through
- * `AiIntegrationModule`. Those two modules intentionally do not overlap —
- * one owns the port + provider-agnostic code, the other owns the adapter.
+ * The Vercel / Fake completion adapters live in `libs/integrations/ai/`
+ * and are registered through `AiIntegrationModule`. That module imports
+ * this one to resolve `AI_PROVIDER_CREDENTIALS_PORT_TOKEN` for the Vercel
+ * adapter.
  *
  * @module libs/core/src/ai
  */
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { PROMPT_TEMPLATE_REPOSITORY_TOKEN, PROMPT_TEMPLATE_SERVICE_TOKEN } from './ai.tokens';
+import { CryptoService } from '@openlinker/shared';
+import { IntegrationsModule as CoreIntegrationsModule } from '../integrations/integrations.module';
+import {
+  AI_PROVIDER_CREDENTIALS_PORT_TOKEN,
+  AI_PROVIDER_SETTINGS_SERVICE_TOKEN,
+  PROMPT_TEMPLATE_REPOSITORY_TOKEN,
+  PROMPT_TEMPLATE_SERVICE_TOKEN,
+} from './ai.tokens';
+import { AiProviderSettingsService } from './application/services/ai-provider-settings.service';
 import { PromptTemplateService } from './application/services/prompt-template.service';
+import { CredentialsAiProviderAdapter } from './infrastructure/adapters/credentials-ai-provider.adapter';
 import { PromptTemplateOrmEntity } from './infrastructure/persistence/entities/prompt-template.orm-entity';
 import { PromptTemplateRepository } from './infrastructure/persistence/repositories/prompt-template.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PromptTemplateOrmEntity])],
+  imports: [
+    ConfigModule,
+    // For INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN consumed by the credentials
+    // adapter and the settings service.
+    CoreIntegrationsModule,
+    TypeOrmModule.forFeature([PromptTemplateOrmEntity]),
+  ],
   providers: [
+    // CoreIntegrationsModule provides CryptoService internally but does not
+    // export it; we register it locally so AiProviderSettingsService and
+    // CredentialsAiProviderAdapter can construct.
+    CryptoService,
     PromptTemplateRepository,
     PromptTemplateService,
     {
@@ -33,7 +59,22 @@ import { PromptTemplateRepository } from './infrastructure/persistence/repositor
       provide: PROMPT_TEMPLATE_SERVICE_TOKEN,
       useExisting: PromptTemplateService,
     },
+    CredentialsAiProviderAdapter,
+    {
+      provide: AI_PROVIDER_CREDENTIALS_PORT_TOKEN,
+      useExisting: CredentialsAiProviderAdapter,
+    },
+    AiProviderSettingsService,
+    {
+      provide: AI_PROVIDER_SETTINGS_SERVICE_TOKEN,
+      useExisting: AiProviderSettingsService,
+    },
   ],
-  exports: [PROMPT_TEMPLATE_REPOSITORY_TOKEN, PROMPT_TEMPLATE_SERVICE_TOKEN],
+  exports: [
+    PROMPT_TEMPLATE_REPOSITORY_TOKEN,
+    PROMPT_TEMPLATE_SERVICE_TOKEN,
+    AI_PROVIDER_CREDENTIALS_PORT_TOKEN,
+    AI_PROVIDER_SETTINGS_SERVICE_TOKEN,
+  ],
 })
 export class AiModule {}

--- a/libs/core/src/ai/ai.tokens.ts
+++ b/libs/core/src/ai/ai.tokens.ts
@@ -4,10 +4,16 @@
  * Symbol tokens for AI module providers. `AI_COMPLETION_PORT_TOKEN` is bound
  * to the configured adapter (Vercel/Anthropic or Fake) by
  * `AiIntegrationModule`. The prompt-template tokens are bound by the core
- * `AiModule` to the in-process repository + service.
+ * `AiModule` to the in-process repository + service. The
+ * `AI_PROVIDER_CREDENTIALS_PORT_TOKEN` and `AI_PROVIDER_SETTINGS_SERVICE_TOKEN`
+ * are bound by `AiIntegrationModule` (alongside the completion adapter) so
+ * the credential resolver and the admin write-side service share the same
+ * lifecycle as the adapter that consumes them.
  *
  * @module libs/core/src/ai
  */
 export const AI_COMPLETION_PORT_TOKEN = Symbol('AiCompletionPort');
 export const PROMPT_TEMPLATE_REPOSITORY_TOKEN = Symbol('PromptTemplateRepositoryPort');
 export const PROMPT_TEMPLATE_SERVICE_TOKEN = Symbol('IPromptTemplateService');
+export const AI_PROVIDER_CREDENTIALS_PORT_TOKEN = Symbol('AiProviderCredentialsPort');
+export const AI_PROVIDER_SETTINGS_SERVICE_TOKEN = Symbol('IAiProviderSettingsService');

--- a/libs/core/src/ai/application/services/ai-provider-settings.service.interface.ts
+++ b/libs/core/src/ai/application/services/ai-provider-settings.service.interface.ts
@@ -1,0 +1,39 @@
+/**
+ * AI Provider Settings Service Interface
+ *
+ * Application-layer contract for managing the active AI provider's API key.
+ * Backed by the encrypted `integration_credentials` store; consumed by the
+ * `AiProviderSettingsController` admin endpoints.
+ *
+ * Co-located with the implementation, matching `prompt-template.service.interface.ts`
+ * — the local convention for the `libs/core/src/ai/` bounded context.
+ *
+ * @module libs/core/src/ai/application/services
+ */
+import type { AiProviderSettingsView } from '../../domain/types/ai-provider-credentials.types';
+
+export interface IAiProviderSettingsService {
+  /**
+   * Current settings view: which provider is active, whether a key is
+   * configured, and where the key resolves from. Never returns the key.
+   */
+  get(): Promise<AiProviderSettingsView>;
+
+  /**
+   * Persist a new API key for the active provider.
+   *
+   * Throws `AiProviderSettingsNotApplicableError` when the active provider
+   * does not require a key (e.g. `OL_AI_PROVIDER=fake`) — the controller
+   * maps this to an HTTP 400.
+   */
+  set(apiKey: string, actorUserId?: string): Promise<void>;
+
+  /**
+   * Remove the stored key for the active provider, falling back to the env
+   * fallback (or `none`).
+   *
+   * Throws `AiProviderSettingsNotApplicableError` when the active provider
+   * does not require a key.
+   */
+  clear(actorUserId?: string): Promise<void>;
+}

--- a/libs/core/src/ai/application/services/ai-provider-settings.service.spec.ts
+++ b/libs/core/src/ai/application/services/ai-provider-settings.service.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * AI Provider Settings Service — Unit Tests
+ *
+ * Mocks all collaborators (credentials port, credential repo, crypto,
+ * config). Asserts: write paths upsert with encryption + invalidate the
+ * port; fake-provider writes throw the not-applicable error; the structured
+ * log payload matches the webhook-secret precedent shape.
+ *
+ * @module libs/core/src/ai/application/services
+ */
+import { Logger as NestLogger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CryptoService } from '@openlinker/shared';
+import {
+  IntegrationCredentialRepositoryPort,
+  CredentialNotFoundException,
+} from '@openlinker/core/integrations';
+import { IntegrationCredential } from '@openlinker/core/integrations/domain/entities/integration-credential.entity';
+import {
+  AiProviderCredentialsPort,
+  aiProviderCredentialsRef,
+} from '../../domain/ports/ai-provider-credentials.port';
+import { AiProviderSettingsView } from '../../domain/types/ai-provider-credentials.types';
+import { AiProviderSettingsNotApplicableError } from '../../domain/exceptions/ai-provider-settings-not-applicable.exception';
+import { AiProviderSettingsService } from './ai-provider-settings.service';
+
+const buildConfigService = (overrides: Record<string, string | undefined> = {}): ConfigService =>
+  ({
+    get: <T = string>(key: string, defaultValue?: T): T => {
+      const v = overrides[key];
+      return (v ?? defaultValue) as T;
+    },
+  }) as unknown as ConfigService;
+
+const sampleCredential = (ref: string): IntegrationCredential =>
+  new IntegrationCredential(
+    'cred-id',
+    ref,
+    'anthropic',
+    { ciphertext: 'cipher' },
+    true,
+    new Date(),
+    new Date(),
+  );
+
+describe('AiProviderSettingsService', () => {
+  let credentialsPort: jest.Mocked<AiProviderCredentialsPort>;
+  let repository: jest.Mocked<IntegrationCredentialRepositoryPort>;
+  let crypto: jest.Mocked<Pick<CryptoService, 'encrypt' | 'decrypt'>>;
+  let logSpy: jest.SpyInstance;
+
+  const buildService = (
+    config: ConfigService = buildConfigService({ OL_AI_PROVIDER: 'anthropic' }),
+  ): AiProviderSettingsService =>
+    new AiProviderSettingsService(
+      credentialsPort,
+      repository,
+      crypto as unknown as CryptoService,
+      config,
+    );
+
+  beforeEach(() => {
+    credentialsPort = {
+      getApiKey: jest.fn(),
+      describe: jest.fn(),
+      invalidate: jest.fn(),
+    };
+    repository = {
+      getByRef: jest.fn(),
+      create: jest.fn().mockResolvedValue(sampleCredential('ai-provider:anthropic')),
+      update: jest.fn().mockResolvedValue(sampleCredential('ai-provider:anthropic')),
+      delete: jest.fn().mockResolvedValue(true),
+    };
+    crypto = {
+      encrypt: jest.fn().mockReturnValue('cipher'),
+      decrypt: jest.fn(),
+    };
+    logSpy = jest.spyOn(NestLogger.prototype, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  describe('get', () => {
+    it('delegates to credentialsPort.describe', async () => {
+      const view: AiProviderSettingsView = {
+        provider: 'anthropic',
+        configured: true,
+        source: 'db',
+      };
+      credentialsPort.describe.mockResolvedValue(view);
+
+      const result = await buildService().get();
+
+      expect(result).toBe(view);
+      expect(credentialsPort.describe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('set', () => {
+    it('updates an existing row, invalidates the cache, and logs the actor', async () => {
+      await buildService().set('sk-ant-test-12345678', 'user-1');
+
+      expect(crypto.encrypt).toHaveBeenCalledWith('sk-ant-test-12345678');
+      expect(repository.update).toHaveBeenCalledWith('ai-provider:anthropic', {
+        credentialsJson: { ciphertext: 'cipher' },
+        encrypted: true,
+      });
+      expect(repository.create).not.toHaveBeenCalled();
+      expect(credentialsPort.invalidate).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith('ai_provider_settings.set', {
+        provider: 'anthropic',
+        actor: 'user-1',
+      });
+    });
+
+    it('creates the row when no existing credential is present', async () => {
+      repository.update.mockRejectedValueOnce(new CredentialNotFoundException('x'));
+
+      await buildService().set('sk-ant-test-12345678');
+
+      expect(repository.create).toHaveBeenCalledWith({
+        ref: 'ai-provider:anthropic',
+        platformType: 'anthropic',
+        credentialsJson: { ciphertext: 'cipher' },
+        encrypted: true,
+      });
+      expect(credentialsPort.invalidate).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith('ai_provider_settings.set', {
+        provider: 'anthropic',
+        actor: 'system',
+      });
+    });
+
+    it('rethrows non-NotFound repository errors without creating', async () => {
+      repository.update.mockRejectedValueOnce(new Error('db down'));
+
+      await expect(buildService().set('sk-ant-test-12345678')).rejects.toThrow('db down');
+      expect(repository.create).not.toHaveBeenCalled();
+      expect(credentialsPort.invalidate).not.toHaveBeenCalled();
+    });
+
+    it('throws AiProviderSettingsNotApplicableError when active provider is fake', async () => {
+      const service = buildService(buildConfigService({ OL_AI_PROVIDER: 'fake' }));
+
+      await expect(service.set('whatever-key')).rejects.toBeInstanceOf(
+        AiProviderSettingsNotApplicableError,
+      );
+      expect(repository.update).not.toHaveBeenCalled();
+      expect(repository.create).not.toHaveBeenCalled();
+      expect(credentialsPort.invalidate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clear', () => {
+    it('deletes the row, invalidates the cache, and logs the actor', async () => {
+      await buildService().clear('user-2');
+
+      expect(repository.delete).toHaveBeenCalledWith('ai-provider:anthropic');
+      expect(credentialsPort.invalidate).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith('ai_provider_settings.clear', {
+        provider: 'anthropic',
+        actor: 'user-2',
+      });
+    });
+
+    it('throws AiProviderSettingsNotApplicableError when active provider is fake', async () => {
+      const service = buildService(buildConfigService({ OL_AI_PROVIDER: 'fake' }));
+
+      await expect(service.clear()).rejects.toBeInstanceOf(
+        AiProviderSettingsNotApplicableError,
+      );
+      expect(repository.delete).not.toHaveBeenCalled();
+      expect(credentialsPort.invalidate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('aiProviderCredentialsRef', () => {
+    it('builds a stable ref per provider', () => {
+      expect(aiProviderCredentialsRef('anthropic')).toBe('ai-provider:anthropic');
+      expect(aiProviderCredentialsRef('fake')).toBe('ai-provider:fake');
+    });
+  });
+
+  describe('OL_AI_PROVIDER fallback', () => {
+    it('treats an unknown OL_AI_PROVIDER value as anthropic (default)', async () => {
+      const service = buildService(buildConfigService({ OL_AI_PROVIDER: 'gibberish' }));
+
+      await service.set('sk-ant-test-12345678');
+
+      expect(repository.update).toHaveBeenCalledWith('ai-provider:anthropic', expect.anything());
+    });
+  });
+});

--- a/libs/core/src/ai/application/services/ai-provider-settings.service.ts
+++ b/libs/core/src/ai/application/services/ai-provider-settings.service.ts
@@ -1,0 +1,117 @@
+/**
+ * AI Provider Settings Service
+ *
+ * Write-side counterpart to `AiProviderCredentialsPort` (read side). Persists
+ * the AI provider API key to the encrypted `integration_credentials` table at
+ * `ref = ai-provider:{provider}` and invalidates the port's cache after every
+ * write so subsequent completion requests see the new value.
+ *
+ * Mirrors the shape of `WebhookSecretService` (`libs/core/src/integrations/`)
+ * — both wrap the same credential repo + crypto pair.
+ *
+ * @module libs/core/src/ai/application/services
+ * @implements {IAiProviderSettingsService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Logger, CryptoService } from '@openlinker/shared';
+import {
+  IntegrationCredentialRepositoryPort,
+  INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
+  CredentialNotFoundException,
+} from '@openlinker/core/integrations';
+import { AI_PROVIDER_CREDENTIALS_PORT_TOKEN } from '../../ai.tokens';
+import {
+  AiProviderCredentialsPort,
+  aiProviderCredentialsRef,
+} from '../../domain/ports/ai-provider-credentials.port';
+import {
+  AiProvider,
+  AiProviderValues,
+} from '../../domain/types/ai-completion.types';
+import { AiProviderSettingsView } from '../../domain/types/ai-provider-credentials.types';
+import { AiProviderSettingsNotApplicableError } from '../../domain/exceptions/ai-provider-settings-not-applicable.exception';
+import { IAiProviderSettingsService } from './ai-provider-settings.service.interface';
+
+const DEFAULT_PROVIDER: AiProvider = 'anthropic';
+
+/** Providers that require an API key. Anything else rejects set/clear with a 400. */
+const PROVIDERS_REQUIRING_KEY: ReadonlySet<AiProvider> = new Set<AiProvider>(['anthropic']);
+
+const isAiProvider = (value: string): value is AiProvider =>
+  (AiProviderValues as readonly string[]).includes(value);
+
+@Injectable()
+export class AiProviderSettingsService implements IAiProviderSettingsService {
+  private readonly logger = new Logger(AiProviderSettingsService.name);
+
+  constructor(
+    @Inject(AI_PROVIDER_CREDENTIALS_PORT_TOKEN)
+    private readonly credentialsPort: AiProviderCredentialsPort,
+    @Inject(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN)
+    private readonly credentialRepository: IntegrationCredentialRepositoryPort,
+    private readonly crypto: CryptoService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async get(): Promise<AiProviderSettingsView> {
+    return this.credentialsPort.describe();
+  }
+
+  async set(apiKey: string, actorUserId?: string): Promise<void> {
+    const provider = this.getActiveProvider();
+    this.assertProviderRequiresKey(provider);
+
+    const ciphertext = this.crypto.encrypt(apiKey);
+    const ref = aiProviderCredentialsRef(provider);
+
+    try {
+      await this.credentialRepository.update(ref, {
+        credentialsJson: { ciphertext },
+        encrypted: true,
+      });
+    } catch (error) {
+      if (error instanceof CredentialNotFoundException) {
+        await this.credentialRepository.create({
+          ref,
+          platformType: provider,
+          credentialsJson: { ciphertext },
+          encrypted: true,
+        });
+      } else {
+        throw error;
+      }
+    }
+
+    this.credentialsPort.invalidate();
+
+    this.logger.log('ai_provider_settings.set', {
+      provider,
+      actor: actorUserId ?? 'system',
+    });
+  }
+
+  async clear(actorUserId?: string): Promise<void> {
+    const provider = this.getActiveProvider();
+    this.assertProviderRequiresKey(provider);
+
+    await this.credentialRepository.delete(aiProviderCredentialsRef(provider));
+    this.credentialsPort.invalidate();
+
+    this.logger.log('ai_provider_settings.clear', {
+      provider,
+      actor: actorUserId ?? 'system',
+    });
+  }
+
+  private getActiveProvider(): AiProvider {
+    const raw = this.configService.get<string>('OL_AI_PROVIDER') ?? DEFAULT_PROVIDER;
+    return isAiProvider(raw) ? raw : DEFAULT_PROVIDER;
+  }
+
+  private assertProviderRequiresKey(provider: AiProvider): void {
+    if (!PROVIDERS_REQUIRING_KEY.has(provider)) {
+      throw new AiProviderSettingsNotApplicableError(provider);
+    }
+  }
+}

--- a/libs/core/src/ai/domain/exceptions/ai-provider-key-missing.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/ai-provider-key-missing.exception.ts
@@ -1,0 +1,18 @@
+/**
+ * AI Provider Key Missing Exception
+ *
+ * Thrown by `AiProviderCredentialsPort.getApiKey()` when no API key is
+ * resolvable for the active provider — neither in the encrypted credentials
+ * store nor in the env-var fallback. The Vercel completion adapter
+ * propagates this; admins resolve it by PUT-ing a key through the admin
+ * settings endpoint.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+export class AiProviderKeyMissingError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'AiProviderKeyMissingError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/ai/domain/exceptions/ai-provider-settings-not-applicable.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/ai-provider-settings-not-applicable.exception.ts
@@ -1,0 +1,19 @@
+/**
+ * AI Provider Settings Not Applicable Exception
+ *
+ * Thrown by `AiProviderSettingsService.set()` / `clear()` when the active
+ * provider does not require an API key (e.g. `OL_AI_PROVIDER=fake`). The
+ * admin controller catches this and translates it to HTTP 400 so the
+ * frontend can surface a clear "this provider doesn't take a key" message.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+import type { AiProvider } from '../types/ai-completion.types';
+
+export class AiProviderSettingsNotApplicableError extends Error {
+  constructor(public readonly provider: AiProvider) {
+    super(`Active AI provider '${provider}' does not require an API key.`);
+    this.name = 'AiProviderSettingsNotApplicableError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/ai/domain/ports/ai-provider-credentials.port.ts
+++ b/libs/core/src/ai/domain/ports/ai-provider-credentials.port.ts
@@ -1,0 +1,52 @@
+/**
+ * AI Provider Credentials Port
+ *
+ * Resolves the API key for the active AI provider (read from
+ * `OL_AI_PROVIDER`). Used by the Vercel completion adapter on every
+ * `complete()` call so key rotations apply without a restart.
+ *
+ * Resolution priority (DB wins when both are set):
+ *   1. Encrypted row in `integration_credentials` at `ref = ai-provider:{provider}`
+ *   2. `ConfigService.get('ANTHROPIC_API_KEY')` (legacy env-var fallback for local dev)
+ *   3. throws `AiProviderKeyMissingError` if neither is set
+ *
+ * For `provider=fake`, `getApiKey()` should never be called — `FakeAiCompletionAdapter`
+ * does not invoke the port. If invoked in fake mode, the implementation throws.
+ *
+ * @module libs/core/src/ai/domain/ports
+ */
+import type { AiProvider } from '../types/ai-completion.types';
+import type { AiProviderSettingsView } from '../types/ai-provider-credentials.types';
+
+/**
+ * Build the credential `ref` for a given provider. Single source of truth
+ * shared between `AiProviderSettingsService` (write side) and
+ * `CredentialsAiProviderAdapter` (read side). Lives in the domain layer so
+ * both application and infrastructure consumers depend on it through the
+ * port file — never on each other. Mirrors `webhookSecretRef` placement at
+ * `libs/core/src/integrations/domain/ports/webhook-secret-provider.port.ts`.
+ */
+export const aiProviderCredentialsRef = (provider: AiProvider): string =>
+  `ai-provider:${provider}`;
+
+export interface AiProviderCredentialsPort {
+  /**
+   * Resolve the API key for the active provider.
+   *
+   * @throws {AiProviderKeyMissingError} when no key is resolvable.
+   */
+  getApiKey(): Promise<string>;
+
+  /**
+   * Where the key currently resolves from, without exposing the value.
+   * Safe to call in any provider mode (including `fake`).
+   */
+  describe(): Promise<AiProviderSettingsView>;
+
+  /**
+   * Drop the cached value. Called by `AiProviderSettingsService` after every
+   * write (PUT / DELETE) so the next `getApiKey()` re-reads the credential
+   * row.
+   */
+  invalidate(): void;
+}

--- a/libs/core/src/ai/domain/types/ai-provider-credentials.types.ts
+++ b/libs/core/src/ai/domain/types/ai-provider-credentials.types.ts
@@ -1,0 +1,44 @@
+/**
+ * AI Provider Credentials Types
+ *
+ * Shared shapes for the `AiProviderCredentialsPort` and the
+ * `AiProviderSettingsService`. The single `AiProviderSettingsView` response
+ * type is what both `port.describe()` and `service.get()` return — keeping
+ * one type avoids drift between the port contract, the HTTP response, and
+ * the FE TanStack Query type.
+ *
+ * @module libs/core/src/ai/domain/types
+ */
+import type { AiProvider } from './ai-completion.types';
+
+/**
+ * Where the API key currently resolves from.
+ *
+ *   - `db`   — encrypted row in `integration_credentials` at
+ *              `ref = ai-provider:{provider}` (the source of truth).
+ *   - `env`  — legacy fallback (`ANTHROPIC_API_KEY` env var). Surfaced as a
+ *              warning state in the FE so admins migrate to DB storage.
+ *   - `none` — neither DB nor env has a key. For `provider=fake` this is the
+ *              expected steady state.
+ *
+ * Resolution priority is **DB → env**: when both are set, `db` is reported
+ * and the env value is unused.
+ */
+export const AiProviderKeySourceValues = ['db', 'env', 'none'] as const;
+export type AiProviderKeySource = (typeof AiProviderKeySourceValues)[number];
+
+/**
+ * Single response shape used by both the port (`describe()`) and the
+ * settings service (`get()`). The HTTP response DTO maps 1:1 onto this.
+ *
+ * `apiKey` is intentionally absent from this type — the key value never
+ * leaves the server in a response body.
+ */
+export interface AiProviderSettingsView {
+  /** Active provider read from `OL_AI_PROVIDER` (default: `anthropic`). */
+  provider: AiProvider;
+  /** True when an API key is currently resolvable for the active provider. */
+  configured: boolean;
+  /** Where the key currently resolves from. */
+  source: AiProviderKeySource;
+}

--- a/libs/core/src/ai/index.ts
+++ b/libs/core/src/ai/index.ts
@@ -2,13 +2,17 @@
  * AI Bounded Context — Public Surface
  *
  * Exports the capability port, types, exceptions, and DI tokens for the AI
- * bounded context. This now includes two concerns:
+ * bounded context. Three concerns:
  *
  *   1. `AiCompletionPort` — provider-agnostic LLM completions. Implemented
  *      by adapters in `libs/integrations/ai/`.
  *   2. Prompt-template storage — editable, versioned templates with a
  *      draft/publish/archive state machine. Owned end-to-end by the core
  *      `AiModule` (repository + service + render helper).
+ *   3. Provider-key management — `AiProviderCredentialsPort` (read) +
+ *      `IAiProviderSettingsService` (write). Backed by the encrypted
+ *      `integration_credentials` store and wired into
+ *      `AiIntegrationModule.register()`.
  *
  * @module libs/core/src/ai
  */
@@ -30,6 +34,12 @@ export * from './application/services/prompt-template.service.interface';
 export * from './application/types/prompt-template-commands.types';
 export { renderTemplate } from './application/internal/render-template';
 export type { RenderTemplateArgs } from './application/internal/render-template';
+
+export * from './domain/ports/ai-provider-credentials.port';
+export * from './domain/types/ai-provider-credentials.types';
+export * from './domain/exceptions/ai-provider-key-missing.exception';
+export * from './domain/exceptions/ai-provider-settings-not-applicable.exception';
+export * from './application/services/ai-provider-settings.service.interface';
 
 export * from './ai.tokens';
 export { AiModule } from './ai.module';

--- a/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts
+++ b/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * Credentials AI Provider Adapter — Unit Tests
+ *
+ * Mocks the credential repo, crypto service, and ConfigService. Asserts:
+ * DB hit (decrypts), DB miss → env fallback (warns once), both missing →
+ * AiProviderKeyMissingError, cache hit, invalidate() clears cache,
+ * describe() reports the resolution source without leaking the key,
+ * provider=fake short-circuits without DB/env lookups, env reads go via
+ * ConfigService (not process.env).
+ *
+ * @module libs/core/src/ai/infrastructure/adapters
+ */
+import { Logger as NestLogger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CryptoService } from '@openlinker/shared';
+import {
+  IntegrationCredentialRepositoryPort,
+  CredentialNotFoundException,
+} from '@openlinker/core/integrations';
+import { IntegrationCredential } from '@openlinker/core/integrations/domain/entities/integration-credential.entity';
+import { AiProviderKeyMissingError } from '../../domain/exceptions/ai-provider-key-missing.exception';
+import { AiProviderSettingsNotApplicableError } from '../../domain/exceptions/ai-provider-settings-not-applicable.exception';
+import { CredentialsAiProviderAdapter } from './credentials-ai-provider.adapter';
+
+const buildConfigService = (overrides: Record<string, string | undefined>): ConfigService =>
+  ({
+    get: jest.fn(<T = string>(key: string, defaultValue?: T): T => {
+      const v = overrides[key];
+      return (v ?? defaultValue) as T;
+    }),
+  }) as unknown as ConfigService;
+
+const dbCredential = (ref: string, ciphertext: string, encrypted = true): IntegrationCredential =>
+  new IntegrationCredential(
+    'cred-id',
+    ref,
+    'anthropic',
+    { ciphertext },
+    encrypted,
+    new Date(),
+    new Date(),
+  );
+
+describe('CredentialsAiProviderAdapter', () => {
+  let repository: jest.Mocked<IntegrationCredentialRepositoryPort>;
+  let crypto: jest.Mocked<Pick<CryptoService, 'encrypt' | 'decrypt'>>;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    repository = {
+      getByRef: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+    crypto = {
+      encrypt: jest.fn(),
+      decrypt: jest.fn(),
+    };
+    warnSpy = jest.spyOn(NestLogger.prototype, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  const buildAdapter = (
+    config: Record<string, string | undefined> = { OL_AI_PROVIDER: 'anthropic' },
+  ): CredentialsAiProviderAdapter =>
+    new CredentialsAiProviderAdapter(
+      repository,
+      crypto as unknown as CryptoService,
+      buildConfigService(config),
+    );
+
+  describe('getApiKey', () => {
+    it('returns the decrypted DB key when present', async () => {
+      repository.getByRef.mockResolvedValue(dbCredential('ai-provider:anthropic', 'cipher'));
+      crypto.decrypt.mockReturnValue('plaintext-key');
+
+      const result = await buildAdapter().getApiKey();
+
+      expect(result).toBe('plaintext-key');
+      expect(repository.getByRef).toHaveBeenCalledWith('ai-provider:anthropic');
+      expect(crypto.decrypt).toHaveBeenCalledWith('cipher');
+    });
+
+    it('falls back to ConfigService env (with one-shot warning) when no DB row', async () => {
+      repository.getByRef.mockRejectedValue(new CredentialNotFoundException('x'));
+      const adapter = buildAdapter({
+        OL_AI_PROVIDER: 'anthropic',
+        ANTHROPIC_API_KEY: 'env-key',
+      });
+
+      const first = await adapter.getApiKey();
+      const second = await adapter.getApiKey();
+
+      expect(first).toBe('env-key');
+      expect(second).toBe('env-key');
+      expect(warnSpy).toHaveBeenCalledTimes(1); // one-shot
+      const warnArgs = warnSpy.mock.calls[0] as unknown as [unknown, ...unknown[]];
+      const warnedMessage = String(warnArgs[0] ?? '');
+      expect(warnedMessage).toContain('ANTHROPIC_API_KEY');
+      expect(warnedMessage).toContain('deprecated');
+    });
+
+    it('throws AiProviderKeyMissingError when neither DB nor env has a key', async () => {
+      repository.getByRef.mockRejectedValue(new CredentialNotFoundException('x'));
+      const adapter = buildAdapter({ OL_AI_PROVIDER: 'anthropic' });
+
+      await expect(adapter.getApiKey()).rejects.toBeInstanceOf(AiProviderKeyMissingError);
+    });
+
+    it('caches the resolved key and avoids re-reading the DB on the next call', async () => {
+      repository.getByRef.mockResolvedValue(dbCredential('ai-provider:anthropic', 'cipher'));
+      crypto.decrypt.mockReturnValue('plaintext-key');
+      const adapter = buildAdapter();
+
+      await adapter.getApiKey();
+      await adapter.getApiKey();
+
+      expect(repository.getByRef).toHaveBeenCalledTimes(1);
+      expect(crypto.decrypt).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-reads the DB after invalidate()', async () => {
+      repository.getByRef.mockResolvedValue(dbCredential('ai-provider:anthropic', 'cipher'));
+      crypto.decrypt.mockReturnValue('plaintext-key');
+      const adapter = buildAdapter();
+
+      await adapter.getApiKey();
+      adapter.invalidate();
+      await adapter.getApiKey();
+
+      expect(repository.getByRef).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws AiProviderSettingsNotApplicableError immediately when active provider is fake', async () => {
+      const adapter = buildAdapter({ OL_AI_PROVIDER: 'fake' });
+
+      await expect(adapter.getApiKey()).rejects.toBeInstanceOf(
+        AiProviderSettingsNotApplicableError,
+      );
+      expect(repository.getByRef).not.toHaveBeenCalled();
+    });
+
+    it('treats a stored unencrypted credential as raw plaintext (does not call decrypt)', async () => {
+      repository.getByRef.mockResolvedValue(
+        dbCredential('ai-provider:anthropic', 'plaintext-stored', false),
+      );
+
+      const result = await buildAdapter().getApiKey();
+
+      expect(result).toBe('plaintext-stored');
+      expect(crypto.decrypt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('describe', () => {
+    it('reports source=db when a DB row exists', async () => {
+      repository.getByRef.mockResolvedValue(dbCredential('ai-provider:anthropic', 'cipher'));
+      crypto.decrypt.mockReturnValue('plaintext-key');
+
+      expect(await buildAdapter().describe()).toEqual({
+        provider: 'anthropic',
+        configured: true,
+        source: 'db',
+      });
+    });
+
+    it('reports source=env when DB is empty and env is set', async () => {
+      repository.getByRef.mockRejectedValue(new CredentialNotFoundException('x'));
+
+      const view = await buildAdapter({
+        OL_AI_PROVIDER: 'anthropic',
+        ANTHROPIC_API_KEY: 'env-key',
+      }).describe();
+
+      expect(view).toEqual({
+        provider: 'anthropic',
+        configured: true,
+        source: 'env',
+      });
+      // describe() must not emit the deprecation warning — only getApiKey() does
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('reports source=none when neither DB nor env is set', async () => {
+      repository.getByRef.mockRejectedValue(new CredentialNotFoundException('x'));
+
+      expect(await buildAdapter({ OL_AI_PROVIDER: 'anthropic' }).describe()).toEqual({
+        provider: 'anthropic',
+        configured: false,
+        source: 'none',
+      });
+    });
+
+    it('short-circuits to source=none for provider=fake without any DB/env lookup', async () => {
+      const adapter = buildAdapter({ OL_AI_PROVIDER: 'fake' });
+
+      const view = await adapter.describe();
+
+      expect(view).toEqual({ provider: 'fake', configured: false, source: 'none' });
+      expect(repository.getByRef).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('env reads use ConfigService, not process.env', () => {
+    it('routes the env lookup through ConfigService.get', async () => {
+      repository.getByRef.mockRejectedValue(new CredentialNotFoundException('x'));
+      const config = buildConfigService({
+        OL_AI_PROVIDER: 'anthropic',
+        ANTHROPIC_API_KEY: 'env-key',
+      });
+      const adapter = new CredentialsAiProviderAdapter(
+        repository,
+        crypto as unknown as CryptoService,
+        config,
+      );
+
+      await adapter.getApiKey();
+
+      expect(config.get).toHaveBeenCalledWith('ANTHROPIC_API_KEY');
+    });
+  });
+});

--- a/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.ts
+++ b/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.ts
@@ -1,0 +1,193 @@
+/**
+ * Credentials-backed AI Provider Adapter
+ *
+ * Implementation of `AiProviderCredentialsPort` backed by the encrypted
+ * `integration_credentials` table. Mirrors `CredentialsWebhookSecretAdapter`:
+ * 60-second cache, DB → env → throw resolution, one-shot deprecation
+ * warning when the env fallback is used.
+ *
+ * The active provider is read from `OL_AI_PROVIDER` (default `anthropic`).
+ * For `provider=fake`, the adapter short-circuits — `describe()` reports
+ * `{ provider: 'fake', configured: false, source: 'none' }` without any DB
+ * or env lookup, and `getApiKey()` throws (the `FakeAiCompletionAdapter`
+ * never invokes it; if it does, that's a programming error).
+ *
+ * Env reads go through `ConfigService.get<string>(...)` exclusively — never
+ * `process.env` — to match the webhook-secret precedent and keep tests
+ * easy to reason about.
+ *
+ * @module libs/core/src/ai/infrastructure/adapters
+ * @implements {AiProviderCredentialsPort}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Logger, CryptoService } from '@openlinker/shared';
+import {
+  IntegrationCredentialRepositoryPort,
+  INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
+  CredentialNotFoundException,
+} from '@openlinker/core/integrations';
+import {
+  AiProviderCredentialsPort,
+  aiProviderCredentialsRef,
+} from '../../domain/ports/ai-provider-credentials.port';
+import {
+  AiProvider,
+  AiProviderValues,
+} from '../../domain/types/ai-completion.types';
+import { AiProviderSettingsView } from '../../domain/types/ai-provider-credentials.types';
+import { AiProviderKeyMissingError } from '../../domain/exceptions/ai-provider-key-missing.exception';
+import { AiProviderSettingsNotApplicableError } from '../../domain/exceptions/ai-provider-settings-not-applicable.exception';
+
+const DEFAULT_PROVIDER: AiProvider = 'anthropic';
+const CACHE_TTL_MS = 60 * 1000;
+
+/**
+ * Env-var name for the legacy fallback per provider. The shape mirrors the
+ * vendor SDK convention so an unmodified fresh checkout works as before.
+ * Today only `anthropic` is mapped — adding a provider also adds its env
+ * var here.
+ */
+const ENV_VAR_BY_PROVIDER: Partial<Record<AiProvider, string>> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+};
+
+const isAiProvider = (value: string): value is AiProvider =>
+  (AiProviderValues as readonly string[]).includes(value);
+
+interface CacheEntry {
+  apiKey: string;
+  expiresAt: number;
+}
+
+@Injectable()
+export class CredentialsAiProviderAdapter implements AiProviderCredentialsPort {
+  private readonly logger = new Logger(CredentialsAiProviderAdapter.name);
+  private readonly activeProvider: AiProvider;
+  private cache: CacheEntry | null = null;
+  private envFallbackWarned = false;
+
+  constructor(
+    @Inject(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN)
+    private readonly credentialRepository: IntegrationCredentialRepositoryPort,
+    private readonly crypto: CryptoService,
+    private readonly configService: ConfigService,
+  ) {
+    const raw = this.configService.get<string>('OL_AI_PROVIDER') ?? DEFAULT_PROVIDER;
+    this.activeProvider = isAiProvider(raw) ? raw : DEFAULT_PROVIDER;
+  }
+
+  async getApiKey(): Promise<string> {
+    if (!this.providerRequiresKey(this.activeProvider)) {
+      // Programming error: the adapter that doesn't require a key should never
+      // call into the credentials port. Use the same exception the service
+      // uses to translate "this provider takes no key" at the HTTP boundary.
+      throw new AiProviderSettingsNotApplicableError(this.activeProvider);
+    }
+
+    if (this.cache && this.cache.expiresAt > Date.now()) {
+      return this.cache.apiKey;
+    }
+
+    const dbKey = await this.tryLoadFromDb();
+    if (dbKey !== null) {
+      this.setCache(dbKey);
+      return dbKey;
+    }
+
+    const envKey = this.tryLoadFromEnv();
+    if (envKey !== null) {
+      this.setCache(envKey);
+      return envKey;
+    }
+
+    throw new AiProviderKeyMissingError(
+      `No API key configured for AI provider '${this.activeProvider}'. ` +
+        `Set one via PUT /ai-provider-settings or the ${ENV_VAR_BY_PROVIDER[this.activeProvider] ?? 'provider env var'} ` +
+        `environment variable.`,
+    );
+  }
+
+  async describe(): Promise<AiProviderSettingsView> {
+    if (!this.providerRequiresKey(this.activeProvider)) {
+      return { provider: this.activeProvider, configured: false, source: 'none' };
+    }
+
+    const dbKey = await this.tryLoadFromDb();
+    if (dbKey !== null) {
+      return { provider: this.activeProvider, configured: true, source: 'db' };
+    }
+
+    const envKey = this.tryReadEnvWithoutWarning();
+    if (envKey !== null) {
+      return { provider: this.activeProvider, configured: true, source: 'env' };
+    }
+
+    return { provider: this.activeProvider, configured: false, source: 'none' };
+  }
+
+  invalidate(): void {
+    this.cache = null;
+  }
+
+  private providerRequiresKey(provider: AiProvider): boolean {
+    return ENV_VAR_BY_PROVIDER[provider] !== undefined;
+  }
+
+  private async tryLoadFromDb(): Promise<string | null> {
+    const ref = aiProviderCredentialsRef(this.activeProvider);
+    try {
+      const credential = await this.credentialRepository.getByRef(ref);
+      const ciphertext = credential.credentialsJson?.ciphertext;
+      if (typeof ciphertext !== 'string') {
+        this.logger.error(
+          `AI provider credential ${ref} is missing a ciphertext field`,
+        );
+        return null;
+      }
+      if (!credential.encrypted) {
+        this.logger.warn(
+          `AI provider credential ${ref} is not marked encrypted — returning raw value`,
+        );
+        return ciphertext;
+      }
+      return this.crypto.decrypt(ciphertext);
+    } catch (error) {
+      if (error instanceof CredentialNotFoundException) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Read the env-var fallback. Emits a one-shot deprecation warning so an
+   * admin running on env-only configuration eventually sees the migration
+   * pointer. Only called from `getApiKey()` (resolution-on-use) — the
+   * `describe()` path uses `tryReadEnvWithoutWarning` to avoid spamming the
+   * log on every status poll.
+   */
+  private tryLoadFromEnv(): string | null {
+    const value = this.tryReadEnvWithoutWarning();
+    if (value !== null && !this.envFallbackWarned) {
+      this.envFallbackWarned = true;
+      const envName = ENV_VAR_BY_PROVIDER[this.activeProvider];
+      this.logger.warn(
+        `AI provider key for '${this.activeProvider}' resolved from ${envName} env var. ` +
+          `This fallback is deprecated — store the key encrypted via PUT /ai-provider-settings to silence this warning.`,
+      );
+    }
+    return value;
+  }
+
+  private tryReadEnvWithoutWarning(): string | null {
+    const envName = ENV_VAR_BY_PROVIDER[this.activeProvider];
+    if (!envName) return null;
+    const value = this.configService.get<string>(envName);
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private setCache(apiKey: string): void {
+    this.cache = { apiKey, expiresAt: Date.now() + CACHE_TTL_MS };
+  }
+}

--- a/libs/integrations/ai/src/ai-integration.module.ts
+++ b/libs/integrations/ai/src/ai-integration.module.ts
@@ -1,9 +1,18 @@
 /**
  * AI Integration Module
  *
- * NestJS module that selects an AiCompletionPort adapter based on
+ * NestJS module that selects an `AiCompletionPort` adapter based on
  * `OL_AI_PROVIDER` (default: `anthropic`; `fake` for tests / offline dev) and
  * binds the chosen instance to `AI_COMPLETION_PORT_TOKEN` via `useExisting`.
+ *
+ * The provider-key resolver (`AI_PROVIDER_CREDENTIALS_PORT_TOKEN`) and the
+ * admin write-side service (`AI_PROVIDER_SETTINGS_SERVICE_TOKEN`) live in
+ * core `AiModule` — they are core code (port + application service +
+ * infrastructure adapter that talks only to the encrypted credential
+ * store), and DI registration follows the code. This module imports core
+ * `AiModule` to resolve `AI_PROVIDER_CREDENTIALS_PORT_TOKEN` for the Vercel
+ * completion adapter and re-exports it so downstream consumers wired
+ * through this module can inject it too.
  *
  * Registered inside `apps/api/src/integrations/integrations.module.ts`
  * alongside `AllegroIntegrationModule` + `PrestashopIntegrationModule` —
@@ -14,8 +23,12 @@
  */
 import { Module, type DynamicModule, type Provider } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { AI_COMPLETION_PORT_TOKEN } from '@openlinker/core/ai/ai.tokens';
-import { AiProviderValues, type AiProvider } from '@openlinker/core/ai/domain/types/ai-completion.types';
+import {
+  AI_COMPLETION_PORT_TOKEN,
+  AiModule as CoreAiModule,
+  AiProviderValues,
+  type AiProvider,
+} from '@openlinker/core/ai';
 import { Logger } from '@openlinker/shared/logging';
 import { FakeAiCompletionAdapter } from './infrastructure/adapters/fake-ai-completion.adapter';
 import { VercelAiCompletionAdapter } from './infrastructure/adapters/vercel-ai-completion.adapter';
@@ -40,7 +53,7 @@ export class AiIntegrationModule {
       logger.log(`AiIntegrationModule using provider: ${provider}`);
     }
 
-    const providers: Provider[] =
+    const completionAdapterProviders: Provider[] =
       provider === 'fake'
         ? [
             FakeAiCompletionAdapter,
@@ -53,8 +66,14 @@ export class AiIntegrationModule {
 
     return {
       module: AiIntegrationModule,
-      imports: [ConfigModule],
-      providers: [ConfigService, ...providers],
+      imports: [ConfigModule, CoreAiModule],
+      providers: [ConfigService, ...completionAdapterProviders],
+      // Only AI_COMPLETION_PORT_TOKEN is owned by this module. Consumers
+      // that need AI_PROVIDER_CREDENTIALS_PORT_TOKEN or
+      // AI_PROVIDER_SETTINGS_SERVICE_TOKEN (e.g. AiApiModule) should import
+      // CoreAiModule directly — re-exporting tokens from an imported
+      // module is not supported by NestJS without re-exporting the module
+      // itself, and the direct import is clearer anyway.
       exports: [AI_COMPLETION_PORT_TOKEN],
     };
   }

--- a/libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.spec.ts
+++ b/libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.spec.ts
@@ -17,6 +17,14 @@ import { AiRateLimitError } from '@openlinker/core/ai/domain/exceptions/ai-rate-
 import { AiTimeoutError } from '@openlinker/core/ai/domain/exceptions/ai-timeout.exception';
 import { AiCompletionError } from '@openlinker/core/ai/domain/exceptions/ai-completion.exception';
 import { AiInvalidResponseError } from '@openlinker/core/ai/domain/exceptions/ai-invalid-response.exception';
+import { AiProviderKeyMissingError } from '@openlinker/core/ai/domain/exceptions/ai-provider-key-missing.exception';
+import type { AiProviderCredentialsPort } from '@openlinker/core/ai/domain/ports/ai-provider-credentials.port';
+
+const buildCredentialsPort = (apiKey = 'test-api-key'): jest.Mocked<AiProviderCredentialsPort> => ({
+  getApiKey: jest.fn().mockResolvedValue(apiKey),
+  describe: jest.fn(),
+  invalidate: jest.fn(),
+});
 
 /**
  * Subset of args we care about asserting in the test. Mirrors the keys passed
@@ -71,7 +79,11 @@ describe('VercelAiCompletionAdapter', () => {
   describe('complete', () => {
     it('should forward model, system, prompt, and cache control to generateText when cacheSystemPrompt is true (default)', async () => {
       const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       await adapter.complete({
         systemPrompt: 'system instructions',
@@ -96,7 +108,11 @@ describe('VercelAiCompletionAdapter', () => {
 
     it('should pass the system prompt as a plain string when cacheSystemPrompt is false', async () => {
       const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       await adapter.complete({
         systemPrompt: 'sys',
@@ -109,7 +125,11 @@ describe('VercelAiCompletionAdapter', () => {
 
     it('should honour per-call model and maxOutputTokens overrides', async () => {
       const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       await adapter.complete({
         systemPrompt: 's',
@@ -126,7 +146,11 @@ describe('VercelAiCompletionAdapter', () => {
 
     it('should report the requested model in modelUsed', async () => {
       const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       const result = await adapter.complete({
         systemPrompt: 's',
@@ -141,7 +165,11 @@ describe('VercelAiCompletionAdapter', () => {
       const generateTextFn = jest
         .fn()
         .mockResolvedValue(buildSuccessResult({ cacheReadTokens: 42, cachedInputTokensDeprecated: 7 }));
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       const result = await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
 
@@ -152,7 +180,11 @@ describe('VercelAiCompletionAdapter', () => {
       const generateTextFn = jest
         .fn()
         .mockResolvedValue(buildSuccessResult({ cachedInputTokensDeprecated: 11 }));
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       const result = await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
 
@@ -161,7 +193,11 @@ describe('VercelAiCompletionAdapter', () => {
 
     it('should default cachedInputTokens to 0 when both signals are absent', async () => {
       const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       const result = await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
 
@@ -171,7 +207,11 @@ describe('VercelAiCompletionAdapter', () => {
     it('should map abort/timeout-shaped errors to AiTimeoutError', async () => {
       const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' });
       const generateTextFn = jest.fn().mockRejectedValue(abortError);
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
         AiTimeoutError,
@@ -181,7 +221,11 @@ describe('VercelAiCompletionAdapter', () => {
     it('should map a 429 statusCode to AiRateLimitError', async () => {
       const rateLimitError = Object.assign(new Error('rate limited'), { statusCode: 429 });
       const generateTextFn = jest.fn().mockRejectedValue(rateLimitError);
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
         AiRateLimitError,
@@ -190,7 +234,11 @@ describe('VercelAiCompletionAdapter', () => {
 
     it('should map an unknown failure to AiCompletionError', async () => {
       const generateTextFn = jest.fn().mockRejectedValue(new Error('boom'));
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
         AiCompletionError,
@@ -199,7 +247,11 @@ describe('VercelAiCompletionAdapter', () => {
 
     it('should throw AiInvalidResponseError when the provider returns empty text', async () => {
       const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult({ text: '' }));
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
         AiInvalidResponseError,
@@ -208,7 +260,11 @@ describe('VercelAiCompletionAdapter', () => {
 
     it('should report a non-negative latency', async () => {
       const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
-      const adapter = new VercelAiCompletionAdapter(buildConfigService(), generateTextFn);
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        buildCredentialsPort(),
+        generateTextFn,
+      );
 
       const result = await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
 
@@ -219,6 +275,7 @@ describe('VercelAiCompletionAdapter', () => {
       const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
       const adapter = new VercelAiCompletionAdapter(
         buildConfigService({ OL_AI_DEFAULT_MAX_TOKENS: '512', OL_AI_TIMEOUT_MS: '15000' }),
+        buildCredentialsPort(),
         generateTextFn,
       );
 
@@ -227,6 +284,40 @@ describe('VercelAiCompletionAdapter', () => {
       const args = captureFirstCallArgs(generateTextFn);
       expect(args.maxOutputTokens).toBe(512);
       expect(args.timeout).toBe(15000);
+    });
+
+    it('should resolve the API key through the credentials port on every call', async () => {
+      const generateTextFn = jest.fn().mockResolvedValue(buildSuccessResult());
+      const credentials = buildCredentialsPort('resolved-key-abc');
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        credentials,
+        generateTextFn,
+      );
+
+      await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
+      await adapter.complete({ systemPrompt: 's', userPrompt: 'u' });
+
+      // Per-call resolution — port-level cache is the seam for amortising cost.
+      expect(credentials.getApiKey).toHaveBeenCalledTimes(2);
+    });
+
+    it('should propagate AiProviderKeyMissingError unchanged so callers can distinguish "no key" from generic completion failures', async () => {
+      const generateTextFn = jest.fn();
+      const credentials = buildCredentialsPort();
+      credentials.getApiKey.mockRejectedValueOnce(
+        new AiProviderKeyMissingError('No API key configured for AI provider'),
+      );
+      const adapter = new VercelAiCompletionAdapter(
+        buildConfigService(),
+        credentials,
+        generateTextFn,
+      );
+
+      await expect(adapter.complete({ systemPrompt: 's', userPrompt: 'u' })).rejects.toBeInstanceOf(
+        AiProviderKeyMissingError,
+      );
+      expect(generateTextFn).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.ts
+++ b/libs/integrations/ai/src/infrastructure/adapters/vercel-ai-completion.adapter.ts
@@ -5,6 +5,12 @@
  * `@ai-sdk/anthropic` provider. Selected by AiIntegrationModule when
  * `OL_AI_PROVIDER=anthropic` (the default).
  *
+ * The API key is resolved per-request through `AiProviderCredentialsPort`
+ * (DB-backed encrypted credential row → env-var fallback). The provider
+ * factory `createAnthropic({ apiKey })` is instantiated inside `complete()`
+ * so admin key rotations take effect without a process restart — the port's
+ * own 60 s cache keeps the hot path cheap.
+ *
  * Anthropic prompt-cache note: when `cacheSystemPrompt` is true (default), this
  * adapter attaches `providerOptions.anthropic.cacheControl = { type: 'ephemeral' }`
  * to the system message. The Anthropic API silently no-ops cache_control when
@@ -23,15 +29,19 @@
 import { Inject, Injectable, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { generateText } from 'ai';
-import { anthropic } from '@ai-sdk/anthropic';
+import { createAnthropic } from '@ai-sdk/anthropic';
 import { Logger } from '@openlinker/shared/logging';
+import { AI_PROVIDER_CREDENTIALS_PORT_TOKEN } from '@openlinker/core/ai/ai.tokens';
 import type { AiCompletionPort } from '@openlinker/core/ai/domain/ports/ai-completion.port';
+import type { AiProviderCredentialsPort } from '@openlinker/core/ai/domain/ports/ai-provider-credentials.port';
 import type {
   AiCompletionInput,
   AiCompletionResult,
 } from '@openlinker/core/ai/domain/types/ai-completion.types';
 import { AiCompletionError } from '@openlinker/core/ai/domain/exceptions/ai-completion.exception';
 import { AiInvalidResponseError } from '@openlinker/core/ai/domain/exceptions/ai-invalid-response.exception';
+import { AiProviderKeyMissingError } from '@openlinker/core/ai/domain/exceptions/ai-provider-key-missing.exception';
+import { AiProviderSettingsNotApplicableError } from '@openlinker/core/ai/domain/exceptions/ai-provider-settings-not-applicable.exception';
 import { AiRateLimitError } from '@openlinker/core/ai/domain/exceptions/ai-rate-limit.exception';
 import { AiTimeoutError } from '@openlinker/core/ai/domain/exceptions/ai-timeout.exception';
 
@@ -59,6 +69,8 @@ export class VercelAiCompletionAdapter implements AiCompletionPort {
 
   constructor(
     private readonly configService: ConfigService,
+    @Inject(AI_PROVIDER_CREDENTIALS_PORT_TOKEN)
+    private readonly credentials: AiProviderCredentialsPort,
     @Optional()
     @Inject(VERCEL_GENERATE_TEXT_FN_TOKEN)
     generateTextOverride?: VercelGenerateTextFn,
@@ -104,8 +116,14 @@ export class VercelAiCompletionAdapter implements AiCompletionPort {
 
     let result: Awaited<ReturnType<typeof generateText>>;
     try {
+      // Resolve the API key per-request so admin rotations apply without a
+      // process restart. The credentials port has its own 60 s cache, so the
+      // hot path stays cheap; an `AiProviderKeyMissingError` here surfaces
+      // straight to the caller.
+      const apiKey = await this.credentials.getApiKey();
+      const anthropicProvider = createAnthropic({ apiKey });
       result = await this.generateTextFn({
-        model: anthropic(model),
+        model: anthropicProvider(model),
         system: systemMessage,
         prompt: input.userPrompt,
         maxOutputTokens,
@@ -114,6 +132,15 @@ export class VercelAiCompletionAdapter implements AiCompletionPort {
         maxRetries: 0,
       });
     } catch (error: unknown) {
+      // Surface credential-config errors with their original type so callers
+      // can distinguish "no key configured" / "wrong active provider" from
+      // transient SDK failures by `instanceof`.
+      if (
+        error instanceof AiProviderKeyMissingError ||
+        error instanceof AiProviderSettingsNotApplicableError
+      ) {
+        throw error;
+      }
       throw this.mapProviderError(error, requestId);
     }
 


### PR DESCRIPTION
## Summary

Move the Anthropic API key out of `process.env.ANTHROPIC_API_KEY` into the existing encrypted `integration_credentials` table so admins can paste / rotate / clear it via REST without a redeploy. Mirrors the webhook-secret precedent: same `CryptoService`, same repository, same one-shot env-fallback deprecation warning.

- **`libs/core/src/ai`** — new `AiProviderCredentialsPort` (read), `CredentialsAiProviderAdapter` (DB → env → throw resolution with a 60s cache), `AiProviderSettingsService` (write side), and two domain exceptions. All wired in core `AiModule` alongside the existing prompt-template providers.
- **`libs/integrations/ai`** — `VercelAiCompletionAdapter` switches from `anthropic(model)` to `createAnthropic({ apiKey })(model)`, resolving the key per-request through the credentials port. `AiProviderKeyMissingError` propagates to callers without being wrapped, so consumers can distinguish "no key configured" from generic completion failures.
- **`apps/api/src/ai`** — `AiProviderSettingsController` exposes admin-only `GET / PUT / DELETE /ai-provider-settings`. Path uses the top-level convention (`@Controller('ai-provider-settings')`) matching `prompt-templates` / `connections`. `Cache-Control: no-store` everywhere; the response DTO has no `apiKey` field; PUT/DELETE return 400 when `OL_AI_PROVIDER=fake`.
- **`apps/api/.env.example`** — documents `OL_AI_PROVIDER` and marks `ANTHROPIC_API_KEY` as a deprecated dev-only fallback that the admin UI overrides.

Closes #398

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 1173 unit tests pass (12 new adapter tests + 9 service tests + 2 new Vercel adapter tests)
- [x] `pnpm test:integration` — 125 tests pass across 20 suites; new `ai-provider-settings.int-spec.ts` (9 tests) covers HTTP behaviour in `fake` mode, the `@Roles('admin')` guard, and a real Postgres encrypt → store → decrypt round-trip
- [x] `pnpm --filter @openlinker/api migration:show` — no new migrations needed
- [ ] Manual: with `OL_AI_PROVIDER=anthropic` + a real `ANTHROPIC_API_KEY` in env, verify a `/products/:id/content/suggest` call still succeeds (env fallback path)
- [ ] Manual: `PUT /ai-provider-settings { apiKey: "sk-ant-..." }` then `GET /ai-provider-settings` reports `source: "db"`
- [ ] Manual: `DELETE /ai-provider-settings` reverts the GET response to `source: "env"` (or `"none"`)

## Architecture notes

- `aiProviderCredentialsRef` lives in the port file (`domain/ports/`), so both the application service and the infrastructure adapter import it from domain — matches the webhook-secret precedent and respects the `infrastructure → domain` dependency rule.
- DI registration for the new providers lives in core `AiModule` (same package as the concrete classes) so `core/ai/index.ts` doesn't have to expose internals. `AiIntegrationModule` (in `libs/integrations/ai/`) only handles completion-adapter selection and imports `CoreAiModule` so the Vercel adapter can resolve `AI_PROVIDER_CREDENTIALS_PORT_TOKEN`.
- `AiApiModule` imports `CoreAiModule` directly to resolve `AI_PROVIDER_SETTINGS_SERVICE_TOKEN` for the new admin controller; no need to route through `IntegrationsModule`.

## Follow-up

- #399 (FE) — admin UI under `/ai/provider-settings`. Blocked on this PR; will be picked up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)