### PR TITLE
feat(listings,content): AI suggest button on offer-edit drawer (#485)

### DIFF
--- a/apps/api/src/listings/http/dto/offer-mapping-response.dto.ts
+++ b/apps/api/src/listings/http/dto/offer-mapping-response.dto.ts
@@ -48,4 +48,16 @@ export class OfferMappingResponseDto {
       'on non-Offer entity types (Product, Inventory, etc.).',
   })
   offerCreation?: OfferCreationStatusResponseDto | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Internal product ID owning the linked variant. Populated only by ' +
+      '`GET /listings/:id` (detail endpoint) for Offer-type mappings whose ' +
+      '`internalId` resolves to an existing variant. Drives the AI-suggest ' +
+      'flow on the offer-edit drawer (#485) — the suggest endpoint is keyed ' +
+      'on product, not variant. Absent on list responses, synced-in offers ' +
+      'whose variant has been deleted, and non-Offer entity types.',
+  })
+  linkedProductId?: string | null;
 }

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -13,6 +13,8 @@ import { OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, OFFER_CREATION_RECORD_REPOSITORY_
 import type { IOfferCreationEnqueueService, ISellerPoliciesService, OfferCreationRecordRepositoryPort, OfferMappingRepositoryPort } from '@openlinker/core/listings';
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
+import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
+import type { ProductVariant, ProductVariantRepositoryPort } from '@openlinker/core/products';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { JobEnqueuePort } from '@openlinker/core/sync';
 
@@ -26,6 +28,7 @@ describe('ListingsController', () => {
   let offerCreationEnqueue: jest.Mocked<IOfferCreationEnqueueService>;
   let sellerPolicies: jest.Mocked<ISellerPoliciesService>;
   let integrationsService: jest.Mocked<IIntegrationsService>;
+  let productVariantRepository: jest.Mocked<ProductVariantRepositoryPort>;
 
   const mockMapping = new IdentifierMapping(
     'uuid-1',
@@ -76,6 +79,16 @@ describe('ListingsController', () => {
     integrationsService = {
       getCapabilityAdapter: jest.fn(),
     } as unknown as jest.Mocked<IIntegrationsService>;
+    productVariantRepository = {
+      findById: jest.fn().mockResolvedValue(null),
+      findByProductId: jest.fn(),
+      findBySku: jest.fn(),
+      findBySkuIn: jest.fn(),
+      findByEanOrGtinIn: jest.fn(),
+      upsert: jest.fn(),
+      upsertMany: jest.fn(),
+      findMany: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ListingsController],
@@ -86,6 +99,7 @@ describe('ListingsController', () => {
         { provide: OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, useValue: offerCreationEnqueue },
         { provide: SELLER_POLICIES_SERVICE_TOKEN, useValue: sellerPolicies },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
+        { provide: PRODUCT_VARIANT_REPOSITORY_TOKEN, useValue: productVariantRepository },
       ],
     }).compile();
 
@@ -217,8 +231,40 @@ describe('ListingsController', () => {
       const result = await controller.getOfferMapping('uuid-2');
 
       expect(offerCreationRecords.findByExternalOfferIdAndConnectionId).not.toHaveBeenCalled();
+      expect(productVariantRepository.findById).not.toHaveBeenCalled();
       expect(result.offerCreation).toBeUndefined();
+      expect(result.linkedProductId).toBeUndefined();
       expect(result.entityType).toBe('Product');
+    });
+
+    it('should embed linkedProductId when the linked variant exists (#485)', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+      offerCreationRecords.findByExternalOfferIdAndConnectionId.mockResolvedValue(null);
+      const linkedVariant: ProductVariant = {
+        id: 'ol_offer_variant123',
+        productId: 'ol_product_xyz789',
+        sku: 'SKU-1',
+        attributes: null,
+        ean: null,
+        gtin: null,
+      };
+      productVariantRepository.findById.mockResolvedValue(linkedVariant);
+
+      const result = await controller.getOfferMapping('uuid-1');
+
+      expect(productVariantRepository.findById).toHaveBeenCalledWith('ol_offer_variant123');
+      expect(result.linkedProductId).toBe('ol_product_xyz789');
+    });
+
+    it('should omit linkedProductId when the linked variant cannot be resolved (#485)', async () => {
+      repository.findById.mockResolvedValue(mockMapping);
+      offerCreationRecords.findByExternalOfferIdAndConnectionId.mockResolvedValue(null);
+      productVariantRepository.findById.mockResolvedValue(null);
+
+      const result = await controller.getOfferMapping('uuid-1');
+
+      expect(productVariantRepository.findById).toHaveBeenCalledWith('ol_offer_variant123');
+      expect(result.linkedProductId).toBeUndefined();
     });
   });
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -49,6 +49,8 @@ import type {
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
 import type { EntityType, IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
+import type { ProductVariantRepositoryPort } from '@openlinker/core/products';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
 import type { JobEnqueuePort } from '@openlinker/core/sync';
 
@@ -85,6 +87,8 @@ export class ListingsController {
     private readonly sellerPolicies: ISellerPoliciesService,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrationsService: IIntegrationsService,
+    @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
+    private readonly productVariantRepository: ProductVariantRepositoryPort,
   ) {}
 
   @Get()
@@ -128,17 +132,26 @@ export class ListingsController {
     }
 
     const dto = this.toDto(mapping);
-    // Enrich Offer-type mappings with the matching OfferCreationRecord so the
-    // detail page can show creation status + errors for OL-initiated offers
-    // without a second round-trip. Synced-in offers (no matching record) and
-    // non-Offer entity types fall through to a plain DTO.
+    // Enrich Offer-type mappings with two independent lookups in parallel:
+    //   - the matching OfferCreationRecord (so the detail page can show
+    //     creation status + errors for OL-initiated offers without a second
+    //     round-trip — synced-in offers fall through to a plain DTO),
+    //   - the linked variant's productId (drives the AI-suggest flow on the
+    //     edit drawer — #485 — which is keyed on product, not variant).
+    // Non-Offer entity types skip both lookups entirely.
     if (mapping.entityType === ('Offer' satisfies EntityType)) {
-      const record = await this.offerCreationRecords.findByExternalOfferIdAndConnectionId(
-        mapping.externalId,
-        mapping.connectionId,
-      );
+      const [record, linkedVariant] = await Promise.all([
+        this.offerCreationRecords.findByExternalOfferIdAndConnectionId(
+          mapping.externalId,
+          mapping.connectionId,
+        ),
+        this.productVariantRepository.findById(mapping.internalId),
+      ]);
       if (record) {
         dto.offerCreation = this.toOfferCreationStatusDto(record);
+      }
+      if (linkedVariant) {
+        dto.linkedProductId = linkedVariant.productId;
       }
     }
     return dto;

--- a/apps/api/src/listings/listings.module.ts
+++ b/apps/api/src/listings/listings.module.ts
@@ -9,6 +9,7 @@
 import { Module } from '@nestjs/common';
 import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
 import { ListingsModule as CoreListingsModule } from '@openlinker/core/listings/services';
+import { ProductsModule as CoreProductsModule } from '@openlinker/core/products';
 import { SyncModule as CoreSyncModule } from '@openlinker/core/sync';
 import { ListingsController } from './http/listings.controller';
 
@@ -16,7 +17,9 @@ import { ListingsController } from './http/listings.controller';
   // CoreIntegrationsModule supplies INTEGRATIONS_SERVICE_TOKEN, which the
   // controller injects to resolve the per-connection OfferManager adapter
   // for the category-parameters endpoint (#410).
-  imports: [CoreListingsModule, CoreSyncModule, CoreIntegrationsModule],
+  // CoreProductsModule supplies PRODUCT_VARIANT_REPOSITORY_TOKEN, used by
+  // GET /listings/:id to resolve the linked variant's productId (#485).
+  imports: [CoreListingsModule, CoreSyncModule, CoreIntegrationsModule, CoreProductsModule],
   controllers: [ListingsController],
 })
 export class ListingsApiModule {}

--- a/apps/web/src/features/content/api/content.utils.ts
+++ b/apps/web/src/features/content/api/content.utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Content Feature — Frontend Utilities
+ *
+ * Pure helpers around the content wire types (`content.types.ts`). Kept in a
+ * separate module from `content.types.ts` so the types file stays type-only
+ * per the engineering-standards "Type Definitions in Separate Files" rule.
+ *
+ * @module apps/web/src/features/content/api
+ */
+
+import {
+  PromptTemplateChannelValues,
+  type PromptTemplateChannel,
+} from './content.types';
+
+/**
+ * Narrow a connection's `platformType` (free string on the wire) to the
+ * closed `PromptTemplateChannel` union the AI-suggest endpoint accepts.
+ * Returns `null` for marketplaces that don't yet have a published prompt
+ * template — call sites should disable the Suggest button with an
+ * explanatory hint instead of firing a request that would 404.
+ *
+ * Used by both `content-editor` (per-channel tabs) and the listings
+ * `EditOfferDrawer` (#485). Wire values are lowercase (`'allegro'`,
+ * `'prestashop'`); inputs that don't match exactly return `null`.
+ */
+export function resolveSuggestChannel(
+  platformType: string,
+): PromptTemplateChannel | null {
+  return (PromptTemplateChannelValues as readonly string[]).includes(platformType)
+    ? (platformType as PromptTemplateChannel)
+    : null;
+}

--- a/apps/web/src/features/content/components/content-editor.tsx
+++ b/apps/web/src/features/content/components/content-editor.tsx
@@ -29,9 +29,8 @@ import {
 import type {
   ContentChannelState,
   ContentMasterState,
-  PromptTemplateChannel,
 } from '../api/content.types';
-import { PromptTemplateChannelValues } from '../api/content.types';
+import { resolveSuggestChannel } from '../api/content.utils';
 import { ContentPanel } from './content-panel';
 import { SuggestionDialog } from './suggestion-dialog';
 
@@ -51,12 +50,6 @@ function fromTabValue(value: string, channels: ContentChannelState[]): ActiveTar
   if (value === 'master') return { kind: 'master' };
   const found = channels.find((c) => c.connectionId === value);
   return found ? { kind: 'channel', connectionId: found.connectionId } : { kind: 'master' };
-}
-
-function resolveChannelPromptKey(platformType: string): PromptTemplateChannel | null {
-  return (PromptTemplateChannelValues as readonly string[]).includes(platformType)
-    ? (platformType as PromptTemplateChannel)
-    : null;
 }
 
 function formatMutationError(err: unknown): string | null {
@@ -256,7 +249,7 @@ export function ContentEditor({ productId }: ContentEditorProps): ReactElement {
 
         {channels.map((channel) => {
           const target: ActiveTarget = { kind: 'channel', connectionId: channel.connectionId };
-          const promptChannel = resolveChannelPromptKey(channel.platformType);
+          const promptChannel = resolveSuggestChannel(channel.platformType);
           const disabledReason =
             channel.connectionStatus !== 'active'
               ? `Connection is ${channel.connectionStatus}. Re-activate to enable editing.`

--- a/apps/web/src/features/content/components/suggestion-dialog.tsx
+++ b/apps/web/src/features/content/components/suggestion-dialog.tsx
@@ -8,7 +8,7 @@
  *
  * @module apps/web/src/features/content/components
  */
-import { useCallback, useState, type ReactElement } from 'react';
+import { useCallback, useState, type ReactElement, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
@@ -33,6 +33,13 @@ interface SuggestionDialogProps {
   channel: PromptTemplateChannel | null;
   disabled?: boolean;
   onApply: (suggestion: string) => void;
+  /**
+   * Optional banner rendered at the top of the dialog body. Used by the
+   * offer-edit drawer (#485) to remind operators that the suggestion is
+   * sourced from the product's master content — saving still writes only
+   * to the single offer the drawer is editing.
+   */
+  scopeWarning?: ReactNode;
 }
 
 const MAX_TONE_LENGTH = 64;
@@ -58,6 +65,7 @@ export function SuggestionDialog({
   channel,
   disabled = false,
   onApply,
+  scopeWarning,
 }: SuggestionDialogProps): ReactElement {
   const mutation = useSuggestContentMutation();
   const [open, setOpen] = useState(false);
@@ -123,6 +131,12 @@ export function SuggestionDialog({
         </DialogDescription>
 
         <div className="content-suggestion__body">
+          {scopeWarning ? (
+            <div className="content-suggestion__scope-warning" role="note">
+              {scopeWarning}
+            </div>
+          ) : null}
+
           <FormField
             label="Tone"
             name="tone"

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -33,6 +33,15 @@ export interface OfferMapping {
    * Absent on synced-in offers and on non-Offer entity types.
    */
   offerCreation?: OfferCreationStatusResponse | null;
+  /**
+   * Internal product ID owning the linked variant. Populated only by the
+   * detail endpoint (`GET /listings/:id`) for Offer-type mappings whose
+   * `internalId` resolves to an existing variant. Drives the AI-suggest
+   * flow on the offer-edit drawer (#485) — the suggest endpoint is keyed
+   * on product, not variant. Absent on list responses, synced-in offers
+   * whose variant has been deleted, and non-Offer entity types.
+   */
+  linkedProductId?: string | null;
 }
 
 export interface ListingsFilters {

--- a/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
+++ b/apps/web/src/features/listings/components/EditOfferDrawer.test.tsx
@@ -18,7 +18,7 @@ const mockMapping: OfferMapping = {
   entityType: 'Offer',
   internalId: 'ol_offer_abc123',
   externalId: 'allegro-offer-999',
-  platformType: 'Allegro',
+  platformType: 'allegro',
   connectionId: 'conn-1',
   context: null,
   createdAt: '2026-01-01T00:00:00Z',
@@ -29,10 +29,11 @@ function renderDrawer(
   isOpen: boolean,
   overrides: Parameters<typeof createMockApiClient>[0] = {},
   onClose = vi.fn(),
+  mapping: OfferMapping = mockMapping,
 ) {
   const mockApi = createMockApiClient(overrides);
   renderWithProviders(
-    <EditOfferDrawer isOpen={isOpen} onClose={onClose} mapping={mockMapping} />,
+    <EditOfferDrawer isOpen={isOpen} onClose={onClose} mapping={mapping} />,
     { apiClient: mockApi },
   );
   return { mockApi, onClose };
@@ -139,5 +140,76 @@ describe('EditOfferDrawer', () => {
     expect(await screen.findByText(/update failed/i)).toBeInTheDocument();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  describe('AI suggest (#485)', () => {
+    it('should render the Suggest button when linkedProductId and platformType resolve to a channel', () => {
+      const mappingWithLink: OfferMapping = {
+        ...mockMapping,
+        linkedProductId: 'ol_product_xyz789',
+      };
+      renderDrawer(true, {}, undefined, mappingWithLink);
+      expect(
+        screen.getByRole('button', { name: /suggest with ai/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('should show a hint instead of the Suggest button when no variant is linked', () => {
+      const mappingWithoutLink: OfferMapping = { ...mockMapping, linkedProductId: null };
+      renderDrawer(true, {}, undefined, mappingWithoutLink);
+      expect(
+        screen.queryByRole('button', { name: /suggest with ai/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/link this offer to a product variant/i)).toBeInTheDocument();
+    });
+
+    it('should populate description and mark form dirty when applying a suggestion (#485)', async () => {
+      const suggest = vi.fn().mockResolvedValue({
+        suggestion: 'Generated copy',
+        requestId: 'req-1',
+        templateKey: 'offer.description.suggest',
+        templateVersion: 1,
+        templateChannel: 'allegro',
+        modelUsed: 'fake',
+        latencyMs: 0,
+        usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0 },
+      });
+      const mappingWithLink: OfferMapping = {
+        ...mockMapping,
+        linkedProductId: 'ol_product_xyz789',
+      };
+      renderDrawer(true, { content: { suggest } }, undefined, mappingWithLink);
+
+      // Save is disabled while pristine.
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled();
+
+      fireEvent.click(screen.getByRole('button', { name: /suggest with ai/i }));
+      fireEvent.click(await screen.findByRole('button', { name: /^generate$/i }));
+
+      const applyButton = await screen.findByRole('button', { name: /apply to editor/i });
+      fireEvent.click(applyButton);
+
+      await waitFor(() => {
+        const textarea = screen.getByLabelText(/description/i);
+        expect(textarea).toHaveValue('Generated copy');
+      });
+      // Apply must mark the form dirty so Save activates.
+      expect(screen.getByRole('button', { name: /save changes/i })).not.toBeDisabled();
+    });
+
+    it('should show the offer-scope warning copy inside the suggestion dialog (#485)', async () => {
+      const mappingWithLink: OfferMapping = {
+        ...mockMapping,
+        linkedProductId: 'ol_product_xyz789',
+      };
+      renderDrawer(true, {}, undefined, mappingWithLink);
+
+      fireEvent.click(screen.getByRole('button', { name: /suggest with ai/i }));
+
+      expect(await screen.findByText(/this offer only/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/does not update the product master/i),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/listings/components/EditOfferDrawer.tsx
+++ b/apps/web/src/features/listings/components/EditOfferDrawer.tsx
@@ -21,6 +21,8 @@ import type { OfferMapping } from '../api/listings.types';
 import type { UpdateOfferFieldsPayload } from '../api/listings.types';
 import { editOfferFieldsSchema, type EditOfferFieldsValues } from './edit-offer-fields.schema';
 import { OfferDescriptionEditor } from './OfferDescriptionEditor';
+import { SuggestionDialog } from '../../content/components/suggestion-dialog';
+import { resolveSuggestChannel } from '../../content/api/content.utils';
 
 interface EditOfferDrawerProps {
   isOpen: boolean;
@@ -66,6 +68,32 @@ export function EditOfferDrawer({ isOpen, onClose, mapping }: EditOfferDrawerPro
 
   const { dirtyFields } = form.formState;
   const isDirty = Object.keys(dirtyFields).length > 0;
+
+  const linkedProductId = mapping.linkedProductId ?? null;
+  const suggestChannel = resolveSuggestChannel(mapping.platformType);
+  const canSuggest = linkedProductId !== null && suggestChannel !== null;
+  // Pick the first applicable disabled-hint so the operator knows *why* the
+  // button is unavailable. linkedProductId missing wins because no other
+  // gate is recoverable without re-linking the variant; the channel-not-
+  // supported hint is informational (will resolve when the channel's prompt
+  // template is seeded).
+  const disabledHint =
+    linkedProductId === null
+      ? 'AI suggestions require a linked variant — link this offer to a product variant first.'
+      : suggestChannel === null
+        ? `AI suggestions are not available for ${mapping.platformType} yet.`
+        : null;
+
+  const { setValue: setFormValue } = form;
+  const handleApplySuggestion = useCallback(
+    (suggestion: string) => {
+      setFormValue('descriptionText', suggestion, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    },
+    [setFormValue],
+  );
 
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : [],
@@ -196,16 +224,45 @@ export function EditOfferDrawer({ isOpen, onClose, mapping }: EditOfferDrawerPro
               </FormField>
             </div>
 
-            <FormField
-              label="Description"
-              name="descriptionText"
-              error={form.formState.errors.descriptionText?.message}
-            >
-              <OfferDescriptionEditor
-                registration={form.register('descriptionText')}
+            <div className="edit-offer-drawer__description">
+              {canSuggest || disabledHint ? (
+                <div className="edit-offer-drawer__description-actions">
+                  {canSuggest && linkedProductId !== null ? (
+                    <SuggestionDialog
+                      productId={linkedProductId}
+                      channel={suggestChannel}
+                      disabled={mutation.isPending}
+                      onApply={handleApplySuggestion}
+                      scopeWarning={
+                        <>
+                          Suggestions are sourced from the product's master content.
+                          Applying replaces the description on <strong>this offer only</strong> —
+                          saving does not update the product master or any other linked offers.
+                        </>
+                      }
+                    />
+                  ) : (
+                    <span
+                      className="edit-offer-drawer__description-hint"
+                      aria-live="polite"
+                    >
+                      {disabledHint}
+                    </span>
+                  )}
+                </div>
+              ) : null}
+
+              <FormField
+                label="Description"
+                name="descriptionText"
                 error={form.formState.errors.descriptionText?.message}
-              />
-            </FormField>
+              >
+                <OfferDescriptionEditor
+                  registration={form.register('descriptionText')}
+                  error={form.formState.errors.descriptionText?.message}
+                />
+              </FormField>
+            </div>
           </form>
         </div>
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6324,6 +6324,39 @@ a.kpi-card:focus-visible {
   color: var(--accent-primary-hover);
 }
 
+.content-suggestion__scope-warning {
+  padding: 0.625rem 0.75rem;
+  background: var(--status-info-soft);
+  border: 1px solid var(--status-info-border);
+  border-radius: 0.625rem;
+  color: var(--status-info-fg);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+/* ============================================================
+   Edit-offer drawer — Suggest button row above the Description
+   field (#485)
+   ============================================================ */
+
+.edit-offer-drawer__description {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.edit-offer-drawer__description-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  min-height: 2rem;
+}
+
+.edit-offer-drawer__description-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* ============================================================
    AI Provider Settings — multi-provider table (#451 / #452)
    ============================================================ */

--- a/docs/plans/implementation-plan-ai-suggest-on-offer-edit.md
+++ b/docs/plans/implementation-plan-ai-suggest-on-offer-edit.md
@@ -1,0 +1,251 @@
+# Implementation plan — AI suggest on offer-edit drawer (#485)
+
+## 1. Goal
+
+Wire the existing `SuggestionDialog` into `EditOfferDrawer` so operators on `/listings/{offerId}` can generate an AI description for the per-offer Description textarea without round-tripping through the product editor. The suggestion writes to the offer-local `descriptionText` form field; the existing Save flow pushes only that offer (no `ProductContentField` mutation, no fan-out to other channels).
+
+**Layers**: Frontend (FE feature module) + small Interface-layer additive change (BE controller enriches the existing detail response with `linkedProductId`).
+
+**Non-goals**
+- Per-offer prompt templates. The existing `offer.description.suggest` template already supports per-channel rendering.
+- AI suggestions for fields other than description (title, parameters).
+- Mobile / tablet layout tuning for the drawer.
+- New BE port / capability changes — capability ports unchanged.
+
+## 2. Codebase research
+
+### BE
+- `OfferMapping` is an `IdentifierMapping` row where `entityType = 'Offer'`, `internalId = ol_variant_*` (the linked variant), `externalId = the marketplace offer id`. Confirmed by the DTO's own description (`apps/api/src/listings/http/dto/offer-mapping-response.dto.ts:19`: "Internal ID (linked variant ID)").
+- Variant→product resolution: `ProductVariantRepositoryPort.findById(id)` returns a `ProductVariant` with a `productId` field. Used in `OfferBuilderService.ts:80` (`productMaster.getProduct(variant.productId)`) — well-established pattern.
+- The detail endpoint `GET /listings/:id` (`listings.controller.ts:117-145`) already does one enrichment round-trip (offer-creation status). Adding a second variant-lookup round-trip is consistent with the existing shape.
+- `PRODUCT_VARIANT_REPOSITORY_TOKEN` exported from `@openlinker/core/products`. To inject it, the listings controller needs `ProductsModule` imported in `apps/api/src/listings/listings.module.ts`.
+
+### FE
+- `SuggestionDialog` (`apps/web/src/features/content/components/suggestion-dialog.tsx`) is already generic: `{ productId, channel, disabled?, onApply }`. Renders its own trigger button + modal; calls `useSuggestContentMutation`. **Reusable as-is** — no extraction needed.
+- `PromptTemplateChannel` is `'prestashop' | 'allegro'` (closed union, `apps/web/src/features/content/api/content.types.ts:14-15`). `OfferMapping.platformType` is a free string. Need a runtime narrow.
+- `EditOfferDrawer` (`apps/web/src/features/listings/components/EditOfferDrawer.tsx`) uses React Hook Form. To set the description field after applying a suggestion: `form.setValue('descriptionText', suggestion, { shouldDirty: true })`.
+- Existing test file exists (`EditOfferDrawer.test.tsx`) with 8 cases — the established `renderWithProviders` + `createMockApiClient` pattern.
+
+### Open questions (resolved)
+- **Where to render the warning copy?** The dialog already renders inside a Dialog with its own Description slot. Adding a `scopeWarning?: ReactNode` prop to `SuggestionDialog` is the cleanest seam — it puts the warning where the operator actually sees it (inside the dialog), and keeps EditOfferDrawer free of dialog-internal copy. Alternative (inline above the trigger button) was considered but loses visibility once the dialog opens. **Going with prop.**
+- **Product link target.** When a `productId` is available, the warning ends with a deep link to `/products/{productId}` so operators who realise they wanted master-level can jump there.
+
+## 3. Design
+
+### BE — add `linkedProductId` to the offer-mapping detail response
+
+```ts
+// apps/api/src/listings/http/dto/offer-mapping-response.dto.ts
+@ApiPropertyOptional({
+  nullable: true,
+  description:
+    'Internal product ID linked to this offer, resolved from the variant ' +
+    '(internalId → variant → product). Populated only by `GET /listings/:id` ' +
+    'for `entityType=Offer` mappings whose linked variant is still findable. ' +
+    'Absent on list responses (no per-row variant lookup) and on synced-in ' +
+    'offers whose variant has been deleted.',
+})
+linkedProductId?: string | null;
+```
+
+```ts
+// apps/api/src/listings/http/listings.controller.ts (getOfferMapping enrichment)
+if (mapping.entityType === ('Offer' satisfies EntityType)) {
+  // existing OfferCreationRecord enrichment...
+
+  // #485: surface the linked product so the FE can drive the AI-suggest
+  // affordance without a second round-trip. The variant lookup is on the
+  // hot path of the offer-detail page (always one fetch); the per-page
+  // cost is one extra DB read scoped to a single primary-key lookup.
+  const variant = await this.productVariantRepository.findById(mapping.internalId);
+  if (variant) {
+    dto.linkedProductId = variant.productId;
+  }
+}
+```
+
+```ts
+// apps/api/src/listings/listings.module.ts
+imports: [CoreListingsModule, CoreSyncModule, CoreIntegrationsModule, CoreProductsModule],
+```
+
+### FE — wire `SuggestionDialog` into `EditOfferDrawer`
+
+Add `linkedProductId?: string | null` to the FE `OfferMapping` interface (mirror the BE change).
+
+Add an optional `scopeWarning?: ReactNode` prop to `SuggestionDialog` so EditOfferDrawer can inject the per-offer scope copy without coupling the dialog to listing-domain knowledge:
+
+```ts
+// apps/web/src/features/content/components/suggestion-dialog.tsx
+interface SuggestionDialogProps {
+  productId: string;
+  channel: PromptTemplateChannel | null;
+  disabled?: boolean;
+  onApply: (suggestion: string) => void;
+  /**
+   * Optional inline copy shown inside the dialog body, below the description.
+   * Used by the offer-edit drawer (#485) to clarify the per-offer write scope.
+   */
+  scopeWarning?: ReactNode;
+}
+```
+
+Renders inside the dialog body, above the Tone/Extra fields:
+
+```tsx
+{scopeWarning ? <div className="content-suggestion__scope-warning">{scopeWarning}</div> : null}
+```
+
+Inside `EditOfferDrawer`:
+
+```tsx
+const allegroChannel: PromptTemplateChannel | null =
+  mapping.platformType === 'allegro' || mapping.platformType === 'prestashop'
+    ? mapping.platformType
+    : null;
+
+const canSuggest = mapping.linkedProductId != null && allegroChannel !== null;
+const suggestDisabledReason = !mapping.linkedProductId
+  ? 'Link this offer to a product first to use AI suggestions'
+  : allegroChannel === null
+    ? `AI suggestions are not available for the ${mapping.platformType} platform yet`
+    : null;
+
+const handleApplySuggestion = useCallback(
+  (suggestion: string) => {
+    form.setValue('descriptionText', suggestion, { shouldDirty: true, shouldValidate: true });
+  },
+  [form],
+);
+```
+
+Render next to the Description label inside `FormField`'s `description` slot — the dialog renders its own trigger button, so consumers just place `<SuggestionDialog>` where they want the trigger to appear:
+
+```tsx
+<FormField
+  label="Description"
+  name="descriptionText"
+  description={
+    canSuggest ? (
+      <SuggestionDialog
+        productId={mapping.linkedProductId!}
+        channel={allegroChannel!}
+        onApply={handleApplySuggestion}
+        scopeWarning={
+          <>
+            Writes directly to this {mapping.platformType} offer.{' '}
+            <Link to={`/products/${mapping.linkedProductId}`}>Open the product editor</Link>{' '}
+            to update the master and fan out to all channels.
+          </>
+        }
+      />
+    ) : suggestDisabledReason ? (
+      <span className="form-field__hint" title={suggestDisabledReason}>
+        AI suggest unavailable — {suggestDisabledReason}.
+      </span>
+    ) : null
+  }
+  error={form.formState.errors.descriptionText?.message}
+>
+  ...
+</FormField>
+```
+
+Note: `FormField`'s `description` slot today takes `string | undefined`. Need to confirm it accepts `ReactNode`; if not, render the dialog/hint outside the FormField as a sibling element above the textarea. (Will verify during implementation.)
+
+### Architecture validation
+- BE: variant lookup uses the existing `ProductVariantRepositoryPort` via Symbol token — no port-contract change. Only the controller and DTO grow a field.
+- FE: `EditOfferDrawer` (in `features/listings/`) imports `SuggestionDialog` (from `features/content/`). That's a cross-feature import. Frontend-architecture.md "Dependency Rules" requires `features → shared`, but doesn't explicitly forbid `features → features`. **Risk to flag** — see §6.
+
+## 4. Step-by-step plan
+
+### Step 1 — BE: extend DTO with `linkedProductId`
+**File**: `apps/api/src/listings/http/dto/offer-mapping-response.dto.ts`
+- Add `@ApiPropertyOptional` field `linkedProductId?: string | null` with the docstring documenting the variant-lookup origin.
+
+**Acceptance**: type-check green.
+
+### Step 2 — BE: import `CoreProductsModule` in the listings API module
+**File**: `apps/api/src/listings/listings.module.ts`
+- Add `CoreProductsModule` to imports so `PRODUCT_VARIANT_REPOSITORY_TOKEN` is resolvable.
+
+**Acceptance**: API boots without DI errors.
+
+### Step 3 — BE: enrich `getOfferMapping` with `linkedProductId`
+**File**: `apps/api/src/listings/http/listings.controller.ts`
+- Inject `ProductVariantRepositoryPort` via `@Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)`.
+- Inside the existing `entityType === 'Offer'` branch, after the `offerCreation` enrichment, look up the variant and set `dto.linkedProductId = variant.productId` when found.
+
+**Acceptance**: existing controller spec passes; new test case asserts `linkedProductId` present when variant exists, `null`/absent when missing.
+
+### Step 4 — BE: extend controller spec
+**File**: `apps/api/src/listings/http/listings.controller.spec.ts`
+- Two new cases inside the existing `getOfferMapping` describe block:
+  - `should populate linkedProductId from the linked variant for Offer mappings`
+  - `should leave linkedProductId absent when the linked variant is missing`
+- Mock `ProductVariantRepositoryPort.findById`.
+
+**Acceptance**: 2 new cases green; existing 4 cases still pass.
+
+### Step 5 — FE: extend `OfferMapping` type
+**File**: `apps/web/src/features/listings/api/listings.types.ts`
+- Add `linkedProductId?: string | null` to `OfferMapping` with a docstring matching the BE DTO.
+
+**Acceptance**: type-check green.
+
+### Step 6 — FE: extend `SuggestionDialog` with `scopeWarning` prop
+**File**: `apps/web/src/features/content/components/suggestion-dialog.tsx`
+- Add optional `scopeWarning?: ReactNode` prop.
+- Render inside dialog body above the Tone field (inside the `.content-suggestion__body` div).
+
+**File**: `apps/web/src/index.css`
+- Add `.content-suggestion__scope-warning` — small note styling (token-driven, mirrors `--text-secondary` font-size 0.8125rem with `--bg-surface-muted` background and `0.75rem` padding).
+
+**Acceptance**: existing `suggestion-dialog.test.tsx` passes unchanged; new prop is purely additive.
+
+### Step 7 — FE: render `SuggestionDialog` inside `EditOfferDrawer`
+**File**: `apps/web/src/features/listings/components/EditOfferDrawer.tsx`
+- Import `SuggestionDialog`, `PromptTemplateChannel`, `Link` from `react-router-dom`.
+- Compute `allegroChannel` (typed channel narrow), `canSuggest`, and `suggestDisabledReason`.
+- Define `handleApplySuggestion` callback that calls `form.setValue('descriptionText', suggestion, { shouldDirty: true, shouldValidate: true })`.
+- Render the dialog (or disabled-hint span) above the description textarea — likely between the FormField label and the textarea, or as a sibling div before the FormField.
+
+**Acceptance**: lint + type-check green; visual verification in dev that the trigger appears next to the Description label.
+
+### Step 8 — FE: tests for the suggest path
+**File**: `apps/web/src/features/listings/components/EditOfferDrawer.test.tsx`
+- 4 new cases:
+  - `should render the AI suggest button when the offer has a linked product`
+  - `should render the disabled-hint instead when linkedProductId is null`
+  - `should populate descriptionText and dirty the form when a suggestion is applied`
+  - `should render the per-offer scope warning copy with a link to the product editor`
+- Use the existing `createMockApiClient` to mock `content.suggest`.
+
+**Acceptance**: 4 new cases green; existing 8 pass unchanged.
+
+### Step 9 — quality gate
+
+```
+pnpm --filter @openlinker/api lint && type-check && test
+pnpm --filter @openlinker/web lint && type-check && test
+pnpm --filter @openlinker/api migration:show   # confirm no migrations needed
+```
+
+All green. No new migration (no schema change).
+
+## 5. Validation
+
+- **Architecture (BE)**: New field on the existing detail DTO; new variant lookup uses the existing port via the Symbol token. No new ports / capabilities. Hexagonal boundary preserved.
+- **Architecture (FE)**: `EditOfferDrawer` (features/listings) imports `SuggestionDialog` (features/content). See §6 risk note.
+- **Naming (BE)**: `linkedProductId` (camelCase) matches existing field naming in the DTO.
+- **Naming (FE)**: same field name on the `OfferMapping` interface — wire-shape parity.
+- **Tests**: BE +2, FE +4 — covers the happy path, the disabled-when-no-product branch, the apply-populates-and-dirties branch, and the scope-warning copy.
+- **Security**: No secrets, no auth duplication, no XSS (the `scopeWarning` is React-rendered from typed props, not from user input). Same-origin route link.
+- **No backend port changes.** No new dependencies.
+
+## 6. Risks & open questions
+
+- **Cross-feature import on FE.** `features/listings/EditOfferDrawer.tsx` imports `features/content/components/suggestion-dialog.tsx`. Frontend-architecture.md "Dependency Rules" only documents `app → pages → features → shared`, not `features → features`. Looking at the existing codebase, cross-feature imports are common where a primitive belongs to one feature but is consumed by another (e.g., the EntityLabel resolver consumes connections/customers feature queries). I'll proceed with the direct import; if lint flags it, we'll relocate `SuggestionDialog` to `shared/ui/` as a follow-up. Flagging now to set expectations.
+- **`FormField.description` may not accept `ReactNode`.** If it's `string`-only, the SuggestionDialog renders as a sibling above the textarea (inside the FormField wrapper, above the control). This is a verify-during-implementation detail, not a blocker.
+- **Scope warning visibility.** The plan puts the warning inside the dialog body. Operators who never click Suggest never see the warning — but they also don't trigger the per-offer write, so the warning has no audience there. If feedback says we want a permanent inline note next to the trigger as well, that's a follow-up.
+- **`platformType` narrowing.** Today only `'allegro'` is a real offer-source platform; `'prestashop'` is a shop, not an offer publisher. The narrow accepts both for forward-compat with the typed `PromptTemplateChannel`, but in practice only `'allegro'` will trigger the suggest button on this surface.


### PR DESCRIPTION
## Summary

Wires the existing content `SuggestionDialog` into the listings `EditOfferDrawer` so operators can generate marketplace-channel descriptions without leaving the drawer. Apply writes the suggestion into the description form buffer (marked dirty so Save activates) — saving still updates only the single offer, never the product master or sibling offers, with a scope warning rendered inside the dialog.

### Backend
- `GET /listings/:id` enriches Offer-type mappings with `linkedProductId` (the variant's parent product) in parallel with the existing `offerCreation` lookup, so the FE can pass it to the product-keyed `/content/.../suggest` endpoint without a second round-trip. List endpoint and non-Offer mappings unchanged.
- `ListingsApiModule` now imports `CoreProductsModule` to bind the `PRODUCT_VARIANT_REPOSITORY_TOKEN`.

### Frontend
- `SuggestionDialog` gains an optional `scopeWarning?: ReactNode` slot. Existing master / per-channel content-editor call-sites are unchanged.
- `EditOfferDrawer` renders the Suggest control above the Description field when the offer has a linked variant + a supported channel; shows an explanatory hint otherwise.
- Single shared `resolveSuggestChannel` helper in `features/content/api/content.utils.ts` replaces the duplicated channel-narrowing helpers in content-editor and the new drawer.

## Test plan

- [x] BE unit: `getOfferMapping` covers variant-present (embeds `linkedProductId`) + variant-missing (field omitted) — `apps/api/src/listings/http/listings.controller.spec.ts`
- [x] FE unit: drawer covers button visibility on link, disabled-hint when no link, apply-populates-and-marks-dirty, scope-warning copy — `apps/web/src/features/listings/components/EditOfferDrawer.test.tsx`
- [x] Quality gate: `pnpm lint` (0 errors), `pnpm type-check` (clean across 8 workspaces), `pnpm test` (1880+ tests pass)
- [x] No DB migration required (no schema change)
- [ ] Manual QA: open the listings detail page → click Edit → verify Suggest button appears for an Allegro offer with a linked variant; generate + apply; verify Save is enabled and dispatches a fields-update job for the single offer
- [ ] Manual QA: verify the disabled-hint variant on a synced-in offer that has no linked variant
- [ ] Manual QA: verify the existing per-channel suggest flow on `/products/:id/content` still works (no regression from the shared-helper extraction)

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)