### PR TITLE
fix(prestashop): set id_carrier on the cart, not just the order body (#503)

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -202,7 +202,20 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       expect(mockIdentifierMapping.getExternalIds).toHaveBeenCalledWith('Product', 'internal-product-456');
       expect(mockIdentifierMapping.getExternalIds).toHaveBeenCalledWith('Product', 'internal-product-789');
       expect(mockIdentifierMapping.getExternalIds).toHaveBeenCalledWith('ProductVariant', 'internal-variant-789');
-      expect(mockOrderMapper.mapCartCreate).toHaveBeenCalled();
+      // #503: cart MUST be called with the same externalCarrierId as the
+      // order body. PS resolves id_carrier from the cart, ignoring the order
+      // body's field — so omitting it here lands every order at id_carrier=0.
+      expect(mockOrderMapper.mapCartCreate).toHaveBeenCalledWith(
+        order,
+        externalCustomerId,
+        expect.any(Map),
+        expect.any(Map),
+        undefined,
+        undefined,
+        1, // currencyId
+        1, // langId
+        undefined, // externalCarrierId — no mapping configured; mapper falls back to id_carrier=1
+      );
       expect(mockOrderMapper.mapOrderCreate).toHaveBeenCalledWith(
         order,
         externalCustomerId,

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -815,7 +815,20 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
 
       await adapterWithMapping.createOrder(buildOrderWithShipping());
 
-      // 9th arg = externalCarrierId
+      // 9th arg = externalCarrierId — passed to BOTH mappers (#503).
+      // Cart-side is the load-bearing assertion: PS resolves the order's
+      // id_carrier from the cart, ignoring the order body's value.
+      expect(mockOrderMapper.mapCartCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(Map),
+        expect.any(Map),
+        undefined,
+        undefined,
+        1,
+        1,
+        4,
+      );
       expect(mockOrderMapper.mapOrderCreate).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
@@ -863,6 +876,58 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         1,
         1,
         7,
+      );
+    });
+
+    it('ignores invalid defaultCarrierId (0, negative, NaN) so the cart never lands at id_carrier=0 (#503 follow-up)', async () => {
+      // Operator sets defaultCarrierId=0 (or negative, or non-numeric) in
+      // connection config. Without the guard, the mapper writes id_carrier=0
+      // to the cart and PS reproduces the #503 failure mode through a
+      // different door — `??` doesn't fall back on 0, only null/undefined.
+      // Adapter must filter and let the mapper apply its DEFAULT_CARRIER_ID=1.
+      wireSuccessfulMappings('42');
+      const connWithBadDefault = createTestConnection();
+      (connWithBadDefault.config as Record<string, unknown>).defaultCarrierId = 0;
+
+      const mockMappingConfig = {
+        resolveCarrierMapping: jest.fn().mockResolvedValue(null),
+      } as unknown as IMappingConfigService;
+      const adapterWithMapping = new PrestashopOrderProcessorManagerAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        mockOrderMapper,
+        connWithBadDefault,
+        mockCustomerProvisioner,
+        mockAddressProvisioner,
+        mockCurrencyResolver,
+        mockCustomerProjectionRepository,
+        mockMappingConfig,
+      );
+
+      await adapterWithMapping.createOrder(buildOrderWithShipping());
+
+      // Adapter returns undefined (not 0); mappers fall back to DEFAULT_CARRIER_ID=1.
+      expect(mockOrderMapper.mapCartCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(Map),
+        expect.any(Map),
+        undefined,
+        undefined,
+        1,
+        1,
+        undefined,
+      );
+      expect(mockOrderMapper.mapOrderCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(Map),
+        expect.any(Map),
+        undefined,
+        undefined,
+        1,
+        1,
+        undefined,
       );
     });
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -281,7 +281,10 @@ export class PrestashopOrderProcessorManagerAdapter
       // Step 5b: Resolve carrier id for #455 — carrier mapping at the destination.
       const externalCarrierId = await this.resolveExternalCarrierId(order, config);
 
-      // Step 6: Create cart in PrestaShop (required for order creation)
+      // Step 6: Create cart in PrestaShop (required for order creation).
+      // The carrier MUST be set on the cart, not just the order body — PS
+      // resolves the order's id_carrier from the cart at POST /orders time
+      // and ignores the order body's field (#503).
       this.logger.debug(`Creating cart in PrestaShop for order creation`);
       const prestashopCartData = this.orderMapper.mapCartCreate(
         order,
@@ -292,6 +295,7 @@ export class PrestashopOrderProcessorManagerAdapter
         externalBillingAddressId,
         externalCurrencyId,
         externalLangId,
+        externalCarrierId,
       );
 
       let externalCartId: string | number;

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -621,12 +621,22 @@ export class PrestashopOrderProcessorManagerAdapter
     }
 
     if (config.defaultCarrierId !== undefined) {
+      // Defend against operator-misconfigured defaults (0, negative, NaN).
+      // Without this guard the mapper writes id_carrier=0 to the cart and
+      // we reproduce the #503 failure mode through a different door — `??`
+      // doesn't fall back on 0, only null/undefined. Log and ignore.
+      if (Number.isFinite(config.defaultCarrierId) && config.defaultCarrierId > 0) {
+        this.logger.warn(
+          `No carrier mapping for methodId=${methodId ?? '<none>'} (methodName=${methodName ?? '<none>'}, ` +
+            `sourceConnectionId=${sourceConnectionId ?? '<none>'}, destinationConnectionId=${this.connection.id}). ` +
+            `Falling back to connection.config.defaultCarrierId=${config.defaultCarrierId}.`,
+        );
+        return config.defaultCarrierId;
+      }
       this.logger.warn(
-        `No carrier mapping for methodId=${methodId ?? '<none>'} (methodName=${methodName ?? '<none>'}, ` +
-          `sourceConnectionId=${sourceConnectionId ?? '<none>'}, destinationConnectionId=${this.connection.id}). ` +
-          `Falling back to connection.config.defaultCarrierId=${config.defaultCarrierId}.`,
+        `Connection config has invalid defaultCarrierId=${String(config.defaultCarrierId)} (must be a positive integer) ` +
+          `for connection ${this.connection.id} — ignoring; falling back to PrestaShop's first carrier (id_carrier=1).`,
       );
-      return config.defaultCarrierId;
     }
 
     this.logger.warn(

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
@@ -735,6 +735,48 @@ describe('PrestashopOrderMapper', () => {
       expect(cartRow.id_product_attribute).toBe(5);
       expect(cartRow.quantity).toBe(2);
     });
+
+    // #503: PS resolves the order's id_carrier from the cart at POST /orders
+    // time and ignores the order body's field. Setting id_carrier on the
+    // order body alone (as we did before) leaves every synced order at
+    // id_carrier=0. These specs lock down the cart-side behaviour.
+    describe('carrier propagation onto the cart (#503)', () => {
+      const externalProductIds = new Map<string, string | number>([['ol_product_1', '10']]);
+      const externalVariantIds = new Map<string, string | number>();
+
+      it('sets id_carrier on the cart when externalCarrierId is provided', () => {
+        const result = mapper.mapCartCreate(
+          mockOrderCreate,
+          '100',
+          externalProductIds,
+          externalVariantIds,
+          '200',
+          '201',
+          '1',
+          '1',
+          2, // resolved Allegro Paczkomat → PS "My carrier"
+        );
+
+        expect(result.id_carrier).toBe(2);
+      });
+
+      it('falls back to id_carrier=1 (PS default) when externalCarrierId is omitted', () => {
+        const result = mapper.mapCartCreate(
+          mockOrderCreate,
+          '100',
+          externalProductIds,
+          externalVariantIds,
+          '200',
+          '201',
+          '1',
+          '1',
+          // externalCarrierId intentionally omitted — mirrors a connection
+          // with no carrier mapping AND no defaultCarrierId in config.
+        );
+
+        expect(result.id_carrier).toBe(1);
+      });
+    });
   });
 });
 

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -315,6 +315,13 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
    *
    * Creates a cart structure that can be used to create a cart in PrestaShop,
    * which is then required to create an order.
+   *
+   * #503: `externalCarrierId` MUST be set on the cart, not just the order
+   * body. PS resolves the order's `id_carrier` from the cart at `POST /orders`
+   * time and ignores the order body's `id_carrier` field. Without this every
+   * synced order lands at `id_carrier=0`, no `order_carriers` row is created,
+   * and `reconcileShippingCost` cannot write the buyer-paid shipping cost
+   * back into PS.
    */
   mapCartCreate(
     orderCreate: OrderCreate,
@@ -325,6 +332,7 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
     externalBillingAddressId?: string | number,
     externalCurrencyId?: string | number,
     externalLangId?: string | number,
+    externalCarrierId?: number,
   ): Record<string, unknown> {
     // Map cart rows (products)
     const cartRows = orderCreate.items.map((item, index) => {
@@ -372,12 +380,16 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
      */
     const DEFAULT_CURRENCY_ID = 1; // EUR
     const DEFAULT_LANGUAGE_ID = 1; // First language
+    const DEFAULT_CARRIER_ID = 1; // First carrier — mirrors mapOrderCreate
 
-    // Build PrestaShop cart structure
+    // Build PrestaShop cart structure. id_carrier is set here (not just on
+    // the order body) because PS resolves the order's carrier from the cart
+    // and ignores the order body's id_carrier (#503).
     const prestashopCart: Record<string, unknown> = {
       id_customer: externalCustomerId,
       id_currency: externalCurrencyId || DEFAULT_CURRENCY_ID,
       id_lang: externalLangId || DEFAULT_LANGUAGE_ID,
+      id_carrier: externalCarrierId ?? DEFAULT_CARRIER_ID,
       associations: {
         cart_rows: {
           cart_row: cartRows,

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -15,6 +15,18 @@ import { PrestashopProvisioningException } from '@openlinker/integrations-presta
 import { Logger } from '@openlinker/shared/logging';
 
 /**
+ * Default values for PrestaShop cart + order creation. Hoisted to
+ * module scope so both `mapOrderCreate` and `mapCartCreate` reference
+ * the same source of truth. Future enhancement: move to connection
+ * config so per-store overrides don't require a code change.
+ */
+const DEFAULT_CURRENCY_ID = 1; // EUR
+const DEFAULT_LANGUAGE_ID = 1; // First language
+const DEFAULT_CARRIER_ID = 1; // First carrier
+const DEFAULT_PAYMENT_MODULE = 'ps_checkpayment';
+const DEFAULT_PAYMENT_METHOD = 'Check payment';
+
+/**
  * PrestaShop Order Mapper
  *
  * Transforms PrestaShop order data to OpenLinker Order schema.
@@ -237,23 +249,8 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
      */
     const conversionRate = 1.0;
 
-    /**
-     * Default values for PrestaShop order creation
-     *
-     * These defaults are used when values are not provided:
-     * - id_currency: 1 (EUR - common default in PrestaShop)
-     * - id_lang: 1 (first language - common default in PrestaShop)
-     * - id_carrier: 1 (first carrier - common default in PrestaShop)
-     * - module: 'ps_checkpayment' (Check payment - common default payment module)
-     * - payment: 'Check payment' (Default payment method name)
-     *
-     * Future enhancement: Make these configurable via connection config or environment variables.
-     */
-    const DEFAULT_CURRENCY_ID = 1; // EUR
-    const DEFAULT_LANGUAGE_ID = 1; // First language
-    const DEFAULT_CARRIER_ID = 1; // First carrier
-    const DEFAULT_PAYMENT_MODULE = 'ps_checkpayment';
-    const DEFAULT_PAYMENT_METHOD = 'Check payment';
+    // Defaults are module-level constants so mapCartCreate and
+    // mapOrderCreate share the same source of truth.
 
     // Build PrestaShop order structure
     const prestashopOrder: Record<string, unknown> = {
@@ -375,16 +372,10 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
       };
     });
 
-    /**
-     * Default values for PrestaShop cart creation (same as order defaults)
-     */
-    const DEFAULT_CURRENCY_ID = 1; // EUR
-    const DEFAULT_LANGUAGE_ID = 1; // First language
-    const DEFAULT_CARRIER_ID = 1; // First carrier — mirrors mapOrderCreate
-
     // Build PrestaShop cart structure. id_carrier is set here (not just on
     // the order body) because PS resolves the order's carrier from the cart
-    // and ignores the order body's id_carrier (#503).
+    // and ignores the order body's id_carrier (#503). DEFAULT_*_ID constants
+    // are module-level — same source of truth as mapOrderCreate.
     const prestashopCart: Record<string, unknown> = {
       id_customer: externalCustomerId,
       id_currency: externalCurrencyId || DEFAULT_CURRENCY_ID,

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
@@ -223,6 +223,11 @@ export interface IPrestashopOrderMapper {
     externalBillingAddressId?: string | number,
     externalCurrencyId?: string | number,
     externalLangId?: string | number,
+    /**
+     * #503: PS reads `id_carrier` off the cart (not the order body) at
+     * `POST /orders` time. Without this, every order lands at id_carrier=0.
+     */
+    externalCarrierId?: number,
   ): Record<string, unknown>;
 }
 


### PR DESCRIPTION
Closes #503.

## Summary

Every Allegro→PrestaShop order synced through OL has been landing at `ps_orders.id_carrier=0` with `total_shipping=0`, regardless of carrier mapping configuration. The carrier mapping pipeline (#455) was correctly resolving "Allegro Paczkomaty InPost" → PS "My carrier" (id_reference=2) and `mapOrderCreate` was setting `id_carrier: 2` on the order body — but PS's `POST /orders` resolves the order's carrier **from the cart** and ignores the order body's `id_carrier` field. `mapCartCreate` was building the cart without `id_carrier`, so PS defaulted it to 0, the order inherited 0, and `reconcileShippingCost` (#467) couldn't run because no `order_carriers` row was auto-created.

This PR routes the already-resolved `externalCarrierId` into the cart create, mirroring what `mapOrderCreate` has been doing all along. Knock-on: once the cart has a real carrier, PS auto-creates the `order_carriers` row and `reconcileShippingCost` writes the buyer-paid shipping cost back to it — total ledger balances end-to-end.

Verified live: orders 23-32 on dev DB all show `id_carrier=0`, `total_shipping=0`, `current_state=8` (Payment error), despite a configured mapping. The carrier-resolution debug log fires correctly; the cart was the missing link.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1549 unit tests pass (2 new mapper specs + 1 extended adapter assertion)
- [ ] Manual: pull, restart API, sync a fresh Allegro order. Verify in MySQL:
  ```sql
  SELECT id_order, id_carrier, total_shipping, total_paid, total_paid_real, current_state
  FROM ps_orders WHERE id_order = <new_order>;
  ```
  Expected: `id_carrier > 0` (matching the configured mapping or 1 for default), `total_shipping = <Allegro delivery.cost.amount>`, `total_paid == total_paid_real`.

## Out of scope

- VAT split on `shipping_cost_tax_excl/incl` — orthogonal accounting concern, separate ticket.
- Backfill for already-synced orders 23-32 — they're test orders in `current_state=8` (Payment error) and will need to be either re-synced after this lands, or manually unstuck on the dev install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)