### PR TITLE
fix(allegro): propagate shipping cost + use delivery.address for shippingAddress

### DIFF
--- a/docs/plans/implementation-plan-454-457-allegro-shipping-cost-and-address.md
+++ b/docs/plans/implementation-plan-454-457-allegro-shipping-cost-and-address.md
@@ -1,0 +1,247 @@
+# Implementation Plan — #454 + #457: Allegro shipping cost + delivery address
+
+## Goal
+
+Stop two silent corruptions on every Allegro→PrestaShop order:
+
+1. **#454** — Allegro orders land with `total_shipping = 0` and PS flags `Payment error: €X.XX paid instead of €Y.YY` because we read `summary.totalToPay` as both `subtotal` and `total`, dropping shipping cost on the floor.
+2. **#457** — Shipping address comes from `buyer.address` (the buyer's profile address) instead of `delivery.address` (the actual checkout-time ship-to). Parcels go to the wrong place when buyers ship to a different address than their profile.
+
+Both root-cause through the same missing piece: `AllegroCheckoutForm.delivery` is not modelled in our types. Fixing the type unblocks both fixes in the same file (`AllegroOrderSourceAdapter.getOrder`).
+
+## Layer classification
+
+- **Integration** — Allegro adapter only. `AllegroCheckoutForm` type + adapter mapping.
+- No core changes (`IncomingOrder.totals.shipping` and `IncomingOrderAddress` already exist).
+- No schema changes, no migration.
+- No FE changes.
+
+## Non-goals
+
+Per the issue bodies, these stay out of scope and are tracked separately:
+
+- **#455** — carrier mapping (Allegro `delivery.method` → PS `id_carrier`). Has an unresolved Option 1 vs 2 design decision.
+- **#458** — pickup-point forwarding for InPost lockers. Has an unresolved Option 1/2/3 design decision.
+- Shipping VAT split — Allegro doesn't expose shipping VAT separately on checkout-form; revisit if/when it does.
+- Mapping by name fallback when `delivery.method.id` is absent.
+
+The `delivery` type added by #454 is **fully shaped** (includes `method`, `pickupPoint`, etc.) so #455 and #458 don't need to re-extend it later — only the adapter's *use* of those fields stays out of scope here.
+
+## Design
+
+### Single change to `AllegroCheckoutForm` type
+
+Extend the existing interface in `libs/integrations/allegro/src/domain/types/allegro-api.types.ts` with an optional `delivery?` block matching the Allegro swagger `CheckoutFormDeliveryReference`. The full shape is typed proactively so #455 and #458 don't need to re-edit the interface — but **the adapter in this PR consumes only `cost` and `address`**. The other fields (`method`, `pickupPoint`, `smart`) are typed for downstream PRs and ignored here:
+
+```typescript
+delivery?: {
+  /** #455 — carrier mapping consumes `method.id`. Ignored in this PR. */
+  method?: { id: string; name?: string };
+  /** #454 — this PR uses `cost.amount` for shipping totals. */
+  cost?: { amount: string; currency: string };
+  /** #457 — this PR prefers `address` over `buyer.address` for shippingAddress. */
+  address?: {
+    firstName?: string;
+    lastName?: string;
+    street?: string;
+    city?: string;
+    zipCode?: string;
+    countryCode?: string;
+    companyName?: string;
+    phoneNumber?: string;
+  };
+  /** #458 — pickup-point forwarding consumes this. Ignored in this PR. */
+  pickupPoint?: {
+    id: string;
+    name?: string;
+    description?: string;
+    address?: {
+      street?: string;
+      zipCode?: string;
+      city?: string;
+      countryCode?: string;
+    };
+  };
+  /** Future use (Smart! free-delivery flag). Ignored in this PR. */
+  smart?: boolean;
+};
+```
+
+All fields are optional because Allegro doesn't always populate every sub-field (pickup-only orders skip `cost`; cash-pickup orders may skip `address`; non-pickup-point orders skip `pickupPoint`).
+
+### `AllegroOrderSourceAdapter.getOrder` — two surgical changes
+
+**Change 1 (#454): recompute totals.**
+
+Today (`allegro-order-source.adapter.ts:169-175`):
+
+```typescript
+totals: {
+  subtotal: parseFloat(checkoutForm.summary.totalToPay.amount), // ❌ includes shipping
+  tax: 0,
+  shipping: 0,                                                  // ❌ always 0
+  total: parseFloat(checkoutForm.summary.totalToPay.amount),
+  currency: checkoutForm.summary.totalToPay.currency,
+},
+```
+
+After:
+
+```typescript
+const subtotal = checkoutForm.lineItems.reduce(
+  (acc, item) => acc + parseFloat(item.price.amount) * item.quantity,
+  0,
+);
+const total = parseFloat(checkoutForm.summary.totalToPay.amount);
+const shipping = checkoutForm.delivery?.cost
+  ? parseFloat(checkoutForm.delivery.cost.amount)
+  : Math.max(0, total - subtotal); // defensive fallback for malformed responses
+
+totals: {
+  subtotal: roundCurrency(subtotal),
+  tax: 0,
+  shipping: roundCurrency(shipping),
+  total: roundCurrency(total),
+  currency: checkoutForm.summary.totalToPay.currency,
+},
+```
+
+`roundCurrency(n)` = `Math.round(n * 100) / 100` — Allegro returns string-decimal amounts, our totals are `number`; rounding once at construction prevents float-drift.
+
+**Change 2 (#457): prefer `delivery.address` for `shippingAddress`.**
+
+Today (`allegro-order-source.adapter.ts:176-186`):
+
+```typescript
+shippingAddress: checkoutForm.buyer.address
+  ? {
+      firstName: checkoutForm.buyer.firstName,
+      lastName: checkoutForm.buyer.lastName,
+      address1: checkoutForm.buyer.address.street ?? '',
+      city: checkoutForm.buyer.address.city ?? '',
+      postalCode: checkoutForm.buyer.address.zipCode ?? '',
+      country: checkoutForm.buyer.address.countryCode ?? '',
+      phone: checkoutForm.buyer.phoneNumber,
+    }
+  : undefined,
+```
+
+After: prefer `delivery.address` if it has at least one populated field, fall back to `buyer.address` otherwise. Each branch sources name + phone from the corresponding side (delivery uses `delivery.address.firstName/lastName/phoneNumber`; buyer fallback uses `buyer.firstName/lastName/phoneNumber`). Log at `debug` which source was used.
+
+The empty-`{}`-guard matters: Allegro can return `delivery.address: {}` on pickup-point orders where the parcel goes to the locker (the locker address is on `delivery.pickupPoint`, not `delivery.address`). Without the guard, we'd emit `address1: '', city: '', postalCode: '', country: ''` — worse than today's `buyer.address` fallback. Pickup-point address resolution is #458's scope; until that ships, pickup-only orders should keep using `buyer.address`.
+
+```typescript
+const shippingAddress = this.resolveShippingAddress(checkoutForm);
+// ...
+private resolveShippingAddress(checkoutForm: AllegroCheckoutForm): IncomingOrderAddress | undefined {
+  const deliveryAddr = checkoutForm.delivery?.address;
+  // Reject empty `delivery.address: {}` — happens on pickup-point orders.
+  // Treat any of street/city/zipCode being non-empty as "real address present."
+  const hasDeliveryAddress = Boolean(
+    deliveryAddr && (deliveryAddr.street || deliveryAddr.city || deliveryAddr.zipCode),
+  );
+
+  if (hasDeliveryAddress && deliveryAddr) {
+    this.logger.debug(
+      `Using delivery.address as shippingAddress for ${checkoutForm.id} (connection: ${this.connectionId})`,
+    );
+    return {
+      firstName: deliveryAddr.firstName,
+      lastName: deliveryAddr.lastName,
+      company: deliveryAddr.companyName,
+      address1: deliveryAddr.street ?? '',
+      city: deliveryAddr.city ?? '',
+      postalCode: deliveryAddr.zipCode ?? '',
+      country: deliveryAddr.countryCode ?? '',
+      phone: deliveryAddr.phoneNumber,
+    };
+  }
+  if (checkoutForm.buyer.address) {
+    this.logger.debug(
+      `Using buyer.address as shippingAddress fallback for ${checkoutForm.id} (connection: ${this.connectionId})`,
+    );
+    return {
+      firstName: checkoutForm.buyer.firstName,
+      lastName: checkoutForm.buyer.lastName,
+      address1: checkoutForm.buyer.address.street ?? '',
+      city: checkoutForm.buyer.address.city ?? '',
+      postalCode: checkoutForm.buyer.address.zipCode ?? '',
+      country: checkoutForm.buyer.address.countryCode ?? '',
+      phone: checkoutForm.buyer.phoneNumber,
+    };
+  }
+  return undefined;
+}
+```
+
+Extracting to a private helper keeps `getOrder` readable now that it has a non-trivial branch.
+
+### Why `IncomingOrderAddress.company` is the right home for `companyName`
+
+`IncomingOrderAddress.company?: string` already exists on the core type. Allegro's `delivery.address.companyName` semantically matches — it's a buyer-supplied company name on the shipping address (e.g. for B2B orders shipping to a company). The PrestaShop side uses it via the address-provisioner's mapping; no PS-side change needed.
+
+### Defensive subtotal fallback — why
+
+The plan computes `shipping = total - subtotal` when `delivery.cost` is absent. This is defensive against:
+
+- Pickup-only orders that omit `cost` but still have `totalToPay > subtotal` (rare).
+- Malformed/partial responses during sandbox repros.
+- Future Allegro response variants we haven't seen.
+
+`Math.max(0, …)` prevents a negative shipping if some discount path produces `subtotal > totalToPay`. In that case we leave `shipping = 0` and `subtotal` accurate — the sum is internally consistent for PS.
+
+## Files
+
+| File | Action | Notes |
+|---|---|---|
+| `libs/integrations/allegro/src/domain/types/allegro-api.types.ts` | extend | add `delivery?` block to `AllegroCheckoutForm` matching swagger `CheckoutFormDeliveryReference` |
+| `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts` | edit | recompute totals (lineItem-based subtotal + delivery.cost shipping); resolve shipping address via new private helper |
+| `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts` | extend | add 5 new test cases (see below); update existing `should hydrate a full IncomingOrder` to assert the new totals shape (split subtotal/shipping) since the existing fixture has no shipping cost — verify it still produces `subtotal=39.98, shipping=0` |
+
+## Step-by-step
+
+### Step 1 — extend the `AllegroCheckoutForm` type
+- Add `delivery?` to the interface.
+- Use full shape (method, cost, address, pickupPoint, smart) so #455/#458 don't need to re-edit it.
+- **AC**: `pnpm --filter @openlinker/integrations-allegro type-check` passes.
+
+### Step 2 — recompute totals (#454)
+- Replace the `totals` block in `getOrder` with line-item-derived `subtotal` + `delivery.cost`-derived `shipping` + `total - subtotal` defensive fallback.
+- Add a small `roundCurrency(n)` helper local to the file.
+- **AC**: existing tests still pass; new totals tests (Step 4) cover all branches.
+
+### Step 3 — refactor shipping-address resolution (#457)
+- Extract a private `resolveShippingAddress(checkoutForm)` method.
+- Branch order: `delivery.address` → `buyer.address` → `undefined`.
+- Source `firstName`, `lastName`, `phone`, and (new) `company` from the same side as the address itself in each branch.
+- `debug` log indicates which source was used.
+- **AC**: existing `should hydrate a full IncomingOrder` test continues to pass with `buyer.address`-only fixture.
+
+### Step 4 — add the new test cases
+1. `should compute subtotal and shipping correctly when delivery.cost is present` — fixture with 1 × €10 line item, `delivery.cost: '12.49'`, `totalToPay: '22.49'` → `{ subtotal: 10, shipping: 12.49, total: 22.49 }`.
+2. `should fall back to total - subtotal when delivery.cost is absent` — same fixture without `delivery.cost` → `shipping: 12.49`.
+3. `should clamp shipping to 0 when subtotal exceeds total (defensive)` — fixture where `lineItems` sum is 50 but `totalToPay: 30` → `shipping: 0`, `subtotal: 50`, `total: 30`.
+4. `should report shipping=0 when delivery.cost is explicitly 0.00 (free delivery)` — fixture with 1 × €10 line item, `delivery.cost: { amount: '0.00' }`, `totalToPay: '10.00'` → `{ subtotal: 10, shipping: 0, total: 10 }`. Catches a regression where someone replaces the ternary with `||` and `'0.00'` falls through to the `total - subtotal` fallback (which would also yield 0 here, but on a different code path — the assertion locks in the right *path*).
+5. `should prefer delivery.address over buyer.address for shippingAddress` — both set, different cities → `shippingAddress.city` is the delivery one; firstName / lastName / phone / company sourced from `delivery.address` consistently.
+6. `should fall back to buyer.address when delivery.address is undefined` — only `buyer.address` set → behaviour unchanged from today.
+7. `should fall back to buyer.address when delivery.address is an empty object` — `delivery: { address: {} }` (pickup-point order) plus `buyer.address` populated → emits `buyer.address`, not the empty object. Verifies the empty-guard introduced in Step 3.
+- Existing `should hydrate a full IncomingOrder` test: update its assertion to the split-totals shape. The current fixture is `2 × €19.99`, `totalToPay: '39.98'`, no `delivery.cost` — so the new assertion is `{ subtotal: 39.98, shipping: 0, total: 39.98 }`. Confirms internally-consistent totals when no shipping is in the picture.
+- **AC**: all 7 new/updated cases pass; no regressions in any other Allegro adapter test.
+
+### Step 5 — quality gate + self-review
+- `pnpm lint && pnpm type-check && pnpm test`.
+- Self-review per `docs/code-review-guide.md`. Fix BLOCKING / IMPORTANT.
+
+## Validation
+
+- **Hexagonal layering**: change is purely in `libs/integrations/allegro/src/` — no core surface changes. `IncomingOrder` shape already supports `shipping`, `company`, etc. No new ports or services.
+- **Naming**: type extension on existing interface; private method on adapter — no new public class. Conventions unchanged.
+- **No migration**: schema-stable. JSONB-stored `OrderRecord.orderSnapshot` is forward-compatible (it stores whatever the adapter emits).
+- **Security**: no new auth surface. Address fields are PII and respect the existing `OL_STORE_PII` flag at the persistence layer (handled by `OrderRecordService`); adapter just emits the value.
+- **Tests**: 5 new cases cover all branches. Adapter is in the 70% coverage tier — these additions take it well past that.
+
+## Risks
+
+1. **Existing fixtures relying on `buyer.address`-as-shipping-address.** Today's test passes `buyer.address` only and asserts `shippingAddress.city`. After the change that test still passes (no `delivery.address` present → fallback). Verify — if it breaks I missed something.
+2. **Round-trip drift on `delivery.cost`.** Allegro returns string-decimal amounts. We `parseFloat` and round to 2 decimals. The `subtotal = Σ(price × quantity)` arithmetic could introduce a sub-cent drift on multi-item orders with prices like `€19.99 × 3 = 59.97000000000001` — `roundCurrency` neutralizes that.
+3. **Pickup-point orders without a delivery address.** Allegro returns `delivery.pickupPoint` but no `delivery.address`. Today: would fall back to `buyer.address` (the home address) — wrong, but consistent with the bug we're fixing for #457. Picking the *right* address for pickup-point is #458's scope, not this PR's. The fallback to `buyer.address` keeps current behaviour for that case until #458 ships.

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -9,7 +9,15 @@
  */
 
 /**
- * Allegro checkout form (from GET /order/checkout-forms/{id})
+ * Allegro checkout form (from GET /order/checkout-forms/{id}).
+ *
+ * The `delivery` block mirrors the Allegro swagger
+ * `CheckoutFormDeliveryReference`. Today's adapter (`AllegroOrderSourceAdapter`)
+ * consumes only `delivery.cost` (#454 — shipping totals) and `delivery.address`
+ * (#457 — preferred shippingAddress source). The remaining fields are typed
+ * proactively so #455 (carrier mapping → `method.id`) and #458
+ * (pickup-point forwarding → `pickupPoint`) don't need to re-extend this
+ * interface.
  */
 export interface AllegroCheckoutForm {
   id: string;
@@ -55,6 +63,41 @@ export interface AllegroCheckoutForm {
       amount: string;
       currency: string;
     };
+  };
+  delivery?: {
+    /** #455 — carrier mapping consumes `method.id`. Ignored in this adapter today. */
+    method?: { id: string; name?: string };
+    /** #454 — `cost.amount` is the per-order shipping cost. */
+    cost?: { amount: string; currency: string };
+    /**
+     * #457 — preferred source for `shippingAddress`. May be present-but-empty
+     * (`{}`) on pickup-point orders where the parcel ships to the locker, not
+     * to a street address; the adapter guards against that case.
+     */
+    address?: {
+      firstName?: string;
+      lastName?: string;
+      street?: string;
+      city?: string;
+      zipCode?: string;
+      countryCode?: string;
+      companyName?: string;
+      phoneNumber?: string;
+    };
+    /** #458 — pickup-point (InPost locker etc.). Ignored in this adapter today. */
+    pickupPoint?: {
+      id: string;
+      name?: string;
+      description?: string;
+      address?: {
+        street?: string;
+        zipCode?: string;
+        city?: string;
+        countryCode?: string;
+      };
+    };
+    /** Allegro Smart! free-delivery flag. Ignored today. */
+    smart?: boolean;
   };
   createdAt?: string;
   updatedAt?: string;

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -229,7 +229,14 @@ describe('AllegroOrderSourceAdapter', () => {
         price: 19.99,
         name: 'Offer 1',
       });
-      expect(incoming.totals).toMatchObject({ total: 39.98, currency: 'PLN' });
+      // No `delivery` block — totals split with shipping=0, subtotal == total.
+      expect(incoming.totals).toEqual({
+        subtotal: 39.98,
+        tax: 0,
+        shipping: 0,
+        total: 39.98,
+        currency: 'PLN',
+      });
       expect(incoming.shippingAddress?.city).toBe('Warsaw');
     });
 
@@ -255,6 +262,186 @@ describe('AllegroOrderSourceAdapter', () => {
       const incoming = await adapter.getOrder({ externalOrderId: 'checkout-2' });
 
       expect(incoming.status).toBe('pending');
+    });
+
+    describe('totals — shipping cost (#454)', () => {
+      const baseForm = (): AllegroCheckoutForm => ({
+        id: 'cf',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        buyer: { id: 'b', email: 'b@e.com', login: 'b' },
+        lineItems: [
+          {
+            id: 'l1',
+            offer: { id: 'o1', name: 'O1' },
+            quantity: 1,
+            price: { amount: '10.00', currency: 'PLN' },
+          },
+        ],
+        summary: { totalToPay: { amount: '22.49', currency: 'PLN' } },
+        payment: { type: 'ONLINE' },
+      });
+
+      it('should compute subtotal and shipping correctly when delivery.cost is present', async () => {
+        const form = baseForm();
+        form.delivery = { cost: { amount: '12.49', currency: 'PLN' } };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.totals).toEqual({
+          subtotal: 10,
+          tax: 0,
+          shipping: 12.49,
+          total: 22.49,
+          currency: 'PLN',
+        });
+      });
+
+      it('should fall back to total - subtotal when delivery.cost is absent', async () => {
+        const form = baseForm();
+        // No `delivery` block — fallback path.
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.totals.shipping).toBe(12.49);
+      });
+
+      it('should clamp shipping to 0 when subtotal exceeds total (defensive)', async () => {
+        const form = baseForm();
+        form.lineItems = [
+          {
+            id: 'l1',
+            offer: { id: 'o1', name: 'O1' },
+            quantity: 5,
+            price: { amount: '10.00', currency: 'PLN' },
+          },
+        ];
+        form.summary = { totalToPay: { amount: '30.00', currency: 'PLN' } };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.totals.subtotal).toBe(50);
+        expect(incoming.totals.shipping).toBe(0);
+        expect(incoming.totals.total).toBe(30);
+      });
+
+      it('should report shipping=0 when delivery.cost is explicitly 0.00 (free delivery)', async () => {
+        // Locks in the right code path: a `||` regression would pass this test
+        // accidentally because subtotal == total, but the assertion that
+        // `delivery.cost` was the source still belongs in the suite — future
+        // edits that diverge the two paths (e.g. tax handling) will catch it.
+        const form = baseForm();
+        form.delivery = { cost: { amount: '0.00', currency: 'PLN' } };
+        form.summary = { totalToPay: { amount: '10.00', currency: 'PLN' } };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.totals).toEqual({
+          subtotal: 10,
+          tax: 0,
+          shipping: 0,
+          total: 10,
+          currency: 'PLN',
+        });
+      });
+    });
+
+    describe('shippingAddress — delivery.address preference (#457)', () => {
+      const baseForm = (): AllegroCheckoutForm => ({
+        id: 'cf',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        buyer: {
+          id: 'b',
+          email: 'b@e.com',
+          login: 'b',
+          firstName: 'Buyer',
+          lastName: 'Profile',
+          phoneNumber: '+48000000000',
+          address: {
+            street: 'Profile Street 1',
+            city: 'BuyerCity',
+            zipCode: '00-001',
+            countryCode: 'PL',
+          },
+        },
+        lineItems: [
+          {
+            id: 'l1',
+            offer: { id: 'o1', name: 'O1' },
+            quantity: 1,
+            price: { amount: '10.00', currency: 'PLN' },
+          },
+        ],
+        summary: { totalToPay: { amount: '10.00', currency: 'PLN' } },
+        payment: { type: 'ONLINE' },
+      });
+
+      it('should prefer delivery.address over buyer.address for shippingAddress', async () => {
+        const form = baseForm();
+        form.delivery = {
+          address: {
+            firstName: 'Recipient',
+            lastName: 'Different',
+            companyName: 'Acme Sp. z o.o.',
+            street: 'Delivery Street 99',
+            city: 'DeliveryCity',
+            zipCode: '99-999',
+            countryCode: 'PL',
+            phoneNumber: '+48999999999',
+          },
+        };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.shippingAddress).toEqual({
+          firstName: 'Recipient',
+          lastName: 'Different',
+          company: 'Acme Sp. z o.o.',
+          address1: 'Delivery Street 99',
+          city: 'DeliveryCity',
+          postalCode: '99-999',
+          country: 'PL',
+          phone: '+48999999999',
+        });
+      });
+
+      it('should fall back to buyer.address when delivery.address is undefined', async () => {
+        const form = baseForm();
+        // No `delivery` block at all.
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.shippingAddress).toMatchObject({
+          firstName: 'Buyer',
+          lastName: 'Profile',
+          address1: 'Profile Street 1',
+          city: 'BuyerCity',
+          postalCode: '00-001',
+          country: 'PL',
+          phone: '+48000000000',
+        });
+      });
+
+      it('should fall back to buyer.address when delivery.address is an empty object', async () => {
+        // Pickup-point order: parcel goes to delivery.pickupPoint (#458 scope),
+        // delivery.address is empty {}. Without the empty-guard, we'd emit
+        // empty strings — worse than today's buyer.address fallback.
+        const form = baseForm();
+        form.delivery = { address: {} };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.shippingAddress?.city).toBe('BuyerCity');
+        expect(incoming.shippingAddress?.address1).toBe('Profile Street 1');
+      });
     });
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -442,6 +442,26 @@ describe('AllegroOrderSourceAdapter', () => {
         expect(incoming.shippingAddress?.city).toBe('BuyerCity');
         expect(incoming.shippingAddress?.address1).toBe('Profile Street 1');
       });
+
+      it('should fall back to buyer.address when delivery.address has only name fields (no geography)', async () => {
+        // Defensive: a delivery.address with firstName/lastName but no
+        // street/city/zipCode is geographically meaningless — the empty-guard
+        // pushes it to the buyer.address fallback rather than emitting empty
+        // strings. This case is exotic but cheap to lock in.
+        const form = baseForm();
+        form.delivery = {
+          address: {
+            firstName: 'Recipient',
+            lastName: 'NoGeography',
+          },
+        };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.shippingAddress?.firstName).toBe('Buyer'); // from buyer.address
+        expect(incoming.shippingAddress?.address1).toBe('Profile Street 1');
+      });
     });
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -16,6 +16,7 @@ import type {
   OrderFeedOutput,
   OrderFeedEventType,
   IncomingOrder,
+  IncomingOrderAddress,
 } from '@openlinker/core/orders';
 import { Connection } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
@@ -149,6 +150,19 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort {
       const createdAt = checkoutForm.createdAt ?? new Date().toISOString();
       const updatedAt = checkoutForm.updatedAt ?? createdAt;
 
+      // #454 — split totals: derive subtotal from line items, shipping from
+      // delivery.cost (or fallback). Previously we used `totalToPay` as both
+      // subtotal and total, which left PrestaShop with `total_shipping=0` and
+      // a `Payment error` reconciliation gap on every Allegro order.
+      const subtotal = checkoutForm.lineItems.reduce(
+        (acc, item) => acc + Number.parseFloat(item.price.amount) * item.quantity,
+        0,
+      );
+      const total = Number.parseFloat(checkoutForm.summary.totalToPay.amount);
+      const shipping = checkoutForm.delivery?.cost
+        ? Number.parseFloat(checkoutForm.delivery.cost.amount)
+        : Math.max(0, total - subtotal);
+
       return {
         externalOrderId: checkoutFormId,
         orderNumber: checkoutFormId,
@@ -167,23 +181,13 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort {
           // internal product catalog is tracked as a separate follow-up.
         })),
         totals: {
-          subtotal: Number.parseFloat(checkoutForm.summary.totalToPay.amount),
+          subtotal: roundCurrency(subtotal),
           tax: 0,
-          shipping: 0,
-          total: Number.parseFloat(checkoutForm.summary.totalToPay.amount),
+          shipping: roundCurrency(shipping),
+          total: roundCurrency(total),
           currency: checkoutForm.summary.totalToPay.currency,
         },
-        shippingAddress: checkoutForm.buyer.address
-          ? {
-              firstName: checkoutForm.buyer.firstName,
-              lastName: checkoutForm.buyer.lastName,
-              address1: checkoutForm.buyer.address.street ?? '',
-              city: checkoutForm.buyer.address.city ?? '',
-              postalCode: checkoutForm.buyer.address.zipCode ?? '',
-              country: checkoutForm.buyer.address.countryCode ?? '',
-              phone: checkoutForm.buyer.phoneNumber,
-            }
-          : undefined,
+        shippingAddress: this.resolveShippingAddress(checkoutForm),
         billingAddress: undefined,
         createdAt,
         updatedAt,
@@ -202,6 +206,60 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort {
       throw error;
     }
   }
+
+  /**
+   * Resolve the shipping address from the checkout form (#457).
+   *
+   * Prefers `delivery.address` (the actual checkout-time ship-to that the
+   * buyer chose) over `buyer.address` (the buyer's stored profile address).
+   * Falls back to `buyer.address` when `delivery.address` is absent or empty.
+   *
+   * The empty-object guard matters for pickup-point orders: Allegro can
+   * return `delivery: { address: {} }` when the parcel ships to an InPost
+   * locker (the locker address lives on `delivery.pickupPoint`, which is
+   * #458's scope, not this PR's). Without the guard, we'd emit empty
+   * strings for every address field — worse than today's `buyer.address`
+   * fallback.
+   */
+  private resolveShippingAddress(
+    checkoutForm: AllegroCheckoutForm,
+  ): IncomingOrderAddress | undefined {
+    const deliveryAddr = checkoutForm.delivery?.address;
+    const hasDeliveryAddress = Boolean(
+      deliveryAddr && (deliveryAddr.street || deliveryAddr.city || deliveryAddr.zipCode),
+    );
+
+    if (hasDeliveryAddress && deliveryAddr) {
+      this.logger.debug(
+        `Using delivery.address as shippingAddress for ${checkoutForm.id} (connection: ${this.connectionId})`,
+      );
+      return {
+        firstName: deliveryAddr.firstName,
+        lastName: deliveryAddr.lastName,
+        company: deliveryAddr.companyName,
+        address1: deliveryAddr.street ?? '',
+        city: deliveryAddr.city ?? '',
+        postalCode: deliveryAddr.zipCode ?? '',
+        country: deliveryAddr.countryCode ?? '',
+        phone: deliveryAddr.phoneNumber,
+      };
+    }
+    if (checkoutForm.buyer.address) {
+      this.logger.debug(
+        `Using buyer.address as shippingAddress fallback for ${checkoutForm.id} (connection: ${this.connectionId})`,
+      );
+      return {
+        firstName: checkoutForm.buyer.firstName,
+        lastName: checkoutForm.buyer.lastName,
+        address1: checkoutForm.buyer.address.street ?? '',
+        city: checkoutForm.buyer.address.city ?? '',
+        postalCode: checkoutForm.buyer.address.zipCode ?? '',
+        country: checkoutForm.buyer.address.countryCode ?? '',
+        phone: checkoutForm.buyer.phoneNumber,
+      };
+    }
+    return undefined;
+  }
 }
 
 function mapAllegroEventType(type: string): OrderFeedEventType {
@@ -210,4 +268,15 @@ function mapAllegroEventType(type: string): OrderFeedEventType {
   if (t.includes('PAID')) return 'paid';
   if (t.includes('BOUGHT')) return 'created';
   return 'updated';
+}
+
+/**
+ * Round a number to 2-decimal currency precision.
+ *
+ * MVP: assumes 2-decimal currencies (PLN, EUR, USD). Allegro PL is the only
+ * marketplace today, so PLN coverage is sufficient. Revisit when a non-2-decimal
+ * currency surfaces (JPY = 0, BHD = 3, etc.) — likely via an Allegro CZ/SK seller.
+ */
+function roundCurrency(amount: number): number {
+  return Math.round(amount * 100) / 100;
 }


### PR DESCRIPTION
## Summary

Two surgical changes to `AllegroOrderSourceAdapter.getOrder`, both rooted in the same missing piece — `AllegroCheckoutForm.delivery` was untyped, so the adapter ignored fields Allegro returns.

**#454 — shipping cost.** Totals were computed as `subtotal == total == totalToPay`, leaving `shipping = 0`. Every Allegro order landed in PrestaShop with `total_shipping = 0` and `Payment error: paid instead of expected`. Now subtotal is derived from line items, shipping from `delivery.cost` (fallback: `total - subtotal`, clamped at 0), total from `totalToPay`. `roundCurrency` neutralizes float drift on multi-item arithmetic.

**#457 — delivery address.** `shippingAddress` was sourced from `buyer.address` (the buyer's profile address), not `delivery.address` (the actual checkout-time ship-to). Parcels went to the wrong place when buyers shipped somewhere different from their profile. Now prefers `delivery.address` with an empty-`{}`-guard so pickup-point orders (where `delivery.address = {}` and the locker lives on `delivery.pickupPoint`) keep falling back to `buyer.address` until #458 ships.

## Architecture

Pure integration-layer change — `libs/integrations/allegro/` only. No core surface, no schema, no migration.

The `delivery` type extension covers the full Allegro swagger shape (`method`, `cost`, `address`, `pickupPoint`, `smart`) so #455 (carrier mapping) and #458 (pickupPoint forwarding) don't need to re-edit the interface. JSDoc on each field marks what's consumed today vs typed for downstream PRs.

`IncomingOrderAddress.company` already exists in the core type; mapping `delivery.address.companyName` to it is semantically right (B2B shipments).

## Test plan

- [x] Unit tests: 15 cases on the adapter — happy path, totals with `delivery.cost` present, totals fallback, defensive subtotal-clamp, free-delivery (`cost: '0.00'`), `delivery.address` preference, `buyer.address` fallback (undefined), `buyer.address` fallback (empty `{}`), `buyer.address` fallback (name-only, no geography), event-feed parsing, status mapping.
- [x] `pnpm lint && pnpm type-check && pnpm test` — green across all 7 backend packages (1345 tests) + web (770 tests).
- [x] Existing Allegro adapter tests (221 total) still pass with the updated totals shape.

## Out of scope

Tracked in their own issues:
- **#455** — carrier mapping (Allegro `delivery.method` → PS `id_carrier`). Has unresolved Option 1 vs 2 design decision.
- **#458** — pickup-point forwarding for InPost lockers. Has unresolved Option 1/2/3 design decision.
- Shipping VAT split — Allegro doesn't expose shipping VAT separately on checkout-form.
- Mapping by name fallback when `delivery.method.id` is absent.

## Implementation plan

`docs/plans/implementation-plan-454-457-allegro-shipping-cost-and-address.md` (added in this PR).

Closes #454
Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)