### PR TITLE
fix(migrations): self-heal AddOutcomeToSyncJobs for orphan column state

### DIFF
--- a/apps/api/src/migrations/1790000000003-add-outcome-to-sync-jobs.ts
+++ b/apps/api/src/migrations/1790000000003-add-outcome-to-sync-jobs.ts
@@ -9,12 +9,28 @@
  * historical rows keep NULL outcome (status tells the story for them).
  *
  * Reversible: down() drops the column.
+ *
+ * Self-healing (#427): some dev DBs acquired the `outcome` column by a
+ * prior path — a feature-branch test run, a pre-merge timestamp variant,
+ * or a long-ago `synchronize: true` accident — without recording the
+ * corresponding `migrations` row. On the first `migration:run` after the
+ * canonical `1790000000003` timestamp landed in main, the original
+ * non-idempotent `ADD COLUMN` tripped `column "outcome" of relation
+ * "sync_jobs" already exists`. The fix mirrors the pattern proven for
+ * `AddCurrencyToProducts1790000000002` (#374): `ADD COLUMN IF NOT EXISTS`
+ * makes re-application a no-op on affected envs while staying behaviorally
+ * identical on fresh DBs and on DBs that already applied the original
+ * `up()` cleanly (TypeORM skips already-recorded migrations by name).
  */
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddOutcomeToSyncJobs1790000000003 implements MigrationInterface {
+  name = 'AddOutcomeToSyncJobs1790000000003';
+
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "sync_jobs" ADD "outcome" character varying`);
+    await queryRunner.query(
+      `ALTER TABLE "sync_jobs" ADD COLUMN IF NOT EXISTS "outcome" character varying`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #427.

Make migration `AddOutcomeToSyncJobs1790000000003` self-healing — same shape as `AddCurrencyToProducts1790000000002` (#374). Switches `up()` to `ADD COLUMN IF NOT EXISTS` so dev DBs that already have `sync_jobs.outcome` from a prior branch state (test feature-branch run, pre-merge timestamp variant, ancient `synchronize: true` accident, etc.) but no corresponding `migrations` row can converge on the next `migration:run` instead of tripping `column "outcome" of relation "sync_jobs" already exists`.

Adds an explicit `name = 'AddOutcomeToSyncJobs1790000000003'` field for symmetry with the precedent at `1790000000002-add-currency-to-products.ts`.

## Why this exists in the wild

Reported when running `pnpm migration:run` on `main` after #426 merged:

```
QueryFailedError: column "outcome" of relation "sync_jobs" already exists
    at AddOutcomeToSyncJobs1790000000003.up
```

The DB state mismatches the migration ledger — the column exists but the row was scrubbed. The `migrations.md` §5 "Duplicate migration timestamp" section already documents this exact failure mode and prescribes the self-heal pattern.

## What this changes

`apps/api/src/migrations/1790000000003-add-outcome-to-sync-jobs.ts`:

- `up()` switches `ADD "outcome"` → `ADD COLUMN IF NOT EXISTS "outcome"`. No-op on affected envs, identical DDL on fresh DBs.
- Adds explicit `name` field (matches `1790000000002`).
- Extends JSDoc with the self-heal explainer + #427 reference.

`down()` unchanged.

## Verification

Reproduced the orphan state and confirmed the fix end-to-end on a local DB:

1. `pnpm migration:revert` — drops the column + the migrations row.
2. `psql ... ALTER TABLE "sync_jobs" ADD COLUMN "outcome" character varying;` — manually re-creates the orphan state (column present, row absent).
3. `pnpm migration:run` — clean run, body is `ADD COLUMN IF NOT EXISTS` + INSERT, both committed atomically inside the migration transaction.

Behavior on fresh DBs is unchanged: `IF NOT EXISTS` reduces to a regular `ADD COLUMN` when no column is present, and TypeORM still records the row. Behavior on DBs that already applied the original `up()` cleanly is also unchanged: TypeORM skips already-recorded migrations by name, so the new body never executes there.

## Test plan

- [x] `pnpm lint` (clean — only pre-existing warnings unrelated to this change)
- [x] `pnpm type-check` (clean across all packages)
- [x] `pnpm test` (2055 unit tests pass)
- [x] `pnpm --filter @openlinker/api migration:show` (36 migrations, target row applied)
- [x] `scripts/check-migration-timestamps.mjs` invariant green (timestamp + class name unchanged)
- [x] Manual orphan-state reproduction: `revert` → out-of-band `ADD COLUMN` → `migration:run` succeeds

## References

- `docs/migrations.md` §5 "Duplicate migration timestamp" — documents the self-heal pattern
- `apps/api/src/migrations/1790000000002-add-currency-to-products.ts` — reference implementation
- #374 — original duplicate-timestamp incident that established the pattern
- #426 — the merge that surfaced this on the user's local DB