### PR TITLE
fix(allegro): emit productSet[0] with GPSR on inline path even when productParameters are empty

### DIFF
--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -1175,6 +1175,47 @@ describe('AllegroOfferManagerAdapter', () => {
         expect(body).not.toHaveProperty('product');
       });
 
+      // #439 — discriminator parity: when sellerDefaults uses the
+      // `SAFETY_INFORMATION` branch (free-text content rather than the
+      // "no risks" declaration), the adapter must pass the entire object
+      // through to `productSet[0].safetyInformation` — `type` + `content`.
+      it('passes SAFETY_INFORMATION discriminator with content through to productSet[0].safetyInformation', async () => {
+        httpClient.post.mockResolvedValue(
+          mockHttpResponse({ id: 'allegro-offer-safety-text', publication: { status: 'INACTIVE' } }),
+        );
+
+        const adapterWithSafetyText = new AllegroOfferManagerAdapter(
+          connectionId,
+          httpClient,
+          uploadHttpClient,
+          identifierMapping,
+          connection,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            ...DEFAULT_SELLER_DEFAULTS,
+            safetyInformation: {
+              type: 'SAFETY_INFORMATION',
+              content: 'Keep dry. Not for children under 3.',
+            },
+          },
+        );
+
+        await adapterWithSafetyText.createOffer(baseCmd);
+
+        const body = httpClient.post.mock.calls[0][1] as {
+          productSet?: Array<{
+            safetyInformation?: { type: string; content?: string };
+          }>;
+        };
+        expect(body.productSet?.[0]?.safetyInformation).toEqual({
+          type: 'SAFETY_INFORMATION',
+          content: 'Keep dry. Not for children under 3.',
+        });
+      });
+
       it('drops malformed product-parameter entries through the same shape validator', async () => {
         httpClient.post.mockResolvedValue(
           mockHttpResponse({ id: 'allegro-offer-product-mal', publication: { status: 'INACTIVE' } }),

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -1135,7 +1135,13 @@ describe('AllegroOfferManagerAdapter', () => {
         expect(body).not.toHaveProperty('product');
       });
 
-      it('omits body.productSet entirely when productParameters is missing or empty', async () => {
+      // #439 — emit `productSet[0]` on every non-card-linked offer even when
+      // `productParameters` is missing or empty. Allegro's GPSR enforcement
+      // requires `responsibleProducer` + `safetyInformation` on the inline
+      // entry; omitting `productSet` yielded a sandbox 422 with
+      // `SAFETY_INFO_NOT_DEFINED` at `productSet[0].safetyInformation`.
+      // `product.parameters` stays absent when the operator supplied none.
+      it('emits productSet[0] with GPSR + product.name when productParameters is missing or empty', async () => {
         httpClient.post.mockResolvedValue(
           mockHttpResponse({ id: 'allegro-offer-no-product', publication: { status: 'INACTIVE' } }),
         );
@@ -1151,10 +1157,21 @@ describe('AllegroOfferManagerAdapter', () => {
           },
         });
 
-        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
-        // Allegro 422s on `productSet: []` and `productSet: [{ product: { parameters: [] } }]`
-        // just like the offer-side mismatch — empty array must round-trip to a missing key.
-        expect(body).not.toHaveProperty('productSet');
+        const body = httpClient.post.mock.calls[0][1] as {
+          productSet?: Array<{
+            product?: { id?: string; name?: string; parameters?: unknown };
+            responsibleProducer?: { id: string };
+            safetyInformation?: { type: string };
+          }>;
+        };
+        // Inline path: product.id absent (no smart-link), product.name reuses
+        // the offer title, GPSR fields written from sellerDefaults.
+        expect(body.productSet?.[0]?.product?.id).toBeUndefined();
+        expect(body.productSet?.[0]?.product?.name).toBe('Test Offer Title');
+        expect(body.productSet?.[0]?.product?.parameters).toBeUndefined();
+        expect(body.productSet?.[0]?.responsibleProducer).toEqual({ id: 'rp-test-1' });
+        expect(body.productSet?.[0]?.safetyInformation).toEqual({ type: 'NO_SAFETY_INFORMATION' });
+        // `body.product` is still rejected as an unknown property.
         expect(body).not.toHaveProperty('product');
       });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -1180,19 +1180,23 @@ export class AllegroOfferManagerAdapter
     const filtered = Array.isArray(productParameters)
       ? productParameters.filter(isAllegroOfferParameterShape)
       : [];
+    // `parameters` is attached only when the operator supplied any — Allegro
+    // rejects an explicit empty array on inline products. Spread-with-conditional
+    // keeps the construction declarative and avoids a post-create mutation.
     const inlineProduct: NonNullable<AllegroProductSetEntry['product']> = {
       name: body.name,
+      ...(filtered.length > 0 ? { parameters: filtered } : {}),
     };
-    if (filtered.length > 0) {
-      inlineProduct.parameters = filtered;
-    }
+    // The `sellerDefaults!` non-null assertions below are guaranteed by the
+    // per-field preflight in `createOffer` (`collectMissingSellerDefaultsFields`,
+    // #430 / #437): if `responsibleProducerId` or `safetyInformation` were
+    // missing, the preflight throws `OfferCreateRejectedException` before this
+    // method runs. Do not weaken the preflight without revisiting these sites.
     body.productSet = [
       {
         product: inlineProduct,
         // #430 — GPSR fields required by Allegro on inline-product creation
-        // (Reg. 2023/988, mandatory since 13 Dec 2024). Sourced from the
-        // connection's seller defaults (the per-field preflight in
-        // `createOffer` ensures these exist).
+        // (Reg. 2023/988, mandatory since 13 Dec 2024).
         responsibleProducer: { id: this.sellerDefaults!.responsibleProducerId },
         safetyInformation: this.sellerDefaults!.safetyInformation,
       },

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -56,6 +56,7 @@ import {
   AllegroMatchingCategoriesResponse,
   AllegroProductOfferCreateRequest,
   AllegroProductOfferCreateResponse,
+  AllegroProductSetEntry,
   AllegroValidationError,
   AllegroShippingRatesResponse,
   AllegroReturnPoliciesResponse,
@@ -1158,33 +1159,44 @@ export class AllegroOfferManagerAdapter
     // doing it here would copy the pre-upload operator URL, which Allegro
     // rejects.
     //
-    // Omit `body.productSet` entirely when the array would be empty: sending
-    // `productSet: []` or `productSet: [{ product: { parameters: [] } }]` is
-    // rejected the same way `body.product` was. The empty-rejection
-    // assumption is inherited from #415 and is itself unverified — if the
-    // sandbox repro contradicts it we revisit here.
+    // #439 — `productSet[0]` is emitted on every non-card-linked offer,
+    // even when the operator hasn't supplied any `productParameters`. The
+    // earlier code gated the entire entry on `productParameters.length > 0`
+    // (an unverified assumption inherited from #415). Allegro's GPSR
+    // enforcement (Reg. 2023/988, mandatory since 13 Dec 2024) requires
+    // `responsibleProducer` + `safetyInformation` on `productSet[0]` for
+    // every inline product, so omitting the array yields a 422 with
+    // `SAFETY_INFO_NOT_DEFINED` at `productSet[0].safetyInformation`. The
+    // 2026-04-29 sandbox repro confirmed this: smart-link missed, the
+    // offer carried no `productParameters`, and the create was rejected
+    // because the GPSR fields never reached Allegro.
+    //
+    // #420 — `body.name` arrives already sanitized via sanitizeAllegroName
+    // in buildCreateOfferRequest (which calls this method); no re-sanitization
+    // needed at this site. Keeping a single sanitization point per request
+    // lifecycle avoids "why is this being sanitized — wasn't it already?"
+    // reader confusion.
     const productParameters = platformParams['productParameters'];
-    if (Array.isArray(productParameters)) {
-      const filtered = productParameters.filter(isAllegroOfferParameterShape);
-      if (filtered.length > 0) {
-        // #420 — `body.name` arrives already sanitized via sanitizeAllegroName
-        // in buildCreateOfferRequest (which calls this method); no
-        // re-sanitization needed at this site. Keeping a single sanitization
-        // point per request lifecycle avoids "why is this being sanitized
-        // — wasn't it already?" reader confusion.
-        body.productSet = [
-          {
-            product: { name: body.name, parameters: filtered },
-            // #430 — GPSR fields required by Allegro on inline-product
-            // creation (Reg. 2023/988, mandatory since 13 Dec 2024).
-            // Sourced from the connection's seller defaults (preflight
-            // guard in `createOffer` ensures these exist).
-            responsibleProducer: { id: this.sellerDefaults!.responsibleProducerId },
-            safetyInformation: this.sellerDefaults!.safetyInformation,
-          },
-        ];
-      }
+    const filtered = Array.isArray(productParameters)
+      ? productParameters.filter(isAllegroOfferParameterShape)
+      : [];
+    const inlineProduct: NonNullable<AllegroProductSetEntry['product']> = {
+      name: body.name,
+    };
+    if (filtered.length > 0) {
+      inlineProduct.parameters = filtered;
     }
+    body.productSet = [
+      {
+        product: inlineProduct,
+        // #430 — GPSR fields required by Allegro on inline-product creation
+        // (Reg. 2023/988, mandatory since 13 Dec 2024). Sourced from the
+        // connection's seller defaults (the per-field preflight in
+        // `createOffer` ensures these exist).
+        responsibleProducer: { id: this.sellerDefaults!.responsibleProducerId },
+        safetyInformation: this.sellerDefaults!.safetyInformation,
+      },
+    ];
   }
 
   private resolveCreateOfferStatus(


### PR DESCRIPTION
## Summary

Sandbox repro on 2026-04-29 (post-#438) hit Allegro 422 `SAFETY_INFO_NOT_DEFINED` at `productSet[0].safetyInformation` whenever smart-link missed AND the offer carried no `productParameters`. The seller-defaults preflight from #437 passed — operators had `safetyInformation` configured — but `AllegroOfferManagerAdapter.applyPlatformParams()` was gating the entire `body.productSet = [...]` write on `productParameters.length > 0`. With zero product-section parameters, the array was omitted entirely, taking the GPSR fields (`responsibleProducer`, `safetyInformation`) with it.

Allegro's GPSR enforcement (Reg. 2023/988, mandatory since 2024-12-13) requires both fields on `productSet[0]` for every inline-product offer, regardless of category parameters. The "omit when empty" assumption was inherited from #415 and explicitly flagged as unverified — the 2026-04-29 sandbox repro contradicted it.

## Fix

On the inline path (`cardLinkResult.kind !== 'unique'`), always emit `productSet[0]` carrying:
- `product.name` (always — Allegro requires it for inline products)
- `product.parameters` (only when the wizard supplied any)
- `product.images` (still attached later in `createOffer` post-upload, unchanged)
- `responsibleProducer` + `safetyInformation` (always — GPSR)

The card-linked branch (`cardLinkResult.kind === 'unique'`) is unchanged: Allegro inherits GPSR from the matched card.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1318 backend tests pass; 766 frontend tests pass (2084 total)
- [x] Replaced the previous "omits productSet entirely" branch with a new "emits productSet[0] with GPSR + product.name when productParameters is missing or empty" branch — asserts `product.id` absent, `product.name` = offer title, `product.parameters` absent, `responsibleProducer` + `safetyInformation` present, no top-level `body.product` key
- [x] Existing inline-with-productParameters branch unchanged and still passes
- [x] Existing smart-link-unique branch unchanged and still passes (no GPSR on card-linked entries)
- [ ] **Manual sandbox repro** (post-merge operator task): re-run the failing offer-create flow on the same connection + variant + category to confirm the 422 no longer surfaces

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)