### PR TITLE
feat(web,api,allegro): surface required category parameters in create-offer wizard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Mark large vendor / fixture payloads as generated so GitHub collapses
+# their diffs by default and excludes them from language statistics. They
+# are still tracked normally — this only changes the review surface.
+libs/integrations/allegro/src/infrastructure/adapters/__fixtures__/*.json linguist-generated=true

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,7 +23,7 @@
     "migration:run": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' bash node_modules/.bin/typeorm migration:run -d src/database/data-source.ts",
     "migration:revert": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' bash node_modules/.bin/typeorm migration:revert -d src/database/data-source.ts",
     "migration:show": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' bash node_modules/.bin/typeorm migration:show -d src/database/data-source.ts",
-    "allegro:capture-cat-params": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' node scripts/capture-allegro-cat-params.ts"
+    "dev:allegro:capture-cat-params": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' node scripts/capture-allegro-cat-params.ts"
   },
   "dependencies": {
     "@nestjs/axios": "3.0.2",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,7 +22,8 @@
     "migration:generate": "bash scripts/migration-generate.sh",
     "migration:run": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' bash node_modules/.bin/typeorm migration:run -d src/database/data-source.ts",
     "migration:revert": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' bash node_modules/.bin/typeorm migration:revert -d src/database/data-source.ts",
-    "migration:show": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' bash node_modules/.bin/typeorm migration:show -d src/database/data-source.ts"
+    "migration:show": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' bash node_modules/.bin/typeorm migration:show -d src/database/data-source.ts",
+    "allegro:capture-cat-params": "NODE_OPTIONS='-r ts-node/register -r tsconfig-paths/register' node scripts/capture-allegro-cat-params.ts"
   },
   "dependencies": {
     "@nestjs/axios": "3.0.2",

--- a/apps/api/scripts/capture-allegro-cat-params.ts
+++ b/apps/api/scripts/capture-allegro-cat-params.ts
@@ -1,13 +1,19 @@
 /**
- * Capture Allegro category-parameters response (dev tool)
+ * Capture Allegro category-parameters response (DEV-ONLY tool)
+ *
+ * ⚠️  This script is for local fixture capture only. Do NOT invoke it from
+ * production, CI, or any deployed environment — it boots the full Nest
+ * application context and writes to the source tree. There is no
+ * authentication, no rate-limit handling, and the output path is
+ * developer-controlled.
  *
  * Bootstraps the Nest application context, resolves the Allegro
  * `OfferManager` adapter for the given connection, and dumps the raw
  * `/sale/categories/{id}/parameters` response to disk. Used to capture
  * fixtures for the mapper / adapter specs (#410).
  *
- * Usage:
- *   pnpm --filter @openlinker/api allegro:capture-cat-params \
+ * Usage (from a developer machine, against an Allegro sandbox connection):
+ *   pnpm --filter @openlinker/api dev:allegro:capture-cat-params \
  *     <connectionId> <categoryId> [outputPath]
  *
  * If `outputPath` is omitted, the script writes to the conventional fixture

--- a/apps/api/scripts/capture-allegro-cat-params.ts
+++ b/apps/api/scripts/capture-allegro-cat-params.ts
@@ -1,0 +1,149 @@
+/**
+ * Capture Allegro category-parameters response (dev tool)
+ *
+ * Bootstraps the Nest application context, resolves the Allegro
+ * `OfferManager` adapter for the given connection, and dumps the raw
+ * `/sale/categories/{id}/parameters` response to disk. Used to capture
+ * fixtures for the mapper / adapter specs (#410).
+ *
+ * Usage:
+ *   pnpm --filter @openlinker/api allegro:capture-cat-params \
+ *     <connectionId> <categoryId> [outputPath]
+ *
+ * If `outputPath` is omitted, the script writes to the conventional fixture
+ * path:
+ *   libs/integrations/allegro/src/infrastructure/adapters/__fixtures__/category-parameters-{categoryId}.json
+ *
+ * The `OL_FIXTURE_OUT_PATH` env var overrides everything. Useful when pnpm's
+ * arg-forwarding eats the third positional argument in some workspace
+ * configurations.
+ *
+ * @module apps/api/scripts
+ */
+import { NestFactory } from '@nestjs/core';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { INTEGRATIONS_SERVICE_TOKEN, type IIntegrationsService } from '@openlinker/core/integrations';
+import type { OfferManagerPort } from '@openlinker/core/listings';
+import { AppModule } from '../src/app.module';
+
+interface AllegroLikeAdapter extends OfferManagerPort {
+  fetchCategoryParametersRaw?: (categoryId: string) => Promise<unknown>;
+}
+
+// Worktree root resolved from this script's location: apps/api/scripts/<this>
+// → ../../.. takes us to the repo root regardless of where pnpm sets cwd.
+const WORKTREE_ROOT = resolve(__dirname, '..', '..', '..');
+const DEFAULT_FIXTURE_DIR =
+  'libs/integrations/allegro/src/infrastructure/adapters/__fixtures__';
+
+async function main(): Promise<void> {
+  const [, , connectionId, categoryId, outputPathArg] = process.argv;
+
+  if (!connectionId || !categoryId) {
+    process.stderr.write(
+      'Usage: capture-allegro-cat-params <connectionId> <categoryId> [outputPath]\n',
+    );
+    process.exit(1);
+  }
+
+  // Resolve the output path with this priority: env var > positional arg >
+  // conventional fixture path. Relative paths resolve against the worktree
+  // root (not pnpm's cwd, which is apps/api when invoked via pnpm --filter).
+  const envPath = process.env.OL_FIXTURE_OUT_PATH;
+  const rawOutputPath =
+    envPath ?? outputPathArg ?? `${DEFAULT_FIXTURE_DIR}/category-parameters-${categoryId}.json`;
+  const resolvedOutputPath = resolve(WORKTREE_ROOT, rawOutputPath);
+
+  // Bootstrap Nest with logs muted — our own progress lines go to stderr.
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+
+  try {
+    process.stderr.write(`> Resolving OfferManager adapter for connection ${connectionId}…\n`);
+    const integrationsService = app.get<IIntegrationsService>(INTEGRATIONS_SERVICE_TOKEN);
+    const adapter = (await integrationsService.getCapabilityAdapter(
+      connectionId,
+      'OfferManager',
+    )) as AllegroLikeAdapter;
+
+    if (typeof adapter.fetchCategoryParametersRaw !== 'function') {
+      process.stderr.write(
+        `! Adapter for connection ${connectionId} does not expose fetchCategoryParametersRaw — only the Allegro adapter implements this dev hook.\n`,
+      );
+      process.exit(2);
+    }
+
+    process.stderr.write(`> Fetching /sale/categories/${categoryId}/parameters…\n`);
+    const raw = await adapter.fetchCategoryParametersRaw(categoryId);
+    const json = JSON.stringify(raw, null, 2);
+
+    mkdirSync(dirname(resolvedOutputPath), { recursive: true });
+    writeFileSync(resolvedOutputPath, json + '\n', 'utf8');
+    process.stderr.write(
+      `> Wrote ${json.length.toLocaleString()} bytes to ${resolvedOutputPath}\n`,
+    );
+    reportShape(raw);
+  } finally {
+    await app.close();
+  }
+}
+
+/**
+ * Quick scout output: how many parameters the response contains, and whether
+ * any dictionary entry carries `dependsOnParameterValueIds` (the marker that
+ * makes a category a useful "cascading dictionary" fixture).
+ */
+function reportShape(raw: unknown): void {
+  if (!raw || typeof raw !== 'object' || !('parameters' in raw)) {
+    process.stderr.write('! Response did not contain a `parameters` array.\n');
+    return;
+  }
+  const params = (raw as { parameters: unknown[] }).parameters;
+  if (!Array.isArray(params)) {
+    process.stderr.write('! `parameters` is not an array.\n');
+    return;
+  }
+
+  let entryFilterCount = 0;
+  let paramVisibilityCount = 0;
+  let dictionaryEntries = 0;
+  for (const p of params) {
+    if (!p || typeof p !== 'object') continue;
+    const op = p as Record<string, unknown>;
+    const options = (op.options ?? null) as Record<string, unknown> | null;
+    if (options && typeof options.dependsOnParameterId === 'string') {
+      paramVisibilityCount += 1;
+    }
+    const dict = Array.isArray(op.dictionary) ? (op.dictionary as Array<Record<string, unknown>>) : [];
+    dictionaryEntries += dict.length;
+    for (const entry of dict) {
+      if (Array.isArray(entry.dependsOnValueIds) && entry.dependsOnValueIds.length > 0) {
+        entryFilterCount += 1;
+      }
+    }
+  }
+
+  process.stderr.write(
+    `> Shape: ${params.length} parameters, ${dictionaryEntries.toLocaleString()} dictionary entries, ` +
+      `${paramVisibilityCount} parameter-level dependsOnParameterId, ` +
+      `${entryFilterCount.toLocaleString()} entries with dependsOnValueIds.\n`,
+  );
+
+  if (entryFilterCount > 0) {
+    process.stderr.write(
+      '> ✅ This category has dictionary-entry filtering — good candidate for the cascading fixture.\n',
+    );
+  } else {
+    process.stderr.write(
+      '> ⚠ This category has no dictionary-entry filtering. Try another category if you need the cascading fixture.\n',
+    );
+  }
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.stack ?? err.message : String(err);
+  process.stderr.write(`! Capture failed: ${message}\n`);
+  process.exit(1);
+});

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from '@openlinker/shared/database';
 import { RedisConfigModule } from '@openlinker/shared/redis';
+import { CacheModule } from '@openlinker/shared/cache';
 import { HealthModule } from './health/health.module';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { CustomersModule } from '@openlinker/core/customers';
@@ -42,6 +43,7 @@ import { ContentApiModule } from './content/content.module';
     ScheduleModule.forRoot(),
     DatabaseModule,
     RedisConfigModule,
+    CacheModule,
     HealthModule,
     AuthModule,
     IdentifierMappingModule,

--- a/apps/api/src/listings/http/dto/category-parameter-response.dto.ts
+++ b/apps/api/src/listings/http/dto/category-parameter-response.dto.ts
@@ -1,0 +1,109 @@
+/**
+ * Category Parameter Response DTO
+ *
+ * Wire shape returned by
+ * `GET /listings/connections/:connectionId/categories/:categoryId/parameters`
+ * (#410). Mirrors the marketplace-neutral `CategoryParameter` from
+ * `@openlinker/core/listings` 1:1 — the controller hands the FE the same
+ * structure CORE exposes so there is no transport-level remapping to keep in
+ * sync. Restricts the surface to read-only.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+import { CategoryParameterTypeValues } from '@openlinker/core/listings';
+
+export class CategoryParameterDictionaryEntryResponseDto {
+  @ApiProperty({ description: 'Allegro-issued dictionary entry ID.' })
+  id!: string;
+
+  @ApiProperty({ description: 'Human-readable label for the entry (operator-language).' })
+  value!: string;
+
+  @ApiProperty({
+    type: [String],
+    required: false,
+    description:
+      'Entry-level dependency. When non-empty, this entry is selectable only when the parent parameter (identified by the parameter\'s `dependsOn.parameterId`) has one of these value IDs.',
+  })
+  dependsOnValueIds?: string[];
+}
+
+export class CategoryParameterRestrictionsResponseDto {
+  @ApiProperty({ required: false })
+  multipleChoices?: boolean;
+  @ApiProperty({ required: false })
+  range?: boolean;
+  @ApiProperty({ required: false })
+  min?: number;
+  @ApiProperty({ required: false })
+  max?: number;
+  @ApiProperty({ required: false })
+  minLength?: number;
+  @ApiProperty({ required: false })
+  maxLength?: number;
+  @ApiProperty({ required: false })
+  precision?: number;
+  @ApiProperty({
+    required: false,
+    description: 'Maximum number of values the user may submit (e.g. 1 for single, 5/20 for capped multi-text).',
+  })
+  allowedNumberOfValues?: number;
+  @ApiProperty({
+    required: false,
+    description: 'Dictionary allows free-text entries alongside the dictionary list (combobox).',
+  })
+  customValuesEnabled?: boolean;
+}
+
+export class CategoryParameterDependsOnResponseDto {
+  @ApiProperty({ description: 'Parent parameter ID this parameter depends on for visibility.' })
+  parameterId!: string;
+
+  @ApiProperty({
+    type: [String],
+    description: 'Parent value IDs that activate this parameter (any-of).',
+  })
+  valueIds!: string[];
+}
+
+export class CategoryParameterResponseDto {
+  @ApiProperty({ description: 'Stable parameter ID (Allegro-issued).' })
+  id!: string;
+
+  @ApiProperty({ description: 'Human label (operator-language, typically Polish).' })
+  name!: string;
+
+  @ApiProperty({ enum: CategoryParameterTypeValues })
+  type!: (typeof CategoryParameterTypeValues)[number];
+
+  @ApiProperty({ description: 'Whether the parameter is required for offer creation.' })
+  required!: boolean;
+
+  @ApiProperty({ required: false, description: 'Optional unit label (e.g. "mm", "kg", "Mpx").' })
+  unit?: string;
+
+  @ApiProperty({
+    type: [CategoryParameterDictionaryEntryResponseDto],
+    required: false,
+    description: 'Present when type === "dictionary".',
+  })
+  dictionary?: CategoryParameterDictionaryEntryResponseDto[];
+
+  @ApiProperty({ type: CategoryParameterRestrictionsResponseDto })
+  restrictions!: CategoryParameterRestrictionsResponseDto;
+
+  @ApiProperty({
+    type: CategoryParameterDependsOnResponseDto,
+    required: false,
+    description:
+      'Parameter-level visibility dependency. Distinct from `dictionary[i].dependsOnValueIds`, which filters dictionary entries within an already-visible parameter.',
+  })
+  dependsOn?: CategoryParameterDependsOnResponseDto;
+}
+
+export class CategoryParametersListResponseDto {
+  @ApiProperty({ type: [CategoryParameterResponseDto] })
+  parameters!: CategoryParameterResponseDto[];
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -6,10 +6,13 @@
 import { NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
-import type { SellerPolicies } from '@openlinker/core/listings';
+import type { CategoryParameter, OfferManagerPort, SellerPolicies } from '@openlinker/core/listings';
+import { CategoryNotFoundException } from '@openlinker/core/listings';
 import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
 import { OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, OFFER_CREATION_RECORD_REPOSITORY_TOKEN, OFFER_MAPPING_REPOSITORY_TOKEN, OfferCreationRecord, SELLER_POLICIES_SERVICE_TOKEN } from '@openlinker/core/listings';
 import type { IOfferCreationEnqueueService, ISellerPoliciesService, OfferCreationRecordRepositoryPort, OfferMappingRepositoryPort } from '@openlinker/core/listings';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { JobEnqueuePort } from '@openlinker/core/sync';
 
@@ -22,6 +25,7 @@ describe('ListingsController', () => {
   let offerCreationRecords: jest.Mocked<OfferCreationRecordRepositoryPort>;
   let offerCreationEnqueue: jest.Mocked<IOfferCreationEnqueueService>;
   let sellerPolicies: jest.Mocked<ISellerPoliciesService>;
+  let integrationsService: jest.Mocked<IIntegrationsService>;
 
   const mockMapping = new IdentifierMapping(
     'uuid-1',
@@ -69,6 +73,9 @@ describe('ListingsController', () => {
     sellerPolicies = {
       getSellerPolicies: jest.fn(),
     };
+    integrationsService = {
+      getCapabilityAdapter: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ListingsController],
@@ -78,6 +85,7 @@ describe('ListingsController', () => {
         { provide: OFFER_CREATION_RECORD_REPOSITORY_TOKEN, useValue: offerCreationRecords },
         { provide: OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, useValue: offerCreationEnqueue },
         { provide: SELLER_POLICIES_SERVICE_TOKEN, useValue: sellerPolicies },
+        { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
       ],
     }).compile();
 
@@ -360,6 +368,97 @@ describe('ListingsController', () => {
 
       expect(result).toEqual(policies);
       expect(sellerPolicies.getSellerPolicies).toHaveBeenCalledWith('conn-1');
+    });
+  });
+
+  describe('getCategoryParameters', () => {
+    const sampleNeutral: CategoryParameter[] = [
+      {
+        id: '11323',
+        name: 'Stan',
+        type: 'dictionary',
+        required: true,
+        dictionary: [{ id: '11323_1', value: 'Nowy' }],
+        restrictions: { multipleChoices: false },
+      },
+      {
+        id: '229205',
+        name: 'Stan opakowania',
+        type: 'dictionary',
+        required: false,
+        dictionary: [
+          {
+            id: '229205_340245',
+            value: 'oryginalne',
+            dependsOnValueIds: ['11323_1'],
+          },
+        ],
+        restrictions: { multipleChoices: false },
+        dependsOn: { parameterId: '11323', valueIds: ['11323_1'] },
+      },
+    ];
+
+    function makeAdapter(
+      withCategoryParametersReader: boolean,
+      fetch: jest.Mock = jest.fn().mockResolvedValue(sampleNeutral),
+    ): OfferManagerPort {
+      // Adapter is a plain object — only the `fetchCategoryParameters` method
+      // matters for the type-guard narrowing.
+      const base = { updateOfferQuantity: jest.fn() } as unknown as OfferManagerPort;
+      if (withCategoryParametersReader) {
+        return Object.assign(base, { fetchCategoryParameters: fetch });
+      }
+      return base;
+    }
+
+    it('returns parameters wrapped under `parameters`, mapping the neutral shape verbatim', async () => {
+      const fetch = jest.fn().mockResolvedValue(sampleNeutral);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeAdapter(true, fetch));
+
+      const result = await controller.getCategoryParameters('conn-1', '257933');
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith('conn-1', 'OfferManager');
+      expect(fetch).toHaveBeenCalledWith({ categoryId: '257933' });
+      expect(result.parameters).toHaveLength(2);
+      expect(result.parameters[0]).toMatchObject({
+        id: '11323',
+        type: 'dictionary',
+        required: true,
+        dictionary: [{ id: '11323_1', value: 'Nowy' }],
+      });
+      expect(result.parameters[1].dependsOn).toEqual({
+        parameterId: '11323',
+        valueIds: ['11323_1'],
+      });
+      expect(result.parameters[1].dictionary?.[0].dependsOnValueIds).toEqual(['11323_1']);
+    });
+
+    it('throws 422 when the adapter does not implement CategoryParametersReader', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeAdapter(false));
+
+      await expect(controller.getCategoryParameters('conn-1', '257933')).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('translates CategoryNotFoundException to a 404 NotFoundException', async () => {
+      const fetch = jest
+        .fn()
+        .mockRejectedValue(new CategoryNotFoundException('999999', 'allegro'));
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeAdapter(true, fetch));
+
+      await expect(controller.getCategoryParameters('conn-1', '999999')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('propagates upstream errors that are not CategoryNotFoundException', async () => {
+      const fetch = jest.fn().mockRejectedValue(new Error('upstream-503'));
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeAdapter(true, fetch));
+
+      await expect(controller.getCategoryParameters('conn-1', '257933')).rejects.toThrow(
+        'upstream-503',
+      );
     });
   });
 });

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -21,13 +21,31 @@ import {
   Param,
   Post,
   Query,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { randomUUID } from 'crypto';
 
 import { Roles } from '../../auth/decorators/roles.decorator';
-import { OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, OFFER_CREATION_RECORD_REPOSITORY_TOKEN, OFFER_MAPPING_REPOSITORY_TOKEN, SELLER_POLICIES_SERVICE_TOKEN } from '@openlinker/core/listings';
-import type { IOfferCreationEnqueueService, ISellerPoliciesService, OfferCreationRecord, OfferCreationRecordRepositoryPort, OfferMappingRepositoryPort } from '@openlinker/core/listings';
+import {
+  CategoryNotFoundException,
+  isCategoryParametersReader,
+  OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
+  OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
+  OFFER_MAPPING_REPOSITORY_TOKEN,
+  SELLER_POLICIES_SERVICE_TOKEN,
+} from '@openlinker/core/listings';
+import type {
+  CategoryParameter,
+  IOfferCreationEnqueueService,
+  ISellerPoliciesService,
+  OfferCreationRecord,
+  OfferCreationRecordRepositoryPort,
+  OfferManagerPort,
+  OfferMappingRepositoryPort,
+} from '@openlinker/core/listings';
+import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
 import type { EntityType, IdentifierMapping } from '@openlinker/core/identifier-mapping';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { JobEnqueuePort } from '@openlinker/core/sync';
@@ -41,6 +59,10 @@ import { CreateOfferDto } from './dto/create-offer.dto';
 import { CreateOfferResponseDto } from './dto/create-offer-response.dto';
 import { OfferCreationStatusResponseDto } from './dto/offer-creation-status-response.dto';
 import { SellerPoliciesResponseDto } from './dto/seller-policies-response.dto';
+import {
+  CategoryParametersListResponseDto,
+  CategoryParameterResponseDto,
+} from './dto/category-parameter-response.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -58,6 +80,8 @@ export class ListingsController {
     private readonly offerCreationEnqueue: IOfferCreationEnqueueService,
     @Inject(SELLER_POLICIES_SERVICE_TOKEN)
     private readonly sellerPolicies: ISellerPoliciesService,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
   ) {}
 
   @Get()
@@ -254,6 +278,76 @@ export class ListingsController {
     @Param('connectionId') connectionId: string,
   ): Promise<SellerPoliciesResponseDto> {
     return this.sellerPolicies.getSellerPolicies(connectionId);
+  }
+
+  @Get('connections/:connectionId/categories/:categoryId/parameters')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiParam({ name: 'categoryId', description: 'Marketplace category ID (Allegro-issued).' })
+  @ApiOperation({
+    summary: 'List category parameters for offer creation (#410)',
+    description:
+      'Returns the full set of marketplace category parameters (required + optional) the create-offer wizard renders for the given connection. The adapter caches the upstream response for 24h by default; the FE additionally caches per (connectionId, categoryId) in TanStack Query.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Category parameters wrapped under `parameters`.',
+    type: CategoryParametersListResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Connection or category not found.' })
+  @ApiResponse({ status: 409, description: 'Connection disabled.' })
+  @ApiResponse({
+    status: 422,
+    description: 'Adapter does not support category-parameters reading.',
+  })
+  async getCategoryParameters(
+    @Param('connectionId') connectionId: string,
+    @Param('categoryId') categoryId: string,
+  ): Promise<CategoryParametersListResponseDto> {
+    // Throws ConnectionNotFoundException (404) / ConnectionDisabledException (409) /
+    // CapabilityNotSupportedException (422) for upstream connection-level issues.
+    const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      connectionId,
+      'OfferManager',
+    );
+
+    if (!isCategoryParametersReader(adapter)) {
+      throw new UnprocessableEntityException(
+        `Adapter for connection ${connectionId} does not support category-parameters reading`,
+      );
+    }
+
+    let parameters: CategoryParameter[];
+    try {
+      parameters = await adapter.fetchCategoryParameters({ categoryId });
+    } catch (err) {
+      if (err instanceof CategoryNotFoundException) {
+        // Bubble category-level 404 distinct from connection-level 404 — the FE
+        // can show a friendlier message and let the operator pick a different
+        // category without re-resolving the connection.
+        throw new NotFoundException(`Category ${categoryId} not found on connection ${connectionId}`);
+      }
+      throw err;
+    }
+
+    return { parameters: parameters.map((p) => this.toCategoryParameterResponseDto(p)) };
+  }
+
+  private toCategoryParameterResponseDto(p: CategoryParameter): CategoryParameterResponseDto {
+    return {
+      id: p.id,
+      name: p.name,
+      type: p.type,
+      required: p.required,
+      unit: p.unit,
+      dictionary: p.dictionary?.map((entry) => ({
+        id: entry.id,
+        value: entry.value,
+        dependsOnValueIds: entry.dependsOnValueIds,
+      })),
+      restrictions: { ...p.restrictions },
+      dependsOn: p.dependsOn ? { ...p.dependsOn } : undefined,
+    };
   }
 
   private toDto(mapping: IdentifierMapping): OfferMappingResponseDto {

--- a/apps/api/src/listings/listings.module.ts
+++ b/apps/api/src/listings/listings.module.ts
@@ -7,12 +7,16 @@
  * @module apps/api/src/listings
  */
 import { Module } from '@nestjs/common';
+import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
 import { ListingsModule as CoreListingsModule } from '@openlinker/core/listings/services';
 import { SyncModule as CoreSyncModule } from '@openlinker/core/sync';
 import { ListingsController } from './http/listings.controller';
 
 @Module({
-  imports: [CoreListingsModule, CoreSyncModule],
+  // CoreIntegrationsModule supplies INTEGRATIONS_SERVICE_TOKEN, which the
+  // controller injects to resolve the per-connection OfferManager adapter
+  // for the category-parameters endpoint (#410).
+  imports: [CoreListingsModule, CoreSyncModule, CoreIntegrationsModule],
   controllers: [ListingsController],
 })
 export class ListingsApiModule {}

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -7,6 +7,7 @@
  * @module apps/web/src/features/listings/api
  */
 import type {
+  CategoryParametersListResponse,
   CreateOfferRequest,
   CreateOfferResponse,
   ListingsFilters,
@@ -41,6 +42,10 @@ export interface ListingsApi {
     offerCreationRecordId: string,
   ) => Promise<OfferCreationStatusResponse>;
   getSellerPolicies: (connectionId: string) => Promise<SellerPoliciesResponse>;
+  getCategoryParameters: (
+    connectionId: string,
+    categoryId: string,
+  ) => Promise<CategoryParametersListResponse>;
 }
 
 interface ApiRequest {
@@ -95,6 +100,11 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
     },
     getSellerPolicies(connectionId): Promise<SellerPoliciesResponse> {
       return request<SellerPoliciesResponse>(`/listings/connections/${connectionId}/seller-policies`);
+    },
+    getCategoryParameters(connectionId, categoryId): Promise<CategoryParametersListResponse> {
+      return request<CategoryParametersListResponse>(
+        `/listings/connections/${connectionId}/categories/${categoryId}/parameters`,
+      );
     },
   };
 }

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -12,4 +12,6 @@ export const listingsQueryKeys = {
     ['listings', 'offerCreationStatus', connectionId, offerCreationRecordId] as const,
   sellerPolicies: (connectionId: string) =>
     ['listings', 'sellerPolicies', connectionId] as const,
+  categoryParameters: (connectionId: string, categoryId: string) =>
+    ['listings', 'categoryParameters', connectionId, categoryId] as const,
 };

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -163,3 +163,67 @@ export interface SellerPoliciesResponse {
   warranties: SellerPolicy[];
   impliedWarranties: SellerPolicy[];
 }
+
+/** ----- Category parameters (#410) ----------------------------------------
+ *
+ * Marketplace-neutral shape for category parameters returned by
+ * `GET /listings/connections/:connectionId/categories/:categoryId/parameters`.
+ * Mirrors the backend `CategoryParameter` 1:1 — no transport-level remapping.
+ *
+ * Two distinct dependency mechanisms surface separately:
+ *   - parameter-level visibility (`dependsOn`) — show/hide the whole field
+ *   - dictionary-entry filtering (`dictionary[i].dependsOnValueIds`) —
+ *     filter individual options inside an already-visible field
+ *
+ * The wizard renderer uses both: `dependsOn` to skip rendering, the
+ * per-entry list to filter dictionary options once the parent has a value.
+ * --------------------------------------------------------------------- */
+
+export const CategoryParameterTypeValues = [
+  'dictionary',
+  'string',
+  'integer',
+  'float',
+] as const;
+export type CategoryParameterType = (typeof CategoryParameterTypeValues)[number];
+
+export interface CategoryParameterDictionaryEntry {
+  id: string;
+  value: string;
+  dependsOnValueIds?: string[];
+}
+
+export interface CategoryParameterRestrictions {
+  multipleChoices?: boolean;
+  range?: boolean;
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
+  precision?: number;
+  /** Maximum number of values the user may submit. `1` = single, `2+` = bounded multi. */
+  allowedNumberOfValues?: number;
+  /** Dictionary allows free-text entries alongside the dictionary list (combobox). */
+  customValuesEnabled?: boolean;
+}
+
+export interface CategoryParameterDependsOn {
+  parameterId: string;
+  valueIds: string[];
+}
+
+export interface CategoryParameter {
+  id: string;
+  name: string;
+  type: CategoryParameterType;
+  required: boolean;
+  unit?: string;
+  dictionary?: CategoryParameterDictionaryEntry[];
+  restrictions: CategoryParameterRestrictions;
+  /** Parameter-level visibility — see file header. */
+  dependsOn?: CategoryParameterDependsOn;
+}
+
+export interface CategoryParametersListResponse {
+  parameters: CategoryParameter[];
+}

--- a/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
@@ -9,7 +9,11 @@ import { renderWithProviders, createMockApiClient } from '../../../test/test-uti
 import { CreateOfferWizard } from './CreateOfferWizard';
 import type { Connection } from '../../connections/api/connections.types';
 import type { Product } from '../../products/api/products.types';
-import type { CreateOfferRequest, SellerPoliciesResponse } from '../api/listings.types';
+import type {
+  CategoryParameter,
+  CreateOfferRequest,
+  SellerPoliciesResponse,
+} from '../api/listings.types';
 
 const allegroConnection: Connection = {
   id: 'conn_allegro_1',
@@ -700,5 +704,157 @@ describe('CreateOfferWizard', () => {
         { timeout: 1000 },
       );
     });
+  });
+
+  describe('category parameters step (#410)', () => {
+    /**
+     * Two-parameter fixture covering the auto-prefill, dynamic-validation,
+     * and serialiser branches in one shot:
+     *  - `p_ean` is an EAN-class string field (matches the auto-prefill
+     *    `EAN_NAME_PATTERNS` list).
+     *  - `p_stan` is a required dictionary that contains a "Nowy" entry,
+     *    so the auto-prefill defaults it to `p_stan_new`.
+     */
+    const parametersFixture: CategoryParameter[] = [
+      {
+        id: 'p_ean',
+        name: 'EAN (GTIN)',
+        type: 'string',
+        required: false,
+        restrictions: { maxLength: 20 },
+      },
+      {
+        id: 'p_stan',
+        name: 'Stan',
+        type: 'dictionary',
+        required: true,
+        dictionary: [
+          { id: 'p_stan_new', value: 'Nowy' },
+          { id: 'p_stan_used', value: 'Używany' },
+        ],
+        restrictions: {},
+      },
+    ];
+
+    it('auto-prefills EAN from variant + Stan default and serialises both into the submit payload', async () => {
+      const createOffer = vi
+        .fn()
+        .mockResolvedValue({ jobId: 'job-1', offerCreationRecordId: 'rec-1' });
+      const onSubmitted = vi.fn();
+      const onClose = vi.fn();
+      const mockApi = defaultMocks({
+        listings: {
+          createOffer,
+          getSellerPolicies: vi.fn().mockResolvedValue(policies),
+          getCategoryParameters: vi
+            .fn()
+            .mockResolvedValue({ parameters: parametersFixture }),
+        },
+      });
+
+      renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={onClose}
+          defaultConnectionId={allegroConnection.id}
+          onSubmitted={onSubmitted}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await advanceToStep2();
+      await pickFirstLeafCategory();
+      fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
+      fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+      // Step 3 (parameters) — required EAN field is rendered and pre-filled
+      // from the variant's EAN; Stan defaults to "Nowy".
+      const eanInput = await screen.findByLabelText(/ean \(gtin\)/i);
+      await waitFor(() => expect(eanInput).toHaveValue('5901234567890'));
+      const stanSelect = screen.getByLabelText<HTMLSelectElement>(/^stan$/i);
+      await waitFor(() => expect(stanSelect.value).toBe('p_stan_new'));
+
+      // Advance — dynamic Zod validation passes because Stan is filled.
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      await screen.findByLabelText(/delivery policy/i);
+      fireEvent.change(screen.getByLabelText(/delivery policy/i), {
+        target: { value: 'del-1' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      fireEvent.click(await screen.findByRole('button', { name: /create offer/i }));
+
+      await waitFor(() =>
+        expect(createOffer).toHaveBeenCalledWith(
+          allegroConnection.id,
+          expect.objectContaining({
+            overrides: expect.objectContaining({
+              platformParams: expect.objectContaining({
+                deliveryPolicyId: 'del-1',
+                parameters: expect.arrayContaining([
+                  { id: 'p_ean', values: ['5901234567890'] },
+                  { id: 'p_stan', valuesIds: ['p_stan_new'] },
+                ]),
+              }),
+            }),
+          }),
+          expect.objectContaining({ idempotencyKey: expect.stringMatching(/.+/) }),
+        ),
+      );
+      expect(onSubmitted).toHaveBeenCalledWith('rec-1', allegroConnection.id);
+    });
+
+    it('blocks advancement past Step 3 when a required dictionary parameter is empty', async () => {
+      // Same fixture, but tests that clearing Stan rejects advancement.
+      const mockApi = defaultMocks({
+        listings: {
+          createOffer: vi.fn(),
+          getSellerPolicies: vi.fn().mockResolvedValue(policies),
+          // Stan has no "Nowy" entry → autoprefill leaves it empty,
+          // exercising the required-when-visible Zod rule.
+          getCategoryParameters: vi.fn().mockResolvedValue({
+            parameters: [
+              {
+                ...parametersFixture[1],
+                dictionary: [{ id: 'p_stan_used', value: 'Używany' }],
+              },
+            ],
+          }),
+        },
+      });
+
+      renderWithProviders(
+        <CreateOfferWizard
+          isOpen={true}
+          onClose={vi.fn()}
+          defaultConnectionId={allegroConnection.id}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await advanceToStep2();
+      await pickFirstLeafCategory();
+      fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
+      fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+      // Step 3 — Stan is rendered, empty, required.
+      const stanSelect = await screen.findByLabelText<HTMLSelectElement>(/^stan$/i);
+      expect(stanSelect.value).toBe('');
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      // The dynamic-validation message is set on the form, and the policies
+      // step (Step 4) does not appear.
+      expect(await screen.findByText(/stan is required/i)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/delivery policy/i)).not.toBeInTheDocument();
+    });
+
+    // Note: the "categoryId change clears the parameters slice" effect is
+    // small enough to live in the wizard's clearing useEffect, and the
+    // wired path is covered by the visibility / serializer / Zod helper
+    // unit tests. We deliberately don't add a wizard-level test for it
+    // here — driving the CategoryPicker through the picker's "Selected"
+    // → re-pick UI is brittle and the marginal coverage is low.
   });
 });

--- a/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.test.tsx
@@ -68,6 +68,11 @@ function defaultMocks(overrides: Parameters<typeof createMockApiClient>[0] = {})
         .fn()
         .mockResolvedValue({ jobId: 'job-1', offerCreationRecordId: 'rec-1' }),
       getSellerPolicies: vi.fn().mockResolvedValue(policies),
+      // Default the category-parameters fetch to "no parameters" so the step
+      // renders a friendly empty message and the existing happy-path tests
+      // can advance past it with a single Next click. Individual tests
+      // override when they exercise parameter rendering / validation.
+      getCategoryParameters: vi.fn().mockResolvedValue({ parameters: [] }),
     },
     mappings: {
       // Single-leaf root tree for simple happy-path coverage. Individual tests
@@ -90,6 +95,19 @@ async function pickFirstLeafCategory(): Promise<void> {
   await waitFor(() =>
     expect(screen.getByRole('button', { name: /^selected$/i })).toBeInTheDocument(),
   );
+}
+
+/**
+ * Advance through the (empty by default) Step-3 "Category parameters" step,
+ * landing on Step-4 "Policies". Used by the existing tests that don't care
+ * about parameter rendering — keeps them readable while the new step still
+ * gets traversed.
+ */
+async function advanceThroughEmptyParameters(): Promise<void> {
+  expect(
+    await screen.findByText(/no additional parameters required/i),
+  ).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /next/i }));
 }
 
 async function advanceToStep2(): Promise<void> {
@@ -210,7 +228,9 @@ describe('CreateOfferWizard', () => {
     expect(
       await screen.findByText(/allegro category id is required/i),
     ).toBeInTheDocument();
-    // Still on Step 2 — delivery-policy select (Step 3) is not rendered.
+    // Still on Step 2 — neither the parameters step (#410) nor the
+    // delivery-policy select (Step 4) are rendered.
+    expect(screen.queryByText(/no additional parameters required/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/delivery policy/i)).not.toBeInTheDocument();
   });
 
@@ -235,7 +255,7 @@ describe('CreateOfferWizard', () => {
     expect(await screen.findByText(/75 characters or fewer/i)).toBeInTheDocument();
   });
 
-  it('requires delivery policy on step 3 when policies are present', async () => {
+  it('requires delivery policy on the policies step when policies are present', async () => {
     const mockApi = defaultMocks();
     renderWithProviders(
       <CreateOfferWizard
@@ -254,7 +274,10 @@ describe('CreateOfferWizard', () => {
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
-    // Now on Step 3 — try to advance without picking delivery
+    // Step 3 (#410) — no parameters for this category in the default mock.
+    await advanceThroughEmptyParameters();
+
+    // Now on Step 4 — try to advance without picking delivery
     await screen.findByLabelText(/delivery policy/i);
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
     expect(await screen.findByText(/delivery policy is required/i)).toBeInTheDocument();
@@ -287,6 +310,7 @@ describe('CreateOfferWizard', () => {
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await advanceThroughEmptyParameters();
 
     expect(await screen.findByText(/no seller policies configured/i)).toBeInTheDocument();
   });
@@ -312,13 +336,14 @@ describe('CreateOfferWizard', () => {
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await advanceThroughEmptyParameters();
 
-    // Step 3 — pick delivery
+    // Step 4 — pick delivery
     const deliverySelect = await screen.findByLabelText(/delivery policy/i);
     fireEvent.change(deliverySelect, { target: { value: 'del-1' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
-    // Step 4 — submit
+    // Step 5 — submit
     fireEvent.click(await screen.findByRole('button', { name: /create offer/i }));
 
     await waitFor(() =>
@@ -365,6 +390,7 @@ describe('CreateOfferWizard', () => {
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await advanceThroughEmptyParameters();
     fireEvent.change(await screen.findByLabelText(/delivery policy/i), { target: { value: 'del-1' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
@@ -404,6 +430,7 @@ describe('CreateOfferWizard', () => {
     fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
     fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    await advanceThroughEmptyParameters();
     fireEvent.change(await screen.findByLabelText(/delivery policy/i), { target: { value: 'del-1' } });
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
@@ -516,6 +543,7 @@ describe('CreateOfferWizard', () => {
       fireEvent.change(screen.getByLabelText(/^price$/i), { target: { value: '99.99' } });
       fireEvent.change(screen.getByLabelText(/^stock$/i), { target: { value: '5' } });
       fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      await advanceThroughEmptyParameters();
       fireEvent.change(await screen.findByLabelText(/delivery policy/i), {
         target: { value: 'del-1' },
       });
@@ -543,9 +571,11 @@ describe('CreateOfferWizard', () => {
         />,
       );
 
-      // We land on Step 2 pre-filled; advance through Step 3 → submit.
+      // We land on Step 2 pre-filled; advance through the empty parameters
+      // step (#410) and the policies step → submit.
       await screen.findByLabelText(/^title$/i);
       fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      await advanceThroughEmptyParameters();
       // Delivery policy pre-fills from initialValues; just advance.
       await screen.findByLabelText(/delivery policy/i);
       fireEvent.click(screen.getByRole('button', { name: /next/i }));

--- a/apps/web/src/features/listings/components/CreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.tsx
@@ -1,15 +1,18 @@
 /**
  * CreateOfferWizard
  *
- * Four-step wizard that publishes an OpenLinker variant as a new offer
+ * Five-step wizard that publishes an OpenLinker variant as a new offer
  * on a marketplace connection. Steps:
  *   1. Connection & Variant — pick the target connection, search and
  *      select a product variant
  *   2. Offer details — title override, Allegro category id, price, stock,
  *      description, publish-immediately toggle
- *   3. Policies — delivery (required), return / warranty / implied
+ *   3. Category parameters (#410) — required-first / optional-collapsed
+ *      Allegro per-category attributes; renders a friendly empty message
+ *      when the category has no parameters.
+ *   4. Policies — delivery (required), return / warranty / implied
  *      warranty (optional), populated from the seller-policies endpoint
- *   4. Review — summary of all chosen values
+ *   5. Review — summary of all chosen values
  *
  * Retry-safe: a stable `x-idempotency-key` is generated on open
  * (`crypto.randomUUID()`) and reused until success or explicit cancel,
@@ -24,7 +27,13 @@
  * @module apps/web/src/features/listings/components
  */
 import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
-import { Controller, useForm, type Path } from 'react-hook-form';
+import {
+  Controller,
+  FormProvider,
+  useForm,
+  type FieldPath,
+  type Path,
+} from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
@@ -43,8 +52,17 @@ import { useProductsQuery } from '../../products/hooks/use-products-query';
 import type { Product, ProductVariant } from '../../products/api/products.types';
 import { useCreateOfferMutation } from '../hooks/use-create-offer-mutation';
 import { useSellerPoliciesQuery } from '../hooks/use-seller-policies-query';
+import { useCategoryParametersQuery } from '../hooks/use-category-parameters-query';
 import { CategoryPicker } from './CategoryPicker';
-import type { CreateOfferRequest } from '../api/listings.types';
+import { CategoryParametersStep } from './category-parameters-step';
+import { autoPrefillParameters } from './auto-prefill-parameters';
+import { buildParametersZodSchema } from './build-parameters-zod-schema';
+import {
+  serializeAllegroParameters,
+  type AllegroParameterInput,
+} from './serialize-allegro-parameters';
+import type { CategoryParameterFormValues } from './category-parameter-form.types';
+import type { CategoryParameter, CreateOfferRequest } from '../api/listings.types';
 import {
   CREATE_OFFER_DEFAULT_VALUES,
   createOfferFieldsSchema,
@@ -53,11 +71,20 @@ import {
 } from './create-offer-fields.schema';
 import { createOfferRequestToFormValues } from './create-offer-request-to-form-values';
 
-const STEP_LABELS = ['Connection & Variant', 'Offer details', 'Policies', 'Review'] as const;
+const STEP_LABELS = [
+  'Connection & Variant',
+  'Offer details',
+  'Category parameters',
+  'Policies',
+  'Review',
+] as const;
 
 const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<CreateOfferFieldsValues>>> = [
   ['connectionId', 'internalVariantId'],
   ['title', 'categoryId', 'priceAmount', 'priceCurrency', 'stock'],
+  // Step 3 (parameters) is validated dynamically via buildParametersZodSchema —
+  // its field shape is runtime-driven so we cannot list keys statically.
+  [],
   ['deliveryPolicyId'],
   [],
 ];
@@ -89,6 +116,73 @@ function variantLabel(product: Product, variant: ProductVariant): string {
   return product.name;
 }
 
+interface ReviewParameterRow {
+  id: string;
+  label: string;
+  value: string;
+}
+
+/**
+ * Project the wizard's parameter form-state into a flat label/value list for
+ * the Review step. Keeps the rendering data-flow inside the wizard rather
+ * than leaking display logic into the field renderer.
+ */
+function renderReviewParameters(
+  values: CategoryParameterFormValues,
+  parameters: CategoryParameter[],
+): ReviewParameterRow[] {
+  const rows: ReviewParameterRow[] = [];
+  for (const param of parameters) {
+    const raw = values[param.id];
+    if (raw === undefined || raw === '') continue;
+
+    let display = '';
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) continue;
+      display = raw
+        .map((id) => param.dictionary?.find((e) => e.id === id)?.value ?? id)
+        .join(', ');
+    } else if (typeof raw === 'string') {
+      const matched = param.dictionary?.find((e) => e.id === raw);
+      display = matched ? matched.value : raw;
+    } else if (typeof raw === 'object' && raw !== null) {
+      const r = raw as { from?: string; to?: string };
+      const from = r.from?.trim() ?? '';
+      const to = r.to?.trim() ?? '';
+      if (from === '' && to === '') continue;
+      display = `${from || '—'} – ${to || '—'}${param.unit ? ` ${param.unit}` : ''}`;
+    } else {
+      continue;
+    }
+
+    rows.push({ id: param.id, label: param.name, value: display });
+  }
+  return rows;
+}
+
+function renderReviewParametersBlock(
+  values: CategoryParameterFormValues,
+  parameters: CategoryParameter[],
+): ReactElement | null {
+  const rows = renderReviewParameters(values, parameters);
+  if (rows.length === 0) return null;
+  return (
+    <>
+      <dt>Category parameters</dt>
+      <dd>
+        <ul className="wizard-review-list__nested">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <span className="muted-text">{row.label}: </span>
+              <span>{row.value}</span>
+            </li>
+          ))}
+        </ul>
+      </dd>
+    </>
+  );
+}
+
 export function CreateOfferWizard({
   isOpen,
   onClose,
@@ -115,6 +209,20 @@ export function CreateOfferWizard({
   // Lets Step 1 render a hint explaining why the picker looks empty
   // despite the form carrying a variant id from the prior attempt.
   const [wasPrefilled, setWasPrefilled] = useState(false);
+  // EAN of the variant the operator picked in Step 1 — fed to the Step 3
+  // parameter auto-prefill so EAN/GTIN-class fields populate from the
+  // variant's barcode without needing the variant detail re-fetched.
+  const [pickedVariantEan, setPickedVariantEan] = useState<string | null>(null);
+  // Set of parameter ids that were auto-prefilled by `autoPrefillParameters`
+  // for the current (connectionId, categoryId) pair. Surfaced to the step as
+  // a `prefilledIds` hint so the operator sees which fields were
+  // pre-populated. Stays static after the initial fill — chasing dirty state
+  // would add complexity for small UX gain.
+  const [prefilledIds, setPrefilledIds] = useState<ReadonlySet<string>>(new Set());
+  // Wire snapshot of the parameters we sent on submit. Anchors error mapping
+  // when Allegro returns positional `parameters[N]` validation errors after
+  // a failed submit (each index → parameter id via this snapshot).
+  const submittedParametersRef = useRef<AllegroParameterInput[]>([]);
   const debouncedProductSearch = useDebouncedValue(productSearchInput, VARIANT_SEARCH_DEBOUNCE_MS);
 
   // Reset wizard state on open. A fresh idempotency key is minted every
@@ -152,6 +260,9 @@ export function CreateOfferWizard({
       }
       setProductSearchInput('');
       setProductOffset(0);
+      setPickedVariantEan(null);
+      setPrefilledIds(new Set());
+      submittedParametersRef.current = [];
       mutation.reset();
     }
     prevIsOpenRef.current = isOpen;
@@ -213,6 +324,75 @@ export function CreateOfferWizard({
         policies.impliedWarranties.length),
   );
 
+  // Step 3 (#410) — fetch the per-category parameter schema.
+  const currentCategoryId = form.watch('categoryId');
+  const categoryParametersQuery = useCategoryParametersQuery(
+    currentConnectionId || undefined,
+    currentCategoryId || undefined,
+  );
+  const categoryParameters = useMemo(
+    () => categoryParametersQuery.data ?? [],
+    [categoryParametersQuery.data],
+  );
+
+  // Auto-prefill EAN/Stan when the parameter schema first arrives for the
+  // current (connectionId, categoryId) pair. Re-runs only when the pair
+  // changes — values the operator has already typed are preserved.
+  const prefilledKeyRef = useRef<string>('');
+  useEffect(() => {
+    if (categoryParametersQuery.data === undefined) return;
+    const key = `${currentConnectionId}::${currentCategoryId}`;
+    if (prefilledKeyRef.current === key) return;
+    prefilledKeyRef.current = key;
+    if (categoryParametersQuery.data.length === 0) {
+      setPrefilledIds(new Set());
+      return;
+    }
+    const filled = autoPrefillParameters(categoryParametersQuery.data, {
+      ean: pickedVariantEan,
+    });
+    if (Object.keys(filled).length === 0) {
+      setPrefilledIds(new Set());
+      return;
+    }
+    const current =
+      (form.getValues('parameters') as CategoryParameterFormValues | undefined) ?? {};
+    // Operator-set values win over auto-fill — only fill keys the form
+    // does not have a value for yet.
+    const merged: CategoryParameterFormValues = { ...current };
+    const filledIds = new Set<string>();
+    for (const [paramId, value] of Object.entries(filled)) {
+      if (current[paramId] === undefined || current[paramId] === '') {
+        merged[paramId] = value;
+        filledIds.add(paramId);
+      }
+    }
+    if (filledIds.size > 0) {
+      form.setValue('parameters', merged, { shouldDirty: false, shouldValidate: false });
+    }
+    setPrefilledIds(filledIds);
+  }, [
+    categoryParametersQuery.data,
+    currentConnectionId,
+    currentCategoryId,
+    pickedVariantEan,
+    form,
+  ]);
+
+  // Clear the parameters slice whenever the chosen category changes — the
+  // shape is category-specific so prior values would never be valid under a
+  // new schema.
+  const lastCategoryIdRef = useRef<string>(currentCategoryId);
+  useEffect(() => {
+    if (lastCategoryIdRef.current && lastCategoryIdRef.current !== currentCategoryId) {
+      form.setValue('parameters', {}, { shouldDirty: false, shouldValidate: false });
+      form.clearErrors('parameters');
+      setPrefilledIds(new Set());
+      prefilledKeyRef.current = '';
+    }
+    lastCategoryIdRef.current = currentCategoryId;
+  }, [currentCategoryId, form]);
+
   const validationMessages = Object.values(form.formState.errors).flatMap((e) =>
     e?.message ? [String(e.message)] : [],
   );
@@ -223,6 +403,34 @@ export function CreateOfferWizard({
       const valid = await form.trigger([...fields]);
       if (!valid) return;
     }
+
+    // Step 3 (#410) — dynamic per-category Zod validation. Skipped when the
+    // category has no parameters or when the schema is still loading (the
+    // serialiser drops empty/missing values, so an under-filled draft just
+    // produces a smaller payload — submission still surfaces server-side
+    // validation errors at the Review step).
+    if (stepIndex === 2 && categoryParameters.length > 0) {
+      const values =
+        (form.getValues('parameters') as CategoryParameterFormValues | undefined) ?? {};
+      const result = buildParametersZodSchema(categoryParameters).safeParse(values);
+      if (!result.success) {
+        // Surface per-field issues onto the form — the renderer reads them
+        // via `formState.errors['parameters.{paramId}']` (flat key, set
+        // explicitly because RHF cannot infer the dynamic path shape).
+        form.clearErrors('parameters' as FieldPath<CreateOfferFieldsValues>);
+        for (const issue of result.error.issues) {
+          const paramId = String(issue.path[0] ?? '');
+          if (paramId === '') continue;
+          form.setError(
+            `parameters.${paramId}` as FieldPath<CreateOfferFieldsValues>,
+            { type: 'manual', message: issue.message },
+          );
+        }
+        return;
+      }
+      form.clearErrors('parameters' as FieldPath<CreateOfferFieldsValues>);
+    }
+
     setCompletedSteps((prev) => new Set(prev).add(stepIndex));
     setStepIndex((i) => Math.min(i + 1, STEP_LABELS.length - 1));
   }
@@ -242,6 +450,9 @@ export function CreateOfferWizard({
     if (!form.getValues('priceAmount') && product.price !== null) {
       form.setValue('priceAmount', String(product.price.toFixed(2)), { shouldDirty: true });
     }
+    // Capture the variant's EAN for Step 3 auto-prefill (EAN/GTIN parameters
+    // populate from the variant's barcode).
+    setPickedVariantEan(variant.ean ?? null);
   }
 
   const onSubmit = form.handleSubmit(async (values) => {
@@ -249,6 +460,19 @@ export function CreateOfferWizard({
     if (values.returnPolicyId) platformParams.returnPolicyId = values.returnPolicyId;
     if (values.warrantyId) platformParams.warrantyId = values.warrantyId;
     if (values.impliedWarrantyId) platformParams.impliedWarrantyId = values.impliedWarrantyId;
+
+    // Serialise Step-3 parameter values into Allegro's wire shape. The
+    // returned snapshot stays in `submittedParametersRef` for positional
+    // error mapping (Allegro returns `parameters[N]` indices on validation
+    // failure → look up the parameter id via this snapshot).
+    const { submitted: submittedParameters } = serializeAllegroParameters(
+      (values.parameters as CategoryParameterFormValues | undefined) ?? {},
+      categoryParameters,
+    );
+    submittedParametersRef.current = submittedParameters;
+    if (submittedParameters.length > 0) {
+      platformParams.parameters = submittedParameters;
+    }
 
     const request: CreateOfferRequest = {
       internalVariantId: values.internalVariantId,
@@ -305,6 +529,7 @@ export function CreateOfferWizard({
           </Alert>
         ) : null}
 
+        <FormProvider {...form}>
         <form
           id="create-offer-form"
           onSubmit={(e) => void onSubmit(e)}
@@ -570,6 +795,37 @@ export function CreateOfferWizard({
 
           {stepIndex === 2 ? (
             <>
+              {categoryParametersQuery.isLoading ? (
+                <p className="muted-text" role="status" aria-live="polite">
+                  Loading category parameters…
+                </p>
+              ) : categoryParametersQuery.error ? (
+                <Alert tone="error" title="Unable to load category parameters">
+                  <span>{categoryParametersQuery.error.message}</span>
+                  <Button
+                    tone="secondary"
+                    type="button"
+                    onClick={() => void categoryParametersQuery.refetch()}
+                  >
+                    Retry
+                  </Button>
+                </Alert>
+              ) : categoryParameters.length === 0 ? (
+                <p className="muted-text">
+                  No additional parameters required for this category.
+                </p>
+              ) : (
+                <CategoryParametersStep
+                  parameters={categoryParameters}
+                  formNamespace="parameters"
+                  prefilledIds={prefilledIds}
+                />
+              )}
+            </>
+          ) : null}
+
+          {stepIndex === 3 ? (
+            <>
               {sellerPoliciesQuery.isLoading ? (
                 <p className="muted-text">Loading seller policies…</p>
               ) : sellerPoliciesQuery.error ? (
@@ -638,7 +894,7 @@ export function CreateOfferWizard({
             </>
           ) : null}
 
-          {stepIndex === 3 ? (
+          {stepIndex === 4 ? (
             <dl className="wizard-review-list">
               <dt>Connection</dt>
               <dd>
@@ -656,6 +912,10 @@ export function CreateOfferWizard({
               <dd>{values.stock}</dd>
               <dt>Publish immediately</dt>
               <dd>{values.publishImmediately ? 'Yes' : 'No (create as draft)'}</dd>
+              {renderReviewParametersBlock(
+                (values.parameters as CategoryParameterFormValues | undefined) ?? {},
+                categoryParameters,
+              )}
               <dt>Delivery policy</dt>
               <dd>
                 {policies?.deliveryPolicies.find((p) => p.id === values.deliveryPolicyId)?.name ??
@@ -698,6 +958,7 @@ export function CreateOfferWizard({
             </dl>
           ) : null}
         </form>
+        </FormProvider>
 
         <div className="wizard-actions">
           <div className="wizard-actions__group">

--- a/apps/web/src/features/listings/components/CreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.tsx
@@ -57,10 +57,7 @@ import { CategoryPicker } from './CategoryPicker';
 import { CategoryParametersStep } from './category-parameters-step';
 import { autoPrefillParameters } from './auto-prefill-parameters';
 import { buildParametersZodSchema } from './build-parameters-zod-schema';
-import {
-  serializeAllegroParameters,
-  type AllegroParameterInput,
-} from './serialize-allegro-parameters';
+import { serializeAllegroParameters } from './serialize-allegro-parameters';
 import type { CategoryParameterFormValues } from './category-parameter-form.types';
 import type { CategoryParameter, CreateOfferRequest } from '../api/listings.types';
 import {
@@ -103,6 +100,17 @@ interface CreateOfferWizardProps {
    *  while the wizard is already open has no effect. */
   initialValues?: CreateOfferRequest;
   onSubmitted: (offerCreationRecordId: string, connectionId: string) => void;
+}
+
+/**
+ * RHF cannot infer the dynamic `parameters.{paramId}` path from
+ * `CreateOfferFieldsValues` (the `parameters` slice is `z.record(z.unknown())`
+ * by design, since per-field shapes come from the runtime `CategoryParameter`
+ * list). Centralise the cast so the unsafe widening lives in exactly one
+ * place — every call site goes through this helper.
+ */
+function parametersFieldPath(paramId: string): FieldPath<CreateOfferFieldsValues> {
+  return `parameters.${paramId}` as FieldPath<CreateOfferFieldsValues>;
 }
 
 function variantLabel(product: Product, variant: ProductVariant): string {
@@ -215,14 +223,10 @@ export function CreateOfferWizard({
   const [pickedVariantEan, setPickedVariantEan] = useState<string | null>(null);
   // Set of parameter ids that were auto-prefilled by `autoPrefillParameters`
   // for the current (connectionId, categoryId) pair. Surfaced to the step as
-  // a `prefilledIds` hint so the operator sees which fields were
-  // pre-populated. Stays static after the initial fill — chasing dirty state
-  // would add complexity for small UX gain.
+  // a `prefilledIds` hint; the step itself narrows the set per-render to
+  // exclude any field the operator has dirtied (so the hint disappears once
+  // they edit the value).
   const [prefilledIds, setPrefilledIds] = useState<ReadonlySet<string>>(new Set());
-  // Wire snapshot of the parameters we sent on submit. Anchors error mapping
-  // when Allegro returns positional `parameters[N]` validation errors after
-  // a failed submit (each index → parameter id via this snapshot).
-  const submittedParametersRef = useRef<AllegroParameterInput[]>([]);
   const debouncedProductSearch = useDebouncedValue(productSearchInput, VARIANT_SEARCH_DEBOUNCE_MS);
 
   // Reset wizard state on open. A fresh idempotency key is minted every
@@ -262,7 +266,6 @@ export function CreateOfferWizard({
       setProductOffset(0);
       setPickedVariantEan(null);
       setPrefilledIds(new Set());
-      submittedParametersRef.current = [];
       mutation.reset();
     }
     prevIsOpenRef.current = isOpen;
@@ -415,20 +418,19 @@ export function CreateOfferWizard({
       const result = buildParametersZodSchema(categoryParameters).safeParse(values);
       if (!result.success) {
         // Surface per-field issues onto the form — the renderer reads them
-        // via `formState.errors['parameters.{paramId}']` (flat key, set
-        // explicitly because RHF cannot infer the dynamic path shape).
-        form.clearErrors('parameters' as FieldPath<CreateOfferFieldsValues>);
+        // via `formState.errors['parameters.{paramId}']`.
+        form.clearErrors('parameters');
         for (const issue of result.error.issues) {
           const paramId = String(issue.path[0] ?? '');
           if (paramId === '') continue;
-          form.setError(
-            `parameters.${paramId}` as FieldPath<CreateOfferFieldsValues>,
-            { type: 'manual', message: issue.message },
-          );
+          form.setError(parametersFieldPath(paramId), {
+            type: 'manual',
+            message: issue.message,
+          });
         }
         return;
       }
-      form.clearErrors('parameters' as FieldPath<CreateOfferFieldsValues>);
+      form.clearErrors('parameters');
     }
 
     setCompletedSteps((prev) => new Set(prev).add(stepIndex));
@@ -462,14 +464,13 @@ export function CreateOfferWizard({
     if (values.impliedWarrantyId) platformParams.impliedWarrantyId = values.impliedWarrantyId;
 
     // Serialise Step-3 parameter values into Allegro's wire shape. The
-    // returned snapshot stays in `submittedParametersRef` for positional
-    // error mapping (Allegro returns `parameters[N]` indices on validation
-    // failure → look up the parameter id via this snapshot).
+    // serialiser drops empty / hidden values so an underfilled draft just
+    // produces a smaller payload — server-side validation surfaces any
+    // remaining required-field gaps via `mutation.error`.
     const { submitted: submittedParameters } = serializeAllegroParameters(
       (values.parameters as CategoryParameterFormValues | undefined) ?? {},
       categoryParameters,
     );
-    submittedParametersRef.current = submittedParameters;
     if (submittedParameters.length > 0) {
       platformParams.parameters = submittedParameters;
     }

--- a/apps/web/src/features/listings/components/auto-prefill-parameters.test.ts
+++ b/apps/web/src/features/listings/components/auto-prefill-parameters.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Auto-Prefill Parameters — unit tests
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { describe, expect, it } from 'vitest';
+import type { CategoryParameter } from '../api/listings.types';
+import { autoPrefillParameters } from './auto-prefill-parameters';
+
+function param(overrides: Partial<CategoryParameter>): CategoryParameter {
+  return {
+    id: 'x',
+    name: 'X',
+    type: 'string',
+    required: false,
+    restrictions: {},
+    ...overrides,
+  };
+}
+
+describe('autoPrefillParameters', () => {
+  it('fills EAN parameter from variant.ean', () => {
+    const out = autoPrefillParameters(
+      [param({ id: 'p1', name: 'EAN (GTIN)', type: 'string' })],
+      { ean: '5901234123457' },
+    );
+    expect(out.p1).toBe('5901234123457');
+  });
+
+  it('matches multiple EAN-class names case-insensitively', () => {
+    const out = autoPrefillParameters(
+      [
+        param({ id: 'p1', name: 'GTIN', type: 'string' }),
+        param({ id: 'p2', name: 'kod ean', type: 'string' }),
+      ],
+      { ean: '111' },
+    );
+    expect(out.p1).toBe('111');
+    expect(out.p2).toBe('111');
+  });
+
+  it('does not fill EAN when variant.ean is empty', () => {
+    const out = autoPrefillParameters([param({ id: 'p1', name: 'EAN' })], { ean: undefined });
+    expect(out.p1).toBeUndefined();
+  });
+
+  it('defaults Stan to "Nowy" entry id when present in dictionary', () => {
+    const out = autoPrefillParameters(
+      [
+        param({
+          id: 'p1',
+          name: 'Stan',
+          type: 'dictionary',
+          dictionary: [
+            { id: 'p1_new', value: 'Nowy' },
+            { id: 'p1_used', value: 'Używany' },
+          ],
+        }),
+      ],
+      {},
+    );
+    expect(out.p1).toBe('p1_new');
+  });
+
+  it('skips Stan default when no "new"-like entry exists', () => {
+    const out = autoPrefillParameters(
+      [
+        param({
+          id: 'p1',
+          name: 'Stan',
+          type: 'dictionary',
+          dictionary: [{ id: 'p1_used', value: 'Używany' }],
+        }),
+      ],
+      {},
+    );
+    expect(out.p1).toBeUndefined();
+  });
+
+  it('skips brand and producer-code (deferred to #412)', () => {
+    const out = autoPrefillParameters(
+      [
+        param({ id: 'p1', name: 'Marka', type: 'dictionary' }),
+        param({ id: 'p2', name: 'Kod producenta', type: 'string' }),
+      ],
+      { ean: '999' },
+    );
+    expect(out.p1).toBeUndefined();
+    expect(out.p2).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/listings/components/auto-prefill-parameters.ts
+++ b/apps/web/src/features/listings/components/auto-prefill-parameters.ts
@@ -1,0 +1,72 @@
+/**
+ * Auto-Prefill Category Parameters
+ *
+ * Conservative auto-fill for the create-offer wizard's Step 2 (#410). Maps
+ * structured variant fields onto matching marketplace category parameters
+ * by name (case-insensitive substring match against a small, hard-coded
+ * pattern list).
+ *
+ * Only EAN-class fields and the `Stan` (condition) default are auto-filled.
+ * Brand / producer-code prefill is deferred to #412 — those mappings are
+ * fuzzy enough that wrong auto-fills are worse than no auto-fill (silently
+ * broken listings, hard to debug).
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import type { CategoryParameter } from '../api/listings.types';
+import type { CategoryParameterFormValues, FormParameterValue } from './category-parameter-form.types';
+
+const EAN_NAME_PATTERNS = ['ean (gtin)', 'ean', 'gtin', 'kod ean'];
+const CONDITION_NAME_PATTERNS = ['stan'];
+const NEW_VALUE_PATTERNS = ['nowy', 'new', 'nowe', 'nowa'];
+
+/**
+ * Variant fields available for auto-prefill. Intentionally a narrow subset —
+ * the wizard form holds the canonical variant; we only need the bits that
+ * map onto category parameters.
+ */
+export interface AutoPrefillVariantFields {
+  ean?: string | null;
+}
+
+export function autoPrefillParameters(
+  parameters: CategoryParameter[],
+  variant: AutoPrefillVariantFields,
+): CategoryParameterFormValues {
+  const out: CategoryParameterFormValues = {};
+
+  for (const param of parameters) {
+    const filled = prefillOne(param, variant);
+    if (filled !== undefined) out[param.id] = filled;
+  }
+
+  return out;
+}
+
+function prefillOne(
+  param: CategoryParameter,
+  variant: AutoPrefillVariantFields,
+): FormParameterValue {
+  const nameLower = param.name.toLowerCase().trim();
+
+  // EAN/GTIN — variant.ean lifted onto any matching string-typed parameter.
+  if (variant.ean && EAN_NAME_PATTERNS.includes(nameLower)) {
+    return variant.ean;
+  }
+
+  // Stan (condition) — default to "Nowy" when the parameter is a dictionary
+  // and contains a value matching the "new" patterns. Most OL operators sell
+  // new goods; user can change it.
+  if (
+    CONDITION_NAME_PATTERNS.includes(nameLower) &&
+    param.type === 'dictionary' &&
+    !param.restrictions.multipleChoices
+  ) {
+    const newOption = param.dictionary?.find((entry) =>
+      NEW_VALUE_PATTERNS.includes(entry.value.toLowerCase().trim()),
+    );
+    if (newOption) return newOption.id;
+  }
+
+  return undefined;
+}

--- a/apps/web/src/features/listings/components/auto-prefill-parameters.ts
+++ b/apps/web/src/features/listings/components/auto-prefill-parameters.ts
@@ -16,6 +16,22 @@
 import type { CategoryParameter } from '../api/listings.types';
 import type { CategoryParameterFormValues, FormParameterValue } from './category-parameter-form.types';
 
+/**
+ * Known fragility — these matchers are case-insensitive *exact* string
+ * compares against Allegro's PL/EN parameter names and dictionary entry
+ * values. Any of the following will silently break prefill until the lists
+ * below are updated:
+ *
+ *   - Allegro adds a new locale (e.g. an `allegro.de` connection),
+ *   - Allegro renames a parameter ("Stan" → "Stan produktu"),
+ *   - the canonical "Nowy" entry is replaced with a localised string.
+ *
+ * The fixture-based unit tests catch the *current* spelling but cannot
+ * detect drift on the live API. When the brand / producer-code prefill
+ * lands in #412, replace these literals with a config map keyed by
+ * connection locale + parameter role, so each adapter can declare its own
+ * mapping table.
+ */
 const EAN_NAME_PATTERNS = ['ean (gtin)', 'ean', 'gtin', 'kod ean'];
 const CONDITION_NAME_PATTERNS = ['stan'];
 const NEW_VALUE_PATTERNS = ['nowy', 'new', 'nowe', 'nowa'];

--- a/apps/web/src/features/listings/components/build-parameters-zod-schema.test.ts
+++ b/apps/web/src/features/listings/components/build-parameters-zod-schema.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Build Parameters Zod Schema — unit tests
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { describe, expect, it } from 'vitest';
+import type { CategoryParameter } from '../api/listings.types';
+import { buildParametersZodSchema } from './build-parameters-zod-schema';
+
+function param(overrides: Partial<CategoryParameter>): CategoryParameter {
+  return {
+    id: 'x',
+    name: 'X',
+    type: 'string',
+    required: false,
+    restrictions: {},
+    ...overrides,
+  };
+}
+
+describe('buildParametersZodSchema', () => {
+  it('flags missing required string', () => {
+    const schema = buildParametersZodSchema([param({ id: 'p1', name: 'P1', required: true })]);
+    const result = schema.safeParse({ p1: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('passes when required field has a value', () => {
+    const schema = buildParametersZodSchema([param({ id: 'p1', name: 'P1', required: true })]);
+    const result = schema.safeParse({ p1: 'something' });
+    expect(result.success).toBe(true);
+  });
+
+  it('skips required-check for hidden (dependsOn-unsatisfied) fields', () => {
+    const schema = buildParametersZodSchema([
+      param({ id: 'parent', type: 'dictionary' }),
+      param({
+        id: 'child',
+        type: 'dictionary',
+        required: true,
+        dependsOn: { parameterId: 'parent', valueIds: ['p_yes'] },
+        dictionary: [{ id: 'c_a', value: 'A' }],
+      }),
+    ]);
+    // parent unset → child hidden → child.required NOT enforced
+    const result = schema.safeParse({ parent: undefined, child: undefined });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects integer that is not a whole number', () => {
+    const schema = buildParametersZodSchema([
+      param({ id: 'p1', type: 'integer' }),
+    ]);
+    expect(schema.safeParse({ p1: '1.5' }).success).toBe(false);
+    expect(schema.safeParse({ p1: '1' }).success).toBe(true);
+  });
+
+  it('rejects float that is not numeric', () => {
+    const schema = buildParametersZodSchema([
+      param({ id: 'p1', type: 'float' }),
+    ]);
+    expect(schema.safeParse({ p1: 'abc' }).success).toBe(false);
+    expect(schema.safeParse({ p1: '3.14' }).success).toBe(true);
+  });
+
+  it('rejects ranges with from > to', () => {
+    const schema = buildParametersZodSchema([
+      param({ id: 'p1', type: 'integer', restrictions: { range: true } }),
+    ]);
+    expect(schema.safeParse({ p1: { from: '10', to: '5' } }).success).toBe(false);
+    expect(schema.safeParse({ p1: { from: '5', to: '10' } }).success).toBe(true);
+  });
+
+  it('rejects strings outside length bounds', () => {
+    const schema = buildParametersZodSchema([
+      param({
+        id: 'p1',
+        type: 'string',
+        restrictions: { minLength: 8, maxLength: 14 },
+      }),
+    ]);
+    expect(schema.safeParse({ p1: 'short' }).success).toBe(false);
+    expect(schema.safeParse({ p1: '12345678' }).success).toBe(true);
+    expect(schema.safeParse({ p1: '123456789012345' }).success).toBe(false);
+  });
+
+  it('rejects dictionary selection that is not in the parent-narrowed entry set', () => {
+    const schema = buildParametersZodSchema([
+      param({ id: 'parent', type: 'dictionary' }),
+      param({
+        id: 'child',
+        type: 'dictionary',
+        dependsOn: { parameterId: 'parent', valueIds: ['p_a'] },
+        dictionary: [
+          { id: 'c_only_under_a', value: 'A-only', dependsOnValueIds: ['p_a'] },
+          { id: 'c_only_under_b', value: 'B-only', dependsOnValueIds: ['p_b'] },
+        ],
+      }),
+    ]);
+    // parent = p_a → c_only_under_a allowed, c_only_under_b is not
+    const ok = schema.safeParse({ parent: 'p_a', child: 'c_only_under_a' });
+    expect(ok.success).toBe(true);
+    const bad = schema.safeParse({ parent: 'p_a', child: 'c_only_under_b' });
+    expect(bad.success).toBe(false);
+  });
+});

--- a/apps/web/src/features/listings/components/build-parameters-zod-schema.ts
+++ b/apps/web/src/features/listings/components/build-parameters-zod-schema.ts
@@ -1,0 +1,158 @@
+/**
+ * Build Parameters Zod Schema (dynamic)
+ *
+ * Constructs a Zod schema for the wizard's Step 2 parameter form (#410) from
+ * the runtime-fetched `CategoryParameter[]`. Memoize the result against the
+ * parameters reference upstream — schema rebuild on every render is fine
+ * structurally but wasteful.
+ *
+ * Encodes:
+ *   - per-field shape (string / integer / float scalar / range / dict
+ *     single / dict multi)
+ *   - per-field constraints (min/max, length bounds, precision, allowed
+ *     value count, regex sanity for numeric fields)
+ *   - cross-field rules in `superRefine`:
+ *       * required fields must be non-empty when visible
+ *       * dictionary selections must be among the parent-narrowed entry set
+ *
+ * Hidden parameters (per `isParameterVisible`) are deliberately not validated
+ * — their values are cleared on hide and we don't want stale data blocking
+ * submission. The visibility check uses the `values` argument as snapshotted
+ * at validation time; consumers pass the entire form state in.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { z, type ZodTypeAny } from 'zod';
+
+import type { CategoryParameter } from '../api/listings.types';
+import type { CategoryParameterFormValues } from './category-parameter-form.types';
+import {
+  isFormValueEmpty,
+  isParameterVisible,
+  visibleDictionaryEntries,
+} from './category-parameter-visibility';
+
+const INTEGER_REGEX = /^-?\d+$/;
+const FLOAT_REGEX = /^-?\d+(\.\d+)?$/;
+
+export function buildParametersZodSchema(parameters: CategoryParameter[]): ZodTypeAny {
+  const shape: Record<string, ZodTypeAny> = {};
+  for (const p of parameters) {
+    shape[p.id] = fieldSchema(p);
+  }
+  const base = z.object(shape).passthrough();
+
+  return base.superRefine((rawValues, ctx) => {
+    const values = rawValues as CategoryParameterFormValues;
+    for (const p of parameters) {
+      if (!isParameterVisible(p, values)) continue;
+
+      const v = values[p.id];
+
+      if (p.required && isFormValueEmpty(v)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [p.id],
+          message: `${p.name} is required`,
+        });
+        continue;
+      }
+
+      if (
+        p.type === 'dictionary' &&
+        !isFormValueEmpty(v) &&
+        p.dictionary !== undefined &&
+        p.dictionary.length > 0 &&
+        !p.restrictions.customValuesEnabled
+      ) {
+        const allowedIds = new Set(visibleDictionaryEntries(p, values).map((e) => e.id));
+        const selected = Array.isArray(v) ? v : typeof v === 'string' ? [v] : [];
+        for (const id of selected) {
+          if (!allowedIds.has(id)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [p.id],
+              message: `${p.name}: selected option is no longer available for the current parent value`,
+            });
+            break;
+          }
+        }
+      }
+    }
+  });
+}
+
+function fieldSchema(p: CategoryParameter): ZodTypeAny {
+  switch (p.type) {
+    case 'dictionary':
+      return p.restrictions.multipleChoices
+        ? z.array(z.string()).optional()
+        : z.string().optional();
+
+    case 'string':
+      return stringFieldSchema(p);
+
+    case 'integer':
+      return p.restrictions.range
+        ? rangeSchema()
+        : z.string().optional().refine(
+            (s) => s === undefined || s === '' || INTEGER_REGEX.test(s),
+            'Must be a whole number',
+          );
+
+    case 'float':
+      return p.restrictions.range
+        ? rangeSchema()
+        : z.string().optional().refine(
+            (s) => s === undefined || s === '' || FLOAT_REGEX.test(s),
+            'Must be a number',
+          );
+  }
+}
+
+function stringFieldSchema(p: CategoryParameter): ZodTypeAny {
+  return z
+    .string()
+    .optional()
+    .refine(
+      (s) => {
+        if (s === undefined || s === '') return true;
+        if (p.restrictions.minLength !== undefined && s.length < p.restrictions.minLength) {
+          return false;
+        }
+        if (p.restrictions.maxLength !== undefined && s.length > p.restrictions.maxLength) {
+          return false;
+        }
+        return true;
+      },
+      lengthMessage(p),
+    );
+}
+
+function lengthMessage(p: CategoryParameter): string {
+  const min = p.restrictions.minLength;
+  const max = p.restrictions.maxLength;
+  if (min !== undefined && max !== undefined) return `Must be between ${min} and ${max} characters`;
+  if (min !== undefined) return `Must be at least ${min} characters`;
+  if (max !== undefined) return `Must be at most ${max} characters`;
+  return 'Invalid length';
+}
+
+function rangeSchema(): ZodTypeAny {
+  return z
+    .object({ from: z.string().optional(), to: z.string().optional() })
+    .optional()
+    .refine(
+      (r) => {
+        if (r === undefined) return true;
+        const from = r.from?.trim() ?? '';
+        const to = r.to?.trim() ?? '';
+        if (from === '' || to === '') return true; // partial fill — required-check covers the empty case
+        const fromNum = Number(from);
+        const toNum = Number(to);
+        if (!Number.isFinite(fromNum) || !Number.isFinite(toNum)) return false;
+        return fromNum <= toNum;
+      },
+      'Range must be valid (from ≤ to)',
+    );
+}

--- a/apps/web/src/features/listings/components/category-parameter-form.types.ts
+++ b/apps/web/src/features/listings/components/category-parameter-form.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Category-Parameter Form Types
+ *
+ * Shared form-state shape for the create-offer wizard's Step 2 (#410).
+ * Stored as a flat dict on React Hook Form: `parameters[paramId] = value`,
+ * where the value type depends on the parameter's `(type, restrictions)`
+ * combination:
+ *
+ *   - dictionary single (no multi)            → string (the entry's id)
+ *   - dictionary multi                        → string[] (entry ids)
+ *   - dictionary single + customValuesEnabled → string (raw text — submit-time
+ *     serializer matches against the dictionary and emits valuesIds vs values)
+ *   - string                                  → string (raw text)
+ *   - integer / float, range=false            → string (numeric raw)
+ *   - integer / float, range=true             → { from: string; to: string }
+ *
+ * Empty / missing values are represented by either an empty string or
+ * `undefined` — the serializer treats both as "not submitted".
+ *
+ * @module apps/web/src/features/listings/components
+ */
+export type FormParameterValue =
+  | string
+  | string[]
+  | { from: string; to: string }
+  | undefined;
+
+export type CategoryParameterFormValues = Record<string, FormParameterValue>;

--- a/apps/web/src/features/listings/components/category-parameter-visibility.ts
+++ b/apps/web/src/features/listings/components/category-parameter-visibility.ts
@@ -1,0 +1,101 @@
+/**
+ * Category-Parameter Visibility Helpers
+ *
+ * Shared logic for the two dependency mechanisms surfaced by the API (#410):
+ *   - parameter-level visibility: `param.dependsOn` — the parameter is hidden
+ *     until the parent has one of the listed values.
+ *   - dictionary-entry filtering: `dictionary[i].dependsOnValueIds` — within a
+ *     visible dictionary, an entry is selectable only when the parent has one
+ *     of its listed values.
+ *
+ * Used by:
+ *   - the field renderer (skip rendering, narrow option list)
+ *   - the dynamic Zod schema (don't validate hidden fields, reject orphan
+ *     dictionary selections)
+ *   - the submit-time serializer (drop hidden fields entirely)
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import type {
+  CategoryParameter,
+  CategoryParameterDictionaryEntry,
+} from '../api/listings.types';
+import type { CategoryParameterFormValues } from './category-parameter-form.types';
+
+/**
+ * Resolve the parent value(s) the user has currently selected, normalized to
+ * a string array (single-select dictionaries return `[id]`, multi-select
+ * return `ids`, scalars return `[value]`, custom-text is included verbatim).
+ * Returns an empty array for unset / blank values.
+ */
+function readParentValues(values: CategoryParameterFormValues, parameterId: string): string[] {
+  const v = values[parameterId];
+  if (v === undefined || v === null) return [];
+  if (typeof v === 'string') return v === '' ? [] : [v];
+  if (Array.isArray(v)) return v.filter((s) => s !== '');
+  // Range objects can't be parents — Allegro only uses dictionary parents.
+  return [];
+}
+
+/**
+ * Whether the parameter should be rendered for the current form values.
+ *
+ * - No `dependsOn` declared → always visible.
+ * - `dependsOn` declared but parent has no value yet → hidden (deliberate; the
+ *   wizard waits for the parent to be set before showing dependent fields).
+ * - `dependsOn` declared and parent has at least one value matching the
+ *   declared `valueIds` → visible.
+ */
+export function isParameterVisible(
+  param: CategoryParameter,
+  values: CategoryParameterFormValues,
+): boolean {
+  if (!param.dependsOn) return true;
+  const parentValues = readParentValues(values, param.dependsOn.parameterId);
+  if (parentValues.length === 0) return false;
+  const allowed = new Set(param.dependsOn.valueIds);
+  return parentValues.some((pv) => allowed.has(pv));
+}
+
+/**
+ * For dictionary parameters with parameter-level `dependsOn`, return only the
+ * entries whose `dependsOnValueIds` overlap the current parent value(s).
+ * Entries with no `dependsOnValueIds` are always included (they are not
+ * filtered).
+ *
+ * For non-dictionary parameters or parameters without `dependsOn`, returns
+ * the entries unchanged.
+ */
+export function visibleDictionaryEntries(
+  param: CategoryParameter,
+  values: CategoryParameterFormValues,
+): CategoryParameterDictionaryEntry[] {
+  if (!param.dictionary) return [];
+  if (!param.dependsOn) return param.dictionary;
+
+  const parentValues = readParentValues(values, param.dependsOn.parameterId);
+  if (parentValues.length === 0) return param.dictionary;
+
+  return param.dictionary.filter((entry) => {
+    if (!entry.dependsOnValueIds || entry.dependsOnValueIds.length === 0) return true;
+    return entry.dependsOnValueIds.some((id) => parentValues.includes(id));
+  });
+}
+
+/**
+ * Whether `value` can be considered "filled". Used by the Zod superRefine and
+ * the submit serializer.
+ */
+export function isFormValueEmpty(v: unknown): boolean {
+  if (v === undefined || v === null) return true;
+  if (typeof v === 'string') return v.trim() === '';
+  if (Array.isArray(v)) return v.length === 0;
+  if (typeof v === 'object') {
+    const r = v as { from?: string; to?: string };
+    return (
+      (r.from === undefined || r.from.trim() === '') &&
+      (r.to === undefined || r.to.trim() === '')
+    );
+  }
+  return false;
+}

--- a/apps/web/src/features/listings/components/category-parameters-step.tsx
+++ b/apps/web/src/features/listings/components/category-parameters-step.tsx
@@ -66,7 +66,7 @@ export function CategoryParametersStep({
   formNamespace,
   prefilledIds,
 }: CategoryParametersStepProps): ReactElement {
-  const { control, setValue, getValues } = useFormContext();
+  const { control, setValue, getValues, formState } = useFormContext();
   // Watching the entire `parameters` slice keeps visibility / option-narrowing
   // in sync with the form state on every keystroke. Acceptable cost — the
   // wizard form is small and per-render evaluation is O(parameters × constant).
@@ -75,6 +75,20 @@ export function CategoryParametersStep({
     () => (formValuesRaw && typeof formValuesRaw === 'object' ? (formValuesRaw as CategoryParameterFormValues) : {}),
     [formValuesRaw],
   );
+
+  // Strip the "Auto-filled" hint from any field the operator has already
+  // edited. RHF tracks dirty state per-field — auto-prefill writes with
+  // `shouldDirty: false`, so a dirty entry here is operator-authored.
+  const dirtyParameters =
+    (formState.dirtyFields as Record<string, Record<string, unknown> | undefined>)[formNamespace] ?? {};
+  const liveprefilledIds = useMemo(() => {
+    if (!prefilledIds || prefilledIds.size === 0) return prefilledIds ?? new Set<string>();
+    const next = new Set<string>();
+    for (const id of prefilledIds) {
+      if (!dirtyParameters[id]) next.add(id);
+    }
+    return next;
+  }, [prefilledIds, dirtyParameters]);
 
   // Visibility filter: when a parent parameter's value changes such that a
   // dependent parameter becomes hidden, clear the dependent's form value so
@@ -110,7 +124,7 @@ export function CategoryParametersStep({
               parameter={param}
               formNamespace={formNamespace}
               parentValues={formValues}
-              prefilled={prefilledIds?.has(param.id) ?? false}
+              prefilled={liveprefilledIds.has(param.id)}
             />
           ))}
         </fieldset>
@@ -129,7 +143,7 @@ export function CategoryParametersStep({
                 parameter={param}
                 formNamespace={formNamespace}
                 parentValues={formValues}
-                prefilled={prefilledIds?.has(param.id) ?? false}
+                prefilled={liveprefilledIds.has(param.id)}
               />
             ))}
           </fieldset>
@@ -154,9 +168,15 @@ function ParameterField({
 }: ParameterFieldProps): ReactElement {
   const { control, formState } = useFormContext();
   const fieldName = `${formNamespace}.${parameter.id}`;
-  const error = (formState.errors as Record<string, { message?: string } | undefined>)[
-    `${formNamespace}.${parameter.id}`
-  ]?.message;
+  // RHF stores errors set via dotted paths (`form.setError('parameters.p_x',
+  // …)`) at `formState.errors.parameters.p_x`, not as a flat key. Walk the
+  // nested object — the field name's parts are statically known.
+  const namespaceErrors = (formState.errors as Record<string, unknown>)[formNamespace];
+  const fieldError =
+    namespaceErrors && typeof namespaceErrors === 'object'
+      ? (namespaceErrors as Record<string, { message?: string } | undefined>)[parameter.id]
+      : undefined;
+  const error = fieldError?.message;
 
   const description = describeFilter(parameter, parentValues);
   const autoFillHint = prefilled ? 'Auto-filled from variant data' : undefined;

--- a/apps/web/src/features/listings/components/category-parameters-step.tsx
+++ b/apps/web/src/features/listings/components/category-parameters-step.tsx
@@ -1,0 +1,373 @@
+/**
+ * Category Parameters Step (#410)
+ *
+ * Step 2 of the create-offer wizard. Renders the marketplace's per-category
+ * parameter schema as RHF-bound fields, grouped required-first / optional in
+ * a collapsible expander.
+ *
+ * Field renderer dispatches on `(type, restrictions)`:
+ *   - dictionary < 50 entries, single, no customValues → native <Select>
+ *   - dictionary ≥ 50 entries OR customValuesEnabled OR multipleChoices → <Combobox>
+ *   - string                                              → <Input>
+ *   - integer / float, range=false                        → <Input type="number">
+ *   - integer / float, range=true                         → from/to inline pair
+ *
+ * Honors both dependency mechanisms:
+ *   - parameter-level visibility — the field is skipped when `dependsOn`
+ *     unsatisfied; on transition-to-hidden, the value is cleared via
+ *     `form.setValue(p.id, undefined)` (effect on visibility change).
+ *   - dictionary-entry filtering — the option list narrows based on the
+ *     parent's current value; a small "Filtered by …" hint above the field
+ *     surfaces the narrowing so operators don't think the dictionary shrank
+ *     mysteriously.
+ *
+ * Auto-fill prefill (EAN + Stan) is driven from the parent wizard via
+ * `form.reset()` when parameters first load — this component just renders.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { useEffect, useMemo, type ReactElement, type ReactNode } from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+
+import { Combobox, type ComboboxOption, type ComboboxValue } from '../../../shared/ui/combobox';
+import { FormField } from '../../../shared/ui/form-field';
+
+import type {
+  CategoryParameter,
+  CategoryParameterDictionaryEntry,
+} from '../api/listings.types';
+import type { CategoryParameterFormValues, FormParameterValue } from './category-parameter-form.types';
+import {
+  isParameterVisible,
+  visibleDictionaryEntries,
+} from './category-parameter-visibility';
+
+const NATIVE_SELECT_THRESHOLD = 50;
+
+interface CategoryParametersStepProps {
+  parameters: CategoryParameter[];
+  /**
+   * RHF dot-prefix the renderer prepends to every parameter id. The wizard
+   * stores the per-parameter form state under this key, e.g. `'parameters'`
+   * → fields become `parameters.{paramId}`.
+   */
+  formNamespace: string;
+  /**
+   * Map of parameter id → "auto-filled" hint visibility. A field shows the
+   * subtitle until the user dirties it (RHF dirty state). The wizard owns
+   * the dirty tracking because RHF's `formState.dirtyFields` is scoped to
+   * the form root.
+   */
+  prefilledIds?: ReadonlySet<string>;
+}
+
+export function CategoryParametersStep({
+  parameters,
+  formNamespace,
+  prefilledIds,
+}: CategoryParametersStepProps): ReactElement {
+  const { control, setValue, getValues } = useFormContext();
+  // Watching the entire `parameters` slice keeps visibility / option-narrowing
+  // in sync with the form state on every keystroke. Acceptable cost — the
+  // wizard form is small and per-render evaluation is O(parameters × constant).
+  const formValuesRaw = useWatch({ control, name: formNamespace }) as unknown;
+  const formValues: CategoryParameterFormValues = useMemo(
+    () => (formValuesRaw && typeof formValuesRaw === 'object' ? (formValuesRaw as CategoryParameterFormValues) : {}),
+    [formValuesRaw],
+  );
+
+  // Visibility filter: when a parent parameter's value changes such that a
+  // dependent parameter becomes hidden, clear the dependent's form value so
+  // it doesn't get accidentally submitted.
+  useEffect(() => {
+    for (const p of parameters) {
+      if (!p.dependsOn) continue;
+      if (!isParameterVisible(p, formValues)) {
+        const current = getValues(`${formNamespace}.${p.id}`);
+        if (current !== undefined && current !== '' && (!Array.isArray(current) || current.length > 0)) {
+          setValue(`${formNamespace}.${p.id}`, undefined, { shouldDirty: false });
+        }
+      }
+    }
+  }, [parameters, formValues, formNamespace, getValues, setValue]);
+
+  const visibleParameters = useMemo(
+    () => parameters.filter((p) => isParameterVisible(p, formValues)),
+    [parameters, formValues],
+  );
+
+  const required = visibleParameters.filter((p) => p.required);
+  const optional = visibleParameters.filter((p) => !p.required);
+
+  return (
+    <div className="category-parameters-step">
+      {required.length > 0 && (
+        <fieldset className="category-parameters-step__group">
+          <legend className="category-parameters-step__group-legend">Required</legend>
+          {required.map((param) => (
+            <ParameterField
+              key={param.id}
+              parameter={param}
+              formNamespace={formNamespace}
+              parentValues={formValues}
+              prefilled={prefilledIds?.has(param.id) ?? false}
+            />
+          ))}
+        </fieldset>
+      )}
+
+      {optional.length > 0 && (
+        <details className="category-parameters-step__expander">
+          <summary className="category-parameters-step__expander-summary">
+            Show optional fields ({optional.length})
+          </summary>
+          <fieldset className="category-parameters-step__group category-parameters-step__group--optional">
+            <legend className="sr-only">Optional</legend>
+            {optional.map((param) => (
+              <ParameterField
+                key={param.id}
+                parameter={param}
+                formNamespace={formNamespace}
+                parentValues={formValues}
+                prefilled={prefilledIds?.has(param.id) ?? false}
+              />
+            ))}
+          </fieldset>
+        </details>
+      )}
+    </div>
+  );
+}
+
+interface ParameterFieldProps {
+  parameter: CategoryParameter;
+  formNamespace: string;
+  parentValues: CategoryParameterFormValues;
+  prefilled: boolean;
+}
+
+function ParameterField({
+  parameter,
+  formNamespace,
+  parentValues,
+  prefilled,
+}: ParameterFieldProps): ReactElement {
+  const { control, formState } = useFormContext();
+  const fieldName = `${formNamespace}.${parameter.id}`;
+  const error = (formState.errors as Record<string, { message?: string } | undefined>)[
+    `${formNamespace}.${parameter.id}`
+  ]?.message;
+
+  const description = describeFilter(parameter, parentValues);
+  const autoFillHint = prefilled ? 'Auto-filled from variant data' : undefined;
+
+  const label = (
+    <span>
+      {parameter.name}
+      {parameter.unit ? <span className="category-parameters-step__unit"> ({parameter.unit})</span> : null}
+    </span>
+  );
+
+  return (
+    <FormField
+      label={label}
+      name={fieldName}
+      description={[description, autoFillHint].filter(Boolean).join(' · ') || undefined}
+      error={error}
+    >
+      <Controller
+        control={control}
+        name={fieldName}
+        render={({ field }): ReactElement => renderControl(parameter, parentValues, field)}
+      />
+    </FormField>
+  );
+}
+
+interface ControllerField {
+  name: string;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  onBlur: () => void;
+  ref: (instance: unknown) => void;
+}
+
+function renderControl(
+  parameter: CategoryParameter,
+  parentValues: CategoryParameterFormValues,
+  field: ControllerField,
+): ReactElement {
+  if (parameter.type === 'dictionary') {
+    return renderDictionary(parameter, parentValues, field);
+  }
+  if (parameter.restrictions.range) {
+    return renderRange(parameter, field);
+  }
+  return renderScalar(parameter, field);
+}
+
+function renderDictionary(
+  parameter: CategoryParameter,
+  parentValues: CategoryParameterFormValues,
+  field: ControllerField,
+): ReactElement {
+  const entries = visibleDictionaryEntries(parameter, parentValues);
+  const useCombobox =
+    parameter.restrictions.multipleChoices ||
+    parameter.restrictions.customValuesEnabled ||
+    entries.length >= NATIVE_SELECT_THRESHOLD;
+
+  if (useCombobox) {
+    return (
+      <Combobox
+        ariaLabel={parameter.name}
+        options={entries.map((e) => toComboboxOption(e))}
+        mode={parameter.restrictions.multipleChoices ? 'multi' : 'single'}
+        allowCustomValues={parameter.restrictions.customValuesEnabled}
+        value={toComboboxValue(parameter, field.value as FormParameterValue)}
+        onChange={(next): void => field.onChange(fromComboboxValue(parameter, next))}
+        placeholder={`Pick ${parameter.name.toLowerCase()}`}
+        invalid={false}
+      />
+    );
+  }
+
+  // Native select — small dictionaries, single-select, no custom values
+  const selected = typeof field.value === 'string' ? field.value : '';
+  return (
+    <select
+      className="control"
+      value={selected}
+      onChange={(e): void => field.onChange(e.target.value === '' ? undefined : e.target.value)}
+      onBlur={field.onBlur}
+      aria-label={parameter.name}
+    >
+      <option value="">Select…</option>
+      {entries.map((entry) => (
+        <option key={entry.id} value={entry.id}>
+          {entry.value}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function renderScalar(parameter: CategoryParameter, field: ControllerField): ReactElement {
+  const isNumeric = parameter.type === 'integer' || parameter.type === 'float';
+  return (
+    <input
+      type={isNumeric ? 'number' : 'text'}
+      className="control"
+      value={typeof field.value === 'string' ? field.value : ''}
+      onChange={(e): void => field.onChange(e.target.value)}
+      onBlur={field.onBlur}
+      aria-label={parameter.name}
+      step={parameter.type === 'float' ? scaleStep(parameter.restrictions.precision) : undefined}
+      min={parameter.restrictions.min}
+      max={parameter.restrictions.max}
+      minLength={parameter.restrictions.minLength}
+      maxLength={parameter.restrictions.maxLength}
+    />
+  );
+}
+
+function renderRange(parameter: CategoryParameter, field: ControllerField): ReactElement {
+  const v = (field.value && typeof field.value === 'object' && !Array.isArray(field.value)
+    ? field.value
+    : { from: '', to: '' }) as { from?: string; to?: string };
+
+  const update = (next: { from?: string; to?: string }): void => {
+    field.onChange({ from: next.from ?? '', to: next.to ?? '' });
+  };
+
+  const step = parameter.type === 'float' ? scaleStep(parameter.restrictions.precision) : undefined;
+
+  return (
+    <span className="category-parameters-step__range">
+      <input
+        type="number"
+        className="control"
+        value={v.from ?? ''}
+        onChange={(e): void => update({ ...v, from: e.target.value })}
+        onBlur={field.onBlur}
+        aria-label={`${parameter.name} from`}
+        step={step}
+        min={parameter.restrictions.min}
+        max={parameter.restrictions.max}
+      />
+      <span className="category-parameters-step__range-sep" aria-hidden>
+        –
+      </span>
+      <input
+        type="number"
+        className="control"
+        value={v.to ?? ''}
+        onChange={(e): void => update({ ...v, to: e.target.value })}
+        onBlur={field.onBlur}
+        aria-label={`${parameter.name} to`}
+        step={step}
+        min={parameter.restrictions.min}
+        max={parameter.restrictions.max}
+      />
+      {parameter.unit ? (
+        <span className="category-parameters-step__range-unit">{parameter.unit}</span>
+      ) : null}
+    </span>
+  );
+}
+
+function toComboboxOption(entry: CategoryParameterDictionaryEntry): ComboboxOption {
+  return { id: entry.id, label: entry.value, hint: entry.id };
+}
+
+function toComboboxValue(
+  parameter: CategoryParameter,
+  raw: FormParameterValue,
+): ComboboxValue | null {
+  if (parameter.restrictions.multipleChoices) {
+    if (Array.isArray(raw)) return raw.length === 0 ? null : { kind: 'dictionary', ids: raw };
+    return null;
+  }
+  if (typeof raw !== 'string' || raw === '') return null;
+
+  if (parameter.restrictions.customValuesEnabled) {
+    const matched = parameter.dictionary?.find(
+      (e) => e.value.trim().toLowerCase() === raw.trim().toLowerCase(),
+    );
+    return matched ? { kind: 'dictionary', ids: [matched.id] } : { kind: 'custom', text: raw };
+  }
+  // Plain dict single — RHF stores the entry id
+  return { kind: 'dictionary', ids: [raw] };
+}
+
+function fromComboboxValue(
+  parameter: CategoryParameter,
+  value: ComboboxValue | null,
+): FormParameterValue {
+  if (value === null) {
+    return parameter.restrictions.multipleChoices ? [] : undefined;
+  }
+  if (value.kind === 'dictionary') {
+    if (parameter.restrictions.multipleChoices) return value.ids;
+    return value.ids[0];
+  }
+  // custom-text — only meaningful when customValuesEnabled
+  return value.text;
+}
+
+function describeFilter(
+  parameter: CategoryParameter,
+  parentValues: CategoryParameterFormValues,
+): ReactNode {
+  if (!parameter.dependsOn || parameter.type !== 'dictionary' || !parameter.dictionary) {
+    return null;
+  }
+  const visible = visibleDictionaryEntries(parameter, parentValues);
+  if (visible.length === parameter.dictionary.length) return null;
+  return `Filtered by parent: ${visible.length} of ${parameter.dictionary.length} options available`;
+}
+
+function scaleStep(precision: number | undefined): string | undefined {
+  if (precision === undefined || precision <= 0) return undefined;
+  return `0.${'0'.repeat(precision - 1)}1`;
+}

--- a/apps/web/src/features/listings/components/create-offer-fields.schema.ts
+++ b/apps/web/src/features/listings/components/create-offer-fields.schema.ts
@@ -1,10 +1,16 @@
 /**
  * Create Offer Fields Schema
  *
- * Zod schema and types for the CreateOfferWizard form. Covers all four
+ * Zod schema and types for the CreateOfferWizard form. Covers all five
  * steps in a single schema so `form.trigger(stepFields)` can validate
  * incrementally. Field names mirror the wire shape where sensible so
  * the submit-time mapping in the wizard is straightforward.
+ *
+ * The `parameters` slice (Step 3) holds dynamic per-category Allegro
+ * parameter values keyed by parameter id. The static schema only requires
+ * a record shape — actual per-field validation runs at step-advance time
+ * via the dynamic `buildParametersZodSchema(parameters)` (see
+ * `build-parameters-zod-schema.ts`).
  *
  * @module apps/web/src/features/listings/components
  */
@@ -37,7 +43,10 @@ export const createOfferFieldsSchema = z.object({
   description: z.string().optional(),
   publishImmediately: z.boolean(),
 
-  // Step 3 — Policies
+  // Step 3 — Category parameters (dynamic; validated at step-advance time)
+  parameters: z.record(z.string(), z.unknown()).default({}),
+
+  // Step 4 — Policies
   deliveryPolicyId: z.string().min(1, 'Delivery policy is required'),
   returnPolicyId: z.string().optional(),
   warrantyId: z.string().optional(),
@@ -58,6 +67,7 @@ export const CREATE_OFFER_DEFAULT_VALUES: CreateOfferFieldsValues = {
   stock: 0,
   description: '',
   publishImmediately: false,
+  parameters: {},
   deliveryPolicyId: '',
   returnPolicyId: '',
   warrantyId: '',

--- a/apps/web/src/features/listings/components/create-offer-request-to-form-values.test.ts
+++ b/apps/web/src/features/listings/components/create-offer-request-to-form-values.test.ts
@@ -48,11 +48,51 @@ describe('createOfferRequestToFormValues', () => {
       stock: 7,
       description: 'Cotton, black, crew neck.',
       publishImmediately: true,
+      parameters: {},
       deliveryPolicyId: 'del-1',
       returnPolicyId: 'ret-1',
       warrantyId: 'war-1',
       impliedWarrantyId: 'iw-1',
     });
+  });
+
+  it('reverse-maps platformParams.parameters into the form-shape parameters slice', () => {
+    const request: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_xyz',
+      stock: 1,
+      publishImmediately: false,
+      overrides: {
+        title: 't',
+        categoryId: 'c',
+        platformParams: {
+          deliveryPolicyId: 'del-1',
+          parameters: [
+            { id: 'single', valuesIds: ['v1'] },
+            { id: 'multi', valuesIds: ['m1', 'm2'] },
+            { id: 'scalar', values: ['hello'] },
+            { id: 'range', rangeValue: { from: '1', to: '10' } },
+          ],
+        },
+      },
+    };
+
+    const values = createOfferRequestToFormValues(request, 'conn_1');
+    expect(values.parameters).toEqual({
+      single: 'v1',
+      multi: ['m1', 'm2'],
+      scalar: 'hello',
+      range: { from: '1', to: '10' },
+    });
+  });
+
+  it('returns an empty parameters slice when the snapshot omits the array', () => {
+    const request: CreateOfferRequest = {
+      internalVariantId: 'ol_variant_xyz',
+      stock: 1,
+      publishImmediately: false,
+    };
+    const values = createOfferRequestToFormValues(request, 'conn_1');
+    expect(values.parameters).toEqual({});
   });
 
   it('falls back to defaults when optional fields are missing', () => {

--- a/apps/web/src/features/listings/components/create-offer-request-to-form-values.ts
+++ b/apps/web/src/features/listings/components/create-offer-request-to-form-values.ts
@@ -25,10 +25,71 @@ import {
   CREATE_OFFER_DEFAULT_VALUES,
   type CreateOfferFieldsValues,
 } from './create-offer-fields.schema';
+import type { CategoryParameterFormValues } from './category-parameter-form.types';
 
 function readString(params: Record<string, unknown> | undefined, key: string): string {
   const value = params?.[key];
   return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Reverse the wire-shape `parameters[]` array Allegro accepts back into the
+ * wizard's flat form-shape. Used by the retry path so a failed snapshot
+ * re-opens with values visible to the operator. Without the parameter
+ * meta we infer the form-side type from the wire payload:
+ *
+ *   - `rangeValue`             → `{ from, to }`
+ *   - `valuesIds.length > 1`   → `string[]` (multi-select dictionary)
+ *   - `valuesIds.length === 1` → `string`   (single dictionary)
+ *   - `values.length >= 1`     → `string`   (scalar / custom-text first)
+ *
+ * Once the parameters meta resolves, the renderer interprets the raw value
+ * correctly even when our heuristic guessed the wrong shape.
+ */
+function readParameters(params: Record<string, unknown> | undefined): CategoryParameterFormValues {
+  const raw = params?.parameters;
+  if (!Array.isArray(raw)) return {};
+
+  const out: CategoryParameterFormValues = {};
+  for (const entry of raw) {
+    if (entry === null || typeof entry !== 'object') continue;
+    const e = entry as {
+      id?: unknown;
+      values?: unknown;
+      valuesIds?: unknown;
+      rangeValue?: unknown;
+    };
+    if (typeof e.id !== 'string' || e.id === '') continue;
+
+    if (
+      e.rangeValue !== undefined &&
+      e.rangeValue !== null &&
+      typeof e.rangeValue === 'object'
+    ) {
+      const r = e.rangeValue as { from?: unknown; to?: unknown };
+      out[e.id] = {
+        from: typeof r.from === 'string' ? r.from : '',
+        to: typeof r.to === 'string' ? r.to : '',
+      };
+      continue;
+    }
+
+    if (Array.isArray(e.valuesIds) && e.valuesIds.every((v) => typeof v === 'string')) {
+      const ids = e.valuesIds as string[];
+      if (ids.length > 1) {
+        out[e.id] = ids;
+      } else if (ids.length === 1) {
+        out[e.id] = ids[0];
+      }
+      continue;
+    }
+
+    if (Array.isArray(e.values) && e.values.every((v) => typeof v === 'string')) {
+      const vals = e.values as string[];
+      if (vals.length > 0) out[e.id] = vals[0];
+    }
+  }
+  return out;
 }
 
 /**
@@ -64,6 +125,7 @@ export function createOfferRequestToFormValues(
     stock: request.stock,
     description: overrides?.description ?? '',
     publishImmediately: request.publishImmediately,
+    parameters: readParameters(platformParams),
     deliveryPolicyId: readString(platformParams, 'deliveryPolicyId'),
     returnPolicyId: readString(platformParams, 'returnPolicyId'),
     warrantyId: readString(platformParams, 'warrantyId'),

--- a/apps/web/src/features/listings/components/serialize-allegro-parameters.test.ts
+++ b/apps/web/src/features/listings/components/serialize-allegro-parameters.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Serialize Allegro Parameters — unit tests
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { describe, expect, it } from 'vitest';
+import type { CategoryParameter } from '../api/listings.types';
+import { serializeAllegroParameters } from './serialize-allegro-parameters';
+
+function param(overrides: Partial<CategoryParameter>): CategoryParameter {
+  return {
+    id: 'x',
+    name: 'X',
+    type: 'string',
+    required: false,
+    restrictions: {},
+    ...overrides,
+  };
+}
+
+describe('serializeAllegroParameters', () => {
+  it('emits dictionary single → valuesIds', () => {
+    const meta = [param({ id: 'p1', type: 'dictionary' })];
+    const { submitted } = serializeAllegroParameters({ p1: 'p1_a' }, meta);
+    expect(submitted).toEqual([{ id: 'p1', valuesIds: ['p1_a'] }]);
+  });
+
+  it('emits dictionary multi → valuesIds with the array', () => {
+    const meta = [param({ id: 'p1', type: 'dictionary', restrictions: { multipleChoices: true } })];
+    const { submitted } = serializeAllegroParameters({ p1: ['a', 'b'] }, meta);
+    expect(submitted).toEqual([{ id: 'p1', valuesIds: ['a', 'b'] }]);
+  });
+
+  it('customValues match → valuesIds (case-insensitive); no match → values', () => {
+    const meta = [
+      param({
+        id: 'p1',
+        type: 'dictionary',
+        restrictions: { customValuesEnabled: true },
+        dictionary: [{ id: 'p1_apple', value: 'Apple' }],
+      }),
+    ];
+    const matched = serializeAllegroParameters({ p1: 'apple' }, meta).submitted;
+    expect(matched).toEqual([{ id: 'p1', valuesIds: ['p1_apple'] }]);
+    const free = serializeAllegroParameters({ p1: 'AcmeCorp' }, meta).submitted;
+    expect(free).toEqual([{ id: 'p1', values: ['AcmeCorp'] }]);
+  });
+
+  it('emits scalar string/integer/float → values: [String(v)]', () => {
+    const meta = [
+      param({ id: 'p1', type: 'string' }),
+      param({ id: 'p2', type: 'integer' }),
+    ];
+    const { submitted } = serializeAllegroParameters({ p1: 'abc', p2: '42' }, meta);
+    expect(submitted).toEqual([
+      { id: 'p1', values: ['abc'] },
+      { id: 'p2', values: ['42'] },
+    ]);
+  });
+
+  it('emits range → rangeValue', () => {
+    const meta = [param({ id: 'p1', type: 'integer', restrictions: { range: true } })];
+    const { submitted } = serializeAllegroParameters({ p1: { from: '1', to: '10' } }, meta);
+    expect(submitted).toEqual([{ id: 'p1', rangeValue: { from: '1', to: '10' } }]);
+  });
+
+  it('drops empty values silently', () => {
+    const meta = [
+      param({ id: 'p1', type: 'string' }),
+      param({ id: 'p2', type: 'dictionary' }),
+      param({ id: 'p3', type: 'integer', restrictions: { range: true } }),
+    ];
+    const { submitted } = serializeAllegroParameters(
+      { p1: '', p2: undefined, p3: { from: '', to: '' } },
+      meta,
+    );
+    expect(submitted).toEqual([]);
+  });
+
+  it('skips hidden parameters (parameter-level visibility)', () => {
+    const meta = [
+      param({ id: 'parent', type: 'dictionary' }),
+      param({
+        id: 'child',
+        type: 'dictionary',
+        dependsOn: { parameterId: 'parent', valueIds: ['p_yes'] },
+        dictionary: [{ id: 'c_a', value: 'A' }],
+      }),
+    ];
+    // parent value 'p_no' does NOT match the child's dependsOn
+    const { submitted } = serializeAllegroParameters(
+      { parent: 'p_no', child: 'c_a' },
+      meta,
+    );
+    expect(submitted).toEqual([{ id: 'parent', valuesIds: ['p_no'] }]);
+  });
+
+  it('preserves submission order matching the parameters argument (anchors error mapping)', () => {
+    const meta = [
+      param({ id: 'a', type: 'string' }),
+      param({ id: 'b', type: 'string' }),
+      param({ id: 'c', type: 'string' }),
+    ];
+    const { submitted } = serializeAllegroParameters({ a: '1', b: '2', c: '3' }, meta);
+    expect(submitted.map((s) => s.id)).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/apps/web/src/features/listings/components/serialize-allegro-parameters.ts
+++ b/apps/web/src/features/listings/components/serialize-allegro-parameters.ts
@@ -1,0 +1,104 @@
+/**
+ * Serialize Category-Parameter Form Values → Allegro Wire Shape
+ *
+ * Converts the wizard's flat `parameters[paramId]` form state into the
+ * `parameters[]` array Allegro's `POST /sale/product-offers` expects (#410).
+ * Output is appended to `platformParams.parameters` on the existing
+ * create-offer mutation payload.
+ *
+ * Handles all four submit shapes:
+ *   - dictionary single → `{ id, valuesIds: [v] }`
+ *   - dictionary multi  → `{ id, valuesIds: [...vs] }`
+ *   - dictionary single + customValuesEnabled → match against the
+ *     dictionary; matched entry → `valuesIds`, otherwise → `values: [text]`
+ *   - integer / float range → `{ id, rangeValue: { from, to } }`
+ *   - integer / float / string scalar → `{ id, values: [String(v)] }`
+ *
+ * Hidden parameters (per `isParameterVisible`) are excluded entirely. The
+ * caller keeps the returned array as a snapshot for error-mapping after a
+ * failed submit (the positional `parameters[N]` index Allegro returns in
+ * validation errors maps back to a parameter id via this snapshot).
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import type { CategoryParameter } from '../api/listings.types';
+import type { CategoryParameterFormValues } from './category-parameter-form.types';
+import { isFormValueEmpty, isParameterVisible } from './category-parameter-visibility';
+
+export interface AllegroParameterInput {
+  id: string;
+  values?: string[];
+  valuesIds?: string[];
+  rangeValue?: { from: string; to: string };
+}
+
+export interface SerializedParameters {
+  /** Wire-ready array, in the order Allegro receives. Used for error mapping. */
+  submitted: AllegroParameterInput[];
+}
+
+export function serializeAllegroParameters(
+  values: CategoryParameterFormValues,
+  parameters: CategoryParameter[],
+): SerializedParameters {
+  const submitted: AllegroParameterInput[] = [];
+
+  for (const param of parameters) {
+    if (!isParameterVisible(param, values)) continue;
+    const out = mapOne(param, values[param.id]);
+    if (out !== null) submitted.push(out);
+  }
+
+  return { submitted };
+}
+
+function mapOne(
+  param: CategoryParameter,
+  raw: CategoryParameterFormValues[string],
+): AllegroParameterInput | null {
+  if (isFormValueEmpty(raw)) return null;
+
+  if (param.type === 'dictionary') {
+    if (param.restrictions.multipleChoices) {
+      const ids = Array.isArray(raw) ? raw.filter((s) => s !== '') : [];
+      return ids.length > 0 ? { id: param.id, valuesIds: ids } : null;
+    }
+    if (typeof raw !== 'string') return null;
+
+    const trimmed = raw.trim();
+    if (trimmed === '') return null;
+
+    if (param.restrictions.customValuesEnabled) {
+      const match = param.dictionary?.find(
+        (entry) => entry.value.trim().toLowerCase() === trimmed.toLowerCase(),
+      );
+      return match
+        ? { id: param.id, valuesIds: [match.id] }
+        : { id: param.id, values: [trimmed] };
+    }
+
+    return { id: param.id, valuesIds: [trimmed] };
+  }
+
+  // Range scalar (integer/float)
+  if (
+    param.restrictions.range &&
+    typeof raw === 'object' &&
+    !Array.isArray(raw) &&
+    raw !== null
+  ) {
+    const r = raw as { from?: string; to?: string };
+    const from = r.from?.trim() ?? '';
+    const to = r.to?.trim() ?? '';
+    if (from === '' && to === '') return null;
+    return { id: param.id, rangeValue: { from, to } };
+  }
+
+  // Single scalar (string / integer / float)
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    return trimmed === '' ? null : { id: param.id, values: [trimmed] };
+  }
+
+  return null;
+}

--- a/apps/web/src/features/listings/hooks/use-category-parameters-query.ts
+++ b/apps/web/src/features/listings/hooks/use-category-parameters-query.ts
@@ -1,0 +1,40 @@
+/**
+ * use-category-parameters-query
+ *
+ * Fetches the create-offer wizard's per-category parameter schema (#410).
+ * Backend caches the upstream Allegro response for 24h via the shared
+ * CachePort; the FE query keeps a 24h staleTime so repeated wizard opens
+ * within a session do not re-fetch.
+ *
+ * Returns the unwrapped `CategoryParameter[]` — the response envelope's
+ * `parameters` wrapper is unpacked here so consumers don't repeat the
+ * `data?.parameters ?? []` dance.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { CategoryParameter } from '../api/listings.types';
+
+export const CATEGORY_PARAMETERS_STALE_TIME_MS = 24 * 60 * 60 * 1000;
+
+export function useCategoryParametersQuery(
+  connectionId: string | undefined,
+  categoryId: string | undefined,
+): UseQueryResult<CategoryParameter[]> {
+  const apiClient = useApiClient();
+
+  return useQuery<CategoryParameter[]>({
+    queryKey: listingsQueryKeys.categoryParameters(connectionId ?? '', categoryId ?? ''),
+    queryFn: async () => {
+      const response = await apiClient.listings.getCategoryParameters(
+        connectionId as string,
+        categoryId as string,
+      );
+      return response.parameters;
+    },
+    enabled: Boolean(connectionId && categoryId),
+    staleTime: CATEGORY_PARAMETERS_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3620,6 +3620,448 @@ a.kpi-card:focus-visible {
   z-index: 50;
 }
 
+/* Category Parameters Step (#410) ---------------------------------- */
+
+.category-parameters-step {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.category-parameters-step__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.category-parameters-step__group-legend {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 0;
+  margin-bottom: 0.25rem;
+}
+
+.category-parameters-step__group--optional {
+  margin-top: 0.5rem;
+}
+
+.category-parameters-step__expander {
+  margin-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 0.75rem;
+}
+
+.category-parameters-step__expander-summary {
+  list-style: none;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  padding: 0.25rem 0;
+  user-select: none;
+}
+
+.category-parameters-step__expander-summary::-webkit-details-marker {
+  display: none;
+}
+
+.category-parameters-step__expander-summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.5rem;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.category-parameters-step__expander[open] > .category-parameters-step__expander-summary::before {
+  transform: rotate(90deg);
+}
+
+.category-parameters-step__expander-summary:hover {
+  color: var(--text-primary);
+}
+
+.category-parameters-step__unit {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.category-parameters-step__range {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.category-parameters-step__range > .control {
+  width: 9rem;
+}
+
+.category-parameters-step__range-sep {
+  color: var(--text-muted);
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.875rem;
+}
+
+.category-parameters-step__range-unit {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+}
+
+/* Combobox (virtualized typeahead, wraps Popover) ------------------ */
+
+.combobox__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: 32px;
+  padding: 0 0.625rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  text-align: left;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 0.625rem;
+  cursor: pointer;
+}
+
+.combobox__trigger:hover:not(:disabled) {
+  border-color: var(--border-strong);
+}
+
+.combobox__trigger:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 2px;
+}
+
+.combobox__trigger[aria-expanded='true'] {
+  border-color: var(--border-strong);
+}
+
+.combobox__trigger--invalid,
+.combobox__trigger[aria-invalid='true'] {
+  border-color: var(--status-error-border);
+}
+
+.combobox__trigger--disabled,
+.combobox__trigger:disabled {
+  color: var(--text-disabled);
+  background: var(--bg-surface-muted);
+  cursor: not-allowed;
+}
+
+.combobox__summary {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.combobox__trigger:not([aria-expanded='true']) .combobox__summary:empty::before {
+  content: 'Select…';
+  color: var(--text-muted);
+}
+
+.combobox__custom-value {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-style: italic;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  border-left: 2px dotted var(--border-strong);
+  padding-left: 0.5rem;
+  margin-left: -0.125rem;
+}
+
+.combobox__chevron {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.combobox__trigger[aria-expanded='true'] .combobox__chevron {
+  transform: rotate(180deg);
+  color: var(--text-secondary);
+}
+
+.combobox__chips {
+  display: inline-flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding: 0.125rem 0;
+  overflow: hidden;
+}
+
+.combobox__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  height: 22px;
+  padding: 0 0.375rem 0 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-primary);
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.combobox__chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 14ch;
+}
+
+.combobox__chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  font-size: 0.875rem;
+  line-height: 1;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.combobox__chip-remove:hover {
+  color: var(--text-primary);
+  background: var(--bg-surface-hover);
+}
+
+.combobox__chip-more {
+  align-self: center;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.combobox__panel {
+  display: flex;
+  flex-direction: column;
+  width: var(--radix-popover-trigger-width, 320px);
+  min-width: 280px;
+  max-width: 480px;
+  padding: 0;
+  overflow: hidden;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 0.625rem;
+  box-shadow: var(--shadow-overlay);
+}
+
+.combobox__panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.5rem 0.625rem 0.375rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.combobox__search {
+  width: 100%;
+  height: 28px;
+  padding: 0 0.375rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+.combobox__search::placeholder {
+  color: var(--text-muted);
+}
+
+.combobox__counter {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.combobox__listbox {
+  max-height: 320px;
+  min-height: 32px;
+  overflow-y: auto;
+  padding: 0.25rem 0;
+}
+
+.combobox__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 32px;
+  padding: 0 0.625rem;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  cursor: pointer;
+  user-select: none;
+}
+
+@media (pointer: coarse) {
+  .combobox__option {
+    height: 40px;
+  }
+}
+
+.combobox__option-arrow {
+  flex: 0 0 auto;
+  width: 1em;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  opacity: 0;
+}
+
+.combobox__option--active {
+  background: var(--bg-surface-hover);
+}
+
+.combobox__option--active .combobox__option-arrow {
+  opacity: 1;
+  color: var(--text-primary);
+}
+
+.combobox__option--selected {
+  background: var(--bg-surface-muted);
+}
+
+.combobox__option--selected .combobox__option-label {
+  font-weight: 600;
+}
+
+.combobox__option--selected .combobox__option-arrow {
+  opacity: 1;
+  color: var(--text-primary);
+}
+
+.combobox__option--disabled {
+  color: var(--text-disabled);
+  cursor: not-allowed;
+}
+
+.combobox__option--disabled .combobox__option-label {
+  text-decoration: line-through;
+}
+
+.combobox__option--custom .combobox__option-arrow {
+  opacity: 1;
+}
+
+.combobox__option--custom .combobox__option-custom-text {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-style: italic;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.combobox__option-label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 400;
+}
+
+.combobox__match {
+  font-weight: 600;
+  background: transparent;
+  color: inherit;
+}
+
+.combobox__option-hint {
+  flex: 0 0 auto;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.combobox__empty {
+  padding: 1rem 0.625rem;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.combobox__panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-surface-muted);
+}
+
+.combobox__keyhint {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.combobox__keyhint kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 0.25rem;
+  font-family: inherit;
+  font-size: 0.625rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+}
+
+.combobox__clear {
+  font-family: inherit;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.combobox__clear:hover {
+  color: var(--text-primary);
+  text-decoration: underline;
+}
+
 /* Radix Tabs wrapper ----------------------------------------------- */
 
 .tabs {
@@ -3871,6 +4313,14 @@ a.kpi-card:focus-visible {
   color: var(--text-primary);
   font-size: 0.875rem;
   word-break: break-word;
+}
+
+.wizard-review-list__nested {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.25rem;
 }
 
 .wizard-test-result {

--- a/apps/web/src/shared/ui/combobox.test.tsx
+++ b/apps/web/src/shared/ui/combobox.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Combobox Tests
+ *
+ * Covers single + multi selection, custom-value passthrough, filter-first
+ * gating, keyboard navigation, and ARIA combobox semantics.
+ *
+ * @module shared/ui
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Combobox, type ComboboxOption, type ComboboxValue } from './combobox';
+
+const SHORT_OPTIONS: ComboboxOption[] = [
+  { id: 'a1', label: 'Adidas', hint: '#a1' },
+  { id: 'a2', label: 'Apple', hint: '#a2' },
+  { id: 'n1', label: 'Nike', hint: '#n1' },
+  { id: 'p1', label: 'Puma', hint: '#p1' },
+];
+
+const LARGE_OPTIONS: ComboboxOption[] = Array.from({ length: 60 }, (_, i) => ({
+  id: `id-${i}`,
+  label: `Brand ${i.toString().padStart(2, '0')}`,
+}));
+
+function ControlledCombobox(props: {
+  initial?: ComboboxValue | null;
+  options?: ComboboxOption[];
+  mode?: 'single' | 'multi';
+  allowCustomValues?: boolean;
+  onChangeSpy?: (next: ComboboxValue | null) => void;
+}): React.ReactElement {
+  const [value, setValue] = React.useState<ComboboxValue | null>(props.initial ?? null);
+  return (
+    <Combobox
+      options={props.options ?? SHORT_OPTIONS}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        props.onChangeSpy?.(next);
+      }}
+      mode={props.mode}
+      allowCustomValues={props.allowCustomValues}
+      ariaLabel="Brand"
+      placeholder="Select brand"
+    />
+  );
+}
+
+describe('Combobox', () => {
+  afterEach(cleanup);
+
+  it('renders trigger with role=combobox and ARIA wiring', () => {
+    render(<ControlledCombobox />);
+    const trigger = screen.getByRole('combobox', { name: 'Brand' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('opens listbox on trigger click and renders all options below the filter-first threshold', async () => {
+    const user = userEvent.setup();
+    render(<ControlledCombobox />);
+    await user.click(screen.getByRole('combobox', { name: 'Brand' }));
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    for (const opt of SHORT_OPTIONS) {
+      expect(screen.getByText(opt.label)).toBeInTheDocument();
+    }
+  });
+
+  it('commits a single dictionary selection and closes the panel', async () => {
+    const onChangeSpy = vi.fn();
+    const user = userEvent.setup();
+    render(<ControlledCombobox onChangeSpy={onChangeSpy} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Brand' }));
+    await user.click(screen.getByText('Adidas'));
+
+    expect(onChangeSpy).toHaveBeenLastCalledWith({ kind: 'dictionary', ids: ['a1'] });
+  });
+
+  it('toggles multi selection without closing the panel', async () => {
+    const onChangeSpy = vi.fn();
+    const user = userEvent.setup();
+    render(<ControlledCombobox mode="multi" onChangeSpy={onChangeSpy} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Brand' }));
+    await user.click(screen.getByText('Adidas'));
+    await user.click(screen.getByText('Nike'));
+
+    expect(onChangeSpy.mock.calls.at(-1)?.[0]).toEqual({ kind: 'dictionary', ids: ['a1', 'n1'] });
+    // Listbox stays open in multi mode
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('shows the filter-first prompt and no options until the user types when over the threshold', async () => {
+    const user = userEvent.setup();
+    render(<ControlledCombobox options={LARGE_OPTIONS} />);
+    await user.click(screen.getByRole('combobox', { name: 'Brand' }));
+
+    expect(screen.getByText(/Type to search 60 options\./)).toBeInTheDocument();
+    expect(screen.queryByText('Brand 00')).toBeNull();
+
+    await user.type(screen.getByPlaceholderText(/Type to search/i), 'Brand 03');
+    expect(screen.getByText('Brand 03')).toBeInTheDocument();
+  });
+
+  it('emits a custom-value commit when allowCustomValues=true and the typed text has no exact match', async () => {
+    const onChangeSpy = vi.fn();
+    const user = userEvent.setup();
+    render(<ControlledCombobox allowCustomValues onChangeSpy={onChangeSpy} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Brand' }));
+    await user.type(
+      screen.getByPlaceholderText(/Type to search or enter a custom value/i),
+      'AcmeCorp',
+    );
+
+    // Custom row appears and is selectable
+    const customRow = screen.getByText('AcmeCorp');
+    await user.click(customRow);
+
+    expect(onChangeSpy).toHaveBeenLastCalledWith({ kind: 'custom', text: 'AcmeCorp' });
+  });
+
+  it('renders the trigger summary for a dictionary selection', () => {
+    render(<ControlledCombobox initial={{ kind: 'dictionary', ids: ['a1'] }} />);
+    expect(screen.getByRole('combobox', { name: 'Brand' })).toHaveTextContent('Adidas');
+  });
+
+  it('renders custom-value chip differentiation in the trigger', () => {
+    render(<ControlledCombobox initial={{ kind: 'custom', text: 'AcmeCorp' }} />);
+    const trigger = screen.getByRole('combobox', { name: 'Brand' });
+    expect(trigger).toHaveTextContent('AcmeCorp');
+    expect(trigger.querySelector('.combobox__custom-value')).not.toBeNull();
+  });
+
+  it('supports keyboard navigation and Enter to commit', async () => {
+    const onChangeSpy = vi.fn();
+    const user = userEvent.setup();
+    render(<ControlledCombobox onChangeSpy={onChangeSpy} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Brand' }));
+    const search = screen.getByPlaceholderText(/Type to filter/i);
+    await user.click(search);
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+
+    expect(onChangeSpy).toHaveBeenLastCalledWith({ kind: 'dictionary', ids: ['n1'] });
+  });
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup();
+    render(<ControlledCombobox />);
+    await user.click(screen.getByRole('combobox', { name: 'Brand' }));
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('forwards ref to the trigger button', () => {
+    const ref = { current: null as HTMLButtonElement | null };
+    render(
+      <Combobox
+        ref={ref}
+        options={SHORT_OPTIONS}
+        value={null}
+        onChange={() => undefined}
+        ariaLabel="Brand"
+      />,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it('marks the trigger as aria-invalid when invalid prop is set', () => {
+    render(
+      <Combobox
+        options={SHORT_OPTIONS}
+        value={null}
+        onChange={() => undefined}
+        ariaLabel="Brand"
+        invalid
+      />,
+    );
+    expect(screen.getByRole('combobox', { name: 'Brand' })).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('renders disabled options with line-through and skips commit', async () => {
+    const onChangeSpy = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Combobox
+        options={[
+          { id: 'a1', label: 'Adidas' },
+          { id: 'n1', label: 'Nike', disabled: true, disabledReason: 'Filtered out' },
+        ]}
+        value={null}
+        onChange={onChangeSpy}
+        ariaLabel="Brand"
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox', { name: 'Brand' }));
+    const disabledRow = screen.getByText('Nike').closest('[role="option"]');
+    expect(disabledRow).toHaveAttribute('aria-disabled', 'true');
+
+    await user.click(screen.getByText('Nike'));
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/shared/ui/combobox.tsx
+++ b/apps/web/src/shared/ui/combobox.tsx
@@ -1,0 +1,627 @@
+/**
+ * Combobox
+ *
+ * Virtualized combobox primitive for large dictionaries (Allegro `Marka` has
+ * ~5000 entries). Composes `popover.tsx` (Radix) for portal + positioning and
+ * implements the W3C combobox pattern with arrow-key navigation, filter-first
+ * gating for large lists, and optional custom-value passthrough for fields
+ * that allow both dictionary selection and free text.
+ *
+ * Design intent: refined cockpit minimalism. Typography carries the signal —
+ * dictionary values in Plex Sans, IDs in mono muted, custom values in italic
+ * mono. No decorative shadows, no hover transitions, no chromatic accents
+ * beyond the focus ring. Selection indicator is a mono `→` glyph (Linear
+ * direction style), not the generic admin checkmark.
+ *
+ * @module shared/ui
+ * @see {@link Popover} for the underlying portal primitive
+ */
+import { useVirtualizer } from '@tanstack/react-virtual';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+} from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+
+export interface ComboboxOption {
+  /** Stable id; what `value.ids` references for dictionary mode. */
+  id: string;
+  /** Human label rendered in Plex Sans. */
+  label: string;
+  /** Optional secondary metadata rendered in mono muted (e.g. dict id). */
+  hint?: string;
+  /** Visually disabled (e.g. filtered out by parent dependency). Still searchable. */
+  disabled?: boolean;
+  /** Tooltip / aria-description when disabled. */
+  disabledReason?: string;
+}
+
+export type ComboboxValue =
+  | { kind: 'dictionary'; ids: string[] }
+  | { kind: 'custom'; text: string };
+
+export interface ComboboxProps {
+  options: ComboboxOption[];
+  value: ComboboxValue | null;
+  onChange: (next: ComboboxValue | null) => void;
+  /** Single-select returns `{ kind: 'dictionary', ids: [id] }`. Multi returns the array. */
+  mode?: 'single' | 'multi';
+  /** When true, free-text input that doesn't match any option commits as `{ kind: 'custom', text }`. */
+  allowCustomValues?: boolean;
+  /** Threshold for filter-first: when options.length >= threshold, no options render until the user types. */
+  filterFirstThreshold?: number;
+  placeholder?: string;
+  disabled?: boolean;
+  invalid?: boolean;
+  /** FormField wiring. */
+  id?: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean;
+  /** When the parent doesn't provide a `<label>` (i.e. not inside FormField). */
+  ariaLabel?: string;
+  /** Class merge slot. */
+  className?: string;
+  /** For test introspection. */
+  'data-testid'?: string;
+}
+
+const DEFAULT_FILTER_FIRST_THRESHOLD = 50;
+const VIRTUALIZE_THRESHOLD = 200;
+const OPTION_ROW_HEIGHT = 32;
+// Touch density (40px) is applied via CSS @media (pointer: coarse). The
+// virtualizer estimate intentionally uses the desktop value — over-estimate
+// on touch is harmless and the actual rendered row size drives scroll math.
+
+export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(function Combobox(
+  {
+    options,
+    value,
+    onChange,
+    mode = 'single',
+    allowCustomValues = false,
+    filterFirstThreshold = DEFAULT_FILTER_FIRST_THRESHOLD,
+    placeholder,
+    disabled = false,
+    invalid = false,
+    id,
+    'aria-describedby': ariaDescribedBy,
+    'aria-invalid': ariaInvalidProp,
+    ariaLabel,
+    className = '',
+    'data-testid': dataTestId,
+  },
+  ref,
+): ReactElement {
+  const generatedId = useId();
+  const triggerId = id ?? `combobox-${generatedId}`;
+  const listboxId = `${triggerId}-listbox`;
+  const counterId = `${triggerId}-counter`;
+  const searchId = `${triggerId}-search`;
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const optionsById = useMemo(() => {
+    const map = new Map<string, ComboboxOption>();
+    for (const opt of options) map.set(opt.id, opt);
+    return map;
+  }, [options]);
+
+  const trimmed = query.trim();
+  const filterFirst = options.length >= filterFirstThreshold;
+  const showOptions = !filterFirst || trimmed.length > 0;
+
+  const filteredOptions = useMemo(() => {
+    if (!showOptions) return [];
+    if (trimmed.length === 0) return options;
+    const needle = trimmed.toLowerCase();
+    return options.filter((o) => o.label.toLowerCase().includes(needle));
+  }, [options, trimmed, showOptions]);
+
+  const customMatch = useMemo(() => {
+    if (!allowCustomValues || trimmed.length === 0) return null;
+    const exact = options.find((o) => o.label.trim().toLowerCase() === trimmed.toLowerCase());
+    return exact ? null : trimmed;
+  }, [allowCustomValues, options, trimmed]);
+
+  // Reset highlight when results change
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [filteredOptions, customMatch]);
+
+  // Determine current state for trigger label
+  const selectedIds = value?.kind === 'dictionary' ? value.ids : [];
+  const selectedCustom = value?.kind === 'custom' ? value.text : null;
+  const triggerSummary = formatTriggerSummary(value, optionsById, placeholder);
+
+  const listboxRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const virtualizer = useVirtualizer({
+    count: filteredOptions.length + (customMatch ? 1 : 0),
+    getScrollElement: () => listboxRef.current,
+    estimateSize: () => OPTION_ROW_HEIGHT,
+    overscan: 8,
+    enabled: showOptions && filteredOptions.length >= VIRTUALIZE_THRESHOLD,
+  });
+
+  const useVirtual =
+    showOptions && filteredOptions.length >= VIRTUALIZE_THRESHOLD;
+
+  // Keep the highlighted option in view
+  useEffect(() => {
+    if (!open || !showOptions || !useVirtual) return;
+    virtualizer.scrollToIndex(activeIndex, { align: 'auto' });
+  }, [activeIndex, open, showOptions, useVirtual, virtualizer]);
+
+  // Autofocus search on open
+  useEffect(() => {
+    if (open) {
+      // Defer to next frame so the popover content is mounted
+      requestAnimationFrame(() => searchRef.current?.focus());
+    } else {
+      setQuery('');
+    }
+  }, [open]);
+
+  const totalRows = filteredOptions.length + (customMatch ? 1 : 0);
+
+  const commitDictionary = useCallback(
+    (optionId: string) => {
+      if (mode === 'single') {
+        onChange({ kind: 'dictionary', ids: [optionId] });
+        setOpen(false);
+      } else {
+        const current = value?.kind === 'dictionary' ? value.ids : [];
+        const next = current.includes(optionId)
+          ? current.filter((id) => id !== optionId)
+          : [...current, optionId];
+        onChange(next.length === 0 ? null : { kind: 'dictionary', ids: next });
+      }
+    },
+    [mode, onChange, value],
+  );
+
+  const commitCustom = useCallback(
+    (text: string) => {
+      onChange({ kind: 'custom', text });
+      if (mode === 'single') setOpen(false);
+    },
+    [mode, onChange],
+  );
+
+  const commitActive = useCallback(() => {
+    if (!totalRows) return;
+    if (customMatch && activeIndex === filteredOptions.length) {
+      commitCustom(customMatch);
+      return;
+    }
+    const opt = filteredOptions[activeIndex];
+    if (opt && !opt.disabled) commitDictionary(opt.id);
+  }, [activeIndex, commitCustom, commitDictionary, customMatch, filteredOptions, totalRows]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, totalRows - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveIndex(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setActiveIndex(Math.max(totalRows - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      commitActive();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setOpen(false);
+    } else if (e.key === 'Backspace' && query.length === 0 && mode === 'multi' && selectedIds.length > 0) {
+      // Quick remove last chip when typing into empty input
+      const next = selectedIds.slice(0, -1);
+      onChange(next.length === 0 ? null : { kind: 'dictionary', ids: next });
+    }
+  };
+
+  const handleRemoveChip = (optionId: string): void => {
+    const next = selectedIds.filter((id) => id !== optionId);
+    onChange(next.length === 0 ? null : { kind: 'dictionary', ids: next });
+  };
+
+  const handleClearCustom = (): void => {
+    onChange(null);
+  };
+
+  const triggerClasses = [
+    'combobox__trigger',
+    invalid || ariaInvalidProp ? 'combobox__trigger--invalid' : '',
+    disabled ? 'combobox__trigger--disabled' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <Popover open={open} onOpenChange={(next) => !disabled && setOpen(next)}>
+      <PopoverTrigger asChild>
+        <button
+          ref={ref}
+          id={triggerId}
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+          aria-label={ariaLabel}
+          aria-describedby={ariaDescribedBy}
+          aria-invalid={invalid || ariaInvalidProp}
+          disabled={disabled}
+          className={triggerClasses}
+          data-testid={dataTestId}
+        >
+          {mode === 'multi' && selectedIds.length > 0 ? (
+            <span className="combobox__chips">
+              {selectedIds.slice(0, 3).map((selectedId) => {
+                const opt = optionsById.get(selectedId);
+                return (
+                  <ChipPill
+                    key={selectedId}
+                    label={opt?.label ?? selectedId}
+                    onRemove={() => handleRemoveChip(selectedId)}
+                  />
+                );
+              })}
+              {selectedIds.length > 3 ? (
+                <span className="combobox__chip-more">+{selectedIds.length - 3} more</span>
+              ) : null}
+            </span>
+          ) : selectedCustom ? (
+            <span className="combobox__custom-value" title="Custom value (not from list)">
+              {selectedCustom}
+            </span>
+          ) : (
+            <span className="combobox__summary">{triggerSummary}</span>
+          )}
+          <ChevronGlyph />
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent className="combobox__panel" sideOffset={4} align="start">
+        <div className="combobox__panel-header">
+          <input
+            ref={searchRef}
+            id={searchId}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="combobox__search"
+            placeholder={
+              allowCustomValues
+                ? 'Type to search or enter a custom value…'
+                : filterFirst
+                  ? `Type to search ${options.length.toLocaleString()} options…`
+                  : 'Type to filter…'
+            }
+            autoComplete="off"
+            spellCheck={false}
+            aria-controls={listboxId}
+            aria-activedescendant={
+              showOptions && totalRows > 0 ? `${listboxId}-row-${activeIndex}` : undefined
+            }
+          />
+          <span className="combobox__counter" id={counterId} aria-live="polite">
+            {!showOptions
+              ? `${options.length.toLocaleString()} ${pluralize(options.length, 'option')}`
+              : `Showing ${filteredOptions.length.toLocaleString()} of ${options.length.toLocaleString()}`}
+          </span>
+        </div>
+
+        <div
+          ref={listboxRef}
+          id={listboxId}
+          role="listbox"
+          aria-multiselectable={mode === 'multi'}
+          className="combobox__listbox"
+          tabIndex={-1}
+        >
+          {!showOptions ? (
+            <EmptyHint text={`Type to search ${options.length.toLocaleString()} options.`} />
+          ) : totalRows === 0 ? (
+            <EmptyHint text={`No options match “${trimmed}”.`} />
+          ) : useVirtual ? (
+            <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+              {virtualizer.getVirtualItems().map((vRow) => {
+                const isCustomRow = customMatch && vRow.index === filteredOptions.length;
+                if (isCustomRow) {
+                  return (
+                    <CustomMatchRow
+                      key="custom"
+                      style={{
+                        position: 'absolute',
+                        top: vRow.start,
+                        left: 0,
+                        right: 0,
+                        height: vRow.size,
+                      }}
+                      text={customMatch}
+                      active={activeIndex === vRow.index}
+                      listboxId={listboxId}
+                      onActivate={() => setActiveIndex(vRow.index)}
+                      onCommit={() => commitCustom(customMatch)}
+                    />
+                  );
+                }
+                const opt = filteredOptions[vRow.index];
+                return (
+                  <OptionRow
+                    key={opt.id}
+                    option={opt}
+                    queryHighlight={trimmed}
+                    style={{
+                      position: 'absolute',
+                      top: vRow.start,
+                      left: 0,
+                      right: 0,
+                      height: vRow.size,
+                    }}
+                    selected={selectedIds.includes(opt.id)}
+                    active={activeIndex === vRow.index}
+                    listboxId={listboxId}
+                    rowIndex={vRow.index}
+                    onActivate={() => setActiveIndex(vRow.index)}
+                    onCommit={() => commitDictionary(opt.id)}
+                  />
+                );
+              })}
+            </div>
+          ) : (
+            <>
+              {filteredOptions.map((opt, idx) => (
+                <OptionRow
+                  key={opt.id}
+                  option={opt}
+                  queryHighlight={trimmed}
+                  selected={selectedIds.includes(opt.id)}
+                  active={activeIndex === idx}
+                  listboxId={listboxId}
+                  rowIndex={idx}
+                  onActivate={() => setActiveIndex(idx)}
+                  onCommit={() => commitDictionary(opt.id)}
+                />
+              ))}
+              {customMatch ? (
+                <CustomMatchRow
+                  text={customMatch}
+                  active={activeIndex === filteredOptions.length}
+                  listboxId={listboxId}
+                  onActivate={() => setActiveIndex(filteredOptions.length)}
+                  onCommit={() => commitCustom(customMatch)}
+                />
+              ) : null}
+            </>
+          )}
+        </div>
+
+        <div className="combobox__panel-footer">
+          <span className="combobox__keyhint">
+            <kbd>↑</kbd>
+            <kbd>↓</kbd>
+            <span>navigate</span>
+            <span aria-hidden>·</span>
+            <kbd>↵</kbd>
+            <span>select</span>
+            <span aria-hidden>·</span>
+            <kbd>esc</kbd>
+            <span>close</span>
+          </span>
+          {selectedCustom ? (
+            <button
+              type="button"
+              className="combobox__clear"
+              onClick={handleClearCustom}
+            >
+              Clear custom value
+            </button>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+});
+
+function formatTriggerSummary(
+  value: ComboboxValue | null,
+  optionsById: Map<string, ComboboxOption>,
+  placeholder: string | undefined,
+): string {
+  if (!value) return placeholder ?? 'Select…';
+  if (value.kind === 'custom') return value.text;
+  if (value.ids.length === 1) {
+    const opt = optionsById.get(value.ids[0]);
+    return opt?.label ?? value.ids[0];
+  }
+  if (value.ids.length === 0) return placeholder ?? 'Select…';
+  return `${value.ids.length} selected`;
+}
+
+function pluralize(n: number, word: string): string {
+  return `${word}${n === 1 ? '' : 's'}`;
+}
+
+interface OptionRowProps {
+  option: ComboboxOption;
+  queryHighlight: string;
+  selected: boolean;
+  active: boolean;
+  listboxId: string;
+  rowIndex: number;
+  onActivate: () => void;
+  onCommit: () => void;
+  style?: React.CSSProperties;
+}
+
+function OptionRow({
+  option,
+  queryHighlight,
+  selected,
+  active,
+  listboxId,
+  rowIndex,
+  onActivate,
+  onCommit,
+  style,
+}: OptionRowProps): ReactElement {
+  const classes = [
+    'combobox__option',
+    selected ? 'combobox__option--selected' : '',
+    active ? 'combobox__option--active' : '',
+    option.disabled ? 'combobox__option--disabled' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      id={`${listboxId}-row-${rowIndex}`}
+      role="option"
+      aria-selected={selected}
+      aria-disabled={option.disabled || undefined}
+      className={classes}
+      style={style}
+      onMouseEnter={onActivate}
+      onMouseDown={(e) => {
+        e.preventDefault(); // prevent input blur
+        if (!option.disabled) onCommit();
+      }}
+      title={option.disabled ? option.disabledReason : undefined}
+    >
+      <span className="combobox__option-arrow" aria-hidden>
+        →
+      </span>
+      <span className="combobox__option-label">
+        {highlightMatch(option.label, queryHighlight)}
+      </span>
+      {option.hint ? <span className="combobox__option-hint">{option.hint}</span> : null}
+    </div>
+  );
+}
+
+interface CustomMatchRowProps {
+  text: string;
+  active: boolean;
+  listboxId: string;
+  onActivate: () => void;
+  onCommit: () => void;
+  style?: React.CSSProperties;
+}
+
+function CustomMatchRow({
+  text,
+  active,
+  listboxId,
+  onActivate,
+  onCommit,
+  style,
+}: CustomMatchRowProps): ReactElement {
+  const classes = [
+    'combobox__option',
+    'combobox__option--custom',
+    active ? 'combobox__option--active' : '',
+  ].join(' ');
+  return (
+    <div
+      id={`${listboxId}-row-custom`}
+      role="option"
+      aria-selected={false}
+      className={classes}
+      style={style}
+      onMouseEnter={onActivate}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onCommit();
+      }}
+    >
+      <span className="combobox__option-arrow" aria-hidden>
+        +
+      </span>
+      <span className="combobox__option-label">
+        Use as custom value:&nbsp;
+        <em className="combobox__option-custom-text">{text}</em>
+      </span>
+    </div>
+  );
+}
+
+function highlightMatch(label: string, query: string): ReactElement {
+  if (query.length === 0) return <>{label}</>;
+  const lower = label.toLowerCase();
+  const idx = lower.indexOf(query.toLowerCase());
+  if (idx === -1) return <>{label}</>;
+  return (
+    <>
+      {label.slice(0, idx)}
+      <mark className="combobox__match">{label.slice(idx, idx + query.length)}</mark>
+      {label.slice(idx + query.length)}
+    </>
+  );
+}
+
+interface ChipPillProps {
+  label: string;
+  onRemove: () => void;
+}
+
+function ChipPill({ label, onRemove }: ChipPillProps): ReactElement {
+  return (
+    <span className="combobox__chip" data-chip>
+      <span className="combobox__chip-label">{label}</span>
+      <button
+        type="button"
+        className="combobox__chip-remove"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        onMouseDown={(e) => e.stopPropagation()}
+        aria-label={`Remove ${label}`}
+      >
+        ×
+      </button>
+    </span>
+  );
+}
+
+function ChevronGlyph(): ReactElement {
+  return (
+    <svg
+      className="combobox__chevron"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      aria-hidden
+      focusable="false"
+    >
+      <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+interface EmptyHintProps {
+  text: string;
+}
+
+function EmptyHint({ text }: EmptyHintProps): ReactElement {
+  return <div className="combobox__empty">{text}</div>;
+}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -218,6 +218,9 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
         warranties: [],
         impliedWarranties: [],
       }),
+      // #410 — default to "no parameters" so the wizard's category step
+      // renders the friendly empty state in tests that don't override.
+      getCategoryParameters: vi.fn().mockResolvedValue({ parameters: [] }),
       ...overrides.listings,
     } as ApiClient['listings'],
     products: {

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -75,8 +75,8 @@ All TypeScript projects must use strict mode:
 
 - **ORM Entities**: `*.orm-entity.ts` (e.g., `product.orm-entity.ts`)
 - **Repositories**: `*.repository.ts` (e.g., `product.repository.ts`)
-- **Adapter Interfaces**: `*-adapter.interface.ts` (e.g., `prestashop-inventory-master.adapter.interface.ts`) - interface definition only (if needed)
-- **Adapters**: `*-adapter.ts` (e.g., `prestashop-inventory-master.adapter.ts`) - implements port interface
+- **Adapter Interfaces**: `*.adapter.interface.ts` (e.g., `prestashop-inventory-master.adapter.interface.ts`) - interface definition only (if needed)
+- **Adapters**: `*.adapter.ts` (e.g., `prestashop-inventory-master.adapter.ts`) - implements port interface
 - **Mappers**: `*.mapper.ts` (e.g., `product.mapper.ts`)
 - **Types**: `*.types.ts` (e.g., `adapter.types.ts`) - type definitions only
 

--- a/docs/plans/implementation-plan-410-allegro-category-parameters-wizard.md
+++ b/docs/plans/implementation-plan-410-allegro-category-parameters-wizard.md
@@ -1,0 +1,1084 @@
+# Implementation Plan — #410 Allegro category-parameters in the create-offer wizard
+
+> Status: design locked after `/grill-me` (Q1–Q8) + 3 review passes (`/tech-review`, `/frontend-design`, `/tech-review` synthesis). Spawned follow-up #412 for richer auto-prefill.
+
+## 1. Goal
+
+Make `marketplace.offer.create` against Allegro succeed past
+`ConstraintViolationException.MissingRequiredParameters`. Today the wizard
+captures a fixed set of fields (title / category / price / description /
+images / 4 policy IDs) but never asks operators for the **category-required
+parameters** that Allegro's offer-create endpoint demands (Brand, Model,
+EAN, technical specs, etc.). Result: every category with required
+parameters fails.
+
+This PR delivers the full vertical slice: shared `CachePort` →
+CORE capability → Allegro adapter implementation → API endpoint → FE wizard
+step (desktop-only) → wire-shape mapping in `platformParams.parameters`.
+
+## 2. Classification
+
+- **Layer:** Multi-layer — `libs/shared` (CachePort), CORE (port + types + new exception), Integration (Allegro adapter + cache wiring), Interface (API controller), Frontend (new wizard step + virtualized combobox).
+- **Effort:** ~3.5 days.
+- **No DB / migration impact.**
+- **Mobile scope:** desktop-only (≥ 1024 px). Below 1024 px the wizard renders the documented "Open on a desktop screen to edit" affordance — see §7.10.
+
+### Files
+
+**New — shared CachePort:**
+- `libs/shared/src/cache/cache.port.ts`
+- `libs/shared/src/cache/cache.types.ts`
+- `libs/shared/src/cache/redis-cache.adapter.ts`
+- `libs/shared/src/cache/cache.module.ts`
+- `libs/shared/src/cache/index.ts` — barrel
+- `libs/shared/src/cache/__tests__/redis-cache.adapter.spec.ts`
+
+**New — CORE:**
+- `libs/core/src/listings/domain/types/category-parameter.types.ts`
+- `libs/core/src/listings/domain/ports/capabilities/category-parameters-reader.capability.ts`
+- `libs/core/src/listings/domain/ports/capabilities/__tests__/category-parameters-reader.guard.spec.ts`
+- `libs/core/src/listings/domain/exceptions/category-not-found.exception.ts`
+
+**New — Allegro adapter:**
+- `libs/integrations/allegro/src/infrastructure/adapters/__fixtures__/category-parameters-257933.json` — single fixture covering **both** dependency mechanisms in one capture: parameter `229205` ("Stan opakowania") has parameter-level visibility (`options.dependsOnParameterId: "11323"`) AND its dictionary entries carry `dependsOnValueIds: ["11323_..."]` arrays. A second fixture is therefore not required for #410.
+- `libs/integrations/allegro/src/infrastructure/mappers/allegro-category-parameter.mapper.ts`
+- `libs/integrations/allegro/src/infrastructure/mappers/__tests__/allegro-category-parameter.mapper.spec.ts`
+
+**New — API:**
+- `apps/api/src/listings/http/dto/category-parameter-response.dto.ts`
+
+**New — FE (kebab-case filenames per `frontend-architecture.md` §"Naming conventions"):**
+- `apps/web/src/shared/ui/combobox.tsx` + `combobox.test.tsx` — virtualized combobox primitive
+- `apps/web/src/features/listings/components/category-parameters-step.tsx` + `category-parameters-step.test.tsx`
+- `apps/web/src/features/listings/components/auto-prefill-parameters.ts` + `auto-prefill-parameters.test.ts`
+- `apps/web/src/features/listings/components/serialize-allegro-parameters.ts` + `serialize-allegro-parameters.test.ts`
+- `apps/web/src/features/listings/components/build-parameters-zod-schema.ts` + `build-parameters-zod-schema.test.ts`
+- `apps/web/src/features/listings/hooks/use-category-parameters-query.ts`
+
+**Edited:**
+- `libs/shared/src/index.ts` — export cache barrel
+- `libs/core/src/listings/index.ts` — export new types + capability + exception
+- `libs/integrations/allegro/src/domain/types/allegro-api.types.ts` — expand `AllegroCategoryParametersResponse`
+- `libs/integrations/allegro/src/allegro-integration.module.ts` — wire `CachePort` into adapter factory
+- `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts` — implement capability with `CachePort`, refactor `fetchOfferIdentifiers`
+- `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts` — new specs
+- `apps/api/src/listings/http/listings.controller.ts` — new endpoint (existing prefix `@Controller('listings')` confirmed)
+- `apps/api/src/listings/http/__tests__/listings.controller.spec.ts` — new specs
+- `apps/web/src/features/listings/api/listings.api.ts` — new method
+- `apps/web/src/features/listings/api/listings.types.ts` — new types
+- `apps/web/src/features/listings/api/listings.query-keys.ts` — new key
+- `apps/web/src/features/listings/components/CreateOfferWizard.tsx` — insert Step 2, dynamic Zod, submit serializer, retry deep-link, sticky footer
+- `apps/web/src/features/listings/components/CreateOfferWizard.test.tsx` — extend coverage
+- `apps/web/src/features/listings/components/create-offer-fields.schema.ts` — extend with `parameters` field
+- `apps/web/src/features/listings/components/create-offer-request-to-form-values.ts` — round-trip retry pre-fill
+- `apps/web/src/index.css` — Combobox tokens and category-parameters-step styles
+
+> Existing FE component files (`CreateOfferWizard.tsx`, `CategoryPicker.tsx`, etc.) keep their PascalCase names — the kebab-case rule applies to new files.
+
+## 3. Architecture
+
+```
+┌───────────────────────────────────────────────────────────────────────────┐
+│                              FRONTEND (≥ 1024 px)                         │
+│  CreateOfferWizard (5 steps)                                              │
+│    0. Connection & Variant                                                │
+│    1. Offer details (title / category / price / stock)                    │
+│    2. Category parameters  ← NEW                                          │
+│        ├─ useCategoryParametersQuery(connectionId, categoryId)            │
+│        ├─ auto-prefill (EAN + Stan)                                       │
+│        ├─ build dynamic Zod schema (parameter-visibility +                │
+│        │   dictionary-entry filtering)                                    │
+│        ├─ render fields (dispatch on type × restrictions)                 │
+│        ├─ visibility filter via parameter.dependsOn                       │
+│        └─ option filter via dictionary[i].dependsOnParameterValueIds      │
+│    3. Policies                                                            │
+│    4. Review                                                              │
+│         submit → serialize parameters[] → POST /listings/.../offers       │
+│         on validation errors → form.setError + "Edit parameters" deep-link│
+│                                                                           │
+│  < 1024 px → EmptyState "Open on a desktop screen to edit" + Back link    │
+└────────────────────────────────────────┬──────────────────────────────────┘
+                                         │ HTTP GET
+                                         ▼
+┌───────────────────────────────────────────────────────────────────────────┐
+│                                API                                        │
+│  ListingsController (@Controller('listings'))                             │
+│    GET /listings/connections/:connectionId/categories/:categoryId/        │
+│      parameters                                                           │
+│      ↓                                                                    │
+│    IntegrationsService.getCapabilityAdapter('OfferManager')               │
+│      ↓ narrow via isCategoryParametersReader(adapter)                     │
+│      ↓ if not supported → 501 NotImplementedException                     │
+│      ↓                                                                    │
+│    adapter.fetchCategoryParameters({ categoryId }) → CategoryParameter[]  │
+└────────────────────────────────────────┬──────────────────────────────────┘
+                                         │
+                                         ▼
+┌───────────────────────────────────────────────────────────────────────────┐
+│                         ALLEGRO ADAPTER                                   │
+│  AllegroOfferManagerAdapter implements …, CategoryParametersReader        │
+│    fetchCategoryParameters({ categoryId })                                │
+│      1. CachePort.get(allegro:cat-params:{categoryId})                    │
+│      2. miss → HTTP GET /sale/categories/{id}/parameters                  │
+│      3. raw → neutral via allegro-category-parameter.mapper               │
+│      4. CachePort.set(...) ttl=24h (env-overridable)                      │
+│      5. return CategoryParameter[]                                        │
+└──────────────┬────────────────────────────────────────────────────────────┘
+               │ uses                                              ▲
+               ▼                                                   │
+┌───────────────────────────────────────────────────────────────┐  │
+│                  libs/shared/src/cache/                        │  │
+│  CachePort (interface)                                         │  │
+│  RedisCacheAdapter (wraps existing 'REDIS_CLIENT')             │  │
+│  CACHE_PORT_TOKEN (Symbol)                                     │  │
+└───────────────────────────────────────────────────────────────┘  │
+                                                                   │
+CORE (libs/core/src/listings/):                                    │
+  domain/types/category-parameter.types.ts                         │
+  domain/ports/capabilities/category-parameters-reader.capability.ts ─┘
+  domain/exceptions/category-not-found.exception.ts
+```
+
+## 4. CORE — types, capability, exception
+
+### 4.1 Neutral parameter type — two distinct dependency mechanisms
+
+**Critical correction (post-tech-review):** Allegro models two independent dependency mechanisms; the neutral type must surface both:
+
+1. **Parameter visibility** — a parameter is shown/hidden based on a parent parameter's value. Modeled as `parameter.dependsOn`.
+2. **Dictionary-entry filtering** — within a *visible* dictionary parameter, individual entries appear/disappear based on a parent's value. Modeled per-entry as `dictionary[i].dependsOnParameterValueIds`.
+
+Conflating these (as the previous draft did) silently mis-renders both classes of category. Capture a second sandbox fixture before locking the implementation (see §8 step 1b).
+
+```ts
+// libs/core/src/listings/domain/types/category-parameter.types.ts
+
+/**
+ * Category Parameter Types
+ *
+ * Marketplace-neutral shape for category parameters. The 4 base types
+ * (dictionary | string | integer | float) and the restriction flags
+ * generalize across Allegro / eBay / Amazon / Shopify.
+ *
+ * Allegro distinguishes two dependency mechanisms — both are surfaced:
+ *   - parameter-level visibility (`dependsOn`)
+ *   - dictionary-entry filtering (`dependsOnParameterValueIds`)
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+export const CategoryParameterTypeValues = [
+  'dictionary',
+  'string',
+  'integer',
+  'float',
+] as const;
+export type CategoryParameterType = (typeof CategoryParameterTypeValues)[number];
+
+export interface CategoryParameterDictionaryEntry {
+  id: string;
+  value: string;
+  /**
+   * Entry-level dependency. When present, this entry is selectable only when
+   * the parent parameter (identified by `parameter.dependsOn?.parameterId`,
+   * if any) has one of these value IDs. Independent from parameter-level
+   * visibility — a parameter can be visible while only a subset of its
+   * dictionary entries is selectable for a given parent value.
+   */
+  dependsOnParameterValueIds?: string[];
+}
+
+export interface CategoryParameterRestrictions {
+  /** Dictionary multi-select. */
+  multipleChoices?: boolean;
+  /** Numeric range — user supplies { from, to } instead of single value. */
+  range?: boolean;
+  /** Numeric bounds. */
+  min?: number;
+  max?: number;
+  /** String length bounds. */
+  minLength?: number;
+  maxLength?: number;
+  /** Float decimal precision. */
+  precision?: number;
+  /** SINGLE = max one value, MULTIPLE = many. Allegro-derived but generic. */
+  allowedNumberOfValues?: 'SINGLE' | 'MULTIPLE';
+  /** Dictionary allows free-text values alongside the dictionary list (combobox). */
+  customValuesEnabled?: boolean;
+}
+
+/**
+ * Parameter-level visibility dependency. The parameter is hidden until
+ * the parent has one of these values. Used for true show/hide semantics —
+ * NOT for filtering dictionary entries within an already-visible parameter.
+ */
+export interface CategoryParameterDependsOn {
+  parameterId: string;
+  valueIds: string[];
+}
+
+export interface CategoryParameter {
+  id: string;
+  name: string;
+  type: CategoryParameterType;
+  required: boolean;
+  /** Optional unit label (e.g. "mm", "kg"). */
+  unit?: string;
+  /** Present when type === 'dictionary'. Entries may carry their own `dependsOnParameterValueIds`. */
+  dictionary?: CategoryParameterDictionaryEntry[];
+  restrictions: CategoryParameterRestrictions;
+  /** Parameter-level visibility (show/hide). Distinct from per-entry filtering. */
+  dependsOn?: CategoryParameterDependsOn;
+}
+```
+
+**What is deliberately not modeled in CORE for #410:**
+
+- Allegro's `requiredIf` / `displayedIf` (richer JSONPath-ish predicates) — if a category needs them, the worst case is the user submits and Allegro returns a validation error, the same failure mode as today. Add later if real-world data demands it.
+- Allegro's `formerData` — adapter-only legacy field.
+- Allegro's `options.describesProduct` / `options.saleProperty` — adapter-internal flags.
+
+### 4.2 Capability + guard
+
+```ts
+// libs/core/src/listings/domain/ports/capabilities/category-parameters-reader.capability.ts
+
+/**
+ * Category Parameters Reader Capability
+ *
+ * Optional sub-capability of OfferManagerPort. Implemented by adapters that
+ * expose marketplace category parameter schemas (e.g. Allegro). Returns the
+ * full parameter set — required + optional. UI decides what to surface.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { CategoryParameter } from '../../types/category-parameter.types';
+
+export interface CategoryParametersReader {
+  fetchCategoryParameters(input: { categoryId: string }): Promise<CategoryParameter[]>;
+}
+
+export function isCategoryParametersReader(
+  adapter: unknown,
+): adapter is CategoryParametersReader {
+  return (
+    typeof adapter === 'object' &&
+    adapter !== null &&
+    typeof (adapter as { fetchCategoryParameters?: unknown }).fetchCategoryParameters === 'function'
+  );
+}
+```
+
+Pattern matches the existing capabilities in
+`libs/core/src/listings/domain/ports/capabilities/`. Barrel-export from
+`@openlinker/core/listings`.
+
+### 4.3 Domain exception
+
+```ts
+// libs/core/src/listings/domain/exceptions/category-not-found.exception.ts
+
+/**
+ * Category Not Found Exception
+ *
+ * Thrown by adapters implementing CategoryParametersReader when the
+ * marketplace returns 404 for a categoryId.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+export class CategoryNotFoundException extends Error {
+  constructor(categoryId: string, platform: string) {
+    super(`Category not found: ${categoryId} (platform=${platform})`);
+    this.name = 'CategoryNotFoundException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+```
+
+Auth and generic-upstream errors continue to use the existing
+`IntegrationError` family in the Allegro adapter.
+
+## 5. Allegro adapter
+
+### 5.1 Expand `AllegroCategoryParametersResponse` to real shape
+
+The captured fixture from sandbox `/sale/categories/257933/parameters`
+shows the real shape (visibility-style dependencies). A second fixture
+exercising **dictionary-entry filtering** must be captured before
+implementation locks (see §8 step 1b).
+
+```ts
+// libs/integrations/allegro/src/domain/types/allegro-api.types.ts (replace stub)
+
+export interface AllegroCategoryParameter {
+  id: string;
+  name: string;
+  type: 'dictionary' | 'string' | 'integer' | 'float';
+  required: boolean;
+  requiredForProduct?: boolean;
+  /** JSONPath-ish conditional predicates. Adapter-only — not surfaced to CORE. */
+  requiredIf?: unknown;
+  displayedIf?: unknown;
+  unit?: string;
+  options?: {
+    ambiguousValueId?: string;
+    /** Parent parameter id when this parameter has visibility-level dependency. */
+    dependsOnParameterId?: string;
+    describesProduct?: boolean;
+    customValuesEnabled?: boolean;
+  };
+  /**
+   * Inline dictionary entries; Marka has ~5000 entries.
+   * `dependsOnParameterValueIds` on an entry is the entry-level filter
+   * (independent from `options.dependsOnParameterId`).
+   */
+  dictionary?: Array<{
+    id: string;
+    value: string;
+    dependsOnParameterValueIds?: string[];
+  }>;
+  restrictions?: {
+    multipleChoices?: boolean;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+    range?: boolean;
+    precision?: number;
+    allowedNumberOfValues?: 'SINGLE' | 'MULTIPLE';
+  };
+  /** Legacy migration data — adapter ignores. */
+  formerData?: unknown;
+}
+
+export interface AllegroCategoryParametersResponse {
+  parameters: AllegroCategoryParameter[];
+}
+```
+
+### 5.2 Raw → neutral mapper (separates the two dependency mechanisms)
+
+```ts
+// libs/integrations/allegro/src/infrastructure/mappers/allegro-category-parameter.mapper.ts
+
+/**
+ * Allegro Category Parameter Mapper
+ *
+ * Maps Allegro's raw parameter response shape to the marketplace-neutral
+ * CategoryParameter contract. Surfaces both dependency mechanisms:
+ *   - parameter-level visibility (options.dependsOnParameterId)
+ *   - dictionary-entry filtering (dictionary[i].dependsOnParameterValueIds)
+ *
+ * @module libs/integrations/allegro/src/infrastructure/mappers
+ */
+import type {
+  CategoryParameter,
+  CategoryParameterDictionaryEntry,
+} from '@openlinker/core/listings';
+import type { AllegroCategoryParameter } from '../../domain/types/allegro-api.types';
+
+export function toNeutralCategoryParameter(
+  raw: AllegroCategoryParameter,
+): CategoryParameter {
+  const dependsOnParameterId = raw.options?.dependsOnParameterId;
+
+  // Parameter-level visibility: the union of every dictionary entry's
+  // dependsOnParameterValueIds is the set of parent values for which
+  // *any* option of this parameter is selectable. If that union is empty
+  // and dependsOnParameterId is also absent, the parameter has no
+  // parameter-level dependency.
+  const visibilityValueIds = dependsOnParameterId
+    ? unionEntryParentValues(raw.dictionary ?? [])
+    : [];
+
+  return {
+    id: raw.id,
+    name: raw.name,
+    type: raw.type,
+    required: raw.required,
+    unit: raw.unit,
+    dictionary: raw.dictionary?.map(toNeutralEntry),
+    restrictions: {
+      multipleChoices: raw.restrictions?.multipleChoices,
+      range: raw.restrictions?.range,
+      min: raw.restrictions?.min,
+      max: raw.restrictions?.max,
+      minLength: raw.restrictions?.minLength,
+      maxLength: raw.restrictions?.maxLength,
+      precision: raw.restrictions?.precision,
+      allowedNumberOfValues: raw.restrictions?.allowedNumberOfValues,
+      customValuesEnabled: raw.options?.customValuesEnabled,
+    },
+    dependsOn:
+      dependsOnParameterId && visibilityValueIds.length > 0
+        ? { parameterId: dependsOnParameterId, valueIds: visibilityValueIds }
+        : undefined,
+  };
+}
+
+function toNeutralEntry(d: NonNullable<AllegroCategoryParameter['dictionary']>[number]): CategoryParameterDictionaryEntry {
+  return {
+    id: d.id,
+    value: d.value,
+    dependsOnParameterValueIds: d.dependsOnParameterValueIds,
+  };
+}
+
+function unionEntryParentValues(
+  dict: Array<{ dependsOnParameterValueIds?: string[] }>,
+): string[] {
+  const set = new Set<string>();
+  for (const entry of dict) {
+    for (const id of entry.dependsOnParameterValueIds ?? []) set.add(id);
+  }
+  return [...set];
+}
+```
+
+### 5.3 Adapter implementation + `CachePort` wiring
+
+```ts
+// libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+
+class AllegroOfferManagerAdapter
+  implements OfferManagerPort, /* … existing … */, CategoryParametersReader {
+
+  // injected via factory:
+  //   private readonly cache: CachePort,
+
+  private readonly catParamsTtlSec: number;
+
+  constructor(/* …, */ private readonly cache: CachePort, configService: ConfigService) {
+    this.catParamsTtlSec = Number(configService.get('OL_ALLEGRO_CAT_PARAMS_TTL_SEC') ?? 86400);
+    // … existing
+  }
+
+  async fetchCategoryParameters(input: { categoryId: string }): Promise<CategoryParameter[]> {
+    const cacheKey = `allegro:cat-params:${input.categoryId}`;
+    const cached = await this.cache.get<CategoryParameter[]>(cacheKey);
+    if (cached) return cached;
+
+    this.logger.debug(
+      `Fetching Allegro category parameters: connection=${this.connectionId} categoryId=${input.categoryId}`,
+    );
+
+    let response: AxiosResponse<AllegroCategoryParametersResponse>;
+    try {
+      response = await this.httpClient.get<AllegroCategoryParametersResponse>(
+        `/sale/categories/${input.categoryId}/parameters`,
+      );
+    } catch (err) {
+      if (isAllegroNotFound(err)) {
+        throw new CategoryNotFoundException(input.categoryId, 'allegro');
+      }
+      throw err; // existing IntegrationError mapping handles auth / 5xx etc.
+    }
+
+    const neutral = (response.data.parameters ?? []).map(toNeutralCategoryParameter);
+    await this.cache.set(cacheKey, neutral, this.catParamsTtlSec);
+    return neutral;
+  }
+}
+```
+
+**Cache notes:**
+
+- **`CachePort` is introduced in this PR** at `libs/shared/src/cache/` — it does not currently exist (verified during planning). Existing infrastructure exposes only a raw `'REDIS_CLIENT'` string token via `RedisConfigModule`; the new `CachePort` wraps it. See §5a.
+- Key is **global** (`allegro:cat-params:{categoryId}`), not connection-scoped — Allegro category schemas are public taxonomy and identical for every seller.
+- **TTL: env-overridable** via `OL_ALLEGRO_CAT_PARAMS_TTL_SEC` (default `86400`). Allows quick cache-bust during sandbox debug; keys can also be deleted directly via `redis-cli`.
+- Cache stores the *neutral* shape, not the raw Allegro response — cleaner invalidation semantics if mapping is adjusted.
+
+### 5.4 Refactor `fetchOfferIdentifiers`
+
+Currently calls `httpClient.get<AllegroCategoryParametersResponse>` directly.
+Refactor to call `this.fetchCategoryParameters({ categoryId })` (cached
++ neutral) and find the EAN parameter by name. Single source of truth for
+the endpoint call.
+
+### 5.5 Tests
+
+- **Mapper spec** (`allegro-category-parameter.mapper.spec.ts`): use both fixtures —
+  - `category-parameters-257933.json` → assert per-type round-trip, restriction propagation, parameter-level `dependsOn` derivation, `customValuesEnabled` hoist.
+  - `category-parameters-cascading-dictionary.json` → assert that dictionary entries with `dependsOnParameterValueIds` carry the field through to the neutral entry, and that parameter-level `dependsOn` is **only** derived when `options.dependsOnParameterId` is set.
+- **Adapter spec** (`allegro-offer-manager.adapter.spec.ts`): cache hit (no HTTP call), cache miss (HTTP + cache write), 404 → `CategoryNotFoundException`, env-overridden TTL, `fetchOfferIdentifiers` continues to find EAN after refactor.
+
+## 5a. Shared `CachePort` (new infrastructure)
+
+> Introduced in this PR because no cache abstraction exists today and `engineering-standards.md` discourages coupling adapters to string DI tokens.
+
+```ts
+// libs/shared/src/cache/cache.types.ts
+export const CACHE_PORT_TOKEN = Symbol('CachePort');
+```
+
+```ts
+// libs/shared/src/cache/cache.port.ts
+
+/**
+ * Cache Port
+ *
+ * Contract for distributed key-value caching. Wraps the existing global
+ * 'REDIS_CLIENT' provider behind a refactor-safe Symbol token.
+ *
+ * @module libs/shared/src/cache
+ */
+export interface CachePort {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T, ttlSec: number): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+```
+
+```ts
+// libs/shared/src/cache/redis-cache.adapter.ts
+
+/**
+ * Redis Cache Adapter
+ *
+ * Implements CachePort over the existing 'REDIS_CLIENT' provider. Stores
+ * values as JSON. Logs warnings on parse failure; returns null on cache miss.
+ *
+ * @module libs/shared/src/cache
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import type { RedisClientType } from 'redis';
+import { Logger } from '../logging';
+import type { CachePort } from './cache.port';
+
+@Injectable()
+export class RedisCacheAdapter implements CachePort {
+  private readonly logger = new Logger(RedisCacheAdapter.name);
+
+  constructor(@Inject('REDIS_CLIENT') private readonly client: RedisClientType) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    const raw = await this.client.get(key);
+    if (raw === null) return null;
+    try {
+      return JSON.parse(raw) as T;
+    } catch (err) {
+      this.logger.warn(`Failed to parse cache value for key ${key}: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  async set<T>(key: string, value: T, ttlSec: number): Promise<void> {
+    await this.client.set(key, JSON.stringify(value), { EX: ttlSec });
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+}
+```
+
+```ts
+// libs/shared/src/cache/cache.module.ts
+
+/**
+ * Cache Module
+ *
+ * Binds CachePort to RedisCacheAdapter. Imports the global RedisConfigModule
+ * for the underlying 'REDIS_CLIENT' provider.
+ *
+ * @module libs/shared/src/cache
+ */
+import { Global, Module } from '@nestjs/common';
+import { RedisConfigModule } from '../redis';
+import { RedisCacheAdapter } from './redis-cache.adapter';
+import { CACHE_PORT_TOKEN } from './cache.types';
+
+@Global()
+@Module({
+  imports: [RedisConfigModule],
+  providers: [
+    RedisCacheAdapter,
+    { provide: CACHE_PORT_TOKEN, useExisting: RedisCacheAdapter },
+  ],
+  exports: [CACHE_PORT_TOKEN],
+})
+export class CacheModule {}
+```
+
+`AllegroIntegrationModule` imports `CacheModule` and the adapter factory
+injects `CACHE_PORT_TOKEN`.
+
+**Test:** `redis-cache.adapter.spec.ts` — round-trip get/set, TTL forwarded
+to underlying client, JSON parse failure returns null + logs warning,
+delete clears.
+
+## 6. API — `GET /listings/connections/:connectionId/categories/:categoryId/parameters`
+
+> The `ListingsController` base path is `@Controller('listings')` (verified during planning).
+
+### 6.1 Controller (no service facade — direct `IIntegrationsService` use)
+
+> The previous draft mentioned a `ListingsCategoryParametersService` facade
+> in §3 that contradicted the controller code. **Decision: drop the
+> facade** — the controller is a thin read endpoint and routing through
+> `IIntegrationsService` directly is consistent with sibling listings
+> endpoints. If cross-controller reuse emerges later, introduce the
+> service then.
+
+```ts
+@Get('connections/:connectionId/categories/:categoryId/parameters')
+@UseGuards(JwtAuthGuard)
+async getCategoryParameters(
+  @Param('connectionId') connectionId: string,
+  @Param('categoryId') categoryId: string,
+): Promise<{ parameters: CategoryParameterResponseDto[] }> {
+  const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+    connectionId,
+    'OfferManager',
+  );
+  if (!isCategoryParametersReader(adapter)) {
+    throw new NotImplementedException(
+      `Adapter for connection ${connectionId} does not support CategoryParametersReader`,
+    );
+  }
+  const parameters = await adapter.fetchCategoryParameters({ categoryId });
+  return { parameters: parameters.map(toCategoryParameterResponseDto) };
+}
+```
+
+### 6.2 Response DTO
+
+`apps/api/src/listings/http/dto/category-parameter-response.dto.ts` —
+class with `class-validator` + `@ApiProperty` decorators, mirroring
+`CategoryParameter` 1:1 (including the per-entry `dependsOnParameterValueIds`).
+
+### 6.3 Tests
+
+- happy path: returns `{ parameters: [...] }` with mapped DTOs.
+- connection not found → 404 (existing `getCapabilityAdapter` behavior).
+- adapter doesn't support capability → 501 NotImplementedException.
+- adapter throws `CategoryNotFoundException` → propagates as 404 via existing exception filter (or wrap in a NestJS `NotFoundException` if filter mapping doesn't catch it — verify during implementation).
+
+## 7. FE — wizard integration (desktop ≥ 1024 px)
+
+### 7.1 API client + query hook
+
+```ts
+// apps/web/src/features/listings/api/listings.types.ts
+export interface CategoryParameterDictionaryEntry {
+  id: string;
+  value: string;
+  dependsOnParameterValueIds?: string[]; // entry-level filter
+}
+
+export interface CategoryParameter {
+  id: string;
+  name: string;
+  type: 'dictionary' | 'string' | 'integer' | 'float';
+  required: boolean;
+  unit?: string;
+  dictionary?: CategoryParameterDictionaryEntry[];
+  restrictions: {
+    multipleChoices?: boolean;
+    range?: boolean;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+    precision?: number;
+    allowedNumberOfValues?: 'SINGLE' | 'MULTIPLE';
+    customValuesEnabled?: boolean;
+  };
+  dependsOn?: { parameterId: string; valueIds: string[] }; // parameter-level visibility
+}
+
+// apps/web/src/features/listings/api/listings.query-keys.ts
+export const listingsQueryKeys = {
+  // …existing keys
+  categoryParameters: (connectionId: string, categoryId: string) =>
+    ['listings', 'category-parameters', connectionId, categoryId] as const,
+};
+
+// apps/web/src/features/listings/hooks/use-category-parameters-query.ts
+export function useCategoryParametersQuery(
+  connectionId: string | undefined,
+  categoryId: string | undefined,
+): UseQueryResult<CategoryParameter[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: listingsQueryKeys.categoryParameters(connectionId ?? '', categoryId ?? ''),
+    queryFn: () => apiClient.listings.fetchCategoryParameters(connectionId!, categoryId!),
+    enabled: Boolean(connectionId && categoryId),
+    staleTime: 24 * 60 * 60 * 1000, // matches Redis TTL default
+  });
+}
+```
+
+### 7.2 Virtualized `Combobox` primitive — design spec
+
+`apps/web/src/shared/ui/combobox.tsx` (kebab-case per
+`frontend-architecture.md` §"Naming conventions"). Wraps
+`shared/ui/popover.tsx` (which itself wraps `@radix-ui/react-popover`)
+for portal + positioning + dismissal — inherits focus management for
+free.
+
+**Density & tokens** (matches `frontend-ui-style-guide.md` §"Density & Row Heights"):
+
+| Element | Spec |
+|---|---|
+| Trigger height | `32px` (matches `Input` / `Select`) |
+| Trigger radius | `6px` |
+| Trigger border (resting) | `--border-default` |
+| Trigger border (focus) | `--accent-focus` |
+| Listbox panel padding | `4px` |
+| Listbox panel radius | `8px` |
+| Listbox panel border | `--border-default` |
+| Listbox panel shadow | level-1 only (no glow) |
+| Option row height | `32px` desktop / `40px` touch (`@media (pointer: coarse)`) |
+| Option resting bg | `transparent` |
+| Option hover bg | `--bg-surface-hover` |
+| Option selected bg | `--bg-surface-muted` + `--text-primary` `font-weight: 600` |
+| Option label font | body `13.5/20` |
+| Secondary metadata (id) | `12/16` `--text-muted` (mono if id) |
+
+**Variants:**
+
+- `mode="single"` → returns single `id` string.
+- `mode="multi"` → returns `id[]`. Selected items render as inline chips inside the trigger (28px height, `--bg-surface-muted` background, ✕ remove). Overflow `+N more`.
+- `customValues={true}` → free-text passthrough. Behavior in §7.3.
+
+**Filter-first behavior** (mandatory for dictionaries with `entries.length ≥ 50`):
+
+- On open, autofocus the search input.
+- Show **no options** until the user types ≥ 1 character.
+- Render counter line: `Showing {visible} of {total} options`.
+- Empty-search state: `Type to search {parameterName}…`.
+
+**ARIA combobox pattern:**
+
+- Trigger: `role="combobox"`, `aria-expanded`, `aria-controls={listboxId}`, `aria-autocomplete="list"`.
+- Listbox: `role="listbox"`, `aria-multiselectable={multi}`.
+- Options: `role="option"`, `aria-selected`.
+- Keyboard: `ArrowDown`/`ArrowUp` (with virtualizer scrollIntoView), `Home`/`End`, `Enter` to commit, `Escape` to dismiss, `Backspace` removes last chip in multi-mode when input is empty.
+
+**Virtualization:**
+
+`@tanstack/react-virtual` (verify already a transitive dep via
+`@tanstack/react-table`; otherwise add). Active when `entries.length ≥ 200`.
+
+**Test:** `combobox.test.tsx` — single, multi, custom passthrough, filter-first
+gating, keyboard nav, virtualization activation threshold.
+
+### 7.3 `category-parameters-step` component
+
+`apps/web/src/features/listings/components/category-parameters-step.tsx`.
+
+**Header:**
+- Single line: `Category {categoryId} · {leafName}` — `leafName` from existing category cache. Mono for `categoryId`. Avoids the cost of building a multi-segment breadcrumb endpoint for #410. (Breadcrumb endpoint is a follow-up if operators ask.)
+
+**States:**
+- **loading** → `<LoadingState>` skeleton — N=5 skeleton FormField rows at the documented row heights so layout doesn't shift on data arrival.
+- **error** → `<Alert tone="error">` with retry button.
+- **empty** (`parameters.length === 0`) → `<EmptyState>` `"No additional parameters required for this category."` + **pre-focused Continue button** (operator advances deliberately; no auto-advance).
+- **data** → render the fields.
+
+**Layout:**
+- **Required-first** section, expanded.
+- **Optional** behind a `<details>`-style expander: `Show optional fields ({visibleOptionalCount})`. Count uses `useMemo` keyed on visibility — recomputes on every form change.
+
+**Visibility filter (`dependsOn`):**
+- Each parameter checks `dependsOn` against current form values; hidden parameters are skipped.
+- On hide, form values are cleared via `form.setValue(p.id, undefined)` in an effect (matches Q3 grilling decision).
+- On submit failure where Zod cites a hidden-but-required field: the optional expander auto-opens, the field is scrolled into view, and a transient `<Toast>` reads `"{N} additional fields became required"`.
+
+**Dictionary-entry filtering visual cue:**
+
+When a parent parameter narrows visible dictionary entries for a child parameter (via per-entry `dependsOnParameterValueIds`), the child field renders a `12/16` muted helper line above the input:
+
+```
+Filtered by {parentParameter.name}: {parentValue.label}
+```
+
+Operator immediately understands why their option list is shorter than the full dictionary. Helper line drops when the parent has no value yet (and the field is therefore filtered to its always-available subset, or empty).
+
+**Renderer dispatch on `(type, restrictions)`:**
+
+| `(type, restrictions)` | Renderer |
+|---|---|
+| `dictionary`, `entries.length < 50`, single | native `<Select>` |
+| `dictionary`, `entries.length ≥ 50` or `customValuesEnabled`, single | `<Combobox mode="single">` |
+| `dictionary`, `multipleChoices: true` | `<Combobox mode="multi">` |
+| `dictionary`, `customValuesEnabled: true` | `<Combobox customValues>` |
+| `string` | `<Input>` text |
+| `integer`, no `range` | `<Input type="number">` (integer step) |
+| `integer`, `range: true` | `[from] – [to] [unit]` inline (two `<Input type="number">`) |
+| `float`, no `range` | `<Input type="number">` (decimal step from `precision`) |
+| `float`, `range: true` | `[from] – [to] [unit]` inline |
+
+**`customValuesEnabled` affordance** (UX-visible, not just submit logic):
+
+- Combobox placeholder: `"Pick from list or type a custom value"` when focused.
+- Listbox bottom row when typed input doesn't match: `"Use as custom value: «typed»"` — selecting commits as free text.
+- Custom-value chip differentiated by `border-left: 2px dotted var(--border-strong)` (shape, not color, per `frontend-ui-style-guide.md` rule "color must never be the only signal").
+
+**Auto-fill hint** (§7.4):
+
+- Subtitle below input: `"Auto-filled from variant data"`, `12/16` `--text-muted`, no icon, no color. Disappears when the field becomes RHF-dirty.
+
+**Typography slot pinning:**
+
+- Step eyebrow ("Category parameters") → `0.6875rem / 600 / 0.09em`.
+- Step description ("Required and optional fields for {category}") → `0.875rem` body.
+- Parameter label → `0.75rem / 600 / 0.05em` (FormField label slot).
+- Parameter description → `0.75rem / 400` muted.
+- Required asterisk → `--status-error` text after label, no other color.
+
+Co-located test (`category-parameters-step.test.tsx`): required validation,
+type dispatch, parameter-visibility hide-and-clear, dictionary-entry
+filtering narrows options, customValues passthrough, prefill apply,
+empty state renders pre-focused Continue, auto-expand on hidden-required
+error.
+
+### 7.4 Auto-prefill helper
+
+```ts
+// apps/web/src/features/listings/components/auto-prefill-parameters.ts
+
+const EAN_NAME_PATTERNS = ['ean (gtin)', 'ean', 'gtin', 'kod ean'];
+const CONDITION_NAME_PATTERNS = ['stan'];
+const NEW_VALUE_PATTERNS = ['nowy', 'new'];
+
+export function autoPrefillParameters(
+  parameters: CategoryParameter[],
+  variant: { ean?: string },
+): Record<string, FormParameterValue> {
+  const out: Record<string, FormParameterValue> = {};
+  for (const p of parameters) {
+    const nameLower = p.name.toLowerCase();
+
+    if (EAN_NAME_PATTERNS.includes(nameLower) && variant.ean) {
+      out[p.id] = variant.ean;
+      continue;
+    }
+
+    if (CONDITION_NAME_PATTERNS.includes(nameLower) && p.type === 'dictionary') {
+      const newOption = p.dictionary?.find((d) =>
+        NEW_VALUE_PATTERNS.includes(d.value.toLowerCase()),
+      );
+      if (newOption) out[p.id] = newOption.id;
+    }
+  }
+  return out;
+}
+```
+
+Applied via `form.reset({ …current, parameters: { …prefilled, …current.parameters } })`
+when parameters first load (via `useEffect` keyed on the parameters reference).
+Already-typed values win over prefill (don't clobber on re-fetch). Brand /
+producer-code prefill is deferred to **#412**.
+
+### 7.5 Dynamic Zod schema (handles both dependency mechanisms)
+
+```ts
+// apps/web/src/features/listings/components/build-parameters-zod-schema.ts
+export function buildParametersZodSchema(parameters: CategoryParameter[]): z.ZodTypeAny {
+  return z.object(
+    Object.fromEntries(parameters.map((p) => [p.id, fieldSchema(p)])),
+  ).superRefine((values, ctx) => {
+    for (const p of parameters) {
+      if (!isParameterVisible(p, values)) continue;          // dependsOn check
+      if (!p.required) continue;
+      if (isEmpty(values[p.id])) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [p.id],
+          message: `${p.name} is required`,
+        });
+      }
+      // Reject dictionary value(s) whose entry is filtered out by current parent value
+      if (p.type === 'dictionary' && p.dependsOn) {
+        const allowedIds = allowedDictionaryEntryIds(p, values);
+        const selected = toIdArray(values[p.id]);
+        for (const id of selected) {
+          if (!allowedIds.has(id)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [p.id],
+              message: `${p.name}: selected option is not available for current ${p.dependsOn.parameterId}`,
+            });
+          }
+        }
+      }
+    }
+  });
+}
+```
+
+`isParameterVisible(p, values)` → checks `p.dependsOn` against current parent value.
+`allowedDictionaryEntryIds(p, values)` → returns the set of dictionary entry IDs whose `dependsOnParameterValueIds` includes the current parent value (or whose field is empty, meaning "available regardless").
+
+Schema rebuilt + memoized whenever `parameters` reference changes; merged
+with the existing wizard schema and plumbed into RHF via
+`useForm({ resolver: zodResolver(combinedSchema) })`.
+
+### 7.6 Submit serializer
+
+```ts
+// apps/web/src/features/listings/components/serialize-allegro-parameters.ts
+export function serializeAllegroParameters(
+  values: Record<string, FormParameterValue>,
+  meta: CategoryParameter[],
+): { submitted: AllegroParameterInput[] } {
+  const submitted = meta
+    .filter((p) => isParameterVisible(p, values))
+    .map((p) => mapOne(p, values[p.id]))
+    .filter((x): x is AllegroParameterInput => x !== null);
+  return { submitted };
+}
+```
+
+`mapOne` handles the four cases (single dictionary, multi dictionary,
+range, scalar). For `customValuesEnabled`: if user input matches a
+dictionary entry (case-insensitive, trimmed) → emit `valuesIds`, else
+`values`. Output is appended to `platformParams.parameters`.
+
+The function returns `{ submitted }` (an object, not a bare array) so the
+caller can keep the array reference alongside the form-level submission
+state and use it for error mapping (§7.7).
+
+### 7.7 Wizard integration in `CreateOfferWizard.tsx`
+
+- Update `STEP_LABELS` to 5 steps:
+  ```
+  ['Connection & Variant', 'Offer details', 'Category parameters', 'Policies', 'Review']
+  ```
+- Update `STEP_FIELDS[2]` to validate `parameters` field on advance.
+- Pre-fetch `useCategoryParametersQuery` at wizard mount once `categoryId` is set; when the user reaches Step 2 the data is usually already there.
+- On `categoryId` change in Step 1, clear `parameters` form values (`form.setValue('parameters', {})`) — schemas differ per category.
+- Render `<CategoryParametersStep>` when `stepIndex === 2`.
+- Submit serializer (§7.6) called inside the existing `toApiInput` mapper before `useCreateOfferMutation`.
+- **Sticky wizard footer on Step 2:** the Back/Continue footer position-sticks at the bottom of the wizard card (`position: sticky; bottom: 0; background: var(--bg-surface); border-top: 1px solid var(--border-subtle); padding: 12px 16px;`). Optional sections can grow long; Continue must remain in reach.
+
+**Error-mapping snapshot (explicit lifetime):**
+
+```
+1. serializeAllegroParameters(values, meta) → { submitted }
+2. Wizard captures `submittedSnapshot = submitted` in component state at submit time.
+3. useCreateOfferMutation runs; on validation error:
+4.    for each error in error.validation.errors:
+5.        const m = error.path?.match(/^parameters\[(\d+)\]/);
+6.        const paramId = m ? submittedSnapshot[Number(m[1])]?.id : null;
+7.        if (paramId) form.setError(`parameters.${paramId}`, { message: error.userMessage ?? error.message });
+```
+
+The snapshot **must** come from the serializer's submitted array (with hidden parameters filtered out) — `parameters[N]` indexes that array, not the metadata array.
+
+Add a "Edit parameters" button on the Review step that calls `setStepIndex(2)`.
+
+### 7.8 Retry pre-fill
+
+`create-offer-request-to-form-values.ts` — extract the existing
+`platformParams.parameters` array on retry; store as raw passthrough
+in form state until the parameters query resolves; on parameters load,
+hydrate form values against the schema (mismatched parameter IDs are
+dropped; mismatched dictionary value-IDs are dropped — schema is the
+source of truth).
+
+### 7.9 Tests
+
+- `combobox.test.tsx` — see §7.2.
+- `category-parameters-step.test.tsx` — see §7.3.
+- `auto-prefill-parameters.test.ts` — EAN, Stan, no-match, missing variant fields.
+- `serialize-allegro-parameters.test.ts` — single, multi, range, customValues match-or-passthrough, hidden-skipped, returns `{ submitted }` shape.
+- `build-parameters-zod-schema.test.ts` — required + visible blocks submit, hidden required passes, dictionary-entry filter rejects orphan selections, range cross-field.
+- `CreateOfferWizard.test.tsx` extension — 5-step layout, params loaded on category change, parameters cleared on category change, retry pre-fill, error-mapping deep-link, sub-1024 viewport renders the desktop-only affordance (see §7.10).
+
+### 7.10 Responsive — desktop-only for #410
+
+Per `frontend-ui-style-guide.md` §Responsive ("Complex editors → read-only +
+'open on desktop to edit' below 1024 px"), the create-offer wizard ships
+**desktop-only** in this PR:
+
+- **`< 1024 px`** — the wizard route renders `<EmptyState>` with copy
+  *"Open on a desktop screen to edit"* + `<BackLink>` to `/listings`.
+  Continue / Save are not rendered. The state lives at the wizard root,
+  so all steps share the affordance.
+- **`≥ 1024 px`** — full wizard as designed in §7.1–§7.9.
+
+Implementation: a single `useMediaQuery('(min-width: 1024px)')` gate at
+`CreateOfferWizard.tsx` top-level. Existing `useMediaQuery` hook in
+`shared/utils` (verify during implementation; trivial to add otherwise).
+
+This applies to **all** wizard steps, not just the new Step 2 — the
+existing Steps 0/1/3/4 also fail the responsive parity rule for "complex
+editors". Documenting this here keeps it explicit; mobile/tablet
+interactivity is a separate epic.
+
+Test: `CreateOfferWizard.test.tsx` mocks `matchMedia` and asserts the
+empty-state affordance renders below 1024 px.
+
+## 8. Step-by-step implementation
+
+| # | Task | Files |
+|---|---|---|
+| 1 | Capture sandbox fixture for category 257933 via `pnpm --filter @openlinker/api allegro:capture-cat-params <connId> 257933 <path>`. The single capture covers both mechanisms (visibility + entry-filter) — no second fixture required. | `__fixtures__/category-parameters-257933.json` |
+| 2 | **Shared CachePort + RedisCacheAdapter + CacheModule + spec** | 5 new files in `libs/shared/src/cache/` + barrel update |
+| 3 | CORE — `CategoryParameter` types + capability + guard + `CategoryNotFoundException` + spec | 4 new files in `libs/core/src/listings/domain/` + barrel update |
+| 4 | Allegro — expand `AllegroCategoryParametersResponse`; add raw→neutral mapper (parameter-visibility + dictionary-entry-filtering separation) + mapper spec using **both** fixtures | edit `allegro-api.types.ts`; new `allegro-category-parameter.mapper.ts` + spec |
+| 5 | Allegro — implement `fetchCategoryParameters` with `CachePort` + env-overridable TTL, declare `CategoryParametersReader` in `implements`, refactor `fetchOfferIdentifiers`, wire `CacheModule` in `AllegroIntegrationModule`, extend adapter spec | edits in `libs/integrations/allegro/src/` |
+| 6 | API — controller endpoint + DTO (mirrors per-entry filter) + spec | `apps/api/src/listings/http/` |
+| 7 | FE — API client method, types (incl. per-entry `dependsOnParameterValueIds`), query keys, query hook | `apps/web/src/features/listings/api/` + `hooks/` |
+| 8 | FE — virtualized `combobox.tsx` primitive in `shared/ui/` (Radix-popover-wrapped, density spec, ARIA, filter-first, customValues affordance) + spec | new `combobox.tsx` + `combobox.test.tsx` |
+| 9 | FE — `category-parameters-step.tsx` + `auto-prefill-parameters.ts` + `serialize-allegro-parameters.ts` + `build-parameters-zod-schema.ts` + tests | new in `features/listings/components/` |
+| 10 | FE — wizard integration: insert Step 2, dynamic Zod, submit serializer with `{ submitted }` snapshot, error-mapping deep-link, retry pre-fill, sticky footer, sub-1024 desktop-only affordance | edits in `CreateOfferWizard.tsx`, `create-offer-fields.schema.ts`, `create-offer-request-to-form-values.ts` + tests |
+| 11 | File-header sweep: every new `.ts`/`.tsx` carries the JSDoc header documented in `engineering-standards.md` §"File Headers" | — |
+| 12 | Quality gate: `pnpm lint && pnpm type-check && pnpm test` | — |
+| 13 | Manual sandbox verification: pick a category with required params (e.g. 257933), step through wizard, submit, verify offer creates without `MissingRequiredParameters` | — |
+
+## 9. Locked-in design decisions (post-grilling + post-review)
+
+1. **Type taxonomy** — 4 base types (`dictionary | string | integer | float`) + a `restrictions` struct. Cross-marketplace portable.
+2. **Two distinct dependency mechanisms** — parameter-level visibility (`parameter.dependsOn`) and dictionary-entry filtering (`dictionary[i].dependsOnValueIds` — Allegro's exact field name) modeled separately throughout. Single fixture (cat 257933) covers both, verified by inspection.
+3. **Brand typeahead** — Full dictionary inline; FE renders via virtualized `Combobox` (filter-first when ≥ 50 entries); backend cache via the new `CachePort`, **24h default TTL** (`OL_ALLEGRO_CAT_PARAMS_TTL_SEC`), **global key** (`allegro:cat-params:{categoryId}`).
+4. **Cache abstraction** — Introduce `CachePort` in `libs/shared/src/cache/` (no fallback). Wraps the existing `'REDIS_CLIENT'` provider behind a Symbol token.
+5. **Cascading dependencies** — Static render + visibility filter (`dependsOn`) + entry-level filter (`dependsOnParameterValueIds`). Hidden parameters' form values are cleared on hide. Skip Allegro's richer `requiredIf` / `displayedIf` for this PR.
+6. **Wizard layout** — New dedicated Step 2 between Offer details and Policies. Wizard becomes 5 steps. Parameter values cleared when `categoryId` changes. Sticky Back/Continue footer on Step 2.
+7. **Form state shape** — Flat dict `parameters: Record<paramId, FormParameterValue>`. Submit-time serializer returns `{ submitted }` for use as the error-mapping snapshot.
+8. **Auto-prefill** — Conservative for #410: EAN (matched by name patterns) + Stan defaulted to "Nowy". Brand / producer-code deferred to **#412**.
+9. **Retry pre-fill** — Stay on Review on failure; map Allegro `validation.errors[]` positional paths back to parameter IDs via the *submitted-snapshot* (not the metadata array); surface inline via `form.setError`; "Edit parameters" button deep-links to Step 2.
+10. **API + CORE shape** — Capability `CategoryParametersReader` returns full parameter set. Controller talks directly to `IIntegrationsService` (no service facade). Endpoint: `GET /listings/connections/:connectionId/categories/:categoryId/parameters` (verified `@Controller('listings')` prefix).
+11. **Service facade** — Not introduced. The §3 architecture diagram and the §6.1 controller code agree.
+12. **FE filenames** — kebab-case for new files (`combobox.tsx`, `category-parameters-step.tsx`, etc.). Existing PascalCase siblings keep their names.
+13. **Empty Step 2 UX** — `<EmptyState>` + pre-focused Continue button, no auto-advance.
+14. **Custom values affordance** — Visible UI cue when `customValuesEnabled` is true; custom-value chip differentiated by dotted left border (shape, not color).
+15. **Responsive** — Desktop-only for #410 (≥ 1024 px). Below threshold: documented "Open on a desktop screen to edit" affordance for the entire wizard.
+
+## 10. Validation against engineering standards
+
+- ✅ **Hexagonal:** capability port lives in CORE `domain/ports/capabilities/`; adapter implements; API resolves via `IIntegrationsService` + capability narrowing; FE talks only to the API.
+- ✅ **Capability sub-interface pattern:** matches existing `OfferLister` / `OfferCreator` shape — `*.capability.ts` with co-located `is{Capability}` guard.
+- ✅ **Types in `*.types.ts`:** all parameter-shape types in dedicated files.
+- ✅ **`as const` + union pattern:** used for `CategoryParameterType`, `allowedNumberOfValues`.
+- ✅ **No `any`:** discriminated form-value handling, typed wire-shape mapping.
+- ✅ **No DB / migration impact.**
+- ✅ **Symbol DI tokens:** `CACHE_PORT_TOKEN` is a Symbol (no string DI tokens introduced for our code; underlying `'REDIS_CLIENT'` is existing infrastructure).
+- ✅ **Domain exception placement:** `CategoryNotFoundException` in `libs/core/src/listings/domain/exceptions/`.
+- ✅ **File headers:** all new `.ts`/`.tsx` files include the JSDoc header documented in `engineering-standards.md` §"File Headers" (sweep step in §8).
+- ✅ **Cache port abstraction:** `libs/shared/src/cache/` follows the same shape as existing port + adapter pairs in CORE.
+- ✅ **FE rules:**
+  - Component primitives reused (`<Input>`, `<Select>`, `FormField`, `EmptyState`, `LoadingState`, `Alert`, `Toast`, `BackLink`); new `<Combobox>` lives in `shared/ui/` (not `features/`) per dependency-direction rule.
+  - Combobox wraps `shared/ui/popover.tsx` (Radix) per "headless wrapped by primitive" rule.
+  - Query hook follows `use-X-query.ts` pattern; query key in `*.query-keys.ts`.
+  - Form state via React Hook Form + Zod; loading/error/empty/data states all handled.
+  - No raw API calls from components.
+  - Filenames kebab-case for new files.
+  - Color is never the sole signal (custom-value chips use shape).
+  - Density: 32 px form controls, 32/40 px option rows, 28 px chips.
+  - Typography: pinned to canonical scale per `frontend-ui-style-guide.md`.
+
+## 11. Non-goals (explicit)
+
+- **Allegro `product`-typed parameters / catalog binding** — out of scope; if a category surfaces this we render a read-only banner.
+- **Allegro `requiredIf` / `displayedIf` rich predicates** — not modeled in CORE; rely on Allegro's response on submit if a category needs them.
+- **Brand and producer-code auto-prefill** — deferred to **#412**.
+- **Per-shop / per-connection prefill mapping config** — out of scope.
+- **Cross-category parameter-value reuse** — schema fetched fresh per category; no client-side merging.
+- **Localization toggle for parameter names** — render verbatim what Allegro returns (operator-language, typically Polish).
+- **Mobile / tablet interactive editing** — explicitly out of scope. The wizard is desktop-only (≥ 1024 px) and shows the documented "Open on a desktop screen to edit" affordance below the threshold. Mobile-interactive wizards are a separate epic.
+- **Multi-segment category breadcrumb endpoint** — not added in this PR. Step 2 header shows `Category {id} · {leafName}` only. Breadcrumb endpoint is a follow-up if operators ask.
+- **`ListingsCategoryParametersService` facade** — not introduced. Controller routes through `IIntegrationsService` directly. Add only if cross-controller reuse emerges.

--- a/libs/core/src/listings/domain/exceptions/category-not-found.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/category-not-found.exception.ts
@@ -1,0 +1,21 @@
+/**
+ * Category Not Found Exception
+ *
+ * Neutral domain exception thrown by adapters implementing
+ * `CategoryParametersReader` (or any future per-category capability) when
+ * the marketplace returns a 404 for the requested categoryId. The platform
+ * label is included so logs and HTTP error filters can disambiguate which
+ * adapter raised it.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+export class CategoryNotFoundException extends Error {
+  constructor(
+    public readonly categoryId: string,
+    public readonly platform: string,
+  ) {
+    super(`Category not found: ${categoryId} (platform=${platform})`);
+    this.name = 'CategoryNotFoundException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/domain/ports/capabilities/__tests__/offer-manager-capabilities.spec.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/__tests__/offer-manager-capabilities.spec.ts
@@ -17,6 +17,7 @@ import { isOfferQuantityBatchUpdater } from '../offer-quantity-batch-updater.cap
 import { isOfferFieldUpdater } from '../offer-field-updater.capability';
 import { isCategoryBrowser } from '../category-browser.capability';
 import { isCategoryBarcodeMatcher } from '../category-barcode-matcher.capability';
+import { isCategoryParametersReader } from '../category-parameters-reader.capability';
 import { isOfferCreator } from '../offer-creator.capability';
 import { isSellerPoliciesReader } from '../seller-policies-reader.capability';
 
@@ -29,6 +30,7 @@ const cases: ReadonlyArray<readonly [string, Guard, string]> = [
   ['OfferFieldUpdater', isOfferFieldUpdater, 'updateOfferFields'],
   ['CategoryBrowser', isCategoryBrowser, 'fetchCategories'],
   ['CategoryBarcodeMatcher', isCategoryBarcodeMatcher, 'matchCategoryByBarcode'],
+  ['CategoryParametersReader', isCategoryParametersReader, 'fetchCategoryParameters'],
   ['OfferCreator', isOfferCreator, 'createOffer'],
   ['SellerPoliciesReader', isSellerPoliciesReader, 'fetchSellerPolicies'],
 ];

--- a/libs/core/src/listings/domain/ports/capabilities/category-parameters-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/category-parameters-reader.capability.ts
@@ -1,0 +1,28 @@
+/**
+ * Category Parameters Reader Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that expose the
+ * marketplace's per-category parameter schema (Allegro "required parameters",
+ * eBay "Item Specifics", Amazon "Product Type Definitions") declare
+ * `implements CategoryParametersReader`. Used by the create-offer wizard
+ * (#410) to render dynamic per-category fields.
+ *
+ * Returns the full parameter set (required + optional). UI decides what to
+ * surface and in what order.
+ *
+ * See `category-browser.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { CategoryParameter } from '../../types/category-parameter.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface CategoryParametersReader {
+  fetchCategoryParameters(input: { categoryId: string }): Promise<CategoryParameter[]>;
+}
+
+export function isCategoryParametersReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & CategoryParametersReader {
+  return typeof (adapter as Partial<CategoryParametersReader>).fetchCategoryParameters === 'function';
+}

--- a/libs/core/src/listings/domain/types/category-parameter.types.ts
+++ b/libs/core/src/listings/domain/types/category-parameter.types.ts
@@ -1,0 +1,91 @@
+/**
+ * Category Parameter Types
+ *
+ * Marketplace-neutral shape for marketplace-category parameters (Allegro
+ * "category required parameters", eBay "Item Specifics" / "aspects",
+ * Amazon "Product Type Definitions"). The 4 base types
+ * (dictionary | string | integer | float) and the restriction flags
+ * generalize across platforms.
+ *
+ * Allegro distinguishes two independent dependency mechanisms; both are
+ * surfaced separately:
+ *   - parameter-level visibility (`parameter.dependsOn`) — the parameter
+ *     shows / hides based on a parent parameter's value.
+ *   - dictionary-entry filtering (`dictionary[i].dependsOnParameterValueIds`)
+ *     — within a visible dictionary parameter, individual entries appear /
+ *     disappear based on a parent's value.
+ *
+ * Conflating them would mis-render both classes of category — see issue #410
+ * for context.
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+export const CategoryParameterTypeValues = [
+  'dictionary',
+  'string',
+  'integer',
+  'float',
+] as const;
+export type CategoryParameterType = (typeof CategoryParameterTypeValues)[number];
+
+export interface CategoryParameterDictionaryEntry {
+  id: string;
+  value: string;
+  /**
+   * Entry-level dependency (Allegro's exact field name). When non-empty, this
+   * entry is selectable only when the parent parameter (identified by
+   * `parameter.dependsOn?.parameterId`, if any) has one of these value IDs.
+   * Independent from parameter-level visibility — a parameter can be visible
+   * while only a subset of its dictionary entries is selectable for a given
+   * parent value.
+   */
+  dependsOnValueIds?: string[];
+}
+
+export interface CategoryParameterRestrictions {
+  /** Dictionary multi-select. */
+  multipleChoices?: boolean;
+  /** Numeric range — user supplies { from, to } instead of single value. */
+  range?: boolean;
+  /** Numeric bounds. */
+  min?: number;
+  max?: number;
+  /** String length bounds. */
+  minLength?: number;
+  maxLength?: number;
+  /** Float decimal precision. */
+  precision?: number;
+  /**
+   * Maximum number of values the user may submit for this parameter.
+   * `1` = single-value, `2+` = bounded multi-value (e.g. `5` for short text-tag
+   * lists, `20` for keyword fields). Allegro-derived but generic.
+   */
+  allowedNumberOfValues?: number;
+  /** Dictionary allows free-text values alongside the dictionary list (combobox). */
+  customValuesEnabled?: boolean;
+}
+
+/**
+ * Parameter-level visibility dependency. The parameter is hidden until
+ * the parent has one of these values. Used for true show/hide semantics —
+ * NOT for filtering dictionary entries within an already-visible parameter.
+ */
+export interface CategoryParameterDependsOn {
+  parameterId: string;
+  valueIds: string[];
+}
+
+export interface CategoryParameter {
+  id: string;
+  name: string;
+  type: CategoryParameterType;
+  required: boolean;
+  /** Optional unit label (e.g. "mm", "kg"). */
+  unit?: string;
+  /** Present when type === 'dictionary'. Entries may carry their own `dependsOnParameterValueIds`. */
+  dictionary?: CategoryParameterDictionaryEntry[];
+  restrictions: CategoryParameterRestrictions;
+  /** Parameter-level visibility (show/hide). Distinct from per-entry filtering. */
+  dependsOn?: CategoryParameterDependsOn;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -137,6 +137,17 @@ export type { CategoryBrowser } from './domain/ports/capabilities/category-brows
 export { isCategoryBrowser } from './domain/ports/capabilities/category-browser.capability';
 export type { CategoryBarcodeMatcher } from './domain/ports/capabilities/category-barcode-matcher.capability';
 export { isCategoryBarcodeMatcher } from './domain/ports/capabilities/category-barcode-matcher.capability';
+export type { CategoryParametersReader } from './domain/ports/capabilities/category-parameters-reader.capability';
+export { isCategoryParametersReader } from './domain/ports/capabilities/category-parameters-reader.capability';
+export type {
+  CategoryParameter,
+  CategoryParameterDictionaryEntry,
+  CategoryParameterRestrictions,
+  CategoryParameterDependsOn,
+  CategoryParameterType,
+} from './domain/types/category-parameter.types';
+export { CategoryParameterTypeValues } from './domain/types/category-parameter.types';
+export { CategoryNotFoundException } from './domain/exceptions/category-not-found.exception';
 export type { OfferCreator } from './domain/ports/capabilities/offer-creator.capability';
 export { isOfferCreator } from './domain/ports/capabilities/offer-creator.capability';
 export type { SellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -21,6 +21,7 @@ import { AllegroTokenRefreshService } from './infrastructure/token-refresh/alleg
 import { ALLEGRO_QUANTITY_COMMAND_REPOSITORY_TOKEN } from './allegro.tokens';
 import { Logger } from '@openlinker/shared/logging';
 import { AllegroQuantityCommandRepositoryPort } from './domain/ports/allegro-quantity-command-repository.port';
+import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared';
 
 @Module({
   imports: [
@@ -77,6 +78,15 @@ export class AllegroIntegrationModule implements OnModuleInit {
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
     @Optional()
     private readonly configService?: ConfigService,
+    /**
+     * Distributed cache used by the offer-manager adapter for category-parameter
+     * responses (#410). Optional so unit-test bootstraps that don't import
+     * `CacheModule` keep working — production wiring imports it via
+     * `apps/api/src/app.module.ts`.
+     */
+    @Optional()
+    @Inject(CACHE_PORT_TOKEN)
+    private readonly cache?: CachePort,
   ) {}
 
   onModuleInit(): void {
@@ -86,6 +96,8 @@ export class AllegroIntegrationModule implements OnModuleInit {
       this.tokenRefreshService,
       this.commandRepository,
       this.readQuantityPollConfig(),
+      this.cache,
+      this.readCatParamsTtlSec(),
     );
     this.factoryResolver.registerFactory('allegro.publicapi.v1', factory);
     this.connectionTesterRegistry.register(
@@ -115,6 +127,18 @@ export class AllegroIntegrationModule implements OnModuleInit {
     if (maxDelayMs !== undefined) config.maxDelayMs = maxDelayMs;
     if (backoffMultiplier !== undefined) config.backoffMultiplier = backoffMultiplier;
     return Object.keys(config).length > 0 ? config : undefined;
+  }
+
+  /**
+   * Read the cache-TTL override for `/sale/categories/{id}/parameters` from
+   * `OL_ALLEGRO_CAT_PARAMS_TTL_SEC`. Returns `undefined` when unset or
+   * non-positive — the adapter then uses its 24h default.
+   */
+  private readCatParamsTtlSec(): number | undefined {
+    const raw = this.configService?.get<string>('OL_ALLEGRO_CAT_PARAMS_TTL_SEC');
+    if (!raw) return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
   }
 }
 

--- a/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
+++ b/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
@@ -30,6 +30,7 @@ import { AllegroOrderSourceAdapter } from '../infrastructure/adapters/allegro-or
 import { TokenRefreshResult } from '../infrastructure/http/allegro-http-client.types';
 import { AllegroTokenRefreshService } from '../infrastructure/token-refresh/allegro-token-refresh.service';
 import { Logger } from '@openlinker/shared/logging';
+import type { CachePort } from '@openlinker/shared';
 import { AllegroQuantityCommandRepositoryPort } from '../domain/ports/allegro-quantity-command-repository.port';
 
 /**
@@ -47,7 +48,11 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
     _customerIdentityResolver?: CustomerIdentityResolverPort,
     private readonly tokenRefreshService?: AllegroTokenRefreshService,
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
-    private readonly quantityPollConfig?: Partial<QuantityPollConfig>
+    private readonly quantityPollConfig?: Partial<QuantityPollConfig>,
+    /** Distributed cache for category parameters (#410). Optional; missing → no caching. */
+    private readonly cache?: CachePort,
+    /** TTL override for the category parameters cache in seconds. Defaults to 24h. */
+    private readonly catParamsTtlSec?: number,
   ) {
     void _customerIdentityResolver;
   }
@@ -110,7 +115,9 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
       identifierMapping,
       connection,
       this.commandRepository,
-      this.quantityPollConfig
+      this.quantityPollConfig,
+      this.cache,
+      this.catParamsTtlSec,
     );
     const orderSourceAdapter = new AllegroOrderSourceAdapter(connection.id, httpClient, connection);
 

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -232,13 +232,65 @@ export interface AllegroCategoriesResponse {
 }
 
 /**
+ * Allegro category parameter — raw shape from
+ * GET /sale/categories/{categoryId}/parameters
+ *
+ * Surfaces both dependency mechanisms separately:
+ *   - parameter-level visibility (`options.dependsOnParameterId`)
+ *   - dictionary-entry filtering (`dictionary[i].dependsOnParameterValueIds`)
+ *
+ * `requiredIf` / `displayedIf` are richer JSONPath-ish predicates that the
+ * adapter does not currently surface to CORE — kept here for traceability
+ * when capturing fixtures.
+ */
+export interface AllegroCategoryParameter {
+  id: string;
+  name: string;
+  type: 'dictionary' | 'string' | 'integer' | 'float';
+  required: boolean;
+  requiredForProduct?: boolean;
+  requiredIf?: unknown;
+  displayedIf?: unknown;
+  unit?: string;
+  options?: {
+    ambiguousValueId?: string;
+    dependsOnParameterId?: string;
+    describesProduct?: boolean;
+    customValuesEnabled?: boolean;
+  };
+  dictionary?: Array<{
+    id: string;
+    value: string;
+    /**
+     * Entry-level dependency. Allegro's field name is exactly `dependsOnValueIds`
+     * (not `dependsOnParameterValueIds`). When non-empty, this entry is only
+     * selectable when the parent parameter (identified by the parameter's
+     * `options.dependsOnParameterId`) has one of these value IDs.
+     */
+    dependsOnValueIds?: string[];
+    /** Legacy migration data on individual entries — adapter ignores. */
+    formerData?: unknown;
+  }>;
+  restrictions?: {
+    multipleChoices?: boolean;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+    range?: boolean;
+    precision?: number;
+    /** Numeric — e.g. 1 for single value, 5 / 20 for capped multi-value strings. */
+    allowedNumberOfValues?: number;
+  };
+  /** Legacy migration data — adapter ignores. */
+  formerData?: unknown;
+}
+
+/**
  * Allegro category parameters response (from GET /sale/categories/{categoryId}/parameters)
  */
 export interface AllegroCategoryParametersResponse {
-  parameters: Array<{
-    id: string;
-    name: string;
-  }>;
+  parameters: AllegroCategoryParameter[];
 }
 
 /**

--- a/libs/integrations/allegro/src/infrastructure/adapters/__fixtures__/category-parameters-257933.json
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__fixtures__/category-parameters-257933.json
@@ -1,0 +1,16816 @@
+{
+  "parameters": [
+    {
+      "id": "11323",
+      "name": "Stan",
+      "type": "dictionary",
+      "required": true,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": false,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "11323_1",
+          "value": "Nowy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "nowe",
+              "nowa"
+            ]
+          }
+        },
+        {
+          "id": "11323_2",
+          "value": "Używany",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "11323_238066",
+          "value": "Po zwrocie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "11323_1223453",
+          "value": "Na części",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "11323_238070",
+          "value": "Niepełny komplet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "11323_246514",
+          "value": "Nowy z defektem",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "11323_238058",
+          "value": "Powystawowy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "11323_238062",
+          "value": "Uszkodzony",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "uszkodzone",
+              "niesprawny",
+              "niesprawne"
+            ]
+          }
+        },
+        {
+          "id": "11323_246534",
+          "value": "Odnowiony przez producenta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "11323_246538",
+          "value": "Odnowiony przez sprzedawcę",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "11323_1223636",
+          "value": "Przepakowany",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      }
+    },
+    {
+      "id": "248811",
+      "name": "Marka",
+      "type": "dictionary",
+      "required": true,
+      "requiredForProduct": true,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "248811_958954",
+          "value": "bez marki",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938476",
+          "value": "100",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948583",
+          "value": "100%PeakPower",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938477",
+          "value": "101 Inc.",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948585",
+          "value": "1Life",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948586",
+          "value": "1Mii",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948587",
+          "value": "1One",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938480",
+          "value": "1X",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948589",
+          "value": "1z",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938482",
+          "value": "2BM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922577",
+          "value": "2Control",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948594",
+          "value": "2UUL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943854",
+          "value": "2Wolfs",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938483",
+          "value": "2X3",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943855",
+          "value": "360",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948598",
+          "value": "3Com",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948602",
+          "value": "3L",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973491",
+          "value": "3M",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "243549_804729"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938490",
+          "value": "3mk",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1135068"
+            ]
+          }
+        },
+        {
+          "id": "248811_1990401",
+          "value": "4DRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990402",
+          "value": "4DRC V22",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131479",
+          "value": "4F",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "7174_217317",
+              "7108_113",
+              "3786_189"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938493",
+          "value": "4kom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922511",
+          "value": "4wild",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943862",
+          "value": "4World",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922516",
+          "value": "555",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1054666",
+          "value": "7&7",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948614",
+          "value": "7Artisans",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948615",
+          "value": "8Sinn",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948623",
+          "value": "A7",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948619",
+          "value": "A. B. Tor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1071582",
+          "value": "AAA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949835",
+          "value": "Aab cooling",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948624",
+          "value": "AB",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248928_1891830",
+              "248924_1902460",
+              "127788_1876059"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938501",
+          "value": "ABA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948746",
+          "value": "Abafia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949836",
+          "value": "ABB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922840",
+          "value": "ABC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_976520",
+          "value": "ABC-RC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948753",
+          "value": "AbergBest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948754",
+          "value": "Abitus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938503",
+          "value": "ABS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1106768",
+          "value": "Access",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_977192",
+          "value": "ACCUD",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Accud"
+            ]
+          }
+        },
+        {
+          "id": "248811_1943941",
+          "value": "Accura",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139205",
+          "value": "Acer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948774",
+          "value": "Aclas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948775",
+          "value": "Acme",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938506",
+          "value": "ACS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938547",
+          "value": "Act",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948636",
+          "value": "ACTii",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1023578",
+          "value": "Action",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948784",
+          "value": "Actis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136342",
+          "value": "Activ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949864",
+          "value": "ActiveJet",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Activejet"
+            ]
+          }
+        },
+        {
+          "id": "248811_1948633",
+          "value": "ACTIVEON",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136351",
+          "value": "Activeshop",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013579",
+          "value": "Acuter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948793",
+          "value": "Adam Elements",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948794",
+          "value": "Adapt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943954",
+          "value": "Adapter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948796",
+          "value": "Adaptout",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1146617",
+          "value": "Adar",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127769_748412",
+              "127509_1106961",
+              "129369_1646584",
+              "127788_591757",
+              "248924_1101781",
+              "3786_846196",
+              "248929_968691",
+              "25929_577529",
+              "229173_1681599",
+              "127812_645109"
+            ]
+          }
+        },
+        {
+          "id": "248811_949870",
+          "value": "ADGO",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Adgo"
+            ]
+          }
+        },
+        {
+          "id": "248811_949871",
+          "value": "ADLER",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Adler"
+            ]
+          }
+        },
+        {
+          "id": "248811_1948808",
+          "value": "Admir",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948811",
+          "value": "Adoo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922859",
+          "value": "Adox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2027049",
+          "value": "Advent",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948645",
+          "value": "AEE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_975439",
+          "value": "AEG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943961",
+          "value": "Aerial",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990421",
+          "value": "Aerium",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137742",
+          "value": "AF",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_1875297"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938509",
+          "value": "AFE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1966036",
+          "value": "AGC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948314",
+          "value": "AG Chemia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948652",
+          "value": "AGFA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943972",
+          "value": "AgfaPhoto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943973",
+          "value": "Agiler",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948655",
+          "value": "AGM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013535",
+          "value": "AGM Global Vision",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948315",
+          "value": "AG TermoPasty",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1150776",
+          "value": "aha",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Aha"
+            ]
+          }
+        },
+        {
+          "id": "248811_1948840",
+          "value": "Ahead",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1983922",
+          "value": "Ahlirmoy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949878",
+          "value": "Aigostar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943978",
+          "value": "Aikove",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990424",
+          "value": "Aircraf",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948853",
+          "value": "AirLive",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2027065",
+          "value": "Airthd",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1159694",
+          "value": "Aitsite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131260",
+          "value": "Ajax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943985",
+          "value": "Akai",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943988",
+          "value": "Akasa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955705",
+          "value": "AKASO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948667",
+          "value": "AKG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948869",
+          "value": "Akira",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948870",
+          "value": "Akita",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043112",
+          "value": "AKKU-3000-BATT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_971837",
+          "value": "AKS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1068331",
+          "value": "Aksotronik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948877",
+          "value": "Akurat",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1018536",
+          "value": "Akyga",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131510",
+          "value": "Alantec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948888",
+          "value": "Albott",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938578",
+          "value": "Albrecht",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990425",
+          "value": "Alctron",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922324",
+          "value": "Alecto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938581",
+          "value": "Alen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1957048",
+          "value": "Alessio",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944002",
+          "value": "Alex",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_505373"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938583",
+          "value": "Aligator",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955581",
+          "value": "all4you",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1890439",
+          "value": "Allbe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948918",
+          "value": "Allnet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131522",
+          "value": "Allocacoc",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944013",
+          "value": "Allpowers",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948924",
+          "value": "Alogic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1135157",
+          "value": "Alogy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948673",
+          "value": "ALOMEJOR",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1093778",
+          "value": "ALPHA",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Alpha"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938600",
+          "value": "Alpine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1114668",
+          "value": "Altra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013643",
+          "value": "Alvo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2054254",
+          "value": "AMARAN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948956",
+          "value": "Amass",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948957",
+          "value": "Amazfit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949913",
+          "value": "Amazon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955715",
+          "value": "AmazonBasic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948964",
+          "value": "American DJ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949917",
+          "value": "AMES",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Ames"
+            ]
+          }
+        },
+        {
+          "id": "248811_1990410",
+          "value": "AMETA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1957179",
+          "value": "Amewi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938519",
+          "value": "AMG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943907",
+          "value": "AMI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948967",
+          "value": "Amiga",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948978",
+          "value": "Amosfun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948980",
+          "value": "Amphenol",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1084396",
+          "value": "AMT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948318",
+          "value": "AMZDEAL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948992",
+          "value": "Analogis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944038",
+          "value": "Anchor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948995",
+          "value": "Anda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948998",
+          "value": "Andoer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013651",
+          "value": "Andonstar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948999",
+          "value": "Andowl",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949001",
+          "value": "Angelbird",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2059304",
+          "value": "Anitgravity",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1896021",
+          "value": "Anker",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_974134",
+          "value": "Anlux",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922108",
+          "value": "Ansmann",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949015",
+          "value": "Anteake",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2059063",
+          "value": "ANTIGRAVITY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_985101",
+          "value": "Antyki24",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1059275",
+          "value": "Anytech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1090558",
+          "value": "Anza",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013665",
+          "value": "Aomekie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948692",
+          "value": "AP",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1908019",
+              "127788_1876092",
+              "129369_1879212",
+              "248924_1902527",
+              "248928_1891883"
+            ]
+          }
+        },
+        {
+          "id": "248811_1983899",
+          "value": "APAK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1930717",
+          "value": "Apexel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131942",
+          "value": "Apli",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_1073845"
+            ]
+          }
+        },
+        {
+          "id": "248811_1948696",
+          "value": "APM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1068614",
+          "value": "Apollo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131476",
+          "value": "Apple",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_983988"
+            ]
+          }
+        },
+        {
+          "id": "248811_1957289",
+          "value": "April",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1071222",
+          "value": "APS",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Aps"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922507",
+          "value": "APT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948327",
+          "value": "Apte",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949934",
+          "value": "Aptel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949040",
+          "value": "Aputure",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922957",
+          "value": "Aqua",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1936234",
+          "value": "Aquatech",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Aqua-Tech"
+            ]
+          }
+        },
+        {
+          "id": "248811_2046507",
+          "value": "ARAREE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949052",
+          "value": "Arcas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949058",
+          "value": "Arcora",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950135",
+          "value": "Arctic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1998850",
+          "value": "Arctic Hunter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137976",
+          "value": "Arda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139226",
+          "value": "Ardon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_982220",
+          "value": "area-led",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1019325",
+          "value": "Ares",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949069",
+          "value": "Argus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1096507",
+          "value": "Arhatreya",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1170739",
+          "value": "Arkas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949076",
+          "value": "Arkon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131949",
+          "value": "Arlo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013696",
+          "value": "Armasight",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013701",
+          "value": "Armoptics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949080",
+          "value": "Armor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013702",
+          "value": "ArmorCase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949081",
+          "value": "ArmorShield",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938635",
+          "value": "Arpol",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949087",
+          "value": "Arrow",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1916054",
+          "value": "ARSA GO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949089",
+          "value": "Arsenal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949853",
+          "value": "Art",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248920_1132344"
+            ]
+          }
+        },
+        {
+          "id": "248811_1948319",
+          "value": "ARTBRON",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2020593",
+          "value": "Artbull",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143630",
+          "value": "Artcop",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922035",
+          "value": "Artemis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1773723",
+          "value": "Artnico",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949960",
+          "value": "Artpol",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Art-Pol"
+            ]
+          }
+        },
+        {
+          "id": "248811_1949102",
+          "value": "Arzopa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1112881",
+          "value": "AS",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248928_1078541"
+            ]
+          }
+        },
+        {
+          "id": "248811_972267",
+          "value": "Asahi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948709",
+          "value": "ASAP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1926106",
+          "value": "Asato",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922994",
+          "value": "ASD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1077491",
+          "value": "Asgard",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1943917",
+          "value": "ASHATA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1989980",
+          "value": "ASIS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1191827",
+          "value": "Asist",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139206",
+          "value": "Assmann",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2056845",
+          "value": "AstrHori",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013727",
+          "value": "AstroMaster",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949123",
+          "value": "AstroMedia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1160047",
+          "value": "Astron",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "129369_920097"
+            ]
+          }
+        },
+        {
+          "id": "248811_1131493",
+          "value": "Asus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948716",
+          "value": "ATA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131533",
+          "value": "Aten",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949132",
+          "value": "Athabasca",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949979",
+          "value": "Atlas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1082225",
+          "value": "Atmos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1956883",
+          "value": "ATN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949136",
+          "value": "Atoll",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949981",
+          "value": "Atom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949138",
+          "value": "Atomos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1158661",
+          "value": "ATS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948721",
+          "value": "ATTEN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1135834",
+          "value": "Audi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949151",
+          "value": "AudioDesign",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990455",
+          "value": "Audioport",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949152",
+          "value": "AudioQuest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949150",
+          "value": "Audio-Technica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131481",
+          "value": "Aukey",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949172",
+          "value": "Aura",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949175",
+          "value": "Auriol",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1077690",
+          "value": "Aurora",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_1129970",
+              "127812_761251"
+            ]
+          }
+        },
+        {
+          "id": "248811_1949178",
+          "value": "Autel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990459",
+          "value": "Autel Robotics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948726",
+          "value": "AUTOPkio",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922005",
+          "value": "Avacom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949204",
+          "value": "Avante",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136864",
+          "value": "Avec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2011574",
+          "value": "Avena Robotics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949210",
+          "value": "Avenger",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948736",
+          "value": "AVer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948737",
+          "value": "AVerMedia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1109902",
+          "value": "Avery",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_586765"
+            ]
+          }
+        },
+        {
+          "id": "248811_1139663",
+          "value": "Avery-Zweckform",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Avery zweckform"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955711",
+          "value": "AVINITY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948734",
+          "value": "AVO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949226",
+          "value": "Axagon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1095542",
+          "value": "Axis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949234",
+          "value": "Axtel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_949988",
+          "value": "Azaris",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1972492",
+          "value": "Azden",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043126",
+          "value": "B + W",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013766",
+          "value": "Baader Planetarium",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990465",
+          "value": "Baazar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1972573",
+          "value": "Babyprops",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1018851",
+          "value": "Bacher",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949326",
+          "value": "Bagmaster",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949328",
+          "value": "Baigio",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1151116",
+          "value": "Balda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949342",
+          "value": "Bamix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949349",
+          "value": "Bange",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949348",
+          "value": "Bang & Olufsen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949359",
+          "value": "Barco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013784",
+          "value": "Barride Optics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013783",
+          "value": "Barr&Stroud",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949364",
+          "value": "Barska",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_971501",
+          "value": "Basetech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950017",
+          "value": "Baseus",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1030644",
+              "248929_1127650"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955585",
+          "value": "basicXL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950018",
+          "value": "Bass",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2020784",
+          "value": "Basta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922014",
+          "value": "Batimex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949374",
+          "value": "Batmax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949376",
+          "value": "Battletron",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944219",
+          "value": "Bauer",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_835532"
+            ]
+          }
+        },
+        {
+          "id": "248811_976908",
+          "value": "BazarPL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990462",
+          "value": "BC Master",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1972629",
+          "value": "Beanbag",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "baen bag",
+              "baenbag"
+            ]
+          }
+        },
+        {
+          "id": "248811_950026",
+          "value": "Beast",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949388",
+          "value": "Beats",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949390",
+          "value": "Beauty",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949391",
+          "value": "Beboncool",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944225",
+          "value": "Beco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1855002",
+          "value": "Bedee",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_1911430",
+              "129970_1893345",
+              "127509_1884791",
+              "127812_1897056",
+              "129265_1863049",
+              "129369_1025772",
+              "248135_1904998"
+            ]
+          }
+        },
+        {
+          "id": "248811_1068527",
+          "value": "Beha Amprobe",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Beha-Amprobe"
+            ]
+          }
+        },
+        {
+          "id": "248811_1949399",
+          "value": "Behringer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950028",
+          "value": "Beko",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1929896",
+          "value": "Belantro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944231",
+          "value": "Belkin",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_859326"
+            ]
+          }
+        },
+        {
+          "id": "248811_1131950",
+          "value": "Bell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949405",
+          "value": "Bellini",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949409",
+          "value": "Bellroy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949411",
+          "value": "Belomo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1972663",
+          "value": "Beltrami",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_986974",
+          "value": "Bemi",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "BEMI"
+            ]
+          }
+        },
+        {
+          "id": "248811_975802",
+          "value": "Benetech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955729",
+          "value": "BenQ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949423",
+          "value": "Benro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944241",
+          "value": "Bentley",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013820",
+          "value": "Berkut",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1114065",
+          "value": "Berner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944252",
+          "value": "Besportble",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131854",
+          "value": "Best",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949441",
+          "value": "Bestar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013831",
+          "value": "Bestguarder",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949444",
+          "value": "Bestope",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949445",
+          "value": "Bestphone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078430",
+          "value": "Beta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1957744",
+          "value": "BetaFPV",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_990051",
+          "value": "Beurer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944268",
+          "value": "Bewinner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949451",
+          "value": "Beyerdynamic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949455",
+          "value": "Bezzera",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_958566",
+          "value": "BGS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1151040",
+          "value": "BGS Technic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1151515",
+          "value": "BIG",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_566877"
+            ],
+            "values": [
+              "Big"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955731",
+          "value": "Bigben",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955586",
+          "value": "bigEYE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949462",
+          "value": "Bilora",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949466",
+          "value": "Bingo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1019218",
+          "value": "Biomus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949273",
+          "value": "BK",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_1875413"
+            ]
+          }
+        },
+        {
+          "id": "248811_1949276",
+          "value": "BL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944302",
+          "value": "Black+Decker",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_950070"
+            ],
+            "values": [
+              "Black&Decker",
+              "black and decker",
+              "Black Decker"
+            ]
+          }
+        },
+        {
+          "id": "248811_1949483",
+          "value": "BlackBerry",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984107",
+          "value": "Blackfire",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949485",
+          "value": "Blackmagic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1163248",
+          "value": "Black Tree",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1896045",
+          "value": "Blade",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_978696",
+          "value": "Blaupunkt",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "bleupunkt",
+              "bleu punkt"
+            ]
+          }
+        },
+        {
+          "id": "248811_1949492",
+          "value": "Blavec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950073",
+          "value": "Blesiya",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950075",
+          "value": "Blitzwolf",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "BlitzWolf"
+            ]
+          }
+        },
+        {
+          "id": "248811_1070709",
+          "value": "Blow",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922997",
+          "value": "Blue",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949506",
+          "value": "Blue Star",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1977361",
+          "value": "Bluetti",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949516",
+          "value": "Blukar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949517",
+          "value": "Blumax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944323",
+          "value": "Blun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949518",
+          "value": "Blux",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949284",
+          "value": "BN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1783307",
+          "value": "BNTrade",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949520",
+          "value": "Boblbee",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938685",
+          "value": "BODYGUARD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1957954",
+          "value": "Bogner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949528",
+          "value": "Bokman",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2048510",
+          "value": "Bolex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949533",
+          "value": "Bomaker",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2040678",
+          "value": "Bonvvie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949541",
+          "value": "Boogie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949545",
+          "value": "Boompods",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949546",
+          "value": "Booq",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949548",
+          "value": "Boots",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1062827",
+          "value": "Borko",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143294",
+          "value": "Borofone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950093",
+          "value": "Bosch",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "129265_3",
+              "234365_802890",
+              "128608_3"
+            ],
+            "values": [
+              "bosh"
+            ]
+          }
+        },
+        {
+          "id": "248811_1944360",
+          "value": "Bose",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1643654"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938785",
+          "value": "Bossbulls",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2042571",
+          "value": "BOTC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949566",
+          "value": "Bowens",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949567",
+          "value": "Bower",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949568",
+          "value": "Bowers & Wilkins",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1057063",
+          "value": "Bowi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949569",
+          "value": "BoxCase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949292",
+          "value": "BOYA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1797408",
+          "value": "B&R",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949572",
+          "value": "Bracker",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1854967",
+          "value": "Bracket",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949577",
+          "value": "Brasforma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134096",
+          "value": "Braun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944367",
+          "value": "Braun Phototechnik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1189072",
+          "value": "Braveheart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949297",
+          "value": "BRDRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013893",
+          "value": "Breaker",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950105",
+          "value": "Brennenstuhl",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949583",
+          "value": "Brenner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938793",
+          "value": "Bresser",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013896",
+          "value": "Bresser Optics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950108",
+          "value": "Brinno",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944377",
+          "value": "Brodit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1063323",
+          "value": "Brooklyn",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1135843",
+          "value": "Brother",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949300",
+          "value": "BSH",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1742507",
+          "value": "BSH ADVENTURE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922773",
+          "value": "BT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922094",
+          "value": "BTE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949304",
+          "value": "BTER",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949617",
+          "value": "Bubm",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2021055",
+          "value": "Buddy Toys",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013912",
+          "value": "Buki",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984152",
+          "value": "Buki France",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_1958093"
+            ]
+          }
+        },
+        {
+          "id": "248811_2013915",
+          "value": "Burris",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949633",
+          "value": "Bush",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944405",
+          "value": "Bushnell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013917",
+          "value": "Butler Creek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938815",
+          "value": "BUYPRO",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Buypro"
+            ]
+          }
+        },
+        {
+          "id": "248811_1019204",
+          "value": "BVN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949243",
+          "value": "B&W",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949307",
+          "value": "BWO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2041566",
+          "value": "BWOO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950125",
+          "value": "Cabletech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949730",
+          "value": "Cactus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990497",
+          "value": "Cahaya",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949734",
+          "value": "Caiul",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949749",
+          "value": "Cameo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1921982",
+          "value": "Cameron Sino",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949750",
+          "value": "Camgloss",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984184",
+          "value": "CamKing",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949751",
+          "value": "Camlight",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949743",
+          "value": "CamLink",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2054551",
+          "value": "Camp Snap",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949755",
+          "value": "Camrock",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949762",
+          "value": "Canon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1958229",
+          "value": "Canson",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_366785"
+            ]
+          }
+        },
+        {
+          "id": "248811_1944467",
+          "value": "Canyon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949651",
+          "value": "CAR",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949774",
+          "value": "Carat",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949783",
+          "value": "Carena",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949788",
+          "value": "Carl Zeiss",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013958",
+          "value": "Carl Zeiss Jena",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949790",
+          "value": "Carmedia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1105062",
+          "value": "Carmotion",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1722653",
+          "value": "Caro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949797",
+          "value": "Carrera",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_208329"
+            ]
+          }
+        },
+        {
+          "id": "248811_1134084",
+          "value": "Carson",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949801",
+          "value": "Carton",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990492",
+          "value": "CARTOYS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949654",
+          "value": "CAS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949805",
+          "value": "Case",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949807",
+          "value": "Case Logic",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_859124"
+            ]
+          }
+        },
+        {
+          "id": "248811_1949817",
+          "value": "Casio",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_929028"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938819",
+          "value": "CCCP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949666",
+          "value": "CE",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248924_1899537",
+              "248928_1889389"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922103",
+          "value": "Cedis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949834",
+          "value": "Celestron",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944520",
+          "value": "Cellularline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944521",
+          "value": "Celly",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_974940",
+          "value": "CEM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2061525",
+          "value": "CENEI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949845",
+          "value": "Centon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143976",
+          "value": "Centrum",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_575625",
+              "127812_1897206",
+              "248928_1130655",
+              "248929_1057613"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938821",
+          "value": "CH",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_1897502",
+              "127788_1875434"
+            ]
+          }
+        },
+        {
+          "id": "248811_1944535",
+          "value": "Chasing",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1102151",
+          "value": "Cherry",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1937902",
+          "value": "Chevrolet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949871",
+          "value": "Chic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1979492",
+          "value": "Chigods",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949877",
+          "value": "Chill",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949878",
+          "value": "Chinon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938881",
+          "value": "Chiny",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139615",
+          "value": "Chuangbao",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949674",
+          "value": "CID",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949890",
+          "value": "CineGEN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949893",
+          "value": "Cirrus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131489",
+          "value": "Cisco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922157",
+          "value": "Citizen",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_983362"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922066",
+          "value": "CJC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949896",
+          "value": "Ckmova",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938889",
+          "value": "Clavier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965667",
+          "value": "click4TOYS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949915",
+          "value": "Clicktronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949917",
+          "value": "Clin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949921",
+          "value": "Clover",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013999",
+          "value": "Club 3D",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949922",
+          "value": "Clubman",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938824",
+          "value": "CM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136066",
+          "value": "CMP",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "7108_341949"
+            ]
+          }
+        },
+        {
+          "id": "248811_957963",
+          "value": "CMT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949925",
+          "value": "Co2Crea",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1047278",
+          "value": "Cobra",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248922_964442"
+            ]
+          }
+        },
+        {
+          "id": "248811_1949946",
+          "value": "Cokin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1124767",
+          "value": "Colfuline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949947",
+          "value": "Collection",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1923186",
+          "value": "Color",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949951",
+          "value": "Colorado",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949952",
+          "value": "Colorama",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1151674",
+          "value": "Coloriso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949950",
+          "value": "ColorWay",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949688",
+          "value": "COM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2033242",
+          "value": "CO-man",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132360",
+          "value": "Comet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949689",
+          "value": "COMICA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949968",
+          "value": "Comitso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949971",
+          "value": "Commlite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949974",
+          "value": "Compact",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949981",
+          "value": "Computar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922558",
+          "value": "Concept",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949989",
+          "value": "Concord",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950185",
+          "value": "Condor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1110566",
+          "value": "Condor Foto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1221460",
+          "value": "Connect IT",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "conectit",
+              "conect it"
+            ]
+          }
+        },
+        {
+          "id": "248811_1187898",
+          "value": "Conotech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1098657",
+          "value": "Conrad",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014020",
+          "value": "Conrad Electronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1949999",
+          "value": "Conrad Energy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950003",
+          "value": "Contax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1784785",
+          "value": "Continental",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "9300_3"
+            ]
+          }
+        },
+        {
+          "id": "248811_1973090",
+          "value": "CoolStaff",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922051",
+          "value": "CoreParts",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950030",
+          "value": "Coronet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950034",
+          "value": "Cosina",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1119636",
+          "value": "Costway",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137856",
+          "value": "Craft",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "25929_7"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922723",
+          "value": "Creative",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_987799",
+          "value": "Crelando",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1152158",
+          "value": "Crivit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_990104",
+          "value": "Cromwell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950068",
+          "value": "Crong",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950075",
+          "value": "Crumpler",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948361",
+          "value": "CubeNest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950082",
+          "value": "Cullmann",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950091",
+          "value": "Cyber Clean",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950100",
+          "value": "Cyfrowy Polsat",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950102",
+          "value": "Cynova",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1958704",
+          "value": "Cytronix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1937894",
+          "value": "CZ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950106",
+          "value": "Czarno-Białe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950108",
+          "value": "Cztool",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1144221",
+          "value": "DAF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950221",
+          "value": "Dahua",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950175",
+          "value": "Daisy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1651436",
+          "value": "Datacolor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922073",
+          "value": "Datalogic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950195",
+          "value": "DataVideo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_972896",
+          "value": "DAXGD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938941",
+          "value": "DB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131941",
+          "value": "DBautomotive",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955593",
+          "value": "dB Technologies",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950116",
+          "value": "DBX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948366",
+          "value": "Decathlon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1016616",
+          "value": "Decora",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950235",
+          "value": "Decortrend",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014093",
+          "value": "Dedal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950237",
+          "value": "Dedra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2048250",
+          "value": "Deenzy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944714",
+          "value": "Deeper",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950122",
+          "value": "DEFA",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_1895899"
+            ]
+          }
+        },
+        {
+          "id": "248811_1984337",
+          "value": "Deha Design",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950227",
+          "value": "Deity",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_975092",
+          "value": "Dekor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950234",
+          "value": "Delamax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955594",
+          "value": "deleyCON",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1125991",
+          "value": "Delfin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950237",
+          "value": "Delkin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131529",
+          "value": "Dell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1067909",
+          "value": "Delock",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938973",
+          "value": "Delsey",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_984727",
+          "value": "Delta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131254",
+          "value": "Deltaco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950239",
+          "value": "Delta Electronics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984341",
+          "value": "Delta Optical",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950246",
+          "value": "Denmark",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950248",
+          "value": "Denon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944728",
+          "value": "Denso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938979",
+          "value": "Denver",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948365",
+          "value": "DeOne",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938986",
+          "value": "Deuter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950257",
+          "value": "Devia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950256",
+          "value": "DeWalt",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "128608_5"
+            ]
+          }
+        },
+        {
+          "id": "248811_1150111",
+          "value": "Dexon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081152",
+          "value": "DexXer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2027488",
+          "value": "DF-Models",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938944",
+          "value": "DG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944746",
+          "value": "Diana",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2035940",
+          "value": "DIAWAY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950273",
+          "value": "Dicapac",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950287",
+          "value": "Digipod",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950283",
+          "value": "DigiPower",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950288",
+          "value": "Digital",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950289",
+          "value": "Digitnow",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131282",
+          "value": "Digitus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1072390",
+          "value": "Digma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950294",
+          "value": "Dimavery",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014115",
+          "value": "Dino Lite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938991",
+          "value": "Discovery",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_1676620"
+            ]
+          }
+        },
+        {
+          "id": "248811_2014117",
+          "value": "Discovery Adventures",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131910",
+          "value": "Disney",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_4",
+              "127812_7"
+            ]
+          }
+        },
+        {
+          "id": "248811_1950310",
+          "value": "Divoom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136865",
+          "value": "DJI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1017682",
+          "value": "DKM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950137",
+          "value": "DLP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1741976",
+          "value": "DM",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_1874726"
+            ],
+            "values": [
+              "Dm"
+            ]
+          }
+        },
+        {
+          "id": "248811_1938948",
+          "value": "DNA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950142",
+          "value": "DNP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940633",
+          "value": "dnt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938992",
+          "value": "Do",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248924_1902041"
+            ]
+          }
+        },
+        {
+          "id": "248811_1950321",
+          "value": "Docooler",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950322",
+          "value": "Doerr",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950323",
+          "value": "Doi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950324",
+          "value": "DolAccessories",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1966453",
+          "value": "DOMET",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1021290",
+          "value": "Domifito",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950334",
+          "value": "Domke",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1138284",
+          "value": "DoModa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1142696",
+          "value": "Donau",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_983408",
+              "248929_968823",
+              "127788_520249"
+            ]
+          }
+        },
+        {
+          "id": "248811_1950387",
+          "value": "Dörr",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2038568",
+          "value": "DoubleShot",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1923767",
+          "value": "doUp.",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_959956",
+          "value": "DPM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944652",
+          "value": "D-Pro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1088714",
+          "value": "Draco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1973363",
+          "value": "Dragon Touch",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1022398",
+          "value": "Draper",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950354",
+          "value": "Drekker",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2048659",
+          "value": "drewutnia-art",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043656",
+          "value": "DR Fischer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950149",
+          "value": "DRIFT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990524",
+          "value": "Drone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950152",
+          "value": "DSE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014148",
+          "value": "Dsoon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944793",
+          "value": "Dudao",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939007",
+          "value": "DuPont",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131443",
+          "value": "Durable",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143981",
+          "value": "Duracell",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_859400"
+            ]
+          }
+        },
+        {
+          "id": "248811_1944803",
+          "value": "Duragon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2021627",
+          "value": "Dura PRO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1966529",
+          "value": "Duratec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950364",
+          "value": "DuraTruss",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1107637",
+          "value": "Duronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950368",
+          "value": "Duro Pro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2046964",
+          "value": "DWARFLAB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950291",
+          "value": "Dymo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950379",
+          "value": "Dynasun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950294",
+          "value": "Dyson",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948370",
+          "value": "Dzika Knieja",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2052595",
+          "value": "DZOFILM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950449",
+          "value": "Eachine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131432",
+          "value": "Eagle",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_656989",
+              "248929_968835"
+            ]
+          }
+        },
+        {
+          "id": "248811_1959201",
+          "value": "Eagle Creek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014181",
+          "value": "Eakins",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955754",
+          "value": "Earfun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939025",
+          "value": "Eastpak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131699",
+          "value": "Easy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_1127055"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955604",
+          "value": "easyCover",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1062817",
+          "value": "Easymaxx",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950461",
+          "value": "Easypix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950459",
+          "value": "EasyTouch",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950306",
+          "value": "Eaton",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950392",
+          "value": "EBL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1022730",
+          "value": "Echo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1979966",
+          "value": "Echopt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2032791",
+          "value": "e-cloth",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1147353",
+          "value": "Ecobra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2042047",
+          "value": "ECS AG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2061364",
+          "value": "edelkrone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944855",
+          "value": "Edge",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950482",
+          "value": "Edifier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131954",
+          "value": "Edimax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1966542",
+          "value": "EDKAR-Import",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1022280",
+          "value": "EECOO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950400",
+          "value": "EFB Elektronik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973509",
+          "value": "Efox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950406",
+          "value": "EIKI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950324",
+          "value": "Einhell",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "129265_5"
+            ],
+            "values": [
+              "einhel",
+              "ein hel"
+            ]
+          }
+        },
+        {
+          "id": "248811_1950409",
+          "value": "EIZO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950503",
+          "value": "Eken",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984415",
+          "value": "eKids",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Ekids"
+            ]
+          }
+        },
+        {
+          "id": "248811_1950513",
+          "value": "Elecom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922194",
+          "value": "Electronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143312",
+          "value": "Elegiant",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950528",
+          "value": "Elektronika",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1148414",
+          "value": "Element",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950532",
+          "value": "Elementrix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922024",
+          "value": "Eleoption",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132024",
+          "value": "Elgato",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950538",
+          "value": "Eliart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950539",
+          "value": "Elikon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950540",
+          "value": "Elinchrom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_999646",
+          "value": "Elite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134709",
+          "value": "Elmak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922186",
+          "value": "Elta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1785968",
+          "value": "Elysee",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950418",
+          "value": "EMB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955599",
+          "value": "eMeet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1125005",
+          "value": "EM&EM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950569",
+          "value": "Eminent",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950352",
+          "value": "Emos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950579",
+          "value": "Emtec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950586",
+          "value": "Eneloop",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136078",
+          "value": "Energizer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1986024",
+          "value": "eNitro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950601",
+          "value": "Enna",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1154146",
+          "value": "eos",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Eos"
+            ]
+          }
+        },
+        {
+          "id": "248811_1939065",
+          "value": "Epos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131516",
+          "value": "Epson",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950616",
+          "value": "Equip",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1966608",
+          "value": "Ermenrich",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950631",
+          "value": "Ersatz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984446",
+          "value": "Ertom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1112735",
+          "value": "Escal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950633",
+          "value": "Eschenbach",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950365",
+          "value": "Esperanza",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950434",
+          "value": "ESR",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1944834",
+          "value": "ESS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1161930",
+          "value": "Esschert",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955603",
+          "value": "eSTUFF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940634",
+          "value": "eSynic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1790004",
+          "value": "ETA",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Eta"
+            ]
+          }
+        },
+        {
+          "id": "248811_2011203",
+          "value": "Etalon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922036",
+          "value": "ETiME",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131484",
+          "value": "ETI Polam",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Eti-Polam"
+            ]
+          }
+        },
+        {
+          "id": "248811_1939011",
+          "value": "E-trade",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950649",
+          "value": "EtuiTab",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1157875",
+          "value": "Eufy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990543",
+          "value": "Eumig",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1019305",
+          "value": "Eurobatt",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "EUROBATT"
+            ]
+          }
+        },
+        {
+          "id": "248811_1950660",
+          "value": "Eurokomp",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1743278",
+          "value": "Eurolook",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1086161",
+          "value": "Europa",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "EUROPA"
+            ]
+          }
+        },
+        {
+          "id": "248811_1221279",
+          "value": "EVA",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Eva"
+            ]
+          }
+        },
+        {
+          "id": "248811_1944966",
+          "value": "Eval marine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984464",
+          "value": "Eve4You",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950666",
+          "value": "Evecase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131494",
+          "value": "Everactive",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950377",
+          "value": "Everest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1918828",
+          "value": "EVI",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "evi"
+            ]
+          }
+        },
+        {
+          "id": "248811_1944970",
+          "value": "Evoc",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939087",
+          "value": "Evolveo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950684",
+          "value": "Ewent",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950687",
+          "value": "Exa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950691",
+          "value": "Exacta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950692",
+          "value": "Exakta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950696",
+          "value": "Excelsior",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134098",
+          "value": "EXO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950385",
+          "value": "Expert",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014261",
+          "value": "Explore Scientific",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143313",
+          "value": "Extech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_975871",
+          "value": "Extol",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "EXTOL"
+            ]
+          }
+        },
+        {
+          "id": "248811_1939092",
+          "value": "Extol Light",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_989377",
+          "value": "Extra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131519",
+          "value": "Extralink",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950707",
+          "value": "Extra Value Tools",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014263",
+          "value": "Eyebre",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990550",
+          "value": "F3",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1959524",
+          "value": "Faburo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2057849",
+          "value": "FACEGLE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990553",
+          "value": "Faithpro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1047327",
+          "value": "Falcon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950765",
+          "value": "Falcon Eyes",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950766",
+          "value": "Falken",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "9300_20"
+            ]
+          }
+        },
+        {
+          "id": "248811_1950773",
+          "value": "Fancier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1219198",
+          "value": "Fancii",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950775",
+          "value": "Fandare",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950776",
+          "value": "Fandy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248928_1705316",
+              "248929_1712370",
+              "127788_657517",
+              "127812_1767480",
+              "234581_1062794"
+            ]
+          }
+        },
+        {
+          "id": "248811_950405",
+          "value": "Faro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945045",
+          "value": "Fdit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950723",
+          "value": "FDK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1153916",
+          "value": "FDM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939132",
+          "value": "Fedus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1144219",
+          "value": "Feegar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950803",
+          "value": "Feelworld",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950806",
+          "value": "FeiyuTech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922710",
+          "value": "Fellowes",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_968860"
+            ]
+          }
+        },
+        {
+          "id": "248811_950414",
+          "value": "Fenix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950423",
+          "value": "Festool",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950727",
+          "value": "FFG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950828",
+          "value": "Fifine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945076",
+          "value": "Fighter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950833",
+          "value": "Filters",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950834",
+          "value": "Filtry",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950835",
+          "value": "Fimi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950843",
+          "value": "Fintie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1087988",
+          "value": "Firecore",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2035387",
+          "value": "firefield",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950848",
+          "value": "First",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950429",
+          "value": "Fischer",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "181_7"
+            ]
+          }
+        },
+        {
+          "id": "248811_1104378",
+          "value": "Fisher",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1138573",
+          "value": "Fisher-Price",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_765844"
+            ],
+            "values": [
+              "fischer price",
+              "fischerprice"
+            ]
+          }
+        },
+        {
+          "id": "248811_1939153",
+          "value": "Fixed",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078353",
+          "value": "Flameey",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950438",
+          "value": "Flex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950870",
+          "value": "Flexible",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1923148",
+          "value": "Flintronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1094191",
+          "value": "Flir",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991183",
+          "value": "Flycam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1189015",
+          "value": "Flysea",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950886",
+          "value": "FlySky",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2052290",
+          "value": "FLYSTORE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950734",
+          "value": "FMA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945155",
+          "value": "Focal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948383",
+          "value": "FOCUS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984524",
+          "value": "Focus Nordic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014322",
+          "value": "Focus Sport Optics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950895",
+          "value": "Foen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950898",
+          "value": "Foleto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1076549",
+          "value": "Folia",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_1898448"
+            ]
+          }
+        },
+        {
+          "id": "248811_1019020",
+          "value": "Foma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950902",
+          "value": "Fomei",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2054750",
+          "value": "FOMEX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950908",
+          "value": "Forcell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014327",
+          "value": "Foresight",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950913",
+          "value": "Forestzone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080341",
+          "value": "Forever",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973256",
+          "value": "Format",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950915",
+          "value": "Formax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950920",
+          "value": "Forpus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1022019",
+          "value": "Fortis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950928",
+          "value": "Fosmon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043049",
+          "value": "Fossibot",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1959741",
+          "value": "Fotkom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950932",
+          "value": "Fotodiox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939177",
+          "value": "FotoElite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950933",
+          "value": "Fotoenergia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939178",
+          "value": "Foton",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1959742",
+          "value": "Fotopol",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950934",
+          "value": "Fotopro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1070519",
+          "value": "Fox",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "228377_626745"
+            ]
+          }
+        },
+        {
+          "id": "248811_1950937",
+          "value": "Foxfoto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939179",
+          "value": "Fox Outdoor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922102",
+          "value": "Foxter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984536",
+          "value": "Frahs",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973021",
+          "value": "Frame",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950943",
+          "value": "Frameo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984541",
+          "value": "Frames Factory",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "234581_1016216"
+            ]
+          }
+        },
+        {
+          "id": "248811_1139227",
+          "value": "Freepower",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014335",
+          "value": "FreeSoldier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950745",
+          "value": "FREEWELL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945186",
+          "value": "Fresh 'n Rebel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2008237",
+          "value": "Frischer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950746",
+          "value": "FSFoto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939118",
+          "value": "FT",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248928_1889731"
+            ]
+          }
+        },
+        {
+          "id": "248811_1973764",
+          "value": "Fuhui",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950457",
+          "value": "Fuji",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1959813",
+          "value": "Fujian",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984551",
+          "value": "Fujiary",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950969",
+          "value": "Fujica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950970",
+          "value": "Fujifilm",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950972",
+          "value": "Fujinon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950973",
+          "value": "Fujitsu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950986",
+          "value": "Fusion One Protector",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950715",
+          "value": "F&V",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950989",
+          "value": "Fxlion",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922488",
+          "value": "Fysic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2054397",
+          "value": "Gadgetic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950470",
+          "value": "Gadget Master",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014384",
+          "value": "GadgetMonster",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951048",
+          "value": "Gaekol",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922703",
+          "value": "GALAX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1838558",
+          "value": "GALAXIA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1087683",
+          "value": "Galaxy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "GALAXY"
+            ]
+          }
+        },
+        {
+          "id": "248811_1959885",
+          "value": "Galeria Ramek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1771154",
+          "value": "Gallart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950480",
+          "value": "Gamma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950488",
+          "value": "Gares",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945261",
+          "value": "Garmin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939222",
+          "value": "Gart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922318",
+          "value": "GAT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1950999",
+          "value": "GE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939226",
+          "value": "Gear",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951079",
+          "value": "GearPro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945274",
+          "value": "Gedeon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950495",
+          "value": "Geko",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127509_9"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951095",
+          "value": "Gelid",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1135854",
+          "value": "Gembird",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1647185",
+          "value": "General Electric",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1116271",
+          "value": "Genesis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014417",
+          "value": "Genetics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1735503",
+          "value": "Genie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951109",
+          "value": "Genuine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1959943",
+          "value": "GeoSafari",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014421",
+          "value": "GeowFii",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951112",
+          "value": "Gepe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1959855",
+          "value": "GEPRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_959018",
+          "value": "German",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951114",
+          "value": "Germany",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951113",
+          "value": "GerTong",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951004",
+          "value": "GGS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2036236",
+          "value": "Giecy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1087705",
+          "value": "Giftdeco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951012",
+          "value": "GIM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1068757",
+          "value": "Gimex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951136",
+          "value": "Giottos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951138",
+          "value": "Gitzo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951142",
+          "value": "Gizomos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951147",
+          "value": "Glare One",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991207",
+          "value": "Glidecam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991206",
+          "value": "Glide Gear",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951149",
+          "value": "Glimmerstone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945301",
+          "value": "Gllaser",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950513",
+          "value": "Globo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951157",
+          "value": "Glorious",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951158",
+          "value": "Glossy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2030773",
+          "value": "Glovex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984616",
+          "value": "Gobe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950518",
+          "value": "Gockowiak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948400",
+          "value": "Goclever",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951168",
+          "value": "Godox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939240",
+          "value": "GoGEN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1989860",
+          "value": "Golla",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2006032",
+          "value": "Golpin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1072402",
+          "value": "GOMEDIA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950525",
+          "value": "Goobay",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950528",
+          "value": "Goodking",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951182",
+          "value": "Google",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984612",
+          "value": "Go Paper",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951164",
+          "value": "GoPole",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951165",
+          "value": "GoPro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1921993",
+          "value": "Gorilla",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1797586",
+          "value": "Go Solid!",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_1797569"
+            ],
+            "values": [
+              "Go Solid"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951188",
+          "value": "Gossen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081845",
+          "value": "Gotel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1152848",
+          "value": "Govee",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950534",
+          "value": "GP",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1134737"
+            ]
+          }
+        },
+        {
+          "id": "248811_1945226",
+          "value": "GP Batteries",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1930761",
+          "value": "GPO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951024",
+          "value": "GP TONER",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951191",
+          "value": "Grado",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_978539",
+          "value": "Graf",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131939",
+          "value": "Grand",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "129265_1863996",
+              "248929_968895",
+              "127788_520253",
+              "248135_983447",
+              "248928_1127018",
+              "127812_524361"
+            ]
+          }
+        },
+        {
+          "id": "248811_1078431",
+          "value": "Granit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1138446",
+          "value": "Graupner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950545",
+          "value": "Green Cell",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_863387"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951202",
+          "value": "Green Clean",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1999143",
+          "value": "Greens",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951203",
+          "value": "Green Stuff World",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081091",
+          "value": "Greifen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951209",
+          "value": "Greisinger",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1099754",
+          "value": "Grifema",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951215",
+          "value": "Gritin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043098",
+          "value": "GrizzProtector",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950558",
+          "value": "Grundig",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951225",
+          "value": "Grykon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1073180",
+          "value": "G&S",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948394",
+          "value": "GSM Hurt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014380",
+          "value": "GSO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951032",
+          "value": "GSP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951033",
+          "value": "GSS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922879",
+          "value": "GT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951035",
+          "value": "GTF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955763",
+          "value": "GT Media",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951227",
+          "value": "Guard",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991218",
+          "value": "Gudsen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939266",
+          "value": "Guide",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951229",
+          "value": "Guide Sensmart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951041",
+          "value": "GVDA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1082391",
+          "value": "Habotest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939294",
+          "value": "Hadex",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_1899027"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951282",
+          "value": "Hahnel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951283",
+          "value": "Hahnemuhle",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951285",
+          "value": "Haida",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951274",
+          "value": "HaKa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951290",
+          "value": "Hakuba",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951294",
+          "value": "Halina",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950573",
+          "value": "Hama",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_5"
+            ]
+          }
+        },
+        {
+          "id": "248811_1945410",
+          "value": "Hammer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014497",
+          "value": "HandeVision",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1047429",
+          "value": "Handloteka",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1160971",
+          "value": "Hand Made",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Handmade"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951304",
+          "value": "Hanimex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014501",
+          "value": "Hanno",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950577",
+          "value": "Hansa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1980564",
+          "value": "Hanying",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922623",
+          "value": "Haoran",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950582",
+          "value": "Hardy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945366",
+          "value": "HARMAN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951327",
+          "value": "Hasselblad",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945422",
+          "value": "Havit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984673",
+          "value": "Havo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951333",
+          "value": "Hawke",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014516",
+          "value": "Hayear",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939316",
+          "value": "Hayne",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939279",
+          "value": "HD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1919557",
+          "value": "HDeye",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_971157",
+          "value": "Heckermann",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1156486",
+          "value": "Hedo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951350",
+          "value": "Heliopan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950594",
+          "value": "Helios",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951354",
+          "value": "Hello Case",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014524",
+          "value": "Henbaker",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945446",
+          "value": "Hengbird",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950599",
+          "value": "Hensel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951363",
+          "value": "Herma",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_701705"
+            ]
+          }
+        },
+        {
+          "id": "248811_988773",
+          "value": "Herman",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951366",
+          "value": "Hero",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1082167",
+          "value": "Hertz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951377",
+          "value": "Hewlett-Packard",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2022393",
+          "value": "HHD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939347",
+          "value": "Highlander",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1159597",
+          "value": "Hikari",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951398",
+          "value": "Hikmicro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950607",
+          "value": "Hikvision",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "HiKVision"
+            ]
+          }
+        },
+        {
+          "id": "248811_959404",
+          "value": "Hilda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950608",
+          "value": "Hilti",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951401",
+          "value": "Himawari",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1960430",
+          "value": "Himoto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951386",
+          "value": "HiPro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951387",
+          "value": "HiT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950609",
+          "value": "Hitachi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951408",
+          "value": "Hitek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951409",
+          "value": "Hiti",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1122090",
+          "value": "Hivexagon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948278",
+          "value": "hobbyelektronika",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1135835",
+          "value": "Hoco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081126",
+          "value": "Hoegert Technik",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_1939359",
+              "248811_1939357"
+            ],
+            "values": [
+              "Hogert",
+              "Hoegert"
+            ]
+          }
+        },
+        {
+          "id": "248811_1991238",
+          "value": "Hohem",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1960454",
+          "value": "Holla",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2027957",
+          "value": "HollaKids",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951421",
+          "value": "Hollyland",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990600",
+          "value": "HolyStone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951427",
+          "value": "Homeet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1941240",
+          "value": "Homkel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950620",
+          "value": "Honeywell",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_988424"
+            ],
+            "values": [
+              "honeywel",
+              "Honeywall",
+              "honey wel"
+            ]
+          }
+        },
+        {
+          "id": "248811_1945485",
+          "value": "Honor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1133568",
+          "value": "Horizon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945491",
+          "value": "Horizont",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131780",
+          "value": "Hot",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248924_1128003"
+            ]
+          }
+        },
+        {
+          "id": "248811_2056678",
+          "value": "HOVERAir",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951448",
+          "value": "Hoya",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1099706",
+          "value": "HP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2056920",
+          "value": "HPRT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945385",
+          "value": "HQ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078323",
+          "value": "HQ Power",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951262",
+          "value": "HS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1729142",
+          "value": "HT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945390",
+          "value": "HTC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131527",
+          "value": "Huawei",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951457",
+          "value": "Hubsan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1161762",
+          "value": "Huepar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955771",
+          "value": "HUGO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945519",
+          "value": "Humanas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1096575",
+          "value": "Hunter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143310",
+          "value": "Hurtel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973472",
+          "value": "HurthAG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945396",
+          "value": "HY",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_769349"
+            ]
+          }
+        },
+        {
+          "id": "248811_1024870",
+          "value": "Hykker",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951480",
+          "value": "HyperDrive",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1974127",
+          "value": "Hyperice",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950641",
+          "value": "Hyundai",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "128877_9"
+            ]
+          }
+        },
+        {
+          "id": "248811_1984721",
+          "value": "Ibiza Sound",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1142103",
+          "value": "iBOX",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "IBox"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922776",
+          "value": "Ica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951538",
+          "value": "Icar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951498",
+          "value": "ICC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951499",
+          "value": "ICGC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1978057",
+          "value": "i-coucou",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951549",
+          "value": "Idea",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_990250",
+          "value": "IDEAL",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Ideal"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951502",
+          "value": "IDX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951551",
+          "value": "Iggual",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950654",
+          "value": "IKEA",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Ikea"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951507",
+          "value": "IK Multimedia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_999703",
+          "value": "Ikonka",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_747194"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951555",
+          "value": "Ilford",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951556",
+          "value": "Ilfrod",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1680808"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951562",
+          "value": "Imation",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951514",
+          "value": "IMG Stage Line",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951515",
+          "value": "IMIT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945571",
+          "value": "Imperial",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984728",
+          "value": "Impossible",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1974171",
+          "value": "Impresja",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1126066",
+          "value": "INA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955781",
+          "value": "In-Akustik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951570",
+          "value": "Inateck",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951571",
+          "value": "Inca",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951579",
+          "value": "Induro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014629",
+          "value": "Industar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945533",
+          "value": "INDYGO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_959598",
+          "value": "INF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951583",
+          "value": "InfiRay",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951567",
+          "value": "InFocus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1120851",
+          "value": "Infotar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014606",
+          "value": "INFOV",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951591",
+          "value": "Ingenico",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1219211",
+          "value": "InLine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939415",
+          "value": "Inn",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2047293",
+          "value": "INNEXO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1024962",
+          "value": "InnovaGoods",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "inovagoods",
+              "inova goods"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951610",
+          "value": "Inskam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1086209",
+          "value": "INSPIRE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922151",
+          "value": "inSPORTline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951612",
+          "value": "Insta360",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951614",
+          "value": "Instax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939418",
+          "value": "Intempo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922101",
+          "value": "Intenso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143506",
+          "value": "Interdruk",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_968932",
+              "248928_1127092",
+              "127812_654401",
+              "127788_512649",
+              "248924_1900240"
+            ]
+          }
+        },
+        {
+          "id": "248811_1084171",
+          "value": "Interlook",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951620",
+          "value": "Intermec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939392",
+          "value": "INTEY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137836",
+          "value": "Invento",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131490",
+          "value": "ION",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945541",
+          "value": "IRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951641",
+          "value": "Irix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1937951",
+          "value": "ISO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_957893",
+          "value": "Iso Trade",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951652",
+          "value": "Isotta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945545",
+          "value": "ISY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951658",
+          "value": "Itel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1062027",
+          "value": "Item",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945547",
+          "value": "ITIMPORT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951535",
+          "value": "ITT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1980729",
+          "value": "I Want",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951661",
+          "value": "Iwata",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1190391",
+          "value": "Izoxis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955665",
+          "value": "j5create",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939451",
+          "value": "Jabra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014679",
+          "value": "Jahti Jakt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137675",
+          "value": "Jakemy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951717",
+          "value": "Jamara",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951728",
+          "value": "JapanParts",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1734781",
+          "value": "JAWORSKI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2012958",
+          "value": "JayTech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1055141",
+          "value": "JB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_974486",
+          "value": "JBL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951671",
+          "value": "JCC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951673",
+          "value": "JDB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948417",
+          "value": "Jeep",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2052722",
+          "value": "JENOPTIK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945648",
+          "value": "Jenzi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951745",
+          "value": "Jessops",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951678",
+          "value": "JG Smart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951751",
+          "value": "Jimmy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951752",
+          "value": "Jinbei",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951753",
+          "value": "Jinhoo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951679",
+          "value": "JJC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1960680",
+          "value": "JJRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951757",
+          "value": "Jobo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951758",
+          "value": "Joby",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951772",
+          "value": "Jovision",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951773",
+          "value": "Joyart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945676",
+          "value": "Joyroom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939447",
+          "value": "JSB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_982089",
+          "value": "Jumi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951780",
+          "value": "Juniper",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951782",
+          "value": "Jupio",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1156139",
+          "value": "Jupiter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939449",
+          "value": "JVC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1096793",
+          "value": "JY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951706",
+          "value": "JYC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2053414",
+          "value": "JYIPure",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_2054196"
+            ],
+            "values": [
+              "JIYPure"
+            ]
+          }
+        },
+        {
+          "id": "248811_989812",
+          "value": "JYSK",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Jysk"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951837",
+          "value": "KabelDirekt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1016137",
+          "value": "Kaiser",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951846",
+          "value": "Kaiser Fototechnik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951847",
+          "value": "Kaisi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143629",
+          "value": "Kaku",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951850",
+          "value": "Kalahari",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951856",
+          "value": "Kaline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945727",
+          "value": "Kamera",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951861",
+          "value": "Kamoka",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939513",
+          "value": "Kandar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951864",
+          "value": "Kanex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1980953",
+          "value": "KANON",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043742",
+          "value": "Kanza",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2022923",
+          "value": "Kapsolo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1020916",
+          "value": "Karwil",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1996913",
+          "value": "Kase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951797",
+          "value": "KBR Games",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950734",
+          "value": "Keenso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939534",
+          "value": "Keltin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939539",
+          "value": "Kenko",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951902",
+          "value": "Kennedy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1133963",
+          "value": "Kensington",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951907",
+          "value": "Kenu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_960276",
+          "value": "Kenwood",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951911",
+          "value": "Kepler",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951914",
+          "value": "Kern",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951915",
+          "value": "Kern Optics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939541",
+          "value": "Kershaw",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945763",
+          "value": "Kestrel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951928",
+          "value": "Keystone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951790",
+          "value": "K&F",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1960863",
+          "value": "KF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951791",
+          "value": "K&F Concept",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950747",
+          "value": "Kgedon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1937971",
+          "value": "KIA",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Kia"
+            ]
+          }
+        },
+        {
+          "id": "248811_1731742",
+          "value": "Kiano",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1998755",
+          "value": "KIDdesigns",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143372",
+          "value": "Kids Euroswan",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_689393",
+              "127812_769567",
+              "3786_1129570",
+              "248924_966252"
+            ]
+          }
+        },
+        {
+          "id": "248811_1974391",
+          "value": "Kids Licensing",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950748",
+          "value": "Kier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950749",
+          "value": "KIK",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Kik"
+            ]
+          }
+        },
+        {
+          "id": "248811_1990636",
+          "value": "Kimafun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939545",
+          "value": "Kinetic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1023778",
+          "value": "King",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951948",
+          "value": "Kingjoy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1079467",
+          "value": "KingLine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951949",
+          "value": "Kingma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951953",
+          "value": "Kingstore",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014761",
+          "value": "Kino Precision",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014762",
+          "value": "Kiron",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1782083",
+          "value": "Kite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1110425",
+          "value": "Kiwi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951967",
+          "value": "KiwiFotos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1016793",
+          "value": "Kkmoon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014767",
+          "value": "Klanet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1023191",
+          "value": "Klaus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951808",
+          "value": "KLIM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955787",
+          "value": "KLIPSCH",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1016754",
+          "value": "K&M",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "KM"
+            ]
+          }
+        },
+        {
+          "id": "248811_1951814",
+          "value": "KMP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945705",
+          "value": "KMZ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1834489",
+          "value": "Knor",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "KNOR"
+            ]
+          }
+        },
+        {
+          "id": "248811_1087680",
+          "value": "Koala",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939558",
+          "value": "Koanni",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080350",
+          "value": "Kodak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984867",
+          "value": "Koeximpo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080420",
+          "value": "Koh-I-Noor",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248928_984493",
+              "127788_496969"
+            ]
+          }
+        },
+        {
+          "id": "248811_2014777",
+          "value": "Kolba",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951994",
+          "value": "Kolor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2023048",
+          "value": "Komax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1960873",
+          "value": "KOMET",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014785",
+          "value": "Komine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014786",
+          "value": "Komz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952002",
+          "value": "Konica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955791",
+          "value": "Konica-Minolta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952054",
+          "value": "König",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955792",
+          "value": "Kono",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1079999",
+          "value": "Kontext",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952007",
+          "value": "Konus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1961102",
+          "value": "Kooper",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_976179",
+          "value": "Koopman",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945825",
+          "value": "Kopier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1108036",
+          "value": "Korbi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014794",
+          "value": "Kosmaty",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952017",
+          "value": "Kowa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1133153",
+          "value": "Kraftika",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_745179",
+              "127812_771295",
+              "248928_1068394"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922059",
+          "value": "Kraftmax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952020",
+          "value": "KrainaGSM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131428",
+          "value": "Krauss",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_975433",
+          "value": "Kreator",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1879902",
+          "value": "KREOleo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952032",
+          "value": "Kristal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952033",
+          "value": "Kropp",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1135853",
+          "value": "Kruger&Matz",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Kruger&matz"
+            ]
+          }
+        },
+        {
+          "id": "248811_1997187",
+          "value": "KRUMAD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945844",
+          "value": "Kruzzel",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_582537"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952038",
+          "value": "Kryptontek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_985291",
+          "value": "Krzymark",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948430",
+          "value": "Ksix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939502",
+          "value": "KT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939582",
+          "value": "Kurtzy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945712",
+          "value": "KW",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945861",
+          "value": "Kwmobile",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1951831",
+          "value": "KW Trade",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_750450",
+              "248135_983394",
+              "248929_968942"
+            ]
+          }
+        },
+        {
+          "id": "248811_950835",
+          "value": "Kyocera",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_968968"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952057",
+          "value": "LA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952094",
+          "value": "Lab31",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014829",
+          "value": "Lacerta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1188421",
+          "value": "Lama",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945889",
+          "value": "Lamax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131280",
+          "value": "Lambda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1096997",
+          "value": "Lamborghini",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973112",
+          "value": "Lamex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952108",
+          "value": "Lamicall",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1729106",
+          "value": "Lampa",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "lampa"
+            ]
+          }
+        },
+        {
+          "id": "248811_984916",
+          "value": "Lanberg",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078349",
+          "value": "LANDGRAF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984923",
+          "value": "Lanteng",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952119",
+          "value": "Laowa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952123",
+          "value": "Laserliner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952125",
+          "value": "Lastolite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952068",
+          "value": "LEA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1022396",
+          "value": "LEAN Toys",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Lean toys",
+              "Lean Toys"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952141",
+          "value": "LeapFrog",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1057801",
+          "value": "Lechpol",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950856",
+          "value": "Led",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939615",
+          "value": "Ledlenser",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950866",
+          "value": "Ledoneled",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1884067",
+          "value": "ledrgb",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950869",
+          "value": "Ledvance",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939616",
+          "value": "Lee",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952150",
+          "value": "Lee Filters",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952153",
+          "value": "Leeq",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1082155",
+          "value": "Leica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136347",
+          "value": "Leitz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952161",
+          "value": "Leitz Wetzlar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984937",
+          "value": "Lemmart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952167",
+          "value": "Lemo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945866",
+          "value": "LEMON",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1961429",
+          "value": "Lemurart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1097456",
+          "value": "Lena Lighting",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952176",
+          "value": "Lenmar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136339",
+          "value": "Lenovo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1945925",
+          "value": "Lens",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952179",
+          "value": "Lensbaby",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990643",
+          "value": "LENSGO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952180",
+          "value": "Lenso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952181",
+          "value": "Lenspen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952182",
+          "value": "Lensso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952183",
+          "value": "Lention",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1961433",
+          "value": "Lenzo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043207",
+          "value": "Leofoto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973689",
+          "value": "Lethe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952193",
+          "value": "Leuchtturm",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014860",
+          "value": "Leupold",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131438",
+          "value": "Leurart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952197",
+          "value": "Levenhuk",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952198",
+          "value": "Leventi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922503",
+          "value": "Lewer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990659",
+          "value": "Lewitt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990660",
+          "value": "Lexar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939626",
+          "value": "Lexibook",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "243385_1648185",
+              "127788_1874531",
+              "127812_536477",
+              "248135_1903212"
+            ]
+          }
+        },
+        {
+          "id": "248811_1799237",
+          "value": "Lexman",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950877",
+          "value": "LG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952210",
+          "value": "Libec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952211",
+          "value": "Libella",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991290",
+          "value": "LibertyLine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952213",
+          "value": "Libratone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014863",
+          "value": "Lichifit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922098",
+          "value": "Life",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952228",
+          "value": "Light4Me",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1146649",
+          "value": "Lightcraft",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2060757",
+          "value": "LightPix Labs",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081241",
+          "value": "lightswim",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948437",
+          "value": "Liitokala",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952232",
+          "value": "Liliput",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952233",
+          "value": "Lilliput",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950883",
+          "value": "Limit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1896060",
+          "value": "Linda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1142089",
+          "value": "Lindy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1968265",
+          "value": "LineComp",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952244",
+          "value": "LinkinPerk",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2055355",
+          "value": "LIPA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1961508",
+          "value": "Lisciani",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_765520",
+              "127812_393577"
+            ]
+          }
+        },
+        {
+          "id": "248811_2019684",
+          "value": "LITE-ON",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078360",
+          "value": "Livarno",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952270",
+          "value": "Livoo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132011",
+          "value": "Lixada",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952076",
+          "value": "LMP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984961",
+          "value": "Lofree",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952284",
+          "value": "Logiix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950894",
+          "value": "Logilink",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1087299",
+          "value": "LOGIT",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Logit"
+            ]
+          }
+        },
+        {
+          "id": "248811_1142682",
+          "value": "Logitech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952285",
+          "value": "Logo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2062193",
+          "value": "LogosDamian",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948439",
+          "value": "Lomo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952288",
+          "value": "Lomography",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136694",
+          "value": "Lomond",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137046",
+          "value": "Lotmar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952306",
+          "value": "LoveInstant",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952310",
+          "value": "Lowepro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950900",
+          "value": "LP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952081",
+          "value": "LPL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014814",
+          "value": "L-Shine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990666",
+          "value": "Lsrc",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950902",
+          "value": "LTC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965889",
+          "value": "Luca",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1937696",
+          "value": "Lucas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922078",
+          "value": "Luck",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939651",
+          "value": "Lucky",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939656",
+          "value": "Luka",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952315",
+          "value": "Lukka",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946009",
+          "value": "Lupine",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952322",
+          "value": "Lupo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952323",
+          "value": "Lupus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016158",
+          "value": "Łuszczek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990668",
+          "value": "Luucco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952332",
+          "value": "LuxCase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952336",
+          "value": "Luxon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014902",
+          "value": "Luxun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1984977",
+          "value": "Lytro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016157",
+          "value": "ŁZK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952349",
+          "value": "M.J",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952446",
+          "value": "MaAnt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952450",
+          "value": "Mackie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950918",
+          "value": "Maclean",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950919",
+          "value": "Maco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1057558",
+          "value": "Mad",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "MAD"
+            ]
+          }
+        },
+        {
+          "id": "248811_1946072",
+          "value": "Made by Joan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946073",
+          "value": "Madej",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_720642",
+              "127812_525309",
+              "127769_568029"
+            ]
+          }
+        },
+        {
+          "id": "248811_1939692",
+          "value": "Madman",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2028351",
+          "value": "Magical",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946081",
+          "value": "Maginon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143230",
+          "value": "Magnetic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952469",
+          "value": "Magnifier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014951",
+          "value": "MaiFeng",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939698",
+          "value": "Majdan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014956",
+          "value": "Makinon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950929",
+          "value": "Makita",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "128608_9"
+            ]
+          }
+        },
+        {
+          "id": "248811_1735474",
+          "value": "Makro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950932",
+          "value": "Malatec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080419",
+          "value": "MalPlay",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "malplay"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952485",
+          "value": "Mamiya",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952487",
+          "value": "Manfrotto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131414",
+          "value": "Manhattan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1119403",
+          "value": "Manta",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_1681528"
+            ],
+            "values": [
+              "MANTA"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952496",
+          "value": "Mantona",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043224",
+          "value": "Manufaktura Stylu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952498",
+          "value": "Maono",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1069985",
+          "value": "Marc O'Polo",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Marco Polo",
+              "Marc O’Polo"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952511",
+          "value": "Marmitek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952515",
+          "value": "Mars2",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952517",
+          "value": "Marshall",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1076728",
+          "value": "Martom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952522",
+          "value": "Marumi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952524",
+          "value": "Marvo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955673",
+          "value": "masa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132933",
+          "value": "Massa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1793791",
+          "value": "Master Prints",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "MasterPrints"
+            ]
+          }
+        },
+        {
+          "id": "248811_950967",
+          "value": "Mata",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952534",
+          "value": "Matador",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "9300_40"
+            ]
+          }
+        },
+        {
+          "id": "248811_1985054",
+          "value": "Matana",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2047920",
+          "value": "Mathorn",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952539",
+          "value": "Matin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946149",
+          "value": "Matisto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_990366",
+          "value": "MatMay",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2052210",
+          "value": "Matnox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952543",
+          "value": "Mauser",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_983574",
+          "value": "Mawe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_989023",
+          "value": "MAX",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "maks",
+              "Max"
+            ]
+          }
+        },
+        {
+          "id": "248811_1138725",
+          "value": "Maxcom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080352",
+          "value": "Maxell",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "maxell"
+            ]
+          }
+        },
+        {
+          "id": "248811_2014913",
+          "value": "MAXHUNTER",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2047731",
+          "value": "Maxilow",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1218390",
+          "value": "Maximex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950971",
+          "value": "Maximus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946162",
+          "value": "Maxlife",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1097216",
+          "value": "MAXSELL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2052545",
+          "value": "Maxta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952559",
+          "value": "Maxtools",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952560",
+          "value": "Maxview",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952561",
+          "value": "Maxwell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952564",
+          "value": "Maxxter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938004",
+          "value": "Mazda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950975",
+          "value": "MBG Line",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "MBGLine"
+            ]
+          }
+        },
+        {
+          "id": "248811_1087319",
+          "value": "MBM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014907",
+          "value": "M-Cab",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948448",
+          "value": "McDodo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014992",
+          "value": "Meade",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950982",
+          "value": "Mean Well",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Mean well"
+            ]
+          }
+        },
+        {
+          "id": "248811_2023667",
+          "value": "Meble Krokus",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_2048033",
+              "248811_1136866"
+            ],
+            "values": [
+              "Krokus Meble"
+            ]
+          }
+        },
+        {
+          "id": "248811_950983",
+          "value": "Mechanic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014994",
+          "value": "Media Jet",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952586",
+          "value": "Medialove",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952584",
+          "value": "MediaRange",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078344",
+          "value": "Mediashop",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Media Shop"
+            ]
+          }
+        },
+        {
+          "id": "248811_1019223",
+          "value": "Media-tech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950985",
+          "value": "Medion",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143851",
+          "value": "Medisana",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_957942",
+          "value": "Meec Tools",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "MeecTools"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952590",
+          "value": "MegaGear",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952592",
+          "value": "Megara",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952597",
+          "value": "Meike",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1782318",
+          "value": "Mekko",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_976751",
+          "value": "Meliconi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1191938",
+          "value": "Melissa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1221756",
+          "value": "Memfis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1135168",
+          "value": "Memobe",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_969017"
+            ]
+          }
+        },
+        {
+          "id": "248811_1135154",
+          "value": "Memoboards",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081233",
+          "value": "Mengs",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952615",
+          "value": "Mentor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952617",
+          "value": "Meopta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015002",
+          "value": "Meprolight Ltd.",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015003",
+          "value": "Meratronik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132035",
+          "value": "Mercury",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990695",
+          "value": "Mestizo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_950997",
+          "value": "Metabo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2019687",
+          "value": "Metabones",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952638",
+          "value": "Metra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952641",
+          "value": "Metz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952642",
+          "value": "Meyer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015013",
+          "value": "Meyer-Optik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015012",
+          "value": "Meyer Optik Görlitz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1138502",
+          "value": "MFC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1133197",
+          "value": "MFH",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2028439",
+          "value": "Mg",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2046609",
+          "value": "MG Chemicals",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955815",
+          "value": "Mi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952656",
+          "value": "Micnova",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952659",
+          "value": "MicroBattery",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1141844",
+          "value": "Microconnect",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131486",
+          "value": "Microsoft",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1064479",
+          "value": "Mikam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952678",
+          "value": "Mikrusy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_991131",
+          "value": "Mik-Star",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946237",
+          "value": "Mileseey",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939774",
+          "value": "Miller",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1122102",
+          "value": "Mil-Tec",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Mil Tec",
+              "Miltec"
+            ]
+          }
+        },
+        {
+          "id": "248811_1080227",
+          "value": "M-import",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Mimport"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922429",
+          "value": "MINI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991326",
+          "value": "Minis Forum",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952691",
+          "value": "Miniso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952692",
+          "value": "Minolta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952694",
+          "value": "Minox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955816",
+          "value": "MiNT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1188580",
+          "value": "M-Interio",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139547",
+          "value": "Minx",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139651",
+          "value": "Mio",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "MIO"
+            ]
+          }
+        },
+        {
+          "id": "248811_1962091",
+          "value": "Mir",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015037",
+          "value": "Mirai Optics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946253",
+          "value": "Miranda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922448",
+          "value": "MISURA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952706",
+          "value": "Mitakon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952392",
+          "value": "MITOYA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951035",
+          "value": "Mitsubishi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1148150",
+          "value": "Mitutoyo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952394",
+          "value": "MIX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952395",
+          "value": "MJX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951037",
+          "value": "MK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990675",
+          "value": "MKF kQamil",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946041",
+          "value": "MKL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946043",
+          "value": "MM",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "3946_1791949"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952401",
+          "value": "MO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946268",
+          "value": "Mobilari",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948453",
+          "value": "Mobilepart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131499",
+          "value": "Modecom",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "MODECOM"
+            ]
+          }
+        },
+        {
+          "id": "248811_1771091",
+          "value": "Modeus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952733",
+          "value": "Modus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015050",
+          "value": "Moge",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1116465",
+          "value": "MoKo",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Moko"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952742",
+          "value": "Molicel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952743",
+          "value": "Moman",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952745",
+          "value": "Monaco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1647251",
+          "value": "Monacor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951050",
+          "value": "Mondex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015052",
+          "value": "Monokular",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946293",
+          "value": "Monster",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951051",
+          "value": "Montana",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1016117",
+          "value": "Montis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951054",
+          "value": "Moobilly",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946300",
+          "value": "Mophie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1735546",
+          "value": "Morex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136553",
+          "value": "Moses",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248928_1704947",
+              "248924_966352",
+              "127812_569621",
+              "127788_687893"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952787",
+          "value": "Moshi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952788",
+          "value": "Moskwa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1190153",
+          "value": "Moso",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948454",
+          "value": "Moto-Mer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922635",
+          "value": "Motorola",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1153818",
+          "value": "MOVO",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Movo"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922705",
+          "value": "moXomi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955809",
+          "value": "MOZA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1221314",
+          "value": "Mozos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132672",
+          "value": "MP",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_1017578",
+              "248928_1126936",
+              "248924_1125211",
+              "127812_787862",
+              "248135_1031922",
+              "127788_682413"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952411",
+          "value": "MPINK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939805",
+          "value": "Mpow",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951058",
+          "value": "MS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131517",
+          "value": "MSI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_974554",
+          "value": "MTA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946055",
+          "value": "MTB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1185241",
+          "value": "MTD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2014929",
+          "value": "MTO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952820",
+          "value": "Multimedia Polska",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946352",
+          "value": "Muscccm",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952835",
+          "value": "Mustool",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952840",
+          "value": "Muvit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985008",
+          "value": "MVK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922525",
+          "value": "MVPower",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952439",
+          "value": "MXM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2028545",
+          "value": "Myfirst",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015077",
+          "value": "Myłkus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015098",
+          "value": "Nachtjäger",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951071",
+          "value": "Name",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952902",
+          "value": "Nanlite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952905",
+          "value": "Nanocable",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1647253",
+          "value": "Narva",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1135161",
+          "value": "natec",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Natec"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952911",
+          "value": "National",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939838",
+          "value": "National Geographic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939839",
+          "value": "Native Union",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952913",
+          "value": "Nato",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952915",
+          "value": "Natural",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1055816",
+          "value": "Navaris",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2012944",
+          "value": "Naxa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939818",
+          "value": "NB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952927",
+          "value": "Neato",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952857",
+          "value": "NEC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131263",
+          "value": "Nedis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952929",
+          "value": "Neewer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1981898",
+          "value": "NeKan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1088302",
+          "value": "Nela-Styl",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951083",
+          "value": "NEO",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Neo"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952940",
+          "value": "Neomounts",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1115013",
+          "value": "Neopak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922006",
+          "value": "Neos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951084",
+          "value": "NEO TOOLS",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Neo Tools"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952946",
+          "value": "Nest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2035933",
+          "value": "NETBUY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952948",
+          "value": "NetDan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136340",
+          "value": "Netgear",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939821",
+          "value": "NEW",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_1897748"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955822",
+          "value": "New Brand",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143623",
+          "value": "Newell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952964",
+          "value": "Newland",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939849",
+          "value": "Newstar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952967",
+          "value": "NexiGo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952968",
+          "value": "Nexoo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946449",
+          "value": "Nextbase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951094",
+          "value": "Nexus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1838585",
+          "value": "Niceboy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "niceboy ion"
+            ]
+          }
+        },
+        {
+          "id": "248811_1171218",
+          "value": "Nice Wall",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Nice wall"
+            ]
+          }
+        },
+        {
+          "id": "248811_1962505",
+          "value": "Nielsen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015128",
+          "value": "Niggeloh",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015132",
+          "value": "Nightfox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015130",
+          "value": "Night Pearl",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952976",
+          "value": "NightVision",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134338",
+          "value": "Nike",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248922_964964",
+              "3786_48"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952978",
+          "value": "Nikkei",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939856",
+          "value": "Nikon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015133",
+          "value": "Nikula",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946462",
+          "value": "Nilox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952982",
+          "value": "Nintendo",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_756318"
+            ]
+          }
+        },
+        {
+          "id": "248811_1952983",
+          "value": "Nippon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952971",
+          "value": "NiSi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952986",
+          "value": "Nissin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939858",
+          "value": "Nitecore",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1087129",
+          "value": "NN",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "130110_1030136"
+            ]
+          }
+        },
+        {
+          "id": "248811_2015088",
+          "value": "NO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015137",
+          "value": "Noblex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952995",
+          "value": "Nobo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043233",
+          "value": "NOCPIX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1928560",
+          "value": "Nocton",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1141923",
+          "value": "Noctua",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131501",
+          "value": "Nokia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953000",
+          "value": "Nolan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953005",
+          "value": "None",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143632",
+          "value": "NORIMPEX",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Norimpex"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953011",
+          "value": "Noritsu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1114785",
+          "value": "Norma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953021",
+          "value": "Northix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953023",
+          "value": "Nothing",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951114",
+          "value": "Nova",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1952872",
+          "value": "NOVATECH",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1924297",
+          "value": "Novaza Tech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953025",
+          "value": "Novex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953028",
+          "value": "Novoflex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_976690",
+          "value": "Nowa",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "nowe",
+              "nowy"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953034",
+          "value": "Nowsonic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1082472",
+          "value": "Noyafa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939873",
+          "value": "Ntn",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015093",
+          "value": "NUM'AXES FRANCE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015152",
+          "value": "Nvectech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953050",
+          "value": "Nylon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2011535",
+          "value": "OA NAIL SYSTEM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131504",
+          "value": "Oehlbach",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953095",
+          "value": "Oficio",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953096",
+          "value": "Ogio",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953111",
+          "value": "Olympus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_982514",
+          "value": "Omega",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_1874794"
+            ]
+          }
+        },
+        {
+          "id": "248811_2015176",
+          "value": "Omegon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_958787",
+          "value": "Omna",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953121",
+          "value": "Omoton",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015162",
+          "value": "OM System",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953124",
+          "value": "Ona",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953126",
+          "value": "One For All",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946575",
+          "value": "OnePlus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955682",
+          "value": "ootb",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938023",
+          "value": "Opel",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "128877_21"
+            ]
+          }
+        },
+        {
+          "id": "248811_1967410",
+          "value": "Opel OE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953138",
+          "value": "Oppo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015188",
+          "value": "Optek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1108801",
+          "value": "Optex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953140",
+          "value": "Opti",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951147",
+          "value": "Opticon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953143",
+          "value": "Opticron",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1736317",
+          "value": "Opticum",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1116197",
+          "value": "Optima",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953141",
+          "value": "OptiPro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953148",
+          "value": "Optoma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922974",
+          "value": "Orca",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "ORCA"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953163",
+          "value": "Orico",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953165",
+          "value": "Oriflame",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951153",
+          "value": "Orion",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953175",
+          "value": "Orthland",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953180",
+          "value": "Orwo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951159",
+          "value": "Osram",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939882",
+          "value": "OTH",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948469",
+          "value": "OUKITEL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015201",
+          "value": "Outdoor Connection",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078325",
+          "value": "Overmax",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "OVERMAX"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955828",
+          "value": "OVERSTEEL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2056924",
+          "value": "O-VIS POWER OF ENERGY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953077",
+          "value": "OWL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1736334",
+          "value": "OXE",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Oxe"
+            ]
+          }
+        },
+        {
+          "id": "248811_1138668",
+          "value": "Oxford",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_366781"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953201",
+          "value": "Oyaide",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953203",
+          "value": "Oyster",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953278",
+          "value": "Pacsafe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953210",
+          "value": "PAL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1021386",
+          "value": "Paladone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953282",
+          "value": "Pallas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015234",
+          "value": "Panagor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1915886",
+          "value": "Panaro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951173",
+          "value": "Panasonic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939928",
+          "value": "Panda",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "PANDA"
+            ]
+          }
+        },
+        {
+          "id": "248811_1647257",
+          "value": "Panorama",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953288",
+          "value": "Panta Plast",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_569001",
+              "248929_969075",
+              "248928_1704940"
+            ]
+          }
+        },
+        {
+          "id": "248811_1946669",
+          "value": "Pantera",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2041520",
+          "value": "PANTONE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953290",
+          "value": "Panzerglass",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015238",
+          "value": "Paperang",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1975529",
+          "value": "Paperllo&Itemy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953294",
+          "value": "Paragon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137402",
+          "value": "Parat",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015240",
+          "value": "Pard",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953295",
+          "value": "Paris",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951182",
+          "value": "Parkside",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1087682",
+          "value": "Parrot",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951185",
+          "value": "Partner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1967466",
+          "value": "Partnersite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953299",
+          "value": "Partner Tele",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953273",
+          "value": "PaSe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953306",
+          "value": "Paterson",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_990225",
+          "value": "Patio",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_494205",
+              "248928_1130177"
+            ]
+          }
+        },
+        {
+          "id": "248811_1072874",
+          "value": "Paton",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946692",
+          "value": "Patona",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953217",
+          "value": "PC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953218",
+          "value": "PCB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132822",
+          "value": "PD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953226",
+          "value": "PDS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953227",
+          "value": "PDZ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131858",
+          "value": "PE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953317",
+          "value": "Peak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946699",
+          "value": "Peak Design",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043048",
+          "value": "Pecron",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953321",
+          "value": "Peerless",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1025626",
+          "value": "Pegasus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939959",
+          "value": "Peli",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946707",
+          "value": "Pelican",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131851",
+          "value": "Pelikan",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_393762",
+              "248929_969083"
+            ]
+          }
+        },
+        {
+          "id": "248811_1946711",
+          "value": "Pendo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946712",
+          "value": "Penguin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990753",
+          "value": "Penivo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953329",
+          "value": "Pentacon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953332",
+          "value": "Pentax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_987102",
+          "value": "Pepco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973994",
+          "value": "Perel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1097895",
+          "value": "Perfect",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2034258",
+          "value": "Perfekta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015261",
+          "value": "Peripage",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953352",
+          "value": "Petri",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953344",
+          "value": "PetTec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2024379",
+          "value": "Pex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953237",
+          "value": "PGYTECH",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953358",
+          "value": "Phanteks",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1963097",
+          "value": "Phenix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953359",
+          "value": "Phihong",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951212",
+          "value": "Philips",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_1086164"
+            ]
+          }
+        },
+        {
+          "id": "248811_982287",
+          "value": "Phoenix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953366",
+          "value": "Phomemo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922082",
+          "value": "Phonak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953370",
+          "value": "Phoneo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939969",
+          "value": "Phottix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131291",
+          "value": "PILOT",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Pilot"
+            ]
+          }
+        },
+        {
+          "id": "248811_1939976",
+          "value": "Pinnacle",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939978",
+          "value": "Pioneer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1071324",
+          "value": "Pipi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953390",
+          "value": "Pipishell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953392",
+          "value": "Piramida",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951222",
+          "value": "PIX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953396",
+          "value": "Pixel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015280",
+          "value": "Pixfra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953399",
+          "value": "Planar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1101808",
+          "value": "Planeta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1939986",
+          "value": "Plantronics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015283",
+          "value": "Plastica Panaro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_975767",
+          "value": "Plast-Rol",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Plastrol"
+            ]
+          }
+        },
+        {
+          "id": "248811_1080009",
+          "value": "PLATINET",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080539",
+          "value": "Platinium",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953407",
+          "value": "Platinum",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1115999",
+          "value": "Plus",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_689477"
+            ]
+          }
+        },
+        {
+          "id": "248811_1946642",
+          "value": "PNY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953420",
+          "value": "PocketWizard",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1681289",
+          "value": "POKAR",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1923116",
+          "value": "Polamp",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137223",
+          "value": "Polaris",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953424",
+          "value": "Polaroid",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953423",
+          "value": "PolarPro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985348",
+          "value": "PolFrames",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953432",
+          "value": "Pollux",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946775",
+          "value": "Polo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953436",
+          "value": "Poly",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1982323",
+          "value": "Popup",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1792132",
+          "value": "Porkert",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1646030",
+          "value": "Postergaleria",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1963263",
+          "value": "Potensic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953457",
+          "value": "Powe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946801",
+          "value": "Power",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922034",
+          "value": "Powerbase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990760",
+          "value": "PowerBee",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922031",
+          "value": "Powerextra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953467",
+          "value": "Powerlux",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1099455",
+          "value": "Power Smart",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Powersmart"
+            ]
+          }
+        },
+        {
+          "id": "248811_2015303",
+          "value": "Power Theory",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953469",
+          "value": "Powerton",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946810",
+          "value": "PowerVision",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922053",
+          "value": "POWERY",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Powery"
+            ]
+          }
+        },
+        {
+          "id": "248811_1065595",
+          "value": "PPD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946819",
+          "value": "Praktica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015310",
+          "value": "Prakticar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946648",
+          "value": "PRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951262",
+          "value": "Premier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951265",
+          "value": "Premium",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1191288",
+          "value": "PremiumCord",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991378",
+          "value": "Premium Gold",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015316",
+          "value": "Presenta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951268",
+          "value": "Prestige",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2011710",
+          "value": "Preston",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946832",
+          "value": "Preston Innovations",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_1137603"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953484",
+          "value": "Pretec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015322",
+          "value": "Primary Arms",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953489",
+          "value": "Primewire",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953490",
+          "value": "Primos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953493",
+          "value": "PrintPro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1021632",
+          "value": "Printworks",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248928_1130048",
+              "127788_761515"
+            ]
+          }
+        },
+        {
+          "id": "248811_1061564",
+          "value": "Printz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951273",
+          "value": "Prinz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015326",
+          "value": "Prinzflex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922861",
+          "value": "Prism",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951274",
+          "value": "Prisma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953498",
+          "value": "Prix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955840",
+          "value": "Prixton",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951275",
+          "value": "PRL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951276",
+          "value": "Pro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953509",
+          "value": "Procell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953512",
+          "value": "Proda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1997017",
+          "value": "prodigy.cat",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951287",
+          "value": "Profil",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953520",
+          "value": "Profitec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953523",
+          "value": "Profoto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_981595",
+          "value": "ProGarden",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946871",
+          "value": "Projack",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951296",
+          "value": "Proline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955842",
+          "value": "Pro-Link",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953531",
+          "value": "Promaster",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953536",
+          "value": "Promounts",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1019789",
+          "value": "Pronett",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946879",
+          "value": "Proove",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953507",
+          "value": "ProPaper",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990767",
+          "value": "Propel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953539",
+          "value": "Prorelax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_988045",
+          "value": "Proskit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953543",
+          "value": "Prostuff",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_990074",
+          "value": "Pro-Technik",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Pro Technik"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953553",
+          "value": "Prowell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139660",
+          "value": "Prym",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948487",
+          "value": "Przydasie.pl",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_1734858",
+              "248811_2024562"
+            ],
+            "values": [
+              "PrzydasiePL",
+              "PrzydaSie"
+            ]
+          }
+        },
+        {
+          "id": "248811_2037713",
+          "value": "PrzyPas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953560",
+          "value": "Psion",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953561",
+          "value": "Pskom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951307",
+          "value": "Pulsar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940042",
+          "value": "Puluz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953574",
+          "value": "PureLink",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953272",
+          "value": "PZO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990773",
+          "value": "QCT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1069027",
+          "value": "QianLi",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Qianli"
+            ]
+          }
+        },
+        {
+          "id": "248811_1982420",
+          "value": "QiCheng&LYS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946920",
+          "value": "Qilive",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2028822",
+          "value": "QL-268",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131262",
+          "value": "Qoltec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985397",
+          "value": "QPLOVE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953609",
+          "value": "Quadralite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953610",
+          "value": "Qualcomm",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953611",
+          "value": "Qualit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137854",
+          "value": "Quantum",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946927",
+          "value": "Quasar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940054",
+          "value": "Quechua",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953622",
+          "value": "Quell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946929",
+          "value": "Quer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1124400",
+          "value": "Queta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1071024",
+          "value": "Quick",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953624",
+          "value": "Quick Brake",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127509_783556"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953632",
+          "value": "Qumox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015372",
+          "value": "Qunse",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922343",
+          "value": "R2",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946940",
+          "value": "R2 Invest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946941",
+          "value": "R70",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2048576",
+          "value": "Racam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953679",
+          "value": "Radian",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953687",
+          "value": "Rain Design",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1191223",
+          "value": "Raleno",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946971",
+          "value": "Ram mounts",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985433",
+          "value": "Ram-Serwis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080189",
+          "value": "RANEX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951336",
+          "value": "Rapid",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953712",
+          "value": "Ravencam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953715",
+          "value": "Raver",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1734780",
+          "value": "Rawe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985441",
+          "value": "Raw-West",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953720",
+          "value": "Raynox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951340",
+          "value": "Raytech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134072",
+          "value": "Razer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953646",
+          "value": "RC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953648",
+          "value": "RDS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940094",
+          "value": "RealHunter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1018980",
+          "value": "Realme",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015410",
+          "value": "Realne Ceny",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1946985",
+          "value": "RealPower",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1121545",
+          "value": "Reball",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080521",
+          "value": "Rebel",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248920_962868",
+              "127812_505713"
+            ]
+          }
+        },
+        {
+          "id": "248811_1940099",
+          "value": "RED",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Red"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953742",
+          "value": "Redleaf",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1644339",
+              "128975_1672688"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953744",
+          "value": "Redmi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1925178",
+          "value": "RedSteel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947001",
+          "value": "Reely",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953751",
+          "value": "Reflecta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953754",
+          "value": "Refutuna",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922715",
+          "value": "Regmag",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947006",
+          "value": "Reinston",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990785",
+          "value": "Relacart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081237",
+          "value": "RELASSY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951352",
+          "value": "Relaxdays",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "13288_834706",
+              "213674_835128",
+              "248927_1127381",
+              "248922_965103",
+              "129265_706829",
+              "129970_619705",
+              "127812_777900",
+              "225429_847413",
+              "248929_969120",
+              "246061_672117"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953762",
+          "value": "Relife",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1144138",
+          "value": "Remax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953765",
+          "value": "Remington",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953766",
+          "value": "Removu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953768",
+          "value": "Renata",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1937719",
+          "value": "Renault",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "128877_24"
+            ]
+          }
+        },
+        {
+          "id": "248811_1838543",
+          "value": "Renew Force",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_977323",
+          "value": "Renkforce",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953777",
+          "value": "Reporter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947019",
+          "value": "Reto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951357",
+          "value": "RETOO",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Retoo"
+            ]
+          }
+        },
+        {
+          "id": "248811_1153641",
+          "value": "Retro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131487",
+          "value": "REV",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1018118",
+          "value": "Revell",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_484909"
+            ]
+          }
+        },
+        {
+          "id": "248811_1928648",
+          "value": "Revento",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "REVENTO"
+            ]
+          }
+        },
+        {
+          "id": "248811_1953792",
+          "value": "Revue",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953793",
+          "value": "Revuenon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953795",
+          "value": "Rexing",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1064447",
+          "value": "RGR",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2024749",
+          "value": "Rheinmetall",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081140",
+          "value": "Richter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143906",
+          "value": "Rico",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953806",
+          "value": "Ricoh",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951366",
+          "value": "Ridgid",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080342",
+          "value": "Ring",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1978055",
+          "value": "Rio Beauty",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947054",
+          "value": "Rivacase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1214577",
+          "value": "Riwall",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1963665",
+          "value": "Robbe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953844",
+          "value": "Rodenstock",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2046931",
+          "value": "ROHSEL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2059209",
+          "value": "ROKINON",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1735480",
+          "value": "Roline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947080",
+          "value": "Rollei",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_990368",
+          "value": "Roneberg",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1782000",
+          "value": "Rosfix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1103820",
+          "value": "Rosja",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953871",
+          "value": "Roter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953872",
+          "value": "Rotin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953873",
+          "value": "Rotolight",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953878",
+          "value": "Rovtop",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1874970",
+          "value": "Rowenta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1133202",
+          "value": "Royal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951399",
+          "value": "Rozz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990777",
+          "value": "RQ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953671",
+          "value": "RUIGPRO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1967665",
+          "value": "Ruko",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015468",
+          "value": "Rusan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953895",
+          "value": "Rycote",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990799",
+          "value": "Røde",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248811_1947075"
+            ],
+            "values": [
+              "Rode"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954009",
+          "value": "Sabrent",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954010",
+          "value": "Sachtler",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954013",
+          "value": "Saeco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1094379",
+          "value": "Safe",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954018",
+          "value": "Saft",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1145726",
+          "value": "Sagemcom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954022",
+          "value": "Sagittarius",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954027",
+          "value": "Sainlogic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2028903",
+          "value": "SAINSMART JR.",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015503",
+          "value": "Sainsonic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990811",
+          "value": "Sairen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954029",
+          "value": "Sakar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954045",
+          "value": "Samson",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132002",
+          "value": "Samsonite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951414",
+          "value": "Samsung",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_859210",
+              "248811_2024669",
+              "248811_2045894",
+              "227165_319629"
+            ],
+            "values": [
+              "Samsung  LE22B541",
+              "Rarotype Samsung"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954048",
+          "value": "Samyang",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947212",
+          "value": "Sandberg",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015509",
+          "value": "SanDisk",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951417",
+          "value": "Sanjo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1150749",
+          "value": "Sankyo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947220",
+          "value": "Sanyo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940186",
+          "value": "Saramonic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_974540",
+          "value": "SATA",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Sata"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954063",
+          "value": "Satechi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_960402",
+          "value": "SATIS",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Satis"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954069",
+          "value": "Satzuma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947232",
+          "value": "Save",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131503",
+          "value": "Savio",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "SAVIO"
+            ]
+          }
+        },
+        {
+          "id": "248811_1940156",
+          "value": "SB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1975982",
+          "value": "SBM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947132",
+          "value": "SBS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1021508",
+          "value": "Schemat",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_990092",
+              "248930_1732358",
+              "248928_1151723",
+              "127788_647309",
+              "127769_772007",
+              "248135_1030512",
+              "127812_766121"
+            ]
+          }
+        },
+        {
+          "id": "248811_1947241",
+          "value": "Schneide Electric",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954095",
+          "value": "Schneider",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_704685",
+              "248929_1128543"
+            ]
+          }
+        },
+        {
+          "id": "248811_2015527",
+          "value": "Schneider-Kreuznach",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954097",
+          "value": "Schott",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953918",
+          "value": "SCHUT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954102",
+          "value": "Schwaiger",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954106",
+          "value": "Schweizer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951445",
+          "value": "Scotch",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_662509",
+              "248929_1127049"
+            ]
+          }
+        },
+        {
+          "id": "248811_1131445",
+          "value": "Scrapdesing",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1017002",
+          "value": "SD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954116",
+          "value": "Seagull",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948509",
+          "value": "SeaLife",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1016955",
+          "value": "Seat",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1188961",
+          "value": "Seben",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955857",
+          "value": "SECOMP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1736304",
+          "value": "Secutek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1175627",
+          "value": "Seek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1082120",
+          "value": "Seek Thermal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2052189",
+          "value": "Seetec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015539",
+          "value": "Sefitopher",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954133",
+          "value": "Selco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947274",
+          "value": "Selecline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954138",
+          "value": "Selens",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1160311",
+          "value": "Sell",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954144",
+          "value": "Selvim",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1218261",
+          "value": "Sem",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "SEM"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954145",
+          "value": "Sem Lastik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940215",
+          "value": "Sena",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131694",
+          "value": "Sencor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951460",
+          "value": "Senernable",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954150",
+          "value": "Sennheiser",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1967759",
+          "value": "Sentry",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947298",
+          "value": "Setty",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131525",
+          "value": "SF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940159",
+          "value": "SFD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991416",
+          "value": "Shanren",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954165",
+          "value": "Shape",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954166",
+          "value": "Sharkoon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922673",
+          "value": "Sharp",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922619",
+          "value": "Shaxxz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953941",
+          "value": "SHE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947312",
+          "value": "Shearwater",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954167",
+          "value": "Shein",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "3786_1648501",
+              "3946_1648502"
+            ]
+          }
+        },
+        {
+          "id": "248811_1922402",
+          "value": "Shenzhen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954176",
+          "value": "ShiftСam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043280",
+          "value": "SHIMODA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1081131",
+          "value": "Shinwa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954180",
+          "value": "Shiru",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954183",
+          "value": "Shokz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954184",
+          "value": "Shoot",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2059583",
+          "value": "ShotKam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990826",
+          "value": "Shudder",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1854978",
+          "value": "Shumee",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954192",
+          "value": "Shure",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955858",
+          "value": "SID",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954203",
+          "value": "Sideon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951474",
+          "value": "Siemens",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954207",
+          "value": "Sigel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954208",
+          "value": "Sightmark",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1059603",
+          "value": "Sigma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947338",
+          "value": "Silicon Power",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1189729",
+          "value": "Silva",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951477",
+          "value": "Silver",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1060335",
+          "value": "SilverCrest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954221",
+          "value": "SilverHT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990831",
+          "value": "Silverlit",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_504541"
+            ]
+          }
+        },
+        {
+          "id": "248811_1880883",
+          "value": "Silver Monkey",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2011850",
+          "value": "SILVER SHARKY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940241",
+          "value": "Silverstone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1982814",
+          "value": "Simmons",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137403",
+          "value": "Singercon",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "SINGERCON"
+            ]
+          }
+        },
+        {
+          "id": "248811_1985577",
+          "value": "Sinpo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1221749",
+          "value": "sinsay",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Sinsay"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954241",
+          "value": "Sirius",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954243",
+          "value": "Sirui",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954246",
+          "value": "Sizzix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948501",
+          "value": "SJCam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1964124",
+          "value": "Sjrc",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1976188",
+          "value": "Skandika",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954248",
+          "value": "Skill",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954249",
+          "value": "SkinClear",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1088889",
+          "value": "Skiva",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134325",
+          "value": "Skoda",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947364",
+          "value": "Skross",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954257",
+          "value": "Skullcandy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1143231",
+          "value": "Skylight",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "SKYLIGHT"
+            ]
+          }
+        },
+        {
+          "id": "248811_1947369",
+          "value": "Skymaster",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947365",
+          "value": "SkyRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954261",
+          "value": "Skyreat",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015580",
+          "value": "Sky-Watcher",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015581",
+          "value": "Sky-Watcher (Synta)",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954267",
+          "value": "Slayo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954271",
+          "value": "Slik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954276",
+          "value": "SmallRig",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954278",
+          "value": "Smardy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951505",
+          "value": "Smart",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_989432"
+            ]
+          }
+        },
+        {
+          "id": "248811_1947377",
+          "value": "Smart Choice",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1964165",
+          "value": "Smartech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947381",
+          "value": "SmartGuard",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1158654",
+          "value": "Smart-Tel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947387",
+          "value": "Smarty",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954286",
+          "value": "Smatree",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954289",
+          "value": "Smena",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1976221",
+          "value": "Smiki",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940260",
+          "value": "Smile",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940265",
+          "value": "Snap-On",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136357",
+          "value": "Snaptain",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954296",
+          "value": "Sniper",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947393",
+          "value": "Snooper",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954305",
+          "value": "Soft",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1729065",
+          "value": "Soft99",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985604",
+          "value": "Sofun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954308",
+          "value": "Sokani",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951516",
+          "value": "Sola",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954313",
+          "value": "SolderLab",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954314",
+          "value": "Solex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1095612",
+          "value": "Solier",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1053972",
+          "value": "Solife",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_988863",
+          "value": "Solight",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954317",
+          "value": "Soligor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955686",
+          "value": "solla",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951521",
+          "value": "Solo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940273",
+          "value": "Solognac",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2055962",
+          "value": "Solomark",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922860",
+          "value": "Solution",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954321",
+          "value": "Somikon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954322",
+          "value": "Somita",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954324",
+          "value": "Somostel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1192719",
+          "value": "Sonem",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954326",
+          "value": "Sonero",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1967795",
+          "value": "Sonny",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954333",
+          "value": "Sonos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940277",
+          "value": "Sony",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "234577_1668815"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954337",
+          "value": "Sony Ericsson",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954339",
+          "value": "Sooteway",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1998010",
+          "value": "Sorand",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954352",
+          "value": "Soundcore",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2011789",
+          "value": "SOUNIX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2056296",
+          "value": "SpaceStar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951534",
+          "value": "Spacetronik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954371",
+          "value": "Spark",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_986884",
+          "value": "Spartus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131507",
+          "value": "SpeaKa Professional",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947429",
+          "value": "SpecialReplicas",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1964265",
+          "value": "Spectrue",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954379",
+          "value": "Spectrum Art",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955867",
+          "value": "SpeedLink",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1073225",
+          "value": "SPI 55",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940288",
+          "value": "Spider",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131465",
+          "value": "Spigen",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "213674_769344",
+              "248135_1119931"
+            ]
+          }
+        },
+        {
+          "id": "248811_1932177",
+          "value": "sportown",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1799871",
+          "value": "Spreest",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_979322",
+          "value": "Springos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015632",
+          "value": "Spuhr",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947168",
+          "value": "SS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940170",
+          "value": "ST",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_1875487"
+            ]
+          }
+        },
+        {
+          "id": "248811_951552",
+          "value": "Stanley",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_1896744"
+            ]
+          }
+        },
+        {
+          "id": "248811_1047373",
+          "value": "Star",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1119186",
+          "value": "Stark",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1797416",
+          "value": "Starline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947524",
+          "value": "Start",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954421",
+          "value": "Startech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953985",
+          "value": "STARTRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1117720",
+          "value": "Stator",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1782194",
+          "value": "Stazer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954425",
+          "value": "Stealth Gear",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955871",
+          "value": "SteelSeries",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "stylseries"
+            ]
+          }
+        },
+        {
+          "id": "248811_951560",
+          "value": "Steinberg",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134707",
+          "value": "Steiner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_974508",
+          "value": "Sternhoff",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015648",
+          "value": "Stil Crin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954450",
+          "value": "Stopka",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137864",
+          "value": "Strado",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951577",
+          "value": "Strend Pro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1117938",
+          "value": "Strong",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954466",
+          "value": "StudioKing",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940320",
+          "value": "Stylion",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938061",
+          "value": "Subaru",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955860",
+          "value": "SUBSONIC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2047533",
+          "value": "SucceBuy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954479",
+          "value": "Sumdex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1133709",
+          "value": "Sun",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "SUN"
+            ]
+          }
+        },
+        {
+          "id": "248811_1947574",
+          "value": "Suneo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938062",
+          "value": "Sunlight",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947576",
+          "value": "Sunny",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954491",
+          "value": "Sunnylife",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954493",
+          "value": "Sunpak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015670",
+          "value": "Sun Rain",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1120311",
+          "value": "SunShine",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Sunshine"
+            ]
+          }
+        },
+        {
+          "id": "248811_951591",
+          "value": "Suntekonline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954486",
+          "value": "SunUP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954498",
+          "value": "Sunwayfoto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1998868",
+          "value": "SUNYEETEK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1964447",
+          "value": "Suob",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954502",
+          "value": "Superbee",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1731417",
+          "value": "SUPERO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954503",
+          "value": "Supon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1963808",
+          "value": "SUPVOX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951598",
+          "value": "Survgeo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954508",
+          "value": "Susisun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990857",
+          "value": "Sutefoto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940338",
+          "value": "Suunto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940339",
+          "value": "Svbony",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1953998",
+          "value": "SVEN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954515",
+          "value": "Swarovski",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015689",
+          "value": "Swarovski-Optik",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954516",
+          "value": "Sweex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_978457",
+          "value": "SwiatKabli",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947606",
+          "value": "Swift",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947611",
+          "value": "Swissten",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1921824",
+          "value": "Switchbot",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954523",
+          "value": "Swordfish",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1647318",
+          "value": "Sygonix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_982200",
+          "value": "Sylvania",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951605",
+          "value": "Syma",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954527",
+          "value": "Symbol",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922639",
+          "value": "Symfony",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951606",
+          "value": "Synchro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954529",
+          "value": "Synco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954530",
+          "value": "Syncwire",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139673",
+          "value": "Syosin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954535",
+          "value": "Syrp",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015699",
+          "value": "Sythong",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015700",
+          "value": "Sytong",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955687",
+          "value": "szklaochronne",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954540",
+          "value": "SzybexPol",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1921985",
+          "value": "T6 Power",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1215008"
+            ]
+          }
+        },
+        {
+          "id": "248811_959994",
+          "value": "Tacklife",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1731455",
+          "value": "Tactix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954614",
+          "value": "Tactus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1964579",
+          "value": "Tadekmark",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954623",
+          "value": "Takstar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015750",
+          "value": "Takumar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1066014",
+          "value": "Talvico",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954629",
+          "value": "Tamrac",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954630",
+          "value": "Tamron",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940373",
+          "value": "Tangxi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922515",
+          "value": "TaoTronics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954642",
+          "value": "Targus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954644",
+          "value": "Tascam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947681",
+          "value": "Tasco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940377",
+          "value": "Tatonka",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951625",
+          "value": "TB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954550",
+          "value": "TC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948531",
+          "value": "Tchibo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940350",
+          "value": "TCM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954552",
+          "value": "TC Technic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_970432",
+          "value": "Teccpo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951628",
+          "value": "Tech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131523",
+          "value": "Techly",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947690",
+          "value": "Technaxx",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954673",
+          "value": "Technicolor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954674",
+          "value": "Technics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940388",
+          "value": "TechniSat",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_859341"
+            ]
+          }
+        },
+        {
+          "id": "248811_1967901",
+          "value": "Technoid",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1736977",
+          "value": "Technoline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947697",
+          "value": "Techonic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985735",
+          "value": "TechProject",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940384",
+          "value": "Tech-protect",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_859262"
+            ]
+          }
+        },
+        {
+          "id": "248811_1156467",
+          "value": "Techrebal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1089534",
+          "value": "Tech Sterowniki",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_974894",
+          "value": "TecTake",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1991449",
+          "value": "Tectra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1923119",
+          "value": "Tedi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948527",
+          "value": "TELESIN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1080344",
+          "value": "TelForceOne",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1134754"
+            ]
+          }
+        },
+        {
+          "id": "248811_1976471",
+          "value": "Tello",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955879",
+          "value": "TELLUR",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015775",
+          "value": "Telmu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940394",
+          "value": "Telwin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954715",
+          "value": "Tenba",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990870",
+          "value": "Teng1",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1023777",
+          "value": "Teng Tools",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "TengTools"
+            ]
+          }
+        },
+        {
+          "id": "248811_1964665",
+          "value": "Tento",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1107753",
+          "value": "Tenzi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951656",
+          "value": "Tesa",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_1129208"
+            ]
+          }
+        },
+        {
+          "id": "248811_978273",
+          "value": "Tesco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1768653",
+          "value": "TESLA",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Tesla"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954729",
+          "value": "Testboy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954730",
+          "value": "Tetenal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954731",
+          "value": "Tether Tools",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954564",
+          "value": "TF1",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1192244",
+          "value": "TFA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1107654",
+          "value": "TFA Dostmann",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "TFA-Dostmann"
+            ]
+          }
+        },
+        {
+          "id": "248811_1143980",
+          "value": "TFO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951660",
+          "value": "TG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954740",
+          "value": "The Kase",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947723",
+          "value": "The North Face",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "3786_648213"
+            ],
+            "values": [
+              "nort face",
+              "the nort face",
+              "north face",
+              "nortface",
+              "northface"
+            ]
+          }
+        },
+        {
+          "id": "248811_1131540",
+          "value": "Thermaltake",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015789",
+          "value": "Thermeye",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015788",
+          "value": "ThermTec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990862",
+          "value": "THE T.BONE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947733",
+          "value": "ThiEYE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043301",
+          "value": "THINKTANK",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1186004",
+          "value": "Thomson",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947736",
+          "value": "Thule",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1087657",
+          "value": "thumbsUp!",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015794",
+          "value": "Thundeal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947737",
+          "value": "Thunder",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1022228",
+          "value": "Tianya",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954764",
+          "value": "TicWatch",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954767",
+          "value": "Tie",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954769",
+          "value": "Tiffen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_983246",
+          "value": "Tiger",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954770",
+          "value": "Tigernu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990874",
+          "value": "Tikysky",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954773",
+          "value": "Tilta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954774",
+          "value": "Timbuk2",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1731940",
+          "value": "Timeless Tools",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954780",
+          "value": "Tinko",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951675",
+          "value": "Titan",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248920_1136986",
+              "246061_1729203"
+            ]
+          }
+        },
+        {
+          "id": "248811_984486",
+          "value": "Titanium",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_984908",
+          "value": "Titanum",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_969204",
+              "127812_1143318",
+              "127788_366797",
+              "248928_991278",
+              "248924_1126560",
+              "248135_983308"
+            ]
+          }
+        },
+        {
+          "id": "248811_1108326",
+          "value": "T-Line",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1126224",
+          "value": "TMY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954792",
+          "value": "Tokina",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2057259",
+          "value": "Toladrone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1020934",
+          "value": "Tolsen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1105008",
+          "value": "Toma",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_541853",
+              "248929_969207"
+            ]
+          }
+        },
+        {
+          "id": "248811_1940421",
+          "value": "Tomshoo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955881",
+          "value": "Tomtoc",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954803",
+          "value": "Tomy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127812_50"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955914",
+          "value": "tonies",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954805",
+          "value": "Tonor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947764",
+          "value": "Toocki",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_958511",
+          "value": "Toolcraft",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1729314",
+          "value": "TOP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955880",
+          "value": "TOP-2000",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954820",
+          "value": "Topcon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947774",
+          "value": "Topdon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951691",
+          "value": "TOPEX",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Topex"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954823",
+          "value": "Tophunt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2008139",
+          "value": "TopMac",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922169",
+          "value": "Toptel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1121561",
+          "value": "Toshiba",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954838",
+          "value": "Tosuny",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1929610",
+          "value": "totalstore",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1996997",
+          "value": "Towa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955883",
+          "value": "Toyo",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "9300_30"
+            ]
+          }
+        },
+        {
+          "id": "248811_1218507",
+          "value": "Toys4Boys",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954592",
+          "value": "TOZO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1124906",
+          "value": "TPL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131498",
+          "value": "Tp-Link",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "tp ling",
+              "TP-LINK",
+              "tpling"
+            ]
+          }
+        },
+        {
+          "id": "248811_1132027",
+          "value": "Tracer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954851",
+          "value": "Tradebit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947804",
+          "value": "Traveler",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954861",
+          "value": "Travor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015835",
+          "value": "TrendGeek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954864",
+          "value": "TreQ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1159813",
+          "value": "Trevi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954869",
+          "value": "Triad-Orbit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1734817",
+          "value": "Trigger",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954874",
+          "value": "Trimble",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1144132",
+          "value": "Trimming Shop",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2056141",
+          "value": "TRIOPO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954875",
+          "value": "Tripod",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954877",
+          "value": "Tripp Lite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2025680",
+          "value": "Triseven",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1132930",
+          "value": "Trixie",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "228217_327781"
+            ]
+          }
+        },
+        {
+          "id": "248811_1800114",
+          "value": "Trizand",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Trizard"
+            ]
+          }
+        },
+        {
+          "id": "248811_1947826",
+          "value": "Tronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2013424",
+          "value": "T-RQ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954598",
+          "value": "TRS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947828",
+          "value": "Truecam",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922144",
+          "value": "TrueLife",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1114525",
+          "value": "Trust",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1134774"
+            ]
+          }
+        },
+        {
+          "id": "248811_1937729",
+          "value": "TRX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_975537",
+          "value": "TS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954601",
+          "value": "TTArtisan",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954905",
+          "value": "Tucano",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1964886",
+          "value": "Tudor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1976595",
+          "value": "Tuluszka",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954908",
+          "value": "Tumax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954917",
+          "value": "Turtle Beach",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1781535",
+          "value": "Twinkly",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954926",
+          "value": "Twodots",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954605",
+          "value": "TWS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990890",
+          "value": "Tyrc",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131278",
+          "value": "Ubiquiti",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954934",
+          "value": "UDG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922790",
+          "value": "Ueetek",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "UEETEK"
+            ]
+          }
+        },
+        {
+          "id": "248811_1947865",
+          "value": "UGO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131458",
+          "value": "Ugreen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954956",
+          "value": "Ulanzi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940465",
+          "value": "Ulefone",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2055444",
+          "value": "ULIRVISION",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940466",
+          "value": "Ultimate",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2025733",
+          "value": "Ultralite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954965",
+          "value": "Ultron",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922504",
+          "value": "UMA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940472",
+          "value": "Umarex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951735",
+          "value": "Umbra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2026938",
+          "value": "Umnuou",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954970",
+          "value": "Una",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951736",
+          "value": "UNI",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Uni"
+            ]
+          }
+        },
+        {
+          "id": "248811_1954975",
+          "value": "Unica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951743",
+          "value": "Uniprodo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954987",
+          "value": "Unistellar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951737",
+          "value": "UNI-T",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Uni-t"
+            ]
+          }
+        },
+        {
+          "id": "248811_1131674",
+          "value": "Unitek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015876",
+          "value": "Unitor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954989",
+          "value": "Unitra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940480",
+          "value": "Universal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947897",
+          "value": "Univertel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1126232",
+          "value": "Uniwersal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954997",
+          "value": "Unotec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955889",
+          "value": "Uprint",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947902",
+          "value": "Urbii",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1954945",
+          "value": "USA",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136353",
+          "value": "Usams",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1983324",
+          "value": "Ushining",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940484",
+          "value": "Utendors",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015881",
+          "value": "Uverbon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2012178",
+          "value": "Uxxu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922616",
+          "value": "V7",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1139545",
+          "value": "Vakoss",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955046",
+          "value": "Valenta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955047",
+          "value": "Valentino",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1934735",
+          "value": "Value",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "VALUE"
+            ]
+          }
+        },
+        {
+          "id": "248811_1947935",
+          "value": "Valueline",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955057",
+          "value": "Vanguard",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955892",
+          "value": "Vans",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955061",
+          "value": "Vantage",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947941",
+          "value": "Vantrue",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947911",
+          "value": "VANWIN",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951767",
+          "value": "Vario",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131477",
+          "value": "Varta",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_1031827"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955016",
+          "value": "VAYDEER",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955017",
+          "value": "VBESTLIFE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1947948",
+          "value": "Vector",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248135_983348"
+            ]
+          }
+        },
+        {
+          "id": "248811_2015920",
+          "value": "Vector Optics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948550",
+          "value": "Vega",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955073",
+          "value": "Veho",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1736989",
+          "value": "Velamp",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955074",
+          "value": "Velbon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078419",
+          "value": "Velleman",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955079",
+          "value": "Vena",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955083",
+          "value": "Ventvinal",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134070",
+          "value": "Venus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940505",
+          "value": "Vera",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1647327",
+          "value": "Verbatim",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951784",
+          "value": "Verk",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_987725",
+          "value": "Verk Group",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955088",
+          "value": "Verna",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2032855",
+          "value": "Vertix",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955099",
+          "value": "Vevice",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1131288",
+          "value": "Vevor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2019700",
+          "value": "VFFOTO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1157363",
+          "value": "VF Kraków",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "VF.Kraków"
+            ]
+          }
+        },
+        {
+          "id": "248811_951789",
+          "value": "vhbw",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Vhbw"
+            ]
+          }
+        },
+        {
+          "id": "248811_1098589",
+          "value": "Vicloon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1937734",
+          "value": "Vicon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1097090",
+          "value": "Victor",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951793",
+          "value": "Victorinox",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "206310_236242"
+            ]
+          }
+        },
+        {
+          "id": "248811_978165",
+          "value": "VicTsing",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "VictSing"
+            ]
+          }
+        },
+        {
+          "id": "248811_1132034",
+          "value": "Victure",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951794",
+          "value": "VidaXL",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "129970_417445",
+              "13968_525741"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955896",
+          "value": "ViewSonic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955122",
+          "value": "ViewZ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1936210",
+          "value": "Viking",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "9300_47"
+            ],
+            "values": [
+              "VIKING"
+            ]
+          }
+        },
+        {
+          "id": "248811_1131528",
+          "value": "Vileda",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "13288_1861326",
+              "248135_1030402",
+              "225429_311601"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955130",
+          "value": "Villa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955131",
+          "value": "Viltrox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922116",
+          "value": "Vinnic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951805",
+          "value": "Vintage",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_977737",
+          "value": "Vipolimex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1078356",
+          "value": "Vipow",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955139",
+          "value": "Virgin",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1068118",
+          "value": "Vision",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965157",
+          "value": "Visuo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955155",
+          "value": "Vitacon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1151117",
+          "value": "Vitalco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955159",
+          "value": "Vitu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955160",
+          "value": "Viture",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1069435",
+          "value": "Vivanco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965197",
+          "value": "Viviana",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955163",
+          "value": "Vivitar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955164",
+          "value": "Vivitek",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955165",
+          "value": "VivoLink",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1921997",
+          "value": "Vixen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990907",
+          "value": "Viz4",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1097873",
+          "value": "Vlizo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955173",
+          "value": "Vogel's",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955177",
+          "value": "Voigtlander",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1999559",
+          "value": "VoKo-Smile",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_957930",
+          "value": "Voltcraft",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2048114",
+          "value": "Voltière",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955181",
+          "value": "VolumePlus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1938087",
+          "value": "Volvo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955184",
+          "value": "Vonmählen",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_983715",
+          "value": "Vonroc",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955185",
+          "value": "Vonyx",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965220",
+          "value": "Vorcool",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951814",
+          "value": "Vorel",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127509_27"
+            ]
+          }
+        },
+        {
+          "id": "248811_1063562",
+          "value": "Vortex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015951",
+          "value": "Vortex Optics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955031",
+          "value": "VRIG",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955033",
+          "value": "VSGO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940492",
+          "value": "VTech",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Vtech"
+            ]
+          }
+        },
+        {
+          "id": "248811_1948033",
+          "value": "Wadeo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955232",
+          "value": "Walimex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965254",
+          "value": "Walkera",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948043",
+          "value": "Walter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940528",
+          "value": "Walther",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965258",
+          "value": "Walther design",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1121809",
+          "value": "Warmener",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955246",
+          "value": "Warp",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985906",
+          "value": "Washi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955253",
+          "value": "Wasserstein",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955201",
+          "value": "WD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1854957",
+          "value": "Webhiddenbrand",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951836",
+          "value": "Webski",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955275",
+          "value": "Weian Electronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955279",
+          "value": "Weimar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955206",
+          "value": "WELIKE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948072",
+          "value": "Wembley",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940543",
+          "value": "Wenger",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955298",
+          "value": "Wentronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955208",
+          "value": "WEP",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951848",
+          "value": "West",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955303",
+          "value": "Westcott",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_970954",
+          "value": "Westfalia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2015991",
+          "value": "WestHunter",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_959438",
+          "value": "Westinghouse",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "westinghouse"
+            ]
+          }
+        },
+        {
+          "id": "248811_1948081",
+          "value": "Wheeler",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951849",
+          "value": "Whitenergy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955899",
+          "value": "White Shark",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940548",
+          "value": "Wiking",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955321",
+          "value": "Wild",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955323",
+          "value": "WildGamePlus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016000",
+          "value": "William Optics",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2056772",
+          "value": "WINANQE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948103",
+          "value": "Winner Group",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951862",
+          "value": "Wintact",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955341",
+          "value": "Wireworld",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940554",
+          "value": "Wisport",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_985871",
+          "value": "Wiz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965242",
+          "value": "WL Toys",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951867",
+          "value": "WM",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Wm"
+            ]
+          }
+        },
+        {
+          "id": "248811_1133141",
+          "value": "Wolf",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_989761",
+          "value": "Wolff",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1976891",
+          "value": "Woltu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_959244",
+          "value": "Worx",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016017",
+          "value": "Wosport",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948138",
+          "value": "Wozinsky",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1054811",
+          "value": "WS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955371",
+          "value": "WulkanCenPL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951880",
+          "value": "Wurth",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1771190",
+          "value": "WW",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2060686",
+          "value": "WZFO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_971972",
+          "value": "WZTO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1926466",
+          "value": "XBAY",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948166",
+          "value": "Xblitz",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955403",
+          "value": "Xbox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990932",
+          "value": "XciteRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2029451",
+          "value": "Xerall",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955408",
+          "value": "Xerox",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016039",
+          "value": "Xeye",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955903",
+          "value": "XGIMI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955383",
+          "value": "XGSM",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_973724",
+          "value": "Xiaomi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955410",
+          "value": "Xiaoyi",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955415",
+          "value": "Xioami",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955416",
+          "value": "Xit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1136350",
+          "value": "XO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955421",
+          "value": "Xoro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1154587",
+          "value": "XPart",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948178",
+          "value": "Xqisit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016034",
+          "value": "XREAL",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948179",
+          "value": "Xrec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2057102",
+          "value": "X-Rite",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955395",
+          "value": "XSories",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940580",
+          "value": "Xtar",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1053952",
+          "value": "Xtech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948180",
+          "value": "Xtorm",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1095785",
+          "value": "Xtreme",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_958082",
+          "value": "Xytronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922946",
+          "value": "XYZ",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948190",
+          "value": "Yakima",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955905",
+          "value": "YAKUMO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1145078",
+          "value": "Yamaha",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955460",
+          "value": "Yashica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955461",
+          "value": "Yashica/Contax",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951886",
+          "value": "Yato",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "25328_8",
+              "127509_29"
+            ]
+          }
+        },
+        {
+          "id": "248811_1940581",
+          "value": "YDI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955465",
+          "value": "Yealink",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951887",
+          "value": "Yeelight",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "yeeligt",
+              "yee ligt",
+              "ye light",
+              "yelight"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955468",
+          "value": "Yelangu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955469",
+          "value": "Yellow One",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "248929_969266"
+            ]
+          }
+        },
+        {
+          "id": "248811_1948197",
+          "value": "Yenkee",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1985969",
+          "value": "Yenock",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1110587",
+          "value": "Yermos",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955437",
+          "value": "YI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955906",
+          "value": "Yojo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955482",
+          "value": "Yokohama",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "9300_32"
+            ]
+          }
+        },
+        {
+          "id": "248811_1955483",
+          "value": "Yongnuo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955486",
+          "value": "Yoozon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1054195",
+          "value": "Yorbay",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951894",
+          "value": "Yosoo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955488",
+          "value": "Yotto",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955489",
+          "value": "Young",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955490",
+          "value": "Youpro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1940601",
+          "value": "Yukon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1965491",
+          "value": "Yuneec",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955497",
+          "value": "Yunteng",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922124",
+          "value": "Yuyu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1922450",
+          "value": "YX",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955516",
+          "value": "Zacro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2054878",
+          "value": "ZAIRO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955519",
+          "value": "Zakazany Długopis",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951905",
+          "value": "Zamel",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955523",
+          "value": "Zapco",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1096680",
+          "value": "ZD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955529",
+          "value": "Zeapon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1133711",
+          "value": "Zebra",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955530",
+          "value": "ZeeTech",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955533",
+          "value": "Zeiss",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1137222",
+          "value": "Zelmer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955539",
+          "value": "Zenit",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134654",
+          "value": "Zenith",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "127788_512681"
+            ]
+          }
+        },
+        {
+          "id": "248811_1990949",
+          "value": "Zenro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2008940",
+          "value": "ZENT",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2046837",
+          "value": "Zenza Bronica",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955541",
+          "value": "Zep",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_951916",
+          "value": "Zgeer",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955548",
+          "value": "Zhiyun",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_989757",
+          "value": "Zilner",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1986011",
+          "value": "Zilverstad Ohio",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2056771",
+          "value": "Zingbabu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955555",
+          "value": "Zink",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948250",
+          "value": "Zintronic",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990944",
+          "value": "ZLL Beast",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1990945",
+          "value": "ZLRC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016114",
+          "value": "Zodiak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1063097",
+          "value": "Zolta",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1948256",
+          "value": "Zontex",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1134104",
+          "value": "Zoom",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016116",
+          "value": "Zoomion",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955570",
+          "value": "Zorki",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1930474",
+          "value": "Zosudull",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2008165",
+          "value": "Zree",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955512",
+          "value": "ZSRR",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955575",
+          "value": "Zt",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016123",
+          "value": "Zuslab",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2043330",
+          "value": "ZWO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_2016127",
+          "value": "Zylu",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "248811_1955577",
+          "value": "Zyxel",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      },
+      "formerData": {
+        "ids": [
+          "212538"
+        ],
+        "names": [
+          "Marka (nowa)",
+          "Marka keyboardu",
+          "Producent radia",
+          "Producent (new)",
+          "Wydawnictwo",
+          "Producent akumulatora",
+          "Producent (n)",
+          "Producent części",
+          "Producent wagi",
+          "Marka telefonu",
+          "Producent piły",
+          "Marka / wytwórnia",
+          "Marka opon",
+          "Producent anteny"
+        ]
+      }
+    },
+    {
+      "id": "237206",
+      "name": "Model",
+      "type": "string",
+      "required": true,
+      "requiredForProduct": true,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "minLength": 1,
+        "maxLength": 50,
+        "allowedNumberOfValues": 1
+      },
+      "formerData": {
+        "names": [
+          "Model",
+          "Model opony"
+        ]
+      }
+    },
+    {
+      "id": "38",
+      "name": "Rozdzielczość",
+      "type": "float",
+      "required": true,
+      "requiredForProduct": true,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "Mpx",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 1000,
+        "range": false,
+        "precision": 2
+      }
+    },
+    {
+      "id": "206914",
+      "name": "Przekątna ekranu",
+      "type": "float",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "\"",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 10,
+        "range": false,
+        "precision": 2
+      },
+      "formerData": {
+        "ids": [
+          "226573"
+        ]
+      }
+    },
+    {
+      "id": "14228",
+      "name": "Typ matrycy",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": "14228_228934",
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "14228_1",
+          "value": "CCD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14228_2",
+          "value": "CMOS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14228_3",
+          "value": "CMOS BSI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14228_228930",
+          "value": "Foveon",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14228_4",
+          "value": "Live CCD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14228_5",
+          "value": "Live MOS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14228_6",
+          "value": "MOS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14228_228934",
+          "value": "inny",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      }
+    },
+    {
+      "id": "814",
+      "name": "W zestawie",
+      "type": "dictionary",
+      "required": true,
+      "requiredForProduct": true,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "814_385121",
+          "value": "brak informacji",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "814_1",
+          "value": "korpus",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "814_2",
+          "value": "korpus + obiektyw",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      }
+    },
+    {
+      "id": "218145",
+      "name": "Model załączonego obiektywu",
+      "type": "string",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "minLength": 1,
+        "maxLength": 50,
+        "allowedNumberOfValues": 5
+      }
+    },
+    {
+      "id": "201417",
+      "name": "Mocowanie",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": "201417_208209",
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": true
+      },
+      "dictionary": [
+        {
+          "id": "201417_1783557",
+          "value": "4/3",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "201417_1783560",
+          "value": "Canon EF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "201417_1783559",
+          "value": "Canon EF-S",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "201417_1783555",
+          "value": "Nikon F",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "201417_1783558",
+          "value": "Pentax K",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "201417_1783556",
+          "value": "Sony A",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "201417_208209",
+          "value": "inne",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      },
+      "formerData": {
+        "ids": [
+          "207110"
+        ],
+        "names": [
+          "Mocowanie zacisków"
+        ]
+      }
+    },
+    {
+      "id": "206882",
+      "name": "Rozmiar matrycy",
+      "type": "dictionary",
+      "required": true,
+      "requiredForProduct": true,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": "206882_228794",
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "206882_228762",
+          "value": "średni format",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206882_228766",
+          "value": "pełna klatka",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206882_228770",
+          "value": "APS-H",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206882_228774",
+          "value": "APS-C",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206882_228778",
+          "value": "4/3",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206882_228782",
+          "value": "1\"",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206882_228786",
+          "value": "1/1.7\"",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206882_228790",
+          "value": "1/2.3\"",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206882_228794",
+          "value": "inny",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      }
+    },
+    {
+      "id": "249512",
+      "name": "Kolor",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": "249512_1647427",
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "249512_1647425",
+          "value": "bezbarwny",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "249512_2005858",
+              "250589_1935961"
+            ],
+            "values": [
+              "przezroczysty"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647424",
+          "value": "beżowy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "249512_2005859",
+              "250589_1935962",
+              "250589_1937745"
+            ],
+            "values": [
+              "kremowy"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647414",
+          "value": "biały",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1937743",
+              "250589_1935963"
+            ],
+            "values": [
+              "ecru",
+              "perłowy"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647418",
+          "value": "brązowy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935964"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647413",
+          "value": "czarny",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935965"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647416",
+          "value": "czerwony",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935978",
+              "250589_1935966"
+            ],
+            "values": [
+              "bordowy"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647423",
+          "value": "fioletowy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935967"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647422",
+          "value": "niebieski",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935969",
+              "250589_1935980",
+              "250589_1937742"
+            ],
+            "values": [
+              "granatowy",
+              "turkusowy"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647417",
+          "value": "pomarańczowy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935970"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647415",
+          "value": "różowy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935971"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647426",
+          "value": "srebrny",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935982",
+              "250589_1935972",
+              "250589_1937746"
+            ],
+            "values": [
+              "chrom",
+              "platynowy"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647420",
+          "value": "szary",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935981",
+              "250589_1935973",
+              "250589_1937744"
+            ],
+            "values": [
+              "antracytowy",
+              "grafitowy"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647428",
+          "value": "wielokolorowy",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "249512_1935889",
+              "250589_1935974"
+            ],
+            "values": [
+              "różne kolory"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647421",
+          "value": "zielony",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935975"
+            ],
+            "values": [
+              "khaki",
+              "miętowy"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647429",
+          "value": "złoty",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "249512_1990060",
+              "250589_1935976"
+            ],
+            "values": [
+              "złoto"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647419",
+          "value": "żółty",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "250589_1935977"
+            ]
+          }
+        },
+        {
+          "id": "249512_1647427",
+          "value": "inny kolor",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      },
+      "formerData": {
+        "ids": [
+          "206002"
+        ],
+        "names": [
+          "Kolor body",
+          "Kolor nóg",
+          "Kolor korpusu krzesła",
+          "Kolor szkła",
+          "Kolor dominujący",
+          "kolor dominujący",
+          "Kolor mebla",
+          "Kolor producenta",
+          "Gama kolorystyczna",
+          "Kolor",
+          "Kolor żywicy"
+        ]
+      }
+    },
+    {
+      "id": "14349",
+      "name": "Stabilizacja",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "14349_8",
+          "value": "brak stabilizacji",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14349_1",
+          "value": "cyfrowa",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14349_2",
+          "value": "mechaniczna matrycy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "14349_4",
+          "value": "optyczna obiektywu",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": true
+      }
+    },
+    {
+      "id": "206918",
+      "name": "Zdjęcia seryjne",
+      "type": "float",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "kl./s",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 100,
+        "range": false,
+        "precision": 2
+      }
+    },
+    {
+      "id": "206922",
+      "name": "Wizjer",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": "206922_228862",
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "206922_228866",
+          "value": "brak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206922_228854",
+          "value": "elektroniczny",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206922_228858",
+          "value": "hybrydowy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206922_228850",
+          "value": "optyczny",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206922_228862",
+          "value": "inny",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      }
+    },
+    {
+      "id": "206962",
+      "name": "Jakość video",
+      "type": "dictionary",
+      "required": true,
+      "requiredForProduct": true,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "206962_228938",
+          "value": "480p",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206962_228942",
+          "value": "720p",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206962_228946",
+          "value": "1080p",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206962_228950",
+          "value": "4K",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206962_228954",
+          "value": "brak nagrywania",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      }
+    },
+    {
+      "id": "206930",
+      "name": "Lampa błyskowa",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "206930_4",
+          "value": "brak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206930_2",
+          "value": "możliwość podpięcia",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206930_1",
+          "value": "wbudowana",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": true
+      }
+    },
+    {
+      "id": "211350",
+      "name": "Czułość ISO",
+      "type": "integer",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 10000000,
+        "range": true
+      }
+    },
+    {
+      "id": "209202",
+      "name": "Zasilanie",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "209202_1769478",
+          "value": "akumulatorowe",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "209202_238318"
+            ],
+            "values": [
+              "akumulator"
+            ]
+          }
+        },
+        {
+          "id": "209202_1769477",
+          "value": "baterie",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "ids": [
+              "209202_238314"
+            ],
+            "values": [
+              "bateryjne"
+            ]
+          }
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      },
+      "formerData": {
+        "ids": [
+          "206934"
+        ],
+        "names": [
+          "Rodzaj zasilania",
+          "Zasilanie rożna",
+          "Zasilanie grilla"
+        ]
+      }
+    },
+    {
+      "id": "206938",
+      "name": "Liczba zdjęć na jednym ładowaniu (standard CIPA)",
+      "type": "integer",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "szt.",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 10000,
+        "range": false
+      }
+    },
+    {
+      "id": "249724",
+      "name": "Procesor obrazu",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": "249724_1731361",
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": true
+      },
+      "dictionary": [
+        {
+          "id": "249724_1731704",
+          "value": "Ambarella A7LS75",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731337",
+          "value": "BIONZ",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Bionz XR",
+              "Blonz",
+              "2x BIONZ"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731332",
+          "value": "BIONZ X",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "PROCESOR BIONZ",
+              "Bizon X"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731717",
+          "value": "Capture NX",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Nikon Capture NX"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731773",
+          "value": "DIGIC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731694",
+          "value": "DIGIC 2",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "DIGIC II"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731695",
+          "value": "DIGIC 3",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "DIGIC III z technologią iSAPS",
+              "DIGIC III",
+              "2 x DIGIC III"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731350",
+          "value": "DIGIC 4",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Dwa procesory DIGIC IV",
+              "DiG!C4",
+              "DIGIC 4 (Canon)",
+              "DIGIC IV"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731334",
+          "value": "DIGIC 4+",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "DIGIC 4+ z technologią iSAPS"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731702",
+          "value": "DIGIC 5",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "DIGIC 5 z technologią iSAPS",
+              "DIGIC 5 (Canon)"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731348",
+          "value": "DIGIC 5+",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "2 x DIGIC 5+"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731339",
+          "value": "DIGIC 6",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Podwójny EXPEED 6",
+              "Podwójny DIGIC 6"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731347",
+          "value": "DIGIC 6+",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Procesor Dual DIGIC 6+"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731336",
+          "value": "DIGIC 7",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "DIGIC 7 Image Processor"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731333",
+          "value": "DIGIC 8",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731344",
+          "value": "DIGIC X",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731716",
+          "value": "DRIMe II Pro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731703",
+          "value": "EXILIM Engine 5.0",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731711",
+          "value": "Exmor",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Przetwornik CMOS Exmor R"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731342",
+          "value": "EXPEED",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731357",
+          "value": "EXPEED 2",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Expeed 2"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731345",
+          "value": "EXPEED 3",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "EXPEED 3 (Nikon)"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731335",
+          "value": "EXPEED 4",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "procesor Expeed 4",
+              "EXPEED 4A"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731346",
+          "value": "EXPEED 4 (Nikon)",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731341",
+          "value": "EXPEED 5",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "EXPEED 5A"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731352",
+          "value": "EXPEED 6",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731338",
+          "value": "EXPEED C2",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731710",
+          "value": "EXR II",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731767",
+          "value": "EXR II (Fujifilm)",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731712",
+          "value": "EXR Pro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731700",
+          "value": "GR Engine 6",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731698",
+          "value": "Maestro II",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731701",
+          "value": "Maestro III",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731768",
+          "value": "PRIME II",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731777",
+          "value": "PRIME III",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731708",
+          "value": "PRIME IV",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731705",
+          "value": "Prime M",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731707",
+          "value": "PRIME MII",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731706",
+          "value": "PRIME MIII",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731714",
+          "value": "Safox VIII",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731715",
+          "value": "SLR-DIGIC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731351",
+          "value": "TruePic III",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731353",
+          "value": "TruePic Turbo",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "TruePic"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731360",
+          "value": "TruePic V",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731358",
+          "value": "TruePic VI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731697",
+          "value": "TruePic VII",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "2x TruePic VIII"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731343",
+          "value": "TruePic VIII",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731340",
+          "value": "Venus Engine",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Venus",
+              "Venus Engine FHD"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731696",
+          "value": "Venus Engine II",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Venus Engine HD II",
+              "Panasonic Venus II"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731699",
+          "value": "Venus Engine III",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731355",
+          "value": "Venus Engine IV",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731709",
+          "value": "Venus Engine Plus",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Silnik Venus"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731356",
+          "value": "Venus Engine V",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731354",
+          "value": "Venus Engine VI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731713",
+          "value": "Venus Engine VII",
+          "dependsOnValueIds": [],
+          "formerData": {
+            "values": [
+              "Venus Engine VII FHD",
+              "Venus Engine VII HD"
+            ]
+          }
+        },
+        {
+          "id": "249724_1731349",
+          "value": "X-Processor 4",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731359",
+          "value": "X-Processor Pro",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731718",
+          "value": "X-Trans BSI CMOS 4",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "249724_1731361",
+          "value": "inny",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      },
+      "formerData": {
+        "ids": [
+          "218149"
+        ]
+      }
+    },
+    {
+      "id": "218153",
+      "name": "Autofocus",
+      "type": "string",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "minLength": 1,
+        "maxLength": 50,
+        "allowedNumberOfValues": 1
+      }
+    },
+    {
+      "id": "218157",
+      "name": "Czas ekspozycji",
+      "type": "string",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "minLength": 1,
+        "maxLength": 20,
+        "allowedNumberOfValues": 1
+      }
+    },
+    {
+      "id": "206942",
+      "name": "Obsługiwane karty pamięci",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": "206942_64",
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "206942_8",
+          "value": "CF",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206942_32",
+          "value": "Memory Stick Pro Duo",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206942_1",
+          "value": "SD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206942_2",
+          "value": "SDHC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206942_4",
+          "value": "SDXC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206942_16",
+          "value": "XQD",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206942_64",
+          "value": "inne",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": true
+      }
+    },
+    {
+      "id": "206958",
+      "name": "Komunikacja",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "206958_2",
+          "value": "Bluetooth",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206958_8",
+          "value": "GPS",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206958_4",
+          "value": "NFC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206958_1",
+          "value": "Wi-Fi",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": true
+      }
+    },
+    {
+      "id": "206954",
+      "name": "Złącza",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "206954_1",
+          "value": "audio 3,5 mm",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206954_16",
+          "value": "AV",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206954_32",
+          "value": "microHDMI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206954_8",
+          "value": "miniHDMI",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206954_2",
+          "value": "microUSB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206954_4",
+          "value": "miniUSB",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "206954_64",
+          "value": "USB typ C",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": true
+      }
+    },
+    {
+      "id": "207018",
+      "name": "Konstrukcja",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "207018_8",
+          "value": "automatyczne czyszczenie matrycy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "207018_1",
+          "value": "ekran dotykowy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "207018_2",
+          "value": "ekran ruchomy",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "207018_4",
+          "value": "podwójny slot kart pamięci",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "207018_16",
+          "value": "uszczelnienia",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": true
+      }
+    },
+    {
+      "id": "207022",
+      "name": "Funkcje",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "207022_4",
+          "value": "auto ISO",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "207022_8",
+          "value": "focus peaking",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "207022_2",
+          "value": "interwałometr",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "207022_1",
+          "value": "wirtualny horyzont",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": true
+      }
+    },
+    {
+      "id": "218161",
+      "name": "Załączone wyposażenie",
+      "type": "string",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "minLength": 1,
+        "maxLength": 50,
+        "allowedNumberOfValues": 20
+      }
+    },
+    {
+      "id": "223333",
+      "name": "Szerokość produktu",
+      "type": "float",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "cm",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 1000000,
+        "range": false,
+        "precision": 2
+      },
+      "formerData": {
+        "names": [
+          "Długość całkowita",
+          "Szerokość (mm)",
+          "Długość",
+          "Długość produktu"
+        ]
+      }
+    },
+    {
+      "id": "223329",
+      "name": "Wysokość produktu",
+      "type": "float",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "cm",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 1000000,
+        "range": false,
+        "precision": 2
+      }
+    },
+    {
+      "id": "201321",
+      "name": "Głębokość produktu",
+      "type": "float",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "cm",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 1000000,
+        "range": false,
+        "precision": 2
+      },
+      "formerData": {
+        "names": [
+          "Głębokość"
+        ]
+      }
+    },
+    {
+      "id": "203709",
+      "name": "Waga produktu",
+      "type": "float",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "g",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 1000000,
+        "range": false,
+        "precision": 2
+      },
+      "formerData": {
+        "ids": [
+          "210286",
+          "242693"
+        ]
+      }
+    },
+    {
+      "id": "17448",
+      "name": "Waga produktu z opakowaniem jednostkowym",
+      "type": "float",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": "kg",
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "min": 0,
+        "max": 1000000,
+        "range": false,
+        "precision": 3
+      }
+    },
+    {
+      "id": "225693",
+      "name": "EAN (GTIN)",
+      "type": "string",
+      "required": true,
+      "requiredForProduct": true,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "minLength": 8,
+        "maxLength": 14,
+        "allowedNumberOfValues": 1
+      }
+    },
+    {
+      "id": "224017",
+      "name": "Kod producenta",
+      "type": "string",
+      "required": true,
+      "requiredForProduct": true,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "minLength": 1,
+        "maxLength": 45,
+        "allowedNumberOfValues": 1
+      }
+    },
+    {
+      "id": "229205",
+      "name": "Stan opakowania",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": "11323",
+        "describesProduct": false,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "229205_340245",
+          "value": "oryginalne",
+          "dependsOnValueIds": [
+            "11323_253798",
+            "11323_246534",
+            "11323_1",
+            "11323_1223636",
+            "11323_1223462",
+            "11323_2036072",
+            "11323_246510",
+            "11323_253802",
+            "11323_852680",
+            "11323_246514",
+            "11323_253806",
+            "11323_246466",
+            "11323_2",
+            "11323_1223635",
+            "11323_238066",
+            "11323_238058",
+            "11323_246462",
+            "11323_238062",
+            "11323_246538",
+            "11323_1223453",
+            "11323_238070"
+          ]
+        },
+        {
+          "id": "229205_340249",
+          "value": "otwarte",
+          "dependsOnValueIds": [
+            "11323_253798",
+            "11323_246534",
+            "11323_1223636",
+            "11323_1223462",
+            "11323_2036072",
+            "11323_246510",
+            "11323_253802",
+            "11323_852680",
+            "11323_246514",
+            "11323_253806",
+            "11323_246466",
+            "11323_2",
+            "11323_1223635",
+            "11323_238066",
+            "11323_238058",
+            "11323_246462",
+            "11323_238062",
+            "11323_246538",
+            "11323_1223453",
+            "11323_238070"
+          ]
+        },
+        {
+          "id": "229205_340253",
+          "value": "uszkodzone",
+          "dependsOnValueIds": [
+            "11323_253798",
+            "11323_246534",
+            "11323_1223636",
+            "11323_1223462",
+            "11323_2036072",
+            "11323_246510",
+            "11323_253802",
+            "11323_852680",
+            "11323_246514",
+            "11323_253806",
+            "11323_246466",
+            "11323_2",
+            "11323_1223635",
+            "11323_238066",
+            "11323_238058",
+            "11323_246462",
+            "11323_238062",
+            "11323_246538",
+            "11323_1223453",
+            "11323_238070"
+          ],
+          "formerData": {
+            "values": [
+              "uszkodzony",
+              "niesprawny",
+              "niesprawne"
+            ]
+          }
+        },
+        {
+          "id": "229205_340257",
+          "value": "zastępcze",
+          "dependsOnValueIds": [
+            "11323_253798",
+            "11323_246534",
+            "11323_1223636",
+            "11323_1223462",
+            "11323_2036072",
+            "11323_246510",
+            "11323_253802",
+            "11323_852680",
+            "11323_246514",
+            "11323_253806",
+            "11323_246466",
+            "11323_2",
+            "11323_1223635",
+            "11323_238066",
+            "11323_238058",
+            "11323_246462",
+            "11323_238062",
+            "11323_246538",
+            "11323_1223453",
+            "11323_238070"
+          ]
+        },
+        {
+          "id": "229205_340261",
+          "value": "brak opakowania",
+          "dependsOnValueIds": [
+            "11323_253798",
+            "11323_246534",
+            "11323_1223636",
+            "11323_1223462",
+            "11323_2036072",
+            "11323_246510",
+            "11323_253802",
+            "11323_852680",
+            "11323_246514",
+            "11323_253806",
+            "11323_246466",
+            "11323_2",
+            "11323_1223635",
+            "11323_238066",
+            "11323_238058",
+            "11323_246462",
+            "11323_238062",
+            "11323_246538",
+            "11323_1223453",
+            "11323_238070"
+          ]
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      }
+    },
+    {
+      "id": "218669",
+      "name": "Certyfikaty zgodności",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "218669_1",
+          "value": "CE",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "218669_2056274",
+          "value": "EN 71-3",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "218669_2056275",
+          "value": "EN 716",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "218669_2056276",
+          "value": "EN 747",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "218669_2056277",
+          "value": "FSC",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "218669_2056278",
+          "value": "REACH",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "218669_2056279",
+          "value": "TÜV Rheinland",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "218669_1880913",
+          "value": "WEEE",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": true
+      },
+      "formerData": {
+        "names": [
+          "Informacje o bezpieczeństwie",
+          "Certyfikat"
+        ]
+      }
+    },
+    {
+      "id": "250685",
+      "name": "Zawiera baterie",
+      "type": "dictionary",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "dictionary": [
+        {
+          "id": "250685_2006716",
+          "value": "tak",
+          "dependsOnValueIds": []
+        },
+        {
+          "id": "250685_2006717",
+          "value": "nie",
+          "dependsOnValueIds": []
+        }
+      ],
+      "restrictions": {
+        "multipleChoices": false
+      }
+    },
+    {
+      "id": "250792",
+      "name": "Kod taryfy celnej",
+      "type": "string",
+      "required": false,
+      "requiredForProduct": false,
+      "requiredIf": null,
+      "displayedIf": null,
+      "unit": null,
+      "options": {
+        "ambiguousValueId": null,
+        "dependsOnParameterId": null,
+        "describesProduct": true,
+        "customValuesEnabled": false
+      },
+      "restrictions": {
+        "minLength": 4,
+        "maxLength": 14,
+        "allowedNumberOfValues": 20
+      },
+      "formerData": {
+        "names": [
+          "HSN"
+        ]
+      }
+    }
+  ]
+}

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -16,7 +16,12 @@ import {
   AllegroProductOfferCreateResponse,
 } from '../../../domain/types/allegro-api.types';
 import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
-import { OfferCreateRejectedException, type CreateOfferCommand } from '@openlinker/core/listings';
+import {
+  CategoryNotFoundException,
+  OfferCreateRejectedException,
+  type CreateOfferCommand,
+} from '@openlinker/core/listings';
+import type { CachePort } from '@openlinker/shared';
 
 describe('AllegroOfferManagerAdapter', () => {
   let adapter: AllegroOfferManagerAdapter;
@@ -1103,6 +1108,128 @@ describe('AllegroOfferManagerAdapter', () => {
         .mockResolvedValueOnce(makeResponse({ impliedWarranties: [] }));
 
       await expect(adapter.fetchSellerPolicies()).rejects.toBeInstanceOf(AllegroApiException);
+    });
+  });
+
+  describe('fetchCategoryParameters (cached + neutral)', () => {
+    function makeResponse<T>(data: T): { data: T; status: number; headers: Record<string, string> } {
+      return { data, status: 200, headers: {} };
+    }
+
+    function makeCache(): jest.Mocked<CachePort> {
+      return {
+        get: jest.fn(),
+        set: jest.fn(),
+        delete: jest.fn(),
+      };
+    }
+
+    function buildAdapter(cache: jest.Mocked<CachePort>, ttlSec?: number): AllegroOfferManagerAdapter {
+      return new AllegroOfferManagerAdapter(
+        connectionId,
+        httpClient,
+        uploadHttpClient,
+        identifierMapping,
+        connection,
+        undefined,
+        undefined,
+        cache,
+        ttlSec,
+      );
+    }
+
+    const RAW_RESPONSE = {
+      parameters: [
+        {
+          id: '11323',
+          name: 'Stan',
+          type: 'dictionary' as const,
+          required: true,
+          options: { dependsOnParameterId: null, customValuesEnabled: false },
+          dictionary: [
+            { id: '11323_1', value: 'Nowy', dependsOnValueIds: [] },
+          ],
+          restrictions: { multipleChoices: false },
+        },
+      ],
+    };
+
+    it('returns cached value without hitting Allegro on cache HIT', async () => {
+      const cache = makeCache();
+      const adapterWithCache = buildAdapter(cache);
+      cache.get.mockResolvedValueOnce([
+        { id: 'cached', name: 'Pre-warmed', type: 'string', required: false, restrictions: {} },
+      ]);
+
+      const result = await adapterWithCache.fetchCategoryParameters({ categoryId: '257933' });
+
+      expect(cache.get).toHaveBeenCalledWith('allegro:cat-params:257933');
+      expect(httpClient.get).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        { id: 'cached', name: 'Pre-warmed', type: 'string', required: false, restrictions: {} },
+      ]);
+      expect(cache.set).not.toHaveBeenCalled();
+    });
+
+    it('fetches, maps, and caches on cache MISS — TTL forwarded to CachePort', async () => {
+      const cache = makeCache();
+      const adapterWithCache = buildAdapter(cache, 3600);
+      cache.get.mockResolvedValueOnce(null);
+      httpClient.get.mockResolvedValueOnce(makeResponse(RAW_RESPONSE));
+
+      const result = await adapterWithCache.fetchCategoryParameters({ categoryId: '257933' });
+
+      expect(httpClient.get).toHaveBeenCalledWith('/sale/categories/257933/parameters');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: '11323',
+        type: 'dictionary',
+        required: true,
+      });
+      expect(cache.set).toHaveBeenCalledWith('allegro:cat-params:257933', result, 3600);
+    });
+
+    it('uses the 24h default TTL when no override is supplied', async () => {
+      const cache = makeCache();
+      const adapterWithCache = buildAdapter(cache);
+      cache.get.mockResolvedValueOnce(null);
+      httpClient.get.mockResolvedValueOnce(makeResponse(RAW_RESPONSE));
+
+      await adapterWithCache.fetchCategoryParameters({ categoryId: '257933' });
+
+      expect(cache.set).toHaveBeenCalledWith('allegro:cat-params:257933', expect.any(Array), 86400);
+    });
+
+    it('translates Allegro 404 to CategoryNotFoundException', async () => {
+      const cache = makeCache();
+      const adapterWithCache = buildAdapter(cache);
+      cache.get.mockResolvedValueOnce(null);
+      httpClient.get.mockRejectedValueOnce(new AllegroApiException('not found', 404));
+
+      await expect(
+        adapterWithCache.fetchCategoryParameters({ categoryId: 'unknown' }),
+      ).rejects.toBeInstanceOf(CategoryNotFoundException);
+      expect(cache.set).not.toHaveBeenCalled();
+    });
+
+    it('propagates non-404 AllegroApiException unchanged', async () => {
+      const cache = makeCache();
+      const adapterWithCache = buildAdapter(cache);
+      cache.get.mockResolvedValueOnce(null);
+      httpClient.get.mockRejectedValueOnce(new AllegroApiException('upstream', 503));
+
+      await expect(
+        adapterWithCache.fetchCategoryParameters({ categoryId: '257933' }),
+      ).rejects.toMatchObject({ name: 'AllegroApiException', statusCode: 503 });
+      expect(cache.set).not.toHaveBeenCalled();
+    });
+
+    it('still works without a cache (degrades to no caching)', async () => {
+      // adapter from the outer beforeEach has no cache
+      httpClient.get.mockResolvedValueOnce(makeResponse(RAW_RESPONSE));
+      const result = await adapter.fetchCategoryParameters({ categoryId: '257933' });
+      expect(httpClient.get).toHaveBeenCalledWith('/sale/categories/257933/parameters');
+      expect(result).toHaveLength(1);
     });
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-adapter-factory-wrapper.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-adapter-factory-wrapper.ts
@@ -10,6 +10,7 @@
 import { AdapterFactoryPort, CredentialsResolverPort, Capability } from '@openlinker/core/integrations';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CustomerIdentityResolverPort } from '@openlinker/core/customers';
+import type { CachePort } from '@openlinker/shared';
 import { AllegroAdapterFactory } from '../../application/allegro-adapter.factory';
 import { AllegroTokenRefreshService } from '../token-refresh/allegro-token-refresh.service';
 import { AllegroQuantityCommandRepositoryPort } from '../../domain/ports/allegro-quantity-command-repository.port';
@@ -29,12 +30,18 @@ export class AllegroAdapterFactoryWrapper implements AdapterFactoryPort {
     private readonly tokenRefreshService?: AllegroTokenRefreshService,
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
     private readonly quantityPollConfig?: Partial<QuantityPollConfig>,
+    /** Distributed cache for category parameters (#410). */
+    private readonly cache?: CachePort,
+    /** TTL override (seconds) for the category parameters cache. Defaults to 24h in the adapter. */
+    private readonly catParamsTtlSec?: number,
   ) {
     this.factory = new AllegroAdapterFactory(
       this.customerIdentityResolver,
       this.tokenRefreshService,
       this.commandRepository,
       this.quantityPollConfig,
+      this.cache,
+      this.catParamsTtlSec,
     );
   }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -16,6 +16,7 @@ import type {
   OfferFieldUpdater,
   CategoryBrowser,
   CategoryBarcodeMatcher,
+  CategoryParametersReader,
   OfferCreator,
   SellerPoliciesReader,
   OfferFeedInput,
@@ -27,11 +28,14 @@ import type {
   CreateOfferResultStatus,
   CreateOfferValidationError,
   OfferCategory,
+  CategoryParameter,
   SellerPolicies,
 } from '@openlinker/core/listings';
-import { OfferCreateRejectedException } from '@openlinker/core/listings';
+import { OfferCreateRejectedException, CategoryNotFoundException } from '@openlinker/core/listings';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import type { CachePort } from '@openlinker/shared';
 import { IAllegroHttpClient } from '../http/allegro-http-client.interface';
+import { toNeutralCategoryParameter } from '../mappers/allegro-category-parameter.mapper';
 import {
   AllegroOfferQuantityChangeCommandResponse,
   AllegroQuantityChangeCommandStatusResponse,
@@ -64,6 +68,11 @@ import {
 
 /** Adapter key registered for the Allegro marketplace integration. */
 const ALLEGRO_ADAPTER_KEY = 'allegro.publicapi.v1';
+
+/** Default cache TTL (24h) for `/sale/categories/{id}/parameters` responses. */
+const DEFAULT_CAT_PARAMS_TTL_SEC = 24 * 60 * 60;
+/** Cache key prefix — global namespace; Allegro category schemas are public taxonomy. */
+const CAT_PARAMS_CACHE_PREFIX = 'allegro:cat-params:';
 
 /**
  * Type guard used when filtering untyped `platformParams.parameters` into the
@@ -114,11 +123,13 @@ export class AllegroOfferManagerAdapter
     OfferFieldUpdater,
     CategoryBrowser,
     CategoryBarcodeMatcher,
+    CategoryParametersReader,
     OfferCreator,
     SellerPoliciesReader {
   private readonly logger = new Logger(AllegroOfferManagerAdapter.name);
 
   private readonly quantityPollConfig: QuantityPollConfig;
+  private readonly catParamsTtlSec: number;
 
   constructor(
     private readonly connectionId: string,
@@ -134,6 +145,14 @@ export class AllegroOfferManagerAdapter
     _connection: Connection,
     private readonly commandRepository?: AllegroQuantityCommandRepositoryPort,
     quantityPollConfig?: Partial<QuantityPollConfig>,
+    /**
+     * Optional distributed cache for `/sale/categories/{id}/parameters`
+     * responses. When omitted, every fetch hits Allegro — acceptable for
+     * unit tests but not production. The factory injects a `RedisCacheAdapter`
+     * via `CACHE_PORT_TOKEN` in real wiring.
+     */
+    private readonly cache?: CachePort,
+    catParamsTtlSec?: number,
   ) {
     this.quantityPollConfig = {
       maxAttempts: quantityPollConfig?.maxAttempts ?? 5,
@@ -141,6 +160,7 @@ export class AllegroOfferManagerAdapter
       maxDelayMs: quantityPollConfig?.maxDelayMs ?? 30000,
       backoffMultiplier: quantityPollConfig?.backoffMultiplier ?? 2,
     };
+    this.catParamsTtlSec = catParamsTtlSec ?? DEFAULT_CAT_PARAMS_TTL_SEC;
     void _connection;
   }
 
@@ -386,11 +406,9 @@ export class AllegroOfferManagerAdapter
     let gtinIds: Set<string> = new Set();
 
     if (resolvedCategoryId) {
-      const categoryParamsResponse = await this.httpClient.get<AllegroCategoryParametersResponse>(
-        `/sale/categories/${resolvedCategoryId}/parameters`,
-      );
+      const categoryParams = await this.fetchCategoryParametersRaw(resolvedCategoryId);
       const { eanIds: resolvedEanIds, gtinIds: resolvedGtinIds } =
-        this.findIdentifierParameterIds(categoryParamsResponse.data.parameters);
+        this.findIdentifierParameterIds(categoryParams.parameters);
       eanIds = resolvedEanIds;
       gtinIds = resolvedGtinIds;
     }
@@ -407,6 +425,69 @@ export class AllegroOfferManagerAdapter
       ean: this.pickSingleValue(eanValues),
       gtin: this.pickSingleValue(gtinValues),
     };
+  }
+
+  /**
+   * Raw, uncached fetch of `/sale/categories/{id}/parameters`. Returns Allegro's
+   * native shape verbatim. Single source of truth for the HTTP call —
+   * `fetchOfferIdentifiers` and `fetchCategoryParameters` (cached + neutral)
+   * both delegate here. Public so dev tooling can capture fixtures.
+   */
+  async fetchCategoryParametersRaw(
+    categoryId: string,
+  ): Promise<AllegroCategoryParametersResponse> {
+    this.logger.debug(
+      `Fetching Allegro category parameters (raw): connection=${this.connectionId} categoryId=${categoryId}`,
+    );
+    const response = await this.httpClient.get<AllegroCategoryParametersResponse>(
+      `/sale/categories/${categoryId}/parameters`,
+    );
+    return response.data;
+  }
+
+  /**
+   * Cached, neutral-shape fetch of category parameters for the create-offer
+   * wizard (#410). Implements `CategoryParametersReader`.
+   *
+   * Cache: global key `allegro:cat-params:{categoryId}` (Allegro category
+   * schemas are public taxonomy and identical for every seller). TTL defaults
+   * to 24h; override via constructor `catParamsTtlSec` (env-driven from the
+   * adapter factory).
+   *
+   * 404 from Allegro maps to the neutral `CategoryNotFoundException`; other
+   * upstream errors propagate as-is so the existing `IntegrationError` chain
+   * keeps working.
+   */
+  async fetchCategoryParameters(input: { categoryId: string }): Promise<CategoryParameter[]> {
+    const cacheKey = `${CAT_PARAMS_CACHE_PREFIX}${input.categoryId}`;
+
+    if (this.cache) {
+      const cached = await this.cache.get<CategoryParameter[]>(cacheKey);
+      if (cached) {
+        this.logger.debug(
+          `Category parameters cache HIT: connection=${this.connectionId} categoryId=${input.categoryId}`,
+        );
+        return cached;
+      }
+    }
+
+    let raw: AllegroCategoryParametersResponse;
+    try {
+      raw = await this.fetchCategoryParametersRaw(input.categoryId);
+    } catch (err) {
+      if (err instanceof AllegroApiException && err.statusCode === 404) {
+        throw new CategoryNotFoundException(input.categoryId, 'allegro');
+      }
+      throw err;
+    }
+
+    const neutral = (raw.parameters ?? []).map(toNeutralCategoryParameter);
+
+    if (this.cache) {
+      await this.cache.set(cacheKey, neutral, this.catParamsTtlSec);
+    }
+
+    return neutral;
   }
 
   async fetchCategories(parentId?: string): Promise<OfferCategory[]> {

--- a/libs/integrations/allegro/src/infrastructure/mappers/__tests__/allegro-category-parameter.mapper.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/mappers/__tests__/allegro-category-parameter.mapper.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Allegro Category Parameter Mapper — unit tests
+ *
+ * Drives the mapper against a real sandbox capture (cat 257933, "Aparaty
+ * cyfrowe"). The fixture covers both dependency mechanisms in a single file:
+ *   - parameter `229205` ("Stan opakowania") has `options.dependsOnParameterId`
+ *     pointing to parameter `11323` ("Stan"), and each of its dictionary
+ *     entries carries `dependsOnValueIds` arrays.
+ *   - all other parameters have no parameter-level dependency and empty
+ *     `dependsOnValueIds` on their entries.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/mappers
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import type {
+  AllegroCategoryParameter,
+  AllegroCategoryParametersResponse,
+} from '../../../domain/types/allegro-api.types';
+import { toNeutralCategoryParameter } from '../allegro-category-parameter.mapper';
+
+const FIXTURE_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  'adapters',
+  '__fixtures__',
+  'category-parameters-257933.json',
+);
+
+function loadFixture(): AllegroCategoryParametersResponse {
+  return JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as AllegroCategoryParametersResponse;
+}
+
+function findRaw(
+  fixture: AllegroCategoryParametersResponse,
+  id: string,
+): AllegroCategoryParameter {
+  const found = fixture.parameters.find((p) => p.id === id);
+  if (!found) throw new Error(`Fixture missing parameter ${id}`);
+  return found;
+}
+
+describe('toNeutralCategoryParameter', () => {
+  let fixture: AllegroCategoryParametersResponse;
+  beforeAll(() => {
+    fixture = loadFixture();
+  });
+
+  describe('basic field round-trip', () => {
+    it('preserves id, name, type, required, unit', () => {
+      const raw = findRaw(fixture, '38'); // "Rozdzielczość", float, Mpx
+      const neutral = toNeutralCategoryParameter(raw);
+      expect(neutral.id).toBe('38');
+      expect(neutral.name).toBe('Rozdzielczość');
+      expect(neutral.type).toBe('float');
+      expect(neutral.required).toBe(true);
+      expect(neutral.unit).toBe('Mpx');
+    });
+
+    it('passes through numeric restrictions (min/max/range/precision)', () => {
+      const raw = findRaw(fixture, '38');
+      const { restrictions } = toNeutralCategoryParameter(raw);
+      expect(restrictions.min).toBe(0);
+      expect(restrictions.max).toBe(1000);
+      expect(restrictions.range).toBe(false);
+      expect(restrictions.precision).toBe(2);
+    });
+
+    it('passes through string-length restrictions and numeric allowedNumberOfValues', () => {
+      const raw = findRaw(fixture, '237206'); // "Model", string, 1..50, 1 value
+      const { restrictions } = toNeutralCategoryParameter(raw);
+      expect(restrictions.minLength).toBe(1);
+      expect(restrictions.maxLength).toBe(50);
+      expect(restrictions.allowedNumberOfValues).toBe(1);
+    });
+
+    it('passes through multipleChoices for multi-select dictionaries', () => {
+      const raw = findRaw(fixture, '14349'); // "Stabilizacja", dictionary, multipleChoices
+      const { restrictions, type } = toNeutralCategoryParameter(raw);
+      expect(type).toBe('dictionary');
+      expect(restrictions.multipleChoices).toBe(true);
+    });
+
+    it('hoists customValuesEnabled from options into restrictions', () => {
+      const raw = findRaw(fixture, '201417'); // "Mocowanie", customValuesEnabled
+      const { restrictions } = toNeutralCategoryParameter(raw);
+      expect(restrictions.customValuesEnabled).toBe(true);
+    });
+
+    it('produces a dictionary array for dictionary-typed parameters', () => {
+      const raw = findRaw(fixture, '11323'); // "Stan"
+      const neutral = toNeutralCategoryParameter(raw);
+      expect(Array.isArray(neutral.dictionary)).toBe(true);
+      expect(neutral.dictionary?.length).toBeGreaterThan(0);
+      expect(neutral.dictionary?.[0]).toMatchObject({ id: expect.any(String), value: expect.any(String) });
+    });
+
+    it('returns no dictionary on non-dictionary parameters', () => {
+      const raw = findRaw(fixture, '38'); // float, no dictionary
+      const neutral = toNeutralCategoryParameter(raw);
+      expect(neutral.dictionary).toBeUndefined();
+    });
+  });
+
+  describe('parameter-level visibility (dependsOn)', () => {
+    it('returns undefined when there is no parameter-level dependency', () => {
+      const raw = findRaw(fixture, '11323'); // "Stan", no dependsOnParameterId
+      const neutral = toNeutralCategoryParameter(raw);
+      expect(neutral.dependsOn).toBeUndefined();
+    });
+
+    it('builds dependsOn from options.dependsOnParameterId + entry-level value union', () => {
+      const raw = findRaw(fixture, '229205'); // "Stan opakowania"
+      const neutral = toNeutralCategoryParameter(raw);
+
+      expect(neutral.dependsOn).toBeDefined();
+      expect(neutral.dependsOn?.parameterId).toBe('11323');
+
+      // Each of the 5 entries on parameter 229205 carries the same 21-value
+      // dependsOnValueIds list in the captured fixture; the mapper unions
+      // them into the visibility set.
+      const expected = raw.dictionary![0].dependsOnValueIds!;
+      expect(new Set(neutral.dependsOn?.valueIds ?? [])).toEqual(new Set(expected));
+    });
+  });
+
+  describe('dictionary-entry filtering (dependsOnValueIds on entries)', () => {
+    it('preserves non-empty dependsOnValueIds verbatim on each entry', () => {
+      const raw = findRaw(fixture, '229205');
+      const neutral = toNeutralCategoryParameter(raw);
+
+      // Pick the first entry — should carry the same parent value IDs as in
+      // the raw fixture.
+      const rawEntry = raw.dictionary![0];
+      const neutralEntry = neutral.dictionary![0];
+      expect(neutralEntry.id).toBe(rawEntry.id);
+      expect(neutralEntry.value).toBe(rawEntry.value);
+      expect(neutralEntry.dependsOnValueIds).toEqual(rawEntry.dependsOnValueIds);
+    });
+
+    it('drops dependsOnValueIds when the array is empty (avoids meaningless field on every entry)', () => {
+      const raw = findRaw(fixture, '11323'); // entries all carry empty arrays
+      const neutral = toNeutralCategoryParameter(raw);
+
+      for (const entry of neutral.dictionary ?? []) {
+        expect(entry.dependsOnValueIds).toBeUndefined();
+      }
+    });
+  });
+
+  describe('boundary correctness', () => {
+    it('does not surface formerData / requiredIf / displayedIf to CORE', () => {
+      const raw = findRaw(fixture, '11323');
+      const neutral = toNeutralCategoryParameter(raw) as unknown as Record<string, unknown>;
+      expect(neutral.formerData).toBeUndefined();
+      expect(neutral.requiredIf).toBeUndefined();
+      expect(neutral.displayedIf).toBeUndefined();
+    });
+
+    it('produces the expected number of mapped entries on the large `Marka` dictionary', () => {
+      const raw = findRaw(fixture, '248811'); // "Marka", ~2000 entries
+      const neutral = toNeutralCategoryParameter(raw);
+      expect(neutral.dictionary?.length).toBe(raw.dictionary?.length);
+    });
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/mappers/allegro-category-parameter.mapper.ts
+++ b/libs/integrations/allegro/src/infrastructure/mappers/allegro-category-parameter.mapper.ts
@@ -1,0 +1,81 @@
+/**
+ * Allegro Category Parameter Mapper
+ *
+ * Maps Allegro's raw `/sale/categories/{id}/parameters` response shape to the
+ * marketplace-neutral `CategoryParameter` contract from `@openlinker/core/listings`.
+ *
+ * Surfaces both Allegro dependency mechanisms separately, per #410:
+ *   - parameter-level visibility — `options.dependsOnParameterId` plus the
+ *     union of parent value IDs collected from the parameter's dictionary
+ *     entries' `dependsOnValueIds` arrays.
+ *   - dictionary-entry filtering — `dictionary[i].dependsOnValueIds` is
+ *     preserved verbatim on each neutral entry so the FE renderer can filter
+ *     options based on the current parent value.
+ *
+ * `requiredIf`, `displayedIf`, and `formerData` are dropped at this boundary —
+ * they are Allegro-specific predicates that #410 intentionally does not
+ * surface to CORE.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/mappers
+ */
+import type {
+  CategoryParameter,
+  CategoryParameterDictionaryEntry,
+} from '@openlinker/core/listings';
+import type { AllegroCategoryParameter } from '../../domain/types/allegro-api.types';
+
+export function toNeutralCategoryParameter(
+  raw: AllegroCategoryParameter,
+): CategoryParameter {
+  const dependsOnParameterId = raw.options?.dependsOnParameterId;
+  const visibilityValueIds = dependsOnParameterId
+    ? unionEntryParentValues(raw.dictionary ?? [])
+    : [];
+
+  return {
+    id: raw.id,
+    name: raw.name,
+    type: raw.type,
+    required: raw.required,
+    unit: raw.unit,
+    dictionary: raw.dictionary?.map(toNeutralEntry),
+    restrictions: {
+      multipleChoices: raw.restrictions?.multipleChoices,
+      range: raw.restrictions?.range,
+      min: raw.restrictions?.min,
+      max: raw.restrictions?.max,
+      minLength: raw.restrictions?.minLength,
+      maxLength: raw.restrictions?.maxLength,
+      precision: raw.restrictions?.precision,
+      allowedNumberOfValues: raw.restrictions?.allowedNumberOfValues,
+      customValuesEnabled: raw.options?.customValuesEnabled,
+    },
+    dependsOn:
+      dependsOnParameterId && visibilityValueIds.length > 0
+        ? { parameterId: dependsOnParameterId, valueIds: visibilityValueIds }
+        : undefined,
+  };
+}
+
+function toNeutralEntry(
+  raw: NonNullable<AllegroCategoryParameter['dictionary']>[number],
+): CategoryParameterDictionaryEntry {
+  return {
+    id: raw.id,
+    value: raw.value,
+    dependsOnValueIds:
+      raw.dependsOnValueIds && raw.dependsOnValueIds.length > 0
+        ? raw.dependsOnValueIds
+        : undefined,
+  };
+}
+
+function unionEntryParentValues(
+  dict: ReadonlyArray<{ dependsOnValueIds?: string[] }>,
+): string[] {
+  const set = new Set<string>();
+  for (const entry of dict) {
+    for (const id of entry.dependsOnValueIds ?? []) set.add(id);
+  }
+  return [...set];
+}

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -34,6 +34,10 @@
     "./redis": {
       "types": "./dist/redis/index.d.ts",
       "require": "./dist/redis/index.js"
+    },
+    "./cache": {
+      "types": "./dist/cache/index.d.ts",
+      "require": "./dist/cache/index.js"
     }
   },
   "files": ["dist"],

--- a/libs/shared/src/cache/__tests__/redis-cache.adapter.spec.ts
+++ b/libs/shared/src/cache/__tests__/redis-cache.adapter.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Redis Cache Adapter Unit Tests
+ *
+ * Verifies JSON round-trip, TTL forwarding, miss → null, parse-failure → null,
+ * delete behavior. The Redis client is mocked at the constructor seam.
+ *
+ * @module libs/shared/src/cache
+ */
+import type { RedisClientType } from 'redis';
+import { RedisCacheAdapter } from '../redis-cache.adapter';
+
+interface MockRedis {
+  get: jest.Mock;
+  set: jest.Mock;
+  del: jest.Mock;
+}
+
+function makeAdapter(): { adapter: RedisCacheAdapter; redis: MockRedis } {
+  const redis: MockRedis = {
+    get: jest.fn(),
+    set: jest.fn().mockResolvedValue('OK'),
+    del: jest.fn().mockResolvedValue(1),
+  };
+  const adapter = new RedisCacheAdapter(redis as unknown as RedisClientType);
+  return { adapter, redis };
+}
+
+describe('RedisCacheAdapter', () => {
+  describe('get', () => {
+    it('returns null on cache miss', async () => {
+      const { adapter, redis } = makeAdapter();
+      redis.get.mockResolvedValueOnce(null);
+      await expect(adapter.get('missing')).resolves.toBeNull();
+      expect(redis.get).toHaveBeenCalledWith('missing');
+    });
+
+    it('parses JSON and returns the typed value', async () => {
+      const { adapter, redis } = makeAdapter();
+      const stored = { hello: 'world', nested: { n: 1 } };
+      redis.get.mockResolvedValueOnce(JSON.stringify(stored));
+      await expect(adapter.get<typeof stored>('hit')).resolves.toEqual(stored);
+    });
+
+    it('returns null and logs a warning when stored value is malformed JSON', async () => {
+      const { adapter, redis } = makeAdapter();
+      redis.get.mockResolvedValueOnce('{not valid json');
+      await expect(adapter.get('bad')).resolves.toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    it('JSON-stringifies the value and forwards TTL via { EX }', async () => {
+      const { adapter, redis } = makeAdapter();
+      const value = { a: 1, b: ['x', 'y'] };
+      await adapter.set('key', value, 3600);
+      expect(redis.set).toHaveBeenCalledWith('key', JSON.stringify(value), { EX: 3600 });
+    });
+
+    it('honors a 1-second TTL (boundary)', async () => {
+      const { adapter, redis } = makeAdapter();
+      await adapter.set('key', 'v', 1);
+      expect(redis.set).toHaveBeenCalledWith('key', JSON.stringify('v'), { EX: 1 });
+    });
+  });
+
+  describe('delete', () => {
+    it('forwards the key to client.del', async () => {
+      const { adapter, redis } = makeAdapter();
+      await adapter.delete('to-remove');
+      expect(redis.del).toHaveBeenCalledWith('to-remove');
+    });
+  });
+});

--- a/libs/shared/src/cache/cache.module.ts
+++ b/libs/shared/src/cache/cache.module.ts
@@ -1,0 +1,25 @@
+/**
+ * Cache Module
+ *
+ * Binds CachePort (via CACHE_PORT_TOKEN) to RedisCacheAdapter. Marked @Global
+ * so adapters across the monorepo can inject the port without importing
+ * CacheModule into every feature module. Imports RedisConfigModule for the
+ * underlying 'REDIS_CLIENT' provider.
+ *
+ * @module libs/shared/src/cache
+ */
+import { Global, Module } from '@nestjs/common';
+import { RedisConfigModule } from '../redis';
+import { CACHE_PORT_TOKEN } from './cache.types';
+import { RedisCacheAdapter } from './redis-cache.adapter';
+
+@Global()
+@Module({
+  imports: [RedisConfigModule],
+  providers: [
+    RedisCacheAdapter,
+    { provide: CACHE_PORT_TOKEN, useExisting: RedisCacheAdapter },
+  ],
+  exports: [CACHE_PORT_TOKEN],
+})
+export class CacheModule {}

--- a/libs/shared/src/cache/cache.port.ts
+++ b/libs/shared/src/cache/cache.port.ts
@@ -1,0 +1,27 @@
+/**
+ * Cache Port
+ *
+ * Marketplace-neutral contract for distributed key-value caching. Wraps the
+ * underlying Redis client behind a refactor-safe Symbol token (`CACHE_PORT_TOKEN`)
+ * so adapters depend on the abstraction rather than the global 'REDIS_CLIENT'
+ * string token. Values are JSON-serialized at the boundary.
+ *
+ * @module libs/shared/src/cache
+ */
+export interface CachePort {
+  /**
+   * Read a value by key. Returns null on miss or on JSON parse failure.
+   */
+  get<T>(key: string): Promise<T | null>;
+
+  /**
+   * Write a value with a hard TTL (seconds). Implementations MUST honor the
+   * TTL — callers rely on this for cache freshness contracts.
+   */
+  set<T>(key: string, value: T, ttlSec: number): Promise<void>;
+
+  /**
+   * Remove a value by key. No-op if the key does not exist.
+   */
+  delete(key: string): Promise<void>;
+}

--- a/libs/shared/src/cache/cache.types.ts
+++ b/libs/shared/src/cache/cache.types.ts
@@ -1,0 +1,9 @@
+/**
+ * Cache Types
+ *
+ * Symbol DI token for CachePort. Engineering standards prefer Symbol tokens
+ * over string tokens for type-safe, refactor-safe injection.
+ *
+ * @module libs/shared/src/cache
+ */
+export const CACHE_PORT_TOKEN = Symbol('CachePort');

--- a/libs/shared/src/cache/index.ts
+++ b/libs/shared/src/cache/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Cache Module Exports
+ *
+ * Public API for the shared cache abstraction. Adapters depend on
+ * `CachePort` injected via `CACHE_PORT_TOKEN`.
+ *
+ * @module libs/shared/src/cache
+ */
+export type { CachePort } from './cache.port';
+export { CACHE_PORT_TOKEN } from './cache.types';
+export { CacheModule } from './cache.module';
+export { RedisCacheAdapter } from './redis-cache.adapter';

--- a/libs/shared/src/cache/redis-cache.adapter.ts
+++ b/libs/shared/src/cache/redis-cache.adapter.ts
@@ -1,0 +1,41 @@
+/**
+ * Redis Cache Adapter
+ *
+ * Implements CachePort over the global 'REDIS_CLIENT' provider exposed by
+ * RedisConfigModule. Stores values as JSON; logs and returns null on parse
+ * failure so callers can treat malformed cache entries as misses.
+ *
+ * @module libs/shared/src/cache
+ * @implements {CachePort}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import type { RedisClientType } from 'redis';
+import { Logger } from '../logging';
+import type { CachePort } from './cache.port';
+
+@Injectable()
+export class RedisCacheAdapter implements CachePort {
+  private readonly logger = new Logger(RedisCacheAdapter.name);
+
+  constructor(@Inject('REDIS_CLIENT') private readonly client: RedisClientType) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    const raw = await this.client.get(key);
+    if (raw === null) return null;
+    try {
+      return JSON.parse(raw) as T;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Failed to parse cache value for key ${key}: ${message}`);
+      return null;
+    }
+  }
+
+  async set<T>(key: string, value: T, ttlSec: number): Promise<void> {
+    await this.client.set(key, JSON.stringify(value), { EX: ttlSec });
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+}

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from './config';
 export * from './database';
 export * from './errors';
 export * from './redis';
+export * from './cache';
 export * from './types';
 export * from './crypto';
 


### PR DESCRIPTION
## Summary

Full vertical slice for **#410** — operators can now fill required Allegro category parameters in the create-offer wizard before submission, instead of getting opaque server-side validation errors after the fact.

- **CORE** — new `CategoryParametersReader` sub-capability on `OfferManagerPort`, neutral `CategoryParameter` type with separate `dependsOn` (parameter-level visibility) and `dictionary[i].dependsOnValueIds` (per-entry filtering) mechanisms, `CategoryNotFoundException` domain error.
- **Shared** — new `CachePort` + `RedisCacheAdapter` + `@Global() CacheModule` so adapters can cache without depending on Redis directly.
- **Allegro adapter** — implements `fetchCategoryParameters({ categoryId })` against `GET /sale/categories/{id}/parameters`, cached for 24h via `CachePort`. Mapper covers all four Allegro types (`dictionary` / `string` / `integer` / `float`), surfaces both dependency mechanisms cleanly. Real Allegro fixture (cat 257933 — covers both mechanisms) included.
- **API** — `GET /listings/connections/:connectionId/categories/:categoryId/parameters` with capability narrowing, 422 on unsupported, 404 on missing category.
- **FE** — API client + 24h-staleTime query hook, new step in `CreateOfferWizard` between *Offer details* and *Policies*. Required-first / optional-collapsed groups; field renderer dispatches on `(type, restrictions)` to native `<select>` (small dicts), virtualised `Combobox` (≥50 entries / multi / customValues), scalar `<input>`, range `from/to` pair. Dynamic per-step Zod validation, EAN/Stan auto-prefill, parameters cleared on category change, retry pre-fill via reverse-mapped wire snapshot.
- **Wizard tests** updated to traverse the new step (default empty fixture renders a friendly message).

Quality gate: `pnpm lint`, `pnpm type-check`, `pnpm test` all clean across the workspace (1 295 unit tests, 0 failures, 0 lint errors).

## Test plan

- [ ] Open the create-offer wizard against an Allegro connection
- [ ] Pick a leaf category that has parameters (e.g. category `257933` — bedding) and verify required fields render before optional ones
- [ ] Verify EAN auto-fills from the picked variant and *Stan* defaults to *Nowy*
- [ ] Try advancing without filling a required field and confirm the inline error fires
- [ ] Change the category and confirm the parameter slice is cleared (no stale values from the previous schema)
- [ ] Pick a category with the *Stan opakowania* parameter; verify the dependent dropdown only shows entries valid for the chosen *Stan*
- [ ] Submit and confirm the wire payload's `platformParams.parameters` matches the wizard state
- [ ] Pick a category with no parameters and confirm the friendly empty message appears
- [ ] Disconnect from network mid-wizard and verify the *Retry* button on the parameter-fetch error works

🤖 Generated with [Claude Code](https://claude.com/claude-code)