### PR TITLE
fix(web): polish FileUpload UX from #449 tech-review

### DIFF
--- a/apps/web/src/features/connections/components/allegro-seller-defaults-section.test.tsx
+++ b/apps/web/src/features/connections/components/allegro-seller-defaults-section.test.tsx
@@ -18,13 +18,25 @@ import { renderWithProviders, createMockApiClient } from '../../../test/test-uti
 import { AllegroSellerDefaultsSection } from './allegro-seller-defaults-section';
 import type { EditConnectionFormValues } from './edit-connection.schema';
 
+interface HarnessAttachment {
+  id: string;
+  fileName?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+}
+
 interface HarnessProps {
   apiClient?: ReturnType<typeof createMockApiClient>;
   initialSafetyType?: 'NO_SAFETY_INFORMATION' | 'TEXT' | 'ATTACHMENTS';
+  initialAttachments?: HarnessAttachment[];
   onChange?: () => void;
 }
 
-function Harness({ initialSafetyType, onChange }: HarnessProps): ReactElement {
+function Harness({
+  initialSafetyType,
+  initialAttachments,
+  onChange,
+}: HarnessProps): ReactElement {
   const form = useForm<EditConnectionFormValues>({
     defaultValues: {
       name: 'Allegro sandbox',
@@ -36,6 +48,7 @@ function Harness({ initialSafetyType, onChange }: HarnessProps): ReactElement {
         safetyInformation: {
           type: initialSafetyType ?? 'NO_SAFETY_INFORMATION',
           description: '',
+          attachments: initialAttachments,
         },
       },
     },
@@ -142,5 +155,53 @@ describe('AllegroSellerDefaultsSection', () => {
     fireEvent.change(cityInput, { target: { value: 'Warszawa' } });
 
     expect(onChange).toHaveBeenCalled();
+  });
+
+  it('shows the full filename via title attribute on the truncated row', () => {
+    renderWithProviders(
+      <Harness
+        initialSafetyType="ATTACHMENTS"
+        initialAttachments={[
+          { id: 'att-1', fileName: 'Safety_Information_Long_Brand_Suffix_Q3.pdf', sizeBytes: 2048 },
+        ]}
+      />,
+    );
+
+    const nameSpan = screen.getByText('Safety_Information_Long_Brand_Suffix_Q3.pdf');
+    expect(nameSpan).toHaveAttribute('title', 'Safety_Information_Long_Brand_Suffix_Q3.pdf');
+  });
+
+  it('clears a lingering upload-error Alert when the operator removes an attachment', async () => {
+    const apiClient = createMockApiClient({
+      allegro: {
+        uploadSafetyAttachment: vi.fn().mockRejectedValue(new Error('Upload service down')),
+      },
+    });
+
+    renderWithProviders(
+      <Harness
+        initialSafetyType="ATTACHMENTS"
+        initialAttachments={[{ id: 'att-1', fileName: 'first.pdf', sizeBytes: 100 }]}
+      />,
+      { apiClient },
+    );
+
+    // Trigger an upload that fails so `uploadMutation.error` is set and the
+    // red Alert renders.
+    const fileInput = document.querySelector('input[type=file]') as HTMLInputElement;
+    const blob = new Blob([new Uint8Array(50)], { type: 'application/pdf' });
+    const newFile = new File([blob], 'second.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [newFile] } });
+
+    expect(await screen.findByText(/upload service down/i)).toBeInTheDocument();
+
+    // Removing the *existing* attachment must clear the stale error — without
+    // the explicit mutation.reset() in removeAt, TanStack Query keeps
+    // `error` set until a fresh upload resolves.
+    fireEvent.click(screen.getByRole('button', { name: /^remove first\.pdf$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/upload service down/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
+++ b/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
@@ -385,6 +385,12 @@ function SafetyAttachmentsField({
       shouldDirty: true,
       shouldValidate: true,
     });
+    // Clear any lingering upload-error surfaces — TanStack Query holds
+    // `mutation.error` until the next mutateAsync resolves, so without
+    // this a failed upload's red Alert would persist while the operator
+    // remediates by removing an unrelated attachment.
+    setInlineError(null);
+    uploadMutation.reset();
     onChange();
   };
 
@@ -406,7 +412,10 @@ function SafetyAttachmentsField({
         <ul className="file-upload__list" aria-label="Uploaded safety attachments">
           {attachments.map((att, index) => (
             <li key={att.id} className="file-upload__list-item">
-              <span className="file-upload__list-item-name">
+              <span
+                className="file-upload__list-item-name"
+                title={att.fileName ?? att.id}
+              >
                 {att.fileName ?? att.id}
               </span>
               <span className="file-upload__list-item-meta">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -721,6 +721,10 @@ textarea {
   white-space: nowrap;
 }
 
+/* Mobile-only refinements for the FileUpload primitive. The
+   `.file-upload__list-item-remove` class is applied at all viewport
+   widths but only carries styles inside this media query — on desktop
+   the row-level remove button keeps `button--sm` defaults. */
 @media (max-width: 767px) {
   .file-upload {
     /* Tap target — operator may upload from a phone. */


### PR DESCRIPTION
## Summary

Three surgical refinements to the safety-attachments field shipped in #449, found during a tech-review of the FileUpload UI.

- **Stale error fix:** `SafetyAttachmentsField.removeAt` now calls `uploadMutation.reset()` and clears the local `inlineError`. Without this, TanStack Query keeps `mutation.error` set until the next mutateAsync resolves, so a failed upload's red Alert would persist while the operator remediated by removing an unrelated attachment.
- **Long filename UX:** truncated filename rows gain `title={fileName}` so hover-tooltips surface the full name on desktop. Long names like `Safety_Information_Long_Brand_Suffix_Q3.pdf` were ellipsis-clipped with no escape hatch.
- **CSS clarity:** one-line comment above the file-upload mobile media query explaining why `.file-upload__list-item-remove` only carries styles inside the breakpoint — prevents future contributors chasing why the desktop class appears to be a no-op.

Follow-up to #449. Not strictly blocking — the original PR is already merged and shipped — but worth landing as polish.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 803 unit tests pass (was 801; +2 new cases in `allegro-seller-defaults-section.test.tsx`)
- [ ] Manual: open the connection-edit wizard for an Allegro connection, pick `ATTACHMENTS`, upload a long-named PDF → hover the filename row → tooltip surfaces the full name.
- [ ] Manual: kill the BE upload route to force a 500, attempt one upload → red Alert shows. Click Remove on an existing (successfully-uploaded) attachment → the Alert disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
