### PR TITLE
fix(ai,content,web): seed master-channel prompt + actionable 404 in suggestion dialog

### DIFF
--- a/apps/api/src/migrations/1794000000000-seed-master-prompt-template.ts
+++ b/apps/api/src/migrations/1794000000000-seed-master-prompt-template.ts
@@ -1,0 +1,71 @@
+/**
+ * Migration: seed master-channel prompt template (#490)
+ *
+ * Inserts the missing `(offer.description.suggest, channel=NULL, v1, published)`
+ * row so master-tab AI suggestions stop 404-ing. The earlier seed
+ * (`SeedPromptTemplates1790000000001`) only covered `prestashop` and `allegro`
+ * — the null-channel master row was acknowledged-but-deferred at the time
+ * (`content-suggestion.service.ts:70-72`) and is now bridged here.
+ *
+ * Idempotent via `ON CONFLICT DO NOTHING` against the partial unique index
+ * "at most one published per (key, channel)" — environments where someone
+ * manually inserted a master row keep theirs, this is a no-op.
+ *
+ * Variables shape mirrors the `prestashop`/`allegro` rows so the suggestion
+ * flow can pass the same product payload regardless of channel.
+ *
+ * @module apps/api/src/migrations
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const VARIABLES_JSON = JSON.stringify([
+  { name: 'product.name', type: 'string', required: true },
+  { name: 'product.attributes', type: 'object', required: false },
+  { name: 'product.category', type: 'string', required: false },
+  { name: 'tone', type: 'string', required: false },
+  { name: 'extraInstructions', type: 'string', required: false },
+]);
+
+const MASTER_SYSTEM_PROMPT = `You are a senior e-commerce copywriter producing canonical product \
+descriptions for the OpenLinker master catalogue. The master description is published \
+directly into the shop's product-description field (today: PrestaShop), so output semantic \
+HTML: wrap the summary in a <p>, list features as a <ul> of <li> bullets, and close with a \
+short call-to-action paragraph. Never inline CSS or scripts. Write in the same language as \
+the product name. Channel-specific publishers may further adapt the output for marketplace \
+formats (e.g. Allegro block-formatted descriptions) — keep the HTML clean enough to survive \
+that translation.`;
+
+const MASTER_USER_TEMPLATE = `Write a master product description (120–220 words) for the following product.
+
+Product: {{product.name}}
+Category: {{product.category}}
+Attributes: {{product.attributes}}
+
+Tone: {{tone}}
+Additional instructions: {{extraInstructions}}
+
+Output only the HTML body — no <html>, <head>, or wrapping tags.`;
+
+export class SeedMasterPromptTemplate1794000000000 implements MigrationInterface {
+  name = 'SeedMasterPromptTemplate1794000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+      INSERT INTO "prompt_templates"
+        ("key", "channel", "version", "system_prompt", "user_prompt_template", "variables", "state", "published_at", "created_by")
+      VALUES
+        ($1, NULL, 1, $2, $3, $4::jsonb, 'published', now(), NULL)
+      ON CONFLICT DO NOTHING
+      `,
+      ['offer.description.suggest', MASTER_SYSTEM_PROMPT, MASTER_USER_TEMPLATE, VARIABLES_JSON],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "prompt_templates" WHERE "key" = $1 AND "version" = 1 AND "channel" IS NULL`,
+      ['offer.description.suggest'],
+    );
+  }
+}

--- a/apps/web/src/features/content/components/suggestion-dialog.test.tsx
+++ b/apps/web/src/features/content/components/suggestion-dialog.test.tsx
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SuggestionDialog } from './suggestion-dialog';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { ApiError } from '../../../shared/api/api-error';
 import type { SuggestionResponse } from '../api/content.types';
 
 function makeSuggestionResponse(suggestion: string): SuggestionResponse {
@@ -93,6 +94,60 @@ describe('SuggestionDialog', () => {
     await user.click(within_.getByRole('button', { name: 'Apply to editor' }));
 
     expect(onApply).toHaveBeenCalledWith('Generated text');
+  });
+
+  it('renders a deep link to /ai/prompt-templates when the suggest API returns a 404 missing-template error (#490)', async () => {
+    const suggest = vi.fn().mockRejectedValue(
+      new ApiError(
+        'Prompt template not found: key=offer.description.suggest, channel=master, version=1. ' +
+          'Seed a template with channel=null for this key, or use a channel-specific template.',
+        404,
+        { statusCode: 404, message: 'Prompt template not found: ...' },
+      ),
+    );
+    const mockApi = createMockApiClient({ content: { suggest } });
+
+    renderWithProviders(
+      <SuggestionDialog productId="ol_product_1" channel={null} onApply={vi.fn()} />,
+      { apiClient: mockApi },
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Suggest with AI/ }));
+    const dialog = await screen.findByRole('dialog');
+    const within_ = within(dialog);
+
+    await user.click(within_.getByRole('button', { name: 'Generate' }));
+
+    // The error body shows up inside the dialog's Alert.
+    expect(
+      await within_.findByText(/Prompt template not found/),
+    ).toBeInTheDocument();
+    // And it carries the actionable deep link to the admin UI.
+    const deepLink = within_.getByRole('link', { name: /Open prompt templates/ });
+    expect(deepLink).toHaveAttribute('href', '/ai/prompt-templates');
+  });
+
+  it('does not render the deep link for unrelated errors', async () => {
+    const suggest = vi
+      .fn()
+      .mockRejectedValue(new ApiError('Server exploded', 500, { statusCode: 500 }));
+    const mockApi = createMockApiClient({ content: { suggest } });
+
+    renderWithProviders(
+      <SuggestionDialog productId="ol_product_1" channel={null} onApply={vi.fn()} />,
+      { apiClient: mockApi },
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Suggest with AI/ }));
+    const dialog = await screen.findByRole('dialog');
+    const within_ = within(dialog);
+
+    await user.click(within_.getByRole('button', { name: 'Generate' }));
+
+    expect(await within_.findByText('Server exploded')).toBeInTheDocument();
+    expect(within_.queryByRole('link', { name: /Open prompt templates/ })).toBeNull();
   });
 
   it('omits empty tone and extraInstructions from the request payload', async () => {

--- a/apps/web/src/features/content/components/suggestion-dialog.tsx
+++ b/apps/web/src/features/content/components/suggestion-dialog.tsx
@@ -9,6 +9,7 @@
  * @module apps/web/src/features/content/components
  */
 import { useCallback, useState, type ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import {
@@ -23,6 +24,7 @@ import {
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
 import { Textarea } from '../../../shared/ui/textarea';
+import { ApiError } from '../../../shared/api/api-error';
 import { useSuggestContentMutation } from '../hooks/use-content-mutations';
 import type { PromptTemplateChannel } from '../api/content.types';
 
@@ -35,6 +37,21 @@ interface SuggestionDialogProps {
 
 const MAX_TONE_LENGTH = 64;
 const MAX_EXTRA_LENGTH = 1024;
+
+/**
+ * #490: detect the structured 404 the API returns when a prompt template is
+ * unseeded for the requested (key, channel) — most commonly the master tab's
+ * `offer.description.suggest` row before the seed migration runs. Stepping
+ * stone: the back-end could emit a typed error code, but the message-prefix
+ * match is good enough until the unified error-shape work picks it up.
+ */
+function isMissingTemplateError(error: Error): boolean {
+  return (
+    error instanceof ApiError &&
+    error.isNotFound() &&
+    error.message.startsWith('Prompt template not found')
+  );
+}
 
 export function SuggestionDialog({
   productId,
@@ -137,7 +154,17 @@ export function SuggestionDialog({
             />
           </FormField>
 
-          {mutation.error && <Alert tone="error">{mutation.error.message}</Alert>}
+          {mutation.error &&
+            (isMissingTemplateError(mutation.error) ? (
+              <Alert tone="error">
+                {mutation.error.message}{' '}
+                <Link to="/ai/prompt-templates" className="content-suggestion__alert-link">
+                  Open prompt templates →
+                </Link>
+              </Alert>
+            ) : (
+              <Alert tone="error">{mutation.error.message}</Alert>
+            ))}
 
           {suggestion !== null && (
             <div className="content-suggestion__preview">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6312,6 +6312,18 @@ a.kpi-card:focus-visible {
   color: var(--text-muted);
 }
 
+.content-suggestion__alert-link {
+  color: var(--accent-primary);
+  text-decoration: underline;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.content-suggestion__alert-link:hover,
+.content-suggestion__alert-link:focus-visible {
+  color: var(--accent-primary-hover);
+}
+
 /* ============================================================
    AI Provider Settings — multi-provider table (#451 / #452)
    ============================================================ */

--- a/docs/plans/implementation-plan-master-prompt-template.md
+++ b/docs/plans/implementation-plan-master-prompt-template.md
@@ -1,0 +1,237 @@
+# Implementation plan — master-channel prompt template (#490)
+
+## 1. Goal
+
+Master-tab AI suggestions are silently broken: the FE sends `channel: null`, `PromptTemplateService.getPublished({ key: 'offer.description.suggest', channel: null })` finds no row (only `allegro` + `prestashop` are seeded), and the request 404s with `Prompt template not found: key=offer.description.suggest, channel=master`. Three changes, one PR:
+
+1. **Seed** the missing `(offer.description.suggest, channel=NULL, v1, published)` row so master-tab Suggest actually generates copy.
+2. **Tighten the exception message** when `channel === null` so operators landing on the error know what to do.
+3. **FE Alert with deep-link** in `suggestion-dialog.tsx` so the operator can jump straight to `/ai/prompt-templates` to author the missing row (also serves as future-proofing if a new key gets added without a master seed).
+
+**Layer:** Infrastructure (seed migration in `apps/api`) + Domain (exception copy in `libs/core/src/ai`) + Frontend (dialog error rendering in `apps/web`).
+
+**Non-goals**
+- Channel-fallback logic (`null → channel` or `channel → null`). The strict per-`(key, channel)` lookup is intentional — channel-specific divergence is the feature.
+- Authoring "great" master prompt prose. The seed is sensible, neutral, channel-agnostic; iteration belongs to the admin UI (#488).
+- Adding seeds for new keys (e.g., future `product.title.suggest`).
+
+## 2. Codebase research
+
+### BE
+- **Existing seed migration** (`apps/api/src/migrations/1790000000001-seed-prompt-templates.ts`): inserts `prestashop` + `allegro` rows for `offer.description.suggest` v1 with shared `VARIABLES_JSON`. Plain `INSERT INTO prompt_templates (...) VALUES (...)`. Down deletes those two rows. Channel-specific copy lives in the prompt body.
+- **Latest migration timestamp** in the tree: `1793000000000-add-order-record-sync-attempts.ts`. Next free lane: **`1794000000000`** (per the timestamp-uniqueness invariant in `docs/migrations.md`).
+- **Exception**: `libs/core/src/ai/domain/exceptions/prompt-template-not-found.exception.ts` line 27 builds the `channel=...` part with `args.channel ?? 'master'` — the message word is correct, just incomplete for the operator. Constructor receives `channel?: PromptTemplateChannel | null`, so `channel === null` is distinguishable from `channel === undefined` (id-based lookup).
+- **HTTP boundary**: `apps/api/src/content/http/content.controller.ts:194` rethrows `PromptTemplateNotFoundException` as a NestJS `NotFoundException` (HTTP 404) with the exception's message string as the body.
+- **No existing test** for the exception class itself (grep confirmed). The service spec covers thrown-exception cases by class but not message format.
+- **Partial unique index**: `prompt_templates` has "at most one published per (key, channel)" (per architecture-overview §13 + the migration adding the table). For a fresh DB this insert is uncontested; for an existing DB where someone already inserted a master row manually, `ON CONFLICT DO NOTHING` is cheap insurance (matches the spirit of "idempotent seed").
+
+### FE
+- **API client**: errors land as `ApiError` (`apps/web/src/shared/api/api-error.ts`) with `.status: number` + `.message: string` + `.isNotFound()` helper. The 404 body's `message` field becomes `error.message`.
+- **Dialog**: `apps/web/src/features/content/components/suggestion-dialog.tsx:140` currently renders `<Alert tone="error">{mutation.error.message}</Alert>` with no special-casing. Today's UX is the bare exception message, no link to remediate.
+- **Existing dialog test**: `apps/web/src/features/content/components/suggestion-dialog.test.tsx` exists and uses the standard `renderWithProviders` + `createMockApiClient` pattern. Good place to add the 404-branch test.
+
+### Open question (resolved)
+- Should the FE match by status code or by message content? **Status code + message-prefix.** `error instanceof ApiError && error.isNotFound() && error.message.includes('Prompt template not found')` — matches even if the message gets future polish, and avoids false positives on other 404s (e.g., product not found).
+
+## 3. Design
+
+### BE — seed migration (idempotent)
+
+```ts
+// apps/api/src/migrations/1794000000000-seed-prompt-template-offer-description-suggest-master.ts
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const VARIABLES_JSON = JSON.stringify([
+  { name: 'product.name', type: 'string', required: true },
+  { name: 'product.attributes', type: 'object', required: false },
+  { name: 'product.category', type: 'string', required: false },
+  { name: 'tone', type: 'string', required: false },
+  { name: 'extraInstructions', type: 'string', required: false },
+]);
+
+const SYSTEM_PROMPT = `You are a senior e-commerce copywriter producing canonical product
+descriptions for the OpenLinker master catalogue. Write clean, persuasive prose without any
+HTML, markdown, or platform-specific formatting. The output is the master copy — it gets
+adapted into HTML for shop platforms (PrestaShop) and into block-formatted listings for
+marketplaces (Allegro) by channel-specific publishers, so keep the structure simple: a short
+benefit-focused opening sentence or two, then a clear bulleted-on-newlines feature
+enumeration, then a closing sentence. Match the language of the product name.`;
+
+const USER_TEMPLATE = `Write a master product description (120–220 words) for the following product.
+
+Product: {{product.name}}
+Category: {{product.category}}
+Attributes: {{product.attributes}}
+
+Tone: {{tone}}
+Additional instructions: {{extraInstructions}}
+
+Output plain prose only — no HTML, no markdown, no platform-specific formatting. The
+description will be adapted by channel publishers downstream.`;
+
+export class SeedPromptTemplateOfferDescriptionSuggestMaster1794000000000 implements MigrationInterface {
+  name = 'SeedPromptTemplateOfferDescriptionSuggestMaster1794000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+      INSERT INTO "prompt_templates"
+        ("key", "channel", "version", "system_prompt", "user_prompt_template", "variables", "state", "published_at", "created_by")
+      VALUES
+        ($1, NULL, 1, $2, $3, $4::jsonb, 'published', now(), NULL)
+      ON CONFLICT DO NOTHING
+      `,
+      ['offer.description.suggest', SYSTEM_PROMPT, USER_TEMPLATE, VARIABLES_JSON],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "prompt_templates" WHERE "key" = $1 AND "version" = 1 AND "channel" IS NULL`,
+      ['offer.description.suggest'],
+    );
+  }
+}
+```
+
+`ON CONFLICT DO NOTHING` is the idempotent escape hatch: if the partial-unique index for "at most one published per (key, channel)" already has a master row (manually inserted), the migration is a no-op rather than a failure. `down` is symmetric.
+
+### BE — exception message
+
+Only expand the message when `channel === null` (the master case). Other branches stay unchanged:
+
+```ts
+constructor(args: {...}) {
+  const parts: string[] = [];
+  if (args.templateId !== undefined) parts.push(`id=${args.templateId}`);
+  if (args.key !== undefined) parts.push(`key=${args.key}`);
+  if (args.channel !== undefined) parts.push(`channel=${args.channel ?? 'master'}`);
+  if (args.version !== undefined) parts.push(`version=${args.version}`);
+  const base = `Prompt template not found: ${parts.join(', ')}`;
+  // #490: master-channel hits the unseeded gap most often. Append an
+  // operator-actionable hint so the FE / API consumer knows what to do.
+  const isMasterLookup = args.channel === null && args.key !== undefined;
+  super(
+    isMasterLookup
+      ? `${base}. Seed a template with channel=null for this key, or pick a channel-specific tab in the content editor.`
+      : base,
+  );
+  // ... rest unchanged
+}
+```
+
+The hint text is operator-facing but stable (no template-string interpolation of user input), safe to ship through the 404 body.
+
+### FE — dialog error rendering
+
+Replace the bare `<Alert>{mutation.error.message}</Alert>` with a status-aware branch:
+
+```tsx
+{mutation.error && (
+  isMissingTemplateError(mutation.error) ? (
+    <Alert tone="error">
+      {mutation.error.message}{' '}
+      <Link to="/ai/prompt-templates" className="content-suggestion__alert-link">
+        Open prompt templates →
+      </Link>
+    </Alert>
+  ) : (
+    <Alert tone="error">{mutation.error.message}</Alert>
+  )
+)}
+```
+
+Helper colocated in the file (small, single-use):
+
+```ts
+function isMissingTemplateError(error: Error): boolean {
+  return (
+    error instanceof ApiError &&
+    error.isNotFound() &&
+    error.message.startsWith('Prompt template not found')
+  );
+}
+```
+
+The `ApiError` import already exists at the FE app layer; needs a relative import path. The `Link` is React Router's standard nav link (already used elsewhere in `apps/web/src/pages/...`). The CSS class is one tiny addition to `index.css` matching existing alert-link conventions.
+
+### Why not parse a structured error code?
+
+We could pipe a structured `code: 'PROMPT_TEMPLATE_NOT_FOUND'` field through the 404 body via a NestJS exception filter and have the FE match on `error.details.code`. Cleaner, but pulls in an exception filter rewrite that's out of scope for a behavioural fix. Status + message-prefix is fine and follows the existing #486 Allegro-422 pattern (the FE also matches on body shape, not on a custom code).
+
+## 4. Step-by-step plan
+
+### Step 1 — BE: seed migration
+
+**File:** `apps/api/src/migrations/1794000000000-seed-prompt-template-offer-description-suggest-master.ts` (new)
+
+Insert the master row with `ON CONFLICT DO NOTHING`. Standard `MigrationInterface` shape, file-header comment per `engineering-standards.md`.
+
+**Acceptance:** `pnpm lint` passes (timestamp-uniqueness invariant green). `pnpm --filter @openlinker/api migration:show` lists the new migration as pending.
+
+### Step 2 — BE: exception copy
+
+**File:** `libs/core/src/ai/domain/exceptions/prompt-template-not-found.exception.ts`
+
+Append the operator-actionable hint to the message body when `channel === null && key !== undefined`. Other cases unchanged.
+
+**Acceptance:** Type-check green. Existing service spec still passes (it asserts class identity, not message content).
+
+### Step 3 — BE: exception unit test
+
+**File:** `libs/core/src/ai/domain/exceptions/prompt-template-not-found.exception.spec.ts` (new)
+
+Three cases:
+- `channel === null` (master) → message ends with the actionable hint.
+- `channel === 'allegro'` → message has no hint, ends with `channel=allegro`.
+- id-based lookup (`templateId` only) → message has no hint, body is just `id=...`.
+
+**Acceptance:** 3/3 pass with `pnpm --filter @openlinker/core test`.
+
+### Step 4 — FE: dialog deep-link Alert
+
+**File:** `apps/web/src/features/content/components/suggestion-dialog.tsx`
+
+- Import `ApiError` from `../../../shared/api/api-error`.
+- Import `Link` from `react-router-dom`.
+- Add `isMissingTemplateError` helper (top of file or below `MAX_*` constants).
+- Replace the single `Alert` line with the conditional rendering described above.
+
+Add the small CSS class `.content-suggestion__alert-link` in `apps/web/src/index.css` styled as a standard inline alert link (matches existing alert link styling — find a sibling pattern like `.alert__link` if one exists; otherwise inline tokens: `color: var(--accent-primary); text-decoration: underline; margin-left: 0.25rem`).
+
+**Acceptance:** `pnpm --filter @openlinker/web type-check` + `lint` green. Dialog still renders normal `<Alert>` for non-template errors.
+
+### Step 5 — FE: dialog test for the 404 branch
+
+**File:** `apps/web/src/features/content/components/suggestion-dialog.test.tsx`
+
+Add one case: when `useSuggestContentMutation`'s underlying API call rejects with `new ApiError('Prompt template not found: key=offer.description.suggest, channel=master. Seed...', 404, ...)`, the dialog renders an `<Alert>` whose body contains the message AND a link with `href="/ai/prompt-templates"`. Assert the link is absent for a generic non-404 error (or non-matching message).
+
+**Acceptance:** new test passes with the existing test file's full suite.
+
+### Step 6 — Quality gate
+
+```
+pnpm --filter @openlinker/api lint && type-check
+pnpm --filter @openlinker/core lint && type-check && test
+pnpm --filter @openlinker/web lint && type-check && test
+pnpm --filter @openlinker/api migration:show
+```
+
+All clean; the new migration shows as pending against any non-migrated DB.
+
+## 5. Validation
+
+- **Architecture (BE):** Migration in `apps/api/src/migrations/` (correct layer). Exception change in `libs/core/src/ai/domain/exceptions/` (correct layer). No CORE/Integration boundary crossed.
+- **Architecture (FE):** Dialog stays under `features/content/components/` — no page-level changes needed. Imports `ApiError` from `shared/api/`, follows `features → shared` direction. `Link` is a `react-router-dom` primitive (allowed).
+- **Naming:** Migration class name matches its filename timestamp suffix (`...1794000000000`) per the timestamp invariant. Test file follows `*.spec.ts` for BE, `*.test.tsx` for FE.
+- **Idempotency:** `ON CONFLICT DO NOTHING` covers re-runs against a DB where someone manually authored a master row; `down()` is symmetric.
+- **No regression risk:** allegro/prestashop seed migration untouched; channel-specific lookup still hits its row first; the new master row is only consulted when the master tab is active (FE sends `channel: null`).
+- **Security:** No user input in the prompt body. The hint text is a static string. The deep link is a same-origin route. No XSS / injection vectors.
+- **Migration safety:** Single `INSERT` wrapped in TypeORM's default transaction. No DDL — no lock-up risk.
+
+## 6. Risks & open questions
+
+- **Master-prompt prose quality.** The seed body is sensible-but-generic. If operators dislike the channel-neutral output once they actually use it, they can override per-product or author a v2 via the admin UI. Acceptable risk for a seed.
+- **Nest exception filter coupling.** This PR doesn't introduce a structured error code. If a future PR (#488 or the unified error-shape work) wants to do that, the FE matcher gets simpler — the message-prefix match here is a stepping stone, not a long-term design.
+- **`ON CONFLICT DO NOTHING` masking real failures.** The only way it masks a problem is if a master row already exists with different prompt body. That's intended — operators who manually authored one keep theirs. If it later turns out we need to refresh the seed across environments, that's a separate "v2 seed" migration.

--- a/libs/core/src/ai/domain/exceptions/prompt-template-not-found.exception.spec.ts
+++ b/libs/core/src/ai/domain/exceptions/prompt-template-not-found.exception.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Prompt Template Not Found Exception — unit tests
+ *
+ * Locks in the message-format contract the FE suggestion dialog matches
+ * against (#490). Master-channel lookups gain an operator-actionable hint;
+ * other lookup shapes preserve their pre-existing terse format.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+import { PromptTemplateNotFoundException } from './prompt-template-not-found.exception';
+
+describe('PromptTemplateNotFoundException', () => {
+  it('appends an operator hint when channel is null (master) and key is present', () => {
+    const err = new PromptTemplateNotFoundException({
+      key: 'offer.description.suggest',
+      channel: null,
+      version: 1,
+    });
+
+    expect(err.message).toBe(
+      'Prompt template not found: key=offer.description.suggest, channel=master, version=1. ' +
+        'Seed a template with channel=null for this key, or use a channel-specific template.',
+    );
+    expect(err.key).toBe('offer.description.suggest');
+    expect(err.channel).toBeNull();
+  });
+
+  it('does not append the hint for channel-specific lookups', () => {
+    const err = new PromptTemplateNotFoundException({
+      key: 'offer.description.suggest',
+      channel: 'allegro',
+      version: 1,
+    });
+
+    expect(err.message).toBe(
+      'Prompt template not found: key=offer.description.suggest, channel=allegro, version=1',
+    );
+    expect(err.message).not.toContain('Seed a template');
+  });
+
+  it('does not append the hint for id-only lookups', () => {
+    const err = new PromptTemplateNotFoundException({ templateId: 'tpl_abc' });
+
+    expect(err.message).toBe('Prompt template not found: id=tpl_abc');
+    expect(err.message).not.toContain('Seed a template');
+  });
+
+  it('does not append the hint when channel is null but no key is present (id-based lookup)', () => {
+    // Edge case: channel passed as null without a key. None of the current
+    // call sites do this, but locking it down means future refactors that
+    // pair channel with templateId won't accidentally trigger the hint.
+    const err = new PromptTemplateNotFoundException({
+      templateId: 'tpl_abc',
+      channel: null,
+    });
+
+    expect(err.message).toBe('Prompt template not found: id=tpl_abc, channel=master');
+    expect(err.message).not.toContain('Seed a template');
+  });
+});

--- a/libs/core/src/ai/domain/exceptions/prompt-template-not-found.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/prompt-template-not-found.exception.ts
@@ -26,7 +26,17 @@ export class PromptTemplateNotFoundException extends Error {
     if (args.key !== undefined) parts.push(`key=${args.key}`);
     if (args.channel !== undefined) parts.push(`channel=${args.channel ?? 'master'}`);
     if (args.version !== undefined) parts.push(`version=${args.version}`);
-    super(`Prompt template not found: ${parts.join(', ')}`);
+    const base = `Prompt template not found: ${parts.join(', ')}`;
+    // #490: master-channel lookups (channel === null) hit the unseeded gap
+    // most often. Append an operator-actionable hint so consumers — including
+    // the FE suggestion dialog — know the remediation. Gated on key being
+    // present so id-only lookups (which never carry channel) are unaffected.
+    const isMasterLookup = args.channel === null && args.key !== undefined;
+    super(
+      isMasterLookup
+        ? `${base}. Seed a template with channel=null for this key, or use a channel-specific template.`
+        : base,
+    );
     this.name = 'PromptTemplateNotFoundException';
     this.templateId = args.templateId ?? null;
     this.key = args.key ?? null;


### PR DESCRIPTION
## Summary

The AI suggestion flow on the master content tab silently 404s — only `prestashop` and `allegro` channels were seeded for `offer.description.suggest`, so master lookups (`channel: null`) hit `Prompt template not found`. The gap was already acknowledged in `content-suggestion.service.ts:70-72` ("a null channel (master) has no seeded template today, and the service surface will fail fast"). Three coordinated changes, one PR.

### 1. BE: seed migration

- New `1794000000000-seed-master-prompt-template.ts` inserts the missing `(offer.description.suggest, channel=NULL, v1, published)` row.
- Per `architecture-overview.md` §12, master content publishes via `ProductMasterPort.updateProduct` — today PrestaShop's product-description field, which accepts HTML. Prompt asks for semantic HTML (`<p>`, `<ul>/<li>`) matching the spirit of the existing PrestaShop seed, plus a closing-line note that channel-specific publishers may further adapt for marketplace formats (Allegro block-formatted listings, etc.).
- `ON CONFLICT DO NOTHING` keeps the migration idempotent on environments where someone manually inserted a master row. `down()` is symmetric.

### 2. BE: exception copy

`PromptTemplateNotFoundException` (`libs/core/src/ai/domain/exceptions/`) appends an operator-actionable hint when `channel === null && key !== undefined` — the master-lookup case:

```
Prompt template not found: key=…, channel=master, version=1. Seed a template
with channel=null for this key, or use a channel-specific template.
```

Other lookup shapes (channel-specific, id-only, id+channel) keep their pre-existing terse format. New unit spec covers all four branches to lock the contract for FE consumers.

### 3. FE: actionable 404 in suggestion dialog

`apps/web/src/features/content/components/suggestion-dialog.tsx` catches the structured 404 (status 404 + message starts with `Prompt template not found`) and renders a deep link to `/ai/prompt-templates` so admins can author the missing row in one click. Falls back to the existing bare `<Alert>` for unrelated errors. New CSS class `.content-suggestion__alert-link` is token-driven (`var(--accent-primary)`, no raw hex).

## Test plan

- [x] `pnpm --filter @openlinker/core test` — 4 new exception cases pass (master-hint / channel-specific / id-only / id+channel-no-key)
- [x] `pnpm --filter @openlinker/core test prompt-template.service` — 20 existing service tests still pass (no regression)
- [x] `pnpm --filter @openlinker/web test suggestion-dialog` — 7 dialog tests including 2 new (404-branch deep link + non-404 baseline); full FE suite 824/824
- [x] `pnpm --filter @openlinker/api lint` — clean (migration timestamp invariant green)
- [x] `pnpm --filter @openlinker/{api,core,web} type-check` — clean
- [x] `pnpm --filter @openlinker/api migration:show` — lists `SeedMasterPromptTemplate1794000000000` as pending
- [ ] Manual: `pnpm --filter @openlinker/api migration:run` against a fresh DB, then open the master content tab → Suggest → confirm a description is generated
- [ ] Manual: simulate the unseeded-master case (delete the row), confirm the dialog renders an inline `<Alert>` with the "Open prompt templates →" deep link

## Risks

- **Master prompt prose quality.** Operators see the suggestion in the editor and can revise before saving; iterate via the admin UI when feedback comes in.
- **Message-prefix matching on the FE** is a stepping stone — a structured error code is a follow-up if the broader unified-error-shape work picks it up. The existing 404 message format is contract-locked by the new exception spec.
- **`ON CONFLICT DO NOTHING`** masks the rare case where someone has a master row with diverging prompt body. That's intended — operators who manually authored one keep theirs. A future seed v2 can refresh the body explicitly.

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)