### PR TITLE
fix(allegro): union catalogues across PL/CZ/SK/HU for cross-border me…

### DIFF
--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -663,26 +663,39 @@ describe('AllegroOrderSourceAdapter', () => {
       const KURIER_ID = '2bc67g80-bbb2-bbbb-bbbb-bbbbbbbbbbbb';
       const DPD_ID = '3cd78h91-ccc3-cccc-cccc-cccccccccccc';
 
-      // Helper: queue the canonical method-catalogue mock so the parallel
-      // `/sale/delivery-methods` fetch resolves with operator-friendly names
-      // (#496). Dispatched in Promise.all order with `/sale/shipping-rates`
-      // — see resolution semantics below.
+      // Helper: queue the canonical method-catalogue mocks. The adapter
+      // queries `/sale/delivery-methods` once per seller-marketplace
+      // (allegro-pl, allegro-cz, allegro-sk, allegro-hu) in parallel, so we
+      // queue four responses. The default behavior — same content for every
+      // marketplace — is fine for tests that don't care about cross-marketplace
+      // overlap; tests that DO care pass `perMarketplace` to vary by index.
+      // Dispatched in Promise.all order with `/sale/shipping-rates`.
       function mockDeliveryMethodsCatalogue(
         entries: Array<{ id: string; name: string }>,
+        perMarketplace?: {
+          [K in 'allegro-pl' | 'allegro-cz' | 'allegro-sk' | 'allegro-hu']?: Array<{
+            id: string;
+            name: string;
+          }>;
+        },
       ): void {
-        httpClient.get.mockResolvedValueOnce({
-          data: {
-            deliveryMethods: entries.map((e) => ({
-              id: e.id,
-              name: e.name,
-              marketplaces: ['allegro.pl'],
-              dispatchCountry: 'PL',
-              destinationCountry: 'PL',
-            })),
-          },
-          status: 200,
-          headers: {},
-        });
+        const marketplaces = ['allegro-pl', 'allegro-cz', 'allegro-sk', 'allegro-hu'] as const;
+        for (const marketplace of marketplaces) {
+          const methods = perMarketplace?.[marketplace] ?? entries;
+          httpClient.get.mockResolvedValueOnce({
+            data: {
+              deliveryMethods: methods.map((e) => ({
+                id: e.id,
+                name: e.name,
+                marketplaces: [marketplace],
+                dispatchCountry: 'PL',
+                destinationCountry: marketplace === 'allegro-pl' ? 'PL' : marketplace.split('-')[1].toUpperCase(),
+              })),
+            },
+            status: 200,
+            headers: {},
+          });
+        }
       }
 
       it('flattens carrier methods across rate-tables, deduped by methodId, with names resolved from the catalogue', async () => {
@@ -733,13 +746,24 @@ describe('AllegroOrderSourceAdapter', () => {
         const result = await adapter.listDeliveryMethods();
 
         expect(httpClient.get).toHaveBeenNthCalledWith(1, '/sale/shipping-rates');
-        // Catalogue MUST be scoped to allegro-pl — without the marketplace
-        // query param the sandbox returns an empty list (verified live).
+        // Catalogue is fanned out across PL + CZ + SK + HU because PL-seller
+        // cenniki carry method ids belonging to destination marketplaces too
+        // (the buyer-side "do Czech / do Słowacji / do Węgier" variants live
+        // under their own marketplace catalogue, not allegro-pl).
         expect(httpClient.get).toHaveBeenNthCalledWith(2, '/sale/delivery-methods', {
           queryParams: { marketplace: 'allegro-pl' },
         });
-        expect(httpClient.get).toHaveBeenNthCalledWith(3, '/sale/shipping-rates/rate-set-1');
-        expect(httpClient.get).toHaveBeenNthCalledWith(4, '/sale/shipping-rates/rate-set-2');
+        expect(httpClient.get).toHaveBeenNthCalledWith(3, '/sale/delivery-methods', {
+          queryParams: { marketplace: 'allegro-cz' },
+        });
+        expect(httpClient.get).toHaveBeenNthCalledWith(4, '/sale/delivery-methods', {
+          queryParams: { marketplace: 'allegro-sk' },
+        });
+        expect(httpClient.get).toHaveBeenNthCalledWith(5, '/sale/delivery-methods', {
+          queryParams: { marketplace: 'allegro-hu' },
+        });
+        expect(httpClient.get).toHaveBeenNthCalledWith(6, '/sale/shipping-rates/rate-set-1');
+        expect(httpClient.get).toHaveBeenNthCalledWith(7, '/sale/shipping-rates/rate-set-2');
         expect(result).toEqual([
           { value: PACZKOMAT_ID, label: 'Allegro Paczkomaty InPost' },
           { value: KURIER_ID, label: 'Allegro Kurier24 InPost' },
@@ -807,10 +831,49 @@ describe('AllegroOrderSourceAdapter', () => {
         ]);
       });
 
+      it('unions catalogues across PL/CZ/SK/HU marketplaces so cross-border ids resolve', async () => {
+        // PL-seller cennik referencing one PL-side method (Paczkomat) and
+        // one CZ-side method (the buyer-facing Czech variant) — if we only
+        // queried allegro-pl the CZ id would fall back to a UUID label.
+        httpClient.get.mockResolvedValueOnce({
+          data: { shippingRates: [{ id: 'rate-set-1', name: 'Cennik' }] },
+          status: 200,
+          headers: {},
+        });
+        mockDeliveryMethodsCatalogue(
+          [], // unused fallback
+          {
+            'allegro-pl': [{ id: PACZKOMAT_ID, name: 'Allegro Paczkomaty InPost' }],
+            'allegro-cz': [{ id: KURIER_ID, name: 'Allegro International Kurier Czechy, InPost' }],
+            'allegro-sk': [],
+            'allegro-hu': [],
+          },
+        );
+        httpClient.get.mockResolvedValueOnce({
+          data: {
+            id: 'rate-set-1',
+            name: 'Cennik',
+            rates: [
+              { deliveryMethod: { id: PACZKOMAT_ID } },
+              { deliveryMethod: { id: KURIER_ID } },
+            ],
+          },
+          status: 200,
+          headers: {},
+        });
+
+        const result = await adapter.listDeliveryMethods();
+        expect(result).toEqual([
+          { value: PACZKOMAT_ID, label: 'Allegro Paczkomaty InPost' },
+          { value: KURIER_ID, label: 'Allegro International Kurier Czechy, InPost' },
+        ]);
+      });
+
       it('returns empty list when seller has no rate-tables', async () => {
-        // Step 1 still fires both calls in parallel; the catalogue load is
-        // wasted work in this branch but the early-return on empty rate-set
-        // ids prevents any per-id detail fetches.
+        // Step 1 still fires the shipping-rates call AND the four
+        // catalogue calls (PL + CZ + SK + HU) in parallel; the catalogue
+        // loads are wasted work in this branch but the early-return on
+        // empty rate-set ids prevents any per-id detail fetches.
         httpClient.get.mockResolvedValueOnce({
           data: { shippingRates: [] },
           status: 200,
@@ -820,7 +883,7 @@ describe('AllegroOrderSourceAdapter', () => {
 
         const result = await adapter.listDeliveryMethods();
         expect(result).toEqual([]);
-        expect(httpClient.get).toHaveBeenCalledTimes(2);
+        expect(httpClient.get).toHaveBeenCalledTimes(5);
       });
 
       it('falls back to deliveryMethod.id as label when name is missing from both catalogue and rate', async () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -343,27 +343,51 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptions
   }
 
   async listDeliveryMethods(): Promise<MappingOption[]> {
-    // Step 1: list the seller's rate-tables AND fetch the canonical
-    // method catalogue in parallel. The catalogue (`/sale/delivery-methods`)
-    // resolves bare method-ids into operator-friendly names (#496) since the
-    // rate-table response itself only carries `deliveryMethod.id`, not name.
+    // Step 1: list the seller's rate-tables AND fetch the canonical method
+    // catalogue per relevant marketplace in parallel. The catalogue
+    // (`/sale/delivery-methods`) is **per-marketplace-scoped**: querying
+    // `?marketplace=allegro-pl` returns only PL-side methods. Polish sellers
+    // doing cross-border have cenniki referencing methods from destination
+    // marketplaces too (the buyer-side variant of an "International ... do
+    // Czech" method lives under `allegro-cz`, etc.). To resolve every id a
+    // PL-seller's cenniki can reference, we union the catalogues across PL +
+    // CZ + SK + HU. Per-marketplace scoping is non-negotiable: dropping the
+    // param entirely returns an empty list on sandbox.
     //
-    // The catalogue MUST be scoped via `?marketplace=allegro-pl` — without it
-    // sandbox returns an empty list and every dropdown row falls back to its
-    // UUID. Hardcoded to `allegro-pl` because OL today only supports the PL
-    // marketplace; revisit when other Allegro markets come online.
-    const [rateSets, methodsResponse] = await Promise.all([
+    // The set is hardcoded because OL today only supports PL-anchored
+    // sellers; revisit when other Allegro markets come online.
+    const sellerMarketplaces = ['allegro-pl', 'allegro-cz', 'allegro-sk', 'allegro-hu'] as const;
+    const [rateSets, ...catalogueResponses] = await Promise.all([
       this.httpClient.get<AllegroShippingRatesResponse>('/sale/shipping-rates'),
-      this.httpClient.get<AllegroDeliveryMethodsResponse>('/sale/delivery-methods', {
-        queryParams: { marketplace: 'allegro-pl' },
-      }),
+      ...sellerMarketplaces.map((marketplace) =>
+        this.httpClient.get<AllegroDeliveryMethodsResponse>('/sale/delivery-methods', {
+          queryParams: { marketplace },
+        }),
+      ),
     ]);
     const rateSetIds = (rateSets.data.shippingRates ?? []).map((r) => r.id);
-    const catalogue = methodsResponse.data.deliveryMethods ?? [];
-    const nameById = new Map<string, string>(catalogue.map((m) => [m.id, m.name]));
+
+    // Union catalogues across marketplaces. First-seen wins, but in practice
+    // names are stable per id across markets — Allegro uses one global id
+    // namespace per method. Per-marketplace sizes logged below for diagnostic.
+    const nameById = new Map<string, string>();
+    const perMarketplaceSizes = new Map<string, number>();
+    for (let i = 0; i < sellerMarketplaces.length; i += 1) {
+      const marketplace = sellerMarketplaces[i];
+      const methods = catalogueResponses[i].data.deliveryMethods ?? [];
+      perMarketplaceSizes.set(marketplace, methods.length);
+      for (const method of methods) {
+        if (!nameById.has(method.id)) {
+          nameById.set(method.id, method.name);
+        }
+      }
+    }
 
     this.logger.debug(
-      `listDeliveryMethods: connection=${this.connectionId} rateSetIds=${rateSetIds.length} catalogue=${catalogue.length}`,
+      `listDeliveryMethods: connection=${this.connectionId} rateSetIds=${rateSetIds.length} ` +
+        `catalogue=${nameById.size} (per-marketplace: ${[...perMarketplaceSizes.entries()]
+          .map(([m, n]) => `${m}=${n}`)
+          .join(', ')})`,
     );
 
     if (rateSetIds.length === 0) {
@@ -422,7 +446,7 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptions
     const unresolved = result.filter((r) => r.value === r.label);
     if (unresolved.length > 0) {
       this.logger.warn(
-        `listDeliveryMethods: ${unresolved.length}/${result.length} method ids could not be resolved from /sale/delivery-methods catalogue (size=${catalogue.length}) for connection ${this.connectionId} — labels falling back to UUIDs.`,
+        `listDeliveryMethods: ${unresolved.length}/${result.length} method ids could not be resolved from /sale/delivery-methods catalogue (size=${nameById.size}) for connection ${this.connectionId} — labels falling back to UUIDs.`,
       );
     }
     return result;


### PR DESCRIPTION
…thods

Live testing of the prior commit on this branch surfaced ~33% of method ids still resolving as UUIDs against a real PL-seller account. The unresolved ones share UUID-suffixes with resolved siblings — a strong tell that they're paired methods (the buyer-side / destination-marketplace variant of an "International ... do Czech / Słowacji / Węgier" method), which live under their own marketplace catalogue, not allegro-pl.

PL-sellers doing cross-border have cenniki referencing methods from destination marketplaces too. Querying only `marketplace=allegro-pl` returns the seller-side methods plus some International outbound variants, but misses the buyer-side / inbound variants that show up on allegro-cz / allegro-sk / allegro-hu.

Fix: fan out `/sale/delivery-methods` across PL + CZ + SK + HU in parallel (alongside the existing shipping-rates fetch), union the results into one Map<id, name>, and resolve labels off the union. First-seen wins; in practice id namespaces are global per method.

Hardcoded set is the four marketplaces a PL-seller realistically ships to today; revisit when OL supports non-PL-anchored sellers.

Diagnostic log extended with per-marketplace catalogue sizes:
  listDeliveryMethods: connection=… rateSetIds=10 catalogue=185
    (per-marketplace: allegro-pl=120, allegro-cz=25, allegro-sk=20, allegro-hu=20)

If the dropdown still shows UUIDs, those numbers tell us which marketplace returned thin/empty data and where to look next.

Tests:
- New spec asserts union semantics: rate-table references one PL-side
  + one CZ-side method, only the PL catalogue has the PL one and only the CZ catalogue has the CZ one — both resolve.
- Existing happy-path test extended to assert all four /sale/delivery-methods calls fire with their respective marketplace query params (positions 2-5 in the call sequence).
- mockDeliveryMethodsCatalogue helper now queues four responses (one per marketplace) and accepts a per-marketplace override map.

Quality gate: pnpm lint, type-check, test (1535 unit tests).