### PR TITLE
fix(web): stabilise ThemeToggle ref-callback identity to prevent infinite render loop

### DIFF
--- a/apps/web/src/shared/ui/theme-toggle.test.tsx
+++ b/apps/web/src/shared/ui/theme-toggle.test.tsx
@@ -1,4 +1,6 @@
+import { StrictMode } from 'react';
 import { act, cleanup, render, screen } from '@testing-library/react';
+import { Link, MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeProvider } from '../theme/theme-provider';
 import { THEME_STORAGE_KEY } from '../theme/theme.types';
@@ -129,6 +131,45 @@ describe('ThemeToggle', () => {
     light.focus();
     act(() => keyDown(light, 'End'));
     expect(screen.getByRole('radio', { name: 'System' }).getAttribute('aria-checked')).toBe('true');
+
+    restore();
+  });
+
+  it('survives a re-render under StrictMode + router ancestry (forward-guard for #461)', () => {
+    // Forward-guard against the class of bug fixed in #461: the inline
+    // `ref={(el) => { ... }}` pattern produces a fresh callback identity on
+    // every render, which under React 19's stricter ref-cleanup contract
+    // combined with merged-ref machinery (react-router-dom Link refs, Radix
+    // DropdownMenu slots) repeatedly tears down and reattaches the ref —
+    // dispatching state updates that trigger re-renders → infinite loop.
+    //
+    // The literal production crash requires the full Radix DropdownMenu
+    // provider tree (where AppShell mounts ThemeToggle), which is too heavy
+    // to reconstruct here — even with StrictMode + MemoryRouter + Link the
+    // bug doesn't reproduce in jsdom. This test instead exercises the
+    // broader path so any future refactor that re-introduces an unstable
+    // per-option ref identity has at least one tripwire. The real
+    // correctness guarantee comes from the useMemo-built stable callback
+    // array in theme-toggle.tsx itself.
+    const { restore } = stubLightPreferred();
+
+    function Harness(): React.ReactElement {
+      return (
+        <StrictMode>
+          <MemoryRouter>
+            <ThemeProvider>
+              <Link to="/">
+                <ThemeToggle />
+              </Link>
+            </ThemeProvider>
+          </MemoryRouter>
+        </StrictMode>
+      );
+    }
+
+    const { rerender } = render(<Harness />);
+    expect(() => rerender(<Harness />)).not.toThrow();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
 
     restore();
   });

--- a/apps/web/src/shared/ui/theme-toggle.tsx
+++ b/apps/web/src/shared/ui/theme-toggle.tsx
@@ -14,7 +14,7 @@
  * Intended to live in the user-chip dropdown once AppShell is rebuilt;
  * callers can also place it elsewhere.
  */
-import { useRef, type KeyboardEvent, type ReactElement } from 'react';
+import { useMemo, useRef, type KeyboardEvent, type ReactElement } from 'react';
 import { useTheme } from '../theme/use-theme';
 import { ThemeValues, type Theme } from '../theme/theme.types';
 
@@ -49,6 +49,24 @@ export function ThemeToggle({
   const { theme, setTheme } = useTheme();
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const classes = ['theme-toggle', className].filter(Boolean).join(' ');
+
+  // Pre-build per-index ref callbacks once. The previous inline form
+  // `ref={(el) => { optionRefs.current[i] = el; }}` produced a fresh
+  // function identity on every render, which under React 19's stricter
+  // ref-cleanup contract — combined with merged-ref machinery in ancestor
+  // components like Radix's DropdownMenu slots and react-router's Link —
+  // tore down and reattached the ref on every render, dispatching state
+  // updates that triggered re-renders → infinite loop (#461). The explicit
+  // `: void` return type guards future refactors that drop the braces and
+  // accidentally return the assignment value (which React 19 treats as a
+  // cleanup callback).
+  const setOptionRef = useMemo(
+    () =>
+      THEME_OPTIONS.map((_, index) => (el: HTMLButtonElement | null): void => {
+        optionRefs.current[index] = el;
+      }),
+    [],
+  );
 
   function moveTo(nextIndex: number): void {
     const option = THEME_OPTIONS[nextIndex];
@@ -90,9 +108,7 @@ export function ThemeToggle({
         return (
           <button
             key={option.value}
-            ref={(el) => {
-              optionRefs.current[index] = el;
-            }}
+            ref={setOptionRef[index]}
             type="button"
             role="radio"
             aria-checked={selected}

--- a/apps/web/src/shared/ui/theme-toggle.tsx
+++ b/apps/web/src/shared/ui/theme-toggle.tsx
@@ -50,16 +50,12 @@ export function ThemeToggle({
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const classes = ['theme-toggle', className].filter(Boolean).join(' ');
 
-  // Pre-build per-index ref callbacks once. The previous inline form
-  // `ref={(el) => { optionRefs.current[i] = el; }}` produced a fresh
-  // function identity on every render, which under React 19's stricter
-  // ref-cleanup contract — combined with merged-ref machinery in ancestor
-  // components like Radix's DropdownMenu slots and react-router's Link —
-  // tore down and reattached the ref on every render, dispatching state
-  // updates that triggered re-renders → infinite loop (#461). The explicit
-  // `: void` return type guards future refactors that drop the braces and
-  // accidentally return the assignment value (which React 19 treats as a
-  // cleanup callback).
+  // Stable ref-callback identities. Inline `ref={(el) => {...}}` produces
+  // a fresh function each render, which under React 19's stricter
+  // ref-cleanup contract — combined with merged-ref machinery in ancestors
+  // like Radix's DropdownMenu Slot and react-router's Link — tears down
+  // and reattaches the ref on every render, dispatching state updates
+  // that trigger more renders → infinite loop (#461).
   const setOptionRef = useMemo(
     () =>
       THEME_OPTIONS.map((_, index) => (el: HTMLButtonElement | null): void => {


### PR DESCRIPTION
## Summary

Fixes the "Maximum update depth exceeded" crash that fires the moment `ThemeToggle` mounts in production (#461).

The inline `ref={(el) => { optionRefs.current[i] = el; }}` callback produced a fresh function identity on every render. Under React 19's stricter ref-cleanup contract — combined with merged-ref machinery in ancestor components (Radix `DropdownMenu` slots where `AppShell` mounts the toggle, and react-router `Link` refs) — the callback got torn down and reattached on every render, dispatching state updates that triggered re-renders → infinite loop.

## Fix

Pre-build a stable per-index callback array via `useMemo` (one closure per option, identity preserved across renders). Each callback has an explicit `: void` return type to guard future refactors that drop the braces and accidentally return the assignment value (which React 19 would treat as a cleanup callback).

```tsx
const setOptionRef = useMemo(
  () =>
    THEME_OPTIONS.map((_, index) => (el: HTMLButtonElement | null): void => {
      optionRefs.current[index] = el;
    }),
  [],
);
// ...
<button ref={setOptionRef[index]} ... />
```

No CSS, no behavior, no API change. Keyboard parity (ArrowLeft/Right/Up/Down/Home/End/Enter/Space), roving tabindex, and ARIA contract are unchanged — verified by the existing 6 keyboard tests still passing.

## Codebase sweep

`grep -rn "ref={(" apps/web/src` is clean apart from the fixed file:
- `theme-toggle.tsx:93` — fixed.
- All other matches are `rowHref={(...)}` callbacks on `DataTable`, which are not refs.

No other shared primitive carries the same anti-pattern lying in wait.

## Test plan

- [x] `pnpm lint` — zero errors
- [x] `pnpm type-check` — zero errors
- [x] `pnpm --filter @openlinker/web test` — 760 tests pass (113 files), incl. 7 in `theme-toggle.test.tsx`
- [x] New forward-guard test: `survives a re-render under StrictMode + router ancestry (forward-guard for #461)`

### Test honesty note

The literal production crash requires the full Radix `DropdownMenu` provider tree where `AppShell` mounts `ThemeToggle`. Even with `<StrictMode>` + `<MemoryRouter>` + `<Link>` wrapping, the bug doesn't reproduce in jsdom — it needs Radix's Slot ref-merging machinery (heavy to reconstruct in a unit test). The new test is therefore framed as a **forward-guard** against the broader class of bug, not as a literal repro. The real correctness guarantee comes from the `useMemo`-built stable callback array in source — identity stability is provable by construction.

This is called out explicitly in the test comment so future readers don't misread it as a green-on-the-actual-bug test.

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)