### PR TITLE
feat(orders): retry a failed destination sync from the order detail page

### DIFF
--- a/apps/api/src/orders/http/dto/retry-order-destination-response.dto.ts
+++ b/apps/api/src/orders/http/dto/retry-order-destination-response.dto.ts
@@ -1,0 +1,36 @@
+/**
+ * Retry Order Destination Response DTO
+ *
+ * Response shape for `POST /orders/:internalOrderId/destinations/:connectionId/retry`.
+ * Returns the new sync-job id created for the retry so the FE can deep-link
+ * into `/sync/jobs/:id` if the operator wants to follow the retry.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RetryOrderDestinationResponseDto {
+  @ApiProperty({
+    description: 'Internal order id the retry was issued for',
+    example: 'ol_order_abc123',
+  })
+  internalOrderId!: string;
+
+  @ApiProperty({
+    description: 'Destination connection id whose row was retried',
+    example: '0aa1c2e0-1234-4abc-8def-0123456789ab',
+  })
+  destinationConnectionId!: string;
+
+  @ApiProperty({
+    description: 'Newly enqueued sync-job id',
+    example: '7f0a89c2-9f33-4d51-8cce-7a37a9c45d11',
+  })
+  jobId!: string;
+
+  @ApiProperty({
+    description: 'Job type — always `marketplace.order.sync` for now',
+    example: 'marketplace.order.sync',
+  })
+  jobType!: string;
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -4,17 +4,30 @@
  * @module apps/api/src/orders/http
  */
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { OrdersController } from './orders.controller';
 import {
   ORDER_RECORD_REPOSITORY_TOKEN,
+  ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
   OrderRecord,
+  OrderRecordNotFoundException,
+  OrderDestinationNotFoundException,
+  OrderDestinationNotRetryableException,
+  MissingSourceExternalIdException,
 } from '@openlinker/core/orders';
-import type { OrderRecordRepositoryPort } from '@openlinker/core/orders';
+import type {
+  OrderRecordRepositoryPort,
+  IOrderDestinationRetryService,
+} from '@openlinker/core/orders';
 
 describe('OrdersController', () => {
   let controller: OrdersController;
   let repository: jest.Mocked<OrderRecordRepositoryPort>;
+  let retryService: jest.Mocked<IOrderDestinationRetryService>;
 
   const mockOrder = new OrderRecord(
     'ol_order_001',
@@ -44,6 +57,10 @@ describe('OrdersController', () => {
       findMany: jest.fn(),
     };
 
+    const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {
+      retry: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [OrdersController],
       providers: [
@@ -51,11 +68,16 @@ describe('OrdersController', () => {
           provide: ORDER_RECORD_REPOSITORY_TOKEN,
           useValue: mockRepository,
         },
+        {
+          provide: ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
+          useValue: mockRetryService,
+        },
       ],
     }).compile();
 
     controller = module.get<OrdersController>(OrdersController);
     repository = module.get(ORDER_RECORD_REPOSITORY_TOKEN);
+    retryService = module.get(ORDER_DESTINATION_RETRY_SERVICE_TOKEN);
   });
 
   describe('listOrders', () => {
@@ -156,6 +178,69 @@ describe('OrdersController', () => {
       repository.findById.mockResolvedValue(null);
 
       await expect(controller.getOrder('ol_order_999')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('retryDestination', () => {
+    const internalOrderId = 'ol_order_001';
+    const connectionId = '0aa1c2e0-1234-4abc-8def-0123456789ab';
+
+    it('should return job id and types on success (202)', async () => {
+      retryService.retry.mockResolvedValue({
+        jobId: 'job-new',
+        jobType: 'marketplace.order.sync',
+      });
+
+      const result = await controller.retryDestination(internalOrderId, connectionId);
+
+      expect(result).toEqual({
+        internalOrderId,
+        destinationConnectionId: connectionId,
+        jobId: 'job-new',
+        jobType: 'marketplace.order.sync',
+      });
+      expect(retryService.retry).toHaveBeenCalledWith({
+        internalOrderId,
+        destinationConnectionId: connectionId,
+      });
+    });
+
+    it('should map OrderRecordNotFoundException to NotFoundException (404)', async () => {
+      retryService.retry.mockRejectedValue(new OrderRecordNotFoundException(internalOrderId));
+
+      await expect(
+        controller.retryDestination(internalOrderId, connectionId),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should map OrderDestinationNotFoundException to NotFoundException (404)', async () => {
+      retryService.retry.mockRejectedValue(
+        new OrderDestinationNotFoundException(internalOrderId, connectionId),
+      );
+
+      await expect(
+        controller.retryDestination(internalOrderId, connectionId),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should map OrderDestinationNotRetryableException to ConflictException (409)', async () => {
+      retryService.retry.mockRejectedValue(
+        new OrderDestinationNotRetryableException(internalOrderId, connectionId, 'synced'),
+      );
+
+      await expect(
+        controller.retryDestination(internalOrderId, connectionId),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('should map MissingSourceExternalIdException to InternalServerErrorException (500)', async () => {
+      retryService.retry.mockRejectedValue(
+        new MissingSourceExternalIdException(internalOrderId, 'conn-source-001'),
+      );
+
+      await expect(
+        controller.retryDestination(internalOrderId, connectionId),
+      ).rejects.toBeInstanceOf(InternalServerErrorException);
     });
   });
 });

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -9,24 +9,34 @@
 import {
   Controller,
   Get,
+  Post,
   Query,
   Param,
   HttpCode,
   HttpStatus,
   NotFoundException,
+  ConflictException,
+  InternalServerErrorException,
   Inject,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import {
   OrderRecordRepositoryPort,
   ORDER_RECORD_REPOSITORY_TOKEN,
+  ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
+  OrderRecordNotFoundException,
+  OrderDestinationNotFoundException,
+  OrderDestinationNotRetryableException,
+  MissingSourceExternalIdException,
 } from '@openlinker/core/orders';
-import type { OrderRecord, OrderSyncStatus } from '@openlinker/core/orders';
+import type { OrderRecord, OrderSyncStatus, IOrderDestinationRetryService } from '@openlinker/core/orders';
 import { ListOrdersQueryDto } from './dto/list-orders-query.dto';
 import { OrderRecordResponseDto } from './dto/order-record-response.dto';
 import { OrderSyncStatusResponseDto } from './dto/order-sync-status-response.dto';
 import { PaginatedOrdersResponseDto } from './dto/paginated-orders-response.dto';
+import { RetryOrderDestinationResponseDto } from './dto/retry-order-destination-response.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -36,6 +46,8 @@ export class OrdersController {
   constructor(
     @Inject(ORDER_RECORD_REPOSITORY_TOKEN)
     private readonly orderRecordRepository: OrderRecordRepositoryPort,
+    @Inject(ORDER_DESTINATION_RETRY_SERVICE_TOKEN)
+    private readonly destinationRetryService: IOrderDestinationRetryService,
   ) {}
 
   @Get()
@@ -82,6 +94,53 @@ export class OrdersController {
       throw new NotFoundException(`Order not found: ${internalOrderId}`);
     }
     return this.toDto(order);
+  }
+
+  @Post(':internalOrderId/destinations/:connectionId/retry')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({
+    summary: 'Retry a failed destination sync for an order',
+    description:
+      'Re-enqueues the source-side `marketplace.order.sync` job with a fresh idempotency key. Only destinations whose current status is `failed` can be retried — `pending` / `syncing` / `synced` rows are rejected with 409. The destination row is flipped to `pending` immediately so the operator sees the retry queued.',
+  })
+  @ApiResponse({
+    status: 202,
+    description: 'Retry accepted; new sync job enqueued',
+    type: RetryOrderDestinationResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Order or destination row not found' })
+  @ApiResponse({ status: 409, description: 'Destination is not in a retryable state' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async retryDestination(
+    @Param('internalOrderId') internalOrderId: string,
+    @Param('connectionId', ParseUUIDPipe) connectionId: string,
+  ): Promise<RetryOrderDestinationResponseDto> {
+    try {
+      const result = await this.destinationRetryService.retry({
+        internalOrderId,
+        destinationConnectionId: connectionId,
+      });
+      return {
+        internalOrderId,
+        destinationConnectionId: connectionId,
+        jobId: result.jobId,
+        jobType: result.jobType,
+      };
+    } catch (error) {
+      if (
+        error instanceof OrderRecordNotFoundException ||
+        error instanceof OrderDestinationNotFoundException
+      ) {
+        throw new NotFoundException(error.message);
+      }
+      if (error instanceof OrderDestinationNotRetryableException) {
+        throw new ConflictException(error.message);
+      }
+      if (error instanceof MissingSourceExternalIdException) {
+        throw new InternalServerErrorException(error.message);
+      }
+      throw error;
+    }
   }
 
   private toDto(order: OrderRecord): OrderRecordResponseDto {

--- a/apps/api/test/integration/order-destination-retry.int-spec.ts
+++ b/apps/api/test/integration/order-destination-retry.int-spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Order Destination Retry Integration Test
+ *
+ * Vertical slice for `POST /orders/:internalOrderId/destinations/:connectionId/retry`.
+ * Verifies wiring through the controller → service → identifier mapping →
+ * sync-job repository against real Postgres + Redis.
+ *
+ * @module apps/api/test/integration
+ */
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+import { createTestOrderRecord } from './fixtures/order.fixtures';
+import { createTestConnection } from './helpers/test-connection.helper';
+import { IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping';
+
+describe('Order Destination Retry Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('should accept retry, claim the slot, and enqueue a marketplace.order.sync job (202)', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const redis = harness.getRedisClient();
+    if (!redis) {
+      throw new Error('Redis client unavailable in test harness');
+    }
+    const token = await loginAsAdmin(http, dataSource);
+
+    const sourceConnection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro Source',
+      adapterKey: 'allegro.publicapi.v1',
+    });
+    const destConnection = await createTestConnection(dataSource, {
+      name: 'PrestaShop Dest',
+    });
+
+    const orderRecord = await createTestOrderRecord(dataSource, {
+      sourceConnectionId: sourceConnection.id,
+      sourceEventId: 'evt-99',
+      syncStatus: [
+        {
+          destinationConnectionId: destConnection.id,
+          status: 'failed',
+          error: 'PrestaShop country PL not active',
+        },
+      ],
+    });
+
+    // Seed the source-side identifier mapping so the service can resolve externalOrderId.
+    const mappingRepo = dataSource.getRepository(IdentifierMappingOrmEntity);
+    await mappingRepo.save(
+      mappingRepo.create({
+        entityType: 'Order',
+        internalId: orderRecord.internalOrderId,
+        externalId: 'allegro-order-1',
+        platformType: 'allegro',
+        connectionId: sourceConnection.id,
+      }),
+    );
+
+    const response = await http
+      .post(`/orders/${orderRecord.internalOrderId}/destinations/${destConnection.id}/retry`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(202);
+
+    expect(response.body).toMatchObject({
+      internalOrderId: orderRecord.internalOrderId,
+      destinationConnectionId: destConnection.id,
+      jobType: 'marketplace.order.sync',
+    });
+    expect(typeof response.body.jobId).toBe('string');
+
+    // Verify a message landed on the Redis stream that workers consume.
+    const streamLen = await redis.xLen('jobs.sync');
+    expect(streamLen).toBeGreaterThanOrEqual(1);
+
+    // The idempotency key was stored with the expected shape.
+    const expectedKeyPattern = `jobdedup:marketplace:${sourceConnection.id}:order:evt-99:retry:`;
+    const keys = await redis.keys(`${expectedKeyPattern}*`);
+    expect(keys).toHaveLength(1);
+
+    // Order row's destination flipped from 'failed' → 'pending'
+    const detail = await http
+      .get(`/orders/${orderRecord.internalOrderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const row = detail.body.syncStatus.find(
+      (s: { destinationConnectionId: string }) => s.destinationConnectionId === destConnection.id,
+    );
+    expect(row?.status).toBe('pending');
+  });
+
+  it('should reject with 409 when the destination is not in failed state', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const redis = harness.getRedisClient();
+    if (!redis) {
+      throw new Error('Redis client unavailable in test harness');
+    }
+    const token = await loginAsAdmin(http, dataSource);
+
+    const sourceConnection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro Source',
+      adapterKey: 'allegro.publicapi.v1',
+    });
+    const destConnection = await createTestConnection(dataSource, { name: 'PrestaShop Dest' });
+
+    const orderRecord = await createTestOrderRecord(dataSource, {
+      sourceConnectionId: sourceConnection.id,
+      sourceEventId: 'evt-100',
+      syncStatus: [
+        {
+          destinationConnectionId: destConnection.id,
+          status: 'synced',
+          syncedAt: new Date().toISOString(),
+          externalOrderId: 'PS-123',
+        },
+      ],
+    });
+
+    await http
+      .post(`/orders/${orderRecord.internalOrderId}/destinations/${destConnection.id}/retry`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(409);
+
+    // No message published to the queue
+    const streamLen = await redis.xLen('jobs.sync').catch(() => 0);
+    expect(streamLen).toBe(0);
+  });
+
+  it('should return 404 for an unknown order', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const unknownConnectionId = '99999999-9999-4999-8999-999999999999';
+
+    await http
+      .post(`/orders/ol_order_does_not_exist/destinations/${unknownConnectionId}/retry`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404);
+  });
+
+  it('should return 401 without token', async () => {
+    const http = harness.getHttp();
+    const unknownConnectionId = '99999999-9999-4999-8999-999999999999';
+
+    await http
+      .post(`/orders/ol_order_x/destinations/${unknownConnectionId}/retry`)
+      .expect(401);
+  });
+});

--- a/apps/web/src/features/orders/api/orders.api.ts
+++ b/apps/web/src/features/orders/api/orders.api.ts
@@ -11,11 +11,16 @@ import type {
   OrderPagination,
   PaginatedOrders,
   OrderRecord,
+  RetryOrderDestinationResult,
 } from './orders.types';
 
 export interface OrdersApi {
   list: (filters?: OrderFilters, pagination?: OrderPagination) => Promise<PaginatedOrders>;
   getById: (internalOrderId: string) => Promise<OrderRecord>;
+  retryDestination: (
+    internalOrderId: string,
+    destinationConnectionId: string,
+  ) => Promise<RetryOrderDestinationResult>;
 }
 
 interface ApiRequest {
@@ -43,6 +48,12 @@ export function createOrdersApi(request: ApiRequest): OrdersApi {
     },
     getById(internalOrderId): Promise<OrderRecord> {
       return request<OrderRecord>(`/orders/${internalOrderId}`);
+    },
+    retryDestination(internalOrderId, destinationConnectionId): Promise<RetryOrderDestinationResult> {
+      return request<RetryOrderDestinationResult>(
+        `/orders/${encodeURIComponent(internalOrderId)}/destinations/${encodeURIComponent(destinationConnectionId)}/retry`,
+        { method: 'POST' },
+      );
     },
   };
 }

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -57,3 +57,10 @@ export interface PaginatedOrders {
   limit: number;
   offset: number;
 }
+
+export interface RetryOrderDestinationResult {
+  internalOrderId: string;
+  destinationConnectionId: string;
+  jobId: string;
+  jobType: string;
+}

--- a/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
@@ -127,4 +127,32 @@ describe('OrderActivityTimeline', () => {
     expect(within(failedRow).getByText('PrestaShop returned 500')).toBeInTheDocument();
     expect(failedRow.querySelector('.order-activity__dot--error')).not.toBeNull();
   });
+
+  it('does not show "in progress" for a failed sync without syncedAt', () => {
+    // Real-world failed rows have no syncedAt — only an error string. Before the
+    // fix, the time pill mistakenly read "in progress" because it fell into the
+    // null-timestamp branch. Now the error tone branches before the pending pill.
+    const syncStatus: OrderSyncStatus[] = [
+      {
+        destinationConnectionId: 'ol_connection_dst',
+        status: 'failed',
+        syncedAt: null,
+        externalOrderId: null,
+        externalOrderNumber: null,
+        error: 'PrestaShop country PL not active',
+      },
+    ];
+
+    renderTimeline({
+      createdAt: '2026-04-20T10:00:00.000Z',
+      recordStatus: 'ready',
+      syncStatus,
+    });
+
+    const items = screen.getAllByRole('listitem');
+    const failedRow = items[1];
+    expect(within(failedRow).getByText(/failed to sync to/)).toBeInTheDocument();
+    expect(within(failedRow).queryByText('in progress')).toBeNull();
+    expect(failedRow.querySelector('.order-activity__dot--error')).not.toBeNull();
+  });
 });

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -137,6 +137,11 @@ export function OrderActivityTimeline({
             <time className="order-activity__time" dateTime={event.timestamp}>
               <TimeDisplay iso={event.timestamp} format="datetime" />
             </time>
+          ) : event.tone === 'error' ? (
+            // Failed destinations have no `syncedAt` — the dot tone (red) and verb
+            // ("failed to sync to {destination}") already convey state, so the time
+            // pill stays empty rather than lying with "in progress".
+            <span className="order-activity__time" aria-hidden="true" />
           ) : (
             <span className="order-activity__time order-activity__time--pending">in progress</span>
           )}

--- a/apps/web/src/features/orders/hooks/use-retry-order-destination-mutation.ts
+++ b/apps/web/src/features/orders/hooks/use-retry-order-destination-mutation.ts
@@ -1,0 +1,35 @@
+/**
+ * Retry Order Destination Mutation Hook
+ *
+ * Provides a mutation for retrying a failed destination sync from the order
+ * detail page. Invalidates the order detail query on success so the row
+ * reflects its new `pending` status without a manual refresh.
+ *
+ * @module apps/web/src/features/orders/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { ordersQueryKeys } from '../api/orders.query-keys';
+import type { RetryOrderDestinationResult } from '../api/orders.types';
+
+export interface RetryOrderDestinationInput {
+  internalOrderId: string;
+  destinationConnectionId: string;
+}
+
+export function useRetryOrderDestinationMutation(): UseMutationResult<
+  RetryOrderDestinationResult,
+  Error,
+  RetryOrderDestinationInput
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ internalOrderId, destinationConnectionId }) =>
+      apiClient.orders.retryDestination(internalOrderId, destinationConnectionId),
+    onSuccess: async (_, { internalOrderId }) => {
+      await queryClient.invalidateQueries({ queryKey: ordersQueryKeys.detail(internalOrderId) });
+    },
+  });
+}

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
@@ -106,5 +107,93 @@ describe('OrderDetailPage', () => {
       'href',
       `/orders/failed?connectionId=${sampleConnection.id}`,
     );
+  });
+
+  describe('destination retry', () => {
+    const orderWithFailure: OrderRecord = {
+      ...sampleOrder,
+      syncStatus: [
+        {
+          destinationConnectionId: sampleConnection.id,
+          status: 'failed',
+          syncedAt: null,
+          externalOrderId: null,
+          externalOrderNumber: null,
+          error: 'PrestaShop country PL not active',
+        },
+      ],
+    };
+
+    it('renders the Retry button only on failed sync rows', async () => {
+      const orderMixed: OrderRecord = {
+        ...orderWithFailure,
+        syncStatus: [
+          ...orderWithFailure.syncStatus,
+          {
+            destinationConnectionId: 'conn-other',
+            status: 'synced',
+            syncedAt: '2026-04-29T11:00:00.000Z',
+            externalOrderId: 'PS-1',
+            externalOrderNumber: '1',
+            error: null,
+          },
+        ],
+      };
+      const api = createMockApiClient({
+        orders: { getById: vi.fn().mockResolvedValue(orderMixed) },
+      });
+
+      renderDetail(api);
+
+      // Only the failed row gets a Retry button (the banner-level "View failed orders"
+      // is a link, not a button, so getAllByRole('button', ...) excludes it).
+      const retryButtons = await screen.findAllByRole('button', { name: 'Retry' });
+      expect(retryButtons).toHaveLength(1);
+    });
+
+    it('calls retryDestination with the right ids on click', async () => {
+      const retryFn = vi.fn().mockResolvedValue({
+        internalOrderId: 'ol_order_abc123',
+        destinationConnectionId: sampleConnection.id,
+        jobId: 'job-new',
+        jobType: 'marketplace.order.sync',
+      });
+      const api = createMockApiClient({
+        orders: {
+          getById: vi.fn().mockResolvedValue(orderWithFailure),
+          retryDestination: retryFn,
+        },
+      });
+
+      renderDetail(api);
+
+      const retryButton = await screen.findByRole('button', { name: 'Retry' });
+      await userEvent.click(retryButton);
+
+      expect(retryFn).toHaveBeenCalledWith('ol_order_abc123', sampleConnection.id);
+    });
+
+    it('disables the Retry button while the mutation is in flight', async () => {
+      // Deferred retry that never resolves — keeps the mutation in `isPending` state
+      // for the duration of the assertion.
+      const retryFn = vi.fn().mockReturnValue(new Promise(() => {}));
+      const api = createMockApiClient({
+        orders: {
+          getById: vi.fn().mockResolvedValue(orderWithFailure),
+          retryDestination: retryFn,
+        },
+      });
+
+      renderDetail(api);
+
+      const retryButton = await screen.findByRole('button', { name: 'Retry' });
+      expect(retryButton).toBeEnabled();
+      await userEvent.click(retryButton);
+
+      // After the click, the button text flips to "Retrying…" and is disabled until the
+      // promise settles. Looking up by name covers the new accessible label.
+      const retryingButton = await screen.findByRole('button', { name: 'Retrying…' });
+      expect(retryingButton).toBeDisabled();
+    });
   });
 });

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import { useCallback, useMemo, type ReactElement } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Alert } from '../../shared/ui/alert';
@@ -10,7 +10,9 @@ import { KeyValueList, type KeyValueItem } from '../../shared/ui/key-value-list'
 import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
+import { useToast } from '../../shared/ui/toast-provider';
 import { useOrderQuery } from '../../features/orders/hooks/use-order-query';
+import { useRetryOrderDestinationMutation } from '../../features/orders/hooks/use-retry-order-destination-mutation';
 import type { OrderSyncStatus, OrderSyncStatusValue } from '../../features/orders/api/orders.types';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
 import { CustomerEntityLabel } from '../../features/customers/components/CustomerEntityLabel';
@@ -30,62 +32,86 @@ const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
   failed: 'error',
 };
 
-const SYNC_COLUMNS: DataTableColumn<OrderSyncStatus>[] = [
-  {
-    id: 'destinationConnectionId',
-    header: 'Destination',
-    cell: (s) => <ConnectionEntityLabel connectionId={s.destinationConnectionId} showId={false} />,
-  },
-  {
-    id: 'status',
-    header: 'Status',
-    cell: (s) => (
-      <StatusBadge tone={SYNC_STATUS_TONES[s.status]} compact>
-        {s.status}
-      </StatusBadge>
-    ),
-  },
-  {
-    id: 'externalOrderId',
-    header: 'External Order ID',
-    cell: (s) =>
-      s.externalOrderId ? (
-        <span className="mono-text">{s.externalOrderId}</span>
-      ) : (
-        <EmptyValue />
+function buildSyncColumns(
+  onRetry: (destinationConnectionId: string) => void,
+  isRetrying: (destinationConnectionId: string) => boolean,
+): DataTableColumn<OrderSyncStatus>[] {
+  return [
+    {
+      id: 'destinationConnectionId',
+      header: 'Destination',
+      cell: (s) => <ConnectionEntityLabel connectionId={s.destinationConnectionId} showId={false} />,
+    },
+    {
+      id: 'status',
+      header: 'Status',
+      cell: (s) => (
+        <StatusBadge tone={SYNC_STATUS_TONES[s.status]} compact>
+          {s.status}
+        </StatusBadge>
       ),
-    hideBelow: 768,
-  },
-  {
-    id: 'externalOrderNumber',
-    header: 'External Order #',
-    cell: (s) =>
-      s.externalOrderNumber ? (
-        <span className="mono-text">{s.externalOrderNumber}</span>
-      ) : (
-        <EmptyValue />
-      ),
-  },
-  {
-    id: 'syncedAt',
-    header: 'Synced At',
-    cell: (s) => (s.syncedAt ? <TimeDisplay iso={s.syncedAt} /> : <EmptyValue />),
-    hideBelow: 768,
-  },
-  {
-    id: 'error',
-    header: 'Error',
-    cell: (s) =>
-      s.error ? (
-        <span className="text-muted" title={s.error}>
-          {s.error.length > 80 ? `${s.error.slice(0, 80)}…` : s.error}
-        </span>
-      ) : (
-        <EmptyValue />
-      ),
-    hideBelow: 1024,
-  },
-];
+    },
+    {
+      id: 'externalOrderId',
+      header: 'External Order ID',
+      cell: (s) =>
+        s.externalOrderId ? (
+          <span className="mono-text">{s.externalOrderId}</span>
+        ) : (
+          <EmptyValue />
+        ),
+      hideBelow: 768,
+    },
+    {
+      id: 'externalOrderNumber',
+      header: 'External Order #',
+      cell: (s) =>
+        s.externalOrderNumber ? (
+          <span className="mono-text">{s.externalOrderNumber}</span>
+        ) : (
+          <EmptyValue />
+        ),
+    },
+    {
+      id: 'syncedAt',
+      header: 'Synced At',
+      cell: (s) => (s.syncedAt ? <TimeDisplay iso={s.syncedAt} /> : <EmptyValue />),
+      hideBelow: 768,
+    },
+    {
+      id: 'error',
+      header: 'Error',
+      cell: (s) =>
+        s.error ? (
+          <span className="text-muted" title={s.error}>
+            {s.error.length > 80 ? `${s.error.slice(0, 80)}…` : s.error}
+          </span>
+        ) : (
+          <EmptyValue />
+        ),
+      hideBelow: 1024,
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      cell: (s) => {
+        if (s.status !== 'failed') {
+          return <EmptyValue />;
+        }
+        const pending = isRetrying(s.destinationConnectionId);
+        return (
+          <Button
+            tone="secondary"
+            onClick={() => onRetry(s.destinationConnectionId)}
+            disabled={pending}
+          >
+            {pending ? 'Retrying…' : 'Retry'}
+          </Button>
+        );
+      },
+    },
+  ];
+}
 
 function buildAddressItems(address: ParsedAddress, label: string): KeyValueItem[] {
   const fullName = [address.firstName, address.lastName].filter(Boolean).join(' ');
@@ -103,6 +129,41 @@ function buildAddressItems(address: ParsedAddress, label: string): KeyValueItem[
 export function OrderDetailPage(): ReactElement {
   const { internalOrderId = '' } = useParams<{ internalOrderId: string }>();
   const query = useOrderQuery(internalOrderId);
+  const retry = useRetryOrderDestinationMutation();
+  const { showToast } = useToast();
+
+  const pendingDestinationId =
+    retry.isPending && retry.variables ? retry.variables.destinationConnectionId : null;
+
+  const handleRetry = useCallback(
+    (destinationConnectionId: string): void => {
+      retry.mutate(
+        { internalOrderId, destinationConnectionId },
+        {
+          onSuccess: () => {
+            showToast({
+              tone: 'success',
+              title: 'Retry queued',
+              description: 'Sync queued for the failed destination.',
+            });
+          },
+          onError: (error) => {
+            showToast({ tone: 'error', title: 'Retry failed', description: error.message });
+          },
+        },
+      );
+    },
+    [retry, internalOrderId, showToast],
+  );
+
+  const syncColumns = useMemo(
+    () =>
+      buildSyncColumns(
+        handleRetry,
+        (destinationConnectionId) => pendingDestinationId === destinationConnectionId,
+      ),
+    [handleRetry, pendingDestinationId],
+  );
 
   if (query.isLoading) {
     return (
@@ -241,7 +302,7 @@ export function OrderDetailPage(): ReactElement {
           {order.syncStatus.length > 0 ? (
             <DataTable
               caption="Order sync status"
-              columns={SYNC_COLUMNS}
+              columns={syncColumns}
               rows={order.syncStatus}
               rowKey={(s) => s.destinationConnectionId}
             />

--- a/docs/plans/implementation-plan-450-order-destination-retry.md
+++ b/docs/plans/implementation-plan-450-order-destination-retry.md
@@ -1,0 +1,186 @@
+# Implementation Plan — #450: Retry a failed destination sync from the order detail page
+
+## Goal
+
+Operators must be able to retry a failed destination sync directly from the order detail page once the underlying root cause (e.g. inactive country in PrestaShop) has been fixed. Today the only retry path is through `/sync` → find the dead `marketplace.order.sync` job by id → click retry — opaque and not discoverable.
+
+## Layer classification
+
+- **CORE** — new application service `OrderDestinationRetryService` + interface, two new domain exceptions
+- **Interface (BE)** — new endpoint on `OrdersController`
+- **Frontend** — Retry button per failed sync-status row + mutation hook + toast
+- **DX** — Side-bug fix in `OrderActivityTimeline` so the activity row no longer reads "in progress" for `failed` destinations
+
+## Non-goals
+
+- Not introducing a per-destination job type (`marketplace.order.destination-sync`) — re-enqueueing the existing source-side `marketplace.order.sync` is sufficient. Per #348, destination adapters' `createOrder` is idempotent for already-synced destinations, so re-running a fan-out is safe.
+- Not changing automatic retry policy or backoff.
+- Not re-running source-side ingestion via a separate "re-pull" affordance — destination retry is the case the issue describes.
+- Not surfacing per-destination retry across the order list (bulk operation already covered by `/sync/jobs/retry-grouped`).
+
+## Background — what already exists
+
+- `marketplace.order.sync` worker handler (`apps/worker/src/sync/handlers/marketplace-order-sync.handler.ts`) — delegates to `OrderIngestionService.syncOrderFromSource` which re-fetches from the source, persists snapshot, then dispatches via `OrderSyncService.syncOrder` to **every** active `OrderProcessorManager` adapter (excluding the source connection).
+- Per-destination success/failure is captured in `order_records.syncStatus` JSONB; `OrderRecordRepository.updateSyncStatus` writes one row per destination with `status: 'pending' | 'syncing' | 'synced' | 'failed'`.
+- `JobEnqueuePort.enqueueJob` already enforces idempotency via `idempotencyKey`. `SyncJobRepository.createIfNotExistsByIdempotencyKey` returns the existing job if the key collides.
+- `SyncJobRetryService.retryJob(id)` requeues a single dead job (used by `POST /sync/jobs/:id/retry`).
+- The frontend already renders `failedDestinations` in an Alert + a Sync Status `DataTable` on the order detail page; no per-row action column exists.
+
+## Design — pragmatic re-enqueue
+
+When the operator clicks **Retry** on a failed destination row:
+
+1. The FE calls `POST /orders/:internalOrderId/destinations/:connectionId/retry`.
+2. The endpoint finds the `OrderRecord`. Returns `404` if missing.
+3. Looks up the row in `syncStatus` for `:connectionId`. Returns `404` if no such destination row.
+4. Validates that the destination row's status is `failed`. Returns `409` if `pending` / `syncing` / `synced` (nothing to retry, or already in flight).
+5. **Flips the destination's sync-status row from `failed` → `pending` immediately** (claim-the-slot: this acts as the de-facto lock; a concurrent click reads `pending` at step 4 and 409s).
+6. Constructs a fresh idempotency key: `marketplace:{sourceConnectionId}:order:{sourceEventId}:retry:{Date.now()}` so the queue's idempotency table does not collide with the original (now-dead) job.
+7. Enqueues a new `marketplace.order.sync` job via `JobEnqueuePort.enqueueJob` with payload `{ schemaVersion: 1, externalOrderId, sourceEventId }` (read from the OrderRecord and the IdentifierMappingService).
+8. **If enqueue fails, reverts the sync-status row back to `failed`** (with the original error preserved) so the operator can retry again.
+9. Returns `202 Accepted` with `{ jobId, jobType: 'marketplace.order.sync', destinationConnectionId, internalOrderId }`.
+
+When the worker picks up the job, it re-fans-out to every destination. Already-synced destinations stay synced (idempotent at the destination adapter level per #348); the previously-failed destination either succeeds → status flips to `synced`, or fails again → status flips back to `failed` with the new error message.
+
+### Why claim-then-enqueue (not enqueue-then-claim)
+
+Claiming the slot (status → `pending`) **before** enqueue closes the only realistic concurrent-click race: two operators (or a double-click) reading `failed` simultaneously and both enqueuing separate jobs. With the order reversed, the second click reads `pending` at step 4 and 409s. The narrow remaining race — two reads passing through step 4 within the same handler tick before either has written — is bounded by the request-handler concurrency model and acceptable for MVP; a true CAS update (`updateSyncStatusIf(fromStatus, toStatus)`) would close it absolutely, but it requires a new repository method and is not needed at current operator scale. Worth revisiting if multi-tenant operator concurrency becomes a real load pattern.
+
+### Why a fresh idempotency key
+
+The queue's idempotency table is not what protects against double-retry — the status-flip-as-lock above is. The original `marketplace:{conn}:order:{eventKey}` key would still match the now-dead job and short-circuit the new enqueue. The `:retry:{timestamp}` suffix is purely a way to bypass the historical key so we get a fresh `queued` row; it deliberately does not serve as a deduplication key for retries.
+
+### Why mark `pending`, not `syncing`
+
+`syncing` semantically means "worker has picked it up and is dispatching". The job is queued but not yet picked up at the moment we return 202. `pending` matches the existing semantic (`OrderIngestionService.persistOrder` sets the initial status to `pending`).
+
+## Files
+
+### CORE (libs/core/src/orders/)
+
+| File | Action | Notes |
+|---|---|---|
+| `application/interfaces/order-destination-retry.service.interface.ts` | new | `IOrderDestinationRetryService.retry(input: { internalOrderId, destinationConnectionId }): Promise<{ jobId, jobType }>` |
+| `application/services/order-destination-retry.service.ts` | new | `@Injectable` class implementing the interface; injects `ORDER_RECORD_REPOSITORY_TOKEN`, `ORDER_RECORD_SERVICE_TOKEN`, `JOB_ENQUEUE_TOKEN`, `IDENTIFIER_MAPPING_SERVICE_TOKEN`, plus `Logger` |
+| `application/services/__tests__/order-destination-retry.service.spec.ts` | new | unit-test the four error branches + happy path |
+| `domain/exceptions/order-destination-not-found.exception.ts` | new | thrown when no matching syncStatus row |
+| `domain/exceptions/order-destination-not-retryable.exception.ts` | new | thrown when status is not `failed` |
+| `domain/exceptions/missing-source-external-id.exception.ts` | new | thrown when `IdentifierMappingService.getExternalIds('Order', internalOrderId)` returns no entry for the OrderRecord's source connection — defensive guard against stale/inconsistent data |
+| `orders.tokens.ts` | extend | add `ORDER_DESTINATION_RETRY_SERVICE_TOKEN` symbol |
+| `orders.module.ts` | extend | register the new service + bind to its token |
+| `index.ts` | extend | export interface + token + exceptions for API layer consumption |
+
+### Interface — apps/api/src/orders/
+
+| File | Action | Notes |
+|---|---|---|
+| `http/orders.controller.ts` | extend | add `@Post(':internalOrderId/destinations/:connectionId/retry')` returning 202; map domain exceptions to 404 / 409 |
+| `http/dto/retry-order-destination-response.dto.ts` | new | `{ jobId: string; jobType: 'marketplace.order.sync'; destinationConnectionId: string; internalOrderId: string }` |
+| `http/orders.controller.spec.ts` | extend | unit tests for 202 / 404 / 409 paths (mock the service) |
+
+### Frontend — apps/web/src/
+
+| File | Action | Notes |
+|---|---|---|
+| `features/orders/api/orders.api.ts` | extend | add `retryDestination(internalOrderId, connectionId)` method calling `POST /orders/:internalOrderId/destinations/:connectionId/retry` |
+| `features/orders/api/orders.types.ts` | extend | add `RetryOrderDestinationResult` type |
+| `features/orders/hooks/use-retry-order-destination-mutation.ts` | new | mutation hook; on success invalidate `ordersQueryKeys.detail(internalOrderId)` and toast success |
+| `pages/orders/order-detail-page.tsx` | extend | add `Actions` column to `SYNC_COLUMNS` rendering a `<Button>` only for `failed` rows; pass mutation state down so the button can disable during in-flight |
+| `features/orders/components/order-activity-timeline.tsx` | fix side bug | render time pill as the failure context (not "in progress") when status is `failed`; pending/syncing keeps "in progress" |
+| `features/orders/components/order-activity-timeline.test.tsx` | extend | add a test for the failed-status case |
+| `pages/orders/order-detail-page.test.tsx` | new (small) | covers Retry button visibility (only `failed` rows) + click triggers mutation |
+
+## Step-by-step
+
+### Step 1 — domain exceptions + service interface
+- Write the two exception classes (`OrderDestinationNotFoundException`, `OrderDestinationNotRetryableException`) in `domain/exceptions/` following the project's existing exception conventions (extend `Error`, capture stack trace).
+- Write `IOrderDestinationRetryService` interface in `application/interfaces/`.
+- **AC**: typecheck passes; interface and exception names match naming conventions.
+
+### Step 2 — implement the service
+- Implement `OrderDestinationRetryService` in `application/services/`.
+- Logic (claim-then-enqueue ordering):
+  1. `orderRecordRepository.findById(internalOrderId)` → throw `OrderRecordNotFoundException` if null.
+  2. Find the destination's syncStatus row → throw `OrderDestinationNotFoundException` if missing.
+  3. Validate `status === 'failed'` → throw `OrderDestinationNotRetryableException` with the current status if not.
+  4. Resolve `externalOrderId` via `IdentifierMappingService.getExternalIds('Order', internalOrderId)` filtered to the entry whose `connectionId` matches the OrderRecord's `sourceConnectionId`. If no such entry exists, throw `MissingSourceExternalIdException`.
+  5. **Claim the slot**: call `orderRecordService.updateSyncStatus(internalOrderId, destinationConnectionId, { destinationConnectionId, status: 'pending' })`. From here on, a concurrent click sees `pending` and 409s.
+  6. Build a fresh idempotency key `marketplace:{sourceConnectionId}:order:{sourceEventId}:retry:{Date.now()}`.
+  7. Try `JobEnqueuePort.enqueueJob({ jobType: 'marketplace.order.sync', connectionId: sourceConnectionId, payload, idempotencyKey })`.
+  8. **On enqueue failure**: revert the status row back to `failed` with the original error preserved (read from the syncStatus snapshot taken at step 2), then re-throw. The operator must be able to retry again.
+  9. Return `{ jobId, jobType: 'marketplace.order.sync' }`.
+- **AC**: each branch logs an appropriate `log` / `warn` line, and the revert-on-enqueue-failure path is unit-tested.
+
+### Step 3 — service unit tests
+- Cover: happy path (claim + enqueue + return), order-not-found, destination-not-found, status-pending → 409, status-syncing → 409, status-synced → 409, missing source external id (`MissingSourceExternalIdException`), enqueue failure (status reverted to `failed` with original error preserved, then re-throw).
+- **AC**: all branches pass; ports are mocked, no real adapters; the revert-on-enqueue-failure path explicitly asserts both the second `updateSyncStatus` call and the original error string is preserved.
+
+### Step 4 — register the service in the core module
+- Add the token symbol, register provider in `OrdersModule`, export from `index.ts`.
+- **AC**: `pnpm --filter @openlinker/core build` passes if applicable; service is resolvable.
+
+### Step 5 — controller endpoint
+- Extend `OrdersController` with `retryDestination` method.
+- Inject the new service via the new token.
+- Use `ParseUUIDPipe` on `:connectionId` (UUID per `Connection.id`); leave `:internalOrderId` as a plain string param (internal IDs are `ol_order_{uuid}` TEXT, not UUID).
+- Map exceptions to HTTP status codes:
+  - `OrderRecordNotFoundException` → 404
+  - `OrderDestinationNotFoundException` → 404
+  - `OrderDestinationNotRetryableException` → 409
+  - `MissingSourceExternalIdException` → 500 (this is data inconsistency, not a normal user error)
+- Return DTO with 202 status.
+- Add Swagger decorators consistent with the rest of the file.
+- **AC**: the existing controller spec still passes; new spec covers all branches.
+
+### Step 6 — controller unit tests
+- Mock `IOrderDestinationRetryService`; assert the controller calls `retry()` with the right arguments and shapes the response.
+- Assert exception → status mapping.
+
+### Step 7 — frontend API + types + hook
+- Extend `OrdersApi` with `retryDestination`. POST with empty body, returns the DTO.
+- Add `RetryOrderDestinationResult` type to `orders.types.ts`.
+- Write `useRetryOrderDestinationMutation` hook in `hooks/`. Invalidate `ordersQueryKeys.detail(internalOrderId)` on success.
+- **AC**: `pnpm --filter @openlinker/web type-check` passes.
+
+### Step 8 — order detail page Retry button
+- Extend `SYNC_COLUMNS` with a new `actions` column rendering a `<Button>` only for `failed` rows. Other rows render a small `<EmptyValue />` or nothing.
+- Wire the click handler to `useRetryOrderDestinationMutation`; disable while pending; toast success/error.
+- **AC**: button only visible on `failed` rows; clicking flips the row to `pending` after the mutation settles via query invalidation.
+
+### Step 9 — fix the activity timeline side bug
+- In `OrderActivityTimeline.tsx`, change the time-pill render so events with `tone === 'error'` and no real timestamp show nothing (or "—") instead of "in progress". The dot tone is already `error` and the title verb already says "failed to sync to {destination}" — the time pill is the only piece that lies. Branching on `tone === 'error'` keeps the timeline component self-contained without threading the raw OrderSyncStatusValue through.
+- Update the existing test to cover this case.
+
+### Step 10 — page-level test
+- A small test asserting:
+  - Retry button is rendered for failed rows only.
+  - Clicking it calls the mutation with `(internalOrderId, destinationConnectionId)`.
+
+### Step 11 — integration test (vertical slice)
+- New `apps/api/test/integration/order-destination-retry.int-spec.ts` against the standard Testcontainers harness.
+- Covers:
+  - **202 happy path**: seed an OrderRecord with one `failed` destination row + an identifier mapping for the source external id; POST the endpoint; assert 202 + new `marketplace.order.sync` row in `sync_jobs` (status `queued`) + the destination's `syncStatus` flipped to `pending`.
+  - **409 path**: seed an OrderRecord with the destination row in `synced`; POST → expect 409 + no new sync_jobs row + status unchanged.
+  - **404 path**: post against an unknown internalOrderId → expect 404.
+- **AC**: runs under `pnpm test:integration` against real Postgres + Redis; verifies wiring (token resolution, JSONB upsert, idempotency-key insertion).
+
+### Step 12 — quality gate + self-review
+- Run `pnpm lint && pnpm type-check && pnpm test`.
+- Self-review using `docs/code-review-guide.md`. Fix BLOCKING / IMPORTANT before commit.
+
+## Validation
+
+- **Hexagonal layering**: new service is in `application/services/` and depends only on ports + the existing record service. Domain exceptions are in `domain/exceptions/`. No framework leak into `domain/`.
+- **Naming**: `*.service.interface.ts` + `*.service.ts` for the new service; `*.exception.ts` for new exceptions; `*-response.dto.ts` for the controller DTO.
+- **Repository ports pattern**: not adding a new repository port — reusing `OrderRecordRepositoryPort` and `OrderRecordService` plus the existing `JobEnqueuePort` + `IdentifierMappingService`. No new repo lookup is needed.
+- **Idempotency**: fresh `:retry:{timestamp}` key. Concurrent clicks within the same millisecond would both enqueue, but the optimistic `pending` flip after the first enqueue causes the second request to 409.
+- **Security**: endpoint already covered by the controller-level `@Roles('admin')` decorator. No new auth surface.
+- **No migration**: no schema changes.
+- **Tests**: unit tests on new service, controller test for new endpoint, page-level FE test for button visibility/click, timeline test for the side-bug fix.
+
+## Risk + open questions
+
+1. **Re-enqueueing fans out to all destinations.** Successful destinations should be no-ops because of #348 idempotency at the destination adapter level. If a future destination adapter is *not* idempotent on `createOrder`, its row could flip from `synced` back to `failed` due to a duplicate-create error. Today only PrestaShop's `OrderProcessorAdapter` exists and #348 has already wired in idempotency for it. If a future destination adapter is non-idempotent, that's a defect in the adapter, not in this retry plumbing.
+2. **Concurrent retries across multiple destinations of the same order.** Two operators clicking Retry on two different failed destinations of the same order each produce a fresh `marketplace.order.sync` job. Both jobs re-fan-out to all destinations, doubling work. With #348 idempotency this is functionally safe — successful destinations stay synced — but it doubles outbound HTTP traffic to the destination. Acceptable for MVP; if it becomes a problem we can serialize by checking for any in-flight `marketplace.order.sync` job for this order's source before enqueuing.
+3. **The original dead job stays in the `dead` table.** That's fine — `/sync` already shows it for forensic context, and the new retry produces a separate job with its own audit trail.
+4. **Single-destination claim race (narrow).** Two clicks on the *same* destination within the same handler tick can both pass step 4 before either has written `pending`. The claim-then-enqueue ordering closes the wide window; this narrow tick-level window remains. Closing it requires a CAS update method on the repository (`updateSyncStatusIf(fromStatus, toStatus)`) which is out of scope for this PR. Worth revisiting if real-world operator concurrency surfaces it.

--- a/libs/core/src/orders/application/interfaces/order-destination-retry.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-destination-retry.service.interface.ts
@@ -1,0 +1,45 @@
+/**
+ * Order Destination Retry Service Interface
+ *
+ * Defines the contract for retrying a failed destination sync of an existing
+ * OrderRecord. The service re-enqueues the source-side `marketplace.order.sync`
+ * job with a fresh idempotency key so the worker re-fans-out to all
+ * destinations. Already-synced destinations stay synced via destination-adapter
+ * idempotency (#348); only the previously-failed destination is materially
+ * re-attempted.
+ *
+ * @module libs/core/src/orders/application/interfaces
+ */
+import type { JobType } from '@openlinker/core/sync';
+
+export interface OrderDestinationRetryInput {
+  /** Internal order id (`ol_order_*`) */
+  internalOrderId: string;
+  /** Destination connection id whose row was clicked Retry on */
+  destinationConnectionId: string;
+}
+
+export interface OrderDestinationRetryResult {
+  /** Sync-job row id created for this retry */
+  jobId: string;
+  /** Job type — always `marketplace.order.sync` for now */
+  jobType: JobType;
+}
+
+export interface IOrderDestinationRetryService {
+  /**
+   * Retry a failed destination sync.
+   *
+   * Validates the OrderRecord exists, the destination row exists and is
+   * currently `failed`, claims the slot by flipping it to `pending`,
+   * resolves the source external id, then enqueues a fresh
+   * `marketplace.order.sync` job. On enqueue failure the status is
+   * reverted to `failed` with the original error preserved.
+   *
+   * @throws {OrderRecordNotFoundException} if the order does not exist
+   * @throws {OrderDestinationNotFoundException} if the destination row is missing
+   * @throws {OrderDestinationNotRetryableException} if status !== 'failed'
+   * @throws {MissingSourceExternalIdException} if source identifier mapping is missing
+   */
+  retry(input: OrderDestinationRetryInput): Promise<OrderDestinationRetryResult>;
+}

--- a/libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * Order Destination Retry Service Tests
+ *
+ * Unit tests for OrderDestinationRetryService. Covers happy path, all 4xx
+ * branches, and the revert-on-enqueue-failure path.
+ *
+ * @module libs/core/src/orders/application/services/__tests__
+ */
+import { OrderDestinationRetryService } from '../order-destination-retry.service';
+import { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
+import { IOrderRecordService } from '../../interfaces/order-record.service.interface';
+import { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
+import type { JobEnqueuePort } from '@openlinker/core/sync';
+import { OrderRecord, OrderSyncStatus } from '../../../domain/entities/order-record.entity';
+import { OrderRecordNotFoundException } from '../../../domain/exceptions/order-record-not-found.exception';
+import { OrderDestinationNotFoundException } from '../../../domain/exceptions/order-destination-not-found.exception';
+import { OrderDestinationNotRetryableException } from '../../../domain/exceptions/order-destination-not-retryable.exception';
+import { MissingSourceExternalIdException } from '../../../domain/exceptions/missing-source-external-id.exception';
+
+describe('OrderDestinationRetryService', () => {
+  let service: OrderDestinationRetryService;
+  let orderRepo: jest.Mocked<OrderRecordRepositoryPort>;
+  let recordService: jest.Mocked<IOrderRecordService>;
+  let identifierMapping: jest.Mocked<IIdentifierMappingService>;
+  let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+
+  const INTERNAL_ORDER_ID = 'ol_order_123';
+  const SOURCE_CONN = 'conn-source';
+  const DEST_CONN = 'conn-dest';
+  const SOURCE_EVENT_ID = 'evt-99';
+  const SOURCE_EXTERNAL_ID = 'ext-order-1';
+
+  const failedRow: OrderSyncStatus = {
+    destinationConnectionId: DEST_CONN,
+    status: 'failed',
+    error: 'PrestaShop country PL not active',
+  };
+
+  const buildOrder = (rows: OrderSyncStatus[] = [failedRow]): OrderRecord =>
+    new OrderRecord(
+      INTERNAL_ORDER_ID,
+      'ol_customer_1',
+      SOURCE_CONN,
+      SOURCE_EVENT_ID,
+      {},
+      rows,
+      'ready',
+      new Date(),
+      new Date(),
+    );
+
+  beforeEach(() => {
+    orderRepo = {
+      findById: jest.fn(),
+      findMany: jest.fn(),
+      upsert: jest.fn(),
+      updateSyncStatus: jest.fn(),
+    } as unknown as jest.Mocked<OrderRecordRepositoryPort>;
+
+    recordService = {
+      persistOrder: jest.fn(),
+      updateSyncStatus: jest.fn().mockResolvedValue(undefined),
+      persistIncomingSnapshot: jest.fn(),
+      getOrderRecord: jest.fn(),
+    } as unknown as jest.Mocked<IOrderRecordService>;
+
+    identifierMapping = {
+      getOrCreateInternalId: jest.fn(),
+      getInternalId: jest.fn(),
+      getExternalIds: jest.fn(),
+      createMapping: jest.fn(),
+      batchGetOrCreateInternalIds: jest.fn(),
+    } as unknown as jest.Mocked<IIdentifierMappingService>;
+
+    jobEnqueue = {
+      enqueueJob: jest.fn(),
+    } as unknown as jest.Mocked<JobEnqueuePort>;
+
+    service = new OrderDestinationRetryService(
+      orderRepo,
+      recordService,
+      identifierMapping,
+      jobEnqueue,
+    );
+  });
+
+  describe('retry', () => {
+    it('should claim slot, enqueue, and return job id on the happy path', async () => {
+      orderRepo.findById.mockResolvedValue(buildOrder());
+      identifierMapping.getExternalIds.mockResolvedValue([
+        {
+          externalId: SOURCE_EXTERNAL_ID,
+          platformType: 'allegro',
+          connectionId: SOURCE_CONN,
+          entityType: 'Order',
+        },
+      ]);
+      jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'job-new', isExisting: false });
+
+      const result = await service.retry({
+        internalOrderId: INTERNAL_ORDER_ID,
+        destinationConnectionId: DEST_CONN,
+      });
+
+      expect(result).toEqual({ jobId: 'job-new', jobType: 'marketplace.order.sync' });
+
+      // Slot was claimed before enqueue
+      expect(recordService.updateSyncStatus).toHaveBeenCalledTimes(1);
+      expect(recordService.updateSyncStatus).toHaveBeenCalledWith(
+        INTERNAL_ORDER_ID,
+        DEST_CONN,
+        { destinationConnectionId: DEST_CONN, status: 'pending' },
+      );
+
+      // Enqueued for the source connection (not the destination) with the right payload
+      expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(1);
+      const [req] = jobEnqueue.enqueueJob.mock.calls[0];
+      expect(req.jobType).toBe('marketplace.order.sync');
+      expect(req.connectionId).toBe(SOURCE_CONN);
+      expect(req.payload).toMatchObject({
+        schemaVersion: 1,
+        externalOrderId: SOURCE_EXTERNAL_ID,
+        sourceEventId: SOURCE_EVENT_ID,
+      });
+      expect(req.idempotencyKey).toMatch(
+        new RegExp(`^marketplace:${SOURCE_CONN}:order:${SOURCE_EVENT_ID}:retry:\\d+$`),
+      );
+    });
+
+    it('should throw OrderRecordNotFoundException when the order does not exist', async () => {
+      orderRepo.findById.mockResolvedValue(null);
+
+      await expect(
+        service.retry({
+          internalOrderId: INTERNAL_ORDER_ID,
+          destinationConnectionId: DEST_CONN,
+        }),
+      ).rejects.toBeInstanceOf(OrderRecordNotFoundException);
+
+      expect(recordService.updateSyncStatus).not.toHaveBeenCalled();
+      expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+    });
+
+    it('should throw OrderDestinationNotFoundException when no syncStatus row matches', async () => {
+      orderRepo.findById.mockResolvedValue(buildOrder([])); // no destinations
+
+      await expect(
+        service.retry({
+          internalOrderId: INTERNAL_ORDER_ID,
+          destinationConnectionId: DEST_CONN,
+        }),
+      ).rejects.toBeInstanceOf(OrderDestinationNotFoundException);
+
+      expect(recordService.updateSyncStatus).not.toHaveBeenCalled();
+      expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+    });
+
+    it.each(['pending', 'syncing', 'synced'] as const)(
+      'should throw OrderDestinationNotRetryableException when status is %s',
+      async (status) => {
+        orderRepo.findById.mockResolvedValue(
+          buildOrder([{ destinationConnectionId: DEST_CONN, status }]),
+        );
+
+        await expect(
+          service.retry({
+            internalOrderId: INTERNAL_ORDER_ID,
+            destinationConnectionId: DEST_CONN,
+          }),
+        ).rejects.toBeInstanceOf(OrderDestinationNotRetryableException);
+
+        expect(recordService.updateSyncStatus).not.toHaveBeenCalled();
+        expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should throw MissingSourceExternalIdException when source mapping is absent', async () => {
+      orderRepo.findById.mockResolvedValue(buildOrder());
+      identifierMapping.getExternalIds.mockResolvedValue([
+        // mapping for some other connection only
+        {
+          externalId: 'other',
+          platformType: 'prestashop',
+          connectionId: 'unrelated-conn',
+          entityType: 'Order',
+        },
+      ]);
+
+      await expect(
+        service.retry({
+          internalOrderId: INTERNAL_ORDER_ID,
+          destinationConnectionId: DEST_CONN,
+        }),
+      ).rejects.toBeInstanceOf(MissingSourceExternalIdException);
+
+      expect(recordService.updateSyncStatus).not.toHaveBeenCalled();
+      expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
+    });
+
+    it('should revert status to failed with original error preserved when enqueue fails', async () => {
+      orderRepo.findById.mockResolvedValue(buildOrder());
+      identifierMapping.getExternalIds.mockResolvedValue([
+        {
+          externalId: SOURCE_EXTERNAL_ID,
+          platformType: 'allegro',
+          connectionId: SOURCE_CONN,
+          entityType: 'Order',
+        },
+      ]);
+      jobEnqueue.enqueueJob.mockRejectedValue(new Error('redis down'));
+
+      await expect(
+        service.retry({
+          internalOrderId: INTERNAL_ORDER_ID,
+          destinationConnectionId: DEST_CONN,
+        }),
+      ).rejects.toThrow('redis down');
+
+      // First call: claim (failed → pending). Second call: revert (pending → failed with original error).
+      expect(recordService.updateSyncStatus).toHaveBeenCalledTimes(2);
+      expect(recordService.updateSyncStatus).toHaveBeenNthCalledWith(
+        1,
+        INTERNAL_ORDER_ID,
+        DEST_CONN,
+        { destinationConnectionId: DEST_CONN, status: 'pending' },
+      );
+      expect(recordService.updateSyncStatus).toHaveBeenNthCalledWith(
+        2,
+        INTERNAL_ORDER_ID,
+        DEST_CONN,
+        {
+          destinationConnectionId: DEST_CONN,
+          status: 'failed',
+          error: 'PrestaShop country PL not active',
+        },
+      );
+    });
+
+    it('should re-throw the original enqueue error even if the revert itself fails', async () => {
+      orderRepo.findById.mockResolvedValue(buildOrder());
+      identifierMapping.getExternalIds.mockResolvedValue([
+        {
+          externalId: SOURCE_EXTERNAL_ID,
+          platformType: 'allegro',
+          connectionId: SOURCE_CONN,
+          entityType: 'Order',
+        },
+      ]);
+      jobEnqueue.enqueueJob.mockRejectedValue(new Error('redis down'));
+      // First call succeeds (the claim), second call (revert) fails.
+      recordService.updateSyncStatus
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('db connection lost'));
+
+      await expect(
+        service.retry({
+          internalOrderId: INTERNAL_ORDER_ID,
+          destinationConnectionId: DEST_CONN,
+        }),
+      ).rejects.toThrow('redis down'); // original enqueue error, not the revert error
+
+      expect(recordService.updateSyncStatus).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/libs/core/src/orders/application/services/order-destination-retry.service.ts
+++ b/libs/core/src/orders/application/services/order-destination-retry.service.ts
@@ -1,0 +1,158 @@
+/**
+ * Order Destination Retry Service
+ *
+ * Operator-driven retry for a failed destination sync. Re-enqueues the
+ * source-side `marketplace.order.sync` job with a fresh idempotency key
+ * (the original key would still match the now-dead job and short-circuit).
+ *
+ * Concurrency model: claim-then-enqueue. The destination's sync-status row
+ * is flipped from `failed` → `pending` *before* enqueue, acting as the
+ * de-facto lock. A concurrent click reads `pending` and 409s. On enqueue
+ * failure, the row is reverted to `failed` with the original error preserved.
+ *
+ * @module libs/core/src/orders/application/services
+ * @implements {IOrderDestinationRetryService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  IIdentifierMappingService,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+} from '@openlinker/core/identifier-mapping';
+import {
+  JobEnqueuePort,
+  JOB_ENQUEUE_TOKEN,
+  type SyncJobRequest,
+} from '@openlinker/core/sync';
+import {
+  IOrderDestinationRetryService,
+  OrderDestinationRetryInput,
+  OrderDestinationRetryResult,
+} from '../interfaces/order-destination-retry.service.interface';
+import { IOrderRecordService } from '../interfaces/order-record.service.interface';
+import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
+import { OrderRecordNotFoundException } from '../../domain/exceptions/order-record-not-found.exception';
+import { OrderDestinationNotFoundException } from '../../domain/exceptions/order-destination-not-found.exception';
+import { OrderDestinationNotRetryableException } from '../../domain/exceptions/order-destination-not-retryable.exception';
+import { MissingSourceExternalIdException } from '../../domain/exceptions/missing-source-external-id.exception';
+import {
+  ORDER_RECORD_REPOSITORY_TOKEN,
+  ORDER_RECORD_SERVICE_TOKEN,
+} from '../../orders.tokens';
+
+@Injectable()
+export class OrderDestinationRetryService implements IOrderDestinationRetryService {
+  private readonly logger = new Logger(OrderDestinationRetryService.name);
+
+  constructor(
+    @Inject(ORDER_RECORD_REPOSITORY_TOKEN)
+    private readonly orderRecordRepository: OrderRecordRepositoryPort,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecordService: IOrderRecordService,
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IIdentifierMappingService,
+    @Inject(JOB_ENQUEUE_TOKEN)
+    private readonly jobEnqueue: JobEnqueuePort,
+  ) {}
+
+  async retry(input: OrderDestinationRetryInput): Promise<OrderDestinationRetryResult> {
+    const { internalOrderId, destinationConnectionId } = input;
+
+    this.logger.log(
+      `Operator retry requested: order=${internalOrderId} destination=${destinationConnectionId}`,
+    );
+
+    const order = await this.orderRecordRepository.findById(internalOrderId);
+    if (!order) {
+      throw new OrderRecordNotFoundException(internalOrderId);
+    }
+
+    const destinationRow = order.syncStatus.find(
+      (s) => s.destinationConnectionId === destinationConnectionId,
+    );
+    if (!destinationRow) {
+      throw new OrderDestinationNotFoundException(internalOrderId, destinationConnectionId);
+    }
+
+    if (destinationRow.status !== 'failed') {
+      throw new OrderDestinationNotRetryableException(
+        internalOrderId,
+        destinationConnectionId,
+        destinationRow.status,
+      );
+    }
+
+    const sourceExternalIds = await this.identifierMapping.getExternalIds(
+      'Order',
+      internalOrderId,
+    );
+    const sourceMapping = sourceExternalIds.find(
+      (m) => m.connectionId === order.sourceConnectionId,
+    );
+    if (!sourceMapping) {
+      throw new MissingSourceExternalIdException(internalOrderId, order.sourceConnectionId);
+    }
+
+    // Snapshot the original failure so we can revert with it on enqueue failure.
+    const originalError = destinationRow.error;
+
+    // Claim the slot: flip failed → pending. From here a concurrent click 409s.
+    await this.orderRecordService.updateSyncStatus(
+      internalOrderId,
+      destinationConnectionId,
+      {
+        destinationConnectionId,
+        status: 'pending',
+      },
+    );
+
+    const idempotencyKey = `marketplace:${order.sourceConnectionId}:order:${order.sourceEventId ?? internalOrderId}:retry:${Date.now()}`;
+
+    const jobRequest: SyncJobRequest = {
+      jobType: 'marketplace.order.sync',
+      connectionId: order.sourceConnectionId,
+      payload: {
+        schemaVersion: 1,
+        externalOrderId: sourceMapping.externalId,
+        sourceEventId: order.sourceEventId ?? undefined,
+      },
+      idempotencyKey,
+    };
+
+    try {
+      const { jobId } = await this.jobEnqueue.enqueueJob(jobRequest);
+      this.logger.log(
+        `Retry enqueued: jobId=${jobId} order=${internalOrderId} destination=${destinationConnectionId} sourceConnection=${order.sourceConnectionId}`,
+      );
+      return { jobId, jobType: 'marketplace.order.sync' };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Retry enqueue failed; reverting destination back to 'failed'. order=${internalOrderId} destination=${destinationConnectionId}: ${message}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      // Revert: restore failed state with the original error preserved. If the revert
+      // *itself* throws (rare DB blip between claim and revert), the row is left in
+      // `pending` and the operator can no longer click Retry on it — log loudly so
+      // someone notices and can flip the row by hand.
+      try {
+        await this.orderRecordService.updateSyncStatus(
+          internalOrderId,
+          destinationConnectionId,
+          {
+            destinationConnectionId,
+            status: 'failed',
+            error: originalError,
+          },
+        );
+      } catch (revertError) {
+        const revertMessage = revertError instanceof Error ? revertError.message : String(revertError);
+        this.logger.error(
+          `Revert to 'failed' also failed; destination row stuck in 'pending'. order=${internalOrderId} destination=${destinationConnectionId}: ${revertMessage}`,
+          revertError instanceof Error ? revertError.stack : undefined,
+        );
+      }
+      throw error;
+    }
+  }
+}

--- a/libs/core/src/orders/domain/exceptions/missing-source-external-id.exception.ts
+++ b/libs/core/src/orders/domain/exceptions/missing-source-external-id.exception.ts
@@ -1,0 +1,25 @@
+/**
+ * Missing Source External Id Exception
+ *
+ * Defensive guard thrown when an OrderRecord exists but no identifier mapping
+ * for its source connection is found. Indicates internal data inconsistency —
+ * this should never happen for an OrderRecord persisted through the normal
+ * ingestion path, since `OrderIngestionService.syncOrderFromSource` creates
+ * the mapping before persisting the record. Surfaces as 5xx in the API layer.
+ *
+ * @module libs/core/src/orders/domain/exceptions
+ */
+export class MissingSourceExternalIdException extends Error {
+  constructor(
+    public readonly internalOrderId: string,
+    public readonly sourceConnectionId: string,
+  ) {
+    super(
+      `Order ${internalOrderId} has no source external id mapping for connection ${sourceConnectionId}`,
+    );
+    this.name = 'MissingSourceExternalIdException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MissingSourceExternalIdException);
+    }
+  }
+}

--- a/libs/core/src/orders/domain/exceptions/order-destination-not-found.exception.ts
+++ b/libs/core/src/orders/domain/exceptions/order-destination-not-found.exception.ts
@@ -1,0 +1,24 @@
+/**
+ * Order Destination Not Found Exception
+ *
+ * Domain exception thrown when attempting to act on a destination sync-status
+ * row that doesn't exist on the OrderRecord. Distinct from
+ * `OrderRecordNotFoundException` (the order itself is missing) — here the
+ * order exists but has no row for the requested destination connection.
+ *
+ * @module libs/core/src/orders/domain/exceptions
+ */
+export class OrderDestinationNotFoundException extends Error {
+  constructor(
+    public readonly internalOrderId: string,
+    public readonly destinationConnectionId: string,
+  ) {
+    super(
+      `Order ${internalOrderId} has no sync status for destination ${destinationConnectionId}`,
+    );
+    this.name = 'OrderDestinationNotFoundException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, OrderDestinationNotFoundException);
+    }
+  }
+}

--- a/libs/core/src/orders/domain/exceptions/order-destination-not-retryable.exception.ts
+++ b/libs/core/src/orders/domain/exceptions/order-destination-not-retryable.exception.ts
@@ -1,0 +1,26 @@
+/**
+ * Order Destination Not Retryable Exception
+ *
+ * Domain exception thrown when an operator attempts to retry a destination
+ * sync that is not in a retryable state. Only destinations whose status is
+ * `failed` can be retried — `pending` / `syncing` / `synced` rows reject.
+ *
+ * @module libs/core/src/orders/domain/exceptions
+ */
+import type { OrderSyncStatus } from '../entities/order-record.entity';
+
+export class OrderDestinationNotRetryableException extends Error {
+  constructor(
+    public readonly internalOrderId: string,
+    public readonly destinationConnectionId: string,
+    public readonly currentStatus: OrderSyncStatus['status'],
+  ) {
+    super(
+      `Cannot retry destination ${destinationConnectionId} for order ${internalOrderId}: current status is '${currentStatus}', expected 'failed'`,
+    );
+    this.name = 'OrderDestinationNotRetryableException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, OrderDestinationNotRetryableException);
+    }
+  }
+}

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -56,10 +56,16 @@ export {
 export { IOrderRecordService } from './application/interfaces/order-record.service.interface';
 export { OrderRecordService } from './application/services/order-record.service';
 export {
+  IOrderDestinationRetryService,
+  OrderDestinationRetryInput,
+  OrderDestinationRetryResult,
+} from './application/interfaces/order-destination-retry.service.interface';
+export {
   ORDER_SYNC_SERVICE_TOKEN,
   ORDER_INGESTION_SERVICE_TOKEN,
   ORDER_RECORD_REPOSITORY_TOKEN,
   ORDER_RECORD_SERVICE_TOKEN,
+  ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
 } from './orders.tokens';
 
 // Domain entities
@@ -68,6 +74,9 @@ export { OrderRecord, OrderSyncStatus } from './domain/entities/order-record.ent
 // Domain exceptions
 export { OrderRecordNotFoundException } from './domain/exceptions/order-record-not-found.exception';
 export { MissingOrderItemMappingError } from './domain/exceptions/missing-order-item-mapping.error';
+export { OrderDestinationNotFoundException } from './domain/exceptions/order-destination-not-found.exception';
+export { OrderDestinationNotRetryableException } from './domain/exceptions/order-destination-not-retryable.exception';
+export { MissingSourceExternalIdException } from './domain/exceptions/missing-source-external-id.exception';
 
 // Ports
 export { OrderRecordRepositoryPort } from './domain/ports/order-record-repository.port';

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -12,6 +12,7 @@ import { OrderSyncService } from './application/services/order-sync.service';
 import { OrderIngestionService } from './application/services/order-ingestion.service';
 import { OrderItemRefResolverService } from './application/services/order-item-ref-resolver.service';
 import { OrderRecordService } from './application/services/order-record.service';
+import { OrderDestinationRetryService } from './application/services/order-destination-retry.service';
 import { OrderRecordRepository } from './infrastructure/persistence/repositories/order-record.repository';
 import { OrderRecordOrmEntity } from './infrastructure/persistence/entities/order-record.orm-entity';
 import {
@@ -19,6 +20,7 @@ import {
   ORDER_INGESTION_SERVICE_TOKEN,
   ORDER_RECORD_REPOSITORY_TOKEN,
   ORDER_RECORD_SERVICE_TOKEN,
+  ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
 } from './orders.tokens';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
@@ -46,6 +48,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     OrderIngestionService,
     OrderItemRefResolverService,
     OrderRecordService,
+    OrderDestinationRetryService,
     OrderRecordRepository,
     // Then provide token bindings using useExisting
     {
@@ -64,6 +67,10 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
       provide: ORDER_RECORD_SERVICE_TOKEN,
       useExisting: OrderRecordService,
     },
+    {
+      provide: ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
+      useExisting: OrderDestinationRetryService,
+    },
   ],
   exports: [
     OrderRecordService, // Export service class for direct injection
@@ -71,6 +78,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     ORDER_INGESTION_SERVICE_TOKEN,
     ORDER_RECORD_REPOSITORY_TOKEN,
     ORDER_RECORD_SERVICE_TOKEN,
+    ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
   ],
 })
 export class OrdersModule {}

--- a/libs/core/src/orders/orders.tokens.ts
+++ b/libs/core/src/orders/orders.tokens.ts
@@ -13,6 +13,7 @@ export const ORDER_SYNC_SERVICE_TOKEN = Symbol('IOrderSyncService');
 export const ORDER_INGESTION_SERVICE_TOKEN = Symbol('IOrderIngestionService');
 export const ORDER_RECORD_REPOSITORY_TOKEN = Symbol('OrderRecordRepositoryPort');
 export const ORDER_RECORD_SERVICE_TOKEN = Symbol('IOrderRecordService');
+export const ORDER_DESTINATION_RETRY_SERVICE_TOKEN = Symbol('IOrderDestinationRetryService');
 
 
 


### PR DESCRIPTION
## Summary

- Adds `POST /orders/:internalOrderId/destinations/:connectionId/retry` plus the FE Retry button on each `failed` Sync Status row of the order detail page.
- Re-enqueues a fresh `marketplace.order.sync` job (the original is dead). Already-synced destinations stay synced via destination-adapter idempotency (#348); the failed destination is re-attempted.
- Concurrent clicks on the same destination are blocked by **claim-then-enqueue** — the row flips `failed` → `pending` *before* enqueue, acting as the de-facto lock; on enqueue failure we revert to `failed` with the original error preserved (and log loudly if even the revert fails).
- Side bug fixed in the same area: the activity timeline rendered "in progress" for failed destinations because they have no `syncedAt`. Now the time pill stays empty when the event tone is `error`, matching the red dot + "failed to sync to {destination}" verb already on the row.

## Architecture

- New `OrderDestinationRetryService` (`IOrderDestinationRetryService`) in `libs/core/src/orders/application/services/` — depends only on ports (`OrderRecordRepositoryPort`, `IOrderRecordService`, `IIdentifierMappingService`, `JobEnqueuePort`).
- Three new domain exceptions in `libs/core/src/orders/domain/exceptions/` (`OrderDestinationNotFoundException`, `OrderDestinationNotRetryableException`, `MissingSourceExternalIdException`).
- Controller maps domain exceptions → 404 / 409 / 500. `ParseUUIDPipe` on `:connectionId`; `:internalOrderId` left as TEXT (`ol_order_*`).
- FE: new `useRetryOrderDestinationMutation` hook invalidates the order detail query on success. Toast on success/error. No new global state.

## Test plan

- [x] Unit tests: 8 cases on the service (happy path, all 4xx branches, missing source mapping, enqueue-failure-revert, revert-failure-still-throws-original).
- [x] Controller spec: 5 cases covering 202 + each exception → HTTP mapping.
- [x] Integration test (`order-destination-retry.int-spec.ts`): 202 happy path against real Postgres + Redis, asserts queue stream + idempotency key shape + status flip; plus 409 / 404 / 401.
- [x] FE component tests: button only on failed rows, click triggers mutation with right ids, button is disabled while in flight.
- [x] Timeline test: `failed` rows with no `syncedAt` no longer render "in progress".
- [x] `pnpm lint && pnpm type-check && pnpm test && pnpm test:integration` all pass.

## Out of scope

- Per-destination job type (`marketplace.order.destinationSync`) — the source-side `marketplace.order.sync` re-fan-out is sufficient with destination-level idempotency.
- Source-side re-pull from Allegro/PrestaShop.
- Bulk retry across orders — already covered by `/sync/jobs/retry-grouped`.

## Implementation plan

`docs/plans/implementation-plan-450-order-destination-retry.md` (added in this PR).

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)