### PR TITLE
feat(allegro): preserve full error bodies; surface offer-creation drafts on Job detail

### DIFF
--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -77,7 +77,11 @@ export interface UpdateOfferFieldsResult {
  * OL-initiated offer creation lifecycle status.
  *
  * Mirrors `OfferCreationStatus` on the backend. Terminal values are
- * `'active'` and `'failed'` — the tracker stops polling on those.
+ * `'draft'`, `'active'`, and `'failed'` — the tracker stops polling on
+ * those. `'draft'` is terminal because Allegro accepted the offer (it's
+ * sitting in the seller panel awaiting manual publish); OL will not
+ * transition it. `'validating'` stays non-terminal until the
+ * `marketplace.offer.pollCreationStatus` follow-up handler lands. (#407)
  */
 export const OfferCreationStatusValues = [
   'pending',
@@ -88,7 +92,11 @@ export const OfferCreationStatusValues = [
 ] as const;
 export type OfferCreationStatus = (typeof OfferCreationStatusValues)[number];
 
-export const TERMINAL_OFFER_CREATION_STATUSES: readonly OfferCreationStatus[] = ['active', 'failed'];
+export const TERMINAL_OFFER_CREATION_STATUSES: readonly OfferCreationStatus[] = [
+  'draft',
+  'active',
+  'failed',
+];
 
 export interface OfferCreationError {
   field?: string;

--- a/apps/web/src/features/listings/components/OfferCreationTracker.test.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationTracker.test.tsx
@@ -332,4 +332,100 @@ describe('OfferCreationTracker', () => {
       expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
     });
   });
+
+  describe('draft status (#407)', () => {
+    it('renders external id, sandbox seller-panel link, and the error list when errors are present', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi.fn().mockResolvedValue(
+            makeRecord('draft', {
+              externalOfferId: 'allegro-555',
+              errors: [
+                { field: 'parameters.42', code: 'MissingValue', message: 'Brand is required.' },
+              ],
+            }),
+          ),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          marketplacePlatformType="allegro"
+          marketplaceEnvironment="sandbox"
+          onDismiss={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      expect(await screen.findByText('Draft')).toBeInTheDocument();
+      expect(screen.getByText('allegro-555')).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /open in allegro seller panel/i });
+      expect(link).toHaveAttribute(
+        'href',
+        'https://allegro.pl.allegrosandbox.pl/oferta/allegro-555/edit',
+      );
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(screen.getByText('Brand is required.')).toBeInTheDocument();
+    });
+
+    it('renders the production seller-panel link and "no inline validation issues" copy when errors are empty', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi.fn().mockResolvedValue(
+            makeRecord('draft', { externalOfferId: 'allegro-777', errors: null }),
+          ),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          marketplacePlatformType="allegro"
+          marketplaceEnvironment="production"
+          onDismiss={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      expect(await screen.findByText('Draft')).toBeInTheDocument();
+      expect(screen.getByText('allegro-777')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /open in allegro seller panel/i })).toHaveAttribute(
+        'href',
+        'https://allegro.pl/oferta/allegro-777/edit',
+      );
+      expect(
+        screen.getByText(/no inline validation issues/i),
+      ).toBeInTheDocument();
+    });
+
+    it('renders the draft body without an id or seller-panel link when externalOfferId is null and props are omitted', async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          getOfferCreationStatus: vi.fn().mockResolvedValue(
+            makeRecord('draft', { externalOfferId: null, errors: null }),
+          ),
+        },
+      });
+
+      renderWithProviders(
+        <OfferCreationTracker
+          connectionId="conn-1"
+          offerCreationRecordId="rec-1"
+          onDismiss={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      expect(await screen.findByText('Draft')).toBeInTheDocument();
+      expect(screen.getByText(/offer created as a draft on allegro/i)).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /open in allegro seller panel/i })).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/no inline validation issues/i),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/features/listings/components/OfferCreationTracker.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationTracker.tsx
@@ -21,6 +21,7 @@ import {
   TERMINAL_OFFER_CREATION_STATUSES,
   type OfferCreationStatusResponse,
 } from '../api/listings.types';
+import { buildAllegroSellerPanelUrl } from '../lib/allegro-seller-panel-url';
 import { canReadCreateOfferRequestSnapshot } from './create-offer-request-to-form-values';
 import { OfferCreationStatusBadge } from './OfferCreationStatusBadge';
 import { OfferCreationErrorList } from './OfferCreationErrorList';
@@ -28,6 +29,13 @@ import { OfferCreationErrorList } from './OfferCreationErrorList';
 interface OfferCreationTrackerProps {
   connectionId: string;
   offerCreationRecordId: string;
+  /** Platform type of the connection. When 'allegro' (and environment
+   *  provided), the draft branch renders an "Open in Allegro seller
+   *  panel" deep link. Optional so existing callers don't break. (#407) */
+  marketplacePlatformType?: string;
+  /** Connection environment ('sandbox' | 'production'). Used together with
+   *  marketplacePlatformType to derive the seller-panel host. (#407) */
+  marketplaceEnvironment?: string;
   /** Optional. When provided, a Dismiss button appears on terminal statuses
    *  and the error variant is rendered with a Dismiss action. When omitted,
    *  the consumer is treated as a static read-only surface (e.g. a page
@@ -45,6 +53,8 @@ interface OfferCreationTrackerProps {
 export function OfferCreationTracker({
   connectionId,
   offerCreationRecordId,
+  marketplacePlatformType,
+  marketplaceEnvironment,
   onDismiss,
   onRetry,
 }: OfferCreationTrackerProps): ReactElement {
@@ -92,6 +102,11 @@ export function OfferCreationTracker({
   }
 
   const isTerminal = TERMINAL_OFFER_CREATION_STATUSES.includes(record.status);
+  const sellerPanelUrl = buildAllegroSellerPanelUrl(
+    marketplacePlatformType,
+    marketplaceEnvironment,
+    record.externalOfferId,
+  );
   // Hide Retry when the snapshot is absent (old records) or carries a
   // schemaVersion this client does not know how to read. A server newer
   // than the client can persist v2+ snapshots; we must not silently
@@ -143,6 +158,41 @@ export function OfferCreationTracker({
           ) : null}
           .
         </p>
+      ) : null}
+
+      {record.status === 'draft' ? (
+        <>
+          <p className="offer-creation-tracker__body">
+            Offer created as a draft on Allegro
+            {record.externalOfferId ? (
+              <>
+                {' '}· external id{' '}
+                <span className="mono-text">{record.externalOfferId}</span>
+              </>
+            ) : null}
+            .
+            {sellerPanelUrl ? (
+              <>
+                {' '}
+                <a href={sellerPanelUrl} target="_blank" rel="noopener noreferrer">
+                  Open in Allegro seller panel
+                </a>
+              </>
+            ) : null}
+          </p>
+          {record.errors && record.errors.length > 0 ? (
+            <>
+              <p className="offer-creation-tracker__body">
+                Allegro reported validation issues that block publishing:
+              </p>
+              <OfferCreationErrorList errors={record.errors} />
+            </>
+          ) : (
+            <p className="offer-creation-tracker__body offer-creation-tracker__body--muted">
+              No inline validation issues — publish manually in the Allegro seller panel.
+            </p>
+          )}
+        </>
       ) : null}
 
       {record.status === 'failed' ? (

--- a/apps/web/src/features/listings/hooks/use-offer-creation-status-query.test.tsx
+++ b/apps/web/src/features/listings/hooks/use-offer-creation-status-query.test.tsx
@@ -31,6 +31,10 @@ function active(): OfferCreationStatusResponse {
   return { ...pending(), status: 'active', externalOfferId: 'ext-1' };
 }
 
+function draft(): OfferCreationStatusResponse {
+  return { ...pending(), status: 'draft', externalOfferId: 'ext-1' };
+}
+
 describe('useOfferCreationStatusQuery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,6 +63,21 @@ describe('useOfferCreationStatusQuery', () => {
     });
     await waitFor(() => expect(result.current.data?.status).toBe('active'));
     // Wait well past one poll interval — the hook must not call again.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(getOfferCreationStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops polling on draft status (#407)', async () => {
+    // 'draft' is a terminal outcome of the create lifecycle (Allegro
+    // accepted, awaiting manual publish in the seller panel) — polling
+    // it forever wastes requests and keeps "still processing" copy on
+    // screen indefinitely. Regression guard for the terminal-status fix.
+    const getOfferCreationStatus = vi.fn().mockResolvedValue(draft());
+    const apiClient = createMockApiClient({ listings: { getOfferCreationStatus } });
+    const { result } = renderHook(() => useOfferCreationStatusQuery('conn-1', 'rec-1'), {
+      wrapper: wrap(apiClient),
+    });
+    await waitFor(() => expect(result.current.data?.status).toBe('draft'));
     await new Promise((r) => setTimeout(r, 80));
     expect(getOfferCreationStatus).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/features/listings/lib/allegro-seller-panel-url.test.ts
+++ b/apps/web/src/features/listings/lib/allegro-seller-panel-url.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Allegro Seller Panel URL Helper Tests
+ *
+ * Pure-function coverage for the six branches of `buildAllegroSellerPanelUrl`.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+import { describe, expect, it } from 'vitest';
+import { buildAllegroSellerPanelUrl } from './allegro-seller-panel-url';
+
+describe('buildAllegroSellerPanelUrl', () => {
+  it('uses the production host when environment is "production"', () => {
+    expect(buildAllegroSellerPanelUrl('allegro', 'production', 'offer-1')).toBe(
+      'https://allegro.pl/oferta/offer-1/edit',
+    );
+  });
+
+  it('uses the sandbox host when environment is "sandbox"', () => {
+    expect(buildAllegroSellerPanelUrl('allegro', 'sandbox', 'offer-1')).toBe(
+      'https://allegro.pl.allegrosandbox.pl/oferta/offer-1/edit',
+    );
+  });
+
+  it('falls back to sandbox host when environment is undefined', () => {
+    // Matches the BE adapter's getDefaultApiBaseUrl default — operators
+    // most often hit this surface during sandbox onboarding.
+    expect(buildAllegroSellerPanelUrl('allegro', undefined, 'offer-1')).toBe(
+      'https://allegro.pl.allegrosandbox.pl/oferta/offer-1/edit',
+    );
+  });
+
+  it('falls back to sandbox host on an unknown environment string', () => {
+    expect(buildAllegroSellerPanelUrl('allegro', 'staging', 'offer-1')).toBe(
+      'https://allegro.pl.allegrosandbox.pl/oferta/offer-1/edit',
+    );
+  });
+
+  it('returns null for a non-allegro platform type', () => {
+    expect(buildAllegroSellerPanelUrl('prestashop', 'production', 'offer-1')).toBeNull();
+    expect(buildAllegroSellerPanelUrl(undefined, 'production', 'offer-1')).toBeNull();
+  });
+
+  it('returns null when externalOfferId is null', () => {
+    expect(buildAllegroSellerPanelUrl('allegro', 'production', null)).toBeNull();
+  });
+
+  it('encodeURIComponent-escapes the offer id', () => {
+    // Defends against any pathological id values from Allegro that contain
+    // path-segment delimiters or query-string characters.
+    expect(buildAllegroSellerPanelUrl('allegro', 'production', 'a/b?c')).toBe(
+      'https://allegro.pl/oferta/a%2Fb%3Fc/edit',
+    );
+  });
+});

--- a/apps/web/src/features/listings/lib/allegro-seller-panel-url.ts
+++ b/apps/web/src/features/listings/lib/allegro-seller-panel-url.ts
@@ -1,0 +1,32 @@
+/**
+ * Allegro Seller Panel URL Helper
+ *
+ * Pure derivation of the Allegro seller-panel deep link for an offer.
+ * Mirrors the BE adapter's environment → host switch in
+ * `libs/integrations/allegro/src/application/allegro-adapter.factory.ts`
+ * (see `getDefaultApiBaseUrl`). Returns null when the platform is not
+ * 'allegro' or the external offer id is missing.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+
+/**
+ * Build the Allegro seller-panel "edit offer" deep link.
+ *
+ * @param platformType — connection platform type; non-'allegro' returns null
+ * @param environment — 'sandbox' | 'production'; unknown / missing falls back
+ *   to sandbox (same default as the BE adapter — operators most often hit this
+ *   surface during sandbox onboarding)
+ * @param externalOfferId — Allegro offer id from `OfferCreationRecord`; null
+ *   means the offer hasn't yet been created externally and there's nothing
+ *   to deep-link to
+ */
+export function buildAllegroSellerPanelUrl(
+  platformType: string | undefined,
+  environment: string | undefined,
+  externalOfferId: string | null,
+): string | null {
+  if (platformType !== 'allegro' || !externalOfferId) return null;
+  const host = environment === 'production' ? 'allegro.pl' : 'allegro.pl.allegrosandbox.pl';
+  return `https://${host}/oferta/${encodeURIComponent(externalOfferId)}/edit`;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4366,6 +4366,10 @@ a.kpi-card:focus-visible {
   color: var(--text-secondary);
 }
 
+.offer-creation-tracker__body--muted {
+  color: var(--text-muted);
+}
+
 /*
  * ── Listing detail — Offer creation section (#306) ────────────────
  * Header row (title + status badge) for the embedded OfferCreation

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx
@@ -13,6 +13,7 @@ import { useSyncJobQuery } from '../../features/sync-jobs/hooks/use-sync-job-que
 import { useRetrySyncJobMutation } from '../../features/sync-jobs/hooks/use-retry-sync-job-mutation';
 import type { SyncJob } from '../../features/sync-jobs/api/sync-jobs.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
 import { OfferCreationTracker } from '../../features/listings/components/OfferCreationTracker';
 
 /**
@@ -69,6 +70,11 @@ function buildSyncJobItems(job: SyncJob): KeyValueItem[] {
 export function SyncJobDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
   const query = useSyncJobQuery(id);
+  // Connection lookup feeds the OfferCreationTracker's draft branch with
+  // platform + environment so it can render the Allegro seller-panel link
+  // (#407). The hook self-disables on empty id, so it's safe to call
+  // before the loading/error guards below.
+  const connectionQuery = useConnectionQuery(query.data?.connectionId ?? '');
   const retry = useRetrySyncJobMutation();
   const { showToast } = useToast();
 
@@ -148,6 +154,12 @@ export function SyncJobDetailPage(): ReactElement {
           <OfferCreationTracker
             connectionId={job.connectionId}
             offerCreationRecordId={offerCreationRecordId}
+            marketplacePlatformType={connectionQuery.data?.platformType}
+            marketplaceEnvironment={
+              typeof connectionQuery.data?.config?.environment === 'string'
+                ? connectionQuery.data.config.environment
+                : undefined
+            }
           />
         </section>
       ) : null}

--- a/docs/plans/implementation-plan-409-407-allegro-error-bodies-and-tracker-draft.md
+++ b/docs/plans/implementation-plan-409-407-allegro-error-bodies-and-tracker-draft.md
@@ -1,0 +1,481 @@
+# Implementation Plan — #409 + #407 (Allegro full error bodies + Job-detail draft tracker)
+
+Two independent fixes shipped together because they sit on the same end-to-end Allegro `marketplace.offer.create` path that #401 / #406 / #411 just unblocked. They're orthogonal at the code level (different files, no shared symbols) but flow naturally to the same operator: #409 finally surfaces the real Allegro error in `OfferCreationRecord.errors`, and #407 finally renders that field on the Job-detail page for `draft` records. Bundling avoids two separate review cycles for what is one diagnostic-loop closure.
+
+## Part A — #409: full error bodies + resilient JSON parser
+
+### 1. Understand
+
+**Goal.** When Allegro rejects `POST /sale/product-offers` with an error body > 500 chars, OpenLinker silently produces `errors=0` logs and an `OfferCreateRejectedException` with empty `errors[]`. Two compounding bugs in the same path: (a) `AllegroHttpClient` truncates `responseBody` to 500 chars before storing it on `AllegroApiException`, and (b) `parseAllegroErrors` in `AllegroOfferManagerAdapter` silently swallows `JSON.parse` failures on the truncated half-body. Sandbox confirms three real Allegro error codes (`DownloadError.Forbidden`, `ImpliedWarrantyNotDefinedException`, `ConstraintViolationException.MissingRequiredParameters`) all collapse to the same `errors=0` symptom.
+
+**Layer.** Integration (Allegro adapter + http client). No CORE / port surface change. No FE work in this part.
+
+**Non-goals.**
+- Translating Allegro error codes into operator-friendly messages — separate FE concern (e.g. `MissingRequiredParameters` ID → human name lookup, which depends on #410's category-parameter capability).
+- Truncating large error bodies in `OfferCreationRecord.errors` persistence — Allegro errors are bounded by Allegro's own response size; we don't need a separate cap.
+- Any retry-policy change — error visibility only.
+
+### 2. Research
+
+#### Truncation sites in `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts`
+
+Three call sites pass a `body.substring(0, 500)` to `AllegroApiException`:
+
+| Line | Context |
+|---|---|
+| **L315–320** | `executeRequest` JSON-parse failure on a 2xx body: `Invalid JSON response from Allegro API` |
+| **L417–422** | `handleError` 5xx branch: `Allegro API server error (${statusCode})` |
+| **L427–432** | `handleError` 4xx-other branch (the **#409 hot path**): `Allegro API error (${statusCode})` |
+
+Plus one *log* line at **L426** that uses `body.substring(0, 200)` — that one is operator scroll-back, deliberately tight, and stays.
+
+`body` at all three sites comes from `await response.text()` at L302 — already in memory, no streaming benefit to truncating.
+
+#### Parser site in `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts:867-878`
+
+```ts
+private parseAllegroErrors(responseBody: string | undefined): AllegroValidationError[] {
+  if (!responseBody) return [];
+  try {
+    const parsed = JSON.parse(responseBody) as { errors?: AllegroValidationError[] };
+    if (Array.isArray(parsed.errors)) return parsed.errors;
+  } catch {
+    // Response wasn't JSON or didn't match the expected shape.   ← silently swallowed
+  }
+  return [];
+}
+```
+
+Caller at L667–681 (the `createOffer` catch block) feeds `error.responseBody` in and produces the `errors=0` log when the parser returns `[]`.
+
+#### Existing test patterns
+
+- `allegro-http-client.spec.ts` already has `it('should throw AllegroApiException on 4xx errors', …)` at L441 that mocks `text: () => Promise.resolve('{"error": "bad_request"}')` — pattern is solid, just needs a new spec asserting `responseBody` is the full original (not truncated).
+- `allegro-offer-manager.adapter.spec.ts` (~140 specs already) — needs two new specs in the `createOffer` describe block: large-body parse-OK round-trip, and unparseable-body warn-log assertion.
+
+### 3. Design
+
+#### Adapter change — `AllegroHttpClient`
+
+Pass full `body` to the exception at all three sites; keep the 200-char cap only on the L426 log line. Concrete diff:
+
+```ts
+// L315-320 (JSON-parse failure on 2xx)
+throw new AllegroApiException(
+  `Invalid JSON response from Allegro API: ${url.toString()}`,
+  response.status,
+  responseBody,                                      // was: responseBody.substring(0, 500)
+  url.toString(),
+);
+
+// L417-422 (5xx)
+throw new AllegroApiException(
+  `Allegro API server error (${statusCode}): ${url}`,
+  statusCode,
+  body,                                              // was: body.substring(0, 500)
+  url,
+);
+
+// L427-432 (4xx-other) + L426 log preview cap stays
+this.logger.error(`[${traceId}] Allegro API error (${statusCode}): ${url} - ${body.substring(0, 200)}`);
+throw new AllegroApiException(
+  `Allegro API error (${statusCode}): ${url}`,
+  statusCode,
+  body,                                              // was: body.substring(0, 500)
+  url,
+);
+```
+
+No type signature change — `AllegroApiException.responseBody` is already `string | undefined` (verified at `domain/exceptions/allegro-api.exception.ts:13`).
+
+#### Parser change — `parseAllegroErrors`
+
+Replace silent `catch {}` with a `warn` log carrying the parser-error message and a 500-char preview. Keep the empty-array return so the upstream `OfferCreateRejectedException` shape is unchanged for genuinely-unparseable bodies (HTML proxy errors, etc.):
+
+```ts
+private parseAllegroErrors(responseBody: string | undefined): AllegroValidationError[] {
+  if (!responseBody) return [];
+  try {
+    const parsed = JSON.parse(responseBody) as { errors?: AllegroValidationError[] };
+    if (Array.isArray(parsed.errors)) return parsed.errors;
+  } catch (err) {
+    this.logger.warn(
+      `Failed to parse Allegro error body as JSON: ${(err as Error).message}. ` +
+        `Raw body (first 500 chars): ${responseBody.slice(0, 500)}`,
+    );
+  }
+  return [];
+}
+```
+
+The `warn` is the bridge: with (a) fixed, the parser will succeed for most real Allegro error bodies; the `warn` only fires for the residual class (truly malformed responses), and now carries breadcrumbs.
+
+### 4. Implementation Steps (Part A)
+
+#### Step A.1 — Adapter HTTP client
+
+**File:** `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts`
+
+Three one-line changes at L318, L420, L430 — drop `.substring(0, 500)` on the `responseBody` argument to `AllegroApiException`. L426 log line untouched.
+
+#### Step A.2 — `parseAllegroErrors` warn
+
+**File:** `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts:867-878`
+
+Replace `catch {}` with the `catch (err) { this.logger.warn(...) }` block above.
+
+#### Step A.3 — HTTP client spec
+
+**File:** `libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts`
+
+Add one spec in the existing 4xx/5xx describe block:
+
+```ts
+it('preserves the full Allegro error body on AllegroApiException (#409)', async () => {
+  const longErrorJson = JSON.stringify({
+    errors: [
+      {
+        code: 'ConstraintViolationException.MissingRequiredParameters',
+        message: 'x'.repeat(2000),
+        details: 'y'.repeat(2000),
+      },
+    ],
+  });
+  expect(longErrorJson.length).toBeGreaterThan(500);
+
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: false,
+    status: 422,
+    headers: new Headers(),
+    text: () => Promise.resolve(longErrorJson),
+  });
+
+  await expect(client.get('/test')).rejects.toMatchObject({
+    statusCode: 422,
+    responseBody: longErrorJson,           // not truncated
+  });
+});
+```
+
+Acceptance: spec fails against pre-fix code, passes after Step A.1.
+
+#### Step A.4 — Adapter spec
+
+**File:** `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts` — locate the `createOffer` describe block (existing happy path at `:715`, #406 specs at `:751-784`).
+
+Two new specs:
+
+```ts
+it('preserves Allegro error codes through full responseBody round-trip (#409)', async () => {
+  const longBody = JSON.stringify({
+    errors: [
+      { code: 'ConstraintViolationException.MissingRequiredParameters', message: 'M', details: 'd'.repeat(6000) },
+    ],
+  });
+  expect(longBody.length).toBeGreaterThan(500);
+
+  httpClient.post.mockRejectedValue(
+    new AllegroApiException('Allegro API error (422)', 422, longBody, 'https://…/sale/product-offers'),
+  );
+
+  await expect(adapter.createOffer(baseCmd)).rejects.toMatchObject({
+    errors: [
+      expect.objectContaining({ code: 'ConstraintViolationException.MissingRequiredParameters' }),
+    ],
+  });
+});
+
+it('logs warn when Allegro response body is not parseable JSON (#409)', async () => {
+  // Access the private logger to assert the breadcrumb warn fires; no
+  // existing log-spy pattern in this suite to follow.
+  const warnSpy = jest.spyOn((adapter as unknown as { logger: { warn: jest.Mock } }).logger, 'warn');
+
+  httpClient.post.mockRejectedValue(
+    new AllegroApiException('Allegro API error (502)', 502, '<html>upstream proxy error</html>', 'https://…/sale/product-offers'),
+  );
+
+  await expect(adapter.createOffer(baseCmd)).rejects.toBeInstanceOf(OfferCreateRejectedException);
+  expect(warnSpy).toHaveBeenCalledWith(
+    expect.stringContaining('Failed to parse Allegro error body as JSON'),
+  );
+});
+```
+
+Acceptance: both specs pass; spec 1 specifically fails against pre-A.1 code (assertion would see `errors: []`).
+
+---
+
+## Part B — #407: Job-detail OfferCreationTracker draft branch
+
+### 1. Understand
+
+**Goal.** When Allegro accepts an offer-create as `draft` (offer exists in seller panel but not yet published), the Job-detail page renders three problems: tracker keeps polling forever ("Still processing"), `externalOfferId` and `record.errors` are hidden, and there's no link to the seller panel. All three trace to a single FE assumption that `draft` is non-terminal — which is wrong: `draft` is the *terminal* outcome of the create lifecycle ("offer created, now sitting awaiting manual publish"). `validating` correctly stays non-terminal until the future `marketplace.offer.pollCreationStatus` handler arrives.
+
+**Layer.** Frontend (web). No BE / port / API surface change. The data is already on the wire — just unrendered.
+
+**Non-goals.**
+- The `marketplace.offer.pollCreationStatus` follow-up for `validating` records — explicitly deferred per `OfferCreationExecutionService:144`.
+- A "Publish from OL" action — needs an `OfferPublisher` capability the codebase doesn't expose. Allegro seller-panel link is the MVP path.
+- Surfacing offer creation status on the Listings page — scoped to Job-detail.
+
+### 2. Research
+
+#### Terminal statuses
+
+`apps/web/src/features/listings/api/listings.types.ts:91`
+```ts
+export const TERMINAL_OFFER_CREATION_STATUSES: readonly OfferCreationStatus[] = ['active', 'failed'];
+```
+
+Read by:
+- `use-offer-creation-status-query.ts:32-35` — `refetchInterval` returns `false` (stop polling) when status is terminal.
+- `OfferCreationTracker.tsx:94` — `isTerminal` gates the "Still processing" copy and the Dismiss button.
+
+The hook test at `use-offer-creation-status-query.test.tsx:54` asserts polling stops on terminal — the same assertion needs to hold for `draft`.
+
+#### Tracker render branches (`OfferCreationTracker.tsx:106-157`)
+
+Currently:
+- Header: badge + record id + optional Retry/Dismiss
+- Body: "Still processing" (when `!isTerminal`), "Offer is live · external id …" (when `active`), "Offer creation failed" + `OfferCreationErrorList` (when `failed`)
+
+No `draft` branch. With `draft` flipped terminal but no body branch, the tracker would render only the header — strictly worse UX. So the branch addition is mandatory, not optional.
+
+#### Seller-panel URL derivation
+
+Allegro factory at `libs/integrations/allegro/src/application/allegro-adapter.factory.ts:128-138` switches on `connection.config.environment` (`'sandbox' | 'production'`) to pick the API host. The seller-panel host follows the same convention:
+- production: `https://allegro.pl/oferta/{externalOfferId}/edit`
+- sandbox: `https://allegro.pl.allegrosandbox.pl/oferta/{externalOfferId}/edit`
+
+FE `Connection` type already exposes `config: Record<string, unknown>` (verified at `apps/web/src/features/connections/api/connections.types.ts:22`). Reading `(connection.config?.environment as 'sandbox' | 'production' | undefined)` is sufficient — **no BE change needed**, contrary to issue Step 3 option (a)'s "may need to add to response DTO" caveat.
+
+`OfferCreationTracker` is presentational and only sees `connectionId: string`. Two options for surfacing the platform + environment to the tracker so it can compute the seller-panel URL:
+
+1. **Hook inside the tracker** — `useConnectionsQuery()` (list) or `useConnectionQuery(connectionId)` (single) inside the tracker, look up by id, read `config.environment`. Couples a presentational component to a network dep that doesn't exist today and adds a render-time fetch every time the tracker mounts.
+2. **Props from the caller** — the Job-detail page (`apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx:148`) already knows `job.connectionId`; add `useConnectionQuery(job.connectionId)` there (one hook call, the page is the data-coordination layer) and pass `marketplacePlatformType` + `marketplaceEnvironment` as optional scalar props to the tracker.
+
+**Choosing option 2** — keeps the tracker presentational, makes the network dep visible at the page boundary (where it belongs per `frontend-architecture.md` § Components — "page components own route composition and layout only" but composition includes wiring data into feature components), and the tracker test no longer needs to mock `connections.list`. Verified: `apps/web/src/features/connections/hooks/use-connection-query.ts` exposes a single-connection fetch by id, and Job-detail does **not** currently fetch the connection.
+
+### 3. Design
+
+#### Step B.1 — Mark `draft` terminal
+
+```ts
+export const TERMINAL_OFFER_CREATION_STATUSES: readonly OfferCreationStatus[] = ['draft', 'active', 'failed'];
+```
+
+Hook polling and tracker `isTerminal` immediately follow.
+
+#### Step B.2 — Seller-panel URL helper
+
+New tiny helper in `apps/web/src/features/listings/lib/allegro-seller-panel-url.ts`:
+
+```ts
+/** Derives the Allegro seller-panel deep link for an offer.
+ *  Returns null when platform is not allegro or external id missing. */
+export function buildAllegroSellerPanelUrl(
+  platformType: string,
+  environment: string | undefined,
+  externalOfferId: string | null,
+): string | null {
+  if (platformType !== 'allegro' || !externalOfferId) return null;
+  const host = environment === 'production'
+    ? 'allegro.pl'
+    : 'allegro.pl.allegrosandbox.pl';
+  return `https://${host}/oferta/${encodeURIComponent(externalOfferId)}/edit`;
+}
+```
+
+Pure function, easy unit test, lives inside `features/listings/` so it reuses the listings dependency boundary (no shared/ leak). Default to sandbox host on unknown / missing environment matches the BE adapter's `getDefaultApiBaseUrl` fallback.
+
+#### Step B.3 — Tracker draft branch
+
+`OfferCreationTracker` props gain two optional scalars:
+
+```tsx
+interface OfferCreationTrackerProps {
+  connectionId: string;
+  offerCreationRecordId: string;
+  /** Platform type of the connection. When 'allegro' (and environment provided),
+   *  the draft branch renders an "Open in Allegro seller panel" deep link. */
+  marketplacePlatformType?: string;
+  /** Connection environment ('sandbox' | 'production'). Used together with
+   *  marketplacePlatformType to derive the seller-panel host. */
+  marketplaceEnvironment?: string;
+  onDismiss?: () => void;
+  onRetry?: (record: OfferCreationStatusResponse) => void;
+}
+```
+
+Compute `sellerPanelUrl` via the helper. Render the draft branch only when `record.status === 'draft'`:
+
+```tsx
+{record.status === 'draft' ? (
+  <>
+    <p className="offer-creation-tracker__body">
+      Offer created as a draft on Allegro
+      {record.externalOfferId ? (
+        <> · external id <span className="mono-text">{record.externalOfferId}</span></>
+      ) : null}
+      .{' '}
+      {sellerPanelUrl ? (
+        <a href={sellerPanelUrl} target="_blank" rel="noopener noreferrer">
+          Open in Allegro seller panel
+        </a>
+      ) : null}
+    </p>
+    {record.errors && record.errors.length > 0 ? (
+      <>
+        <p className="offer-creation-tracker__body">
+          Allegro reported validation issues that block publishing:
+        </p>
+        <OfferCreationErrorList errors={record.errors} />
+      </>
+    ) : (
+      <p className="offer-creation-tracker__body offer-creation-tracker__body--muted">
+        No inline validation issues — publish manually in the Allegro seller panel.
+      </p>
+    )}
+  </>
+) : null}
+```
+
+Single new CSS modifier `.offer-creation-tracker__body--muted` (one rule, `color: var(--text-muted)`) to keep "no issues" copy visually subordinate. Per `frontend-ui-style-guide.md` § Color Usage Rules — token-driven, no hex.
+
+`rel="noopener noreferrer"` (not `nofollow`, which is for crawlers) — security best practice for `target="_blank"` external links.
+
+### 4. Implementation Steps (Part B)
+
+#### Step B.1 — Terminal statuses + hook test
+
+**File:** `apps/web/src/features/listings/api/listings.types.ts:91`
+
+Add `'draft'` to the array.
+
+**File:** `apps/web/src/features/listings/hooks/use-offer-creation-status-query.test.tsx`
+
+Add one spec mirroring the existing "stops polling once the status is terminal" but with a `draft` factory:
+
+```ts
+function draft(): OfferCreationStatusResponse {
+  return { ...pending(), status: 'draft', externalOfferId: 'ext-1' };
+}
+
+it('stops polling on draft status (#407)', async () => {
+  const getOfferCreationStatus = vi.fn().mockResolvedValue(draft());
+  const apiClient = createMockApiClient({ listings: { getOfferCreationStatus } });
+  const { result } = renderHook(() => useOfferCreationStatusQuery('conn-1', 'rec-1'), {
+    wrapper: wrap(apiClient),
+  });
+  await waitFor(() => expect(result.current.data?.status).toBe('draft'));
+  await new Promise((r) => setTimeout(r, 80));
+  expect(getOfferCreationStatus).toHaveBeenCalledTimes(1);
+});
+```
+
+#### Step B.2 — Seller-panel URL helper + spec
+
+**File:** `apps/web/src/features/listings/lib/allegro-seller-panel-url.ts` (new)
+**File:** `apps/web/src/features/listings/lib/allegro-seller-panel-url.test.ts` (new)
+
+Helper as designed. Spec covers: production host, sandbox host, sandbox default on undefined/unknown environment, null on non-allegro platform, null on missing externalOfferId, encodeURIComponent on offer ids with special chars.
+
+#### Step B.3 — Tracker draft branch
+
+**File:** `apps/web/src/features/listings/components/OfferCreationTracker.tsx`
+
+Add the two new optional props per the design above. Compute `sellerPanelUrl = buildAllegroSellerPanelUrl(marketplacePlatformType, marketplaceEnvironment, record.externalOfferId)`. Insert the draft branch between the `active` and `failed` branches.
+
+When the caller doesn't supply the props (or supplies a non-allegro platform / unknown environment), `sellerPanelUrl` stays null and the link is omitted — the rest of the draft body still renders.
+
+**Caller update:** `apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx` adds `useConnectionQuery(job.connectionId)` and threads `connection?.platformType` + `(connection?.config?.environment as string | undefined)` into the tracker. The page is the right layer for that data per `frontend-architecture.md` § Components.
+
+#### Step B.4 — CSS modifier
+
+**File:** `apps/web/src/index.css` — find the `.offer-creation-tracker__body` block, add one modifier rule:
+
+```css
+.offer-creation-tracker__body--muted {
+  color: var(--text-muted);
+}
+```
+
+#### Step B.5 — Tracker test
+
+**File:** `apps/web/src/features/listings/components/OfferCreationTracker.test.tsx`
+
+Three new specs in a new `describe('draft status (#407)', …)` block, passing the new props directly (no connection-query mock needed since the tracker no longer hooks the API for environment):
+
+1. `draft + externalOfferId + non-empty errors + marketplaceEnvironment='sandbox' + marketplacePlatformType='allegro'` → renders id, link to `allegro.pl.allegrosandbox.pl`, error list.
+2. `draft + externalOfferId + empty errors + marketplaceEnvironment='production' + marketplacePlatformType='allegro'` → renders id, link to `allegro.pl`, "no inline validation issues" copy.
+3. `draft + null externalOfferId + props omitted` → renders body without id/link, no crash.
+
+### 5. Quality gate
+
+```
+pnpm test:ci          # build libs + run all backend unit tests (covers Part A specs)
+pnpm --filter @openlinker/web test   # web tests (covers Part B specs)
+pnpm lint
+pnpm type-check
+```
+
+Both parts must pass with zero new errors.
+
+### 6. Commit
+
+Single commit (small enough, both halves coherent under "close the offer-create diagnostic loop"):
+
+```
+fix(allegro,web): preserve full Allegro error bodies + render draft offers on Job detail
+
+Two complementary fixes that together close the operator-debug loop on
+the Allegro marketplace.offer.create path that #401 unblocked.
+
+allegro: AllegroHttpClient was truncating responseBody to 500 chars at
+all three error sites (5xx / 4xx-other / 2xx-with-bad-JSON), then
+parseAllegroErrors silently swallowed the JSON.parse failure on the
+truncated body — producing useless errors=0 logs and empty
+OfferCreateRejectedException.errors[]. Sandbox confirmed three real
+Allegro error codes (DownloadError.Forbidden,
+ImpliedWarrantyNotDefinedException,
+ConstraintViolationException.MissingRequiredParameters) all collapsed
+to the same symptom. Pass the full body to AllegroApiException; keep
+the 200-char preview cap on the operator-visible log line. Make
+parseAllegroErrors log warn with the parser-error message + raw-body
+preview when JSON.parse genuinely fails (HTML proxy errors etc).
+Closes #409.
+
+web: OfferCreationTracker treated 'draft' as non-terminal so the
+polling hook kept refetching forever, the body kept showing "Still
+processing", and externalOfferId + record.errors stayed hidden. Mark
+'draft' terminal in TERMINAL_OFFER_CREATION_STATUSES, add a draft body
+branch that renders the Allegro external id, an error list when
+present, and a deep link to the Allegro seller panel (sandbox vs
+production derived from connection.config.environment via a new pure
+buildAllegroSellerPanelUrl helper). 'validating' stays non-terminal
+until the marketplace.offer.pollCreationStatus follow-up handler
+lands.
+Closes #407.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+### 7. Push & PR
+
+`409-407-allegro-error-bodies-and-tracker-draft` → PR with `Closes #409` + `Closes #407` (both on separate lines so GitHub auto-closes both).
+
+## Validate
+
+**Architecture.** Part A is integration-layer (Allegro adapter + http client). Part B is FE-only. No CORE / port surface change in either. No new capabilities.
+
+**Naming / standards.** New helper `allegro-seller-panel-url.ts` matches kebab-case feature-lib convention. New test spec names follow the project's verb-form (`it('preserves the full…', …)`). No `any`, no `console.log`. Comments explain *why* (cite issue numbers), not *what*.
+
+**Testing strategy.** 3 new BE specs (1 http client + 2 adapter) and ≈10 new FE specs across 3 files (1 hook + 6 helper + 3 tracker). All unit-level — no integration tests warranted because the change is pure behavior-preservation at integration layer + presentation-only at FE.
+
+**Security.** `target="_blank"` on the Allegro deep link uses `rel="noopener noreferrer"` (per OWASP guidance). Helper uses `encodeURIComponent` on the offer id to defend against any pathological id values from Allegro.
+
+**Risks.**
+- *#410 was filed assuming this `errors=0` truncation bug is still present and uses the partial body to investigate*. After Part A lands, future Allegro error responses will surface fully — operators get clearer signal, and the "first manual sandbox verify" sub-task on #410 becomes much easier (can read `MissingRequiredParameters` parameter IDs directly from `OfferCreationRecord.errors`).
+- *Connection query in tracker is best-effort* — if the connections list query fails or hasn't loaded by render time, the seller-panel link is omitted and the rest renders. Acceptable degradation per `frontend-ui-style-guide.md` § Color Usage Rules ("color is never the only signal" — the link is a convenience, not the only path to the info).
+
+**Open questions.** None.

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -712,6 +712,66 @@ describe('AllegroOfferManagerAdapter', () => {
       );
     });
 
+    it('preserves Allegro error codes through full responseBody round-trip (#409)', async () => {
+      // Pre-#409 the http-client truncated `responseBody` to 500 chars before
+      // it reached `parseAllegroErrors`, which silently swallowed the
+      // resulting `JSON.parse` failure on the half-message and produced an
+      // `OfferCreateRejectedException` with empty `errors[]`. This regression
+      // guard ensures the full body now round-trips end-to-end.
+      const longBody = JSON.stringify({
+        errors: [
+          {
+            code: 'ConstraintViolationException.MissingRequiredParameters',
+            message: 'Missing required parameters',
+            details: 'd'.repeat(6000),
+          },
+        ],
+      });
+      expect(longBody.length).toBeGreaterThan(500);
+
+      httpClient.post.mockRejectedValue(
+        new AllegroApiException(
+          'Allegro API error (422)',
+          422,
+          longBody,
+          'https://api.allegro.pl/sale/product-offers',
+        ),
+      );
+
+      await expect(adapter.createOffer(baseCmd)).rejects.toMatchObject({
+        errors: [
+          expect.objectContaining({
+            code: 'ConstraintViolationException.MissingRequiredParameters',
+          }),
+        ],
+      });
+    });
+
+    it('logs warn when Allegro response body is not parseable JSON (#409)', async () => {
+      // Access the private logger to assert the breadcrumb warn fires; no
+      // existing log-spy pattern in this suite to follow.
+      const warnSpy = jest.spyOn(
+        (adapter as unknown as { logger: { warn: jest.Mock } }).logger,
+        'warn',
+      );
+
+      httpClient.post.mockRejectedValue(
+        new AllegroApiException(
+          'Allegro API error (502)',
+          502,
+          '<html>upstream proxy error</html>',
+          'https://api.allegro.pl/sale/product-offers',
+        ),
+      );
+
+      await expect(adapter.createOffer(baseCmd)).rejects.toBeInstanceOf(
+        OfferCreateRejectedException,
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to parse Allegro error body as JSON'),
+      );
+    });
+
     it('maps platformParams to delivery/return/warranty/invoice/parameters', async () => {
       httpClient.post.mockResolvedValue(
         mockHttpResponse({ id: 'allegro-offer-5', publication: { status: 'INACTIVE' } }),

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -871,8 +871,13 @@ export class AllegroOfferManagerAdapter
       if (Array.isArray(parsed.errors)) {
         return parsed.errors;
       }
-    } catch {
-      // Response wasn't JSON or didn't match the expected shape.
+    } catch (err) {
+      // Genuinely malformed body (HTML proxy errors, etc.) — log breadcrumbs
+      // so operators don't see an opaque `errors=0` upstream (#409).
+      this.logger.warn(
+        `Failed to parse Allegro error body as JSON: ${(err as Error).message}. ` +
+          `Raw body (first 500 chars): ${responseBody.slice(0, 500)}`,
+      );
     }
     return [];
   }

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts
@@ -474,6 +474,34 @@ describe('AllegroHttpClient', () => {
       await expect(noRetryClient.get('/test')).rejects.toThrow(AllegroApiException);
     });
 
+    it('preserves the full Allegro error body on AllegroApiException (#409)', async () => {
+      // Pre-#409 the body was truncated to 500 chars before being stored on
+      // the exception, which broke downstream `parseAllegroErrors` for any
+      // real Allegro error body (multiple-KB).
+      const longErrorJson = JSON.stringify({
+        errors: [
+          {
+            code: 'ConstraintViolationException.MissingRequiredParameters',
+            message: 'x'.repeat(2000),
+            details: 'y'.repeat(2000),
+          },
+        ],
+      });
+      expect(longErrorJson.length).toBeGreaterThan(500);
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        headers: new Headers(),
+        text: () => Promise.resolve(longErrorJson),
+      });
+
+      await expect(noRetryClient.get('/test')).rejects.toMatchObject({
+        statusCode: 422,
+        responseBody: longErrorJson,
+      });
+    });
+
     it('should throw AllegroApiException on timeout', async () => {
       // noRetryClient: get the timeout exception directly without a retry storm.
       // Mock fetch to resolve only when its AbortSignal fires.

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
@@ -312,10 +312,13 @@ export class AllegroHttpClient implements IAllegroHttpClient {
         data = responseBody ? (JSON.parse(responseBody) as T) : ({} as T);
       } catch (parseError) {
         this.logger.error(`[${traceId}] Failed to parse JSON response: ${(parseError as Error).message}`);
+        // Pass full body to the exception (#409) — `parseAllegroErrors`
+        // and similar downstream parsers need the complete payload, not
+        // a truncated half-message.
         throw new AllegroApiException(
           `Invalid JSON response from Allegro API: ${url.toString()}`,
           response.status,
-          responseBody.substring(0, 500),
+          responseBody,
           url.toString(),
         );
       }
@@ -414,20 +417,25 @@ export class AllegroHttpClient implements IAllegroHttpClient {
 
     if (statusCode >= 500) {
       this.logger.error(`[${traceId}] Allegro API server error (${statusCode}): ${url}`);
+      // Full body on the exception (#409); the operator-visible log line
+      // above stays terse since callers don't read multi-KB scroll-back.
       throw new AllegroApiException(
         `Allegro API server error (${statusCode}): ${url}`,
         statusCode,
-        body.substring(0, 500),
+        body,
         url,
       );
     }
 
     // Other client errors (4xx)
     this.logger.error(`[${traceId}] Allegro API error (${statusCode}): ${url} - ${body.substring(0, 200)}`);
+    // Full body on the exception (#409) — `parseAllegroErrors` needs the
+    // complete JSON to pull out Allegro's `errors[]`; the 200-char preview
+    // on the log line above stays for scroll-back readability.
     throw new AllegroApiException(
       `Allegro API error (${statusCode}): ${url}`,
       statusCode,
-      body.substring(0, 500),
+      body,
       url,
     );
   }


### PR DESCRIPTION
## Summary

Two operator-debug improvements bundled because they close one diagnostic loop together — when offer-create returns a 422, the operator can now both read Allegro's full structured `errors[]` and (for draft outcomes) jump straight from the Job-detail page to the offer in the seller panel.

### #409 — Allegro full error bodies
- Drop `.substring(0, 500)` truncation at the three `AllegroApiException` throw sites in `allegro-http-client.ts` so downstream parsers (notably `parseAllegroErrors`) get the complete payload. The 200-char preview on the operator log line stays.
- Replace silent `catch {}` in `AllegroOfferManagerAdapter.parseAllegroErrors` with `logger.warn` containing the parse error + first 500 chars of the raw body, so genuinely malformed responses (HTML proxy errors etc.) don't vanish into an opaque `errors=0`.

### #407 — OfferCreationTracker draft branch + Job-detail wiring
- Add `'draft'` to `TERMINAL_OFFER_CREATION_STATUSES` (Allegro accepted the offer, OL won't transition it further until `pollCreationStatus` lands).
- New `buildAllegroSellerPanelUrl(platformType, environment, externalId)` helper resolves to `https://allegro.pl/oferta/{id}/edit` (production) or `https://allegro.pl.allegrosandbox.pl/oferta/{id}/edit` (sandbox or unknown env). `encodeURIComponent` guards against pathological ids.
- `OfferCreationTracker` gains optional `marketplacePlatformType` + `marketplaceEnvironment` props; on `status === 'draft'` it renders the external id, the seller-panel deep link (Allegro only), and either inline validation issues or a muted "publish manually" hint.
- `SyncJobDetailPage` calls `useConnectionQuery` and threads `platformType` + `config.environment` into the tracker so the link works on the read-only Job-detail surface.

Closes #409
Closes #407

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test:ci` — all suites green (web 109, core 475, api 262, worker 109, allegro 144, prestashop 200, ai 21, shared 7)
- [x] New BE specs — `allegro-http-client.spec.ts` (full body round-trip) + `allegro-offer-manager.adapter.spec.ts` (errors[] preserved through full body, warn-on-malformed)
- [x] New FE specs — `allegro-seller-panel-url.test.ts` (7 specs), `OfferCreationTracker.test.tsx` draft branch (sandbox+errors, production+empty, omitted-props), `use-offer-creation-status-query.test.tsx` (stops polling on `draft`)
- [ ] Manual: trigger a real Allegro offer-create with invalid params → confirm structured `errors[]` flow into the OfferCreationRecord
- [ ] Manual: trigger a draft outcome → confirm Job-detail page shows the seller-panel link and it opens the right environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)