### PR TITLE
feat(allegro,web): connection-level seller defaults + smart-link by EAN

### DIFF
--- a/apps/api/src/integrations/http/allegro.controller.spec.ts
+++ b/apps/api/src/integrations/http/allegro.controller.spec.ts
@@ -10,6 +10,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { AllegroController } from './allegro.controller';
 import { IAllegroOAuthService, ALLEGRO_OAUTH_SERVICE_TOKEN } from '../application/interfaces/allegro-oauth.service.interface';
+import { INTEGRATIONS_SERVICE_TOKEN, type IIntegrationsService } from '@openlinker/core/integrations';
 import { ConnectionCursorRepositoryPort, CONNECTION_CURSOR_REPOSITORY_TOKEN } from '@openlinker/core/sync';
 import {
   AllegroQuantityCommandRepositoryPort,
@@ -63,6 +64,12 @@ describe('AllegroController', () => {
       updateStatus: jest.fn(),
     } as unknown as jest.Mocked<AllegroQuantityCommandRepositoryPort>;
 
+    const mockIntegrationsService = {
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      getCapabilityAdapters: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AllegroController],
       providers: [
@@ -77,6 +84,10 @@ describe('AllegroController', () => {
         {
           provide: ALLEGRO_QUANTITY_COMMAND_REPOSITORY_TOKEN,
           useValue: mockCommandRepository,
+        },
+        {
+          provide: INTEGRATIONS_SERVICE_TOKEN,
+          useValue: mockIntegrationsService,
         },
       ],
     }).compile();

--- a/apps/api/src/integrations/http/allegro.controller.ts
+++ b/apps/api/src/integrations/http/allegro.controller.ts
@@ -35,6 +35,15 @@ import {
 import { AllegroQuantityCommandResponseDto } from './dto/allegro-quantity-command-response.dto';
 import { AllegroCommandsQueryDto } from './dto/allegro-commands-query.dto';
 import { Logger } from '@openlinker/shared/logging';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+} from '@openlinker/core/integrations';
+import {
+  type OfferManagerPort,
+  type ResponsibleProducerEntry,
+  isResponsibleProducerReader,
+} from '@openlinker/core/listings';
 
 @ApiTags('allegro')
 @Controller('integrations/allegro')
@@ -48,6 +57,8 @@ export class AllegroController {
     private readonly cursorRepository: ConnectionCursorRepositoryPort,
     @Inject(ALLEGRO_QUANTITY_COMMAND_REPOSITORY_TOKEN)
     private readonly commandRepository: AllegroQuantityCommandRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
   ) {}
 
   @Roles('admin')
@@ -344,6 +355,43 @@ export class AllegroController {
     }
 
     return AllegroQuantityCommandResponseDto.fromDomain(command);
+  }
+
+  /**
+   * List the seller's EU GPSR responsible-producer registry. Backs the
+   * dropdown on the Allegro connection-edit page (#430). Adapter-resolved
+   * per connection: returns 200 with the neutral entry list, or 400 when
+   * the resolved adapter doesn't support the `ResponsibleProducerReader`
+   * capability.
+   *
+   * No local persistence — the registry is operator-driven (entries are
+   * created in Allegro's seller panel, not from inside OL), so freshness
+   * matters more than latency for a settings page.
+   */
+  @Roles('admin')
+  @ApiBearerAuth()
+  @Get('connections/:id/responsible-producers')
+  @ApiOperation({
+    summary: 'List EU GPSR responsible-producer entries for the connection',
+  })
+  @ApiParam({ name: 'id', description: 'Connection ID' })
+  @ApiResponse({ status: 200, description: 'Responsible-producer entries returned' })
+  async listResponsibleProducers(
+    @Param('id') connectionId: string,
+  ): Promise<ResponsibleProducerEntry[]> {
+    this.logger.debug(
+      `Listing Allegro responsible producers (connection: ${connectionId})`,
+    );
+    const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      connectionId,
+      'OfferManager',
+    );
+    if (!isResponsibleProducerReader(adapter)) {
+      throw new BadRequestException(
+        `Connection ${connectionId} does not support the ResponsibleProducerReader capability`,
+      );
+    }
+    return adapter.fetchResponsibleProducers();
   }
 }
 

--- a/apps/api/src/integrations/http/dto/allegro-connection-config.dto.ts
+++ b/apps/api/src/integrations/http/dto/allegro-connection-config.dto.ts
@@ -2,12 +2,31 @@
  * Allegro Connection Config DTO
  *
  * Request DTO for Allegro connection configuration. Validates Allegro-specific
- * config fields (environment, apiBaseUrl) and provides Swagger documentation.
+ * config fields (environment, apiBaseUrl, sellerDefaults) and provides Swagger
+ * documentation.
  *
  * @module apps/api/src/integrations/http/dto
  */
-import { IsEnum, IsOptional, IsString, IsUrl, IsUUID } from 'class-validator';
+import {
+  IsEnum,
+  IsIn,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUrl,
+  IsUUID,
+  Matches,
+  MaxLength,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  AllegroSafetyInformationTypeValues,
+  PolishVoivodeshipValues,
+} from '@openlinker/integrations-allegro';
 
 /**
  * Allegro environment values
@@ -51,5 +70,102 @@ export class AllegroConnectionConfigDto {
   @IsUUID('4', { message: 'masterCatalogConnectionId must be a valid UUID' })
   @IsOptional()
   masterCatalogConnectionId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Connection-level seller defaults required by `POST /sale/product-offers` ' +
+      '— `location` (every offer), plus `responsibleProducerId` and ' +
+      '`safetyInformation` for the inline-product path. See #430.',
+    type: () => AllegroSellerDefaultsDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AllegroSellerDefaultsDto)
+  sellerDefaults?: AllegroSellerDefaultsDto;
+}
+
+/**
+ * Allegro ship-from address. `countryCode` is pinned to `'PL'` for now —
+ * multi-market support is out of scope for #430. The voivodeship enum is
+ * Allegro's own (16 values) and the postcode regex matches the PL format.
+ */
+export class AllegroSellerLocationDto {
+  @ApiProperty({ description: 'ISO country code', enum: ['PL'], example: 'PL' })
+  @IsIn(['PL'])
+  countryCode!: 'PL';
+
+  @ApiProperty({
+    description: 'Polish voivodeship (Allegro enum)',
+    enum: PolishVoivodeshipValues,
+  })
+  @IsIn(PolishVoivodeshipValues as readonly string[])
+  province!: (typeof PolishVoivodeshipValues)[number];
+
+  @ApiProperty({ description: 'City name', example: 'Warszawa' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  city!: string;
+
+  @ApiProperty({ description: 'PL postcode (NN-NNN)', example: '00-001' })
+  @IsString()
+  @Matches(/^\d{2}-\d{3}$/, {
+    message: 'postCode must match the PL format NN-NNN',
+  })
+  postCode!: string;
+}
+
+/**
+ * EU GPSR safety-information payload. Discriminated by `type` — when
+ * `SAFETY_INFORMATION`, `content` is required free text.
+ */
+export class AllegroSafetyInformationDto {
+  @ApiProperty({
+    description: 'Safety-information discriminator',
+    enum: AllegroSafetyInformationTypeValues,
+  })
+  @IsIn(AllegroSafetyInformationTypeValues as readonly string[])
+  type!: (typeof AllegroSafetyInformationTypeValues)[number];
+
+  @ApiPropertyOptional({
+    description:
+      'Free-text safety information content. Required when `type === SAFETY_INFORMATION`.',
+    maxLength: 2000,
+  })
+  // Conditional require: when `type === SAFETY_INFORMATION`, `content` must
+  // be a non-empty string. Otherwise the field is ignored entirely (every
+  // subsequent validator is skipped by `@ValidateIf`).
+  @ValidateIf((o: AllegroSafetyInformationDto) => o.type === 'SAFETY_INFORMATION')
+  @IsString()
+  @IsNotEmpty({
+    message: 'safetyInformation.content is required when type is SAFETY_INFORMATION',
+  })
+  @MaxLength(2000)
+  content?: string;
+}
+
+export class AllegroSellerDefaultsDto {
+  @ApiProperty({ description: 'Ship-from location', type: () => AllegroSellerLocationDto })
+  @ValidateNested()
+  @Type(() => AllegroSellerLocationDto)
+  @IsObject()
+  location!: AllegroSellerLocationDto;
+
+  @ApiProperty({
+    description:
+      'Allegro responsible-producer id from `/sale/responsible-producers` registry',
+  })
+  @IsString()
+  @IsNotEmpty()
+  responsibleProducerId!: string;
+
+  @ApiProperty({
+    description: 'EU GPSR safety information',
+    type: () => AllegroSafetyInformationDto,
+  })
+  @ValidateNested()
+  @Type(() => AllegroSafetyInformationDto)
+  @IsObject()
+  safetyInformation!: AllegroSafetyInformationDto;
 }
 

--- a/apps/web/src/features/allegro/api/allegro.api.ts
+++ b/apps/web/src/features/allegro/api/allegro.api.ts
@@ -18,9 +18,25 @@ export interface AllegroCallbackResponse {
   connectionName: string;
 }
 
+/**
+ * One entry from `GET /integrations/allegro/connections/:id/responsible-producers`.
+ * Mirrors the BE neutral `ResponsibleProducerEntry` shape so the FE Select
+ * can render directly from the API response.
+ */
+export interface AllegroResponsibleProducer {
+  id: string;
+  name: string;
+  kind:
+    | 'PRODUCER'
+    | 'IMPORTER'
+    | 'AUTHORIZED_REPRESENTATIVE'
+    | 'FULFILLMENT_SERVICE_PROVIDER';
+}
+
 export interface AllegroApi {
   startOAuth: (input: StartAllegroOAuthInput) => Promise<StartAllegroOAuthResponse>;
   handleCallback: (code: string, state: string) => Promise<AllegroCallbackResponse>;
+  listResponsibleProducers: (connectionId: string) => Promise<AllegroResponsibleProducer[]>;
 }
 
 interface ApiRequest {
@@ -39,6 +55,12 @@ export function createAllegroApi(request: ApiRequest): AllegroApi {
     handleCallback(code, state): Promise<AllegroCallbackResponse> {
       const params = new URLSearchParams({ code, state });
       return request<AllegroCallbackResponse>(`/integrations/allegro/oauth/callback?${params.toString()}`);
+    },
+
+    listResponsibleProducers(connectionId): Promise<AllegroResponsibleProducer[]> {
+      return request<AllegroResponsibleProducer[]>(
+        `/integrations/allegro/connections/${connectionId}/responsible-producers`,
+      );
     },
   };
 }

--- a/apps/web/src/features/allegro/api/allegro.query-keys.ts
+++ b/apps/web/src/features/allegro/api/allegro.query-keys.ts
@@ -1,3 +1,5 @@
 export const allegroQueryKeys = {
   all: ['allegro'] as const,
+  responsibleProducers: (connectionId: string) =>
+    ['allegro', 'responsible-producers', connectionId] as const,
 };

--- a/apps/web/src/features/allegro/hooks/use-responsible-producers-query.ts
+++ b/apps/web/src/features/allegro/hooks/use-responsible-producers-query.ts
@@ -1,0 +1,22 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { allegroQueryKeys } from '../api/allegro.query-keys';
+import type { AllegroResponsibleProducer } from '../api/allegro.api';
+
+/**
+ * Fetches the seller's EU GPSR responsible-producer registry for the given
+ * connection (#430). Backs the dropdown on the Allegro connection-edit
+ * page. Disabled when `connectionId` is empty so the form can render its
+ * structured inputs before the connection is fully loaded.
+ */
+export function useResponsibleProducersQuery(
+  connectionId: string,
+): UseQueryResult<AllegroResponsibleProducer[]> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: allegroQueryKeys.responsibleProducers(connectionId),
+    queryFn: () => apiClient.allegro.listResponsibleProducers(connectionId),
+    enabled: connectionId.length > 0,
+  });
+}

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -21,6 +21,8 @@ import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
 import { Textarea } from '../../../shared/ui/textarea';
 import { useToast } from '../../../shared/ui/toast-provider';
+import { AllegroSellerDefaultsSection } from './allegro-seller-defaults-section';
+import { POLISH_VOIVODESHIP_VALUES } from '../types/polish-voivodeship.types';
 
 interface EditConnectionFormProps {
   connection: Connection;
@@ -32,6 +34,54 @@ type PlatformBranch = 'prestashop' | 'marketplace' | 'raw';
 function readString(config: Record<string, unknown>, key: string): string {
   const value = config[key];
   return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Read the connection-level Allegro seller defaults out of `config` (#430).
+ * Always returns a fully-populated form-shape — empty-string fields where
+ * the operator hasn't filled them yet — so RHF's `register()` paths work
+ * without per-field undefined guards.
+ */
+function readSellerDefaults(
+  config: Record<string, unknown>,
+): NonNullable<EditConnectionFormValues['sellerDefaults']> {
+  const raw =
+    typeof config.sellerDefaults === 'object' && config.sellerDefaults !== null
+      ? (config.sellerDefaults as Record<string, unknown>)
+      : {};
+  const location =
+    typeof raw.location === 'object' && raw.location !== null
+      ? (raw.location as Record<string, unknown>)
+      : {};
+  const safety =
+    typeof raw.safetyInformation === 'object' && raw.safetyInformation !== null
+      ? (raw.safetyInformation as Record<string, unknown>)
+      : {};
+  const safetyType: 'NO_SAFETY_INFORMATION' | 'SAFETY_INFORMATION' =
+    safety.type === 'SAFETY_INFORMATION' ? 'SAFETY_INFORMATION' : 'NO_SAFETY_INFORMATION';
+  // Narrow `province` to the FE Zod union; out-of-band values fall through
+  // as '' so the operator picks again. Mirrors `safetyInformation.type`'s
+  // guard above.
+  const provinceRaw = typeof location.province === 'string' ? location.province : '';
+  const province: NonNullable<
+    NonNullable<EditConnectionFormValues['sellerDefaults']>['location']
+  >['province'] = (POLISH_VOIVODESHIP_VALUES as readonly string[]).includes(provinceRaw)
+    ? (provinceRaw as (typeof POLISH_VOIVODESHIP_VALUES)[number])
+    : '';
+  return {
+    location: {
+      countryCode: 'PL',
+      province,
+      city: typeof location.city === 'string' ? location.city : '',
+      postCode: typeof location.postCode === 'string' ? location.postCode : '',
+    },
+    responsibleProducerId:
+      typeof raw.responsibleProducerId === 'string' ? raw.responsibleProducerId : '',
+    safetyInformation: {
+      type: safetyType,
+      content: typeof safety.content === 'string' ? safety.content : '',
+    },
+  };
 }
 
 function isParseableJson(text: string): boolean {
@@ -58,6 +108,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
       masterCatalogConnectionId: readString(connection.config, 'masterCatalogConnectionId'),
       configText: JSON.stringify(connection.config, null, 2),
       adapterKey: connection.adapterKey ?? '',
+      sellerDefaults: readSellerDefaults(connection.config),
     },
     resolver: zodResolver(editConnectionSchema),
   });
@@ -118,6 +169,19 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
     const parsed = JSON.parse(form.getValues('configText')) as Record<string, unknown>;
     const merged = mergeStructuredIntoConfig(parsed, { [field]: value });
     form.setValue('configText', JSON.stringify(merged, null, 2), { shouldDirty: markDirty });
+  }
+
+  // #430 — re-serialize the entire `sellerDefaults` shape into configText
+  // on every sub-field change. Treated as a single structured patch (vs.
+  // the per-field syncs above) because the BE DTO requires the full nested
+  // shape on save and partial-empty fields would round-trip awkwardly.
+  function syncSellerDefaultsToJson(): void {
+    if (!configIsParseable) return;
+    const parsed = JSON.parse(form.getValues('configText')) as Record<string, unknown>;
+    const merged = mergeStructuredIntoConfig(parsed, {
+      sellerDefaults: form.getValues('sellerDefaults'),
+    });
+    form.setValue('configText', JSON.stringify(merged, null, 2), { shouldDirty: true });
   }
 
   // Auto-select the sole candidate ONCE on mount, only when the server never
@@ -274,6 +338,15 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
           disabled={!configIsParseable}
           onChange={(value) => syncStructuredToJson('masterCatalogConnectionId', value)}
           onRetry={() => void connectionsQuery.refetch()}
+        />
+      ) : null}
+
+      {connection.platformType === 'allegro' ? (
+        <AllegroSellerDefaultsSection
+          connectionId={connection.id}
+          form={form}
+          onChange={syncSellerDefaultsToJson}
+          disabled={!configIsParseable}
         />
       ) : null}
 

--- a/apps/web/src/features/connections/components/allegro-seller-defaults-section.test.tsx
+++ b/apps/web/src/features/connections/components/allegro-seller-defaults-section.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * AllegroSellerDefaultsSection — Tests
+ *
+ * Branches per `.claude/rules/fe-pages.md` "Testing Priorities":
+ * - happy path: renders the three field groups (location / RP / safety info)
+ * - loading: RP query in flight → Select disabled with loading copy
+ * - error: RP query fails → error Alert with retry
+ * - empty: RP query returns [] → info Alert prompting Allegro panel
+ * - conditional textarea: visible only when type === SAFETY_INFORMATION
+ *
+ * @module apps/web/src/features/connections/components
+ */
+import { useForm, type UseFormReturn } from 'react-hook-form';
+import { type ReactElement } from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import { AllegroSellerDefaultsSection } from './allegro-seller-defaults-section';
+import type { EditConnectionFormValues } from './edit-connection.schema';
+
+interface HarnessProps {
+  apiClient?: ReturnType<typeof createMockApiClient>;
+  initialSafetyType?: 'NO_SAFETY_INFORMATION' | 'SAFETY_INFORMATION';
+  onChange?: () => void;
+}
+
+function Harness({ initialSafetyType, onChange }: HarnessProps): ReactElement {
+  const form = useForm<EditConnectionFormValues>({
+    defaultValues: {
+      name: 'Allegro sandbox',
+      configText: '{}',
+      adapterKey: '',
+      sellerDefaults: {
+        location: { countryCode: 'PL', province: '', city: '', postCode: '' },
+        responsibleProducerId: '',
+        safetyInformation: {
+          type: initialSafetyType ?? 'NO_SAFETY_INFORMATION',
+          content: '',
+        },
+      },
+    },
+  }) as unknown as UseFormReturn<EditConnectionFormValues>;
+  return (
+    <AllegroSellerDefaultsSection
+      connectionId="conn_allegro_1"
+      form={form}
+      onChange={onChange ?? vi.fn()}
+    />
+  );
+}
+
+describe('AllegroSellerDefaultsSection', () => {
+  it('renders the three field groups (location, responsible producer, safety info)', async () => {
+    const apiClient = createMockApiClient({
+      allegro: {
+        listResponsibleProducers: vi
+          .fn()
+          .mockResolvedValue([{ id: 'rp-1', name: 'ACME GmbH', kind: 'PRODUCER' }]),
+      },
+    });
+
+    renderWithProviders(<Harness />, { apiClient });
+
+    expect(
+      screen.getByRole('heading', { name: /ship-from location/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/voivodeship/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^city$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/post code/i)).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: /^responsible producer$/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: /^safety information$/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Type$/)).toBeInTheDocument();
+
+    // Wait for the RP query to settle so the dropdown carries the entry.
+    await waitFor(() =>
+      expect(apiClient.allegro.listResponsibleProducers).toHaveBeenCalledWith(
+        'conn_allegro_1',
+      ),
+    );
+  });
+
+  it('shows error Alert when the responsible-producer query fails', async () => {
+    const apiClient = createMockApiClient({
+      allegro: {
+        listResponsibleProducers: vi.fn().mockRejectedValue(new Error('Network kaboom')),
+      },
+    });
+
+    renderWithProviders(<Harness />, { apiClient });
+
+    expect(
+      await screen.findByText(/could not load responsible producers/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/network kaboom/i)).toBeInTheDocument();
+  });
+
+  it('shows empty-state Alert when the registry returns no entries', async () => {
+    const apiClient = createMockApiClient({
+      allegro: {
+        listResponsibleProducers: vi.fn().mockResolvedValue([]),
+      },
+    });
+
+    renderWithProviders(<Harness />, { apiClient });
+
+    expect(
+      await screen.findByText(/no responsible-producer entries yet/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Allegro seller panel/i)).toBeInTheDocument();
+  });
+
+  it('hides the safety-information content textarea when type is NO_SAFETY_INFORMATION', () => {
+    renderWithProviders(<Harness initialSafetyType="NO_SAFETY_INFORMATION" />);
+
+    expect(screen.queryByLabelText(/safety information content/i)).not.toBeInTheDocument();
+  });
+
+  it('reveals the content textarea when the operator picks SAFETY_INFORMATION', async () => {
+    renderWithProviders(<Harness initialSafetyType="NO_SAFETY_INFORMATION" />);
+
+    expect(screen.queryByLabelText(/safety information content/i)).not.toBeInTheDocument();
+
+    const typeSelect = screen.getByLabelText(/^Type$/);
+    fireEvent.change(typeSelect, { target: { value: 'SAFETY_INFORMATION' } });
+
+    expect(
+      await screen.findByLabelText(/safety information content/i),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onChange when the operator updates a field', async () => {
+    const onChange = vi.fn();
+    renderWithProviders(<Harness onChange={onChange} />);
+
+    const cityInput = screen.getByLabelText(/^city$/i);
+    fireEvent.change(cityInput, { target: { value: 'Warszawa' } });
+
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
+++ b/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import { useResponsibleProducersQuery } from '../../allegro/hooks/use-responsible-producers-query';
 import {
@@ -47,24 +47,11 @@ export function AllegroSellerDefaultsSection({
 }: AllegroSellerDefaultsSectionProps): ReactElement {
   const producersQuery = useResponsibleProducersQuery(connectionId);
 
+  // The default safety-information type is seeded by the parent's
+  // `readSellerDefaults` helper at form-construction time (always one of
+  // the two enum values, never `undefined`), so `safetyType` is guaranteed
+  // truthy on first render — no mount-only effect needed here.
   const safetyType = form.watch('sellerDefaults.safetyInformation.type');
-
-  // Default safety type to NO_SAFETY_INFORMATION on first render so the
-  // BE always sees a valid discriminator the moment the operator engages
-  // with the section. Operators can switch to SAFETY_INFORMATION explicitly.
-  // The mount-only guard (`mounted` ref) is preferable to the lint-disable
-  // dance for `[]` deps; matches existing patterns in the codebase that
-  // avoid `react-hooks/exhaustive-deps` annotations entirely.
-  const didDefaultRef = useRef(false);
-  useEffect(() => {
-    if (didDefaultRef.current) return;
-    didDefaultRef.current = true;
-    if (!safetyType) {
-      form.setValue('sellerDefaults.safetyInformation.type', 'NO_SAFETY_INFORMATION', {
-        shouldDirty: false,
-      });
-    }
-  }, [form, safetyType]);
 
   const errors = form.formState.errors.sellerDefaults;
 

--- a/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
+++ b/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useRef, type ReactElement } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import { useResponsibleProducersQuery } from '../../allegro/hooks/use-responsible-producers-query';
+import {
+  POLISH_VOIVODESHIP_LABELS,
+  POLISH_VOIVODESHIP_VALUES,
+} from '../types/polish-voivodeship.types';
+import type { EditConnectionFormValues } from './edit-connection.schema';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
+import { Textarea } from '../../../shared/ui/textarea';
+
+interface AllegroSellerDefaultsSectionProps {
+  connectionId: string;
+  form: UseFormReturn<EditConnectionFormValues>;
+  /**
+   * Called whenever any seller-defaults sub-field changes — the parent form
+   * uses this to re-serialize the whole `sellerDefaults` object into
+   * `configText` JSON via `mergeStructuredIntoConfig`. Keeping the merge
+   * logic in the parent (where `configText` lives) avoids duplicating the
+   * empty-string-pruning rules here.
+   */
+  onChange: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Connection-edit section for Allegro seller defaults (#430). Three field
+ * groups — ship-from location, EU GPSR responsible producer, and safety
+ * information — required by `POST /sale/product-offers` since the GPSR
+ * rollout on 2024-12-13.
+ *
+ * Lives inside the existing `EditConnectionForm`; rendered only when
+ * `connection.platformType === 'allegro'`. The form already syncs the
+ * structured fields into a single `configText` JSON via the merge helper —
+ * this section follows that pattern (every input change calls `onChange`,
+ * the parent re-serializes).
+ */
+export function AllegroSellerDefaultsSection({
+  connectionId,
+  form,
+  onChange,
+  disabled = false,
+}: AllegroSellerDefaultsSectionProps): ReactElement {
+  const producersQuery = useResponsibleProducersQuery(connectionId);
+
+  const safetyType = form.watch('sellerDefaults.safetyInformation.type');
+
+  // Default safety type to NO_SAFETY_INFORMATION on first render so the
+  // BE always sees a valid discriminator the moment the operator engages
+  // with the section. Operators can switch to SAFETY_INFORMATION explicitly.
+  // The mount-only guard (`mounted` ref) is preferable to the lint-disable
+  // dance for `[]` deps; matches existing patterns in the codebase that
+  // avoid `react-hooks/exhaustive-deps` annotations entirely.
+  const didDefaultRef = useRef(false);
+  useEffect(() => {
+    if (didDefaultRef.current) return;
+    didDefaultRef.current = true;
+    if (!safetyType) {
+      form.setValue('sellerDefaults.safetyInformation.type', 'NO_SAFETY_INFORMATION', {
+        shouldDirty: false,
+      });
+    }
+  }, [form, safetyType]);
+
+  const errors = form.formState.errors.sellerDefaults;
+
+  return (
+    <section className="seller-defaults" aria-labelledby="seller-defaults-heading">
+      <header className="seller-defaults__header">
+        <p className="seller-defaults__eyebrow">Allegro seller defaults</p>
+        <h3 id="seller-defaults-heading" className="seller-defaults__title">
+          Required by Allegro for offer creation
+        </h3>
+        <p className="seller-defaults__description">
+          Allegro requires a ship-from location and EU GPSR data
+          (Reg. 2023/988, mandatory since 13 Dec 2024) on every offer. These
+          defaults are sent on the inline-product path and used as a fallback
+          when smart-linking to an existing product card misses.
+        </p>
+      </header>
+
+      <div className="seller-defaults__group">
+        <h4 className="seller-defaults__group-title">Ship-from location</h4>
+        <p className="seller-defaults__group-description">
+          Used as <code className="mono-text">body.location</code> on every offer.
+        </p>
+
+        <FormField
+          label="Voivodeship"
+          name="sellerDefaults.location.province"
+          error={errors?.location?.province?.message}
+        >
+          <Select
+            {...form.register('sellerDefaults.location.province')}
+            onChange={(event) => {
+              const next = event.target.value;
+              const province = (POLISH_VOIVODESHIP_VALUES as readonly string[]).includes(next)
+                ? (next as (typeof POLISH_VOIVODESHIP_VALUES)[number])
+                : '';
+              form.setValue('sellerDefaults.location.province', province, {
+                shouldDirty: true,
+              });
+              form.setValue('sellerDefaults.location.countryCode', 'PL', {
+                shouldDirty: true,
+              });
+              onChange();
+            }}
+            disabled={disabled}
+          >
+            <option value="">Select voivodeship…</option>
+            {POLISH_VOIVODESHIP_VALUES.map((value) => (
+              <option key={value} value={value}>
+                {POLISH_VOIVODESHIP_LABELS[value]}
+              </option>
+            ))}
+          </Select>
+        </FormField>
+
+        <div className="seller-defaults__row">
+          <FormField
+            label="City"
+            name="sellerDefaults.location.city"
+            error={errors?.location?.city?.message}
+          >
+            <Input
+              {...form.register('sellerDefaults.location.city')}
+              onChange={(event) => {
+                form.setValue('sellerDefaults.location.city', event.target.value, {
+                  shouldDirty: true,
+                });
+                onChange();
+              }}
+              maxLength={200}
+              autoComplete="address-level2"
+              disabled={disabled}
+              invalid={Boolean(errors?.location?.city)}
+            />
+          </FormField>
+
+          <FormField
+            label="Post code"
+            name="sellerDefaults.location.postCode"
+            error={errors?.location?.postCode?.message}
+            description="Polish format NN-NNN."
+          >
+            <Input
+              {...form.register('sellerDefaults.location.postCode')}
+              onChange={(event) => {
+                form.setValue('sellerDefaults.location.postCode', event.target.value, {
+                  shouldDirty: true,
+                });
+                onChange();
+              }}
+              placeholder="00-001"
+              inputMode="numeric"
+              autoComplete="postal-code"
+              disabled={disabled}
+              invalid={Boolean(errors?.location?.postCode)}
+            />
+          </FormField>
+        </div>
+      </div>
+
+      <div className="seller-defaults__group">
+        <div className="seller-defaults__group-head">
+          <div>
+            <h4 className="seller-defaults__group-title">Responsible producer</h4>
+            <p className="seller-defaults__group-description">
+              EU GPSR registry entry from your Allegro seller account.
+            </p>
+          </div>
+          <Button
+            tone="secondary"
+            type="button"
+            onClick={() => void producersQuery.refetch()}
+            disabled={disabled || producersQuery.isFetching}
+          >
+            {producersQuery.isFetching ? 'Refreshing…' : 'Refresh'}
+          </Button>
+        </div>
+
+        {producersQuery.error ? (
+          <Alert tone="error" title="Could not load responsible producers">
+            {producersQuery.error.message}
+          </Alert>
+        ) : null}
+
+        {!producersQuery.isLoading &&
+        !producersQuery.error &&
+        (producersQuery.data ?? []).length === 0 ? (
+          <Alert tone="info" title="No responsible-producer entries yet">
+            Create a Responsible Producer in your Allegro seller panel, then
+            click Refresh.
+          </Alert>
+        ) : null}
+
+        <FormField
+          label="Responsible producer"
+          name="sellerDefaults.responsibleProducerId"
+          error={errors?.responsibleProducerId?.message}
+        >
+          <Select
+            {...form.register('sellerDefaults.responsibleProducerId')}
+            onChange={(event) => {
+              form.setValue(
+                'sellerDefaults.responsibleProducerId',
+                event.target.value,
+                { shouldDirty: true },
+              );
+              onChange();
+            }}
+            disabled={
+              disabled ||
+              producersQuery.isLoading ||
+              Boolean(producersQuery.error) ||
+              (producersQuery.data ?? []).length === 0
+            }
+          >
+            <option value="">
+              {producersQuery.isLoading
+                ? 'Loading…'
+                : (producersQuery.data ?? []).length === 0
+                  ? 'No entries'
+                  : 'Select an entry…'}
+            </option>
+            {(producersQuery.data ?? []).map((entry) => (
+              <option key={entry.id} value={entry.id}>
+                {entry.name}
+              </option>
+            ))}
+          </Select>
+        </FormField>
+      </div>
+
+      <div className="seller-defaults__group">
+        <h4 className="seller-defaults__group-title">Safety information</h4>
+        <p className="seller-defaults__group-description">
+          Pick <strong>None applies</strong> for products without GPSR safety
+          obligations, or provide free-text safety details.
+        </p>
+
+        <FormField
+          label="Type"
+          name="sellerDefaults.safetyInformation.type"
+          error={errors?.safetyInformation?.type?.message}
+        >
+          <Select
+            {...form.register('sellerDefaults.safetyInformation.type')}
+            onChange={(event) => {
+              form.setValue(
+                'sellerDefaults.safetyInformation.type',
+                event.target.value as 'NO_SAFETY_INFORMATION' | 'SAFETY_INFORMATION',
+                { shouldDirty: true },
+              );
+              onChange();
+            }}
+            disabled={disabled}
+          >
+            <option value="NO_SAFETY_INFORMATION">None applies</option>
+            <option value="SAFETY_INFORMATION">Provide safety information</option>
+          </Select>
+        </FormField>
+
+        {safetyType === 'SAFETY_INFORMATION' ? (
+          <FormField
+            label="Safety information content"
+            name="sellerDefaults.safetyInformation.content"
+            error={errors?.safetyInformation?.content?.message}
+            description="Free text shown to buyers. 1–2000 characters."
+          >
+            <Textarea
+              {...form.register('sellerDefaults.safetyInformation.content')}
+              onChange={(event) => {
+                form.setValue(
+                  'sellerDefaults.safetyInformation.content',
+                  event.target.value,
+                  { shouldDirty: true },
+                );
+                onChange();
+              }}
+              rows={4}
+              maxLength={2000}
+              disabled={disabled}
+              invalid={Boolean(errors?.safetyInformation?.content)}
+            />
+          </FormField>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -1,5 +1,41 @@
 import { z } from 'zod';
 import type { UpdateConnectionInput } from '../api/connections.types';
+import { POLISH_VOIVODESHIP_VALUES } from '../types/polish-voivodeship.types';
+
+/**
+ * Connection-level seller-defaults schema (#430). Each sub-field is
+ * optional at the FE level so the operator can save incremental progress
+ * (e.g. fill location now, return for safety info later); the BE DTO
+ * validator at `apps/api/src/integrations/http/dto/allegro-connection-config.dto.ts`
+ * is the strict gate.
+ *
+ * `safetyInformation` is a discriminated union — when `type` is
+ * `SAFETY_INFORMATION`, `content` becomes required server-side.
+ */
+const allegroSellerLocationSchema = z.object({
+  countryCode: z.literal('PL').optional(),
+  province: z.union([z.enum(POLISH_VOIVODESHIP_VALUES), z.literal('')]).optional(),
+  city: z.string().trim().max(200).optional(),
+  postCode: z
+    .union([
+      z.string().regex(/^\d{2}-\d{3}$/, 'Postcode must use the PL format NN-NNN'),
+      z.literal(''),
+    ])
+    .optional(),
+});
+
+const allegroSafetyInformationSchema = z.object({
+  type: z.enum(['NO_SAFETY_INFORMATION', 'SAFETY_INFORMATION']).optional(),
+  content: z.string().trim().max(2000).optional(),
+});
+
+const allegroSellerDefaultsSchema = z.object({
+  location: allegroSellerLocationSchema.optional(),
+  responsibleProducerId: z.string().trim().optional(),
+  safetyInformation: allegroSafetyInformationSchema.optional(),
+});
+
+export type AllegroSellerDefaultsFormValues = z.input<typeof allegroSellerDefaultsSchema>;
 
 export const editConnectionSchema = z.object({
   name: z.string().trim().min(1, 'Connection name is required'),
@@ -34,6 +70,9 @@ export const editConnectionSchema = z.object({
       }
     }, 'Configuration must be valid JSON'),
   adapterKey: z.string().trim().optional(),
+  // #430 — Allegro-only structured fields. Always optional at the form
+  // level; the BE DTO validates strict shape on PATCH.
+  sellerDefaults: allegroSellerDefaultsSchema.optional(),
 });
 
 export type EditConnectionFormValues = z.input<typeof editConnectionSchema>;
@@ -47,6 +86,21 @@ export function toUpdateConnectionInput(values: EditConnectionFormSubmission): U
   };
 }
 
+export interface StructuredConfigPatch {
+  baseUrl?: string;
+  shopId?: string;
+  storefrontBaseUrl?: string;
+  masterCatalogConnectionId?: string;
+  /**
+   * #430 — Allegro seller defaults. The merge helper writes a fully
+   * resolved object into `config.sellerDefaults` whenever `sellerDefaults`
+   * is supplied; pass `null` to clear the key entirely (operator opting
+   * out — rare). Partial updates are not supported here intentionally,
+   * because the BE DTO requires the full nested shape on save.
+   */
+  sellerDefaults?: AllegroSellerDefaultsFormValues | null;
+}
+
 /**
  * Merge structured inputs into a raw config object. Preserves unknown keys so
  * operators can still drop in custom config fields via the JSON view without
@@ -54,12 +108,7 @@ export function toUpdateConnectionInput(values: EditConnectionFormSubmission): U
  */
 export function mergeStructuredIntoConfig(
   base: Record<string, unknown>,
-  structured: {
-    baseUrl?: string;
-    shopId?: string;
-    storefrontBaseUrl?: string;
-    masterCatalogConnectionId?: string;
-  },
+  structured: StructuredConfigPatch,
 ): Record<string, unknown> {
   const next: Record<string, unknown> = { ...base };
   if (structured.baseUrl !== undefined) {
@@ -90,5 +139,47 @@ export function mergeStructuredIntoConfig(
   if (structured.masterCatalogConnectionId !== undefined) {
     next.masterCatalogConnectionId = structured.masterCatalogConnectionId;
   }
+  if (structured.sellerDefaults !== undefined) {
+    if (structured.sellerDefaults === null) {
+      delete next.sellerDefaults;
+    } else {
+      // Drop empty-string sub-fields so the BE DTO sees a clean shape (the
+      // FE schema accepts `''` for incremental editing; the BE rejects it).
+      next.sellerDefaults = pruneEmptySellerDefaults(structured.sellerDefaults);
+    }
+  }
   return next;
+}
+
+function pruneEmptySellerDefaults(
+  values: AllegroSellerDefaultsFormValues,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (values.location) {
+    const loc: Record<string, unknown> = {};
+    if (values.location.countryCode) loc.countryCode = values.location.countryCode;
+    if (values.location.province) loc.province = values.location.province;
+    if (values.location.city && values.location.city.length > 0) {
+      loc.city = values.location.city;
+    }
+    if (values.location.postCode && values.location.postCode.length > 0) {
+      loc.postCode = values.location.postCode;
+    }
+    if (Object.keys(loc).length > 0) out.location = loc;
+  }
+  if (values.responsibleProducerId && values.responsibleProducerId.length > 0) {
+    out.responsibleProducerId = values.responsibleProducerId;
+  }
+  if (values.safetyInformation?.type) {
+    const safety: Record<string, unknown> = { type: values.safetyInformation.type };
+    if (
+      values.safetyInformation.type === 'SAFETY_INFORMATION' &&
+      values.safetyInformation.content &&
+      values.safetyInformation.content.length > 0
+    ) {
+      safety.content = values.safetyInformation.content;
+    }
+    out.safetyInformation = safety;
+  }
+  return out;
 }

--- a/apps/web/src/features/connections/types/polish-voivodeship.types.ts
+++ b/apps/web/src/features/connections/types/polish-voivodeship.types.ts
@@ -1,0 +1,55 @@
+/**
+ * Polish Voivodeship Types
+ *
+ * Mirror of the BE `PolishVoivodeshipValues` (#430) with operator-facing
+ * Polish display labels for the Allegro seller-defaults Select. Kept in
+ * sync manually — if the BE ever changes the enum, this file fails the
+ * `EditConnectionForm` test that asserts every BE value is rendered.
+ *
+ * Source of truth: `libs/integrations/allegro/src/domain/types/allegro-location.types.ts`.
+ */
+
+export const POLISH_VOIVODESHIP_VALUES = [
+  'DOLNOSLASKIE',
+  'KUJAWSKO_POMORSKIE',
+  'LUBELSKIE',
+  'LUBUSKIE',
+  'LODZKIE',
+  'MALOPOLSKIE',
+  'MAZOWIECKIE',
+  'OPOLSKIE',
+  'PODKARPACKIE',
+  'PODLASKIE',
+  'POMORSKIE',
+  'SLASKIE',
+  'SWIETOKRZYSKIE',
+  'WARMINSKO_MAZURSKIE',
+  'WIELKOPOLSKIE',
+  'ZACHODNIOPOMORSKIE',
+] as const;
+
+export type PolishVoivodeship = (typeof POLISH_VOIVODESHIP_VALUES)[number];
+
+/**
+ * Operator-facing display labels — Polish locale, since this is a
+ * PL-marketplace connection setting and operators are typically Polish
+ * sellers.
+ */
+export const POLISH_VOIVODESHIP_LABELS: Record<PolishVoivodeship, string> = {
+  DOLNOSLASKIE: 'dolnośląskie',
+  KUJAWSKO_POMORSKIE: 'kujawsko-pomorskie',
+  LUBELSKIE: 'lubelskie',
+  LUBUSKIE: 'lubuskie',
+  LODZKIE: 'łódzkie',
+  MALOPOLSKIE: 'małopolskie',
+  MAZOWIECKIE: 'mazowieckie',
+  OPOLSKIE: 'opolskie',
+  PODKARPACKIE: 'podkarpackie',
+  PODLASKIE: 'podlaskie',
+  POMORSKIE: 'pomorskie',
+  SLASKIE: 'śląskie',
+  SWIETOKRZYSKIE: 'świętokrzyskie',
+  WARMINSKO_MAZURSKIE: 'warmińsko-mazurskie',
+  WIELKOPOLSKIE: 'wielkopolskie',
+  ZACHODNIOPOMORSKIE: 'zachodniopomorskie',
+};

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4562,6 +4562,97 @@ a.kpi-card:focus-visible {
 }
 
 /*
+ * ── Allegro seller defaults section (#430) ───────────────────────────
+ * Connection-edit sub-section composed of three field groups (location,
+ * responsible producer, safety information). Renders inside
+ * `EditConnectionForm` for `platformType === 'allegro'`. Tokens only —
+ * mirrors the surrounding form's typographic hierarchy.
+ */
+.seller-defaults {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1rem 1rem 1.25rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.625rem;
+  background: var(--bg-surface-elevated);
+}
+
+.seller-defaults__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.seller-defaults__eyebrow {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.seller-defaults__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.seller-defaults__description {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.seller-defaults__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-top: 1rem;
+  border-top: 1px dashed var(--border-subtle);
+}
+
+.seller-defaults__group:first-of-type {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.seller-defaults__group-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.seller-defaults__group-title {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.seller-defaults__group-description {
+  margin: 0.125rem 0 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.seller-defaults__row {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .seller-defaults__row {
+    grid-template-columns: 2fr 1fr;
+  }
+}
+
+/*
  * ── Phase 6 — Dashboard triage ──────────────────────────────────────
  * KPI strip responsive matrix per style guide §Responsive:
  *   mobile (<768)  → 1×4 vertical stack

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4572,7 +4572,7 @@ a.kpi-card:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  padding: 1rem 1rem 1.25rem;
+  padding: 1rem;
   border: 1px solid var(--border-subtle);
   border-radius: 0.625rem;
   background: var(--bg-surface-elevated);
@@ -4635,7 +4635,7 @@ a.kpi-card:focus-visible {
 }
 
 .seller-defaults__group-description {
-  margin: 0.125rem 0 0;
+  margin: 0.25rem 0 0;
   font-size: 0.75rem;
   line-height: 1.5;
   color: var(--text-muted);

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -82,6 +82,7 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
         connectionId: 'conn_allegro_1',
         connectionName: 'Allegro sandbox',
       }),
+      listResponsibleProducers: vi.fn().mockResolvedValue([]),
       ...overrides.allegro,
     } as ApiClient['allegro'],
     auth: {

--- a/docs/plans/implementation-plan-430-431-allegro-seller-defaults-smart-link.md
+++ b/docs/plans/implementation-plan-430-431-allegro-seller-defaults-smart-link.md
@@ -1,0 +1,305 @@
+# Implementation Plan — #430 + #431: Allegro seller defaults + smart-link to product cards
+
+Closes #430 (P0 — connection-level seller defaults: `location` + GPSR fallback for inline product creation) and #431 (P0 — smart-link offers to existing Allegro product cards by EAN). Tracked under epic #429. Sandbox-blocking 422 from 2026-04-28: `INVALID_STATE` on `location.state`, `RESPONSIBLE_PRODUCER_NOT_SPECIFIED`, `SAFETY_INFO_NOT_DEFINED`.
+
+## 1. Goal
+
+Make Allegro `POST /sale/product-offers` succeed end-to-end on the PL marketplace by:
+
+1. **#430 — Connection-level seller defaults.** Persist `location.{countryCode, province, city, postCode}`, `responsibleProducerId`, and `safetyInformation` on `Connection.config.allegro.sellerDefaults`. Read at offer-build time and write into the request body. Inline-product path (today's only path) sets all three; future smart-linked path inherits GPSR from the card.
+2. **#431 — Smart-link by EAN.** Before constructing inline-product `productSet`, resolve the variant's EAN against Allegro's product catalogue (`GET /sale/products?phrase={ean}&category.id={categoryId}`). On unique match, build `productSet = [{ product: { id }, quantity }]` instead of inline — Allegro inherits GPSR + parameters from the card.
+
+Both ship in one PR because they share the `productSet[0]` codepath in `buildCreateOfferRequest` / `applyPlatformParams` and the GPSR write needs the smart-link guard to know whether to skip itself.
+
+## 2. Layer classification
+
+| Layer | Change |
+|---|---|
+| **CORE** | New sub-capability `responsible-producer-reader.capability.ts` + `isResponsibleProducerReader` guard at `libs/core/src/listings/domain/ports/capabilities/`. Mirrors the `SellerPoliciesReader` pattern. Carries the neutral `ResponsibleProducerEntry` type. |
+| **Integration (Allegro)** | (a) `AllegroOfferManagerAdapter` writes `location` + GPSR fields, implements `ResponsibleProducerReader`, gains a smart-link pre-step in `createOffer`. (b) New `AllegroProductCardResolver` util alongside `upload-images-via-allegro.ts`. (c) `AllegroAdapterFactory` reads `connection.config.allegro.sellerDefaults` and forwards as adapter constructor option. **No new domain exception** — missing seller defaults surface as `OfferCreateRejectedException` with code `SELLER_DEFAULTS_NOT_CONFIGURED` thrown directly by the adapter (avoids reverse `core → integration` dependency). |
+| **Interface (API)** | (a) Extend `AllegroConnectionConfigDto` with optional `sellerDefaults` shape, class-validator-validated (province enum, postcode regex, type-discriminated safetyInformation). (b) New `AllegroConnectionsController` exposes `GET /api/integrations/allegro/connections/:id/responsible-producers`. **Registered in the existing `IntegrationsModule`** at `apps/api/src/integrations/integrations.module.ts` — no new module. |
+| **Frontend** | Extend `EditConnectionForm.tsx` with an Allegro seller-defaults section (only when `platformType === 'allegro'`): location fields, RP dropdown (TanStack Query against the new endpoint), safetyInformation radio + conditional textarea. Zod schema extension. |
+| **DX** | None. |
+| **Migrations** | None — `Connection.config` is JSONB. |
+
+## 3. Non-goals
+
+- **No per-offer wizard override.** Seller defaults are connection-level. Per-offer overrides ship customer-driven (deferred under #429).
+- **No Responsible Producer registry CRUD from inside OL.** Operator creates entries in their Allegro account; we read-only fetch the registry for the dropdown.
+- **No `safetyInformation` pictograms** — text-only initially per #430 OOS.
+- **No card-blocked marker** for smart-link parameter-mismatch failures. Issue #431 calls for it; we defer it as gold-plating. When the card-link path 422s on parameter-mismatch, the operator sees the error in the Job-detail view and retries; if the same EAN repeatedly fails, we'll add the marker. Tracked as a future enhancement on #431's followup line.
+- **No multi-EAN smart-link.** Resolve by `variant.ean ?? variant.gtin` — one value per variant. Cross-category card matching out-of-scope; always scope by `categoryId`.
+- **No backfill** for existing Allegro connections without `sellerDefaults`. First offer attempt fails fast with `AllegroSellerDefaultsNotConfiguredException`; operator configures and retries.
+- **No automatic `body.stock` ↔ `productSet[0].quantity` reconciliation.** Allegro docs are ambiguous on coexistence; we'll set `productSet[0].quantity` on smart-linked offers and leave `body.stock` as-is, then trim post-sandbox if Allegro rejects.
+
+## 4. Design
+
+### 4.1 `Connection.config.allegro.sellerDefaults` shape
+
+```ts
+interface AllegroSellerDefaultsConfig {
+  location: {
+    countryCode: 'PL';                  // future: extend to other markets
+    province: PolishVoivodeship;         // 16-value enum
+    city: string;                        // 1-200 chars
+    postCode: string;                    // /^\d{2}-\d{3}$/
+  };
+  responsibleProducerId: string;         // from /sale/responsible-producers
+  safetyInformation:
+    | { type: 'NO_SAFETY_INFORMATION' }
+    | { type: 'SAFETY_INFORMATION'; content: string };  // 1-2000 chars
+}
+```
+
+The `PolishVoivodeship` enum lives at `libs/integrations/allegro/src/domain/types/allegro-location.types.ts` as an `as const` string array (engineering-standards.md "Union Types: `as const` Pattern"). Values: `DOLNOSLASKIE`, `KUJAWSKO_POMORSKIE`, `LUBELSKIE`, `LUBUSKIE`, `LODZKIE`, `MALOPOLSKIE`, `MAZOWIECKIE`, `OPOLSKIE`, `PODKARPACKIE`, `PODLASKIE`, `POMORSKIE`, `SLASKIE`, `SWIETOKRZYSKIE`, `WARMINSKO_MAZURSKIE`, `WIELKOPOLSKIE`, `ZACHODNIOPOMORSKIE` (Allegro's own enum — verified against `POST /sale/product-offers` 422 message).
+
+### 4.2 Adapter wiring (`AllegroOfferManagerAdapter`)
+
+Constructor gains optional `sellerDefaults?: AllegroSellerDefaultsConfig`. `AllegroAdapterFactory.createAdapters()` extracts it from `connection.config.allegro.sellerDefaults` (typed via the existing `AllegroConnectionConfig` type) and passes it through.
+
+`buildCreateOfferRequest` gains a precondition guard that throws the **existing** `OfferCreateRejectedException` directly — no new exception class, no CORE-side mapping (avoids the reverse `core → integration` dependency that a custom Allegro exception would introduce):
+
+```ts
+if (!this.sellerDefaults) {
+  throw new OfferCreateRejectedException(ALLEGRO_ADAPTER_KEY, 0, [
+    {
+      field: 'sellerDefaults.location',
+      code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+      message: `Allegro connection ${this.connectionId} has no seller defaults configured. Set location, responsibleProducerId, and safetyInformation on the connection edit page before creating offers.`,
+    },
+    {
+      field: 'sellerDefaults.responsibleProducerId',
+      code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+      message: 'Configure a Responsible Producer in Allegro and select it on the connection edit page.',
+    },
+    {
+      field: 'sellerDefaults.safetyInformation',
+      code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+      message: 'Configure GPSR safety information on the connection edit page.',
+    },
+  ]);
+}
+```
+
+This matches the existing precedent for image-related preflight errors (`upload-images-via-allegro.ts` returns `CreateOfferValidationError[]` with `code: 'IMAGE_DOWNLOAD_FAILED'` etc., which the adapter wraps into `OfferCreateRejectedException` at the same call site). FE Alert path unchanged.
+
+After the guard:
+- Always: `body.location = sellerDefaults.location`.
+- Smart-link pre-step (§4.3) decides whether to set `productSet[0].product.id` (linked) or fall through to inline.
+- Inline path only: `body.productSet[0].responsibleProducer = { id: sellerDefaults.responsibleProducerId }`; `body.productSet[0].safetyInformation = sellerDefaults.safetyInformation`.
+
+### 4.3 Smart-link pre-step
+
+New util at `libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.ts` (mirrors the `upload-images-via-allegro.ts` shape — single function, types in a sibling `*.types.ts`):
+
+```ts
+export type ResolveProductCardResult =
+  | { kind: 'unique'; productId: string }
+  | { kind: 'ambiguous'; matches: AllegroProductCardSummary[] }
+  | { kind: 'no_match' };
+
+export async function resolveAllegroProductCardByEan(
+  httpClient: IAllegroHttpClient,
+  cache: CachePort | undefined,
+  input: { ean: string; categoryId: string },
+  options?: { cacheTtlSec?: number; cacheKeyPrefix?: string },
+): Promise<ResolveProductCardResult>;
+```
+
+Behaviour:
+1. Cache key `allegro:product-card:{ean}:{categoryId}`. Hit returns cached `unique` or `no_match` (both worth caching). Ambiguous results are NOT cached — they're rare and we want to re-evaluate on the next attempt in case the operator narrowed the catalogue.
+2. Miss: `GET /sale/products?phrase={ean}&category.id={categoryId}&limit=10`. Filter results where the card's `ean` field matches the input exactly (Allegro's matcher is fuzzy). Determine `unique` (1 exact match) / `ambiguous` (≥2 exact matches) / `no_match` (0 exact matches).
+3. Cache `unique` and `no_match` with 24h TTL.
+4. Returns the discriminated result; **never throws** for resolver failures — on HTTP error from Allegro, returns `no_match` and logs (treats as "couldn't resolve, fall back to inline").
+
+**Async resolution lives in `createOffer`, not `applyPlatformParams`.** `createOffer` is already async — it computes the smart-link result once at the top, then threads it as an optional `cardLinkResult: ResolveProductCardResult` parameter through `buildCreateOfferRequest` → `applyPlatformParams`. This keeps `applyPlatformParams` synchronous (its current contract) and avoids cascading async through the body-builder. The branch on the result happens synchronously inside `applyPlatformParams` once it's been handed the resolved value.
+
+```ts
+// inside createOffer (async)
+const cardLinkResult = await maybeResolveProductCard({
+  ean: variant.ean ?? variant.gtin ?? null,
+  categoryId: cmd.overrides.categoryId,
+  httpClient: this.httpClient,
+  cache: this.cache,
+});
+// cardLinkResult is { kind: 'unique' | 'ambiguous' | 'no_match' }
+const body = this.buildCreateOfferRequest(cmd, cardLinkResult);
+// ... rest of createOffer unchanged
+```
+
+`applyPlatformParams` receives `cardLinkResult` and branches synchronously **before** the inline `productSet` block at line 988. On `unique`:
+
+```ts
+body.productSet = [{
+  product: { id: cardLinkResult.productId },
+  quantity: cmd.stock,
+}];
+// Skip name / parameters / images / GPSR on product side — inherited from card.
+// Offer-section parameters[] still go through normally.
+```
+
+On `ambiguous` or `no_match` → fall through to current inline behaviour (writes `productSet[0].product.{name, parameters, images}` + GPSR from sellerDefaults).
+
+Telemetry per offer (structured log, not metrics — same shape as existing `Logger.log`):
+```
+{
+  smartLink: {
+    attempted: true,
+    ean: '...',
+    categoryId: '...',
+    outcome: 'unique' | 'ambiguous' | 'no_match',
+    matchCount: number,           // for ambiguous diagnostics
+  }
+}
+```
+
+### 4.4 `ResponsibleProducerReader` capability
+
+```ts
+// libs/core/src/listings/domain/ports/capabilities/responsible-producer-reader.capability.ts
+import { OfferManagerPort } from '../offer-manager.port';
+
+export interface ResponsibleProducerEntry {
+  id: string;          // Allegro's responsibleProducer ID
+  name: string;        // human-readable label
+  type: 'PRODUCER' | 'IMPORTER' | 'AUTHORIZED_REPRESENTATIVE' | 'FULFILLMENT_SERVICE_PROVIDER';
+  // Other Allegro-returned fields kept opaque under `raw` if needed; today
+  // the dropdown only needs id + name + type.
+}
+
+export interface ResponsibleProducerReader {
+  fetchResponsibleProducers(): Promise<ResponsibleProducerEntry[]>;
+}
+
+export function isResponsibleProducerReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & ResponsibleProducerReader {
+  return typeof (adapter as Partial<ResponsibleProducerReader>).fetchResponsibleProducers === 'function';
+}
+```
+
+`AllegroOfferManagerAdapter` implements it with `GET /sale/responsible-producers`. No caching — operator-driven dropdown; freshness > latency.
+
+### 4.5 API endpoint
+
+`AllegroConnectionsController` at `apps/api/src/integrations/allegro/http/allegro-connections.controller.ts`:
+
+```ts
+@Controller('integrations/allegro/connections/:id')
+@UseGuards(JwtAuthGuard)
+export class AllegroConnectionsController {
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+  ) {}
+
+  @Get('responsible-producers')
+  async listResponsibleProducers(
+    @Param('id') connectionId: string,
+  ): Promise<ResponsibleProducerEntry[]> {
+    const adapter = await this.integrations.getCapabilityAdapter<OfferManagerPort>(
+      connectionId, 'OfferManager',
+    );
+    if (!isResponsibleProducerReader(adapter)) {
+      throw new CapabilityNotSupportedException('ResponsibleProducerReader', connectionId);
+    }
+    return adapter.fetchResponsibleProducers();
+  }
+}
+```
+
+Returns the neutral list directly. No DTO mapping needed since the type is already platform-neutral.
+
+### 4.6 Frontend wiring
+
+`EditConnectionForm.tsx` already conditionally renders structured inputs by platform branch. Add:
+
+```tsx
+{connection.platformType === 'allegro' && (
+  <AllegroSellerDefaultsSection
+    connectionId={connection.id}
+    control={form.control}
+    register={form.register}
+    errors={form.formState.errors}
+  />
+)}
+```
+
+`AllegroSellerDefaultsSection` lives at `apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx`. It composes:
+- `Select` (province, 16 options) — values from a small `apps/web/src/features/connections/types/polish-voivodeship.ts` constant array
+- `Input` (city)
+- `Input` (postCode, with `pattern` HTML attr `\d{2}-\d{3}`)
+- `Select` (responsibleProducer) — populated from `useResponsibleProducersQuery(connectionId)` TanStack Query against the new API endpoint, with a "Refresh" button that invalidates the query cache
+- Radio + Textarea (safetyInformation; textarea shown only when `type === 'SAFETY_INFORMATION'`)
+
+The form's submit handler merges these structured fields into `connection.config.allegro.sellerDefaults` via the existing `mergeStructuredIntoConfig` pattern. The Zod schema at `edit-connection.schema.ts` is extended with a discriminated-union `sellerDefaults` field; when the platform isn't `'allegro'`, the field is `.optional()` and ignored.
+
+### 4.7 Why one PR for both
+
+- They share `applyPlatformParams` line 988 — splitting them means PR #1 writes GPSR unconditionally, then PR #2 has to add the smart-link guard. Fewer churn cycles to do them together.
+- The smart-link only buys you anything if seller defaults exist (otherwise the inline fallback also fails). The two halves complete the unblock together; either alone is half-shipped.
+
+## 5. Step-by-step plan
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| 1 | `libs/integrations/allegro/src/domain/types/allegro-location.types.ts` (new) | Define `PolishVoivodeshipValues` + `PolishVoivodeship` per `as const` pattern. Export from package barrel. | Type compiles; 16 values match Allegro's enum. |
+| 2 | `libs/integrations/allegro/src/domain/types/allegro-seller-defaults.types.ts` (new) | Define `AllegroSellerDefaultsConfig` + `AllegroSafetyInformation` discriminated union. Export from package barrel. | Type compiles; matches §4.1. |
+| 3 | `libs/core/src/listings/domain/ports/capabilities/responsible-producer-reader.capability.ts` (new) | Per §4.4. Export `ResponsibleProducerEntry`, `ResponsibleProducerReader`, `isResponsibleProducerReader`. Add to capabilities barrel. | Type compiles; guard pattern matches existing `is{Capability}` files. |
+| 4 | `libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.types.ts` (new) | `ResolveProductCardResult` discriminated union; `AllegroProductCardSummary` shape (id, ean, name). | Type compiles; mirrors `upload-images-via-allegro.types.ts` shape. |
+| 5 | `libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.ts` (new) | Per §4.3. Single async function; never throws. Cache hits/misses via injected `CachePort`. | Returns correct discriminant for unique/ambiguous/no_match; HTTP failure → `no_match` + log; cache hit short-circuits. |
+| 6 | `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts` | (a) Constructor accepts optional `sellerDefaults` and `cache`. (b) Throw `OfferCreateRejectedException` directly at top of `buildCreateOfferRequest` when `sellerDefaults` is missing — code `SELLER_DEFAULTS_NOT_CONFIGURED`, one error per missing field. (c) `createOffer` (top-level async) computes `cardLinkResult` via the smart-link resolver and threads it as a parameter into `buildCreateOfferRequest` → `applyPlatformParams`. (d) Write `body.location` from sellerDefaults always. (e) In `applyPlatformParams`, on `cardLinkResult.kind === 'unique'` → build `productSet = [{ product: { id }, quantity }]` and skip GPSR/parameters/name/images on product side. On ambiguous/no_match → fall through to existing inline block, then write `responsibleProducer` + `safetyInformation`. (f) Implement `fetchResponsibleProducers()`. | Adapter compiles; `applyPlatformParams` stays synchronous; branch logic matches §4.3. |
+| 7 | `libs/integrations/allegro/src/application/allegro-adapter.factory.ts` | Read `connection.config.allegro.sellerDefaults`. Pass to `AllegroOfferManagerAdapter` constructor along with the existing `cache` instance. | Factory compiles; sellerDefaults flows from config to adapter. |
+| 8 | `apps/api/src/integrations/http/dto/allegro-connection-config.dto.ts` | Extend with optional `sellerDefaults`. Use class-validator: `@ValidateNested() @Type(() => AllegroSellerDefaultsDto)`. New nested DTO classes for `AllegroLocationDto` (province enum, postcode `/^\d{2}-\d{3}$/`), `AllegroSafetyInformationDto` (discriminated by `type` via `@Type({ discriminator: { property: 'type', subTypes: [...] } })`). | DTO compiles; class-validator rejects bad province/postcode/missing-content-when-type=SAFETY_INFORMATION. |
+| 9 | `apps/api/src/integrations/allegro/http/allegro-connections.controller.ts` (new) | Per §4.5. `@Controller('integrations/allegro/connections/:id')`, `GET responsible-producers`, JWT-guarded. **Register in `apps/api/src/integrations/integrations.module.ts` `controllers: [...]` array** alongside the existing controllers — no new module. | Endpoint returns 200 with `ResponsibleProducerEntry[]`; 404 when adapter doesn't support capability; controller is reachable end-to-end. |
+| 10 | `apps/web/src/features/connections/types/polish-voivodeship.types.ts` (new) | `as const` array + derived type, mirrors BE. Display labels in Polish (operator-facing). | Type-only; no runtime behavior. |
+| 11 | `apps/web/src/features/connections/api/responsible-producers.api.ts` (new) | Thin API client + `useResponsibleProducersQuery(connectionId)` TanStack hook. | Hook compiles; uses existing `apiClient` shared instance. |
+| 12 | `apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx` (new) | Per §4.6. Composes `FormField` + primitives. RHF-controlled. | Renders only when `platformType === 'allegro'`; province + postcode validation; safetyInformation textarea conditional. |
+| 13 | `apps/web/src/features/connections/components/edit-connection.schema.ts` | Extend Zod schema with optional discriminated `sellerDefaults`. | Submit wires fields correctly into `config.allegro.sellerDefaults`. |
+| 14 | `apps/web/src/features/connections/components/EditConnectionForm.tsx` | Render `<AllegroSellerDefaultsSection>` inside the existing platform-branch conditional when platform is `allegro`. | Form renders; submit merges sellerDefaults into config JSONB. |
+| 15 | Tests (BE) | (a) Adapter spec — 5 new branches: `body.location` write, `responsibleProducer`/`safetyInformation` on inline path, unique smart-link swaps `productSet`, ambiguous/no_match fall through to inline, missing sellerDefaults throws `OfferCreateRejectedException` with code `SELLER_DEFAULTS_NOT_CONFIGURED`. (b) Resolver spec — unique/ambiguous/no_match/HTTP-failure-fallback/cache-hit. (c) Factory spec — sellerDefaults flows from config to constructor. | All branches green; existing 66 createOffer specs stay green by being seeded with sellerDefaults in `baseCmd` setup. |
+| 16 | Tests (FE) | Vitest spec for `AllegroSellerDefaultsSection` — renders all fields, validates province/postcode/safetyInformation. | Component renders + submits valid input. |
+| 17 | All — quality gate | `pnpm lint`, `pnpm type-check`, `pnpm test`. | Clean. |
+| 18 | Manual sandbox repro — **hard merge gate** | Same Allegro sandbox flow that 422'd on 2026-04-28 (cat 257933 / Canon variant). After configuring sellerDefaults via the new admin UI: (a) offer reaches `active`/`validating` (most likely on cat 257933 which has many product cards), or (b) if no card match, offer creates inline with all three required fields populated. Either outcome confirms structural fix. The only failure is another `INVALID_STATE`/`RESPONSIBLE_PRODUCER_NOT_SPECIFIED`/`SAFETY_INFO_NOT_DEFINED` from Allegro — that means the wiring is broken. | Sandbox round-trip succeeds. |
+
+## 6. Tests-of-record
+
+- **Adapter spec** — 5 new createOffer branches (location write, responsibleProducer + safetyInformation on inline path, smart-link unique/ambiguous/no_match, missing-sellerDefaults preflight rejection) + `fetchResponsibleProducers` happy + 4xx paths.
+- **Resolver spec (new)** — unique/ambiguous/no_match/HTTP-error/cache-hit branches.
+- **Factory spec** — sellerDefaults wiring from `connection.config` into adapter constructor.
+- **API DTO validation** — Jest covers province enum / postcode regex / discriminated safetyInformation.
+- **FE component spec** — Vitest covers `AllegroSellerDefaultsSection` form behaviour.
+
+No integration test (`*.int-spec.ts`) added — bug is wiring-only with no DB/wire schema changes; existing E2E coverage continues to exercise happy path. The "integration test" wording in #431's acceptance criteria refers to the manual Allegro sandbox repro at step 18, not OL's Testcontainers `*.int-spec.ts` jargon (testing-guide.md).
+
+## 7. Validation
+
+- **Hexagonal compliance** — capability + entry type live in CORE (`libs/core/src/listings/domain/ports/capabilities/`); adapter implements it in `libs/integrations/allegro/`; the new exception lives in the Allegro infrastructure package because it's a marketplace-specific signal mapped to a CORE exception by `OfferCreationExecutionService`. ✅
+- **Naming** — `*.capability.ts` + `is{Capability}` guard, `*.types.ts`, `*.exception.ts`, `*-controller.ts` all follow engineering-standards.md. ✅
+- **Domain layer purity** — capability file imports only the existing `OfferManagerPort` interface (no NestJS, no TypeORM). ✅
+- **DTO validation** — class-validator at the controller boundary; `province` enum + `postCode` regex + discriminated `safetyInformation` enforced server-side. ✅
+- **Headers** — every new file gets the standard JSDoc header per engineering-standards.md "File Headers". ✅
+- **Migrations** — none required. `Connection.config` is JSONB. ✅
+- **Security** — RP endpoint behind `JwtAuthGuard`; no credentials/secrets in FE; the operator's Allegro token already lives in the existing connection-credentials store. ✅
+- **Frontend dependency direction** — section component lives under `features/connections/`; API hook lives under `features/connections/api/`; only imports from `shared/ui/`. ✅
+
+## 8. Risks & open questions
+
+- **Allegro voivodeship enum drift.** The 16 voivodeship strings are stable but Allegro could rename them. Acceptable because `AllegroSellerDefaultsNotConfiguredException` won't fire — but a 422 on `province` validation would surface in the existing FE Alert via the `OfferCreateRejectedException` flow. Risk: low.
+- **`body.stock` ↔ `productSet[0].quantity` coexistence.** Allegro docs are ambiguous. Plan ships both fields populated on smart-linked offers (current `body.stock` + new `productSet[0].quantity`). If Allegro rejects, trim post-sandbox.
+- **Smart-link cache coherence.** Cards rarely change but their `ean` field could be edited by Allegro's catalogue team. 24h TTL bounds the window. Operator can clear via Redis-flush if a known-good card stops linking — acceptable for MVP.
+- **Smart-link false positive.** A card matches by EAN but its required parameters don't align with the variant's attributes — Allegro 422s on create. Today the operator sees the error in the Job-detail view. Adding the "card-blocked marker" to suppress repeat smart-links is gold-plating per §3 — open as a future enhancement once we see real-world hits.
+- **No `responsibleProducer` registry sync to local storage.** Every dropdown render hits Allegro. Latency ~200-500ms acceptable for a settings page; if it becomes friction, a 5-minute Redis cache is one line of code.
+- **Old-config compatibility.** Connections without `sellerDefaults` get `AllegroSellerDefaultsNotConfiguredException` on first offer attempt. Operator sees the error message naming the missing fields and a hint to configure on the connection edit page. No silent fallback (which would surface as the original Allegro 422 — strictly worse UX).
+
+## 9. Out of scope (explicitly deferred)
+
+- Per-offer wizard override of seller defaults (#430 OOS).
+- Creating Responsible Producer entries from inside OL (#430 OOS).
+- Multi-warehouse / multi-location support (#430 OOS).
+- GPSR pictograms in safetyInformation (#430 OOS).
+- Manual operator override "force inline" / "force card-link" UX (#431 OOS).
+- Multi-EAN smart-link, cross-category card matching, creating new product cards via `POST /sale/products` (#431 OOS).
+- Card-blocked marker for smart-link parameter-mismatch failures (deferred — see §8).
+- Surfacing Allegro 422 details in wizard (tracked under #433, deferred).
+- Detecting category-conditional required fields in wizard (tracked under #432, deferred).

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -118,6 +118,8 @@ describe('OfferBuilderService', () => {
           imageUrls: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
         },
         idempotencyKey: undefined,
+        // #431 — barcode threaded through for adapter-side smart-link.
+        variantBarcode: '5901234123457',
       });
     });
   });

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -128,6 +128,9 @@ export class OfferBuilderService implements IOfferBuilderService {
       publishImmediately: input.publishImmediately ?? false,
       overrides: Object.keys(cleanedOverrides).length > 0 ? cleanedOverrides : undefined,
       idempotencyKey: input.idempotencyKey,
+      // #431 — smart-link by barcode. Pre-resolved here so adapters that
+      // need it (Allegro) don't have to re-fetch the variant.
+      variantBarcode: variant.ean ?? variant.gtin ?? null,
     };
 
     this.logger.debug(

--- a/libs/core/src/listings/domain/ports/capabilities/responsible-producer-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/responsible-producer-reader.capability.ts
@@ -1,0 +1,27 @@
+/**
+ * Responsible Producer Reader Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can list the
+ * EU GPSR responsible-producer registry on the seller's account declare
+ * `implements ResponsibleProducerReader`. Required at offer-create time on
+ * Allegro (`productSet[*].responsibleProducer.{ id }`); the FE connection
+ * settings page consumes this to populate the seller-defaults dropdown
+ * (#430). Mirrors the `seller-policies-reader.capability.ts` shape.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { ResponsibleProducerEntry } from '../../types/responsible-producer.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface ResponsibleProducerReader {
+  fetchResponsibleProducers(): Promise<ResponsibleProducerEntry[]>;
+}
+
+export function isResponsibleProducerReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & ResponsibleProducerReader {
+  return (
+    typeof (adapter as Partial<ResponsibleProducerReader>).fetchResponsibleProducers ===
+    'function'
+  );
+}

--- a/libs/core/src/listings/domain/types/offer-create.types.ts
+++ b/libs/core/src/listings/domain/types/offer-create.types.ts
@@ -68,6 +68,15 @@ export interface CreateOfferCommand {
   overrides?: CreateOfferOverrides;
   /** Optional idempotency key for deduplication at the adapter / job layer. */
   idempotencyKey?: string;
+  /**
+   * Variant barcode (EAN ?? GTIN) carried through from the master catalog.
+   * Adapters that support smart-linking to existing marketplace product
+   * cards (e.g. Allegro #431) use it to look up an existing card before
+   * falling back to inline product creation. Pre-resolved by
+   * `OfferBuilderService` so adapters don't have to re-fetch the variant.
+   * `null` means "no usable barcode" (variant has neither EAN nor GTIN).
+   */
+  variantBarcode?: string | null;
 }
 
 /**

--- a/libs/core/src/listings/domain/types/responsible-producer.types.ts
+++ b/libs/core/src/listings/domain/types/responsible-producer.types.ts
@@ -1,0 +1,39 @@
+/**
+ * Responsible Producer Types
+ *
+ * Neutral shape returned by `ResponsibleProducerReader.fetchResponsibleProducers()`
+ * — a marketplace-agnostic view of the EU GPSR-mandated responsible-producer
+ * registry. Adapters that implement the `ResponsibleProducerReader` capability
+ * map their platform-native registry into this shape so the FE settings page
+ * can render a connection-level dropdown without knowing about marketplace
+ * specifics. Today only Allegro implements it (#430).
+ *
+ * Framework-free. Interface-layer DTOs decorate these fields with Swagger
+ * annotations separately.
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+/**
+ * Operator-classification of a registered responsible-producer entry, as
+ * required by EU Regulation 2023/988 (GPSR). Mirrors Allegro's enum but
+ * named neutrally so other marketplaces can map their own classifications
+ * onto the same values.
+ */
+export const ResponsibleProducerKindValues = [
+  'PRODUCER',
+  'IMPORTER',
+  'AUTHORIZED_REPRESENTATIVE',
+  'FULFILLMENT_SERVICE_PROVIDER',
+] as const;
+
+export type ResponsibleProducerKind = (typeof ResponsibleProducerKindValues)[number];
+
+export interface ResponsibleProducerEntry {
+  /** Platform-native id used by `productSet[*].responsibleProducer.{ id }` on offer create. */
+  id: string;
+  /** Human-readable label for dropdown display (operator-facing). */
+  name: string;
+  /** GPSR classification. */
+  kind: ResponsibleProducerKind;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -157,3 +157,10 @@ export type { OfferCreator } from './domain/ports/capabilities/offer-creator.cap
 export { isOfferCreator } from './domain/ports/capabilities/offer-creator.capability';
 export type { SellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';
 export { isSellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';
+export type { ResponsibleProducerReader } from './domain/ports/capabilities/responsible-producer-reader.capability';
+export { isResponsibleProducerReader } from './domain/ports/capabilities/responsible-producer-reader.capability';
+export type {
+  ResponsibleProducerEntry,
+  ResponsibleProducerKind,
+} from './domain/types/responsible-producer.types';
+export { ResponsibleProducerKindValues } from './domain/types/responsible-producer.types';

--- a/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
+++ b/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
@@ -118,6 +118,13 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
       this.quantityPollConfig,
       this.cache,
       this.catParamsTtlSec,
+      // #430 — connection-level seller defaults sourced from
+      // `Connection.config.allegro.sellerDefaults`. Passed through unparsed
+      // (the API DTO layer validates province enum / postcode regex /
+      // discriminated safetyInformation before persistence). Undefined when
+      // operator hasn't configured them yet — adapter throws
+      // `OfferCreateRejectedException` on the first offer attempt.
+      config.sellerDefaults,
     );
     const orderSourceAdapter = new AllegroOrderSourceAdapter(connection.id, httpClient, connection);
 

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -218,10 +218,42 @@ export interface AllegroOfferParameter {
  */
 export interface AllegroProductSetEntry {
   product?: {
+    /**
+     * Existing Allegro product-card id. Set on the smart-link path (#431) —
+     * presence of `id` means the entry references an existing card and
+     * Allegro inherits `name`, `parameters`, `images`, and GPSR data from
+     * the card. The inline-product path leaves `id` undefined and supplies
+     * those fields explicitly alongside `responsibleProducer` /
+     * `safetyInformation` on the entry.
+     */
+    id?: string;
     name?: string;
     parameters?: AllegroOfferParameter[];
     images?: string[];
   };
+  /**
+   * Per-entry quantity, used on the smart-link path (#431) where stock is
+   * declared on the productSet entry rather than on `body.stock`. The
+   * inline-product path leaves this undefined and uses `body.stock`.
+   */
+  quantity?: number;
+  /**
+   * EU GPSR (Reg. 2023/988) responsible-producer reference. Required by
+   * Allegro on every `productSet[]` entry when the entry creates an inline
+   * product (no `product.id`). Smart-linked entries inherit this from the
+   * referenced card and may omit it. See #430.
+   */
+  responsibleProducer?: { id: string };
+  /**
+   * EU GPSR safety information. Same applicability as `responsibleProducer`:
+   * required on the inline path, inherited on the smart-link path. The
+   * `NO_SAFETY_INFORMATION` branch is Allegro's "this category does not
+   * carry safety risks" declaration; `SAFETY_INFORMATION` carries free-text
+   * content. See #430.
+   */
+  safetyInformation?:
+    | { type: 'NO_SAFETY_INFORMATION' }
+    | { type: 'SAFETY_INFORMATION'; content: string };
 }
 
 /**
@@ -432,6 +464,34 @@ export interface AllegroProductOfferCreateRequest extends Record<string, unknown
   payments?: { invoice?: 'VAT' | 'NO_INVOICE' | 'VAT_MARGIN' };
   publication?: { status: 'INACTIVE' | 'ACTIVE' };
   external?: { id: string };
+  /**
+   * Ship-from address. Required for every offer regardless of inline vs
+   * smart-link path (#430 — sandbox 422 on `location.state` was the
+   * original trigger). Sourced from `Connection.config.allegro
+   * .sellerDefaults.location` at offer-build time.
+   */
+  location?: {
+    countryCode: string;
+    province: string;
+    city: string;
+    postCode: string;
+  };
+}
+
+/**
+ * One entry in `GET /sale/products?phrase=…&category.id=…` (#431). Allegro's
+ * matcher is fuzzy on `phrase`, so the smart-link resolver post-filters by
+ * exact `ean` match. `name` is informational (used in logs and the
+ * `ambiguous` diagnostic payload).
+ */
+export interface AllegroProductCardSummary {
+  id: string;
+  name?: string;
+  ean?: string;
+}
+
+export interface AllegroProductsSearchResponse {
+  products: AllegroProductCardSummary[];
 }
 
 /**
@@ -453,6 +513,23 @@ export interface AllegroProductOfferCreateResponse {
 export interface AllegroSellerPolicyEntry {
   id: string;
   name: string;
+}
+
+/**
+ * One entry returned by Allegro's `GET /sale/responsible-producers`. The
+ * registry is the EU GPSR (Reg. 2023/988) operator-side list of producers
+ * the seller can declare on offer creation. Adapter surfaces this through
+ * the `ResponsibleProducerReader` capability for the FE settings dropdown
+ * (#430).
+ */
+export interface AllegroResponsibleProducerEntry {
+  id: string;
+  name?: string;
+  type?: 'PRODUCER' | 'IMPORTER' | 'AUTHORIZED_REPRESENTATIVE' | 'FULFILLMENT_SERVICE_PROVIDER';
+}
+
+export interface AllegroResponsibleProducersResponse {
+  responsibleProducers: AllegroResponsibleProducerEntry[];
 }
 
 /**

--- a/libs/integrations/allegro/src/domain/types/allegro-config.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-config.types.ts
@@ -8,6 +8,7 @@
  *
  * @module libs/integrations/allegro/src/domain/types
  */
+import type { AllegroSellerDefaultsConfig } from './allegro-seller-defaults.types';
 
 /**
  * Allegro environment (sandbox or production)
@@ -46,6 +47,15 @@ export interface AllegroConnectionConfig {
    * - Production: https://upload.allegro.pl
    */
   uploadBaseUrl?: string;
+
+  /**
+   * Connection-level seller defaults required by `POST /sale/product-offers`
+   * — `location` (every offer), plus `responsibleProducerId` and
+   * `safetyInformation` for the inline-product path. See #430. Optional at
+   * the type level so existing connections without it parse cleanly; offer
+   * creation fails fast with `SELLER_DEFAULTS_NOT_CONFIGURED` if missing.
+   */
+  sellerDefaults?: AllegroSellerDefaultsConfig;
 }
 
 

--- a/libs/integrations/allegro/src/domain/types/allegro-location.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-location.types.ts
@@ -1,0 +1,36 @@
+/**
+ * Allegro Location Types
+ *
+ * Polish voivodeship enum + display labels — backs the `province` field on
+ * `productSet[*]` `location` (offer-level ship-from address). Allegro's
+ * `POST /sale/product-offers` validator rejects `INVALID_STATE` on
+ * `location.state` for any value not in this set, surfaced in the
+ * 2026-04-28 sandbox repro that motivated #430.
+ *
+ * `as const` runtime array per engineering-standards.md "Union Types"
+ * pattern; the FE Select reads the same array (re-exported via package
+ * barrel) so the values stay aligned without a duplicated mirror.
+ *
+ * @module libs/integrations/allegro/src/domain/types
+ */
+
+export const PolishVoivodeshipValues = [
+  'DOLNOSLASKIE',
+  'KUJAWSKO_POMORSKIE',
+  'LUBELSKIE',
+  'LUBUSKIE',
+  'LODZKIE',
+  'MALOPOLSKIE',
+  'MAZOWIECKIE',
+  'OPOLSKIE',
+  'PODKARPACKIE',
+  'PODLASKIE',
+  'POMORSKIE',
+  'SLASKIE',
+  'SWIETOKRZYSKIE',
+  'WARMINSKO_MAZURSKIE',
+  'WIELKOPOLSKIE',
+  'ZACHODNIOPOMORSKIE',
+] as const;
+
+export type PolishVoivodeship = (typeof PolishVoivodeshipValues)[number];

--- a/libs/integrations/allegro/src/domain/types/allegro-seller-defaults.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-seller-defaults.types.ts
@@ -1,0 +1,64 @@
+/**
+ * Allegro Seller Defaults Types
+ *
+ * Connection-level seller defaults persisted on `Connection.config.allegro
+ * .sellerDefaults`. Three fields make `POST /sale/product-offers` succeed
+ * on the inline-product path (when smart-link to an existing product card
+ * misses) — `location` is required for every offer regardless of path
+ * (#430).
+ *
+ * Adapter behaviour: when these are missing on a connection that attempts
+ * offer creation, `AllegroOfferManagerAdapter.buildCreateOfferRequest`
+ * throws `OfferCreateRejectedException` with code
+ * `SELLER_DEFAULTS_NOT_CONFIGURED` directly, naming the missing fields.
+ * No CORE-side mapping (avoids `core → integration` reverse dependency).
+ *
+ * @module libs/integrations/allegro/src/domain/types
+ */
+import type { PolishVoivodeship } from './allegro-location.types';
+
+/**
+ * `safetyInformation.type` discriminator. EU GPSR (Reg. 2023/988) requires
+ * one of these on every `productSet[*]` payload sent to Allegro.
+ *
+ * - `NO_SAFETY_INFORMATION`: seller declares no safety information applies.
+ * - `SAFETY_INFORMATION`: free-text content with the safety details.
+ */
+export const AllegroSafetyInformationTypeValues = [
+  'NO_SAFETY_INFORMATION',
+  'SAFETY_INFORMATION',
+] as const;
+
+export type AllegroSafetyInformationType = (typeof AllegroSafetyInformationTypeValues)[number];
+
+/**
+ * Discriminated union mirroring Allegro's `safetyInformation` shape on
+ * `productSet[*]`. Only the `SAFETY_INFORMATION` branch carries free text.
+ */
+export type AllegroSafetyInformation =
+  | { type: 'NO_SAFETY_INFORMATION' }
+  | { type: 'SAFETY_INFORMATION'; content: string };
+
+/**
+ * Ship-from address sent on every offer's `body.location`. `countryCode` is
+ * pinned to `'PL'` for now — multi-market support is out of scope for #430
+ * (and Allegro's voivodeship enum only applies to Poland).
+ */
+export interface AllegroSellerLocation {
+  countryCode: 'PL';
+  province: PolishVoivodeship;
+  city: string;
+  postCode: string; // /^\d{2}-\d{3}$/
+}
+
+/**
+ * Connection-level seller defaults persisted in `Connection.config.allegro
+ * .sellerDefaults`. All three sub-fields are required when present;
+ * partial configurations fail validation at the API DTO layer.
+ */
+export interface AllegroSellerDefaultsConfig {
+  location: AllegroSellerLocation;
+  /** Id from Allegro's `/sale/responsible-producers` registry. */
+  responsibleProducerId: string;
+  safetyInformation: AllegroSafetyInformation;
+}

--- a/libs/integrations/allegro/src/index.ts
+++ b/libs/integrations/allegro/src/index.ts
@@ -16,6 +16,17 @@ export { IAllegroAdapterFactory } from './application/interfaces/allegro-adapter
 export { AllegroConnectionConfig, AllegroEnvironment, AllegroEnvironmentValues } from './domain/types/allegro-config.types';
 export { AllegroCredentials } from './domain/types/allegro-credentials.types';
 export {
+  PolishVoivodeshipValues,
+  type PolishVoivodeship,
+} from './domain/types/allegro-location.types';
+export {
+  AllegroSafetyInformationTypeValues,
+  type AllegroSafetyInformationType,
+  type AllegroSafetyInformation,
+  type AllegroSellerLocation,
+  type AllegroSellerDefaultsConfig,
+} from './domain/types/allegro-seller-defaults.types';
+export {
   AllegroOrderEventsResponse,
   AllegroOfferQuantityChangeCommand,
   AllegroOfferQuantityChangeCommandResponse,

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -22,6 +22,25 @@ import {
   type CreateOfferCommand,
 } from '@openlinker/core/listings';
 import type { CachePort } from '@openlinker/shared';
+import type { AllegroSellerDefaultsConfig } from '../../../domain/types/allegro-seller-defaults.types';
+
+/**
+ * Default seller defaults seeded by the createOffer specs (#430). All
+ * createOffer tests previously assumed these were configured implicitly;
+ * the new preflight throws when missing, so the test fixture exposes them
+ * explicitly. Individual specs can omit them by constructing the adapter
+ * via the dedicated `null sellerDefaults` test path.
+ */
+const DEFAULT_SELLER_DEFAULTS: AllegroSellerDefaultsConfig = {
+  location: {
+    countryCode: 'PL',
+    province: 'MAZOWIECKIE',
+    city: 'Warszawa',
+    postCode: '00-001',
+  },
+  responsibleProducerId: 'rp-test-1',
+  safetyInformation: { type: 'NO_SAFETY_INFORMATION' },
+};
 
 /**
  * Build a minimal valid PNG header (24 bytes) for the given dimensions.
@@ -106,6 +125,11 @@ describe('AllegroOfferManagerAdapter', () => {
       uploadHttpClient,
       identifierMapping,
       connection,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      DEFAULT_SELLER_DEFAULTS,
     );
   });
 
@@ -1098,6 +1122,9 @@ describe('AllegroOfferManagerAdapter', () => {
               ],
               images: expectedCdnImages,
             },
+            // #430 — GPSR fields written from sellerDefaults on inline path.
+            responsibleProducer: { id: 'rp-test-1' },
+            safetyInformation: { type: 'NO_SAFETY_INFORMATION' },
           },
         ]);
         // Mirroring contract: product.images is the post-upload offer-level
@@ -1167,6 +1194,9 @@ describe('AllegroOfferManagerAdapter', () => {
               parameters: [{ id: '248811', valuesIds: ['248811_canon'] }],
               images: ['https://images.allegrostatic.com/test/uploaded-1.jpg'],
             },
+            // #430 — GPSR fields on inline-product path.
+            responsibleProducer: { id: 'rp-test-1' },
+            safetyInformation: { type: 'NO_SAFETY_INFORMATION' },
           },
         ]);
       });
@@ -1407,6 +1437,178 @@ describe('AllegroOfferManagerAdapter', () => {
         'image/jpeg',
         expect.any(Uint8Array),
       );
+    });
+
+    describe('seller defaults (#430)', () => {
+      it('throws OfferCreateRejectedException with SELLER_DEFAULTS_NOT_CONFIGURED when sellerDefaults are missing', async () => {
+        // Construct an adapter without sellerDefaults — preflight must fire.
+        const adapterWithoutDefaults = new AllegroOfferManagerAdapter(
+          connectionId,
+          httpClient,
+          uploadHttpClient,
+          identifierMapping,
+          connection,
+        );
+
+        await expect(adapterWithoutDefaults.createOffer(baseCmd)).rejects.toMatchObject({
+          name: 'OfferCreateRejectedException',
+          statusCode: 0,
+          errors: expect.arrayContaining([
+            expect.objectContaining({
+              field: 'sellerDefaults.location',
+              code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+            }),
+            expect.objectContaining({
+              field: 'sellerDefaults.responsibleProducerId',
+              code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+            }),
+            expect.objectContaining({
+              field: 'sellerDefaults.safetyInformation',
+              code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+            }),
+          ]),
+        });
+        // Preflight must short-circuit before any HTTP call.
+        expect(httpClient.post).not.toHaveBeenCalled();
+        expect(uploadHttpClient.postBinary).not.toHaveBeenCalled();
+      });
+
+      it('writes body.location from sellerDefaults on every offer create', async () => {
+        httpClient.post.mockResolvedValue(
+          mockHttpResponse({
+            id: 'allegro-offer-loc',
+            publication: { status: 'INACTIVE' },
+          }),
+        );
+
+        await adapter.createOffer(baseCmd);
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body.location).toEqual({
+          countryCode: 'PL',
+          province: 'MAZOWIECKIE',
+          city: 'Warszawa',
+          postCode: '00-001',
+        });
+      });
+    });
+
+    describe('smart-link by EAN (#431)', () => {
+      it('on unique match: links via productSet[0].product.id, omits inline name/parameters/images/GPSR, uses per-entry quantity', async () => {
+        httpClient.post.mockResolvedValue(
+          mockHttpResponse({
+            id: 'allegro-offer-linked',
+            publication: { status: 'INACTIVE' },
+          }),
+        );
+        // Mock the smart-link resolver path: one exact-EAN match.
+        httpClient.get.mockResolvedValueOnce({
+          data: {
+            products: [{ id: 'allegro-card-1', ean: '5901234123457' }],
+          },
+          status: 200,
+          headers: {},
+        });
+
+        await adapter.createOffer({
+          ...baseCmd,
+          variantBarcode: '5901234123457',
+          stock: 7,
+          overrides: {
+            ...baseCmd.overrides,
+            platformParams: {
+              productParameters: [
+                // Would normally produce an inline product; smart-link must
+                // win and skip these.
+                { id: '248811', valuesIds: ['248811_canon'] },
+              ],
+            },
+          },
+        });
+
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body.productSet).toEqual([
+          {
+            product: { id: 'allegro-card-1' },
+            quantity: 7,
+          },
+        ]);
+        // Card-linked offers inherit GPSR from the card — adapter must NOT
+        // write `responsibleProducer` / `safetyInformation` on the entry.
+        expect(body.productSet).not.toContainEqual(
+          expect.objectContaining({ responsibleProducer: expect.anything() }),
+        );
+      });
+
+      it('falls through to inline path when variantBarcode is missing (smart-link short-circuits)', async () => {
+        httpClient.post.mockResolvedValue(
+          mockHttpResponse({
+            id: 'allegro-offer-inline',
+            publication: { status: 'INACTIVE' },
+          }),
+        );
+
+        await adapter.createOffer({
+          ...baseCmd,
+          variantBarcode: undefined,
+          overrides: {
+            ...baseCmd.overrides,
+            platformParams: {
+              productParameters: [{ id: '248811', valuesIds: ['248811_canon'] }],
+            },
+          },
+        });
+
+        // Resolver was never called because variantBarcode was missing.
+        expect(httpClient.get).not.toHaveBeenCalledWith(
+          '/sale/products',
+          expect.anything(),
+        );
+        const body = httpClient.post.mock.calls[0][1] as {
+          productSet?: Array<{
+            product?: { id?: string; name?: string };
+            responsibleProducer?: unknown;
+          }>;
+        };
+        // Inline path: product.id absent, GPSR fields written from sellerDefaults.
+        expect(body.productSet?.[0]?.product?.id).toBeUndefined();
+        expect(body.productSet?.[0]?.product?.name).toBe('Test Offer Title');
+        expect(body.productSet?.[0]?.responsibleProducer).toEqual({ id: 'rp-test-1' });
+      });
+    });
+
+    describe('fetchResponsibleProducers (#430)', () => {
+      it('maps Allegro entries to the neutral ResponsibleProducerEntry shape', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: {
+            responsibleProducers: [
+              { id: 'rp-1', name: 'ACME GmbH', type: 'PRODUCER' },
+              { id: 'rp-2', name: 'Importer Co.', type: 'IMPORTER' },
+            ],
+          },
+          status: 200,
+          headers: {},
+        });
+
+        const result = await adapter.fetchResponsibleProducers();
+
+        expect(result).toEqual([
+          { id: 'rp-1', name: 'ACME GmbH', kind: 'PRODUCER' },
+          { id: 'rp-2', name: 'Importer Co.', kind: 'IMPORTER' },
+        ]);
+      });
+
+      it('defaults missing kind to PRODUCER and falls back name → id', async () => {
+        httpClient.get.mockResolvedValueOnce({
+          data: { responsibleProducers: [{ id: 'rp-3' }] },
+          status: 200,
+          headers: {},
+        });
+
+        const result = await adapter.fetchResponsibleProducers();
+
+        expect(result).toEqual([{ id: 'rp-3', name: 'rp-3', kind: 'PRODUCER' }]);
+      });
     });
   });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -19,6 +19,8 @@ import type {
   CategoryParametersReader,
   OfferCreator,
   SellerPoliciesReader,
+  ResponsibleProducerReader,
+  ResponsibleProducerEntry,
   OfferFeedInput,
   OfferFeedOutput,
   UpdateOfferQuantityCommand,
@@ -32,6 +34,11 @@ import type {
   SellerPolicies,
 } from '@openlinker/core/listings';
 import { OfferCreateRejectedException, CategoryNotFoundException } from '@openlinker/core/listings';
+import type { AllegroSellerDefaultsConfig } from '../../domain/types/allegro-seller-defaults.types';
+import {
+  resolveAllegroProductCardByEan,
+  type ResolveProductCardResult,
+} from '../util/resolve-allegro-product-card-by-ean';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import type { CachePort } from '@openlinker/shared';
 import { IAllegroHttpClient } from '../http/allegro-http-client.interface';
@@ -55,6 +62,8 @@ import {
   AllegroWarrantiesResponse,
   AllegroImpliedWarrantiesResponse,
   AllegroSellerPolicyEntry,
+  AllegroResponsibleProducerEntry,
+  AllegroResponsibleProducersResponse,
 } from '../../domain/types/allegro-api.types';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
 import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
@@ -124,7 +133,8 @@ export class AllegroOfferManagerAdapter
     CategoryBarcodeMatcher,
     CategoryParametersReader,
     OfferCreator,
-    SellerPoliciesReader {
+    SellerPoliciesReader,
+    ResponsibleProducerReader {
   private readonly logger = new Logger(AllegroOfferManagerAdapter.name);
 
   private readonly quantityPollConfig: QuantityPollConfig;
@@ -152,6 +162,16 @@ export class AllegroOfferManagerAdapter
      */
     private readonly cache?: CachePort,
     catParamsTtlSec?: number,
+    /**
+     * Connection-level seller defaults — `location` (every offer),
+     * `responsibleProducerId` and `safetyInformation` (inline-product path).
+     * Sourced from `Connection.config.allegro.sellerDefaults` by
+     * `AllegroAdapterFactory`. When undefined, `createOffer` throws
+     * `OfferCreateRejectedException` with code
+     * `SELLER_DEFAULTS_NOT_CONFIGURED` rather than silently producing a
+     * partial body Allegro will 422 on (#430).
+     */
+    private readonly sellerDefaults?: AllegroSellerDefaultsConfig,
   ) {
     this.quantityPollConfig = {
       maxAttempts: quantityPollConfig?.maxAttempts ?? 5,
@@ -714,7 +734,40 @@ export class AllegroOfferManagerAdapter
    * `CreateOfferResult.validationErrors`.
    */
   async createOffer(cmd: CreateOfferCommand): Promise<CreateOfferResult> {
-    const body = this.buildCreateOfferRequest(cmd);
+    // #430 — preflight: connection-level seller defaults must exist before we
+    // can build a body Allegro will accept. Surface as the existing neutral
+    // `OfferCreateRejectedException` (one error per missing field) rather
+    // than a custom Allegro exception type — keeps the `core → integration`
+    // boundary clean (no CORE-side mapping needed).
+    if (!this.sellerDefaults) {
+      throw new OfferCreateRejectedException(ALLEGRO_ADAPTER_KEY, 0, [
+        {
+          field: 'sellerDefaults.location',
+          code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+          message: `Allegro connection ${this.connectionId} has no seller defaults configured. Set the ship-from location, Responsible Producer, and Safety Information on the connection edit page before creating offers.`,
+        },
+        {
+          field: 'sellerDefaults.responsibleProducerId',
+          code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+          message:
+            'Configure a Responsible Producer entry in your Allegro account, then select it on the OpenLinker connection edit page.',
+        },
+        {
+          field: 'sellerDefaults.safetyInformation',
+          code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+          message: 'Configure GPSR safety information on the connection edit page.',
+        },
+      ]);
+    }
+
+    // #431 — smart-link pre-step. Compute once at the top so the body
+    // builder + platform-params applier stay synchronous (their current
+    // contract). On `unique`, `productSet[0]` becomes a card-link reference
+    // and Allegro inherits GPSR + parameters from the card; otherwise we
+    // fall through to inline (which uses the seller-defaults checked above).
+    const cardLinkResult = await this.maybeResolveProductCard(cmd);
+
+    const body = this.buildCreateOfferRequest(cmd, cardLinkResult);
 
     // Pre-step: re-host any operator image URLs onto Allegro's CDN. Allegro
     // resolves URLs in `images[]` server-side and rejects offer creation when
@@ -752,7 +805,17 @@ export class AllegroOfferManagerAdapter
     // one entry with a populated `product` — see `applyPlatformParams`,
     // which is the only writer. The optional-chaining guard below is
     // belt-and-braces against future writers introducing a different shape.
-    if (body.productSet?.[0]?.product && body.images && body.images.length > 0) {
+    //
+    // #431 — Smart-linked entries (`product.id` set) inherit images from
+    // the existing Allegro product card; mirroring would write a sibling
+    // `images` field that Allegro does not expect on the link path. Skip
+    // when `product.id` is present.
+    if (
+      body.productSet?.[0]?.product &&
+      body.productSet[0].product.id === undefined &&
+      body.images &&
+      body.images.length > 0
+    ) {
       body.productSet[0].product.images = body.images;
     }
 
@@ -839,7 +902,59 @@ export class AllegroOfferManagerAdapter
     };
   }
 
-  private buildCreateOfferRequest(cmd: CreateOfferCommand): AllegroProductOfferCreateRequest {
+  /**
+   * Fetch the seller's EU GPSR responsible-producer registry
+   * (`GET /sale/responsible-producers`). Maps the Allegro response shape
+   * into the neutral `ResponsibleProducerEntry[]` consumed by the FE
+   * connection-settings dropdown. No caching — operator-driven, freshness
+   * over latency. (#430)
+   */
+  async fetchResponsibleProducers(): Promise<ResponsibleProducerEntry[]> {
+    this.logger.debug(
+      `Fetching Allegro responsible producers (connection: ${this.connectionId})`,
+    );
+    const response = await this.httpClient.get<AllegroResponsibleProducersResponse>(
+      '/sale/responsible-producers',
+    );
+    const entries = response.data.responsibleProducers ?? [];
+    return entries.map(
+      (e: AllegroResponsibleProducerEntry): ResponsibleProducerEntry => ({
+        id: e.id,
+        name: e.name ?? e.id,
+        // Allegro defaults unknown classifications to PRODUCER; mirror that
+        // so the FE never has to handle `undefined` here.
+        kind: e.type ?? 'PRODUCER',
+      }),
+    );
+  }
+
+  /**
+   * Smart-link pre-step (#431). Resolves the variant's barcode against
+   * Allegro's product catalogue *only* when both an EAN-shaped barcode
+   * and a category id are available; otherwise short-circuits to
+   * `no_match` so `applyPlatformParams` falls through to inline.
+   *
+   * Splitting out the precondition logic keeps `createOffer` flat and
+   * makes the smart-link skip-paths trivially traceable in tests.
+   */
+  private async maybeResolveProductCard(
+    cmd: CreateOfferCommand,
+  ): Promise<ResolveProductCardResult> {
+    const ean = cmd.variantBarcode;
+    const categoryId = cmd.overrides?.categoryId;
+    if (!ean || !categoryId) {
+      return { kind: 'no_match' };
+    }
+    return resolveAllegroProductCardByEan(this.httpClient, this.cache, {
+      ean,
+      categoryId,
+    });
+  }
+
+  private buildCreateOfferRequest(
+    cmd: CreateOfferCommand,
+    cardLinkResult: ResolveProductCardResult,
+  ): AllegroProductOfferCreateRequest {
     const platformParams = cmd.overrides?.platformParams ?? {};
 
     // #420 — Allegro's product-name validator (and presumably the offer-name
@@ -903,7 +1018,12 @@ export class AllegroOfferManagerAdapter
       body.images = cmd.overrides.imageUrls;
     }
 
-    this.applyPlatformParams(body, platformParams);
+    // #430 — every offer needs a ship-from address. Always written from the
+    // connection-level seller defaults (preflight guard in `createOffer`
+    // ensures `this.sellerDefaults` is defined by the time we get here).
+    body.location = { ...this.sellerDefaults!.location };
+
+    this.applyPlatformParams(body, platformParams, cardLinkResult, cmd.stock);
 
     return body;
   }
@@ -911,6 +1031,8 @@ export class AllegroOfferManagerAdapter
   private applyPlatformParams(
     body: AllegroProductOfferCreateRequest,
     platformParams: Record<string, unknown>,
+    cardLinkResult: ResolveProductCardResult,
+    stock: number,
   ): void {
     const deliveryPolicyId = platformParams['deliveryPolicyId'];
     const handlingTime = platformParams['handlingTime'];
@@ -953,6 +1075,35 @@ export class AllegroOfferManagerAdapter
       body.parameters = parameters.filter(isAllegroOfferParameterShape);
     }
 
+    // #431 — smart-link short-circuit. When the variant's EAN uniquely
+    // matches an existing Allegro product card, build the productSet entry
+    // as a card reference: `product.id` only, plus the per-entry quantity.
+    // Allegro inherits `name`, `parameters`, `images`, and the EU GPSR
+    // fields (`responsibleProducer`, `safetyInformation`) from the card,
+    // so we **skip** writing all of those on the entry. Offer-section
+    // `body.parameters[]` (set above) still flows through normally.
+    if (cardLinkResult.kind === 'unique') {
+      body.productSet = [
+        {
+          product: { id: cardLinkResult.productId },
+          quantity: stock,
+        },
+      ];
+      this.logger.log(
+        `Allegro smart-link applied: connection=${this.connectionId} ` +
+          `productId=${cardLinkResult.productId} outcome=unique`,
+      );
+      return;
+    }
+
+    if (cardLinkResult.kind === 'ambiguous') {
+      this.logger.log(
+        `Allegro smart-link skipped: connection=${this.connectionId} ` +
+          `outcome=ambiguous matchCount=${cardLinkResult.matches.length}`,
+      );
+    }
+    // `no_match` — not logged here; resolver path is the cheap default.
+
     // #419 — product-section parameters travel under
     // `body.productSet[0].product.parameters[]`. The earlier #415 fix wrote
     // them under a top-level `body.product`, which Allegro rejects with
@@ -985,7 +1136,17 @@ export class AllegroOfferManagerAdapter
         // re-sanitization needed at this site. Keeping a single sanitization
         // point per request lifecycle avoids "why is this being sanitized
         // — wasn't it already?" reader confusion.
-        body.productSet = [{ product: { name: body.name, parameters: filtered } }];
+        body.productSet = [
+          {
+            product: { name: body.name, parameters: filtered },
+            // #430 — GPSR fields required by Allegro on inline-product
+            // creation (Reg. 2023/988, mandatory since 13 Dec 2024).
+            // Sourced from the connection's seller defaults (preflight
+            // guard in `createOffer` ensures these exist).
+            responsibleProducer: { id: this.sellerDefaults!.responsibleProducerId },
+            safetyInformation: this.sellerDefaults!.safetyInformation,
+          },
+        ];
       }
     }
   }

--- a/libs/integrations/allegro/src/infrastructure/util/__tests__/resolve-allegro-product-card-by-ean.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/__tests__/resolve-allegro-product-card-by-ean.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Resolve Allegro Product Card By EAN — Tests
+ *
+ * Branches: cache hit (unique + no_match), miss → unique, miss → ambiguous
+ * (not cached), miss → no_match (cached), HTTP failure (no_match, not
+ * cached). Covers the contract documented in the util's JSDoc.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/util/__tests__
+ */
+import type { CachePort } from '@openlinker/shared';
+import { IAllegroHttpClient } from '../../http/allegro-http-client.interface';
+import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
+import { resolveAllegroProductCardByEan } from '../resolve-allegro-product-card-by-ean';
+
+describe('resolveAllegroProductCardByEan', () => {
+  let httpClient: jest.Mocked<IAllegroHttpClient>;
+  let cache: jest.Mocked<CachePort>;
+
+  beforeEach(() => {
+    httpClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      patch: jest.fn(),
+      postBinary: jest.fn(),
+    } as unknown as jest.Mocked<IAllegroHttpClient>;
+
+    cache = {
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<CachePort>;
+  });
+
+  it('returns cached unique without hitting Allegro on cache HIT', async () => {
+    cache.get.mockResolvedValue({ kind: 'unique', productId: 'allegro-prod-cached' });
+
+    const result = await resolveAllegroProductCardByEan(httpClient, cache, {
+      ean: '5901234123457',
+      categoryId: 'cat-1',
+    });
+
+    expect(result).toEqual({ kind: 'unique', productId: 'allegro-prod-cached' });
+    expect(httpClient.get).not.toHaveBeenCalled();
+  });
+
+  it('returns cached no_match without hitting Allegro on cache HIT', async () => {
+    cache.get.mockResolvedValue({ kind: 'no_match' });
+
+    const result = await resolveAllegroProductCardByEan(httpClient, cache, {
+      ean: '5901234123457',
+      categoryId: 'cat-1',
+    });
+
+    expect(result).toEqual({ kind: 'no_match' });
+    expect(httpClient.get).not.toHaveBeenCalled();
+  });
+
+  it('cache MISS → fetches, returns unique on exactly one EAN match, caches the productId', async () => {
+    cache.get.mockResolvedValue(null);
+    httpClient.get.mockResolvedValue({
+      data: {
+        products: [
+          { id: 'allegro-prod-1', name: 'Canon SX740', ean: '5901234123457' },
+          { id: 'allegro-prod-2', name: 'Other', ean: '9999999999999' }, // fuzzy match, filtered
+        ],
+      },
+      status: 200,
+      headers: {},
+    });
+
+    const result = await resolveAllegroProductCardByEan(httpClient, cache, {
+      ean: '5901234123457',
+      categoryId: 'cat-1',
+    });
+
+    expect(result).toEqual({ kind: 'unique', productId: 'allegro-prod-1' });
+    expect(httpClient.get).toHaveBeenCalledWith('/sale/products', {
+      queryParams: { phrase: '5901234123457', 'category.id': 'cat-1', limit: 10 },
+    });
+    expect(cache.set).toHaveBeenCalledWith(
+      'allegro:product-card:cat-1:5901234123457',
+      { kind: 'unique', productId: 'allegro-prod-1' },
+      expect.any(Number),
+    );
+  });
+
+  it('cache MISS → returns ambiguous when multiple cards match exactly; does NOT cache', async () => {
+    cache.get.mockResolvedValue(null);
+    httpClient.get.mockResolvedValue({
+      data: {
+        products: [
+          { id: 'allegro-prod-1', name: 'Variant A', ean: '5901234123457' },
+          { id: 'allegro-prod-2', name: 'Variant B', ean: '5901234123457' },
+        ],
+      },
+      status: 200,
+      headers: {},
+    });
+
+    const result = await resolveAllegroProductCardByEan(httpClient, cache, {
+      ean: '5901234123457',
+      categoryId: 'cat-1',
+    });
+
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind === 'ambiguous') {
+      expect(result.matches).toHaveLength(2);
+    }
+    // Ambiguous results re-evaluate next call — never cached.
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('cache MISS → returns no_match (and caches it) when zero exact-EAN matches', async () => {
+    cache.get.mockResolvedValue(null);
+    httpClient.get.mockResolvedValue({
+      data: {
+        products: [
+          { id: 'allegro-prod-1', name: 'Fuzzy match', ean: '9999999999999' },
+        ],
+      },
+      status: 200,
+      headers: {},
+    });
+
+    const result = await resolveAllegroProductCardByEan(httpClient, cache, {
+      ean: '5901234123457',
+      categoryId: 'cat-1',
+    });
+
+    expect(result).toEqual({ kind: 'no_match' });
+    expect(cache.set).toHaveBeenCalledWith(
+      'allegro:product-card:cat-1:5901234123457',
+      { kind: 'no_match' },
+      expect.any(Number),
+    );
+  });
+
+  it('returns no_match without throwing when Allegro responds with an error; does NOT cache', async () => {
+    cache.get.mockResolvedValue(null);
+    httpClient.get.mockRejectedValue(
+      new AllegroApiException(
+        'Internal',
+        500,
+        '{"errors":[{"code":"INTERNAL"}]}',
+        'https://api.allegro.pl/sale/products',
+      ),
+    );
+
+    const result = await resolveAllegroProductCardByEan(httpClient, cache, {
+      ean: '5901234123457',
+      categoryId: 'cat-1',
+    });
+
+    expect(result).toEqual({ kind: 'no_match' });
+    // HTTP failure is transient — do NOT cache, so the next attempt re-evaluates.
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('works without a cache (degrades to no caching)', async () => {
+    httpClient.get.mockResolvedValue({
+      data: {
+        products: [{ id: 'allegro-prod-1', ean: '5901234123457' }],
+      },
+      status: 200,
+      headers: {},
+    });
+
+    const result = await resolveAllegroProductCardByEan(httpClient, undefined, {
+      ean: '5901234123457',
+      categoryId: 'cat-1',
+    });
+
+    expect(result).toEqual({ kind: 'unique', productId: 'allegro-prod-1' });
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.ts
@@ -1,0 +1,119 @@
+/**
+ * Resolve Allegro Product Card By EAN
+ *
+ * Smart-link resolver (#431). Given a variant's EAN and the target Allegro
+ * category, look up Allegro's product catalogue (`GET /sale/products`) and
+ * return whether a unique product card exists. The adapter uses this *before*
+ * building the offer body: on `unique`, it links via
+ * `productSet[0].product.id`, inheriting GPSR + parameters from the card.
+ * On `ambiguous` or `no_match`, the adapter falls through to the inline-
+ * product path (which requires the connection-level seller defaults from
+ * #430).
+ *
+ * The util **never throws** for resolver-side failures — HTTP errors collapse
+ * into `no_match` so the offer-create pipeline is unconditionally able to
+ * fall through to inline. Two flavours of failure are caught:
+ *
+ * - **HTTP non-2xx / network error** (Allegro `AllegroApiException`):
+ *   logged + returned as `no_match`. The cache is **not** populated for this
+ *   path — we want to retry on the next attempt.
+ * - **Allegro returned a result we couldn't make sense of** (no products
+ *   array, malformed shape): treated the same way.
+ *
+ * Cache semantics (`(ean, categoryId) -> ResolveProductCardResult`):
+ * - `unique` and `no_match` are cached for `cacheTtlSec` (default 24 h).
+ * - `ambiguous` is **not** cached — operators may narrow the catalogue or
+ *   a duplicate card may be merged on Allegro's side; re-evaluating cheaply
+ *   on the next attempt is correct.
+ *
+ * Mirrors the no-throw contract used by `upload-images-via-allegro.ts`.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/util
+ * @see {@link AllegroOfferManagerAdapter.createOffer} — sole consumer
+ */
+import type { CachePort } from '@openlinker/shared';
+import type {
+  AllegroProductCardSummary,
+  AllegroProductsSearchResponse,
+} from '../../domain/types/allegro-api.types';
+import type { IAllegroHttpClient } from '../http/allegro-http-client.interface';
+import type {
+  ResolveAllegroProductCardOptions,
+  ResolveProductCardResult,
+} from './resolve-allegro-product-card-by-ean.types';
+
+export type {
+  ResolveAllegroProductCardOptions,
+  ResolveProductCardResult,
+} from './resolve-allegro-product-card-by-ean.types';
+
+const DEFAULT_CACHE_TTL_SEC = 24 * 60 * 60;
+const DEFAULT_CACHE_KEY_PREFIX = 'allegro:product-card';
+const DEFAULT_SEARCH_LIMIT = 10;
+
+/**
+ * Cache-shape: we serialize the `unique`/`no_match` discriminant as a
+ * minimal payload. `ambiguous` is intentionally not cached.
+ */
+type CachedOutcome =
+  | { kind: 'unique'; productId: string }
+  | { kind: 'no_match' };
+
+export async function resolveAllegroProductCardByEan(
+  httpClient: IAllegroHttpClient,
+  cache: CachePort | undefined,
+  input: { ean: string; categoryId: string },
+  options?: ResolveAllegroProductCardOptions,
+): Promise<ResolveProductCardResult> {
+  const ttl = options?.cacheTtlSec ?? DEFAULT_CACHE_TTL_SEC;
+  const prefix = options?.cacheKeyPrefix ?? DEFAULT_CACHE_KEY_PREFIX;
+  const limit = options?.searchLimit ?? DEFAULT_SEARCH_LIMIT;
+  const cacheKey = `${prefix}:${input.categoryId}:${input.ean}`;
+
+  if (cache) {
+    const cached = await cache.get<CachedOutcome>(cacheKey);
+    if (cached) {
+      return cached.kind === 'unique'
+        ? { kind: 'unique', productId: cached.productId }
+        : { kind: 'no_match' };
+    }
+  }
+
+  let products: AllegroProductCardSummary[];
+  try {
+    const response = await httpClient.get<AllegroProductsSearchResponse>('/sale/products', {
+      queryParams: {
+        phrase: input.ean,
+        'category.id': input.categoryId,
+        limit,
+      },
+    });
+    products = Array.isArray(response.data?.products) ? response.data.products : [];
+  } catch {
+    // Resolver-side HTTP failure must not block offer creation. Surface as
+    // no_match without caching — next attempt re-evaluates. Both
+    // `AllegroApiException` (non-2xx) and ad-hoc network errors land here.
+    return { kind: 'no_match' };
+  }
+
+  // Allegro's matcher is fuzzy on `phrase` — filter to exact-EAN matches.
+  const exact = products.filter((p) => typeof p.ean === 'string' && p.ean === input.ean);
+
+  if (exact.length === 1) {
+    const productId = exact[0].id;
+    if (cache) {
+      await cache.set<CachedOutcome>(cacheKey, { kind: 'unique', productId }, ttl);
+    }
+    return { kind: 'unique', productId };
+  }
+
+  if (exact.length === 0) {
+    if (cache) {
+      await cache.set<CachedOutcome>(cacheKey, { kind: 'no_match' }, ttl);
+    }
+    return { kind: 'no_match' };
+  }
+
+  // exact.length >= 2 → ambiguous. Do not cache — operators may resolve.
+  return { kind: 'ambiguous', matches: exact };
+}

--- a/libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.types.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.types.ts
@@ -1,0 +1,41 @@
+/**
+ * Resolve Allegro Product Card By EAN — Types
+ *
+ * Public type surface for the smart-link resolver (#431). Kept in a
+ * dedicated `.types.ts` file per Engineering Standards "Type Definitions in
+ * Separate Files".
+ *
+ * @module libs/integrations/allegro/src/infrastructure/util
+ */
+import type { AllegroProductCardSummary } from '../../domain/types/allegro-api.types';
+
+/**
+ * Discriminated outcome of `resolveAllegroProductCardByEan`. The util never
+ * throws for resolver-side failures — HTTP errors collapse into `no_match`
+ * and are logged at the call site. This keeps the offer-create pipeline
+ * unconditionally able to fall through to the inline-product path.
+ *
+ * - `unique`     — exactly one card matched the EAN exactly. Adapter will
+ *                  link via `productSet[0].product.id`.
+ * - `ambiguous`  — multiple cards matched. Adapter falls back to inline.
+ *                  `matches` carries the candidate summaries for ops logs.
+ * - `no_match`   — zero exact matches (or HTTP error). Adapter falls back
+ *                  to inline.
+ */
+export type ResolveProductCardResult =
+  | { kind: 'unique'; productId: string }
+  | { kind: 'ambiguous'; matches: AllegroProductCardSummary[] }
+  | { kind: 'no_match' };
+
+/**
+ * Optional knobs for `resolveAllegroProductCardByEan`. Defaults match the
+ * production wiring in `AllegroAdapterFactory`.
+ */
+export interface ResolveAllegroProductCardOptions {
+  /** Cache TTL in seconds. Default 86 400 (24 h). */
+  cacheTtlSec?: number;
+  /** Cache key prefix. Default `'allegro:product-card'`. Override for tests. */
+  cacheKeyPrefix?: string;
+  /** Allegro `GET /sale/products` page size. Default 10. */
+  searchLimit?: number;
+}


### PR DESCRIPTION
## Summary

Closes #430. Closes #431. Tracked under epic #429.

P0 fix for the 2026-04-28 Allegro sandbox 422 — `INVALID_STATE` on `location.state`, `RESPONSIBLE_PRODUCER_NOT_SPECIFIED`, `SAFETY_INFO_NOT_DEFINED`. Two coordinated changes that share the `productSet[0]` codepath in `applyPlatformParams`:

### #430 — Connection-level seller defaults

`Connection.config.allegro.sellerDefaults` (JSONB, no migration) carries `location`, `responsibleProducerId`, and `safetyInformation`. The Allegro adapter now writes `body.location` on every offer, and writes the GPSR fields on `productSet[0]` for the inline-product path. Missing defaults surface as `OfferCreateRejectedException` with code `SELLER_DEFAULTS_NOT_CONFIGURED` thrown directly by the adapter — no new exception class, no CORE-side mapping (avoids reverse `core → integration` dependency).

### #431 — Smart-link by EAN

New `resolveAllegroProductCardByEan` util calls `GET /sale/products?phrase={ean}&category.id={categoryId}` and returns `unique` / `ambiguous` / `no_match`. On `unique`, the adapter swaps to `productSet = [{ product: { id }, quantity }]` and Allegro inherits GPSR + parameters from the existing product card. On `ambiguous` / `no_match`, falls through to the inline-product path. The resolver runs once at the top of `createOffer` (already async); result is threaded as an optional parameter into `buildCreateOfferRequest` → `applyPlatformParams` so the body builder stays synchronous. Cache `unique` and `no_match` for 24h via `CachePort`; ambiguous is never cached. HTTP failures collapse to `no_match` so the offer-create pipeline always has a fallback.

## Surface area

**CORE** (`libs/core/src/listings/`)
- `domain/ports/capabilities/responsible-producer-reader.capability.ts` (new) — sub-capability + `isResponsibleProducerReader` guard, mirrors `SellerPoliciesReader`
- `domain/types/responsible-producer.types.ts` (new) — neutral `ResponsibleProducerEntry` shape
- `CreateOfferCommand.variantBarcode` — pre-resolved by `OfferBuilderService` so adapters that smart-link don't re-fetch the variant

**Allegro adapter** (`libs/integrations/allegro/`)
- New `allegro-location.types.ts` (PL voivodeship `as const`) + `allegro-seller-defaults.types.ts` (location + GPSR shapes)
- New `resolve-allegro-product-card-by-ean.ts` util + types
- `AllegroOfferManagerAdapter`: location + GPSR writes, smart-link pre-step, `fetchResponsibleProducers()` (`GET /sale/responsible-producers`); skips the `productSet[0].product.images` mirror on the smart-link path so card-linked offers inherit images cleanly
- `AllegroAdapterFactory` reads `connection.config.allegro.sellerDefaults` and forwards to the adapter constructor

**API** (`apps/api/src/integrations/`)
- `AllegroConnectionConfigDto` extended with class-validator: PL voivodeship enum (`@IsIn(PolishVoivodeshipValues)`), postcode regex (`/^\d{2}-\d{3}$/`), discriminated `safetyInformation` (`@ValidateIf` for `content` required when `type === 'SAFETY_INFORMATION'`)
- New `GET /integrations/allegro/connections/:id/responsible-producers` on the existing `AllegroController` (registered in `IntegrationsModule.controllers` already — no new module)

**Frontend** (`apps/web/`)
- `AllegroSellerDefaultsSection` rendered conditionally in `EditConnectionForm` when `platformType === 'allegro'`. Three field groups (location / RP / safety info), TanStack Query for the registry with loading / error / empty Alerts, conditional textarea revealed only when type is `SAFETY_INFORMATION`
- Zod schema extension + `mergeStructuredIntoConfig` re-serializes into `configText` JSON via the existing structured-input pattern
- New CSS in `index.css` — vanilla CSS + design tokens, follows `.claude/rules/ui-components.md` (BEM-flat, 4px grid, `0.625rem` radius)

## Tests

**New BE specs**
- `resolve-allegro-product-card-by-ean.spec.ts` — 6 branches: cache hit (unique + no_match), miss → unique / ambiguous (not cached) / no_match (cached), HTTP failure (not cached), no-cache degraded path
- Adapter spec — 6 new branches: missing-sellerDefaults preflight, `body.location` write, smart-link unique swap, smart-link short-circuits when `variantBarcode` missing, `fetchResponsibleProducers` happy + minimal-fields paths
- API DTO + controller spec extended with the new `INTEGRATIONS_SERVICE_TOKEN` mock

**New FE spec**
- `allegro-seller-defaults-section.test.tsx` — 6 branches: renders three field groups, RP loading / error / empty Alerts, conditional textarea, onChange propagation

## Test plan

- [x] `pnpm lint` (clean, only pre-existing warnings)
- [x] `pnpm type-check` (clean across all packages)
- [x] `pnpm test` (**2074 tests pass** — allegro 207, prestashop 201, core 478, api 267, worker 109, web 766, ai 21, shared 25)
- [x] Pre-commit hook ran the same gate at commit time
- [ ] **Hard merge gate**: re-run the same Allegro sandbox flow that 422'd on 2026-04-28. Configure `sellerDefaults` via the new admin UI on the Allegro connection edit page, then retry offer creation. Two outcomes both confirm the structural fix:
  - **(a)** offer reaches `active`/`validating` because the variant's EAN smart-links to an existing card (most likely on cat 257933, which has many cards) — Allegro inherits GPSR from the card
  - **(b)** offer creates inline with all three originally-missing fields populated — `body.location`, `productSet[0].responsibleProducer.id`, `productSet[0].safetyInformation` all present
  - The only failure is another `INVALID_STATE` / `RESPONSIBLE_PRODUCER_NOT_SPECIFIED` / `SAFETY_INFO_NOT_DEFINED` from Allegro — that means the wiring is broken

## Notes

- **No migration** — `Connection.config` is JSONB.
- **No backfill** for existing Allegro connections without `sellerDefaults`. First offer attempt fails fast with `OfferCreateRejectedException` naming the missing fields.
- **Card-blocked marker** for smart-link parameter-mismatch failures (issue #431 acceptance) is intentionally deferred per plan §3 / §8 — operator sees the 422 once and retries; if real-world hits accumulate we add the marker in a follow-up.
- **Polish voivodeship labels** in the FE are duplicated from the BE `PolishVoivodeshipValues` to avoid an FE → integration value-import. Tracked as a doc-polish concern only.