### PR TITLE
feat(listings): surface live marketplace offer on listing detail page

### DIFF
--- a/apps/api/src/listings/http/dto/marketplace-offer-response.dto.ts
+++ b/apps/api/src/listings/http/dto/marketplace-offer-response.dto.ts
@@ -1,0 +1,77 @@
+/**
+ * Marketplace Offer Response DTO
+ *
+ * Wire shape for `GET /listings/:mappingId/offer` (#464). Mirrors the neutral
+ * `MarketplaceOffer` domain DTO 1:1; published as a plain class so NestJS can
+ * generate Swagger schema without leaking the domain type.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { MarketplaceOffer } from '@openlinker/core/listings';
+
+class MarketplaceOfferPriceDto {
+  @ApiProperty({ description: 'Decimal string preserving precision', example: '99.99' })
+  amount!: string;
+
+  @ApiProperty({ description: 'ISO 4217 currency code', example: 'PLN' })
+  currency!: string;
+}
+
+class MarketplaceOfferCategoryDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiPropertyOptional()
+  name?: string;
+}
+
+export class MarketplaceOfferResponseDto {
+  @ApiProperty({ description: 'Marketplace-native offer id' })
+  externalId!: string;
+
+  @ApiProperty()
+  title!: string;
+
+  @ApiPropertyOptional({ description: 'Description preview (raw text/HTML)' })
+  description?: string;
+
+  @ApiPropertyOptional({ description: 'Public primary-image URL' })
+  imageUrl?: string;
+
+  @ApiProperty({ type: MarketplaceOfferPriceDto })
+  price!: MarketplaceOfferPriceDto;
+
+  @ApiProperty()
+  availableQuantity!: number;
+
+  @ApiProperty({
+    description: 'Marketplace lifecycle status (string passthrough — no closed enum)',
+    example: 'ACTIVE',
+  })
+  status!: string;
+
+  @ApiPropertyOptional({ type: MarketplaceOfferCategoryDto })
+  category?: MarketplaceOfferCategoryDto;
+
+  @ApiPropertyOptional({ description: 'Public buyer-facing URL' })
+  marketplaceUrl?: string;
+
+  @ApiPropertyOptional({ description: 'ISO 8601 — last marketplace-side change' })
+  updatedAt?: string;
+
+  static fromDomain(offer: MarketplaceOffer): MarketplaceOfferResponseDto {
+    return {
+      externalId: offer.externalId,
+      title: offer.title,
+      description: offer.description,
+      imageUrl: offer.imageUrl,
+      price: { amount: offer.price.amount, currency: offer.price.currency },
+      availableQuantity: offer.availableQuantity,
+      status: offer.status,
+      category: offer.category ? { id: offer.category.id, name: offer.category.name } : undefined,
+      marketplaceUrl: offer.marketplaceUrl,
+      updatedAt: offer.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/listings/http/dto/marketplace-offer-response.dto.ts
+++ b/apps/api/src/listings/http/dto/marketplace-offer-response.dto.ts
@@ -57,8 +57,11 @@ export class MarketplaceOfferResponseDto {
   @ApiPropertyOptional({ description: 'Public buyer-facing URL' })
   marketplaceUrl?: string;
 
-  @ApiPropertyOptional({ description: 'ISO 8601 — last marketplace-side change' })
-  updatedAt?: string;
+  @ApiPropertyOptional({
+    description:
+      'ISO 8601 — when the offer\'s marketplace-side validity ends (Allegro: publication.endingAt). Optional; not every marketplace publishes a fixed end date.',
+  })
+  endsAt?: string;
 
   static fromDomain(offer: MarketplaceOffer): MarketplaceOfferResponseDto {
     return {
@@ -71,7 +74,7 @@ export class MarketplaceOfferResponseDto {
       status: offer.status,
       category: offer.category ? { id: offer.category.id, name: offer.category.name } : undefined,
       marketplaceUrl: offer.marketplaceUrl,
-      updatedAt: offer.updatedAt,
+      endsAt: offer.endsAt,
     };
   }
 }

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -222,6 +222,100 @@ describe('ListingsController', () => {
     });
   });
 
+  describe('getMarketplaceOffer (#464)', () => {
+    const liveOffer = {
+      externalId: 'allegro-offer-456',
+      title: 'Vintage Camera Lens',
+      description: 'Mint condition, original case included.',
+      imageUrl: 'https://a.allegroimg.com/original/abc/lens.jpg',
+      price: { amount: '249.00', currency: 'PLN' },
+      availableQuantity: 3,
+      status: 'ACTIVE',
+      category: { id: '12345', name: 'Lenses' },
+      marketplaceUrl: 'https://allegro.pl/oferta/allegro-offer-456',
+      updatedAt: '2026-04-30T10:00:00Z',
+    };
+
+    function makeOfferReaderAdapter(getOffer: jest.Mock): OfferManagerPort {
+      return {
+        updateOfferQuantity: jest.fn(),
+        getOffer,
+      } as unknown as OfferManagerPort;
+    }
+
+    it('should return MarketplaceOfferResponseDto on happy path', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+      const getOffer = jest.fn().mockResolvedValue(liveOffer);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeOfferReaderAdapter(getOffer));
+
+      const result = await controller.getMarketplaceOffer('uuid-1');
+
+      expect(repository.findById).toHaveBeenCalledWith('uuid-1');
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith('conn-1', 'OfferManager');
+      expect(getOffer).toHaveBeenCalledWith({ externalId: 'allegro-offer-456' });
+      expect(result).toEqual({
+        externalId: 'allegro-offer-456',
+        title: 'Vintage Camera Lens',
+        description: 'Mint condition, original case included.',
+        imageUrl: 'https://a.allegroimg.com/original/abc/lens.jpg',
+        price: { amount: '249.00', currency: 'PLN' },
+        availableQuantity: 3,
+        status: 'ACTIVE',
+        category: { id: '12345', name: 'Lenses' },
+        marketplaceUrl: 'https://allegro.pl/oferta/allegro-offer-456',
+        updatedAt: '2026-04-30T10:00:00Z',
+      });
+    });
+
+    it('should throw NotFoundException when mapping does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(controller.getMarketplaceOffer('uuid-missing')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when mapping entityType is not Offer', async () => {
+      const productMapping = new IdentifierMapping(
+        'uuid-2',
+        'Product',
+        'ol_product_1',
+        'ext-product-1',
+        'allegro',
+        'conn-1',
+        null,
+        new Date(),
+        new Date(),
+      );
+      repository.findById.mockResolvedValue(productMapping);
+
+      await expect(controller.getMarketplaceOffer('uuid-2')).rejects.toThrow(NotFoundException);
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('should throw UnprocessableEntityException when adapter does not implement OfferReader', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+      // Adapter without `getOffer` method.
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+      } as unknown as OfferManagerPort);
+
+      await expect(controller.getMarketplaceOffer('uuid-1')).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should propagate adapter errors verbatim', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+      const upstream = new Error('Allegro 502');
+      const getOffer = jest.fn().mockRejectedValue(upstream);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(makeOfferReaderAdapter(getOffer));
+
+      await expect(controller.getMarketplaceOffer('uuid-1')).rejects.toThrow('Allegro 502');
+    });
+  });
+
   describe('createOffer', () => {
     const validDto = {
       internalVariantId: 'ol_variant_abc123',

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -233,7 +233,7 @@ describe('ListingsController', () => {
       status: 'ACTIVE',
       category: { id: '12345', name: 'Lenses' },
       marketplaceUrl: 'https://allegro.pl/oferta/allegro-offer-456',
-      updatedAt: '2026-04-30T10:00:00Z',
+      endsAt: '2026-04-30T10:00:00Z',
     };
 
     function makeOfferReaderAdapter(getOffer: jest.Mock): OfferManagerPort {
@@ -263,7 +263,7 @@ describe('ListingsController', () => {
         status: 'ACTIVE',
         category: { id: '12345', name: 'Lenses' },
         marketplaceUrl: 'https://allegro.pl/oferta/allegro-offer-456',
-        updatedAt: '2026-04-30T10:00:00Z',
+        endsAt: '2026-04-30T10:00:00Z',
       });
     });
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -13,6 +13,7 @@ import {
   Body,
   Controller,
   Get,
+  Header,
   Headers,
   HttpCode,
   HttpStatus,
@@ -30,6 +31,7 @@ import { Roles } from '../../auth/decorators/roles.decorator';
 import {
   CategoryNotFoundException,
   isCategoryParametersReader,
+  isOfferReader,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   OFFER_MAPPING_REPOSITORY_TOKEN,
@@ -51,6 +53,7 @@ import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { JobEnqueuePort } from '@openlinker/core/sync';
 
 import { ListOfferMappingsQueryDto } from './dto/list-offer-mappings-query.dto';
+import { MarketplaceOfferResponseDto } from './dto/marketplace-offer-response.dto';
 import { OfferMappingResponseDto } from './dto/offer-mapping-response.dto';
 import { PaginatedOfferMappingsResponseDto } from './dto/paginated-offer-mappings-response.dto';
 import { UpdateOfferFieldsDto, UpdateOfferFieldsResponseDto } from './dto/update-offer-fields.dto';
@@ -139,6 +142,58 @@ export class ListingsController {
       }
     }
     return dto;
+  }
+
+  @Get(':id/offer')
+  @HttpCode(HttpStatus.OK)
+  // 30 s cache lets quick back-and-forth navigation between the listings
+  // list and the detail page reuse a single Allegro fetch — `staleTime` on
+  // the FE query mirrors the same window. Keep `public` because the response
+  // carries no per-user state (everything is connection-scoped marketplace
+  // data the operator can already see in the UI).
+  @Header('Cache-Control', 'public, max-age=30')
+  @ApiParam({ name: 'id', description: 'Offer mapping row ID (UUID)' })
+  @ApiOperation({
+    summary: 'Get live marketplace offer for an offer mapping (#464)',
+    description:
+      'Fetches the live marketplace-side offer (title, image, price, qty, status, …) referenced by an `entityType=Offer` mapping. Resolves the connection\'s `OfferManagerPort` and requires it to implement the `OfferReader` sub-capability; adapters that do not are surfaced as 422 so the FE can render a soft "live data unavailable" fallback while the rest of the page (raw mapping fields, OfferCreation status) keeps rendering.',
+  })
+  @ApiResponse({ status: 200, description: 'Live offer detail', type: MarketplaceOfferResponseDto })
+  @ApiResponse({ status: 404, description: 'Offer mapping not found, or mapping is not of `entityType=Offer`' })
+  @ApiResponse({
+    status: 422,
+    description: 'Adapter for this connection does not implement `OfferReader`',
+  })
+  async getMarketplaceOffer(@Param('id') id: string): Promise<MarketplaceOfferResponseDto> {
+    const mapping = await this.offerMappingRepository.findById(id);
+    if (!mapping) {
+      throw new NotFoundException(`Offer mapping not found: ${id}`);
+    }
+    // Treat non-Offer mappings as 404 rather than a separate 4xx — the
+    // existence of the mapping isn't actionable for the live-offer surface
+    // and the response shape is identical to "mapping doesn't exist".
+    if (mapping.entityType !== ('Offer' satisfies EntityType)) {
+      throw new NotFoundException(
+        `Offer mapping ${id} is not of entityType=Offer (got: ${mapping.entityType})`,
+      );
+    }
+
+    // Connection-level errors (404 / 409) propagate from getCapabilityAdapter
+    // unchanged via Nest's exception filter — same convention as
+    // getCategoryParameters above.
+    const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      mapping.connectionId,
+      'OfferManager',
+    );
+
+    if (!isOfferReader(adapter)) {
+      throw new UnprocessableEntityException(
+        `Adapter for connection ${mapping.connectionId} does not support live offer reading`,
+      );
+    }
+
+    const offer = await adapter.getOffer({ externalId: mapping.externalId });
+    return MarketplaceOfferResponseDto.fromDomain(offer);
   }
 
   @Post('connections/:connectionId/offers/:offerId/fields')

--- a/apps/api/src/products/http/dto/product-variant-summary-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-variant-summary-response.dto.ts
@@ -1,0 +1,33 @@
+/**
+ * Product Variant Summary Response DTO
+ *
+ * Lightweight projection of `ProductVariant` returned by
+ * `GET /products/variants/:variantId`. Scoped to the fields the listing-detail
+ * page (#464) needs to enrich the Internal ID row inline (parent product id,
+ * SKU, EAN, optional variant name). Distinct from `ProductVariantResponseDto`
+ * — that DTO carries `attributes` / `gtin` / timestamps; this one is a tiny
+ * read-side projection that the FE can render in a single span without
+ * additional plumbing.
+ *
+ * @module apps/api/src/products/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ProductVariantSummaryResponseDto {
+  @ApiProperty({ description: 'Internal variant ID', example: 'ol_variant_xxx' })
+  id!: string;
+
+  @ApiProperty({ description: 'Internal parent product ID', example: 'ol_product_xxx' })
+  productId!: string;
+
+  @ApiProperty({ description: 'Variant SKU', nullable: true })
+  sku!: string | null;
+
+  @ApiProperty({ description: 'Variant EAN', nullable: true })
+  ean!: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Display label assembled from variant attributes (e.g. "Red / 42")',
+  })
+  name?: string;
+}

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -50,6 +50,7 @@ function createMockProductsService(): jest.Mocked<IProductsService> {
     upsertProduct: jest.fn(),
     upsertVariants: jest.fn(),
     getProduct: jest.fn(),
+    getVariant: jest.fn(),
     listProducts: jest.fn(),
     listVariants: jest.fn(),
   };
@@ -197,6 +198,47 @@ describe('ProductsController', () => {
         { productId: 'ol_product_1', search: undefined },
         { limit: 20, offset: 0 },
       );
+    });
+  });
+
+  describe('getVariantSummary (#464)', () => {
+    it('should return id, productId, sku, ean, and attribute-derived name on hit', async () => {
+      productsService.getVariant.mockResolvedValue(
+        makeVariant({
+          id: 'ol_variant_42',
+          productId: 'ol_product_1',
+          sku: 'SKU-RED-42',
+          ean: '5901234123457',
+          attributes: { color: 'Red', size: '42' },
+        }),
+      );
+
+      const result = await controller.getVariantSummary('ol_variant_42');
+
+      expect(result).toEqual({
+        id: 'ol_variant_42',
+        productId: 'ol_product_1',
+        sku: 'SKU-RED-42',
+        ean: '5901234123457',
+        name: 'Red / 42',
+      });
+      expect(productsService.getVariant).toHaveBeenCalledWith('ol_variant_42');
+    });
+
+    it('should leave name undefined when the variant has no string attributes', async () => {
+      productsService.getVariant.mockResolvedValue(
+        makeVariant({ id: 'ol_variant_43', attributes: {} }),
+      );
+
+      const result = await controller.getVariantSummary('ol_variant_43');
+
+      expect(result.name).toBeUndefined();
+    });
+
+    it('should throw NotFoundException when variant not found', async () => {
+      productsService.getVariant.mockResolvedValue(null);
+
+      await expect(controller.getVariantSummary('missing')).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -219,12 +219,16 @@ export class ProductsController {
   /**
    * Lightweight projection used by `GET /products/variants/:variantId` (#464).
    * Builds a human label from the variant's attribute map when present
-   * (e.g. `{ size: '42', color: 'Red' }` → `"42 / Red"`); falls back to
-   * undefined so the FE can render the SKU as the primary label.
+   * (e.g. `{ color: 'Red', size: '42' }` → `"Red / 42"`); falls back to
+   * undefined so the FE can render the SKU as the primary label. Sorts by
+   * attribute key so the label is deterministic regardless of how the
+   * variant came off the wire (JSONB column reads, future projections,
+   * etc.) — `Object.values` would otherwise rely on insertion order.
    */
   private toVariantSummaryDto(variant: ProductVariant): ProductVariantSummaryResponseDto {
-    const attributeValues = Object.values(variant.attributes ?? {})
-      .map((v) => (typeof v === 'string' ? v.trim() : ''))
+    const attributeValues = Object.entries(variant.attributes ?? {})
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([, v]) => (typeof v === 'string' ? v.trim() : ''))
       .filter((v) => v.length > 0);
     return {
       id: variant.id,

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -31,6 +31,7 @@ import { ListProductsQueryDto } from './dto/list-products-query.dto';
 import { ListProductVariantsQueryDto } from './dto/list-product-variants-query.dto';
 import { ProductResponseDto } from './dto/product-response.dto';
 import { ProductVariantResponseDto } from './dto/product-variant-response.dto';
+import { ProductVariantSummaryResponseDto } from './dto/product-variant-summary-response.dto';
 import { PaginatedProductsResponseDto } from './dto/paginated-products-response.dto';
 import { PaginatedProductVariantsResponseDto } from './dto/paginated-product-variants-response.dto';
 import { ExternalIdMappingDto } from './dto/external-id-mapping.dto';
@@ -94,6 +95,30 @@ export class ProductsController {
       limit,
       offset,
     };
+  }
+
+  // Declared before @Get(':id') so /products/variants/:variantId is matched
+  // by this handler rather than getProduct (which would treat 'variants' as
+  // an invalid product ID). Nest's pattern matcher follows registration order,
+  // so route ordering matters here.
+  @Get('variants/:variantId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get variant summary by internal variant ID',
+    description:
+      'Lightweight projection of a product variant — id, parent product id, SKU, EAN, optional name. Used by the listing-detail page (#464) to surface the linked variant inline next to the Internal ID row without forcing the FE to know the parent product first.',
+  })
+  @ApiParam({ name: 'variantId', description: 'Internal variant ID (e.g. ol_variant_...)' })
+  @ApiResponse({ status: 200, description: 'Variant summary', type: ProductVariantSummaryResponseDto })
+  @ApiResponse({ status: 404, description: 'Variant not found' })
+  async getVariantSummary(
+    @Param('variantId') variantId: string,
+  ): Promise<ProductVariantSummaryResponseDto> {
+    const variant = await this.productsService.getVariant(variantId);
+    if (!variant) {
+      throw new NotFoundException(`Variant not found: ${variantId}`);
+    }
+    return this.toVariantSummaryDto(variant);
   }
 
   @Get(':id')
@@ -189,6 +214,25 @@ export class ProductsController {
 
   private toVariantDto(variant: ProductVariant): ProductVariantResponseDto {
     return variantToDto(variant);
+  }
+
+  /**
+   * Lightweight projection used by `GET /products/variants/:variantId` (#464).
+   * Builds a human label from the variant's attribute map when present
+   * (e.g. `{ size: '42', color: 'Red' }` → `"42 / Red"`); falls back to
+   * undefined so the FE can render the SKU as the primary label.
+   */
+  private toVariantSummaryDto(variant: ProductVariant): ProductVariantSummaryResponseDto {
+    const attributeValues = Object.values(variant.attributes ?? {})
+      .map((v) => (typeof v === 'string' ? v.trim() : ''))
+      .filter((v) => v.length > 0);
+    return {
+      id: variant.id,
+      productId: variant.productId,
+      sku: variant.sku,
+      ean: variant.ean ?? null,
+      name: attributeValues.length > 0 ? attributeValues.join(' / ') : undefined,
+    };
   }
 
   private toExternalIdDto(mapping: { externalId: string; platformType: string; connectionId: string }): ExternalIdMappingDto {

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -12,6 +12,7 @@ import type {
   CreateOfferResponse,
   ListingsFilters,
   ListingsPagination,
+  MarketplaceOfferResponse,
   OfferCreationStatusResponse,
   OfferMapping,
   PaginatedOfferMappings,
@@ -31,6 +32,13 @@ export interface CreateOfferOptions {
 export interface ListingsApi {
   list: (filters?: ListingsFilters, pagination?: ListingsPagination) => Promise<PaginatedOfferMappings>;
   getById: (id: string) => Promise<OfferMapping>;
+  /**
+   * Fetches the live marketplace-side offer (#464). Returns 404 if the
+   * mapping doesn't exist or isn't `entityType=Offer`; 422 if the connection's
+   * adapter does not implement `OfferReader`. Callers handle both as a soft
+   * "live data unavailable" fallback.
+   */
+  getMarketplaceOffer: (mappingId: string) => Promise<MarketplaceOfferResponse>;
   updateOfferFields: (connectionId: string, offerId: string, fields: UpdateOfferFieldsPayload) => Promise<UpdateOfferFieldsResult>;
   createOffer: (
     connectionId: string,
@@ -71,6 +79,9 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
     },
     getById(id): Promise<OfferMapping> {
       return request<OfferMapping>(`/listings/${id}`);
+    },
+    getMarketplaceOffer(mappingId): Promise<MarketplaceOfferResponse> {
+      return request<MarketplaceOfferResponse>(`/listings/${mappingId}/offer`);
     },
     updateOfferFields(connectionId, offerId, fields): Promise<UpdateOfferFieldsResult> {
       return request<UpdateOfferFieldsResult>(

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -9,6 +9,8 @@ export const listingsQueryKeys = {
   list: (filters?: ListingsFilters, pagination?: ListingsPagination) =>
     ['listings', 'list', filters ?? {}, pagination ?? {}] as const,
   detail: (id: string) => ['listings', 'detail', id] as const,
+  marketplaceOffer: (mappingId: string) =>
+    ['listings', 'marketplaceOffer', mappingId] as const,
   offerCreationStatus: (connectionId: string, offerCreationRecordId: string) =>
     ['listings', 'offerCreationStatus', connectionId, offerCreationRecordId] as const,
   sellerPolicies: (connectionId: string) =>

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -54,6 +54,36 @@ export interface PaginatedOfferMappings {
   offset: number;
 }
 
+/**
+ * Live marketplace-side offer state surfaced on the listing detail page (#464).
+ * Mirrors the backend `MarketplaceOfferResponseDto`. `status` is a string
+ * passthrough — different marketplaces use different lifecycle vocabularies
+ * (Allegro: `ACTIVE` / `ENDED` / `INACTIVE` / `BIDDING`); the FE renders
+ * known values with a tone and falls back to a neutral badge for the rest.
+ */
+export interface MarketplaceOfferPrice {
+  amount: string;
+  currency: string;
+}
+
+export interface MarketplaceOfferCategory {
+  id: string;
+  name?: string;
+}
+
+export interface MarketplaceOfferResponse {
+  externalId: string;
+  title: string;
+  description?: string;
+  imageUrl?: string;
+  price: MarketplaceOfferPrice;
+  availableQuantity: number;
+  status: string;
+  category?: MarketplaceOfferCategory;
+  marketplaceUrl?: string;
+  updatedAt?: string;
+}
+
 export interface UpdateOfferDescriptionSectionItem {
   type: 'TEXT';
   content: string;

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -81,7 +81,12 @@ export interface MarketplaceOfferResponse {
   status: string;
   category?: MarketplaceOfferCategory;
   marketplaceUrl?: string;
-  updatedAt?: string;
+  /**
+   * ISO 8601 — when the offer's marketplace-side validity ends (Allegro:
+   * `publication.endingAt`). Optional because not every marketplace publishes
+   * a fixed end date.
+   */
+  endsAt?: string;
 }
 
 export interface UpdateOfferDescriptionSectionItem {

--- a/apps/web/src/features/listings/components/listing-marketplace-offer-section.tsx
+++ b/apps/web/src/features/listings/components/listing-marketplace-offer-section.tsx
@@ -153,12 +153,12 @@ export function ListingMarketplaceOfferSection({
                 },
               ]
             : []),
-          ...(offer.updatedAt
+          ...(offer.endsAt
             ? [
                 {
-                  id: 'updatedAt',
-                  label: 'Marketplace-side updated',
-                  value: <TimeDisplay iso={offer.updatedAt} />,
+                  id: 'endsAt',
+                  label: 'Ends at',
+                  value: <TimeDisplay iso={offer.endsAt} />,
                 },
               ]
             : []),

--- a/apps/web/src/features/listings/components/listing-marketplace-offer-section.tsx
+++ b/apps/web/src/features/listings/components/listing-marketplace-offer-section.tsx
@@ -1,0 +1,175 @@
+/**
+ * ListingMarketplaceOfferSection — live marketplace offer details (#464).
+ *
+ * Embedded state machine on the listing detail page. Fails soft so the rest
+ * of the page (raw mapping fields + OfferCreation panel) keeps rendering:
+ *
+ *   - 404 — never expected here (the page already loaded the mapping); if it
+ *     happens we treat it as the soft fallback so we don't double-error.
+ *   - 422 — adapter doesn't implement OfferReader. Show the soft fallback.
+ *   - 5xx / network / unknown — show ErrorState with retry; raw mapping below
+ *     stays visible because this is a section, not a page-level state.
+ *   - Loading — inline LoadingState.
+ *   - Data — thumbnail + title + status badge + price + qty + category +
+ *     description preview (collapsed, expandable).
+ */
+import type { ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
+import { KeyValueList } from '../../../shared/ui/key-value-list';
+import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import { TimeDisplay } from '../../../shared/ui/time-display';
+import { ApiError } from '../../../shared/api/api-error';
+import { useListingMarketplaceOfferQuery } from '../hooks/use-listing-marketplace-offer-query';
+
+interface ListingMarketplaceOfferSectionProps {
+  mappingId: string;
+  /** When the parent mapping isn't an offer the section is a no-op — page renders nothing extra. */
+  enabled: boolean;
+}
+
+/**
+ * Map marketplace-native status strings to our restrained badge palette.
+ * Unknown statuses render with the neutral tone (no exception thrown — the
+ * status field is intentionally a string passthrough).
+ */
+function statusTone(status: string): StatusBadgeTone {
+  const normalised = status.trim().toUpperCase();
+  if (normalised === 'ACTIVE' || normalised === 'BIDDING') return 'success';
+  if (normalised === 'ENDED' || normalised === 'INACTIVE') return 'warning';
+  return 'neutral';
+}
+
+export function ListingMarketplaceOfferSection({
+  enabled,
+  mappingId,
+}: ListingMarketplaceOfferSectionProps): ReactElement | null {
+  const query = useListingMarketplaceOfferQuery(mappingId, { enabled });
+
+  if (!enabled) {
+    return null;
+  }
+
+  if (query.isLoading) {
+    return (
+      <section className="detail-section">
+        <h3 className="detail-section__title">Listing details</h3>
+        <LoadingState
+          liveRegion="off"
+          title="Loading listing details"
+          message="Fetching live marketplace state…"
+        />
+      </section>
+    );
+  }
+
+  if (query.error) {
+    // 422 → adapter doesn't implement OfferReader; render the soft fallback
+    // rather than the error UI. 404 (defensive — shouldn't happen since the
+    // page already loaded the mapping) gets the same soft treatment.
+    if (query.error instanceof ApiError && (query.error.status === 422 || query.error.status === 404)) {
+      return (
+        <section className="detail-section">
+          <h3 className="detail-section__title">Listing details</h3>
+          <p className="detail-section__muted">
+            Live data unavailable for this adapter.
+          </p>
+        </section>
+      );
+    }
+
+    return (
+      <section className="detail-section">
+        <h3 className="detail-section__title">Listing details</h3>
+        <ErrorState
+          title="Unable to load listing details"
+          message={query.error.message}
+          action={
+            <Button onClick={(): void => { void query.refetch(); }}>
+              Retry
+            </Button>
+          }
+        />
+      </section>
+    );
+  }
+
+  const offer = query.data;
+  if (!offer) {
+    return null;
+  }
+
+  const formattedPrice = `${offer.price.amount} ${offer.price.currency}`;
+
+  return (
+    <section className="detail-section listing-marketplace-offer">
+      <div className="listing-marketplace-offer__header">
+        <ProductThumbnail size="md" name={offer.title} src={offer.imageUrl} />
+        <div className="listing-marketplace-offer__heading">
+          <h3 className="listing-marketplace-offer__title">{offer.title}</h3>
+          <StatusBadge tone={statusTone(offer.status)}>{offer.status}</StatusBadge>
+        </div>
+      </div>
+      <KeyValueList
+        items={[
+          {
+            id: 'externalId',
+            label: 'External ID',
+            value: offer.externalId,
+            mono: true,
+          },
+          { id: 'price', label: 'Price', value: formattedPrice, mono: true },
+          {
+            id: 'availableQuantity',
+            label: 'Available quantity',
+            value: String(offer.availableQuantity),
+            mono: true,
+          },
+          ...(offer.category
+            ? [
+                {
+                  id: 'category',
+                  label: 'Category',
+                  value: offer.category.name ?? offer.category.id,
+                  mono: !offer.category.name,
+                },
+              ]
+            : []),
+          ...(offer.marketplaceUrl
+            ? [
+                {
+                  id: 'marketplaceUrl',
+                  label: 'Marketplace',
+                  value: (
+                    <a
+                      href={offer.marketplaceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Open on marketplace ↗
+                    </a>
+                  ),
+                },
+              ]
+            : []),
+          ...(offer.updatedAt
+            ? [
+                {
+                  id: 'updatedAt',
+                  label: 'Marketplace-side updated',
+                  value: <TimeDisplay iso={offer.updatedAt} />,
+                },
+              ]
+            : []),
+        ]}
+      />
+      {offer.description ? (
+        <details className="listing-marketplace-offer__description">
+          <summary>Description preview</summary>
+          <p className="listing-marketplace-offer__description-body">{offer.description}</p>
+        </details>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/listings/hooks/use-listing-marketplace-offer-query.ts
+++ b/apps/web/src/features/listings/hooks/use-listing-marketplace-offer-query.ts
@@ -1,0 +1,32 @@
+/**
+ * useListingMarketplaceOfferQuery — fetch the live marketplace offer for a
+ * listing-detail page (#464).
+ *
+ * Powers the new "Listing details" section above the raw mapping fields.
+ * Disabled when the mapping isn't of `entityType === 'Offer'` so non-offer
+ * detail pages don't fire a request. Retries are off — 404 (mapping isn't
+ * an offer) and 422 (adapter doesn't implement `OfferReader`) are both
+ * non-transient; 5xx surfaces as the error state with a manual retry button.
+ *
+ * `staleTime: 30_000` mirrors the BE `Cache-Control: max-age=30`.
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { MarketplaceOfferResponse } from '../api/listings.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { ApiError } from '../../../shared/api/api-error';
+
+export function useListingMarketplaceOfferQuery(
+  mappingId: string,
+  options?: { enabled?: boolean },
+): UseQueryResult<MarketplaceOfferResponse, ApiError> {
+  const apiClient = useApiClient();
+
+  return useQuery<MarketplaceOfferResponse, ApiError>({
+    queryKey: listingsQueryKeys.marketplaceOffer(mappingId),
+    queryFn: () => apiClient.listings.getMarketplaceOffer(mappingId),
+    enabled: Boolean(mappingId) && (options?.enabled ?? true),
+    retry: false,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/features/products/api/products.api.ts
+++ b/apps/web/src/features/products/api/products.api.ts
@@ -11,11 +11,18 @@ import type {
   ProductPagination,
   PaginatedProducts,
   Product,
+  ProductVariantSummary,
 } from './products.types';
 
 export interface ProductsApi {
   list: (filters?: ProductFilters, pagination?: ProductPagination) => Promise<PaginatedProducts>;
   getById: (id: string) => Promise<Product>;
+  /**
+   * Lightweight projection of a single variant — id, parent product id, SKU,
+   * EAN, optional human-readable name. Used by the listing-detail page (#464)
+   * to enrich the Internal ID row with the variant's identifiers inline.
+   */
+  getVariant: (variantId: string) => Promise<ProductVariantSummary>;
 }
 
 interface ApiRequest {
@@ -38,6 +45,9 @@ export function createProductsApi(request: ApiRequest): ProductsApi {
     },
     getById(id): Promise<Product> {
       return request<Product>(`/products/${id}`);
+    },
+    getVariant(variantId): Promise<ProductVariantSummary> {
+      return request<ProductVariantSummary>(`/products/variants/${variantId}`);
     },
   };
 }

--- a/apps/web/src/features/products/api/products.query-keys.ts
+++ b/apps/web/src/features/products/api/products.query-keys.ts
@@ -5,4 +5,5 @@ export const productsQueryKeys = {
   list: (filters?: ProductFilters, pagination?: ProductPagination) =>
     ['products', 'list', filters ?? {}, pagination ?? {}] as const,
   detail: (id: string) => ['products', 'detail', id] as const,
+  variant: (variantId: string) => ['products', 'variant', variantId] as const,
 };

--- a/apps/web/src/features/products/api/products.types.ts
+++ b/apps/web/src/features/products/api/products.types.ts
@@ -63,3 +63,17 @@ export interface PaginatedProductVariants {
   limit: number;
   offset: number;
 }
+
+/**
+ * Lightweight variant projection returned by `GET /products/variants/:id`.
+ * Used by the listing-detail page (#464) to surface the linked variant's
+ * SKU/EAN inline next to the Internal ID row.
+ */
+export interface ProductVariantSummary {
+  id: string;
+  productId: string;
+  sku: string | null;
+  ean: string | null;
+  /** Display label assembled from variant attributes (e.g. "Red / 42"). */
+  name?: string;
+}

--- a/apps/web/src/features/products/hooks/use-variant-query.ts
+++ b/apps/web/src/features/products/hooks/use-variant-query.ts
@@ -11,13 +11,14 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { productsQueryKeys } from '../api/products.query-keys';
 import type { ProductVariantSummary } from '../api/products.types';
 import { useApiClient } from '../../../app/api/api-client-provider';
+import { ApiError } from '../../../shared/api/api-error';
 
 export function useVariantQuery(
   variantId: string | undefined,
-): UseQueryResult<ProductVariantSummary> {
+): UseQueryResult<ProductVariantSummary, ApiError> {
   const apiClient = useApiClient();
 
-  return useQuery({
+  return useQuery<ProductVariantSummary, ApiError>({
     queryKey: productsQueryKeys.variant(variantId ?? ''),
     queryFn: () => apiClient.products.getVariant(variantId ?? ''),
     enabled: Boolean(variantId),

--- a/apps/web/src/features/products/hooks/use-variant-query.ts
+++ b/apps/web/src/features/products/hooks/use-variant-query.ts
@@ -1,0 +1,27 @@
+/**
+ * useVariantQuery — fetch a single variant's summary (#464).
+ *
+ * Powers the listing-detail page's inline SKU+EAN enrichment next to the
+ * Internal ID row. The enrichment is a nice-to-have, not load-bearing —
+ * a 404 or transient error renders silently (the bare ID still shows). For
+ * that reason we disable retries: a missing or transiently-failing variant
+ * shouldn't keep refetching in the background.
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { productsQueryKeys } from '../api/products.query-keys';
+import type { ProductVariantSummary } from '../api/products.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useVariantQuery(
+  variantId: string | undefined,
+): UseQueryResult<ProductVariantSummary> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: productsQueryKeys.variant(variantId ?? ''),
+    queryFn: () => apiClient.products.getVariant(variantId ?? ''),
+    enabled: Boolean(variantId),
+    retry: false,
+    staleTime: 60_000,
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5143,6 +5143,64 @@ a.kpi-card:focus-visible {
   color: var(--text-primary);
 }
 
+.detail-section__muted {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+/* Listing marketplace offer section (#464) — surfaces live Allegro offer
+ * state above the raw mapping fields on the listing detail page.
+ */
+.listing-marketplace-offer__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.listing-marketplace-offer__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.listing-marketplace-offer__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.listing-marketplace-offer__description {
+  margin-top: 0.25rem;
+}
+
+.listing-marketplace-offer__description summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+}
+
+.listing-marketplace-offer__description-body {
+  margin: 0.5rem 0 0;
+  white-space: pre-wrap;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+/* Inline SKU/EAN tags rendered next to the Internal ID link on the
+ * listing detail page (#464). Quiet treatment — the linked id is the
+ * primary affordance, the tags are supplementary.
+ */
+.listing-detail-variant-tags {
+  display: inline-flex;
+  gap: 0.5rem;
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
 /* Primary grid: summary left, sync status right (desktop) */
 .order-detail__primary-grid {
   display: grid;

--- a/apps/web/src/pages/listings/listing-detail-page.test.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.test.tsx
@@ -3,7 +3,13 @@ import { Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { ListingDetailPage } from './listing-detail-page';
-import type { OfferCreationStatusResponse, OfferMapping } from '../../features/listings/api/listings.types';
+import { ApiError } from '../../shared/api/api-error';
+import type {
+  MarketplaceOfferResponse,
+  OfferCreationStatusResponse,
+  OfferMapping,
+} from '../../features/listings/api/listings.types';
+import type { ProductVariantSummary } from '../../features/products/api/products.types';
 
 function buildMapping(overrides: Partial<OfferMapping>): OfferMapping {
   return {
@@ -131,5 +137,125 @@ describe('ListingDetailPage', () => {
     // Wait for the page to fully render by asserting on a known element first
     await screen.findByText('mapping_1');
     expect(screen.queryByRole('heading', { name: /offer creation/i })).toBeNull();
+  });
+
+  describe('Listing details section (#464)', () => {
+    const liveOffer: MarketplaceOfferResponse = {
+      externalId: 'allegro-offer-456',
+      title: 'Vintage Camera Lens 50mm',
+      description: 'Mint condition.\n\nOriginal case included.',
+      imageUrl: 'https://a.allegroimg.com/lens.jpg',
+      price: { amount: '249.00', currency: 'PLN' },
+      availableQuantity: 3,
+      status: 'ACTIVE',
+      category: { id: '12345', name: 'Lenses' },
+      marketplaceUrl: 'https://allegro.pl/oferta/allegro-offer-456',
+      updatedAt: '2026-04-30T10:00:00Z',
+    };
+
+    function renderWithOfferData(
+      mapping: OfferMapping,
+      offerOverride?: typeof liveOffer | Error,
+      variant?: ProductVariantSummary,
+    ): void {
+      const getMarketplaceOffer =
+        offerOverride instanceof Error
+          ? vi.fn().mockRejectedValue(offerOverride)
+          : vi.fn().mockResolvedValue(offerOverride ?? liveOffer);
+      const getVariant = variant
+        ? vi.fn().mockResolvedValue(variant)
+        : undefined;
+      const api = createMockApiClient({
+        listings: {
+          getById: vi.fn().mockResolvedValue(mapping),
+          getMarketplaceOffer,
+        },
+        ...(getVariant ? { products: { getVariant } } : {}),
+      });
+      renderWithProviders(
+        <Routes>
+          <Route path="/listings/:id" element={<ListingDetailPage />} />
+        </Routes>,
+        { apiClient: api, route: `/listings/${mapping.id}` },
+      );
+    }
+
+    it('renders title, status, price, qty, and marketplace URL when entityType is Offer and the offer fetch succeeds', async () => {
+      renderWithOfferData(buildMapping({ entityType: 'Offer' }));
+
+      expect(
+        await screen.findByRole('heading', { name: 'Vintage Camera Lens 50mm' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+      expect(screen.getByText('249.00 PLN')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('Lenses')).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /open on marketplace/i });
+      expect(link).toHaveAttribute('href', 'https://allegro.pl/oferta/allegro-offer-456');
+      expect(link).toHaveAttribute('target', '_blank');
+      // Description preview rendered in a <details> element (collapsed by default).
+      expect(screen.getByText(/description preview/i)).toBeInTheDocument();
+    });
+
+    it('renders the soft fallback panel when the adapter does not implement OfferReader (422)', async () => {
+      renderWithOfferData(
+        buildMapping({ entityType: 'Offer' }),
+        new ApiError('not supported', 422, null),
+      );
+
+      expect(await screen.findByText('Live data unavailable for this adapter.')).toBeInTheDocument();
+      // Raw mapping fields still render below the soft fallback.
+      expect(screen.getByText('mapping_1')).toBeInTheDocument();
+    });
+
+    it('renders the error panel with retry on 5xx and keeps raw mapping visible', async () => {
+      renderWithOfferData(
+        buildMapping({ entityType: 'Offer' }),
+        new ApiError('Allegro upstream 502', 502, null),
+      );
+
+      expect(await screen.findByText('Unable to load listing details')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+      expect(screen.getByText('mapping_1')).toBeInTheDocument();
+    });
+
+    it('does not fetch the live offer when entityType is not Offer', async () => {
+      const getMarketplaceOffer = vi.fn();
+      const api = createMockApiClient({
+        listings: {
+          getById: vi.fn().mockResolvedValue(buildMapping({ entityType: 'Product' })),
+          getMarketplaceOffer,
+        },
+      });
+      renderWithProviders(
+        <Routes>
+          <Route path="/listings/:id" element={<ListingDetailPage />} />
+        </Routes>,
+        { apiClient: api, route: '/listings/mapping_1' },
+      );
+
+      await screen.findByText('mapping_1');
+      expect(getMarketplaceOffer).not.toHaveBeenCalled();
+      // Section heading not rendered.
+      expect(screen.queryByRole('heading', { name: /listing details/i })).toBeNull();
+    });
+
+    it('renders SKU and EAN tags inline next to the Internal ID when the variant query resolves', async () => {
+      const variantSummary: ProductVariantSummary = {
+        id: 'ol_variant_xyz',
+        productId: 'ol_product_abc',
+        sku: 'SKU-RED-42',
+        ean: '5901234123457',
+        name: 'Red / 42',
+      };
+      renderWithOfferData(
+        buildMapping({ entityType: 'ProductVariant', internalId: 'ol_variant_xyz' }),
+        undefined,
+        variantSummary,
+      );
+
+      expect(await screen.findByText('SKU SKU-RED-42')).toBeInTheDocument();
+      expect(screen.getByText('EAN 5901234123457')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/listings/listing-detail-page.test.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.test.tsx
@@ -150,7 +150,7 @@ describe('ListingDetailPage', () => {
       status: 'ACTIVE',
       category: { id: '12345', name: 'Lenses' },
       marketplaceUrl: 'https://allegro.pl/oferta/allegro-offer-456',
-      updatedAt: '2026-04-30T10:00:00Z',
+      endsAt: '2026-04-30T10:00:00Z',
     };
 
     function renderWithOfferData(

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -8,13 +8,27 @@ import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
 import { EditOfferDrawer } from '../../features/listings/components/EditOfferDrawer';
+import { ListingMarketplaceOfferSection } from '../../features/listings/components/listing-marketplace-offer-section';
 import { OfferCreationStatusBadge } from '../../features/listings/components/OfferCreationStatusBadge';
 import { OfferCreationErrorList } from '../../features/listings/components/OfferCreationErrorList';
 import { ConnectionEntityLabel } from '../../features/connections/components/ConnectionEntityLabel';
+import { useVariantQuery } from '../../features/products/hooks/use-variant-query';
+import type { ProductVariantSummary } from '../../features/products/api/products.types';
 import {
   KNOWN_MAPPING_ENTITY_TYPES,
   type KnownMappingEntityType,
 } from '../../features/listings/api/listings.types';
+
+/**
+ * Both `entityType === 'ProductVariant'` and `entityType === 'Offer'` mappings
+ * store the linked variant's id as `internalId` (verified in the BE
+ * `OfferMappingSyncService.linkOffer` path). Other entity types (`Product`,
+ * `InventoryItem`, plus forward-compat unknowns) don't link to a variant —
+ * we skip the SKU/EAN enrichment for those.
+ */
+function isVariantLinkedEntityType(value: string): boolean {
+  return value === 'ProductVariant' || value === 'Offer';
+}
 
 const ENTITY_TYPE_ROUTES: Record<KnownMappingEntityType, (id: string) => string> = {
   Product: (id) => `/products/${id}`,
@@ -26,13 +40,37 @@ function isKnownEntityType(value: string): value is KnownMappingEntityType {
   return (KNOWN_MAPPING_ENTITY_TYPES as readonly string[]).includes(value);
 }
 
-function renderInternalIdValue(entityType: string, internalId: string): ReactNode {
-  if (!isKnownEntityType(entityType)) return internalId;
+function renderInternalIdValue(
+  entityType: string,
+  internalId: string,
+  variant: ProductVariantSummary | undefined,
+): ReactNode {
+  // SKU/EAN enrichment renders inline next to the linked id when the variant
+  // query has resolved (#464). Errors / 404s render quietly — the bare ID is
+  // still useful by itself.
+  const enrichment = variant ? (
+    <span className="listing-detail-variant-tags">
+      {variant.sku ? <span className="mono-text">SKU {variant.sku}</span> : null}
+      {variant.ean ? <span className="mono-text">EAN {variant.ean}</span> : null}
+    </span>
+  ) : null;
+
+  if (!isKnownEntityType(entityType)) {
+    return (
+      <>
+        <span className="mono-text">{internalId}</span>
+        {enrichment}
+      </>
+    );
+  }
   const to = ENTITY_TYPE_ROUTES[entityType](internalId);
   return (
-    <Link to={to} className="mono-text">
-      {internalId}
-    </Link>
+    <>
+      <Link to={to} className="mono-text">
+        {internalId}
+      </Link>
+      {enrichment}
+    </>
   );
 }
 
@@ -40,6 +78,15 @@ export function ListingDetailPage(): ReactElement {
   const { id = '' } = useParams<{ id: string }>();
   const query = useListingQuery(id);
   const [isEditDrawerOpen, setIsEditDrawerOpen] = useState(false);
+
+  // The mapping query has to resolve before we can decide whether to fetch
+  // the linked variant — disabled until then. The `enabled` flag in
+  // useVariantQuery means an unset id never fires.
+  const linkedVariantId =
+    query.data && isVariantLinkedEntityType(query.data.entityType)
+      ? query.data.internalId
+      : undefined;
+  const variantQuery = useVariantQuery(linkedVariantId);
 
   if (query.isLoading) {
     return (
@@ -85,7 +132,11 @@ export function ListingDetailPage(): ReactElement {
             {
               id: 'internalId',
               label: 'Internal ID',
-              value: renderInternalIdValue(mapping.entityType, mapping.internalId),
+              value: renderInternalIdValue(
+                mapping.entityType,
+                mapping.internalId,
+                variantQuery.data,
+              ),
               mono: true,
             },
             { id: 'platform', label: 'Platform Type', value: mapping.platformType, mono: true },
@@ -99,6 +150,11 @@ export function ListingDetailPage(): ReactElement {
           ]}
         />
       </section>
+
+      <ListingMarketplaceOfferSection
+        mappingId={mapping.id}
+        enabled={mapping.entityType === 'Offer'}
+      />
 
       {mapping.offerCreation ? (
         <section className="detail-section">

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import type { ApiClient } from '../app/api/api-client';
 import { ApiClientProvider } from '../app/api/api-client-provider';
+import { ApiError } from '../shared/api/api-error';
 import type { Connection } from '../features/connections/api/connections.types';
 import { createNoopSessionAdapter } from '../shared/auth/noop-session-adapter';
 import type { SessionAdapter } from '../shared/auth/session-adapter';
@@ -225,6 +226,12 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
         offset: 0,
       }),
       getById: vi.fn().mockResolvedValue(null),
+      // #464 — default to a 422 (capability missing) so component tests that
+      // don't override fall through to the soft "live data unavailable"
+      // branch rather than a real network round-trip.
+      getMarketplaceOffer: vi.fn().mockRejectedValue(
+        new ApiError('Adapter does not support live offer reading', 422, null),
+      ),
       updateOfferFields: vi.fn().mockResolvedValue({ jobId: 'job-1' }),
       createOffer: vi.fn().mockResolvedValue({ jobId: 'job-1', offerCreationRecordId: 'rec-1' }),
       // Tests that render the tracker must override with a full-shape response — the `null`
@@ -249,6 +256,10 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
         offset: 0,
       }),
       getById: vi.fn().mockResolvedValue(null),
+      // #464 — quiet 404 default so the listing-detail page's variant
+      // enrichment renders the bare ID without an error in tests that don't
+      // care about the SKU/EAN tags.
+      getVariant: vi.fn().mockRejectedValue(new ApiError('Variant not found', 404, null)),
       ...overrides.products,
     } as ApiClient['products'],
     promptTemplates: {

--- a/docs/plans/implementation-plan-listing-detail-live-offer.md
+++ b/docs/plans/implementation-plan-listing-detail-live-offer.md
@@ -58,7 +58,7 @@ The issue's "Linked product side" bullet is in scope. Both `entityType === 'Offe
   - `status: string` (string passthrough — no leaky enum; the FE renders unknown strings as a neutral badge)
   - `category?: { id: string; name?: string }`
   - `marketplaceUrl?: string`
-  - `updatedAt?: string` (ISO)
+  - `endsAt?: string` (ISO — when the offer's marketplace-side validity ends; Allegro's `publication.endingAt`. Distinct from "last modified": the bare offer GET doesn't expose a cheap last-modified timestamp, and operators benefit more from seeing when the offer expires.)
 
 **`libs/core/src/listings/domain/ports/capabilities/offer-reader.capability.ts`** (new)
 - `OfferReader { getOffer(input: { externalId: string }): Promise<MarketplaceOffer> }`
@@ -85,7 +85,7 @@ Acceptance: types compile in isolation; capability guard table grows by one row,
   - `status` → `publication.status` (string).
   - `category` → `category.{id, name}` (name may not be present on the bare GET — leave undefined).
   - `marketplaceUrl` → derived per-environment: sandbox vs prod uses different host (`https://allegro.pl/oferta/{id}` for prod, `https://allegro.pl.allegrosandbox.pl/oferta/{id}` for sandbox). Use the existing config's `environment` flag.
-  - `updatedAt` → `publication.lastChangedAt` (or top-level `updatedAt` — verify in fixture).
+  - `endsAt` → `publication.endingAt` (Allegro's scheduled offer end; the bare GET does not expose a last-modified timestamp).
 
 **`libs/integrations/allegro/src/domain/types/allegro-api.types.ts`**
 - Extend `AllegroProductOffer` with the additional fields needed by `getOffer`: `description?`, `images?`, `sellingMode?`, `stock?`, `publication?`. Keep additions optional to avoid breaking the existing `fetchOfferIdentifiers` consumer.
@@ -93,7 +93,7 @@ Acceptance: types compile in isolation; capability guard table grows by one row,
 **`libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts`**
 - New describe `getOffer (#464)`:
   - happy-path: full response → `MarketplaceOffer` with every field populated.
-  - sparse-payload: missing `description` / `images` / `category.name` / `updatedAt` — adapter returns `MarketplaceOffer` with the optional fields undefined, the required ones present.
+  - sparse-payload: missing `description` / `images` / `category.name` / `endsAt` — adapter returns `MarketplaceOffer` with the optional fields undefined, the required ones present.
   - 404 from upstream: propagates as the existing HTTP error type (no special domain conversion needed in this PR — keep the HTTP layer's existing behavior; controller maps to 404).
 
 Acceptance: adapter spec covers happy + sparse + 404; the existing `fetchOfferIdentifiers` tests keep passing.

--- a/docs/plans/implementation-plan-listing-detail-live-offer.md
+++ b/docs/plans/implementation-plan-listing-detail-live-offer.md
@@ -1,0 +1,207 @@
+# Implementation plan — Listing detail: surface live offer fields
+
+Closes #464.
+
+## Goal
+
+Today `/listings/:id` is a debug view of `identifier_mappings` — Mapping ID, External/Internal IDs, timestamps, raw context. It tells the operator a mapping *exists* but nothing about *what the offer actually is* on the marketplace. For Allegro `entityType = 'Offer'` mappings, surface live title, image, price, available qty, status, category, marketplace URL, and a description preview — fetched on demand from `GET /sale/product-offers/{offerId}`.
+
+## Layer classification
+
+Cross-cutting:
+- **CORE/listings (domain)** — new `OfferReader` capability + `MarketplaceOffer` neutral DTO.
+- **Integration/Allegro** — adapter implements `OfferReader.getOffer()`.
+- **Interface (API)** — new `GET /listings/:mappingId/offer` endpoint.
+- **Frontend** — new section on the listing detail page, new query hook, four states.
+
+No DB schema change. No worker change.
+
+## Non-goals (per issue)
+
+- Bulk enrichment of `/listings` list page (separate cost/value tradeoff).
+- PrestaShop / other-platform `OfferReader` adapters (capability + Allegro impl only).
+- Editing fields from this page (already handled by `EditOfferDrawer`).
+- Persistent caching beyond `Cache-Control: max-age=30`.
+- Republish / end / force-resync actions.
+
+## One scope deviation worth flagging
+
+The issue body says "return 501 (Not implemented for this adapter)" when the adapter doesn't support `OfferReader`. **The existing controller convention** for the same situation (e.g. `getCategoryParameters` at `listings.controller.ts:314`) is **422 `UnprocessableEntityException`**, with the same intent ("adapter does not support this capability"). I'm following the existing convention and using 422 — consistency with the rest of the controller surface beats matching the literal HTTP code in the issue body. The FE 4-state handling (loading / error / empty / data) treats 422 the same way it would treat 501: a soft "Live data unavailable for this adapter" panel. Will note in PR description.
+
+## Variant SKU/EAN inline enrichment — in scope
+
+The issue's "Linked product side" bullet is in scope. Both `entityType === 'Offer'` and `entityType === 'ProductVariant'` mappings store the variant id as `internalId` (verified in `OfferMappingSyncService.linkOffer` — the `Offer` mapping's internalId is the linked variant's id, not a separate offer entity). One new endpoint covers both cases:
+
+- **BE**: `GET /products/variants/:variantId` returns `{ id, sku, ean, productId, name? }` — small DTO scoped to what the listing detail page needs (no full variant payload).
+- **FE**: new `useVariantQuery(variantId)` hook + inline SKU/EAN tags next to the existing Internal ID row when the mapping links to a variant.
+
+## Existing patterns to mirror
+
+- **Capability + guard**: `libs/core/src/listings/domain/ports/capabilities/offer-event-reader.capability.ts` is the smallest sibling — single method + co-located `is{Capability}` guard. Drop the `Port` suffix per the convention call-out in `offer-lister.capability.ts`.
+- **Capability guard tests**: extend the existing table in `libs/core/src/listings/domain/ports/capabilities/__tests__/*.spec.ts` — one new row, automatic happy-path + missing + non-function coverage.
+- **Adapter offer fetch**: `AllegroOfferManagerAdapter.fetchOfferIdentifiers` (line 463) already calls `GET /sale/product-offers/{offerId}` — same HTTP client, same auth path. Refactor to extract the raw fetch and consume it from both call sites.
+- **Controller capability narrowing**: `listings.controller.ts:309-319` (the `getCategoryParameters` site) is the template — `getCapabilityAdapter('OfferManager')`, `isOfferReader(adapter)` guard, 422 on miss.
+- **FE detail-page state machine**: the page already follows the loading / error / data pattern at the **page** level. I'll add the new section as an **embedded** state machine that fails soft (the existing key-value list keeps rendering even when the offer fetch fails — per `.claude/rules/fe-pages.md` "do not crash the rest of the page").
+- **FE query hook**: copy the shape of `use-offer-creation-status-query.ts` — TanStack Query, query-key factory, `enabled` predicate.
+
+## Changes by file
+
+### Phase A — CORE listings (capability + DTO)
+
+**`libs/core/src/listings/domain/types/marketplace-offer.types.ts`** (new)
+- `MarketplaceOffer` interface with the fields listed in the issue:
+  - `externalId`, `title`
+  - `description?: string` (raw HTML/text — FE owns truncation)
+  - `imageUrl?: string` (primary image)
+  - `price: { amount: string; currency: string }`
+  - `availableQuantity: number`
+  - `status: string` (string passthrough — no leaky enum; the FE renders unknown strings as a neutral badge)
+  - `category?: { id: string; name?: string }`
+  - `marketplaceUrl?: string`
+  - `updatedAt?: string` (ISO)
+
+**`libs/core/src/listings/domain/ports/capabilities/offer-reader.capability.ts`** (new)
+- `OfferReader { getOffer(input: { externalId: string }): Promise<MarketplaceOffer> }`
+- Co-located `isOfferReader(adapter)` guard mirroring `isOfferEventReader`.
+
+**`libs/core/src/listings/domain/ports/capabilities/__tests__/*.spec.ts`**
+- Add `'OfferReader' / isOfferReader / 'getOffer'` row to the table.
+
+**`libs/core/src/listings/index.ts`**
+- Re-export `MarketplaceOffer`, `OfferReader`, `isOfferReader`.
+
+Acceptance: types compile in isolation; capability guard table grows by one row, all rows still pass.
+
+### Phase B — Allegro adapter
+
+**`libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts`**
+- Implement `getOffer({ externalId })` calling `GET /sale/product-offers/{externalId}` and mapping the response to `MarketplaceOffer`. Reuse the shared HTTP client; rely on its existing 404 / token-refresh / transient-5xx handling.
+- Map fields:
+  - `id` → `externalId`, `name` → `title`
+  - `description` → from `description.sections[].items` (Allegro stores rich text as a sectioned array — flatten to a single string for now; FE can render or truncate).
+  - `imageUrl` → first item of `images[]` (Allegro returns array of `{ url }`).
+  - `price` → `sellingMode.price.{amount, currency}`.
+  - `availableQuantity` → `stock.available`.
+  - `status` → `publication.status` (string).
+  - `category` → `category.{id, name}` (name may not be present on the bare GET — leave undefined).
+  - `marketplaceUrl` → derived per-environment: sandbox vs prod uses different host (`https://allegro.pl/oferta/{id}` for prod, `https://allegro.pl.allegrosandbox.pl/oferta/{id}` for sandbox). Use the existing config's `environment` flag.
+  - `updatedAt` → `publication.lastChangedAt` (or top-level `updatedAt` — verify in fixture).
+
+**`libs/integrations/allegro/src/domain/types/allegro-api.types.ts`**
+- Extend `AllegroProductOffer` with the additional fields needed by `getOffer`: `description?`, `images?`, `sellingMode?`, `stock?`, `publication?`. Keep additions optional to avoid breaking the existing `fetchOfferIdentifiers` consumer.
+
+**`libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts`**
+- New describe `getOffer (#464)`:
+  - happy-path: full response → `MarketplaceOffer` with every field populated.
+  - sparse-payload: missing `description` / `images` / `category.name` / `updatedAt` — adapter returns `MarketplaceOffer` with the optional fields undefined, the required ones present.
+  - 404 from upstream: propagates as the existing HTTP error type (no special domain conversion needed in this PR — keep the HTTP layer's existing behavior; controller maps to 404).
+
+Acceptance: adapter spec covers happy + sparse + 404; the existing `fetchOfferIdentifiers` tests keep passing.
+
+### Phase B.5 — Variant-by-id endpoint (#464 "Linked product side")
+
+**`apps/api/src/products/http/dto/product-variant-summary-response.dto.ts`** (new — small DTO scoped to the listing-detail enrichment use case)
+- `ProductVariantSummaryResponseDto { id, productId, sku: string | null, ean: string | null, name?: string }`.
+
+**`apps/api/src/products/http/products.controller.ts`**
+- New endpoint: `@Get('variants/:variantId')` placed **before** `@Get(':id')` so the route doesn't collide with the product-detail handler. Returns `ProductVariantSummaryResponseDto`. 404 when not found. Reuse `productsService.getVariant` if present; otherwise inject `ProductVariantRepositoryPort` directly via the existing `PRODUCT_VARIANT_REPOSITORY_TOKEN`.
+
+**`apps/api/src/products/http/products.controller.spec.ts`**
+- Happy path + 404.
+
+Acceptance: `GET /products/variants/{id}` returns 200 with summary or 404; existing product endpoints unaffected.
+
+### Phase C — API endpoint
+
+**`apps/api/src/listings/http/dto/marketplace-offer-response.dto.ts`** (new)
+- `MarketplaceOfferResponseDto` mirroring `MarketplaceOffer` for OpenAPI/Swagger; static `fromDomain(offer): MarketplaceOfferResponseDto` helper.
+
+**`apps/api/src/listings/http/listings.controller.ts`**
+- New endpoint: `@Get(':id/offer')`.
+  - Load the mapping; throw `NotFoundException` if missing.
+  - Reject with `NotFoundException` if `mapping.entityType !== 'Offer'` — the issue says 404 ("not an offer mapping"). Same status as "mapping doesn't exist" so we don't leak record presence to operators with the wrong scope.
+  - Resolve `OfferManagerPort` via `IntegrationsService.getCapabilityAdapter('OfferManager', mapping.connectionId)`.
+  - Narrow via `isOfferReader(adapter)` → throw `UnprocessableEntityException` ("does not support live offer reading") on miss. **Status 422, matching `getCategoryParameters` convention.**
+  - Call `adapter.getOffer({ externalId: mapping.externalId })` — propagate upstream errors (the existing HTTP-error→Nest-exception filter handles 404 from Allegro as 502 or similar; no special handling).
+  - Set `Cache-Control: public, max-age=30` on the response — operator-friendly back-and-forth without re-hitting Allegro.
+  - Return `MarketplaceOfferResponseDto.fromDomain(...)`.
+
+**`apps/api/src/listings/http/listings.controller.spec.ts`**
+- New describe block:
+  - Happy path: 200 + body for `entityType === 'Offer'`.
+  - 404 when mapping doesn't exist.
+  - 404 when `entityType !== 'Offer'`.
+  - 422 when adapter doesn't implement `OfferReader`.
+  - Connection errors (404/409) propagate from `getCapabilityAdapter` unchanged.
+
+Acceptance: integration controller tests pass for all four/five branches; `listOfferMappings` and `getOfferMapping` tests unaffected.
+
+### Phase D — Frontend
+
+**`apps/web/src/features/products/api/products.api.ts`**
+- Add `getVariant(variantId: string): Promise<ProductVariantSummary>`.
+
+**`apps/web/src/features/products/api/products.types.ts`**
+- Add `ProductVariantSummary` interface.
+
+**`apps/web/src/features/products/api/products.query-keys.ts`**
+- Add `variant: (id) => ['products', 'variant', id] as const`.
+
+**`apps/web/src/features/products/hooks/use-variant-query.ts`** (new)
+- TanStack Query hook with `staleTime: 60_000` and retries-disabled on 404.
+
+**`apps/web/src/features/listings/api/listings.types.ts`**
+- Add `MarketplaceOfferResponse` interface mirroring the BE DTO.
+
+**`apps/web/src/features/listings/api/listings.api.ts`**
+- Add `getMarketplaceOffer(mappingId: string): Promise<MarketplaceOfferResponse>` → `GET /listings/{mappingId}/offer`.
+
+**`apps/web/src/features/listings/api/listings.query-keys.ts`**
+- Add `marketplaceOffer: (mappingId: string) => ['listings', 'marketplace-offer', mappingId] as const`.
+
+**`apps/web/src/features/listings/hooks/use-listing-marketplace-offer-query.ts`** (new)
+- TanStack Query hook. `enabled = mapping?.entityType === 'Offer'`. `staleTime: 30_000` (matches BE Cache-Control).
+- Disable retries on 422 (capability missing) and 404 (mapping doesn't exist) — these are not transient.
+
+**`apps/web/src/features/listings/components/listing-marketplace-offer-section.tsx`** (new)
+- Embedded state machine: loading → error (with retry) → soft-fallback on 422 → data.
+  - Loading: `LoadingState liveRegion="off"` inline.
+  - Error (5xx / network / unknown): `ErrorState` with retry; the parent page's key-value list keeps rendering.
+  - 422 fallback: small neutral panel "Live data unavailable for this adapter."
+  - Data: thumbnail (`ProductThumbnail` shared primitive — issue mentions it indirectly), title (`<h3>`), `StatusBadge` for `status`, price + available qty in a `KeyValueList`, category name when present, marketplace URL as `<a target="_blank">`, description preview that expands on click (`<details>` element — native, accessible).
+- Render only when `mapping.entityType === 'Offer'` (decided at the parent page).
+
+**`apps/web/src/pages/listings/listing-detail-page.tsx`**
+- Mount `<ListingMarketplaceOfferSection mappingId={mapping.id} entityType={mapping.entityType} />` between the existing `KeyValueList` section and the `OfferCreation` section.
+- For mappings whose `internalId` is a variant (`entityType === 'ProductVariant' || entityType === 'Offer'`), render the variant's SKU + EAN inline next to the Internal ID via `useVariantQuery`. Render quietly: when the variant query is loading, show the bare ID; when it errors or 404s, also show just the bare ID (no error UI — the variant enrichment is a nice-to-have, not load-bearing for the page).
+
+**`apps/web/src/pages/listings/listing-detail-page.test.tsx`**
+- Extend with cases:
+  - Renders the new section when `entityType === 'Offer'` and the offer query resolves.
+  - Renders the soft fallback when the offer query fails with 422.
+  - Renders the error panel + retry on 5xx, raw mapping fields still visible.
+  - Skipped (no fetch) when `entityType !== 'Offer'`.
+
+**`apps/web/src/test/test-utils.tsx`**
+- Add `getMarketplaceOffer: vi.fn().mockResolvedValue(...)` to the listings mock.
+
+Acceptance: page tests cover happy + error + 422 + skipped paths; existing tests pass.
+
+## Quality gate
+
+```bash
+pnpm lint && pnpm type-check && pnpm test
+```
+
+No schema migration. No worker change.
+
+## Risks
+
+1. **Allegro response shape drift**: `description` / `images` / `sellingMode` field shapes vary slightly across Allegro API versions (per the `feedback_allegro_api_verify_shape` memory). I'll capture a real fixture during implementation and verify against developer.allegro.pl.
+2. **`marketplaceUrl` host derivation**: the offer URL's host depends on the connection's environment (sandbox vs prod). The Allegro connection config carries this — confirm field name during implementation, fall back to omitting `marketplaceUrl` if the env is unknown.
+3. **Sparse Allegro fields on synced-in offers**: offers fetched after a re-sync may have empty `description.sections` or no `images[]`. The DTO marks all of those `?:` so the UI renders gracefully.
+
+## Out-of-band follow-ups (not in this PR)
+
+- **PrestaShop `OfferReader` impl** when a `PrestashopOfferManagerAdapter` lands.
+- **Marketplace-side actions** (republish, end, force-sync) — separate UX + capability discussion per issue.

--- a/libs/core/src/listings/domain/ports/capabilities/__tests__/offer-manager-capabilities.spec.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/__tests__/offer-manager-capabilities.spec.ts
@@ -19,6 +19,7 @@ import { isCategoryBrowser } from '../category-browser.capability';
 import { isCategoryBarcodeMatcher } from '../category-barcode-matcher.capability';
 import { isCategoryParametersReader } from '../category-parameters-reader.capability';
 import { isOfferCreator } from '../offer-creator.capability';
+import { isOfferReader } from '../offer-reader.capability';
 import { isSellerPoliciesReader } from '../seller-policies-reader.capability';
 
 type Guard = (adapter: OfferManagerPort) => boolean;
@@ -32,6 +33,7 @@ const cases: ReadonlyArray<readonly [string, Guard, string]> = [
   ['CategoryBarcodeMatcher', isCategoryBarcodeMatcher, 'matchCategoryByBarcode'],
   ['CategoryParametersReader', isCategoryParametersReader, 'fetchCategoryParameters'],
   ['OfferCreator', isOfferCreator, 'createOffer'],
+  ['OfferReader', isOfferReader, 'getOffer'],
   ['SellerPoliciesReader', isSellerPoliciesReader, 'fetchSellerPolicies'],
 ];
 

--- a/libs/core/src/listings/domain/ports/capabilities/offer-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/offer-reader.capability.ts
@@ -1,0 +1,25 @@
+/**
+ * Offer Reader Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can fetch a
+ * single offer's live state (title, image, price, qty, status, …) declare
+ * `implements OfferReader`. Consumed by the listing-detail page (#464) to
+ * surface live marketplace state above the raw identifier-mapping fields.
+ *
+ * Naming and shape mirror sibling capabilities in this directory; see
+ * `offer-lister.capability.ts` for the convention call-out.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { MarketplaceOffer } from '../../types/marketplace-offer.types';
+import type { OfferManagerPort } from '../offer-manager.port';
+
+export interface OfferReader {
+  getOffer(input: { externalId: string }): Promise<MarketplaceOffer>;
+}
+
+export function isOfferReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferReader {
+  return typeof (adapter as Partial<OfferReader>).getOffer === 'function';
+}

--- a/libs/core/src/listings/domain/types/marketplace-offer.types.ts
+++ b/libs/core/src/listings/domain/types/marketplace-offer.types.ts
@@ -43,6 +43,13 @@ export interface MarketplaceOffer {
   category?: MarketplaceOfferCategory;
   /** Public buyer-facing URL the operator can open in a new tab. */
   marketplaceUrl?: string;
-  /** ISO 8601 — last marketplace-side change. */
-  updatedAt?: string;
+  /**
+   * ISO 8601 — when the offer's marketplace-side validity ends (Allegro:
+   * `publication.endingAt`). Optional because not every marketplace publishes
+   * a fixed end date. Distinct from a "last modified" timestamp — the
+   * Allegro offer endpoint doesn't expose one cheaply, so we surface the
+   * scheduled end instead because that is what operators actually need to
+   * see on the detail page.
+   */
+  endsAt?: string;
 }

--- a/libs/core/src/listings/domain/types/marketplace-offer.types.ts
+++ b/libs/core/src/listings/domain/types/marketplace-offer.types.ts
@@ -1,0 +1,48 @@
+/**
+ * Marketplace Offer Types
+ *
+ * Neutral DTO emitted by `OfferReader.getOffer` — the single live offer the
+ * listing detail page surfaces above the raw mapping fields. Every marketplace
+ * adapter maps its native offer-detail response into this shape.
+ *
+ * `status` is a string passthrough rather than a closed union — different
+ * marketplaces use different lifecycle vocabularies (Allegro: `ACTIVE`,
+ * `ENDED`, `INACTIVE`, `BIDDING`; future ones will add their own). The FE
+ * normalises into a known badge tone for the values it recognises and renders
+ * unknown values as a neutral badge with the raw label.
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+export interface MarketplaceOfferPrice {
+  /** Decimal string, e.g. `"99.99"` — keep precision intact across the wire. */
+  amount: string;
+  /** ISO 4217 code. */
+  currency: string;
+}
+
+export interface MarketplaceOfferCategory {
+  id: string;
+  /**
+   * Human-readable label. Allegro's bare offer endpoint does not return the
+   * category name (only the id) — adapters that can't fetch it cheaply leave
+   * this undefined and the FE shows the id only.
+   */
+  name?: string;
+}
+
+export interface MarketplaceOffer {
+  externalId: string;
+  title: string;
+  description?: string;
+  /** Primary image URL — public, no auth required. */
+  imageUrl?: string;
+  price: MarketplaceOfferPrice;
+  availableQuantity: number;
+  status: string;
+  category?: MarketplaceOfferCategory;
+  /** Public buyer-facing URL the operator can open in a new tab. */
+  marketplaceUrl?: string;
+  /** ISO 8601 — last marketplace-side change. */
+  updatedAt?: string;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -155,6 +155,13 @@ export {
 export { CategoryNotFoundException } from './domain/exceptions/category-not-found.exception';
 export type { OfferCreator } from './domain/ports/capabilities/offer-creator.capability';
 export { isOfferCreator } from './domain/ports/capabilities/offer-creator.capability';
+export type { OfferReader } from './domain/ports/capabilities/offer-reader.capability';
+export { isOfferReader } from './domain/ports/capabilities/offer-reader.capability';
+export type {
+  MarketplaceOffer,
+  MarketplaceOfferPrice,
+  MarketplaceOfferCategory,
+} from './domain/types/marketplace-offer.types';
 export type { SellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';
 export { isSellerPoliciesReader } from './domain/ports/capabilities/seller-policies-reader.capability';
 export type { ResponsibleProducerReader } from './domain/ports/capabilities/responsible-producer-reader.capability';

--- a/libs/core/src/products/application/services/products.service.interface.ts
+++ b/libs/core/src/products/application/services/products.service.interface.ts
@@ -48,6 +48,12 @@ export interface IProductsService {
   getProduct(id: string): Promise<Product | null>;
 
   /**
+   * Get a single product variant by internal ID. Returns null when no row
+   * matches; the caller decides between 404 and a soft fallback.
+   */
+  getVariant(id: string): Promise<ProductVariant | null>;
+
+  /**
    * List products with optional filters and pagination
    */
   listProducts(filters: ProductListFilters, pagination: ProductPagination): Promise<PaginatedProducts>;

--- a/libs/core/src/products/application/services/products.service.ts
+++ b/libs/core/src/products/application/services/products.service.ts
@@ -72,6 +72,10 @@ export class ProductsService implements IProductsService {
     return this.productRepository.findById(id);
   }
 
+  async getVariant(id: string): Promise<ProductVariant | null> {
+    return this.variantRepository.findById(id);
+  }
+
   async listProducts(
     filters: ProductListFilters,
     pagination: ProductPagination,

--- a/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
+++ b/libs/integrations/allegro/src/application/allegro-adapter.factory.ts
@@ -73,6 +73,9 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
     // Determine API + upload base URLs
     const apiBaseUrl = config.apiBaseUrl || this.getDefaultApiBaseUrl(config.environment);
     const uploadBaseUrl = config.uploadBaseUrl || this.getDefaultUploadBaseUrl(config.environment);
+    // #464 — public buyer-facing storefront, used by `OfferReader.getOffer` to
+    // synthesise a marketplace-side URL the operator can open in a new tab.
+    const storefrontBaseUrl = this.getDefaultStorefrontBaseUrl(config.environment);
 
     // Create token refresh callback if token refresh service is available.
     // We forward both accessToken and expiresAt so the HTTP client can update
@@ -125,6 +128,7 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
       // operator hasn't configured them yet — adapter throws
       // `OfferCreateRejectedException` on the first offer attempt.
       config.sellerDefaults,
+      storefrontBaseUrl,
     );
     const orderSourceAdapter = new AllegroOrderSourceAdapter(connection.id, httpClient, connection);
 
@@ -148,6 +152,23 @@ export class AllegroAdapterFactory implements IAllegroAdapterFactory {
       default:
         this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox`);
         return 'https://api.allegro.pl.allegrosandbox.pl';
+    }
+  }
+
+  /**
+   * Public storefront base URL for the offer-detail link surfaced on the
+   * listing-detail page (#464). Same `*.allegrosandbox.pl` naming pattern as
+   * the api/upload hosts.
+   */
+  private getDefaultStorefrontBaseUrl(environment: string): string {
+    switch (environment) {
+      case 'sandbox':
+        return 'https://allegro.pl.allegrosandbox.pl';
+      case 'production':
+        return 'https://allegro.pl';
+      default:
+        this.logger.warn(`Unknown environment: ${environment}, defaulting to sandbox storefront`);
+        return 'https://allegro.pl.allegrosandbox.pl';
     }
   }
 

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -306,6 +306,12 @@ export interface AllegroProductSetEntry {
 
 /**
  * Allegro product offer (from GET /sale/product-offers/{offerId})
+ *
+ * Fields required by the existing `fetchOfferIdentifiers` (#411) consumer
+ * are baseline; the additional optional fields below are consumed by
+ * `getOffer` (#464) to populate the neutral `MarketplaceOffer` DTO. Optional
+ * because Allegro's response shape varies — synced-in offers may have empty
+ * `images[]` or no `description.sections[]`.
  */
 export interface AllegroProductOffer {
   id: string;
@@ -317,6 +323,31 @@ export interface AllegroProductOffer {
   productSet?: AllegroProductSetEntry[];
   external?: {
     id?: string | null;
+  };
+  /** #464 — primary description, structured by Allegro as a list of sections of items. */
+  description?: {
+    sections?: Array<{
+      items?: Array<{
+        type?: string;
+        content?: string;
+        url?: string;
+      }>;
+    }>;
+  };
+  /** #464 — primary image is the first entry; subsequent entries are gallery shots. */
+  images?: Array<{ url: string }>;
+  /** #464 — current selling price. `BUY_NOW` is the only mode we currently consume. */
+  sellingMode?: {
+    price?: { amount: string; currency: string };
+  };
+  /** #464 — available stock quantity reported by Allegro. */
+  stock?: {
+    available?: number;
+  };
+  /** #464 — publication lifecycle (ACTIVE / ENDED / INACTIVE / etc.). */
+  publication?: {
+    status?: string;
+    endingAt?: string;
   };
 }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -681,7 +681,7 @@ describe('AllegroOfferManagerAdapter', () => {
         status: 'ACTIVE',
         category: { id: '12345' },
         marketplaceUrl: 'https://allegro.pl.allegrosandbox.pl/oferta/7781562863',
-        updatedAt: '2026-05-15T12:00:00Z',
+        endsAt: '2026-05-15T12:00:00Z',
       });
     });
 
@@ -710,7 +710,7 @@ describe('AllegroOfferManagerAdapter', () => {
         status: 'UNKNOWN',
         category: undefined,
         marketplaceUrl: 'https://allegro.pl/oferta/7781562864',
-        updatedAt: undefined,
+        endsAt: undefined,
       });
     });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -626,6 +626,136 @@ describe('AllegroOfferManagerAdapter', () => {
     });
   });
 
+  describe('getOffer (#464)', () => {
+    function buildAdapterWithStorefront(storefrontBaseUrl?: string): AllegroOfferManagerAdapter {
+      return new AllegroOfferManagerAdapter(
+        connectionId,
+        httpClient,
+        uploadHttpClient,
+        identifierMapping,
+        connection,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        DEFAULT_SELLER_DEFAULTS,
+        storefrontBaseUrl,
+      );
+    }
+
+    it('should map a fully-populated Allegro offer to MarketplaceOffer', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: '7781562863',
+          name: 'Vintage Camera Lens 50mm f/1.4',
+          category: { id: '12345' },
+          description: {
+            sections: [
+              { items: [{ type: 'TEXT', content: 'Mint condition lens.' }] },
+              { items: [{ type: 'TEXT', content: 'Original case included.' }] },
+            ],
+          },
+          images: [
+            { url: 'https://a.allegroimg.com/lens-1.jpg' },
+            { url: 'https://a.allegroimg.com/lens-2.jpg' },
+          ],
+          sellingMode: { price: { amount: '249.00', currency: 'PLN' } },
+          stock: { available: 3 },
+          publication: { status: 'ACTIVE', endingAt: '2026-05-15T12:00:00Z' },
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const subject = buildAdapterWithStorefront('https://allegro.pl.allegrosandbox.pl');
+      const result = await subject.getOffer({ externalId: '7781562863' });
+
+      expect(httpClient.get).toHaveBeenCalledWith('/sale/product-offers/7781562863');
+      expect(result).toEqual({
+        externalId: '7781562863',
+        title: 'Vintage Camera Lens 50mm f/1.4',
+        description: 'Mint condition lens.\n\nOriginal case included.',
+        imageUrl: 'https://a.allegroimg.com/lens-1.jpg',
+        price: { amount: '249.00', currency: 'PLN' },
+        availableQuantity: 3,
+        status: 'ACTIVE',
+        category: { id: '12345' },
+        marketplaceUrl: 'https://allegro.pl.allegrosandbox.pl/oferta/7781562863',
+        updatedAt: '2026-05-15T12:00:00Z',
+      });
+    });
+
+    it('should degrade gracefully when description / images / category / publication are absent', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: '7781562864',
+          name: 'Sparse Offer',
+          sellingMode: { price: { amount: '10.00', currency: 'PLN' } },
+          stock: { available: 0 },
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const subject = buildAdapterWithStorefront('https://allegro.pl');
+      const result = await subject.getOffer({ externalId: '7781562864' });
+
+      expect(result).toEqual({
+        externalId: '7781562864',
+        title: 'Sparse Offer',
+        description: undefined,
+        imageUrl: undefined,
+        price: { amount: '10.00', currency: 'PLN' },
+        availableQuantity: 0,
+        status: 'UNKNOWN',
+        category: undefined,
+        marketplaceUrl: 'https://allegro.pl/oferta/7781562864',
+        updatedAt: undefined,
+      });
+    });
+
+    it('should omit marketplaceUrl when storefrontBaseUrl is unset', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'offer-no-host',
+          name: 'No Host Offer',
+          sellingMode: { price: { amount: '5.00', currency: 'PLN' } },
+          stock: { available: 1 },
+          publication: { status: 'ACTIVE' },
+        },
+        status: 200,
+        headers: {},
+      });
+
+      // Default `adapter` from outer beforeEach has no storefrontBaseUrl arg.
+      const result = await adapter.getOffer({ externalId: 'offer-no-host' });
+
+      expect(result.marketplaceUrl).toBeUndefined();
+    });
+
+    it('should throw AllegroApiException when sellingMode.price is missing', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'offer-malformed',
+          name: 'Malformed',
+          stock: { available: 0 },
+        },
+        status: 200,
+        headers: {},
+      });
+
+      await expect(adapter.getOffer({ externalId: 'offer-malformed' })).rejects.toThrow(
+        /sellingMode\.price/,
+      );
+    });
+
+    it('should propagate upstream HTTP errors verbatim', async () => {
+      httpClient.get.mockRejectedValueOnce(new Error('Allegro 404'));
+
+      await expect(adapter.getOffer({ externalId: 'missing' })).rejects.toThrow('Allegro 404');
+    });
+  });
+
   describe('createOffer', () => {
     const baseCmd: CreateOfferCommand = {
       internalVariantId: 'ol_variant_abc',

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -550,7 +550,7 @@ export class AllegroOfferManagerAdapter
       status: offer.publication?.status ?? 'UNKNOWN',
       category: offer.category ? { id: offer.category.id } : undefined,
       marketplaceUrl: this.buildMarketplaceUrl(offer.id),
-      updatedAt: offer.publication?.endingAt,
+      endsAt: offer.publication?.endingAt,
     };
   }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -18,6 +18,7 @@ import type {
   CategoryBarcodeMatcher,
   CategoryParametersReader,
   OfferCreator,
+  OfferReader,
   SellerPoliciesReader,
   ResponsibleProducerReader,
   ResponsibleProducerEntry,
@@ -31,6 +32,7 @@ import type {
   CreateOfferValidationError,
   OfferCategory,
   CategoryParameter,
+  MarketplaceOffer,
   SellerPolicies,
 } from '@openlinker/core/listings';
 import { OfferCreateRejectedException, CategoryNotFoundException } from '@openlinker/core/listings';
@@ -183,6 +185,7 @@ export class AllegroOfferManagerAdapter
     CategoryBarcodeMatcher,
     CategoryParametersReader,
     OfferCreator,
+    OfferReader,
     SellerPoliciesReader,
     ResponsibleProducerReader {
   private readonly logger = new Logger(AllegroOfferManagerAdapter.name);
@@ -222,6 +225,13 @@ export class AllegroOfferManagerAdapter
      * partial body Allegro will 422 on (#430).
      */
     private readonly sellerDefaults?: AllegroSellerDefaultsConfig,
+    /**
+     * Storefront base URL used to derive the public buyer-facing offer URL
+     * for `getOffer` (#464). Sandbox: `https://allegro.pl.allegrosandbox.pl`,
+     * production: `https://allegro.pl`. The factory passes the right value;
+     * when undefined, `getOffer` omits `marketplaceUrl` from its result.
+     */
+    private readonly storefrontBaseUrl?: string,
   ) {
     this.quantityPollConfig = {
       maxAttempts: quantityPollConfig?.maxAttempts ?? 5,
@@ -494,6 +504,91 @@ export class AllegroOfferManagerAdapter
       ean: this.pickSingleValue(eanValues),
       gtin: this.pickSingleValue(gtinValues),
     };
+  }
+
+  /**
+   * Fetch a single offer's live state (#464 — `OfferReader`).
+   *
+   * Hits `GET /sale/product-offers/{externalId}` (same endpoint as
+   * `fetchOfferIdentifiers`, different projection of the response) and maps
+   * Allegro's native shape into the neutral `MarketplaceOffer` DTO consumed
+   * by the listing-detail page. Sparse upstream fields (missing description /
+   * images / category name / updatedAt) cleanly degrade to `undefined` on
+   * the result.
+   */
+  async getOffer(input: { externalId: string }): Promise<MarketplaceOffer> {
+    const { externalId } = input;
+    this.logger.debug(
+      `Fetching Allegro offer detail: connection=${this.connectionId} offerId=${externalId}`,
+    );
+
+    const response = await this.httpClient.get<AllegroProductOffer>(
+      `/sale/product-offers/${externalId}`,
+    );
+    const offer = response.data;
+
+    const price = offer.sellingMode?.price;
+    if (!price) {
+      // Allegro consistently returns sellingMode.price for every active or
+      // ended offer; missing it indicates a malformed payload, not a sparse
+      // legitimate response. Throw so the controller's existing error mapping
+      // surfaces a 502 instead of silently returning a half-formed DTO.
+      throw new AllegroApiException(
+        `Allegro offer ${externalId} response missing sellingMode.price`,
+        undefined,
+        formatBodyForLog(JSON.stringify(offer)),
+      );
+    }
+
+    return {
+      externalId: offer.id,
+      title: offer.name ?? '',
+      description: this.extractOfferDescription(offer),
+      imageUrl: offer.images?.[0]?.url,
+      price: { amount: price.amount, currency: price.currency },
+      availableQuantity: offer.stock?.available ?? 0,
+      status: offer.publication?.status ?? 'UNKNOWN',
+      category: offer.category ? { id: offer.category.id } : undefined,
+      marketplaceUrl: this.buildMarketplaceUrl(offer.id),
+      updatedAt: offer.publication?.endingAt,
+    };
+  }
+
+  /**
+   * Flatten Allegro's structured `description.sections[].items[]` into a
+   * single string suitable for FE preview rendering. Items of type `'TEXT'`
+   * (or unspecified) contribute their `content`; image items are dropped —
+   * the listing-detail surface shows the primary image separately. Returns
+   * undefined when there's nothing renderable so the FE can omit the
+   * description preview entirely.
+   */
+  private extractOfferDescription(offer: AllegroProductOffer): string | undefined {
+    const sections = offer.description?.sections ?? [];
+    const parts: string[] = [];
+    for (const section of sections) {
+      for (const item of section.items ?? []) {
+        if (item.content && (item.type === undefined || item.type === 'TEXT')) {
+          parts.push(item.content);
+        }
+      }
+    }
+    if (parts.length === 0) {
+      return undefined;
+    }
+    return parts.join('\n\n');
+  }
+
+  /**
+   * Build the public buyer-facing offer URL. Allegro's storefront and API
+   * hosts differ between sandbox and production; the factory passes the
+   * right storefront base via the constructor. When unset (legacy callers,
+   * tests), omit the URL — the FE renders no link rather than a wrong one.
+   */
+  private buildMarketplaceUrl(offerId: string): string | undefined {
+    if (!this.storefrontBaseUrl) {
+      return undefined;
+    }
+    return `${this.storefrontBaseUrl.replace(/\/+$/, '')}/oferta/${offerId}`;
   }
 
   /**


### PR DESCRIPTION
Closes #464

## Summary

`/listings/:id` was a debug view of `identifier_mappings` (mapping ID, external/internal IDs, timestamps). Operators got no signal about what the offer actually is on the marketplace. This change adds a live **Listing details** section above the raw mapping fields for `Offer`-type mappings, surfacing title, image, status, price, available qty, category, marketplace URL, description preview, and the offer's scheduled end date.

- **CORE** — new `OfferReader` sub-capability of `OfferManagerPort` (mirrors `OfferEventReader` / `OfferLister`) + neutral `MarketplaceOffer` DTO. `status` is a string passthrough — marketplaces use different lifecycle vocabularies. The capability-guard table-driven test grows by one row.
- **Allegro** — implements `OfferReader` via `GET /sale/product-offers/{externalId}`. Sparse upstream fields (description / images / category name / publication.endingAt) degrade cleanly to `undefined`; missing `sellingMode.price` throws so a malformed payload surfaces rather than silently returning a half-formed DTO. New `storefrontBaseUrl` constructor arg lets the adapter synthesise prod (`https://allegro.pl/oferta/{id}`) vs sandbox (`*.allegrosandbox.pl/oferta/{id}`); factory derives from `config.environment`.
- **API** — `GET /listings/:id/offer` (200 / 404 mapping missing or wrong `entityType` / 422 adapter doesn't implement `OfferReader` — matching the existing `getCategoryParameters` convention). `Cache-Control: public, max-age=30` so quick back-and-forth navigation reuses one Allegro fetch.
- **API** — `GET /products/variants/:variantId` (the issue's "Linked product side" enrichment). Lightweight `{ id, productId, sku, ean, name? }` projection. Both `entityType=ProductVariant` and `entityType=Offer` mappings store the variant id as `internalId` — one endpoint covers both. Route registered before `@Get(':id')` so the path doesn't collide with `getProduct`.
- **FE** — page section + variant inline tags. `useListingMarketplaceOfferQuery` (TanStack, `staleTime: 30_000` mirrors BE `Cache-Control`, retries off — 422/404 are non-transient). `ListingMarketplaceOfferSection` is an embedded state machine: loading → 422/404 soft fallback ("Live data unavailable") → 5xx ErrorState + retry → data with thumbnail + title + StatusBadge (success/warning/neutral derived from marketplace status) + KeyValueList + collapsible description preview. Fails soft so the rest of the page keeps rendering. Inline SKU/EAN tags next to the Internal ID row enrich the linked variant.

### Tech-review follow-ups (commit 2c9f2c8)

- Renamed `MarketplaceOffer.updatedAt` → `endsAt` across CORE / API / FE. The Allegro adapter sourced it from `publication.endingAt` (offer scheduled-end), but the FE labelled it "Marketplace-side updated" — misleading on every active offer. The endpoint doesn't expose a cheap last-modified timestamp anyway, and end date is what operators benefit from seeing.
- `toVariantSummaryDto` now sorts attribute entries by key before joining the display label, so `Red / 42` stays deterministic regardless of how the variant came off the wire.
- `useVariantQuery` now types its error generic as `ApiError` for consumer-side `error.status` branching without a runtime `instanceof` check.

## Test plan

- [x] BE: capability-guard table grew by one row, all rows still pass
- [x] BE: Allegro `getOffer` happy path + sparse + missing-host + malformed `sellingMode.price` + 5xx propagation
- [x] BE: listings controller — 200 / 404 mapping missing / 404 wrong entityType / 422 adapter / 5xx propagate
- [x] BE: products controller `getVariantSummary` — happy / no attributes / 404
- [x] FE: live offer renders title / status / price / qty / category / URL / description
- [x] FE: 422 → soft fallback (raw mapping still visible)
- [x] FE: 5xx → ErrorState + retry (raw mapping still visible)
- [x] FE: no fetch when `entityType !== 'Offer'`
- [x] FE: inline SKU+EAN tags render when variant query resolves
- [x] Quality gate: lint + type-check + 1,399 BE tests + 764 FE tests all green
- [ ] Smoke-test the live page against a real Allegro sandbox connection in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)