### PR TITLE
fix(allegro): resolve delivery-method names via /sale/delivery-methods (#496)

### DIFF
--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -669,6 +669,29 @@ export interface AllegroShippingRateDetailResponse {
 }
 
 /**
+ * Response from `GET /sale/delivery-methods` — the canonical catalogue of
+ * delivery methods available to the seller, with their human-readable names
+ * (#496). Used by `listDeliveryMethods()` to resolve the bare method-ids
+ * returned by the rate-table walk into operator-friendly labels in the
+ * carrier-mapping dropdown.
+ *
+ * Per developer.allegro.pl/news/get-sale-delivery-methods-dodatkowe-informacje-o-metodach-dostawy-E7Zbq7OBnSE
+ * the response includes `marketplaces`, `dispatchCountry`, and
+ * `destinationCountry` per entry; we currently only consume `id` and `name`,
+ * but the full shape is declared so future filtering (e.g. dispatch-country
+ * scoping) doesn't need a type change.
+ */
+export interface AllegroDeliveryMethodsResponse {
+  deliveryMethods: Array<{
+    id: string;
+    name: string;
+    marketplaces?: string[];
+    dispatchCountry?: string | null;
+    destinationCountry?: string | null;
+  }>;
+}
+
+/**
  * Response from `GET /after-sales-service-conditions/return-policies`.
  */
 export interface AllegroReturnPoliciesResponse {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -663,7 +663,31 @@ describe('AllegroOrderSourceAdapter', () => {
       const KURIER_ID = '2bc67g80-bbb2-bbbb-bbbb-bbbbbbbbbbbb';
       const DPD_ID = '3cd78h91-ccc3-cccc-cccc-cccccccccccc';
 
-      it('flattens carrier methods across rate-tables, deduped by methodId', async () => {
+      // Helper: queue the canonical method-catalogue mock so the parallel
+      // `/sale/delivery-methods` fetch resolves with operator-friendly names
+      // (#496). Dispatched in Promise.all order with `/sale/shipping-rates`
+      // — see resolution semantics below.
+      function mockDeliveryMethodsCatalogue(
+        entries: Array<{ id: string; name: string }>,
+      ): void {
+        httpClient.get.mockResolvedValueOnce({
+          data: {
+            deliveryMethods: entries.map((e) => ({
+              id: e.id,
+              name: e.name,
+              marketplaces: ['allegro.pl'],
+              dispatchCountry: 'PL',
+              destinationCountry: 'PL',
+            })),
+          },
+          status: 200,
+          headers: {},
+        });
+      }
+
+      it('flattens carrier methods across rate-tables, deduped by methodId, with names resolved from the catalogue', async () => {
+        // Step 1 fires `/sale/shipping-rates` and `/sale/delivery-methods` in
+        // parallel; jest's mockResolvedValueOnce queue dequeues in call order.
         httpClient.get.mockResolvedValueOnce({
           data: {
             shippingRates: [
@@ -674,13 +698,20 @@ describe('AllegroOrderSourceAdapter', () => {
           status: 200,
           headers: {},
         });
+        mockDeliveryMethodsCatalogue([
+          { id: PACZKOMAT_ID, name: 'Allegro Paczkomaty InPost' },
+          { id: KURIER_ID, name: 'Allegro Kurier24 InPost' },
+          { id: DPD_ID, name: 'DPD' },
+        ]);
+        // Rate-table response carries only `id` on each rate's deliveryMethod
+        // — names live on the catalogue. Mirrors the live API shape (#496).
         httpClient.get.mockResolvedValueOnce({
           data: {
             id: 'rate-set-1',
             name: 'Cennik główny',
             rates: [
-              { deliveryMethod: { id: PACZKOMAT_ID, name: 'Allegro Paczkomaty InPost' } },
-              { deliveryMethod: { id: KURIER_ID, name: 'Allegro Kurier24 InPost' } },
+              { deliveryMethod: { id: PACZKOMAT_ID } },
+              { deliveryMethod: { id: KURIER_ID } },
             ],
           },
           status: 200,
@@ -691,8 +722,8 @@ describe('AllegroOrderSourceAdapter', () => {
             id: 'rate-set-2',
             name: 'Cennik premium',
             rates: [
-              { deliveryMethod: { id: PACZKOMAT_ID, name: 'Allegro Paczkomaty InPost' } }, // dup
-              { deliveryMethod: { id: DPD_ID, name: 'DPD' } },
+              { deliveryMethod: { id: PACZKOMAT_ID } }, // dup
+              { deliveryMethod: { id: DPD_ID } },
             ],
           },
           status: 200,
@@ -702,8 +733,9 @@ describe('AllegroOrderSourceAdapter', () => {
         const result = await adapter.listDeliveryMethods();
 
         expect(httpClient.get).toHaveBeenNthCalledWith(1, '/sale/shipping-rates');
-        expect(httpClient.get).toHaveBeenNthCalledWith(2, '/sale/shipping-rates/rate-set-1');
-        expect(httpClient.get).toHaveBeenNthCalledWith(3, '/sale/shipping-rates/rate-set-2');
+        expect(httpClient.get).toHaveBeenNthCalledWith(2, '/sale/delivery-methods');
+        expect(httpClient.get).toHaveBeenNthCalledWith(3, '/sale/shipping-rates/rate-set-1');
+        expect(httpClient.get).toHaveBeenNthCalledWith(4, '/sale/shipping-rates/rate-set-2');
         expect(result).toEqual([
           { value: PACZKOMAT_ID, label: 'Allegro Paczkomaty InPost' },
           { value: KURIER_ID, label: 'Allegro Kurier24 InPost' },
@@ -711,23 +743,91 @@ describe('AllegroOrderSourceAdapter', () => {
         ]);
       });
 
+      it('falls back to the id as label when a method is absent from the catalogue (#496 defensive)', async () => {
+        const ORPHAN_ID = '99999999-aaaa-bbbb-cccc-dddddddddddd';
+        httpClient.get.mockResolvedValueOnce({
+          data: { shippingRates: [{ id: 'rate-set-1', name: 'Cennik' }] },
+          status: 200,
+          headers: {},
+        });
+        // Catalogue only knows about PACZKOMAT — the rate-table also references
+        // ORPHAN_ID, which should fall through to id-as-label.
+        mockDeliveryMethodsCatalogue([
+          { id: PACZKOMAT_ID, name: 'Allegro Paczkomaty InPost' },
+        ]);
+        httpClient.get.mockResolvedValueOnce({
+          data: {
+            id: 'rate-set-1',
+            name: 'Cennik',
+            rates: [
+              { deliveryMethod: { id: PACZKOMAT_ID } },
+              { deliveryMethod: { id: ORPHAN_ID } },
+            ],
+          },
+          status: 200,
+          headers: {},
+        });
+
+        const result = await adapter.listDeliveryMethods();
+        expect(result).toEqual([
+          { value: PACZKOMAT_ID, label: 'Allegro Paczkomaty InPost' },
+          { value: ORPHAN_ID, label: ORPHAN_ID },
+        ]);
+      });
+
+      it('prefers the catalogue name over a name carried on the rate itself', async () => {
+        // Edge case: if Allegro ever does inline a name on the rate (legacy
+        // shape, or a future-shape change), the canonical catalogue still
+        // wins — single source of truth.
+        httpClient.get.mockResolvedValueOnce({
+          data: { shippingRates: [{ id: 'rate-set-1', name: 'Cennik' }] },
+          status: 200,
+          headers: {},
+        });
+        mockDeliveryMethodsCatalogue([
+          { id: PACZKOMAT_ID, name: 'Allegro Paczkomaty InPost' },
+        ]);
+        httpClient.get.mockResolvedValueOnce({
+          data: {
+            id: 'rate-set-1',
+            name: 'Cennik',
+            rates: [{ deliveryMethod: { id: PACZKOMAT_ID, name: 'Stale name from rate' } }],
+          },
+          status: 200,
+          headers: {},
+        });
+
+        const result = await adapter.listDeliveryMethods();
+        expect(result).toEqual([
+          { value: PACZKOMAT_ID, label: 'Allegro Paczkomaty InPost' },
+        ]);
+      });
+
       it('returns empty list when seller has no rate-tables', async () => {
+        // Step 1 still fires both calls in parallel; the catalogue load is
+        // wasted work in this branch but the early-return on empty rate-set
+        // ids prevents any per-id detail fetches.
         httpClient.get.mockResolvedValueOnce({
           data: { shippingRates: [] },
           status: 200,
           headers: {},
         });
+        mockDeliveryMethodsCatalogue([]);
+
         const result = await adapter.listDeliveryMethods();
         expect(result).toEqual([]);
-        expect(httpClient.get).toHaveBeenCalledTimes(1);
+        expect(httpClient.get).toHaveBeenCalledTimes(2);
       });
 
-      it('falls back to deliveryMethod.id as label when name is missing', async () => {
+      it('falls back to deliveryMethod.id as label when name is missing from both catalogue and rate', async () => {
         httpClient.get.mockResolvedValueOnce({
           data: { shippingRates: [{ id: 'rate-set-1', name: 'Cennik główny' }] },
           status: 200,
           headers: {},
         });
+        // Catalogue empty — forces the chain to fall through to the
+        // rate-inline name (also missing here), then to the id.
+        mockDeliveryMethodsCatalogue([]);
         httpClient.get.mockResolvedValueOnce({
           data: {
             id: 'rate-set-1',
@@ -748,6 +848,9 @@ describe('AllegroOrderSourceAdapter', () => {
           status: 200,
           headers: {},
         });
+        // Catalogue empty here so the rate-inline 'Paczkomat' name is the one
+        // that lands as the label — covers the legacy fallback path.
+        mockDeliveryMethodsCatalogue([]);
         httpClient.get.mockResolvedValueOnce({
           data: {
             id: 'rate-set-1',
@@ -780,6 +883,7 @@ describe('AllegroOrderSourceAdapter', () => {
           status: 200,
           headers: {},
         });
+        mockDeliveryMethodsCatalogue([]);
         httpClient.get.mockResolvedValueOnce({
           data: {
             id: 'rate-set-1',

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -25,6 +25,7 @@ import { Logger } from '@openlinker/shared/logging';
 import { IAllegroHttpClient } from '../http/allegro-http-client.interface';
 import {
   AllegroCheckoutForm,
+  AllegroDeliveryMethodsResponse,
   AllegroOrderEventsResponse,
   AllegroShippingRatesResponse,
   AllegroShippingRateDetailResponse,
@@ -342,11 +343,18 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptions
   }
 
   async listDeliveryMethods(): Promise<MappingOption[]> {
-    // Step 1: list the seller's rate-tables (cheap — single response).
-    const rateSets = await this.httpClient.get<AllegroShippingRatesResponse>(
-      '/sale/shipping-rates',
-    );
+    // Step 1: list the seller's rate-tables AND fetch the canonical
+    // method catalogue in parallel. The catalogue (`/sale/delivery-methods`)
+    // resolves bare method-ids into operator-friendly names (#496) since the
+    // rate-table response itself only carries `deliveryMethod.id`, not name.
+    const [rateSets, methodsResponse] = await Promise.all([
+      this.httpClient.get<AllegroShippingRatesResponse>('/sale/shipping-rates'),
+      this.httpClient.get<AllegroDeliveryMethodsResponse>('/sale/delivery-methods'),
+    ]);
     const rateSetIds = (rateSets.data.shippingRates ?? []).map((r) => r.id);
+    const nameById = new Map<string, string>(
+      (methodsResponse.data.deliveryMethods ?? []).map((m) => [m.id, m.name]),
+    );
 
     if (rateSetIds.length === 0) {
       this.logger.warn(
@@ -370,13 +378,16 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptions
     // Step 3: flatten + dedup by methodId. Allegro returns the method object
     // under `deliveryMethod` per developer.allegro.pl/documentation#operation/getShippingRateUsingGET
     // — #494 fixed an earlier `rate.method` typo that silently produced [].
+    // Resolve labels via the catalogue (#496); fall back to the rate's own
+    // name if present, then the id (defensive — should be rare for properly-
+    // configured cenniki).
     const seen = new Map<string, string>();
     for (const detail of details) {
       for (const rate of detail.data.rates ?? []) {
         const id = rate.deliveryMethod?.id;
         if (!id) continue;
         if (!seen.has(id)) {
-          seen.set(id, rate.deliveryMethod?.name ?? id);
+          seen.set(id, nameById.get(id) ?? rate.deliveryMethod?.name ?? id);
         }
       }
     }


### PR DESCRIPTION
Closes #496.

## Summary

After #494 fixed the rate-table parser, `listDeliveryMethods` returned the right method ids — but with UUIDs in both `value` AND `label` slots because `/sale/shipping-rates/{id}` only carries `deliveryMethod.id`, not name. Operators saw a 55-row dropdown of UUIDs and couldn't tell Paczkomat from DPD.

This PR adds a parallel call to `GET /sale/delivery-methods` (the canonical method catalogue, [per Allegro docs](https://developer.allegro.pl/news/get-sale-delivery-methods-dodatkowe-informacje-o-metodach-dostawy-E7Zbq7OBnSE)) at the start of `listDeliveryMethods`, builds `Map<id, name>`, and resolves labels during the dedup walk. `Promise.all` keeps the catalogue + rate-tables fetches concurrent — no added wall-clock latency.

**Resolution priority** (defensive layering):
1. Catalogue name (canonical, the new path).
2. Inline name on the rate (legacy fallback — rate-table response doesn't actually carry it today, but kept for forward-compat in case Allegro adds it).
3. The id itself (only fires for orphan ids missing from the catalogue, which shouldn't happen for properly configured cenniki — but covered by a defensive test so the next regression is loud).

## Tests

Three new specs:
- Happy path: rate-table → catalogue lookup → resolved label (`"Allegro Paczkomaty InPost"`).
- Orphan fallback: rate-table references an id absent from the catalogue → label falls through to the id.
- Catalogue precedence: rate-inline name is ignored when the catalogue has the id — single source of truth.

Existing 4 tests updated to mock the new catalogue call (Promise.all dispatches both upfront, even on the empty-rate-tables short-circuit, so every list path now mocks the catalogue too).

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1533 unit tests pass
- [ ] Manual: pull branch, restart API, refresh `/connections/{allegroConnectionId}/mappings` → Carriers tab. The dropdown should now show **method names** (`Allegro Paczkomaty InPost`, `Allegro Kurier24 InPost`, `DPD`, etc.) instead of UUIDs.
- [ ] Manual: confirm row count is reasonable (Polish marketplace typically has 5–15 unique methods across all cenniki for a non-trivial seller).

## Out of scope

- Caching `/sale/delivery-methods`. Operator-driven endpoint, hit on page-load; revisit if latency bites.
- The VAT split on `shipping_cost_tax_excl` vs `shipping_cost_tax_incl` in `reconcileShippingCost` — separate accounting concern surfaced during the same investigation, will be filed separately if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)