### PR TITLE
fix(allegro): scope delivery-methods catalogue to allegro-pl + diag warn

### DIFF
--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -733,7 +733,11 @@ describe('AllegroOrderSourceAdapter', () => {
         const result = await adapter.listDeliveryMethods();
 
         expect(httpClient.get).toHaveBeenNthCalledWith(1, '/sale/shipping-rates');
-        expect(httpClient.get).toHaveBeenNthCalledWith(2, '/sale/delivery-methods');
+        // Catalogue MUST be scoped to allegro-pl — without the marketplace
+        // query param the sandbox returns an empty list (verified live).
+        expect(httpClient.get).toHaveBeenNthCalledWith(2, '/sale/delivery-methods', {
+          queryParams: { marketplace: 'allegro-pl' },
+        });
         expect(httpClient.get).toHaveBeenNthCalledWith(3, '/sale/shipping-rates/rate-set-1');
         expect(httpClient.get).toHaveBeenNthCalledWith(4, '/sale/shipping-rates/rate-set-2');
         expect(result).toEqual([
@@ -901,6 +905,51 @@ describe('AllegroOrderSourceAdapter', () => {
         expect(result).toEqual([]);
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringMatching(/produced 0 delivery methods.*possible API shape regression/i),
+        );
+
+        warnSpy.mockRestore();
+      });
+
+      // Diagnostic for the bug surfaced live on #496/PR #497: if the
+      // catalogue is empty (or scoped to the wrong marketplace), every
+      // method id misses the lookup and the dropdown shows UUIDs. Asserts
+      // the operator-visible warn fires so the cause is loud, not silent.
+      it('warns when method ids cannot be resolved from the catalogue', async () => {
+        const warnSpy = jest
+          .spyOn((adapter as unknown as { logger: { warn: (m: string) => void } }).logger, 'warn')
+          .mockImplementation(() => {});
+
+        httpClient.get.mockResolvedValueOnce({
+          data: { shippingRates: [{ id: 'rate-set-1', name: 'Cennik' }] },
+          status: 200,
+          headers: {},
+        });
+        // Catalogue empty — simulates a scope mismatch (wrong marketplace,
+        // pagination cut, namespace drift, etc).
+        mockDeliveryMethodsCatalogue([]);
+        httpClient.get.mockResolvedValueOnce({
+          data: {
+            id: 'rate-set-1',
+            name: 'Cennik',
+            rates: [
+              { deliveryMethod: { id: PACZKOMAT_ID } },
+              { deliveryMethod: { id: KURIER_ID } },
+            ],
+          },
+          status: 200,
+          headers: {},
+        });
+
+        const result = await adapter.listDeliveryMethods();
+
+        // Result is non-empty (parser worked), but every label is the id
+        // — the unresolved diagnostic must fire.
+        expect(result).toEqual([
+          { value: PACZKOMAT_ID, label: PACZKOMAT_ID },
+          { value: KURIER_ID, label: KURIER_ID },
+        ]);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/2\/2 method ids could not be resolved.*falling back to UUIDs/i),
         );
 
         warnSpy.mockRestore();

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -347,13 +347,23 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptions
     // method catalogue in parallel. The catalogue (`/sale/delivery-methods`)
     // resolves bare method-ids into operator-friendly names (#496) since the
     // rate-table response itself only carries `deliveryMethod.id`, not name.
+    //
+    // The catalogue MUST be scoped via `?marketplace=allegro-pl` — without it
+    // sandbox returns an empty list and every dropdown row falls back to its
+    // UUID. Hardcoded to `allegro-pl` because OL today only supports the PL
+    // marketplace; revisit when other Allegro markets come online.
     const [rateSets, methodsResponse] = await Promise.all([
       this.httpClient.get<AllegroShippingRatesResponse>('/sale/shipping-rates'),
-      this.httpClient.get<AllegroDeliveryMethodsResponse>('/sale/delivery-methods'),
+      this.httpClient.get<AllegroDeliveryMethodsResponse>('/sale/delivery-methods', {
+        queryParams: { marketplace: 'allegro-pl' },
+      }),
     ]);
     const rateSetIds = (rateSets.data.shippingRates ?? []).map((r) => r.id);
-    const nameById = new Map<string, string>(
-      (methodsResponse.data.deliveryMethods ?? []).map((m) => [m.id, m.name]),
+    const catalogue = methodsResponse.data.deliveryMethods ?? [];
+    const nameById = new Map<string, string>(catalogue.map((m) => [m.id, m.name]));
+
+    this.logger.debug(
+      `listDeliveryMethods: connection=${this.connectionId} rateSetIds=${rateSetIds.length} catalogue=${catalogue.length}`,
     );
 
     if (rateSetIds.length === 0) {
@@ -401,6 +411,18 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptions
       const totalRates = details.reduce((n, d) => n + (d.data.rates?.length ?? 0), 0);
       this.logger.warn(
         `Walked ${rateSetIds.length} rate-tables with ${totalRates} rates for connection ${this.connectionId} but produced 0 delivery methods — possible API shape regression.`,
+      );
+    }
+
+    // Diagnostic: any method id whose label fell through to the id itself
+    // means the catalogue lookup missed. A few misses are tolerable (Allegro
+    // can have legacy method-ids no longer in the catalogue), but a high
+    // ratio means the marketplace scope is wrong, the catalogue is paginated,
+    // or the id namespaces have drifted. Helps next-time-this-breaks debug.
+    const unresolved = result.filter((r) => r.value === r.label);
+    if (unresolved.length > 0) {
+      this.logger.warn(
+        `listDeliveryMethods: ${unresolved.length}/${result.length} method ids could not be resolved from /sale/delivery-methods catalogue (size=${catalogue.length}) for connection ${this.connectionId} — labels falling back to UUIDs.`,
       );
     }
     return result;


### PR DESCRIPTION
Live follow-up to #496 / PR #497.

## Summary

PR #497 added the `/sale/delivery-methods` resolver but the dropdown still rendered UUIDs against a real seller account. Root cause: calling the catalogue endpoint without a `marketplace` query parameter returns an empty list on Allegro sandbox (the OpenAPI spec marks it optional, but in practice it's effectively required for non-trivial responses).

This PR:
- Hardcodes `?marketplace=allegro-pl` on the catalogue call. Polish marketplace is the only one OL supports today; revisit when other Allegro markets come online.
- Adds two diagnostic surfaces so a future regression of this kind is loud, not silent:
  - `DEBUG`: `connection=… rateSetIds=N catalogue=M` per call.
  - `WARN`: `N/M method ids could not be resolved from /sale/delivery-methods catalogue (size=K)` — distinguishes scope/pagination drift (high N/M) from a few legacy ids no longer in the catalogue (low N/M, tolerable).

## Tests

- Happy-path test now asserts the catalogue call carries `{queryParams: {marketplace: 'allegro-pl'}}` so a future regression that drops the param fails the suite immediately.
- New spec covers the "every id unresolved" path: empty catalogue + rate-table referencing two methods → result has UUID labels, warn fires with the expected `2/2` ratio.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1534 unit tests pass
- [ ] Manual: pull, restart API, refresh `/connections/{allegroConnectionId}/mappings` → Carriers tab. Dropdown should read `Allegro Paczkomaty InPost`, `Kurier DPD`, etc.
- [ ] If still UUIDs, the new WARN line will tell us exactly why (catalogue size + unresolved ratio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)