### PR TITLE
fix(allegro): correct safetyInformation discriminator from SAFETY_INFORMATION/content to TEXT/description

### DIFF
--- a/apps/api/src/integrations/application/dto/allegro-connection-config.dto.ts
+++ b/apps/api/src/integrations/application/dto/allegro-connection-config.dto.ts
@@ -12,6 +12,9 @@
  * @module apps/api/src/integrations/application/dto
  */
 import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
   IsEnum,
   IsIn,
   IsNotEmpty,
@@ -72,8 +75,31 @@ export class AllegroSellerLocationDto {
 }
 
 /**
- * EU GPSR safety-information payload. Discriminated by `type` — when
- * `SAFETY_INFORMATION`, `content` is required free text.
+ * Single attachment reference for the `ATTACHMENTS` safety-info variant.
+ * `id` is the upload-reference returned by Allegro's attachment-upload
+ * endpoint (out of scope for #445; the upload UI / adapter call will be
+ * a follow-up).
+ */
+export class AllegroSafetyAttachmentDto {
+  @ApiProperty({
+    description: 'Allegro attachment id (UUID returned by attachment upload)',
+  })
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+}
+
+/**
+ * EU GPSR safety-information payload. Discriminated by `type` — three
+ * variants:
+ * - `NO_SAFETY_INFORMATION` — no extra fields
+ * - `TEXT` — `description` required (1–5000 chars per Allegro)
+ * - `ATTACHMENTS` — `attachments` required (1–20 entries per Allegro)
+ *
+ * Shape verified against Allegro Developer Portal (#445); see
+ * `AllegroSafetyInformation` in
+ * `libs/integrations/allegro/src/domain/types/allegro-seller-defaults.types.ts`
+ * for the canonical type and source links.
  */
 export class AllegroSafetyInformationDto {
   @ApiProperty({
@@ -85,19 +111,38 @@ export class AllegroSafetyInformationDto {
 
   @ApiPropertyOptional({
     description:
-      'Free-text safety information content. Required when `type === SAFETY_INFORMATION`.',
-    maxLength: 2000,
+      'Free-text safety information. Required when `type === TEXT`. ' +
+      'Allegro accepts 1–5000 characters; no HTML, newlines allowed.',
+    minLength: 1,
+    maxLength: 5000,
   })
-  // Conditional require: when `type === SAFETY_INFORMATION`, `content` must
-  // be a non-empty string. Otherwise the field is ignored entirely (every
-  // subsequent validator is skipped by `@ValidateIf`).
-  @ValidateIf((o: AllegroSafetyInformationDto) => o.type === 'SAFETY_INFORMATION')
+  // Conditional require: only enforced when `type === 'TEXT'`. Every
+  // subsequent validator is skipped on the other discriminator branches.
+  @ValidateIf((o: AllegroSafetyInformationDto) => o.type === 'TEXT')
   @IsString()
   @IsNotEmpty({
-    message: 'safetyInformation.content is required when type is SAFETY_INFORMATION',
+    message: 'safetyInformation.description is required when type is TEXT',
   })
-  @MaxLength(2000)
-  content?: string;
+  @MaxLength(5000)
+  description?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Attachment references for the `ATTACHMENTS` safety-info variant. ' +
+      'Required when `type === ATTACHMENTS`. Allegro accepts 1–20 attachments per product.',
+    type: () => [AllegroSafetyAttachmentDto],
+  })
+  @ValidateIf((o: AllegroSafetyInformationDto) => o.type === 'ATTACHMENTS')
+  @IsArray()
+  @ArrayMinSize(1, {
+    message: 'safetyInformation.attachments must contain at least 1 attachment when type is ATTACHMENTS',
+  })
+  @ArrayMaxSize(20, {
+    message: 'safetyInformation.attachments cannot contain more than 20 attachments',
+  })
+  @ValidateNested({ each: true })
+  @Type(() => AllegroSafetyAttachmentDto)
+  attachments?: AllegroSafetyAttachmentDto[];
 }
 
 export class AllegroSellerDefaultsDto {

--- a/apps/api/src/integrations/application/services/connection.service.spec.ts
+++ b/apps/api/src/integrations/application/services/connection.service.spec.ts
@@ -419,18 +419,64 @@ describe('ConnectionService', () => {
         expect(connectionPort.update).not.toHaveBeenCalled();
       });
 
-      it('should reject SAFETY_INFORMATION without content', async () => {
+      it('should reject TEXT without description (#445)', async () => {
         const partial = {
           ...validAllegroConfig,
           sellerDefaults: {
             ...validAllegroConfig.sellerDefaults,
-            safetyInformation: { type: 'SAFETY_INFORMATION' },
+            safetyInformation: { type: 'TEXT' },
           },
         };
         await expect(
           service.update('allegro-conn-1', { config: partial }),
         ).rejects.toThrow(BadRequestException);
         expect(connectionPort.update).not.toHaveBeenCalled();
+      });
+
+      it('should reject ATTACHMENTS without attachments array (#445)', async () => {
+        const partial = {
+          ...validAllegroConfig,
+          sellerDefaults: {
+            ...validAllegroConfig.sellerDefaults,
+            safetyInformation: { type: 'ATTACHMENTS' },
+          },
+        };
+        await expect(
+          service.update('allegro-conn-1', { config: partial }),
+        ).rejects.toThrow(BadRequestException);
+        expect(connectionPort.update).not.toHaveBeenCalled();
+      });
+
+      it('should reject ATTACHMENTS exceeding 20 entries (#445)', async () => {
+        const tooMany = Array.from({ length: 21 }, (_, i) => ({ id: `att-${i}` }));
+        const partial = {
+          ...validAllegroConfig,
+          sellerDefaults: {
+            ...validAllegroConfig.sellerDefaults,
+            safetyInformation: { type: 'ATTACHMENTS', attachments: tooMany },
+          },
+        };
+        await expect(
+          service.update('allegro-conn-1', { config: partial }),
+        ).rejects.toThrow(BadRequestException);
+        expect(connectionPort.update).not.toHaveBeenCalled();
+      });
+
+      it('should accept TEXT with valid description (#445)', async () => {
+        const partial = {
+          ...validAllegroConfig,
+          sellerDefaults: {
+            ...validAllegroConfig.sellerDefaults,
+            safetyInformation: {
+              type: 'TEXT',
+              description: 'Aparat z akumulatorem litowo-jonowym. Spelnia normy CE/RoHS.',
+            },
+          },
+        };
+        await expect(
+          service.update('allegro-conn-1', { config: partial }),
+        ).resolves.toEqual(allegroConnection);
+        expect(connectionPort.update).toHaveBeenCalled();
       });
 
       it('should skip Allegro validation for non-Allegro connections', async () => {

--- a/apps/api/src/migrations/1791000000000-rewrite-allegro-safety-information-shape.ts
+++ b/apps/api/src/migrations/1791000000000-rewrite-allegro-safety-information-shape.ts
@@ -1,0 +1,66 @@
+/**
+ * Rewrite Allegro Safety Information Shape (#445)
+ *
+ * Pre-#445 versions of the Allegro adapter persisted
+ * `Connection.config.sellerDefaults.safetyInformation` as:
+ *   { type: 'SAFETY_INFORMATION', content: string }
+ *
+ * Allegro's actual API (per developer.allegro.pl, GPSR) uses a different
+ * discriminator and field name:
+ *   { type: 'TEXT', description: string }
+ *
+ * The `SAFETY_INFORMATION` discriminator is unrecognized — Allegro silently
+ * drops the malformed object on POST /sale/product-offers and reports the
+ * field as missing via a misleading `SAFETY_INFO_NOT_DEFINED` error.
+ *
+ * This migration rewrites every legacy-shape row in-place. It is idempotent
+ * — only matches rows where `type === 'SAFETY_INFORMATION'` survives, so
+ * re-running has no effect. `NO_SAFETY_INFORMATION`, `TEXT`, and
+ * `ATTACHMENTS` rows are left untouched.
+ *
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RewriteAllegroSafetyInformationShape1791000000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE connections
+      SET config = jsonb_set(
+        config,
+        '{sellerDefaults,safetyInformation}',
+        jsonb_build_object(
+          'type', 'TEXT',
+          'description', config->'sellerDefaults'->'safetyInformation'->>'content'
+        )
+      )
+      WHERE "platformType" = 'allegro'
+        AND config->'sellerDefaults'->'safetyInformation'->>'type' = 'SAFETY_INFORMATION'
+        AND (config->'sellerDefaults'->'safetyInformation'->>'content') IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Best-effort reversal: rewrite any TEXT-shape rows we just promoted back
+    // to the legacy SAFETY_INFORMATION shape. Cannot distinguish rows that
+    // were originally TEXT from rows promoted by `up()` — but rolling back
+    // through this migration also rolls back the code that recognized TEXT,
+    // so the legacy shape is what the older adapter expected.
+    await queryRunner.query(`
+      UPDATE connections
+      SET config = jsonb_set(
+        config,
+        '{sellerDefaults,safetyInformation}',
+        jsonb_build_object(
+          'type', 'SAFETY_INFORMATION',
+          'content', config->'sellerDefaults'->'safetyInformation'->>'description'
+        )
+      )
+      WHERE "platformType" = 'allegro'
+        AND config->'sellerDefaults'->'safetyInformation'->>'type' = 'TEXT'
+        AND (config->'sellerDefaults'->'safetyInformation'->>'description') IS NOT NULL
+    `);
+  }
+}

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -57,8 +57,27 @@ function readSellerDefaults(
     typeof raw.safetyInformation === 'object' && raw.safetyInformation !== null
       ? (raw.safetyInformation as Record<string, unknown>)
       : {};
-  const safetyType: 'NO_SAFETY_INFORMATION' | 'SAFETY_INFORMATION' =
-    safety.type === 'SAFETY_INFORMATION' ? 'SAFETY_INFORMATION' : 'NO_SAFETY_INFORMATION';
+  // #445 — discriminator now matches Allegro's actual API: `TEXT` (with
+  // `description`) and `ATTACHMENTS` replace the legacy `SAFETY_INFORMATION`
+  // shape. Pre-#445 persisted configs may still carry `{ type: 'SAFETY_INFORMATION',
+  // content }` if the data migration hasn't run yet on this environment;
+  // when seen, we surface them as `TEXT` + `description` so the operator
+  // can re-save them in the correct shape.
+  const legacySafetyContent =
+    safety.type === 'SAFETY_INFORMATION' && typeof safety.content === 'string'
+      ? safety.content
+      : '';
+  // Edge case: a legacy `SAFETY_INFORMATION` row with empty `content` falls
+  // through to `NO_SAFETY_INFORMATION` because empty content cannot be a
+  // valid `TEXT` value either — the operator would have to re-enter the
+  // text anyway. The dedicated migration (#445) rewrites
+  // `SAFETY_INFORMATION` → `TEXT` for non-empty content rows in production.
+  const safetyType: 'NO_SAFETY_INFORMATION' | 'TEXT' | 'ATTACHMENTS' =
+    safety.type === 'TEXT' || (safety.type === 'SAFETY_INFORMATION' && legacySafetyContent.length > 0)
+      ? 'TEXT'
+      : safety.type === 'ATTACHMENTS'
+        ? 'ATTACHMENTS'
+        : 'NO_SAFETY_INFORMATION';
   // Narrow `province` to the FE Zod union; out-of-band values fall through
   // as '' so the operator picks again. Mirrors `safetyInformation.type`'s
   // guard above.
@@ -79,7 +98,13 @@ function readSellerDefaults(
       typeof raw.responsibleProducerId === 'string' ? raw.responsibleProducerId : '',
     safetyInformation: {
       type: safetyType,
-      content: typeof safety.content === 'string' ? safety.content : '',
+      description:
+        typeof safety.description === 'string'
+          ? safety.description
+          : legacySafetyContent,
+      attachments: Array.isArray(safety.attachments)
+        ? (safety.attachments as Array<{ id: string }>)
+        : undefined,
     },
   };
 }

--- a/apps/web/src/features/connections/components/allegro-seller-defaults-section.test.tsx
+++ b/apps/web/src/features/connections/components/allegro-seller-defaults-section.test.tsx
@@ -6,7 +6,7 @@
  * - loading: RP query in flight → Select disabled with loading copy
  * - error: RP query fails → error Alert with retry
  * - empty: RP query returns [] → info Alert prompting Allegro panel
- * - conditional textarea: visible only when type === SAFETY_INFORMATION
+ * - conditional textarea: visible only when type === TEXT (#445)
  *
  * @module apps/web/src/features/connections/components
  */
@@ -20,7 +20,7 @@ import type { EditConnectionFormValues } from './edit-connection.schema';
 
 interface HarnessProps {
   apiClient?: ReturnType<typeof createMockApiClient>;
-  initialSafetyType?: 'NO_SAFETY_INFORMATION' | 'SAFETY_INFORMATION';
+  initialSafetyType?: 'NO_SAFETY_INFORMATION' | 'TEXT' | 'ATTACHMENTS';
   onChange?: () => void;
 }
 
@@ -35,7 +35,7 @@ function Harness({ initialSafetyType, onChange }: HarnessProps): ReactElement {
         responsibleProducerId: '',
         safetyInformation: {
           type: initialSafetyType ?? 'NO_SAFETY_INFORMATION',
-          content: '',
+          description: '',
         },
       },
     },
@@ -115,22 +115,22 @@ describe('AllegroSellerDefaultsSection', () => {
     expect(screen.getByText(/Allegro seller panel/i)).toBeInTheDocument();
   });
 
-  it('hides the safety-information content textarea when type is NO_SAFETY_INFORMATION', () => {
+  it('hides the safety-information description textarea when type is NO_SAFETY_INFORMATION', () => {
     renderWithProviders(<Harness initialSafetyType="NO_SAFETY_INFORMATION" />);
 
-    expect(screen.queryByLabelText(/safety information content/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/safety information description/i)).not.toBeInTheDocument();
   });
 
-  it('reveals the content textarea when the operator picks SAFETY_INFORMATION', async () => {
+  it('reveals the description textarea when the operator picks TEXT (#445)', async () => {
     renderWithProviders(<Harness initialSafetyType="NO_SAFETY_INFORMATION" />);
 
-    expect(screen.queryByLabelText(/safety information content/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/safety information description/i)).not.toBeInTheDocument();
 
     const typeSelect = screen.getByLabelText(/^Type$/);
-    fireEvent.change(typeSelect, { target: { value: 'SAFETY_INFORMATION' } });
+    fireEvent.change(typeSelect, { target: { value: 'TEXT' } });
 
     expect(
-      await screen.findByLabelText(/safety information content/i),
+      await screen.findByLabelText(/safety information description/i),
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
+++ b/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
@@ -227,7 +227,12 @@ export function AllegroSellerDefaultsSection({
         <h4 className="seller-defaults__group-title">Safety information</h4>
         <p className="seller-defaults__group-description">
           Pick <strong>None applies</strong> for products without GPSR safety
-          obligations, or provide free-text safety details.
+          obligations, or provide free-text safety details. Some categories
+          (cameras, electronics with batteries, etc.) require <strong>TEXT</strong>
+          and reject the &quot;None applies&quot; option. The
+          <strong> ATTACHMENTS</strong> variant (referencing pre-uploaded
+          attachment ids) is supported by the API but no upload UI is shipped
+          yet — operators using attachments must edit the JSON view directly.
         </p>
 
         <FormField
@@ -240,7 +245,7 @@ export function AllegroSellerDefaultsSection({
             onChange={(event) => {
               form.setValue(
                 'sellerDefaults.safetyInformation.type',
-                event.target.value as 'NO_SAFETY_INFORMATION' | 'SAFETY_INFORMATION',
+                event.target.value as 'NO_SAFETY_INFORMATION' | 'TEXT' | 'ATTACHMENTS',
                 { shouldDirty: true },
               );
               onChange();
@@ -248,31 +253,31 @@ export function AllegroSellerDefaultsSection({
             disabled={disabled}
           >
             <option value="NO_SAFETY_INFORMATION">None applies</option>
-            <option value="SAFETY_INFORMATION">Provide safety information</option>
+            <option value="TEXT">Provide safety information (text)</option>
           </Select>
         </FormField>
 
-        {safetyType === 'SAFETY_INFORMATION' ? (
+        {safetyType === 'TEXT' ? (
           <FormField
-            label="Safety information content"
-            name="sellerDefaults.safetyInformation.content"
-            error={errors?.safetyInformation?.content?.message}
-            description="Free text shown to buyers. 1–2000 characters."
+            label="Safety information description"
+            name="sellerDefaults.safetyInformation.description"
+            error={errors?.safetyInformation?.description?.message}
+            description="Free text shown to buyers. 1–5000 characters; no HTML, newlines allowed."
           >
             <Textarea
-              {...form.register('sellerDefaults.safetyInformation.content')}
+              {...form.register('sellerDefaults.safetyInformation.description')}
               onChange={(event) => {
                 form.setValue(
-                  'sellerDefaults.safetyInformation.content',
+                  'sellerDefaults.safetyInformation.description',
                   event.target.value,
                   { shouldDirty: true },
                 );
                 onChange();
               }}
               rows={4}
-              maxLength={2000}
+              maxLength={5000}
               disabled={disabled}
-              invalid={Boolean(errors?.safetyInformation?.content)}
+              invalid={Boolean(errors?.safetyInformation?.description)}
             />
           </FormField>
         ) : null}

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -3,14 +3,17 @@ import type { UpdateConnectionInput } from '../api/connections.types';
 import { POLISH_VOIVODESHIP_VALUES } from '../types/polish-voivodeship.types';
 
 /**
- * Connection-level seller-defaults schema (#430). Each sub-field is
+ * Connection-level seller-defaults schema (#430 / #445). Each sub-field is
  * optional at the FE level so the operator can save incremental progress
  * (e.g. fill location now, return for safety info later); the BE DTO
  * validator at `apps/api/src/integrations/application/dto/allegro-connection-config.dto.ts`
  * is the strict gate.
  *
- * `safetyInformation` is a discriminated union — when `type` is
- * `SAFETY_INFORMATION`, `content` becomes required server-side.
+ * `safetyInformation` is a discriminated union — when `type` is `TEXT`,
+ * `description` becomes required server-side (1–5000 chars per Allegro).
+ * `ATTACHMENTS` carries `attachments[].id`; the FE upload UI for that
+ * variant is out of scope for #445 — operators can still target it via
+ * the JSON view if they have pre-uploaded attachment ids.
  */
 const allegroSellerLocationSchema = z.object({
   countryCode: z.literal('PL').optional(),
@@ -24,9 +27,15 @@ const allegroSellerLocationSchema = z.object({
     .optional(),
 });
 
+// FE schema is permissive (optional everywhere) so the operator can save
+// incremental progress. The BE DTO is the strict gate — see #445.
 const allegroSafetyInformationSchema = z.object({
-  type: z.enum(['NO_SAFETY_INFORMATION', 'SAFETY_INFORMATION']).optional(),
-  content: z.string().trim().max(2000).optional(),
+  type: z.enum(['NO_SAFETY_INFORMATION', 'TEXT', 'ATTACHMENTS']).optional(),
+  description: z.string().trim().max(5000).optional(),
+  attachments: z
+    .array(z.object({ id: z.string().trim().min(1) }))
+    .max(20)
+    .optional(),
 });
 
 const allegroSellerDefaultsSchema = z.object({
@@ -173,11 +182,17 @@ function pruneEmptySellerDefaults(
   if (values.safetyInformation?.type) {
     const safety: Record<string, unknown> = { type: values.safetyInformation.type };
     if (
-      values.safetyInformation.type === 'SAFETY_INFORMATION' &&
-      values.safetyInformation.content &&
-      values.safetyInformation.content.length > 0
+      values.safetyInformation.type === 'TEXT' &&
+      values.safetyInformation.description &&
+      values.safetyInformation.description.length > 0
     ) {
-      safety.content = values.safetyInformation.content;
+      safety.description = values.safetyInformation.description;
+    } else if (
+      values.safetyInformation.type === 'ATTACHMENTS' &&
+      Array.isArray(values.safetyInformation.attachments) &&
+      values.safetyInformation.attachments.length > 0
+    ) {
+      safety.attachments = values.safetyInformation.attachments;
     }
     out.safetyInformation = safety;
   }

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -246,14 +246,19 @@ export interface AllegroProductSetEntry {
   responsibleProducer?: { id: string };
   /**
    * EU GPSR safety information. Same applicability as `responsibleProducer`:
-   * required on the inline path, inherited on the smart-link path. The
-   * `NO_SAFETY_INFORMATION` branch is Allegro's "this category does not
-   * carry safety risks" declaration; `SAFETY_INFORMATION` carries free-text
-   * content. See #430.
+   * required on the inline path, inherited on the smart-link path.
+   * Discriminator + sibling fields verified against
+   * developer.allegro.pl (#445):
+   * - `NO_SAFETY_INFORMATION` — declares no safety info applies. Forbidden
+   *   in some categories (cameras / electronics / etc.) — Allegro then
+   *   returns `NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED`.
+   * - `TEXT` + `description` — free-text 1–5000 chars, no HTML, `\n` allowed.
+   * - `ATTACHMENTS` + `attachments[].id` — max 20 entries.
    */
   safetyInformation?:
     | { type: 'NO_SAFETY_INFORMATION' }
-    | { type: 'SAFETY_INFORMATION'; content: string };
+    | { type: 'TEXT'; description: string }
+    | { type: 'ATTACHMENTS'; attachments: Array<{ id: string }> };
 }
 
 /**

--- a/libs/integrations/allegro/src/domain/types/allegro-seller-defaults.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-seller-defaults.types.ts
@@ -21,23 +21,41 @@ import type { PolishVoivodeship } from './allegro-location.types';
  * `safetyInformation.type` discriminator. EU GPSR (Reg. 2023/988) requires
  * one of these on every `productSet[*]` payload sent to Allegro.
  *
+ * Shape verified against Allegro Developer Portal (#445):
+ *   https://developer.allegro.pl/news/gpsr-umozliwiamy-dodanie-informacji-o-bezpieczenstwie-produktu-w-postaci-opisu-tekstowego-5L0rGGoZwH0
+ *   https://github.com/allegro/allegro-api/issues/10402
+ *
  * - `NO_SAFETY_INFORMATION`: seller declares no safety information applies.
- * - `SAFETY_INFORMATION`: free-text content with the safety details.
+ *   Forbidden in some categories (cameras / electronics / etc.) — Allegro
+ *   then returns `NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED`.
+ * - `TEXT`: free-text safety information in `description` (1–5000 chars,
+ *   no HTML, `\n` allowed, multilingual when offer crosses marketplaces).
+ * - `ATTACHMENTS`: array of attachment ids in `attachments[].id` (max 20).
+ *   Attachments must be uploaded separately first; the upload flow is
+ *   not yet implemented (out of scope for #445).
+ *
+ * Earlier versions of this file used `'SAFETY_INFORMATION'` with a
+ * `content` field — that shape is unrecognized by Allegro's strict
+ * validator, gets silently dropped, and surfaces as the misleading
+ * `SAFETY_INFO_NOT_DEFINED` error. See #445 for the diagnosis.
  */
 export const AllegroSafetyInformationTypeValues = [
   'NO_SAFETY_INFORMATION',
-  'SAFETY_INFORMATION',
+  'TEXT',
+  'ATTACHMENTS',
 ] as const;
 
 export type AllegroSafetyInformationType = (typeof AllegroSafetyInformationTypeValues)[number];
 
 /**
  * Discriminated union mirroring Allegro's `safetyInformation` shape on
- * `productSet[*]`. Only the `SAFETY_INFORMATION` branch carries free text.
+ * `productSet[*]`. Only the `TEXT` branch carries free text in `description`;
+ * only the `ATTACHMENTS` branch carries `attachments`.
  */
 export type AllegroSafetyInformation =
   | { type: 'NO_SAFETY_INFORMATION' }
-  | { type: 'SAFETY_INFORMATION'; content: string };
+  | { type: 'TEXT'; description: string }
+  | { type: 'ATTACHMENTS'; attachments: Array<{ id: string }> };
 
 /**
  * Ship-from address sent on every offer's `body.location`. `countryCode` is

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -1175,11 +1175,13 @@ describe('AllegroOfferManagerAdapter', () => {
         expect(body).not.toHaveProperty('product');
       });
 
-      // #439 — discriminator parity: when sellerDefaults uses the
-      // `SAFETY_INFORMATION` branch (free-text content rather than the
-      // "no risks" declaration), the adapter must pass the entire object
-      // through to `productSet[0].safetyInformation` — `type` + `content`.
-      it('passes SAFETY_INFORMATION discriminator with content through to productSet[0].safetyInformation', async () => {
+      // #439 / #445 — discriminator parity: when sellerDefaults uses the
+      // `TEXT` branch (free-text description rather than the "no risks"
+      // declaration), the adapter must pass the entire object through to
+      // `productSet[0].safetyInformation` — `type` + `description`. #445
+      // corrected the discriminator from `SAFETY_INFORMATION`/`content` to
+      // `TEXT`/`description` per developer.allegro.pl.
+      it('passes TEXT discriminator with description through to productSet[0].safetyInformation (#445)', async () => {
         httpClient.post.mockResolvedValue(
           mockHttpResponse({ id: 'allegro-offer-safety-text', publication: { status: 'INACTIVE' } }),
         );
@@ -1197,8 +1199,8 @@ describe('AllegroOfferManagerAdapter', () => {
           {
             ...DEFAULT_SELLER_DEFAULTS,
             safetyInformation: {
-              type: 'SAFETY_INFORMATION',
-              content: 'Keep dry. Not for children under 3.',
+              type: 'TEXT',
+              description: 'Keep dry. Not for children under 3.',
             },
           },
         );
@@ -1207,12 +1209,56 @@ describe('AllegroOfferManagerAdapter', () => {
 
         const body = httpClient.post.mock.calls[0][1] as {
           productSet?: Array<{
-            safetyInformation?: { type: string; content?: string };
+            safetyInformation?: { type: string; description?: string };
           }>;
         };
         expect(body.productSet?.[0]?.safetyInformation).toEqual({
-          type: 'SAFETY_INFORMATION',
-          content: 'Keep dry. Not for children under 3.',
+          type: 'TEXT',
+          description: 'Keep dry. Not for children under 3.',
+        });
+      });
+
+      // #445 — ATTACHMENTS variant flows through unchanged.
+      it('passes ATTACHMENTS discriminator with attachment ids through to productSet[0].safetyInformation (#445)', async () => {
+        httpClient.post.mockResolvedValue(
+          mockHttpResponse({
+            id: 'allegro-offer-safety-att',
+            publication: { status: 'INACTIVE' },
+          }),
+        );
+
+        const adapterWithAttachments = new AllegroOfferManagerAdapter(
+          connectionId,
+          httpClient,
+          uploadHttpClient,
+          identifierMapping,
+          connection,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            ...DEFAULT_SELLER_DEFAULTS,
+            safetyInformation: {
+              type: 'ATTACHMENTS',
+              attachments: [{ id: 'att-1' }, { id: 'att-2' }],
+            },
+          },
+        );
+
+        await adapterWithAttachments.createOffer(baseCmd);
+
+        const body = httpClient.post.mock.calls[0][1] as {
+          productSet?: Array<{
+            safetyInformation?: {
+              type: string;
+              attachments?: Array<{ id: string }>;
+            };
+          }>;
+        };
+        expect(body.productSet?.[0]?.safetyInformation).toEqual({
+          type: 'ATTACHMENTS',
+          attachments: [{ id: 'att-1' }, { id: 'att-2' }],
         });
       });
 
@@ -1594,10 +1640,10 @@ describe('AllegroOfferManagerAdapter', () => {
         expect(httpClient.post).not.toHaveBeenCalled();
       });
 
-      it('reports sellerDefaults.safetyInformation.content when type=SAFETY_INFORMATION but content is missing', async () => {
+      it('reports sellerDefaults.safetyInformation.description when type=TEXT but description is missing (#445)', async () => {
         const partial = {
           ...DEFAULT_SELLER_DEFAULTS,
-          safetyInformation: { type: 'SAFETY_INFORMATION' } as unknown as AllegroSellerDefaultsConfig['safetyInformation'],
+          safetyInformation: { type: 'TEXT' } as unknown as AllegroSellerDefaultsConfig['safetyInformation'],
         };
         const partialAdapter = new AllegroOfferManagerAdapter(
           connectionId,
@@ -1616,7 +1662,37 @@ describe('AllegroOfferManagerAdapter', () => {
           name: 'OfferCreateRejectedException',
           errors: [
             expect.objectContaining({
-              field: 'sellerDefaults.safetyInformation.content',
+              field: 'sellerDefaults.safetyInformation.description',
+              code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
+            }),
+          ],
+        });
+        expect(httpClient.post).not.toHaveBeenCalled();
+      });
+
+      it('reports sellerDefaults.safetyInformation.attachments when type=ATTACHMENTS but attachments is missing/empty (#445)', async () => {
+        const partial = {
+          ...DEFAULT_SELLER_DEFAULTS,
+          safetyInformation: { type: 'ATTACHMENTS' } as unknown as AllegroSellerDefaultsConfig['safetyInformation'],
+        };
+        const partialAdapter = new AllegroOfferManagerAdapter(
+          connectionId,
+          httpClient,
+          uploadHttpClient,
+          identifierMapping,
+          connection,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          partial,
+        );
+
+        await expect(partialAdapter.createOffer(baseCmd)).rejects.toMatchObject({
+          name: 'OfferCreateRejectedException',
+          errors: [
+            expect.objectContaining({
+              field: 'sellerDefaults.safetyInformation.attachments',
               code: 'SELLER_DEFAULTS_NOT_CONFIGURED',
             }),
           ],

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -138,10 +138,18 @@ function collectMissingSellerDefaultsFields(
   if (!safety?.type) {
     missing.push('sellerDefaults.safetyInformation.type');
   } else if (
-    safety.type === 'SAFETY_INFORMATION' &&
-    (typeof safety.content !== 'string' || safety.content.length === 0)
+    safety.type === 'TEXT' &&
+    (typeof safety.description !== 'string' || safety.description.length === 0)
   ) {
-    missing.push('sellerDefaults.safetyInformation.content');
+    // Allegro accepts 1–5000 chars on `TEXT.description` (#445). The DTO
+    // validator enforces the upper bound at save time; here we only catch
+    // empty/missing description which would silently pass the type check.
+    missing.push('sellerDefaults.safetyInformation.description');
+  } else if (
+    safety.type === 'ATTACHMENTS' &&
+    (!Array.isArray(safety.attachments) || safety.attachments.length === 0)
+  ) {
+    missing.push('sellerDefaults.safetyInformation.attachments');
   }
   return missing;
 }
@@ -858,14 +866,6 @@ export class AllegroOfferManagerAdapter
 
     this.logger.debug(
       `Creating Allegro offer: connection=${this.connectionId} externalRef=${body.external?.id ?? 'n/a'} publishImmediately=${cmd.publishImmediately}`,
-    );
-    // #441 — diagnostic: dump the literal POST body so a sandbox 422 (e.g.
-    // `SAFETY_INFO_NOT_DEFINED` post-#440) can be diagnosed against ground
-    // truth rather than against unit-test expectations. Will be removed or
-    // demoted once the issue is closed; passes through `formatBodyForLog` so
-    // operator-controlled long strings can't blow up logs.
-    this.logger.log(
-      `Allegro offer-create POST body: connection=${this.connectionId} body=${formatBodyForLog(JSON.stringify(body))}`,
     );
 
     let response: AllegroProductOfferCreateResponse;


### PR DESCRIPTION
## Summary

Closes the GPSR loop (#436 → #437 → #439 → #442 → #443 → #444). The `AllegroSafetyInformation` discriminated union introduced in #430 used `{ type: 'SAFETY_INFORMATION', content: string }`. Allegro's actual API expects `{ type: 'TEXT', description: string }` per the [Allegro Developer Portal](https://developer.allegro.pl/news/gpsr-umozliwiamy-dodanie-informacji-o-bezpieczenstwie-produktu-w-postaci-opisu-tekstowego-5L0rGGoZwH0) and [GitHub issue #10402](https://github.com/allegro/allegro-api/issues/10402).

`SAFETY_INFORMATION` is not a valid discriminator. Allegro's strict validator silently drops the malformed object and reports the field as missing via the misleading `SAFETY_INFO_NOT_DEFINED` error. Every previous fix asserted against our own (wrong) type definition and never hit Allegro's wire-level expectation. The body-log diagnostic from #441 finally made the actual JSON visible; the operator-side test with `NO_SAFETY_INFORMATION` confirmed the discriminator semantics (Allegro returned a different error code, proving it recognized the value).

## What changed

- **Type** (`libs/integrations/allegro/src/domain/types/allegro-seller-defaults.types.ts`, `allegro-api.types.ts`): three discriminators — `NO_SAFETY_INFORMATION`, `TEXT` + `description` (1–5000 chars), `ATTACHMENTS` + `attachments[].id` (max 20).
- **DTO** (`apps/api/src/integrations/application/dto/allegro-connection-config.dto.ts`): `class-validator` rules for the new shape including `@ArrayMinSize(1)` + `@ArrayMaxSize(20)` for `ATTACHMENTS`.
- **Adapter preflight** (`AllegroOfferManagerAdapter`): branches on `TEXT.description` and `ATTACHMENTS.attachments` instead of `SAFETY_INFORMATION.content`. Diagnostic body-log from #441 removed.
- **FE wizard**: Zod schema covers all three discriminators; the Select offers `NO_SAFETY_INFORMATION` and `TEXT` (the `ATTACHMENTS` upload UI is a follow-up). `EditConnectionForm.readSellerDefaults` includes a backwards-compat fallback so legacy rows surface as `TEXT` even before the migration runs on a given environment.
- **Migration** (`1791000000000-rewrite-allegro-safety-information-shape.ts`): rewrites every Allegro connection's persisted JSONB blob from `{ type: 'SAFETY_INFORMATION', content }` → `{ type: 'TEXT', description }` in-place, idempotently. `down()` reverts.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1324 backend (Allegro 211→214, API 273→276) + 766 frontend = 2090 tests pass
- [ ] **Sandbox re-run** (post-merge, with worker rebuilt + migration applied): trigger the same offer-create flow on connection `eecbdcd2-...`. Allegro should accept the create now (201 instead of 422).

## Out of scope (follow-up issues)

- `ATTACHMENTS` end-to-end UI (file upload, attachment-id storage, attachment-upload adapter call)
- Multilingual safety text for cross-marketplace offers
- Operator-facing error mapping for Allegro's `SAFETY_INFO_NOT_DEFINED` and `NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED` (translate to actionable FE messages)

## Related

- #430 (introduced wrong shape)
- #436 / #437 / #439 / #442 / #443 / #444 (chasing wrong placement / values; none addressed the type)
- #441 (diagnostic body-log that made the actual wire format visible)

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)