### PR TITLE
feat(web): show human label + faded id-hint on mapping rows (#474 Phase 1)

### DIFF
--- a/apps/web/src/features/mappings/components/MappingPanel.test.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * MappingPanel Tests
+ *
+ * Locks in the rendering of the saved-mapping rows and the dropdown options,
+ * including the new label + faded-id-hint treatment introduced for #474, plus
+ * the existing loading / error / empty / dedup / save-flow paths that this
+ * component has carried since #472. Plain `render` (no providers) — the
+ * component is presentational and takes everything via props.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MappingPanel, type MappingRow } from './MappingPanel';
+import type { MappingOption } from '../api/mappings.types';
+
+const baseProps = {
+  title: 'Carrier Mappings',
+  description: 'Map Allegro delivery methods to PrestaShop carriers.',
+  sourceLabel: 'Allegro delivery method',
+  targetLabel: 'PrestaShop carrier',
+  isSaving: false,
+  saveError: null,
+  optionsLoading: false,
+  optionsError: null,
+};
+
+const ALLEGRO_PACZKOMAT: MappingOption = {
+  value: '1fa56f79-1234-5678-90ab-cdef12345678',
+  label: 'Allegro Paczkomaty InPost',
+};
+const ALLEGRO_KURIER: MappingOption = {
+  value: '7c2b3d4e-5678-90ab-cdef-1234567890ab',
+  label: 'Allegro Kurier24 InPost',
+};
+const PS_INPOST: MappingOption = { value: '5', label: 'InPost Paczkomat' };
+const PS_DPD: MappingOption = { value: '12', label: 'DPD courier' };
+
+describe('MappingPanel', () => {
+  afterEach(cleanup);
+
+  describe('label + id-hint rendering (#474)', () => {
+    it('renders the human label plus a truncated id-hint when value !== label', () => {
+      const savedRows: MappingRow[] = [
+        { sourceValue: ALLEGRO_PACZKOMAT.value, targetValue: PS_INPOST.value },
+      ];
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_PACZKOMAT]}
+          targetOptions={[PS_INPOST]}
+          savedRows={savedRows}
+          onSave={vi.fn()}
+        />,
+      );
+
+      // Primary label visible.
+      expect(screen.getByText('Allegro Paczkomaty InPost')).toBeInTheDocument();
+      // Id-hint truncated to 8 chars + ellipsis (matches the issue example shape).
+      expect(screen.getByText('1fa56f79…')).toBeInTheDocument();
+      const hint = screen.getByText('1fa56f79…');
+      expect(hint).toHaveClass('mapping-panel__id-hint');
+    });
+
+    it('skips the id-hint when value === label (degraded data)', () => {
+      // Adapter fallback path: when Allegro returns no `method.name`, the
+      // adapter uses the id as the label. Verify we don't render the hint
+      // twice in that case.
+      const sameValueAsLabel: MappingOption = { value: 'PAYU_GATEWAY', label: 'PAYU_GATEWAY' };
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[sameValueAsLabel]}
+          targetOptions={[]}
+          savedRows={[{ sourceValue: 'PAYU_GATEWAY', targetValue: '' }]}
+          onSave={vi.fn()}
+        />,
+      );
+
+      expect(screen.getAllByText('PAYU_GATEWAY')).toHaveLength(1);
+      expect(screen.queryByText('PAYU_GATEWAY…')).toBeNull();
+    });
+
+    it('renders short values verbatim with no ellipsis', () => {
+      // PrestaShop carrier ids are small ints — `5`, `12`. The truncation
+      // helper must short-circuit on length ≤ 9.
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_PACZKOMAT]}
+          targetOptions={[PS_INPOST]}
+          savedRows={[{ sourceValue: ALLEGRO_PACZKOMAT.value, targetValue: PS_INPOST.value }]}
+          onSave={vi.fn()}
+        />,
+      );
+
+      // PS target carrier id is `5` — should render as `5`, not `5…`.
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.queryByText('5…')).toBeNull();
+    });
+
+    it('renders dropdown options as plain "Label (truncatedValue)" text', () => {
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_PACZKOMAT, ALLEGRO_KURIER]}
+          targetOptions={[PS_INPOST]}
+          savedRows={[]}
+          onSave={vi.fn()}
+        />,
+      );
+
+      const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
+      const options = within(select).getAllByRole('option');
+      // First option is the placeholder ("— Allegro delivery method —"), then the two methods.
+      expect(options[1]).toHaveTextContent('Allegro Paczkomaty InPost (1fa56f79…)');
+      expect(options[2]).toHaveTextContent('Allegro Kurier24 InPost (7c2b3d4e…)');
+    });
+
+    it('falls back to the raw value when a saved mapping references a value missing from the source options', () => {
+      // Seller deleted the cennik on Allegro's side — saved row points at a
+      // method id no longer in the live list. Render the raw value so the
+      // operator can still see what's there.
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[]}
+          targetOptions={[]}
+          savedRows={[{ sourceValue: 'orphan-id-xyz', targetValue: 'orphan-target' }]}
+          onSave={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText('orphan-id-xyz')).toBeInTheDocument();
+      expect(screen.getByText('orphan-target')).toBeInTheDocument();
+    });
+  });
+
+  describe('panel states', () => {
+    it('renders LoadingState while options are loading', () => {
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[]}
+          targetOptions={[]}
+          savedRows={[]}
+          onSave={vi.fn()}
+          optionsLoading
+        />,
+      );
+      expect(screen.getByText(/loading carrier mappings options/i)).toBeInTheDocument();
+    });
+
+    it('renders ErrorState when options fail to load', () => {
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[]}
+          targetOptions={[]}
+          savedRows={[]}
+          onSave={vi.fn()}
+          optionsError={new Error('Allegro 502')}
+        />,
+      );
+      expect(screen.getByText(/unable to load options/i)).toBeInTheDocument();
+      expect(screen.getByText('Allegro 502')).toBeInTheDocument();
+    });
+
+    it('shows the empty-state copy when no rows are configured', () => {
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_PACZKOMAT]}
+          targetOptions={[PS_INPOST]}
+          savedRows={[]}
+          onSave={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(/no mappings configured yet/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('add-row flow', () => {
+    it('filters already-mapped sources out of the add-row dropdown', () => {
+      // Primary dedup affordance: an already-mapped source can't be re-picked
+      // because it's removed from `availableSourceOptions`. Defensive
+      // `setAddError` branch in `handleAddRow` only fires for programmatic
+      // bypasses, which the UI can't trigger.
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_PACZKOMAT, ALLEGRO_KURIER]}
+          targetOptions={[PS_INPOST, PS_DPD]}
+          savedRows={[{ sourceValue: ALLEGRO_PACZKOMAT.value, targetValue: PS_INPOST.value }]}
+          onSave={vi.fn()}
+        />,
+      );
+
+      const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
+      const optionTexts = within(select)
+        .getAllByRole('option')
+        .map((o) => o.textContent ?? '');
+      // Mapped Paczkomat is gone from the add-row dropdown; only Kurier remains.
+      expect(optionTexts.some((t) => t.includes('Paczkomaty'))).toBe(false);
+      expect(optionTexts.some((t) => t.includes('Kurier24'))).toBe(true);
+    });
+
+    it('save flow calls onSave with the full row list', () => {
+      const onSave = vi.fn();
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_PACZKOMAT]}
+          targetOptions={[PS_INPOST]}
+          savedRows={[{ sourceValue: ALLEGRO_PACZKOMAT.value, targetValue: PS_INPOST.value }]}
+          onSave={onSave}
+        />,
+      );
+
+      // Save button is disabled when not dirty — remove a row to dirty the
+      // panel, then click Save.
+      const removeButton = screen.getByRole('button', { name: /remove mapping/i });
+      fireEvent.click(removeButton);
+
+      const saveButton = screen.getByRole('button', { name: /save mappings/i });
+      expect(saveButton).not.toBeDisabled();
+      fireEvent.click(saveButton);
+
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(onSave).toHaveBeenCalledWith([]);
+    });
+  });
+});

--- a/apps/web/src/features/mappings/components/MappingPanel.test.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.test.tsx
@@ -59,7 +59,7 @@ describe('MappingPanel', () => {
       // Id-hint truncated to 8 chars + ellipsis (matches the issue example shape).
       expect(screen.getByText('1fa56f79…')).toBeInTheDocument();
       const hint = screen.getByText('1fa56f79…');
-      expect(hint).toHaveClass('mapping-panel__id-hint');
+      expect(hint).toHaveClass('mapping-id-hint');
     });
 
     it('skips the id-hint when value === label (degraded data)', () => {

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -8,7 +8,7 @@
  * @module apps/web/src/features/mappings/components
  */
 
-import { useState, useEffect, type ReactElement } from 'react';
+import { useState, useEffect, type ReactElement, type ReactNode } from 'react';
 import { Button } from '../../../shared/ui/button';
 import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import type { MappingOption } from '../api/mappings.types';
@@ -35,8 +35,46 @@ interface MappingPanelProps {
   optionsError: Error | null;
 }
 
-function labelFor(options: MappingOption[], value: string): string {
-  return options.find((o) => o.value === value)?.label ?? value;
+/**
+ * Truncates a long stable id (Allegro UUIDs are 36 chars) to 8 + "…" so it
+ * fits inline next to the human label without dominating the row. Short
+ * values (like PrestaShop carrier ids `5`, `12`) render verbatim — the
+ * length guard short-circuits anything ≤ 9 chars (#474).
+ */
+function shortValue(value: string): string {
+  return value.length <= 9 ? value : `${value.slice(0, 8)}…`;
+}
+
+function optionByValue(options: MappingOption[], value: string): MappingOption | null {
+  return options.find((o) => o.value === value) ?? null;
+}
+
+/**
+ * Renders a `MappingOption` with the human label as the primary text and a
+ * faded mono id-hint when the value differs from the label (#474). When
+ * `value === label` (degraded data — adapter fell back to using the id as
+ * the name), render a single label and skip the redundant hint.
+ */
+function renderOptionLabel(option: MappingOption): ReactNode {
+  if (option.label === option.value) {
+    return option.label;
+  }
+  return (
+    <>
+      {option.label}{' '}
+      <span className="mapping-panel__id-hint mono-text">{shortValue(option.value)}</span>
+    </>
+  );
+}
+
+/**
+ * Plain-text variant for `<option>` elements — native `<select>` strips
+ * styled children, so the id chip is approximated as parenthesised text.
+ */
+function optionPlainText(option: MappingOption): string {
+  return option.label === option.value
+    ? option.label
+    : `${option.label} (${shortValue(option.value)})`;
 }
 
 export function MappingPanel({
@@ -135,21 +173,37 @@ export function MappingPanel({
             </tr>
           </thead>
           <tbody>
-            {localRows.map((row) => (
-              <tr key={row.sourceValue}>
-                <td>{labelFor(sourceOptions, row.sourceValue)}</td>
-                <td>{labelFor(targetOptions, row.targetValue)}</td>
-                <td>
-                  <Button
-                    tone="ghost"
-                    aria-label={`Remove mapping for ${labelFor(sourceOptions, row.sourceValue)}`}
-                    onClick={() => { handleDeleteRow(row.sourceValue); }}
-                  >
-                    Remove
-                  </Button>
-                </td>
-              </tr>
-            ))}
+            {localRows.map((row) => {
+              const sourceOption = optionByValue(sourceOptions, row.sourceValue);
+              const targetOption = optionByValue(targetOptions, row.targetValue);
+              return (
+                <tr key={row.sourceValue}>
+                  <td>
+                    {sourceOption ? (
+                      renderOptionLabel(sourceOption)
+                    ) : (
+                      <span className="mono-text">{row.sourceValue}</span>
+                    )}
+                  </td>
+                  <td>
+                    {targetOption ? (
+                      renderOptionLabel(targetOption)
+                    ) : (
+                      <span className="mono-text">{row.targetValue}</span>
+                    )}
+                  </td>
+                  <td>
+                    <Button
+                      tone="ghost"
+                      aria-label={`Remove mapping for ${sourceOption?.label ?? row.sourceValue}`}
+                      onClick={() => { handleDeleteRow(row.sourceValue); }}
+                    >
+                      Remove
+                    </Button>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       )}
@@ -164,7 +218,7 @@ export function MappingPanel({
         >
           <option value="">— {sourceLabel} —</option>
           {availableSourceOptions.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
+            <option key={o.value} value={o.value}>{optionPlainText(o)}</option>
           ))}
         </select>
 
@@ -175,7 +229,7 @@ export function MappingPanel({
         >
           <option value="">— {targetLabel} —</option>
           {targetOptions.map((o) => (
-            <option key={o.value} value={o.value}>{o.label}</option>
+            <option key={o.value} value={o.value}>{optionPlainText(o)}</option>
           ))}
         </select>
 

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -62,7 +62,7 @@ function renderOptionLabel(option: MappingOption): ReactNode {
   return (
     <>
       {option.label}{' '}
-      <span className="mapping-panel__id-hint mono-text">{shortValue(option.value)}</span>
+      <span className="mapping-id-hint mono-text">{shortValue(option.value)}</span>
     </>
   );
 }
@@ -195,7 +195,7 @@ export function MappingPanel({
                   <td>
                     <Button
                       tone="ghost"
-                      aria-label={`Remove mapping for ${sourceOption?.label ?? row.sourceValue}`}
+                      aria-label={`Remove mapping for ${sourceOption?.label ?? 'orphaned source'}`}
                       onClick={() => { handleDeleteRow(row.sourceValue); }}
                     >
                       Remove

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2016,6 +2016,17 @@ textarea {
   margin-left: 0.5rem;
 }
 
+/*
+ * Mapping panel id-hint (#474) — muted, monospaced supplementary id chip
+ * rendered next to the human label on saved-mapping rows. Pairs with the
+ * `.mono-text` class for the mono treatment.
+ */
+.mapping-panel__id-hint {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: -0.01em;
+}
+
 .data-table {
   width: 100%;
   border-collapse: collapse;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2017,11 +2017,11 @@ textarea {
 }
 
 /*
- * Mapping panel id-hint (#474) — muted, monospaced supplementary id chip
- * rendered next to the human label on saved-mapping rows. Pairs with the
- * `.mono-text` class for the mono treatment.
+ * Mapping id-hint (#474) — muted, monospaced supplementary id chip rendered
+ * next to the human label on saved-mapping rows. Flat-name helper (no BEM
+ * parent block) — matches `.sku-label` / `.num` siblings above.
  */
-.mapping-panel__id-hint {
+.mapping-id-hint {
   color: var(--text-muted);
   font-size: 0.75rem;
   letter-spacing: -0.01em;

--- a/docs/plans/implementation-plan-mapping-panel-id-hint.md
+++ b/docs/plans/implementation-plan-mapping-panel-id-hint.md
@@ -1,0 +1,150 @@
+# Implementation plan — show human label + faded ID on mapping rows (#474 Phase 1)
+
+## 1. Goal
+
+Render the Allegro delivery method's human-readable name alongside its UUID on the carrier-mapping panel so operators no longer need to cross-reference Allegro's seller portal to recognise which method is which. The BE half of the issue (`listDeliveryMethods()` returning `{ value: methodId, label: methodName }`) shipped with **#472** — that endpoint already returns labelled data live from the seller's `/sale/shipping-rates`. The remaining gap is purely **FE rendering**: today `MappingPanel` shows only `{label}`, hiding the UUID; the issue spec asks for "human-readable name plus a faded UUID".
+
+**Layer:** Frontend only. No BE / CORE / Integration changes.
+
+**Phase 2 (carrier-family / pattern matching) is explicitly deferred.** The issue body says it should only ship if Phase 1 isn't enough — punt to a follow-up issue once we have signal.
+
+## 2. Codebase research
+
+- **BE endpoint**: `apps/api/src/mappings/http/mapping-options.controller.ts:112` — `@Get('source/delivery-methods')` already wires through to the adapter's `listDeliveryMethods` via the SourceOptionsReader capability resolution. Existing controller spec at `mapping-options.controller.spec.ts:48` mocks `listDeliveryMethods` returning `{ value: 'paczkomat-uuid', label: 'Paczkomat' }`.
+- **BE adapter**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts:344` — fully implemented, walks `/sale/shipping-rates` then per-id details, flattens + dedupes by methodId, returns `MappingOption[]`. Comment header credits `(#472 / #474)` — meaning the adapter scope was always intended to cover both.
+- **FE consumer**: `apps/web/src/features/mappings/components/MappingPanel.tsx`. Used by all three mapping tabs (statuses / carriers / payments) on `connection-mappings-page.tsx`. The dropdown renders `{o.label}` (line 167) and the saved-rows table renders `labelFor(sourceOptions, row.sourceValue)` (line 140), which returns just the label or falls back to the raw value if the saved value is no longer in the options list.
+- **Type contract**: `libs/core/src/orders/domain/types/mapping-option.types.ts` — `MappingOption { value, label }`. Both required strings. The mirror FE type is `apps/web/src/features/mappings/api/mappings.types.ts`.
+- **Test gap**: no `MappingPanel.test.tsx` exists today (only `AllegroCategorySearch.test.tsx` and the hooks tests). This change is a natural place to add one alongside the visual update — covers acceptance bullet #5 (Vitest on dropdown rendering) directly.
+- **Hooks test**: `use-mapping-options.test.tsx` already covers the source-options query hook (also acceptance bullet #5).
+
+## 3. Design
+
+### Visual treatment
+
+Render mappings with two pieces of information when `value !== label`:
+
+```
+Allegro Paczkomaty InPost  1fa56f79-…
+^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^
+primary text               muted, smaller, monospace
+```
+
+When `value === label` (rare — happens when the Allegro adapter falls back to using id-as-name because the rate-table row had no `method.name`), render the value once and skip the muted hint. This keeps the surface clean for degraded data without forcing the operator to read the same string twice.
+
+### Surfaces
+
+Two render sites in `MappingPanel`:
+
+1. **Saved-rows table cells** (line 140 / 141). Real DOM, can carry styled `<span>`s. Render `{label}` + a `<span class="mapping-panel__id-hint mono-text">{truncatedValue}</span>` when `value !== label`.
+2. **Dropdown `<option>` elements** (line 167 / 178). Native `<select>` doesn't accept styled children — browsers strip everything but text. Render `{label} ({truncatedValue})` as plain text when `value !== label`. The visual "fade" treatment isn't possible inside a native option, but the operator still gets both pieces of information.
+
+### Truncation
+
+Allegro UUIDs are 36 characters and would dominate the row visually if rendered in full. Truncate to first 8 chars + `…` (matching the issue's example: `1fa56f79-…`). Helper:
+
+```ts
+function shortValue(value: string): string {
+  return value.length <= 9 ? value : `${value.slice(0, 8)}…`;
+}
+```
+
+Length check guards against truncating short values like PrestaShop carrier ids (`5`, `12`) — those render as-is.
+
+The truncated id is supplementary, not the primary disambiguator. Allegro method names are already self-disambiguating in operator language ("Allegro Paczkomaty InPost" vs "Allegro Kurier24 InPost"); the id chip exists so an operator can confirm a saved row matches the underlying UUID without leaving the page, not so they can distinguish two near-identical methods by id. Collision odds on 8 hex chars within a seller's 10–15 methods are negligible.
+
+### Helper function
+
+Extract a single helper inside `MappingPanel.tsx`:
+
+```ts
+function renderOptionLabel(option: MappingOption): ReactNode {
+  if (option.label === option.value) {
+    return option.label;
+  }
+  return (
+    <>
+      {option.label}{' '}
+      <span className="mapping-panel__id-hint mono-text">{shortValue(option.value)}</span>
+    </>
+  );
+}
+
+function optionPlainText(option: MappingOption): string {
+  return option.label === option.value
+    ? option.label
+    : `${option.label} (${shortValue(option.value)})`;
+}
+```
+
+`renderOptionLabel` returns ReactNode for the table; `optionPlainText` returns string for `<option>` text. The two helpers stay tight (4 + 4 lines) and live next to the existing `labelFor`.
+
+The existing `labelFor(options, value)` keeps its current behaviour (used to resolve a saved row value back to its option). Update its call sites in the table to `renderOptionLabel(option)` once the option is found.
+
+### Why `MappingPanel` (shared) and not `CarrierMappingPanel` (carrier-only)
+
+The issue title is carrier-specific, but `MappingPanel` is shared across all 3 mapping tabs (statuses / carriers / payments). The `value !== label` polish is universally useful: PS carrier rows become `Carrier Name (5)`, Allegro status rows stay clean (`SENT === SENT`, treated as the degraded case → no hint). Adding it generically is no extra work and avoids forking the panel into 3 variants. Aligns with frontend-architecture's "shared components must remain generic enough to be reused across features".
+
+## 4. Step-by-step plan
+
+### Step 1 — Update `MappingPanel`
+
+**File:** `apps/web/src/features/mappings/components/MappingPanel.tsx` (edit)
+
+- Add `shortValue(value)` helper (top of file, after imports).
+- Add `renderOptionLabel(option)` (returns `ReactNode`) and `optionPlainText(option)` (returns `string`) helpers.
+- Replace `labelFor` with `optionByValue(options, value): MappingOption | null` — straight `Array.find`, returns the full option. Lists are tiny (3 panels × ≤20 items) so a Map is overkill; `Array.find` matches the existing tone of the file.
+- In the saved-rows `<td>` cells: call `optionByValue` and pass the result to `renderOptionLabel`. When the option is **not** found (saved value no longer in the live source list — e.g., seller deleted the cennik), fall back to rendering the raw `row.sourceValue` in a single mono span. Preserves today's graceful degradation.
+- In the `<option>` elements, render `optionPlainText(option)`.
+
+**Acceptance:** existing usage continues to work — `connection-mappings-page.tsx` doesn't change at all; pure internal refactor of the rendering helpers. Compilation green.
+
+### Step 2 — CSS
+
+**File:** `apps/web/src/index.css` (edit)
+
+- Add `.mapping-panel__id-hint` rule using `var(--text-muted)`, `0.75rem` font-size, slightly reduced letter-spacing for the dense look. Combined with `.mono-text` (already exists) for the monospace treatment.
+
+**Acceptance:** tokens-only, no raw hex; selector follows BEM convention; lint passes.
+
+### Step 3 — Add `MappingPanel.test.tsx`
+
+**File:** `apps/web/src/features/mappings/components/MappingPanel.test.tsx` (new)
+
+Cover the rendering states and the new label+id behaviour:
+
+- **Mapped row with distinct value/label**: renders `{label}` + truncated value (`1fa56f79-…` shape) in the table cell.
+- **Mapped row with value === label**: renders a single label, no id-hint span.
+- **Mapped row with short value**: a 1–2 char value (e.g., PS carrier id `5`) renders verbatim with no ellipsis (asserts `shortValue` short-circuits on `length <= 9`).
+- **Dropdown options**: distinct value/label produces `Label (1fa56f79-…)` plain text; matching value/label produces just the label.
+- **Loading state**: renders `LoadingState`.
+- **Options error**: renders `ErrorState` with the error message.
+- **Empty saved rows**: renders the "No mappings configured yet" copy.
+- **Duplicate-source guard**: tries to add a second mapping for an already-mapped source, expects the inline error and no row added.
+- **Save flow**: clicking Save calls `onSave` with the current `localRows` snapshot.
+
+**Acceptance:** 8 tests, all pass against the updated component. Existing FE test suite total grows by exactly these 8.
+
+### Step 4 — Quality gate
+
+```
+pnpm --filter @openlinker/web lint
+pnpm --filter @openlinker/web type-check
+pnpm --filter @openlinker/web test
+```
+
+**Acceptance:** zero new errors; pre-existing warnings unchanged.
+
+## 5. Validation
+
+- **Architecture:** pure FE feature, dep direction `pages → features → shared` preserved (no dep changes — this is an internal-rendering polish). No CORE / Integration touch.
+- **Naming:** kebab-class CSS, helper functions camelCase, test file matches `*.test.tsx` convention.
+- **Type safety:** strict — all helpers fully typed; `renderOptionLabel` returns `ReactNode`; `optionPlainText` returns `string`. No `any`.
+- **Accessibility:** the muted span is decorative supplementary text alongside the primary label; the `<option>` plain text already conveys both name and id to screen readers; no `aria-` changes needed. The Remove button's `aria-label` already includes the resolved label — that path keeps working unchanged.
+- **Testing:** acceptance bullet #5 (Vitest on dropdown rendering + on source-options query hook) — query hook covered by existing `use-mapping-options.test.tsx`, dropdown rendering covered by the new `MappingPanel.test.tsx` cases.
+- **Security:** no user input rendered as HTML; React text-node escapes the value string.
+
+## 6. Risks & open questions
+
+- **`<option>` styling fundamentally limited**: Native `<select>` doesn't render styled children. The "faded UUID in the dropdown" the issue mentions is realistically only achievable in the saved-rows table (real DOM). Plain text `Label (1fa56f79-…)` in dropdown options is the closest native approximation — flagging in PR description so it's a deliberate constraint, not an oversight. Replacing the native `<select>` with a styled `Select` primitive (Radix-wrapped, already in `shared/ui/select.tsx`) is a larger refactor and out of scope for this PR.
+- **Truncation length**: 8 chars handles UUID disambiguation in 99% of cases (UUID v4 has near-zero collision in the first 8 hex chars within a single seller's 10–15 methods). If two methods share the same first 8 chars, the operator can still recover by hovering the table row (full UUID is preserved as the underlying `value`) — but this is a degenerate case I'm not going to solve unless it shows up in real data.
+- **No new shared primitive**: the `__id-hint` span is a one-off helper class for `MappingPanel`. If a second mapping-style surface needs the same treatment, promote to a `<MutedIdHint>` primitive in `shared/ui/`. Don't pre-build it.


### PR DESCRIPTION
Closes #474

## Summary

The carrier-mapping panel today shows raw Allegro `delivery.method.id` UUIDs in both the dropdown and the saved-row table cells, forcing operators to cross-reference Allegro's seller portal to recognise which method is which. Setting up a fresh connection takes 10+ row entries, each requiring a UUID lookup, before order sync routes correctly.

The BE half of #474 already shipped with #472 — `AllegroOrderSourceAdapter.listDeliveryMethods()` walks the seller's `/sale/shipping-rates` and per-id details, flattens + dedupes by methodId, and returns labelled `MappingOption[]` via `GET /connections/:id/mappings/options/source/delivery-methods`. The remaining gap was purely FE: the shared `MappingPanel` rendered `{o.label}` only, hiding the id entirely when a label was present and rendering an opaque UUID when it wasn't.

## Changes

**`apps/web/src/features/mappings/components/MappingPanel.tsx`** — three small helpers, no API change to the component:
- `shortValue(value)` — 8-char + `…` truncation; short values (≤9 chars, e.g. PS carrier ids `5` / `12`) render verbatim with no ellipsis.
- `optionByValue(options, value)` — replaces the old `labelFor`, returns the full `MappingOption` so callers can render label + id-hint together.
- `renderOptionLabel(option)` — returns React node: `{label}` followed by a muted mono `<span class="mapping-id-hint mono-text">` with the truncated value, only when `value !== label`. Degraded data (`label === value`) renders a single label and skips the redundant hint.
- `optionPlainText(option)` — plain-text variant for `<option>` elements (native `<select>` strips styled children — the faded treatment isn't achievable inside an option without a Radix migration, which is out of scope here per `frontend-architecture.md` "prefer native `<select>`").
- Saved-row table cells render `renderOptionLabel(option)`; orphan rows (saved value no longer in the live source list) fall back to a single `<span class="mono-text">` with the raw value.

**CSS** — `.mapping-id-hint` flat-name helper (no BEM `__child` suffix — sibling one-off helpers like `.sku-label` and `.num` use the same flat-name style). Uses `--text-muted` + `0.75rem` + `-0.01em` letter-spacing.

The polish lands on the shared `MappingPanel`, so all three mapping tabs (statuses / carriers / payments) get the upgrade. Carriers benefit the most (long Allegro UUIDs become readable), payments and PS targets get an incidental win (`InPost Paczkomat 5`), and statuses degrade cleanly when value === label.

## Tests

New `MappingPanel.test.tsx` (none existed before) — 10 cases covering:
- id-hint rendering when value !== label
- suppression when value === label
- short-value verbatim (no ellipsis on `5`)
- dropdown plain-text format
- orphan-row fallback to raw value
- loading / error / empty panel states
- dedup-via-filter (already-mapped source disappears from add-row dropdown)
- save-flow calling `onSave` with the row list

## Tech-review follow-up (commit `5818c55`)

Two cosmetic polish items from the review:
- CSS class renamed `.mapping-panel__id-hint` → `.mapping-id-hint` (BEM `__child` suffix implied a `.mapping-panel` parent block that doesn't exist; flat-name matches sibling helpers).
- `aria-label` on the Remove button now reads "Remove mapping for orphaned source" instead of inlining a raw 36-char UUID when the option is missing from the live list.

## Acceptance per #474 Phase 1

- [x] `GET .../source/delivery-methods` returns labelled live data (already shipped via #472).
- [x] Source dropdown shows the human-readable name plus a truncated id (visual "fade" is real in saved-row table cells; `<option>` text is the closest native approximation).
- [x] No schema change to `connection_carrier_mappings`.
- [x] Loading / error / empty states preserved per `frontend-architecture.md`.
- [x] Vitest coverage on dropdown rendering + on the source-options query hook (existing `use-mapping-options.test.tsx`).

## Deferred

**Phase 2** (carrier-family / pattern matching) per the issue body — ship Phase 1 first, evaluate operator workload on the new labelled UI, decide whether Phase 2 is needed.

## Test plan

- [x] `MappingPanel.test.tsx` — 10 new cases, all pass
- [x] Quality gate: lint clean, type-check green, **797 tests passing** (+10 from this PR)
- [ ] Visual check on the live `/connections/:id/mappings` Carriers tab against a real Allegro sandbox connection — confirm dropdown reads "Allegro Paczkomaty InPost (1fa56f79…)" and the saved-row cell renders the muted id chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)