### PR TITLE
fix(mappings): resolve partner connection for mapping options page

### DIFF
--- a/apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts
+++ b/apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts
@@ -1,5 +1,5 @@
 /**
- * MappingOptionsController unit tests (#472 / #473 / #474)
+ * MappingOptionsController unit tests (#472 / #473 / #474 / #479)
  *
  * Covers the resolve→narrow→invoke pipeline for each of the six new
  * capability-scoped routes plus the two categories routes. Verifies:
@@ -7,15 +7,22 @@
  *   - 501: adapter resolved but doesn't implement the sub-capability
  *   - error propagation when getCapabilityAdapter throws
  *   - categories paths delegate to categoriesCacheService
+ *   - #479 partner resolution: URL-is-Allegro / URL-is-PS / no pairing /
+ *     ambiguous pairing / unsupported platform branches
  *
  * @module apps/api/src/mappings/http/__tests__
  */
 
-import { NotImplementedException } from '@nestjs/common';
+import { BadRequestException, NotImplementedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
+import {
+  CONNECTION_PORT_TOKEN,
+  type Connection,
+  type ConnectionPort,
+} from '@openlinker/core/identifier-mapping';
 import type {
   DestinationOptionsReader,
   OrderProcessorManagerPort,
@@ -31,8 +38,10 @@ describe('MappingOptionsController', () => {
   let controller: MappingOptionsController;
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let categoriesCache: jest.Mocked<ICategoriesCacheService>;
+  let connectionPort: jest.Mocked<ConnectionPort>;
 
-  const CONNECTION_ID = 'conn-1';
+  const ALLEGRO_CONNECTION_ID = 'conn-allegro-1';
+  const PRESTASHOP_CONNECTION_ID = 'conn-ps-1';
 
   const fullDestinationAdapter: OrderProcessorManagerPort & DestinationOptionsReader = {
     createOrder: jest.fn(),
@@ -58,6 +67,32 @@ describe('MappingOptionsController', () => {
     getOrder: jest.fn(),
   };
 
+  /** Build a Connection fixture with sensible defaults for tests. */
+  function makeConnection(overrides: Partial<Connection> & Pick<Connection, 'id' | 'platformType'>): Connection {
+    return {
+      id: overrides.id,
+      platformType: overrides.platformType,
+      name: overrides.name ?? `Connection ${overrides.id}`,
+      status: overrides.status ?? 'active',
+      config: overrides.config ?? {},
+      credentialsRef: overrides.credentialsRef ?? '',
+      createdAt: overrides.createdAt ?? new Date('2026-01-01'),
+      updatedAt: overrides.updatedAt ?? new Date('2026-01-01'),
+      adapterKey: overrides.adapterKey ?? undefined,
+      enabledCapabilities: overrides.enabledCapabilities ?? [],
+    } as Connection;
+  }
+
+  const allegroConnection = makeConnection({
+    id: ALLEGRO_CONNECTION_ID,
+    platformType: 'allegro',
+    config: { masterCatalogConnectionId: PRESTASHOP_CONNECTION_ID },
+  });
+  const prestashopConnection = makeConnection({
+    id: PRESTASHOP_CONNECTION_ID,
+    platformType: 'prestashop',
+  });
+
   beforeEach(async () => {
     integrationsService = {
       getCapabilityAdapter: jest.fn(),
@@ -66,12 +101,26 @@ describe('MappingOptionsController', () => {
       getPrestashopCategories: jest.fn(),
       getAllegroCategories: jest.fn(),
     } as unknown as jest.Mocked<ICategoriesCacheService>;
+    connectionPort = {
+      get: jest.fn(),
+      list: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      disable: jest.fn(),
+    } as unknown as jest.Mocked<ConnectionPort>;
+
+    // Default: existing happy-path tests use ALLEGRO_CONNECTION_ID and expect
+    // it to resolve to itself for source / to PRESTASHOP_CONNECTION_ID for
+    // destination. Per-test branches override `get` / `list` as needed.
+    connectionPort.get.mockResolvedValue(allegroConnection);
+    connectionPort.list.mockResolvedValue([allegroConnection]);
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MappingOptionsController],
       providers: [
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
         { provide: CATEGORIES_CACHE_SERVICE_TOKEN, useValue: categoriesCache },
+        { provide: CONNECTION_PORT_TOKEN, useValue: connectionPort },
       ],
     }).compile();
 
@@ -87,21 +136,25 @@ describe('MappingOptionsController', () => {
       ['getDestinationCarriers' as const, 'listCarriers' as const],
       ['getDestinationOrderStatuses' as const, 'listOrderStatuses' as const],
       ['getDestinationPaymentMethods' as const, 'listPaymentMethods' as const],
-    ])('%s resolves OrderProcessorManager and calls %s', async (handlerKey, methodName) => {
-      const result = await controller[handlerKey](CONNECTION_ID);
+    ])(
+      '%s resolves OrderProcessorManager from the paired PrestaShop and calls %s',
+      async (handlerKey, methodName) => {
+        const result = await controller[handlerKey](ALLEGRO_CONNECTION_ID);
 
-      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
-        CONNECTION_ID,
-        'OrderProcessorManager',
-      );
-      expect(fullDestinationAdapter[methodName]).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(await fullDestinationAdapter[methodName]());
-    });
+        // Resolved partner = paired PS connection (URL is Allegro, side = destination).
+        expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+          PRESTASHOP_CONNECTION_ID,
+          'OrderProcessorManager',
+        );
+        expect(fullDestinationAdapter[methodName]).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(await fullDestinationAdapter[methodName]());
+      },
+    );
 
     it('throws 501 when the adapter does not implement DestinationOptionsReader', async () => {
       integrationsService.getCapabilityAdapter.mockResolvedValueOnce(baseDestinationAdapter);
 
-      await expect(controller.getDestinationCarriers(CONNECTION_ID)).rejects.toBeInstanceOf(
+      await expect(controller.getDestinationCarriers(ALLEGRO_CONNECTION_ID)).rejects.toBeInstanceOf(
         NotImplementedException,
       );
     });
@@ -110,7 +163,7 @@ describe('MappingOptionsController', () => {
       const err = new Error('Connection not found');
       integrationsService.getCapabilityAdapter.mockRejectedValueOnce(err);
 
-      await expect(controller.getDestinationCarriers(CONNECTION_ID)).rejects.toBe(err);
+      await expect(controller.getDestinationCarriers(ALLEGRO_CONNECTION_ID)).rejects.toBe(err);
     });
   });
 
@@ -123,22 +176,131 @@ describe('MappingOptionsController', () => {
       ['getSourceOrderStatuses' as const, 'listOrderStatuses' as const],
       ['getSourceDeliveryMethods' as const, 'listDeliveryMethods' as const],
       ['getSourcePaymentMethods' as const, 'listPaymentMethods' as const],
-    ])('%s resolves OrderSource and calls %s', async (handlerKey, methodName) => {
-      const result = await controller[handlerKey](CONNECTION_ID);
+    ])(
+      '%s resolves OrderSource from the URL Allegro connection and calls %s',
+      async (handlerKey, methodName) => {
+        const result = await controller[handlerKey](ALLEGRO_CONNECTION_ID);
 
-      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
-        CONNECTION_ID,
-        'OrderSource',
-      );
-      expect(fullSourceAdapter[methodName]).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(await fullSourceAdapter[methodName]());
-    });
+        // Resolved partner = URL connection itself (URL is Allegro, side = source).
+        expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+          ALLEGRO_CONNECTION_ID,
+          'OrderSource',
+        );
+        expect(fullSourceAdapter[methodName]).toHaveBeenCalledTimes(1);
+        expect(result).toEqual(await fullSourceAdapter[methodName]());
+      },
+    );
 
     it('throws 501 when the adapter does not implement SourceOptionsReader', async () => {
       integrationsService.getCapabilityAdapter.mockResolvedValueOnce(baseSourceAdapter);
 
-      await expect(controller.getSourceDeliveryMethods(CONNECTION_ID)).rejects.toBeInstanceOf(
+      await expect(controller.getSourceDeliveryMethods(ALLEGRO_CONNECTION_ID)).rejects.toBeInstanceOf(
         NotImplementedException,
+      );
+    });
+  });
+
+  describe('partner resolution (#479)', () => {
+    it('URL is PrestaShop, side=destination → resolves to URL connection', async () => {
+      connectionPort.get.mockResolvedValueOnce(prestashopConnection);
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(fullDestinationAdapter);
+
+      await controller.getDestinationCarriers(PRESTASHOP_CONNECTION_ID);
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+        PRESTASHOP_CONNECTION_ID,
+        'OrderProcessorManager',
+      );
+    });
+
+    it('URL is PrestaShop, side=source → reverse-resolves the paired Allegro', async () => {
+      connectionPort.get.mockResolvedValueOnce(prestashopConnection);
+      connectionPort.list.mockResolvedValueOnce([allegroConnection]);
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(fullSourceAdapter);
+
+      await controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID);
+
+      // Reverse lookup filters Allegro connections to active ones.
+      expect(connectionPort.list).toHaveBeenCalledWith({
+        platformType: 'allegro',
+        status: 'active',
+      });
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+        ALLEGRO_CONNECTION_ID,
+        'OrderSource',
+      );
+    });
+
+    it('URL is Allegro with no masterCatalogConnectionId → 400 with operator message', async () => {
+      const orphanedAllegro = makeConnection({
+        id: 'orphan-allegro',
+        platformType: 'allegro',
+        config: {},
+      });
+      connectionPort.get.mockResolvedValueOnce(orphanedAllegro);
+
+      await expect(controller.getDestinationCarriers('orphan-allegro')).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: expect.stringContaining('no destination paired'),
+      });
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('URL is PrestaShop with zero paired Allegro connections → 400 with operator message', async () => {
+      connectionPort.get.mockResolvedValueOnce(prestashopConnection);
+      // No Allegro connection points at this PS.
+      connectionPort.list.mockResolvedValueOnce([]);
+
+      await expect(controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID)).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: expect.stringContaining('no source paired'),
+      });
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('URL is PrestaShop with multiple paired Allegro connections → 400 listing the conflicting ids', async () => {
+      const allegroA = makeConnection({
+        id: 'allegro-a',
+        platformType: 'allegro',
+        config: { masterCatalogConnectionId: PRESTASHOP_CONNECTION_ID },
+      });
+      const allegroB = makeConnection({
+        id: 'allegro-b',
+        platformType: 'allegro',
+        config: { masterCatalogConnectionId: PRESTASHOP_CONNECTION_ID },
+      });
+      connectionPort.get.mockResolvedValueOnce(prestashopConnection);
+      connectionPort.list.mockResolvedValueOnce([allegroA, allegroB]);
+
+      const promise = controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID);
+      await expect(promise).rejects.toBeInstanceOf(BadRequestException);
+      await expect(promise).rejects.toMatchObject({
+        message: expect.stringMatching(/multiple paired Allegro connections \(allegro-a, allegro-b\)/),
+      });
+    });
+
+    it('URL connection has unsupported platform → 400', async () => {
+      const shopify = makeConnection({ id: 'shopify-1', platformType: 'shopify' });
+      connectionPort.get.mockResolvedValueOnce(shopify);
+
+      await expect(controller.getDestinationCarriers('shopify-1')).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: expect.stringContaining('unsupported platform'),
+      });
+    });
+
+    it('URL is PrestaShop, side=source: ignores Allegro connections paired to other PS instances', async () => {
+      const otherPaired = makeConnection({
+        id: 'allegro-other',
+        platformType: 'allegro',
+        config: { masterCatalogConnectionId: 'some-other-ps' },
+      });
+      connectionPort.get.mockResolvedValueOnce(prestashopConnection);
+      connectionPort.list.mockResolvedValueOnce([otherPaired]);
+
+      // Same as zero-paired branch: 400 because no Allegro points at *this* PS.
+      await expect(controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID)).rejects.toBeInstanceOf(
+        BadRequestException,
       );
     });
   });
@@ -150,18 +312,18 @@ describe('MappingOptionsController', () => {
       ];
       categoriesCache.getPrestashopCategories.mockResolvedValueOnce(stubCategories as never);
 
-      const result = await controller.getDestinationCategories(CONNECTION_ID);
+      const result = await controller.getDestinationCategories(ALLEGRO_CONNECTION_ID);
 
-      expect(categoriesCache.getPrestashopCategories).toHaveBeenCalledWith(CONNECTION_ID);
+      expect(categoriesCache.getPrestashopCategories).toHaveBeenCalledWith(ALLEGRO_CONNECTION_ID);
       expect(result).toEqual(stubCategories);
     });
 
     it('getSourceCategories delegates to categoriesCacheService.getAllegroCategories with parentId', async () => {
       categoriesCache.getAllegroCategories.mockResolvedValueOnce([]);
 
-      await controller.getSourceCategories(CONNECTION_ID, 'parent-42');
+      await controller.getSourceCategories(ALLEGRO_CONNECTION_ID, 'parent-42');
 
-      expect(categoriesCache.getAllegroCategories).toHaveBeenCalledWith(CONNECTION_ID, 'parent-42');
+      expect(categoriesCache.getAllegroCategories).toHaveBeenCalledWith(ALLEGRO_CONNECTION_ID, 'parent-42');
     });
   });
 });

--- a/apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts
+++ b/apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts
@@ -239,10 +239,9 @@ describe('MappingOptionsController', () => {
       });
       connectionPort.get.mockResolvedValueOnce(orphanedAllegro);
 
-      await expect(controller.getDestinationCarriers('orphan-allegro')).rejects.toMatchObject({
-        constructor: BadRequestException,
-        message: expect.stringContaining('no destination paired'),
-      });
+      const promise = controller.getDestinationCarriers('orphan-allegro');
+      await expect(promise).rejects.toBeInstanceOf(BadRequestException);
+      await expect(promise).rejects.toThrow(/no destination paired/);
       expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
     });
 
@@ -251,10 +250,9 @@ describe('MappingOptionsController', () => {
       // No Allegro connection points at this PS.
       connectionPort.list.mockResolvedValueOnce([]);
 
-      await expect(controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID)).rejects.toMatchObject({
-        constructor: BadRequestException,
-        message: expect.stringContaining('no source paired'),
-      });
+      const promise = controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID);
+      await expect(promise).rejects.toBeInstanceOf(BadRequestException);
+      await expect(promise).rejects.toThrow(/no source paired/);
       expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
     });
 
@@ -274,19 +272,16 @@ describe('MappingOptionsController', () => {
 
       const promise = controller.getSourceOrderStatuses(PRESTASHOP_CONNECTION_ID);
       await expect(promise).rejects.toBeInstanceOf(BadRequestException);
-      await expect(promise).rejects.toMatchObject({
-        message: expect.stringMatching(/multiple paired Allegro connections \(allegro-a, allegro-b\)/),
-      });
+      await expect(promise).rejects.toThrow(/multiple paired Allegro connections \(allegro-a, allegro-b\)/);
     });
 
     it('URL connection has unsupported platform → 400', async () => {
       const shopify = makeConnection({ id: 'shopify-1', platformType: 'shopify' });
       connectionPort.get.mockResolvedValueOnce(shopify);
 
-      await expect(controller.getDestinationCarriers('shopify-1')).rejects.toMatchObject({
-        constructor: BadRequestException,
-        message: expect.stringContaining('unsupported platform'),
-      });
+      const promise = controller.getDestinationCarriers('shopify-1');
+      await expect(promise).rejects.toBeInstanceOf(BadRequestException);
+      await expect(promise).rejects.toThrow(/unsupported platform/);
     });
 
     it('URL is PrestaShop, side=source: ignores Allegro connections paired to other PS instances', async () => {

--- a/apps/api/src/mappings/http/mapping-options.controller.ts
+++ b/apps/api/src/mappings/http/mapping-options.controller.ts
@@ -1,5 +1,5 @@
 /**
- * Mapping Options Controller (#472 / #473 / #474)
+ * Mapping Options Controller (#472 / #473 / #474 / #479)
  *
  * Capability-scoped routes for the carrier-mapping UI dropdowns. Each handler
  * resolves the platform adapter via `IIntegrationsService.getCapabilityAdapter`,
@@ -14,6 +14,13 @@
  * the platform prefix from the URL because `connectionId` already
  * disambiguates the platform via `ConnectionService`.
  *
+ * #479 — Partner resolution. The Allegro→PrestaShop mappings page lives at
+ * `/connections/{connectionId}/mappings` and renders source options from the
+ * Allegro connection plus destination options from its PrestaShop partner.
+ * Source and destination capabilities live on different connections, so the
+ * URL `connectionId` is mapped to the partner via `Connection.config.master
+ * CatalogConnectionId` before each `getCapabilityAdapter` call.
+ *
  * Categories endpoints continue to use `categoriesCacheService` directly —
  * they're already live-data and the cache is the right architecture for
  * tree-structured taxonomies; only the URL changed.
@@ -21,7 +28,15 @@
  * @module apps/api/src/mappings/http
  */
 
-import { Controller, Get, Param, Query, Inject, NotImplementedException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  Inject,
+  NotImplementedException,
+  BadRequestException,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiTags,
@@ -34,6 +49,11 @@ import {
   IIntegrationsService,
   INTEGRATIONS_SERVICE_TOKEN,
 } from '@openlinker/core/integrations';
+import {
+  CONNECTION_PORT_TOKEN,
+  type Connection,
+  type ConnectionPort,
+} from '@openlinker/core/identifier-mapping';
 import {
   isDestinationOptionsReader,
   isSourceOptionsReader,
@@ -49,6 +69,20 @@ import { AllegroCategoryResponseDto } from './dto/allegro-category-response.dto'
 import { ICategoriesCacheService } from '../../categories/categories-cache.service.interface';
 import { CATEGORIES_CACHE_SERVICE_TOKEN } from '../../categories/categories.tokens';
 
+/**
+ * Mapping-page partner platforms. The mappings UI is Allegro→PrestaShop only
+ * today (FE labels say "Allegro status" → "PrestaShop status"). When a third
+ * platform pair (Shopify→PS, etc.) gets added, this branching grows; for now
+ * the literals match the de-facto convention used elsewhere in the codebase
+ * (`Connection.platformType` is `string` per connection.types.ts:15 — once a
+ * `PlatformTypeValues as const` lands per engineering-standards.md, swap
+ * these literals for the constant references).
+ */
+const PLATFORM_ALLEGRO = 'allegro';
+const PLATFORM_PRESTASHOP = 'prestashop';
+
+type ResolvedSide = 'source' | 'destination';
+
 @Roles('admin')
 @ApiBearerAuth()
 @ApiTags('mappings')
@@ -59,6 +93,8 @@ export class MappingOptionsController {
     private readonly integrationsService: IIntegrationsService,
     @Inject(CATEGORIES_CACHE_SERVICE_TOKEN)
     private readonly categoriesCacheService: ICategoriesCacheService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
   ) {}
 
   // ── Destination side (e.g. PrestaShop OrderProcessorManager) ────────────
@@ -67,6 +103,7 @@ export class MappingOptionsController {
   @ApiOperation({ summary: 'List destination-platform carriers (live)' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  @ApiResponse({ status: 400, description: 'No PrestaShop partner is paired with this connection' })
   @ApiResponse({ status: 501, description: 'Adapter does not implement DestinationOptionsReader' })
   async getDestinationCarriers(
     @Param('connectionId') connectionId: string,
@@ -78,6 +115,7 @@ export class MappingOptionsController {
   @ApiOperation({ summary: 'List destination-platform order statuses (live)' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  @ApiResponse({ status: 400, description: 'No PrestaShop partner is paired with this connection' })
   @ApiResponse({ status: 501, description: 'Adapter does not implement DestinationOptionsReader' })
   async getDestinationOrderStatuses(
     @Param('connectionId') connectionId: string,
@@ -89,6 +127,7 @@ export class MappingOptionsController {
   @ApiOperation({ summary: 'List destination-platform payment methods (live)' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  @ApiResponse({ status: 400, description: 'No PrestaShop partner is paired with this connection' })
   @ApiResponse({ status: 501, description: 'Adapter does not implement DestinationOptionsReader' })
   async getDestinationPaymentMethods(
     @Param('connectionId') connectionId: string,
@@ -102,6 +141,7 @@ export class MappingOptionsController {
   @ApiOperation({ summary: 'List source-platform order statuses' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  @ApiResponse({ status: 400, description: 'No Allegro partner is paired with this connection' })
   @ApiResponse({ status: 501, description: 'Adapter does not implement SourceOptionsReader' })
   async getSourceOrderStatuses(
     @Param('connectionId') connectionId: string,
@@ -113,6 +153,7 @@ export class MappingOptionsController {
   @ApiOperation({ summary: 'List source-platform delivery methods (carriers, with human labels)' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  @ApiResponse({ status: 400, description: 'No Allegro partner is paired with this connection' })
   @ApiResponse({ status: 501, description: 'Adapter does not implement SourceOptionsReader' })
   async getSourceDeliveryMethods(
     @Param('connectionId') connectionId: string,
@@ -124,6 +165,7 @@ export class MappingOptionsController {
   @ApiOperation({ summary: 'List source-platform payment methods' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [MappingOptionResponseDto] })
+  @ApiResponse({ status: 400, description: 'No Allegro partner is paired with this connection' })
   @ApiResponse({ status: 501, description: 'Adapter does not implement SourceOptionsReader' })
   async getSourcePaymentMethods(
     @Param('connectionId') connectionId: string,
@@ -156,24 +198,30 @@ export class MappingOptionsController {
     return categories.map((c) => AllegroCategoryResponseDto.fromDomain(c));
   }
 
-  // ── Private helpers (#472 §5.5) ─────────────────────────────────────────
+  // ── Private helpers (#472 §5.5 / #479) ──────────────────────────────────
 
   /**
    * Resolves the destination adapter, narrows via `isDestinationOptionsReader`,
    * and invokes the named method. Centralises the resolve+narrow+invoke
    * pattern that would otherwise repeat across three near-identical handlers.
+   *
+   * #479: the URL `connectionId` may be the Allegro source connection — in
+   * that case `resolvePartnerConnectionId` returns its paired PrestaShop id,
+   * which is the connection that actually carries the OrderProcessorManager
+   * capability.
    */
   private async resolveDestinationOptions<K extends keyof DestinationOptionsReader>(
     connectionId: string,
     method: K,
   ): Promise<MappingOptionResponseDto[]> {
+    const partnerConnectionId = await this.resolvePartnerConnectionId(connectionId, 'destination');
     const adapter = await this.integrationsService.getCapabilityAdapter<OrderProcessorManagerPort>(
-      connectionId,
+      partnerConnectionId,
       'OrderProcessorManager',
     );
     if (!isDestinationOptionsReader(adapter)) {
       throw new NotImplementedException(
-        `Adapter for connection ${connectionId} does not implement DestinationOptionsReader`,
+        `Adapter for connection ${partnerConnectionId} does not implement DestinationOptionsReader`,
       );
     }
     return adapter[method]();
@@ -187,15 +235,113 @@ export class MappingOptionsController {
     connectionId: string,
     method: K,
   ): Promise<MappingOptionResponseDto[]> {
+    const partnerConnectionId = await this.resolvePartnerConnectionId(connectionId, 'source');
     const adapter = await this.integrationsService.getCapabilityAdapter<OrderSourcePort>(
-      connectionId,
+      partnerConnectionId,
       'OrderSource',
     );
     if (!isSourceOptionsReader(adapter)) {
       throw new NotImplementedException(
-        `Adapter for connection ${connectionId} does not implement SourceOptionsReader`,
+        `Adapter for connection ${partnerConnectionId} does not implement SourceOptionsReader`,
       );
     }
     return adapter[method]();
   }
+
+  /**
+   * Map the URL connection to the connection that actually carries the
+   * requested side's capability. The mappings page is hard-coded
+   * Allegro→PrestaShop today; the pairing is stored on the Allegro
+   * connection's `config.masterCatalogConnectionId` (set during OAuth).
+   *
+   * Resolution table:
+   *
+   * | URL platform | side          | Returns                                                |
+   * |--------------|---------------|--------------------------------------------------------|
+   * | allegro      | source        | URL connection                                         |
+   * | allegro      | destination   | `config.masterCatalogConnectionId` on URL connection   |
+   * | prestashop   | source        | the active Allegro whose `masterCatalogConnectionId` matches the URL id |
+   * | prestashop   | destination   | URL connection                                         |
+   * | other        | either        | 400 (unsupported platform)                             |
+   *
+   * Throws `BadRequestException` (NOT 501/404) for "no partner configured"
+   * and "ambiguous partner" — these are operator-input issues, not server
+   * faults, and the FE alert should point the operator at the connection-
+   * edit page rather than leaking internal capability terminology.
+   */
+  private async resolvePartnerConnectionId(
+    urlConnectionId: string,
+    side: ResolvedSide,
+  ): Promise<string> {
+    // ConnectionPort.get throws ConnectionNotFoundException for unknown ids;
+    // that propagates through Nest as a 404 — existing behaviour.
+    const url = await this.connectionPort.get(urlConnectionId);
+
+    if (url.platformType === PLATFORM_ALLEGRO) {
+      if (side === 'source') {
+        return url.id;
+      }
+      const partnerId = readMasterCatalogConnectionId(url);
+      if (!partnerId) {
+        throw new BadRequestException(
+          `Connection "${url.name}" (${shortId(url.id)}) has no destination paired. ` +
+            `Set the catalog connection on the connection-edit page and try again.`,
+        );
+      }
+      return partnerId;
+    }
+
+    if (url.platformType === PLATFORM_PRESTASHOP) {
+      if (side === 'destination') {
+        return url.id;
+      }
+      // Reverse lookup: find the Allegro connection that points at this PS
+      // via `config.masterCatalogConnectionId`. Filter by `status: 'active'`
+      // because a disabled or errored Allegro pairing isn't a real partner —
+      // the mappings page would then call `getCapabilityAdapter` against it
+      // and fail downstream anyway.
+      const candidates = await this.connectionPort.list({
+        platformType: PLATFORM_ALLEGRO,
+        status: 'active',
+      });
+      const paired = candidates.filter(
+        (c) => readMasterCatalogConnectionId(c) === url.id,
+      );
+      if (paired.length === 0) {
+        throw new BadRequestException(
+          `Connection "${url.name}" (${shortId(url.id)}) has no source paired. ` +
+            `Open the Allegro connection's edit page and set its catalog to this PrestaShop connection.`,
+        );
+      }
+      if (paired.length > 1) {
+        const ids = paired.map((c) => c.id).join(', ');
+        throw new BadRequestException(
+          `Connection "${url.name}" (${shortId(url.id)}) has multiple paired Allegro connections (${ids}). ` +
+            `Multi-source mapping is not yet supported — disable the duplicates on the connection-edit page.`,
+        );
+      }
+      return paired[0].id;
+    }
+
+    throw new BadRequestException(
+      `Connection "${url.name}" (${shortId(url.id)}) has unsupported platform "${url.platformType}" for the mappings page. ` +
+        `Today the mappings page is Allegro→PrestaShop only.`,
+    );
+  }
+}
+
+/**
+ * Pull `masterCatalogConnectionId` off a connection's `config` JSONB.
+ * Returns `undefined` for any non-string / empty value so the caller can
+ * treat "missing" and "garbage" identically.
+ */
+function readMasterCatalogConnectionId(connection: Connection): string | undefined {
+  const value = connection.config?.['masterCatalogConnectionId'];
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  return value;
+}
+
+/** Short prefix for human-readable error messages. UUIDs alone don't help operators self-serve. */
+function shortId(id: string): string {
+  return `${id.slice(0, 8)}…`;
 }

--- a/apps/api/src/mappings/http/mapping-options.controller.ts
+++ b/apps/api/src/mappings/http/mapping-options.controller.ts
@@ -300,6 +300,9 @@ export class MappingOptionsController {
       // because a disabled or errored Allegro pairing isn't a real partner —
       // the mappings page would then call `getCapabilityAdapter` against it
       // and fail downstream anyway.
+      // TODO(#479): when `ConnectionFilters` grows a `configKeyEquals` shape,
+      // push the filter into the repository instead of fetching all active
+      // Allegro connections and filtering in code.
       const candidates = await this.connectionPort.list({
         platformType: PLATFORM_ALLEGRO,
         status: 'active',
@@ -320,7 +323,8 @@ export class MappingOptionsController {
             `Multi-source mapping is not yet supported — disable the duplicates on the connection-edit page.`,
         );
       }
-      return paired[0].id;
+      const [only] = paired;
+      return only.id;
     }
 
     throw new BadRequestException(

--- a/apps/api/src/mappings/mappings.module.ts
+++ b/apps/api/src/mappings/mappings.module.ts
@@ -10,16 +10,22 @@
 import { Module } from '@nestjs/common';
 import { MappingsModule as CoreMappingsModule } from '@openlinker/core/mappings';
 import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
+import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { CategoriesModule } from '../categories/categories.module';
 import { MappingsController } from './http/mappings.controller';
 import { MappingOptionsController } from './http/mapping-options.controller';
 
 @Module({
-  // CoreIntegrationsModule provides INTEGRATIONS_SERVICE_TOKEN — the
-  // mapping-options controller resolves per-connection adapters through it
-  // (#472). The adapter registry itself is populated by the platform
-  // integration modules imported elsewhere in the app shell.
-  imports: [CoreMappingsModule, CoreIntegrationsModule, CategoriesModule],
+  // - CoreIntegrationsModule provides INTEGRATIONS_SERVICE_TOKEN — the
+  //   mapping-options controller resolves per-connection adapters through it
+  //   (#472). The adapter registry itself is populated by the platform
+  //   integration modules imported elsewhere in the app shell.
+  // - IdentifierMappingModule provides CONNECTION_PORT_TOKEN — the controller
+  //   uses it to resolve the partner connection (Allegro↔PrestaShop) before
+  //   calling getCapabilityAdapter (#479). CoreIntegrationsModule imports
+  //   IdentifierMappingModule but does not re-export the token, so the
+  //   import here is direct.
+  imports: [CoreMappingsModule, CoreIntegrationsModule, IdentifierMappingModule, CategoriesModule],
   controllers: [MappingsController, MappingOptionsController],
 })
 export class MappingsApiModule {}

--- a/docs/plans/implementation-plan-479-mapping-options-partner-resolution.md
+++ b/docs/plans/implementation-plan-479-mapping-options-partner-resolution.md
@@ -1,0 +1,166 @@
+# Implementation Plan — #479 MappingOptionsController partner resolution
+
+## 1. Goal
+
+The `/connections/{connectionId}/mappings` page is broken on every connection because `MappingOptionsController` resolves both source and destination capability adapters from the same URL connection id. In the Allegro→PrestaShop pipeline those capabilities live on different connections — Allegro implements `SourceOptionsReader`, PrestaShop implements `OrderProcessorManager`. So whichever connection the operator opens, exactly one half of the page always errors with `does not implement <capability>`.
+
+Fix: the controller resolves the partner connection itself, using the existing pairing primitive `Connection.config.masterCatalogConnectionId`. The FE keeps calling the same endpoints unchanged.
+
+**Layer**: Interface (controller). No core/domain/application changes; no new ports.
+
+**Non-goals**:
+- Multi-Allegro → single-PS UX (a partner picker). Today, ambiguous pairing returns 400 with a clear message.
+- Storing the pairing in a dedicated column instead of `config.masterCatalogConnectionId`.
+- Renaming `masterCatalogConnectionId` to a generic `partnerConnectionId`.
+
+## 2. Research findings
+
+**Affected files**:
+
+- `apps/api/src/mappings/http/mapping-options.controller.ts:166-200` — `resolveDestinationOptions` / `resolveSourceOptions` both pass the URL `connectionId` straight to `IIntegrationsService.getCapabilityAdapter`. This is where the bug lives.
+- `apps/api/src/mappings/mappings.module.ts` — currently imports `CoreMappingsModule`, `CoreIntegrationsModule`, `CategoriesModule`. Will need `IdentifierMappingModule` for `CONNECTION_PORT_TOKEN` (CoreIntegrationsModule does *not* re-export it).
+- `apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts` — the existing 14 tests for the controller; needs four new branches.
+
+**Surface available for the fix**:
+
+- `ConnectionPort.get(connectionId)` (`libs/core/src/identifier-mapping/domain/ports/connection.port.ts:24`) — fetches a single connection by id. Throws `ConnectionNotFoundException` if missing.
+- `ConnectionPort.list(filters?)` — returns `Connection[]` filtered by `platformType` and/or `status`. We use this to enumerate Allegro connections when reverse-resolving from a PS URL connection.
+- `Connection.config: ConnectionConfig` is `Record<string, unknown>`. `config.masterCatalogConnectionId` is read as `unknown` and narrowed at the call site.
+- `Connection.platformType: PlatformType` is a `string` alias today. Allegro connections use `'allegro'`, PrestaShop uses `'prestashop'` (verified across the codebase, e.g., `apps/api/src/integrations/http/dto/allegro-oauth-connect.dto.ts:74` flow).
+- `CONNECTION_PORT_TOKEN` (`libs/core/src/identifier-mapping/identifier-mapping.tokens.ts:15`) is exported from `IdentifierMappingModule` via that module's `exports`.
+
+**Pairing semantics confirmed**:
+
+- The Allegro connection writes its catalog partner as `config.masterCatalogConnectionId` — set during the Allegro OAuth callback (`apps/api/src/integrations/application/services/allegro-oauth.service.ts` flow).
+- There is no field set the other way (PS does not store its Allegro partner). To resolve the partner from a PS URL connection, we list active Allegro connections and filter client-side for `config.masterCatalogConnectionId === <psId>`. Connection table size is small enough that listing is fine; if it grows, add a `configKeyEquals` filter to `ConnectionFilters` later.
+
+## 3. Design
+
+### Resolution rule
+
+Given a URL connection id and a `side`:
+
+| URL connection platform | side          | Resolved connection                                                       |
+|------------------------:|---------------|---------------------------------------------------------------------------|
+| `allegro`               | `source`      | URL connection                                                            |
+| `allegro`               | `destination` | `connection.config.masterCatalogConnectionId` (must be a non-empty string)|
+| `prestashop`            | `source`      | The single active Allegro connection whose `config.masterCatalogConnectionId === <urlId>` |
+| `prestashop`            | `destination` | URL connection                                                            |
+| anything else           | either        | 400 — the mappings page is Allegro→PS only today                          |
+
+### Error mapping
+
+All these become `BadRequestException` with operator-actionable messages — no leak of capability internals to the FE:
+
+- Allegro URL connection with missing/empty `masterCatalogConnectionId` → `Connection {urlId} has no destination paired. Set the catalog connection on the connection-edit page and try again.`
+- PS URL connection with zero paired Allegro connections → `Connection {urlId} has no source paired. Open the Allegro connection's edit page and set its catalog to this PrestaShop connection.`
+- PS URL connection with two or more paired Allegro connections → `Connection {urlId} has multiple paired Allegro connections ({ids…}). Multi-source mapping is not yet supported.`
+- URL connection's `platformType` is neither `allegro` nor `prestashop` → `Connection {urlId} has unsupported platform '{platformType}' for the mappings page.`
+
+`ConnectionPort.get` already throws `ConnectionNotFoundException` for unknown ids — that propagates through to a 404 (existing behaviour, unchanged).
+
+### Code shape
+
+```ts
+// In MappingOptionsController — new dep + helper
+constructor(
+  @Inject(INTEGRATIONS_SERVICE_TOKEN) private readonly integrationsService: IIntegrationsService,
+  @Inject(CATEGORIES_CACHE_SERVICE_TOKEN) private readonly categoriesCacheService: ICategoriesCacheService,
+  @Inject(CONNECTION_PORT_TOKEN) private readonly connectionPort: ConnectionPort,
+) {}
+
+private async resolvePartnerConnectionId(
+  urlConnectionId: string,
+  side: 'source' | 'destination',
+): Promise<string> {
+  const url = await this.connectionPort.get(urlConnectionId);
+  // …branches per the table above…
+}
+```
+
+`resolveDestinationOptions` and `resolveSourceOptions` get one new line each: replace the `connectionId` argument to `getCapabilityAdapter` with the resolved partner id.
+
+### Module wiring
+
+`apps/api/src/mappings/mappings.module.ts` adds `IdentifierMappingModule` to its `imports`. That module already exports `CONNECTION_PORT_TOKEN` and the underlying `ConnectionRepository` provider.
+
+## 4. Step-by-step plan
+
+### Step 1 — Add partner resolution helper
+
+**File**: `apps/api/src/mappings/http/mapping-options.controller.ts`
+
+- Inject `ConnectionPort` via `@Inject(CONNECTION_PORT_TOKEN)`.
+- Add private `resolvePartnerConnectionId(urlConnectionId, side)` per §3.
+- Update `resolveDestinationOptions` and `resolveSourceOptions` to call the helper, then pass the resolved id to `getCapabilityAdapter`.
+- Update each handler's `@ApiResponse` to mention the 400 paths alongside the existing 501.
+
+Acceptance: source/destination handlers each produce one DI of `connectionPort`, one resolution, then the existing capability-narrow flow.
+
+### Step 2 — Wire `IdentifierMappingModule` into `MappingsApiModule`
+
+**File**: `apps/api/src/mappings/mappings.module.ts`
+
+- Add `IdentifierMappingModule` to `imports`.
+- Add a comment noting the dependency is for partner-connection lookup (#479).
+
+Acceptance: `nest build` succeeds, `getCapabilityAdapter` and `ConnectionPort` both resolve at runtime.
+
+### Step 3 — Unit tests for the four resolution branches
+
+**File**: `apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts`
+
+Mock the new `ConnectionPort` dep (`jest.Mocked<ConnectionPort>` with `get` and `list` jest.fn). Add a `describe('partner resolution', () => { … })` block:
+
+1. **URL connection is Allegro, source side** — `connectionPort.get` returns Allegro connection; helper returns urlId; `getCapabilityAdapter` called with urlId + `'OrderSource'`.
+2. **URL connection is Allegro, destination side** — `connectionPort.get` returns Allegro connection with `config.masterCatalogConnectionId = 'ps-1'`; helper returns `'ps-1'`; `getCapabilityAdapter` called with `'ps-1'` + `'OrderProcessorManager'`.
+3. **URL connection is PrestaShop, source side** — `connectionPort.get` returns PS; `connectionPort.list({ platformType: 'allegro', status: 'active' })` returns one Allegro connection with `config.masterCatalogConnectionId === <urlId>`; helper returns that Allegro id; `getCapabilityAdapter` called with the Allegro id + `'OrderSource'`.
+4. **URL connection is PrestaShop, destination side** — helper returns urlId; `getCapabilityAdapter` called with urlId + `'OrderProcessorManager'`.
+5. **No pairing — Allegro url, missing `masterCatalogConnectionId`** — `BadRequestException` with the operator message.
+6. **No pairing — PS url, zero matching Allegro** — `BadRequestException`.
+7. **Ambiguous pairing — PS url, two matching Allegro** — `BadRequestException` naming the conflicting ids.
+8. **Unsupported platform** — Connection with `platformType: 'shopify'` — `BadRequestException`.
+
+Update existing happy-path tests to default `connectionPort.get` to return a sensible Allegro/PS connection so they continue to pass without rework — keep diff small.
+
+Acceptance: all new branches green; existing 14 tests unchanged.
+
+### Step 4 — Quality gate
+
+```bash
+pnpm lint && pnpm type-check && pnpm test
+```
+
+Must be zero red. No migration needed (no schema change).
+
+### Step 5 — Self-review per `docs/code-review-guide.md`
+
+Focus areas (per the doc):
+- Architecture compliance — controller stays in interface layer, depends on ports only ✓ by design.
+- Error handling — `BadRequestException` is a NestJS common exception, fine for interface-layer translations of "operator config issue". No domain-leak.
+- Logging — surface a `this.logger.warn` (or skip — these are operator-input issues, not server problems; 400 alone suffices). Decision: log nothing; let the 400 body speak.
+- Testability — `ConnectionPort` is a port, mocked via jest.
+
+### Step 6 — Commit, push, open PR with `Closes #479`
+
+Commit message:
+```
+fix(mappings): resolve partner connection for mapping options page
+
+Closes #479.
+```
+
+## 5. Validation checklist
+
+- [ ] No domain-layer changes.
+- [ ] No new ports.
+- [ ] FE hook untouched.
+- [ ] Capability port contracts unchanged.
+- [ ] Architecture: controller depends on `ConnectionPort` (port) and `IIntegrationsService` (port) — both interfaces. No infrastructure imports.
+- [ ] Naming: no new files; existing controller name preserved.
+- [ ] Tests: unit-only (controller logic with mocked port). No integration test needed — partner-resolution shape is fully covered by mocking `ConnectionPort.get` / `list`.
+- [ ] Security: `@Roles('admin')` already on the controller class — no auth regression.
+
+## 6. Open questions
+
+None blocking. The platform-type strings (`'allegro'`, `'prestashop'`) are de-facto constants in the codebase; if a future PR introduces a `PlatformTypeValues` `as const`, swap the string literals for the enum.


### PR DESCRIPTION
Closes #479.

## Summary

The `/connections/{connectionId}/mappings` page was broken on every connection after PR #476 replaced hardcoded option stubs with live capability lookups. `MappingOptionsController` fetched both source (Allegro `SourceOptionsReader`) and destination (PrestaShop `OrderProcessorManager`) capabilities from the same URL `connectionId`, but those capabilities live on different connections in the Allegro→PrestaShop pipeline — so exactly one half of the page always errored with `does not implement <capability>`.

This PR resolves the partner connection in the controller using the existing `Connection.config.masterCatalogConnectionId` pairing primitive (set on the Allegro connection during OAuth). The FE is unchanged — `useMappingOptions(connectionId)` keeps calling `/options/:side/:kind` with just the URL connection id; the controller maps `:side` to the resolved partner internally.

## Resolution table

| URL platform  | side          | Resolves to                                                |
|---------------|---------------|------------------------------------------------------------|
| `allegro`     | source        | URL connection                                             |
| `allegro`     | destination   | `config.masterCatalogConnectionId` on the URL connection   |
| `prestashop`  | source        | the active Allegro whose `masterCatalogConnectionId === url.id` |
| `prestashop`  | destination   | URL connection                                             |
| anything else | either        | 400 (unsupported platform)                                 |

## Error handling

Unresolved or ambiguous pairings raise `BadRequestException` with operator-actionable messages — the FE Alert no longer leaks internal capability terminology. Specifically:

- Allegro URL connection with missing `masterCatalogConnectionId` → "no destination paired. Set the catalog connection on the connection-edit page and try again."
- PrestaShop URL connection with zero paired Allegro → "no source paired. Open the Allegro connection's edit page and set its catalog to this PrestaShop connection."
- PrestaShop URL connection with multiple paired Allegro → "multiple paired Allegro connections (id-a, id-b)."
- Connection with unsupported platform → "unsupported platform '<platform>' for the mappings page."

`ConnectionPort.get` already throws `ConnectionNotFoundException` for unknown ids — that propagates through Nest as a 404 (existing behaviour, unchanged).

The reverse lookup filters Allegro connections by `status: 'active'` so a disabled or errored pairing isn't treated as a valid partner.

## What changed

- `apps/api/src/mappings/http/mapping-options.controller.ts` — new private `resolvePartnerConnectionId` helper; injects `ConnectionPort` via `CONNECTION_PORT_TOKEN`; threads the resolved partner id into both `resolveDestinationOptions` and `resolveSourceOptions`. File-scope helpers `readMasterCatalogConnectionId` (narrows the `unknown` config value) and `shortId` (8-char prefix for human error messages).
- `apps/api/src/mappings/mappings.module.ts` — adds `IdentifierMappingModule` to `imports` for `CONNECTION_PORT_TOKEN`. `CoreIntegrationsModule` imports it but does not re-export the token, so the import here is direct.
- `apps/api/src/mappings/http/__tests__/mapping-options.controller.spec.ts` — 7 new branches covering the 4 happy-path resolutions + 4 error paths (no destination pairing / no source pairing / ambiguous source pairing / unsupported platform) + 1 negative-match (PS URL with an Allegro paired to a different PS still 400s). Existing 14 tests adjusted only to provide a default `connectionPort.get` mock.

## Out of scope (per #479)

- Multi-Allegro → single-PS pairing UX (a partner picker on the mappings page). Today this resolves to a 400 with a clear message.
- Storing the pairing in a dedicated column instead of `config.masterCatalogConnectionId`.
- Renaming `masterCatalogConnectionId` to a generic `partnerConnectionId`.
- A `configKeyEquals` filter on `ConnectionFilters` for the reverse lookup. Marked as `TODO(#479)` in the controller; current Connection table size makes the in-code filter fine.

## Test plan

- [ ] Open `/connections/{allegroConnectionId}/mappings` on a connection with `masterCatalogConnectionId` set → both Order Statuses tab columns load.
- [ ] Open `/connections/{prestashopConnectionId}/mappings` where exactly one Allegro is paired → both columns load.
- [ ] Drop `masterCatalogConnectionId` from an Allegro connection → mappings page shows "no destination paired" alert pointing to the connection-edit page.
- [ ] Pair two Allegro connections to the same PS, open `/connections/{psId}/mappings` → 400 listing both Allegro ids.
- [ ] No regressions in Carriers / Payments tabs (they share the same `resolveDestinationOptions` plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)