### PR TITLE
fix(allegro,prestashop): bump PS image variant + early-reject on Allegro 400px gate

### DIFF
--- a/docs/plans/implementation-plan-424-allegro-image-too-small.md
+++ b/docs/plans/implementation-plan-424-allegro-image-too-small.md
@@ -1,0 +1,212 @@
+# Implementation Plan — #424: PrestaShop image-variant + Allegro dimension early-reject
+
+## 1. Goal
+
+Allegro's `productSet[0].product.images[]` validator rejects offer creation with `ProductValidationException: TOO_SMALL_IMAGE` when any image's longer side is < 400px. Confirmed by sandbox repro on 2026-04-27 — the offer-side `body.images[]` validator is lenient and accepted the same image, but the inline-product validator (introduced in #420 / commit `100a222`) is stricter.
+
+Two cooperating root causes:
+
+1. **PrestaShop adapter requests the wrong image variant.** `PrestashopProductMapper.buildImageUrl` (line 393-397) hardcodes `home_default` — a thumbnail variant (typically 250×250px on a default PS install). The TODO at line 390-391 explicitly flags this for replacement: *"image type ('home_default') is fixed for v1. Expose via options when detail-page or retina sizes land."* Most PS installs serve `large_default` ≥ 800px on the longer side, which clears the 400px gate.
+2. **No early dimension validation in the upload pipeline.** `uploadImagesViaAllegro` validates content-type but not dimensions. When the operator's source image is *genuinely* too small (or PS happens to serve a small `large_default`), we still upload bytes to Allegro's CDN and only learn it's too small at the very end of the offer-creation flow — terrible diagnostics.
+
+The fix is two coordinated changes:
+
+- **Switch PS to `large_default`.** Closes the existing TODO. Solves the common case where PS has a high-res source but our adapter was requesting a thumbnail.
+- **Add dimension validation to the Allegro upload util.** When source image's longer side < 400px, reject with `IMAGE_TOO_SMALL_FOR_PRODUCT` *before* bytes ever leave OL — operator sees an actionable error in the Job-detail view with a clear reason.
+
+## 2. Layer classification
+
+| Layer | Change |
+|---|---|
+| **CORE** | None — image dimensioning is an Allegro-specific platform constraint. |
+| **Integration (PrestaShop)** | Change `home_default` → `large_default` in `PrestashopProductMapper.buildImageUrl`. Optionally expose as a per-connection mapper option with `large_default` as default (closes the inline TODO). |
+| **Integration (Allegro)** | Add dimension validation to `uploadImagesViaAllegro`. New error code `IMAGE_TOO_SMALL_FOR_PRODUCT`. Threshold constant `ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX = 400` (named per the validator path it gates). New runtime dependency: `image-size` (~3KB, zero deps, MIT, 56M weekly downloads — battle-tested for header-only dimension extraction). |
+| **Interface (API)** | None. |
+| **Frontend** | None — error surfaces via the existing `mutation.error` Alert in `CreateOfferWizard`, same path as today's `IMAGE_DOWNLOAD_FAILED` etc. |
+| **DX** | `package.json` adds `image-size` to the Allegro package's runtime deps. |
+
+## 3. Non-goals
+
+- **No client-side upscaling.** Generating 400px from a 200px source produces blurry results that won't sell on a marketplace. If the PS image is genuinely small, surface the failure clearly.
+- **No backend image-CDN integration** (e.g., Sharp resize on the worker). Out of MVP scope.
+- **No per-PS-instance image-variant probing.** The PS `/api/images/products/{id}/{imageId}` metadata endpoint returns the list of available types, but iterating it adds a per-request HTTP round-trip we don't need today. `large_default` is the standard variant on every PS install we've encountered; the Allegro early-reject is the safety net for outliers.
+- **No fallback chain** (`large_default` → `medium_default` → `home_default`). Same reason — over-engineering for the MVP. If a future PS install genuinely doesn't have `large_default`, the adapter throws at download time with a clear `IMAGE_DOWNLOAD_FAILED` (404) and we extend then.
+- **No dimension validation for `body.images[]`** (offer-section, not inline-product). Allegro's offer-side validator is more lenient; today we have no evidence of a 400px requirement there. If an Allegro update tightens that path, we extend the gate.
+
+## 4. Design
+
+### 4.1 PrestaShop image-variant bump
+
+**Current** (`prestashop-product.mapper.ts:393-397`):
+
+```typescript
+private buildImageUrl(imageId: string): string {
+  const base = this.options.storefrontBaseUrl.replace(/\/+$/, '');
+  const split = this.splitImageId(imageId);
+  return `${base}/img/p/${split}/${imageId}-home_default.jpg`;
+}
+```
+
+**After** — variant becomes a per-connection option with a sane default:
+
+```typescript
+// prestashop-product.mapper.types.ts
+export interface PrestashopProductMapperOptions {
+  storefrontBaseUrl: string;
+  currency?: string;
+  /**
+   * PrestaShop image-variant suffix used in the public storefront URL
+   * (`/img/p/{split}/{imageId}-{imageVariant}.jpg`). Defaults to
+   * `'large_default'` (~800px on standard PS installs) so images pass
+   * Allegro's product-side `productSet[0].product.images` 400px-longer-side
+   * rule (#424). Override per connection if the PS instance uses a
+   * non-standard variant name or different sizing.
+   */
+  imageVariant?: string;
+}
+
+// prestashop-product.mapper.ts (constants section)
+const DEFAULT_IMAGE_VARIANT = 'large_default';
+
+// prestashop-product.mapper.ts (buildImageUrl)
+private buildImageUrl(imageId: string): string {
+  const base = this.options.storefrontBaseUrl.replace(/\/+$/, '');
+  const split = this.splitImageId(imageId);
+  const variant = this.options.imageVariant ?? DEFAULT_IMAGE_VARIANT;
+  return `${base}/img/p/${split}/${imageId}-${variant}.jpg`;
+}
+```
+
+The `imageVariant` option is **optional** and the existing factory wiring need not change — undefined falls through to `large_default`. The TODO comment in the original is removed (closed by this change).
+
+### 4.2 Allegro dimension early-reject
+
+**New constant** (in `upload-images-via-allegro.ts`, alongside `ACCEPTED_IMAGE_CONTENT_TYPES`):
+
+```typescript
+/**
+ * Allegro's `productSet[0].product.images[]` validator rejects images
+ * whose longer side is below this threshold with
+ * `ProductValidationException: TOO_SMALL_IMAGE`. Confirmed by sandbox
+ * repro 2026-04-27 (#424). Apply at download-time so we fail fast with
+ * actionable diagnostics instead of incurring an upload + a 422 at the
+ * end of the offer-creation flow.
+ *
+ * The offer-side `body.images[]` validator is lenient — same threshold
+ * may eventually apply there too, in which case extend this gate; for
+ * now we apply it on the assumption that any image used at offer-creation
+ * is also used for the inline product (we mirror them today, #420).
+ */
+const ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX = 400;
+```
+
+**New error code** (`IMAGE_TOO_SMALL_FOR_PRODUCT`) added to the existing union:
+
+```typescript
+function downloadFailure(
+  code: 'IMAGE_DOWNLOAD_FAILED' | 'IMAGE_DOWNLOAD_INVALID_TYPE' | 'IMAGE_TOO_SMALL_FOR_PRODUCT',
+  message: string,
+): DownloadErr { … }
+```
+
+**Validation step** — inserted into `downloadImage` after content-type validation, before returning:
+
+```typescript
+import imageSize from 'image-size';
+
+// inside downloadImage, after `bytes = new Uint8Array(...)`:
+let dimensions: { width?: number; height?: number };
+try {
+  dimensions = imageSize(bytes);
+} catch (error) {
+  // Header decode failure — treat as type validation failure rather than
+  // a hard reject, because the content-type validator already ran. This
+  // path is unlikely (the bytes claimed to be image/jpeg etc. but couldn't
+  // be parsed); if hit, it points at corrupt source data.
+  const message = error instanceof Error ? error.message : String(error);
+  return downloadFailure(
+    'IMAGE_DOWNLOAD_INVALID_TYPE',
+    `Image URL '${url}': bytes claimed content-type '${contentType}' but could not be decoded — ${message}`,
+  );
+}
+
+const longerSide = Math.max(dimensions.width ?? 0, dimensions.height ?? 0);
+if (longerSide < ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX) {
+  return downloadFailure(
+    'IMAGE_TOO_SMALL_FOR_PRODUCT',
+    `Image URL '${url}' is ${dimensions.width ?? '?'}×${dimensions.height ?? '?'}px; ` +
+      `Allegro requires a longer side ≥ ${ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX}px ` +
+      `for product images. Use a larger source image.`,
+  );
+}
+
+return { ok: true, contentType, bytes };
+```
+
+Failures still flow through the existing `OfferCreateRejectedException` path in `AllegroOfferManagerAdapter.createOffer` — no adapter-level changes needed beyond importing the new error code in tests.
+
+### 4.3 Why the `image-size` package over hand-rolled parsing
+
+Three options enumerated:
+
+1. **DIY header parser** (~50-80 LOC for JPEG/PNG/GIF/WebP). No new dep but real maintenance risk — WebP alone has VP8 / VP8L / VP8X variants with different header formats; getting this wrong means false rejections.
+2. **`image-size` (npm: ~3KB compressed, zero deps, MIT)**. 56M weekly downloads, battle-tested by Next.js, Vercel, and most major Node tooling. Reads JPEG / PNG / GIF / WebP / HEIF / TIFF / BMP / ICO / SVG dimensions from the buffer header without a full decode.
+3. **`probe-image-size`** (similar but streams from URLs). Heavier, less applicable here since we already have the bytes buffered.
+
+Picking (2). The trade-off is one new runtime dep against ~80 LOC of WebP-spec-encoding maintenance. The package is a textbook MVP-appropriate solution.
+
+### 4.4 Threshold constant naming
+
+The constant is `ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX = 400` (not `ALLEGRO_IMAGE_MIN_*` or `ALLEGRO_MIN_*`) because:
+- It gates the `productSet[0].product.images` validator path specifically.
+- The offer-side `body.images` validator is more lenient and may not require 400px.
+- Naming the field path keeps the scope-of-applicability obvious to future readers.
+
+If Allegro tightens the offer-side validator later, we either rename to drop the `_PRODUCT_` qualifier or add a peer constant.
+
+## 5. Step-by-step plan
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| 1 | `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.types.ts` | Add optional `imageVariant?: string` field to `PrestashopProductMapperOptions` with a JSDoc block referencing #424 and explaining the `large_default` default. | Type compiles; option is optional and consumers without it default to current behaviour (sans the variant change in step 2). |
+| 2 | `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts` | (a) Add `const DEFAULT_IMAGE_VARIANT = 'large_default';` (top-of-file constant). (b) `buildImageUrl` reads `this.options.imageVariant ?? DEFAULT_IMAGE_VARIANT`. (c) Remove the existing `home_default` TODO comment (now closed). | Image URLs change from `…-home_default.jpg` to `…-large_default.jpg` for the default path; per-connection override works. |
+| 3 | `libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts` | Update existing image-URL assertions (search for `home_default`) to expect `large_default`. Add one new test that exercises the option override (e.g., `imageVariant: 'medium_default'` produces `…-medium_default.jpg`). | All affected assertions updated; one new branch covers the override. |
+| 4 | `libs/integrations/allegro/package.json` | Add `"image-size": "^1.0.0"` to `dependencies` (caret-pin the v1 major; v2 broke the default-export API per §8). Run `pnpm install` to record the lockfile entry. | `pnpm install` resolves and lockfile updates; resolved version is `1.x.y`. |
+| 5 | `libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.ts` | (a) Import `imageSize` from `image-size`. (b) Add `ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX = 400` constant alongside `ACCEPTED_IMAGE_CONTENT_TYPES`. (c) Extend `downloadFailure` code-union with `'IMAGE_TOO_SMALL_FOR_PRODUCT'`. (d) Add the dimension-check block at the end of `downloadImage` per §4.2. (e) Update the file header to enumerate the new error code alongside the existing three. | Validation runs after content-type check, before the upload step; failures surface through the existing `UploadImagesResult.failures` path. |
+| 6 | `libs/integrations/allegro/src/infrastructure/util/__tests__/upload-images-via-allegro.spec.ts` | Add three test branches: (a) returns `IMAGE_TOO_SMALL_FOR_PRODUCT` when source is 200×200px; (b) accepts a 400×400px image (boundary — equal-to-min is fine); (c) returns `IMAGE_DOWNLOAD_INVALID_TYPE` when the bytes claim to be PNG but `image-size` cannot parse them (corrupt buffer). **Fixture strategy: inline base64 PNG constants** (`Buffer.from('…', 'base64')`) for each dimension — most explicit, zero binary in repo, and PNG headers are tiny (~70 bytes for a 1×1 then padded to declared dims via IHDR width/height fields, since `image-size` reads only the IHDR chunk and not the IDAT pixel data). Two constants needed: `PNG_200x200_BASE64` and `PNG_400x400_BASE64`; the corrupt-buffer test uses `Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x00, 0x00, 0x00])` (PNG signature + truncated). | Three new branches covering the dimension gate; existing branches stay green; no binary files added to the repo. |
+| 7 | `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts` | Add one end-to-end branch: `createOffer` rejects with `OfferCreateRejectedException` containing `IMAGE_TOO_SMALL_FOR_PRODUCT` when the operator's image is < 400px, and **does not** call `POST /sale/product-offers`. Mirrors the existing `IMAGE_DOWNLOAD_FAILED` branch structure. | Adapter-level integration confirms the new code surfaces through the existing rejection path. |
+| 8 | All — quality gate | `pnpm lint`, `pnpm type-check`, `pnpm test`. | Clean. |
+| 9 | Manual sandbox repro — **hard merge gate** | After deploying, retry the same flow that surfaced this on 2026-04-27 (cat 257933 / Canon variant). Two outcomes are both acceptable evidence #424 is structurally fixed: (a) **offer reaches `active`/`validating`** because PS's `large_default` for that image is ≥ 400px (most likely); (b) **offer rejects with `IMAGE_TOO_SMALL_FOR_PRODUCT`** *before* hitting Allegro because the source image really is small — operator gets actionable diagnostics in the Job detail view. The only failure mode is the original `ProductValidationException: TOO_SMALL_IMAGE` reaching us from Allegro again — that means neither fix landed correctly. | Sandbox round-trip either succeeds or fails-fast with clean diagnostics. |
+
+## 6. Tests-of-record
+
+- **PS mapper spec** — image-URL assertions move to `large_default`; new branch for the option override.
+- **Upload util spec** — three new branches: too-small reject, boundary acceptance, undecodable buffer.
+- **Adapter spec** — one new end-to-end branch confirming the new error code surfaces correctly.
+- **No integration test** — bug is FE/adapter-pure; existing E2E coverage continues to exercise the happy path.
+
+## 7. Validation
+
+- **Hexagonal compliance** — change is purely inside the two integration packages' infrastructure layers. CORE / FE / API DTO untouched. ✅
+- **Naming** — `DEFAULT_IMAGE_VARIANT` is UPPER_SNAKE_CASE per engineering-standards.md. `ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX` similarly. The new error code `IMAGE_TOO_SMALL_FOR_PRODUCT` follows the existing `IMAGE_*_FAILED` convention. ✅
+- **Headers** — both modified files already have JSDoc headers; updates note #424. New file (none — strictly additive code in existing files). ✅
+- **Tests** — co-located in `__tests__/` per package conventions. ✅
+- **Type contract** — extending the error-code union is a strict superset; no consumer breaks. ✅
+- **Dependency hygiene** — new package is well-known, zero-dep, MIT, sub-5KB. Justified by single-use case (header-only dimension extraction); the alternative (DIY parser) is real maintenance risk for marginal benefit. ✅
+- **Migrations** — none. ✅
+- **Public API** — new constant exported from upload-util module so tests can import it; otherwise additive. ✅
+
+## 8. Risks & open questions
+
+- **`large_default` may not be ≥ 400px on every PS instance.** Default theme on PS 1.7+ ships with `large_default` at 800px, but operators can resize it via "Image Settings" in the back-office. If we land in production and an operator has a custom-sized `large_default` < 400px, the early-reject (§4.2) catches it cleanly. Acceptable — no action needed unless we see real-world hits.
+- **`image-size` mis-detects on edge-case images.** The package is well-tested but not infallible (e.g., progressive JPEGs without standard SOI markers). We pass the buffer through it after the content-type validator has already accepted it as `image/jpeg|png|gif|webp`, so the input is well-formed in the typical case. Pathological inputs surface as `IMAGE_DOWNLOAD_INVALID_TYPE` per §4.2's error mapping.
+- **The `image-size` package's API changed at v2.** v1.x exports a default function `imageSize(bytes)`; v2.x exports a named `imageSize`. Caret-pin to `^1.0.0` (semver allows 1.x.y patches/minors but blocks the v2 break); revisit during the next-major upgrade with a code update.
+- **No frontend warning before submit.** Operator only learns the image is too small when they submit. A future enhancement could probe dimensions client-side via the wizard's image-preview step, but that's outside #424's scope. Tracked as a potential follow-up if friction shows up.
+
+## 9. Out of scope (explicitly deferred)
+
+- Client-side image-preview dimension hint in the wizard.
+- PS `/api/images/products/{id}/{imageId}` metadata-driven variant probing.
+- Backend image resizing pipeline (Sharp / Lambda / etc.).
+- Multi-variant fallback chain (`large_default` → `medium_default` → `home_default`).
+- Per-marketplace dimension gates (e.g., separate `body.images[]` threshold if Allegro adds one).

--- a/libs/integrations/allegro/package.json
+++ b/libs/integrations/allegro/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@openlinker/core": "workspace:*",
-    "@openlinker/shared": "workspace:*"
+    "@openlinker/shared": "workspace:*",
+    "image-size": "^1.0.0"
   },
   "peerDependencies": {
     "@nestjs/common": "^10.0.0"

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -23,6 +23,33 @@ import {
 } from '@openlinker/core/listings';
 import type { CachePort } from '@openlinker/shared';
 
+/**
+ * Build a minimal valid PNG header (24 bytes) for the given dimensions.
+ *
+ * Used by `createOffer` specs to feed `uploadImagesViaAllegro` bytes that
+ * pass `image-size`'s header parser and clear Allegro's 400px-longer-side
+ * gate (#424).
+ */
+function makeValidPng(width: number, height: number): Uint8Array {
+  const buf = Buffer.alloc(24);
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  buf[4] = 0x0d;
+  buf[5] = 0x0a;
+  buf[6] = 0x1a;
+  buf[7] = 0x0a;
+  buf.writeUInt32BE(13, 8);
+  buf[12] = 0x49;
+  buf[13] = 0x48;
+  buf[14] = 0x44;
+  buf[15] = 0x52;
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return new Uint8Array(buf);
+}
+
 describe('AllegroOfferManagerAdapter', () => {
   let adapter: AllegroOfferManagerAdapter;
   let httpClient: jest.Mocked<IAllegroHttpClient>;
@@ -599,13 +626,16 @@ describe('AllegroOfferManagerAdapter', () => {
     let fetchSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      // Default fetch: 200 + image/jpeg + minimal JPEG bytes — keeps existing
-      // specs that don't care about the upload step green.
+      // Default fetch: 200 + image/jpeg + a valid 800×800 PNG header —
+      // image-size's PNG handler will accept this regardless of the
+      // declared content-type, and 800×800 clears Allegro's 400px-longer-side
+      // gate (#424). Keeps existing specs that don't care about the upload
+      // step green.
       fetchSpy = jest
         .spyOn(globalThis, 'fetch')
         .mockImplementation(() =>
           Promise.resolve(
-            new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+            new Response(makeValidPng(800, 800), {
               status: 200,
               headers: { 'content-type': 'image/jpeg' },
             }),
@@ -1322,6 +1352,32 @@ describe('AllegroOfferManagerAdapter', () => {
         ],
       });
       expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('throws OfferCreateRejectedException with IMAGE_TOO_SMALL_FOR_PRODUCT when source image is below the 400px gate', async () => {
+      // #424 — full e2e check that the new code surfaces through the
+      // existing OfferCreateRejectedException path and prevents the
+      // POST /sale/product-offers call.
+      fetchSpy.mockResolvedValue(
+        new Response(makeValidPng(200, 200), {
+          status: 200,
+          headers: { 'content-type': 'image/jpeg' },
+        }),
+      );
+
+      await expect(adapter.createOffer(baseCmd)).rejects.toMatchObject({
+        name: 'OfferCreateRejectedException',
+        statusCode: 0,
+        errors: [
+          expect.objectContaining({
+            field: 'images',
+            code: 'IMAGE_TOO_SMALL_FOR_PRODUCT',
+            message: expect.stringMatching(/200×200px/),
+          }),
+        ],
+      });
+      expect(httpClient.post).not.toHaveBeenCalled();
+      expect(uploadHttpClient.postBinary).not.toHaveBeenCalled();
     });
 
     it('does not call POST /sale/product-offers when the image upload step fails', async () => {

--- a/libs/integrations/allegro/src/infrastructure/util/__tests__/upload-images-via-allegro.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/__tests__/upload-images-via-allegro.spec.ts
@@ -10,7 +10,41 @@
  */
 import { IAllegroHttpClient } from '../../http/allegro-http-client.interface';
 import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
-import { uploadImagesViaAllegro } from '../upload-images-via-allegro';
+import {
+  ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX,
+  uploadImagesViaAllegro,
+} from '../upload-images-via-allegro';
+
+/**
+ * Build a minimal valid PNG header (24 bytes) for the given dimensions.
+ *
+ * `image-size`'s PNG handler reads only the signature + IHDR chunk
+ * (`signature[8] + length[4] + 'IHDR'[4] + width[4] + height[4]`); the
+ * chunk-length / CRC bytes can be anything. Lets us build dimension fixtures
+ * without shipping binary blobs in the repo.
+ */
+function makeValidPng(width: number, height: number): Uint8Array {
+  const buf = Buffer.alloc(24);
+  // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  buf[4] = 0x0d;
+  buf[5] = 0x0a;
+  buf[6] = 0x1a;
+  buf[7] = 0x0a;
+  // Chunk length (13) — value does not affect `image-size` parsing.
+  buf.writeUInt32BE(13, 8);
+  // 'IHDR'
+  buf[12] = 0x49;
+  buf[13] = 0x48;
+  buf[14] = 0x44;
+  buf[15] = 0x52;
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return new Uint8Array(buf);
+}
 
 describe('uploadImagesViaAllegro', () => {
   let uploadHttpClient: jest.Mocked<IAllegroHttpClient>;
@@ -42,7 +76,7 @@ describe('uploadImagesViaAllegro', () => {
   });
 
   it('happy path — single 200 jpeg returns one Allegro CDN location', async () => {
-    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(new Uint8Array([0xff, 0xd8, 0xff])));
+    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(makeValidPng(800, 800)));
     uploadHttpClient.postBinary.mockResolvedValue({
       data: { location: 'https://images.allegrostatic.com/uploaded-1.jpg' },
       status: 201,
@@ -71,7 +105,7 @@ describe('uploadImagesViaAllegro', () => {
     // Fresh Response per call — Response bodies can only be consumed once.
     const fetchImpl = jest
       .fn()
-      .mockImplementation(() => Promise.resolve(okFetchResponse(new Uint8Array([1]))));
+      .mockImplementation(() => Promise.resolve(okFetchResponse(makeValidPng(800, 800))));
     let counter = 0;
     uploadHttpClient.postBinary.mockImplementation(() =>
       Promise.resolve({
@@ -166,7 +200,7 @@ describe('uploadImagesViaAllegro', () => {
 
   it('normalizes image/jpg to image/jpeg when forwarding to Allegro', async () => {
     const fetchImpl = jest.fn().mockResolvedValue(
-      new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+      new Response(makeValidPng(600, 600), {
         status: 200,
         headers: { 'content-type': 'image/jpg' }, // non-standard but ubiquitous
       }),
@@ -192,7 +226,7 @@ describe('uploadImagesViaAllegro', () => {
   });
 
   it('IMAGE_UPLOAD_FAILED when Allegro postBinary rejects with 4xx', async () => {
-    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(new Uint8Array([0xff])));
+    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(makeValidPng(600, 600)));
     uploadHttpClient.postBinary.mockRejectedValue(
       new AllegroApiException(
         'Unprocessable entity',
@@ -218,7 +252,7 @@ describe('uploadImagesViaAllegro', () => {
   });
 
   it('IMAGE_UPLOAD_FAILED when Allegro response is missing the location field', async () => {
-    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(new Uint8Array([0xff])));
+    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(makeValidPng(600, 600)));
     uploadHttpClient.postBinary.mockResolvedValue({
       data: {},
       status: 201,
@@ -245,7 +279,7 @@ describe('uploadImagesViaAllegro', () => {
       if (url.includes('bad')) {
         return Promise.resolve(errFetchResponse(403));
       }
-      return Promise.resolve(okFetchResponse(new Uint8Array([0xff])));
+      return Promise.resolve(okFetchResponse(makeValidPng(600, 600)));
     });
     uploadHttpClient.postBinary.mockResolvedValue({
       data: { location: 'https://images.allegrostatic.com/ok.jpg' },
@@ -264,5 +298,77 @@ describe('uploadImagesViaAllegro', () => {
     expect(result.failures).toHaveLength(1);
     expect(result.failures[0].message).toContain('http://shop.local/bad.jpg');
     expect(result.failures[0].message).not.toContain('http://shop.local/good.jpg');
+  });
+
+  it('IMAGE_TOO_SMALL_FOR_PRODUCT when source longer side < 400px — postBinary never called', async () => {
+    // #424 — Allegro's productSet[0].product.images[] validator rejects
+    // anything below 400px on the longer side. Catch it before we burn an
+    // upload + a 422 at offer-creation time.
+    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(makeValidPng(200, 200)));
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/tiny.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failures[0]).toEqual({
+      field: 'images',
+      code: 'IMAGE_TOO_SMALL_FOR_PRODUCT',
+      message: expect.stringMatching(/200×200px/),
+    });
+    expect(result.failures[0].message).toContain(
+      `≥ ${ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX}px`,
+    );
+    expect(uploadHttpClient.postBinary).not.toHaveBeenCalled();
+  });
+
+  it('accepts an image at the 400px boundary (longer side === min is allowed)', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(okFetchResponse(makeValidPng(400, 400)));
+    uploadHttpClient.postBinary.mockResolvedValue({
+      data: { location: 'https://images.allegrostatic.com/boundary.jpg' },
+      status: 201,
+      headers: {},
+    });
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/boundary.jpg'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      locations: ['https://images.allegrostatic.com/boundary.jpg'],
+    });
+  });
+
+  it('IMAGE_DOWNLOAD_INVALID_TYPE when bytes claim image/* but image-size cannot decode them', async () => {
+    // PNG signature with truncated IHDR — passes content-type check (server
+    // claims image/png) but `image-size` throws on the malformed header.
+    const corrupt = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0x00, 0x00, 0x00]);
+    const fetchImpl = jest.fn().mockResolvedValue(
+      new Response(corrupt, {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      }),
+    );
+
+    const result = await uploadImagesViaAllegro(
+      uploadHttpClient,
+      ['http://shop.local/corrupt.png'],
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failures[0]).toEqual({
+      field: 'images',
+      code: 'IMAGE_DOWNLOAD_INVALID_TYPE',
+      message: expect.stringMatching(/could not be decoded/),
+    });
+    expect(uploadHttpClient.postBinary).not.toHaveBeenCalled();
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.ts
@@ -12,13 +12,20 @@
  * discriminated `UploadImagesResult`. Failure surfaces as a list of
  * `CreateOfferValidationError` carrying:
  *
- * - `IMAGE_DOWNLOAD_FAILED`        — non-2xx, network error, or timeout when
- *                                    GETting the operator's image URL
- * - `IMAGE_DOWNLOAD_INVALID_TYPE`  — GET succeeded but Content-Type is not
- *                                    `image/jpeg|png|gif|webp`
- * - `IMAGE_UPLOAD_FAILED`          — Allegro's `POST /sale/images` rejected
- *                                    the upload, or its response is missing
- *                                    the `location` field
+ * - `IMAGE_DOWNLOAD_FAILED`         — non-2xx, network error, or timeout when
+ *                                     GETting the operator's image URL
+ * - `IMAGE_DOWNLOAD_INVALID_TYPE`   — GET succeeded but Content-Type is not
+ *                                     `image/jpeg|png|gif|webp`, or the bytes
+ *                                     could not be parsed by `image-size`
+ * - `IMAGE_TOO_SMALL_FOR_PRODUCT`   — image dimensions are below Allegro's
+ *                                     `productSet[0].product.images[]`
+ *                                     400px-longer-side rule. Rejecting up-front
+ *                                     avoids burning an upload on bytes that
+ *                                     would fail product validation at the
+ *                                     end of the offer-creation flow (#424).
+ * - `IMAGE_UPLOAD_FAILED`           — Allegro's `POST /sale/images` rejected
+ *                                     the upload, or its response is missing
+ *                                     the `location` field
  *
  * Adapter-key context (e.g. `'allegro.publicapi.v1'`) lives in the calling
  * adapter, not here — the util stays adapter-agnostic.
@@ -35,6 +42,7 @@
  * @module libs/integrations/allegro/src/infrastructure/util
  * @see {@link AllegroOfferManagerAdapter.createOffer} — sole consumer
  */
+import imageSize from 'image-size';
 import { CreateOfferValidationError } from '@openlinker/core/listings';
 import { IAllegroHttpClient } from '../http/allegro-http-client.interface';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
@@ -50,6 +58,20 @@ const ACCEPTED_IMAGE_CONTENT_TYPES: ReadonlySet<string> = new Set([
   'image/gif',
   'image/webp',
 ]);
+
+/**
+ * Allegro's `productSet[0].product.images[]` validator rejects images whose
+ * longer side is below this threshold with `ProductValidationException:
+ * TOO_SMALL_IMAGE` (sandbox repro 2026-04-27, #424). Apply at download time
+ * so we fail fast with actionable diagnostics instead of incurring an upload
+ * + a 422 at the end of the offer-creation flow.
+ *
+ * The offer-side `body.images[]` validator is more lenient — same threshold
+ * may eventually apply there too. We gate up-front on the assumption that
+ * any image used for an offer is also used to create the inline product
+ * (mirrored since #420).
+ */
+export const ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX = 400;
 
 export async function uploadImagesViaAllegro(
   uploadHttpClient: IAllegroHttpClient,
@@ -148,6 +170,37 @@ async function downloadImage(
     return downloadFailure('IMAGE_DOWNLOAD_FAILED', `Image URL '${url}': failed to read body — ${message}`);
   }
 
+  // Header-only dimension check — `image-size` reads the format header
+  // (e.g. PNG IHDR, JPEG SOF) without decoding pixel data, so this stays
+  // cheap even for the upper end of typical product-image sizes (~5MB).
+  let width: number | undefined;
+  let height: number | undefined;
+  try {
+    const dimensions = imageSize(bytes);
+    width = dimensions.width;
+    height = dimensions.height;
+  } catch (error) {
+    // The content-type validator already accepted the bytes as image/*;
+    // a header-decode failure here points at corrupt or truncated source
+    // data. Surface as INVALID_TYPE so the operator gets the same actionable
+    // copy ("not a usable image") rather than a generic download failure.
+    const message = error instanceof Error ? error.message : String(error);
+    return downloadFailure(
+      'IMAGE_DOWNLOAD_INVALID_TYPE',
+      `Image URL '${url}': bytes claimed content-type '${contentType}' but could not be decoded — ${message}`,
+    );
+  }
+
+  const longerSide = Math.max(width ?? 0, height ?? 0);
+  if (longerSide < ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX) {
+    return downloadFailure(
+      'IMAGE_TOO_SMALL_FOR_PRODUCT',
+      `Image URL '${url}' is ${width ?? '?'}×${height ?? '?'}px; ` +
+        `Allegro requires a longer side ≥ ${ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX}px ` +
+        `for product images. Use a larger source image.`,
+    );
+  }
+
   return { ok: true, contentType, bytes };
 }
 
@@ -193,7 +246,7 @@ function normalizeImageContentType(raw: string | null): string | null {
 }
 
 function downloadFailure(
-  code: 'IMAGE_DOWNLOAD_FAILED' | 'IMAGE_DOWNLOAD_INVALID_TYPE',
+  code: 'IMAGE_DOWNLOAD_FAILED' | 'IMAGE_DOWNLOAD_INVALID_TYPE' | 'IMAGE_TOO_SMALL_FOR_PRODUCT',
   message: string,
 ): DownloadErr {
   return { ok: false, failure: { field: 'images', code, message } };

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-product.mapper.spec.ts
@@ -394,7 +394,7 @@ describe('PrestashopProductMapper', () => {
       const prestashopProduct = makeProductWithImages({ image: { id: '7' } });
 
       const result = mapper.mapProduct(prestashopProduct, 1);
-      expect(result.images).toEqual(['https://shop.test/img/p/7/7-home_default.jpg']);
+      expect(result.images).toEqual(['https://shop.test/img/p/7/7-large_default.jpg']);
     });
 
     it('should extract a multi-image array and preserve order (cover first)', () => {
@@ -404,9 +404,9 @@ describe('PrestashopProductMapper', () => {
 
       const result = mapper.mapProduct(prestashopProduct, 1);
       expect(result.images).toEqual([
-        'https://shop.test/img/p/1/1-home_default.jpg',
-        'https://shop.test/img/p/2/2-home_default.jpg',
-        'https://shop.test/img/p/3/3-home_default.jpg',
+        'https://shop.test/img/p/1/1-large_default.jpg',
+        'https://shop.test/img/p/2/2-large_default.jpg',
+        'https://shop.test/img/p/3/3-large_default.jpg',
       ]);
     });
 
@@ -417,8 +417,8 @@ describe('PrestashopProductMapper', () => {
 
       const result = mapper.mapProduct(prestashopProduct, 1);
       expect(result.images).toEqual([
-        'https://shop.test/img/p/4/2/42-home_default.jpg',
-        'https://shop.test/img/p/1/2/3/123-home_default.jpg',
+        'https://shop.test/img/p/4/2/42-large_default.jpg',
+        'https://shop.test/img/p/1/2/3/123-large_default.jpg',
       ]);
     });
 
@@ -429,10 +429,10 @@ describe('PrestashopProductMapper', () => {
 
       const result = mapper.mapProduct(prestashopProduct, 1);
       expect(result.images).toEqual([
-        'https://shop.test/img/p/1/1-home_default.jpg',
-        'https://shop.test/img/p/4/2/42-home_default.jpg',
-        'https://shop.test/img/p/1/2/3/123-home_default.jpg',
-        'https://shop.test/img/p/1/2/3/4/1234-home_default.jpg',
+        'https://shop.test/img/p/1/1-large_default.jpg',
+        'https://shop.test/img/p/4/2/42-large_default.jpg',
+        'https://shop.test/img/p/1/2/3/123-large_default.jpg',
+        'https://shop.test/img/p/1/2/3/4/1234-large_default.jpg',
       ]);
     });
 
@@ -443,7 +443,7 @@ describe('PrestashopProductMapper', () => {
       const prestashopProduct = makeProductWithImages({ image: { id: '1' } });
 
       const result = localMapper.mapProduct(prestashopProduct, 1);
-      expect(result.images).toEqual(['https://shop.test/img/p/1/1-home_default.jpg']);
+      expect(result.images).toEqual(['https://shop.test/img/p/1/1-large_default.jpg']);
     });
 
     it('should skip entries without a usable id and still return the rest', () => {
@@ -453,8 +453,8 @@ describe('PrestashopProductMapper', () => {
 
       const result = mapper.mapProduct(prestashopProduct, 1);
       expect(result.images).toEqual([
-        'https://shop.test/img/p/1/1-home_default.jpg',
-        'https://shop.test/img/p/3/3-home_default.jpg',
+        'https://shop.test/img/p/1/1-large_default.jpg',
+        'https://shop.test/img/p/3/3-large_default.jpg',
       ]);
     });
 
@@ -471,7 +471,7 @@ describe('PrestashopProductMapper', () => {
       const prestashopProduct = makeProductWithImages({ image: { id: 55 } });
 
       const result = mapper.mapProduct(prestashopProduct, 1);
-      expect(result.images).toEqual(['https://shop.test/img/p/5/5/55-home_default.jpg']);
+      expect(result.images).toEqual(['https://shop.test/img/p/5/5/55-large_default.jpg']);
     });
 
     it('should extract images from JSON shape (flat array, no image wrapper)', () => {
@@ -482,8 +482,8 @@ describe('PrestashopProductMapper', () => {
 
       const result = mapper.mapProduct(prestashopProduct, 1);
       expect(result.images).toEqual([
-        'https://shop.test/img/p/1/1-home_default.jpg',
-        'https://shop.test/img/p/2/2-home_default.jpg',
+        'https://shop.test/img/p/1/1-large_default.jpg',
+        'https://shop.test/img/p/2/2-large_default.jpg',
       ]);
     });
 
@@ -494,6 +494,23 @@ describe('PrestashopProductMapper', () => {
 
       const result = mapper.mapProduct(prestashopProduct, 1);
       expect(result.images).toBeNull();
+    });
+
+    it('should honour the imageVariant option override', () => {
+      // #424 — `imageVariant` lets a connection override the default
+      // `large_default` suffix when the PS instance uses non-standard
+      // image-type names or sizing.
+      const localMapper = new PrestashopProductMapper({
+        storefrontBaseUrl: 'https://shop.test',
+        imageVariant: 'medium_default',
+      });
+      const prestashopProduct = makeProductWithImages({ image: [{ id: '1' }, { id: '42' }] });
+
+      const result = localMapper.mapProduct(prestashopProduct, 1);
+      expect(result.images).toEqual([
+        'https://shop.test/img/p/1/1-medium_default.jpg',
+        'https://shop.test/img/p/4/2/42-medium_default.jpg',
+      ]);
     });
   });
 

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts
@@ -12,6 +12,17 @@ import { IPrestashopProductMapper, PrestashopProduct, PrestashopCombination } fr
 import { PrestashopProductMapperOptions } from './prestashop-product.mapper.types';
 
 /**
+ * PrestaShop image-variant suffix used by `buildImageUrl` when the
+ * connection has not specified `options.imageVariant`.
+ *
+ * `large_default` is the standard high-resolution storefront variant
+ * (~800px on a stock PS install), chosen so emitted image URLs satisfy
+ * Allegro's `productSet[0].product.images[]` 400px-longer-side rule (#424).
+ * Operators with non-standard PS image settings can override per connection.
+ */
+const DEFAULT_IMAGE_VARIANT = 'large_default';
+
+/**
  * PrestaShop Product Mapper
  *
  * Transforms PrestaShop product data to OpenLinker Product schema.
@@ -382,18 +393,18 @@ export class PrestashopProductMapper implements IPrestashopProductMapper {
   /**
    * Build a public front-office image URL for a given PrestaShop image id.
    *
-   * Uses the numeric path format (`/img/p/{split}/{id}-{type}.jpg`) which
+   * Uses the numeric path format (`/img/p/{split}/{id}-{variant}.jpg`) which
    * PrestaShop serves regardless of "Friendly URL" configuration. `split` is
    * the image id with digits separated by `/` (e.g. `123` → `1/2/3`). Digit
-   * splitting handles arbitrarily long ids.
-   *
-   * TODO: image type ('home_default') is fixed for v1. Expose via options
-   * when detail-page or retina sizes land.
+   * splitting handles arbitrarily long ids. The variant suffix comes from
+   * `options.imageVariant` and falls back to `DEFAULT_IMAGE_VARIANT`
+   * (`large_default`) — see #424 for why thumbnails are unsuitable.
    */
   private buildImageUrl(imageId: string): string {
     const base = this.options.storefrontBaseUrl.replace(/\/+$/, '');
     const split = this.splitImageId(imageId);
-    return `${base}/img/p/${split}/${imageId}-home_default.jpg`;
+    const variant = this.options.imageVariant ?? DEFAULT_IMAGE_VARIANT;
+    return `${base}/img/p/${split}/${imageId}-${variant}.jpg`;
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.types.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.types.ts
@@ -30,4 +30,19 @@ export interface PrestashopProductMapperOptions {
    * `currency: null` and downstream persistence treats currency as unknown.
    */
   currency?: string;
+
+  /**
+   * PrestaShop image-variant suffix used when constructing public storefront
+   * image URLs (`/img/p/{split}/{imageId}-{variant}.jpg`).
+   *
+   * Defaults to `'large_default'` (~800px on a stock PS install) so images
+   * pass Allegro's `productSet[0].product.images[]` validator, which rejects
+   * anything whose longer side is < 400px with `TOO_SMALL_IMAGE` (#424).
+   * The previous `'home_default'` thumbnail (~250px) reliably tripped that
+   * gate.
+   *
+   * Override per connection if the PS instance uses a non-standard variant
+   * name or has resized `large_default` below 400px in the back-office.
+   */
+  imageVariant?: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
       '@openlinker/shared':
         specifier: workspace:*
         version: link:../../shared
+      image-size:
+        specifier: ^1.0.0
+        version: 1.2.1
     devDependencies:
       '@types/jest':
         specifier: 29.5.12
@@ -3447,6 +3450,11 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -4447,6 +4455,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -8750,6 +8761,10 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -9918,6 +9933,10 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   randombytes@2.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #424.

Two coordinated fixes for Allegro's `productSet[0].product.images[]` validator (`ProductValidationException: TOO_SMALL_IMAGE`, sandbox repro 2026-04-27):

- **PrestaShop variant bump** — `PrestashopProductMapper.buildImageUrl` now requests `large_default` (≈800px) instead of `home_default` (≈250px thumbnail). Closes the existing TODO. New optional `imageVariant?: string` mapper option lets a connection override per instance when the back-office has resized `large_default`.
- **Allegro early-reject** — `uploadImagesViaAllegro` header-decodes the operator's source image via `image-size` and rejects with new code `IMAGE_TOO_SMALL_FOR_PRODUCT` *before* uploading bytes when the longer side is < 400px. Operator sees actionable diagnostics in the Job-detail view (image dimensions + threshold) instead of a 422 at the end of the offer-creation flow.

The new error code surfaces through the existing `OfferCreateRejectedException` path; no FE changes required — the wizard's `mutation.error` Alert renders the new message verbatim, same path as today's `IMAGE_DOWNLOAD_FAILED`.

## What changed

- `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.types.ts` — added optional `imageVariant?: string` field with #424 JSDoc.
- `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts` — `DEFAULT_IMAGE_VARIANT = 'large_default'`; `buildImageUrl` now reads `options.imageVariant ?? DEFAULT_IMAGE_VARIANT`; previous `home_default` TODO removed (closed).
- `libs/integrations/allegro/package.json` — added `image-size: ^1.0.0` (caret-pin v1 major; v2 broke the default-export API).
- `libs/integrations/allegro/src/infrastructure/util/upload-images-via-allegro.ts` — exports `ALLEGRO_PRODUCT_IMAGE_MIN_LONGER_SIDE_PX = 400`; header-only dim-check via `image-size` after content-type validation; new error code `IMAGE_TOO_SMALL_FOR_PRODUCT`; module header enumerates the new code.
- Tests — PS mapper assertions updated for `large_default` + override branch; util spec gains 3 new branches (too-small reject, 400px boundary acceptance, undecodable buffer); adapter spec gains 1 new e2e branch confirming `IMAGE_TOO_SMALL_FOR_PRODUCT` surfaces through `OfferCreateRejectedException` and **does not** call `POST /sale/product-offers`. Both test files use a 24-byte `makeValidPng(w, h)` helper so we don't ship binary fixtures.

## Why two coordinated fixes

The PS bump alone is the common-case fix — most operators have `large_default` ≥ 400px on stock PS settings. The Allegro early-reject is the safety net for outliers (custom-resized `large_default`, genuinely-small source images): instead of burning an Allegro upload + producing a 422 with platform-language at the end of the flow, we reject up-front with operator-language and stop before bytes leave OL. Either branch yields actionable diagnostics in the Job-detail view.

## Test plan

- [x] `pnpm lint` (clean — only pre-existing warnings unrelated to this change)
- [x] `pnpm type-check` (clean across all packages)
- [x] `pnpm test` (2055 unit tests pass: allegro 194, prestashop 201, core 478, api 267, worker 109, web 760, ai 21, shared 25)
- [x] Pre-commit hook re-ran the same gate at commit time — clean
- [ ] **Hard merge gate**: re-run the same Allegro sandbox flow that surfaced this on 2026-04-27 (cat 257933 / Canon variant). Two outcomes both confirm the structural fix:
  - **(a)** offer reaches `active`/`validating` because PS's `large_default` for the image is ≥ 400px (most likely path)
  - **(b)** offer rejects with `IMAGE_TOO_SMALL_FOR_PRODUCT` *before* hitting Allegro because the source really is small — operator gets actionable copy in the Job-detail view
  - Failure mode: original `ProductValidationException: TOO_SMALL_IMAGE` from Allegro reaches us again — that means neither fix landed correctly
