### PR TITLE
chore(allegro): log outbound createOffer body for sandbox diagnosis

### DIFF
--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -859,6 +859,14 @@ export class AllegroOfferManagerAdapter
     this.logger.debug(
       `Creating Allegro offer: connection=${this.connectionId} externalRef=${body.external?.id ?? 'n/a'} publishImmediately=${cmd.publishImmediately}`,
     );
+    // #441 — diagnostic: dump the literal POST body so a sandbox 422 (e.g.
+    // `SAFETY_INFO_NOT_DEFINED` post-#440) can be diagnosed against ground
+    // truth rather than against unit-test expectations. Will be removed or
+    // demoted once the issue is closed; passes through `formatBodyForLog` so
+    // operator-controlled long strings can't blow up logs.
+    this.logger.log(
+      `Allegro offer-create POST body: connection=${this.connectionId} body=${formatBodyForLog(JSON.stringify(body))}`,
+    );
 
     let response: AllegroProductOfferCreateResponse;
     try {


### PR DESCRIPTION
## Summary

**Diagnostic-only PR.** Adds a single LOG-level dump of the literal JSON body sent to `POST /sale/product-offers`, routed through `formatBodyForLog` so operator-controlled long strings can't blow up logs.

## Why

After #438 (#436+#437) and #440 (#439) shipped, the 2026-04-29 sandbox kept returning Allegro 422 `SAFETY_INFO_NOT_DEFINED` at `productSet[0].safetyInformation` for the same camera offer (variant `ol_variant_0c6eeb1b522144339b0882a225597859`, category `257933`, EAN `4549292246117`). Our unit tests assert that `safetyInformation` is on the outbound `body` — Allegro disagrees. Two possibilities:

1. The body shape we test diverges from the body that's actually serialized at runtime
2. Allegro expects `safetyInformation` at a different nesting level than our `AllegroProductSetEntry` type encodes — most likely under `productSet[0].product.safetyInformation` rather than `productSet[0].safetyInformation`

The sandbox-side diagnostic loop has been "merge → re-test → still 422" three times running, because we've been guessing instead of looking at the actual JSON. This PR closes that gap.

## What

Single `this.logger.log(...)` line in `AllegroOfferManagerAdapter.createOffer` immediately before the `httpClient.post` call. No behavioral change.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 2085 tests pass (no regressions)
- [ ] **Sandbox re-run** (post-merge): trigger the same offer-create flow, paste the new log line so we can see the literal JSON `body` Allegro received

Once the underlying issue is closed, this log will be removed or demoted to debug-level.

Refs #439 (sandbox repro persisted post-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)