### PR TITLE
fix(customers): wire OrderCustomerProjectionUpdater into ingestion + backfill names

### DIFF
--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -13,7 +13,6 @@ import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { ProductsModule } from '@openlinker/core/products';
 import { InventoryModule } from '@openlinker/core/inventory';
 import { OrdersModule } from '@openlinker/core/orders';
-import { CustomersModule } from '@openlinker/core/customers';
 import { ListingsModule } from '@openlinker/core/listings/services';
 import { AllegroIntegrationModule } from '@openlinker/integrations-allegro';
 import { JobIntakeConsumer } from './job-intake.consumer';
@@ -41,7 +40,6 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     ProductsModule, // Import ProductsModule to access PRODUCTS_SERVICE_TOKEN
     InventoryModule, // Import InventoryModule to access INVENTORY_SERVICE_TOKEN
     OrdersModule, // Import OrdersModule to access ORDER_SYNC_SERVICE_TOKEN
-    CustomersModule, // Import CustomersModule to access OrderCustomerProjectionUpdaterService
     ListingsModule, // Import ListingsModule to access OFFER_MAPPING_SYNC_SERVICE_TOKEN
     AllegroIntegrationModule, // Import AllegroIntegrationModule to access ALLEGRO_QUANTITY_COMMAND_REPOSITORY_TOKEN
   ],

--- a/docs/plans/implementation-plan-customer-projection-wiring.md
+++ b/docs/plans/implementation-plan-customer-projection-wiring.md
@@ -1,0 +1,238 @@
+# Implementation Plan — #465: wire `OrderCustomerProjectionUpdater` into ingestion + backfill names
+
+## 1. Goal
+
+Make customer-projection rows actually populated when an Allegro (or any source) order is ingested:
+
+- **Bug A — addresses**: `OrderCustomerProjectionUpdaterService` is registered but never called. Hook it into `OrderIngestionService.syncOrderFromSource()`.
+- **Bug B — names**: identity resolver writes `firstName: null, lastName: null` because at that point names aren't available. Backfill from `order.shippingAddress` (fallback to `billingAddress`) inside the same updater, with non-clobbering semantics (don't overwrite a set name with `null`).
+
+## 2. Layer classification
+
+- **Bounded context**: Customers (extend updater), Orders (call site).
+- **Layer**: Application services on both sides + a small interface addition on `ICustomerProjectionService`.
+- **Hexagonal compliance**: Orders → Customers application interface (token-injected). No new infrastructure. No schema change.
+
+## 3. Non-goals
+
+- Backfilling the existing 19 sandbox orders. Re-ingest after fix.
+- Making `firstName/lastName` available *during* identity resolution. The resolver's hardcoded `null` names at `customer-identity-resolver.service.ts:255-256` stay; backfill happens in the updater after the order is built.
+- `phone` / `company` on the projection (schema doesn't carry them).
+- Auto-promoting projection PII off `order.buyer` (no buyer block on `Order` today).
+- Touching the destination provisioning path (PrestaShop customer create) — that already gets shipping name via `OrderCreate.shippingAddress`.
+
+## 4. Existing-code baseline
+
+| Path | Role today |
+|---|---|
+| `libs/core/src/customers/application/services/order-customer-projection-updater.service.ts` | Working impl for address projections only; never called in production. No interface (rule violation). |
+| `libs/core/src/customers/application/services/customer-projection.service.ts` | Wraps repo `upsert`; `OL_STORE_PII` filter applied at the service. No `find` method. |
+| `libs/core/src/customers/application/interfaces/customer-projection.service.interface.ts` | `ICustomerProjectionService` — three methods, no read. |
+| `libs/core/src/customers/customers.module.ts` | Registers updater as a class. Comment: "Export service class for direct injection". No DI token. |
+| `libs/core/src/customers/customers.tokens.ts` | Symbols for the other 3 services; **none for the updater**. |
+| `libs/core/src/customers/application/services/customer-identity-resolver.service.ts:251-261` | Hardcodes `firstName: null, lastName: null`. Will not change. |
+| `libs/core/src/orders/application/services/order-ingestion.service.ts:170-269` | Builds unified `Order` at :233, dispatches to `orderSyncService.syncOrder` at :236. **Insertion point: between :234 and :236.** |
+| `libs/core/src/orders/orders.module.ts:30,43` | Already imports `CustomersModule`. |
+| `apps/worker/src/sync/sync-worker.module.ts:44` | Imports `CustomersModule` "to access OrderCustomerProjectionUpdaterService" — cargo. Worker never injects it. Leaving as-is (module-level imports are cheap; removing is a separate cleanup). |
+
+## 5. Design
+
+### 5.1 Interface + token (Customers context)
+
+Bring the updater in line with project rules: every service implements an interface; cross-context injection uses a Symbol token.
+
+- New file `libs/core/src/customers/application/interfaces/order-customer-projection-updater.service.interface.ts`:
+  ```ts
+  export interface IOrderCustomerProjectionUpdaterService {
+    updateProjectionsForOrder(
+      order: Order,
+      internalCustomerId: string,
+      sourceConnectionId: string,
+    ): Promise<void>;
+  }
+  ```
+- Add `ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN = Symbol('IOrderCustomerProjectionUpdaterService')` to `customers.tokens.ts`.
+- Bind `useExisting: OrderCustomerProjectionUpdaterService` to the new token and **export the token** from `CustomersModule`. **Remove the now-dead class export.** Per the review, keeping it preserves a code path that has never been used. Engineering-standards.md "Service Interface Implementation" says services are accessed via their interface; with the token wired, that's the only access path.
+- Drop the worker's direct `CustomersModule` import at `apps/worker/src/sync/sync-worker.module.ts:44` (and its stale comment). The worker injects the updater transitively via `OrdersModule` (which already imports `CustomersModule` and is itself imported by the worker).
+
+### 5.2 `ICustomerProjectionService.getProjection(internalCustomerId)`
+
+The updater needs to read the existing projection to merge names without clobbering. Simplest dependency-correct path: extend the projection service (already injected into the updater) rather than adding a second collaborator. Implementation delegates to `repository.findById`.
+
+Add to `ICustomerProjectionService`:
+```ts
+getProjection(internalCustomerId: string): Promise<CustomerProjection | null>;
+```
+
+Implementation in `CustomerProjectionService`:
+```ts
+async getProjection(internalCustomerId: string): Promise<CustomerProjection | null> {
+  return this.repository.findById(internalCustomerId);
+}
+```
+
+### 5.3 `OrderCustomerProjectionUpdaterService` extension
+
+**Structure (post-review fix):** `updateProjectionsForOrder` becomes a thin orchestrator that calls two private helpers — `backfillCustomerNames` and `upsertAddresses`. Each helper owns its own short-circuiting; neither short-circuits the other. The address path stays exactly as it is today (just moved into a private method); the name-backfill path is new.
+
+```ts
+async updateProjectionsForOrder(order, internalCustomerId, sourceConnectionId): Promise<void> {
+  if (!internalCustomerId?.trim()) {
+    throw new CustomerProjectionException(...); // unchanged guard
+  }
+  await this.backfillCustomerNames(order, internalCustomerId, sourceConnectionId);
+  await this.upsertAddresses(order, internalCustomerId);
+}
+
+private async backfillCustomerNames(order, internalCustomerId, sourceConnectionId): Promise<void> {
+  const incomingFirst = trimToNull(order.shippingAddress?.firstName) ?? trimToNull(order.billingAddress?.firstName);
+  const incomingLast  = trimToNull(order.shippingAddress?.lastName)  ?? trimToNull(order.billingAddress?.lastName);
+
+  const existing = await this.customerProjectionService.getProjection(internalCustomerId);
+  if (!existing) {
+    this.logger.warn(
+      `No projection found for ${internalCustomerId} (connection: ${sourceConnectionId}); skipping name backfill`,
+    );
+    return; // skips ONLY the name backfill — addresses still run from updateProjectionsForOrder
+  }
+
+  const piiOn = getPiiConfig().storePii;
+  const mergedFirstName = piiOn ? (incomingFirst ?? existing.firstName) : null;
+  const mergedLastName  = piiOn ? (incomingLast  ?? existing.lastName)  : null;
+
+  const sameNames = mergedFirstName === existing.firstName && mergedLastName === existing.lastName;
+  const sameConn  = sourceConnectionId === existing.lastSourceConnectionId;
+  if (sameNames && sameConn) return;
+
+  await this.customerProjectionService.upsertProjection(
+    new CustomerProjection(
+      existing.internalCustomerId,
+      existing.emailHash,
+      existing.normalizedEmail,
+      mergedFirstName,
+      mergedLastName,
+      new Date(),                 // lastSeenAt
+      sourceConnectionId,
+      existing.createdAt,
+      new Date(),                 // updatedAt
+    ),
+  );
+}
+
+private async upsertAddresses(order, internalCustomerId): Promise<void> {
+  // exact body of today's address handling — extracted unchanged
+}
+```
+
+**Helper:**
+
+```ts
+const trimToNull = (v?: string | null): string | null => {
+  const t = v?.trim() ?? '';
+  return t === '' ? null : t;
+};
+```
+
+**Notes:**
+
+- **Why the structural split** (review BLOCKING fix): the original sketch used bare `return` inside one big function; that would have skipped the address path on the "no projection found" or "idempotent" branches and silently regressed the existing 6 address tests. With two helpers, each branch is local.
+- **Why the no-op skip is safe (lastSeenAt):** `customer-identity-resolver.service.ts:240-271` runs *earlier* in the ingestion pipeline (`order-ingestion.service.ts:188`) and already advances `lastSeenAt` on every order. So when names are unchanged we can safely skip the round-trip without leaving `lastSeenAt` stale.
+- **PII-off behavior is intentionally clobbering:** when `OL_STORE_PII=false`, `mergedFirstName/lastName` are forced to `null`. If the toggle ever flips `true → false` mid-stream, the next ingestion purges any previously-stored names. This matches `CustomerProjectionService.upsertProjection` (`customer-projection.service.ts:30-44`), which already nulls names on save in hash-only mode. Documented here so it's not flagged again in PR review.
+- **Read-modify-write race:** under truly concurrent ingestion of two orders for the same customer, last-write-wins. Same outcome as without the merge step. Not worth a transaction.
+- **Rename:** `_sourceConnectionId` (currently unused, underscore-prefixed) becomes `sourceConnectionId` — it's now consumed.
+
+### 5.4 Wiring into `OrderIngestionService`
+
+Add one constructor dep, one call:
+
+```ts
+constructor(
+  // …existing deps…
+  @Inject(ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN)
+  private readonly customerProjectionUpdater: IOrderCustomerProjectionUpdaterService,
+) {}
+
+// inside syncOrderFromSource, between persistOrder (line 234) and syncOrder (line 236):
+if (internalCustomerId) {
+  try {
+    await this.customerProjectionUpdater.updateProjectionsForOrder(order, internalCustomerId, connectionId);
+  } catch (error) {
+    this.logger.warn(
+      `Failed to update customer projections for order ${order.id} (customer: ${internalCustomerId}, connection: ${connectionId}): ${(error as Error).message}`,
+      error,
+    );
+    // swallow — projections are non-authoritative
+  }
+}
+```
+
+Position chosen per the issue: *before* the destination dispatch so a destination failure doesn't drop projection updates. The `try/catch` mirrors `customer-identity-resolver.service.ts:264-269`'s posture.
+
+### 5.5 Module wiring
+
+`customers.module.ts`:
+- Add token binding `{ provide: ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN, useExisting: OrderCustomerProjectionUpdaterService }`.
+- Export the token. **Drop `OrderCustomerProjectionUpdaterService` from `exports`** — see §5.1 for rationale.
+
+`orders.module.ts`: no change needed (already imports `CustomersModule`).
+
+`apps/worker/src/sync/sync-worker.module.ts`: drop the direct `CustomersModule` import + comment. The worker reaches `OrderCustomerProjectionUpdaterService` transitively through the `OrdersModule` it already imports.
+
+`libs/core/src/customers/index.ts`: barrel already re-exports `application/services/order-customer-projection-updater.service` and `customers.tokens`. Add a re-export for the new interface file: `export * from './application/interfaces/order-customer-projection-updater.service.interface'`.
+
+## 6. Step-by-step implementation
+
+| # | File | Action |
+|---|---|---|
+| 1 | `libs/core/src/customers/customers.tokens.ts` | Add `ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN` Symbol. |
+| 2 | `libs/core/src/customers/application/interfaces/order-customer-projection-updater.service.interface.ts` | Create new interface file. |
+| 3 | `libs/core/src/customers/application/interfaces/customer-projection.service.interface.ts` | Add `getProjection(internalCustomerId)` to `ICustomerProjectionService`. |
+| 4 | `libs/core/src/customers/application/services/customer-projection.service.ts` | Implement `getProjection`. |
+| 5 | `libs/core/src/customers/application/services/order-customer-projection-updater.service.ts` | Implement `IOrderCustomerProjectionUpdaterService`. Add name-backfill block. Use `sourceConnectionId` parameter. Add `Logger` field. Add `trimToNull` helper. |
+| 6 | `libs/core/src/customers/customers.module.ts` | Bind + export `ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN`. |
+| 7 | `libs/core/src/customers/index.ts` (barrel) | Re-export token + interface, if pattern matches the other tokens. |
+| 8 | `libs/core/src/orders/application/services/order-ingestion.service.ts` | Inject updater, call before `syncOrder`, wrap try/catch. |
+| 9 | `libs/core/src/customers/application/services/customer-projection.service.spec.ts` | Add `getProjection` happy + miss tests. |
+| 10 | `libs/core/src/customers/application/services/order-customer-projection-updater.service.spec.ts` | Add 6 cases (see §7). Existing address tests stay green; update mock to include `getProjection` returning a base projection. |
+| 11 | `libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts` | Add updater mock to constructor. Add tests for: updater called with correct args after `persistOrder`; updater error swallowed and `syncOrder` still called. |
+
+## 7. Test cases for the updater (additions)
+
+All operate on `backfillCustomerNames` behavior (observable via `upsertProjection` calls):
+
+1. `shippingAddress.firstName/lastName` set, `OL_STORE_PII=true`, existing projection has `null` names → `upsertProjection` called once with merged names.
+2. `shippingAddress` missing, `billingAddress` has names → falls back to billing.
+3. Neither address has names, existing projection ALSO has `null` names → `upsertProjection` NOT called (nothing to merge, no `lastSourceConnectionId` change either).
+4. Neither address has names, existing projection has `'Old'` names → preserved (no clobber, no upsert).
+5. Existing has `'Old'`, incoming is empty string `""` or `"   "` → `trimToNull` returns null, preserved as `'Old'` (no clobber, no upsert).
+6. Existing has `'Old'`, incoming has `'New'` → updated to `'New'`.
+7. `OL_STORE_PII=false`, existing has `'Old'` names → upsert called with `firstName: null, lastName: null` (intentional clobber, mirrors `CustomerProjectionService.upsertProjection` behavior).
+8. `getProjection` returns `null` → warn log emitted, no `upsertProjection` called, **address path still runs** (assert `upsertAddressProjection` is invoked normally for shipping/billing).
+9. Existing projection identical to incoming names AND same `lastSourceConnectionId` → no `upsertProjection` (idempotent skip).
+
+Existing 6 address-handling tests must continue to pass. Add `customerProjectionService.getProjection = jest.fn().mockResolvedValue(<base projection with null names>)` to the shared `beforeEach`. Test 8 specifically asserts the structural fix from §5.3 — address writes don't get short-circuited when name backfill bails.
+
+## 8. Risks / open questions
+
+- **Read-modify-write race**: addressed under §5.3. Acceptable LWW.
+- **`getProjection` round-trip cost per order**: ~1ms PG primary-key lookup. Negligible against the rest of ingestion.
+- **Backfill of existing 19 orders**: not in scope. User acknowledged "easier to just re-ingest" in dev.
+- **Worker module's dead `CustomersModule` import comment**: leaving as-is. Any cleanup is a separate PR.
+
+## 9. Quality gate
+
+```bash
+pnpm lint && pnpm type-check && pnpm test
+```
+
+No migrations. No `pnpm migration:show` needed.
+
+## 10. Acceptance (mirrors issue)
+
+- [ ] Customer detail shows buyer first/last name after one Allegro order with `shippingAddress.firstName/lastName`.
+- [ ] Customer detail shows ≥1 `'shipping'` address projection after one such order.
+- [ ] Two orders with identical shipping → one address row, `lastSeenAt` advances.
+- [ ] `OL_STORE_PII=false`: emailHash + addressHash present, names + address fields all `null`.
+- [ ] Projection-write failure does not break order sync.
+- [ ] No new dependency from Orders → Customers infrastructure (only on the new interface + token).
+- [ ] `pnpm lint && pnpm type-check && pnpm test` green.

--- a/libs/core/src/customers/application/interfaces/customer-projection.service.interface.ts
+++ b/libs/core/src/customers/application/interfaces/customer-projection.service.interface.ts
@@ -16,6 +16,15 @@ import { DestinationAddressMapping } from '../../domain/entities/destination-add
 
 export interface ICustomerProjectionService {
   /**
+   * Get customer projection by internal id, or null if missing.
+   *
+   * Used by callers that need to merge with existing projection state
+   * (e.g. backfilling names from an order without clobbering values that
+   * are already populated). Returns the domain entity, not the ORM row.
+   */
+  getProjection(internalCustomerId: string): Promise<CustomerProjection | null>;
+
+  /**
    * Upsert customer projection
    * Updates lastSeenAt and other fields if projection exists
    */

--- a/libs/core/src/customers/application/interfaces/order-customer-projection-updater.service.interface.ts
+++ b/libs/core/src/customers/application/interfaces/order-customer-projection-updater.service.interface.ts
@@ -1,0 +1,34 @@
+/**
+ * Order Customer Projection Updater Service Interface
+ *
+ * Defines the contract for syncing customer projection state from an ingested
+ * order: address projections (shipping / billing) and name backfill onto the
+ * customer projection itself. Implemented by OrderCustomerProjectionUpdaterService.
+ *
+ * @module libs/core/src/customers/application/interfaces
+ * @see {@link OrderCustomerProjectionUpdaterService} for the implementation
+ */
+import type { Order } from '@openlinker/core/orders';
+
+export interface IOrderCustomerProjectionUpdaterService {
+  /**
+   * Update customer + address projections from an ingested order.
+   *
+   * - Backfills `firstName` / `lastName` on the customer projection from
+   *   `order.shippingAddress` (fallback to `order.billingAddress`), without
+   *   clobbering already-set names with `null`.
+   * - Upserts shipping + billing address projections.
+   * - Honours `OL_STORE_PII`: hash-only mode forces names + address fields to `null`.
+   *
+   * Designed to be called best-effort from the order ingestion pipeline; the
+   * caller wraps in try/catch and never lets a projection failure block order sync.
+   */
+  updateProjectionsForOrder(
+    order: Order,
+    internalCustomerId: string,
+    sourceConnectionId: string,
+  ): Promise<void>;
+}
+
+// Re-export token for convenience
+export { ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN } from '../../customers.tokens';

--- a/libs/core/src/customers/application/services/customer-projection.service.spec.ts
+++ b/libs/core/src/customers/application/services/customer-projection.service.spec.ts
@@ -28,6 +28,7 @@ describe('CustomerProjectionService', () => {
       upsert: jest.fn(),
       upsertAddress: jest.fn(),
       upsertDestinationAddressMapping: jest.fn(),
+      findById: jest.fn(),
       findByEmailHash: jest.fn(),
       findDestinationAddressMapping: jest.fn(),
     } as unknown as jest.Mocked<CustomerProjectionRepositoryPort>;
@@ -57,6 +58,37 @@ describe('CustomerProjectionService', () => {
     } else {
       delete process.env.OL_PII_HASH_SALT;
     }
+  });
+
+  describe('getProjection', () => {
+    it('should return the domain projection when the repository finds a row', async () => {
+      const projection = new CustomerProjection(
+        'internal-customer-123',
+        'emailHash123',
+        'customer@example.com',
+        'John',
+        'Doe',
+        new Date(),
+        'connection-456',
+        new Date(),
+        new Date(),
+      );
+      repository.findById.mockResolvedValue(projection);
+
+      const result = await service.getProjection('internal-customer-123');
+
+      expect(result).toBe(projection);
+      expect(repository.findById).toHaveBeenCalledWith('internal-customer-123');
+    });
+
+    it('should return null when no projection exists', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      const result = await service.getProjection('internal-customer-missing');
+
+      expect(result).toBeNull();
+      expect(repository.findById).toHaveBeenCalledWith('internal-customer-missing');
+    });
   });
 
   describe('upsertProjection - PII enabled', () => {

--- a/libs/core/src/customers/application/services/customer-projection.service.ts
+++ b/libs/core/src/customers/application/services/customer-projection.service.ts
@@ -27,6 +27,10 @@ export class CustomerProjectionService implements ICustomerProjectionService {
     private readonly repository: CustomerProjectionRepositoryPort,
   ) {}
 
+  async getProjection(internalCustomerId: string): Promise<CustomerProjection | null> {
+    return this.repository.findById(internalCustomerId);
+  }
+
   async upsertProjection(projection: CustomerProjection): Promise<CustomerProjection> {
     // If PII storage is disabled, clear PII fields but keep emailHash
     const projectionToSave = this.piiConfig.storePii

--- a/libs/core/src/customers/application/services/order-customer-projection-updater.service.spec.ts
+++ b/libs/core/src/customers/application/services/order-customer-projection-updater.service.spec.ts
@@ -11,6 +11,7 @@ import { OrderCustomerProjectionUpdaterService } from './order-customer-projecti
 import { ICustomerProjectionService } from '../interfaces/customer-projection.service.interface';
 import { Order } from '@openlinker/core/orders';
 import { CUSTOMER_PROJECTION_SERVICE_TOKEN } from '../interfaces/customer-projection.service.interface';
+import { CustomerProjection } from '../../domain/entities/customer-projection.entity';
 import { CustomerAddressProjection } from '../../domain/entities/customer-address-projection.entity';
 
 describe('OrderCustomerProjectionUpdaterService', () => {
@@ -24,6 +25,19 @@ describe('OrderCustomerProjectionUpdaterService', () => {
     // Set required environment variable for PII config
     process.env.OL_PII_HASH_SALT = 'test-salt-for-hashing';
     customerProjectionService = {
+      getProjection: jest.fn().mockResolvedValue(
+        new CustomerProjection(
+          'internal-customer-456',
+          'emailHash-test',
+          null, // normalizedEmail
+          null, // firstName — base case: identity-resolver wrote a names-null projection
+          null, // lastName
+          new Date(),
+          'connection-123',
+          new Date(),
+          new Date(),
+        ),
+      ),
       upsertProjection: jest.fn(),
       upsertAddressProjection: jest.fn(),
       upsertDestinationAddressMapping: jest.fn(),
@@ -280,6 +294,229 @@ describe('OrderCustomerProjectionUpdaterService', () => {
       const billingHash = (customerProjectionService.upsertAddressProjection.mock.calls[1][0]).addressHash;
 
       expect(shippingHash).not.toBe(billingHash);
+    });
+  });
+
+  describe('Customer name backfill', () => {
+    type ProjectionOverrides = {
+      firstName?: string | null;
+      lastName?: string | null;
+      lastSourceConnectionId?: string | null;
+    };
+
+    const baseProjection = (overrides: ProjectionOverrides = {}): CustomerProjection =>
+      new CustomerProjection(
+        'internal-customer-456',
+        'emailHash-test',
+        null, // normalizedEmail
+        'firstName' in overrides ? overrides.firstName ?? null : null,
+        'lastName' in overrides ? overrides.lastName ?? null : null,
+        new Date('2026-04-30T00:00:00Z'),
+        'lastSourceConnectionId' in overrides
+          ? overrides.lastSourceConnectionId ?? null
+          : 'connection-123',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-30T00:00:00Z'),
+      );
+
+    beforeEach(() => {
+      process.env.OL_STORE_PII = 'true';
+    });
+
+    it('upserts projection with merged names when shipping has firstName/lastName and existing has nulls', async () => {
+      customerProjectionService.getProjection.mockResolvedValue(
+        baseProjection({ firstName: null, lastName: null }),
+      );
+      const order = createOrder({
+        shippingAddress: {
+          address1: '123 Main St',
+          city: 'Warsaw',
+          postalCode: '00-001',
+          country: 'PL',
+          firstName: 'Piotr',
+          lastName: 'Swierzy',
+        },
+      });
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      expect(customerProjectionService.upsertProjection).toHaveBeenCalledTimes(1);
+      const written = customerProjectionService.upsertProjection.mock.calls[0][0];
+      expect(written.firstName).toBe('Piotr');
+      expect(written.lastName).toBe('Swierzy');
+      expect(written.lastSourceConnectionId).toBe('connection-123');
+      expect(written.emailHash).toBe('emailHash-test'); // preserved
+    });
+
+    it('falls back to billing address names when shipping is missing them', async () => {
+      customerProjectionService.getProjection.mockResolvedValue(baseProjection());
+      const order = createOrder({
+        shippingAddress: {
+          address1: '123 Main St',
+          city: 'Warsaw',
+          postalCode: '00-001',
+          country: 'PL',
+          // no firstName/lastName
+        },
+        billingAddress: {
+          address1: '456 Billing St',
+          city: 'Krakow',
+          postalCode: '30-001',
+          country: 'PL',
+          firstName: 'Anna',
+          lastName: 'Kowalska',
+        },
+      });
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      expect(customerProjectionService.upsertProjection).toHaveBeenCalledTimes(1);
+      const written = customerProjectionService.upsertProjection.mock.calls[0][0];
+      expect(written.firstName).toBe('Anna');
+      expect(written.lastName).toBe('Kowalska');
+    });
+
+    it('does not call upsertProjection when neither address has names and existing names are also null', async () => {
+      customerProjectionService.getProjection.mockResolvedValue(baseProjection());
+      const order = createOrder({
+        shippingAddress: {
+          address1: '123 Main St',
+          city: 'Warsaw',
+          postalCode: '00-001',
+          country: 'PL',
+        },
+        billingAddress: undefined,
+      });
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      expect(customerProjectionService.upsertProjection).not.toHaveBeenCalled();
+    });
+
+    it('preserves existing names when neither address has names (no clobber to null)', async () => {
+      customerProjectionService.getProjection.mockResolvedValue(
+        baseProjection({ firstName: 'Old', lastName: 'Name' }),
+      );
+      const order = createOrder({
+        shippingAddress: {
+          address1: '123 Main St',
+          city: 'Warsaw',
+          postalCode: '00-001',
+          country: 'PL',
+        },
+        billingAddress: undefined,
+      });
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      // sameNames === true, sameConn === true → idempotent skip
+      expect(customerProjectionService.upsertProjection).not.toHaveBeenCalled();
+    });
+
+    it('treats whitespace-only and empty-string incoming names as null (no clobber)', async () => {
+      customerProjectionService.getProjection.mockResolvedValue(
+        baseProjection({ firstName: 'Old', lastName: 'Name' }),
+      );
+      const order = createOrder({
+        shippingAddress: {
+          address1: '123 Main St',
+          city: 'Warsaw',
+          postalCode: '00-001',
+          country: 'PL',
+          firstName: '   ',
+          lastName: '',
+        },
+        billingAddress: undefined,
+      });
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      expect(customerProjectionService.upsertProjection).not.toHaveBeenCalled();
+    });
+
+    it('updates names when incoming differs from existing', async () => {
+      customerProjectionService.getProjection.mockResolvedValue(
+        baseProjection({ firstName: 'Old', lastName: 'Name' }),
+      );
+      const order = createOrder({
+        shippingAddress: {
+          address1: '123 Main St',
+          city: 'Warsaw',
+          postalCode: '00-001',
+          country: 'PL',
+          firstName: 'New',
+          lastName: 'Name',
+        },
+      });
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      expect(customerProjectionService.upsertProjection).toHaveBeenCalledTimes(1);
+      const written = customerProjectionService.upsertProjection.mock.calls[0][0];
+      expect(written.firstName).toBe('New');
+      expect(written.lastName).toBe('Name');
+    });
+
+    it('forces names to null when OL_STORE_PII=false (intentional clobber)', async () => {
+      process.env.OL_STORE_PII = 'false';
+      customerProjectionService.getProjection.mockResolvedValue(
+        baseProjection({ firstName: 'Old', lastName: 'Name' }),
+      );
+      const order = createOrder({
+        shippingAddress: {
+          address1: '123 Main St',
+          city: 'Warsaw',
+          postalCode: '00-001',
+          country: 'PL',
+          firstName: 'New',
+          lastName: 'Name',
+        },
+      });
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      expect(customerProjectionService.upsertProjection).toHaveBeenCalledTimes(1);
+      const written = customerProjectionService.upsertProjection.mock.calls[0][0];
+      expect(written.firstName).toBeNull();
+      expect(written.lastName).toBeNull();
+    });
+
+    it('skips name backfill but still runs address projections when getProjection returns null', async () => {
+      customerProjectionService.getProjection.mockResolvedValue(null);
+      const order = createOrder(); // shipping + billing both populated
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      // No upsertProjection call (no projection to merge into)
+      expect(customerProjectionService.upsertProjection).not.toHaveBeenCalled();
+      // BUT addresses still get written — this is the structural fix
+      expect(customerProjectionService.upsertAddressProjection).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips upsert when names match existing AND lastSourceConnectionId matches (idempotent)', async () => {
+      customerProjectionService.getProjection.mockResolvedValue(
+        baseProjection({
+          firstName: 'Piotr',
+          lastName: 'Swierzy',
+          lastSourceConnectionId: 'connection-123',
+        }),
+      );
+      const order = createOrder({
+        shippingAddress: {
+          address1: '123 Main St',
+          city: 'Warsaw',
+          postalCode: '00-001',
+          country: 'PL',
+          firstName: 'Piotr',
+          lastName: 'Swierzy',
+        },
+      });
+
+      await service.updateProjectionsForOrder(order, 'internal-customer-456', 'connection-123');
+
+      expect(customerProjectionService.upsertProjection).not.toHaveBeenCalled();
+      // Addresses still upserted as a separate concern
+      expect(customerProjectionService.upsertAddressProjection).toHaveBeenCalled();
     });
   });
 });

--- a/libs/core/src/customers/application/services/order-customer-projection-updater.service.ts
+++ b/libs/core/src/customers/application/services/order-customer-projection-updater.service.ts
@@ -1,50 +1,58 @@
 /**
  * Order Customer Projection Updater Service
  *
- * Service for updating customer projections from order data. Extracts customer
- * and address information from orders and updates projections accordingly.
- * Handles PII toggle logic and ensures projections are kept in sync with order data.
+ * Syncs customer projection state from an ingested order:
+ *  - backfills `firstName` / `lastName` on the customer projection from
+ *    `order.shippingAddress` (fallback `order.billingAddress`), without
+ *    clobbering already-set names with `null`;
+ *  - upserts shipping + billing address projections.
+ *
+ * Honours `OL_STORE_PII`: hash-only mode forces names + address fields to
+ * `null` (matches `CustomerProjectionService.upsertProjection`).
  *
  * @module libs/core/src/customers/application/services
+ * @implements {IOrderCustomerProjectionUpdaterService}
  */
 import { Injectable, Inject } from '@nestjs/common';
-import { Order } from '@openlinker/core/orders';
-import { ICustomerProjectionService, CUSTOMER_PROJECTION_SERVICE_TOKEN } from '../interfaces/customer-projection.service.interface';
+import type { Order } from '@openlinker/core/orders';
+import { Logger } from '@openlinker/shared/logging';
+import { getPiiConfig, hashAddress, normalizeAddress } from '@openlinker/shared/config';
+import {
+  ICustomerProjectionService,
+  CUSTOMER_PROJECTION_SERVICE_TOKEN,
+} from '../interfaces/customer-projection.service.interface';
+import { IOrderCustomerProjectionUpdaterService } from '../interfaces/order-customer-projection-updater.service.interface';
+import { CustomerProjection } from '../../domain/entities/customer-projection.entity';
 import { CustomerAddressProjection } from '../../domain/entities/customer-address-projection.entity';
 import { CustomerProjectionException } from '../../domain/exceptions/customer-projection.exception';
-import { getPiiConfig } from '@openlinker/shared/config';
-import { hashAddress, normalizeAddress } from '@openlinker/shared/config';
 
 /**
- * Order Customer Projection Updater Service
+ * Returns a trimmed string, or `null` for `undefined` / `null` / empty / whitespace-only input.
  *
- * Updates customer projections from order data. Extracts customer information
- * (email, name) and address information (shipping, billing) from orders and
- * updates projections accordingly.
+ * Allegro occasionally ships `""` for first/last name fields on guest orders;
+ * we never want to write those into the projection as a non-null value.
  */
+function trimToNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? '';
+  return trimmed === '' ? null : trimmed;
+}
+
 @Injectable()
-export class OrderCustomerProjectionUpdaterService {
+export class OrderCustomerProjectionUpdaterService
+  implements IOrderCustomerProjectionUpdaterService
+{
+  private readonly logger = new Logger(OrderCustomerProjectionUpdaterService.name);
+
   constructor(
     @Inject(CUSTOMER_PROJECTION_SERVICE_TOKEN)
     private readonly customerProjectionService: ICustomerProjectionService,
   ) {}
 
-  /**
-   * Update customer projections for an order
-   *
-   * Extracts customer and address data from the order and updates projections.
-   * Handles PII toggle logic: if PII storage is disabled, only hashes are stored.
-   *
-   * @param order - Unified order with internal IDs
-   * @param internalCustomerId - Internal customer ID (from identity resolution)
-   * @param sourceConnectionId - Source connection ID (where order originated)
-   */
   async updateProjectionsForOrder(
     order: Order,
     internalCustomerId: string,
-    _sourceConnectionId: string,
+    sourceConnectionId: string,
   ): Promise<void> {
-    // Validate customer ID
     if (!internalCustomerId || internalCustomerId.trim() === '') {
       throw new CustomerProjectionException(
         'Internal customer ID is required for projection updates',
@@ -53,13 +61,80 @@ export class OrderCustomerProjectionUpdaterService {
       );
     }
 
+    // Two independent steps. Each owns its own short-circuiting; one failing or
+    // bailing must NOT prevent the other from running.
+    await this.backfillCustomerNames(order, internalCustomerId, sourceConnectionId);
+    await this.upsertAddresses(order, internalCustomerId);
+  }
+
+  /**
+   * Backfill firstName / lastName onto the customer projection from the order's
+   * shipping (fallback billing) address.
+   *
+   * Non-clobbering merge: incoming `null` never overwrites an existing name —
+   * `incoming ?? existing`. PII-off mode (`OL_STORE_PII=false`) forces both
+   * fields to `null`, intentionally clobbering any previously-stored values
+   * (matches `CustomerProjectionService.upsertProjection`'s hash-only behaviour).
+   *
+   * Skips the round-trip when names + lastSourceConnectionId are unchanged.
+   * `lastSeenAt` staleness is handled by `CustomerIdentityResolverService`,
+   * which writes the projection earlier in the ingestion pipeline on every order.
+   */
+  private async backfillCustomerNames(
+    order: Order,
+    internalCustomerId: string,
+    sourceConnectionId: string,
+  ): Promise<void> {
+    const incomingFirst =
+      trimToNull(order.shippingAddress?.firstName) ?? trimToNull(order.billingAddress?.firstName);
+    const incomingLast =
+      trimToNull(order.shippingAddress?.lastName) ?? trimToNull(order.billingAddress?.lastName);
+
+    const existing = await this.customerProjectionService.getProjection(internalCustomerId);
+    if (!existing) {
+      this.logger.warn(
+        `No customer projection found for ${internalCustomerId} (connection: ${sourceConnectionId}); skipping name backfill`,
+      );
+      return;
+    }
+
+    const piiOn = getPiiConfig().storePii;
+    const mergedFirstName = piiOn ? incomingFirst ?? existing.firstName : null;
+    const mergedLastName = piiOn ? incomingLast ?? existing.lastName : null;
+
+    const sameNames =
+      mergedFirstName === existing.firstName && mergedLastName === existing.lastName;
+    const sameConn = sourceConnectionId === existing.lastSourceConnectionId;
+    if (sameNames && sameConn) return;
+
+    const now = new Date();
+    await this.customerProjectionService.upsertProjection(
+      new CustomerProjection(
+        existing.internalCustomerId,
+        existing.emailHash,
+        existing.normalizedEmail,
+        mergedFirstName,
+        mergedLastName,
+        now,
+        sourceConnectionId,
+        existing.createdAt,
+        now,
+      ),
+    );
+  }
+
+  /**
+   * Upsert shipping + billing address projections.
+   *
+   * Billing is skipped when its hash matches shipping's (the common case —
+   * buyers typically reuse the same address for both). Hashing is done on the
+   * normalized address regardless of PII mode; PII fields are only written when
+   * `OL_STORE_PII=true`.
+   */
+  private async upsertAddresses(order: Order, internalCustomerId: string): Promise<void> {
     const piiConfig = getPiiConfig();
     const now = new Date();
 
-    // Note: Customer projection (email, name) should be updated during identity resolution.
-    // This service focuses on address projections from order data.
-
-    // Calculate shipping address hash once (reused for billing comparison)
     let shippingHash: string | null = null;
     if (order.shippingAddress) {
       const normalizedAddress = normalizeAddress({
@@ -77,19 +152,18 @@ export class OrderCustomerProjectionUpdaterService {
         shippingHash,
         'shipping',
         piiConfig.storePii ? normalizedAddress.address1 : null,
-        piiConfig.storePii ? (normalizedAddress.address2 ?? null) : null,
+        piiConfig.storePii ? normalizedAddress.address2 ?? null : null,
         piiConfig.storePii ? normalizedAddress.city : null,
-        piiConfig.storePii ? (normalizedAddress.postcode ?? null) : null,
+        piiConfig.storePii ? normalizedAddress.postcode ?? null : null,
         piiConfig.storePii ? normalizedAddress.countryIso2 : null,
-        now, // lastSeenAt
-        now, // createdAt
-        now, // updatedAt
+        now,
+        now,
+        now,
       );
 
       await this.customerProjectionService.upsertAddressProjection(shippingAddressProjection);
     }
 
-    // Update billing address projection (if different from shipping)
     if (order.billingAddress) {
       const normalizedAddress = normalizeAddress({
         address1: order.billingAddress.address1,
@@ -101,20 +175,19 @@ export class OrderCustomerProjectionUpdaterService {
 
       const addressHash = hashAddress(normalizedAddress);
 
-      // Only create billing projection if it's different from shipping
       if (addressHash !== shippingHash) {
         const billingAddressProjection = new CustomerAddressProjection(
           internalCustomerId,
           addressHash,
           'billing',
           piiConfig.storePii ? normalizedAddress.address1 : null,
-          piiConfig.storePii ? (normalizedAddress.address2 ?? null) : null,
+          piiConfig.storePii ? normalizedAddress.address2 ?? null : null,
           piiConfig.storePii ? normalizedAddress.city : null,
-          piiConfig.storePii ? (normalizedAddress.postcode ?? null) : null,
+          piiConfig.storePii ? normalizedAddress.postcode ?? null : null,
           piiConfig.storePii ? normalizedAddress.countryIso2 : null,
-          now, // lastSeenAt
-          now, // createdAt
-          now, // updatedAt
+          now,
+          now,
+          now,
         );
 
         await this.customerProjectionService.upsertAddressProjection(billingAddressProjection);

--- a/libs/core/src/customers/customers.module.ts
+++ b/libs/core/src/customers/customers.module.ts
@@ -21,6 +21,7 @@ import {
   CUSTOMER_PROJECTION_SERVICE_TOKEN,
   CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN,
   CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN,
+  ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN,
 } from './customers.tokens';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 
@@ -56,13 +57,17 @@ import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
       provide: CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN,
       useExisting: CustomerIdentityResolverService,
     },
+    {
+      provide: ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN,
+      useExisting: OrderCustomerProjectionUpdaterService,
+    },
   ],
   exports: [
-    OrderCustomerProjectionUpdaterService, // Export service class for direct injection
     CUSTOMER_PROJECTION_REPOSITORY_TOKEN,
     CUSTOMER_PROJECTION_SERVICE_TOKEN,
     CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN,
     CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN,
+    ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN,
   ],
 })
 export class CustomersModule {}

--- a/libs/core/src/customers/customers.tokens.ts
+++ b/libs/core/src/customers/customers.tokens.ts
@@ -13,3 +13,6 @@ export const CUSTOMER_PROJECTION_REPOSITORY_TOKEN = Symbol('CustomerProjectionRe
 export const CUSTOMER_PROJECTION_SERVICE_TOKEN = Symbol('ICustomerProjectionService');
 export const CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN = Symbol('ICustomerIdentityResolverService');
 export const CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN = Symbol('CustomerIdentityResolverPort');
+export const ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN = Symbol(
+  'IOrderCustomerProjectionUpdaterService',
+);

--- a/libs/core/src/customers/index.ts
+++ b/libs/core/src/customers/index.ts
@@ -18,6 +18,7 @@ export * from './application/interfaces/customer-identity-resolver.service.inter
 export * from './application/services/customer-identity-resolver.service';
 export * from './application/interfaces/customer-projection.service.interface';
 export * from './application/services/customer-projection.service';
+export * from './application/interfaces/order-customer-projection-updater.service.interface';
 export * from './application/services/order-customer-projection-updater.service';
 export * from './customers.tokens';
 export * from './customers.module';

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -15,7 +15,10 @@ import {
   SyncLockPort,
 } from '@openlinker/core/sync';
 import { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
-import { ICustomerIdentityResolverService } from '@openlinker/core/customers';
+import {
+  ICustomerIdentityResolverService,
+  IOrderCustomerProjectionUpdaterService,
+} from '@openlinker/core/customers';
 import { IOrderSyncService } from '../../interfaces/order-sync.service.interface';
 import { IOrderRecordService } from '../../interfaces/order-record.service.interface';
 import { OrderItemRefResolverService } from '../order-item-ref-resolver.service';
@@ -34,6 +37,7 @@ describe('OrderIngestionService', () => {
   let orderSource: jest.Mocked<OrderSourcePort>;
   let orderItemRefResolver: jest.Mocked<OrderItemRefResolverService>;
   let customerIdentityResolver: jest.Mocked<ICustomerIdentityResolverService>;
+  let customerProjectionUpdater: jest.Mocked<IOrderCustomerProjectionUpdaterService>;
 
   const connectionId = 'connection-123';
   const cursorKey = 'allegro.orders.lastEventId';
@@ -100,6 +104,10 @@ describe('OrderIngestionService', () => {
       }),
     } as unknown as jest.Mocked<ICustomerIdentityResolverService>;
 
+    customerProjectionUpdater = {
+      updateProjectionsForOrder: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<IOrderCustomerProjectionUpdaterService>;
+
     service = new OrderIngestionService(
       integrationsService,
       cursorRepository,
@@ -110,6 +118,7 @@ describe('OrderIngestionService', () => {
       orderSyncService,
       customerIdentityResolver,
       orderRecordService,
+      customerProjectionUpdater,
     );
   });
 
@@ -329,6 +338,65 @@ describe('OrderIngestionService', () => {
         'Failed to update order record sync status',
         expect.any(Error),
       );
+    });
+
+    it('should call customerProjectionUpdater after persistOrder and before syncOrder when internalCustomerId is resolved', async () => {
+      orderSyncService.syncOrder.mockResolvedValue([]);
+      orderSource.getOrder.mockResolvedValueOnce({
+        ...baseIncoming,
+        customerExternalId: 'buyer-ext-1',
+        customerEmail: 'buyer@example.com',
+      });
+      identifierMapping.getOrCreateInternalId.mockResolvedValue('ol_order_test');
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(customerProjectionUpdater.updateProjectionsForOrder).toHaveBeenCalledTimes(1);
+      expect(customerProjectionUpdater.updateProjectionsForOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'ol_order_test' }),
+        'ol_customer_test',
+        connectionId,
+      );
+      // Order: persistOrder → updateProjectionsForOrder → syncOrder
+      expect(orderRecordService.persistOrder.mock.invocationCallOrder[0]).toBeLessThan(
+        customerProjectionUpdater.updateProjectionsForOrder.mock.invocationCallOrder[0],
+      );
+      expect(
+        customerProjectionUpdater.updateProjectionsForOrder.mock.invocationCallOrder[0],
+      ).toBeLessThan(orderSyncService.syncOrder.mock.invocationCallOrder[0]);
+    });
+
+    it('should swallow errors from customerProjectionUpdater and still call syncOrder', async () => {
+      const warnSpy = jest.spyOn(service['logger'], 'warn');
+      orderSyncService.syncOrder.mockResolvedValue([]);
+      orderSource.getOrder.mockResolvedValueOnce({
+        ...baseIncoming,
+        customerExternalId: 'buyer-ext-1',
+        customerEmail: 'buyer@example.com',
+      });
+      customerProjectionUpdater.updateProjectionsForOrder.mockRejectedValueOnce(
+        new Error('projection write failed'),
+      );
+
+      await expect(
+        service.syncOrderFromSource(connectionId, externalOrderId),
+      ).resolves.not.toThrow();
+
+      expect(orderSyncService.syncOrder).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to update customer projections'),
+        expect.any(Error),
+      );
+    });
+
+    it('should skip customerProjectionUpdater when internalCustomerId is not resolved', async () => {
+      orderSyncService.syncOrder.mockResolvedValue([]);
+      orderSource.getOrder.mockResolvedValueOnce(baseIncoming); // no buyer info → no resolution call
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(customerProjectionUpdater.updateProjectionsForOrder).not.toHaveBeenCalled();
+      expect(orderSyncService.syncOrder).toHaveBeenCalled();
     });
   });
 

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -30,6 +30,8 @@ import {
 import {
   ICustomerIdentityResolverService,
   CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN,
+  IOrderCustomerProjectionUpdaterService,
+  ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN,
 } from '@openlinker/core/customers';
 import { IOrderSyncService } from '../interfaces/order-sync.service.interface';
 import {
@@ -70,6 +72,8 @@ export class OrderIngestionService implements IOrderIngestionService {
     private readonly customerIdentityResolver: ICustomerIdentityResolverService,
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
     private readonly orderRecordService: IOrderRecordService,
+    @Inject(ORDER_CUSTOMER_PROJECTION_UPDATER_SERVICE_TOKEN)
+    private readonly customerProjectionUpdater: IOrderCustomerProjectionUpdaterService,
   ) {}
 
   async ingestOrders(
@@ -232,6 +236,24 @@ export class OrderIngestionService implements IOrderIngestionService {
     // Step 5: all items resolved — build unified order and upsert with recordStatus='ready'
     const order = this.buildUnifiedOrder(incoming, internalOrderId, internalCustomerId, resolvedItems);
     await this.orderRecordService.persistOrder(order, connectionId, sourceEventId ?? null);
+
+    // Step 6: best-effort customer-projection sync. Runs before destination dispatch so
+    // a destination failure can't drop projection updates. Failure here is swallowed —
+    // projections are non-authoritative and must never block order sync.
+    if (internalCustomerId) {
+      try {
+        await this.customerProjectionUpdater.updateProjectionsForOrder(
+          order,
+          internalCustomerId,
+          connectionId,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to update customer projections for order ${order.id} (customer: ${internalCustomerId}, connection: ${connectionId}): ${(error as Error).message}`,
+          error,
+        );
+      }
+    }
 
     const results = await this.orderSyncService.syncOrder({
       order,


### PR DESCRIPTION
## Summary

Customer detail page showed **"Unknown name"** + **"No addresses"** even after the customer had 19 successfully synced orders. Two distinct bugs, single underlying cause.

- **No address projections**: `OrderCustomerProjectionUpdaterService` was registered in `CustomersModule` and imported by the worker (with a misleading "to access…" comment) but **never actually called** from production code. Three production references in the whole codebase, all wiring; no consumer.
- **"Unknown name"**: identity resolver hardcoded `firstName: null, lastName: null` with the comment *"not available during identity resolution"* — true at that point in the pipeline, but no later step backfilled from the order's shipping/billing address.

Both fixes converge on the same hook point: `OrderIngestionService.syncOrderFromSource`, between `persistOrder` and `syncOrder`.

## What changed

- **New `IOrderCustomerProjectionUpdaterService` interface + Symbol token** — brings the existing service in line with the engineering-standards rule that every service implements an interface and crosses contexts via a token. The service was the only one in `libs/core/src/customers/` missing both.
- **Extended `ICustomerProjectionService`** with `getProjection(internalCustomerId)` so the updater can read existing projection state before merging — needed for the non-clobbering name backfill.
- **Restructured the updater into two private steps** — `backfillCustomerNames` and `upsertAddresses`, orchestrated by `updateProjectionsForOrder`. Each step short-circuits independently; one bailing must not skip the other (specifically pinned by a regression test that mocks `getProjection: null` and asserts addresses still get written).
- **Name-backfill semantics**:
  - Source: `order.shippingAddress.firstName/lastName`, fallback to `order.billingAddress`.
  - `trimToNull()` guards against Allegro's `""` names on guest orders.
  - Merge is `incoming ?? existing` — a missing incoming name never clobbers a stored one.
  - Idempotent skip when names + `lastSourceConnectionId` are unchanged. Safe because `lastSeenAt` is already advanced by the identity resolver earlier in the pipeline.
  - `OL_STORE_PII=false` forces names to `null`, intentionally clobbering — matches the existing hash-only behaviour in `CustomerProjectionService.upsertProjection`.
- **Wired into ingestion** in a `try/catch` that warn-logs and swallows failures. Projections are non-authoritative and must never block order sync. Includes `internalCustomerId` + `connectionId` in the log line for triage.
- **Cleanup**: dropped the dead class export from `CustomersModule` (the token is now the only access path) and the redundant `CustomersModule` import from the worker module — the worker reaches the updater transitively via `OrdersModule`.

## Why this hook point

Position is between `persistOrder` (line 234) and `syncOrder` (line 236). Running before destination dispatch means a destination failure can't drop projection updates. Running after `persistOrder` means the unified `Order` is fully built before the projection step looks at addresses.

## Out of scope

- **Backfilling existing 19 orders** — forward-only fix. Re-ingest in dev to populate projections.
- **Resolver-side name resolution** — the hardcoded `null` in `customer-identity-resolver.service.ts:255-256` stays. Names truly aren't available at identity resolution time; pushing them earlier would couple identity resolution to address parsing.
- **`phone` / `company` on the projection** — schema doesn't carry those.

## Test plan

- [x] `pnpm lint` (zero errors)
- [x] `pnpm type-check` (clean)
- [x] `pnpm test` — 2156 unit tests across 8 packages, all green
- [x] Regression test pins the structural fix (`getProjection: null` → addresses still run)
- [x] PII-on / PII-off both covered explicitly
- [x] Idempotent skip covered
- [x] Whitespace-only / empty-string clobber guard covered
- [ ] **Manual verification on dev**: re-ingest an Allegro sandbox order with named shipping address → customer detail shows the buyer's first/last name and ≥1 `'shipping'` address row

## Files

13 files changed, 768 insertions, 44 deletions.

| Area | Files |
|---|---|
| Customers (new interface + token) | `customers.tokens.ts`, `application/interfaces/order-customer-projection-updater.service.interface.ts`, `customers.module.ts`, `index.ts` |
| Customers (service changes) | `customer-projection.service.{interface.ts,ts,spec.ts}`, `order-customer-projection-updater.service.{ts,spec.ts}` |
| Orders (call site) | `order-ingestion.service.ts`, `__tests__/order-ingestion.service.spec.ts` |
| Worker (cleanup) | `apps/worker/src/sync/sync-worker.module.ts` |
| Plan | `docs/plans/implementation-plan-customer-projection-wiring.md` |

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)