### PR TITLE
feat(sync): separate orchestration status from business outcome on sync jobs

### DIFF
--- a/apps/api/src/migrations/1790000000003-add-outcome-to-sync-jobs.ts
+++ b/apps/api/src/migrations/1790000000003-add-outcome-to-sync-jobs.ts
@@ -1,0 +1,23 @@
+/**
+ * Add Outcome to Sync Jobs
+ *
+ * Issue #400 (Plan B for #391). Adds a nullable `outcome` column to
+ * `sync_jobs` to surface the *business* result of a job (`'ok' |
+ * 'business_failure'`) distinctly from the *orchestration* result
+ * (`status`). NULL by default — only set on the succeeded path by
+ * `SyncJobRepositoryPort.markSucceeded(id, outcome)`. No backfill;
+ * historical rows keep NULL outcome (status tells the story for them).
+ *
+ * Reversible: down() drops the column.
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOutcomeToSyncJobs1790000000003 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sync_jobs" ADD "outcome" character varying`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "sync_jobs" DROP COLUMN "outcome"`);
+  }
+}

--- a/apps/api/src/sync/http/dto/list-sync-jobs-query.dto.ts
+++ b/apps/api/src/sync/http/dto/list-sync-jobs-query.dto.ts
@@ -8,8 +8,8 @@
 import { IsEnum, IsOptional, IsUUID, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { JobStatusValues, JobTypeValues } from '@openlinker/core/sync';
-import type { JobStatus, JobType } from '@openlinker/core/sync';
+import { JobOutcomeValues, JobStatusValues, JobTypeValues } from '@openlinker/core/sync';
+import type { JobOutcome, JobStatus, JobType } from '@openlinker/core/sync';
 
 export class ListSyncJobsQueryDto {
   @ApiPropertyOptional({ enum: JobStatusValues, description: 'Filter by job status' })
@@ -26,6 +26,15 @@ export class ListSyncJobsQueryDto {
   @IsOptional()
   @IsEnum(JobTypeValues)
   jobType?: JobType;
+
+  @ApiPropertyOptional({
+    enum: JobOutcomeValues,
+    description:
+      'Filter by business outcome (only meaningful for succeeded jobs). `business_failure` surfaces succeeded jobs whose underlying business operation was rejected terminally.',
+  })
+  @IsOptional()
+  @IsEnum(JobOutcomeValues)
+  outcome?: JobOutcome;
 
   @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
   @IsOptional()

--- a/apps/api/src/sync/http/dto/sync-job-response.dto.ts
+++ b/apps/api/src/sync/http/dto/sync-job-response.dto.ts
@@ -7,8 +7,8 @@
  * @module apps/api/src/sync/http/dto
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { JobStatusValues, JobTypeValues } from '@openlinker/core/sync';
-import type { JobStatus, JobType } from '@openlinker/core/sync';
+import { JobOutcomeValues, JobStatusValues, JobTypeValues } from '@openlinker/core/sync';
+import type { JobOutcome, JobStatus, JobType } from '@openlinker/core/sync';
 
 export class SyncJobResponseDto {
   @ApiProperty({ description: 'Job UUID' })
@@ -22,6 +22,14 @@ export class SyncJobResponseDto {
 
   @ApiProperty({ enum: JobStatusValues, description: 'Current job status' })
   status!: JobStatus;
+
+  @ApiPropertyOptional({
+    enum: JobOutcomeValues,
+    nullable: true,
+    description:
+      'Business outcome of the job (only set on the succeeded path). `ok` = business operation succeeded; `business_failure` = orchestration ran cleanly but the business operation was rejected terminally (e.g. marketplace validation failed). `null` for queued / running / dead jobs and historical rows pre-dating issue #400.',
+  })
+  outcome!: JobOutcome | null;
 
   @ApiProperty({ description: 'Number of execution attempts so far' })
   attempts!: number;

--- a/apps/api/src/sync/http/sync.controller.ts
+++ b/apps/api/src/sync/http/sync.controller.ts
@@ -126,15 +126,16 @@ export class SyncController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'List sync jobs',
-    description: 'Returns a paginated list of sync jobs. Supports filtering by status, connectionId, and jobType.',
+    description:
+      'Returns a paginated list of sync jobs. Supports filtering by status, outcome, connectionId, and jobType.',
   })
   @ApiResponse({ status: 200, description: 'Paginated job list', type: PaginatedSyncJobsResponseDto })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async listJobs(@Query() query: ListSyncJobsQueryDto): Promise<PaginatedSyncJobsResponseDto> {
-    const { status, connectionId, jobType, limit = 20, offset = 0 } = query;
+    const { status, connectionId, jobType, outcome, limit = 20, offset = 0 } = query;
 
     const { items, total } = await this.syncJobRepository.findMany(
-      { status, connectionId, jobType },
+      { status, connectionId, jobType, outcome },
       { limit, offset },
     );
 
@@ -245,6 +246,7 @@ export class SyncController {
       jobType: job.jobType,
       connectionId: job.connectionId,
       status: job.status,
+      outcome: job.outcome ?? null,
       attempts: job.attempts,
       maxAttempts: job.maxAttempts,
       nextRunAt: job.nextRunAt instanceof Date ? job.nextRunAt.toISOString() : job.nextRunAt,

--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -77,6 +77,16 @@ export async function startHarness(): Promise<void> {
   // Regression guard: test/integration/bootstrap-admin-disabled.int-spec.ts
   process.env.OL_BOOTSTRAP_ADMIN_ENABLED = 'false';
 
+  // Force the AiIntegrationModule into fake mode for every integration test.
+  // The fake adapter is wired by `OL_AI_PROVIDER=fake` and avoids real
+  // outbound LLM calls. `ai-provider-settings.int-spec.ts` also asserts the
+  // "fake mode" branch of `/ai-provider-settings` (PUT/DELETE return 400,
+  // GET returns `provider: 'fake'`); without this, those expectations fail
+  // on any environment that doesn't already set the var (notably CI).
+  // See #402's test docstring claim that the harness "boots with
+  // OL_AI_PROVIDER=fake" — this is the line that makes that claim true.
+  process.env.OL_AI_PROVIDER = 'fake';
+
   // Store containers on globalThis for teardown
   globalThis.__API_TEST_HARNESS__ = { postgres, redis };
 }

--- a/apps/api/test/integration/sync-jobs-read.int-spec.ts
+++ b/apps/api/test/integration/sync-jobs-read.int-spec.ts
@@ -164,6 +164,86 @@ describe('Sync Jobs Read API Integration', () => {
       const http = harness.getHttp();
       await http.get('/sync/jobs').expect(401);
     });
+
+    // Issue #400 — Plan B for #391: outcome field on sync_jobs.
+    describe('outcome field (issue #400)', () => {
+      it('should expose outcome on the response DTO', async () => {
+        const http = harness.getHttp();
+        const dataSource = harness.getDataSource();
+        const token = await loginAsAdmin(http, dataSource);
+
+        await createTestSyncJob(dataSource, {
+          jobType: 'marketplace.offer.create',
+          status: 'succeeded',
+          outcome: 'business_failure',
+        });
+
+        const response = await http
+          .get('/sync/jobs')
+          .set('Authorization', `Bearer ${token}`)
+          .expect(200);
+
+        expect(response.body.items).toHaveLength(1);
+        expect(response.body.items[0].outcome).toBe('business_failure');
+      });
+
+      it('should return null outcome for queued / running / dead jobs', async () => {
+        const http = harness.getHttp();
+        const dataSource = harness.getDataSource();
+        const token = await loginAsAdmin(http, dataSource);
+
+        await createTestSyncJob(dataSource, { status: 'queued' });
+        await createTestSyncJob(dataSource, { status: 'dead' });
+
+        const response = await http
+          .get('/sync/jobs')
+          .set('Authorization', `Bearer ${token}`)
+          .expect(200);
+
+        expect(response.body.total).toBe(2);
+        for (const item of response.body.items) {
+          expect(item.outcome).toBeNull();
+        }
+      });
+
+      it('should filter by outcome=business_failure', async () => {
+        const http = harness.getHttp();
+        const dataSource = harness.getDataSource();
+        const token = await loginAsAdmin(http, dataSource);
+
+        const failedJob = await createTestSyncJob(dataSource, {
+          jobType: 'marketplace.offer.create',
+          status: 'succeeded',
+          outcome: 'business_failure',
+        });
+        await createTestSyncJob(dataSource, {
+          jobType: 'marketplace.offer.create',
+          status: 'succeeded',
+          outcome: 'ok',
+        });
+        await createTestSyncJob(dataSource, { status: 'queued', outcome: null });
+
+        const response = await http
+          .get('/sync/jobs?outcome=business_failure')
+          .set('Authorization', `Bearer ${token}`)
+          .expect(200);
+
+        expect(response.body.total).toBe(1);
+        expect(response.body.items[0].id).toBe(failedJob.id);
+        expect(response.body.items[0].outcome).toBe('business_failure');
+      });
+
+      it('should reject invalid outcome filter values', async () => {
+        const http = harness.getHttp();
+        const dataSource = harness.getDataSource();
+        const token = await loginAsAdmin(http, dataSource);
+
+        await http
+          .get('/sync/jobs?outcome=garbage')
+          .set('Authorization', `Bearer ${token}`)
+          .expect(400);
+      });
+    });
   });
 
   describe('GET /sync/jobs/:id', () => {

--- a/apps/web/src/features/sync-jobs/api/sync-jobs.types.ts
+++ b/apps/web/src/features/sync-jobs/api/sync-jobs.types.ts
@@ -22,6 +22,21 @@ export const SYNC_JOBS_MAX_LIMIT = 100;
 export const JOB_STATUS_VALUES = ['queued', 'running', 'succeeded', 'dead'] as const;
 export type JobStatus = (typeof JOB_STATUS_VALUES)[number];
 
+/**
+ * Business outcome of a successfully-orchestrated job (issue #400 — Plan B
+ * for #391). Distinct from `status`, which is the orchestration result.
+ *
+ * - `'ok'`: business operation succeeded.
+ * - `'business_failure'`: orchestration ran cleanly but the business
+ *   operation was rejected terminally (e.g. marketplace validation failed
+ *   on `marketplace.offer.create`).
+ *
+ * `null` for queued / running / dead jobs and historical rows pre-dating
+ * the column.
+ */
+export const JOB_OUTCOME_VALUES = ['ok', 'business_failure'] as const;
+export type JobOutcome = (typeof JOB_OUTCOME_VALUES)[number];
+
 export const JOB_TYPE_VALUES = [
   'marketplace.orders.poll',
   'marketplace.order.sync',
@@ -43,6 +58,7 @@ export interface SyncJob {
   jobType: string;
   connectionId: string;
   status: JobStatus;
+  outcome: JobOutcome | null;
   attempts: number;
   maxAttempts: number;
   nextRunAt: string;
@@ -59,6 +75,7 @@ export interface SyncJobFilters {
   status?: JobStatus;
   connectionId?: string;
   jobType?: JobType;
+  outcome?: JobOutcome;
 }
 
 export interface SyncJobPagination {

--- a/apps/web/src/features/sync-jobs/api/sync.api.ts
+++ b/apps/web/src/features/sync-jobs/api/sync.api.ts
@@ -66,6 +66,7 @@ function buildQuery(filters?: SyncJobFilters, pagination?: SyncJobPagination): s
   if (filters?.status) params.set('status', filters.status);
   if (filters?.connectionId) params.set('connectionId', filters.connectionId);
   if (filters?.jobType) params.set('jobType', filters.jobType);
+  if (filters?.outcome) params.set('outcome', filters.outcome);
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
   const qs = params.toString();

--- a/apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.test.tsx
+++ b/apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * SyncJobStatusBadge Tests
+ *
+ * Verifies the (status, outcome) → tone derivation introduced in issue #400
+ * (Plan B for #391). The whole point of the change is that `succeeded +
+ * business_failure` reads as a warning, not as success — these tests guard
+ * the tone map so the regression can't slip back in.
+ *
+ * @module apps/web/src/features/sync-jobs/components
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { SyncJobStatusBadge } from './SyncJobStatusBadge';
+
+describe('SyncJobStatusBadge', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders queued with info tone', () => {
+    render(<SyncJobStatusBadge status="queued" outcome={null} />);
+    const badge = screen.getByText('queued').closest('.status-badge');
+    expect(badge).toHaveClass('status-badge--info');
+  });
+
+  it('renders running with review tone', () => {
+    render(<SyncJobStatusBadge status="running" outcome={null} />);
+    const badge = screen.getByText('running').closest('.status-badge');
+    expect(badge).toHaveClass('status-badge--review');
+  });
+
+  it('renders succeeded + outcome=ok with success tone', () => {
+    render(<SyncJobStatusBadge status="succeeded" outcome="ok" />);
+    const badge = screen.getByText('succeeded').closest('.status-badge');
+    expect(badge).toHaveClass('status-badge--success');
+  });
+
+  it('renders succeeded + outcome=business_failure with warning tone (label stays "succeeded")', () => {
+    render(<SyncJobStatusBadge status="succeeded" outcome="business_failure" />);
+    // Two "succeeded" labels would be in the DOM if cleanup isn't running.
+    // afterEach(cleanup) above ensures we read this render's badge only.
+    const badge = screen.getByText('succeeded').closest('.status-badge');
+    expect(badge).toHaveClass('status-badge--warning');
+    expect(badge).not.toHaveClass('status-badge--success');
+  });
+
+  it('renders succeeded + outcome=null (legacy row) with success tone', () => {
+    // Historical sync_jobs rows pre-dating issue #400 carry NULL outcome —
+    // they were marked succeeded under the old contract and shouldn't switch
+    // to warning retroactively just because outcome is unknown.
+    render(<SyncJobStatusBadge status="succeeded" outcome={null} />);
+    const badge = screen.getByText('succeeded').closest('.status-badge');
+    expect(badge).toHaveClass('status-badge--success');
+  });
+
+  it('renders dead with error tone', () => {
+    render(<SyncJobStatusBadge status="dead" outcome={null} />);
+    const badge = screen.getByText('dead').closest('.status-badge');
+    expect(badge).toHaveClass('status-badge--error');
+  });
+});

--- a/apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.tsx
+++ b/apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.tsx
@@ -1,17 +1,27 @@
 /**
  * Sync Job Status Badge
  *
- * Renders a semantic status badge for a sync job status value.
- * Tone mapping mirrors the job lifecycle: queued → info, running → review,
- * succeeded → success, dead → error.
+ * Renders a semantic status badge for a sync job. Tone is derived from the
+ * `(status, outcome)` pair so that succeeded-with-business-failure (issue
+ * #400 — Plan B for #391) reads as warning rather than success — operators
+ * scanning the list shouldn't see green for jobs whose underlying business
+ * operation was rejected terminally.
+ *
+ * Mapping:
+ * - succeeded + outcome=ok → success (green)
+ * - succeeded + outcome=business_failure → warning (yellow)
+ * - succeeded + outcome=null (legacy / pre-#400 row) → success
+ * - queued → info
+ * - running → review
+ * - dead → error
  *
  * @module apps/web/src/features/sync-jobs/components
  */
 import type { ReactElement } from 'react';
 import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
-import type { JobStatus } from '../api/sync-jobs.types';
+import type { JobOutcome, JobStatus } from '../api/sync-jobs.types';
 
-const STATUS_TONE: Record<JobStatus, StatusBadgeTone> = {
+const BASE_TONE: Record<JobStatus, StatusBadgeTone> = {
   queued: 'info',
   running: 'review',
   succeeded: 'success',
@@ -20,10 +30,21 @@ const STATUS_TONE: Record<JobStatus, StatusBadgeTone> = {
 
 interface SyncJobStatusBadgeProps {
   status: string;
+  outcome?: JobOutcome | null;
 }
 
-export function SyncJobStatusBadge({ status }: SyncJobStatusBadgeProps): ReactElement {
-  const tone: StatusBadgeTone = STATUS_TONE[status as JobStatus] ?? 'neutral';
+function deriveTone(status: string, outcome: JobOutcome | null | undefined): StatusBadgeTone {
+  if (status === 'succeeded' && outcome === 'business_failure') {
+    return 'warning';
+  }
+  return BASE_TONE[status as JobStatus] ?? 'neutral';
+}
+
+export function SyncJobStatusBadge({ status, outcome = null }: SyncJobStatusBadgeProps): ReactElement {
+  // Label stays the literal status word — the warning tone alone carries the
+  // succeeded-with-business-failure signal. The outcome chip on the detail
+  // page (Plan A's OfferCreationTracker) provides the explicit narrative.
+  const tone = deriveTone(status, outcome);
   return (
     <StatusBadge tone={tone} withDot>
       {status}

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.test.tsx
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-job-query.test.tsx
@@ -27,6 +27,7 @@ const mockJob: SyncJob = {
   jobType: 'marketplace.orders.poll',
   connectionId: 'conn-1',
   status: 'succeeded',
+  outcome: 'ok',
   attempts: 1,
   maxAttempts: 10,
   nextRunAt: '2026-01-01T00:00:00.000Z',

--- a/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.test.tsx
+++ b/apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.test.tsx
@@ -29,6 +29,7 @@ const mockResult: PaginatedSyncJobs = {
       jobType: 'marketplace.orders.poll',
       connectionId: 'conn-1',
       status: 'queued',
+      outcome: null,
       attempts: 0,
       maxAttempts: 10,
       nextRunAt: '2026-01-01T00:00:00.000Z',

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -22,6 +22,7 @@ function makeSyncJob(overrides: Partial<SyncJob> = {}): SyncJob {
     jobType: 'marketplace.orders.poll',
     connectionId: 'conn_1',
     status: 'succeeded',
+    outcome: 'ok',
     attempts: 1,
     maxAttempts: 3,
     nextRunAt: '2026-04-11T00:00:00.000Z',

--- a/apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx
@@ -201,7 +201,7 @@ export function PromptTemplateDetailPage(): ReactElement {
     );
   }
 
-  if (template === undefined) {
+  if (!template) {
     return (
       <PageLayout eyebrow="Settings" title="Prompt template">
         <EmptyState title="Template not found" message="The template may have been deleted." />

--- a/apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx
@@ -80,7 +80,7 @@ export function PromptTemplateDetailPage(): ReactElement {
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
   useEffect(() => {
-    if (template === undefined) return;
+    if (!template) return;
     setSystemPrompt(template.systemPrompt);
     setUserPromptTemplate(template.userPromptTemplate);
     setVariables(template.variables);
@@ -88,7 +88,7 @@ export function PromptTemplateDetailPage(): ReactElement {
 
   const canEdit = template?.state === 'draft' && !isMobile;
   const isDirty = useMemo(() => {
-    if (template === undefined) return false;
+    if (!template) return false;
     return (
       systemPrompt !== template.systemPrompt ||
       userPromptTemplate !== template.userPromptTemplate ||

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
@@ -11,6 +11,7 @@ const sampleJob: SyncJob = {
   jobType: 'marketplace.orders.poll',
   connectionId: 'conn_allegro_1',
   status: 'succeeded',
+  outcome: 'ok',
   attempts: 1,
   maxAttempts: 3,
   nextRunAt: '2026-01-15T10:05:00.000Z',

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -33,7 +33,11 @@ function extractOfferCreationRecordId(job: SyncJob): string | null {
 
 function buildSyncJobItems(job: SyncJob): KeyValueItem[] {
   const items: KeyValueItem[] = [
-    { id: 'status', label: 'Status', value: <SyncJobStatusBadge status={job.status} /> },
+    {
+      id: 'status',
+      label: 'Status',
+      value: <SyncJobStatusBadge status={job.status} outcome={job.outcome} />,
+    },
     { id: 'jobId', label: 'Job ID', value: job.id, mono: true },
     {
       id: 'connection',

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.test.tsx
@@ -34,6 +34,7 @@ const sampleJobs: PaginatedSyncJobs = {
       jobType: 'marketplace.orders.poll',
       connectionId: 'conn_allegro_1',
       status: 'succeeded',
+      outcome: 'ok',
       attempts: 1,
       maxAttempts: 3,
       nextRunAt: '2026-01-15T10:05:00.000Z',

--- a/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-jobs-page.tsx
@@ -12,8 +12,15 @@ import { SyncJobStatusBadge } from '../../features/sync-jobs/components/SyncJobS
 import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
-import type { SyncJob, SyncJobFilters, JobStatus, JobType } from '../../features/sync-jobs/api/sync-jobs.types';
+import type {
+  SyncJob,
+  SyncJobFilters,
+  JobOutcome,
+  JobStatus,
+  JobType,
+} from '../../features/sync-jobs/api/sync-jobs.types';
 import {
+  JOB_OUTCOME_VALUES,
   JOB_STATUS_VALUES,
   JOB_TYPE_VALUES,
   SYNC_JOBS_MAX_LIMIT,
@@ -26,7 +33,7 @@ const COLUMNS: DataTableColumn<SyncJob>[] = [
   {
     id: 'status',
     header: 'Status',
-    cell: (job) => <SyncJobStatusBadge status={job.status} />,
+    cell: (job) => <SyncJobStatusBadge status={job.status} outcome={job.outcome} />,
     accessor: (job) => job.status,
     sortable: true,
   },
@@ -87,9 +94,10 @@ export function SyncJobsPage(): ReactElement {
   const status = (searchParams.get('status') as JobStatus | null) ?? undefined;
   const jobType = (searchParams.get('jobType') as JobType | null) ?? undefined;
   const connectionId = searchParams.get('connectionId') ?? undefined;
+  const outcome = (searchParams.get('outcome') as JobOutcome | null) ?? undefined;
   const offset = Number(searchParams.get('offset') ?? '0');
 
-  const filters: SyncJobFilters = { status, jobType, connectionId };
+  const filters: SyncJobFilters = { status, jobType, connectionId, outcome };
   const pagination = { limit: PAGE_SIZE, offset };
 
   const query = useSyncJobsQuery(filters, pagination);
@@ -127,12 +135,13 @@ export function SyncJobsPage(): ReactElement {
       next.delete('status');
       next.delete('jobType');
       next.delete('connectionId');
+      next.delete('outcome');
       next.delete('offset');
       return next;
     });
   }
 
-  const filtersActive = Boolean(status || jobType || connectionId);
+  const filtersActive = Boolean(status || jobType || connectionId || outcome);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
@@ -167,6 +176,19 @@ export function SyncJobsPage(): ReactElement {
           {JOB_TYPE_VALUES.map((t) => (
             <option key={t} value={t}>
               {t}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          aria-label="Filter by outcome"
+          value={outcome ?? ''}
+          onChange={(e) => { setFilter('outcome', e.target.value); }}
+        >
+          <option value="">All outcomes</option>
+          {JOB_OUTCOME_VALUES.map((o) => (
+            <option key={o} value={o}>
+              {o === 'business_failure' ? 'business failure' : o}
             </option>
           ))}
         </Select>
@@ -232,7 +254,7 @@ export function SyncJobsPage(): ReactElement {
                   showId={false}
                 />
               ),
-              meta: (job) => <SyncJobStatusBadge status={job.status} />,
+              meta: (job) => <SyncJobStatusBadge status={job.status} outcome={job.outcome} />,
             }}
           />
 

--- a/apps/web/src/shared/ui/toast-provider.tsx
+++ b/apps/web/src/shared/ui/toast-provider.tsx
@@ -32,15 +32,13 @@ interface ToastContextValue {
 
 const ToastContext = createContext<ToastContextValue | null>(null);
 
-// In vitest jsdom runs, Radix's auto-dismiss setTimeout can outlive the test
-// file and fire after the worker tears jsdom down, leaving an unhandled
-// "ReferenceError: window is not defined" that fails CI even when all
-// assertions pass. Under `MODE === 'test'` we cap duration at the max int32
-// (~24.8 days), the largest value Node's setTimeout accepts without
-// silently coercing to 1ms — this prevents the timer from firing during
-// the test run while keeping production/dev behaviour at the configured
-// `durationMs` default. Using `Number.POSITIVE_INFINITY` here is unsafe
-// because Node clamps Infinity to 1ms and the timer fires immediately.
+// In vitest happy-dom runs, Radix's auto-dismiss setTimeout can outlive the
+// test if the toast is still mounted at teardown. Test env caps duration at
+// the max int32 (~24.8 days) — the largest value Node's setTimeout accepts
+// without coercion. Combined with `afterEach(cleanup)` in `test/setup.ts`,
+// this guarantees neither the duration timer nor Radix's announce timer
+// (`@radix-ui/react-toast/dist/index.mjs:477`) leaks past a test file.
+// Production / dev behaviour is unchanged at the configured `durationMs`.
 const IS_TEST_ENV = import.meta.env.MODE === 'test';
 const TEST_ENV_DURATION_MS = 2_147_483_647;
 

--- a/apps/web/src/shared/ui/toast-provider.tsx
+++ b/apps/web/src/shared/ui/toast-provider.tsx
@@ -35,10 +35,14 @@ const ToastContext = createContext<ToastContextValue | null>(null);
 // In vitest jsdom runs, Radix's auto-dismiss setTimeout can outlive the test
 // file and fire after the worker tears jsdom down, leaving an unhandled
 // "ReferenceError: window is not defined" that fails CI even when all
-// assertions pass. Under `MODE === 'test'` we suppress auto-dismiss entirely
-// (tests drive the toast lifecycle via `cleanup()`). Production and dev
-// behaviour are unchanged.
+// assertions pass. Under `MODE === 'test'` we cap duration at the max int32
+// (~24.8 days), the largest value Node's setTimeout accepts without
+// silently coercing to 1ms — this prevents the timer from firing during
+// the test run while keeping production/dev behaviour at the configured
+// `durationMs` default. Using `Number.POSITIVE_INFINITY` here is unsafe
+// because Node clamps Infinity to 1ms and the timer fires immediately.
 const IS_TEST_ENV = import.meta.env.MODE === 'test';
+const TEST_ENV_DURATION_MS = 2_147_483_647;
 
 export function ToastProvider({ children }: PropsWithChildren): ReactElement {
   const [toasts, setToasts] = useState<Toast[]>([]);
@@ -51,7 +55,7 @@ export function ToastProvider({ children }: PropsWithChildren): ReactElement {
   const showToast = useCallback(
     ({ description, durationMs = 4000, title, tone = 'info' }: ShowToastOptions) => {
       const id = nextIdRef.current++;
-      const effectiveDurationMs = IS_TEST_ENV ? Number.POSITIVE_INFINITY : durationMs;
+      const effectiveDurationMs = IS_TEST_ENV ? TEST_ENV_DURATION_MS : durationMs;
       setToasts((current) => [
         ...current,
         { description, durationMs: effectiveDurationMs, id, title, tone },

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,4 +1,18 @@
 import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Auto-unmount rendered components after every test. Without this, components
+// leak across tests within a file and their `useEffect` cleanups never run —
+// notably Radix Toast's `ToastAnnounce` schedules a 1-second `window.setTimeout`
+// (`@radix-ui/react-toast/dist/index.mjs:477`) that fires after happy-dom is
+// torn down, surfacing as an unhandled "ReferenceError: window is not defined"
+// that fails CI even when every assertion passes. RTL only registers this
+// hook automatically when `globals: true` is set in the vitest config; we
+// don't use globals, so we register it explicitly here.
+afterEach(() => {
+  cleanup();
+});
 
 // happy-dom (and jsdom) do not fully implement HTMLDialogElement.showModal / .close
 // with proper focus management. These stubs mirror the browser behaviours that our

--- a/apps/worker/src/sync/__tests__/sync-job.runner.spec.ts
+++ b/apps/worker/src/sync/__tests__/sync-job.runner.spec.ts
@@ -17,6 +17,7 @@ import { SyncJobHandler } from '@openlinker/core/sync/domain/ports/sync-job-hand
 import { SyncJob } from '@openlinker/core/sync/domain/entities/sync-job.entity';
 import { SyncJobExecutionError } from '@openlinker/core/sync/domain/exceptions/sync-job-execution.error';
 import { AllegroApiException } from '@openlinker/integrations-allegro';
+import { OfferCreationInvariantException } from '@openlinker/core/listings';
 import { randomUUID } from 'crypto';
 
 describe('SyncJobRunner', () => {
@@ -118,7 +119,7 @@ describe('SyncJobRunner', () => {
 
     it('should execute handler and mark job as succeeded on success', async () => {
       const job = createMockJob({ status: 'running' });
-      mockHandler.execute.mockResolvedValueOnce(undefined);
+      mockHandler.execute.mockResolvedValueOnce({ outcome: 'ok' });
       handlerRegistry.getHandler.mockReturnValueOnce(mockHandler);
       jobRepository.markSucceeded.mockResolvedValueOnce(undefined);
 
@@ -126,7 +127,20 @@ describe('SyncJobRunner', () => {
 
       expect(handlerRegistry.getHandler).toHaveBeenCalledWith(job.jobType);
       expect(mockHandler.execute).toHaveBeenCalledWith(job);
-      expect(jobRepository.markSucceeded).toHaveBeenCalledWith(job.id);
+      expect(jobRepository.markSucceeded).toHaveBeenCalledWith(job.id, 'ok');
+      expect(jobRepository.markFailed).not.toHaveBeenCalled();
+      expect(jobRepository.markDead).not.toHaveBeenCalled();
+    });
+
+    it('should persist outcome=business_failure when handler reports a terminal business rejection', async () => {
+      const job = createMockJob({ status: 'running' });
+      mockHandler.execute.mockResolvedValueOnce({ outcome: 'business_failure' });
+      handlerRegistry.getHandler.mockReturnValueOnce(mockHandler);
+      jobRepository.markSucceeded.mockResolvedValueOnce(undefined);
+
+      await (runner as any).processJob(job);
+
+      expect(jobRepository.markSucceeded).toHaveBeenCalledWith(job.id, 'business_failure');
       expect(jobRepository.markFailed).not.toHaveBeenCalled();
       expect(jobRepository.markDead).not.toHaveBeenCalled();
     });
@@ -276,6 +290,17 @@ describe('SyncJobRunner', () => {
         'String error',
         expect.any(Date),
       );
+    });
+
+    it('should mark job as dead when OfferCreationInvariantException is thrown (issue #400)', async () => {
+      const job = createMockJob(1, 10);
+      const error = new OfferCreationInvariantException('rec_test_1', 'pending');
+      jobRepository.markDead.mockResolvedValueOnce(undefined);
+
+      await (runner as any).handleJobFailure(job, error);
+
+      expect(jobRepository.markDead).toHaveBeenCalledWith(job.id, error.message);
+      expect(jobRepository.markFailed).not.toHaveBeenCalled();
     });
 
     it('should mark job as dead when AllegroApiException has deterministic 4xx (415)', async () => {
@@ -481,7 +506,7 @@ describe('SyncJobRunner', () => {
         .mockResolvedValueOnce([job1])
         .mockResolvedValueOnce([]);
 
-      mockHandler.execute.mockResolvedValueOnce(undefined);
+      mockHandler.execute.mockResolvedValueOnce({ outcome: 'ok' });
       handlerRegistry.getHandler.mockReturnValue(mockHandler);
       jobRepository.markSucceeded.mockResolvedValue(undefined);
 

--- a/apps/worker/src/sync/handlers/__tests__/marketplace-offer-create.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/marketplace-offer-create.handler.spec.ts
@@ -59,6 +59,7 @@ describe('MarketplaceOfferCreateHandler', () => {
   it('delegates to the execution service with parsed payload + job connection id', async () => {
     offerCreation.executeCreation.mockResolvedValue({
       offerCreationRecord: buildRecord({ status: 'draft', externalOfferId: 'allegro-1' }),
+      outcome: 'ok',
     });
 
     const job = createJob({
@@ -71,8 +72,9 @@ describe('MarketplaceOfferCreateHandler', () => {
       idempotencyKey: 'idem-1',
     });
 
-    await handler.execute(job);
+    const result = await handler.execute(job);
 
+    expect(result).toEqual({ outcome: 'ok' });
     expect(offerCreation.executeCreation).toHaveBeenCalledWith({
       internalVariantId: VARIANT_ID,
       connectionId: CONNECTION_ID,
@@ -85,12 +87,13 @@ describe('MarketplaceOfferCreateHandler', () => {
     });
   });
 
-  it('returns normally when the service records a terminal failure', async () => {
+  it('returns outcome=business_failure when the service records a terminal failure', async () => {
     offerCreation.executeCreation.mockResolvedValue({
       offerCreationRecord: buildRecord({
         status: 'failed',
         errors: [{ field: 'price.amount', code: 'REQUIRED', message: 'Required' }],
       }),
+      outcome: 'business_failure',
     });
 
     const job = createJob({
@@ -100,7 +103,7 @@ describe('MarketplaceOfferCreateHandler', () => {
       publishImmediately: false,
     });
 
-    await expect(handler.execute(job)).resolves.toBeUndefined();
+    await expect(handler.execute(job)).resolves.toEqual({ outcome: 'business_failure' });
   });
 
   it('wraps unknown service errors in SyncJobExecutionError for retry', async () => {

--- a/apps/worker/src/sync/handlers/__tests__/master-inventory-sync-all.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/master-inventory-sync-all.handler.spec.ts
@@ -79,7 +79,7 @@ describe('MasterInventorySyncAllHandler', () => {
       .mockResolvedValueOnce({ jobId: 'j1', isExisting: false })
       .mockRejectedValueOnce(new Error('queue full'));
 
-    await expect(handler.execute(createJob('conn-1'))).resolves.toBeUndefined();
+    await expect(handler.execute(createJob('conn-1'))).resolves.toEqual({ outcome: 'ok' });
     expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/worker/src/sync/handlers/__tests__/master-product-sync-all.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/master-product-sync-all.handler.spec.ts
@@ -116,7 +116,7 @@ describe('MasterProductSyncAllHandler', () => {
       .mockResolvedValueOnce({ jobId: 'j1', isExisting: false })
       .mockRejectedValueOnce(new Error('queue full'));
 
-    await expect(handler.execute(createJob('conn-1'))).resolves.toBeUndefined();
+    await expect(handler.execute(createJob('conn-1'))).resolves.toEqual({ outcome: 'ok' });
     expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/worker/src/sync/handlers/auto-match-variants.handler.ts
+++ b/apps/worker/src/sync/handlers/auto-match-variants.handler.ts
@@ -9,6 +9,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
 } from '@openlinker/core/sync';
@@ -30,7 +31,7 @@ export class AutoMatchVariantsHandler implements SyncJobHandler {
     private readonly autoMatchService: IAutoMatchVariantOffersService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     this.logger.log(
@@ -45,6 +46,8 @@ export class AutoMatchVariantsHandler implements SyncJobHandler {
       this.logger.log(
         `Auto-match complete (job=${job.id}): matched=${result.matched}, skippedAmbiguous=${result.skippedAmbiguous}, skippedNoMatch=${result.skippedNoMatch}, errors=${result.errors.length}`,
       );
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
+++ b/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
@@ -10,6 +10,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   JobEnqueuePort,
@@ -58,7 +59,7 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
     private readonly jobEnqueue: JobEnqueuePort,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const productId = job.payload?.productId as string | undefined;
     this.logger.log(
       `Executing inventory propagate to marketplaces job ${job.id} for product ${productId ?? 'unknown'}`,
@@ -79,7 +80,7 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
         this.logger.warn(
           `No inventory found for product ${payload.productId}${payload.variantId ? `, variant ${payload.variantId}` : ''}. Skipping propagation.`,
         );
-        return;
+        return { outcome: 'ok' };
       }
 
       const availableQuantity = inventory.availableQuantity;
@@ -97,7 +98,7 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
         this.logger.debug(
           `No offer mappings found for product ${payload.productId}. Skipping propagation.`,
         );
-        return;
+        return { outcome: 'ok' };
       }
 
       this.logger.log(
@@ -112,7 +113,7 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
         this.logger.debug(
           `No Allegro offer mappings found for product ${payload.productId}. Skipping propagation.`,
         );
-        return;
+        return { outcome: 'ok' };
       }
 
       const writeEventToken = payload.inventoryUpdatedAt || 'legacy';
@@ -146,6 +147,8 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
       this.logger.log(
         `Successfully enqueued ${allegroMappings.length} offer quantity update job(s) for product ${payload.productId}`,
       );
+
+      return { outcome: 'ok' };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
@@ -14,12 +14,17 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 
-import { IOfferCreationExecutionService, OFFER_CREATION_EXECUTION_SERVICE_TOKEN } from '@openlinker/core/listings';
+import {
+  IOfferCreationExecutionService,
+  OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
+  OfferCreationInvariantException,
+} from '@openlinker/core/listings';
 import {
   MarketplaceOfferCreatePayloadV1,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   SyncJobHandler,
+  SyncJobHandlerResult,
 } from '@openlinker/core/sync';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -34,7 +39,7 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
     private readonly offerCreation: IOfferCreationExecutionService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     this.logger.log(
@@ -42,7 +47,7 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
     );
 
     try {
-      const { offerCreationRecord } = await this.offerCreation.executeCreation({
+      const { offerCreationRecord, outcome } = await this.offerCreation.executeCreation({
         internalVariantId: payload.internalVariantId,
         connectionId: job.connectionId,
         stock: payload.stock,
@@ -54,9 +59,18 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
       });
 
       this.logger.log(
-        `Offer creation finished: job=${job.id} recordId=${offerCreationRecord.id} status=${offerCreationRecord.status} externalOfferId=${offerCreationRecord.externalOfferId ?? 'n/a'}`,
+        `Offer creation finished: job=${job.id} recordId=${offerCreationRecord.id} status=${offerCreationRecord.status} outcome=${outcome} externalOfferId=${offerCreationRecord.externalOfferId ?? 'n/a'}`,
       );
+
+      return { outcome };
     } catch (error) {
+      // OfferCreationInvariantException is a code bug — propagate untouched so
+      // the runner classifies it as non-retryable (markDead). Wrapping it in a
+      // SyncJobExecutionError would route it through the retry path, which is
+      // pointless for an invariant violation.
+      if (error instanceof OfferCreationInvariantException) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(
         `marketplace.offer.create job failed: ${message}`,

--- a/apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts
@@ -10,6 +10,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   MarketplaceOfferFieldUpdatePayloadV1,
@@ -35,7 +36,7 @@ export class MarketplaceOfferFieldUpdateHandler implements SyncJobHandler {
     private readonly integrationsService: IIntegrationsService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     this.logger.log(
@@ -75,6 +76,8 @@ export class MarketplaceOfferFieldUpdateHandler implements SyncJobHandler {
         fields: payload.fields,
         idempotencyKey: payload.idempotencyKey,
       });
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/marketplace-offer-quantity-update.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-quantity-update.handler.ts
@@ -11,6 +11,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   MarketplaceOfferQuantityUpdatePayloadV1,
@@ -32,7 +33,7 @@ export class MarketplaceOfferQuantityUpdateHandler implements SyncJobHandler {
     private readonly inventorySync: IInventorySyncService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     this.logger.log(
@@ -55,6 +56,8 @@ export class MarketplaceOfferQuantityUpdateHandler implements SyncJobHandler {
           job.connectionId,
         );
       }
+
+      return { outcome: 'ok' };
     } catch (error) {
       if (error instanceof SyncJobExecutionError) {
         throw error;

--- a/apps/worker/src/sync/handlers/marketplace-offers-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offers-sync.handler.ts
@@ -9,6 +9,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   MarketplaceOffersSyncPayloadV1,
@@ -36,7 +37,7 @@ export class MarketplaceOffersSyncHandler implements SyncJobHandler {
     private readonly cursorRepository: ConnectionCursorRepositoryPort,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     const feedType = payload.feedType ?? (payload.cursorKey ? 'events' : 'offers');
@@ -102,6 +103,8 @@ export class MarketplaceOffersSyncHandler implements SyncJobHandler {
           `Enqueued follow-up marketplace.offers.sync job (connection=${job.connectionId}, cursor=${nextCursor})`,
         );
       }
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/marketplace-order-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-order-sync.handler.ts
@@ -10,6 +10,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   MarketplaceOrderSyncPayloadV1,
@@ -31,7 +32,7 @@ export class MarketplaceOrderSyncHandler implements SyncJobHandler {
     private readonly orderIngestion: IOrderIngestionService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     this.logger.log(
@@ -44,6 +45,8 @@ export class MarketplaceOrderSyncHandler implements SyncJobHandler {
         payload.externalOrderId,
         payload.sourceEventId,
       );
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/master-inventory-sync-all.handler.ts
+++ b/apps/worker/src/sync/handlers/master-inventory-sync-all.handler.ts
@@ -18,6 +18,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   JobEnqueuePort,
@@ -43,7 +44,7 @@ export class MasterInventorySyncAllHandler implements SyncJobHandler {
     private readonly jobEnqueue: JobEnqueuePort,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     this.logger.log(
       `Executing master.inventory.syncAll job ${job.id} for connection ${job.connectionId}`,
     );
@@ -65,7 +66,7 @@ export class MasterInventorySyncAllHandler implements SyncJobHandler {
         this.logger.log(
           `No product mappings found for connection ${job.connectionId}. Skipping inventory sync.`,
         );
-        return;
+        return { outcome: 'ok' };
       }
 
       this.logger.log(
@@ -109,6 +110,8 @@ export class MasterInventorySyncAllHandler implements SyncJobHandler {
           `master.inventory.syncAll for connection ${job.connectionId}: ${succeeded} inventory sync job(s) enqueued (${externalIds.length - productExternalIds.length} synthetic variant IDs skipped)`,
         );
       }
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/master-inventory-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/master-inventory-sync.handler.ts
@@ -11,6 +11,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   MasterInventorySyncByExternalIdPayloadV1,
@@ -32,7 +33,7 @@ export class MasterInventorySyncHandler implements SyncJobHandler {
     private readonly masterInventorySync: IMasterInventorySyncService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     if (!['inventory', 'product'].includes(String(payload.objectType).toLowerCase())) {
@@ -50,6 +51,8 @@ export class MasterInventorySyncHandler implements SyncJobHandler {
 
     try {
       await this.masterInventorySync.syncFromMasterByExternalId(job.connectionId, payload.externalId);
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/master-product-sync-all.handler.ts
+++ b/apps/worker/src/sync/handlers/master-product-sync-all.handler.ts
@@ -22,6 +22,7 @@ import { Injectable, Inject } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   JobEnqueuePort,
@@ -49,7 +50,7 @@ export class MasterProductSyncAllHandler implements SyncJobHandler {
     private readonly configService: ConfigService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     this.logger.log(
       `Executing master.product.syncAll job ${job.id} for connection ${job.connectionId}`,
     );
@@ -67,7 +68,7 @@ export class MasterProductSyncAllHandler implements SyncJobHandler {
         this.logger.log(
           `No products found on source platform for connection ${job.connectionId}. Nothing to sync.`,
         );
-        return;
+        return { outcome: 'ok' };
       }
 
       this.logger.log(
@@ -109,6 +110,8 @@ export class MasterProductSyncAllHandler implements SyncJobHandler {
           `master.product.syncAll for connection ${job.connectionId}: ${succeeded} product sync job(s) enqueued`,
         );
       }
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/master-product-sync.handler.ts
+++ b/apps/worker/src/sync/handlers/master-product-sync.handler.ts
@@ -11,6 +11,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   MasterProductSyncByExternalIdPayloadV1,
@@ -32,7 +33,7 @@ export class MasterProductSyncHandler implements SyncJobHandler {
     private readonly masterProductSync: IMasterProductSyncService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     if (String(payload.objectType).toLowerCase() !== 'product') {
@@ -50,6 +51,8 @@ export class MasterProductSyncHandler implements SyncJobHandler {
 
     try {
       await this.masterProductSync.syncFromMasterByExternalId(job.connectionId, payload.externalId);
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/handlers/orders-poll.handler.ts
+++ b/apps/worker/src/sync/handlers/orders-poll.handler.ts
@@ -10,6 +10,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import {
   SyncJobHandler,
+  SyncJobHandlerResult,
   SyncJob as SyncJobEntity,
   SyncJobExecutionError,
   MarketplaceOrdersPollPayloadV1,
@@ -31,7 +32,7 @@ export class OrdersPollHandler implements SyncJobHandler {
     private readonly orderIngestion: IOrderIngestionService,
   ) {}
 
-  async execute(job: SyncJob): Promise<void> {
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     this.logger.log(
@@ -49,12 +50,14 @@ export class OrdersPollHandler implements SyncJobHandler {
         this.logger.debug(
           `Skipped ingestion due to lock (connection: ${job.connectionId}). Treating job as succeeded.`,
         );
-        return;
+        return { outcome: 'ok' };
       }
 
       this.logger.log(
         `Ingestion completed (connection: ${job.connectionId}): fetched=${result.fetched}, enqueued=${result.enqueued}, committed=${result.committed}`,
       );
+
+      return { outcome: 'ok' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new SyncJobExecutionError(

--- a/apps/worker/src/sync/sync-job.runner.ts
+++ b/apps/worker/src/sync/sync-job.runner.ts
@@ -15,6 +15,7 @@ import {
   SyncJobEntity,
   SyncJobExecutionError,
 } from '@openlinker/core/sync';
+import { OfferCreationInvariantException } from '@openlinker/core/listings';
 import {
   AllegroApiException,
   AllegroAuthenticationException,
@@ -262,13 +263,13 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
         return;
       }
 
-      // Execute handler
-      await handler.execute(job);
+      // Execute handler — handlers return their business outcome (issue #400)
+      const result = await handler.execute(job);
 
-      // Success - mark as succeeded
-      await this.jobRepository.markSucceeded(job.id);
+      // Success - mark as succeeded with the handler's reported outcome
+      await this.jobRepository.markSucceeded(job.id, result.outcome);
       this.logger.log(
-        `Job ${job.id} (${job.jobType}) succeeded after ${job.attempts + 1} attempt(s)`,
+        `Job ${job.id} (${job.jobType}) succeeded with outcome=${result.outcome} after ${job.attempts + 1} attempt(s)`,
       );
     } catch (error) {
       // Handle execution error
@@ -345,6 +346,14 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
   private isNonRetryableError(error: unknown): boolean {
     const cause =
       error instanceof SyncJobExecutionError && error.cause ? error.cause : error;
+
+    // OfferCreationInvariantException is a code bug (orchestrator returned with a
+    // record still in 'pending'). Retries cannot fix it — the next attempt would
+    // hit the same code path. Mark dead immediately so the operator can see it.
+    // See issue #400 (Plan B for #391).
+    if (cause instanceof OfferCreationInvariantException) {
+      return true;
+    }
 
     // AllegroAuthenticationException extends Error directly (not AllegroApiException),
     // so the two branches are disjoint: a 401 never reaches the status-code set below.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -186,6 +186,7 @@ The system is organized into the following core bounded contexts:
 - **Responsibility**: Job scheduling and retry logic; workers execute jobs. **Sync orchestration policies live in core application services** (e.g., order ingestion, inventory propagation), not in worker handlers.
 - **Key Services**: SyncJobService, RetryService, SchedulerService
 - **Location**: `libs/core/src/sync/` (core sync infrastructure), `apps/worker/src/sync/` (job runners/handlers)
+- **Status vs outcome (#391 / #400)**: `sync_jobs.status` (`queued | running | succeeded | dead`) tracks orchestration. `sync_jobs.outcome` (`'ok' | 'business_failure' | null`) tracks the **business** result, set only on the succeeded path. Each `SyncJobHandler.execute()` returns a `SyncJobHandlerResult` whose `outcome` the runner persists via `markSucceeded(id, outcome)` — atomic with the status flip. `OfferCreationExecutionService` is the first orchestrator to derive `business_failure` from a terminal-rejection branch; other handlers return `'ok'` mechanically until they grow their own domain-failure semantics.
 
 ### 8. Event Bus / Messaging
 - **Responsibility**: Event-driven communication between modules

--- a/docs/plans/implementation-plan-400-sync-job-outcome-field.md
+++ b/docs/plans/implementation-plan-400-sync-job-outcome-field.md
@@ -1,0 +1,461 @@
+# Implementation Plan: Sync Job Outcome Field (Plan B for #391)
+
+**Date**: 2026-04-26
+**Status**: Ready for Review
+**Estimated Effort**: ~1 day
+**Issue**: [#400](https://github.com/SilkSoftwareHouse/openlinker/issues/400) (follow-up to closed #391)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Separate orchestration status from business outcome on `sync_jobs`. Add a nullable `outcome` column populated only on the succeeded path, with values `'ok' | 'business_failure'`. The first concrete user is `marketplace.offer.create`, where Allegro/builder-rejection cases currently land as `succeeded` despite a `failed` `OfferCreationRecord` — the operator sees a misleading green badge on the Jobs list.
+
+**Context**: Follow-up to closed #391. Plan A (PR #396) shipped the detail-page `OfferCreationTracker`. Plan B closes the list-level visibility gap and gives the orchestration-vs-business distinction a first-class home in the data model. This is generalisable: 11 other handlers follow the same "thin delegation" pattern and could grow the same silent-business-failure shape — adopting the contract once prevents repeat work.
+
+**Classification**: CORE (sync domain types, listings orchestrator) + Infrastructure (migration, ORM, runner) + Interface (API DTO, FE badge + filter) + Testing.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- `sync_jobs.outcome` nullable column + reversible migration.
+- `JobOutcome` union type + `JobOutcomeValues` runtime array (per `as const` pattern).
+- `SyncJobHandler` port contract change — `execute()` returns `Promise<{ outcome: JobOutcome }>`, required (no opt-in).
+- `SyncJobRepositoryPort.markSucceeded(id, outcome)` — port + repo + every test mock + every caller.
+- All 12 handlers updated to return `{ outcome }`. Offer-create returns derived outcome; 11 others mechanical `'ok'`.
+- `OfferCreationExecutionService.executeCreation` returns `{ offerCreationRecord, outcome }`. Maps via private `recordToOutcome(status)`. Throws `OfferCreationInvariantException` on `pending`.
+- `OfferCreationInvariantException` domain exception.
+- `SyncJobRunner` reads outcome from handler return; passes to `markSucceeded`; classifies the new exception as non-retryable (markDead).
+- API: `SyncJobResponseDto.outcome` + Swagger annotation; `GET /sync/jobs?outcome=...` filter.
+- FE: `SyncJobStatusBadge` accepts `(status, outcome)`, warning tone for `succeeded + business_failure`. List-page outcome filter via URL search params.
+- Audit-lite of the 11 non-offer-create handlers, findings in PR description, follow-up issues filed for any silent-business-failure branch.
+- Unit tests + 1 integration test covering the vertical slice.
+
+### Out of Scope
+- Per-handler fixes for any silent-business-failure branches the audit surfaces — file follow-up issues, do not bundle.
+- Backfill of historical `sync_jobs.outcome` from `OfferCreationRecord` history.
+- Async-validation poll handler (`marketplace.offer.pollCreationStatus`) — separate planned follow-up; will write its own outcome.
+- Any change to the retry endpoint's "only-dead-jobs" semantics.
+- Index on `outcome` (defer until list-page latency degrades or table > ~1M rows).
+- DB-level CHECK constraint on `outcome` (consistent with how `sync_jobs.status` is shaped today).
+
+### Constraints
+- Backwards-compatible at the DB level (nullable column, no defaults) but **breaking at the type level**: `SyncJobHandler.execute` return type changes, all 12 handlers must update in the same PR or TypeScript fails compile.
+- Honour `migrations.md` timestamp uniqueness invariant (enforced by `pnpm lint` via `scripts/check-migration-timestamps.mjs`).
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: CORE (domain types, listings orchestrator, sync ports), Infrastructure (migration, ORM, repo, runner, handlers), Interface (API DTO, controller, FE).
+
+**Capabilities Involved**:
+- `SyncJobHandler` port (`libs/core/src/sync/domain/ports/sync-job-handler.port.ts:24`) — **contract change**.
+- `SyncJobRepositoryPort` (`libs/core/src/sync/domain/ports/sync-job-repository.port.ts:59`) — **signature change** on `markSucceeded`.
+- `IOfferCreationExecutionService` — **return-type change** on `executeCreation`.
+
+**Existing Services Reused**:
+- `OfferCreationExecutionService` — already centralises the orchestration policy; just returns more.
+- `SyncJobRunner` — already routes to handlers; reads outcome from return value.
+- `SyncJobStatusBadge` (FE) — extends tone map to a `(status, outcome)` mapping.
+- `OfferCreationTracker` (FE, from Plan A) — unchanged; remains the live-state source on the detail page.
+
+**New Components Required**:
+- `JobOutcomeValues` + `JobOutcome` type in `libs/core/src/sync/domain/types/sync-job.types.ts`.
+- `OfferCreationInvariantException` in `libs/core/src/listings/domain/exceptions/offer-creation-invariant.exception.ts`.
+- `recordToOutcome(status)` private helper inside `OfferCreationExecutionService`.
+- Migration file `apps/api/src/migrations/{timestamp}-add-outcome-to-sync-jobs.ts`.
+
+**Core vs Integration Justification**:
+- The outcome contract (`JobOutcome`, `recordToOutcome`, port signature) lives in CORE (`libs/core/src/sync/`, `libs/core/src/listings/`) because the orchestration vs business-outcome distinction is platform-agnostic. No integration package touches these files — adapters publish offers, the orchestrator interprets the resulting record status. Confirmed: no changes under `libs/integrations/`.
+
+**Reference**: [Architecture Overview - Hexagonal Architecture Structure](../architecture-overview.md#hexagonal-architecture-structure)
+
+---
+
+## 4. External / Domain Research
+
+### External System
+N/A — no external API change. Allegro/PrestaShop adapters are unaffected.
+
+### Internal Patterns
+
+**Similar implementations in the codebase**:
+- `JobStatusValues = ['queued','running','succeeded','dead'] as const` in `sync-job.types.ts` is the exact template for `JobOutcomeValues`.
+- `SyncJobRepositoryPort.markSucceeded(id)` / `markFailed(id, error, nextRunAt)` / `markDead(id, error)` already mix domain identifiers with diagnostic strings; adding `outcome` to `markSucceeded` follows the same shape.
+- `OfferCreationExecutionService` already has the three terminal-business-failure branches (lines 87–94 builder, 107–119 platform reject, 136–150 happy path with sub-case warn-log on `validating`).
+- `OfferBuilderValidationException`, `OfferCreateRejectedException`, `MasterCatalogConnectionNotConfiguredException`, `OfferCreationRecordNotFoundException` all live in `libs/core/src/listings/domain/exceptions/` — `OfferCreationInvariantException` slots in beside them.
+- `SyncJobHandler.execute(job): Promise<void>` is a tiny port — only one method to change. Implementations are in `apps/worker/src/sync/handlers/`.
+
+**Reusable components**:
+- `OfferCreationTracker` FE primitive (Plan A) stays as-is for live record state.
+- `SyncJobStatusBadge` already centralises status-tone mapping.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+- None blocking. The retry endpoint's "only-dead" behaviour was confirmed via `apps/api/src/sync/http/sync.controller.ts:227`, which makes `outcome` truly frozen-per-row.
+
+### Assumptions
+- The 11 non-offer-create handlers don't have hidden silent-business-failure branches that need fixing in *this* PR. Verified at audit time; any surfaced branches are filed as separate follow-up issues per the audit-lite (γ) scope.
+- The `OfferCreationRecord.status` enum (`pending | draft | validating | active | failed`) is stable and exhaustive. Adding new values would require a switch-statement update in `recordToOutcome`.
+- `sync_jobs` is small enough today that `outcome` doesn't need an index. Risk #5 in the issue calls out the threshold (~1M rows or visible filter latency).
+
+### Documentation Gaps
+None. `engineering-standards.md`, `architecture-overview.md`, `testing-guide.md`, and `migrations.md` cover every pattern this PR uses.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Domain types & exception (CORE)
+
+**Goal**: Define the outcome vocabulary and the invariant exception. Pure types, no runtime behaviour change yet.
+
+1. **Add `JobOutcome` to sync-job types**
+   - **File**: `libs/core/src/sync/domain/types/sync-job.types.ts`
+   - **Action**: Add `export const JobOutcomeValues = ['ok', 'business_failure'] as const;` and `export type JobOutcome = (typeof JobOutcomeValues)[number];` next to the existing `JobStatusValues`.
+   - **Acceptance**: `import { JobOutcome, JobOutcomeValues } from '@openlinker/core/sync'` resolves; `JobOutcomeValues.includes('ok')` is `true`.
+   - **Reference**: [Engineering Standards — Union Types: `as const` Pattern](../engineering-standards.md#union-types-as-const-pattern-default)
+
+2. **Export `JobOutcome` from the package barrel**
+   - **File**: `libs/core/src/sync/index.ts`
+   - **Action**: Re-export `JobOutcome` and `JobOutcomeValues` alongside `JobStatus` / `JobStatusValues`.
+   - **Acceptance**: Worker / API / FE consumers can import via `@openlinker/core/sync`.
+
+3. **Create `OfferCreationInvariantException`**
+   - **File**: `libs/core/src/listings/domain/exceptions/offer-creation-invariant.exception.ts`
+   - **Action**: New domain exception; extends `Error`; constructor accepts `recordId: string` + `actualStatus: string` and renders a clear message (e.g. `"OfferCreationRecord ${recordId} returned in invariant-violating status: ${actualStatus}. Expected one of: failed | active | draft | validating."`). Include `Error.captureStackTrace`. Mirror the shape of `OfferCreationRecordNotFoundException` already in the same folder.
+   - **Acceptance**: Exception class importable; `new OfferCreationInvariantException('rec_123', 'pending')` produces a useful `.message` and stack trace.
+   - **Reference**: [Engineering Standards — Error Handling](../engineering-standards.md#error-handling)
+
+### Phase 2 — Orchestrator return shape (CORE)
+
+**Goal**: `OfferCreationExecutionService` returns `{ offerCreationRecord, outcome }`, with the mapping logic centralised.
+
+4. **Update `ExecuteOfferCreationResult` type**
+   - **File**: `libs/core/src/listings/application/types/offer-creation-execution.types.ts`
+   - **Action**: Add `outcome: JobOutcome;` (required) to the result interface. Import `JobOutcome` from `@openlinker/core/sync`.
+   - **Acceptance**: TS compiles — both call sites of `executeCreation` (handler + future REST endpoint) will surface as type errors until updated.
+
+5. **Add `recordToOutcome` helper to the orchestrator**
+   - **File**: `libs/core/src/listings/application/services/offer-creation-execution.service.ts`
+   - **Action**: Add a `private recordToOutcome(status: OfferCreationStatus): JobOutcome` method. Implementation:
+     - `'failed'` → `'business_failure'`
+     - `'active' | 'draft' | 'validating'` → `'ok'`
+     - `'pending'` → `throw new OfferCreationInvariantException(record.id, 'pending')`
+     - Use a `switch` with no default so TS exhaustiveness checking flags new enum values.
+   - **Acceptance**: Pure function, fully covered by unit tests in step 6.
+
+6. **Thread `outcome` through every return path of `executeCreation`**
+   - **File**: same as above.
+   - **Action**: Three return points today (lines 91, 116, 150) all become `return { offerCreationRecord: <record>, outcome: this.recordToOutcome(<record>.status) };`. The throw-on-`pending` happens inside `recordToOutcome`, so the orchestrator surfaces the invariant via the normal exception channel. On the `business_failure` branch (`recordToOutcome` returns `business_failure`), add a `Logger.warn` call before returning, carrying `{ recordId, connectionId, errorCount: <record>.errors?.length ?? 0 }` — symmetric with the existing `validating`-warning at lines 144–148.
+   - **Acceptance**: TS compiles; unit tests in step 12 confirm each branch returns the right outcome and logs on `business_failure`.
+
+### Phase 3 — Sync port + repository signature change (CORE + Infrastructure)
+
+**Goal**: `markSucceeded` writes outcome atomically with status. Port + repo + every test mock + every caller.
+
+7. **Update `SyncJobRepositoryPort.markSucceeded` signature**
+   - **File**: `libs/core/src/sync/domain/ports/sync-job-repository.port.ts:59`
+   - **Action**: Change to `markSucceeded(id: string, outcome: JobOutcome): Promise<void>;`. Import `JobOutcome` from the local types file (relative import — same domain module).
+   - **Acceptance**: All callers and implementers surface as TS errors.
+
+8. **Update the TypeORM repository**
+   - **File**: `libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts`
+   - **Action**: `markSucceeded(id, outcome)` issues a single `UPDATE sync_jobs SET status='succeeded', outcome=$outcome, locked_at=NULL, locked_by=NULL, updated_at=NOW() WHERE id=$id` (consistent with how `markFailed` / `markDead` already touch lock fields).
+   - **Acceptance**: Repository unit test (if exists) updated; integration test in step 18 covers persistence.
+
+9. **Add `outcome` to the SyncJob domain entity**
+   - **File**: `libs/core/src/sync/domain/entities/sync-job.entity.ts`
+   - **Action**: Add nullable `outcome: JobOutcome | null` field (mirrors `lastError`).
+   - **Acceptance**: Domain entity carries the outcome through reads.
+
+10. **Add `outcome` to the SyncJob ORM entity**
+    - **File**: `libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts`
+    - **Action**: Add `@Column({ name: 'outcome', type: 'varchar', nullable: true }) outcome: string | null;`. Update the repository's `toDomain` / `toOrm` private mappers to thread the field.
+    - **Acceptance**: TS compiles; ORM column is nullable varchar.
+
+11. **Generate the migration**
+    - **File**: `apps/api/src/migrations/{timestamp}-add-outcome-to-sync-jobs.ts`
+    - **Command**: `pnpm --filter @openlinker/api migration:generate -- src/migrations/AddOutcomeToSyncJobs`
+    - **Action**: Verify the generated `up()` is just `ALTER TABLE "sync_jobs" ADD "outcome" character varying`. `down()` should drop the column. Honour the timestamp uniqueness invariant (filename prefix + class suffix match; check via `pnpm lint`).
+    - **Acceptance**: `pnpm --filter @openlinker/api migration:run` succeeds locally; `pnpm --filter @openlinker/api migration:revert` cleanly drops the column; `pnpm lint` passes the timestamp invariant check.
+    - **Reference**: [docs/migrations.md — Timestamp uniqueness invariant](../migrations.md#timestamp-uniqueness-invariant)
+
+### Phase 4 — Handler port contract change (CORE + Worker)
+
+**Goal**: Every handler returns `{ outcome }`. TypeScript enforces it for all 12.
+
+12. **Update `SyncJobHandler` port**
+    - **File**: `libs/core/src/sync/domain/ports/sync-job-handler.port.ts:24`
+    - **Action**: Add a sibling type `export interface HandlerResult { outcome: JobOutcome; }` and change `execute(job: SyncJob): Promise<void>` to `execute(job: SyncJob): Promise<HandlerResult>`. Update the JSDoc to mention that handlers must return their business outcome and that exceptions remain reserved for transient/fatal failures. Export `HandlerResult` from the package barrel.
+    - **Acceptance**: All 12 handler implementations surface as type errors.
+
+13. **Propagate outcome from `marketplace-offer-create.handler.ts`**
+    - **File**: `apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts`
+    - **Action**: Capture the orchestrator return: `const result = await this.offerCreation.executeCreation(input);` → `return { outcome: result.outcome };`. Keep the existing `try/catch` for `SyncJobExecutionError` wrapping; it doesn't need to change.
+    - **Acceptance**: Handler returns `'business_failure'` when the record landed `failed`, `'ok'` otherwise. Covered by unit tests in step 17.
+
+14. **Mechanical `{ outcome: 'ok' }` for the other 11 handlers**
+    - **Files**: every other `*.handler.ts` under `apps/worker/src/sync/handlers/`:
+      - `auto-match-variants.handler.ts`
+      - `inventory-propagate-to-marketplaces.handler.ts`
+      - `marketplace-offer-field-update.handler.ts`
+      - `marketplace-offer-quantity-update.handler.ts`
+      - `marketplace-offers-sync.handler.ts`
+      - `marketplace-order-sync.handler.ts`
+      - `master-inventory-sync-all.handler.ts`
+      - `master-inventory-sync.handler.ts`
+      - `master-product-sync-all.handler.ts`
+      - `master-product-sync.handler.ts`
+      - `orders-poll.handler.ts`
+    - **Action**: Update each handler's `execute` return type and end every successful return path with `return { outcome: 'ok' };`. Where the existing body is `await ...; return;`, change to `await ...; return { outcome: 'ok' };`.
+    - **Acceptance**: All 12 handlers compile against the new port; existing handler unit tests still pass after the trivial return-shape update.
+
+15. **Audit-lite walkthrough**
+    - **Action**: For each of the 11, read the orchestrator/application service the handler delegates to. Check for the pattern `try { ... } catch (DomainException) { recordFailed(...); return; }` (i.e. swallowed domain rejection persisted as a failure record). Note findings in the PR description. For any handler that *does* have a hidden silent-business-failure branch:
+       - Do NOT fix it in this PR.
+       - File a follow-up issue under `tech-debt`, link it from the PR description, and call out the specific orchestrator file + line range.
+    - **Acceptance**: PR description contains an "Audit-lite findings" section with one bullet per handler ("clean — no business-failure branch found" or "see #NNN — followup filed").
+
+### Phase 5 — Runner reads outcome + classifies invariant (Worker)
+
+**Goal**: Runner persists outcome from handler return; treats invariant violation as non-retryable.
+
+16. **Wire outcome through the runner**
+    - **File**: `apps/worker/src/sync/sync-job.runner.ts`
+    - **Action**: Around line 269 (the `markSucceeded` call site), capture `const result = await handler.execute(job);` and call `await this.jobRepository.markSucceeded(job.id, result.outcome);`. In the catch block (around lines 298–304 where `markDead` is decided for non-retryable errors), add `OfferCreationInvariantException` to the non-retryable classification — same shape as the existing `AuthenticationException` clause.
+    - **Acceptance**: Unit tests in step 17 confirm: succeeded path writes outcome; invariant exception path goes to `markDead` immediately (not retry).
+
+### Phase 6 — Tests (CORE + Worker)
+
+**Goal**: Cover the new behaviour with unit tests; one integration test for the vertical slice.
+
+17. **Unit tests**
+    - **`OfferCreationExecutionService` spec** (`libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts`):
+      - Returns `outcome: 'business_failure'` when builder validation fails.
+      - Returns `outcome: 'business_failure'` when adapter throws `OfferCreateRejectedException`.
+      - Returns `outcome: 'ok'` when adapter returns `'active'`, `'draft'`, or `'validating'` (3 cases).
+      - Throws `OfferCreationInvariantException` when the record is in `'pending'` after the orchestrator's work.
+      - Logs structured `Logger.warn` on the `business_failure` branch.
+    - **`SyncJobRunner` spec**:
+      - Calls `markSucceeded(id, 'ok')` when handler returns `{ outcome: 'ok' }`.
+      - Calls `markSucceeded(id, 'business_failure')` when handler returns `{ outcome: 'business_failure' }`.
+      - Calls `markDead` (not `markFailed`) when handler throws `OfferCreationInvariantException`.
+      - Leaves outcome NULL on the dead/failed paths (existing tests, just verifying nothing regresses).
+    - **Each handler smoke test**: existing handler `*.spec.ts` files keep passing after the return-shape change. For 11, the existing tests just need the assertion that `execute` resolves with `{ outcome: 'ok' }`. For `marketplace-offer-create`, add coverage for the `'business_failure'` propagation.
+    - **`SyncJobStatusBadge` spec** (FE): renders correct tone for `(queued, null)`, `(running, null)`, `(succeeded, 'ok')`, `(succeeded, 'business_failure')`, `(dead, null)`.
+    - **Reference**: [Testing Guide — Unit Tests](../testing-guide.md#unit-tests)
+
+18. **Integration test — vertical slice**
+    - **File**: `apps/api/test/integration/sync-job-outcome.int-spec.ts`
+    - **Action**: Using the existing test harness (Testcontainers Postgres + Redis, real Nest app):
+      - Seed a `sync_jobs` row with `status='queued'` and a `marketplace.offer.create` payload pointing at a pre-seeded `offer_creation_records` row in `failed` status.
+      - Trigger the runner (or directly call `markSucceeded(jobId, 'business_failure')` to validate the persistence path independently of the runner).
+      - Assert the row's `outcome` is `'business_failure'`.
+      - Assert `GET /sync/jobs/:id` response includes `outcome: 'business_failure'`.
+      - Assert `GET /sync/jobs?outcome=business_failure` returns the row.
+    - **Acceptance**: Test passes against a fresh container.
+    - **Reference**: [Testing Guide — Integration Tests](../testing-guide.md#integration-tests)
+
+### Phase 7 — API surface (Interface)
+
+**Goal**: Expose `outcome` in the response DTO and as a list filter.
+
+19. **`SyncJobResponseDto.outcome`**
+    - **File**: `apps/api/src/sync/http/dto/sync-job-response.dto.ts`
+    - **Action**: Add `outcome: JobOutcome | null` with `@ApiProperty({ enum: JobOutcomeValues, nullable: true, description: 'Business outcome of the job (only set on succeeded path).' })`. Make sure the response mapping (likely in the controller or service) threads `outcome` through from the domain entity.
+    - **Acceptance**: Swagger UI shows the field with the enum dropdown.
+
+20. **List filter on `GET /sync/jobs`**
+    - **File**: `apps/api/src/sync/http/sync.controller.ts` + the corresponding query DTO (probably `apps/api/src/sync/http/dto/list-sync-jobs.query.ts` or similar).
+    - **Action**: Add an optional `outcome?: JobOutcome` query param with `@IsOptional()`, `@IsIn(JobOutcomeValues)`. Thread into the application service / repository query method (likely `SyncJobService.listJobs(filters)`). Repository adds a `WHERE outcome = $1` clause when set.
+    - **Acceptance**: `GET /sync/jobs?outcome=business_failure` returns only matching rows.
+
+### Phase 8 — Frontend (Interface)
+
+**Goal**: List-page badge tells the truth; outcome filter dropdown works via URL state.
+
+21. **FE type mirror**
+    - **File**: `apps/web/src/features/sync-jobs/api/sync-jobs.types.ts`
+    - **Action**: Add `outcome: JobOutcome | null` to the `SyncJob` interface, plus matching const+type for `JobOutcome`. Mirror `JobOutcomeValues` from BE for the filter dropdown.
+    - **Acceptance**: TS compiles; consumers can read `job.outcome`.
+
+22. **Status badge tone map**
+    - **File**: `apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.tsx`
+    - **Action**: Change props to `{ status: JobStatus; outcome: JobOutcome | null }`. In the tone derivation: when `status === 'succeeded' && outcome === 'business_failure'`, return `warning`; otherwise keep the existing mapping. The badge label can remain the literal status word (`succeeded`) — the tone change carries the new signal — or, if visual-QA prefers, render a small `(business failure)` subtitle. Recommend keeping label minimal; the operator clicks in for detail.
+    - **Acceptance**: Snapshot/rendering test covers all four (status, outcome) combinations from step 17.
+    - **Reference**: [Frontend UI Style Guide — Status Badge](../frontend-ui-style-guide.md#status-badge)
+
+23. **List-page outcome filter**
+    - **Files**:
+      - `apps/web/src/pages/sync-jobs/sync-jobs-page.tsx` — render a new dropdown beside the status filter; read/write the `outcome` URL search param via `useSearchParams`.
+      - `apps/web/src/features/sync-jobs/hooks/use-sync-jobs-query.ts` — accept the filter and pass it to the API client.
+      - `apps/web/src/features/sync-jobs/api/sync-jobs.api.ts` (or equivalent) — append the query param when set.
+    - **Acceptance**: Selecting "business failure" in the dropdown updates the URL to `?outcome=business_failure` and the table re-fetches with the filter applied. Refreshing the page preserves the filter.
+    - **Reference**: [Frontend Architecture — URL State](../frontend-architecture.md#url-state)
+
+### Phase 9 — Quality gate & PR
+
+**Goal**: Ship green.
+
+24. **Run quality gate**
+    - **Commands**:
+      ```bash
+      pnpm lint
+      pnpm type-check
+      pnpm test
+      pnpm test:integration
+      pnpm --filter @openlinker/api migration:show
+      ```
+    - **Acceptance**: All commands exit 0. `migration:show` lists `AddOutcomeToSyncJobs{timestamp}` as run.
+
+25. **Audit-lite write-up + PR**
+    - **Action**: Write the PR body with: summary; scope; the audit-lite findings (one bullet per handler); links to follow-up issues filed (if any); `Closes #400`. Include screenshot of the FE list page showing the new badge tone for at least one `succeeded + business_failure` row.
+
+---
+
+### Implementation Details (rolled up)
+
+**New Components**:
+- **Domain**: `JobOutcomeValues` + `JobOutcome` (sync types); `OfferCreationInvariantException` (listings exception).
+- **Application**: `recordToOutcome` private helper in `OfferCreationExecutionService`; `outcome` field on `ExecuteOfferCreationResult`.
+- **Infrastructure**: nullable `outcome` column on `sync_jobs`; `markSucceeded(id, outcome)` repository method; SyncJob domain + ORM entity additions.
+- **Interface**: `outcome` field on `SyncJobResponseDto`; `outcome` query param on list endpoint; `SyncJobStatusBadge` (status, outcome) prop pair; outcome filter dropdown on list page.
+
+**Configuration Changes**: None.
+
+**Database Migrations**: Single migration `AddOutcomeToSyncJobs{timestamp}` adding nullable `outcome varchar` column. Reversible.
+
+**Events**: None emitted/consumed. The runner's existing `markSucceeded` write is the only persistence change.
+
+**Error Handling**:
+- New domain exception: `OfferCreationInvariantException` for the `pending` invariant.
+- Runner adds it to the non-retryable classification (markDead, no retry).
+
+**Reference**: [Engineering Standards — Project Structure](../engineering-standards.md#project-structure)
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: FE-only derivation (Option 0 from grilling)
+- **Description**: Don't change the backend. The list page joins/looks up `OfferCreationRecord` for each `marketplace.offer.create` job and renders a warning badge when the record is `failed`.
+- **Why Rejected**: Doesn't generalise (other handlers don't have a single linked record); pushes business semantics into the FE; "show me all jobs with business problems" requires a JOIN on every list query instead of `WHERE outcome=...`. Rejected after Q1 of the grilling.
+
+### Alternative 2: Throw a `TerminalBusinessFailureError` from the orchestrator
+- **Description**: Use the exception channel to signal business failure; runner catches a specific class and marks succeeded with `outcome=business_failure`.
+- **Why Rejected**: Conflates control flow (exceptions) with data (outcome). A business failure is a *fact*, not a control disruption — generates stack traces for routine outcomes, fights the type system on attached data. Rejected after Q4 of the grilling.
+
+### Alternative 3: Optional `outcome?` on handler return
+- **Description**: Keep handlers as `Promise<void | { outcome: JobOutcome }>`, default to `'ok'` when absent. Lets the 11 non-offer-create handlers stay unchanged.
+- **Why Rejected**: Silent footgun — an orchestrator could persist a failed record and forget to set outcome, and TypeScript wouldn't catch it. With required, the type system enforces "every handler explicitly states its business outcome." Rejected after Q4 of the grilling.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Domain layer (`libs/core/src/sync/domain/`, `libs/core/src/listings/domain/`) imports nothing from NestJS / TypeORM.
+- ✅ Outcome mapping lives in the application service (orchestrator), not in the runner or the handler — close to the status-meaning source.
+- ✅ Runner depends on the port (`SyncJobRepositoryPort`, `SyncJobHandler`), not concrete classes.
+- ✅ Repository converts persistence concerns; domain exceptions stay in `domain/exceptions/`.
+- **Reference**: [Architecture Overview — Layer Dependencies](../architecture-overview.md#layer-dependencies)
+
+### Naming Conventions
+- ✅ `*.types.ts` for `JobOutcome`; `*.exception.ts` for the new exception; `*.handler.ts` unchanged.
+- ✅ `as const` array + derived union (no enum).
+- ✅ FE component is `SyncJobStatusBadge.tsx` (PascalCase export, kebab filename per FE conventions).
+- **Reference**: [Engineering Standards — Naming Conventions](../engineering-standards.md#naming-conventions)
+
+### Existing Patterns
+- ✅ Follows `JobStatusValues` → `JobStatus` template for the new union.
+- ✅ Mirrors existing repository write methods' shape (`markFailed(id, error, nextRunAt)`).
+- ✅ FE filter via URL search params, matching how the existing `status` filter works.
+
+### Risks
+- **Port-contract change cascade**: `SyncJobRepositoryPort.markSucceeded` and `SyncJobHandler.execute` both change shape. Surfaces in: ports, TypeORM repo, in-memory test doubles, every handler implementation, every handler unit test, the runner. **Mitigation**: TypeScript catches every site at compile time; reviewer greps for `markSucceeded(` and `execute(` to confirm full coverage.
+- **Invariant retry trap**: If `OfferCreationInvariantException` falls through into the runner's transient bucket, the job retries 10× before dying. **Mitigation**: explicit non-retryable classification in step 16 + a runner unit test in step 17 that asserts `markDead` is called immediately.
+- **Audit-lite false negative**: Reading 11 orchestrators may miss a subtle silent-business-failure branch. **Mitigation**: filing one follow-up issue is cheap; the bug exists today — we're not making anything worse if we miss one. The `outcome='ok'` default is correct for the majority case.
+- **Migration timestamp collision** in branch-merge windows. **Mitigation**: `pnpm lint` enforces uniqueness via `scripts/check-migration-timestamps.mjs`; bump the new migration's prefix if the lint fails.
+
+### Edge Cases
+- **`OfferCreationRecord.status = 'pending'` on return** → throws `OfferCreationInvariantException` → runner classifies non-retryable → `markDead`. No silent corruption.
+- **Retry of a dead `marketplace.offer.create` job** → existing endpoint resets to `queued` (outcome remains NULL); on next run, fresh outcome gets written. Frozen-per-row holds because succeeded rows can't be retried via this endpoint.
+- **Validating → failed transition via the future poll handler** → original create-job's `outcome` stays `'ok'` (frozen, snapshot at job-time). The future poll-job carries its own outcome reflecting the eventual transition. Documented in Risk #4 of the issue body.
+- **Handler that throws after partial work** → throw bypasses return; runner runs the existing failed/dead classification; outcome stays NULL. Correct.
+
+### Backward Compatibility
+- ✅ Database: column is nullable, no defaults, no backfill — historical rows keep working with NULL outcome.
+- ❌ **Type-level breaking** for consumers of `SyncJobHandler.execute` and `SyncJobRepositoryPort.markSucceeded`. Both are internal to the monorepo; no external consumer. Every internal site is updated in the same PR.
+- ✅ API: `outcome` is a new optional response field; new optional query param. Existing FE/clients ignore them.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts` — outcome derivation per status; throws on `pending`; logs on `business_failure`.
+- `apps/worker/src/sync/__tests__/sync-job.runner.spec.ts` (or equivalent) — outcome wiring, invariant-classification path.
+- Each handler's existing `*.spec.ts` updated for the new return shape.
+- `apps/web/src/features/sync-jobs/components/SyncJobStatusBadge.test.tsx` — all four (status, outcome) combinations.
+
+### Integration Tests
+- `apps/api/test/integration/sync-job-outcome.int-spec.ts` — full vertical slice: persistence, response DTO, list filter.
+- **Reference**: [Testing Guide — Integration Tests](../testing-guide.md#integration-tests)
+
+### Mocking Strategy
+- Unit tests mock `SyncJobRepositoryPort`, `IOfferCreationExecutionService`, `OfferCreationRecordRepositoryPort` — never concrete classes.
+- Integration test uses real Postgres + Redis via Testcontainers; mocks only the Allegro HTTP client.
+
+### Acceptance Criteria
+Mirrors the issue body; condensed:
+- [ ] Migration adds nullable `outcome varchar`; up/down verified; `pnpm lint` timestamp check passes.
+- [ ] `JobOutcomeValues` + `JobOutcome` defined per `as const` pattern.
+- [ ] `SyncJobRepositoryPort.markSucceeded(id, outcome)` updated everywhere; grep-clean.
+- [ ] All 12 handlers return `{ outcome }`; offer-create derives, others mechanical `'ok'`.
+- [ ] `OfferCreationInvariantException` + runner non-retryable classification.
+- [ ] Orchestrator `Logger.warn` on `business_failure`.
+- [ ] `SyncJobResponseDto.outcome` + `@ApiProperty` annotation.
+- [ ] `GET /sync/jobs?outcome=business_failure` filter works.
+- [ ] FE badge warning tone for `(succeeded, business_failure)`; tests cover all 4.
+- [ ] FE outcome filter dropdown via URL search params.
+- [ ] Integration test (`*.int-spec.ts`) covering the vertical slice.
+- [ ] Audit-lite write-up in PR description; per-handler follow-ups filed where applicable.
+- [ ] `pnpm lint && pnpm type-check && pnpm test && pnpm test:integration` all green.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture (CORE → Application → Infrastructure → Interface)
+- [x] Respects CORE vs Integration boundaries (no `libs/integrations/` changes)
+- [x] Uses existing patterns (`as const` + union; private repo mappers; runner classification list)
+- [x] Idempotency considered (frozen-per-row; succeeded jobs not retryable)
+- [x] Event-driven patterns N/A (no events emitted/consumed by this change)
+- [x] Rate limits & retries addressed (invariant exception is non-retryable)
+- [x] Error handling comprehensive (domain exception + runner classification)
+- [x] Testing strategy complete (unit + integration vertical slice)
+- [x] Naming conventions followed (`*.types.ts`, `*.exception.ts`, `*.handler.ts`)
+- [x] File structure matches standards
+- [x] Plan is execution-ready (every step has a concrete file path + acceptance criterion)
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)
+- [Code Review Guide](../code-review-guide.md)
+- [Migrations Guide](../migrations.md)
+- [Frontend Architecture](../frontend-architecture.md)
+- [Frontend UI Style Guide](../frontend-ui-style-guide.md)
+- Issue [#400](https://github.com/SilkSoftwareHouse/openlinker/issues/400) — this PR's parent
+- Issue [#391](https://github.com/SilkSoftwareHouse/openlinker/issues/391) — Plan A (closed, shipped via PR #396)

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
@@ -20,6 +20,7 @@ import { OfferCreationExecutionService } from '../offer-creation-execution.servi
 import { OfferCreationRecord } from '../../../domain/entities/offer-creation-record.entity';
 import { MasterCatalogConnectionNotConfiguredException } from '../../../domain/exceptions/master-catalog-connection-not-configured.exception';
 import { OfferBuilderValidationException } from '../../../domain/exceptions/offer-builder-validation.exception';
+import { OfferCreationInvariantException } from '../../../domain/exceptions/offer-creation-invariant.exception';
 import { OfferCreationRecordNotFoundException } from '../../../domain/exceptions/offer-creation-record-not-found.exception';
 import type { OfferCreationRecordRepositoryPort } from '../../../domain/ports/offer-creation-record-repository.port';
 import {
@@ -354,6 +355,109 @@ describe('OfferCreationExecutionService', () => {
       price: { amount: 99.5, currency: 'EUR' },
       overrides,
       idempotencyKey: 'idem-1',
+    });
+  });
+
+  // Issue #400 — Plan B for #391: outcome derivation on the result.
+  describe('outcome derivation', () => {
+    it('returns outcome=ok when adapter persists status=draft', async () => {
+      adapter.createOffer.mockResolvedValueOnce({
+        externalOfferId: EXTERNAL_OFFER_ID,
+        status: 'draft',
+      } satisfies CreateOfferResult);
+
+      const result = await service.executeCreation(baseInput);
+
+      expect(result.outcome).toBe('ok');
+      expect(result.offerCreationRecord.status).toBe('draft');
+    });
+
+    it('returns outcome=ok when adapter persists status=active', async () => {
+      adapter.createOffer.mockResolvedValueOnce({
+        externalOfferId: EXTERNAL_OFFER_ID,
+        status: 'active',
+      } satisfies CreateOfferResult);
+
+      const result = await service.executeCreation(baseInput);
+
+      expect(result.outcome).toBe('ok');
+    });
+
+    it('returns outcome=ok when adapter returns validating (poll handler will resolve later)', async () => {
+      adapter.createOffer.mockResolvedValueOnce({
+        externalOfferId: EXTERNAL_OFFER_ID,
+        status: 'validating',
+      } satisfies CreateOfferResult);
+
+      const result = await service.executeCreation(baseInput);
+
+      expect(result.outcome).toBe('ok');
+    });
+
+    it('returns outcome=business_failure when builder validation fails', async () => {
+      builder.buildCreateOfferCommand.mockRejectedValueOnce(
+        new OfferBuilderValidationException([
+          { field: 'price.amount', code: 'REQUIRED', message: 'Required' },
+        ]),
+      );
+
+      const result = await service.executeCreation(baseInput);
+
+      expect(result.outcome).toBe('business_failure');
+      expect(result.offerCreationRecord.status).toBe('failed');
+    });
+
+    it('returns outcome=business_failure when master catalog is misconfigured', async () => {
+      builder.buildCreateOfferCommand.mockRejectedValueOnce(
+        new MasterCatalogConnectionNotConfiguredException(CONNECTION_ID),
+      );
+
+      const result = await service.executeCreation(baseInput);
+
+      expect(result.outcome).toBe('business_failure');
+    });
+
+    it('returns outcome=business_failure when the adapter rejects with OfferCreateRejectedException', async () => {
+      adapter.createOffer.mockRejectedValueOnce(
+        new OfferCreateRejectedException('allegro.publicapi.v1', 422, [
+          { field: 'category', code: 'INVALID', message: 'Unknown category' },
+        ]),
+      );
+
+      const result = await service.executeCreation(baseInput);
+
+      expect(result.outcome).toBe('business_failure');
+    });
+
+    it('logs a warn line on the business_failure branch', async () => {
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+      adapter.createOffer.mockRejectedValueOnce(
+        new OfferCreateRejectedException('allegro.publicapi.v1', 422, [
+          { field: 'category', code: 'INVALID', message: 'Unknown category' },
+        ]),
+      );
+
+      await service.executeCreation(baseInput);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('business_failure'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('throws OfferCreationInvariantException when the record stays in pending after the flow', async () => {
+      // Return shape never normally occurs — but defensively: the orchestrator should
+      // fail loudly rather than silently mislabel a pending record as ok.
+      adapter.createOffer.mockResolvedValueOnce({
+        externalOfferId: EXTERNAL_OFFER_ID,
+        status: 'active',
+      } satisfies CreateOfferResult);
+      records.updateExternalIdAndStatus.mockResolvedValueOnce(buildRecord({ status: 'pending' }));
+
+      await expect(service.executeCreation(baseInput)).rejects.toBeInstanceOf(
+        OfferCreationInvariantException,
+      );
     });
   });
 });

--- a/libs/core/src/listings/application/services/offer-creation-execution.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-execution.service.ts
@@ -33,6 +33,7 @@ import {
 import { OfferManagerPort, isOfferCreator } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { CreateOfferCommand, CreateOfferResult, CreateOfferValidationError, OfferCreateRejectedException } from '@openlinker/core/listings';
+import type { JobOutcome } from '@openlinker/core/sync';
 import { Logger } from '@openlinker/shared/logging';
 
 import { OfferCreationRecord } from '../../domain/entities/offer-creation-record.entity';
@@ -41,6 +42,7 @@ import {
   OfferBuilderValidationException,
   OfferBuilderValidationIssue,
 } from '../../domain/exceptions/offer-builder-validation.exception';
+import { OfferCreationInvariantException } from '../../domain/exceptions/offer-creation-invariant.exception';
 import { OfferCreationRecordNotFoundException } from '../../domain/exceptions/offer-creation-record-not-found.exception';
 import { OfferCreationRecordRepositoryPort } from '../../domain/ports/offer-creation-record-repository.port';
 import { OfferCreationError } from '../../domain/types/offer-creation-record.types';
@@ -88,7 +90,7 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
       const terminal = this.mapBuilderException(error);
       if (terminal) {
         const updated = await this.offerCreationRecords.updateStatus(record.id, 'failed', terminal);
-        return { offerCreationRecord: updated };
+        return this.buildResult(updated, input.connectionId);
       }
       throw error;
     }
@@ -113,7 +115,7 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
           'failed',
           this.mapRejectionErrors(error),
         );
-        return { offerCreationRecord: updated };
+        return this.buildResult(updated, input.connectionId);
       }
       throw error;
     }
@@ -147,7 +149,46 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
       );
     }
 
-    return { offerCreationRecord: finalRecord };
+    return this.buildResult(finalRecord, input.connectionId);
+  }
+
+  /**
+   * Map an `OfferCreationRecord` to its corresponding `JobOutcome`.
+   *
+   * Domain semantics — kept here (rather than in the worker handler) so the
+   * future REST entrypoint (#259) gets the same mapping for free.
+   *
+   * - `'failed'` → `'business_failure'` (terminal rejection by marketplace,
+   *   builder, or master-catalog config — not retryable; operator action).
+   * - `'active' | 'draft' | 'validating'` → `'ok'` (the create operation
+   *   itself succeeded; any subsequent async transitions are tracked on the
+   *   record, not the job — see issue #400 risk #4).
+   * - `'pending'` → invariant violation (see {@link OfferCreationInvariantException}).
+   */
+  private recordToOutcome(record: OfferCreationRecord): JobOutcome {
+    switch (record.status) {
+      case 'failed':
+        return 'business_failure';
+      case 'active':
+      case 'draft':
+      case 'validating':
+        return 'ok';
+      case 'pending':
+        throw new OfferCreationInvariantException(record.id, record.status);
+    }
+  }
+
+  private buildResult(
+    record: OfferCreationRecord,
+    connectionId: string,
+  ): ExecuteOfferCreationResult {
+    const outcome = this.recordToOutcome(record);
+    if (outcome === 'business_failure') {
+      this.logger.warn(
+        `Offer creation recorded business_failure. recordId=${record.id} connectionId=${connectionId} errorCount=${record.errors?.length ?? 0}`,
+      );
+    }
+    return { offerCreationRecord: record, outcome };
   }
 
   private async loadOrCreateRecord(

--- a/libs/core/src/listings/application/types/offer-creation-execution.types.ts
+++ b/libs/core/src/listings/application/types/offer-creation-execution.types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CreateOfferOverrides } from '@openlinker/core/listings';
+import type { JobOutcome } from '@openlinker/core/sync';
 
 import type { OfferCreationRecord } from '../../domain/entities/offer-creation-record.entity';
 
@@ -37,4 +38,14 @@ export interface ExecuteOfferCreationInput {
 export interface ExecuteOfferCreationResult {
   /** Terminal-state record after the flow finishes (success or recorded failure). */
   offerCreationRecord: OfferCreationRecord;
+  /**
+   * Business outcome of the creation:
+   * - `'ok'` when the record landed in `active` / `draft` / `validating`,
+   * - `'business_failure'` when the record landed in `failed` (builder
+   *   validation, master-catalog misconfig, marketplace rejection).
+   *
+   * Threaded back through the worker handler to `SyncJobRunner`, which
+   * persists it on `sync_jobs.outcome`. See issue #400 (Plan B for #391).
+   */
+  outcome: JobOutcome;
 }

--- a/libs/core/src/listings/domain/exceptions/offer-creation-invariant.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/offer-creation-invariant.exception.ts
@@ -1,0 +1,25 @@
+/**
+ * Offer Creation Invariant Exception
+ *
+ * Domain exception thrown when `OfferCreationExecutionService.executeCreation`
+ * is about to return with the underlying `OfferCreationRecord` still in its
+ * initial `pending` status. That state is unreachable in normal flow — the
+ * orchestrator either persists a terminal status (`failed`) on a domain
+ * rejection or transitions through `draft`/`validating`/`active` on success.
+ *
+ * Surfacing the violation as a typed exception lets the worker runner
+ * classify it as non-retryable (markDead) instead of burning retries on a
+ * code bug. See issue #400 (Plan B follow-up to #391).
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+export class OfferCreationInvariantException extends Error {
+  constructor(recordId: string, actualStatus: string) {
+    super(
+      `OfferCreationRecord ${recordId} returned in invariant-violating status: ` +
+        `${actualStatus}. Expected one of: failed | active | draft | validating.`,
+    );
+    this.name = 'OfferCreationInvariantException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -70,6 +70,7 @@ export type {
 } from './domain/types/offer-creation-request-snapshot.types';
 export type { OfferCreationRecordRepositoryPort } from './domain/ports/offer-creation-record-repository.port';
 export { OfferCreationRecordNotFoundException } from './domain/exceptions/offer-creation-record-not-found.exception';
+export { OfferCreationInvariantException } from './domain/exceptions/offer-creation-invariant.exception';
 export type { IOfferBuilderService } from './application/interfaces/offer-builder.service.interface';
 export type { BuildCreateOfferCommandInput } from './application/types/offer-builder.types';
 export type { IOfferCreationExecutionService } from './application/interfaces/offer-creation-execution.service.interface';

--- a/libs/core/src/sync/domain/entities/sync-job.entity.ts
+++ b/libs/core/src/sync/domain/entities/sync-job.entity.ts
@@ -6,7 +6,7 @@
  *
  * @module libs/core/src/sync/domain/entities
  */
-import { JobType, JobStatus } from '../types/sync-job.types';
+import { JobType, JobStatus, JobOutcome } from '../types/sync-job.types';
 
 export class SyncJob {
   constructor(
@@ -24,6 +24,7 @@ export class SyncJob {
     public readonly lastError: string | null,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
+    public readonly outcome?: JobOutcome | null,
   ) {}
 }
 

--- a/libs/core/src/sync/domain/exceptions/invalid-sync-job-state.error.ts
+++ b/libs/core/src/sync/domain/exceptions/invalid-sync-job-state.error.ts
@@ -10,7 +10,7 @@
  */
 export class InvalidSyncJobStateError extends Error {
   constructor(
-    public readonly field: 'jobType' | 'status',
+    public readonly field: 'jobType' | 'status' | 'outcome',
     public readonly value: string,
     public readonly jobId?: string,
   ) {

--- a/libs/core/src/sync/domain/ports/sync-job-handler.port.ts
+++ b/libs/core/src/sync/domain/ports/sync-job-handler.port.ts
@@ -13,6 +13,7 @@
  * @see {@link PrestashopProductSyncHandler} for an example implementation
  */
 import { SyncJob } from '../entities/sync-job.entity';
+import { SyncJobHandlerResult } from '../types/sync-job.types';
 
 /**
  * Sync Job Handler Port
@@ -23,16 +24,19 @@ import { SyncJob } from '../entities/sync-job.entity';
  */
 export interface SyncJobHandler {
   /**
-   * Execute a sync job
+   * Execute a sync job.
    *
-   * Processes the job by pulling data from adapters and persisting to canonical storage.
-   * Throws domain exceptions (e.g., SyncJobExecutionError) for errors that should
-   * trigger retries. The runner will handle retry logic and backoff.
+   * Resolves with a `SyncJobHandlerResult` whose `outcome` describes the
+   * business result; the runner persists it via `markSucceeded(id, outcome)`.
+   * Throws domain exceptions (e.g. `SyncJobExecutionError`) for errors that
+   * should trigger retries. The runner classifies a small set of exception
+   * classes as non-retryable (markDead).
    *
    * @param job - The sync job to execute
+   * @returns SyncJobHandlerResult with the business outcome of the run
    * @throws SyncJobExecutionError if job execution fails (will trigger retry)
    * @throws Error for unexpected errors (will also trigger retry)
    */
-  execute(job: SyncJob): Promise<void>;
+  execute(job: SyncJob): Promise<SyncJobHandlerResult>;
 }
 

--- a/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
+++ b/libs/core/src/sync/domain/ports/sync-job-repository.port.ts
@@ -11,6 +11,7 @@
  */
 import { SyncJob } from '../entities/sync-job.entity';
 import {
+  JobOutcome,
   SyncJobFilters,
   SyncJobPagination,
   PaginatedSyncJobs,
@@ -52,11 +53,17 @@ export interface SyncJobRepositoryPort {
   findAndLockDueJobs(limit: number, workerId: string): Promise<SyncJob[]>;
 
   /**
-   * Mark job as succeeded
+   * Mark job as succeeded and record its business outcome.
+   *
+   * The outcome captures whether the underlying business operation
+   * succeeded or terminated in a non-retryable rejection (e.g. marketplace
+   * validation failed on `marketplace.offer.create`). It is written
+   * atomically with the status flip — see issue #400 (Plan B for #391).
    *
    * @param id - Job ID
+   * @param outcome - Business outcome of the run (`'ok' | 'business_failure'`)
    */
-  markSucceeded(id: string): Promise<void>;
+  markSucceeded(id: string, outcome: JobOutcome): Promise<void>;
 
   /**
    * Mark job as failed and schedule retry

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -62,6 +62,41 @@ export const JobStatusValues = [
 export type JobStatus = (typeof JobStatusValues)[number];
 
 /**
+ * Job Outcome Values
+ *
+ * Runtime array of all valid job outcome values. Outcome is the *business*
+ * result of a successfully-orchestrated job — distinct from `status`, which
+ * is the orchestration result. Set only when a job reaches `succeeded`;
+ * `null` for queued / running / dead jobs (no business outcome to record).
+ *
+ * - `'ok'`: business operation succeeded.
+ * - `'business_failure'`: orchestration ran cleanly but the business
+ *   operation was rejected terminally (e.g. marketplace validation failed
+ *   on `marketplace.offer.create`). Not retried by the runner.
+ */
+export const JobOutcomeValues = ['ok', 'business_failure'] as const;
+
+/**
+ * Job Outcome
+ *
+ * Derived union type from JobOutcomeValues.
+ */
+export type JobOutcome = (typeof JobOutcomeValues)[number];
+
+/**
+ * Sync Job Handler Result
+ *
+ * Returned by every `SyncJobHandler.execute` implementation on the success
+ * (no-throw) path. Carries the *business* outcome of the run, threaded back
+ * through the worker runner to `sync_jobs.outcome` (issue #400 — Plan B for
+ * #391). Handlers without a meaningful business-failure branch return
+ * `{ outcome: 'ok' }` unconditionally.
+ */
+export interface SyncJobHandlerResult {
+  outcome: JobOutcome;
+}
+
+/**
  * Enqueue Job Result
  *
  * Returned by JobEnqueuePort.enqueueJob. Separates the job ID from the
@@ -114,6 +149,7 @@ export interface SyncJobFilters {
   status?: JobStatus;
   connectionId?: string;
   jobType?: JobType;
+  outcome?: JobOutcome;
 }
 
 /**
@@ -255,6 +291,17 @@ export interface SyncJob extends SyncJobRequest {
    * Last error message (if job failed)
    */
   lastError?: string | null;
+
+  /**
+   * Business outcome of the job (only set on the succeeded path).
+   *
+   * - `'ok'`: business operation succeeded.
+   * - `'business_failure'`: orchestration succeeded but the business
+   *   operation was rejected terminally (e.g. marketplace validation failed).
+   * - `null`: job has not reached `succeeded` (queued / running / dead),
+   *   or this is a historical row predating the outcome column (#400).
+   */
+  outcome?: JobOutcome | null;
 
   /**
    * Creation timestamp

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -30,9 +30,11 @@ export type {
 export type {
   SyncJob,
   SyncJobRequest,
+  SyncJobHandlerResult,
   EnqueueJobResult,
   JobType,
   JobStatus,
+  JobOutcome,
   SyncJobFilters,
   SyncJobPagination,
   PaginatedSyncJobs,
@@ -44,6 +46,7 @@ export type {
 export {
   JobTypeValues,
   JobStatusValues,
+  JobOutcomeValues,
   BULK_RETRY_MAX_BATCH_SIZE,
   SYNC_JOBS_EVENT_STREAM,
 } from './domain/types/sync-job.types';

--- a/libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts
+++ b/libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts
@@ -33,7 +33,14 @@ export class SyncJobOrmEntity {
   payloadJson!: Record<string, unknown>;
 
   @Column({ type: 'varchar' })
-  status!: string; // 'queued' | 'running' | 'succeeded' | 'failed' | 'dead'
+  status!: string; // 'queued' | 'running' | 'succeeded' | 'dead'
+
+  /**
+   * Business outcome of the run (`'ok' | 'business_failure'`); null for
+   * non-succeeded jobs. See issue #400 (Plan B for #391).
+   */
+  @Column({ type: 'varchar', nullable: true })
+  outcome!: string | null;
 
   @Column({ type: 'varchar', unique: true })
   idempotencyKey!: string;

--- a/libs/core/src/sync/infrastructure/persistence/repositories/__tests__/sync-job.repository.spec.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/__tests__/sync-job.repository.spec.ts
@@ -328,15 +328,32 @@ describe('SyncJobRepository', () => {
   });
 
   describe('markSucceeded', () => {
-    it('should update job status to succeeded and clear lock', async () => {
+    it('should update job status to succeeded with outcome=ok and clear lock', async () => {
       const jobId = randomUUID();
 
       ormRepository.update.mockResolvedValue({ affected: 1, generatedMaps: [], raw: [] });
 
-      await repository.markSucceeded(jobId);
+      await repository.markSucceeded(jobId, 'ok');
 
       expect(ormRepository.update).toHaveBeenCalledWith(jobId, {
         status: 'succeeded',
+        outcome: 'ok',
+        lockedAt: null,
+        lockedBy: null,
+        lastError: null,
+      });
+    });
+
+    it('should persist outcome=business_failure when handler reports a terminal business rejection', async () => {
+      const jobId = randomUUID();
+
+      ormRepository.update.mockResolvedValue({ affected: 1, generatedMaps: [], raw: [] });
+
+      await repository.markSucceeded(jobId, 'business_failure');
+
+      expect(ormRepository.update).toHaveBeenCalledWith(jobId, {
+        status: 'succeeded',
+        outcome: 'business_failure',
         lockedAt: null,
         lockedBy: null,
         lastError: null,

--- a/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
+++ b/libs/core/src/sync/infrastructure/persistence/repositories/sync-job.repository.ts
@@ -24,6 +24,8 @@ import { SyncJob } from '../../../domain/entities/sync-job.entity';
 import { InvalidSyncJobStateError } from '../../../domain/exceptions/invalid-sync-job-state.error';
 import { SyncJobNotFoundError } from '../../../domain/exceptions/sync-job-not-found.error';
 import {
+  JobOutcome,
+  JobOutcomeValues,
   JobStatus,
   JobStatusValues,
   JobType,
@@ -81,6 +83,7 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
       entity.lockedAt = null;
       entity.lockedBy = null;
       entity.lastError = null;
+      entity.outcome = null;
 
       const saved = await this.repository.save(entity);
       return this.toDomain(saved);
@@ -166,9 +169,10 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
     });
   }
 
-  async markSucceeded(id: string): Promise<void> {
+  async markSucceeded(id: string, outcome: JobOutcome): Promise<void> {
     await this.repository.update(id, {
       status: 'succeeded',
+      outcome,
       lockedAt: null,
       lockedBy: null,
       lastError: null,
@@ -207,10 +211,11 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
   }
 
   async findMany(filters: SyncJobFilters, pagination: SyncJobPagination): Promise<PaginatedSyncJobs> {
-    const where: { status?: string; connectionId?: string; jobType?: string } = {};
+    const where: { status?: string; connectionId?: string; jobType?: string; outcome?: string } = {};
     if (filters.status) where.status = filters.status;
     if (filters.connectionId) where.connectionId = filters.connectionId;
     if (filters.jobType) where.jobType = filters.jobType;
+    if (filters.outcome) where.outcome = filters.outcome;
 
     const [entities, total] = await this.repository.findAndCount({
       where,
@@ -422,6 +427,16 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
       throw new InvalidSyncJobStateError('status', entity.status, entity.id);
     }
 
+    // Validate outcome if present. NULL/undefined is the expected resting state
+    // for non-succeeded jobs and historical rows pre-dating issue #400.
+    if (
+      entity.outcome !== null &&
+      entity.outcome !== undefined &&
+      !this.isValidJobOutcome(entity.outcome)
+    ) {
+      throw new InvalidSyncJobStateError('outcome', entity.outcome, entity.id);
+    }
+
     return new SyncJob(
       entity.id,
       entity.jobType,
@@ -437,6 +452,7 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
       entity.lastError,
       entity.createdAt,
       entity.updatedAt,
+      entity.outcome ?? null,
     );
   }
 
@@ -452,6 +468,13 @@ export class SyncJobRepository implements SyncJobRepositoryPort {
    */
   private isValidJobStatus(value: string): value is JobStatus {
     return (JobStatusValues as readonly string[]).includes(value);
+  }
+
+  /**
+   * Type guard for JobOutcome
+   */
+  private isValidJobOutcome(value: string): value is JobOutcome {
+    return (JobOutcomeValues as readonly string[]).includes(value);
   }
 }
 


### PR DESCRIPTION
## Summary

Plan B for #391: backend-authoritative + list-level visibility for terminal business failures on sync jobs.

- **Schema**: nullable `sync_jobs.outcome varchar` (`'ok' | 'business_failure' | null`), set only on the succeeded path. NULL for queued / running / dead jobs and historical rows pre-dating the column.
- **Contract**: `SyncJobHandler.execute()` returns a required `SyncJobHandlerResult { outcome }`. `SyncJobRepositoryPort.markSucceeded(id, outcome)` writes status + outcome atomically.
- **Orchestrator owns the mapping**: `OfferCreationExecutionService.recordToOutcome(record)` derives `'business_failure'` from `record.status === 'failed'`; `'active' | 'draft' | 'validating' → 'ok'`; `'pending' → throw OfferCreationInvariantException` (new domain exception).
- **Runner**: classifies `OfferCreationInvariantException` as non-retryable (markDead) — a code bug shouldn't burn 10 retries.
- **API**: `SyncJobResponseDto.outcome` exposed with Swagger annotation; `GET /sync/jobs?outcome=business_failure` filter added.
- **Frontend**: `SyncJobStatusBadge` accepts `(status, outcome)` and renders **warning** tone (yellow) for `succeeded + business_failure` — the label stays `succeeded`, tone alone carries the new signal. New outcome filter dropdown on the list page wired through URL search params (`?outcome=business_failure`). Detail page reuses the same component; Plan A's `OfferCreationTracker` remains the live record narrative.
- **Migration**: single nullable column, reversible, no defaults, no backfill, timestamp invariant honoured (`1790000000003`).

Closes #400

## Audit-lite of the other 11 handlers

Per option γ from the design grilling — each non-offer-create handler walked for the "catch domain exception → persist failed record → return clean" pattern that offer-create had:

| Handler | Verdict |
|---|---|
| `auto-match-variants` | Clean. `result.errors[]` is logged but not surfaced as outcome — partial-success, not silent business failure. |
| `inventory.propagateToMarketplaces` | Clean. Failures from `Promise.all` propagate as `SyncJobExecutionError`. |
| `marketplace.offer.updateFields` | Clean. Adapter rejection propagates. |
| `marketplace.offerQuantity.update` | **Worth a follow-up** — `result.failed[]` is wrapped in `SyncJobExecutionError` (transient retry path) even when the underlying Allegro 4xx is deterministic. Mechanical `'ok'` here today; future ticket should refine. |
| `marketplace.offers.sync` | Clean. |
| `marketplace.order.sync` | Clean. Exceptions propagate. |
| `master.inventory.syncAll` | **Worth a follow-up** — fan-out via `Promise.allSettled`; partial fan-out failures logged but counted as success. |
| `master.inventory.syncByExternalId` | Clean. |
| `master.product.syncAll` | **Worth a follow-up** — same fan-out shape as inventory.syncAll. |
| `master.product.syncByExternalId` | Clean. |
| `marketplace.orders.poll` | Clean. `skippedDueToLock` is a deliberate `'ok'`. |

**No handler ships a wrong outcome today.** All currently return `'ok'` mechanically; the three flagged for follow-ups have *partial-success* / *fan-out* semantics that could grow `business_failure` reporting later but aren't silent business failures in the #391 sense. Follow-up issues will be filed under `tech-debt` after merge.

## Tests

- **Unit (1,167 total — all green):**
  - `OfferCreationExecutionService` — 7 new outcome cases (each status mapping + invariant throw + warn-log).
  - `SyncJobRunner` — outcome wiring on succeeded path; `OfferCreationInvariantException` → markDead classification; outcome=NULL on dead/failed paths.
  - `SyncJobRepository.markSucceeded` — both `'ok'` and `'business_failure'` paths.
  - `SyncJobStatusBadge` — all 6 status × outcome combinations; tone-only label semantics.
  - All 12 handlers' existing unit specs updated for the new `Promise<SyncJobHandlerResult>` shape.
- **Integration (`apps/api/test/integration/sync-jobs-read.int-spec.ts`, 14 total):** 4 new tests for the outcome vertical slice — DTO field, NULL semantics for non-succeeded jobs, `?outcome=business_failure` filter, invalid filter rejection.

## Test plan

- [ ] CI green: `pnpm lint`, `pnpm type-check`, `pnpm test`, `pnpm test:integration`.
- [ ] Migration applies cleanly to a non-test environment: `pnpm --filter @openlinker/api migration:run`, then `migration:revert` to confirm reversibility.
- [ ] Manual smoke: enqueue a `marketplace.offer.create` job that triggers Allegro rejection (e.g., on the sandbox connection from #392's repro). Confirm:
  - List page shows the row with **warning tone** badge (yellow) instead of green.
  - `GET /sync/jobs/:id` returns `outcome: 'business_failure'`.
  - Filter dropdown narrows to that row when `outcome=business_failure` is selected.
  - Detail page badge matches; `OfferCreationTracker` (Plan A) renders the live record state below it.
- [ ] Manual smoke for ok path: a successful offer-create job shows green succeeded badge with `outcome=ok`.
- [ ] Spot-check that all 11 non-offer-create job types still write `outcome=ok` after running.

## Out of scope (follow-ups planned)

- Per-handler refinements for the three flagged handlers above.
- Backfill of historical `sync_jobs.outcome` from `OfferCreationRecord` history.
- Async-validation poll handler (`marketplace.offer.pollCreationStatus`) — it'll write its own outcome once it lands.
- Index on `sync_jobs.outcome` — defer until list-page latency degrades or table > ~1M rows.
- DB-level CHECK constraint — consistent with how `sync_jobs.status` is shaped today.

## Related

- Issue #400 — design + acceptance criteria
- Issue #391 (closed) — Plan A shipped via #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
