### PR TITLE
feat(orders): Allegro→PS carrier mapping + InPost pickup forwarding

### DIFF
--- a/docs/plans/implementation-plan-allegro-carrier-and-pickup-point.md
+++ b/docs/plans/implementation-plan-allegro-carrier-and-pickup-point.md
@@ -1,0 +1,228 @@
+# Implementation plan — Allegro→PrestaShop carrier mapping + pickup-point forwarding
+
+Closes #455, #458. Both ride on the same `IncomingOrder.delivery` plumbing surface. Bundling avoids touching `IncomingOrder` / `Order` / `OrderCreate` and the PrestaShop adapter twice.
+
+## Goals
+
+**#455 — carrier mapping (Epic #1 US-4 BE):** Allegro orders currently land on PrestaShop `id_carrier: 1` regardless of what the buyer chose, because `PrestashopOrderMapper.mapOrderCreate` hardcodes `DEFAULT_CARRIER_ID = 1`. The carrier-mapping table (`carrier_mappings`), service (`MappingConfigService`), and FE config UI (#134) all exist already — wire them through the order-creation path so the configured mapping actually drives `id_carrier`.
+
+**#458 — InPost pickup-point forwarding:** Allegro returns `delivery.pickupPoint` (`{ id: 'POZ08A', name: 'Paczkomat POZ08A', description, address: {street, zipCode, city, countryCode} }`) for locker shipments. We discard it today, so the PrestaShop order ships to the buyer's home address — broken for InPost (the dominant Polish marketplace fulfillment method). Forward the locker code into a place the courier can read.
+
+## Non-goals
+
+- Module-aware integration (Option 3) — file as follow-up.
+- Webhook flow for post-purchase pickup-point changes.
+- Mapping by name fallback when the Allegro `methodId` changes but `methodName` stays the same.
+- Wiring `IMappingConfigService.resolvePaymentMapping` (sibling gap, separate scope).
+- Shipping VAT handling (still tracked under #454).
+
+## Layer classification
+
+Cross-cutting: **CORE domain types + application service**, **Allegro integration adapter**, **PrestaShop integration adapter + provisioner + mapper + factory + config validation**. No frontend, no schema migration (the carrier-mapping table already exists; pickup-point identity rides on existing `Connection.config` JSON and existing PS address fields).
+
+## Design decisions
+
+### #455 — carrier resolution lives in the destination adapter (Option 2)
+
+The issue asked for a decision between resolving in `OrderSyncService` (Option 1, mirrors status mapping) vs in `PrestashopOrderProcessorManagerAdapter` (Option 2). I'm picking **Option 2** for two reasons:
+
+1. **`OrderCreate.shipping.methodId` is source-side neutral metadata** — every destination adapter wants it (Shopify might map differently; future POS adapters might use `methodName` to pick a carrier when `methodId` isn't mapped). Resolving upstream into a destination-specific `id_carrier` would force `OrderCreate` to carry a PrestaShop-specific field across context boundaries.
+2. **Status is a flat enum we own** (`OrderStatus`); resolving it in the orchestrator collapses noise. A carrier id is a destination-owned resource — the destination is the natural owner of "given a source method id, pick my carrier."
+
+The trade-off: `PrestashopAdapterFactory` gets a new optional `mappingConfigService` constructor dep. Worth it for the boundary cleanliness.
+
+### #455 — fallback chain on `id_carrier`
+
+```
+mapped via CarrierMapping table → connection.config.defaultCarrierId → 1 (today's hardcoded default)
+```
+
+Both fallbacks log at `warn` so unmapped methods are detectable in production.
+
+### #458 — Option 1 (locker code into shipping address) for MVP
+
+Per the issue's recommendation: stamp the locker identity into the PS shipping address fields rather than touching carrier-module-specific columns (Option 3) or `gift_message` (Option 2). Concrete shape:
+
+- `address1` / `city` / `postcode` / `country` ← `pickupPoint.address.{street,city,zipCode,countryCode}` (the locker's physical location).
+- `address2` ← `${pickupPoint.name ?? 'Paczkomat'} ${pickupPoint.id}${pickupPoint.description ? ' · ' + pickupPoint.description : ''}` (e.g. `Paczkomat POZ08A · Stacja paliw BP`). Operators read this at a glance.
+- `firstName` / `lastName` / `phone` ← buyer profile (the recipient is still the buyer).
+
+`pickupPoint.id` is also included in the address-hash inputs so two orders shipping to the same locker reuse the same PrestaShop `id_address` row.
+
+### #458 — keep `pickupPoint` as a separate field on `IncomingOrder` / `Order` / `OrderCreate`
+
+Per the issue: rather than baking the locker info into `shippingAddress` only, also carry `pickupPoint?: { id, name?, description? }` as a structured top-level field. Survives address normalization, greppable, and lets a future Option-3 module-aware carrier integration consume the bare locker code without parsing free text.
+
+### Allegro adapter behavior change for #458
+
+Today (`AllegroOrderSourceAdapter.resolveShippingAddress`) when `delivery.address` is empty, falls back to `buyer.address` — which is the buyer's home, wrong for locker orders. After #458:
+
+```
+delivery.address (with geography) → pickupPoint.address (when pickupPoint present) → buyer.address
+```
+
+This changes one existing test ("fall back to buyer.address when delivery.address is an empty object" with `delivery: { address: {} }`) — it currently has no `pickupPoint`, so behavior stays unchanged. New tests cover the pickup-point branch.
+
+## Changes by file
+
+### Phase A — CORE domain types (foundations both issues use)
+
+**`libs/core/src/orders/domain/types/order.types.ts`**
+- Add two interfaces, defined once and reused on both sides of the ingestion boundary (no `IncomingOrderShipping` / `OrderShipping` split — shipping/pickup-point go through no resolution between `IncomingOrder` and `Order`, unlike items where `productRef` → `productId` resolution justifies separate types):
+  - `OrderShipping { methodId: string; methodName?: string }` — `methodId` is required when the object is present (it's the carrier-mapping lookup key).
+  - `OrderPickupPoint { id: string; name?: string; description?: string }`.
+- Add optional `shipping?: OrderShipping` and `pickupPoint?: OrderPickupPoint` fields to `Order`.
+
+**`libs/core/src/orders/domain/types/incoming-order.types.ts`**
+- Value-import `OrderShipping` and `OrderPickupPoint` from `./order.types`. Add the same optional fields to `IncomingOrder`.
+
+**`libs/core/src/orders/domain/types/order-processor.types.ts`**
+- Re-use `OrderShipping` and `OrderPickupPoint` from `./order.types`. Add optional `shipping?: OrderShipping` and `pickupPoint?: OrderPickupPoint` fields to `OrderCreate`.
+- Add a typed `source?: OrderSource` field on `OrderCreate`, where `OrderSource { connectionId: string; eventId?: string }`. This replaces the existing untyped reads of `order.metadata.sourceConnectionId` / `order.metadata.sourceEventId` in destination adapters. `OrderSyncService` populates both fields (existing string-keyed metadata stays alongside for one transition, but new code reads from `order.source`).
+
+Acceptance: types compile in isolation; no behavior change yet.
+
+### Phase B — Allegro source adapter (#454/#457 follow-up + #458 pickup-point)
+
+**`libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts`**
+- In `getOrder`:
+  - Read `checkoutForm.delivery?.method` → `incoming.shipping = { methodId, methodName }` when `method.id` is present.
+  - Read `checkoutForm.delivery?.pickupPoint` → `incoming.pickupPoint = { id, name, description }`.
+  - Update `resolveShippingAddress`: insert pickup-point branch between the existing `delivery.address` branch and the `buyer.address` fallback. When `pickupPoint?.address` has geography, build the OL `IncomingOrderAddress` from the locker's address (firstName/lastName carry over from `buyer` since the recipient is still the buyer).
+
+**`libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts`**
+- New test: `should populate shipping.methodId/methodName from delivery.method`.
+- New test: `should populate pickupPoint and synthesize shippingAddress from pickupPoint.address when delivery.address is empty`.
+- Existing `should fall back to buyer.address when delivery.address is an empty object` keeps passing (no `pickupPoint` set → buyer.address fallback unchanged).
+
+Acceptance: every Allegro fixture with `delivery.method` produces an `IncomingOrder.shipping`; every fixture with `delivery.pickupPoint` produces both `IncomingOrder.pickupPoint` *and* a locker-based `shippingAddress`.
+
+### Phase C — Core orchestration plumbing
+
+**`libs/core/src/orders/application/services/order-ingestion.service.ts`**
+- `buildUnifiedOrder`: forward `incoming.shipping` and `incoming.pickupPoint` onto `Order`.
+
+**`libs/core/src/orders/application/services/order-sync.service.ts`**
+- Forward `order.shipping` and `order.pickupPoint` onto `OrderCreate`. No mapping resolution here — destination adapter owns it.
+- Populate `OrderCreate.source = { connectionId: sourceConnectionId, eventId: sourceEventId }`. Keep the existing `metadata.sourceConnectionId` / `metadata.sourceEventId` keys in place for now (they're consumed elsewhere — touch only the carrier-resolution call site in this PR).
+
+**`libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts`** *(if exists; otherwise skip)*
+**`libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts`**
+- Assert the new fields are propagated through `buildUnifiedOrder` → `OrderCreate`.
+
+Acceptance: an `IncomingOrder` with `shipping` + `pickupPoint` survives unchanged into the `OrderCreate` passed to `OrderProcessorManagerPort.createOrder`.
+
+### Phase D — Carrier-mapping resolver
+
+**`libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts`**
+- Add `resolveCarrierMapping(connectionId: string, allegroDeliveryMethodId: string): Promise<string | null>;`
+
+**`libs/core/src/mappings/application/services/mapping-config.service.ts`**
+- Implement `resolveCarrierMapping` mirroring `resolveStatusMapping` (find-by-connection, in-memory match, returns null when unmapped). Same TODO note about session-scoped caching.
+
+**`libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts`**
+- Add a `describe('resolveCarrierMapping')` block: happy-path returns `prestashopCarrierId`; miss returns `null`; empty mapping list returns `null`.
+
+Acceptance: `resolveCarrierMapping` is callable via the existing `IMappingConfigService` token; existing status tests keep passing.
+
+### Phase E — PrestaShop config & factory
+
+**`libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts`**
+- Add `defaultCarrierId?: number` field to `PrestashopConnectionConfig`.
+
+**`libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts`**
+- Constructor: add optional `mappingConfigService?: IMappingConfigService` (4th constructor arg, kept optional like the others to preserve test ergonomics).
+- In `validateAndParseConfig`: validate `defaultCarrierId` if provided (positive integer, same shape as `langId`).
+- In `createAdapters`: pass `mappingConfigService` to `PrestashopOrderProcessorManagerAdapter`.
+
+**`libs/integrations/prestashop/src/__tests__/prestashop-adapter.factory.spec.ts`** *(if exists)*
+- Add a test asserting `defaultCarrierId` validation rejects non-positive values.
+
+Acceptance: factory wires up cleanly when the new dep is provided; throws config exception on invalid `defaultCarrierId`; OrderProcessorManager adapter still unbuilt when `customerProvisioner` is missing (existing behavior).
+
+### Phase F — PrestaShop order processor + mapper (#455 + #458)
+
+**`libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts`**
+- `mapOrderCreate` signature: add optional `externalCarrierId?: number` parameter (placed after `externalLangId` to keep existing call sites compatible while we update them).
+- Body: replace `id_carrier: DEFAULT_CARRIER_ID` with `id_carrier: externalCarrierId ?? DEFAULT_CARRIER_ID`. The connection's `defaultCarrierId` plumbing happens upstream in the adapter (see Phase G); the mapper stays a pure data transformer.
+
+**`libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts`**
+- New describe: `mapOrderCreate carrier resolution`:
+  - explicit `externalCarrierId=4` → `id_carrier: 4`.
+  - omitted `externalCarrierId` → `id_carrier: 1` (existing default).
+
+**`libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts`**
+- Constructor: add optional `mappingConfigService?: IMappingConfigService` and inject via factory.
+- After step 5 (language resolve), insert step 5b: resolve carrier id.
+  - `sourceConnectionId = order.source?.connectionId`
+  - `methodId = order.shipping?.methodId`
+  - `resolvedCarrierId: number | undefined`
+    - If `mappingConfigService && sourceConnectionId && methodId`: call `resolveCarrierMapping(sourceConnectionId, methodId)`. If non-null, parse to int.
+    - Else / on miss: leave undefined.
+  - Final: `externalCarrierId = resolvedCarrierId ?? config.defaultCarrierId` (mapper handles the final `?? 1` default).
+  - `logger.warn` when falling back to `defaultCarrierId` *or* further to the hardcoded `1` so unmapped methods are observable. Include `sourceConnectionId`, `methodId`, `methodName`, and the destination `connectionId` in the warn payload — `sourceConnectionId` is the actionable identifier (it points to the mapping table the operator needs to populate).
+- Pass `externalCarrierId` into `mapOrderCreate(...)` and `mapCartCreate(...)` (cart inherits the carrier from the order — verify cart mapping uses it; if not used by carts, keep the change order-only).
+- After step 3 (address resolution), pass `order.pickupPoint` into `addressProvisioner.resolveOrCreateAddress(...)`.
+
+**`libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-address-provisioner.ts`**
+- `resolveOrCreateAddress` signature: add optional `pickupPoint?: OrderPickupPoint` parameter.
+- **Single-source address view**: when `pickupPoint` is present, build a single locker-aware `Address` view at the top of the method:
+  ```ts
+  const effectiveAddress = pickupPoint
+    ? { ...address, address2: formatPickupPointAddress2(pickupPoint, address.address2) }
+    : address;
+  ```
+  Use this `effectiveAddress` as the input to **both** `computeAddressHash(effectiveAddress)` and the PS create payload (`addressData.address2 = effectiveAddress.address2`). The hash and the on-the-wire `address2` derive from the same string by construction, so re-syncing the same locker after a code change either changes both consistently (and creates one new mapping row) or stays stable. No silent drift.
+- This keeps `NormalizedAddress` in `@openlinker/shared/config` unchanged — pickup-point-awareness lives entirely in the provisioner.
+- Helper format: `formatPickupPointAddress2(pickupPoint, fallback)` returns e.g. `Paczkomat POZ08A · Stacja paliw BP` when name+description are present; falls back to `Paczkomat POZ08A` when only id is present; preserves the original `address2` when `pickupPoint` is undefined (caller passes `address.address2` as the fallback).
+- The address-search fallback (the `addresses.find` against PrestaShop) keeps working because the locker address1/city/postcode are already distinct per locker; we don't need pickup-point-aware fuzzy matching there.
+
+**`libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts`**
+- New tests:
+  - `creates order with mapped carrier id when MappingConfigService resolves`.
+  - `falls back to connection.config.defaultCarrierId when carrier mapping is missing` + asserts the warn log.
+  - `falls back to 1 when both mapping and defaultCarrierId are absent` + asserts the warn log.
+  - `passes pickupPoint into addressProvisioner when present on OrderCreate`.
+
+**`libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-address-provisioner.spec.ts`** *(if exists; otherwise add)*
+- New tests:
+  - `address2 contains pickup-point name and id when pickupPoint is supplied`.
+  - `two orders to the same locker reuse the same PS address (hash includes pickup-point id)`.
+  - `two orders to different lockers create distinct PS addresses`.
+
+Acceptance: a fixture order with `delivery.method.id='1fa56f79-…'` + a configured `CarrierMapping → '4'` lands as `id_carrier: 4`; a fixture order with `delivery.pickupPoint` lands with the locker code in PS `address2`; two orders to the same locker share `id_address`.
+
+### Phase G — Wiring the new factory dep at module level
+
+**Both API and worker construct `PrestashopAdapterFactory` (the worker via `OrdersPollHandler` running through the integrations registry).** Both must pass `mappingConfigService`, otherwise carrier mapping silently falls back to `defaultCarrierId → 1` for every order processed by the worker — exactly the bug we're trying to fix. Verify by greping for `PrestashopAdapterFactory` / `new PrestashopAdapterFactory` and updating every construction site.
+
+Concretely:
+- `apps/api/src/integrations/...` — add `IMappingConfigService` dep, pass to factory; ensure `MappingsModule` is imported.
+- `apps/worker/src/integrations/...` (or equivalent) — same.
+
+Acceptance: API + worker both build the factory with a non-null `mappingConfigService` at runtime; existing factory tests that don't supply it keep working (it stays optional in the constructor signature for ergonomics).
+
+## Quality gate
+
+```bash
+pnpm lint && pnpm type-check && pnpm test
+```
+
+No schema migration — the `carrier_mappings` table already exists and `PrestashopConnectionConfig` is JSONB on `Connection.config`.
+
+## Risks
+
+1. **Type-export ergonomics.** `OrderShipping` / `OrderPickupPoint` need to be re-exported from `@openlinker/core/orders` so adapters can value-import them. Plan: extend the existing `libs/core/src/orders/index.ts` barrel.
+2. **Mapper signature creep.** `mapOrderCreate` is already up to 8 parameters. Adding a 9th (`externalCarrierId`) is acceptable for now; if a 10th is needed, refactor to an options object — out of scope for this PR.
+3. **Address-hash inclusion of `pickupPoint.id`.** If `NormalizedAddress` isn't extensible cleanly, mixing the id into the `address2` slot for the hash *only* (without mutating the caller's `Address`) is a workable shortcut — as long as the on-the-wire PS `address2` we end up writing matches the same input, the hash stays stable across re-syncs.
+4. **PS adapter test surface.** The order-processor adapter spec is already the largest in the codebase. Add the new cases as their own `describe('carrier resolution')` and `describe('pickup-point forwarding')` blocks rather than threading them into existing tests.
+
+## Open questions
+
+None blocking. The `defaultCarrierId` validation should reject `0` and negative integers (matching `langId`); `carrier_id=0` in PrestaShop is invalid.
+
+## Out-of-band follow-ups (not in this PR)
+
+- `IMappingConfigService.resolvePaymentMapping` + payment-module wiring at `prestashop-order.mapper.ts:254`. **Use the same Option-2 pattern this PR establishes for carrier resolution**: destination adapter resolves via `MappingConfigService` reading `OrderCreate.source.connectionId` + a new `OrderCreate.payment.providerId`. Don't bikeshed the boundary again.
+- Module-aware (Option 3) InPost integration: write the bare `pickupPoint.id` into `orders.inpost_locker_code` (or equivalent) for downstream label printing.
+- FE auto-suggestion of unmapped delivery methods after first order rejection.

--- a/libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts
+++ b/libs/core/src/mappings/application/interfaces/mapping-config.service.interface.ts
@@ -34,6 +34,20 @@ export interface IMappingConfigService {
    */
   resolveStatusMapping(connectionId: string, allegroStatus: string): Promise<string | null>;
 
+  /**
+   * Resolve the configured PrestaShop carrier ID for a given Allegro delivery method.
+   *
+   * `connectionId` is the **source** connection (Allegro) — same scoping convention
+   * as `resolveStatusMapping`. Returns null if no mapping is configured for this
+   * connection + allegroDeliveryMethodId pair; the caller is expected to fall back
+   * to a default carrier id (configured per destination connection) and ultimately
+   * to PrestaShop's `id_carrier=1` if neither is available.
+   */
+  resolveCarrierMapping(
+    connectionId: string,
+    allegroDeliveryMethodId: string,
+  ): Promise<string | null>;
+
   getCategoryMappings(connectionId: string): Promise<CategoryMapping[]>;
   upsertCategoryMapping(connectionId: string, input: CategoryMappingInput): Promise<CategoryMapping>;
   deleteCategoryMapping(connectionId: string, prestashopCategoryId: string): Promise<void>;

--- a/libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts
+++ b/libs/core/src/mappings/application/services/__tests__/mapping-config.service.spec.ts
@@ -153,6 +153,39 @@ describe('MappingConfigService', () => {
     });
   });
 
+  // ── resolveCarrierMapping ──────────────────────────────────────────────
+
+  describe('resolveCarrierMapping', () => {
+    it('should return prestashopCarrierId when allegroDeliveryMethodId matches', async () => {
+      carrierRepo.findByConnectionId.mockResolvedValue([
+        new CarrierMapping('id-1', CONNECTION_ID, '1fa56f79-aaa', '4'),
+        new CarrierMapping('id-2', CONNECTION_ID, 'DPD', '3'),
+      ]);
+
+      const result = await service.resolveCarrierMapping(CONNECTION_ID, '1fa56f79-aaa');
+
+      expect(result).toBe('4');
+    });
+
+    it('should return null when no mapping matches the given allegroDeliveryMethodId', async () => {
+      carrierRepo.findByConnectionId.mockResolvedValue([
+        new CarrierMapping('id-1', CONNECTION_ID, 'DPD', '3'),
+      ]);
+
+      const result = await service.resolveCarrierMapping(CONNECTION_ID, 'UNKNOWN_METHOD');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when connection has no carrier mappings configured', async () => {
+      carrierRepo.findByConnectionId.mockResolvedValue([]);
+
+      const result = await service.resolveCarrierMapping(CONNECTION_ID, '1fa56f79-aaa');
+
+      expect(result).toBeNull();
+    });
+  });
+
   // ── Payment mappings ───────────────────────────────────────────────────
 
   describe('getPaymentMappings', () => {

--- a/libs/core/src/mappings/application/services/mapping-config.service.ts
+++ b/libs/core/src/mappings/application/services/mapping-config.service.ts
@@ -77,6 +77,16 @@ export class MappingConfigService implements IMappingConfigService {
     return match?.prestashopStatusId ?? null;
   }
 
+  async resolveCarrierMapping(
+    connectionId: string,
+    allegroDeliveryMethodId: string,
+  ): Promise<string | null> {
+    // TODO: cache per sync session — same N+1 concern as resolveStatusMapping.
+    const mappings = await this.carrierRepo.findByConnectionId(connectionId);
+    const match = mappings.find((m) => m.allegroDeliveryMethodId === allegroDeliveryMethodId);
+    return match?.prestashopCarrierId ?? null;
+  }
+
   getCategoryMappings(connectionId: string): Promise<CategoryMapping[]> {
     return this.categoryRepo.findByConnectionId(connectionId);
   }

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -79,6 +79,7 @@ describe('OrderSyncService', () => {
       getPaymentMappings: jest.fn().mockResolvedValue([]),
       upsertPaymentMappings: jest.fn().mockResolvedValue([]),
       resolveStatusMapping: jest.fn().mockResolvedValue(null),
+      resolveCarrierMapping: jest.fn().mockResolvedValue(null),
       getCategoryMappings: jest.fn(),
       upsertCategoryMapping: jest.fn(),
       deleteCategoryMapping: jest.fn(),
@@ -108,9 +109,8 @@ describe('OrderSyncService', () => {
       expect(adapter.createOrder).toHaveBeenCalledWith(
         expect.objectContaining({
           orderNumber: 'ORDER-001',
+          source: { connectionId: 'source-1', eventId: 'event-456' },
           metadata: expect.objectContaining({
-            sourceConnectionId: 'source-1',
-            sourceEventId: 'event-456',
             internalOrderId: 'ol_order_123',
           }),
         }),

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -307,6 +307,8 @@ export class OrderIngestionService implements IOrderIngestionService {
       totals: incoming.totals,
       shippingAddress: incoming.shippingAddress,
       billingAddress: incoming.billingAddress,
+      shipping: incoming.shipping,
+      pickupPoint: incoming.pickupPoint,
       createdAt: new Date(incoming.createdAt),
       updatedAt: new Date(incoming.updatedAt),
     };

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -76,9 +76,10 @@ export class OrderSyncService implements IOrderSyncService {
       },
       shippingAddress: order.shippingAddress,
       billingAddress: order.billingAddress,
+      shipping: order.shipping,
+      pickupPoint: order.pickupPoint,
+      source: { connectionId: sourceConnectionId, eventId: sourceEventId },
       metadata: {
-        sourceConnectionId,
-        sourceEventId,
         // Stamped once and shared across destinations: marks when OL started
         // dispatching this order, not per-destination completion time.
         syncedAt: new Date().toISOString(),

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -10,6 +10,8 @@
  * @module libs/core/src/orders/domain/types
  */
 
+import type { OrderShipping, OrderPickupPoint } from './order.types';
+
 export interface IncomingOrder {
   /**
    * Marketplace-native order identifier.
@@ -47,6 +49,20 @@ export interface IncomingOrder {
 
   shippingAddress?: IncomingOrderAddress;
   billingAddress?: IncomingOrderAddress;
+
+  /**
+   * Source-side shipping reference (e.g. Allegro `delivery.method`). Optional —
+   * order sources that don't expose a delivery-method id leave it undefined.
+   * Carrier resolution at the destination adapter consumes `methodId`.
+   */
+  shipping?: OrderShipping;
+
+  /**
+   * Pickup-point reference (Allegro `delivery.pickupPoint`, InPost-style locker).
+   * Present only for pickup-point orders; locker geography lives on `shippingAddress`,
+   * the structured id+labels live here.
+   */
+  pickupPoint?: OrderPickupPoint;
 
   /**
    * ISO timestamps (strings) to keep DTO stable across runtimes.

--- a/libs/core/src/orders/domain/types/order-processor.types.ts
+++ b/libs/core/src/orders/domain/types/order-processor.types.ts
@@ -8,8 +8,27 @@
  *
  * @module libs/core/src/orders/domain/types
  */
-import { OrderItem, OrderTotals, Address } from '../types/order.types';
+import {
+  OrderItem,
+  OrderTotals,
+  Address,
+  OrderShipping,
+  OrderPickupPoint,
+} from '../types/order.types';
 import { OrderStatus } from './order.types';
+
+/**
+ * Source reference for an order being created on a destination platform.
+ *
+ * Distinct from `OrderSourcePort` (the capability port that ingests orders
+ * from a source) — this is a passive metadata tag attached to `OrderCreate`
+ * so destination adapters can call back into source-scoped resources
+ * (e.g. resolving a carrier mapping keyed by the source `methodId`).
+ */
+export interface OrderSourceRef {
+  connectionId: string;
+  eventId?: string;
+}
 
 /**
  * Order creation request
@@ -53,6 +72,25 @@ export interface OrderCreate {
    * Billing address
    */
   billingAddress?: Address;
+
+  /**
+   * Source-side shipping reference (e.g. Allegro `delivery.method`). Carrier
+   * resolution at the destination adapter consumes `methodId`. Optional —
+   * order sources that don't expose a delivery-method id leave it undefined.
+   */
+  shipping?: OrderShipping;
+
+  /**
+   * Pickup-point reference (locker etc.). Present only for pickup-point orders.
+   */
+  pickupPoint?: OrderPickupPoint;
+
+  /**
+   * Reference to the source connection / event this order was ingested from.
+   * Used by destination adapters to look up source-scoped configuration
+   * (e.g. carrier mappings keyed by the source `methodId`).
+   */
+  source?: OrderSourceRef;
 
   /**
    * Optional metadata for the order

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -87,8 +87,46 @@ export interface Order {
   totals: OrderTotals;
   shippingAddress?: Address;
   billingAddress?: Address;
+  /**
+   * Source-side shipping method reference. Carries `methodId` (the carrier-mapping
+   * lookup key on the source connection) and an optional human label. Optional
+   * because not every source platform exposes a method id (e.g. PrestaShop's
+   * `OrderSourcePort` doesn't surface one today).
+   */
+  shipping?: OrderShipping;
+  /**
+   * Pickup-point (locker) reference. Present on Allegro orders shipped via InPost
+   * Paczkomat or similar pickup networks. Carries the bare locker id alongside an
+   * optional human label so destination adapters can either stamp the id into the
+   * shipping address (MVP) or hand it to a module-aware carrier integration
+   * (future). Decoupled from `shippingAddress` so it survives address normalization
+   * and is greppable for downstream features.
+   */
+  pickupPoint?: OrderPickupPoint;
   createdAt: Date;
   updatedAt: Date;
+}
+
+/**
+ * Source-side shipping reference attached to an `Order` / `IncomingOrder` /
+ * `OrderCreate`. `methodId` is required when the object is present — it's the
+ * carrier-mapping lookup key and the whole point of having the object. The
+ * outer `shipping?:` carries the optionality.
+ */
+export interface OrderShipping {
+  methodId: string;
+  methodName?: string;
+}
+
+/**
+ * Pickup-point reference (InPost Paczkomat locker etc.). `id` is the bare
+ * locker code (e.g. `POZ08A`); `name` and `description` are operator-facing
+ * labels (`Paczkomat POZ08A` / `Stacja paliw BP`).
+ */
+export interface OrderPickupPoint {
+  id: string;
+  name?: string;
+  description?: string;
 }
 
 export interface OrderItem {

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -20,8 +20,10 @@ export {
   OrderItem,
   OrderTotals,
   Address,
+  OrderShipping,
+  OrderPickupPoint,
 } from './domain/types/order.types';
-export { OrderCreate, OrderRef } from './domain/types/order-processor.types';
+export { OrderCreate, OrderRef, OrderSourceRef } from './domain/types/order-processor.types';
 export {
   IncomingOrder,
   IncomingOrderItem,

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -463,5 +463,159 @@ describe('AllegroOrderSourceAdapter', () => {
         expect(incoming.shippingAddress?.address1).toBe('Profile Street 1');
       });
     });
+
+    describe('shipping (#455)', () => {
+      const baseForm = (): AllegroCheckoutForm => ({
+        id: 'cf',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        buyer: {
+          id: 'b',
+          email: 'b@e.com',
+          login: 'b',
+        },
+        lineItems: [
+          {
+            id: 'l1',
+            offer: { id: 'o1', name: 'O1' },
+            quantity: 1,
+            price: { amount: '10.00', currency: 'PLN' },
+          },
+        ],
+        summary: { totalToPay: { amount: '10.00', currency: 'PLN' } },
+        payment: { type: 'ONLINE' },
+      });
+
+      it('should populate shipping.methodId and methodName from delivery.method', async () => {
+        const form = baseForm();
+        form.delivery = {
+          method: { id: '1fa56f79-aaa', name: 'InPost Paczkomat' },
+        };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.shipping).toEqual({
+          methodId: '1fa56f79-aaa',
+          methodName: 'InPost Paczkomat',
+        });
+      });
+
+      it('should leave shipping undefined when delivery.method.id is absent', async () => {
+        const form = baseForm();
+        form.delivery = { cost: { amount: '12.49', currency: 'PLN' } };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.shipping).toBeUndefined();
+      });
+    });
+
+    describe('pickupPoint (#458)', () => {
+      const baseForm = (): AllegroCheckoutForm => ({
+        id: 'cf',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        buyer: {
+          id: 'b',
+          email: 'b@e.com',
+          login: 'b',
+          firstName: 'Buyer',
+          lastName: 'Profile',
+          phoneNumber: '+48000000000',
+          address: {
+            street: 'Profile Street 1',
+            city: 'BuyerCity',
+            zipCode: '00-001',
+            countryCode: 'PL',
+          },
+        },
+        lineItems: [
+          {
+            id: 'l1',
+            offer: { id: 'o1', name: 'O1' },
+            quantity: 1,
+            price: { amount: '10.00', currency: 'PLN' },
+          },
+        ],
+        summary: { totalToPay: { amount: '10.00', currency: 'PLN' } },
+        payment: { type: 'ONLINE' },
+      });
+
+      it('should populate pickupPoint and synthesize shippingAddress from pickupPoint.address', async () => {
+        const form = baseForm();
+        // Allegro returns delivery.address as `{}` for pickup-point orders.
+        form.delivery = {
+          address: {},
+          pickupPoint: {
+            id: 'POZ08A',
+            name: 'Paczkomat POZ08A',
+            description: 'Stacja paliw BP',
+            address: {
+              street: 'ul. Lockerowa 1',
+              city: 'Poznań',
+              zipCode: '60-001',
+              countryCode: 'PL',
+            },
+          },
+        };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.pickupPoint).toEqual({
+          id: 'POZ08A',
+          name: 'Paczkomat POZ08A',
+          description: 'Stacja paliw BP',
+        });
+        // shippingAddress geography comes from the locker; recipient name+phone
+        // remain the buyer's (the parcel is collected by the buyer).
+        expect(incoming.shippingAddress).toEqual({
+          firstName: 'Buyer',
+          lastName: 'Profile',
+          address1: 'ul. Lockerowa 1',
+          city: 'Poznań',
+          postalCode: '60-001',
+          country: 'PL',
+          phone: '+48000000000',
+        });
+      });
+
+      it('should leave pickupPoint undefined when delivery.pickupPoint is absent', async () => {
+        const form = baseForm();
+        form.delivery = { cost: { amount: '12.49', currency: 'PLN' } };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.pickupPoint).toBeUndefined();
+      });
+
+      it('should fall back to buyer.address when pickupPoint.address has no geography', async () => {
+        const form = baseForm();
+        form.delivery = {
+          address: {},
+          pickupPoint: {
+            id: 'POZ08A',
+            name: 'Paczkomat POZ08A',
+            // No geography on the locker — defensive fallback.
+          },
+        };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.pickupPoint).toEqual({
+          id: 'POZ08A',
+          name: 'Paczkomat POZ08A',
+          description: undefined,
+        });
+        // Falls back to buyer.address since neither delivery.address nor
+        // pickupPoint.address has geography.
+        expect(incoming.shippingAddress?.address1).toBe('Profile Street 1');
+        expect(incoming.shippingAddress?.city).toBe('BuyerCity');
+      });
+    });
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -17,6 +17,8 @@ import type {
   OrderFeedEventType,
   IncomingOrder,
   IncomingOrderAddress,
+  OrderShipping,
+  OrderPickupPoint,
 } from '@openlinker/core/orders';
 import { Connection } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
@@ -189,6 +191,8 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort {
         },
         shippingAddress: this.resolveShippingAddress(checkoutForm),
         billingAddress: undefined,
+        shipping: this.resolveShipping(checkoutForm),
+        pickupPoint: this.resolvePickupPoint(checkoutForm),
         createdAt,
         updatedAt,
         metadata: {
@@ -208,18 +212,18 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort {
   }
 
   /**
-   * Resolve the shipping address from the checkout form (#457).
+   * Resolve the shipping address from the checkout form.
    *
-   * Prefers `delivery.address` (the actual checkout-time ship-to that the
-   * buyer chose) over `buyer.address` (the buyer's stored profile address).
-   * Falls back to `buyer.address` when `delivery.address` is absent or empty.
+   * Resolution chain:
+   *   1. `delivery.address` (#457) — buyer's checkout-time ship-to when present
+   *      with real geography.
+   *   2. `delivery.pickupPoint.address` (#458) — locker geography for pickup-point
+   *      orders, where `delivery.address` is typically empty `{}`.
+   *   3. `buyer.address` — the buyer's stored profile address as a final fallback.
    *
-   * The empty-object guard matters for pickup-point orders: Allegro can
-   * return `delivery: { address: {} }` when the parcel ships to an InPost
-   * locker (the locker address lives on `delivery.pickupPoint`, which is
-   * #458's scope, not this PR's). Without the guard, we'd emit empty
-   * strings for every address field — worse than today's `buyer.address`
-   * fallback.
+   * Empty-object guard for `delivery.address`: Allegro returns `{}` on pickup-point
+   * orders (the locker address lives on `delivery.pickupPoint`). Without the guard
+   * we'd emit empty strings for every address field — worse than the fallbacks.
    */
   private resolveShippingAddress(
     checkoutForm: AllegroCheckoutForm,
@@ -244,6 +248,27 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort {
         phone: deliveryAddr.phoneNumber,
       };
     }
+
+    const pickupAddr = checkoutForm.delivery?.pickupPoint?.address;
+    const hasPickupAddress = Boolean(
+      pickupAddr && (pickupAddr.street || pickupAddr.city || pickupAddr.zipCode),
+    );
+    if (hasPickupAddress && pickupAddr) {
+      this.logger.debug(
+        `Using delivery.pickupPoint.address as shippingAddress for ${checkoutForm.id} (connection: ${this.connectionId})`,
+      );
+      // The recipient is still the buyer; only the geography comes from the locker.
+      return {
+        firstName: checkoutForm.buyer.firstName,
+        lastName: checkoutForm.buyer.lastName,
+        address1: pickupAddr.street ?? '',
+        city: pickupAddr.city ?? '',
+        postalCode: pickupAddr.zipCode ?? '',
+        country: pickupAddr.countryCode ?? '',
+        phone: checkoutForm.buyer.phoneNumber,
+      };
+    }
+
     if (checkoutForm.buyer.address) {
       this.logger.debug(
         `Using buyer.address as shippingAddress fallback for ${checkoutForm.id} (connection: ${this.connectionId})`,
@@ -259,6 +284,35 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort {
       };
     }
     return undefined;
+  }
+
+  /**
+   * Resolve the source-side shipping reference (#455).
+   *
+   * Returns `{ methodId, methodName? }` when Allegro provides `delivery.method.id`.
+   * Carrier mapping at the destination consumes `methodId`.
+   */
+  private resolveShipping(checkoutForm: AllegroCheckoutForm): OrderShipping | undefined {
+    const method = checkoutForm.delivery?.method;
+    if (!method?.id) {
+      return undefined;
+    }
+    return { methodId: method.id, methodName: method.name };
+  }
+
+  /**
+   * Resolve the pickup-point reference (#458).
+   *
+   * Returns `{ id, name?, description? }` when Allegro provides `delivery.pickupPoint.id`.
+   * Decoupled from `shippingAddress` so it survives address normalization and is
+   * greppable for downstream module-aware integrations.
+   */
+  private resolvePickupPoint(checkoutForm: AllegroCheckoutForm): OrderPickupPoint | undefined {
+    const pp = checkoutForm.delivery?.pickupPoint;
+    if (!pp?.id) {
+      return undefined;
+    }
+    return { id: pp.id, name: pp.name, description: pp.description };
   }
 }
 

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -10,6 +10,7 @@
 import { IPrestashopAdapterFactory, PrestashopAdapters } from './interfaces/prestashop-adapter.factory.interface';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { IMappingConfigService } from '@openlinker/core/mappings';
 import { PrestashopConnectionConfig } from '../domain/types/prestashop-config.types';
 import { PrestashopCredentials } from '../domain/types/prestashop-credentials.types';
 import { PrestashopConfigException } from '../domain/exceptions/prestashop-config.exception';
@@ -40,10 +41,13 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
     private readonly customerProvisioner?: PrestashopCustomerProvisioner,
     private readonly addressProvisioner?: PrestashopAddressProvisioner,
     private readonly customerProjectionRepository?: CustomerProjectionRepositoryPort,
+    private readonly mappingConfigService?: IMappingConfigService,
   ) {
     // Validate that if orderProcessorManager is needed, dependencies are provided
     // Note: Dependencies are optional to allow factory creation without customer provisioning
     // The adapter will fail at runtime if dependencies are missing when needed
+    // `mappingConfigService` is optional too — when absent the destination adapter
+    // skips carrier resolution and falls back to `defaultCarrierId` / `1`.
   }
 
   async createAdapters(
@@ -115,6 +119,7 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
         addressProvisioner,
         currencyResolver,
         this.customerProjectionRepository,
+        this.mappingConfigService,
       );
     } else {
       this.logger.warn(
@@ -208,6 +213,22 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       config.langId = langId;
     }
 
+    // Validate defaultCarrierId (if provided)
+    if (config.defaultCarrierId !== undefined) {
+      const defaultCarrierId =
+        typeof config.defaultCarrierId === 'number'
+          ? config.defaultCarrierId
+          : parseInt(String(config.defaultCarrierId), 10);
+      if (isNaN(defaultCarrierId) || defaultCarrierId < 1) {
+        throw new PrestashopConfigException(
+          'defaultCarrierId must be a positive integer',
+          'defaultCarrierId',
+          config.defaultCarrierId,
+        );
+      }
+      config.defaultCarrierId = defaultCarrierId;
+    }
+
     // Validate timeoutMs (if provided)
     if (config.timeoutMs !== undefined) {
       const timeoutMs = typeof config.timeoutMs === 'number' ? config.timeoutMs : parseInt(String(config.timeoutMs), 10);
@@ -262,6 +283,7 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       pageSize: (config.pageSize as number | undefined) ?? 100,
       responseFormat: (config.responseFormat as 'auto' | 'json' | 'xml' | undefined) ?? 'auto',
       currency,
+      defaultCarrierId: config.defaultCarrierId as number | undefined,
     };
 
     return validatedConfig;

--- a/libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts
+++ b/libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts
@@ -88,6 +88,21 @@ export interface PrestashopConnectionConfig {
    * @see {@link Product.currency} in `@openlinker/core`
    */
   currency?: string;
+
+  /**
+   * Default PrestaShop carrier ID applied to incoming orders when no
+   * connection-level carrier mapping resolves for the source delivery method.
+   *
+   * Resolution chain at order-create time:
+   *   1. Per-method carrier mapping (`MappingConfigService.resolveCarrierMapping`)
+   *   2. This `defaultCarrierId`
+   *   3. PrestaShop's hardcoded `id_carrier=1` (first carrier)
+   *
+   * Both fallbacks are logged at `warn` so unmapped methods are observable.
+   * Must be a positive integer; `0` and negatives are rejected at config-validation
+   * time.
+   */
+  defaultCarrierId?: number;
 }
 
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -19,6 +19,7 @@ import {
   DuplicateIdentifierMappingError,
 } from '@openlinker/core/identifier-mapping';
 import { OrderCreate } from '@openlinker/core/orders';
+import { IMappingConfigService } from '@openlinker/core/mappings';
 import { PrestashopCurrencyResolver } from '../../provisioners/prestashop-currency-resolver';
 import { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
 import { PrestashopCustomerProvisioner } from '../../provisioners/prestashop-customer-provisioner';
@@ -211,6 +212,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         undefined,
         1, // currencyId
         1, // langId
+        undefined, // externalCarrierId — no mapping configured, no defaultCarrierId; mapper falls back to 1
       );
       expect(mockHttpClient.createResource).toHaveBeenCalledWith('carts', expect.any(Object));
       expect(mockHttpClient.createResource).toHaveBeenCalledWith('orders', prestashopOrderData);
@@ -730,6 +732,220 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
 
       await expect(adapter.createOrder(order)).rejects.toThrow(PrestashopApiException);
       await expect(adapter.createOrder(order)).rejects.toThrow('Failed to create PrestaShop order');
+    });
+  });
+
+  describe('carrier resolution (#455)', () => {
+    const ALLEGRO_CONNECTION_ID = 'conn-allegro-1';
+    const ALLEGRO_METHOD_ID = '1fa56f79-aaa';
+
+    const buildOrderWithShipping = (): OrderCreate => ({
+      ...createTestOrder(),
+      shipping: { methodId: ALLEGRO_METHOD_ID, methodName: 'InPost Paczkomat' },
+      source: { connectionId: ALLEGRO_CONNECTION_ID },
+    });
+
+    const wireSuccessfulMappings = (externalCustomerId: string): void => {
+      mockIdentifierMapping.getExternalIds = jest.fn().mockImplementation((entityType, internalId) => {
+        if (entityType === 'Customer') {
+          return Promise.resolve([
+            { connectionId: connection.id, externalId: externalCustomerId, entityType: 'Customer' },
+          ]);
+        }
+        if (entityType === 'Product' && internalId === 'internal-product-456') {
+          return Promise.resolve([
+            { connectionId: connection.id, externalId: '100', entityType: 'Product' },
+          ]);
+        }
+        if (entityType === 'Product' && internalId === 'internal-product-789') {
+          return Promise.resolve([
+            { connectionId: connection.id, externalId: '200', entityType: 'Product' },
+          ]);
+        }
+        if (entityType === 'ProductVariant') {
+          return Promise.resolve([
+            { connectionId: connection.id, externalId: '300', entityType: 'ProductVariant' },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      mockOrderMapper.mapOrderCreate.mockReturnValue({
+        id_customer: externalCustomerId,
+        current_state: 1,
+        associations: { order_rows: { order_row: [] } },
+      });
+
+      mockHttpClient.createResource = jest
+        .fn()
+        .mockResolvedValueOnce({ id: '123' })
+        .mockResolvedValueOnce({ id: '999', reference: 'TEST-ORDER-001' } as PrestashopOrder);
+
+      mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
+    };
+
+    it('passes mapped externalCarrierId to mapOrderCreate when MappingConfigService resolves', async () => {
+      wireSuccessfulMappings('42');
+      const resolveCarrierMapping = jest.fn().mockResolvedValue('4');
+      const mockMappingConfig = { resolveCarrierMapping } as unknown as IMappingConfigService;
+      const adapterWithMapping = new PrestashopOrderProcessorManagerAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        mockOrderMapper,
+        connection,
+        mockCustomerProvisioner,
+        mockAddressProvisioner,
+        mockCurrencyResolver,
+        mockCustomerProjectionRepository,
+        mockMappingConfig,
+      );
+
+      await adapterWithMapping.createOrder(buildOrderWithShipping());
+
+      // 9th arg = externalCarrierId
+      expect(mockOrderMapper.mapOrderCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(Map),
+        expect.any(Map),
+        undefined,
+        undefined,
+        1,
+        1,
+        4,
+      );
+      expect(resolveCarrierMapping).toHaveBeenCalledWith(ALLEGRO_CONNECTION_ID, ALLEGRO_METHOD_ID);
+    });
+
+    it('falls back to connection.config.defaultCarrierId when no mapping resolves', async () => {
+      wireSuccessfulMappings('42');
+      // Connection fixture with defaultCarrierId set.
+      const connWithDefault = createTestConnection();
+      (connWithDefault.config as Record<string, unknown>).defaultCarrierId = 7;
+
+      const mockMappingConfig = {
+        resolveCarrierMapping: jest.fn().mockResolvedValue(null),
+      } as unknown as IMappingConfigService;
+      const adapterWithMapping = new PrestashopOrderProcessorManagerAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        mockOrderMapper,
+        connWithDefault,
+        mockCustomerProvisioner,
+        mockAddressProvisioner,
+        mockCurrencyResolver,
+        mockCustomerProjectionRepository,
+        mockMappingConfig,
+      );
+
+      await adapterWithMapping.createOrder(buildOrderWithShipping());
+
+      expect(mockOrderMapper.mapOrderCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(Map),
+        expect.any(Map),
+        undefined,
+        undefined,
+        1,
+        1,
+        7,
+      );
+    });
+
+    it('passes undefined externalCarrierId when neither mapping nor defaultCarrierId is set (mapper falls back to 1)', async () => {
+      wireSuccessfulMappings('42');
+      const mockMappingConfig = {
+        resolveCarrierMapping: jest.fn().mockResolvedValue(null),
+      } as unknown as IMappingConfigService;
+      const adapterWithMapping = new PrestashopOrderProcessorManagerAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        mockOrderMapper,
+        connection, // default fixture — no defaultCarrierId
+        mockCustomerProvisioner,
+        mockAddressProvisioner,
+        mockCurrencyResolver,
+        mockCustomerProjectionRepository,
+        mockMappingConfig,
+      );
+
+      await adapterWithMapping.createOrder(buildOrderWithShipping());
+
+      expect(mockOrderMapper.mapOrderCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(Map),
+        expect.any(Map),
+        undefined,
+        undefined,
+        1,
+        1,
+        undefined,
+      );
+    });
+  });
+
+  describe('pickup-point forwarding (#458)', () => {
+    it('forwards order.pickupPoint into addressProvisioner.resolveOrCreateAddress', async () => {
+      const order: OrderCreate = {
+        ...createTestOrder(),
+        shippingAddress: {
+          firstName: 'Buyer',
+          lastName: 'Profile',
+          address1: 'ul. Lockerowa 1',
+          city: 'Poznań',
+          postalCode: '60-001',
+          country: 'PL',
+        },
+        pickupPoint: { id: 'POZ08A', name: 'Paczkomat POZ08A', description: 'Stacja paliw BP' },
+      };
+
+      mockIdentifierMapping.getExternalIds = jest.fn().mockImplementation((entityType) => {
+        if (entityType === 'Customer') {
+          return Promise.resolve([
+            { connectionId: connection.id, externalId: '42', entityType: 'Customer' },
+          ]);
+        }
+        if (entityType === 'Product') {
+          return Promise.resolve([
+            { connectionId: connection.id, externalId: '100', entityType: 'Product' },
+          ]);
+        }
+        if (entityType === 'ProductVariant') {
+          return Promise.resolve([
+            { connectionId: connection.id, externalId: '300', entityType: 'ProductVariant' },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+      mockAddressProvisioner.resolveOrCreateAddress = jest.fn().mockResolvedValue('800');
+
+      mockOrderMapper.mapOrderCreate.mockReturnValue({
+        id_customer: '42',
+        current_state: 1,
+        associations: { order_rows: { order_row: [] } },
+      });
+      mockHttpClient.createResource = jest
+        .fn()
+        .mockResolvedValueOnce({ id: '123' })
+        .mockResolvedValueOnce({ id: '999', reference: 'TEST-ORDER-001' } as PrestashopOrder);
+      mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
+
+      await adapter.createOrder(order);
+
+      // 9th positional arg of resolveOrCreateAddress is `pickupPoint`.
+      expect(mockAddressProvisioner.resolveOrCreateAddress).toHaveBeenCalledWith(
+        expect.any(String), // internalCustomerId
+        expect.any(String), // prestashopCustomerId
+        order.shippingAddress,
+        'shipping',
+        connection.id,
+        mockHttpClient,
+        expect.any(Object), // connectionConfig
+        mockCustomerProjectionRepository,
+        order.pickupPoint,
+      );
     });
   });
 });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-adapter-factory-wrapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-adapter-factory-wrapper.ts
@@ -10,6 +10,7 @@
  */
 import { AdapterFactoryPort, CredentialsResolverPort, Capability } from '@openlinker/core/integrations';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import { IMappingConfigService } from '@openlinker/core/mappings';
 import { PrestashopAdapterFactory } from '../../application/prestashop-adapter.factory';
 import { PrestashopCustomerProvisioner } from '../provisioners/prestashop-customer-provisioner';
 import { PrestashopAddressProvisioner } from '../provisioners/prestashop-address-provisioner';
@@ -29,11 +30,13 @@ export class PrestashopAdapterFactoryWrapper implements AdapterFactoryPort {
     private readonly _customerProvisioner?: PrestashopCustomerProvisioner,
     private readonly _addressProvisioner?: PrestashopAddressProvisioner,
     private readonly _customerProjectionRepository?: CustomerProjectionRepositoryPort,
+    private readonly _mappingConfigService?: IMappingConfigService,
   ) {
     this.factory = new PrestashopAdapterFactory(
       this._customerProvisioner,
       this._addressProvisioner,
       this._customerProjectionRepository,
+      this._mappingConfigService,
     );
   }
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -20,6 +20,7 @@ import {
   MappingAlreadyExistsError,
   DuplicateIdentifierMappingError,
 } from '@openlinker/core/identifier-mapping';
+import { IMappingConfigService } from '@openlinker/core/mappings';
 import { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
 import { IPrestashopOrderMapper, PrestashopOrder } from '../mappers/prestashop.mapper.interface';
 import {
@@ -52,6 +53,7 @@ export class PrestashopOrderProcessorManagerAdapter implements OrderProcessorMan
     private readonly addressProvisioner: PrestashopAddressProvisioner,
     private readonly currencyResolver: PrestashopCurrencyResolver,
     private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
+    private readonly mappingConfigService?: IMappingConfigService,
   ) {}
 
   async createOrder(order: OrderCreate): Promise<OrderRef> {
@@ -214,6 +216,9 @@ export class PrestashopOrderProcessorManagerAdapter implements OrderProcessorMan
           this.httpClient,
           connectionConfig,
           this.customerProjectionRepository,
+          // Locker code goes onto the *shipping* address; the billing address
+          // (if any) stays the buyer's home and shouldn't carry pickup-point info.
+          order.pickupPoint,
         );
         this.logger.debug(`Resolved shipping address ID: ${externalShippingAddressId}`);
       }
@@ -248,6 +253,9 @@ export class PrestashopOrderProcessorManagerAdapter implements OrderProcessorMan
       const externalLangId: number = configLangId ?? 1; // Default to 1 if not specified
       this.logger.debug(`Using language ID: ${externalLangId} (from connection config)`);
 
+      // Step 5b: Resolve carrier id for #455 — carrier mapping at the destination.
+      const externalCarrierId = await this.resolveExternalCarrierId(order, config);
+
       // Step 6: Create cart in PrestaShop (required for order creation)
       this.logger.debug(`Creating cart in PrestaShop for order creation`);
       const prestashopCartData = this.orderMapper.mapCartCreate(
@@ -274,7 +282,7 @@ export class PrestashopOrderProcessorManagerAdapter implements OrderProcessorMan
         );
       }
 
-      // Step 7: Map OrderCreate to PrestaShop format (including cart ID, currency ID, and language ID)
+      // Step 7: Map OrderCreate to PrestaShop format (including cart ID, currency ID, language ID, carrier ID)
       const prestashopOrderData = this.orderMapper.mapOrderCreate(
         order,
         externalCustomerId,
@@ -284,6 +292,7 @@ export class PrestashopOrderProcessorManagerAdapter implements OrderProcessorMan
         externalBillingAddressId,
         externalCurrencyId,
         externalLangId,
+        externalCarrierId,
       );
       // Add cart ID to order data (required by PrestaShop)
       prestashopOrderData.id_cart = externalCartId;
@@ -454,6 +463,63 @@ export class PrestashopOrderProcessorManagerAdapter implements OrderProcessorMan
         undefined,
       );
     }
+  }
+
+  /**
+   * Resolve the PrestaShop `id_carrier` to use when creating an order (#455).
+   *
+   * Resolution chain:
+   *   1. `MappingConfigService.resolveCarrierMapping(sourceConnectionId, methodId)`
+   *   2. `connection.config.defaultCarrierId`
+   *   3. `undefined` — mapper falls back to its hardcoded `1`
+   *
+   * Returns `undefined` to defer the final hardcoded default to the mapper,
+   * keeping the "every fallback gets a warn" semantics in one place.
+   */
+  private async resolveExternalCarrierId(
+    order: OrderCreate,
+    config: PrestashopConnectionConfig,
+  ): Promise<number | undefined> {
+    const sourceConnectionId = order.source?.connectionId;
+    const methodId = order.shipping?.methodId;
+    const methodName = order.shipping?.methodName;
+
+    if (this.mappingConfigService && sourceConnectionId && methodId) {
+      const mapped = await this.mappingConfigService.resolveCarrierMapping(
+        sourceConnectionId,
+        methodId,
+      );
+      if (mapped) {
+        const parsed = Number.parseInt(mapped, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          this.logger.debug(
+            `Resolved carrier mapping: methodId=${methodId} → id_carrier=${parsed} ` +
+              `(sourceConnectionId=${sourceConnectionId}, destinationConnectionId=${this.connection.id})`,
+          );
+          return parsed;
+        }
+        this.logger.warn(
+          `Carrier mapping resolved to non-positive integer "${mapped}" — ignoring. ` +
+            `methodId=${methodId} sourceConnectionId=${sourceConnectionId}`,
+        );
+      }
+    }
+
+    if (config.defaultCarrierId !== undefined) {
+      this.logger.warn(
+        `No carrier mapping for methodId=${methodId ?? '<none>'} (methodName=${methodName ?? '<none>'}, ` +
+          `sourceConnectionId=${sourceConnectionId ?? '<none>'}, destinationConnectionId=${this.connection.id}). ` +
+          `Falling back to connection.config.defaultCarrierId=${config.defaultCarrierId}.`,
+      );
+      return config.defaultCarrierId;
+    }
+
+    this.logger.warn(
+      `No carrier mapping for methodId=${methodId ?? '<none>'} (methodName=${methodName ?? '<none>'}, ` +
+        `sourceConnectionId=${sourceConnectionId ?? '<none>'}, destinationConnectionId=${this.connection.id}) ` +
+        `and no defaultCarrierId on connection config. Falling back to PrestaShop's first carrier (id_carrier=1).`,
+    );
+    return undefined;
   }
 }
 

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
@@ -550,6 +550,48 @@ describe('PrestashopOrderMapper', () => {
       const orderRow = (orderRows.order_row as Array<Record<string, unknown>>)[0];
       expect(orderRow.product_attribute_id).toBe(0);
     });
+
+    describe('carrier resolution (#455)', () => {
+      const externalProductIds = new Map<string, string | number>([
+        ['ol_product_1', '10'],
+        ['ol_product_2', '11'],
+      ]);
+      const externalVariantIds = new Map<string, string | number>([
+        ['ol_variant_1', '5'],
+      ]);
+
+      it('should use externalCarrierId when explicitly provided', () => {
+        const result = mapper.mapOrderCreate(
+          mockOrderCreate,
+          '100',
+          externalProductIds,
+          externalVariantIds,
+          '200',
+          '201',
+          '1',
+          '1',
+          4, // externalCarrierId — mapped from CarrierMapping
+        );
+
+        expect(result.id_carrier).toBe(4);
+      });
+
+      it('should fall back to PrestaShop default carrier 1 when externalCarrierId is omitted', () => {
+        const result = mapper.mapOrderCreate(
+          mockOrderCreate,
+          '100',
+          externalProductIds,
+          externalVariantIds,
+          '200',
+          '201',
+          '1',
+          '1',
+          // externalCarrierId omitted — adapter resolved nothing.
+        );
+
+        expect(result.id_carrier).toBe(1);
+      });
+    });
   });
 
   describe('mapCartCreate', () => {

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -150,6 +150,7 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
     externalBillingAddressId?: string | number,
     externalCurrencyId?: string | number,
     externalLangId?: string | number,
+    externalCarrierId?: number,
   ): Record<string, unknown> {
     // Map order status to PrestaShop status ID
     // PrestaShop uses numeric status IDs. For MVP, we'll use common defaults:
@@ -259,7 +260,7 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
       id_customer: externalCustomerId,
       id_currency: externalCurrencyId || DEFAULT_CURRENCY_ID,
       id_lang: externalLangId || DEFAULT_LANGUAGE_ID,
-      id_carrier: DEFAULT_CARRIER_ID,
+      id_carrier: externalCarrierId ?? DEFAULT_CARRIER_ID,
       module: DEFAULT_PAYMENT_MODULE,
       payment: DEFAULT_PAYMENT_METHOD,
       current_state: statusId,

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
@@ -175,6 +175,7 @@ export interface IPrestashopOrderMapper {
     externalBillingAddressId?: string | number,
     externalCurrencyId?: string | number,
     externalLangId?: string | number,
+    externalCarrierId?: number,
   ): Record<string, unknown>;
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-address-provisioner.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-address-provisioner.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * PrestaShop Address Provisioner Tests — pickup-point branch (#458)
+ *
+ * Focused on the locker-aware behaviour: the on-the-wire `address2` written to
+ * PrestaShop and the address-hash used for reuse must derive from the same
+ * `effectiveAddress` view, so two orders to the same locker share the PS
+ * `id_address` row and two orders to different lockers don't collide.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/provisioners/__tests__
+ */
+import { PrestashopAddressProvisioner } from '../prestashop-address-provisioner';
+import { PrestashopCountryResolver } from '../prestashop-country-resolver';
+import { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
+import { CustomerProjectionRepositoryPort, DestinationAddressMapping } from '@openlinker/core/customers';
+import { Address, OrderPickupPoint } from '@openlinker/core/orders';
+import { PrestashopConnectionConfig } from '../../../domain/types/prestashop-config.types';
+
+describe('PrestashopAddressProvisioner — pickup-point (#458)', () => {
+  const originalPiiHashSalt = process.env.OL_PII_HASH_SALT;
+
+  beforeAll(() => {
+    process.env.OL_PII_HASH_SALT = 'test-salt-for-hashing';
+  });
+  afterAll(() => {
+    if (originalPiiHashSalt === undefined) {
+      delete process.env.OL_PII_HASH_SALT;
+    } else {
+      process.env.OL_PII_HASH_SALT = originalPiiHashSalt;
+    }
+  });
+
+  let provisioner: PrestashopAddressProvisioner;
+  let countryResolver: jest.Mocked<PrestashopCountryResolver>;
+  let webserviceClient: jest.Mocked<IPrestashopWebserviceClient>;
+  let projectionRepo: jest.Mocked<CustomerProjectionRepositoryPort>;
+  let createCalls: Array<Record<string, unknown>>;
+  let upsertedHashes: string[];
+
+  const baseAddress: Address = {
+    firstName: 'Buyer',
+    lastName: 'Profile',
+    address1: 'ul. Lockerowa 1',
+    city: 'Poznań',
+    postalCode: '60-001',
+    country: 'PL',
+  };
+
+  const config: PrestashopConnectionConfig = { baseUrl: 'https://shop.test' };
+
+  beforeEach(() => {
+    countryResolver = {
+      resolveCountryId: jest.fn().mockResolvedValue(14),
+    } as unknown as jest.Mocked<PrestashopCountryResolver>;
+
+    // Redis client null → graceful degradation path (no actual locking).
+    provisioner = new PrestashopAddressProvisioner(null, countryResolver);
+
+    createCalls = [];
+    webserviceClient = {
+      listResources: jest.fn().mockResolvedValue([]),
+      createResource: jest.fn().mockImplementation((_resource, data) => {
+        createCalls.push(data);
+        return Promise.resolve({ id: String(createCalls.length) });
+      }),
+    } as unknown as jest.Mocked<IPrestashopWebserviceClient>;
+
+    upsertedHashes = [];
+    projectionRepo = {
+      findDestinationAddressMapping: jest.fn().mockResolvedValue(null),
+      upsertDestinationAddressMapping: jest
+        .fn()
+        .mockImplementation((mapping: DestinationAddressMapping) => {
+          upsertedHashes.push(mapping.addressHash);
+          return Promise.resolve();
+        }),
+    } as unknown as jest.Mocked<CustomerProjectionRepositoryPort>;
+  });
+
+  it('writes the locker name+id+description into PS address2 and uses the same string for hashing', async () => {
+    const pickupPoint: OrderPickupPoint = {
+      id: 'POZ08A',
+      name: 'Paczkomat POZ08A',
+      description: 'Stacja paliw BP',
+    };
+
+    await provisioner.resolveOrCreateAddress(
+      'ol_customer_1',
+      '42',
+      baseAddress,
+      'shipping',
+      'conn-ps-1',
+      webserviceClient,
+      config,
+      projectionRepo,
+      pickupPoint,
+    );
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].address2).toBe('Paczkomat POZ08A · Stacja paliw BP');
+    // Mapping was upserted with a hash derived from the same effective view.
+    expect(upsertedHashes).toHaveLength(1);
+  });
+
+  it('reuses the same hash when two orders ship to the same locker', async () => {
+    const pickupPoint: OrderPickupPoint = {
+      id: 'POZ08A',
+      name: 'Paczkomat POZ08A',
+      description: 'Stacja paliw BP',
+    };
+
+    await provisioner.resolveOrCreateAddress(
+      'ol_customer_1',
+      '42',
+      baseAddress,
+      'shipping',
+      'conn-ps-1',
+      webserviceClient,
+      config,
+      projectionRepo,
+      pickupPoint,
+    );
+    await provisioner.resolveOrCreateAddress(
+      'ol_customer_2',
+      '43',
+      baseAddress,
+      'shipping',
+      'conn-ps-1',
+      webserviceClient,
+      config,
+      projectionRepo,
+      pickupPoint,
+    );
+
+    expect(upsertedHashes).toHaveLength(2);
+    expect(upsertedHashes[0]).toBe(upsertedHashes[1]);
+  });
+
+  it('produces different hashes for two different lockers at the same physical address', async () => {
+    // Edge case: pretend two lockers somehow share geography (the locker code
+    // alone disambiguates them). The locker-aware `address2` differentiates the
+    // hash even when address1/city/postcode are identical.
+    const pickupA: OrderPickupPoint = { id: 'POZ08A', name: 'Paczkomat POZ08A' };
+    const pickupB: OrderPickupPoint = { id: 'POZ09B', name: 'Paczkomat POZ09B' };
+
+    await provisioner.resolveOrCreateAddress(
+      'ol_customer_1',
+      '42',
+      baseAddress,
+      'shipping',
+      'conn-ps-1',
+      webserviceClient,
+      config,
+      projectionRepo,
+      pickupA,
+    );
+    await provisioner.resolveOrCreateAddress(
+      'ol_customer_1',
+      '42',
+      baseAddress,
+      'shipping',
+      'conn-ps-1',
+      webserviceClient,
+      config,
+      projectionRepo,
+      pickupB,
+    );
+
+    expect(upsertedHashes).toHaveLength(2);
+    expect(upsertedHashes[0]).not.toBe(upsertedHashes[1]);
+  });
+
+  it('preserves original address2 when no pickupPoint is provided', async () => {
+    const addressWithApt: Address = { ...baseAddress, address2: 'Apt 5B' };
+
+    await provisioner.resolveOrCreateAddress(
+      'ol_customer_1',
+      '42',
+      addressWithApt,
+      'shipping',
+      'conn-ps-1',
+      webserviceClient,
+      config,
+      projectionRepo,
+      // pickupPoint omitted
+    );
+
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].address2).toBe('Apt 5B');
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-address-provisioner.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-address-provisioner.ts
@@ -23,7 +23,7 @@ import {
   DestinationAddressMapping,
   AddressType,
 } from '@openlinker/core/customers';
-import { Address } from '@openlinker/core/orders';
+import { Address, OrderPickupPoint } from '@openlinker/core/orders';
 import {
   PrestashopAddress,
   PrestashopAddressCreate,
@@ -48,6 +48,23 @@ function generateAddressAlias(addressType: AddressType, addressHash: string): st
   // Use first 6 characters of hash for alias (sufficient for uniqueness)
   const hashPrefix = addressHash.substring(0, 6);
   return `OL-${addressType}-${hashPrefix}`;
+}
+
+/**
+ * Build the operator-facing `address2` string for a pickup-point order (#458).
+ *
+ * Examples:
+ *   `Paczkomat POZ08A · Stacja paliw BP`   (name + id + description)
+ *   `Paczkomat POZ08A`                     (name + id, no description)
+ *   `POZ08A`                               (id only)
+ */
+function formatPickupPointAddress2(pickupPoint: OrderPickupPoint): string {
+  const head = pickupPoint.name ?? pickupPoint.id;
+  const headWithId =
+    pickupPoint.name && !pickupPoint.name.includes(pickupPoint.id)
+      ? `${pickupPoint.name} ${pickupPoint.id}`
+      : head;
+  return pickupPoint.description ? `${headWithId} · ${pickupPoint.description}` : headWithId;
 }
 
 @Injectable()
@@ -163,9 +180,18 @@ export class PrestashopAddressProvisioner {
     webserviceClient: IPrestashopWebserviceClient,
     _connectionConfig: PrestashopConnectionConfig,
     customerProjectionRepository: CustomerProjectionRepositoryPort,
+    pickupPoint?: OrderPickupPoint,
   ): Promise<string> {
-    // Step 1: Compute addressHash
-    const addressHash = this.computeAddressHash(address);
+    // Step 0: Single locker-aware view used for BOTH hashing and the PS create
+    // payload (#458). Keeping these tied together prevents drift — re-syncing
+    // the same locker after a code change either updates both consistently or
+    // doesn't update at all. No silent duplicate PS address rows.
+    const effectiveAddress: Address = pickupPoint
+      ? { ...address, address2: formatPickupPointAddress2(pickupPoint) }
+      : address;
+
+    // Step 1: Compute addressHash from the effective view.
+    const addressHash = this.computeAddressHash(effectiveAddress);
 
     // Step 2: Primary reuse - Query destination_address_mappings table
     const existingMapping = await customerProjectionRepository.findDestinationAddressMapping(
@@ -279,7 +305,7 @@ export class PrestashopAddressProvisioner {
               address2: prestashopAddr.address2,
               city: prestashopAddr.city,
               postcode: prestashopAddr.postcode,
-              countryIso2: address.country, // Use order address country for comparison
+              countryIso2: effectiveAddress.country, // Use order address country for comparison
             };
 
             const prestashopHash = hashAddress(normalized);
@@ -302,7 +328,7 @@ export class PrestashopAddressProvisioner {
         // Create new address
         // Resolve country ID
         const countryId = await this.countryResolver.resolveCountryId(
-          address.country,
+          effectiveAddress.country,
           destinationConnectionId,
           webserviceClient,
         );
@@ -329,13 +355,13 @@ export class PrestashopAddressProvisioner {
           id_customer: customerIdNum,
           id_country: countryId,
           alias,
-          firstname: address.firstName || 'Guest',
-          lastname: address.lastName || 'Customer',
-          address1: address.address1,
-          address2: address.address2,
-          city: address.city,
-          postcode: address.postalCode,
-          phone: address.phone,
+          firstname: effectiveAddress.firstName || 'Guest',
+          lastname: effectiveAddress.lastName || 'Customer',
+          address1: effectiveAddress.address1,
+          address2: effectiveAddress.address2,
+          city: effectiveAddress.city,
+          postcode: effectiveAddress.postalCode,
+          phone: effectiveAddress.phone,
         };
 
         const createdAddress = await webserviceClient.createResource<PrestashopAddress>(

--- a/libs/integrations/prestashop/src/prestashop-integration.module.ts
+++ b/libs/integrations/prestashop/src/prestashop-integration.module.ts
@@ -8,6 +8,11 @@
  */
 import { Module, OnModuleInit, Inject } from '@nestjs/common';
 import { IntegrationsModule, ADAPTER_FACTORY_RESOLVER_TOKEN, AdapterFactoryResolverService, CONNECTION_TESTER_REGISTRY_TOKEN, ConnectionTesterRegistryService } from '@openlinker/core/integrations';
+import {
+  MappingsModule,
+  MAPPING_CONFIG_SERVICE_TOKEN,
+  IMappingConfigService,
+} from '@openlinker/core/mappings';
 import { PrestashopAdapterFactoryWrapper } from './infrastructure/adapters/prestashop-adapter-factory-wrapper';
 import { PrestashopConnectionTesterAdapter } from './infrastructure/adapters/prestashop-connection-tester.adapter';
 import { PrestashopCustomerProvisioner } from './infrastructure/provisioners/prestashop-customer-provisioner';
@@ -22,7 +27,7 @@ import { RedisConfigModule } from '@openlinker/shared/redis';
 import { Logger } from '@openlinker/shared/logging';
 
 @Module({
-  imports: [IntegrationsModule, CustomersModule, RedisConfigModule],
+  imports: [IntegrationsModule, CustomersModule, RedisConfigModule, MappingsModule],
   providers: [PrestashopCustomerProvisioner, PrestashopAddressProvisioner, PrestashopCountryResolver],
 })
 export class PrestashopIntegrationModule implements OnModuleInit {
@@ -37,6 +42,8 @@ export class PrestashopIntegrationModule implements OnModuleInit {
     private readonly addressProvisioner: PrestashopAddressProvisioner,
     @Inject(CUSTOMER_PROJECTION_REPOSITORY_TOKEN)
     private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
+    @Inject(MAPPING_CONFIG_SERVICE_TOKEN)
+    private readonly mappingConfigService: IMappingConfigService,
   ) {}
 
   onModuleInit(): void {
@@ -45,6 +52,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
       this.customerProvisioner,
       this.addressProvisioner,
       this.customerProjectionRepository,
+      this.mappingConfigService,
     );
     this.factoryResolver.registerFactory('prestashop.webservice.v1', factory);
     this.connectionTesterRegistry.register(


### PR DESCRIPTION
## Summary

- **#455 (Epic #1 US-4 BE)** — Allegro orders no longer all land on PrestaShop `id_carrier=1`. New `OrderShipping { methodId, methodName? }` field flows from Allegro `delivery.method` → unified order → `OrderCreate`. `IMappingConfigService.resolveCarrierMapping` (mirroring the existing status helper) is consulted by `PrestashopOrderProcessorManagerAdapter` at the destination boundary. Resolution chain: configured carrier mapping → `connection.config.defaultCarrierId` → PrestaShop's first carrier (`1`). Both fallbacks log at `warn` with `sourceConnectionId` so unmapped methods are visible in production.
- **#458** — Allegro pickup-point orders (InPost Paczkomat etc.) now reach PrestaShop with the locker code on the shipping address. New `OrderPickupPoint { id, name?, description? }` carried as a structured top-level field. `PrestashopAddressProvisioner` builds a single locker-aware `effectiveAddress` view used for **both** the address hash and the on-the-wire `address2` — re-syncs to the same locker share the same `id_address` row by construction. Allegro adapter resolution chain becomes `delivery.address` → `pickupPoint.address` → `buyer.address` so locker geography lands on the order rather than the buyer's home.

Also typed `OrderCreate.source: OrderSourceRef` replaces the previous untyped `metadata.sourceConnectionId` / `metadata.sourceEventId` convention. Destination adapters consume the typed field; old metadata mirrors removed (no other readers existed).

**Architectural choice for #455** — `Option 2` (resolve at destination), not Option 1 (resolve in `OrderSyncService`): `OrderCreate.shipping.methodId` is source-side neutral metadata that every destination adapter can interpret on its own terms. `OrderSyncService` keeps doing status mapping (status is a flat enum we own) but stays out of carrier resolution. Plan and review under `docs/plans/implementation-plan-allegro-carrier-and-pickup-point.md`.

**Behavior change to flag for production order data:** existing Allegro orders with `delivery: { address: {} }` AND a `pickupPoint` set will, on next sync, get the locker geography on the shipping address instead of the buyer's home. This is the intended #458 fix.

## Test plan

- [x] `pnpm lint` (zero errors)
- [x] `pnpm type-check` (zero errors)
- [x] `pnpm test` — 1,383 tests across 8 packages, all green
- [ ] Sandbox integration: ingest an Allegro order with `delivery.method.id` + a configured `CarrierMapping → '4'` → assert PS order has `id_carrier: 4`
- [ ] Sandbox integration: ingest an Allegro pickup-point order → assert PS shipping `address1`/`city`/`postcode` come from the locker and `address2` reads `Paczkomat POZ08A · …`
- [ ] Sandbox integration: ingest two pickup-point orders to the same locker → assert they share the same PS `id_address`
- [ ] Sandbox: ingest an Allegro order with `delivery.method.id` but **no** mapping configured → assert PS order falls back to `connection.config.defaultCarrierId` (or `1` when unset) and a `warn` log fires

## Out of scope (follow-ups)

- `IMappingConfigService.resolvePaymentMapping` + payment-module wiring — should mirror this PR's Option-2 pattern (destination resolves via `MappingConfigService` reading `OrderCreate.source.connectionId` + a future `OrderCreate.payment`)
- Module-aware (Option 3) InPost integration: write the bare `pickupPoint.id` into `orders.inpost_locker_code` for downstream label printing
- FE auto-suggestion of unmapped delivery methods after first order rejection

Closes #455
Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)