### PR TITLE
feat(orders): per-destination append-only attempts log on OrderRecord

### DIFF
--- a/apps/api/src/migrations/1793000000000-add-order-record-sync-attempts.ts
+++ b/apps/api/src/migrations/1793000000000-add-order-record-sync-attempts.ts
@@ -1,0 +1,29 @@
+/**
+ * Add Order Record Sync Attempts
+ *
+ * Adds an append-only `syncAttempts` JSONB column to `order_records` so the
+ * activity timeline can preserve every per-destination attempt instead of
+ * showing only the current state in `syncStatus`. The repository UPDATE
+ * caps each destination's history at the documented per-destination cap
+ * via a window function inside a single statement; no index is needed
+ * because reads are always row-by-PK.
+ *
+ * Zero-downtime: the column has a `[]` default, so the ALTER is a
+ * metadata-only operation in PG 11+ and existing rows start with an empty
+ * history (no backfill).
+ *
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderRecordSyncAttempts1793000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN "syncAttempts" jsonb NOT NULL DEFAULT '[]'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "order_records" DROP COLUMN "syncAttempts"`);
+  }
+}

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -7,9 +7,10 @@
  * @module apps/api/src/orders/http/dto
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { OrderRecordStatusValues } from '@openlinker/core/orders';
+import { OrderRecordStatusValues, SYNC_ATTEMPTS_PER_DESTINATION_CAP } from '@openlinker/core/orders';
 import type { OrderRecordStatus } from '@openlinker/core/orders';
 import { OrderSyncStatusResponseDto } from './order-sync-status-response.dto';
+import { SyncAttemptResponseDto } from './sync-attempt-response.dto';
 
 export class OrderRecordResponseDto {
   @ApiProperty({ description: 'Internal order ID (e.g. ol_order_...)' })
@@ -29,6 +30,15 @@ export class OrderRecordResponseDto {
 
   @ApiProperty({ type: [OrderSyncStatusResponseDto], description: 'Sync status per destination' })
   syncStatus!: OrderSyncStatusResponseDto[];
+
+  @ApiProperty({
+    type: [SyncAttemptResponseDto],
+    description:
+      `Per-destination attempt history (append-only, capped at ${SYNC_ATTEMPTS_PER_DESTINATION_CAP} ` +
+      'most-recent entries per destination). Used by the activity timeline to preserve ' +
+      'failure → retry → success narrative.',
+  })
+  syncAttempts!: SyncAttemptResponseDto[];
 
   @ApiProperty({ description: 'Order creation timestamp (ISO 8601)' })
   createdAt!: string;

--- a/apps/api/src/orders/http/dto/sync-attempt-response.dto.ts
+++ b/apps/api/src/orders/http/dto/sync-attempt-response.dto.ts
@@ -1,0 +1,38 @@
+/**
+ * Sync Attempt Response DTO
+ *
+ * One historical attempt to sync an order to a destination. Returned as part
+ * of `OrderRecordResponseDto.syncAttempts` so the FE activity timeline can
+ * preserve the failure → retry → success narrative on the order detail page.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { OrderSyncStatusFilterValues } from '@openlinker/core/orders';
+import type { OrderSyncStatusFilter } from '@openlinker/core/orders';
+
+export class SyncAttemptResponseDto {
+  @ApiProperty({ description: 'Destination connection ID' })
+  destinationConnectionId!: string;
+
+  @ApiProperty({ enum: OrderSyncStatusFilterValues, description: 'Attempt status' })
+  status!: OrderSyncStatusFilter;
+
+  @ApiProperty({ description: 'Attempt timestamp (ISO 8601)' })
+  attemptedAt!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Error message if attempt failed' })
+  error!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'External order ID if attempt produced one',
+  })
+  externalOrderId!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'External order number if attempt produced one',
+  })
+  externalOrderNumber!: string | null;
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -160,6 +160,57 @@ describe('OrdersController', () => {
       expect(result.items[0].syncStatus[0].externalOrderId).toBeNull();
       expect(result.items[0].syncStatus[0].error).toBeNull();
     });
+
+    it('maps syncAttempts to ISO timestamps and nullable fields', async () => {
+      const orderWithAttempts = new OrderRecord(
+        'ol_order_003',
+        null,
+        'conn-source-001',
+        null,
+        {},
+        [{ destinationConnectionId: 'conn-dest-001', status: 'synced' }],
+        'ready',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T01:00:00Z'),
+        [
+          {
+            destinationConnectionId: 'conn-dest-001',
+            status: 'failed',
+            attemptedAt: new Date('2026-04-01T00:30:00Z'),
+            error: 'PL not active',
+          },
+          {
+            destinationConnectionId: 'conn-dest-001',
+            status: 'synced',
+            attemptedAt: new Date('2026-04-01T01:00:00Z'),
+            externalOrderId: 'PS-456',
+          },
+        ],
+      );
+      repository.findMany.mockResolvedValue({ items: [orderWithAttempts], total: 1 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items[0].syncAttempts).toHaveLength(2);
+      expect(result.items[0].syncAttempts[0]).toEqual({
+        destinationConnectionId: 'conn-dest-001',
+        status: 'failed',
+        attemptedAt: '2026-04-01T00:30:00.000Z',
+        error: 'PL not active',
+        externalOrderId: null,
+        externalOrderNumber: null,
+      });
+      expect(result.items[0].syncAttempts[1].externalOrderId).toBe('PS-456');
+      expect(result.items[0].syncAttempts[1].error).toBeNull();
+    });
+
+    it('exposes an empty syncAttempts array when none exist', async () => {
+      repository.findMany.mockResolvedValue({ items: [mockOrder], total: 1 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items[0].syncAttempts).toEqual([]);
+    });
   });
 
   describe('getOrder', () => {

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -31,10 +31,16 @@ import {
   OrderDestinationNotRetryableException,
   MissingSourceExternalIdException,
 } from '@openlinker/core/orders';
-import type { OrderRecord, OrderSyncStatus, IOrderDestinationRetryService } from '@openlinker/core/orders';
+import type {
+  OrderRecord,
+  OrderSyncStatus,
+  SyncAttempt,
+  IOrderDestinationRetryService,
+} from '@openlinker/core/orders';
 import { ListOrdersQueryDto } from './dto/list-orders-query.dto';
 import { OrderRecordResponseDto } from './dto/order-record-response.dto';
 import { OrderSyncStatusResponseDto } from './dto/order-sync-status-response.dto';
+import { SyncAttemptResponseDto } from './dto/sync-attempt-response.dto';
 import { PaginatedOrdersResponseDto } from './dto/paginated-orders-response.dto';
 import { RetryOrderDestinationResponseDto } from './dto/retry-order-destination-response.dto';
 
@@ -151,6 +157,7 @@ export class OrdersController {
       sourceEventId: order.sourceEventId,
       orderSnapshot: order.orderSnapshot,
       syncStatus: order.syncStatus.map((s) => this.toSyncStatusDto(s)),
+      syncAttempts: order.syncAttempts.map((a) => this.toSyncAttemptDto(a)),
       recordStatus: order.recordStatus,
       createdAt: order.createdAt instanceof Date ? order.createdAt.toISOString() : order.createdAt,
       updatedAt: order.updatedAt instanceof Date ? order.updatedAt.toISOString() : order.updatedAt,
@@ -165,6 +172,17 @@ export class OrdersController {
       externalOrderId: s.externalOrderId ?? null,
       externalOrderNumber: s.externalOrderNumber ?? null,
       error: s.error ?? null,
+    };
+  }
+
+  private toSyncAttemptDto(a: SyncAttempt): SyncAttemptResponseDto {
+    return {
+      destinationConnectionId: a.destinationConnectionId,
+      status: a.status,
+      attemptedAt: a.attemptedAt instanceof Date ? a.attemptedAt.toISOString() : a.attemptedAt,
+      error: a.error ?? null,
+      externalOrderId: a.externalOrderId ?? null,
+      externalOrderNumber: a.externalOrderNumber ?? null,
     };
   }
 }

--- a/apps/api/test/integration/order-record-attempts.int-spec.ts
+++ b/apps/api/test/integration/order-record-attempts.int-spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Order Record Sync-Attempts Integration Test
+ *
+ * Verifies the per-destination append-only history on `OrderRecord`:
+ *   - serial appends preserve chronological order
+ *   - per-destination cap is enforced atomically inside the UPDATE
+ *   - concurrent writers across destinations don't lose attempts
+ *   - missing rows surface OrderRecordNotFoundException
+ *
+ * Exercises the real `OrderRecordRepository` against Testcontainers Postgres,
+ * which is the only reliable way to cover the JSONB window-function +
+ * row-lock semantics that protect the timeline from the read-modify-write
+ * race the previous implementation had (#456).
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { createTestOrderRecord } from './fixtures/order.fixtures';
+import {
+  ORDER_RECORD_REPOSITORY_TOKEN,
+  OrderRecordNotFoundException,
+  OrderRecordRepositoryPort,
+  SyncAttempt,
+  SYNC_ATTEMPTS_PER_DESTINATION_CAP,
+} from '@openlinker/core/orders';
+
+describe('OrderRecord sync attempts (integration)', () => {
+  let harness: IntegrationTestHarness;
+  let repository: OrderRecordRepositoryPort;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    repository = harness.getApp().get<OrderRecordRepositoryPort>(ORDER_RECORD_REPOSITORY_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  function makeAttempt(
+    destinationConnectionId: string,
+    status: SyncAttempt['status'],
+    attemptedAt: Date,
+    extras: Partial<SyncAttempt> = {},
+  ): SyncAttempt {
+    return { destinationConnectionId, status, attemptedAt, ...extras };
+  }
+
+  it('preserves chronological order across serial failure → retry → success', async () => {
+    const destId = '22222222-2222-4222-8222-222222222222';
+    const seeded = await createTestOrderRecord(harness.getDataSource(), {
+      syncStatus: [{ destinationConnectionId: destId, status: 'pending' }],
+    });
+
+    const t1 = new Date('2026-04-29T22:50:00.000Z');
+    const t2 = new Date('2026-04-29T22:55:00.000Z');
+    const t3 = new Date('2026-04-29T23:15:00.000Z');
+
+    await repository.updateSyncStatus(
+      seeded.internalOrderId,
+      destId,
+      { destinationConnectionId: destId, status: 'failed', error: 'PL not active' },
+      makeAttempt(destId, 'failed', t1, { error: 'PL not active' }),
+    );
+    await repository.updateSyncStatus(
+      seeded.internalOrderId,
+      destId,
+      { destinationConnectionId: destId, status: 'pending' },
+      makeAttempt(destId, 'pending', t2),
+    );
+    await repository.updateSyncStatus(
+      seeded.internalOrderId,
+      destId,
+      { destinationConnectionId: destId, status: 'synced', externalOrderId: 'ext-1', syncedAt: t3 },
+      makeAttempt(destId, 'synced', t3, { externalOrderId: 'ext-1' }),
+    );
+
+    const found = await repository.findById(seeded.internalOrderId);
+    expect(found).not.toBeNull();
+    expect(found!.syncAttempts).toHaveLength(3);
+    expect(found!.syncAttempts.map((a) => a.status)).toEqual(['failed', 'pending', 'synced']);
+    expect(found!.syncAttempts[0].error).toBe('PL not active');
+    expect(found!.syncAttempts[2].externalOrderId).toBe('ext-1');
+
+    // Current state still reflects only the latest row per destination.
+    expect(found!.syncStatus).toHaveLength(1);
+    expect(found!.syncStatus[0].status).toBe('synced');
+  });
+
+  it(`caps per-destination history at ${SYNC_ATTEMPTS_PER_DESTINATION_CAP}, dropping the oldest`, async () => {
+    const destId = '22222222-2222-4222-8222-222222222222';
+    const seeded = await createTestOrderRecord(harness.getDataSource(), {
+      syncStatus: [{ destinationConnectionId: destId, status: 'pending' }],
+    });
+
+    const total = SYNC_ATTEMPTS_PER_DESTINATION_CAP + 5;
+    for (let i = 0; i < total; i++) {
+      const attemptedAt = new Date(Date.UTC(2026, 0, 1, 0, 0, i));
+      await repository.updateSyncStatus(
+        seeded.internalOrderId,
+        destId,
+        { destinationConnectionId: destId, status: 'failed', error: `attempt-${i}` },
+        makeAttempt(destId, 'failed', attemptedAt, { error: `attempt-${i}` }),
+      );
+    }
+
+    const found = await repository.findById(seeded.internalOrderId);
+    expect(found!.syncAttempts).toHaveLength(SYNC_ATTEMPTS_PER_DESTINATION_CAP);
+    // The oldest 5 (attempts 0..4) must be dropped; the newest 20 (5..24) preserved.
+    const errors = found!.syncAttempts.map((a) => a.error);
+    expect(errors[0]).toBe(`attempt-${total - SYNC_ATTEMPTS_PER_DESTINATION_CAP}`);
+    expect(errors[errors.length - 1]).toBe(`attempt-${total - 1}`);
+  });
+
+  it('does not lose attempts under concurrent writes across destinations', async () => {
+    const dests = [
+      '22222222-2222-4222-8222-222222222201',
+      '22222222-2222-4222-8222-222222222202',
+      '22222222-2222-4222-8222-222222222203',
+      '22222222-2222-4222-8222-222222222204',
+      '22222222-2222-4222-8222-222222222205',
+    ];
+    const seeded = await createTestOrderRecord(harness.getDataSource(), {
+      syncStatus: dests.map((d) => ({ destinationConnectionId: d, status: 'pending' })),
+    });
+
+    const now = new Date('2026-04-30T00:00:00.000Z');
+    await Promise.all(
+      dests.map((destId, i) =>
+        repository.updateSyncStatus(
+          seeded.internalOrderId,
+          destId,
+          { destinationConnectionId: destId, status: 'failed', error: `dest-${i}` },
+          makeAttempt(destId, 'failed', new Date(now.getTime() + i * 1000), { error: `dest-${i}` }),
+        ),
+      ),
+    );
+
+    const found = await repository.findById(seeded.internalOrderId);
+    expect(found!.syncAttempts).toHaveLength(dests.length);
+    const recordedDests = new Set(found!.syncAttempts.map((a) => a.destinationConnectionId));
+    expect(recordedDests).toEqual(new Set(dests));
+  });
+
+  it('throws OrderRecordNotFoundException when no row matches', async () => {
+    const destId = '22222222-2222-4222-8222-222222222222';
+    await expect(
+      repository.updateSyncStatus(
+        'ol_order_does_not_exist',
+        destId,
+        { destinationConnectionId: destId, status: 'failed' },
+        makeAttempt(destId, 'failed', new Date()),
+      ),
+    ).rejects.toThrow(OrderRecordNotFoundException);
+  });
+});

--- a/apps/api/test/integration/order-record-attempts.int-spec.ts
+++ b/apps/api/test/integration/order-record-attempts.int-spec.ts
@@ -151,6 +151,36 @@ describe('OrderRecord sync attempts (integration)', () => {
     expect(recordedDests).toEqual(new Set(dests));
   });
 
+  it('keeps every attempt under same-destination concurrent writes within the cap', async () => {
+    // Belt-and-braces: even though the row lock makes concurrent writes to the
+    // same destination effectively serial, prove the cap-under-contention path
+    // doesn't lose entries. Fire 5 parallel writes (cap is 20) → all 5 land.
+    const destId = '22222222-2222-4222-8222-222222222222';
+    const seeded = await createTestOrderRecord(harness.getDataSource(), {
+      syncStatus: [{ destinationConnectionId: destId, status: 'pending' }],
+    });
+
+    const now = new Date('2026-04-30T00:00:00.000Z');
+    const writes = 5;
+    await Promise.all(
+      Array.from({ length: writes }, (_, i) =>
+        repository.updateSyncStatus(
+          seeded.internalOrderId,
+          destId,
+          { destinationConnectionId: destId, status: 'failed', error: `concurrent-${i}` },
+          makeAttempt(destId, 'failed', new Date(now.getTime() + i * 1000), {
+            error: `concurrent-${i}`,
+          }),
+        ),
+      ),
+    );
+
+    const found = await repository.findById(seeded.internalOrderId);
+    expect(found!.syncAttempts).toHaveLength(writes);
+    const errors = new Set(found!.syncAttempts.map((a) => a.error));
+    expect(errors.size).toBe(writes);
+  });
+
   it('throws OrderRecordNotFoundException when no row matches', async () => {
     const destId = '22222222-2222-4222-8222-222222222222';
     await expect(

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -20,6 +20,29 @@ export interface OrderSyncStatus {
   error: string | null;
 }
 
+/**
+ * Per-destination append-only attempt entry. Mirrors `SyncAttemptResponseDto`
+ * (BE) and `SyncAttempt` (CORE). The activity timeline renders one row per
+ * attempt to preserve failure → retry → success history (#456).
+ */
+export interface SyncAttempt {
+  destinationConnectionId: string;
+  status: OrderSyncStatusValue;
+  attemptedAt: string;
+  error: string | null;
+  externalOrderId: string | null;
+  externalOrderNumber: string | null;
+}
+
+/**
+ * Hand-mirrored from `SYNC_ATTEMPTS_PER_DESTINATION_CAP` in
+ * `libs/core/src/orders/domain/types/order-sync.types.ts` per the FE-001
+ * contract strategy. Used to decide whether to surface the "view all
+ * attempts" deep link below a destination's group of timeline rows.
+ * Keep in sync with the BE constant if the cap is ever tuned.
+ */
+export const SYNC_ATTEMPTS_PER_DESTINATION_CAP = 20;
+
 // Mirrors the backend `OrderRecordStatusValues` in `@openlinker/core/orders`.
 // Hand-written transport type per FE-001 contract strategy — keep in sync with backend.
 export const OrderRecordStatusValues = ['ready', 'awaiting_mapping'] as const;
@@ -32,6 +55,7 @@ export interface OrderRecord {
   sourceEventId: string | null;
   orderSnapshot: Record<string, unknown>;
   syncStatus: OrderSyncStatus[];
+  syncAttempts: SyncAttempt[];
   recordStatus: OrderRecordStatusValue;
   createdAt: string;
   updatedAt: string;

--- a/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
@@ -132,6 +132,42 @@ describe('OrderActivityTimeline', () => {
     expect(screen.getAllByRole('link', { name: /view all attempts/i })).toHaveLength(1);
   });
 
+  it('attaches the cap link only to the capped destination when destinations are mixed', () => {
+    const otherDestId = 'ol_connection_dst_other';
+    const cappedAttempts: SyncAttempt[] = Array.from(
+      { length: SYNC_ATTEMPTS_PER_DESTINATION_CAP },
+      (_, i) => ({
+        destinationConnectionId: DEST_CONNECTION_ID,
+        status: 'failed' as const,
+        attemptedAt: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+        error: `attempt-${i}`,
+        externalOrderId: null,
+        externalOrderNumber: null,
+      }),
+    );
+    const uncappedAttempt: SyncAttempt = {
+      destinationConnectionId: otherDestId,
+      status: 'synced',
+      attemptedAt: new Date(2026, 0, 1, 0, 1, 0).toISOString(),
+      error: null,
+      externalOrderId: 'ext-99',
+      externalOrderNumber: '9099',
+    };
+
+    renderTimeline({
+      createdAt: '2026-01-01T00:00:00.000Z',
+      recordStatus: 'ready',
+      syncAttempts: [...cappedAttempts, uncappedAttempt],
+      sourceConnectionId: SOURCE_CONNECTION_ID,
+    });
+
+    const links = screen.getAllByRole('link', { name: /view all attempts/i });
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute('href')).toBe(
+      `/sync/jobs?connectionId=${encodeURIComponent(SOURCE_CONNECTION_ID)}`,
+    );
+  });
+
   it('does not show the cap link when below the per-destination cap', () => {
     const attempts: SyncAttempt[] = [
       {

--- a/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
@@ -2,16 +2,20 @@ import { cleanup, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OrderActivityTimeline } from './order-activity-timeline';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
-import type { OrderSyncStatus } from '../api/orders.types';
+import {
+  SYNC_ATTEMPTS_PER_DESTINATION_CAP,
+  type SyncAttempt,
+} from '../api/orders.types';
 
-function renderTimeline(
-  props: React.ComponentProps<typeof OrderActivityTimeline>,
-): void {
+const SOURCE_CONNECTION_ID = 'ol_connection_src';
+const DEST_CONNECTION_ID = 'ol_connection_dst';
+
+function renderTimeline(props: React.ComponentProps<typeof OrderActivityTimeline>): void {
   const api = createMockApiClient({
     connections: {
       // Return a shell connection so ConnectionEntityLabel renders a stable name.
       getById: vi.fn().mockResolvedValue({
-        id: 'ol_connection_dst',
+        id: DEST_CONNECTION_ID,
         name: 'Dest Shop',
         platformType: 'prestashop',
         status: 'active',
@@ -35,7 +39,8 @@ describe('OrderActivityTimeline', () => {
     renderTimeline({
       createdAt: '2026-04-20T10:00:00.000Z',
       recordStatus: 'awaiting_mapping',
-      syncStatus: [],
+      syncAttempts: [],
+      sourceConnectionId: SOURCE_CONNECTION_ID,
     });
 
     const items = screen.getAllByRole('listitem');
@@ -43,116 +48,109 @@ describe('OrderActivityTimeline', () => {
 
     const first = within(items[0]);
     expect(first.getByText('Order received')).toBeInTheDocument();
-    expect(
-      first.getByText(/Awaiting product mapping/),
-    ).toBeInTheDocument();
-    // Warning dot class
+    expect(first.getByText(/Awaiting product mapping/)).toBeInTheDocument();
     expect(items[0].querySelector('.order-activity__dot--warning')).not.toBeNull();
   });
 
-  it('sorts timestamped sync events chronologically after ingestion', () => {
-    const syncStatus: OrderSyncStatus[] = [
+  it('renders failure → retry → success as three rows in chronological order', () => {
+    const attempts: SyncAttempt[] = [
       {
-        destinationConnectionId: 'ol_connection_dst',
+        destinationConnectionId: DEST_CONNECTION_ID,
+        status: 'failed',
+        attemptedAt: '2026-04-29T22:50:00.000Z',
+        error: "Country with ISO2 code 'PL' is not active",
+        externalOrderId: null,
+        externalOrderNumber: null,
+      },
+      {
+        destinationConnectionId: DEST_CONNECTION_ID,
+        status: 'pending',
+        attemptedAt: '2026-04-29T22:55:00.000Z',
+        error: null,
+        externalOrderId: null,
+        externalOrderNumber: null,
+      },
+      {
+        destinationConnectionId: DEST_CONNECTION_ID,
         status: 'synced',
-        syncedAt: '2026-04-20T12:00:00.000Z',
+        attemptedAt: '2026-04-29T23:15:00.000Z',
+        error: null,
         externalOrderId: 'ext-1',
         externalOrderNumber: '9001',
-        error: null,
       },
     ];
 
     renderTimeline({
-      createdAt: '2026-04-20T10:00:00.000Z',
+      createdAt: '2026-04-29T22:47:00.000Z',
       recordStatus: 'ready',
-      syncStatus,
+      syncAttempts: attempts,
+      sourceConnectionId: SOURCE_CONNECTION_ID,
     });
 
     const items = screen.getAllByRole('listitem');
-    expect(items).toHaveLength(2);
-    // First item is ingestion; second is the synced event
+    expect(items).toHaveLength(4);
+
     expect(within(items[0]).getByText('Order received')).toBeInTheDocument();
-    expect(within(items[1]).getByText(/synced to/)).toBeInTheDocument();
-    // Success tone on the sync row
-    expect(items[1].querySelector('.order-activity__dot--success')).not.toBeNull();
+    expect(within(items[1]).getByText(/failed to sync to/)).toBeInTheDocument();
+    expect(within(items[1]).getByText(/Country with ISO2 code/)).toBeInTheDocument();
+    expect(items[1].querySelector('.order-activity__dot--error')).not.toBeNull();
+
+    expect(within(items[2]).getByText(/queued for/)).toBeInTheDocument();
+    expect(items[2].querySelector('.order-activity__dot--default')).not.toBeNull();
+
+    expect(within(items[3]).getByText(/synced to/)).toBeInTheDocument();
+    expect(within(items[3]).getByText(/9001/)).toBeInTheDocument();
+    expect(items[3].querySelector('.order-activity__dot--success')).not.toBeNull();
   });
 
-  it('sinks pending sync events (no syncedAt) to the bottom and shows "in progress"', () => {
-    const syncStatus: OrderSyncStatus[] = [
-      {
-        destinationConnectionId: 'ol_connection_dst',
-        status: 'pending',
-        syncedAt: null,
+  it('shows the "view all attempts" deep link only for capped destinations', () => {
+    const attempts: SyncAttempt[] = Array.from(
+      { length: SYNC_ATTEMPTS_PER_DESTINATION_CAP },
+      (_, i) => ({
+        destinationConnectionId: DEST_CONNECTION_ID,
+        status: 'failed' as const,
+        attemptedAt: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+        error: `attempt-${i}`,
         externalOrderId: null,
         externalOrderNumber: null,
+      }),
+    );
+
+    renderTimeline({
+      createdAt: '2026-01-01T00:00:00.000Z',
+      recordStatus: 'ready',
+      syncAttempts: attempts,
+      sourceConnectionId: SOURCE_CONNECTION_ID,
+    });
+
+    const link = screen.getByRole('link', { name: /view all attempts/i });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toBe(
+      `/sync/jobs?connectionId=${encodeURIComponent(SOURCE_CONNECTION_ID)}`,
+    );
+    // Only one link — attached to the most-recent attempt of the capped destination.
+    expect(screen.getAllByRole('link', { name: /view all attempts/i })).toHaveLength(1);
+  });
+
+  it('does not show the cap link when below the per-destination cap', () => {
+    const attempts: SyncAttempt[] = [
+      {
+        destinationConnectionId: DEST_CONNECTION_ID,
+        status: 'synced',
+        attemptedAt: '2026-04-20T12:00:00.000Z',
         error: null,
+        externalOrderId: 'ext-1',
+        externalOrderNumber: '9001',
       },
     ];
 
     renderTimeline({
       createdAt: '2026-04-20T10:00:00.000Z',
       recordStatus: 'ready',
-      syncStatus,
+      syncAttempts: attempts,
+      sourceConnectionId: SOURCE_CONNECTION_ID,
     });
 
-    const items = screen.getAllByRole('listitem');
-    expect(items).toHaveLength(2);
-    // Ingestion first, pending last
-    expect(within(items[0]).getByText('Order received')).toBeInTheDocument();
-    expect(within(items[1]).getByText(/queued for/)).toBeInTheDocument();
-    expect(within(items[1]).getByText('in progress')).toBeInTheDocument();
-  });
-
-  it('renders a failed sync event with error tone and the error message', () => {
-    const syncStatus: OrderSyncStatus[] = [
-      {
-        destinationConnectionId: 'ol_connection_dst',
-        status: 'failed',
-        syncedAt: '2026-04-20T12:00:00.000Z',
-        externalOrderId: null,
-        externalOrderNumber: null,
-        error: 'PrestaShop returned 500',
-      },
-    ];
-
-    renderTimeline({
-      createdAt: '2026-04-20T10:00:00.000Z',
-      recordStatus: 'ready',
-      syncStatus,
-    });
-
-    const items = screen.getAllByRole('listitem');
-    const failedRow = items[1];
-    expect(within(failedRow).getByText(/failed to sync to/)).toBeInTheDocument();
-    expect(within(failedRow).getByText('PrestaShop returned 500')).toBeInTheDocument();
-    expect(failedRow.querySelector('.order-activity__dot--error')).not.toBeNull();
-  });
-
-  it('does not show "in progress" for a failed sync without syncedAt', () => {
-    // Real-world failed rows have no syncedAt — only an error string. Before the
-    // fix, the time pill mistakenly read "in progress" because it fell into the
-    // null-timestamp branch. Now the error tone branches before the pending pill.
-    const syncStatus: OrderSyncStatus[] = [
-      {
-        destinationConnectionId: 'ol_connection_dst',
-        status: 'failed',
-        syncedAt: null,
-        externalOrderId: null,
-        externalOrderNumber: null,
-        error: 'PrestaShop country PL not active',
-      },
-    ];
-
-    renderTimeline({
-      createdAt: '2026-04-20T10:00:00.000Z',
-      recordStatus: 'ready',
-      syncStatus,
-    });
-
-    const items = screen.getAllByRole('listitem');
-    const failedRow = items[1];
-    expect(within(failedRow).getByText(/failed to sync to/)).toBeInTheDocument();
-    expect(within(failedRow).queryByText('in progress')).toBeNull();
-    expect(failedRow.querySelector('.order-activity__dot--error')).not.toBeNull();
+    expect(screen.queryByRole('link', { name: /view all attempts/i })).toBeNull();
   });
 });

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -9,7 +9,7 @@
  * a "view all attempts" link to `/sync/jobs?connectionId={source}` lets
  * operators dig deeper without coupling the order surface to `sync_jobs`.
  */
-import type { ReactElement } from 'react';
+import { useMemo, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { EmptyState } from '../../../shared/ui/feedback-state';
 import { TimeDisplay } from '../../../shared/ui/time-display';
@@ -169,7 +169,10 @@ export function OrderActivityTimeline({
   syncAttempts,
   sourceConnectionId,
 }: OrderActivityTimelineProps): ReactElement {
-  const events = buildEvents(createdAt, recordStatus, syncAttempts, sourceConnectionId);
+  const events = useMemo(
+    () => buildEvents(createdAt, recordStatus, syncAttempts, sourceConnectionId),
+    [createdAt, recordStatus, syncAttempts, sourceConnectionId],
+  );
 
   if (events.length === 0) {
     return (

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -2,17 +2,23 @@
  * Order Activity Timeline
  *
  * Ordered list of events derived from the order's lifecycle data — ingestion
- * (from `createdAt` + `recordStatus`) and each sync destination's attempt
- * (from `syncStatus`). Events with a real timestamp are sorted chronologically;
- * pending/syncing entries without a `syncedAt` render at the end of the list
- * with "in progress" instead of a fabricated time, so the timeline never shows
- * a misleading timestamp.
+ * (from `createdAt` + `recordStatus`) and each sync **attempt** against a
+ * destination (from `syncAttempts`, the append-only history). Every attempt
+ * has a real `attemptedAt`, so failure → retry → success renders as three
+ * rows in chronological order. When a destination's history hits the cap,
+ * a "view all attempts" link to `/sync/jobs?connectionId={source}` lets
+ * operators dig deeper without coupling the order surface to `sync_jobs`.
  */
 import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 import { EmptyState } from '../../../shared/ui/feedback-state';
 import { TimeDisplay } from '../../../shared/ui/time-display';
 import { ConnectionEntityLabel } from '../../connections/components/ConnectionEntityLabel';
-import type { OrderSyncStatus, OrderSyncStatusValue } from '../api/orders.types';
+import {
+  SYNC_ATTEMPTS_PER_DESTINATION_CAP,
+  type OrderSyncStatusValue,
+  type SyncAttempt,
+} from '../api/orders.types';
 
 interface TimelineEvent {
   id: string;
@@ -20,12 +26,28 @@ interface TimelineEvent {
   title: ReactElement | string;
   description?: ReactElement | string;
   tone: 'default' | 'success' | 'error' | 'warning';
+  /**
+   * Footer rendered below the row body — used to attach the "view all
+   * attempts" deep link to the **last** attempt of a capped destination.
+   */
+  footer?: ReactElement;
 }
 
 interface OrderActivityTimelineProps {
   createdAt: string;
   recordStatus: string;
-  syncStatus: OrderSyncStatus[];
+  /**
+   * Per-destination append-only history. The current state per destination
+   * lives on `OrderRecord.syncStatus` and is consumed by the Sync Status
+   * table — not this component.
+   */
+  syncAttempts: SyncAttempt[];
+  /**
+   * Source connection — drives the "view all attempts" deep-link target.
+   * `marketplace.order.sync` jobs are scoped to the source connection, so
+   * that's the right filter on `/sync/jobs`.
+   */
+  sourceConnectionId: string;
 }
 
 const STATUS_PAST_TENSE: Record<OrderSyncStatusValue, string> = {
@@ -35,10 +57,18 @@ const STATUS_PAST_TENSE: Record<OrderSyncStatusValue, string> = {
   failed: 'failed to sync to',
 };
 
+const TONE_FOR_STATUS: Record<OrderSyncStatusValue, TimelineEvent['tone']> = {
+  pending: 'default',
+  syncing: 'default',
+  synced: 'success',
+  failed: 'error',
+};
+
 function buildEvents(
   createdAt: string,
   recordStatus: string,
-  syncStatus: OrderSyncStatus[],
+  syncAttempts: SyncAttempt[],
+  sourceConnectionId: string,
 ): TimelineEvent[] {
   const events: TimelineEvent[] = [];
 
@@ -53,50 +83,74 @@ function buildEvents(
     tone: recordStatus === 'awaiting_mapping' ? 'warning' : 'default',
   });
 
-  for (const status of syncStatus) {
-    const verb = STATUS_PAST_TENSE[status.status] ?? status.status;
+  // Identify destinations whose history is at or above the cap so we can
+  // attach the "view all attempts" link to the most-recent row of each.
+  const cappedDestinations = new Set<string>();
+  const destinationCounts = new Map<string, number>();
+  for (const a of syncAttempts) {
+    destinationCounts.set(
+      a.destinationConnectionId,
+      (destinationCounts.get(a.destinationConnectionId) ?? 0) + 1,
+    );
+  }
+  for (const [destId, count] of destinationCounts) {
+    if (count >= SYNC_ATTEMPTS_PER_DESTINATION_CAP) {
+      cappedDestinations.add(destId);
+    }
+  }
+
+  // Track the index of each destination's last attempt so the deep link
+  // attaches to the most-recent row (after chronological sort below).
+  const sortedAttempts = [...syncAttempts].sort(
+    (a, b) => new Date(a.attemptedAt).getTime() - new Date(b.attemptedAt).getTime(),
+  );
+  const lastIndexByDestination = new Map<string, number>();
+  sortedAttempts.forEach((a, i) => {
+    lastIndexByDestination.set(a.destinationConnectionId, i);
+  });
+
+  sortedAttempts.forEach((attempt, i) => {
+    const verb = STATUS_PAST_TENSE[attempt.status] ?? attempt.status;
+    const isLastForDestination = lastIndexByDestination.get(attempt.destinationConnectionId) === i;
+    const showCapLink =
+      isLastForDestination && cappedDestinations.has(attempt.destinationConnectionId);
 
     events.push({
-      id: `sync-${status.destinationConnectionId}`,
-      timestamp: status.syncedAt,
+      id: `attempt-${attempt.destinationConnectionId}-${i}`,
+      timestamp: attempt.attemptedAt,
       title: (
         <>
           Order {verb}{' '}
           <ConnectionEntityLabel
-            connectionId={status.destinationConnectionId}
+            connectionId={attempt.destinationConnectionId}
             showId={false}
           />
         </>
       ),
-      description: status.error ? (
-        <span className="mono-text order-activity__error">{status.error}</span>
-      ) : status.externalOrderNumber ? (
+      description: attempt.error ? (
+        <span className="mono-text order-activity__error">{attempt.error}</span>
+      ) : attempt.externalOrderNumber ? (
         <>
           External order{' '}
-          <span className="mono-text">{status.externalOrderNumber}</span>
-          {status.externalOrderId ? (
+          <span className="mono-text">{attempt.externalOrderNumber}</span>
+          {attempt.externalOrderId ? (
             <>
               {' '}
-              <span className="mono-text text-muted">({status.externalOrderId})</span>
+              <span className="mono-text text-muted">({attempt.externalOrderId})</span>
             </>
           ) : null}
         </>
       ) : undefined,
-      tone:
-        status.status === 'failed'
-          ? 'error'
-          : status.status === 'synced'
-            ? 'success'
-            : 'default',
+      tone: TONE_FOR_STATUS[attempt.status] ?? 'default',
+      footer: showCapLink ? (
+        <Link
+          className="order-activity__cap-link"
+          to={`/sync/jobs?connectionId=${encodeURIComponent(sourceConnectionId)}`}
+        >
+          View all attempts
+        </Link>
+      ) : undefined,
     });
-  }
-
-  events.sort((a, b) => {
-    // Events with no real timestamp (pending/syncing) sink to the bottom, in insertion order.
-    if (a.timestamp === null && b.timestamp === null) return 0;
-    if (a.timestamp === null) return 1;
-    if (b.timestamp === null) return -1;
-    return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
   });
 
   return events;
@@ -112,9 +166,10 @@ const TONE_CLASS: Record<TimelineEvent['tone'], string> = {
 export function OrderActivityTimeline({
   createdAt,
   recordStatus,
-  syncStatus,
+  syncAttempts,
+  sourceConnectionId,
 }: OrderActivityTimelineProps): ReactElement {
-  const events = buildEvents(createdAt, recordStatus, syncStatus);
+  const events = buildEvents(createdAt, recordStatus, syncAttempts, sourceConnectionId);
 
   if (events.length === 0) {
     return (
@@ -132,18 +187,14 @@ export function OrderActivityTimeline({
             {event.description ? (
               <p className="order-activity__description">{event.description}</p>
             ) : null}
+            {event.footer ? <p className="order-activity__footer">{event.footer}</p> : null}
           </div>
           {event.timestamp ? (
             <time className="order-activity__time" dateTime={event.timestamp}>
               <TimeDisplay iso={event.timestamp} format="datetime" />
             </time>
-          ) : event.tone === 'error' ? (
-            // Failed destinations have no `syncedAt` — the dot tone (red) and verb
-            // ("failed to sync to {destination}") already convey state, so the time
-            // pill stays empty rather than lying with "in progress".
-            <span className="order-activity__time" aria-hidden="true" />
           ) : (
-            <span className="order-activity__time order-activity__time--pending">in progress</span>
+            <span className="order-activity__time" aria-hidden="true" />
           )}
         </li>
       ))}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5512,6 +5512,22 @@ a.kpi-card:focus-visible {
   word-break: break-word;
 }
 
+.order-activity__footer {
+  margin: 0.375rem 0 0;
+  font-size: 0.75rem;
+}
+
+.order-activity__cap-link {
+  color: var(--text-muted);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.order-activity__cap-link:hover,
+.order-activity__cap-link:focus-visible {
+  color: var(--text-primary);
+}
+
 .order-activity__time {
   font-family: var(--font-mono);
   font-size: 0.78rem;

--- a/apps/web/src/pages/customers/customer-detail-page.test.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.test.tsx
@@ -76,6 +76,7 @@ describe('CustomerDetailPage', () => {
           error: null,
         },
       ],
+      syncAttempts: [],
       recordStatus: 'ready',
       createdAt: '2026-04-20T09:00:00.000Z',
       updatedAt: '2026-04-20T10:00:00.000Z',

--- a/apps/web/src/pages/orders/failed-orders-page.test.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.test.tsx
@@ -16,6 +16,7 @@ function makeOrderRecord(overrides: Partial<OrderRecord> = {}): OrderRecord {
       items: [{ id: 'item-1', productRef: { type: 'offer', externalId: 'offer-a' }, quantity: 1, price: 9.99 }],
     },
     syncStatus: [],
+    syncAttempts: [],
     recordStatus: 'awaiting_mapping',
     createdAt: '2026-04-10T08:00:00.000Z',
     updatedAt: '2026-04-10T10:00:00.000Z',

--- a/apps/web/src/pages/orders/order-detail-page.test.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.test.tsx
@@ -22,6 +22,16 @@ const sampleOrder: OrderRecord = {
       error: null,
     },
   ],
+  syncAttempts: [
+    {
+      destinationConnectionId: sampleConnection.id,
+      status: 'synced',
+      attemptedAt: '2026-04-20T10:00:00.000Z',
+      error: null,
+      externalOrderId: '42',
+      externalOrderNumber: null,
+    },
+  ],
   recordStatus: 'ready',
   createdAt: '2026-04-20T09:00:00.000Z',
   updatedAt: '2026-04-20T10:00:00.000Z',

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -377,7 +377,8 @@ export function OrderDetailPage(): ReactElement {
         <OrderActivityTimeline
           createdAt={order.createdAt}
           recordStatus={order.recordStatus}
-          syncStatus={order.syncStatus}
+          syncAttempts={order.syncAttempts}
+          sourceConnectionId={order.sourceConnectionId}
         />
       </section>
 

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -14,6 +14,7 @@ const sampleOrders: PaginatedOrders = {
       sourceEventId: null,
       orderSnapshot: {},
       syncStatus: [{ destinationConnectionId: 'conn_ps_1', status: 'synced', syncedAt: '2026-01-15T10:00:00.000Z', externalOrderId: '42', externalOrderNumber: null, error: null }],
+      syncAttempts: [],
       recordStatus: 'ready',
       createdAt: '2026-01-15T10:00:00.000Z',
       updatedAt: '2026-01-15T10:00:00.000Z',

--- a/docs/plans/implementation-plan-order-sync-attempts-log.md
+++ b/docs/plans/implementation-plan-order-sync-attempts-log.md
@@ -1,0 +1,261 @@
+# Implementation Plan — Per-destination attempts log on `OrderRecord` (#456)
+
+## 1. Goal & Non-goals
+
+**Goal:** Preserve the timeline of per-destination sync attempts on an `OrderRecord` so a successful retry no longer erases the failed attempt that triggered it. The Activity panel on the order detail page must show **failed → retried → synced** as three distinct rows with real timestamps and the original error.
+
+**Layer classification:**
+- **CORE (Orders bounded context):** new `SyncAttempt` domain type, ORM column, repository write, service write — all in `libs/core/src/orders/`.
+- **Interface (API):** DTO + controller mapping.
+- **Frontend:** transport types, timeline render switch.
+
+**Non-goals (explicit):**
+- Joining `sync_jobs` into the order timeline. Rejected by the issue and architecturally — keeps the Orders/Sync-Manager bounded contexts independent.
+- Showing attempts on the order list page — detail page only.
+- Tracking webhook deliveries / poll runs on the timeline.
+- Backfilling history for orders that already exist — column starts at `[]` for them.
+
+## 2. Architecture summary
+
+The change keeps the existing `syncStatus` JSONB column intact ("current state per destination") and **adds** a sibling `syncAttempts` JSONB column ("append-only history per destination, capped at 20 per destination").
+
+`OrderRecordService.updateSyncStatus()` becomes the single write site that both:
+1. upserts the current-state row in `syncStatus` (existing behavior), and
+2. appends a `SyncAttempt` to `syncAttempts` (new behavior).
+
+The repository implementation is rewritten from `findOne` + mutate + `save` (read-modify-write race) to a **single `UPDATE` statement** using JSONB expressions. Concurrent worker writes serialize at the row level on a single statement, so no attempts are lost even when fan-out / retry hit the same row in parallel.
+
+The Activity timeline switches from `syncStatus` → `syncAttempts`. The Sync Status table (and retry-button visibility, failed-orders banner) stay on `syncStatus`.
+
+## 3. Step-by-step plan
+
+### Phase A — Backend domain & ORM
+
+**A1. Domain types extracted to a new file**
+- New file: `libs/core/src/orders/domain/types/order-sync.types.ts`
+- Move the existing `OrderSyncStatus` interface out of `order-record.entity.ts` into this file (cleans up an existing engineering-standards violation while we're already touching the file).
+- Add `SyncAttempt` interface alongside it:
+  ```ts
+  export interface SyncAttempt {
+    destinationConnectionId: string;
+    status: 'pending' | 'syncing' | 'synced' | 'failed';
+    attemptedAt: Date;
+    error?: string;
+    externalOrderId?: string;
+    externalOrderNumber?: string;
+  }
+  ```
+- Add the cap constant — single source of truth for both the SQL and the FE link trigger:
+  ```ts
+  export const SYNC_ATTEMPTS_PER_DESTINATION_CAP = 20;
+  ```
+- Re-export from `libs/core/src/orders/index.ts` so `OrderSyncStatus`, `SyncAttempt`, and the cap constant are available to API/FE callers (FE only consumes the cap value via the BE response — no runtime import across packages, but if needed the constant lives in a value-importable location).
+- Update `order-record.entity.ts` to import these types instead of defining them inline.
+- Constructor change: extend `OrderRecord` with `public readonly syncAttempts: SyncAttempt[] = []` as the **last positional parameter, with a default value**. The default keeps every existing `new OrderRecord(...)` call site compiling unchanged (15+ fixtures across `order-record.service.spec.ts`, `order-record.repository.spec.ts`, `order-destination-retry.service.spec.ts`, `orders.controller.spec.ts`).
+- File header per `engineering-standards.md` § File Headers.
+
+**A2. ORM JSONB column**
+- File: `libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts`
+- Add `SyncAttemptJson` interface (sibling of `OrderSyncStatusJson`, with `attemptedAt: string` ISO).
+- Add column:
+  ```ts
+  @Column({ type: 'jsonb', default: () => "'[]'" })
+  syncAttempts!: SyncAttemptJson[];
+  ```
+- Acceptance: TypeORM picks up the column with a `[]` default; existing rows on a fresh build start empty.
+
+**A3. Migration**
+- File: `apps/api/src/migrations/1793000000000-add-order-record-sync-attempts.ts`
+- Class name: `AddOrderRecordSyncAttempts1793000000000` (timestamp suffix matches filename prefix per `migrations.md` § Timestamp uniqueness invariant).
+- Up:
+  ```sql
+  ALTER TABLE "order_records"
+    ADD COLUMN "syncAttempts" jsonb NOT NULL DEFAULT '[]';
+  ```
+- Down: drop the column.
+- No index — reads are always full-row-by-PK, never filtered by JSONB content.
+- File header per standards.
+
+**A4. Domain port**
+- File: `libs/core/src/orders/domain/ports/order-record-repository.port.ts`
+- Update `updateSyncStatus` signature: keep three current params, add a fourth `attempt: SyncAttempt`. Doc-comment makes clear the repository is responsible for both the upsert *and* the append in a single SQL statement.
+
+### Phase B — Backend repository
+
+**B1. Single-statement `updateSyncStatus`**
+- File: `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts`
+- Replace the `findOne`/mutate/`save` body with a single `UPDATE … WHERE` query built via `repository.createQueryBuilder().update()` so TypeORM still handles parameter binding.
+- The `SET` clause does three things:
+  1. `"syncStatus"` — drop any existing row for this destination, append the new row at the end. Use `jsonb_build_array` explicitly so the binder can't accidentally collapse object-vs-array semantics:
+     ```sql
+     "syncStatus" = (
+       SELECT COALESCE(jsonb_agg(s), '[]'::jsonb)
+       FROM jsonb_array_elements("syncStatus") s
+       WHERE s->>'destinationConnectionId' != :destId
+     ) || jsonb_build_array(:newStatusRow::jsonb)
+     ```
+  2. `"syncAttempts"` — append the new attempt (wrapped explicitly), then keep only the most-recent N per destination using a window function:
+     ```sql
+     "syncAttempts" = (
+       SELECT COALESCE(jsonb_agg(a ORDER BY ord), '[]'::jsonb)
+       FROM (
+         SELECT
+           a, ord,
+           ROW_NUMBER() OVER (
+             PARTITION BY a->>'destinationConnectionId' ORDER BY ord DESC
+           ) AS recency_rank
+         FROM jsonb_array_elements("syncAttempts" || jsonb_build_array(:newAttempt::jsonb))
+              WITH ORDINALITY AS t(a, ord)
+       ) ranked
+       WHERE recency_rank <= :cap
+     )
+     ```
+  3. `"updatedAt" = NOW()`.
+- Bind `:cap` from `SYNC_ATTEMPTS_PER_DESTINATION_CAP` (no magic number in SQL).
+- Use `.execute()` and check `(result.affected ?? 0) === 0` — if no row matched, throw `OrderRecordNotFoundException`.
+- Acceptance: a single SQL statement updates both columns atomically; concurrent writers serialize on the row's exclusive write lock; the per-destination cap is enforced inside the statement.
+
+**B2. `toDomain` / `toOrm` mapping**
+- Same repository file. Update both mappers to round-trip `syncAttempts` (parse `attemptedAt` ISO → `Date` and back). Mirror the existing per-field mapping pattern.
+
+**B3. Repository unit-test trim**
+- File: `libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts`
+- The current `updateSyncStatus` describe block mocks `findOne` + `save`. After the rewrite that path no longer exists, so:
+  - Drop the existing `should update existing` / `should add new` cases (they covered the in-memory mutation; the new behavior is SQL-resident and is covered end-to-end by the integration test in B4).
+  - Keep one focused unit test: `should throw OrderRecordNotFoundException when no row matched` — mock `createQueryBuilder().update().set().where().execute()` to return `{ affected: 0 }` and assert the exception. This guards the only branch the integration test can't cheaply cover.
+- Existing `findById` / `upsert` / `findMany` test blocks are unchanged in scope; they'll just need `syncAttempts: []` populated on the seeded ORM entities so `toDomain` doesn't blow up on `undefined.map`.
+
+**B4. Repository integration test (concurrency + cap)**
+- New file: `apps/api/test/integration/order-record-attempts.int-spec.ts` (per `testing-guide.md` § Test Organization — integration tests live under `apps/{api,worker}/test/integration/`, not colocated under `libs/`).
+- Reuses the existing `getTestHarness()` / `resetTestHarness()` / `teardownTestHarness()` lifecycle and the `createTestOrderRecord()` fixture.
+- Resolves the repository via `harness.getApp().get(ORDER_RECORD_REPOSITORY_TOKEN)` so the test exercises the real bound implementation.
+- Test 1 — serial appends preserve order: 3 sequential `updateSyncStatus` calls → final `syncAttempts.length === 3`, in chronological order, with the right statuses (`failed → pending → synced`).
+- Test 2 — cap enforcement: append 25 entries for one destination → exactly 20 remain, the oldest 5 dropped, the newest preserved.
+- Test 3 — concurrent writes: `Promise.all` of 5 `updateSyncStatus` calls on the same record from different "destinations" → final `syncAttempts.length === 5`, no entry lost. (Concurrent writes to the *same* destination would test the cap-under-contention; we assert no-loss across destinations to demonstrate the row-lock holds.)
+- Test 4 — missing row: calling on a non-existent `internalOrderId` throws `OrderRecordNotFoundException`.
+- File header per standards.
+
+### Phase C — Backend application service & callers
+
+**C1. Service — set `attemptedAt` and forward**
+- File: `libs/core/src/orders/application/services/order-record.service.ts`
+- `updateSyncStatus` builds a `SyncAttempt`:
+  ```ts
+  const attempt: SyncAttempt = {
+    destinationConnectionId,
+    status: status.status,
+    attemptedAt: new Date(),
+    error: status.error,
+    externalOrderId: status.externalOrderId,
+    externalOrderNumber: status.externalOrderNumber,
+  };
+  await this.repository.updateSyncStatus(internalOrderId, destinationConnectionId, status, attempt);
+  ```
+- Service interface (`order-record.service.interface.ts`) signature unchanged — the `attemptedAt` semantics stay an implementation detail.
+- Acceptance: callers in `order-ingestion.service.ts` and `order-destination-retry.service.ts` need no changes.
+
+**C2. `persistOrder` / `persistIncomingSnapshot`**
+- Same file. Both already pass empty `syncStatus: []`; the new constructor default for `syncAttempts` means no source change is required at these factory call sites.
+
+**C3. Service unit-test updates**
+- File: `libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts`
+- Update the `updateSyncStatus` describe block: the repository mock now expects four args. Use `jest.useFakeTimers()` + `jest.setSystemTime(...)` and assert the fourth arg's `attemptedAt` equals the frozen clock.
+- Existing `new OrderRecord(...)` fixture calls don't need touching thanks to the constructor default.
+
+**C4. Retry-service spec**
+- File: `libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts`
+- Verify both the claim (`failed → pending`) and the revert (`pending → failed`) paths produce repository calls with a fully-formed `SyncAttempt` fourth arg. Existing test structure stays.
+
+**C5. Retry-revert behavior — documented, not suppressed**
+- The `OrderDestinationRetryService` claim/revert path will now produce 2-3 attempt rows on enqueue failure (`failed → pending → failed`). This is strictly more informative than today and matches the issue's "preserve every attempt" intent. Decision: keep the simpler implementation, document the new visible behavior in the PR description so reviewers know what to expect on the timeline.
+
+### Phase D — Backend API surface
+
+**D1. New attempt response DTO**
+- New file: `apps/api/src/orders/http/dto/sync-attempt-response.dto.ts`
+- Mirrors `OrderSyncStatusResponseDto` shape but with `attemptedAt: string` (ISO) and **without** `syncedAt`.
+- File header per standards.
+
+**D2. Extend `OrderRecordResponseDto`**
+- File: `apps/api/src/orders/http/dto/order-record-response.dto.ts`
+- Add `@ApiProperty({ type: [SyncAttemptResponseDto], description: 'Per-destination attempt history (capped at 20 per destination, most recent kept)' }) syncAttempts!: SyncAttemptResponseDto[];`
+
+**D3. Controller mapping**
+- File: `apps/api/src/orders/http/orders.controller.ts`
+- Extend `toDto` with `syncAttempts: order.syncAttempts.map((a) => this.toSyncAttemptDto(a))` and add the `toSyncAttemptDto` method.
+
+**D4. Controller spec update**
+- File: `apps/api/src/orders/http/orders.controller.spec.ts`
+- The existing `mockOrder` will get `syncAttempts: []` automatically from the constructor default. Add one focused test asserting the controller maps a non-empty `syncAttempts` through to the DTO.
+
+### Phase E — Frontend
+
+**E1. Transport type**
+- File: `apps/web/src/features/orders/api/orders.types.ts`
+- Add:
+  ```ts
+  export const SYNC_ATTEMPTS_PER_DESTINATION_CAP = 20;
+  
+  export interface SyncAttempt {
+    destinationConnectionId: string;
+    status: OrderSyncStatusValue;
+    attemptedAt: string;
+    error: string | null;
+    externalOrderId: string | null;
+    externalOrderNumber: string | null;
+  }
+  ```
+- Add `syncAttempts: SyncAttempt[]` to `OrderRecord`.
+- The cap is hand-mirrored from the BE constant per FE-001 contract strategy (`frontend-architecture.md` § API Client Conventions). Both should change together if the cap is ever tuned.
+
+**E2. Activity timeline switches to attempts**
+- File: `apps/web/src/features/orders/components/order-activity-timeline.tsx`
+- Prop rename: `syncStatus` → `syncAttempts`.
+- Iteration uses the attempt's `attemptedAt` as the row timestamp (always present, drops the "in progress" / null-timestamp branch).
+- Tone derives from `attempt.status`; verb from the existing `STATUS_PAST_TENSE` map.
+- Row `id` becomes `attempt-${destinationId}-${index}` to keep React keys unique when a destination has multiple rows.
+- Update the file header doc-comment to reflect the new data source.
+
+**E3. "View all attempts" deep link when capped**
+- Same file. After grouping attempts by destination, when a destination's group has `>= SYNC_ATTEMPTS_PER_DESTINATION_CAP` entries, render a small footer link below that destination's last row pointing to `/sync/jobs?connectionId={sourceConnectionId}` (the source connection — that's where `marketplace.order.sync` jobs are scoped).
+- Use `>=` not `===` so the trigger is robust to either a future cap bump or a brief over-the-cap window before the next prune.
+- `<Link>` from `react-router-dom`.
+
+**E4. `order-detail-page.tsx` prop rename**
+- File: `apps/web/src/pages/orders/order-detail-page.tsx`
+- One-line change: `syncStatus={order.syncStatus}` → `syncAttempts={order.syncAttempts}`.
+
+**E5. Timeline tests**
+- File: `apps/web/src/features/orders/components/order-activity-timeline.test.tsx`
+- Existing tests rewrite to use `syncAttempts` prop with `attemptedAt` instead of `syncedAt`.
+- New test: failure → retry → success renders three timeline rows in chronological order with correct tones.
+- New test: when a destination has `>= 20` entries, the "View all attempts" link appears with the right href.
+
+**E6. Order detail page spec**
+- File: `apps/web/src/pages/orders/order-detail-page.test.tsx` — extend the mocked `OrderRecord` factory with `syncAttempts: []`.
+
+## 4. Architecture compliance check
+
+- Domain layer (`SyncAttempt` interface, `OrderRecord` constructor) has zero framework imports — passes hexagonal rules.
+- New `order-sync.types.ts` file aligns with `engineering-standards.md` § Type Definitions in Separate Files (and corrects the existing inline `OrderSyncStatus` violation).
+- Repository port lives in `domain/ports/`, ORM-flavored types stay in infrastructure — clean.
+- No new dependency from Orders on `sync_jobs` / Sync Manager — the deep link is a URL string, not an import.
+- Single-source-of-truth for the cap value: one `SYNC_ATTEMPTS_PER_DESTINATION_CAP` constant, mirrored hand-written into FE per FE-001 contract strategy.
+- Migration timestamp `1793000000000` is unique vs. `1792000000000-add-ai-provider-active-setting.ts` (the current latest) and the class suffix matches the filename per `migrations.md` § Timestamp uniqueness invariant.
+
+## 5. Risks & open questions
+
+- **Migration on a populated DB:** the column has a `DEFAULT '[]'` so adding it is a metadata-only operation in PG 11+ (no row rewrite). Confirmed.
+- **JSONB statement performance:** the `jsonb_array_elements` + window function runs on at most cap+1 = 21 rows per call — negligible cost.
+- **Cap policy:** issue specifies "drop oldest at append" — implemented as "keep most-recent 20 per destination" via window-function rank, same outcome and single-statement-friendly.
+- **Retry-revert visibility:** explicitly accepted (see C5) — documented in PR rather than suppressed.
+
+## 6. Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+pnpm --filter @openlinker/api migration:show   # confirm migration discovered
+pnpm test:integration                          # repository concurrency + cap test
+```

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -360,13 +360,24 @@ describe('OrderRecordService', () => {
   });
 
   describe('updateSyncStatus', () => {
-    it('should update sync status for a destination', async () => {
+    const FROZEN_NOW = new Date('2026-04-30T11:22:33.000Z');
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(FROZEN_NOW);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should pass through status and stamp attemptedAt with the current time', async () => {
       const internalOrderId = 'order-123';
       const destinationConnectionId = 'dest-connection-456';
       const status: OrderSyncStatus = {
         destinationConnectionId,
         status: 'synced',
-        syncedAt: new Date(),
+        syncedAt: new Date('2026-04-30T11:22:33.000Z'),
         externalOrderId: 'external-order-789',
         externalOrderNumber: 'EXT-001',
       };
@@ -379,10 +390,18 @@ describe('OrderRecordService', () => {
         internalOrderId,
         destinationConnectionId,
         status,
+        {
+          destinationConnectionId,
+          status: 'synced',
+          attemptedAt: FROZEN_NOW,
+          error: undefined,
+          externalOrderId: 'external-order-789',
+          externalOrderNumber: 'EXT-001',
+        },
       );
     });
 
-    it('should handle failed sync status', async () => {
+    it('should propagate the error onto the attempt for failed status', async () => {
       const internalOrderId = 'order-123';
       const destinationConnectionId = 'dest-connection-456';
       const status: OrderSyncStatus = {
@@ -399,6 +418,12 @@ describe('OrderRecordService', () => {
         internalOrderId,
         destinationConnectionId,
         status,
+        expect.objectContaining({
+          destinationConnectionId,
+          status: 'failed',
+          attemptedAt: FROZEN_NOW,
+          error: 'Sync failed: Connection timeout',
+        }),
       );
     });
   });

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -11,7 +11,8 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { Order } from '../../domain/types/order.types';
 import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
-import { OrderRecord, OrderSyncStatus } from '../../domain/entities/order-record.entity';
+import { OrderRecord } from '../../domain/entities/order-record.entity';
+import { OrderSyncStatus, SyncAttempt } from '../../domain/types/order-sync.types';
 import { IOrderRecordService } from '../interfaces/order-record.service.interface';
 import type { IncomingOrder } from '../../domain/types/incoming-order.types';
 import { getPiiConfig } from '@openlinker/shared/config';
@@ -155,7 +156,22 @@ export class OrderRecordService implements IOrderRecordService {
     destinationConnectionId: string,
     status: OrderSyncStatus,
   ): Promise<void> {
-    await this.repository.updateSyncStatus(internalOrderId, destinationConnectionId, status);
+    // The service stamps `attemptedAt` so the repository UPDATE statement
+    // is purely mechanical (no clock dependency in the persistence layer).
+    const attempt: SyncAttempt = {
+      destinationConnectionId,
+      status: status.status,
+      attemptedAt: new Date(),
+      error: status.error,
+      externalOrderId: status.externalOrderId,
+      externalOrderNumber: status.externalOrderNumber,
+    };
+    await this.repository.updateSyncStatus(
+      internalOrderId,
+      destinationConnectionId,
+      status,
+      attempt,
+    );
   }
 
   /**

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -5,27 +5,12 @@
  * (OrderRecord + SyncState) for retry/debug support without re-polling source systems.
  * Order snapshot is PII-aware (respects OL_STORE_PII configuration).
  *
- * @module libs/core/src/orders/domain/entities
+ * @module domain/entities
  */
 import type { OrderRecordStatus } from '../types/order-record.types';
+import type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
 
-/**
- * Sync status for a destination connection
- */
-export interface OrderSyncStatus {
-  /** Destination connection ID */
-  destinationConnectionId: string;
-  /** Sync status: pending, syncing, synced, or failed */
-  status: 'pending' | 'syncing' | 'synced' | 'failed';
-  /** Timestamp when sync completed (for synced status) */
-  syncedAt?: Date;
-  /** External order ID in destination system */
-  externalOrderId?: string;
-  /** External order number in destination system */
-  externalOrderNumber?: string;
-  /** Error message (for failed status) */
-  error?: string;
-}
+export type { OrderSyncStatus, SyncAttempt } from '../types/order-sync.types';
 
 /**
  * Order Record Domain Entity
@@ -35,6 +20,10 @@ export interface OrderSyncStatus {
  *
  * recordStatus='awaiting_mapping': snapshot holds raw IncomingOrder (external refs, no internal IDs).
  * recordStatus='ready': snapshot holds resolved Order (internal product/variant IDs).
+ *
+ * `syncAttempts` is the per-destination append-only history; the constructor
+ * defaults it to `[]` so existing call sites that pre-date the column compile
+ * unchanged (the field is hydrated from the JSONB column by the repository).
  */
 export class OrderRecord {
   constructor(
@@ -47,5 +36,6 @@ export class OrderRecord {
     public readonly recordStatus: OrderRecordStatus,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
+    public readonly syncAttempts: SyncAttempt[] = [],
   ) {}
 }

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -9,6 +9,7 @@
  */
 import { OrderRecord } from '../entities/order-record.entity';
 import type { OrderRecordFilters, OrderRecordPagination, PaginatedOrderRecords } from '../types/order-record.types';
+import type { SyncAttempt } from '../types/order-sync.types';
 
 export interface OrderRecordRepositoryPort {
   /**
@@ -23,12 +24,20 @@ export interface OrderRecordRepositoryPort {
   upsert(orderRecord: OrderRecord): Promise<OrderRecord>;
 
   /**
-   * Update sync status for a destination connection
+   * Update sync status for a destination connection.
+   *
+   * Atomically (single SQL statement):
+   *   1. upserts the per-destination row in `syncStatus` (current state),
+   *   2. appends `attempt` to `syncAttempts`, keeping at most the documented
+   *      per-destination cap of most-recent entries.
+   *
+   * Throws `OrderRecordNotFoundException` if no row matches `internalOrderId`.
    */
   updateSyncStatus(
     internalOrderId: string,
     destinationConnectionId: string,
     status: OrderRecord['syncStatus'][0],
+    attempt: SyncAttempt,
   ): Promise<void>;
 
   /**

--- a/libs/core/src/orders/domain/types/order-sync.types.ts
+++ b/libs/core/src/orders/domain/types/order-sync.types.ts
@@ -1,0 +1,61 @@
+/**
+ * Order Sync Types
+ *
+ * Per-destination sync state and append-only attempt history for an
+ * `OrderRecord`. `OrderSyncStatus` is one row per destination (current
+ * state); `SyncAttempt` is an append-only log entry capped per destination
+ * so the activity timeline can render `failed → retried → synced` history
+ * after a successful retry overwrites the current state.
+ *
+ * @module domain/types
+ */
+
+/**
+ * Current sync state for one destination connection.
+ *
+ * Stored as a JSONB array on `order_records.syncStatus`, one entry per
+ * destination, upserted in place by the repository.
+ */
+export interface OrderSyncStatus {
+  /** Destination connection ID */
+  destinationConnectionId: string;
+  /** Sync status: pending, syncing, synced, or failed */
+  status: 'pending' | 'syncing' | 'synced' | 'failed';
+  /** Timestamp when sync completed (for synced status) */
+  syncedAt?: Date;
+  /** External order ID in destination system */
+  externalOrderId?: string;
+  /** External order number in destination system */
+  externalOrderNumber?: string;
+  /** Error message (for failed status) */
+  error?: string;
+}
+
+/**
+ * One historical attempt to sync an order to a destination.
+ *
+ * Stored as a JSONB array on `order_records.syncAttempts`, append-only,
+ * per-destination cap of {@link SYNC_ATTEMPTS_PER_DESTINATION_CAP}. Unlike
+ * `OrderSyncStatus`, every entry carries a real `attemptedAt` timestamp
+ * (no "in progress" placeholder) so the activity timeline can sort and
+ * render every attempt deterministically.
+ */
+export interface SyncAttempt {
+  destinationConnectionId: string;
+  status: 'pending' | 'syncing' | 'synced' | 'failed';
+  attemptedAt: Date;
+  error?: string;
+  externalOrderId?: string;
+  externalOrderNumber?: string;
+}
+
+/**
+ * Maximum number of attempts retained per destination on `syncAttempts`.
+ *
+ * Single source of truth — the repository binds this into the SQL window
+ * function and the FE compares against it to decide whether to render
+ * the "view all attempts" deep link to `/sync/jobs`. The hand-written FE
+ * mirror lives in `apps/web/src/features/orders/api/orders.types.ts`;
+ * keep both in sync per the FE-001 contract strategy.
+ */
+export const SYNC_ATTEMPTS_PER_DESTINATION_CAP = 20;

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -69,7 +69,12 @@ export {
 } from './orders.tokens';
 
 // Domain entities
-export { OrderRecord, OrderSyncStatus } from './domain/entities/order-record.entity';
+export { OrderRecord } from './domain/entities/order-record.entity';
+export {
+  OrderSyncStatus,
+  SyncAttempt,
+  SYNC_ATTEMPTS_PER_DESTINATION_CAP,
+} from './domain/types/order-sync.types';
 
 // Domain exceptions
 export { OrderRecordNotFoundException } from './domain/exceptions/order-record-not-found.exception';

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -28,6 +28,19 @@ export interface OrderSyncStatusJson {
   error?: string;
 }
 
+/**
+ * Sync attempt JSONB structure (append-only history per destination).
+ * `attemptedAt` is ISO 8601; the domain entity exposes it as a `Date`.
+ */
+export interface SyncAttemptJson {
+  destinationConnectionId: string;
+  status: 'pending' | 'syncing' | 'synced' | 'failed';
+  attemptedAt: string;
+  error?: string;
+  externalOrderId?: string;
+  externalOrderNumber?: string;
+}
+
 @Entity('order_records')
 @Index(['customerId'])
 @Index(['sourceConnectionId'])
@@ -58,6 +71,14 @@ export class OrderRecordOrmEntity {
    */
   @Column({ type: 'jsonb' })
   syncStatus!: OrderSyncStatusJson[];
+
+  /**
+   * Append-only attempt log per destination (JSONB array, capped per
+   * destination by the repository UPDATE statement). Enables the activity
+   * timeline to render `failed → retried → synced` history.
+   */
+  @Column({ type: 'jsonb', default: () => "'[]'" })
+  syncAttempts!: SyncAttemptJson[];
 
   @Column({ type: 'varchar', default: 'ready' })
   @Index()

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -11,7 +11,8 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { OrderRecordRepository } from '../order-record.repository';
 import { OrderRecordOrmEntity, OrderSyncStatusJson } from '../../entities/order-record.orm-entity';
-import { OrderRecord, OrderSyncStatus } from '../../../../domain/entities/order-record.entity';
+import { OrderRecord } from '../../../../domain/entities/order-record.entity';
+import { OrderSyncStatus, SyncAttempt } from '../../../../domain/types/order-sync.types';
 import { OrderRecordNotFoundException } from '../../../../domain/exceptions/order-record-not-found.exception';
 
 describe('OrderRecordRepository', () => {
@@ -30,6 +31,7 @@ describe('OrderRecordRepository', () => {
     const mockOrmRepository = {
       findOne: jest.fn(),
       save: jest.fn(),
+      query: jest.fn(),
       createQueryBuilder: jest.fn().mockReturnValue(qb),
     } as unknown as jest.Mocked<Repository<OrderRecordOrmEntity>> & { _qb: typeof qb };
 
@@ -65,6 +67,7 @@ describe('OrderRecordRepository', () => {
       status: 'pending',
     };
     entity.syncStatus = [];
+    entity.syncAttempts = [];
     entity.recordStatus = 'ready';
     entity.createdAt = new Date('2025-01-01T10:00:00Z');
     entity.updatedAt = new Date('2025-01-01T10:00:00Z');
@@ -262,53 +265,11 @@ describe('OrderRecordRepository', () => {
   });
 
   describe('updateSyncStatus', () => {
-    it('should update existing sync status for a destination', async () => {
-      const entity = createOrmEntity();
-      const existingSyncStatus: OrderSyncStatusJson = {
-        destinationConnectionId: 'dest-connection-789',
-        status: 'pending',
-      };
-      entity.syncStatus = [existingSyncStatus];
-      ormRepository.findOne.mockResolvedValue(entity);
-      ormRepository.save.mockResolvedValue(entity);
-
-      const newStatus: OrderSyncStatus = {
-        destinationConnectionId: 'dest-connection-789',
-        status: 'synced',
-        syncedAt: new Date('2025-01-01T11:00:00Z'),
-        externalOrderId: 'external-order-999',
-      };
-
-      await repository.updateSyncStatus('order-123', 'dest-connection-789', newStatus);
-
-      expect(ormRepository.findOne).toHaveBeenCalledWith({
-        where: { internalOrderId: 'order-123' },
-      });
-      expect(ormRepository.save).toHaveBeenCalledTimes(1);
-      const savedEntity = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(savedEntity.syncStatus).toHaveLength(1);
-      expect(savedEntity.syncStatus[0].status).toBe('synced');
-    });
-
-    it('should add new sync status if destination not found', async () => {
-      const entity = createOrmEntity();
-      entity.syncStatus = [];
-      ormRepository.findOne.mockResolvedValue(entity);
-      ormRepository.save.mockResolvedValue(entity);
-
-      const newStatus: OrderSyncStatus = {
-        destinationConnectionId: 'dest-connection-789',
-        status: 'synced',
-        syncedAt: new Date('2025-01-01T11:00:00Z'),
-      };
-
-      await repository.updateSyncStatus('order-123', 'dest-connection-789', newStatus);
-
-      const savedEntity = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(savedEntity.syncStatus).toHaveLength(1);
-      expect(savedEntity.syncStatus[0].destinationConnectionId).toBe('dest-connection-789');
-    });
-
+    // The current-state upsert + per-destination append + cap is implemented
+    // as a single SQL statement and is covered end-to-end by the integration
+    // test in apps/api/test/integration/order-record-attempts.int-spec.ts.
+    // The unit test here only guards the not-found branch — the only path the
+    // integration test can't cheaply express.
     it('should map recordStatus from ORM to domain on toDomain path', async () => {
       const entity = createOrmEntity();
       entity.recordStatus = 'awaiting_mapping';
@@ -319,24 +280,28 @@ describe('OrderRecordRepository', () => {
       expect(result?.recordStatus).toBe('awaiting_mapping');
     });
 
-    it('should throw OrderRecordNotFoundException if order record not found', async () => {
-      ormRepository.findOne.mockResolvedValue(null);
+    it('should throw OrderRecordNotFoundException when no row matches', async () => {
+      // pg drivers return [rows, affected] from raw UPDATE; TypeORM forwards.
+      (ormRepository.query as jest.Mock).mockResolvedValue([[], 0]);
 
       const newStatus: OrderSyncStatus = {
         destinationConnectionId: 'dest-connection-789',
         status: 'synced',
       };
+      const newAttempt: SyncAttempt = {
+        destinationConnectionId: 'dest-connection-789',
+        status: 'synced',
+        attemptedAt: new Date('2025-01-01T11:00:00Z'),
+      };
 
       await expect(
-        repository.updateSyncStatus('non-existent-order', 'dest-connection-789', newStatus),
+        repository.updateSyncStatus(
+          'non-existent-order',
+          'dest-connection-789',
+          newStatus,
+          newAttempt,
+        ),
       ).rejects.toThrow(OrderRecordNotFoundException);
-      
-      try {
-        await repository.updateSyncStatus('non-existent-order', 'dest-connection-789', newStatus);
-      } catch (error) {
-        expect(error).toBeInstanceOf(OrderRecordNotFoundException);
-        expect((error as OrderRecordNotFoundException).internalOrderId).toBe('non-existent-order');
-      }
     });
   });
 });

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -11,11 +11,25 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, SelectQueryBuilder } from 'typeorm';
-import { OrderRecordOrmEntity, OrderSyncStatusJson } from '../entities/order-record.orm-entity';
+import {
+  OrderRecordOrmEntity,
+  OrderSyncStatusJson,
+  SyncAttemptJson,
+} from '../entities/order-record.orm-entity';
 import { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
-import { OrderRecord, OrderSyncStatus } from '../../../domain/entities/order-record.entity';
+import { OrderRecord } from '../../../domain/entities/order-record.entity';
+import {
+  OrderSyncStatus,
+  SyncAttempt,
+  SYNC_ATTEMPTS_PER_DESTINATION_CAP,
+} from '../../../domain/types/order-sync.types';
 import { OrderRecordNotFoundException } from '../../../domain/exceptions/order-record-not-found.exception';
-import type { OrderRecordFilters, OrderRecordPagination, PaginatedOrderRecords, OrderRecordStatus } from '../../../domain/types/order-record.types';
+import type {
+  OrderRecordFilters,
+  OrderRecordPagination,
+  PaginatedOrderRecords,
+  OrderRecordStatus,
+} from '../../../domain/types/order-record.types';
 
 @Injectable()
 export class OrderRecordRepository implements OrderRecordRepositoryPort {
@@ -98,25 +112,23 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     return this.toDomain(saved);
   }
 
+  /**
+   * Atomic per-destination upsert + append.
+   *
+   * Single SQL statement so concurrent workers serialize on the row's
+   * exclusive write lock (no read-modify-write race). The `syncAttempts`
+   * column is capped per destination using a window function: rows are
+   * ranked most-recent-first within each `destinationConnectionId`, and
+   * only the top N are kept. Entries are wrapped via `jsonb_build_array`
+   * so the binder can't collapse object/array semantics.
+   */
   async updateSyncStatus(
     internalOrderId: string,
     destinationConnectionId: string,
     status: OrderSyncStatus,
+    attempt: SyncAttempt,
   ): Promise<void> {
-    const entity = await this.repository.findOne({
-      where: { internalOrderId },
-    });
-
-    if (!entity) {
-      throw new OrderRecordNotFoundException(internalOrderId);
-    }
-
-    // Update or add sync status for the destination
-    const existingIndex = entity.syncStatus.findIndex(
-      (s) => s.destinationConnectionId === destinationConnectionId,
-    );
-
-    const statusJson: OrderSyncStatusJson = {
+    const newStatusRow: OrderSyncStatusJson = {
       destinationConnectionId: status.destinationConnectionId,
       status: status.status,
       syncedAt: status.syncedAt?.toISOString(),
@@ -125,13 +137,60 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       error: status.error,
     };
 
-    if (existingIndex >= 0) {
-      entity.syncStatus[existingIndex] = statusJson;
-    } else {
-      entity.syncStatus.push(statusJson);
-    }
+    const newAttemptRow: SyncAttemptJson = {
+      destinationConnectionId: attempt.destinationConnectionId,
+      status: attempt.status,
+      attemptedAt: attempt.attemptedAt.toISOString(),
+      error: attempt.error,
+      externalOrderId: attempt.externalOrderId,
+      externalOrderNumber: attempt.externalOrderNumber,
+    };
 
-    await this.repository.save(entity);
+    // Raw query keeps the JSONB expression and the parameter binding explicit
+    // (TypeORM's UpdateQueryBuilder set-with-function path doesn't substitute
+    // named params inside the raw SQL fragment reliably across versions).
+    // pg returns `[rows, affected]` for UPDATE; TypeORM forwards that shape
+    // through `Repository.query`, which is typed `Promise<any>`.
+    const result = (await this.repository.query(
+      `
+      UPDATE "order_records"
+      SET
+        "syncStatus" = (
+          SELECT COALESCE(jsonb_agg(s), '[]'::jsonb)
+          FROM jsonb_array_elements("syncStatus") s
+          WHERE s->>'destinationConnectionId' != $2
+        ) || jsonb_build_array($3::jsonb),
+        "syncAttempts" = (
+          SELECT COALESCE(jsonb_agg(a ORDER BY ord), '[]'::jsonb)
+          FROM (
+            SELECT
+              a, ord,
+              ROW_NUMBER() OVER (
+                PARTITION BY a->>'destinationConnectionId' ORDER BY ord DESC
+              ) AS recency_rank
+            FROM jsonb_array_elements(
+              "syncAttempts" || jsonb_build_array($4::jsonb)
+            ) WITH ORDINALITY AS t(a, ord)
+          ) ranked
+          WHERE recency_rank <= $5
+        ),
+        "updatedAt" = NOW()
+      WHERE "internalOrderId" = $1
+      `,
+      [
+        internalOrderId,
+        destinationConnectionId,
+        JSON.stringify(newStatusRow),
+        JSON.stringify(newAttemptRow),
+        SYNC_ATTEMPTS_PER_DESTINATION_CAP,
+      ],
+    )) as unknown;
+
+    const affected =
+      Array.isArray(result) && typeof result[1] === 'number' ? result[1] : 0;
+    if (affected === 0) {
+      throw new OrderRecordNotFoundException(internalOrderId);
+    }
   }
 
   /**
@@ -147,6 +206,15 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       error: s.error,
     }));
 
+    const syncAttempts: SyncAttempt[] = (entity.syncAttempts ?? []).map((a) => ({
+      destinationConnectionId: a.destinationConnectionId,
+      status: a.status,
+      attemptedAt: new Date(a.attemptedAt),
+      error: a.error,
+      externalOrderId: a.externalOrderId,
+      externalOrderNumber: a.externalOrderNumber,
+    }));
+
     return new OrderRecord(
       entity.internalOrderId,
       entity.customerId,
@@ -157,6 +225,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       (entity.recordStatus as OrderRecordStatus) ?? 'ready',
       entity.createdAt,
       entity.updatedAt,
+      syncAttempts,
     );
   }
 
@@ -177,6 +246,14 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       externalOrderId: s.externalOrderId,
       externalOrderNumber: s.externalOrderNumber,
       error: s.error,
+    }));
+    entity.syncAttempts = orderRecord.syncAttempts.map((a) => ({
+      destinationConnectionId: a.destinationConnectionId,
+      status: a.status,
+      attemptedAt: a.attemptedAt.toISOString(),
+      error: a.error,
+      externalOrderId: a.externalOrderId,
+      externalOrderNumber: a.externalOrderNumber,
     }));
     entity.recordStatus = orderRecord.recordStatus;
     entity.createdAt = orderRecord.createdAt;

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -155,11 +155,19 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       `
       UPDATE "order_records"
       SET
+        -- syncStatus: drop any existing row for this destination, then append
+        -- the new current-state row at the tail. Per-destination upsert in one
+        -- expression — no race because the whole UPDATE is one statement.
         "syncStatus" = (
           SELECT COALESCE(jsonb_agg(s), '[]'::jsonb)
           FROM jsonb_array_elements("syncStatus") s
           WHERE s->>'destinationConnectionId' != $2
         ) || jsonb_build_array($3::jsonb),
+        -- syncAttempts: append the new attempt, then keep only the most-recent
+        -- N per destination. \`ord\` from WITH ORDINALITY = JSONB array insertion
+        -- order (chronological since we always append). The window function
+        -- ranks DESC within each destination so rank 1 = newest; rows above the
+        -- cap drop out. Outer \`ORDER BY ord\` re-chronologises the survivors.
         "syncAttempts" = (
           SELECT COALESCE(jsonb_agg(a ORDER BY ord), '[]'::jsonb)
           FROM (


### PR DESCRIPTION
## Summary

- Adds `syncAttempts` JSONB column on `order_records` so the activity timeline preserves every per-destination attempt instead of overwriting the failed row when retry succeeds (#456).
- Repository write rewritten to a single `UPDATE` with `jsonb_build_array` + window-function cap (per-destination, 20 most-recent) — closes the read-modify-write race the previous `findOne` + `save` path had under concurrent worker writes.
- `syncStatus` is left intact, so the Sync Status table, retry button, and failed-orders banner keep working unchanged.

## What changes

**Backend**
- New domain types in `libs/core/src/orders/domain/types/order-sync.types.ts`: `OrderSyncStatus` (extracted from the entity file), `SyncAttempt`, and the `SYNC_ATTEMPTS_PER_DESTINATION_CAP` constant.
- `OrderRecord` constructor adds `syncAttempts: SyncAttempt[] = []` as a defaulted last param — every existing `new OrderRecord(...)` call site compiles unchanged.
- ORM column `syncAttempts jsonb NOT NULL DEFAULT '[]'` via migration `1793000000000-add-order-record-sync-attempts.ts`. Adding the column with a default is a metadata-only operation in PG 11+.
- `OrderRecordRepository.updateSyncStatus` is now a single raw `UPDATE` that (a) upserts the per-destination row in `syncStatus` and (b) appends the new attempt to `syncAttempts`, keeping at most the cap of most-recent entries per destination via `ROW_NUMBER() OVER (PARTITION BY destinationConnectionId ORDER BY ord DESC)`.
- `OrderRecordService.updateSyncStatus` stamps `attemptedAt = new Date()`. Public service interface signature unchanged — callers in `OrderIngestionService` and `OrderDestinationRetryService` need no changes.

**API**
- New `SyncAttemptResponseDto`; `OrderRecordResponseDto` exposes the `syncAttempts` array; controller maps it through `toSyncAttemptDto`.

**Frontend**
- New `SyncAttempt` transport type and mirrored `SYNC_ATTEMPTS_PER_DESTINATION_CAP` constant in `orders.types.ts` (FE-001 hand-written contract).
- `OrderActivityTimeline` switches its prop from `syncStatus` → `syncAttempts`. Each attempt renders as its own row with a real `attemptedAt` (the "in progress" / null-timestamp branch is gone).
- "View all attempts" deep link to `/sync/jobs?connectionId={sourceConnectionId}` rendered below a destination's most-recent row when the per-destination history hits the cap.
- `buildEvents` wrapped in `useMemo`.

## Notable behavior change

The `OrderDestinationRetryService` claim/revert path (`failed → pending → failed` on enqueue failure) will now produce 2–3 attempt rows on the timeline rather than being silently rolled back. Strictly more informative for triage; flagged in the implementation plan, kept simple intentionally.

## Test plan

- [x] `pnpm lint` (zero errors)
- [x] `pnpm type-check` (zero errors)
- [x] `pnpm test` (1099 unit tests pass — BE + worker)
- [x] `pnpm --filter @openlinker/web test` (759 FE tests pass)
- [x] `pnpm --filter @openlinker/api test:integration -- order-record-attempts` (5 integration tests pass: serial chronology, cap enforcement, cross-destination concurrent writes, same-destination concurrent writes, missing-row error)
- [x] `pnpm --filter @openlinker/api migration:show` (`1793000000000-add-order-record-sync-attempts` discovered as pending)

Acceptance criteria from #456:
- [x] After a retry that succeeds, the order detail Activity section shows three rows for the affected destination (received → failed → synced) with their actual timestamps and the original error message.
- [x] `syncAttempts` is bounded to the last 20 entries per destination.
- [x] Concurrent worker writes do not lose attempts (verified by integration test).
- [x] Existing `syncStatus`-based code paths (Sync Status table, retry button, failed-orders banner) keep working unchanged.
- [x] No new dependency from Orders on `sync_jobs`.

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)