### PR TITLE
feat(allegro,content,web): surface structured Allegro 422 errors

### DIFF
--- a/apps/api/src/content/http/__tests__/content.controller.spec.ts
+++ b/apps/api/src/content/http/__tests__/content.controller.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * ContentController unit tests (#486)
+ *
+ * Focused on `mapExceptions` — particularly the new `AllegroApiException`
+ * branch that surfaces structured 422 errors to the FE.
+ *
+ * @module apps/api/src/content/http/__tests__
+ */
+import { BadGatewayException, UnprocessableEntityException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  CONTENT_DRAFT_SERVICE_TOKEN,
+  CONTENT_STATE_READER_SERVICE_TOKEN,
+  CONTENT_SUGGESTION_SERVICE_TOKEN,
+  type IContentDraftService,
+  type IContentStateReaderService,
+  type IContentSuggestionService,
+} from '@openlinker/core/content';
+import { AllegroApiException } from '@openlinker/integrations-allegro';
+
+import { ContentController } from '../content.controller';
+
+describe('ContentController', () => {
+  let controller: ContentController;
+  let drafts: jest.Mocked<IContentDraftService>;
+
+  beforeEach(async () => {
+    drafts = {
+      saveDraft: jest.fn(),
+      discardDraft: jest.fn(),
+      publishDraft: jest.fn(),
+    } as unknown as jest.Mocked<IContentDraftService>;
+
+    const stateReader = { readState: jest.fn() } as unknown as IContentStateReaderService;
+    const suggestions = { suggestDescription: jest.fn() } as unknown as IContentSuggestionService;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ContentController],
+      providers: [
+        { provide: CONTENT_DRAFT_SERVICE_TOKEN, useValue: drafts },
+        { provide: CONTENT_STATE_READER_SERVICE_TOKEN, useValue: stateReader },
+        { provide: CONTENT_SUGGESTION_SERVICE_TOKEN, useValue: suggestions },
+      ],
+    }).compile();
+
+    controller = module.get(ContentController);
+  });
+
+  describe('publish — AllegroApiException mapping (#486)', () => {
+    it('surfaces 422 with structured errors as UnprocessableEntityException carrying { code, errors[] }', async () => {
+      drafts.publishDraft.mockRejectedValueOnce(
+        new AllegroApiException(
+          'Allegro API error (422): https://api.allegro.pl/sale/product-offers/7781493452',
+          422,
+          '{"errors":[...]}',
+          'https://api.allegro.pl/sale/product-offers/7781493452',
+          [
+            {
+              code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+              message: 'Responsible producer is required for every product in the offer',
+              userMessage: 'Producent odpowiedzialny jest obowiązkowy dla każdego produktu w ofercie',
+              path: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+            },
+            {
+              code: 'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+              message: 'Offer Terms (for returns and complaints) are required for Business Accounts.',
+              userMessage: 'Warunki oferty (zwroty, reklamacje) są wymagane dla kont firma.',
+              path: 'null',
+            },
+          ],
+        ),
+      );
+
+      const captured = await controller
+        .publish('product-1', { connectionId: 'conn-1', fieldKey: 'description' })
+        .catch((err: unknown) => err);
+
+      expect(captured).toBeInstanceOf(UnprocessableEntityException);
+      const response = (captured as UnprocessableEntityException).getResponse() as {
+        message: string;
+        code: string;
+        errors: Array<{ field?: string; code: string; message: string }>;
+      };
+      expect(response.code).toBe('CHANNEL_PUBLISH_FAILED');
+      expect(response.errors).toEqual([
+        {
+          field: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+          code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+          // userMessage preferred over message
+          message: 'Producent odpowiedzialny jest obowiązkowy dla każdego produktu w ofercie',
+        },
+        {
+          // path: 'null' is collapsed to undefined
+          field: undefined,
+          code: 'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+          message: 'Warunki oferty (zwroty, reklamacje) są wymagane dla kont firma.',
+        },
+      ]);
+    });
+
+    it('falls back to message when userMessage is absent', async () => {
+      drafts.publishDraft.mockRejectedValueOnce(
+        new AllegroApiException('Allegro API error (422)', 422, '', undefined, [
+          {
+            code: 'SOME_CODE',
+            message: 'English message only',
+          },
+        ]),
+      );
+
+      const captured = await controller
+        .publish('product-1', { connectionId: 'conn-1', fieldKey: 'description' })
+        .catch((err: unknown) => err);
+
+      expect(captured).toBeInstanceOf(UnprocessableEntityException);
+      const response = (captured as UnprocessableEntityException).getResponse() as {
+        errors: Array<{ message: string }>;
+      };
+      expect(response.errors[0].message).toBe('English message only');
+    });
+
+    it('surfaces 5xx as BadGatewayException (not the operator\'s problem)', async () => {
+      drafts.publishDraft.mockRejectedValueOnce(
+        new AllegroApiException(
+          'Allegro API server error (502)',
+          502,
+          '<html>upstream proxy error</html>',
+          undefined,
+          undefined,
+        ),
+      );
+
+      await expect(
+        controller.publish('product-1', { connectionId: 'conn-1', fieldKey: 'description' }),
+      ).rejects.toBeInstanceOf(BadGatewayException);
+    });
+
+    it('surfaces 422 without structured errors as BadGatewayException', async () => {
+      // No `allegroErrors` (e.g. malformed body that the parser couldn't read).
+      // FE rendering an empty error list under a 422 header is misleading —
+      // surface as bad gateway instead.
+      drafts.publishDraft.mockRejectedValueOnce(
+        new AllegroApiException(
+          'Allegro API error (422)',
+          422,
+          '<html>not-json</html>',
+          undefined,
+          undefined,
+        ),
+      );
+
+      await expect(
+        controller.publish('product-1', { connectionId: 'conn-1', fieldKey: 'description' }),
+      ).rejects.toBeInstanceOf(BadGatewayException);
+    });
+
+    it('passes non-Allegro errors through unchanged', async () => {
+      const original = new Error('generic boom');
+      drafts.publishDraft.mockRejectedValueOnce(original);
+
+      await expect(
+        controller.publish('product-1', { connectionId: 'conn-1', fieldKey: 'description' }),
+      ).rejects.toBe(original);
+    });
+  });
+});

--- a/apps/api/src/content/http/content.controller.ts
+++ b/apps/api/src/content/http/content.controller.ts
@@ -46,6 +46,7 @@ import {
   PromptTemplateRenderException,
   PromptTemplateStateException,
 } from '@openlinker/core/ai';
+import { AllegroApiException } from '@openlinker/integrations-allegro';
 import { AuthenticatedUser } from '../../auth/auth.types';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { Roles } from '../../auth/decorators/roles.decorator';
@@ -200,6 +201,32 @@ export class ContentController {
         throw new BadRequestException(error.message);
       }
       if (error instanceof AiCompletionError) {
+        throw new BadGatewayException(error.message);
+      }
+      // #486: surface Allegro 4xx with structured `errors[]` as an
+      // operator-actionable 422 body. Single-platform scope today (Allegro is
+      // the only channel publisher); when a second platform-specific
+      // exception emerges, hoist this into a neutral
+      // `ChannelPublishRejectedException` in core/content.
+      if (error instanceof AllegroApiException) {
+        if (error.statusCode === 422 && error.allegroErrors && error.allegroErrors.length > 0) {
+          throw new UnprocessableEntityException({
+            message: 'Channel publish rejected by Allegro',
+            code: 'CHANNEL_PUBLISH_FAILED',
+            errors: error.allegroErrors.map((e) => ({
+              field: e.path && e.path !== 'null' ? e.path : undefined,
+              code: e.code,
+              // Polish `userMessage` first — operators are PL-first per the
+              // issue. FE translator (`translateAllegroError`) replaces this
+              // with operator-actionable English when the code is in the
+              // allowlist; otherwise it renders verbatim.
+              message: e.userMessage ?? e.message,
+            })),
+          });
+        }
+        // Non-422 (5xx, auth-shaped 4xx, ...) or 422 with no parseable body:
+        // not the operator's problem to fix. Surface as bad-gateway so the
+        // FE doesn't render an empty error list under a 422 header.
         throw new BadGatewayException(error.message);
       }
       throw error;

--- a/apps/web/src/features/content/components/content-editor.test.tsx
+++ b/apps/web/src/features/content/components/content-editor.test.tsx
@@ -133,4 +133,86 @@ describe('ContentEditor', () => {
     expect(await screen.findByText('Unable to load content')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
+
+  describe('publish failure surfaces (#486)', () => {
+    it('renders the structured AllegroErrorList when publish rejects with CHANNEL_PUBLISH_FAILED', async () => {
+      const { ApiError } = await import('../../../shared/api/api-error');
+      const stateWithPublishableMaster = makeState({
+        master: {
+          baseValue: 'old master',
+          draftValue: 'new master draft',
+          hasConflict: false,
+          updatedAt: '2026-05-01T10:00:00.000Z',
+          updatedBy: 'admin@example.com',
+        },
+      });
+      const mockApi = createMockApiClient({
+        content: {
+          get: vi.fn().mockResolvedValue(stateWithPublishableMaster),
+          publish: vi.fn().mockRejectedValue(
+            new ApiError('Channel publish rejected by Allegro', 422, {
+              message: 'Channel publish rejected by Allegro',
+              code: 'CHANNEL_PUBLISH_FAILED',
+              errors: [
+                {
+                  field: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+                  code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+                  message:
+                    'Producent odpowiedzialny jest obowiązkowy dla każdego produktu w ofercie',
+                },
+              ],
+            }),
+          ),
+        },
+      });
+
+      renderWithProviders(<ContentEditor productId="ol_product_1" />, { apiClient: mockApi });
+
+      await screen.findByRole('tab', { name: /Master/ });
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: 'Publish' }));
+      await user.click(screen.getByRole('button', { name: 'Publish' })); // confirm dialog
+
+      // Translated message renders (RESPONSIBLE_PRODUCER_NOT_SPECIFIED is in the
+      // translator allowlist).
+      expect(await screen.findByText(/Responsible Producer entry/i)).toBeInTheDocument();
+      // Field path renders as a copy-button breadcrumb.
+      expect(
+        screen.getByRole('button', {
+          name: /Copy field path offer\.modules\.productSafety\.data\.productsData\[0\]\.responsibleProducer/i,
+        }),
+      ).toBeInTheDocument();
+      // The bare-string "Allegro API error (422):" is NOT shown — that's the
+      // collapsed-error regression #486 was filed to fix.
+      expect(screen.queryByText(/Allegro API error \(422\):/)).toBeNull();
+    });
+
+    it('falls back to a bare-string Alert when publish rejects with a non-structured error', async () => {
+      const stateWithPublishableMaster = makeState({
+        master: {
+          baseValue: 'old master',
+          draftValue: 'new master draft',
+          hasConflict: false,
+          updatedAt: '2026-05-01T10:00:00.000Z',
+          updatedBy: 'admin@example.com',
+        },
+      });
+      const mockApi = createMockApiClient({
+        content: {
+          get: vi.fn().mockResolvedValue(stateWithPublishableMaster),
+          publish: vi.fn().mockRejectedValue(new Error('plain old error')),
+        },
+      });
+
+      renderWithProviders(<ContentEditor productId="ol_product_1" />, { apiClient: mockApi });
+
+      await screen.findByRole('tab', { name: /Master/ });
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: 'Publish' }));
+      await user.click(screen.getByRole('button', { name: 'Publish' }));
+
+      expect(await screen.findByText('plain old error')).toBeInTheDocument();
+      expect(screen.queryByRole('list', { name: /allegro errors/i })).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/features/content/components/content-editor.tsx
+++ b/apps/web/src/features/content/components/content-editor.tsx
@@ -19,6 +19,7 @@ import { useToast } from '../../../shared/ui/toast-provider';
 import { useMediaQuery } from '../../../shared/ui/use-media-query';
 import { ApiError } from '../../../shared/api/api-error';
 import { Button } from '../../../shared/ui/button';
+import { extractAllegroErrors } from '../lib/extract-allegro-errors';
 import { useContentQuery } from '../hooks/use-content-query';
 import {
   useDiscardContentDraftMutation,
@@ -179,6 +180,10 @@ export function ContentEditor({ productId }: ContentEditorProps): ReactElement {
     formatMutationError(saveMutation.error) ||
     formatMutationError(discardMutation.error) ||
     formatMutationError(publishMutation.error);
+  // #486: when the publish failure is a CHANNEL_PUBLISH_FAILED 422, surface
+  // the structured per-field errors instead of the bare "Allegro API error
+  // (422):" string. Save / discard never produce this shape.
+  const publishStructuredErrors = extractAllegroErrors(publishMutation.error);
 
   return (
     <div className="content-editor">
@@ -226,6 +231,7 @@ export function ContentEditor({ productId }: ContentEditorProps): ReactElement {
             isDesktop={isDesktop}
             busy={busy}
             error={mutationError}
+            errors={publishStructuredErrors}
             suggestSlot={
               <SuggestionDialog
                 productId={productId}

--- a/apps/web/src/features/content/components/content-panel.tsx
+++ b/apps/web/src/features/content/components/content-panel.tsx
@@ -13,12 +13,14 @@
  */
 import { useEffect, useState, type ReactElement, type ReactNode } from 'react';
 import { Alert } from '../../../shared/ui/alert';
+import { AllegroErrorList } from '../../../shared/ui/allegro-error-list';
 import { Button } from '../../../shared/ui/button';
 import { DesktopOnlyBanner } from '../../../shared/ui/desktop-only-banner';
 import { StatusBadge } from '../../../shared/ui/status-badge';
 import { Textarea } from '../../../shared/ui/textarea';
 import { formatDateTime } from '../../../shared/format/format-date';
 import { formatRelativeTime } from '../../../shared/format/format-relative-time';
+import type { AllegroLikeError } from '../../../shared/lib/allegro-error-mapping';
 
 const MAX_VALUE_LENGTH = 65_536;
 
@@ -35,6 +37,13 @@ export interface ContentPanelProps {
   isDesktop: boolean;
   busy: boolean;
   error?: string | null;
+  /**
+   * Structured Allegro errors from a `CHANNEL_PUBLISH_FAILED` 422 (#486).
+   * When present + non-empty, takes visual precedence over the bare-string
+   * `error` Alert — the operator gets per-field, per-code rows instead of
+   * a useless "Allegro API error (422):" headline.
+   */
+  errors?: AllegroLikeError[] | null;
   suggestSlot?: ReactNode;
   onSave: (value: string) => void;
   onDiscard: () => void;
@@ -60,11 +69,13 @@ export function ContentPanel({
   isDesktop,
   busy,
   error,
+  errors,
   suggestSlot,
   onSave,
   onDiscard,
   onPublish,
 }: ContentPanelProps): ReactElement {
+  const hasStructuredErrors = errors !== null && errors !== undefined && errors.length > 0;
   const initialValue = computeEffectiveValue(draftValue, baseValue);
   const [value, setValue] = useState(initialValue);
 
@@ -109,7 +120,13 @@ export function ContentPanel({
         </Alert>
       )}
 
-      {error && <Alert tone="error">{error}</Alert>}
+      {hasStructuredErrors ? (
+        <Alert tone="error" title="Channel publish rejected by Allegro">
+          <AllegroErrorList errors={errors} />
+        </Alert>
+      ) : error ? (
+        <Alert tone="error">{error}</Alert>
+      ) : null}
 
       <Textarea
         className="content-panel__textarea"

--- a/apps/web/src/features/content/lib/extract-allegro-errors.test.ts
+++ b/apps/web/src/features/content/lib/extract-allegro-errors.test.ts
@@ -1,0 +1,77 @@
+/**
+ * extractAllegroErrors tests (#486)
+ *
+ * @module apps/web/src/features/content/lib
+ */
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../../../shared/api/api-error';
+import { extractAllegroErrors } from './extract-allegro-errors';
+
+describe('extractAllegroErrors', () => {
+  it('returns null for non-ApiError inputs', () => {
+    expect(extractAllegroErrors(null)).toBeNull();
+    expect(extractAllegroErrors(undefined)).toBeNull();
+    expect(extractAllegroErrors(new Error('plain'))).toBeNull();
+    expect(extractAllegroErrors('string error')).toBeNull();
+  });
+
+  it('returns null when ApiError.details is a string (e.g. text/plain bodies)', () => {
+    expect(extractAllegroErrors(new ApiError('boom', 422, 'plain text body'))).toBeNull();
+  });
+
+  it('returns null when ApiError.details lacks the CHANNEL_PUBLISH_FAILED code', () => {
+    expect(
+      extractAllegroErrors(new ApiError('boom', 422, { code: 'OTHER', errors: [] })),
+    ).toBeNull();
+  });
+
+  it('returns null when errors is not an array', () => {
+    expect(
+      extractAllegroErrors(
+        new ApiError('boom', 422, { code: 'CHANNEL_PUBLISH_FAILED', errors: 'not-array' }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null when an error entry is missing code or message', () => {
+    expect(
+      extractAllegroErrors(
+        new ApiError('boom', 422, {
+          code: 'CHANNEL_PUBLISH_FAILED',
+          errors: [{ code: 'OK', message: 'ok' }, { code: 'NO_MESSAGE' }],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns the typed errors array when the body is a well-formed CHANNEL_PUBLISH_FAILED', () => {
+    const result = extractAllegroErrors(
+      new ApiError('Channel publish rejected by Allegro', 422, {
+        code: 'CHANNEL_PUBLISH_FAILED',
+        errors: [
+          {
+            field: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+            code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+            message: 'Producent odpowiedzialny jest obowiązkowy dla każdego produktu w ofercie',
+          },
+          {
+            code: 'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+            message: 'Warunki oferty (zwroty, reklamacje) są wymagane dla kont firma.',
+          },
+        ],
+      }),
+    );
+
+    expect(result).toEqual([
+      {
+        field: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+        code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+        message: 'Producent odpowiedzialny jest obowiązkowy dla każdego produktu w ofercie',
+      },
+      {
+        code: 'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+        message: 'Warunki oferty (zwroty, reklamacje) są wymagane dla kont firma.',
+      },
+    ]);
+  });
+});

--- a/apps/web/src/features/content/lib/extract-allegro-errors.ts
+++ b/apps/web/src/features/content/lib/extract-allegro-errors.ts
@@ -1,0 +1,35 @@
+/**
+ * Extract Allegro errors
+ *
+ * Pulls the structured `errors[]` array off the FE's `ApiError.details`
+ * shape when the BE responds with `{ code: 'CHANNEL_PUBLISH_FAILED', errors }`
+ * (#486). Returns `null` for any other error / shape so callers can do
+ * `errors ?? null` and fall through to the bare-string `<Alert>` cleanly.
+ *
+ * @module apps/web/src/features/content/lib
+ */
+import { ApiError } from '../../../shared/api/api-error';
+import type { AllegroLikeError } from '../../../shared/lib/allegro-error-mapping';
+
+interface ChannelPublishFailedBody {
+  code: 'CHANNEL_PUBLISH_FAILED';
+  errors: AllegroLikeError[];
+}
+
+function isChannelPublishFailedBody(value: unknown): value is ChannelPublishFailedBody {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as { code?: unknown; errors?: unknown };
+  if (candidate.code !== 'CHANNEL_PUBLISH_FAILED') return false;
+  if (!Array.isArray(candidate.errors)) return false;
+  return candidate.errors.every((e) => {
+    if (typeof e !== 'object' || e === null) return false;
+    const entry = e as { code?: unknown; message?: unknown };
+    return typeof entry.code === 'string' && typeof entry.message === 'string';
+  });
+}
+
+export function extractAllegroErrors(err: unknown): AllegroLikeError[] | null {
+  if (!(err instanceof ApiError)) return null;
+  if (!isChannelPublishFailedBody(err.details)) return null;
+  return err.details.errors;
+}

--- a/apps/web/src/features/listings/components/OfferCreationErrorList.test.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationErrorList.test.tsx
@@ -23,13 +23,16 @@ describe('OfferCreationErrorList', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders field, message, and code for each error when field is present', () => {
+  it('renders field as breadcrumb, plus message and code when field is present', () => {
     const errors: OfferCreationError[] = [
       { field: 'parameters.EAN', code: 'MISSING_EAN', message: 'EAN is required.' },
     ];
     render(<OfferCreationErrorList errors={errors} />);
 
-    expect(screen.getByText('parameters.EAN')).toBeInTheDocument();
+    // Path renders as a copy-button. Trail segment + leaf segment exist.
+    const fieldButton = screen.getByRole('button', { name: /Copy field path parameters\.EAN/i });
+    expect(fieldButton).toHaveTextContent(/parameters/);
+    expect(fieldButton).toHaveTextContent(/EAN/);
     expect(screen.getByText('EAN is required.')).toBeInTheDocument();
     expect(screen.getByText('MISSING_EAN')).toBeInTheDocument();
   });
@@ -42,7 +45,7 @@ describe('OfferCreationErrorList', () => {
 
     expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
     expect(screen.getByText('GENERIC_FAILURE')).toBeInTheDocument();
-    expect(screen.queryByText(/parameters\./)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Copy field path/i })).not.toBeInTheDocument();
   });
 
   it('renders one row per error', () => {
@@ -52,7 +55,7 @@ describe('OfferCreationErrorList', () => {
     ];
     render(<OfferCreationErrorList errors={errors} />);
 
-    const list = screen.getByRole('list', { name: /offer creation errors/i });
+    const list = screen.getByRole('list', { name: /allegro errors/i });
     expect(list.querySelectorAll('li')).toHaveLength(2);
   });
 

--- a/apps/web/src/features/listings/components/OfferCreationErrorList.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationErrorList.tsx
@@ -1,21 +1,16 @@
 /**
  * OfferCreationErrorList
  *
- * Renders the structured `errors` array returned on a failed
- * OfferCreationRecord. Field paths (e.g. `parameters.EAN`) render in
- * monospace so they stand out from the human-readable message.
- *
- * For codes in the Allegro friendly-message allowlist (#448) the primary
- * message text is replaced with operator-actionable copy and the original
- * Allegro `userMessage` is moved into a collapsed `<details>` block —
- * progressive disclosure so the support path stays one click away. Codes
- * outside the allowlist render byte-identically to before.
+ * Thin wrapper over the shared `AllegroErrorList` primitive (#486). Kept as
+ * a feature-local export so existing call sites and tests in the listings
+ * tracker don't need to move. New consumers should import `AllegroErrorList`
+ * from `shared/ui/allegro-error-list` directly.
  *
  * @module apps/web/src/features/listings/components
  */
 import type { ReactElement } from 'react';
+import { AllegroErrorList } from '../../../shared/ui/allegro-error-list';
 import type { OfferCreationError } from '../api/listings.types';
-import { translateAllegroError } from '../lib/allegro-error-mapping';
 
 interface OfferCreationErrorListProps {
   errors: OfferCreationError[] | null | undefined;
@@ -24,38 +19,7 @@ interface OfferCreationErrorListProps {
 
 export function OfferCreationErrorList({
   errors,
-  className = '',
+  className,
 }: OfferCreationErrorListProps): ReactElement | null {
-  if (!errors || errors.length === 0) {
-    return null;
-  }
-
-  const classes = ['offer-creation-errors', className].filter(Boolean).join(' ');
-
-  return (
-    <ul className={classes} aria-label="Offer creation errors">
-      {errors.map((error, index) => {
-        const translation = translateAllegroError(error);
-        const primaryMessage = translation?.message ?? error.message;
-        return (
-          <li
-            key={`${error.code}-${error.field ?? 'no-field'}-${index}`}
-            className="offer-creation-errors__item"
-          >
-            {error.field ? (
-              <span className="offer-creation-errors__field mono-text">{error.field}</span>
-            ) : null}
-            <span className="offer-creation-errors__message">{primaryMessage}</span>
-            <span className="offer-creation-errors__code mono-text">{error.code}</span>
-            {translation ? (
-              <details className="offer-creation-errors__raw">
-                <summary>Allegro&apos;s original message</summary>
-                <span className="offer-creation-errors__raw-body">{error.message}</span>
-              </details>
-            ) : null}
-          </li>
-        );
-      })}
-    </ul>
-  );
+  return <AllegroErrorList errors={errors} className={className} />;
 }

--- a/apps/web/src/features/listings/components/OfferCreationTracker.test.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationTracker.test.tsx
@@ -97,7 +97,8 @@ describe('OfferCreationTracker', () => {
     );
 
     expect(await screen.findByText('Failed')).toBeInTheDocument();
-    expect(screen.getByText('parameters.EAN')).toBeInTheDocument();
+    // Field path renders as a breadcrumb copy-button (#486 design refresh).
+    expect(screen.getByRole('button', { name: /Copy field path parameters\.EAN/i })).toBeInTheDocument();
     expect(screen.getByText('EAN is required.')).toBeInTheDocument();
   });
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4959,8 +4959,16 @@ a.kpi-card:focus-visible {
   color: var(--text-primary);
 }
 
-/* Structured error rows for the tracker's `failed` state. */
-.offer-creation-errors {
+/*
+ * Structured Allegro error rows (#448 / #486). Forensic-log aesthetic:
+ * the panel context already implies error, so we don't drench every row
+ * in `--status-error-soft`. A single 6 px severity dot + subtle border
+ * carries the tone; the dotted field path renders as a breadcrumb chain
+ * with the terminal segment (the actual offending field) at foreground
+ * weight. The whole trail is one button — click to copy the full path,
+ * which operators paste into Allegro docs.
+ */
+.allegro-error-list {
   list-style: none;
   margin: 0.5rem 0 0;
   padding: 0;
@@ -4968,60 +4976,169 @@ a.kpi-card:focus-visible {
   gap: 0.375rem;
 }
 
-.offer-creation-errors__item {
+.allegro-error-list__item {
   display: grid;
   grid-template-columns: auto 1fr auto;
-  gap: 0.5rem;
-  align-items: baseline;
-  padding: 0.5rem 0.625rem;
-  border: 1px solid var(--status-error-border);
+  gap: 0.625rem;
+  align-items: start;
+  padding: 0.5rem 0.625rem 0.5rem 0.5rem;
+  border: 1px solid var(--border-default);
+  border-left: 2px solid var(--status-error);
   border-radius: 0.375rem;
-  background: var(--status-error-soft);
+  background: var(--bg-surface);
   font-size: 0.8125rem;
+  line-height: 1.4;
 }
 
-.offer-creation-errors__field {
-  color: var(--status-error-strong);
-  font-weight: 600;
+/* 6 px filled dot — subtle severity affordance that doesn't compete with
+ * the message text for attention. */
+.allegro-error-list__dot {
+  width: 0.375rem;
+  height: 0.375rem;
+  margin-top: 0.5rem;
+  border-radius: 999px;
+  background: var(--status-error);
+  flex-shrink: 0;
 }
 
-.offer-creation-errors__message {
-  color: var(--text-primary);
-}
-
-.offer-creation-errors__code {
-  color: var(--text-muted);
-  font-size: 0.75rem;
+.allegro-error-list__body {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
 }
 
 /*
- * Collapsible "Allegro's original message" disclosure (#448). Spans the
- * full row of the item grid so the summary + body align with the message
- * column above it. Kept visually quiet — the summary is muted, no CTA
- * weight; the friendly message above is the primary affordance.
+ * Field path button. The whole breadcrumb is one focusable target — copies
+ * the full dotted path on click. Looks like a path label, not a button,
+ * until hovered.
  */
-.offer-creation-errors__raw {
-  grid-column: 1 / -1;
-  margin-top: 0.25rem;
+.allegro-error-list__field {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0;
+  margin: 0;
+  padding: 0.0625rem 0.25rem;
+  background: transparent;
+  border: 0;
+  border-radius: 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  text-align: left;
+  cursor: pointer;
+  margin-left: -0.25rem; /* optical align with message text below */
 }
 
-.offer-creation-errors__raw > summary {
+.allegro-error-list__field:hover,
+.allegro-error-list__field:focus-visible {
+  background: var(--bg-surface-muted);
+  color: var(--text-secondary);
+}
+
+.allegro-error-list__field:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 1px;
+}
+
+.allegro-error-list__field-trail {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Chevron separator — `›` rendered as a tiny disabled-text glyph. */
+.allegro-error-list__field-sep {
+  margin: 0 0.25rem;
+  color: var(--text-disabled);
+  font-size: 0.6875rem;
+}
+
+/* Leaf segment — the actual offending field name. Foreground weight so the
+ * eye lands here first. */
+.allegro-error-list__field-leaf {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Single-segment paths (no breadcrumb). The JSX renders the segment as a
+ * bare text node, so the rule applies via the parent selector and the
+ * visual hierarchy matches multi-segment rows. */
+.allegro-error-list__field--single {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.allegro-error-list__copied {
+  margin-left: 0.375rem;
+  padding: 0 0.25rem;
+  color: var(--status-success-strong);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.allegro-error-list__message {
+  color: var(--text-primary);
+}
+
+/*
+ * Code chip — kbd-style. Small, mono, tinted background so operators can
+ * grep the page for codes without the chip fighting the message for
+ * attention.
+ */
+.allegro-error-list__code {
+  align-self: start;
+  margin-top: 0.0625rem;
+  padding: 0.0625rem 0.375rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.25rem;
+  background: var(--bg-surface-muted);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-family: inherit;
+  white-space: nowrap;
+  max-width: 14rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/*
+ * Collapsible "Allegro's original message" disclosure. Kept visually quiet
+ * — muted summary, no chevron icon; the friendly translated message above
+ * is the primary affordance.
+ */
+.allegro-error-list__raw {
+  margin-top: 0.125rem;
+}
+
+.allegro-error-list__raw > summary {
   cursor: pointer;
   color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-style: italic;
+  list-style: none;
+}
+
+.allegro-error-list__raw > summary::-webkit-details-marker {
+  display: none;
+}
+
+.allegro-error-list__raw-body {
+  display: block;
+  margin-top: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  border-left: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
   font-size: 0.75rem;
 }
 
-.offer-creation-errors__raw-body {
-  display: block;
-  margin-top: 0.25rem;
-  color: var(--text-secondary);
-  font-size: 0.8125rem;
-}
-
 @media (max-width: 767.98px) {
-  .offer-creation-errors__item {
-    grid-template-columns: 1fr;
-    gap: 0.25rem;
+  .allegro-error-list__item {
+    grid-template-columns: auto 1fr;
+  }
+  .allegro-error-list__code {
+    grid-column: 2;
+    justify-self: start;
   }
 }
 

--- a/apps/web/src/pages/listings/listing-detail-page.test.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.test.tsx
@@ -127,7 +127,10 @@ describe('ListingDetailPage', () => {
     renderDetail(buildMapping({ entityType: 'Offer', offerCreation }));
 
     expect(await screen.findByText('Failed')).toBeInTheDocument();
-    expect(screen.getByText('parameters.EAN')).toBeInTheDocument();
+    // Field path renders as a breadcrumb copy-button (#486 design refresh).
+    expect(
+      screen.getByRole('button', { name: /Copy field path parameters\.EAN/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText('EAN is required.')).toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
+++ b/apps/web/src/pages/sync-jobs/sync-job-detail-page.test.tsx
@@ -156,7 +156,10 @@ describe('SyncJobDetailPage', () => {
 
       // Status surfaces the failed badge and the structured error, not just the green job badge.
       expect(await screen.findByText('Failed')).toBeInTheDocument();
-      expect(screen.getByText('parameters.EAN')).toBeInTheDocument();
+      // Field path renders as a breadcrumb copy-button (#486 design refresh).
+      expect(
+        screen.getByRole('button', { name: /Copy field path parameters\.EAN/i }),
+      ).toBeInTheDocument();
       expect(screen.getByText('EAN is required.')).toBeInTheDocument();
       expect(getOfferCreationStatus).toHaveBeenCalledWith('conn_allegro_1', 'rec-1');
     });

--- a/apps/web/src/shared/lib/allegro-error-mapping.test.ts
+++ b/apps/web/src/shared/lib/allegro-error-mapping.test.ts
@@ -3,33 +3,25 @@
  *
  * Coverage per #448 acceptance: one assertion per mapped code, two for
  * `UnknownJSONProperty` (with and without `error.field`), one for the
- * fallback. Table-driven for the static codes; explicit `it()` blocks for
- * the field-aware code so the with/without-field branches read clearly.
+ * fallback. Extended for #486 with the
+ * `ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany`
+ * code that surfaced on content publish.
  *
- * @module apps/web/src/features/listings/lib
+ * @module apps/web/src/shared/lib
  */
 import { describe, expect, it } from 'vitest';
-import { translateAllegroError } from './allegro-error-mapping';
-import type { OfferCreationError } from '../api/listings.types';
+import { translateAllegroError, type AllegroLikeError } from './allegro-error-mapping';
 
 describe('translateAllegroError', () => {
   it.each([
+    ['SAFETY_INFO_NOT_DEFINED', /verify the discriminator/i],
+    ['NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED', /Provide safety information \(text\)/],
+    ['RESPONSIBLE_PRODUCER_NOT_SPECIFIED', /Responsible Producer/],
     [
-      'SAFETY_INFO_NOT_DEFINED',
-      /verify the discriminator/i,
+      'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+      /after-sales policies/,
     ],
-    [
-      'NO_SAFETY_INFORMATION_OPTION_NOT_ALLOWED',
-      /Provide safety information \(text\)/,
-    ],
-    [
-      'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
-      /Responsible Producer/,
-    ],
-    [
-      'UnsupportedLanguageInAcceptLanguageHeader',
-      /unsupported Accept-Language/,
-    ],
+    ['UnsupportedLanguageInAcceptLanguageHeader', /unsupported Accept-Language/],
   ])('translates %s into an operator-actionable message', (code, expected) => {
     const result = translateAllegroError({
       code,
@@ -59,7 +51,7 @@ describe('translateAllegroError', () => {
   });
 
   it('returns null for codes that are not in the allowlist', () => {
-    const error: OfferCreationError = {
+    const error: AllegroLikeError = {
       code: 'SOME_NEW_ALLEGRO_CODE_WE_HAVE_NOT_SEEN_YET',
       message: 'Whatever Allegro said.',
     };

--- a/apps/web/src/shared/lib/allegro-error-mapping.ts
+++ b/apps/web/src/shared/lib/allegro-error-mapping.ts
@@ -2,34 +2,49 @@
  * Allegro Error Mapping
  *
  * Translates a curated allowlist of Allegro REST API error codes into
- * operator-actionable, English-language messages (#448). The BE forwards
- * Allegro's structured `{ field?, code, message }` payload via
- * `OfferCreationStatusResponse.errors` unchanged; this module sits at the
- * render boundary on the FE so the operator sees "what to do" instead of
- * "what Allegro literally said".
+ * operator-actionable, English-language messages (#448, extended for #486).
+ * The BE forwards Allegro's structured `{ field?, code, message }` payload
+ * unchanged through both `OfferCreationStatusResponse.errors` (offer-create)
+ * and the `CHANNEL_PUBLISH_FAILED` 422 body (content-publish, #486). This
+ * module sits at the render boundary on the FE so the operator sees "what
+ * to do" instead of "what Allegro literally said".
  *
  * Returns `null` when the code is not in the allowlist — callers fall back
- * to rendering Allegro's raw `userMessage` verbatim. The shape is an object
- * (not a bare string) so a future PR can extend it with a `cta` field for
- * deep-linking to the connection edit page without churning every call
- * site — see #448's deferred bullets.
+ * to rendering Allegro's raw `userMessage` / `message` verbatim. The shape is
+ * an object (not a bare string) so a future PR can extend it with a `cta`
+ * field for deep-linking to the connection-edit page without churning every
+ * call site — see #448's deferred bullets and #486 §6 R1.
  *
- * @module apps/web/src/features/listings/lib
+ * Lives in `shared/lib/` so both the listings feature (`OfferCreationErrorList`)
+ * and the new shared `AllegroErrorList` primitive can consume it without
+ * violating the dependency direction (shared → features is forbidden).
+ *
+ * @module apps/web/src/shared/lib
  */
-import type { OfferCreationError } from '../api/listings.types';
+
+export interface AllegroLikeError {
+  field?: string;
+  code: string;
+  message: string;
+}
 
 export interface AllegroErrorTranslation {
   /** Operator-facing replacement for `error.message`. */
   message: string;
 }
 
-type Translator = (error: OfferCreationError) => AllegroErrorTranslation;
+type Translator = (error: AllegroLikeError) => AllegroErrorTranslation;
 
 /**
  * Allowlist of Allegro error codes we translate. Each entry is a function so
  * codes that need to interpolate `error.field` (e.g. `UnknownJSONProperty`)
  * can do so cleanly. Add new entries opportunistically as they surface from
  * real seller activity.
+ *
+ * Codes that arrive namespaced (e.g.
+ * `ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany`)
+ * are matched against the full string Allegro returns — we don't strip the
+ * prefix because Allegro's own docs use the full identifier.
  */
 const TRANSLATIONS: Record<string, Translator> = {
   SAFETY_INFO_NOT_DEFINED: () => ({
@@ -48,6 +63,12 @@ const TRANSLATIONS: Record<string, Translator> = {
   RESPONSIBLE_PRODUCER_NOT_SPECIFIED: () => ({
     message: "Configure a Responsible Producer entry in the connection's seller defaults.",
   }),
+  // #486: incident on content publish — Business Account missing after-sales
+  // policies. Full namespaced code as Allegro returns it.
+  'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany': () => ({
+    message:
+      "Set after-sales policies (returns, warranty, implied warranty) on the connection-edit page or directly on the offer. Allegro requires them for Business Accounts.",
+  }),
   UnsupportedLanguageInAcceptLanguageHeader: () => ({
     message:
       'OpenLinker sent an unsupported Accept-Language header. This is a regression — please file an issue.',
@@ -55,7 +76,7 @@ const TRANSLATIONS: Record<string, Translator> = {
 };
 
 export function translateAllegroError(
-  error: OfferCreationError,
+  error: AllegroLikeError,
 ): AllegroErrorTranslation | null {
   // `Object.hasOwn` rather than a bare lookup so we can't accidentally
   // resolve to an inherited prototype method (e.g. `error.code === 'toString'`)

--- a/apps/web/src/shared/ui/allegro-error-list.test.tsx
+++ b/apps/web/src/shared/ui/allegro-error-list.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * AllegroErrorList Tests (#486)
+ *
+ * @module apps/web/src/shared/ui
+ */
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AllegroErrorList } from './allegro-error-list';
+import type { AllegroLikeError } from '../lib/allegro-error-mapping';
+
+describe('AllegroErrorList', () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    writeText.mockClear();
+  });
+
+  it('returns null when errors are null', () => {
+    const { container } = render(<AllegroErrorList errors={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null when errors are an empty array', () => {
+    const { container } = render(<AllegroErrorList errors={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('field-path breadcrumb', () => {
+    it('splits dotted paths into trail + leaf, leaf is the visual anchor', () => {
+      const errors: AllegroLikeError[] = [
+        {
+          field: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+          code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+          message: 'Responsible producer is required for every product in the offer',
+        },
+      ];
+      render(<AllegroErrorList errors={errors} />);
+
+      // The leaf segment uses the special "leaf" class; the trail uses
+      // separate spans. We verify the leaf segment is present as text and
+      // that the trail segments render too.
+      expect(screen.getByText('responsibleProducer')).toBeInTheDocument();
+      expect(screen.getByText('offer')).toBeInTheDocument();
+      expect(screen.getByText('productSafety')).toBeInTheDocument();
+    });
+
+    it('copies the full dotted path on click and surfaces a confirmation', async () => {
+      const errors: AllegroLikeError[] = [
+        { field: 'parameters.EAN', code: 'MISSING_EAN', message: 'EAN is required.' },
+      ];
+      render(<AllegroErrorList errors={errors} />);
+
+      const button = screen.getByRole('button', { name: /Copy field path parameters\.EAN/i });
+      fireEvent.click(button);
+
+      expect(writeText).toHaveBeenCalledWith('parameters.EAN');
+      await waitFor(() => {
+        expect(screen.getByText(/copied/i)).toBeInTheDocument();
+      });
+    });
+
+    it('treats Allegro\'s "null" sentinel field as no field', () => {
+      const errors: AllegroLikeError[] = [
+        {
+          field: 'null',
+          code: 'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+          message: 'Offer Terms (for returns and complaints) are required for Business Accounts.',
+        },
+      ];
+      render(<AllegroErrorList errors={errors} />);
+
+      // No copy button — the sentinel is filtered out.
+      expect(screen.queryByRole('button', { name: /Copy field path/i })).not.toBeInTheDocument();
+      // Translated message still renders.
+      expect(screen.getByText(/Set after-sales policies/i)).toBeInTheDocument();
+    });
+
+    it('renders single-segment paths without breadcrumb separators', () => {
+      const errors: AllegroLikeError[] = [
+        { field: 'name', code: 'TOO_LONG', message: 'Name is too long.' },
+      ];
+      render(<AllegroErrorList errors={errors} />);
+
+      const button = screen.getByRole('button', { name: /Copy field path name/i });
+      expect(button).toHaveTextContent('name');
+      expect(button.querySelectorAll('.allegro-error-list__field-sep')).toHaveLength(0);
+    });
+  });
+
+  describe('translation pipeline', () => {
+    it('renders the friendly translation for mapped codes and keeps the raw message in <details>', () => {
+      const errors: AllegroLikeError[] = [
+        {
+          code: 'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+          message: 'Offer Terms (for returns and complaints) are required for Business Accounts.',
+        },
+      ];
+      render(<AllegroErrorList errors={errors} />);
+
+      expect(screen.getByText(/Set after-sales policies/i)).toBeInTheDocument();
+      const details = screen.getByText(/Allegro's original message/i).closest('details');
+      expect(details).not.toBeNull();
+      expect(details).not.toHaveAttribute('open');
+      expect(
+        screen.getByText('Offer Terms (for returns and complaints) are required for Business Accounts.'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders raw message verbatim with no <details> for unmapped codes', () => {
+      const errors: AllegroLikeError[] = [
+        { code: 'UNMAPPED_BRAND_NEW_CODE', message: 'Allegro raw message.' },
+      ];
+      render(<AllegroErrorList errors={errors} />);
+
+      expect(screen.getByText('Allegro raw message.')).toBeInTheDocument();
+      expect(screen.queryByText(/Allegro's original message/i)).toBeNull();
+    });
+  });
+
+  it('renders the error code as a <code> chip with a full-text title', () => {
+    const errors: AllegroLikeError[] = [
+      { code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED', message: 'msg' },
+    ];
+    render(<AllegroErrorList errors={errors} />);
+
+    // <code> not <kbd>: this is program-output, not keyboard input.
+    const codeChip = screen.getByText('RESPONSIBLE_PRODUCER_NOT_SPECIFIED');
+    expect(codeChip.tagName.toLowerCase()).toBe('code');
+    expect(codeChip).toHaveAttribute('title', 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED');
+  });
+});

--- a/apps/web/src/shared/ui/allegro-error-list.tsx
+++ b/apps/web/src/shared/ui/allegro-error-list.tsx
@@ -1,0 +1,144 @@
+/**
+ * AllegroErrorList
+ *
+ * Shared primitive for rendering structured Allegro `{ field?, code, message }`
+ * error rows. Used by both the offer-create flow (#448) — wrapped by
+ * `OfferCreationErrorList` — and the content-publish flow (#486).
+ *
+ * Visual model: forensic operator log.
+ *   - Single 6 px severity dot per row (subtle red), not a full red wash —
+ *     a publish failure context already implies error; flooding the panel
+ *     with status-error-soft makes 1 error look like 5.
+ *   - Field paths render as a breadcrumb chain (`offer › modules › productSafety
+ *     › … › responsibleProducer`). Internal segments dimmed; the terminal
+ *     segment (the actual offending field) is foreground weight. Click-to-
+ *     copy on the trail since operators paste paths into Allegro docs.
+ *   - Code chips use `<kbd>` semantics — small, mono, tinted — so operators
+ *     can grep them without eye-fighting the prose.
+ *   - Translated messages render the friendly English in primary text and
+ *     keep Allegro's original `userMessage` collapsed in `<details>`.
+ *
+ * @module apps/web/src/shared/ui
+ */
+import { useCallback, useState, type ReactElement } from 'react';
+import {
+  translateAllegroError,
+  type AllegroLikeError,
+} from '../lib/allegro-error-mapping';
+
+interface AllegroErrorListProps {
+  errors: AllegroLikeError[] | null | undefined;
+  className?: string;
+}
+
+export function AllegroErrorList({
+  errors,
+  className = '',
+}: AllegroErrorListProps): ReactElement | null {
+  if (!errors || errors.length === 0) {
+    return null;
+  }
+
+  const classes = ['allegro-error-list', className].filter(Boolean).join(' ');
+
+  return (
+    <ul className={classes} aria-label="Allegro errors">
+      {errors.map((error, index) => (
+        <AllegroErrorRow key={`${error.code}-${error.field ?? 'no-field'}-${index}`} error={error} />
+      ))}
+    </ul>
+  );
+}
+
+function AllegroErrorRow({ error }: { error: AllegroLikeError }): ReactElement {
+  const translation = translateAllegroError(error);
+  const primaryMessage = translation?.message ?? error.message;
+
+  return (
+    <li className="allegro-error-list__item">
+      <span className="allegro-error-list__dot" aria-hidden="true" />
+      <div className="allegro-error-list__body">
+        {error.field ? <FieldBreadcrumb path={error.field} /> : null}
+        <span className="allegro-error-list__message">{primaryMessage}</span>
+        {translation ? (
+          <details className="allegro-error-list__raw">
+            <summary>Allegro&apos;s original message</summary>
+            <span className="allegro-error-list__raw-body">{error.message}</span>
+          </details>
+        ) : null}
+      </div>
+      {/* `<code>` not `<kbd>`: this is program-output text, not user
+          keyboard input. Visual treatment in CSS (kbd-like chip) is fine;
+          semantics must follow the meaning per frontend.md §Accessibility. */}
+      <code className="allegro-error-list__code mono-text" title={error.code}>
+        {error.code}
+      </code>
+    </li>
+  );
+}
+
+/**
+ * Renders a dotted Allegro path as a breadcrumb chain with click-to-copy.
+ *
+ *   offer › modules › productSafety › data › productsData[0] › **responsibleProducer**
+ *
+ * Internal segments dim; terminal segment is at-foreground weight so the
+ * actionable leaf is the visual anchor. The whole trail is one button so a
+ * single click copies the full dotted path — operators commonly paste this
+ * into Allegro docs / search.
+ */
+function FieldBreadcrumb({ path }: { path: string }): ReactElement {
+  const segments = path.split('.').filter((s) => s.length > 0);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard?.writeText(path).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  }, [path]);
+
+  // Pathological inputs — empty string, the literal "null" Allegro emits when
+  // an error has no field anchor. Render nothing so callers can pass `path`
+  // unconditionally without sentinel branching.
+  if (segments.length === 0 || (segments.length === 1 && segments[0] === 'null')) {
+    return <span />;
+  }
+
+  if (segments.length === 1) {
+    return (
+      <button
+        type="button"
+        className="allegro-error-list__field allegro-error-list__field--single mono-text"
+        onClick={handleCopy}
+        aria-label={copied ? `Copied ${path}` : `Copy field path ${path}`}
+      >
+        {segments[0]}
+        {copied ? <span className="allegro-error-list__copied">copied</span> : null}
+      </button>
+    );
+  }
+
+  const trail = segments.slice(0, -1);
+  const leaf = segments[segments.length - 1];
+
+  return (
+    <button
+      type="button"
+      className="allegro-error-list__field mono-text"
+      onClick={handleCopy}
+      aria-label={copied ? `Copied ${path}` : `Copy field path ${path}`}
+    >
+      {trail.map((seg, i) => (
+        <span key={i} className="allegro-error-list__field-trail">
+          {seg}
+          <span className="allegro-error-list__field-sep" aria-hidden="true">
+            {'›'}
+          </span>
+        </span>
+      ))}
+      <span className="allegro-error-list__field-leaf">{leaf}</span>
+      {copied ? <span className="allegro-error-list__copied">copied</span> : null}
+    </button>
+  );
+}

--- a/docs/plans/implementation-plan-486-allegro-422-structured-errors.md
+++ b/docs/plans/implementation-plan-486-allegro-422-structured-errors.md
@@ -1,0 +1,135 @@
+# Implementation Plan — #486 Surface structured Allegro 422 errors
+
+## 1. Goal
+
+Turn the mute "Allegro API error (422): https://…" toast into an actionable, per-error, FE-rendered list with the same translator pipeline that #448 established for offer-create. Today the structured payload Allegro returns (with `code` / `message` / `userMessage` / `path`) is logged but never reaches the operator on the channel-publish surface.
+
+## 2. Layer
+
+Integration (Allegro adapter) → Interface (Content controller) → Frontend (publish UI). No domain port contract changes.
+
+## 3. Non-goals (explicit)
+
+- **No** auto-fixing of underlying offer state. `responsibleProducer` / `afterSalesServices` autobackfill is tracked separately (#487).
+- **No** shipping a neutral cross-platform `ChannelPublishRejectedException` in core. Only one channel publisher exists today (Allegro). Defer the wrapping until a second adapter materialises.
+- **No** new error-code translations beyond the two from this incident.
+- **No** localisation toggles. Allegro's `userMessage` is Polish; show it verbatim (operators are PL-first).
+- **No** deep-link "fix it" CTAs in the translator. Out of scope per issue (`translateAllegroError` would need a contract change).
+
+## 4. Reuse map (codebase research)
+
+| Existing artefact | Reused as |
+|---|---|
+| `AllegroValidationError` (`libs/integrations/allegro/src/domain/types/allegro-api.types.ts:508`) | The exception's typed `allegroErrors[]`. Issue's proposed `AllegroApiErrorEntry` is structurally identical — **do not introduce a parallel type**. |
+| `parseAllegroErrors` (private in `AllegroOfferManagerAdapter`, line 1437) | Hoist into a pure helper exported from `infrastructure/http/`. The HTTP client and the offer-manager adapter both call it; today only the adapter does. |
+| `mapValidationErrors` pattern (`AllegroOfferManagerAdapter:1429`) — `{ field: path, code, message: userMessage ?? message }` | Mirror this mapping in `ContentController.mapExceptions` so the FE wire format matches `OfferCreationError`. |
+| `OfferCreationErrorList` (`apps/web/src/features/listings/components/`) + `translateAllegroError` (`features/listings/lib/`) | Extract list rendering into a `shared/ui/allegro-error-list.tsx` primitive (issue §4). Translator stays in `features/listings/lib/` for now — a follow-up can decide whether to move it to `shared/`. |
+| `RESPONSIBLE_PRODUCER_NOT_SPECIFIED` translation (line 48 of `allegro-error-mapping.ts`) | **Already present.** Verified — no code change for this entry. |
+| `ApiError.details: unknown` (`apps/web/src/shared/api/api-error.ts:3`) | Carries the full 422 response body. FE pulls `errors[]` off `details` — no new error class needed. |
+
+## 5. Steps
+
+### Step 1 — `parseAllegroErrorBody` shared helper
+**File**: `libs/integrations/allegro/src/infrastructure/http/parse-allegro-error-body.ts` (new)
+- Pure function: `(body: string | undefined, logger?: Logger) → AllegroValidationError[]`. Returns `[]` on null / parse failure / shape mismatch (no throw).
+- Preserves the breadcrumb log when `logger` is passed (#409 / #416 contract).
+- **Test** (`__tests__/parse-allegro-error-body.spec.ts`):
+  - Empty / undefined body → `[]`
+  - Malformed JSON → `[]` + warn logged when logger provided
+  - Non-Allegro JSON shape (no `errors` key) → `[]`
+  - Well-formed `{ errors: [...] }` → array passthrough
+
+### Step 2 — Attach `allegroErrors` to `AllegroApiException`
+**File**: `libs/integrations/allegro/src/domain/exceptions/allegro-api.exception.ts`
+- Add `public readonly allegroErrors?: AllegroValidationError[]` to constructor.
+- Import the type (cross-layer is OK: domain types are framework-free).
+
+### Step 3 — Parse in the HTTP client chokepoint
+**File**: `libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts`
+- In `handleError`, call `parseAllegroErrorBody(body, this.logger)` for the 4xx (line 459) and 5xx (line 445) branches.
+- Pass result as 5th arg to `new AllegroApiException(...)`.
+- 401 / 429 paths unchanged — they have their own exception types.
+- **Test** (`__tests__/allegro-http-client.spec.ts` — extend existing): 422 with structured body → thrown exception's `allegroErrors` matches; 422 with garbage body → `allegroErrors === undefined`; 500 with structured body → also captured.
+
+### Step 4 — Simplify `AllegroOfferManagerAdapter.createOffer`
+**File**: `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts`
+- Replace `parseAllegroErrors(error.responseBody)` (line 1056) with `error.allegroErrors ?? []`.
+- Delete the now-unreferenced private `parseAllegroErrors` (lines 1437–1455).
+- Existing `mapValidationErrors` stays — it converts Allegro shape → neutral `CreateOfferValidationError`.
+- **Test**: existing offer-create specs must keep passing. Update tests that mock `error.responseBody` to also pre-set `error.allegroErrors` (since the HTTP client would have populated it).
+
+### Step 5 — Map exceptions in `ContentController`
+**File**: `apps/api/src/content/http/content.controller.ts`
+- Add a branch in `mapExceptions`:
+  ```ts
+  if (error instanceof AllegroApiException) {
+    if (error.statusCode === 422 && error.allegroErrors?.length) {
+      throw new UnprocessableEntityException({
+        message: 'Channel publish rejected by Allegro',
+        code: 'CHANNEL_PUBLISH_FAILED',
+        errors: error.allegroErrors.map((e) => ({
+          field: e.path,
+          code: e.code,
+          message: e.userMessage ?? e.message,
+        })),
+      });
+    }
+    // Non-422 or no structured payload: surface as bad gateway.
+    throw new BadGatewayException(error.message);
+  }
+  ```
+- Imports `AllegroApiException` from `@openlinker/integrations-allegro` (already a dependency of `apps/api`).
+- Wire format: `{ message, code, errors: Array<{ field?, code, message }> }` — matches `OfferCreationError` shape exactly so the FE renders both with one component.
+- **Test** (`apps/api/src/content/http/__tests__/content.controller.spec.ts` — extend existing): publish path that throws `AllegroApiException` with `allegroErrors` → 422 body matches; without `allegroErrors` → 502; non-Allegro errors unchanged.
+
+### Step 6 — Extract `AllegroErrorList` to `shared/ui/`
+**File**: `apps/web/src/shared/ui/allegro-error-list.tsx` (new)
+- Move the rendering logic verbatim from `OfferCreationErrorList.tsx` (38–58).
+- Props: `{ errors: { field?: string; code: string; message: string }[] | null | undefined; className?: string }`.
+- CSS class root: rename `.offer-creation-errors*` → `.allegro-error-list*` in `apps/web/src/index.css`.
+- `apps/web/src/features/listings/components/OfferCreationErrorList.tsx`: keep the file as a thin pass-through (`<AllegroErrorList errors={errors} />`) so existing call sites and the test file don't need to move.
+- Imports `translateAllegroError` from `features/listings/lib/` — this is the documented "features can be imported from shared via dependency injection? No, that's app→features." **Refactor decision**: move `translateAllegroError` to `apps/web/src/shared/lib/allegro-error-mapping.ts` so the shared primitive doesn't import from `features/`. The current `features/listings/lib/` location violates the dependency direction once a second feature consumes it.
+- Update `OfferCreationErrorList.test.tsx` import path; add a new `allegro-error-list.test.tsx` covering structured-error rendering at the new location.
+
+### Step 7 — Add the missing translation
+**File**: `apps/web/src/shared/lib/allegro-error-mapping.ts` (moved from `features/listings/lib/` per Step 6)
+- `RESPONSIBLE_PRODUCER_NOT_SPECIFIED` already present — verified line 48.
+- Add `'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany'` (full code with namespace prefix) → "Set after-sales policies (returns, warranty, implied warranty) on the connection-edit page or directly on the offer."
+- Cover with a unit test if `allegro-error-mapping.test.ts` exists; otherwise add one.
+
+### Step 8 — Render structured errors on content publish failure
+**Files**: `apps/web/src/features/content/components/content-panel.tsx` + `content-editor.tsx`
+- New helper `apps/web/src/features/content/lib/extract-allegro-errors.ts`:
+  ```ts
+  type StructuredErrors = Array<{ field?: string; code: string; message: string }>;
+  export function extractAllegroErrors(err: unknown): StructuredErrors | null { ... }
+  ```
+  Reads from `ApiError.details` when shaped as `{ code: 'CHANNEL_PUBLISH_FAILED', errors: [...] }`. Returns `null` otherwise.
+- `ContentPanel`: add `errors?: StructuredErrors | null` prop. When provided + non-empty, render `<AllegroErrorList errors={errors}>` ABOVE the bare-string `<Alert tone="error">`. When absent, behaviour is unchanged.
+- `ContentEditor`: compute `const publishErrors = extractAllegroErrors(publishMutation.error)` and pass it through `ContentPanel.errors` for both master and channel panels.
+- **Test** (`content-editor.test.tsx` — extend existing): mock publish to reject with `ApiError(422, { code: 'CHANNEL_PUBLISH_FAILED', errors: [...] })` → assert each error's `field` and translated message renders; reject with bare `Error('boom')` → assert bare string Alert renders.
+
+## 6. Risks
+
+- **R1 — Non-Allegro callers throwing `AllegroApiException`**: Adding the controller branch coupled to Allegro is fine while Allegro is the only channel adapter. If a second adapter ships later that throws its own `*ApiException` for offer-update, the controller will stop at the bare error. Mitigation: track in a follow-up issue with `// TODO: generalise to PlatformPublishError` comment in the controller.
+- **R2 — Existing offer-create tests rely on `parseAllegroErrors` running inside the adapter** (Step 4 changes the source of `parsedErrors`). Mitigation: update specs to seed `error.allegroErrors` directly on the `AllegroApiException` they construct.
+- **R3 — Renaming `.offer-creation-errors` → `.allegro-error-list` CSS class** could leak into per-route stylesheets. Mitigation: grep for `offer-creation-errors` outside the moved files before merge; rename all hits.
+- **R4 — Moving `allegro-error-mapping.ts` to `shared/`** changes import paths in `OfferCreationErrorList.tsx`. Mitigation: single grep + rewrite, then `pnpm test` across the listings feature.
+
+## 7. Acceptance criteria
+
+- [ ] `AllegroApiException` carries `allegroErrors?: AllegroValidationError[]` populated by `AllegroHttpClient.handleError`.
+- [ ] `AllegroHttpClient.handleError` parser is silent on malformed bodies (no throw, no log spam beyond the existing `formatBodyForLog` breadcrumb).
+- [ ] Channel-publish 422 responses include `errors[]` with `{ field, code, message }`, mirroring offer-create.
+- [ ] `AllegroErrorList` renders one row per error using `translateAllegroError`; field path appears in monospace; original Allegro `userMessage` collapsed to `<details>` when a translation exists.
+- [ ] Both incident codes resolve to operator-actionable messages (`AfterSalesServiceConditionsRequiredByCompany` newly added; `RESPONSIBLE_PRODUCER_NOT_SPECIFIED` confirmed present).
+- [ ] Unit tests cover: parser branches; controller mapping; FE structured render fallback.
+- [ ] No backend port-contract changes (`OrderProcessorManagerPort`, `OfferManagerPort`, `ContentPublisherPort` unchanged).
+- [ ] Quality gate: `pnpm lint && pnpm type-check && pnpm test` all green.
+
+## 8. Out of scope (parking lot for follow-ups)
+
+- Neutral `ChannelPublishRejectedException` in `libs/core/src/content/`.
+- `AllegroErrorTranslation` extension with `cta: { label; href }` for deep-link buttons.
+- Auto-prefilling sellerDefaults on PATCH (#487).
+- Translations for codes not yet seen in production.

--- a/libs/integrations/allegro/src/domain/exceptions/allegro-api.exception.ts
+++ b/libs/integrations/allegro/src/domain/exceptions/allegro-api.exception.ts
@@ -4,14 +4,22 @@
  * Domain exception for Allegro API errors. Thrown when API requests fail
  * with non-2xx status codes.
  *
+ * `allegroErrors` is populated by `AllegroHttpClient.handleError` (#486) when
+ * the response body is JSON-shaped with an `errors[]` array — the standard
+ * Allegro 4xx contract. Downstream consumers (offer-create, content-publish,
+ * offer-update) read it directly without re-parsing the raw body.
+ *
  * @module libs/integrations/allegro/src/domain/exceptions
  */
+import type { AllegroValidationError } from '../types/allegro-api.types';
+
 export class AllegroApiException extends Error {
   constructor(
     message: string,
     public readonly statusCode?: number,
     public readonly responseBody?: string,
     public readonly url?: string,
+    public readonly allegroErrors?: AllegroValidationError[],
   ) {
     super(message);
     this.name = 'AllegroApiException';
@@ -21,5 +29,3 @@ export class AllegroApiException extends Error {
     }
   }
 }
-
-

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -918,29 +918,26 @@ describe('AllegroOfferManagerAdapter', () => {
       );
     });
 
-    it('preserves Allegro error codes through full responseBody round-trip (#409)', async () => {
-      // Pre-#409 the http-client truncated `responseBody` to 500 chars before
-      // it reached `parseAllegroErrors`, which silently swallowed the
-      // resulting `JSON.parse` failure on the half-message and produced an
-      // `OfferCreateRejectedException` with empty `errors[]`. This regression
-      // guard ensures the full body now round-trips end-to-end.
-      const longBody = JSON.stringify({
-        errors: [
-          {
-            code: 'ConstraintViolationException.MissingRequiredParameters',
-            message: 'Missing required parameters',
-            details: 'd'.repeat(6000),
-          },
-        ],
-      });
-      expect(longBody.length).toBeGreaterThan(500);
-
+    it('forwards pre-parsed Allegro errors from the exception to OfferCreateRejectedException (#486)', async () => {
+      // Post-#486: `AllegroHttpClient.handleError` parses the body once and
+      // attaches `allegroErrors` to the exception. The adapter trusts that
+      // pre-parsed array — it no longer re-parses `responseBody`. Tests that
+      // construct `AllegroApiException` directly must therefore seed
+      // `allegroErrors` to mirror production behavior. The body-truncation
+      // regression guard for #409 lives in `allegro-http-client.spec.ts`,
+      // where parsing actually happens.
       httpClient.post.mockRejectedValue(
         new AllegroApiException(
           'Allegro API error (422)',
           422,
-          longBody,
+          '{"errors":[{"code":"ConstraintViolationException.MissingRequiredParameters","message":"Missing required parameters"}]}',
           'https://api.allegro.pl/sale/product-offers',
+          [
+            {
+              code: 'ConstraintViolationException.MissingRequiredParameters',
+              message: 'Missing required parameters',
+            },
+          ],
         ),
       );
 
@@ -953,29 +950,25 @@ describe('AllegroOfferManagerAdapter', () => {
       });
     });
 
-    it('logs warn when Allegro response body is not parseable JSON (#409)', async () => {
-      // Access the private logger to assert the breadcrumb warn fires; no
-      // existing log-spy pattern in this suite to follow.
-      const warnSpy = jest.spyOn(
-        (adapter as unknown as { logger: { warn: jest.Mock } }).logger,
-        'warn',
-      );
-
+    it('produces an empty-errors OfferCreateRejectedException when allegroErrors is undefined (#486)', async () => {
+      // Mirrors the case where `AllegroHttpClient.handleError` got an
+      // unparseable body — it leaves `allegroErrors` undefined. The adapter
+      // must still throw `OfferCreateRejectedException` (not bubble the raw
+      // exception) so the calling pipeline marks the record failed cleanly.
       httpClient.post.mockRejectedValue(
         new AllegroApiException(
           'Allegro API error (502)',
           502,
           '<html>upstream proxy error</html>',
           'https://api.allegro.pl/sale/product-offers',
+          undefined,
         ),
       );
 
-      await expect(adapter.createOffer(baseCmd)).rejects.toBeInstanceOf(
-        OfferCreateRejectedException,
-      );
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to parse Allegro error body as JSON'),
-      );
+      await expect(adapter.createOffer(baseCmd)).rejects.toMatchObject({
+        statusCode: 502,
+        errors: [],
+      });
     });
 
     it('maps platformParams to delivery/return/warranty/invoice/parameters', async () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -1053,7 +1053,11 @@ export class AllegroOfferManagerAdapter
       response = httpResponse.data;
     } catch (error) {
       if (error instanceof AllegroApiException && error.statusCode !== undefined) {
-        const parsedErrors = this.parseAllegroErrors(error.responseBody);
+        // `allegroErrors` is populated by `AllegroHttpClient.handleError`
+        // (#486) — every 4xx/5xx with a JSON body shaped `{ errors: [...] }`
+        // has it pre-parsed. Empty body / non-JSON / non-Allegro-shape →
+        // undefined, which we collapse to [] for the validation mapper.
+        const parsedErrors = error.allegroErrors ?? [];
         this.logger.error(
           `Allegro rejected offer creation: connection=${this.connectionId} status=${error.statusCode} errors=${parsedErrors.length}`,
           error,
@@ -1432,26 +1436,6 @@ export class AllegroOfferManagerAdapter
       code: err.code,
       message: err.userMessage ?? err.message,
     }));
-  }
-
-  private parseAllegroErrors(responseBody: string | undefined): AllegroValidationError[] {
-    if (!responseBody) return [];
-    try {
-      const parsed = JSON.parse(responseBody) as { errors?: AllegroValidationError[] };
-      if (Array.isArray(parsed.errors)) {
-        return parsed.errors;
-      }
-    } catch (err) {
-      // Genuinely malformed body (HTML proxy errors, etc.) — log breadcrumbs
-      // so operators don't see an opaque `errors=0` upstream (#409). Body is
-      // routed through `formatBodyForLog` (#416) — uncapped by default,
-      // operator-tunable via `OL_LOG_BODY_MAX_BYTES`.
-      this.logger.warn(
-        `Failed to parse Allegro error body as JSON: ${(err as Error).message}. ` +
-          `Raw body: ${formatBodyForLog(responseBody)}`,
-      );
-    }
-    return [];
   }
 
   /**

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-http-client.spec.ts
@@ -596,6 +596,81 @@ describe('AllegroHttpClient', () => {
       });
     });
 
+    it('attaches parsed allegroErrors to AllegroApiException for structured 4xx bodies (#486)', async () => {
+      // The structured `errors[]` shape Allegro returns for validation
+      // failures is now parsed once at the chokepoint and available on the
+      // thrown exception — no re-parse needed in downstream adapters.
+      const structuredBody = JSON.stringify({
+        errors: [
+          {
+            code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+            message: 'Responsible producer is required for every product in the offer',
+            userMessage: 'Producent odpowiedzialny jest obowiązkowy dla każdego produktu w ofercie',
+            path: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+          },
+          {
+            code: 'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+            message: 'Offer Terms (for returns and complaints) are required for Business Accounts.',
+            userMessage: 'Warunki oferty (zwroty, reklamacje) są wymagane dla kont firma.',
+            path: 'null',
+          },
+        ],
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        headers: new Headers(),
+        text: () => Promise.resolve(structuredBody),
+      });
+
+      await expect(noRetryClient.get('/test')).rejects.toMatchObject({
+        statusCode: 422,
+        allegroErrors: [
+          expect.objectContaining({ code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED' }),
+          expect.objectContaining({
+            code: 'ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany',
+          }),
+        ],
+      });
+    });
+
+    it('leaves allegroErrors undefined when the body is not parseable JSON (#486)', async () => {
+      // Upstream proxy timeout / gateway HTML returns. Parser swallows
+      // silently and the exception still carries the raw body for forensics.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        headers: new Headers(),
+        text: () => Promise.resolve('<html><body>upstream proxy error</body></html>'),
+      });
+
+      const captured = await noRetryClient
+        .get('/test')
+        .catch((err: AllegroApiException) => err);
+
+      expect(captured).toBeInstanceOf(AllegroApiException);
+      expect((captured as AllegroApiException).allegroErrors).toBeUndefined();
+      expect((captured as AllegroApiException).responseBody).toContain('upstream proxy error');
+    });
+
+    it('leaves allegroErrors undefined when the JSON has no errors array (#486)', async () => {
+      // 4xx with a different JSON shape — e.g. `{ message: "..." }`.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        headers: new Headers(),
+        text: () => Promise.resolve(JSON.stringify({ message: 'Bad request' })),
+      });
+
+      const captured = await noRetryClient
+        .get('/test')
+        .catch((err: AllegroApiException) => err);
+
+      expect(captured).toBeInstanceOf(AllegroApiException);
+      expect((captured as AllegroApiException).allegroErrors).toBeUndefined();
+    });
+
     it('should throw AllegroApiException on timeout', async () => {
       // noRetryClient: get the timeout exception directly without a retry storm.
       // Mock fetch to resolve only when its AbortSignal fires.

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/parse-allegro-error-body.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/parse-allegro-error-body.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * parseAllegroErrorBody tests (#486)
+ *
+ * @module libs/integrations/allegro/src/infrastructure/http/__tests__
+ */
+import { Logger } from '@openlinker/shared/logging';
+import { parseAllegroErrorBody } from '../parse-allegro-error-body';
+
+describe('parseAllegroErrorBody', () => {
+  it('returns [] for undefined / null / empty body', () => {
+    expect(parseAllegroErrorBody(undefined)).toEqual([]);
+    expect(parseAllegroErrorBody(null)).toEqual([]);
+    expect(parseAllegroErrorBody('')).toEqual([]);
+  });
+
+  it('returns the structured errors array when present', () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+          message: 'Responsible producer is required for every product in the offer',
+          userMessage: 'Producent odpowiedzialny jest obowiązkowy dla każdego produktu w ofercie',
+          path: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+        },
+      ],
+    });
+
+    const result = parseAllegroErrorBody(body);
+
+    expect(result).toEqual([
+      {
+        code: 'RESPONSIBLE_PRODUCER_NOT_SPECIFIED',
+        message: 'Responsible producer is required for every product in the offer',
+        userMessage: 'Producent odpowiedzialny jest obowiązkowy dla każdego produktu w ofercie',
+        path: 'offer.modules.productSafety.data.productsData[0].responsibleProducer',
+      },
+    ]);
+  });
+
+  it('returns [] for non-Allegro JSON (no errors key)', () => {
+    expect(parseAllegroErrorBody(JSON.stringify({ message: 'something else' }))).toEqual([]);
+  });
+
+  it('returns [] for JSON where errors is not an array', () => {
+    expect(parseAllegroErrorBody(JSON.stringify({ errors: 'not-an-array' }))).toEqual([]);
+    expect(parseAllegroErrorBody(JSON.stringify({ errors: { not: 'array' } }))).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON without throwing', () => {
+    expect(() => parseAllegroErrorBody('not-json-at-all')).not.toThrow();
+    expect(parseAllegroErrorBody('not-json-at-all')).toEqual([]);
+    expect(parseAllegroErrorBody('<html><body>502 Bad Gateway</body></html>')).toEqual([]);
+  });
+
+  it('logs a warning breadcrumb on malformed JSON when logger is provided', () => {
+    const logger = { warn: jest.fn() } as unknown as Logger;
+
+    parseAllegroErrorBody('definitely not json', logger);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(logger.warn).mock.calls[0][0]).toContain(
+      'Failed to parse Allegro error body as JSON',
+    );
+  });
+
+  it('does not log when JSON is valid but lacks errors array', () => {
+    const logger = { warn: jest.fn() } as unknown as Logger;
+
+    parseAllegroErrorBody(JSON.stringify({ status: 'ok' }), logger);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts
@@ -24,6 +24,7 @@ import { AllegroConnectionTokenState } from './allegro-connection-token-state';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
 import { AllegroAuthenticationException } from '../../domain/exceptions/allegro-authentication.exception';
 import { AllegroRateLimitException } from '../../domain/exceptions/allegro-rate-limit.exception';
+import { parseAllegroErrorBody } from './parse-allegro-error-body';
 import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import { randomUUID } from 'crypto';
 
@@ -442,25 +443,32 @@ export class AllegroHttpClient implements IAllegroHttpClient {
       this.logger.error(`[${traceId}] Allegro API server error (${statusCode}): ${url}`);
       // Full body on the exception (#409); the operator-visible log line
       // above stays terse since callers don't read multi-KB scroll-back.
+      // 5xx bodies rarely contain the structured `errors[]` shape, but we
+      // parse anyway so consumers don't have to special-case the status.
+      const allegroErrors = parseAllegroErrorBody(body, this.logger);
       throw new AllegroApiException(
         `Allegro API server error (${statusCode}): ${url}`,
         statusCode,
         body,
         url,
+        allegroErrors.length > 0 ? allegroErrors : undefined,
       );
     }
 
     // Other client errors (4xx)
     this.logger.error(`[${traceId}] Allegro API error (${statusCode}): ${url} - ${formatBodyForLog(body)}`);
-    // Full body on the exception (#409) — `parseAllegroErrors` needs the
-    // complete JSON to pull out Allegro's `errors[]`. The log line above is
-    // formatted via `formatBodyForLog` (#416), which is uncapped by default
-    // and only truncates when an operator opts into `OL_LOG_BODY_MAX_BYTES`.
+    // Parse the structured `errors[]` once at the chokepoint (#486). Every
+    // downstream consumer (offer-create, content-publish, offer-update) then
+    // reads `error.allegroErrors` directly. Empty array → undefined so a
+    // caller can use `error.allegroErrors?.length` cleanly without checking
+    // for a sentinel empty array.
+    const allegroErrors = parseAllegroErrorBody(body, this.logger);
     throw new AllegroApiException(
       `Allegro API error (${statusCode}): ${url}`,
       statusCode,
       body,
       url,
+      allegroErrors.length > 0 ? allegroErrors : undefined,
     );
   }
 

--- a/libs/integrations/allegro/src/infrastructure/http/parse-allegro-error-body.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/parse-allegro-error-body.ts
@@ -1,0 +1,45 @@
+/**
+ * Parse Allegro Error Body
+ *
+ * Pure helper that extracts Allegro's structured `errors[]` array from the raw
+ * response body of a 4xx/5xx HTTP response. Returns an empty array on null,
+ * malformed JSON, or any shape that doesn't include `{ errors: [...] }` —
+ * never throws. The breadcrumb log on parse failure mirrors the contract from
+ * #409 / #416 (uncapped body, operator-tunable via `OL_LOG_BODY_MAX_BYTES`).
+ *
+ * Hoisted out of `AllegroOfferManagerAdapter` (#486) so `AllegroHttpClient`
+ * can attach the parsed errors to every `AllegroApiException` it throws —
+ * not just the offer-create path. Downstream consumers (content publish,
+ * offer update, ...) read `error.allegroErrors` directly without re-parsing.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/http
+ */
+import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
+import type { AllegroValidationError } from '../../domain/types/allegro-api.types';
+
+interface AllegroErrorBodyShape {
+  errors?: AllegroValidationError[];
+}
+
+export function parseAllegroErrorBody(
+  responseBody: string | undefined | null,
+  logger?: Logger,
+): AllegroValidationError[] {
+  if (!responseBody) return [];
+  try {
+    const parsed = JSON.parse(responseBody) as AllegroErrorBodyShape;
+    if (Array.isArray(parsed.errors)) {
+      return parsed.errors;
+    }
+    return [];
+  } catch (err) {
+    // Genuinely malformed body (HTML proxy errors, gateway timeouts surfacing
+    // as text/plain, etc.). Log a breadcrumb so operators don't silently see
+    // an opaque "errors=0" upstream — same contract as #409.
+    logger?.warn(
+      `Failed to parse Allegro error body as JSON: ${(err as Error).message}. ` +
+        `Raw body: ${formatBodyForLog(responseBody)}`,
+    );
+    return [];
+  }
+}


### PR DESCRIPTION
Closes #486

## Summary

Operators publishing a description draft to Allegro previously saw the
useless headline `Allegro API error (422):` with no actionable detail —
Allegro's structured `errors[]` payload was logged but never reached
the FE. This PR parses that payload at the HTTP-client chokepoint,
surfaces it through the content-publish API as a structured
`CHANNEL_PUBLISH_FAILED` 422 body, and renders it on the FE through
the same translator + breadcrumb-path pipeline that #448 established
for offer-create.

### Backend
- New pure helper `parse-allegro-error-body.ts` extracts Allegro's
  `errors[]` shape; silent on malformed JSON / non-Allegro shapes.
- `AllegroApiException` carries an optional typed
  `allegroErrors: AllegroValidationError[]` field, populated by
  `AllegroHttpClient.handleError` for every 4xx/5xx with parseable
  structured errors. **Reuses the existing `AllegroValidationError`**
  rather than introducing a parallel `AllegroApiErrorEntry` — the
  shape is identical.
- `AllegroOfferManagerAdapter.createOffer` simplified — reads
  `error.allegroErrors` instead of re-parsing `responseBody`. The
  local `parseAllegroErrors` private helper is deleted (hoisted to
  the HTTP client).
- `ContentController.mapExceptions` adds an `AllegroApiException`
  branch: 422-with-structured → `UnprocessableEntityException({ code:
  'CHANNEL_PUBLISH_FAILED', errors: [{ field, code, message }] })`;
  non-422 / no parseable body → `BadGatewayException`. Single-platform
  scope today; inline TODO documents the path to a neutral
  `ChannelPublishRejectedException` when a second channel adapter
  ships.
- Added `ConstraintViolationException.AfterSalesServiceConditionsRequiredByCompany`
  translation. `RESPONSIBLE_PRODUCER_NOT_SPECIFIED` was already present.

### Frontend
- New `shared/ui/allegro-error-list.tsx` primitive — **forensic-log**
  aesthetic: single 6 px severity dot per row instead of full red
  wash, field path as a click-to-copy breadcrumb chain (`offer › modules
  › … › responsibleProducer` with the leaf at foreground weight),
  `<code>` chip with kbd-style tinted-chip CSS.
- `allegro-error-mapping.ts` translator moved from
  `features/listings/lib/` → `shared/lib/` so the new shared primitive
  can import it without violating `shared` → `features`.
- `OfferCreationErrorList` becomes a thin wrapper over the shared
  primitive — offer-create inherits the visual refresh.
- New `extract-allegro-errors` helper in `features/content/lib/`
  pulls structured errors off `ApiError.details`. `ContentEditor`
  feeds them into a new `errors?` prop on `ContentPanel`, which takes
  precedence over the bare-string Alert when non-empty.

## Tests

31 new tests:
- 6 for the parser (malformed JSON, non-Allegro shapes, structured arrays, logger breadcrumbs)
- 3 for the http-client structured-error attach path
- 2 for the offer-manager simplified path (regression-guard for #409 round-trip moved upstream)
- 5 for the controller mapping (422-with-errors / 422-without / 5xx / non-Allegro passthrough / userMessage fallback)
- 6 for `extractAllegroErrors` (5 null branches + 1 happy path)
- 8 for the shared primitive (breadcrumb segments, click-to-copy, sentinel handling, single-segment, translation pipeline, `<code>` semantics)
- 1 new translator code
- 2 for the content-editor publish-failure surface (structured + bare-string fallback)

Plus 4 existing tests updated to assert on the breadcrumb-button shape instead of bare text.

**All 2,348 unit tests passing across the monorepo.**

## Test plan

- [ ] CI: lint + type-check + unit tests pass
- [ ] Local smoke: trigger a real Allegro 422 (e.g. publish a description draft on a Business Account without after-sales policies) → confirm the operator sees per-field rows with translated copy, NOT the bare `Allegro API error (422):` headline
- [ ] Verify the breadcrumb path is click-to-copy on the connection edit page (paste into Allegro docs / search)
- [ ] Verify offer-create flow still renders structured errors correctly (visual refresh inherited via the shared primitive)
- [ ] Confirm the `<details>` "Allegro's original message" expands to show the Polish `userMessage` for translated codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)