### PR TITLE
fix(prestashop): set id_default_group on OL-provisioned guests (#505)

### DIFF
--- a/docs/plans/implementation-plan-505-ps-guest-customer-group.md
+++ b/docs/plans/implementation-plan-505-ps-guest-customer-group.md
@@ -1,0 +1,126 @@
+# Implementation Plan — #505 PrestaShop guest customer default group
+
+## Goal
+
+OL-provisioned guest customers must land in a non-zero PS group so `POST /orders` doesn't silently zero the order's `id_carrier` at the group-validation layer. Closes the residual half of the carrier-mapping bug — #503/PR #504 fixed the cart side; this fix unblocks the order side.
+
+## Layer classification
+
+Integration (PrestaShop) — Infrastructure layer only. Touches:
+- one config-type interface
+- one provisioner-input type interface
+- one provisioner method body
+- one new test spec
+
+No CORE changes. No schema migration. No FE work (Tier 2 UI deferred per the issue).
+
+## Step-by-step
+
+### Step 1 — extend `PrestashopConnectionConfig`
+
+**File:** `libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts`
+
+Add `guestCustomerGroupId?: number` field with JSDoc that covers:
+- Optional. Defaults to 2 (PS stock-fixture "Guest" group).
+- Must be a positive integer. `0`, negatives, and non-finite values are rejected at provisioning time with a `warn` log and fall back to 2.
+- Why this exists: PS WS validates the order's `id_carrier` against the customer's groups; carriers with group restrictions reject any group-0 customer. PS's stock fixture puts guests in group 2; non-stock shops can override.
+- Mirrors the resolution-chain pattern used by `defaultCarrierId` (lines 92-105) for consistency.
+
+**Acceptance:** Type compiles. No consumer breakage. The field is purely additive.
+
+### Step 2 — extend `PrestashopCustomerCreate`
+
+**File:** `libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-provisioner.types.ts`
+
+Add two optional fields to the existing interface:
+- `id_default_group?: number`
+- `associations?: { groups?: { group?: Array<{ id: number }> } }` (PS WS XML-association shape — array of group refs)
+
+The interface already has a `[key: string]: unknown` index signature, so technically these would compile without explicit declaration — but explicit declarations carry intent and prevent silent typos at call sites.
+
+**Acceptance:** Type compiles.
+
+### Step 3 — update `resolveOrCreateGuestCustomer`
+
+**File:** `libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-customer-provisioner.ts:248`
+
+Build the `groupId` immediately before the `customerData` object:
+
+```ts
+const PS_GUEST_GROUP_DEFAULT = 2;
+
+const configuredGroupId = connectionConfig.guestCustomerGroupId;
+let groupId = PS_GUEST_GROUP_DEFAULT;
+if (configuredGroupId !== undefined) {
+  if (Number.isFinite(configuredGroupId) && configuredGroupId > 0) {
+    groupId = configuredGroupId;
+  } else {
+    this.logger.warn(
+      `Connection config has invalid guestCustomerGroupId=${String(configuredGroupId)} ` +
+        `(must be a positive integer) for connection ${destinationConnectionId} — ` +
+        `falling back to PS default Guest group (id=${PS_GUEST_GROUP_DEFAULT}).`,
+    );
+  }
+}
+```
+
+Then extend the existing `customerData`:
+
+```ts
+const customerData: PrestashopCustomerCreate = {
+  is_guest: 1,
+  passwd: generatePassword(),
+  firstname: firstName || 'Guest',
+  lastname: lastName || 'Customer',
+  email: normalizedEmail,
+  active: 1,
+  id_default_group: groupId,
+  associations: {
+    groups: { group: [{ id: groupId }] },
+  },
+};
+```
+
+The `associations.groups.group` double-nested shape matches the established PS WS JSON body convention used elsewhere in the codebase (verified: `prestashop-order.mapper.ts:277` uses `associations: { order_rows: { order_row: [...] } }` — same collection-then-singular nesting). Setting only `id_default_group` is insufficient because PS uses the `customer_group` join table for group membership and it's populated from the `associations` block at create time.
+
+**Acceptance:** The customer-create body sent to PS includes both fields. Defensive normalization fires on bad config.
+
+### Step 4 — new test file
+
+**File:** `libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-customer-provisioner.spec.ts` (new)
+
+The adapter spec mocks `PrestashopCustomerProvisioner` directly, so there's no existing suite that exercises `resolveOrCreateGuestCustomer`'s body shape. Three focused unit tests are enough:
+
+1. **Default path** — `connectionConfig.guestCustomerGroupId` unset → asserts the captured body via `expect.objectContaining({ is_guest: 1, active: 1, id_default_group: 2, associations: { groups: { group: [{ id: 2 }] } } })`. Use `objectContaining` (not exact `toEqual`) so the test stays robust when unrelated fields are added later, but include all 4 of the load-bearing fields so a future refactor that drops `is_guest` (or renames `associations.groups.group`) trips the test.
+2. **Override path** — `connectionConfig.guestCustomerGroupId === 5` → both `id_default_group` and the inner `group[0].id` use 5; same `objectContaining` assertion shape.
+3. **Defensive path** — `connectionConfig.guestCustomerGroupId === 0` → body falls back to `id_default_group: 2` and `group: [{ id: 2 }]`; spy asserts `logger.warn` fires with a message matching `/invalid guestCustomerGroupId=0.*falling back/i`.
+
+Each test mocks:
+- `IPrestashopWebserviceClient` — `listResources` returns `[]` (no email match), `createResource` returns `{ id: 'X' }`
+- `IdentifierMappingPort` — `getExternalIds` returns `[]` (no existing mapping), `getOrCreateExactMapping` returns the new external id
+
+Capture the body via `createResource.mock.calls[0][1]` and assert against it.
+
+**Acceptance:** Three new tests pass. The full PS package suite stays green (currently 229).
+
+## Risks
+
+- **Operators with non-stock PS group setups** (no group 2 or group 2 used unconventionally) get the wrong default. Mitigation: the connection-config override is documented in the field's JSDoc; a misconfigured shop sees the same downstream symptom (carrier rejected) and the resolution path is one connection-config edit away.
+- **Backfill is out of scope.** Already-synced test orders stay at `id_carrier=0`. A one-shot `UPDATE ps_customer SET id_default_group=2 WHERE is_guest=1 AND id_default_group=0` would unstick them, but it's outside the regression-test surface.
+- **No integration test.** Per the testing-guide, the carrier-mapping vertical slice is a known gap. This PR doesn't add one; the manual-verification gate stays the load-bearing assertion until a Testcontainers PS harness exists. Tracked separately in **#506**.
+
+## Implementation order
+
+1. Add types (Steps 1 + 2) — no behavior change, no test breakage
+2. Wire the provisioner (Step 3) — full PS suite stays green because no existing spec exercises this code path
+3. Add the new spec (Step 4) — locks down both happy and defensive paths
+4. Run the quality gate (lint / type-check / test)
+5. Self-review per `docs/code-review-guide.md` and apply any pre-flight polish
+6. Manual verification: re-sync one fresh Allegro order against the dev install, confirm `ps_orders.id_carrier > 0`, `total_shipping == 10.95`, `total_paid == total_paid_real`
+
+## Out of scope
+
+- Tier 2 UI for group mapping (separate "nice-to-have" if asked)
+- Group assignment for registered (non-guest) customers — none today via OL
+- VAT split on `shipping_cost_tax_excl/incl` — orthogonal accounting concern
+- Backfill of stuck test orders

--- a/libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts
+++ b/libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts
@@ -105,6 +105,26 @@ export interface PrestashopConnectionConfig {
   defaultCarrierId?: number;
 
   /**
+   * Default PrestaShop customer-group ID applied to OL-provisioned guest
+   * customers (#505). PS WS validates the order's `id_carrier` against the
+   * customer's groups at `POST /orders` time and silently zeros the value
+   * if the carrier doesn't accept any of the customer's groups. Without
+   * this set explicitly, PS defaults the unspecified field to 0, the
+   * customer ends up in group 0 only, and any carrier with group
+   * restrictions (the standard configuration) silently rejects the order.
+   *
+   * Defaults to `2` — PS's stock-fixture "Guest" group, the standard slot
+   * for `is_guest=1` customers on a vanilla PS install. Override only when
+   * the destination shop has a non-standard group setup (group 2 missing
+   * or used for a different role).
+   *
+   * Must be a positive integer; `0`, negatives, and non-finite values are
+   * rejected at provisioning time with a `warn` log and fall back to 2.
+   * Mirrors the resolution-chain pattern of `defaultCarrierId` above.
+   */
+  guestCustomerGroupId?: number;
+
+  /**
    * Additional PrestaShop payment-module names installed on this connection's
    * shop that aren't in the curated `PRESTASHOP_PAYMENT_MODULES` list. Each
    * entry is a module's technical name (matches the `payment` field on

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-customer-provisioner.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-customer-provisioner.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * PrestaShop Customer Provisioner Tests — guest-customer group (#505)
+ *
+ * Focused on the customer-create body shape: PS WS validates the order's
+ * `id_carrier` against the customer's groups at POST /orders time, so OL
+ * must explicitly set `id_default_group` AND populate the `associations`
+ * block (the join-table source). Without these the customer lands in
+ * group 0 only and any group-restricted carrier silently rejects the order.
+ *
+ * The full provisioner suite would also cover the lock/retry concurrency
+ * behaviour (#338-era), but that's a separate concern from the body shape;
+ * this spec scopes itself to the create-body assertion that closes #505.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/provisioners/__tests__
+ */
+import { PrestashopCustomerProvisioner } from '../prestashop-customer-provisioner';
+import { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
+import { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import { PrestashopConnectionConfig } from '../../../domain/types/prestashop-config.types';
+
+describe('PrestashopCustomerProvisioner — resolveOrCreateGuestCustomer (#505)', () => {
+  let provisioner: PrestashopCustomerProvisioner;
+  let webserviceClient: jest.Mocked<IPrestashopWebserviceClient>;
+  let identifierMapping: jest.Mocked<IdentifierMappingPort>;
+  let createCalls: Array<{ resource: string; data: Record<string, unknown> }>;
+
+  beforeEach(() => {
+    // Redis client null → graceful degradation path (no actual locking).
+    provisioner = new PrestashopCustomerProvisioner(null);
+
+    createCalls = [];
+    webserviceClient = {
+      listResources: jest.fn().mockResolvedValue([]),
+      createResource: jest.fn((resource: string, data: unknown) => {
+        createCalls.push({ resource, data: data as Record<string, unknown> });
+        return Promise.resolve({ id: '999' } as unknown);
+      }),
+      getResource: jest.fn(),
+      updateResource: jest.fn(),
+      deleteResource: jest.fn(),
+    } as unknown as jest.Mocked<IPrestashopWebserviceClient>;
+
+    identifierMapping = {
+      getExternalIds: jest.fn().mockResolvedValue([]),
+      getOrCreateExactMapping: jest.fn().mockResolvedValue('999'),
+    } as unknown as jest.Mocked<IdentifierMappingPort>;
+  });
+
+  function captureCustomerCreateBody(): Record<string, unknown> {
+    const call = createCalls.find((c) => c.resource === 'customers');
+    if (!call) {
+      throw new Error('No customers create call captured');
+    }
+    return call.data;
+  }
+
+  it('defaults id_default_group to 2 (PS Guest) and populates associations.groups when guestCustomerGroupId is unset', async () => {
+    const config: PrestashopConnectionConfig = { baseUrl: 'https://shop.test' };
+
+    await provisioner.resolveOrCreateGuestCustomer(
+      'ol_customer_test_1',
+      'buyer@example.com',
+      'hash_1',
+      'Piotr',
+      'Swierzy',
+      'connection-1',
+      webserviceClient,
+      config,
+      identifierMapping,
+    );
+
+    const body = captureCustomerCreateBody();
+    expect(body).toEqual(
+      expect.objectContaining({
+        is_guest: 1,
+        active: 1,
+        email: 'buyer@example.com',
+        id_default_group: 2,
+        associations: {
+          groups: { group: [{ id: 2 }] },
+        },
+      }),
+    );
+  });
+
+  it('honours connection.config.guestCustomerGroupId override on both id_default_group and associations.groups', async () => {
+    const config: PrestashopConnectionConfig = {
+      baseUrl: 'https://shop.test',
+      guestCustomerGroupId: 5,
+    };
+
+    await provisioner.resolveOrCreateGuestCustomer(
+      'ol_customer_test_2',
+      'buyer2@example.com',
+      'hash_2',
+      'Piotr',
+      'Swierzy',
+      'connection-2',
+      webserviceClient,
+      config,
+      identifierMapping,
+    );
+
+    const body = captureCustomerCreateBody();
+    expect(body).toEqual(
+      expect.objectContaining({
+        is_guest: 1,
+        id_default_group: 5,
+        associations: {
+          groups: { group: [{ id: 5 }] },
+        },
+      }),
+    );
+  });
+
+  it('falls back to 2 with a warn when guestCustomerGroupId is invalid (0, negative, NaN)', async () => {
+    const warnSpy = jest
+      .spyOn(
+        (provisioner as unknown as { logger: { warn: (m: string) => void } }).logger,
+        'warn',
+      )
+      .mockImplementation(() => {});
+
+    const config: PrestashopConnectionConfig = {
+      baseUrl: 'https://shop.test',
+      guestCustomerGroupId: 0,
+    };
+
+    await provisioner.resolveOrCreateGuestCustomer(
+      'ol_customer_test_3',
+      'buyer3@example.com',
+      'hash_3',
+      'Piotr',
+      'Swierzy',
+      'connection-3',
+      webserviceClient,
+      config,
+      identifierMapping,
+    );
+
+    const body = captureCustomerCreateBody();
+    expect(body).toEqual(
+      expect.objectContaining({
+        is_guest: 1,
+        id_default_group: 2,
+        associations: {
+          groups: { group: [{ id: 2 }] },
+        },
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/invalid guestCustomerGroupId=0.*falling back/i),
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-customer-provisioner.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-customer-provisioner.spec.ts
@@ -113,45 +113,61 @@ describe('PrestashopCustomerProvisioner — resolveOrCreateGuestCustomer (#505)'
     );
   });
 
-  it('falls back to 2 with a warn when guestCustomerGroupId is invalid (0, negative, NaN)', async () => {
-    const warnSpy = jest
-      .spyOn(
-        (provisioner as unknown as { logger: { warn: (m: string) => void } }).logger,
-        'warn',
-      )
-      .mockImplementation(() => {});
+  // Defensive guard is `Number.isFinite(x) && x > 0`. Parametrize across
+  // the three realistic operator-misconfig values (zero, negative, NaN) so
+  // a future refactor that drops one branch fails the suite.
+  it.each<[string, number]>([
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+  ])(
+    'falls back to 2 with a warn when guestCustomerGroupId is invalid (%s)',
+    async (label, badValue) => {
+      const warnSpy = jest
+        .spyOn(
+          (provisioner as unknown as { logger: { warn: (m: string) => void } }).logger,
+          'warn',
+        )
+        .mockImplementation(() => {});
 
-    const config: PrestashopConnectionConfig = {
-      baseUrl: 'https://shop.test',
-      guestCustomerGroupId: 0,
-    };
+      const config: PrestashopConnectionConfig = {
+        baseUrl: 'https://shop.test',
+        guestCustomerGroupId: badValue,
+      };
 
-    await provisioner.resolveOrCreateGuestCustomer(
-      'ol_customer_test_3',
-      'buyer3@example.com',
-      'hash_3',
-      'Piotr',
-      'Swierzy',
-      'connection-3',
-      webserviceClient,
-      config,
-      identifierMapping,
-    );
+      await provisioner.resolveOrCreateGuestCustomer(
+        `ol_customer_test_invalid_${label}`,
+        `buyer-${label}@example.com`,
+        `hash_${label}`,
+        'Piotr',
+        'Swierzy',
+        `connection-${label}`,
+        webserviceClient,
+        config,
+        identifierMapping,
+      );
 
-    const body = captureCustomerCreateBody();
-    expect(body).toEqual(
-      expect.objectContaining({
-        is_guest: 1,
-        id_default_group: 2,
-        associations: {
-          groups: { group: [{ id: 2 }] },
-        },
-      }),
-    );
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/invalid guestCustomerGroupId=0.*falling back/i),
-    );
+      const body = captureCustomerCreateBody();
+      expect(body).toEqual(
+        expect.objectContaining({
+          is_guest: 1,
+          id_default_group: 2,
+          associations: {
+            groups: { group: [{ id: 2 }] },
+          },
+        }),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/invalid guestCustomerGroupId=.*falling back/i),
+      );
 
-    warnSpy.mockRestore();
-  });
+      warnSpy.mockRestore();
+
+      // Reset the captured-body queue between iterations so the next case
+      // doesn't read the previous case's body.
+      createCalls.length = 0;
+      webserviceClient.createResource.mockClear();
+      identifierMapping.getOrCreateExactMapping.mockClear();
+    },
+  );
 });

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-customer-provisioner.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-customer-provisioner.ts
@@ -245,6 +245,25 @@ export class PrestashopCustomerProvisioner {
 
       // Step 5: Create customer if not found
       if (!prestashopCustomerId) {
+      // PS's stock-fixture "Guest" group. Carriers with group restrictions
+      // reject any group-0 customer at POST /orders time and silently zero
+      // the order's id_carrier (#505). Operators with non-standard group
+      // setups can override via connection.config.guestCustomerGroupId.
+      const PS_GUEST_GROUP_DEFAULT = 2;
+      const configuredGroupId = connectionConfig.guestCustomerGroupId;
+      let groupId = PS_GUEST_GROUP_DEFAULT;
+      if (configuredGroupId !== undefined) {
+        if (Number.isFinite(configuredGroupId) && configuredGroupId > 0) {
+          groupId = configuredGroupId;
+        } else {
+          this.logger.warn(
+            `Connection config has invalid guestCustomerGroupId=${String(configuredGroupId)} ` +
+              `(must be a positive integer) for connection ${destinationConnectionId} — ` +
+              `falling back to PS default Guest group (id=${PS_GUEST_GROUP_DEFAULT}).`,
+          );
+        }
+      }
+
       const customerData: PrestashopCustomerCreate = {
         is_guest: 1,
         passwd: generatePassword(),
@@ -252,6 +271,10 @@ export class PrestashopCustomerProvisioner {
         lastname: lastName || 'Customer',
         email: normalizedEmail,
         active: 1,
+        id_default_group: groupId,
+        associations: {
+          groups: { group: [{ id: groupId }] },
+        },
       };
 
       if (connectionConfig.shopId) {

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-provisioner.types.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-provisioner.types.ts
@@ -32,6 +32,23 @@ export interface PrestashopCustomerCreate {
   active: number;
   id_shop?: number;
   id_shop_group?: number;
+  /**
+   * Customer's default group id (#505). When omitted, PS defaults to 0,
+   * which orphans the customer from any carrier with group restrictions.
+   * The provisioner sets this from `connection.config.guestCustomerGroupId`
+   * (default: 2 — PS's stock "Guest" group).
+   */
+  id_default_group?: number;
+  /**
+   * PS WS associations block (#505). Group membership is populated from
+   * `associations.groups.group[]` at create time — `id_default_group`
+   * alone doesn't add the row to `ps_customer_group`. The double-nested
+   * shape matches the established PS WS JSON convention used by
+   * `PrestashopOrderMapper.mapOrderCreate` for `order_rows`.
+   */
+  associations?: {
+    groups?: { group?: Array<{ id: number }> };
+  };
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Closes #505. Follow-up to PR #504.

## Summary

After PR #504 fixed the cart-side `id_carrier`, a fresh test sync (order `ol_order_0b8083a857284a118a87c7a6a1d202c5`, PS `id_order=33`) showed the cart correctly carries `id_carrier=2` but the order still landed at `id_carrier=0` and `total_shipping=0`. PS WS validates the order's `id_carrier` against the customer's groups at `POST /orders` time. OL-provisioned guests had `id_default_group=0` and only group-0 membership; carrier 2 ("My carrier") is restricted to groups 1-3 (PS stock for Visitor / Guest / Customer); PS rejected the carrier and silently zeroed it.

This PR closes the residual half of the bug.

## Changes

- New optional `connection.config.guestCustomerGroupId` (defaults to 2 — PS stock "Guest" group). Operators with non-standard group setups override here.
- Provisioner sets `id_default_group: groupId` AND populates `associations: { groups: { group: [{ id: groupId }] } }`. The `associations` block is the join-table source — `id_default_group` alone doesn't populate `ps_customer_group`. Double-nested shape verified against existing PS WS JSON convention (`PrestashopOrderMapper.mapOrderCreate`'s `order_rows` block).
- Defensive normalization: invalid `guestCustomerGroupId` (≤ 0 or non-finite) logs a warn and falls back to 2. Mirrors the #504 `defaultCarrierId` polish.
- New focused spec `prestashop-customer-provisioner.spec.ts` covers default / override / defensive paths.

Plan: `docs/plans/implementation-plan-505-ps-guest-customer-group.md` — written first, self-tech-reviewed, suggestions applied (verified the JSON `associations` shape against existing code; tightened test assertions to `objectContaining`).

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1553 unit tests pass (3 new in the provisioner spec)
- [ ] Manual: pull, restart API, sync one fresh Allegro order. Verify in MySQL:
  ```sql
  SELECT id_customer, is_guest, id_default_group FROM ps_customer ORDER BY id_customer DESC LIMIT 1;  -- expect id_default_group=2
  SELECT id_customer, id_group FROM ps_customer_group WHERE id_customer=<new>;  -- expect (new, 2)
  SELECT id_order, id_carrier, total_shipping, total_paid, total_paid_real FROM ps_orders WHERE id_order=<new>;
  -- expect id_carrier=2, total_shipping=10.95, total_paid==total_paid_real
  ```

## Out of scope

- Tier 2 UI for group mapping (deferred per the issue body).
- Group assignment for registered (non-guest) customers — none today via OL.
- Backfill for stuck test orders (current_state=8). One-shot SQL: `UPDATE ps_customer SET id_default_group=2 WHERE is_guest=1 AND id_default_group=0`, then re-sync.
- Integration-test for the carrier-mapping vertical slice — tracked as #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)