### PR TITLE
feat(shared,allegro,prestashop): env-tunable HTTP/adapter log body truncation

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -124,3 +124,14 @@ OL_PII_HASH_SALT=your-org-level-salt-change-in-production
 # OL_AI_DEFAULT_MAX_TOKENS=2048
 # OL_AI_TIMEOUT_MS=60000
 # OL_AI_LOG_PROMPT=false   # set to true to log prompt + response at debug level
+
+# --- Logging -----------------------------------------------------------------
+# Cap on HTTP/adapter response and request body length when embedded in log
+# lines. Default 0 = uncapped — full body in logs, useful for dev / staging
+# / debugging incidents (the original motivation for #416 was a 200-char cap
+# silently cutting an Allegro 422 `userMessage` mid-string). Set to a positive
+# integer (chars, not bytes) to truncate; truncated lines get a
+# `… [truncated, total length: N]` marker so consumers can distinguish a
+# clipped log from a malformed payload. Domain exceptions always carry the
+# full body regardless of this setting (matches Allegro #409 pattern).
+# OL_LOG_BODY_MAX_BYTES=0

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -44,3 +44,13 @@ OL_PII_HASH_SALT=your-org-level-salt-change-in-production
 # true  — store raw PII (required for cross-platform customer provisioning)
 # false — store only hashes (privacy-compliant; disables provisioning that needs email)
 OL_STORE_PII=true
+
+# --- Logging -----------------------------------------------------------------
+# Cap on HTTP/adapter response and request body length when embedded in log
+# lines. Default 0 = uncapped — full body in logs, useful for dev / staging
+# / debugging incidents. Set to a positive integer (chars, not bytes) to
+# truncate; truncated lines get a `… [truncated, total length: N]` marker.
+# Domain exceptions always carry the full body regardless of this setting
+# (matches Allegro #409 pattern). Must match API value when worker and API
+# share log-volume budgets.
+# OL_LOG_BODY_MAX_BYTES=0

--- a/docs/plans/implementation-plan-416-log-body-truncation-env.md
+++ b/docs/plans/implementation-plan-416-log-body-truncation-env.md
@@ -1,0 +1,239 @@
+# Implementation Plan — #416 Configurable HTTP/Adapter Log-Body Truncation
+
+**Issue**: [#416](https://github.com/SilkSoftwareHouse/openlinker/issues/416)
+**Type**: DX / Logging
+**Layer**: `libs/shared/src/logging/` (new helper) + integration call-site replacements
+**Branch**: `416-log-body-truncation-env`
+
+---
+
+## Phase 1 — Understand the task
+
+**Goal.** Replace hand-rolled `body.substring(0, N)` / `body.slice(0, N)` calls scattered across HTTP clients and adapters with a single shared helper `formatBodyForLog(body)` whose cap is controlled by `OL_LOG_BODY_MAX_BYTES` (default `0` = uncapped, full body).
+
+**Why.** A 200-char silent truncation in `allegro-http-client.ts:431` cut an Allegro 422 `userMessage` mid-string and produced what looked like malformed JSON — operators lost the actionable half of the diagnostic. Truncation policy should be:
+
+- **Off by default** (full-fidelity logs in dev / staging / debugging incidents)
+- **Operator-tunable in prod** if log volume / cost is a concern, with a single knob
+
+**Layer classification.** This is a **DX** change. The helper lives in `@openlinker/shared/logging`. Call sites are inside Integration adapters (Allegro, PrestaShop). No CORE / domain logic touched.
+
+**Non-goals (per issue "Out of Scope").**
+- DB-column-bound caps stay (`webhook-to-job.handler.ts:243` `dlqReason`, `webhook.service.ts:197` `rejectionReason`, `sync-job.repository.ts:195,204` `lastError`).
+- Security caps stay (`webhook-auth.service.ts:45` signature first 20 chars).
+- Identifier / hash / pluralisation slicing stays.
+- Log-level / verbosity controls (e.g. `LOG_LEVEL=debug`) — orthogonal, separate ticket if/when wanted.
+
+---
+
+## Phase 2 — Research the codebase
+
+**Existing shared logging surface** (`libs/shared/src/logging/`):
+- `logger.ts` — thin `Logger extends NestLogger` wrapper.
+- `index.ts` — barrel that re-exports `./logger`.
+
+The new helper will be added alongside `logger.ts` and re-exported via `index.ts`. Public path: `@openlinker/shared/logging`.
+
+**Existing truncation marker convention.** `prestashop-webservice.client.ts:427` already produces `${body.substring(0, 1000)}... [truncated, total length: ${body.length}]`. Issue spec aligns with this format (slight typographic upgrade to `…` ellipsis is a SUGGESTION, not required).
+
+**Env-read pattern.** `libs/integrations/ai/src/ai-integration.module.ts:45` reads `process.env.OL_AI_PROVIDER` directly at module init (no `ConfigService` dependency). Same pattern fits here — the helper is module-scoped, framework-agnostic, and read-once is acceptable (operators restart on config change).
+
+**Call-site survey.** Issue lists 9 file/line groups; concretely 14 `.substring(0, N)` / `.slice(0, N)` occurrences when each comma-separated group is expanded:
+
+| # | File | Line | Current pattern | Surface |
+|---|---|---|---|---|
+| 1 | `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts` | 431 | `body.substring(0, 200)` | `logger.error` line |
+| 2 | `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts` | 960 | `responseBody.slice(0, 500)` | `logger.warn` line |
+| 3 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` | 396 | `options.body.substring(0, 500)` | `logger.debug` request body |
+| 4 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` | 427 | `body.substring(0, 1000)... [truncated, total length: ${body.length}]` | `logger.debug` response body (already has marker) |
+| 5 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` | 497 | `body.substring(0, 1000)` | `logger.error` 5xx line |
+| 6 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` | 503 | `body.substring(0, 500)` | `PrestashopApiException` body arg |
+| 7 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` | 512 | `body.substring(0, 500)` | `PrestashopApiException` body arg |
+| 8 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts` | 69 | `responseBody.substring(0, 500)` | `PrestashopParseException` body arg |
+| 9 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts` | 80 | `responseBody.substring(0, 500)` | `PrestashopParseException` body arg |
+| 10 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts` | 98 | `responseBody.substring(0, 500)` | `PrestashopParseException` body arg |
+| 11 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts` | 115 | `responseBody.substring(0, 500)` | `PrestashopParseException` body arg |
+| 12 | `libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts` | 126 | `responseBody.substring(0, 500)` | `PrestashopParseException` body arg |
+| 13 | `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts` | 309 | `errorMessage.substring(0, 200)` | `logger.warn` line |
+| 14 | `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts` | 318 | `responseBody.substring(0, 500)` | `logger.warn` line |
+
+**Surface mix.** 7 sites are direct log-line interpolations; 7 sites pass the truncated body to a domain exception (`PrestashopApiException` / `PrestashopParseException`). Tech-review (post-plan) raised that wrapping the exception payload in `formatBodyForLog` is semantically off — the helper name says "for log", but the exception field is *captured data* that may be re-logged, parsed, or both. Allegro's `parseAllegroErrors` (`allegro-offer-manager.adapter.ts:948`) demonstrates the risk: it parses `error.responseBody` to extract `errors[]`, which is exactly why #409 made `AllegroApiException` carry the **full** body (lines 425, 438) and truncate only the inline log line.
+
+**Decision (revised after tech-review):** apply the Allegro #409 pattern to PrestaShop too. The 7 log sites get `formatBodyForLog(body)`. The 7 exception-construction sites get **full** `body` — truncation is dropped entirely. Today this changes nothing (no PrestaShop caller currently parses `error.responseBody`), but it removes a future foot-gun and aligns the two integrations on the same convention. The PrestaShop log site at `prestashop-order-processor-manager.adapter.ts:318` that re-logs `createError.responseBody` will run that field through `formatBodyForLog` itself, so the operator cap still applies on the log surface even though the exception carries the full payload.
+
+---
+
+## Phase 3 — Design the solution
+
+### Helper
+
+**File**: `libs/shared/src/logging/format-body-for-log.ts`
+
+```ts
+/**
+ * Format Body For Log
+ *
+ * Caps the length of an HTTP/adapter response or request body before it is
+ * embedded in a log line. The cap is read once at module load from
+ * `OL_LOG_BODY_MAX_BYTES`:
+ *   - unset / empty / `0` / negative / non-numeric → return body unchanged (default)
+ *   - strict positive integer N → if `body.length > N`, return
+ *     `${body.slice(0, N)}… [truncated, total length: ${body.length}]`;
+ *     otherwise return body unchanged.
+ *
+ * The cap operates on JS string units (UTF-16 code units), not UTF-8 bytes.
+ * For ASCII the two are equivalent; for multi-byte content (Polish chars in
+ * PrestaShop / Allegro responses) the resulting log line may exceed N bytes.
+ * The env name is kept per #416 for operator clarity; this caveat lives here
+ * so the next debugger sees it.
+ *
+ * The helper is intentionally log-only — values stored on domain exceptions
+ * keep the FULL body (matches #409 / AllegroApiException). If you ever do
+ * store the helper's output, treat it as opaque text: a truncation marker may
+ * be appended and the result is no longer guaranteed to JSON-parse.
+ *
+ * Read-once at module init matches `AiIntegrationModule.register()`. Restart
+ * the process to change the cap.
+ *
+ * @module libs/shared/src/logging
+ */
+
+const MAX_CHARS = parseMaxChars(process.env.OL_LOG_BODY_MAX_BYTES);
+
+function parseMaxChars(raw: string | undefined): number {
+  if (raw === undefined || raw === '') return 0;
+  // Use Number(), not parseInt() — parseInt('10abc', 10) silently returns 10.
+  // We want strict integer parsing: anything else falls back to uncapped.
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) return 0;
+  return n;
+}
+
+export function formatBodyForLog(body: string): string {
+  if (MAX_CHARS === 0 || body.length <= MAX_CHARS) return body;
+  return `${body.slice(0, MAX_CHARS)}… [truncated, total length: ${body.length}]`;
+}
+```
+
+**Design notes:**
+- **`Number()` over `Number.parseInt()`.** Strict numeric parse — `Number('10abc') === NaN`, so malformed values like `OL_LOG_BODY_MAX_BYTES=10abc` correctly fall back to uncapped instead of being silently treated as `10`. Acceptance criterion 5 ("invalid env value falls back to no truncation") is honoured literally.
+- **`Number.isInteger()` rather than `Number.isFinite()`.** Rejects `'1.5'`, `'1e3'`, `Infinity` — the env var is conceptually a non-negative integer count of chars.
+- **Module-scoped `MAX_CHARS`.** Cheaper than re-parsing on every call. Matches `AiIntegrationModule.register()` pattern.
+- **`MAX_CHARS` not `MAX_BYTES`.** The runtime constant reflects what the helper actually measures (JS chars). The env var keeps the public name `OL_LOG_BODY_MAX_BYTES` per the issue.
+- **Marker uses `…` (U+2026) per issue spec.** PrestaShop's existing inline marker uses `...` (three ASCII dots) — that string is removed as part of this refactor (line 4 in the call-site table), so consistency is achieved.
+- **No exports from `parseMaxChars`.** Internal. Tests inject via `process.env` + module re-import (see test plan).
+
+### Barrel export
+
+`libs/shared/src/logging/index.ts` — add `export * from './format-body-for-log';`.
+
+### Call-site replacement
+
+Each site becomes `formatBodyForLog(body)`. Imports added at the top of each file:
+
+```ts
+import { formatBodyForLog } from '@openlinker/shared/logging';
+```
+
+**Special case — line 427** (`prestashop-webservice.client.ts`): the existing inline marker (`... [truncated, total length: ${body.length}]`) is removed; the helper now produces the marker. Resulting line:
+
+```ts
+this.logger.debug(`Response body: ${formatBodyForLog(body)}`);
+```
+
+### Spec
+
+**File**: `libs/shared/src/logging/format-body-for-log.spec.ts`
+
+The helper reads env at module load — tests use `jest.isolateModules` (or `vi.resetModules` equivalent — this codebase is on Jest) to re-import with different env values. Coverage:
+
+| Case | Env | Body | Expected |
+|---|---|---|---|
+| Unset env | `delete process.env.OL_LOG_BODY_MAX_BYTES` | `'hello world'` | `'hello world'` (unchanged) |
+| Zero | `'0'` | `'hello world'` | `'hello world'` (unchanged) |
+| Empty string | `''` | `'hello world'` | `'hello world'` (unchanged) |
+| Negative | `'-100'` | `'hello world'` | `'hello world'` (unchanged) |
+| Non-numeric | `'abc'` | `'hello world'` | `'hello world'` (unchanged) |
+| Trailing garbage | `'10abc'` | `'hello world'` | `'hello world'` (unchanged — `Number('10abc')` is `NaN`) |
+| Float | `'5.5'` | `'hello world'` | `'hello world'` (unchanged — not an integer) |
+| Cap above body | `'100'` | `'hello world'` | `'hello world'` (unchanged) |
+| Cap equal to body | `'11'` | `'hello world'` (length 11) | `'hello world'` (unchanged — boundary `<=` not `<`) |
+| Cap below body | `'5'` | `'hello world'` | `'hello… [truncated, total length: 11]'` |
+| Empty body | `'10'` | `''` | `''` (unchanged) |
+
+The spec file gets the same `@module libs/shared/src/logging` header as the helper.
+
+### Env documentation
+
+**`apps/api/.env.example`** — append a new section after the AI block (lines 107–126), before the trailing newline. Both `apps/api/` and `apps/worker/` files get the same block, since both processes run integration adapters.
+
+```
+# --- Logging -----------------------------------------------------------------
+# Cap on HTTP/adapter response and request body length when embedded in log
+# lines (and integration exception payloads). Default 0 = uncapped — full
+# body in logs, useful for dev / staging / debugging incidents. Set to a
+# positive integer (chars) to truncate; truncated lines get a
+# `… [truncated, total length: N]` marker so consumers can distinguish a
+# clipped log from a malformed payload.
+# OL_LOG_BODY_MAX_BYTES=0
+```
+
+---
+
+## Phase 4 — Step-by-step implementation
+
+| # | Step | File(s) | Acceptance |
+|---|---|---|---|
+| 1 | Create helper | `libs/shared/src/logging/format-body-for-log.ts` | Compiles; default-export-free |
+| 2 | Add barrel export | `libs/shared/src/logging/index.ts` | `import { formatBodyForLog } from '@openlinker/shared/logging'` resolves |
+| 3 | Write spec | `libs/shared/src/logging/format-body-for-log.spec.ts` | All 9 cases above pass |
+| 4 | Replace call site #1 | `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts:431` | Line uses `formatBodyForLog(body)`; import added |
+| 5 | Replace call site #2 | `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts:960` | Line uses `formatBodyForLog(responseBody)`; import added |
+| 6 | Replace log sites in PrestaShop client | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` (lines 396, 427, 497) | Three log calls use helper; line 427's inline marker removed; import added |
+| 7 | Drop truncation on PrestaShop client exception bodies | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` (lines 503, 512) | Pass full `body` to `PrestashopApiException`; matches Allegro #409 |
+| 8 | Drop truncation on PrestaShop parser exception bodies | `libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts` (lines 69, 80, 98, 115, 126) | Pass full `responseBody` to `PrestashopParseException` (5 sites) |
+| 9 | Replace log sites in PrestaShop order-processor adapter | `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts` (lines 309, 318) | Both log lines use helper; import added |
+| 10 | Document env in API | `apps/api/.env.example` | New `--- Logging ---` block added |
+| 11 | Document env in Worker | `apps/worker/.env.example` | Same block appended |
+| 12 | Quality gate | — | `pnpm lint && pnpm type-check && pnpm test` all green |
+| 13 | Manual fixture verify | — | Replay a captured Allegro 422 body locally with `OL_LOG_BODY_MAX_BYTES` unset; confirm full `userMessage` appears in `[AllegroHttpClient]` log. If a captured body isn't accessible in this branch, note as a gap and rely on unit + e2e via the spec. |
+| 14 | Self-review per code-review-guide | — | No BLOCKING / IMPORTANT remaining |
+| 15 | Commit & push | — | Conventional commit message |
+| 16 | Open PR | — | Body contains `Closes #416` |
+
+---
+
+## Phase 5 — Validate
+
+**Architecture compliance.**
+- ✅ Helper lives in `libs/shared/` — pure utility, no NestJS / domain coupling. Domain layer untouched.
+- ✅ Integrations import from `@openlinker/shared/logging` (existing alias, used elsewhere via `Logger`). Dependency direction preserved.
+- ✅ No CORE / Integration boundary touched.
+
+**Naming.**
+- ✅ `format-body-for-log.ts` matches kebab-case file convention.
+- ✅ `formatBodyForLog` is a pure utility function — no class, no port, naming aligns with shared utility conventions (e.g. existing logger surface).
+- ✅ `OL_LOG_BODY_MAX_BYTES` matches the `OL_*` env-var family.
+
+**Testing strategy.**
+- ✅ Unit test only (no Docker / network) — pure function with env-driven module init. `jest.isolateModules` per case.
+- ✅ Coverage of acceptance criteria: unset, 0, positive cap below, positive cap above, invalid value (extended to negative + non-numeric).
+
+**Security.**
+- ✅ Helper does not log anything itself — it returns a string. Caller decides what to log.
+- ✅ Default `0` (full body) preserves diagnostic visibility for incidents.
+- ✅ `webhook-auth.service.ts:45` (signature truncation) is explicitly out of scope — not touched.
+
+**Risk surface.**
+- The 7 exception-body sites now pass **full body** (truncation dropped) instead of being routed through the helper. This means: (a) regardless of `OL_LOG_BODY_MAX_BYTES`, `error.responseBody` is always the complete upstream payload — safe to parse, safe to inspect; (b) the operator log cap still applies on the log surface, because `prestashop-order-processor-manager.adapter.ts:318` re-logs the field through `formatBodyForLog`. Aligns with the Allegro #409 precedent (`AllegroApiException` carries full body; `parseAllegroErrors` parses it).
+- With `OL_LOG_BODY_MAX_BYTES=0` (default), all 14 surfaces show the full body — strictly more diagnostic than today.
+- With operator-set cap `N`, the 7 log sites cap; the 7 exception bodies stay full. No parse-corruption risk on either surface.
+
+**Rollback.**
+- Single-commit change. Revert PR #N if needed.
+
+---
+
+## Open questions / SUGGESTIONs
+
+- **None blocking.** One stylistic SUGGESTION already implicit in the helper: use `…` (U+2026) for the marker rather than `...` — issue spec calls for it; PrestaShop's existing `...` is removed by the refactor naturally.

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -57,7 +57,7 @@ import {
   AllegroSellerPolicyEntry,
 } from '../../domain/types/allegro-api.types';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
-import { Logger } from '@openlinker/shared/logging';
+import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import { createHash } from 'crypto';
 import { sanitizeAllegroDescription } from '../util/sanitize-allegro-description';
 import { uploadImagesViaAllegro } from '../util/upload-images-via-allegro';
@@ -954,10 +954,12 @@ export class AllegroOfferManagerAdapter
       }
     } catch (err) {
       // Genuinely malformed body (HTML proxy errors, etc.) — log breadcrumbs
-      // so operators don't see an opaque `errors=0` upstream (#409).
+      // so operators don't see an opaque `errors=0` upstream (#409). Body is
+      // routed through `formatBodyForLog` (#416) — uncapped by default,
+      // operator-tunable via `OL_LOG_BODY_MAX_BYTES`.
       this.logger.warn(
         `Failed to parse Allegro error body as JSON: ${(err as Error).message}. ` +
-          `Raw body (first 500 chars): ${responseBody.slice(0, 500)}`,
+          `Raw body: ${formatBodyForLog(responseBody)}`,
       );
     }
     return [];

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
@@ -19,7 +19,7 @@ import { AllegroConnectionTokenState } from './allegro-connection-token-state';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
 import { AllegroAuthenticationException } from '../../domain/exceptions/allegro-authentication.exception';
 import { AllegroRateLimitException } from '../../domain/exceptions/allegro-rate-limit.exception';
-import { Logger } from '@openlinker/shared/logging';
+import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import { randomUUID } from 'crypto';
 
 /**
@@ -428,10 +428,11 @@ export class AllegroHttpClient implements IAllegroHttpClient {
     }
 
     // Other client errors (4xx)
-    this.logger.error(`[${traceId}] Allegro API error (${statusCode}): ${url} - ${body.substring(0, 200)}`);
+    this.logger.error(`[${traceId}] Allegro API error (${statusCode}): ${url} - ${formatBodyForLog(body)}`);
     // Full body on the exception (#409) — `parseAllegroErrors` needs the
-    // complete JSON to pull out Allegro's `errors[]`; the 200-char preview
-    // on the log line above stays for scroll-back readability.
+    // complete JSON to pull out Allegro's `errors[]`. The log line above is
+    // formatted via `formatBodyForLog` (#416), which is uncapped by default
+    // and only truncates when an operator opts into `OL_LOG_BODY_MAX_BYTES`.
     throw new AllegroApiException(
       `Allegro API error (${statusCode}): ${url}`,
       statusCode,

--- a/libs/integrations/prestashop/src/domain/exceptions/prestashop-api.exception.ts
+++ b/libs/integrations/prestashop/src/domain/exceptions/prestashop-api.exception.ts
@@ -4,6 +4,12 @@
  * Thrown when PrestaShop WebService API returns an error (5xx, or other API errors).
  * Used for server errors, rate limiting, or other API-level failures.
  *
+ * `responseBody` carries the **full** upstream body — it is intentionally
+ * unbounded so callers can inspect or parse the payload without re-fetching
+ * (matches Allegro `AllegroApiException` since #409). Log surfaces are
+ * separately capped via `formatBodyForLog` (#416). If you re-log this field,
+ * route it through that helper.
+ *
  * @module libs/integrations/prestashop/src/domain/exceptions
  */
 export class PrestashopApiException extends Error {

--- a/libs/integrations/prestashop/src/domain/exceptions/prestashop-parse.exception.ts
+++ b/libs/integrations/prestashop/src/domain/exceptions/prestashop-parse.exception.ts
@@ -4,6 +4,11 @@
  * Thrown when PrestaShop API response cannot be parsed (invalid JSON/XML).
  * Used when response format is unexpected or malformed.
  *
+ * `responseBody` carries the **full** upstream body — it is intentionally
+ * unbounded so callers can inspect the malformed payload (matches the
+ * Allegro #409 / `PrestashopApiException` precedent). Route through
+ * `formatBodyForLog` (#416) when re-logging.
+ *
  * @module libs/integrations/prestashop/src/domain/exceptions
  */
 export class PrestashopParseException extends Error {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -27,7 +27,7 @@ import {
   PrestashopApiException,
   PrestashopProvisioningException,
 } from '@openlinker/integrations-prestashop';
-import { Logger } from '@openlinker/shared/logging';
+import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import { PrestashopCustomerProvisioner } from '../provisioners/prestashop-customer-provisioner';
 import { PrestashopAddressProvisioner } from '../provisioners/prestashop-address-provisioner';
 import { PrestashopCurrencyResolver } from '../provisioners/prestashop-currency-resolver';
@@ -306,7 +306,7 @@ export class PrestashopOrderProcessorManagerAdapter implements OrderProcessorMan
         
         // Log error details for debugging (use warn level so it shows up)
         this.logger.warn(
-          `Order creation error type: ${createError?.constructor?.name || 'unknown'}, message: ${errorMessage.substring(0, 200)}`,
+          `Order creation error type: ${createError?.constructor?.name || 'unknown'}, message: ${formatBodyForLog(errorMessage)}`,
         );
         
         // Check if it's a PrestashopApiException and has responseBody
@@ -315,7 +315,7 @@ export class PrestashopOrderProcessorManagerAdapter implements OrderProcessorMan
             responseBody = createError.responseBody;
             // Also check the response body for duplicate key errors
             errorMessage = `${errorMessage} ${responseBody}`;
-            this.logger.warn(`PrestaShop API error response body: ${responseBody.substring(0, 500)}`);
+            this.logger.warn(`PrestaShop API error response body: ${formatBodyForLog(responseBody)}`);
           }
           this.logger.warn(`PrestaShop API error status code: ${createError.statusCode || 'unknown'}`);
         }

--- a/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-webservice.client.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-webservice.client.spec.ts
@@ -564,7 +564,13 @@ describe('PrestashopWebserviceClient', () => {
       }
     });
 
-    it('should truncate error body to 500 characters', async () => {
+    it('should carry the full error body on the exception (#416)', async () => {
+      // Pre-#416 the client truncated `responseBody` to 500 chars before
+      // attaching it to the exception. That made it impossible for callers
+      // to inspect the full upstream payload. Post-#416 the exception
+      // carries the FULL body (matches Allegro #409); only log lines are
+      // subject to the operator-tunable `OL_LOG_BODY_MAX_BYTES` cap.
+
       // Disable retries for error-handling tests
       const clientNoRetry = new PrestashopWebserviceClient(baseUrl, credentials, config, {
         maxRetries: 0,
@@ -584,10 +590,10 @@ describe('PrestashopWebserviceClient', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(PrestashopApiException);
         if (error instanceof PrestashopApiException) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const apiError = error;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        expect(apiError.responseBody?.length).toBeLessThanOrEqual(500);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          const apiError = error;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          expect(apiError.responseBody).toBe(longErrorBody);
         }
       }
     });

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts
@@ -66,7 +66,7 @@ export class PrestashopResponseParser {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
               const parseError = new PrestashopParseException(
                 combinedMessage,
-                responseBody.substring(0, 500),
+                responseBody,
                 'auto',
                 error instanceof Error ? error : undefined,
               );
@@ -77,7 +77,7 @@ export class PrestashopResponseParser {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
           const parseError = new PrestashopParseException(
             `Failed to parse JSON response: ${errorMessage}`,
-            responseBody.substring(0, 500),
+            responseBody,
             'json',
             error instanceof Error ? error : undefined,
           );
@@ -95,7 +95,7 @@ export class PrestashopResponseParser {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         const parseError = new PrestashopParseException(
           `Failed to parse XML response: ${errorMessage}`,
-          responseBody.substring(0, 500),
+          responseBody,
           'xml',
           error instanceof Error ? error : undefined,
         );
@@ -112,7 +112,7 @@ export class PrestashopResponseParser {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         const parseError = new PrestashopParseException(
           `Failed to parse response: ${errorMessage}`,
-          responseBody.substring(0, 500),
+          responseBody,
           'auto',
           error instanceof Error ? error : undefined,
         );
@@ -123,7 +123,7 @@ export class PrestashopResponseParser {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     const parseError = new PrestashopParseException(
       'Unable to determine response format (not JSON or XML)',
-      responseBody.substring(0, 500),
+      responseBody,
       'auto',
     );
     throw parseError;

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
@@ -18,7 +18,7 @@ import {
 } from '@openlinker/integrations-prestashop';
 import { PrestashopQueryBuilder } from './prestashop-query.builder';
 import { PrestashopResponseParser } from './prestashop-response.parser';
-import { Logger } from '@openlinker/shared/logging';
+import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import { XMLBuilder } from 'fast-xml-parser';
 
 /**
@@ -393,7 +393,7 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
       if (options.method === 'POST' && typeof options.body === 'string') {
         this.logger.debug(`Body (full): ${options.body}`);
       } else {
-        this.logger.debug(`Body: ${typeof options.body === 'string' ? options.body.substring(0, 500) : '[binary]'}`);
+        this.logger.debug(`Body: ${typeof options.body === 'string' ? formatBodyForLog(options.body) : '[binary]'}`);
       }
     }
 
@@ -424,8 +424,7 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
       if (response.status >= 400) {
         this.logger.debug(`Response body (full for error): ${body || '(empty)'}`);
       } else {
-        const bodyPreview = body.length > 1000 ? `${body.substring(0, 1000)}... [truncated, total length: ${body.length}]` : body;
-        this.logger.debug(`Response body: ${bodyPreview}`);
+        this.logger.debug(`Response body: ${formatBodyForLog(body)}`);
       }
 
       // Handle errors
@@ -492,15 +491,17 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
     }
 
     if (statusCode >= 500) {
-      // Log the full error response for debugging
+      // Log line uses `formatBodyForLog` so operators can opt into a cap via
+      // `OL_LOG_BODY_MAX_BYTES`; the exception carries the FULL body so any
+      // downstream consumer can inspect or parse it (matches Allegro #409).
       this.logger.error(
-        `PrestaShop API server error (${statusCode}): ${url}. Response body: ${body.substring(0, 1000)}`,
+        `PrestaShop API server error (${statusCode}): ${url}. Response body: ${formatBodyForLog(body)}`,
       );
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
       const serverError = new PrestashopApiException(
         `PrestaShop API server error (${statusCode}): ${url}`,
         statusCode,
-        body.substring(0, 500),
+        body,
       );
       throw serverError;
     }
@@ -509,7 +510,7 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
     const apiError = new PrestashopApiException(
       `PrestaShop API error (${statusCode}): ${url}`,
       statusCode,
-      body.substring(0, 500),
+      body,
     );
     throw apiError;
   }

--- a/libs/shared/src/logging/format-body-for-log.spec.ts
+++ b/libs/shared/src/logging/format-body-for-log.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Format Body For Log — Spec
+ *
+ * Verifies env-driven truncation behaviour. The helper reads
+ * `OL_LOG_BODY_MAX_BYTES` once at module load, so every case re-imports the
+ * module via `jest.isolateModules` with the env pre-set.
+ *
+ * @module libs/shared/src/logging
+ */
+
+type FormatBodyForLog = (body: string) => string;
+
+function loadHelper(envValue: string | undefined): FormatBodyForLog {
+  let helper!: FormatBodyForLog;
+  jest.isolateModules(() => {
+    if (envValue === undefined) {
+      delete process.env.OL_LOG_BODY_MAX_BYTES;
+    } else {
+      process.env.OL_LOG_BODY_MAX_BYTES = envValue;
+    }
+    // require() inside isolateModules is the only way to re-evaluate a module
+    // with a fresh process.env. ES `import` is hoisted and would bind once.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    helper = (require('./format-body-for-log') as { formatBodyForLog: FormatBodyForLog }).formatBodyForLog;
+  });
+  return helper;
+}
+
+describe('formatBodyForLog', () => {
+  const originalEnv = process.env.OL_LOG_BODY_MAX_BYTES;
+
+  afterAll(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OL_LOG_BODY_MAX_BYTES;
+    } else {
+      process.env.OL_LOG_BODY_MAX_BYTES = originalEnv;
+    }
+  });
+
+  describe('when env is unset or invalid', () => {
+    it('returns body unchanged when env is unset', () => {
+      const formatBodyForLog = loadHelper(undefined);
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+
+    it('returns body unchanged when env is empty string', () => {
+      const formatBodyForLog = loadHelper('');
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+
+    it('returns body unchanged when env is "0"', () => {
+      const formatBodyForLog = loadHelper('0');
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+
+    it('returns body unchanged when env is negative', () => {
+      const formatBodyForLog = loadHelper('-100');
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+
+    it('returns body unchanged when env is non-numeric', () => {
+      const formatBodyForLog = loadHelper('abc');
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+
+    it('returns body unchanged when env has trailing garbage (parseInt foot-gun)', () => {
+      // parseInt('10abc', 10) === 10 silently. Number('10abc') === NaN.
+      // The helper must reject this, not treat it as cap=10.
+      const formatBodyForLog = loadHelper('10abc');
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+
+    it('returns body unchanged when env is a float', () => {
+      const formatBodyForLog = loadHelper('5.5');
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+  });
+
+  describe('when env is a positive integer', () => {
+    it('returns body unchanged when cap exceeds body length', () => {
+      const formatBodyForLog = loadHelper('100');
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+
+    it('returns body unchanged when cap equals body length (boundary <=)', () => {
+      const formatBodyForLog = loadHelper('11');
+      expect(formatBodyForLog('hello world')).toBe('hello world');
+    });
+
+    it('truncates with marker when cap is below body length', () => {
+      const formatBodyForLog = loadHelper('5');
+      expect(formatBodyForLog('hello world')).toBe('hello… [truncated, total length: 11]');
+    });
+
+    it('returns empty body unchanged regardless of cap', () => {
+      const formatBodyForLog = loadHelper('10');
+      expect(formatBodyForLog('')).toBe('');
+    });
+
+    it('preserves the original total length in the marker', () => {
+      const formatBodyForLog = loadHelper('3');
+      const body = 'a'.repeat(1234);
+      expect(formatBodyForLog(body)).toBe(`aaa… [truncated, total length: 1234]`);
+    });
+  });
+});

--- a/libs/shared/src/logging/format-body-for-log.ts
+++ b/libs/shared/src/logging/format-body-for-log.ts
@@ -1,0 +1,44 @@
+/**
+ * Format Body For Log
+ *
+ * Caps the length of an HTTP/adapter response or request body — or any
+ * string-typed log payload (e.g. an `Error.message`) — before it is embedded
+ * in a log line. The cap is read once at module load from
+ * `OL_LOG_BODY_MAX_BYTES`:
+ *   - unset / empty / `0` / negative / non-numeric → return body unchanged (default)
+ *   - strict positive integer N → if `body.length > N`, return
+ *     `${body.slice(0, N)}… [truncated, total length: ${body.length}]`;
+ *     otherwise return body unchanged.
+ *
+ * The cap operates on JS string units (UTF-16 code units), not UTF-8 bytes.
+ * For ASCII the two are equivalent; for multi-byte content (e.g. Polish chars
+ * in PrestaShop / Allegro responses) the resulting log line may exceed N
+ * bytes. The env name is kept per #416 for operator clarity; this caveat
+ * lives here so the next debugger sees it.
+ *
+ * The helper is intentionally log-only — values stored on domain exceptions
+ * keep the FULL body (matches #409 / `AllegroApiException`). If you ever do
+ * store the helper's output, treat it as opaque text: a truncation marker may
+ * be appended and the result is no longer guaranteed to JSON-parse.
+ *
+ * Read-once at module init matches `AiIntegrationModule.register()`. Restart
+ * the process to change the cap.
+ *
+ * @module libs/shared/src/logging
+ */
+
+const MAX_CHARS = parseMaxChars(process.env.OL_LOG_BODY_MAX_BYTES);
+
+function parseMaxChars(raw: string | undefined): number {
+  if (raw === undefined || raw === '') return 0;
+  // Use Number(), not parseInt() — parseInt('10abc', 10) silently returns 10.
+  // We want strict integer parsing: anything else falls back to uncapped.
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) return 0;
+  return n;
+}
+
+export function formatBodyForLog(body: string): string {
+  if (MAX_CHARS === 0 || body.length <= MAX_CHARS) return body;
+  return `${body.slice(0, MAX_CHARS)}… [truncated, total length: ${body.length}]`;
+}

--- a/libs/shared/src/logging/index.ts
+++ b/libs/shared/src/logging/index.ts
@@ -6,4 +6,5 @@
  * @module libs/shared/src/logging
  */
 export * from './logger';
+export * from './format-body-for-log';
 


### PR DESCRIPTION
## Summary

Replaces 14 hand-rolled `body.substring(0, N)` / `.slice(0, N)` calls across the Allegro and PrestaShop integration HTTP clients with a single shared helper `formatBodyForLog`, controlled by `OL_LOG_BODY_MAX_BYTES` (default `0` = uncapped). The original motivating bug — an Allegro 422 `ParameterCategoryException` whose `userMessage` was cut mid-string at a silent 200-char cap with no truncation marker — is now visible in full by default; operators concerned about log volume can opt into a cap.

The 7 log-line sites flow through the helper. The 7 exception-body sites (`PrestashopApiException`, `PrestashopParseException`) now carry the **full** upstream payload, matching the Allegro #409 precedent — log surfaces stay capped via `formatBodyForLog`, exception fields stay inspect-able. The exception classes' headers were updated to document this contract.

Helper rejects malformed env values strictly (`Number()` + `Number.isInteger()`, not `parseInt()`) so `OL_LOG_BODY_MAX_BYTES=10abc` falls back to uncapped instead of being silently treated as `10`.

## Behavioral changes worth flagging for reviewers

- **Default log-line body length: 200 / 500 / 1000 chars → uncapped.** Operators who want the old caps set `OL_LOG_BODY_MAX_BYTES=N` (chars, not bytes — see helper header for the caveat).
- **`PrestashopApiException.responseBody` and `PrestashopParseException.responseBody` are now unbounded.** Previously capped at 500 chars; now carry the full body. This matches the existing `AllegroApiException` contract (#409). Anyone catching either exception elsewhere should be aware. The `prestashop-webservice.client.spec.ts` test for the old contract was renamed and its assertion flipped to encode the new one.

## Files

- `libs/shared/src/logging/format-body-for-log.ts` — new helper + barrel re-export
- `libs/shared/src/logging/format-body-for-log.spec.ts` — 12 unit cases incl. the parseInt-trailing-garbage foot-gun and the boundary `<=` case
- `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts` — line 431 (the line that bit us)
- `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts` — line 960
- `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` — 5 sites (3 log + 2 exception body)
- `libs/integrations/prestashop/src/infrastructure/http/prestashop-response.parser.ts` — 5 exception-body sites
- `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts` — 2 log sites
- `libs/integrations/prestashop/src/domain/exceptions/{prestashop-api,prestashop-parse}.exception.ts` — JSDoc updated to document the full-body contract
- `apps/api/.env.example`, `apps/worker/.env.example` — new `--- Logging ---` block documenting `OL_LOG_BODY_MAX_BYTES`
- `docs/plans/implementation-plan-416-log-body-truncation-env.md` — implementation plan (incl. tech-review revision history)

## Test plan

- [ ] `pnpm lint && pnpm type-check && pnpm test` (already green locally — pre-commit hook ran)
- [ ] Inspect the unit-spec coverage matrix in `format-body-for-log.spec.ts`: unset / `0` / `''` / negative / non-numeric / trailing garbage / float / cap-above / cap-equal (boundary) / cap-below / empty body / marker length preservation
- [ ] Confirm the renamed PrestaShop test (`prestashop-webservice.client.spec.ts:567`) asserts `responseBody === fullBody` rather than length ≤ 500
- [ ] Manual smoke (optional, post-merge): trigger an Allegro 422 against a sandbox seller, confirm full `userMessage` is visible in the `[AllegroHttpClient]` error log with `OL_LOG_BODY_MAX_BYTES` unset; set it to e.g. `200` and confirm the marker `… [truncated, total length: N]` appears

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)