### PR TITLE
feat(web): translate misleading Allegro error codes into actionable operator messages

### DIFF
--- a/apps/web/src/features/listings/components/OfferCreationErrorList.test.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationErrorList.test.tsx
@@ -55,4 +55,42 @@ describe('OfferCreationErrorList', () => {
     const list = screen.getByRole('list', { name: /offer creation errors/i });
     expect(list.querySelectorAll('li')).toHaveLength(2);
   });
+
+  describe('Allegro friendly-message allowlist (#448)', () => {
+    it('renders the friendly message for mapped codes and keeps the raw message in a collapsed <details>', () => {
+      const errors: OfferCreationError[] = [
+        {
+          code: 'SAFETY_INFO_NOT_DEFINED',
+          message: 'Safety information was not defined for product',
+        },
+      ];
+      render(<OfferCreationErrorList errors={errors} />);
+
+      // Primary message slot now carries the friendly text.
+      expect(
+        screen.getByText(/verify the discriminator/i),
+      ).toBeInTheDocument();
+      // Code badge remains visible for grep / debugging.
+      expect(screen.getByText('SAFETY_INFO_NOT_DEFINED')).toBeInTheDocument();
+      // Raw message is rendered inside a <details>, collapsed by default.
+      const details = screen.getByText(/Allegro's original message/i).closest('details');
+      expect(details).not.toBeNull();
+      expect(details).not.toHaveAttribute('open');
+      expect(
+        screen.getByText('Safety information was not defined for product'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render the <details> block for unmapped codes (existing behaviour preserved)', () => {
+      const errors: OfferCreationError[] = [
+        { field: 'parameters.EAN', code: 'MISSING_EAN', message: 'EAN is required.' },
+      ];
+      render(<OfferCreationErrorList errors={errors} />);
+
+      // Allegro's raw message is the only message rendered.
+      expect(screen.getByText('EAN is required.')).toBeInTheDocument();
+      // No <details> block means no "Allegro's original message" summary.
+      expect(screen.queryByText(/Allegro's original message/i)).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/features/listings/components/OfferCreationErrorList.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationErrorList.tsx
@@ -5,10 +5,17 @@
  * OfferCreationRecord. Field paths (e.g. `parameters.EAN`) render in
  * monospace so they stand out from the human-readable message.
  *
+ * For codes in the Allegro friendly-message allowlist (#448) the primary
+ * message text is replaced with operator-actionable copy and the original
+ * Allegro `userMessage` is moved into a collapsed `<details>` block —
+ * progressive disclosure so the support path stays one click away. Codes
+ * outside the allowlist render byte-identically to before.
+ *
  * @module apps/web/src/features/listings/components
  */
 import type { ReactElement } from 'react';
 import type { OfferCreationError } from '../api/listings.types';
+import { translateAllegroError } from '../lib/allegro-error-mapping';
 
 interface OfferCreationErrorListProps {
   errors: OfferCreationError[] | null | undefined;
@@ -27,18 +34,28 @@ export function OfferCreationErrorList({
 
   return (
     <ul className={classes} aria-label="Offer creation errors">
-      {errors.map((error, index) => (
-        <li
-          key={`${error.code}-${error.field ?? 'no-field'}-${index}`}
-          className="offer-creation-errors__item"
-        >
-          {error.field ? (
-            <span className="offer-creation-errors__field mono-text">{error.field}</span>
-          ) : null}
-          <span className="offer-creation-errors__message">{error.message}</span>
-          <span className="offer-creation-errors__code mono-text">{error.code}</span>
-        </li>
-      ))}
+      {errors.map((error, index) => {
+        const translation = translateAllegroError(error);
+        const primaryMessage = translation?.message ?? error.message;
+        return (
+          <li
+            key={`${error.code}-${error.field ?? 'no-field'}-${index}`}
+            className="offer-creation-errors__item"
+          >
+            {error.field ? (
+              <span className="offer-creation-errors__field mono-text">{error.field}</span>
+            ) : null}
+            <span className="offer-creation-errors__message">{primaryMessage}</span>
+            <span className="offer-creation-errors__code mono-text">{error.code}</span>
+            {translation ? (
+              <details className="offer-creation-errors__raw">
+                <summary>Allegro&apos;s original message</summary>
+                <span className="offer-creation-errors__raw-body">{error.message}</span>
+              </details>
+            ) : null}
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/apps/web/src/features/listings/lib/allegro-error-mapping.test.ts
+++ b/apps/web/src/features/listings/lib/allegro-error-mapping.test.ts
@@ -65,4 +65,11 @@ describe('translateAllegroError', () => {
     };
     expect(translateAllegroError(error)).toBeNull();
   });
+
+  it.each(['toString', 'valueOf', 'hasOwnProperty', '__proto__'])(
+    'returns null for prototype-inherited key %s (defensive — never resolves to an Object.prototype method)',
+    (code) => {
+      expect(translateAllegroError({ code, message: 'irrelevant' })).toBeNull();
+    },
+  );
 });

--- a/apps/web/src/features/listings/lib/allegro-error-mapping.test.ts
+++ b/apps/web/src/features/listings/lib/allegro-error-mapping.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Allegro Error Mapping Tests
+ *
+ * Coverage per #448 acceptance: one assertion per mapped code, two for
+ * `UnknownJSONProperty` (with and without `error.field`), one for the
+ * fallback. Table-driven for the static codes; explicit `it()` blocks for
+ * the field-aware code so the with/without-field branches read clearly.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+import { describe, expect, it } from 'vitest';
+import { translateAllegroError } from './allegro-error-mapping';
+import type { OfferCreationError } from '../api/listings.types';
+
+describe('translateAllegroError', () => {
+  it.each([
+    [
+      'SAFETY_INFO_NOT_DEFINED',
+      /verify the discriminator/i,
+    ],
+    [
+      'NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED',
+      /Provide safety information \(text\)/,
+    ],
+    [
+      'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+      /Responsible Producer/,
+    ],
+    [
+      'UnsupportedLanguageInAcceptLanguageHeader',
+      /unsupported Accept-Language/,
+    ],
+  ])('translates %s into an operator-actionable message', (code, expected) => {
+    const result = translateAllegroError({
+      code,
+      message: 'Allegro raw message',
+    });
+    expect(result).not.toBeNull();
+    expect(result?.message).toMatch(expected);
+  });
+
+  it('interpolates the field path into the UnknownJSONProperty message when present', () => {
+    const result = translateAllegroError({
+      code: 'UnknownJSONProperty',
+      field: 'safetyInformation.foo',
+      message: 'Unknown properties found in the request',
+    });
+    expect(result?.message).toContain('`safetyInformation.foo`');
+    expect(result?.message).toMatch(/regression in the OL Allegro adapter/);
+  });
+
+  it('omits the path clause from the UnknownJSONProperty message when field is absent', () => {
+    const result = translateAllegroError({
+      code: 'UnknownJSONProperty',
+      message: 'Unknown properties found in the request',
+    });
+    expect(result?.message).not.toContain('at `');
+    expect(result?.message).toMatch(/regression in the OL Allegro adapter/);
+  });
+
+  it('returns null for codes that are not in the allowlist', () => {
+    const error: OfferCreationError = {
+      code: 'SOME_NEW_ALLEGRO_CODE_WE_HAVE_NOT_SEEN_YET',
+      message: 'Whatever Allegro said.',
+    };
+    expect(translateAllegroError(error)).toBeNull();
+  });
+});

--- a/apps/web/src/features/listings/lib/allegro-error-mapping.ts
+++ b/apps/web/src/features/listings/lib/allegro-error-mapping.ts
@@ -1,0 +1,62 @@
+/**
+ * Allegro Error Mapping
+ *
+ * Translates a curated allowlist of Allegro REST API error codes into
+ * operator-actionable, English-language messages (#448). The BE forwards
+ * Allegro's structured `{ field?, code, message }` payload via
+ * `OfferCreationStatusResponse.errors` unchanged; this module sits at the
+ * render boundary on the FE so the operator sees "what to do" instead of
+ * "what Allegro literally said".
+ *
+ * Returns `null` when the code is not in the allowlist — callers fall back
+ * to rendering Allegro's raw `userMessage` verbatim. The shape is an object
+ * (not a bare string) so a future PR can extend it with a `cta` field for
+ * deep-linking to the connection edit page without churning every call
+ * site — see #448's deferred bullets.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+import type { OfferCreationError } from '../api/listings.types';
+
+export interface AllegroErrorTranslation {
+  /** Operator-facing replacement for `error.message`. */
+  message: string;
+}
+
+type Translator = (error: OfferCreationError) => AllegroErrorTranslation;
+
+/**
+ * Allowlist of Allegro error codes we translate. Each entry is a function so
+ * codes that need to interpolate `error.field` (e.g. `UnknownJSONProperty`)
+ * can do so cleanly. Add new entries opportunistically as they surface from
+ * real seller activity.
+ */
+const TRANSLATIONS: Record<string, Translator> = {
+  SAFETY_INFO_NOT_DEFINED: () => ({
+    message:
+      "Allegro rejected the safety information for this category. Verify the discriminator (`type`) and re-save the connection's seller defaults. If the issue persists, the category likely requires a TEXT discriminator with substantive content rather than NO_SAFETY_INFORMATION.",
+  }),
+  NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED: () => ({
+    message:
+      "This category requires substantive safety information. Edit the connection and choose 'Provide safety information (text)' with category-relevant content (battery warnings, age restrictions, CE/RoHS, etc.).",
+  }),
+  UnknownJSONProperty: (error) => ({
+    message: error.field
+      ? `OpenLinker sent a field Allegro doesn't recognize at \`${error.field}\`. This is usually a regression in the OL Allegro adapter. Please file an issue with the offer id.`
+      : "OpenLinker sent a field Allegro doesn't recognize. This is usually a regression in the OL Allegro adapter. Please file an issue with the offer id.",
+  }),
+  RESPONSIBLE_PRODUCER_NOT_SPECIFIED: () => ({
+    message: "Configure a Responsible Producer entry in the connection's seller defaults.",
+  }),
+  UnsupportedLanguageInAcceptLanguageHeader: () => ({
+    message:
+      'OpenLinker sent an unsupported Accept-Language header. This is a regression — please file an issue.',
+  }),
+};
+
+export function translateAllegroError(
+  error: OfferCreationError,
+): AllegroErrorTranslation | null {
+  const translator = TRANSLATIONS[error.code];
+  return translator ? translator(error) : null;
+}

--- a/apps/web/src/features/listings/lib/allegro-error-mapping.ts
+++ b/apps/web/src/features/listings/lib/allegro-error-mapping.ts
@@ -57,6 +57,12 @@ const TRANSLATIONS: Record<string, Translator> = {
 export function translateAllegroError(
   error: OfferCreationError,
 ): AllegroErrorTranslation | null {
-  const translator = TRANSLATIONS[error.code];
-  return translator ? translator(error) : null;
+  // `Object.hasOwn` rather than a bare lookup so we can't accidentally
+  // resolve to an inherited prototype method (e.g. `error.code === 'toString'`)
+  // and call it with `(error)` — extremely unlikely from Allegro in practice,
+  // but the guard is one line and free.
+  if (!Object.hasOwn(TRANSLATIONS, error.code)) {
+    return null;
+  }
+  return TRANSLATIONS[error.code](error);
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4832,6 +4832,30 @@ a.kpi-card:focus-visible {
   font-size: 0.75rem;
 }
 
+/*
+ * Collapsible "Allegro's original message" disclosure (#448). Spans the
+ * full row of the item grid so the summary + body align with the message
+ * column above it. Kept visually quiet — the summary is muted, no CTA
+ * weight; the friendly message above is the primary affordance.
+ */
+.offer-creation-errors__raw {
+  grid-column: 1 / -1;
+  margin-top: 0.25rem;
+}
+
+.offer-creation-errors__raw > summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.offer-creation-errors__raw-body {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+}
+
 @media (max-width: 767.98px) {
   .offer-creation-errors__item {
     grid-template-columns: 1fr;

--- a/docs/plans/implementation-plan-allegro-error-mapping.md
+++ b/docs/plans/implementation-plan-allegro-error-mapping.md
@@ -1,0 +1,138 @@
+# Implementation plan — translate Allegro misleading error codes (#448)
+
+## 1. Goal
+
+Replace Allegro's raw `userMessage` with operator-actionable text on the job-detail page when the offer-creation record carries a known Allegro error code. Keep the raw payload one click away. Pure FE work — the BE already forwards Allegro's structured `OfferCreationError { code, field?, message }` array via `OfferCreationStatusResponse.errors`.
+
+**Layer:** Frontend only. No CORE / Integration / API changes.
+
+**Non-goals:**
+- Multilingual translation (English only — confirmed in issue).
+- Telemetry on which Allegro errors fire most.
+- BE side: extending `OfferCreationError` with structured `metadata.unknownProperties` (out of scope; would unlock a richer rendering for `UnknownJSONProperty` later).
+
+## 2. Codebase research
+
+- Page: `apps/web/src/pages/sync-jobs/sync-job-detail-page.tsx` is the "job detail" surface (route: `/jobs-logs`). Renders `OfferCreationTracker` when the job is a `marketplace.offer.create` carrying an `offerCreationRecordId`. `OfferCreationTracker` itself renders the structured errors via `OfferCreationErrorList` for the `failed` and `draft` branches.
+- Render site: `apps/web/src/features/listings/components/OfferCreationErrorList.tsx` — for each `OfferCreationError` it renders `[field?] [message] [code]`. This is the one place that needs to consume the new mapping.
+- Type: `apps/web/src/features/listings/api/listings.types.ts:136` defines `OfferCreationError { field?: string; code: string; message: string }`. The `field` is the Allegro path (e.g. `parameters.EAN`), `message` is Allegro's `userMessage`, `code` is the Allegro code we'll key on.
+- Convention precedent for pure helper modules: `apps/web/src/features/listings/lib/allegro-seller-panel-url.ts` + co-located `*.test.ts`. The codebase uses **`lib/`** for pure derivation/lookup helpers; no `util/` directory exists anywhere under `features/`. The issue body suggested `util/` — flagged below.
+
+## 3. Design
+
+### File placement deviation
+
+The issue specifies `apps/web/src/features/listings/util/allegro-error-mapping.ts`. The OpenLinker FE convention is `lib/` (every existing pure helper module lives in `features/<domain>/lib/`). I'll place the file at **`apps/web/src/features/listings/lib/allegro-error-mapping.ts`** alongside `allegro-seller-panel-url.ts`. This is a naming deviation from the issue, not a behavioural one — call out in the PR.
+
+### Public surface
+
+```ts
+// apps/web/src/features/listings/lib/allegro-error-mapping.ts
+import type { OfferCreationError } from '../api/listings.types';
+
+/**
+ * Friendly translation of a single Allegro error code into operator-actionable
+ * text. Returns null when the code is not in our allowlist — callers fall
+ * back to rendering Allegro's raw `userMessage` verbatim.
+ */
+export function translateAllegroError(error: OfferCreationError): string | null;
+```
+
+A function-valued mapping table — some translations interpolate `error.field` (e.g. `UnknownJSONProperty`), so a `Record<string, string>` would be too rigid. Keep the table local to the module so adding a code is a single edit.
+
+### Render integration
+
+Update `OfferCreationErrorList` to:
+- Try `translateAllegroError(error)` first, render its result as the primary message text when non-null.
+- When translated, append a collapsible `<details><summary>Allegro's original message</summary>{error.message}</details>` so the raw `userMessage` is one click away. The `field` and `code` mono badges stay where they are — they're already useful debugging context.
+- When **not** translated, render `error.message` verbatim (existing behaviour preserved).
+
+This keeps the visual structure identical for the unmapped path, satisfies the AC "raw error payload still accessible", and avoids the heavier `RawPayloadPanel` (which is a JSON viewer designed for top-level error blobs, not per-list-item supplements).
+
+### Mapping table contents
+
+Verbatim from the issue, with `error.field` interpolated only where meaningful:
+
+| Code | Translation |
+|---|---|
+| `SAFETY_INFO_NOT_DEFINED` | "Allegro rejected the safety information for this category. Verify the discriminator (`type`) and re-save the connection's seller defaults. If the issue persists, the category likely requires a TEXT discriminator with substantive content rather than NO_SAFETY_INFORMATION." |
+| `NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED` | "This category requires substantive safety information. Edit the connection and choose 'Provide safety information (text)' with category-relevant content (battery warnings, age restrictions, CE/RoHS, etc.)." |
+| `UnknownJSONProperty` | "OpenLinker sent a field Allegro doesn't recognize${field ? \` at \\`${field}\\`\` : ''}. This is usually a regression in the OL Allegro adapter. Please file an issue with the offer id." |
+| `RESPONSIBLE_PRODUCER_NOT_SPECIFIED` | "Configure a Responsible Producer entry in the connection's seller defaults." |
+| `UnsupportedLanguageInAcceptLanguageHeader` | "OpenLinker sent an unsupported Accept-Language header. This is a regression — please file an issue." |
+
+The "link to connection edit" part of the issue's `NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED` and `RESPONSIBLE_PRODUCER_NOT_SPECIFIED` rows is **deferred** for this PR — implementing it requires plumbing the connectionId into the error-list call site (currently only `record.errors` is passed) and deciding whether to deep-link with a hash anchor. The friendly message text by itself is high-value already; making the link clickable is a follow-up.
+
+## 4. Step-by-step plan
+
+### Step 1 — Add the lookup table
+
+**File:** `apps/web/src/features/listings/lib/allegro-error-mapping.ts` (new)
+
+- Export `translateAllegroError(error: OfferCreationError): string | null`.
+- Internal `Record<string, (error: OfferCreationError) => string>` keyed on the 5 Allegro codes.
+- File header per engineering-standards.
+
+**Acceptance:** module is pure, no side effects, no imports beyond the `OfferCreationError` type.
+
+### Step 2 — Tests for the lookup table
+
+**File:** `apps/web/src/features/listings/lib/allegro-error-mapping.test.ts` (new)
+
+- One test per mapped code asserting the friendly text.
+- One test for `UnknownJSONProperty` with an `error.field` set, asserting the field is interpolated.
+- One test for `UnknownJSONProperty` with no field (defensive), asserting the sentence reads correctly without it.
+- One test for an unmapped code returning `null`.
+
+**Acceptance:** `pnpm test` includes these and they pass.
+
+### Step 3 — Wire the mapping into `OfferCreationErrorList`
+
+**File:** `apps/web/src/features/listings/components/OfferCreationErrorList.tsx` (edit)
+
+- Call `translateAllegroError(error)` per row.
+- Primary message slot renders the translation when present, falls back to `error.message` otherwise.
+- When translated, render a `<details>` with summary "Allegro's original message" containing the raw `error.message`.
+- Field and code mono badges are unchanged.
+
+**Acceptance:** existing tests for `OfferCreationErrorList` still pass (they assert on `MISSING_EAN` / `GENERIC_FAILURE` / `TOO_LONG` / `INVALID` — none of which are in the mapping table, so the fallback branch is exercised).
+
+### Step 4 — New tests for the rendered behaviour
+
+**File:** `apps/web/src/features/listings/components/OfferCreationErrorList.test.tsx` (edit)
+
+- Add one test: a `SAFETY_INFO_NOT_DEFINED` error renders the friendly text and exposes the raw message in a collapsed `<details>`.
+- Add one test: an unmapped code (e.g. `MISSING_EAN`, already covered by existing tests) does **not** render a `<details>` block — i.e. behaviour for unknown codes is byte-identical to today.
+
+**Acceptance:** both new tests pass.
+
+### Step 5 — Minimal CSS
+
+**File:** `apps/web/src/index.css` (edit)
+
+- `.offer-creation-errors__raw` (the `<details>` block): small top margin, muted summary text using `var(--text-muted)`, body text `0.8125rem` aligned with siblings.
+
+**Acceptance:** no new tokens, all colour/size via existing CSS custom properties; lint passes.
+
+### Step 6 — Quality gate
+
+```
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+**Acceptance:** zero errors. Existing test counts grow by exactly the new tests added in Steps 2 and 4.
+
+## 5. Validation
+
+- **Architecture:** pure FE feature, dep direction `pages → features → shared` preserved (the new module sits in `features/listings/lib`, only consumed by `features/listings/components`).
+- **Naming:** `lib/` matches existing convention; module exports a `translate*` function in lower-camel, types reused.
+- **Testing:** unit-test only (one mapping table + one component); no integration test needed.
+- **Security:** no user input rendered as HTML, no `dangerouslySetInnerHTML`. The friendly strings are static literals; the only interpolation (`UnknownJSONProperty`) is `error.field` from the BE response, rendered as a React text node so it's escaped.
+
+## 6. Risks & open questions
+
+- **CTA links** (e.g. "Open connection edit page" for `RESPONSIBLE_PRODUCER_NOT_SPECIFIED`) are deferred. The friendly text is high-value standalone; the linkability is a follow-up because it requires plumbing the connection id through `OfferCreationErrorList`.
+- **`UnknownJSONProperty.metadata.unknownProperties`**: the BE doesn't currently expose Allegro's metadata block. This PR doesn't add that — the friendly message just calls out that "OpenLinker sent a field Allegro doesn't recognize at `<path>`", which is enough to file a bug. Surfacing the verbatim list is a follow-up.
+- **Naming deviation**: issue body says `util/`, project convention is `lib/`. Calling out in the PR description.


### PR DESCRIPTION
Closes #448

## Summary

Allegro returns a handful of error codes whose `userMessage` is technically accurate against the schema but misleading to a human. The 2026-04-29 GPSR loop (#436 → #446) burned seven PRs in part because the operator-facing message in OpenLinker was the raw Allegro string, sending us chasing the wrong root cause.

The BE already forwards Allegro's structured `{ field?, code, message }` payload via `OfferCreationStatusResponse.errors` unchanged. This PR adds a pure-FE allowlist that translates 5 known codes into actionable copy at the render boundary inside `OfferCreationErrorList`, while keeping the original Allegro `userMessage` accessible in a collapsed `<details>` block. Codes outside the allowlist render byte-identically to today.

### Surface clarification

The issue body says "render the friendly variant in the `Alert` instead of the raw `userMessage`". The change targets `OfferCreationErrorList` (the structured `record.errors[]` rendering inside `OfferCreationTracker`), **not** the top-level `Alert` on the job-detail page that renders `job.lastError`. `lastError` is a free-form serialised worker-error string; Allegro's structured `userMessage` only flows through `record.errors[]`, which is what `OfferCreationErrorList` consumes — so the structured path is the right surface for code-keyed translation. Translating the `lastError` blob would require regex parsing and is out of scope here.

### Changes

- **NEW** `apps/web/src/features/listings/lib/allegro-error-mapping.ts` — `translateAllegroError(error) → AllegroErrorTranslation | null`. Returns an object (`{ message }`) rather than a bare string so the deferred CTA work (deep-link to connection edit) is a non-breaking addition.
- **UPDATE** `OfferCreationErrorList.tsx` — mapped codes get the friendly text in the primary slot + a collapsed `<details>` with Allegro's raw message; unmapped codes render exactly as before.
- **CSS** `.offer-creation-errors__raw` / `__raw-body` — spans the full row of the existing 3-column item grid; restrained styling using `--text-muted` / `--text-secondary` so the friendly message stays the primary affordance.

### Codes covered (verbatim from issue)

| Allegro code | Friendly action |
|---|---|
| `SAFETY_INFO_NOT_DEFINED` | Verify discriminator and re-save seller defaults; category may require TEXT discriminator |
| `NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED` | Provide substantive safety information (battery / age / CE/RoHS) |
| `UnknownJSONProperty` | Names the field path; flags as OL adapter regression |
| `RESPONSIBLE_PRODUCER_NOT_SPECIFIED` | Configure Responsible Producer in seller defaults |
| `UnsupportedLanguageInAcceptLanguageHeader` | Flags as OL adapter regression |

### Naming deviation from issue

Issue specified `features/listings/util/`, codebase convention is `lib/` (every existing pure-helper module — `allegro-seller-panel-url.ts`, `prompt-templates/lib/*`, etc.). Going with `lib/`.

### Deferred

- **CTA links** for the two connection-edit codes — needs `connectionId` plumbed through `OfferCreationErrorList` from the parent tracker. The `{ message, cta? }` return type leaves this as a non-breaking addition.
- **`UnknownJSONProperty.metadata.unknownProperties`** — BE doesn't currently expose Allegro's metadata block. The friendly message names the field path, which is enough to file a bug.

### Tech-review follow-up (commit `0005c56`)

Hardened `TRANSLATIONS[error.code]` against prototype-inherited keys. Bare lookup on `Record<string, ...>` would resolve `error.code === 'toString'` to `Object.prototype.toString`. Practical risk negligible (Allegro codes never look like that), and not exploitable, but the `Object.hasOwn` guard is one line. Locked in with `it.each` over `toString` / `valueOf` / `hasOwnProperty` / `__proto__`.

## Test plan

- [x] `allegro-error-mapping.test.ts` — `it.each` for the 4 static codes, explicit blocks for `UnknownJSONProperty` with/without `field`, fallback for unknown codes, `it.each` for prototype keys
- [x] `OfferCreationErrorList.test.tsx` — mapped path renders friendly + collapsed `<details>`; unmapped path renders no `<details>` (byte-identical to today)
- [x] Quality gate: lint clean, type-check green, **778 tests passing** (+14 from this PR)
- [ ] Visual check on a real failed offer-creation record to confirm `<details>` collapse + friendly copy reads well at 1440px and 768px

🤖 Generated with [Claude Code](https://claude.com/claude-code)