### PR TITLE
fix(allegro): nest GPSR fields under productSet[0].product

### DIFF
--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -224,12 +224,32 @@ export interface AllegroProductSetEntry {
      * Allegro inherits `name`, `parameters`, `images`, and GPSR data from
      * the card. The inline-product path leaves `id` undefined and supplies
      * those fields explicitly alongside `responsibleProducer` /
-     * `safetyInformation` on the entry.
+     * `safetyInformation` on the same `product` object.
      */
     id?: string;
     name?: string;
     parameters?: AllegroOfferParameter[];
     images?: string[];
+    /**
+     * EU GPSR (Reg. 2023/988) responsible-producer reference. Required by
+     * Allegro on inline products (no `product.id`); smart-linked entries
+     * inherit it from the card and may omit it. Sits **inside** `product`
+     * because Allegro's schema scopes GPSR to the product itself — #442
+     * confirmed via sandbox repro that the entry-level placement #430
+     * originally chose is silently rejected with `SAFETY_INFO_NOT_DEFINED`.
+     */
+    responsibleProducer?: { id: string };
+    /**
+     * EU GPSR safety information. Same applicability and placement as
+     * `responsibleProducer`: required on the inline path, inherited on the
+     * smart-link path, scoped to the product not the entry. The
+     * `NO_SAFETY_INFORMATION` branch is Allegro's "this category does not
+     * carry safety risks" declaration; `SAFETY_INFORMATION` carries
+     * free-text content. See #442.
+     */
+    safetyInformation?:
+      | { type: 'NO_SAFETY_INFORMATION' }
+      | { type: 'SAFETY_INFORMATION'; content: string };
   };
   /**
    * Per-entry quantity, used on the smart-link path (#431) where stock is
@@ -237,23 +257,6 @@ export interface AllegroProductSetEntry {
    * inline-product path leaves this undefined and uses `body.stock`.
    */
   quantity?: number;
-  /**
-   * EU GPSR (Reg. 2023/988) responsible-producer reference. Required by
-   * Allegro on every `productSet[]` entry when the entry creates an inline
-   * product (no `product.id`). Smart-linked entries inherit this from the
-   * referenced card and may omit it. See #430.
-   */
-  responsibleProducer?: { id: string };
-  /**
-   * EU GPSR safety information. Same applicability as `responsibleProducer`:
-   * required on the inline path, inherited on the smart-link path. The
-   * `NO_SAFETY_INFORMATION` branch is Allegro's "this category does not
-   * carry safety risks" declaration; `SAFETY_INFORMATION` carries free-text
-   * content. See #430.
-   */
-  safetyInformation?:
-    | { type: 'NO_SAFETY_INFORMATION' }
-    | { type: 'SAFETY_INFORMATION'; content: string };
 }
 
 /**

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -1121,10 +1121,14 @@ describe('AllegroOfferManagerAdapter', () => {
                 { id: '237206', values: ['PowerShot SX740'] },
               ],
               images: expectedCdnImages,
+              // #442 — GPSR fields nest INSIDE `product`, not at entry level.
+              // Allegro's POST schema scopes responsibleProducer +
+              // safetyInformation to the product itself; entry-level
+              // placement (the original #430 shape) is silently rejected
+              // with `SAFETY_INFO_NOT_DEFINED`.
+              responsibleProducer: { id: 'rp-test-1' },
+              safetyInformation: { type: 'NO_SAFETY_INFORMATION' },
             },
-            // #430 — GPSR fields written from sellerDefaults on inline path.
-            responsibleProducer: { id: 'rp-test-1' },
-            safetyInformation: { type: 'NO_SAFETY_INFORMATION' },
           },
         ]);
         // Mirroring contract: product.images is the post-upload offer-level
@@ -1135,13 +1139,14 @@ describe('AllegroOfferManagerAdapter', () => {
         expect(body).not.toHaveProperty('product');
       });
 
-      // #439 — emit `productSet[0]` on every non-card-linked offer even when
-      // `productParameters` is missing or empty. Allegro's GPSR enforcement
-      // requires `responsibleProducer` + `safetyInformation` on the inline
-      // entry; omitting `productSet` yielded a sandbox 422 with
-      // `SAFETY_INFO_NOT_DEFINED` at `productSet[0].safetyInformation`.
-      // `product.parameters` stays absent when the operator supplied none.
-      it('emits productSet[0] with GPSR + product.name when productParameters is missing or empty', async () => {
+      // #439 / #442 — emit `productSet[0].product` on every non-card-linked
+      // offer even when `productParameters` is missing or empty, and nest
+      // GPSR fields inside `product` (#442 — the entry-level placement #430
+      // originally chose is silently rejected by Allegro). Omitting any of
+      // these yielded a sandbox 422 with `SAFETY_INFO_NOT_DEFINED` at
+      // `productSet[0].safetyInformation`. `product.parameters` stays absent
+      // when the operator supplied none.
+      it('emits productSet[0].product with GPSR + name when productParameters is missing or empty', async () => {
         httpClient.post.mockResolvedValue(
           mockHttpResponse({ id: 'allegro-offer-no-product', publication: { status: 'INACTIVE' } }),
         );
@@ -1159,27 +1164,34 @@ describe('AllegroOfferManagerAdapter', () => {
 
         const body = httpClient.post.mock.calls[0][1] as {
           productSet?: Array<{
-            product?: { id?: string; name?: string; parameters?: unknown };
-            responsibleProducer?: { id: string };
-            safetyInformation?: { type: string };
+            product?: {
+              id?: string;
+              name?: string;
+              parameters?: unknown;
+              responsibleProducer?: { id: string };
+              safetyInformation?: { type: string };
+            };
           }>;
         };
         // Inline path: product.id absent (no smart-link), product.name reuses
-        // the offer title, GPSR fields written from sellerDefaults.
+        // the offer title, GPSR fields nested inside product (#442).
         expect(body.productSet?.[0]?.product?.id).toBeUndefined();
         expect(body.productSet?.[0]?.product?.name).toBe('Test Offer Title');
         expect(body.productSet?.[0]?.product?.parameters).toBeUndefined();
-        expect(body.productSet?.[0]?.responsibleProducer).toEqual({ id: 'rp-test-1' });
-        expect(body.productSet?.[0]?.safetyInformation).toEqual({ type: 'NO_SAFETY_INFORMATION' });
+        expect(body.productSet?.[0]?.product?.responsibleProducer).toEqual({ id: 'rp-test-1' });
+        expect(body.productSet?.[0]?.product?.safetyInformation).toEqual({
+          type: 'NO_SAFETY_INFORMATION',
+        });
         // `body.product` is still rejected as an unknown property.
         expect(body).not.toHaveProperty('product');
       });
 
-      // #439 — discriminator parity: when sellerDefaults uses the
+      // #439 / #442 — discriminator parity: when sellerDefaults uses the
       // `SAFETY_INFORMATION` branch (free-text content rather than the
       // "no risks" declaration), the adapter must pass the entire object
-      // through to `productSet[0].safetyInformation` — `type` + `content`.
-      it('passes SAFETY_INFORMATION discriminator with content through to productSet[0].safetyInformation', async () => {
+      // through to `productSet[0].product.safetyInformation` — `type` +
+      // `content`, nested inside `product`.
+      it('passes SAFETY_INFORMATION discriminator with content through to product.safetyInformation', async () => {
         httpClient.post.mockResolvedValue(
           mockHttpResponse({ id: 'allegro-offer-safety-text', publication: { status: 'INACTIVE' } }),
         );
@@ -1207,10 +1219,10 @@ describe('AllegroOfferManagerAdapter', () => {
 
         const body = httpClient.post.mock.calls[0][1] as {
           productSet?: Array<{
-            safetyInformation?: { type: string; content?: string };
+            product?: { safetyInformation?: { type: string; content?: string } };
           }>;
         };
-        expect(body.productSet?.[0]?.safetyInformation).toEqual({
+        expect(body.productSet?.[0]?.product?.safetyInformation).toEqual({
           type: 'SAFETY_INFORMATION',
           content: 'Keep dry. Not for children under 3.',
         });
@@ -1251,10 +1263,10 @@ describe('AllegroOfferManagerAdapter', () => {
               name: 'Test Offer Title',
               parameters: [{ id: '248811', valuesIds: ['248811_canon'] }],
               images: ['https://images.allegrostatic.com/test/uploaded-1.jpg'],
+              // #442 — GPSR fields nested inside `product`, not at entry level.
+              responsibleProducer: { id: 'rp-test-1' },
+              safetyInformation: { type: 'NO_SAFETY_INFORMATION' },
             },
-            // #430 — GPSR fields on inline-product path.
-            responsibleProducer: { id: 'rp-test-1' },
-            safetyInformation: { type: 'NO_SAFETY_INFORMATION' },
           },
         ]);
       });
@@ -1685,10 +1697,18 @@ describe('AllegroOfferManagerAdapter', () => {
           },
         ]);
         // Card-linked offers inherit GPSR from the card — adapter must NOT
-        // write `responsibleProducer` / `safetyInformation` on the entry.
-        expect(body.productSet).not.toContainEqual(
-          expect.objectContaining({ responsibleProducer: expect.anything() }),
-        );
+        // write `responsibleProducer` / `safetyInformation` anywhere on the
+        // entry (#442 scopes them under product, but on the card-linked
+        // path even product is just `{ id }`).
+        const productSet = body.productSet as Array<{
+          product?: { responsibleProducer?: unknown; safetyInformation?: unknown };
+          responsibleProducer?: unknown;
+          safetyInformation?: unknown;
+        }>;
+        expect(productSet[0].product?.responsibleProducer).toBeUndefined();
+        expect(productSet[0].product?.safetyInformation).toBeUndefined();
+        expect(productSet[0].responsibleProducer).toBeUndefined();
+        expect(productSet[0].safetyInformation).toBeUndefined();
       });
 
       it('falls through to inline path when variantBarcode is missing (smart-link short-circuits)', async () => {
@@ -1717,14 +1737,17 @@ describe('AllegroOfferManagerAdapter', () => {
         );
         const body = httpClient.post.mock.calls[0][1] as {
           productSet?: Array<{
-            product?: { id?: string; name?: string };
-            responsibleProducer?: unknown;
+            product?: {
+              id?: string;
+              name?: string;
+              responsibleProducer?: { id: string };
+            };
           }>;
         };
-        // Inline path: product.id absent, GPSR fields written from sellerDefaults.
+        // Inline path: product.id absent, GPSR fields written under product (#442).
         expect(body.productSet?.[0]?.product?.id).toBeUndefined();
         expect(body.productSet?.[0]?.product?.name).toBe('Test Offer Title');
-        expect(body.productSet?.[0]?.responsibleProducer).toEqual({ id: 'rp-test-1' });
+        expect(body.productSet?.[0]?.product?.responsibleProducer).toEqual({ id: 'rp-test-1' });
       });
     });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -859,14 +859,6 @@ export class AllegroOfferManagerAdapter
     this.logger.debug(
       `Creating Allegro offer: connection=${this.connectionId} externalRef=${body.external?.id ?? 'n/a'} publishImmediately=${cmd.publishImmediately}`,
     );
-    // #441 — diagnostic: dump the literal POST body so a sandbox 422 (e.g.
-    // `SAFETY_INFO_NOT_DEFINED` post-#440) can be diagnosed against ground
-    // truth rather than against unit-test expectations. Will be removed or
-    // demoted once the issue is closed; passes through `formatBodyForLog` so
-    // operator-controlled long strings can't blow up logs.
-    this.logger.log(
-      `Allegro offer-create POST body: connection=${this.connectionId} body=${formatBodyForLog(JSON.stringify(body))}`,
-    );
 
     let response: AllegroProductOfferCreateResponse;
     try {
@@ -1191,24 +1183,23 @@ export class AllegroOfferManagerAdapter
     // `parameters` is attached only when the operator supplied any — Allegro
     // rejects an explicit empty array on inline products. Spread-with-conditional
     // keeps the construction declarative and avoids a post-create mutation.
+    //
+    // #442 — `responsibleProducer` and `safetyInformation` live INSIDE
+    // `product`, not at the entry level. #430's original placement at the
+    // entry level looked plausible against the GET response shape but
+    // Allegro's POST schema scopes GPSR to the product itself; the body-log
+    // diagnostic from #441 confirmed Allegro 422s `SAFETY_INFO_NOT_DEFINED`
+    // when these fields sit outside `product`. The `sellerDefaults!`
+    // non-null assertions are guaranteed by the per-field preflight in
+    // `createOffer` (`collectMissingSellerDefaultsFields`, #430 / #437) —
+    // do not weaken the preflight without revisiting these sites.
     const inlineProduct: NonNullable<AllegroProductSetEntry['product']> = {
       name: body.name,
       ...(filtered.length > 0 ? { parameters: filtered } : {}),
+      responsibleProducer: { id: this.sellerDefaults!.responsibleProducerId },
+      safetyInformation: this.sellerDefaults!.safetyInformation,
     };
-    // The `sellerDefaults!` non-null assertions below are guaranteed by the
-    // per-field preflight in `createOffer` (`collectMissingSellerDefaultsFields`,
-    // #430 / #437): if `responsibleProducerId` or `safetyInformation` were
-    // missing, the preflight throws `OfferCreateRejectedException` before this
-    // method runs. Do not weaken the preflight without revisiting these sites.
-    body.productSet = [
-      {
-        product: inlineProduct,
-        // #430 — GPSR fields required by Allegro on inline-product creation
-        // (Reg. 2023/988, mandatory since 13 Dec 2024).
-        responsibleProducer: { id: this.sellerDefaults!.responsibleProducerId },
-        safetyInformation: this.sellerDefaults!.safetyInformation,
-      },
-    ];
+    body.productSet = [{ product: inlineProduct }];
   }
 
   private resolveCreateOfferStatus(


### PR DESCRIPTION
## Summary

Root cause of the four-PR sandbox loop on `SAFETY_INFO_NOT_DEFINED`. Allegro's POST schema for `/sale/product-offers` scopes EU GPSR fields (`responsibleProducer`, `safetyInformation`) to the **product object**, not to the `productSet[]` entry. #430 originally placed them at the entry level; #439 propagated that placement; both shipped without ever observing the live request body. #441 added a body-log diagnostic that made ground truth visible — the field was being written exactly where our type said, and Allegro silently rejected it because the schema doesn't recognise it there.

The Polish `userMessage` was the dead giveaway: *"Informacja o bezpieczeństwie nie została zdefiniowana **dla produktu**"* ("for the product"). Every other inline-product field already lives under `productSet[0].product` — `name`, `parameters`, `images` — so GPSR belongs there too.

## What changed

- **`AllegroProductSetEntry`** (`libs/integrations/allegro/src/domain/types/allegro-api.types.ts`): `responsibleProducer` + `safetyInformation` moved from the entry level into the nested `product` object. Smart-link entries (`product: { id }` + `quantity`) are unaffected — Allegro inherits GPSR from the linked card.
- **`AllegroOfferManagerAdapter.applyPlatformParams`**: GPSR fields now emit inside `inlineProduct`, alongside `name` / `parameters`.
- **Adapter spec**: every assertion `body.productSet?.[0]?.responsibleProducer|safetyInformation` rewritten to `body.productSet?.[0]?.product?.responsibleProducer|safetyInformation`. The smart-link branch additionally asserts neither placement carries GPSR.
- **Diagnostic log from #441 removed** — its job is done.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1318 backend + 766 frontend = 2084 tests pass
- [ ] **Sandbox re-run** (post-merge, with worker rebuilt): trigger the same offer-create flow on connection `eecbdcd2-862a-4f77-acb7-f764592ed3d5` / variant `ol_variant_0c6eeb1b522144339b0882a225597859` / category `257933`. Allegro should accept the create now, returning a 201 with an offer id rather than 422 `SAFETY_INFO_NOT_DEFINED`.

## Related

- #430 — introduced entry-level placement (the actual bug)
- #436 / #437 — Accept-Language + DTO bypass fixes (real bugs, but unrelated to GPSR placement)
- #439 — propagated entry-level placement to the empty-`productParameters` branch (didn't address the underlying placement bug)
- #441 — diagnostic body-log that surfaced ground truth

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)