### PR TITLE
feat(web): admin UI for AI provider API key settings

### DIFF
--- a/apps/api/test/integration/harness.ts
+++ b/apps/api/test/integration/harness.ts
@@ -77,6 +77,16 @@ export async function startHarness(): Promise<void> {
   // Regression guard: test/integration/bootstrap-admin-disabled.int-spec.ts
   process.env.OL_BOOTSTRAP_ADMIN_ENABLED = 'false';
 
+  // Force the deterministic FakeAiCompletionAdapter for every integration
+  // suite. Without this, `AiIntegrationModule` defaults to `anthropic`, which
+  // (a) requires a real ANTHROPIC_API_KEY in CI and (b) makes any test that
+  // exercises the suggest / provider-settings surface non-deterministic.
+  // Matches the documented intent in the content-editor int-spec docblock
+  // ("OL_AI_PROVIDER=fake makes the suggest path deterministic — no network
+  // egress") and the ai-provider-settings int-spec, which asserts fake-mode
+  // behaviour explicitly.
+  process.env.OL_AI_PROVIDER = 'fake';
+
   // Store containers on globalThis for teardown
   globalThis.__API_TEST_HARNESS__ = { postgres, redis };
 }

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -1,4 +1,8 @@
 import { createAdaptersApi, type AdaptersApi } from '../../features/adapters/api/adapters.api';
+import {
+  createAiProviderSettingsApi,
+  type AiProviderSettingsApi,
+} from '../../features/ai-provider-settings/api/ai-provider-settings.api';
 import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/allegro.api';
 import { createAuthApi, type AuthApi } from '../../features/auth/api/auth.api';
 import { createConnectionsApi, type ConnectionsApi } from '../../features/connections/api/connections.api';
@@ -34,6 +38,7 @@ interface ApiClientConfig {
 
 export interface ApiClient {
   adapters: AdaptersApi;
+  aiProviderSettings: AiProviderSettingsApi;
   allegro: AllegroApi;
   auth: AuthApi;
   connections: ConnectionsApi;
@@ -130,6 +135,7 @@ export function createApiClient({
 
   return {
     adapters: createAdaptersApi(request),
+    aiProviderSettings: createAiProviderSettingsApi(request),
     allegro: createAllegroApi(request),
     auth: createAuthApi(request),
     connections: createConnectionsApi(request),

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -111,7 +111,10 @@ function buildNavGroups({ isAdmin }: NavGroupOptions): NavGroup[] {
     groups.push({
       kind: 'live',
       label: 'AI',
-      items: [{ to: '/ai/prompt-templates', label: 'Prompt templates' }],
+      items: [
+        { to: '/ai/prompt-templates', label: 'Prompt templates' },
+        { to: '/ai/provider-settings', label: 'Provider settings' },
+      ],
     });
   }
 
@@ -147,6 +150,7 @@ const staticCrumbs: Record<string, { group: string; title: string }> = {
   '/adapters': { group: 'Platform', title: 'Adapters' },
   '/settings': { group: 'Platform', title: 'Settings' },
   '/ai/prompt-templates': { group: 'AI', title: 'Prompt templates' },
+  '/ai/provider-settings': { group: 'AI', title: 'Provider settings' },
 };
 
 function resolveCrumbs(pathname: string): { group: string; title: string } {

--- a/apps/web/src/app/routes/ai-provider-settings.route.tsx
+++ b/apps/web/src/app/routes/ai-provider-settings.route.tsx
@@ -1,0 +1,7 @@
+import type { RouteObject } from 'react-router-dom';
+import { AiProviderSettingsPage } from '../../pages/ai-provider-settings/ai-provider-settings-page';
+
+export const aiProviderSettingsRoute: RouteObject = {
+  path: 'ai/provider-settings',
+  element: <AiProviderSettingsPage />,
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -12,6 +12,7 @@ import { cursorsRoute } from './cursors.route';
 import { customersRoute } from './customers.route';
 import { dashboardRoute } from './dashboard.route';
 import { listingsRoute } from './listings.route';
+import { aiProviderSettingsRoute } from './ai-provider-settings.route';
 import { inventoryRoute } from './inventory.route';
 import { jobsLogsRoute } from './jobs-logs.route';
 import { newConnectionRoute } from './new-connection.route';
@@ -57,5 +58,6 @@ export const rootRoute: RouteObject = {
     promptTemplateDetailRoute,
     promptTemplatesLegacyListRedirectRoute,
     promptTemplateLegacyDetailRedirectRoute,
+    aiProviderSettingsRoute,
   ],
 };

--- a/apps/web/src/features/ai-provider-settings/api/ai-provider-settings.api.ts
+++ b/apps/web/src/features/ai-provider-settings/api/ai-provider-settings.api.ts
@@ -1,0 +1,40 @@
+/**
+ * AI Provider Settings API Client
+ *
+ * Thin HTTP adapter over the admin-only `/ai-provider-settings` endpoints
+ * shipped in #402. Instantiated by `createApiClient()` and consumed
+ * through `useApiClient().aiProviderSettings`.
+ *
+ * @module apps/web/src/features/ai-provider-settings/api
+ */
+import type {
+  AiProviderSettingsView,
+  UpdateAiProviderSettingsInput,
+} from './ai-provider-settings.types';
+
+export interface AiProviderSettingsApi {
+  get: () => Promise<AiProviderSettingsView>;
+  update: (input: UpdateAiProviderSettingsInput) => Promise<void>;
+  clear: () => Promise<void>;
+}
+
+interface ApiRequest {
+  <T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+export function createAiProviderSettingsApi(request: ApiRequest): AiProviderSettingsApi {
+  return {
+    get(): Promise<AiProviderSettingsView> {
+      return request<AiProviderSettingsView>('/ai-provider-settings');
+    },
+    async update(input): Promise<void> {
+      await request<void>('/ai-provider-settings', {
+        method: 'PUT',
+        body: JSON.stringify(input),
+      });
+    },
+    async clear(): Promise<void> {
+      await request<void>('/ai-provider-settings', { method: 'DELETE' });
+    },
+  };
+}

--- a/apps/web/src/features/ai-provider-settings/api/ai-provider-settings.query-keys.ts
+++ b/apps/web/src/features/ai-provider-settings/api/ai-provider-settings.query-keys.ts
@@ -1,0 +1,13 @@
+/**
+ * AI Provider Settings — Query Key Factory
+ *
+ * Singular resource (one row server-side) so `current()` is the only key.
+ * The `all` key is the invalidation root used by mutation hooks.
+ *
+ * @module apps/web/src/features/ai-provider-settings/api
+ */
+
+export const aiProviderSettingsQueryKeys = {
+  all: ['ai-provider-settings'] as const,
+  current: () => ['ai-provider-settings', 'current'] as const,
+};

--- a/apps/web/src/features/ai-provider-settings/api/ai-provider-settings.types.ts
+++ b/apps/web/src/features/ai-provider-settings/api/ai-provider-settings.types.ts
@@ -1,0 +1,39 @@
+/**
+ * AI Provider Settings — Frontend Types
+ *
+ * Hand-written wire types mirroring the backend DTOs in
+ * `apps/api/src/ai/http/dto/ai-provider-settings-*.dto.ts`. Kept FE-local
+ * so the web bundle stays independent of NestJS / core imports.
+ *
+ * @module apps/web/src/features/ai-provider-settings/api
+ */
+
+export const AiProviderValues = ['anthropic', 'fake'] as const;
+export type AiProvider = (typeof AiProviderValues)[number];
+
+/**
+ * Where the API key currently resolves from on the server.
+ *   - `db`   — encrypted row in `integration_credentials` (the source of truth)
+ *   - `env`  — legacy `ANTHROPIC_API_KEY` env-var fallback (deprecated)
+ *   - `none` — neither DB nor env has a key
+ *
+ * Resolution priority is **DB → env**: when both are set, the server reports
+ * `db` and the env value is unused.
+ */
+export const AiProviderKeySourceValues = ['db', 'env', 'none'] as const;
+export type AiProviderKeySource = (typeof AiProviderKeySourceValues)[number];
+
+/**
+ * Response shape for `GET /ai-provider-settings`. Never includes the key
+ * value — the server cannot read it once stored.
+ */
+export interface AiProviderSettingsView {
+  provider: AiProvider;
+  configured: boolean;
+  source: AiProviderKeySource;
+}
+
+/** Body for `PUT /ai-provider-settings`. The server trims `apiKey` before validating. */
+export interface UpdateAiProviderSettingsInput {
+  apiKey: string;
+}

--- a/apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.schema.ts
+++ b/apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.schema.ts
@@ -1,0 +1,24 @@
+/**
+ * AI Provider Settings Form — Zod Schema
+ *
+ * Trims the pasted API key before validating (matches the BE DTO at
+ * `apps/api/src/ai/http/dto/update-ai-provider-settings.dto.ts`, which
+ * also trims). Length bounds align with the BE validators (8..512).
+ *
+ * @module apps/web/src/features/ai-provider-settings/components
+ */
+import { z } from 'zod';
+
+export const MIN_API_KEY_LENGTH = 8;
+export const MAX_API_KEY_LENGTH = 512;
+
+export const aiProviderSettingsFormSchema = z.object({
+  apiKey: z
+    .string()
+    .trim()
+    .min(MIN_API_KEY_LENGTH, `API key must be at least ${MIN_API_KEY_LENGTH} characters`)
+    .max(MAX_API_KEY_LENGTH, `API key is too long (max ${MAX_API_KEY_LENGTH} characters)`),
+});
+
+export type AiProviderSettingsFormValues = z.input<typeof aiProviderSettingsFormSchema>;
+export type AiProviderSettingsFormSubmission = z.output<typeof aiProviderSettingsFormSchema>;

--- a/apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.test.tsx
+++ b/apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * AI Provider Settings Form — Unit Tests
+ *
+ * Asserts: validation gates submission, the trimmed key flows to the
+ * update mutation, the clear button only appears for `source=db`, and
+ * the clear flow goes through the confirm dialog before calling the
+ * clear mutation.
+ *
+ * @module apps/web/src/features/ai-provider-settings/components
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { AiProviderSettingsForm } from './ai-provider-settings-form';
+
+// jsdom does not implement showModal/close — stub them on HTMLDialogElement
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+afterEach(cleanup);
+
+describe('AiProviderSettingsForm', () => {
+  it('submits a valid apiKey, calls the update mutation, and clears the field on success', async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ aiProviderSettings: { update } });
+    const user = userEvent.setup();
+
+    renderWithProviders(<AiProviderSettingsForm currentSource="none" />, { apiClient });
+
+    const input = screen.getByLabelText<HTMLInputElement>('API key');
+    await user.type(input, 'sk-ant-test-key-12345');
+    await user.click(screen.getByRole('button', { name: /save key/i }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith({ apiKey: 'sk-ant-test-key-12345' });
+    });
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+  });
+
+  it('trims the key before submitting (paste with surrounding whitespace)', async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ aiProviderSettings: { update } });
+    const user = userEvent.setup();
+
+    renderWithProviders(<AiProviderSettingsForm currentSource="none" />, { apiClient });
+
+    const input = screen.getByLabelText('API key');
+    await user.type(input, '   sk-ant-pasted-with-spaces   ');
+    await user.click(screen.getByRole('button', { name: /save key/i }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith({ apiKey: 'sk-ant-pasted-with-spaces' });
+    });
+  });
+
+  it('blocks submission and shows a validation message when apiKey is too short', async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ aiProviderSettings: { update } });
+    const user = userEvent.setup();
+
+    renderWithProviders(<AiProviderSettingsForm currentSource="none" />, { apiClient });
+
+    await user.type(screen.getByLabelText('API key'), 'short');
+    await user.click(screen.getByRole('button', { name: /save key/i }));
+
+    // Both the inline FieldError and the post-submit FormErrorSummary render the same
+    // message — assert at least one match rather than uniqueness.
+    const matches = await screen.findAllByText(/at least 8 characters/i);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('renders the API error in an Alert at the form top when the update fails', async () => {
+    const update = vi.fn().mockRejectedValue(new Error('Active provider does not require an API key'));
+    const apiClient = createMockApiClient({ aiProviderSettings: { update } });
+    const user = userEvent.setup();
+
+    renderWithProviders(<AiProviderSettingsForm currentSource="none" />, { apiClient });
+
+    await user.type(screen.getByLabelText('API key'), 'sk-ant-valid-shape-key');
+    await user.click(screen.getByRole('button', { name: /save key/i }));
+
+    expect(
+      await screen.findByText('Active provider does not require an API key'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the clear button when source is none', () => {
+    renderWithProviders(<AiProviderSettingsForm currentSource="none" />);
+    expect(
+      screen.queryByRole('button', { name: /clear stored key/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the clear button when source is env', () => {
+    renderWithProviders(<AiProviderSettingsForm currentSource="env" />);
+    expect(
+      screen.queryByRole('button', { name: /clear stored key/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the clear button when source is db and gates the clear behind a confirm dialog', async () => {
+    const clear = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ aiProviderSettings: { clear } });
+    const user = userEvent.setup();
+
+    renderWithProviders(<AiProviderSettingsForm currentSource="db" />, { apiClient });
+
+    await user.click(screen.getByRole('button', { name: /clear stored key/i }));
+
+    // ConfirmDialog opens
+    expect(
+      await screen.findByRole('heading', { name: /clear stored api key\?/i }),
+    ).toBeInTheDocument();
+
+    // Cancel without confirming → clear mutation is not invoked
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it('calls the clear mutation when the user confirms the dialog', async () => {
+    const clear = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ aiProviderSettings: { clear } });
+    const user = userEvent.setup();
+
+    renderWithProviders(<AiProviderSettingsForm currentSource="db" />, { apiClient });
+
+    await user.click(screen.getByRole('button', { name: /clear stored key/i }));
+    await user.click(screen.getByRole('button', { name: 'Clear key' }));
+
+    await waitFor(() => {
+      expect(clear).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.tsx
+++ b/apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.tsx
@@ -1,0 +1,161 @@
+/**
+ * AI Provider Settings Form
+ *
+ * Single-field RHF + Zod form for setting the AI provider API key. Renders
+ * a destructive "Clear stored key" affordance when the current source is
+ * `db` (gated behind a `ConfirmDialog`).
+ *
+ * UX wiring per `.claude/rules/fe-pages.md`:
+ *  - API errors surface in `<Alert>` at the form top
+ *  - Validation summary appears only after the first submit
+ *  - Submit / clear buttons disable while the relevant mutation is pending
+ *  - Toast on success; `form.reset()` after a successful save
+ *
+ * @module apps/web/src/features/ai-provider-settings/components
+ */
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState, type ReactElement } from 'react';
+import { useForm } from 'react-hook-form';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { useToast } from '../../../shared/ui/toast-provider';
+import type { AiProviderKeySource } from '../api/ai-provider-settings.types';
+import { useClearAiProviderSettingsMutation } from '../hooks/use-clear-ai-provider-settings-mutation';
+import { useUpdateAiProviderSettingsMutation } from '../hooks/use-update-ai-provider-settings-mutation';
+import {
+  aiProviderSettingsFormSchema,
+  type AiProviderSettingsFormSubmission,
+  type AiProviderSettingsFormValues,
+} from './ai-provider-settings-form.schema';
+
+interface AiProviderSettingsFormProps {
+  currentSource: AiProviderKeySource;
+}
+
+export function AiProviderSettingsForm({
+  currentSource,
+}: AiProviderSettingsFormProps): ReactElement {
+  const { showToast } = useToast();
+  const [clearOpen, setClearOpen] = useState(false);
+
+  const updateMutation = useUpdateAiProviderSettingsMutation();
+  const clearMutation = useClearAiProviderSettingsMutation();
+
+  const form = useForm<
+    AiProviderSettingsFormValues,
+    undefined,
+    AiProviderSettingsFormSubmission
+  >({
+    defaultValues: { apiKey: '' },
+    resolver: zodResolver(aiProviderSettingsFormSchema),
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      await updateMutation.mutateAsync({ apiKey: values.apiKey });
+      form.reset();
+      showToast({
+        tone: 'success',
+        title: 'API key saved',
+        description: 'Subsequent AI requests will use the new key.',
+      });
+    } catch {
+      // surfaced via updateMutation.error → <Alert> below
+    }
+  });
+
+  const onClearConfirm = async (): Promise<void> => {
+    try {
+      await clearMutation.mutateAsync();
+      setClearOpen(false);
+      showToast({
+        tone: 'success',
+        title: 'API key cleared',
+        description: 'Server falls back to the env variable, or none.',
+      });
+    } catch {
+      // surfaced via clearMutation.error → <Alert> below
+    }
+  };
+
+  const validationMessages = Object.values(form.formState.errors)
+    .map((entry) => entry?.message)
+    .filter((message): message is string => typeof message === 'string');
+
+  const showValidationSummary =
+    form.formState.submitCount > 0 && validationMessages.length > 0;
+
+  const apiError = updateMutation.error ?? clearMutation.error;
+
+  return (
+    <section aria-labelledby="ai-provider-form-heading">
+      <h2 id="ai-provider-form-heading" className="section-title">
+        Set or rotate API key
+      </h2>
+
+      {apiError ? (
+        <Alert tone="error" title="Could not save the key">
+          {apiError.message}
+        </Alert>
+      ) : null}
+
+      <form
+        onSubmit={(event) => {
+          void onSubmit(event);
+        }}
+        noValidate
+      >
+        {showValidationSummary ? <FormErrorSummary errors={validationMessages} /> : null}
+
+        <FormField
+          label="API key"
+          name="apiKey"
+          description="Stored encrypted at rest. Server-side only — never returned by the API."
+          error={form.formState.errors.apiKey?.message}
+        >
+          <Input
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="sk-ant-..."
+            {...form.register('apiKey')}
+          />
+        </FormField>
+
+        <div className="form-actions">
+          <Button type="submit" disabled={updateMutation.isPending}>
+            {updateMutation.isPending ? 'Saving…' : 'Save key'}
+          </Button>
+          {currentSource === 'db' ? (
+            <Button
+              type="button"
+              tone="danger"
+              onClick={() => setClearOpen(true)}
+              disabled={clearMutation.isPending}
+            >
+              Clear stored key
+            </Button>
+          ) : null}
+        </div>
+      </form>
+
+      <ConfirmDialog
+        open={clearOpen}
+        onOpenChange={setClearOpen}
+        title="Clear stored API key?"
+        description="The server will fall back to the env variable (if set) or report no key configured. AI requests will fail until a new key is saved."
+        confirmLabel="Clear key"
+        cancelLabel="Cancel"
+        tone="danger"
+        isConfirming={clearMutation.isPending}
+        onConfirm={() => {
+          void onClearConfirm();
+        }}
+      />
+    </section>
+  );
+}

--- a/apps/web/src/features/ai-provider-settings/components/ai-provider-status-card.test.tsx
+++ b/apps/web/src/features/ai-provider-settings/components/ai-provider-status-card.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * AI Provider Status Card — Unit Tests
+ *
+ * Verifies the three resolution sources (`db` / `env` / `none`) and the
+ * `provider=fake` case render distinct, non-color-only signals so the
+ * card stays accessible.
+ *
+ * @module apps/web/src/features/ai-provider-settings/components
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { AiProviderStatusCard } from './ai-provider-status-card';
+
+afterEach(cleanup);
+
+describe('AiProviderStatusCard', () => {
+  it('renders source=db with the "Stored encrypted" label and success tone', () => {
+    render(
+      <AiProviderStatusCard
+        view={{ provider: 'anthropic', configured: true, source: 'db' }}
+      />,
+    );
+
+    expect(screen.getByText('Stored encrypted')).toBeInTheDocument();
+    expect(screen.getByText('Stored encrypted').closest('.status-badge')).toHaveClass(
+      'status-badge--success',
+    );
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText('anthropic')).toBeInTheDocument();
+  });
+
+  it('renders source=env with the deprecated label and warning tone', () => {
+    render(
+      <AiProviderStatusCard
+        view={{ provider: 'anthropic', configured: true, source: 'env' }}
+      />,
+    );
+
+    expect(screen.getByText('Env fallback (deprecated)')).toBeInTheDocument();
+    expect(
+      screen.getByText('Env fallback (deprecated)').closest('.status-badge'),
+    ).toHaveClass('status-badge--warning');
+  });
+
+  it('renders source=none with the "Not configured" label and neutral tone', () => {
+    render(
+      <AiProviderStatusCard
+        view={{ provider: 'anthropic', configured: false, source: 'none' }}
+      />,
+    );
+
+    expect(screen.getByText('Not configured')).toBeInTheDocument();
+    expect(screen.getByText('Not configured').closest('.status-badge')).toHaveClass(
+      'status-badge--neutral',
+    );
+    expect(screen.getByText('No')).toBeInTheDocument();
+  });
+
+  it('renders the fake provider as configured=No / source=Not configured', () => {
+    render(
+      <AiProviderStatusCard
+        view={{ provider: 'fake', configured: false, source: 'none' }}
+      />,
+    );
+
+    expect(screen.getByText('fake')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.getByText('Not configured')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/ai-provider-settings/components/ai-provider-status-card.tsx
+++ b/apps/web/src/features/ai-provider-settings/components/ai-provider-status-card.tsx
@@ -1,0 +1,62 @@
+/**
+ * AI Provider Status Card
+ *
+ * Stateless presentation of `AiProviderSettingsView`. Renders provider name
+ * (monospace), configured indicator, and a `StatusBadge` for the current
+ * resolution source (`db` / `env` / `none`). Color is paired with text so
+ * the source is never communicated by hue alone.
+ *
+ * @module apps/web/src/features/ai-provider-settings/components
+ */
+import type { ReactElement } from 'react';
+import { KeyValueList, type KeyValueItem } from '../../../shared/ui/key-value-list';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import type {
+  AiProviderKeySource,
+  AiProviderSettingsView,
+} from '../api/ai-provider-settings.types';
+
+interface AiProviderStatusCardProps {
+  view: AiProviderSettingsView;
+}
+
+const SOURCE_TONE: Record<AiProviderKeySource, StatusBadgeTone> = {
+  db: 'success',
+  env: 'warning',
+  none: 'neutral',
+};
+
+const SOURCE_LABEL: Record<AiProviderKeySource, string> = {
+  db: 'Stored encrypted',
+  env: 'Env fallback (deprecated)',
+  none: 'Not configured',
+};
+
+export function AiProviderStatusCard({ view }: AiProviderStatusCardProps): ReactElement {
+  const items: KeyValueItem[] = [
+    { id: 'provider', label: 'Active provider', mono: true, value: view.provider },
+    {
+      id: 'configured',
+      label: 'Key configured',
+      value: view.configured ? 'Yes' : 'No',
+    },
+    {
+      id: 'source',
+      label: 'Source',
+      value: (
+        <StatusBadge tone={SOURCE_TONE[view.source]} withDot>
+          {SOURCE_LABEL[view.source]}
+        </StatusBadge>
+      ),
+    },
+  ];
+
+  return (
+    <section aria-labelledby="ai-provider-status-heading">
+      <h2 id="ai-provider-status-heading" className="section-title">
+        Status
+      </h2>
+      <KeyValueList items={items} />
+    </section>
+  );
+}

--- a/apps/web/src/features/ai-provider-settings/hooks/use-ai-provider-settings-query.ts
+++ b/apps/web/src/features/ai-provider-settings/hooks/use-ai-provider-settings-query.ts
@@ -1,0 +1,27 @@
+/**
+ * AI Provider Settings Query Hook
+ *
+ * Reads the current key-resolution status (provider, configured, source).
+ * Gated on admin role so non-admin sessions don't trigger a 403 round-trip
+ * — the page renders an `ErrorState` for them anyway.
+ *
+ * @module apps/web/src/features/ai-provider-settings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { useSession } from '../../../shared/auth/use-session';
+import { aiProviderSettingsQueryKeys } from '../api/ai-provider-settings.query-keys';
+import type { AiProviderSettingsView } from '../api/ai-provider-settings.types';
+
+export function useAiProviderSettingsQuery(): UseQueryResult<AiProviderSettingsView> {
+  const apiClient = useApiClient();
+  const { session } = useSession();
+  const isAdmin =
+    session.status === 'authenticated' && session.user?.role === 'admin';
+
+  return useQuery({
+    queryKey: aiProviderSettingsQueryKeys.current(),
+    queryFn: () => apiClient.aiProviderSettings.get(),
+    enabled: isAdmin,
+  });
+}

--- a/apps/web/src/features/ai-provider-settings/hooks/use-clear-ai-provider-settings-mutation.ts
+++ b/apps/web/src/features/ai-provider-settings/hooks/use-clear-ai-provider-settings-mutation.ts
@@ -1,0 +1,23 @@
+/**
+ * Clear AI Provider Settings Mutation
+ *
+ * Removes the stored API key. After success the source falls back to
+ * `env` (if `ANTHROPIC_API_KEY` is set) or `none`. Invalidates the
+ * settings query so the status card reflects the new state.
+ *
+ * @module apps/web/src/features/ai-provider-settings/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { aiProviderSettingsQueryKeys } from '../api/ai-provider-settings.query-keys';
+
+export function useClearAiProviderSettingsMutation(): UseMutationResult<void, Error, void> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => apiClient.aiProviderSettings.clear(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: aiProviderSettingsQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/ai-provider-settings/hooks/use-update-ai-provider-settings-mutation.ts
+++ b/apps/web/src/features/ai-provider-settings/hooks/use-update-ai-provider-settings-mutation.ts
@@ -1,0 +1,28 @@
+/**
+ * Update AI Provider Settings Mutation
+ *
+ * Persists a new API key for the active provider. Invalidates the
+ * settings query on success so the status card refetches and surfaces
+ * the new `source: 'db'` resolution.
+ *
+ * @module apps/web/src/features/ai-provider-settings/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { aiProviderSettingsQueryKeys } from '../api/ai-provider-settings.query-keys';
+import type { UpdateAiProviderSettingsInput } from '../api/ai-provider-settings.types';
+
+export function useUpdateAiProviderSettingsMutation(): UseMutationResult<
+  void,
+  Error,
+  UpdateAiProviderSettingsInput
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input) => apiClient.aiProviderSettings.update(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: aiProviderSettingsQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.test.tsx
+++ b/apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * AI Provider Settings Page — Unit Tests
+ *
+ * Covers loading / error / non-admin / admin happy-path / fake-provider
+ * branches. Verifies the query is gated on `isAdmin` (no API call when the
+ * session role is not admin).
+ *
+ * @module apps/web/src/pages/ai-provider-settings
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../test/test-utils';
+import type { AiProviderSettingsView } from '../../features/ai-provider-settings/api/ai-provider-settings.types';
+import { AiProviderSettingsPage } from './ai-provider-settings-page';
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+afterEach(cleanup);
+
+const adminAdapter = createAuthenticatedSessionAdapter({
+  id: 'u1',
+  username: 'admin',
+  email: 'admin@example.com',
+  role: 'admin',
+  permissions: [],
+});
+
+const viewerAdapter = createAuthenticatedSessionAdapter({
+  id: 'u2',
+  username: 'viewer',
+  email: 'viewer@example.com',
+  role: 'viewer',
+  permissions: [],
+});
+
+describe('AiProviderSettingsPage', () => {
+  it('renders the admin-required ErrorState for non-admin sessions and never calls the API', async () => {
+    const get = vi.fn();
+    const apiClient = createMockApiClient({ aiProviderSettings: { get } });
+
+    renderWithProviders(<AiProviderSettingsPage />, {
+      apiClient,
+      sessionAdapter: viewerAdapter,
+    });
+
+    expect(await screen.findByText('Admin role required')).toBeInTheDocument();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('shows the LoadingState while the query is in flight', () => {
+    const get = vi.fn<() => Promise<AiProviderSettingsView>>(
+      () => new Promise<AiProviderSettingsView>(() => undefined),
+    );
+    const apiClient = createMockApiClient({ aiProviderSettings: { get } });
+
+    renderWithProviders(<AiProviderSettingsPage />, {
+      apiClient,
+      sessionAdapter: adminAdapter,
+    });
+
+    expect(screen.getByText('Loading provider settings')).toBeInTheDocument();
+  });
+
+  it('renders the status card and form for an admin when source=db', async () => {
+    const get = vi.fn().mockResolvedValue({
+      provider: 'anthropic',
+      configured: true,
+      source: 'db',
+    });
+    const apiClient = createMockApiClient({ aiProviderSettings: { get } });
+
+    renderWithProviders(<AiProviderSettingsPage />, {
+      apiClient,
+      sessionAdapter: adminAdapter,
+    });
+
+    expect(await screen.findByText('Stored encrypted')).toBeInTheDocument();
+    expect(screen.getByLabelText('API key')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /clear stored key/i })).toBeInTheDocument();
+  });
+
+  it('hides the form and shows an info alert when provider=fake', async () => {
+    const get = vi.fn().mockResolvedValue({
+      provider: 'fake',
+      configured: false,
+      source: 'none',
+    });
+    const apiClient = createMockApiClient({ aiProviderSettings: { get } });
+
+    renderWithProviders(<AiProviderSettingsPage />, {
+      apiClient,
+      sessionAdapter: adminAdapter,
+    });
+
+    expect(await screen.findByText('Fake provider active')).toBeInTheDocument();
+    expect(screen.queryByLabelText('API key')).not.toBeInTheDocument();
+  });
+
+  it('renders the ErrorState with retry when the query fails', async () => {
+    const get = vi.fn().mockRejectedValue(new Error('Network down'));
+    const apiClient = createMockApiClient({ aiProviderSettings: { get } });
+
+    renderWithProviders(<AiProviderSettingsPage />, {
+      apiClient,
+      sessionAdapter: adminAdapter,
+    });
+
+    expect(
+      await screen.findByText('Unable to load provider settings'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.tsx
+++ b/apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.tsx
@@ -1,0 +1,87 @@
+/**
+ * AI Provider Settings Page
+ *
+ * Admin-only page for viewing and updating the AI provider's API key.
+ * Backed by the BE endpoints shipped in #402. The page composes the
+ * status card and the form; the query hook is gated on `isAdmin` so
+ * non-admin sessions never trigger a 403 round-trip.
+ *
+ * @module apps/web/src/pages/ai-provider-settings
+ */
+import type { ReactElement } from 'react';
+import { useSession } from '../../shared/auth/use-session';
+import { Alert } from '../../shared/ui/alert';
+import { Button } from '../../shared/ui/button';
+import { ErrorState, LoadingState } from '../../shared/ui/feedback-state';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { AiProviderSettingsForm } from '../../features/ai-provider-settings/components/ai-provider-settings-form';
+import { AiProviderStatusCard } from '../../features/ai-provider-settings/components/ai-provider-status-card';
+import { useAiProviderSettingsQuery } from '../../features/ai-provider-settings/hooks/use-ai-provider-settings-query';
+
+export function AiProviderSettingsPage(): ReactElement {
+  const { session } = useSession();
+  const query = useAiProviderSettingsQuery();
+
+  // Admin gate before rendering the data surface. Mirrors the prompt-templates
+  // page's pattern; the query hook is `enabled: isAdmin` so non-admins never
+  // hit the network.
+  if (session.status === 'authenticated' && session.user?.role !== 'admin') {
+    return (
+      <PageLayout
+        eyebrow="AI"
+        title="Provider settings"
+        description="Admin-only access."
+      >
+        <ErrorState
+          title="Admin role required"
+          message="This page manages the AI provider API key and requires an admin session."
+        />
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout
+      eyebrow="AI"
+      title="Provider settings"
+      description="Configure the encrypted API key the server uses to talk to the active AI provider."
+    >
+      {/*
+        Use `isPending` (no data yet) instead of `isLoading` so the LoadingState
+        also covers the gap between "session still resolving" (enabled=false) and
+        "session resolved + query in flight" (enabled=true, fetching). Without
+        this, the initial render with `enabled: isAdmin` flickers to an empty
+        viewport while the session adapter resolves.
+      */}
+      {query.isPending ? (
+        <LoadingState
+          title="Loading provider settings"
+          message="Reading current key resolution status…"
+        />
+      ) : query.error ? (
+        <ErrorState
+          title="Unable to load provider settings"
+          message={query.error instanceof Error ? query.error.message : 'Unknown error'}
+          action={
+            <Button tone="secondary" onClick={() => void query.refetch()}>
+              Retry
+            </Button>
+          }
+        />
+      ) : query.data ? (
+        <>
+          <AiProviderStatusCard view={query.data} />
+          {query.data.provider === 'fake' ? (
+            <Alert tone="info" title="Fake provider active">
+              The active AI provider does not require an API key. Set
+              <span className="mono-text"> OL_AI_PROVIDER=anthropic </span>
+              on the server and restart the API to enable the form below.
+            </Alert>
+          ) : (
+            <AiProviderSettingsForm currentSource={query.data.source} />
+          )}
+        </>
+      ) : null}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -37,6 +37,7 @@ export const sampleConnection: Connection = {
 type DeepPartialApiClient = {
   request?: ApiClient['request'];
   adapters?: Partial<ApiClient['adapters']>;
+  aiProviderSettings?: Partial<ApiClient['aiProviderSettings']>;
   allegro?: Partial<ApiClient['allegro']>;
   auth?: Partial<ApiClient['auth']>;
   connections?: Partial<ApiClient['connections']>;
@@ -61,6 +62,16 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       list: vi.fn().mockResolvedValue([]),
       ...overrides.adapters,
     } as ApiClient['adapters'],
+    aiProviderSettings: {
+      get: vi.fn().mockResolvedValue({
+        provider: 'anthropic',
+        configured: false,
+        source: 'none',
+      }),
+      update: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+      ...overrides.aiProviderSettings,
+    } as ApiClient['aiProviderSettings'],
     allegro: {
       startOAuth: vi.fn().mockResolvedValue({
         authorizationUrl: 'https://example.com/oauth',

--- a/docs/plans/implementation-plan-399-ai-provider-settings-admin-ui.md
+++ b/docs/plans/implementation-plan-399-ai-provider-settings-admin-ui.md
@@ -1,0 +1,126 @@
+# Implementation Plan — #399 AI provider settings admin UI
+
+## 1. Goal
+
+Build the admin-only frontend for `/ai-provider-settings` (BE merged in #402). Admins can view the current key-resolution status, paste a new API key (PUT), or clear the stored key (DELETE). Mirrors the existing `prompt-templates` feature slice for structure and the connections / content pages for form patterns.
+
+**Layer**: Frontend (`features/ai-provider-settings/`, `pages/ai-provider-settings/`, `app/`).
+
+**Non-goals**:
+- Multi-provider selection UI (BE only ships `anthropic` for v1).
+- Key rotation history / audit trail (BE doesn't expose one).
+- Editing `OL_AI_PROVIDER` from the UI (deploy-time config).
+
+## 2. Codebase research
+
+### Precedent
+- Feature slice layout: `apps/web/src/features/prompt-templates/` — `api/`, `hooks/`, ~~`components/`~~ (prompt-templates is read/list-heavy and keeps components in `pages/`; this feature has a form so we'll use `components/` as documented in `.claude/rules/fe-pages.md`).
+- API client registration: `apps/web/src/app/api/api-client.ts:48,145` — interface entry + factory call.
+- Admin gating: `apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx:79-92` — render `ErrorState` when `session.user?.role !== 'admin'`.
+- Route registration: `apps/web/src/app/routes/prompt-templates-list.route.tsx` — single `RouteObject` with `path: 'ai/...'` (no leading slash).
+- Nav + breadcrumb: `apps/web/src/app/app-shell.tsx:110-116` (AI group, admin-only) and `:131-150` (`staticCrumbs`).
+
+### Shared UI inventory (already present)
+`PageLayout`, `LoadingState`/`ErrorState`/`EmptyState` (from `feedback-state`), `StatusBadge`, `Chip`, `KeyValueList`, `Button`, `Input`, `FormField`, `FieldError`, `FormErrorSummary`, `Alert`, `ConfirmDialog`, `ToastProvider`/`useToast`. Nothing new to add to `shared/`.
+
+### BE contract (#402)
+```
+GET    /ai-provider-settings → 200 { provider, configured, source }
+PUT    /ai-provider-settings   body { apiKey } → 204
+DELETE /ai-provider-settings → 204
+- 400 when active provider doesn't take a key (e.g. fake)
+- 400 on apiKey validation failure (server trims first)
+- 403 for non-admin
+```
+Response shape comes from `apps/api/src/ai/http/dto/ai-provider-settings-response.dto.ts`.
+
+## 3. Design
+
+### Feature slice
+```
+apps/web/src/features/ai-provider-settings/
+├── api/
+│   ├── ai-provider-settings.api.ts          # request factory
+│   ├── ai-provider-settings.query-keys.ts   # key factory
+│   └── ai-provider-settings.types.ts        # FE-local wire types
+├── hooks/
+│   ├── use-ai-provider-settings-query.ts
+│   └── use-ai-provider-settings-mutations.ts  # update + clear
+└── components/
+    ├── ai-provider-status-card.tsx
+    ├── ai-provider-status-card.test.tsx
+    ├── ai-provider-settings-form.tsx
+    ├── ai-provider-settings-form.test.tsx
+    └── ai-provider-settings-form.schema.ts
+```
+
+### Page composition (`apps/web/src/pages/ai-provider-settings/`)
+- One `ai-provider-settings-page.tsx` with `PageLayout` wrapping a `<section>` for the status card and a `<section>` for the form.
+- Loading → Error → admin-gate → success states per `.claude/rules/fe-pages.md`.
+
+### Status card (read side)
+- Shows `provider` (monospace), `configured` (green check ✓ / muted dash), and a `Chip` for `source` with three tones:
+  - `source=db` → `success` chip "Stored encrypted"
+  - `source=env` → `warning` chip "Env fallback (deprecated)" + helper "Save a key here to override the env."
+  - `source=none` → `neutral` chip "Not configured" + helper "Paste an API key below to enable AI suggestions."
+- Plus a fourth visual case driven purely from `provider === 'fake'`: render an info alert "Active provider is `fake` — no API key required" and *hide* the form section entirely (the BE returns 400 on PUT/DELETE; gating in the UI avoids the round-trip).
+
+### Form (write side)
+- Single `apiKey` field (`<Input type="password" autoComplete="off">`).
+- Zod schema: `z.string().trim().min(8, 'API key must be at least 8 characters').max(512, 'API key is too long')`.
+- Submit → `useUpdateAiProviderSettingsMutation`. On success: toast "Key saved", reset form, query invalidates → status card refetches.
+- "Clear stored key" button (only rendered when `source === 'db'`) → `ConfirmDialog` ("Remove the stored API key? Falls back to the environment variable or 'not configured'.") → `useClearAiProviderSettingsMutation`. On success: toast "Key cleared".
+- API errors surfaced in `<Alert tone="error">` at form top (DTO validation errors from server, plus the 400 "not applicable" case as a defense-in-depth — though the form is hidden when `provider === 'fake'`).
+
+### Mutations
+- `useUpdateAiProviderSettingsMutation` — invalidates `aiProviderSettingsQueryKeys.all` on success.
+- `useClearAiProviderSettingsMutation` — same invalidation.
+
+### Route
+- Path: `ai/provider-settings` (matches `frontend-architecture.md` initial route convention; the BE is at `/ai-provider-settings` which the api client adapter handles).
+- Sibling to `ai/prompt-templates` under the AI nav group.
+- Route element: `<AiProviderSettingsPage />`.
+
+### Nav + breadcrumbs
+- Add `{ to: '/ai/provider-settings', label: 'Provider settings' }` to the existing AI group at `app-shell.tsx:114` (only mounts for admins via the existing `isAdmin` guard).
+- Add `'/ai/provider-settings': { group: 'AI', title: 'Provider settings' }` to `staticCrumbs`.
+
+## 4. Step-by-step
+
+| # | File | What |
+|---|---|---|
+| 1 | `apps/web/src/features/ai-provider-settings/api/ai-provider-settings.types.ts` | Wire types: `AiProvider` (`'anthropic' \| 'fake'` as `as const`), `AiProviderKeySource` (`'db' \| 'env' \| 'none'` as `as const`), `AiProviderSettingsView`, `UpdateAiProviderSettingsInput`. |
+| 2 | `apps/web/src/features/ai-provider-settings/api/ai-provider-settings.query-keys.ts` | `aiProviderSettingsQueryKeys = { all, current() }`. |
+| 3 | `apps/web/src/features/ai-provider-settings/api/ai-provider-settings.api.ts` | `AiProviderSettingsApi` interface + `createAiProviderSettingsApi(request)`. Three methods: `get`, `update`, `clear`. The `clear` method ignores the 204 by typing `Promise<void>`. |
+| 4 | `apps/web/src/app/api/api-client.ts` | Add `aiProviderSettings: AiProviderSettingsApi` to `ApiClient` interface; register `createAiProviderSettingsApi(request)` in the factory. |
+| 5 | `apps/web/src/test/test-utils.tsx` | Add `aiProviderSettings` to `DeepPartialApiClient` and to the `createMockApiClient` defaults: `get` returns `{ provider: 'anthropic', configured: false, source: 'none' }`, `update` / `clear` return `undefined`. |
+| 6 | `apps/web/src/features/ai-provider-settings/hooks/use-ai-provider-settings-query.ts` | TanStack Query hook keyed by `aiProviderSettingsQueryKeys.current()`. |
+| 7 | `apps/web/src/features/ai-provider-settings/hooks/use-ai-provider-settings-mutations.ts` | `useUpdateAiProviderSettingsMutation` + `useClearAiProviderSettingsMutation`. Both invalidate `aiProviderSettingsQueryKeys.all`. |
+| 8 | `apps/web/src/features/ai-provider-settings/components/ai-provider-status-card.tsx` | Stateless presentation. Takes `view: AiProviderSettingsView`. Renders `KeyValueList` rows + the source `Chip` with tone mapping. |
+| 9 | `apps/web/src/features/ai-provider-settings/components/ai-provider-status-card.test.tsx` | Snapshot the three source variants (`db` / `env` / `none`) and the `provider=fake` case. |
+| 10 | `apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.schema.ts` | Zod schema + `FormValues` / `FormSubmission` types. Trim + min(8) + max(512). |
+| 11 | `apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.tsx` | RHF form. Props: `currentSource: AiProviderKeySource`. Renders `<Input type="password">`, `Save` + (conditional) `Clear stored key` button. Toasts + Alert on error. `noValidate`. |
+| 12 | `apps/web/src/features/ai-provider-settings/components/ai-provider-settings-form.test.tsx` | Tests: validation error on empty input; submit triggers update mutation with trimmed value; API error renders in Alert; clear button only renders when `source === 'db'`; clear flow goes through ConfirmDialog. |
+| 13 | `apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.tsx` | Composes `PageLayout` + `LoadingState` / `ErrorState` / status card / form. Admin gate matches the prompt-templates pattern. Hides form when `provider === 'fake'`, surfaces the info alert instead. |
+| 14 | `apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.test.tsx` | Tests: loading state; error state with retry; non-admin shows admin-required ErrorState; admin sees status card + form; `provider=fake` hides the form. |
+| 15 | `apps/web/src/app/routes/ai-provider-settings.route.tsx` | `RouteObject` at `path: 'ai/provider-settings'`. |
+| 16 | `apps/web/src/app/routes/root.route.tsx` | Import + register the new route alongside the prompt-templates routes. |
+| 17 | `apps/web/src/app/app-shell.tsx` | Add nav entry under AI group + breadcrumb entry. |
+
+## 5. Risks / open questions
+
+- **`source: 'env'` semantics on initial pageload**: GET returns `source=env` if BE successfully resolves the env var. The FE warns "deprecated, save here to override". Behaviour after a successful PUT — server reports `source=db` (the new key takes precedence). Test coverage exercises both.
+- **Concurrent admins**: Two PUTs racing → last write wins. The status card refetches after each mutation, so the displayed state converges. Acceptable for a low-concurrency admin endpoint (matches BE).
+- **Toast vs Alert**: API errors go to `Alert` at form top (per `.claude/rules/fe-pages.md` — alerts for errors needing user action). Success → toast.
+- **Mobile tap targets**: Form is single-column; "Save" button uses `Button` size `md` (32 px) which grows to 36 px on touch per `frontend-ui-style-guide.md`.
+- **Out of scope, deliberate**: no rotation history, no per-provider switching, no copy-current-key affordance (server never returns the value).
+
+## 6. Quality gate
+
+```bash
+pnpm lint        # all packages
+pnpm type-check  # strict TS
+pnpm test        # vitest unit + RTL component tests
+```
+
+All must pass with zero errors before commit. No backend changes → no migrations, no integration tests.


### PR DESCRIPTION
## Summary

Admin-only frontend for the AI provider API key, consuming the BE shipped in #402. Mirrors the existing `prompt-templates` feature slice for structure (api / hooks / components) and the documented form pattern in `.claude/rules/fe-pages.md` (RHF + Zod, Alert for API errors, ConfirmDialog for destructive flow, toast on success).

- **`features/ai-provider-settings/`** — types, query-keys, api factory, query hook gated on `isAdmin` (no 403 round-trip for non-admin sessions), separate update + clear mutation hooks, `AiProviderStatusCard` (`KeyValueList` + `StatusBadge` with three source variants: `db` / `env` / `none`), `AiProviderSettingsForm` (single password field, conditional clear button gated by `ConfirmDialog`).
- **`pages/ai-provider-settings/`** — `PageLayout` shell (`eyebrow="AI"`), admin gate matching `prompt-templates`, loading / error / data branches per the rules doc, hides the form and surfaces an info alert when `provider=fake` (BE rejects writes anyway).
- **`app/api/api-client` + `test-utils`** — register `aiProviderSettings` resource alongside the existing per-feature modules, with sensible mock defaults.
- **`app/routes` + `app-shell`** — `/ai/provider-settings` route registered in `root.route.tsx`; nav entry under the existing AI group (admin-gated alongside `Prompt templates`); breadcrumb static map updated.

Closes #399

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] FE unit tests — **691 pass** (17 new tests across status card / form / page)
- [x] Full monorepo unit tests — 1893 pass total (BE unchanged)
- [ ] Manual: log in as admin, navigate to `/ai/provider-settings` → status card renders the current source (`db` / `env` / `none`)
- [ ] Manual: paste a key, save → toast confirms; status flips to `Stored encrypted` (db); form clears
- [ ] Manual: click `Clear stored key` → confirm dialog opens; confirming clears the key; status reverts to `env` or `none`
- [ ] Manual: log in as a non-admin user → page shows admin-required ErrorState; nav entry is hidden
- [ ] Manual: visual checks at three widths (mobile 360 × 812, tablet 768 × 1024, desktop 1440 × 900) per `frontend-ui-style-guide.md` responsive matrix
- [ ] Manual: with `OL_AI_PROVIDER=fake` on the server → page shows the "Fake provider active" info alert and hides the form

## Architecture notes

- One mutation hook per file (`use-update-ai-provider-settings-mutation.ts`, `use-clear-ai-provider-settings-mutation.ts`) per `.claude/rules/fe-pages.md` — diverges from `features/prompt-templates/hooks/use-prompt-template-mutations.ts` which combines them; treating that as drift to clean up later.
- Query hook gates with `enabled: isAdmin` so non-admins never hit the network. Page uses `query.isPending` (not `isLoading`) so the LoadingState also covers the gap between session-resolving and query-firing.
- Form trims the `apiKey` before validation (matches the BE DTO at `apps/api/src/ai/http/dto/update-ai-provider-settings.dto.ts` which also trims).
- No int-spec for FE — the codebase doesn't have FE integration tests; coverage is at the unit level via `renderWithProviders` + `createMockApiClient`. Same precedent as every other feature.

## Follow-ups

- (Optional) Migrate `prompt-templates` mutations to one-hook-per-file for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)