### PR TITLE
feat(ai,web): new-template + soft-archive UX on /ai/prompt-templates (#488 #489)

### DIFF
--- a/apps/api/src/ai/http/dto/archive-prompt-template.dto.ts
+++ b/apps/api/src/ai/http/dto/archive-prompt-template.dto.ts
@@ -1,0 +1,24 @@
+/**
+ * Archive Prompt Template DTO
+ *
+ * Request body for `POST /prompt-templates/:id/archive`. The body is
+ * usually empty (`{}`) for the routine archive case (drafts and stale
+ * published rows that have a replacement). `force` is only required to
+ * archive a `published` row that is the only published version for its
+ * `(key, channel)` pair — see #489.
+ *
+ * @module apps/api/src/ai/http/dto
+ */
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class ArchivePromptTemplateDto {
+  @ApiPropertyOptional({
+    description:
+      'Bypass the "no other published version" guard. Required when archiving the only published row for a (key, channel) pair — the suggestion service will then have no template to render until a replacement is published.',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  force?: boolean;
+}

--- a/apps/api/src/ai/http/prompt-templates.controller.spec.ts
+++ b/apps/api/src/ai/http/prompt-templates.controller.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Prompt Templates Controller — Unit Tests
+ *
+ * Focused on the domain-exception → HTTP-status mapping that
+ * `withDomainExceptionMapping` performs for the archive endpoint
+ * (#489). The service is mocked at the port boundary; tests verify
+ * the controller translates each domain exception to the right HTTP
+ * shape (404 / 409 / 400) and returns the response DTO on the happy
+ * path.
+ *
+ * @module apps/api/src/ai/http
+ */
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  CannotArchivePublishedTemplateException,
+  IPromptTemplateService,
+  PROMPT_TEMPLATE_SERVICE_TOKEN,
+  PromptTemplate,
+  PromptTemplateNotFoundException,
+  PromptTemplateStateException,
+} from '@openlinker/core/ai';
+import { AuthenticatedUser } from '../../auth/auth.types';
+import { PromptTemplatesController } from './prompt-templates.controller';
+
+const adminUser: AuthenticatedUser = {
+  id: 'u1',
+  username: 'admin',
+  role: 'admin',
+};
+
+function makeTemplate(overrides: Partial<PromptTemplate> = {}): PromptTemplate {
+  return new PromptTemplate(
+    overrides.id ?? 'tmpl-1',
+    overrides.key ?? 'offer.description.suggest',
+    overrides.channel !== undefined ? overrides.channel : 'allegro',
+    overrides.version ?? 1,
+    overrides.systemPrompt ?? 'sys',
+    overrides.userPromptTemplate ?? 'user',
+    overrides.variables ?? [],
+    overrides.state ?? 'archived',
+    overrides.publishedAt ?? null,
+    overrides.createdBy ?? 'admin',
+    overrides.createdAt ?? new Date('2026-04-22T10:00:00Z'),
+    overrides.updatedAt ?? new Date('2026-04-22T10:00:00Z'),
+  );
+}
+
+describe('PromptTemplatesController', () => {
+  let controller: PromptTemplatesController;
+  let service: jest.Mocked<IPromptTemplateService>;
+
+  beforeEach(async () => {
+    service = {
+      listLatestByKey: jest.fn(),
+      getById: jest.fn(),
+      getVersions: jest.fn(),
+      getLatestPublished: jest.fn(),
+      createDraft: jest.fn(),
+      updateDraft: jest.fn(),
+      publish: jest.fn(),
+      revertTo: jest.fn(),
+      render: jest.fn(),
+      renderById: jest.fn(),
+      deleteDraft: jest.fn(),
+      archive: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PromptTemplatesController],
+      providers: [{ provide: PROMPT_TEMPLATE_SERVICE_TOKEN, useValue: service }],
+    }).compile();
+
+    controller = module.get(PromptTemplatesController);
+  });
+
+  describe('archive (#489)', () => {
+    it('should return the archived template DTO on the happy path', async () => {
+      const archived = makeTemplate({ state: 'archived', version: 3 });
+      service.archive.mockResolvedValue(archived);
+
+      const result = await controller.archive('tmpl-1', { force: false }, adminUser);
+
+      expect(service.archive).toHaveBeenCalledWith('tmpl-1', {
+        force: false,
+        actor: 'admin',
+      });
+      expect(result.id).toBe('tmpl-1');
+      expect(result.state).toBe('archived');
+      expect(result.version).toBe(3);
+    });
+
+    it('should pass force=true through to the service when the body sets it', async () => {
+      service.archive.mockResolvedValue(makeTemplate({ state: 'archived' }));
+
+      await controller.archive('tmpl-1', { force: true }, adminUser);
+
+      expect(service.archive).toHaveBeenCalledWith('tmpl-1', {
+        force: true,
+        actor: 'admin',
+      });
+    });
+
+    it('should map CannotArchivePublishedTemplateException to ConflictException (409)', async () => {
+      service.archive.mockRejectedValue(
+        new CannotArchivePublishedTemplateException({
+          templateId: 'tmpl-1',
+          key: 'offer.description.suggest',
+          channel: 'allegro',
+        }),
+      );
+
+      await expect(
+        controller.archive('tmpl-1', {}, adminUser),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('should map PromptTemplateNotFoundException to NotFoundException (404)', async () => {
+      service.archive.mockRejectedValue(
+        new PromptTemplateNotFoundException({ templateId: 'tmpl-1' }),
+      );
+
+      await expect(
+        controller.archive('tmpl-1', {}, adminUser),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should map PromptTemplateStateException to BadRequestException (400) for concurrent-modification', async () => {
+      service.archive.mockRejectedValue(
+        new PromptTemplateStateException({
+          templateId: 'tmpl-1',
+          actualState: 'published',
+          requiredState: 'draft',
+          operation: 'be archived (concurrent modification — refresh and retry)',
+        }),
+      );
+
+      await expect(
+        controller.archive('tmpl-1', {}, adminUser),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});

--- a/apps/api/src/ai/http/prompt-templates.controller.ts
+++ b/apps/api/src/ai/http/prompt-templates.controller.ts
@@ -13,6 +13,7 @@
 import {
   BadRequestException,
   Body,
+  ConflictException,
   Controller,
   Delete,
   Get,
@@ -29,6 +30,7 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import {
+  CannotArchivePublishedTemplateException,
   IPromptTemplateService,
   PROMPT_TEMPLATE_SERVICE_TOKEN,
   PromptTemplate,
@@ -41,6 +43,7 @@ import {
 import { AuthenticatedUser } from '../../auth/auth.types';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { ArchivePromptTemplateDto } from './dto/archive-prompt-template.dto';
 import { CreatePromptTemplateDto } from './dto/create-prompt-template.dto';
 import { PromptTemplateResponseDto } from './dto/prompt-template-response.dto';
 import { PromptTemplateSummaryResponseDto } from './dto/prompt-template-summary-response.dto';
@@ -179,6 +182,36 @@ export class PromptTemplatesController {
   }
 
   @Roles('admin')
+  @Post(':id/archive')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Archive a draft or published prompt template (#489)',
+    description:
+      'Soft-archive a prompt template row. Idempotent for already-archived rows. ' +
+      'Refuses to archive a published row without `{ "force": true }` because the ' +
+      'partial unique index makes it the only published version for its (key, channel).',
+  })
+  @ApiResponse({ status: 200, type: PromptTemplateResponseDto })
+  @ApiResponse({ status: 404, description: 'Template not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Cannot archive the only published row for the (key, channel) pair without force',
+  })
+  async archive(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: ArchivePromptTemplateDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ): Promise<PromptTemplateResponseDto> {
+    return this.withDomainExceptionMapping(async () => {
+      const archived = await this.service.archive(id, {
+        force: dto.force,
+        actor: user.username,
+      });
+      return PromptTemplateResponseDto.fromDomain(archived);
+    });
+  }
+
+  @Roles('admin')
   @Post('revert')
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Clone a historical version into a new draft' })
@@ -261,6 +294,9 @@ export class PromptTemplatesController {
     } catch (error) {
       if (error instanceof PromptTemplateNotFoundException) {
         throw new NotFoundException(error.message);
+      }
+      if (error instanceof CannotArchivePublishedTemplateException) {
+        throw new ConflictException(error.message);
       }
       if (error instanceof PromptTemplateStateException) {
         throw new BadRequestException(error.message);

--- a/apps/web/src/features/prompt-templates/api/prompt-templates.api.ts
+++ b/apps/web/src/features/prompt-templates/api/prompt-templates.api.ts
@@ -33,6 +33,7 @@ export interface PromptTemplatesApi {
   create: (input: CreatePromptTemplateInput) => Promise<PromptTemplate>;
   update: (id: string, input: UpdatePromptTemplateInput) => Promise<PromptTemplate>;
   publish: (id: string) => Promise<PromptTemplate>;
+  archive: (id: string, opts?: { force?: boolean }) => Promise<PromptTemplate>;
   revert: (input: RevertPromptTemplateInput) => Promise<PromptTemplate>;
   render: (id: string, input: RenderPromptTemplateInput) => Promise<RenderedPrompt>;
   remove: (id: string) => Promise<void>;
@@ -89,6 +90,12 @@ export function createPromptTemplatesApi(request: ApiRequest): PromptTemplatesAp
     publish(id): Promise<PromptTemplate> {
       return request<PromptTemplate>(`/prompt-templates/${id}/publish`, {
         method: 'POST',
+      });
+    },
+    archive(id, opts): Promise<PromptTemplate> {
+      return request<PromptTemplate>(`/prompt-templates/${id}/archive`, {
+        method: 'POST',
+        body: JSON.stringify(opts ?? {}),
       });
     },
     revert(input): Promise<PromptTemplate> {

--- a/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.test.tsx
+++ b/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.test.tsx
@@ -35,7 +35,7 @@ describe('ArchivePromptTemplateDialog', () => {
       { apiClient: client },
     );
     expect(
-      screen.queryByRole('checkbox', { name: /archive the published row/i }),
+      screen.queryByRole('checkbox', { name: /this is the only published version/i }),
     ).not.toBeInTheDocument();
   });
 
@@ -50,7 +50,7 @@ describe('ArchivePromptTemplateDialog', () => {
       />,
       { apiClient: client },
     );
-    fireEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^archive(\s+published)?\s+v\d+(\s+\(force\))?$/i }));
     await waitFor(() => {
       expect(archive).toHaveBeenCalledWith('tmpl-2', undefined);
     });
@@ -66,10 +66,10 @@ describe('ArchivePromptTemplateDialog', () => {
       />,
       { apiClient: client },
     );
-    const archiveButton = screen.getByRole('button', { name: /^archive$/i });
+    const archiveButton = screen.getByRole('button', { name: /^archive(\s+published)?\s+v\d+(\s+\(force\))?$/i });
     expect(archiveButton).toBeDisabled();
 
-    const forceCheckbox = screen.getByRole('checkbox', { name: /archive the published row/i });
+    const forceCheckbox = screen.getByRole('checkbox', { name: /this is the only published version/i });
     fireEvent.click(forceCheckbox);
     expect(archiveButton).not.toBeDisabled();
   });
@@ -90,8 +90,8 @@ describe('ArchivePromptTemplateDialog', () => {
       />,
       { apiClient: client },
     );
-    fireEvent.click(screen.getByRole('checkbox', { name: /archive the published row/i }));
-    fireEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /this is the only published version/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^archive(\s+published)?\s+v\d+(\s+\(force\))?$/i }));
     await waitFor(() => {
       expect(archive).toHaveBeenCalledWith('tmpl-2', { force: true });
     });
@@ -110,7 +110,7 @@ describe('ArchivePromptTemplateDialog', () => {
       />,
       { apiClient: client },
     );
-    fireEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^archive(\s+published)?\s+v\d+(\s+\(force\))?$/i }));
     expect(await screen.findByText(/cannot archive published template/i)).toBeInTheDocument();
     expect(onOpenChange).not.toHaveBeenCalled();
   });
@@ -131,7 +131,7 @@ describe('ArchivePromptTemplateDialog', () => {
       />,
       { apiClient: client },
     );
-    fireEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^archive(\s+published)?\s+v\d+(\s+\(force\))?$/i }));
     expect(await findToastTitle(/archived v2/i)).toBeInTheDocument();
     expect(screen.getByText(/published v1 is still active/i)).toBeInTheDocument();
   });

--- a/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.test.tsx
+++ b/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * ArchivePromptTemplateDialog — Component Tests
+ *
+ * Covers state-aware rendering (draft vs published), force-checkbox gating,
+ * archive call shape, 409 surface, and the conditional toast message
+ * (Suggestion 4 from the plan tech-review).
+ *
+ * @module apps/web/src/features/prompt-templates/components
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { createMockApiClient, findToastTitle, renderWithProviders } from '../../../test/test-utils';
+import { ArchivePromptTemplateDialog } from './archive-prompt-template-dialog';
+import type { PromptTemplateSummary } from '../api/prompt-templates.types';
+
+function makeRow(overrides: Partial<PromptTemplateSummary> = {}): PromptTemplateSummary {
+  return {
+    key: overrides.key ?? 'offer.description.suggest',
+    channel: overrides.channel !== undefined ? overrides.channel : 'allegro',
+    latestVersion: overrides.latestVersion ?? 2,
+    latestId: overrides.latestId ?? 'tmpl-2',
+    latestState: overrides.latestState ?? 'draft',
+    publishedVersion: overrides.publishedVersion ?? null,
+    publishedId: overrides.publishedId ?? null,
+    hasDraft: overrides.hasDraft ?? true,
+    updatedAt: overrides.updatedAt ?? '2026-04-22T10:00:00.000Z',
+  };
+}
+
+describe('ArchivePromptTemplateDialog', () => {
+  it('does not render the force checkbox for a draft target', () => {
+    const client = createMockApiClient();
+    renderWithProviders(
+      <ArchivePromptTemplateDialog row={makeRow({ latestState: 'draft' })} onOpenChange={vi.fn()} />,
+      { apiClient: client },
+    );
+    expect(
+      screen.queryByRole('checkbox', { name: /archive the published row/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('archives a draft without sending force', async () => {
+    const archive = vi.fn().mockResolvedValue(makeRow({ latestState: 'archived' }));
+    const onOpenChange = vi.fn();
+    const client = createMockApiClient({ promptTemplates: { archive } });
+    renderWithProviders(
+      <ArchivePromptTemplateDialog
+        row={makeRow({ latestId: 'tmpl-2', latestState: 'draft' })}
+        onOpenChange={onOpenChange}
+      />,
+      { apiClient: client },
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    await waitFor(() => {
+      expect(archive).toHaveBeenCalledWith('tmpl-2', undefined);
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('disables the Archive button on a published target until force is checked', () => {
+    const client = createMockApiClient();
+    renderWithProviders(
+      <ArchivePromptTemplateDialog
+        row={makeRow({ latestState: 'published', publishedVersion: 2, publishedId: 'tmpl-2', hasDraft: false })}
+        onOpenChange={vi.fn()}
+      />,
+      { apiClient: client },
+    );
+    const archiveButton = screen.getByRole('button', { name: /^archive$/i });
+    expect(archiveButton).toBeDisabled();
+
+    const forceCheckbox = screen.getByRole('checkbox', { name: /archive the published row/i });
+    fireEvent.click(forceCheckbox);
+    expect(archiveButton).not.toBeDisabled();
+  });
+
+  it('archives a published target with force=true when the checkbox is on', async () => {
+    const archive = vi.fn().mockResolvedValue(makeRow({ latestState: 'archived' }));
+    const client = createMockApiClient({ promptTemplates: { archive } });
+    renderWithProviders(
+      <ArchivePromptTemplateDialog
+        row={makeRow({
+          latestId: 'tmpl-2',
+          latestState: 'published',
+          publishedVersion: 2,
+          publishedId: 'tmpl-2',
+          hasDraft: false,
+        })}
+        onOpenChange={vi.fn()}
+      />,
+      { apiClient: client },
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: /archive the published row/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    await waitFor(() => {
+      expect(archive).toHaveBeenCalledWith('tmpl-2', { force: true });
+    });
+  });
+
+  it('shows an inline error and stays open when the API rejects with 409', async () => {
+    const archive = vi
+      .fn()
+      .mockRejectedValue(new Error('Cannot archive published template — pass force.'));
+    const onOpenChange = vi.fn();
+    const client = createMockApiClient({ promptTemplates: { archive } });
+    renderWithProviders(
+      <ArchivePromptTemplateDialog
+        row={makeRow({ latestState: 'draft' })}
+        onOpenChange={onOpenChange}
+      />,
+      { apiClient: client },
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    expect(await screen.findByText(/cannot archive published template/i)).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('hints about the still-active published version in the success toast (Suggestion 4)', async () => {
+    const archive = vi.fn().mockResolvedValue(makeRow({ latestState: 'archived' }));
+    const client = createMockApiClient({ promptTemplates: { archive } });
+    renderWithProviders(
+      <ArchivePromptTemplateDialog
+        row={makeRow({
+          latestId: 'tmpl-2',
+          latestState: 'draft',
+          publishedVersion: 1,
+          publishedId: 'tmpl-1',
+          hasDraft: true,
+        })}
+        onOpenChange={vi.fn()}
+      />,
+      { apiClient: client },
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^archive$/i }));
+    expect(await findToastTitle(/archived v2/i)).toBeInTheDocument();
+    expect(screen.getByText(/published v1 is still active/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.test.tsx
+++ b/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.test.tsx
@@ -133,6 +133,11 @@ describe('ArchivePromptTemplateDialog', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /^archive(\s+published)?\s+v\d+(\s+\(force\))?$/i }));
     expect(await findToastTitle(/archived v2/i)).toBeInTheDocument();
-    expect(screen.getByText(/published v1 is still active/i)).toBeInTheDocument();
+    // Radix Toast renders the description twice: once visibly inside the
+    // toast and once in an `aria-live` mirror for screen readers. Both are
+    // intentional — assert that at least one occurrence is present.
+    expect(
+      (await screen.findAllByText(/published v1 is still active/i)).length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.tsx
+++ b/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.tsx
@@ -1,0 +1,134 @@
+/**
+ * Archive Prompt Template Dialog
+ *
+ * Confirms archiving a draft or published row (#489). Body copy adapts to
+ * the row's `latestState`; archiving a published row also shows a `force`
+ * checkbox that bypasses the BE safety guard. After a successful archive,
+ * the toast surfaces a hint about whether the row will visually disappear
+ * from the Active filter (Suggestion 4).
+ *
+ * @module apps/web/src/features/prompt-templates/components
+ */
+import { useEffect, useState, type ReactElement } from 'react';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../shared/ui/dialog';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { useArchivePromptTemplateMutation } from '../hooks/use-prompt-template-mutations';
+import type { PromptTemplateSummary } from '../api/prompt-templates.types';
+
+interface ArchivePromptTemplateDialogProps {
+  row: PromptTemplateSummary | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+function channelLabel(channel: PromptTemplateSummary['channel']): string {
+  return channel === null ? 'master' : channel;
+}
+
+export function ArchivePromptTemplateDialog({
+  row,
+  onOpenChange,
+}: ArchivePromptTemplateDialogProps): ReactElement {
+  const { showToast } = useToast();
+  const mutation = useArchivePromptTemplateMutation();
+  const { mutateAsync: archive, reset: resetMutation } = mutation;
+  const [force, setForce] = useState(false);
+
+  // Reset transient state every time the dialog opens onto a new row.
+  useEffect(() => {
+    setForce(false);
+    resetMutation();
+  }, [row, resetMutation]);
+
+  const open = row !== null;
+
+  const handleOpenChange = (next: boolean): void => {
+    if (!next) {
+      onOpenChange(false);
+    }
+  };
+
+  const handleConfirm = async (): Promise<void> => {
+    if (row === null) return;
+    try {
+      await archive({ id: row.latestId, force: force ? true : undefined });
+      const stillVisibleInActive = row.publishedVersion !== null;
+      showToast({
+        tone: 'success',
+        title: `Archived v${row.latestVersion}`,
+        description: stillVisibleInActive
+          ? `Published v${row.publishedVersion} is still active for ${row.key} (${channelLabel(
+              row.channel,
+            )}).`
+          : `${row.key} (${channelLabel(row.channel)}) moved to Archived.`,
+      });
+      onOpenChange(false);
+    } catch {
+      // surfaced inline via mutation.error
+    }
+  };
+
+  const isPublishedTarget = row?.latestState === 'published';
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="archive-prompt-template-dialog">
+        <DialogTitle>
+          Archive {row !== null ? `v${row.latestVersion}` : 'template'}
+        </DialogTitle>
+        <DialogDescription>
+          {row === null ? null : (
+            <>
+              Archive <span className="mono-text">{row.key}</span> (
+              {channelLabel(row.channel)}) v{row.latestVersion}? It will be hidden from the Active
+              list but kept in history for audit and revert.
+              {isPublishedTarget ? (
+                <>
+                  {' '}
+                  This is the only published version for the pair — active suggestions will fail
+                  until you publish a replacement.
+                </>
+              ) : null}
+            </>
+          )}
+        </DialogDescription>
+
+        {isPublishedTarget ? (
+          <label className="archive-prompt-template-dialog__force">
+            <input
+              type="checkbox"
+              checked={force}
+              onChange={(event) => setForce(event.target.checked)}
+            />
+            <span>I understand — archive the published row anyway (force)</span>
+          </label>
+        ) : null}
+
+        {mutation.error ? (
+          <Alert tone="error">{mutation.error.message}</Alert>
+        ) : null}
+
+        <DialogFooter>
+          <Button type="button" tone="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            tone="danger"
+            disabled={mutation.isPending || (isPublishedTarget && !force)}
+            onClick={() => void handleConfirm()}
+          >
+            {mutation.isPending ? 'Archiving…' : 'Archive'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.tsx
+++ b/apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.tsx
@@ -1,11 +1,12 @@
 /**
  * Archive Prompt Template Dialog
  *
- * Confirms archiving a draft or published row (#489). Body copy adapts to
- * the row's `latestState`; archiving a published row also shows a `force`
- * checkbox that bypasses the BE safety guard. After a successful archive,
- * the toast surfaces a hint about whether the row will visually disappear
- * from the Active filter (Suggestion 4).
+ * Confirms archiving a draft or published row (#489). Body surfaces the
+ * row's operational metadata via `KeyValueList` (cockpit pattern: scan-
+ * able status, not prose). Archiving a published row also shows a
+ * danger-zone force checkbox that bypasses the BE safety guard. Confirm
+ * button copy adapts to the row's state and the force flag so the
+ * operator can re-read the action right before clicking.
  *
  * @module apps/web/src/features/prompt-templates/components
  */
@@ -19,17 +20,65 @@ import {
   DialogFooter,
   DialogTitle,
 } from '../../../shared/ui/dialog';
+import { KeyValueList, type KeyValueItem } from '../../../shared/ui/key-value-list';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
 import { useToast } from '../../../shared/ui/toast-provider';
+import { formatRelativeTime } from '../../../shared/format/format-relative-time';
 import { useArchivePromptTemplateMutation } from '../hooks/use-prompt-template-mutations';
-import type { PromptTemplateSummary } from '../api/prompt-templates.types';
+import type {
+  PromptTemplateState,
+  PromptTemplateSummary,
+} from '../api/prompt-templates.types';
 
 interface ArchivePromptTemplateDialogProps {
   row: PromptTemplateSummary | null;
   onOpenChange: (open: boolean) => void;
 }
 
+const STATE_TONE: Record<PromptTemplateState, StatusBadgeTone> = {
+  draft: 'review',
+  published: 'success',
+  archived: 'neutral',
+};
+
 function channelLabel(channel: PromptTemplateSummary['channel']): string {
   return channel === null ? 'master' : channel;
+}
+
+function buildMetadataItems(row: PromptTemplateSummary): KeyValueItem[] {
+  return [
+    {
+      id: 'key',
+      label: 'Key',
+      mono: true,
+      value: row.key,
+    },
+    {
+      id: 'channel',
+      label: 'Channel',
+      value: channelLabel(row.channel),
+    },
+    {
+      id: 'version',
+      label: 'Version',
+      mono: true,
+      value: `v${row.latestVersion}`,
+    },
+    {
+      id: 'state',
+      label: 'State',
+      value: (
+        <StatusBadge tone={STATE_TONE[row.latestState]} compact>
+          {row.latestState}
+        </StatusBadge>
+      ),
+    },
+    {
+      id: 'updated',
+      label: 'Updated',
+      value: formatRelativeTime(row.updatedAt),
+    },
+  ];
 }
 
 export function ArchivePromptTemplateDialog({
@@ -41,11 +90,15 @@ export function ArchivePromptTemplateDialog({
   const { mutateAsync: archive, reset: resetMutation } = mutation;
   const [force, setForce] = useState(false);
 
-  // Reset transient state every time the dialog opens onto a new row.
+  // Reset transient state every time the dialog opens onto a *different*
+  // row. Keying on `row?.latestId` (not the object reference) avoids
+  // spurious resets when the parent's list query refetches and rebuilds
+  // the row object — same logical row, new reference.
+  const targetId = row?.latestId ?? null;
   useEffect(() => {
     setForce(false);
     resetMutation();
-  }, [row, resetMutation]);
+  }, [targetId, resetMutation]);
 
   const open = row !== null;
 
@@ -77,6 +130,18 @@ export function ArchivePromptTemplateDialog({
 
   const isPublishedTarget = row?.latestState === 'published';
 
+  // Confirm-button copy adapts to the path: cockpit pattern is "verb +
+  // explicit object", so the operator re-reads what they're committing
+  // to immediately before clicking.
+  const confirmLabel = ((): string => {
+    if (mutation.isPending) return 'Archiving…';
+    if (row === null) return 'Archive';
+    if (isPublishedTarget) {
+      return force ? `Archive published v${row.latestVersion} (force)` : `Archive published v${row.latestVersion}`;
+    }
+    return `Archive v${row.latestVersion}`;
+  })();
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="archive-prompt-template-dialog">
@@ -84,31 +149,33 @@ export function ArchivePromptTemplateDialog({
           Archive {row !== null ? `v${row.latestVersion}` : 'template'}
         </DialogTitle>
         <DialogDescription>
-          {row === null ? null : (
-            <>
-              Archive <span className="mono-text">{row.key}</span> (
-              {channelLabel(row.channel)}) v{row.latestVersion}? It will be hidden from the Active
-              list but kept in history for audit and revert.
-              {isPublishedTarget ? (
-                <>
-                  {' '}
-                  This is the only published version for the pair — active suggestions will fail
-                  until you publish a replacement.
-                </>
-              ) : null}
-            </>
-          )}
+          The row will be hidden from the Active list but kept in history for audit and revert.
         </DialogDescription>
 
+        {row !== null ? (
+          <div className="archive-prompt-template-dialog__metadata">
+            <KeyValueList items={buildMetadataItems(row)} />
+          </div>
+        ) : null}
+
         {isPublishedTarget ? (
-          <label className="archive-prompt-template-dialog__force">
-            <input
-              type="checkbox"
-              checked={force}
-              onChange={(event) => setForce(event.target.checked)}
-            />
-            <span>I understand — archive the published row anyway (force)</span>
-          </label>
+          <div className="archive-prompt-template-dialog__danger-zone">
+            <p className="archive-prompt-template-dialog__danger-heading">
+              Only published version
+            </p>
+            <p className="archive-prompt-template-dialog__danger-body">
+              Active suggestions for this <span className="mono-text">(key, channel)</span> will
+              fail until a replacement is published.
+            </p>
+            <label className="archive-prompt-template-dialog__force">
+              <input
+                type="checkbox"
+                checked={force}
+                onChange={(event) => setForce(event.target.checked)}
+              />
+              <span>Confirm: this is the only published version</span>
+            </label>
+          </div>
         ) : null}
 
         {mutation.error ? (
@@ -125,7 +192,7 @@ export function ArchivePromptTemplateDialog({
             disabled={mutation.isPending || (isPublishedTarget && !force)}
             onClick={() => void handleConfirm()}
           >
-            {mutation.isPending ? 'Archiving…' : 'Archive'}
+            {confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/features/prompt-templates/components/new-prompt-template-dialog.test.tsx
+++ b/apps/web/src/features/prompt-templates/components/new-prompt-template-dialog.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * NewPromptTemplateDialog — Component Tests
+ *
+ * Covers form rendering, validation, channel mapping ('master' → null),
+ * variables JSON parse + validation, success navigation, and API error
+ * surface (#488).
+ *
+ * @module apps/web/src/features/prompt-templates/components
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { NewPromptTemplateDialog } from './new-prompt-template-dialog';
+import type { PromptTemplate } from '../api/prompt-templates.types';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function makeTemplate(overrides: Partial<PromptTemplate> = {}): PromptTemplate {
+  return {
+    id: overrides.id ?? 'tmpl-new',
+    key: overrides.key ?? 'new.template.key',
+    channel: overrides.channel !== undefined ? overrides.channel : null,
+    version: overrides.version ?? 1,
+    systemPrompt: overrides.systemPrompt ?? 'sys',
+    userPromptTemplate: overrides.userPromptTemplate ?? 'user',
+    variables: overrides.variables ?? [],
+    state: overrides.state ?? 'draft',
+    publishedAt: overrides.publishedAt ?? null,
+    createdBy: overrides.createdBy ?? 'admin',
+    createdAt: overrides.createdAt ?? '2026-04-23T10:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2026-04-23T10:00:00.000Z',
+  };
+}
+
+describe('NewPromptTemplateDialog', () => {
+  it('renders all form fields when open', () => {
+    const client = createMockApiClient();
+    renderWithProviders(
+      <NewPromptTemplateDialog open={true} onOpenChange={vi.fn()} />,
+      { apiClient: client },
+    );
+    expect(screen.getByLabelText(/^key/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^channel/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/system prompt/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/user prompt template/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/variables \(json\)/i)).toBeInTheDocument();
+  });
+
+  it('shows a validation error when the key is empty', async () => {
+    const create = vi.fn();
+    const client = createMockApiClient({ promptTemplates: { create } });
+    renderWithProviders(
+      <NewPromptTemplateDialog open={true} onOpenChange={vi.fn()} />,
+      { apiClient: client },
+    );
+    fireEvent.click(screen.getByRole('button', { name: /create draft/i }));
+    // Both FormErrorSummary and the inline FieldError render the message.
+    expect((await screen.findAllByText(/key is required/i)).length).toBeGreaterThan(0);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("sends channel: null when 'Master (generic)' is selected", async () => {
+    navigateMock.mockClear();
+    const create = vi.fn().mockResolvedValue(makeTemplate({ id: 'tmpl-new', channel: null }));
+    const onOpenChange = vi.fn();
+    const client = createMockApiClient({ promptTemplates: { create } });
+    renderWithProviders(
+      <NewPromptTemplateDialog open={true} onOpenChange={onOpenChange} />,
+      { apiClient: client },
+    );
+
+    fireEvent.change(screen.getByLabelText(/^key/i), {
+      target: { value: 'product.title.suggest' },
+    });
+    fireEvent.change(screen.getByLabelText(/system prompt/i), {
+      target: { value: 'You are an assistant.' },
+    });
+    fireEvent.change(screen.getByLabelText(/user prompt template/i), {
+      target: { value: 'Generate a title.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create draft/i }));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'product.title.suggest',
+          channel: null,
+          systemPrompt: 'You are an assistant.',
+          userPromptTemplate: 'Generate a title.',
+          variables: [],
+        }),
+      );
+    });
+  });
+
+  it('navigates to the detail page on success and closes the dialog', async () => {
+    navigateMock.mockClear();
+    const create = vi.fn().mockResolvedValue(makeTemplate({ id: 'tmpl-new-42' }));
+    const onOpenChange = vi.fn();
+    const client = createMockApiClient({ promptTemplates: { create } });
+    renderWithProviders(
+      <NewPromptTemplateDialog open={true} onOpenChange={onOpenChange} />,
+      { apiClient: client },
+    );
+
+    fireEvent.change(screen.getByLabelText(/^key/i), {
+      target: { value: 'a.b' },
+    });
+    fireEvent.change(screen.getByLabelText(/system prompt/i), {
+      target: { value: 'sys' },
+    });
+    fireEvent.change(screen.getByLabelText(/user prompt template/i), {
+      target: { value: 'user' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create draft/i }));
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith('/ai/prompt-templates/tmpl-new-42');
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('shows an inline alert when the API rejects (e.g. duplicate key)', async () => {
+    const create = vi.fn().mockRejectedValue(new Error('Key already exists'));
+    const client = createMockApiClient({ promptTemplates: { create } });
+    renderWithProviders(
+      <NewPromptTemplateDialog open={true} onOpenChange={vi.fn()} />,
+      { apiClient: client },
+    );
+    fireEvent.change(screen.getByLabelText(/^key/i), { target: { value: 'a.b' } });
+    fireEvent.change(screen.getByLabelText(/system prompt/i), { target: { value: 'sys' } });
+    fireEvent.change(screen.getByLabelText(/user prompt template/i), { target: { value: 'user' } });
+    fireEvent.click(screen.getByRole('button', { name: /create draft/i }));
+
+    expect(await screen.findByText(/key already exists/i)).toBeInTheDocument();
+  });
+
+  it('rejects invalid JSON in the variables field with an inline error', async () => {
+    const create = vi.fn();
+    const client = createMockApiClient({ promptTemplates: { create } });
+    renderWithProviders(
+      <NewPromptTemplateDialog open={true} onOpenChange={vi.fn()} />,
+      { apiClient: client },
+    );
+    fireEvent.change(screen.getByLabelText(/^key/i), { target: { value: 'a.b' } });
+    fireEvent.change(screen.getByLabelText(/system prompt/i), { target: { value: 'sys' } });
+    fireEvent.change(screen.getByLabelText(/user prompt template/i), { target: { value: 'user' } });
+    fireEvent.change(screen.getByLabelText(/variables \(json\)/i), {
+      target: { value: 'not-json' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create draft/i }));
+
+    expect((await screen.findAllByText(/invalid json/i)).length).toBeGreaterThan(0);
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/prompt-templates/components/new-prompt-template-dialog.tsx
+++ b/apps/web/src/features/prompt-templates/components/new-prompt-template-dialog.tsx
@@ -9,7 +9,7 @@
  *
  * @module apps/web/src/features/prompt-templates/components
  */
-import { type ReactElement } from 'react';
+import { useMemo, type ReactElement } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from 'react-router-dom';
@@ -66,6 +66,28 @@ export function NewPromptTemplateDialog({
     error?.message ? [String(error.message)] : [],
   );
 
+  // Live JSON-status indicator below the variables textarea — cockpit
+  // principle "status-first, fast to scan." Tells the operator instantly
+  // whether their JSON parses without waiting for submit.
+  const variablesJsonValue = form.watch('variablesJson');
+  const variablesStatus = useMemo<
+    | { tone: 'ok'; count: number }
+    | { tone: 'error'; message: string }
+    | null
+  >(() => {
+    const trimmed = variablesJsonValue.trim();
+    if (trimmed === '') return { tone: 'ok', count: 0 };
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (!Array.isArray(parsed)) {
+        return { tone: 'error', message: 'must be a JSON array' };
+      }
+      return { tone: 'ok', count: parsed.length };
+    } catch {
+      return { tone: 'error', message: 'invalid JSON syntax' };
+    }
+  }, [variablesJsonValue]);
+
   const handleOpenChange = (next: boolean): void => {
     onOpenChange(next);
     if (!next) {
@@ -115,14 +137,14 @@ export function NewPromptTemplateDialog({
           <FormField
             label="Key"
             name="key"
-            description="Stable identifier the suggestion service looks up. Lowercase, dot- or dash-separated."
+            description="Stable identifier the suggestion service looks up. Lowercase, dot- or dash-separated. Cannot change after publish."
             error={form.formState.errors.key?.message}
           >
             <Input
               {...form.register('key')}
               placeholder="offer.description.suggest"
               maxLength={128}
-              className="mono-text"
+              className="mono-text new-prompt-template-dialog__key-input"
             />
           </FormField>
 
@@ -180,6 +202,18 @@ export function NewPromptTemplateDialog({
               placeholder="[]"
             />
           </FormField>
+          {variablesStatus !== null ? (
+            <p
+              className={`new-prompt-template-dialog__json-status new-prompt-template-dialog__json-status--${
+                variablesStatus.tone === 'ok' ? 'ok' : 'error'
+              }`}
+              aria-live="polite"
+            >
+              {variablesStatus.tone === 'ok'
+                ? `✓ valid JSON · ${variablesStatus.count} variable${variablesStatus.count === 1 ? '' : 's'}`
+                : `✗ ${variablesStatus.message}`}
+            </p>
+          ) : null}
         </form>
 
         <DialogFooter>

--- a/apps/web/src/features/prompt-templates/components/new-prompt-template-dialog.tsx
+++ b/apps/web/src/features/prompt-templates/components/new-prompt-template-dialog.tsx
@@ -1,0 +1,201 @@
+/**
+ * New Prompt Template Dialog
+ *
+ * Admin-only on-ramp for authoring a brand-new draft template (#488).
+ * Backend `POST /prompt-templates` already exists — this dialog provides
+ * the missing UI surface. Submitting a valid form creates the draft and
+ * navigates the operator to the detail editor at `/ai/prompt-templates/{newId}`,
+ * where the richer editor (variables editor, render preview) takes over.
+ *
+ * @module apps/web/src/features/prompt-templates/components
+ */
+import { type ReactElement } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useNavigate } from 'react-router-dom';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../shared/ui/dialog';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
+import { Textarea } from '../../../shared/ui/textarea';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { useCreatePromptTemplateMutation } from '../hooks/use-prompt-template-mutations';
+import {
+  newPromptTemplateSchema,
+  toApiInput,
+  type NewPromptTemplateFormValues,
+} from './new-prompt-template.schema';
+
+interface NewPromptTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const DEFAULT_VALUES: NewPromptTemplateFormValues = {
+  key: '',
+  channel: 'master',
+  systemPrompt: '',
+  userPromptTemplate: '',
+  variablesJson: '[]',
+};
+
+export function NewPromptTemplateDialog({
+  open,
+  onOpenChange,
+}: NewPromptTemplateDialogProps): ReactElement {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const mutation = useCreatePromptTemplateMutation();
+  const { mutateAsync: createTemplate, reset: resetMutation } = mutation;
+
+  const form = useForm<NewPromptTemplateFormValues>({
+    defaultValues: DEFAULT_VALUES,
+    resolver: zodResolver(newPromptTemplateSchema),
+  });
+
+  const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
+    error?.message ? [String(error.message)] : [],
+  );
+
+  const handleOpenChange = (next: boolean): void => {
+    onOpenChange(next);
+    if (!next) {
+      form.reset(DEFAULT_VALUES);
+      resetMutation();
+    }
+  };
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      const created = await createTemplate(toApiInput(values));
+      showToast({
+        tone: 'success',
+        title: 'Draft created',
+        description: `${created.key} v${created.version}`,
+      });
+      handleOpenChange(false);
+      void navigate(`/ai/prompt-templates/${created.id}`);
+    } catch {
+      // surfaced inline via mutation.error
+    }
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="new-prompt-template-dialog">
+        <DialogTitle>New prompt template</DialogTitle>
+        <DialogDescription>
+          Create a draft template for a new <span className="mono-text">(key, channel)</span> pair.
+          Use the editor on the next page to refine the prompts and publish.
+        </DialogDescription>
+
+        <form
+          id="new-prompt-template-form"
+          onSubmit={(e) => void onSubmit(e)}
+          noValidate
+          className="new-prompt-template-form"
+        >
+          {mutation.error ? (
+            <Alert tone="error">{mutation.error.message}</Alert>
+          ) : null}
+
+          {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
+            <FormErrorSummary errors={validationMessages} />
+          ) : null}
+
+          <FormField
+            label="Key"
+            name="key"
+            description="Stable identifier the suggestion service looks up. Lowercase, dot- or dash-separated."
+            error={form.formState.errors.key?.message}
+          >
+            <Input
+              {...form.register('key')}
+              placeholder="offer.description.suggest"
+              maxLength={128}
+              className="mono-text"
+            />
+          </FormField>
+
+          <FormField
+            label="Channel"
+            name="channel"
+            description="Master = generic fallback for any platform. Channel-specific overrides win when published."
+            error={form.formState.errors.channel?.message}
+          >
+            <Select {...form.register('channel')}>
+              <option value="master">Master (generic)</option>
+              <option value="prestashop">PrestaShop</option>
+              <option value="allegro">Allegro</option>
+            </Select>
+          </FormField>
+
+          <FormField
+            label="System prompt"
+            name="systemPrompt"
+            description="Sent as the model's system message. Use {{dotted.path}} placeholders for variables."
+            error={form.formState.errors.systemPrompt?.message}
+          >
+            <Textarea
+              {...form.register('systemPrompt')}
+              rows={6}
+              maxLength={65536}
+              placeholder="You are an assistant that writes marketplace product descriptions…"
+            />
+          </FormField>
+
+          <FormField
+            label="User prompt template"
+            name="userPromptTemplate"
+            description="Sent as the user message. Use {{dotted.path}} placeholders for variables."
+            error={form.formState.errors.userPromptTemplate?.message}
+          >
+            <Textarea
+              {...form.register('userPromptTemplate')}
+              rows={6}
+              maxLength={65536}
+              placeholder="Write a description for {{product.name}} ({{product.category}})…"
+            />
+          </FormField>
+
+          <FormField
+            label="Variables (JSON)"
+            name="variablesJson"
+            description='JSON array of declared variables. Use [] for none. Example: [{"name":"product.name","type":"string","required":true}]'
+            error={form.formState.errors.variablesJson?.message}
+          >
+            <Textarea
+              {...form.register('variablesJson')}
+              rows={5}
+              className="mono-text"
+              placeholder="[]"
+            />
+          </FormField>
+        </form>
+
+        <DialogFooter>
+          <Button type="button" tone="secondary" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="new-prompt-template-form"
+            tone="primary"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Creating…' : 'Create draft'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/prompt-templates/components/new-prompt-template.schema.ts
+++ b/apps/web/src/features/prompt-templates/components/new-prompt-template.schema.ts
@@ -115,8 +115,14 @@ export interface NewPromptTemplateApiInput {
 /**
  * Map the validated form values to the `CreatePromptTemplateDto` wire
  * shape: `master` → `null` channel, parsed `variablesJson` → typed array.
- * Caller must invoke after `safeParse(success)` — the parse is repeated
- * here because `superRefine` does not transform.
+ *
+ * The `JSON.parse` repeats the work `superRefine` already did. We keep
+ * the redundancy on purpose — `superRefine` is validation-only (cannot
+ * transform without changing the schema's output type) and the cost
+ * (one parse of a tiny string per submit) is negligible vs. the
+ * complexity of switching to `.transform()`. Caller must invoke this
+ * only after `safeParse(success)` — the cast below is safe because
+ * `superRefine` already rejected any non-conforming variable shape.
  */
 export function toApiInput(values: NewPromptTemplateOutput): NewPromptTemplateApiInput {
   const variables = (

--- a/apps/web/src/features/prompt-templates/components/new-prompt-template.schema.ts
+++ b/apps/web/src/features/prompt-templates/components/new-prompt-template.schema.ts
@@ -1,0 +1,134 @@
+/**
+ * New Prompt Template — Form Schema
+ *
+ * Zod schema for the "create draft" dialog (#488). Mirrors the backend
+ * `CreatePromptTemplateDto`. The `channel` field surfaces a literal
+ * `'master'` option in the UI and is mapped to `null` at submit time
+ * (matching the wire contract). The `variablesJson` field is a free-form
+ * JSON textarea that's parsed and validated against the variables schema
+ * during `transform` — failures surface inline as form-validation errors,
+ * not as API errors after a round-trip.
+ *
+ * @module apps/web/src/features/prompt-templates/components
+ */
+import { z } from 'zod';
+import {
+  PromptTemplateChannelValues,
+  PromptTemplateVariableTypeValues,
+  type PromptTemplateChannel,
+  type PromptTemplateVariable,
+} from '../api/prompt-templates.types';
+
+const KEY_PATTERN = /^[a-z0-9]+(?:[.-][a-z0-9]+)*$/;
+
+const MAX_PROMPT_LENGTH = 65536;
+const MAX_VARIABLES = 64;
+
+// Safer Zod enum: build a readonly tuple via `as const` so the spread
+// preserves literal types. Leading 'master' represents the null channel.
+const ChannelSelectValues = ['master', ...PromptTemplateChannelValues] as const;
+
+const variableSchema = z.object({
+  name: z.string().trim().min(1, 'Variable name is required').max(128),
+  type: z.enum(PromptTemplateVariableTypeValues),
+  required: z.boolean(),
+  description: z.string().trim().max(256).optional(),
+});
+
+export const newPromptTemplateSchema = z
+  .object({
+    key: z
+      .string()
+      .trim()
+      .min(1, 'Key is required')
+      .max(128)
+      .regex(
+        KEY_PATTERN,
+        'Use lowercase letters, digits, dots, and dashes only (e.g. "offer.description.suggest")',
+      ),
+    channel: z.enum(ChannelSelectValues),
+    systemPrompt: z
+      .string()
+      .min(1, 'System prompt is required')
+      .max(MAX_PROMPT_LENGTH, `System prompt must be ${MAX_PROMPT_LENGTH} characters or fewer`),
+    userPromptTemplate: z
+      .string()
+      .min(1, 'User prompt is required')
+      .max(MAX_PROMPT_LENGTH, `User prompt must be ${MAX_PROMPT_LENGTH} characters or fewer`),
+    /**
+     * Free-form JSON textarea. Parsed + validated during `superRefine`
+     * below — keeps the FE error path off the BE round-trip.
+     */
+    variablesJson: z.string(),
+  })
+  .superRefine((value, ctx) => {
+    let parsed: unknown;
+    try {
+      parsed = value.variablesJson.trim() === '' ? [] : JSON.parse(value.variablesJson);
+    } catch (err) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['variablesJson'],
+        message: `Invalid JSON: ${err instanceof Error ? err.message : 'parse error'}`,
+      });
+      return;
+    }
+    if (!Array.isArray(parsed)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['variablesJson'],
+        message: 'Variables must be a JSON array (use [] for none).',
+      });
+      return;
+    }
+    if (parsed.length > MAX_VARIABLES) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['variablesJson'],
+        message: `At most ${MAX_VARIABLES} variables allowed`,
+      });
+      return;
+    }
+    const variablesResult = z.array(variableSchema).safeParse(parsed);
+    if (!variablesResult.success) {
+      const firstIssue = variablesResult.error.issues[0];
+      const path = firstIssue.path.length > 0 ? `[${firstIssue.path.join('.')}] ` : '';
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['variablesJson'],
+        message: `Invalid variables: ${path}${firstIssue.message}`,
+      });
+    }
+  });
+
+export type NewPromptTemplateFormValues = z.input<typeof newPromptTemplateSchema>;
+type NewPromptTemplateOutput = z.output<typeof newPromptTemplateSchema>;
+
+export interface NewPromptTemplateApiInput {
+  key: string;
+  channel: PromptTemplateChannel | null;
+  systemPrompt: string;
+  userPromptTemplate: string;
+  variables: PromptTemplateVariable[];
+}
+
+/**
+ * Map the validated form values to the `CreatePromptTemplateDto` wire
+ * shape: `master` → `null` channel, parsed `variablesJson` → typed array.
+ * Caller must invoke after `safeParse(success)` — the parse is repeated
+ * here because `superRefine` does not transform.
+ */
+export function toApiInput(values: NewPromptTemplateOutput): NewPromptTemplateApiInput {
+  const variables = (
+    values.variablesJson.trim() === ''
+      ? []
+      : (JSON.parse(values.variablesJson) as PromptTemplateVariable[])
+  );
+  return {
+    key: values.key,
+    channel: values.channel === 'master' ? null : values.channel,
+    systemPrompt: values.systemPrompt,
+    userPromptTemplate: values.userPromptTemplate,
+    variables,
+  };
+}

--- a/apps/web/src/features/prompt-templates/hooks/use-prompt-template-mutations.ts
+++ b/apps/web/src/features/prompt-templates/hooks/use-prompt-template-mutations.ts
@@ -67,6 +67,27 @@ export function usePublishPromptTemplateMutation(): UseMutationResult<
   });
 }
 
+interface ArchiveArgs {
+  id: string;
+  force?: boolean;
+}
+
+export function useArchivePromptTemplateMutation(): UseMutationResult<
+  PromptTemplate,
+  Error,
+  ArchiveArgs
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, force }) =>
+      apiClient.promptTemplates.archive(id, force === undefined ? undefined : { force }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: promptTemplatesQueryKeys.all });
+    },
+  });
+}
+
 export function useRevertPromptTemplateMutation(): UseMutationResult<
   PromptTemplate,
   Error,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6032,20 +6032,75 @@ a.kpi-card:focus-visible {
   gap: 0.75rem;
 }
 
+/* The `key` field is the durable identity of the template — give it a
+   bit more weight than its sibling fields so the hierarchy is obvious. */
+.new-prompt-template-dialog__key-input {
+  font-weight: 500;
+}
+
+.new-prompt-template-dialog__json-status {
+  margin: -0.25rem 0 0 0;
+  font-size: 0.75rem;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  letter-spacing: -0.005em;
+}
+
+.new-prompt-template-dialog__json-status--ok {
+  color: var(--status-success-strong);
+}
+
+.new-prompt-template-dialog__json-status--error {
+  color: var(--status-error-strong);
+}
+
+.archive-prompt-template-dialog__metadata {
+  padding: 0.75rem;
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.625rem;
+}
+
+.archive-prompt-template-dialog__danger-zone {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: var(--status-warning-soft);
+  border: 1px solid var(--status-warning-border);
+  border-top: 3px solid var(--status-warning);
+  border-radius: 0.625rem;
+}
+
+.archive-prompt-template-dialog__danger-heading {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--status-warning-strong);
+}
+
+.archive-prompt-template-dialog__danger-body {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--status-warning-strong);
+  line-height: 1.5;
+}
+
 .archive-prompt-template-dialog__force {
   display: flex;
   gap: 0.5rem;
   align-items: flex-start;
-  padding: 0.625rem 0.75rem;
-  background: var(--status-warning-soft);
-  border: 1px solid var(--status-warning-border);
-  border-radius: 0.625rem;
+  margin-top: 0.25rem;
   font-size: 0.8125rem;
   color: var(--status-warning-strong);
+  font-weight: 500;
+  cursor: pointer;
 }
 
 .archive-prompt-template-dialog__force input {
   margin-top: 0.125rem;
+  cursor: pointer;
 }
 
 .prompt-detail-actions {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6019,6 +6019,35 @@ a.kpi-card:focus-visible {
   color: var(--text-secondary);
 }
 
+/* New-template + archive dialog (#488 / #489)
+   ------------------------------------------ */
+
+.new-prompt-template-dialog {
+  max-width: 640px;
+}
+
+.new-prompt-template-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.archive-prompt-template-dialog__force {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.625rem 0.75rem;
+  background: var(--status-warning-soft);
+  border: 1px solid var(--status-warning-border);
+  border-radius: 0.625rem;
+  font-size: 0.8125rem;
+  color: var(--status-warning-strong);
+}
+
+.archive-prompt-template-dialog__force input {
+  margin-top: 0.125rem;
+}
+
 .prompt-detail-actions {
   display: flex;
   gap: 0.5rem;

--- a/apps/web/src/pages/prompt-templates/prompt-templates-list-page.test.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-templates-list-page.test.tsx
@@ -4,7 +4,7 @@
  * @module apps/web/src/pages/prompt-templates
  */
 import { describe, expect, it, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import {
   createAuthenticatedSessionAdapter,
   createMockApiClient,
@@ -97,5 +97,104 @@ describe('PromptTemplatesListPage', () => {
       sessionAdapter: viewerAdapter,
     });
     expect(await screen.findByText(/Admin role required/i)).toBeInTheDocument();
+  });
+
+  describe('New template button (#488)', () => {
+    it('renders the New template button for admins', async () => {
+      const client = createMockApiClient({
+        promptTemplates: { list: vi.fn().mockResolvedValue([sample]) },
+      });
+      renderWithProviders(<PromptTemplatesListPage />, {
+        apiClient: client,
+        sessionAdapter: adminAdapter,
+      });
+      expect(await screen.findByRole('button', { name: /new template/i })).toBeInTheDocument();
+    });
+
+    it('opens the new-template dialog when clicked', async () => {
+      const client = createMockApiClient({
+        promptTemplates: { list: vi.fn().mockResolvedValue([sample]) },
+      });
+      renderWithProviders(<PromptTemplatesListPage />, {
+        apiClient: client,
+        sessionAdapter: adminAdapter,
+      });
+      fireEvent.click(await screen.findByRole('button', { name: /new template/i }));
+      expect(
+        await screen.findByRole('heading', { name: /new prompt template/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Status filter (#489)', () => {
+    const fullyArchivedRow: PromptTemplateSummary = {
+      key: 'product.experiment.suggest',
+      channel: null,
+      latestVersion: 1,
+      latestId: 'tmpl-archived',
+      latestState: 'archived',
+      publishedVersion: null,
+      publishedId: null,
+      hasDraft: false,
+      updatedAt: new Date('2026-04-19T10:00:00Z').toISOString(),
+    };
+
+    it('hides fully-archived rows by default (Active filter)', async () => {
+      const client = createMockApiClient({
+        promptTemplates: { list: vi.fn().mockResolvedValue([sample, fullyArchivedRow]) },
+      });
+      renderWithProviders(<PromptTemplatesListPage />, {
+        apiClient: client,
+        sessionAdapter: adminAdapter,
+      });
+      expect(await screen.findByText('offer.description.suggest')).toBeInTheDocument();
+      expect(screen.queryByText('product.experiment.suggest')).not.toBeInTheDocument();
+    });
+
+    it('shows fully-archived rows when filter switches to Archived', async () => {
+      const client = createMockApiClient({
+        promptTemplates: { list: vi.fn().mockResolvedValue([sample, fullyArchivedRow]) },
+      });
+      renderWithProviders(<PromptTemplatesListPage />, {
+        apiClient: client,
+        sessionAdapter: adminAdapter,
+      });
+      // Wait for table render before flipping the filter.
+      await screen.findByText('offer.description.suggest');
+      const statusFilter = screen.getByLabelText(/status/i);
+      fireEvent.change(statusFilter, { target: { value: 'archived' } });
+      expect(await screen.findByText('product.experiment.suggest')).toBeInTheDocument();
+      expect(screen.queryByText('offer.description.suggest')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Archive button (#489)', () => {
+    it('renders an Archive button for non-archived rows', async () => {
+      const client = createMockApiClient({
+        promptTemplates: { list: vi.fn().mockResolvedValue([sample]) },
+      });
+      renderWithProviders(<PromptTemplatesListPage />, {
+        apiClient: client,
+        sessionAdapter: adminAdapter,
+      });
+      const row = await screen.findByText('offer.description.suggest');
+      const rowEl = row.closest('tr') ?? row.closest('li');
+      if (rowEl === null) throw new Error('row container not found');
+      expect(within(rowEl as HTMLElement).getByRole('button', { name: /archive/i })).toBeInTheDocument();
+    });
+
+    it('opens the archive dialog without navigating to detail when clicked', async () => {
+      const client = createMockApiClient({
+        promptTemplates: { list: vi.fn().mockResolvedValue([sample]) },
+      });
+      renderWithProviders(<PromptTemplatesListPage />, {
+        apiClient: client,
+        sessionAdapter: adminAdapter,
+      });
+      const archiveButton = await screen.findByRole('button', { name: /archive/i });
+      fireEvent.click(archiveButton);
+      // Dialog title contains "Archive vN".
+      expect(await screen.findByRole('heading', { name: /archive v2/i })).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx
@@ -55,7 +55,9 @@ function parseChannelParam(value: string | null): PromptTemplateListFilters['cha
 }
 
 function parseStatusParam(value: string | null): StatusFilterValue {
-  if (value === 'archived' || value === 'all') return value;
+  if (value !== null && (STATUS_FILTER_VALUES as readonly string[]).includes(value)) {
+    return value as StatusFilterValue;
+  }
   return 'active';
 }
 
@@ -205,7 +207,7 @@ export function PromptTemplatesListPage(): ReactElement {
     },
     {
       id: 'actions',
-      header: '',
+      header: <span className="sr-only">Row actions</span>,
       cell: (row) =>
         row.latestState !== 'archived' ? (
           <Button

--- a/apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx
@@ -3,12 +3,17 @@
  *
  * Admin-only list of prompt templates grouped by `(key, channel)`. Row
  * click navigates to the detail/editor page. Hidden from non-admin sessions.
+ * Page-header action launches the new-template dialog (#488). Each row
+ * exposes an Archive trigger (#489) that opens the archive dialog. The
+ * `?status=` filter (active | archived | all) hides fully-retired rows
+ * from the default Active view.
  *
  * @module apps/web/src/pages/prompt-templates
  */
-import { useMemo, type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useSession } from '../../shared/auth/use-session';
+import { Button } from '../../shared/ui/button';
 import { PageLayout } from '../../shared/ui/page-layout';
 import {
   DataTable,
@@ -22,6 +27,8 @@ import { FormField } from '../../shared/ui/form-field';
 import { formatRelativeTime } from '../../shared/format/format-relative-time';
 import { formatDateTime } from '../../shared/format/format-date';
 import { usePromptTemplatesQuery } from '../../features/prompt-templates/hooks/use-prompt-templates-query';
+import { ArchivePromptTemplateDialog } from '../../features/prompt-templates/components/archive-prompt-template-dialog';
+import { NewPromptTemplateDialog } from '../../features/prompt-templates/components/new-prompt-template-dialog';
 import type {
   PromptTemplateChannel,
   PromptTemplateListFilters,
@@ -34,6 +41,9 @@ const CHANNEL_TONE: Record<string, StatusBadgeTone> = {
   master: 'neutral',
 };
 
+const STATUS_FILTER_VALUES = ['active', 'archived', 'all'] as const;
+type StatusFilterValue = (typeof STATUS_FILTER_VALUES)[number];
+
 function channelLabel(channel: PromptTemplateChannel | null): string {
   return channel === null ? 'master' : channel;
 }
@@ -42,6 +52,21 @@ function parseChannelParam(value: string | null): PromptTemplateListFilters['cha
   if (value === null || value === '') return undefined;
   if (value === 'master' || value === 'prestashop' || value === 'allegro') return value;
   return undefined;
+}
+
+function parseStatusParam(value: string | null): StatusFilterValue {
+  if (value === 'archived' || value === 'all') return value;
+  return 'active';
+}
+
+/**
+ * Client-side status filter. The list endpoint returns one summary per
+ * (key, channel) — Active = at least one usable version exists.
+ */
+function matchesStatusFilter(row: PromptTemplateSummary, status: StatusFilterValue): boolean {
+  if (status === 'all') return true;
+  const isFullyArchived = !row.hasDraft && row.publishedVersion === null;
+  return status === 'archived' ? isFullyArchived : !isFullyArchived;
 }
 
 const CARD_VIEW: DataTableCardView<PromptTemplateSummary> = {
@@ -68,6 +93,7 @@ export function PromptTemplatesListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const channelFilter = parseChannelParam(searchParams.get('channel'));
+  const statusFilter = parseStatusParam(searchParams.get('status'));
 
   const filters = useMemo<PromptTemplateListFilters>(
     () => (channelFilter !== undefined ? { channel: channelFilter } : {}),
@@ -76,7 +102,12 @@ export function PromptTemplatesListPage(): ReactElement {
 
   const query = usePromptTemplatesQuery(filters);
 
-  if (session.status === 'authenticated' && session.user?.role !== 'admin') {
+  const [newDialogOpen, setNewDialogOpen] = useState(false);
+  const [archiveTarget, setArchiveTarget] = useState<PromptTemplateSummary | null>(null);
+
+  const isAdmin = session.status === 'authenticated' && session.user?.role === 'admin';
+
+  if (session.status === 'authenticated' && !isAdmin) {
     return (
       <PageLayout
         eyebrow="Settings"
@@ -103,7 +134,20 @@ export function PromptTemplatesListPage(): ReactElement {
     });
   };
 
-  const rows = query.data ?? [];
+  const handleStatusChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (event.target.value === 'active') {
+        next.delete('status');
+      } else {
+        next.set('status', event.target.value);
+      }
+      return next;
+    });
+  };
+
+  const allRows = query.data ?? [];
+  const rows = allRows.filter((row) => matchesStatusFilter(row, statusFilter));
 
   const columns: DataTableColumn<PromptTemplateSummary>[] = [
     {
@@ -159,6 +203,26 @@ export function PromptTemplatesListPage(): ReactElement {
       sortable: true,
       hideBelow: 1024,
     },
+    {
+      id: 'actions',
+      header: '',
+      cell: (row) =>
+        row.latestState !== 'archived' ? (
+          <Button
+            tone="ghost"
+            onClick={(event) => {
+              // Stop the row-click navigation that DataTable wires via rowHref.
+              event.stopPropagation();
+              event.preventDefault();
+              setArchiveTarget(row);
+            }}
+          >
+            Archive
+          </Button>
+        ) : (
+          <span className="muted-text">archived</span>
+        ),
+    },
   ];
 
   return (
@@ -166,6 +230,13 @@ export function PromptTemplatesListPage(): ReactElement {
       eyebrow="Settings"
       title="Prompt templates"
       description="Author, version, and publish the prompts the AI suggestion flow sends to the model."
+      actions={
+        isAdmin ? (
+          <Button tone="primary" onClick={() => setNewDialogOpen(true)}>
+            New template
+          </Button>
+        ) : undefined
+      }
     >
       <div className="prompt-templates-toolbar">
         <FormField label="Channel" name="prompt-templates-channel-filter" description="Filter by target channel">
@@ -174,6 +245,13 @@ export function PromptTemplatesListPage(): ReactElement {
             <option value="master">Master (generic)</option>
             <option value="prestashop">PrestaShop</option>
             <option value="allegro">Allegro</option>
+          </Select>
+        </FormField>
+        <FormField label="Status" name="prompt-templates-status-filter" description="Hide fully-archived rows by default">
+          <Select value={statusFilter} onChange={handleStatusChange}>
+            <option value="active">Active</option>
+            <option value="archived">Archived</option>
+            <option value="all">All</option>
           </Select>
         </FormField>
       </div>
@@ -205,6 +283,13 @@ export function PromptTemplatesListPage(): ReactElement {
         />
       )}
 
+      <NewPromptTemplateDialog open={newDialogOpen} onOpenChange={setNewDialogOpen} />
+      <ArchivePromptTemplateDialog
+        row={archiveTarget}
+        onOpenChange={(next) => {
+          if (!next) setArchiveTarget(null);
+        }}
+      />
     </PageLayout>
   );
 }

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -270,6 +270,7 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       create: vi.fn().mockResolvedValue(null),
       update: vi.fn().mockResolvedValue(null),
       publish: vi.fn().mockResolvedValue(null),
+      archive: vi.fn().mockResolvedValue(null),
       revert: vi.fn().mockResolvedValue(null),
       render: vi.fn().mockResolvedValue({ templateId: '', version: 1, systemPrompt: '', userPrompt: '' }),
       remove: vi.fn().mockResolvedValue(undefined),

--- a/docs/plans/implementation-plan-prompt-templates-ux.md
+++ b/docs/plans/implementation-plan-prompt-templates-ux.md
@@ -1,0 +1,421 @@
+# Implementation Plan — Prompt Templates UX (#488 + #489)
+
+**Goal**: Close the two operator-facing gaps on `/ai/prompt-templates`:
+
+- **#488 (FE)** — surface a "New template" affordance so admins can author drafts without curl.
+- **#489 (BE + FE)** — let admins soft-archive a template via the UI; back-end refuses to archive the only published row for a `(key, channel)` unless `{ force: true }`.
+
+Single PR. Both issues share the same list-page surface and benefit from being shipped together.
+
+---
+
+## 1 · Layer & scope
+
+| Concern | Layer | Status |
+|---|---|---|
+| `POST /prompt-templates` (create) | Interface (controller) | **Already exists** (`prompt-templates.controller.ts:129`) |
+| `apiClient.promptTemplates.create` | FE API | **Already exists** (`prompt-templates.api.ts:77`) |
+| `useCreatePromptTemplateMutation` | FE hook | **Already exists** (`use-prompt-template-mutations.ts:25`) |
+| New-template dialog | FE feature component | **New** |
+| `POST /prompt-templates/:id/archive` | Interface (controller) | **New** |
+| `PromptTemplateService.archive` | Application service | **New** |
+| `archiveById` repo method | Domain port + Infra impl | **New** |
+| `CannotArchivePublishedTemplateException` | Domain exception | **New** |
+| Archive dialog + per-row trigger | FE feature component | **New** |
+| Status filter on list page | FE page | **New** (client-side) |
+
+Non-goals (per issues):
+
+- No hard delete (#489 explicitly out of scope).
+- No un-archive UI (existing `revert` already covers cloning a historical version into a fresh draft, archived included).
+- No bulk archive.
+- No "duplicate" affordance (#488 explicitly out of scope).
+- No edit-from-list, no JSON-import.
+
+---
+
+## 2 · Backend (#489)
+
+### 2.1 Domain exception
+
+**File**: `libs/core/src/ai/domain/exceptions/cannot-archive-published-template.exception.ts` (new)
+
+```typescript
+/**
+ * Cannot Archive Published Template Exception
+ *
+ * Thrown when an admin tries to archive the only published row for a
+ * `(key, channel)` pair without `{ force: true }`. Archiving the live
+ * row would leave the suggestion service with no template to render —
+ * the API surfaces this as 409 so the operator can either pick a
+ * different row or pass `force: true`.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+import type { PromptTemplateChannel } from '../types/prompt-template.types';
+
+export class CannotArchivePublishedTemplateException extends Error {
+  public readonly templateId: string;
+  public readonly key: string;
+  public readonly channel: PromptTemplateChannel | null;
+
+  constructor(args: {
+    templateId: string;
+    key: string;
+    channel: PromptTemplateChannel | null;
+  }) {
+    const channelLabel = args.channel ?? 'master';
+    super(
+      `Cannot archive published template ${args.templateId} (key=${args.key}, channel=${channelLabel}): no other published version exists for this (key, channel) pair. Publish a replacement first, or pass { "force": true } to bypass.`,
+    );
+    this.name = 'CannotArchivePublishedTemplateException';
+    this.templateId = args.templateId;
+    this.key = args.key;
+    this.channel = args.channel;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+```
+
+Export from `libs/core/src/ai/index.ts`.
+
+### 2.2 Repository port + impl
+
+**File**: `libs/core/src/ai/domain/ports/prompt-template-repository.port.ts` — add one method.
+
+```typescript
+export interface PromptTemplateRepositoryPort {
+  // …existing methods…
+
+  /**
+   * Set state to `archived`. Caller validates pre-conditions (state guard
+   * + force-flag check) — this method just performs the write and returns
+   * the refreshed row.
+   */
+  archiveById(id: string): Promise<PromptTemplate>;
+}
+```
+
+**File**: `libs/core/src/ai/infrastructure/persistence/repositories/prompt-template.repository.ts` — add the implementation. Plain `UPDATE …` (no transaction needed; service already validates state). Use `RETURNING *` style consistent with `updateContent`:
+
+```typescript
+async archiveById(id: string): Promise<PromptTemplate> {
+  const result = await this.ormRepository
+    .createQueryBuilder()
+    .update(PromptTemplateOrmEntity)
+    .set({ state: 'archived' })
+    .where('id = :id', { id })
+    .execute();
+
+  if (result.affected === 0) {
+    throw new PromptTemplateNotFoundException({ templateId: id });
+  }
+  const refreshed = await this.ormRepository.findOne({ where: { id } });
+  if (refreshed === null) {
+    throw new PromptTemplateNotFoundException({ templateId: id });
+  }
+  return this.toDomain(refreshed);
+}
+```
+
+No new tests for the repo (existing repo tests don't cover the other mutators directly — they're exercised via the service spec).
+
+### 2.3 Service method
+
+**File**: `libs/core/src/ai/application/services/prompt-template.service.ts`
+
+```typescript
+async archive(id: string, opts: { force?: boolean; actor?: string | null }): Promise<PromptTemplate> {
+  const existing = await this.repository.findById(id);
+  if (existing === null) {
+    throw new PromptTemplateNotFoundException({ templateId: id });
+  }
+  if (existing.state === 'archived') {
+    throw new PromptTemplateStateException({
+      templateId: id,
+      actualState: existing.state,
+      requiredState: 'draft',
+      operation: 'be archived (already archived)',
+    });
+  }
+  if (existing.state === 'published' && opts.force !== true) {
+    // Partial unique index ensures at most one published row per (key, channel) —
+    // a published target IS by definition the only published row for the pair.
+    throw new CannotArchivePublishedTemplateException({
+      templateId: id,
+      key: existing.key,
+      channel: existing.channel,
+    });
+  }
+
+  const archived = await this.repository.archiveById(id);
+  this.logger.log(
+    `[prompt-template] archived templateId=${archived.id} key=${archived.key} channel=${
+      archived.channel ?? 'master'
+    } version=${archived.version} priorState=${existing.state} actor=${opts.actor ?? 'system'} forced=${opts.force === true}`,
+  );
+  return archived;
+}
+```
+
+**File**: `libs/core/src/ai/application/services/prompt-template.service.interface.ts` — add the method to `IPromptTemplateService`.
+
+### 2.4 Service unit tests
+
+**File**: `libs/core/src/ai/application/services/prompt-template.service.spec.ts` — add a new `describe('archive')` block. Cases:
+
+1. **happy path: draft → archived** (no force needed, no exception).
+2. **happy path: published + force=true → archived**.
+3. **refuses published without force** — throws `CannotArchivePublishedTemplateException`.
+4. **refuses already-archived** — throws `PromptTemplateStateException`.
+5. **NotFound** when repo returns null.
+6. **emits archive log line** containing `templateId`, `key`, `channel`, `version`, `actor`, `forced`.
+
+### 2.5 Controller endpoint
+
+**File**: `apps/api/src/ai/http/dto/archive-prompt-template.dto.ts` (new)
+
+```typescript
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class ArchivePromptTemplateDto {
+  @ApiPropertyOptional({
+    description:
+      'Bypass the "no other published version" guard. Required when archiving the only published row for a (key, channel) pair — the suggestion service will then have no template to render until a replacement is published.',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  force?: boolean;
+}
+```
+
+**File**: `apps/api/src/ai/http/prompt-templates.controller.ts`
+
+Add:
+
+```typescript
+@Roles('admin')
+@Post(':id/archive')
+@HttpCode(HttpStatus.OK)
+@ApiOperation({ summary: 'Archive a draft or published prompt template' })
+@ApiResponse({ status: 200, type: PromptTemplateResponseDto })
+@ApiResponse({ status: 404, description: 'Template not found' })
+@ApiResponse({ status: 409, description: 'Cannot archive the only published row without force' })
+async archive(
+  @Param('id', new ParseUUIDPipe()) id: string,
+  @Body() dto: ArchivePromptTemplateDto,
+  @CurrentUser() user: AuthenticatedUser,
+): Promise<PromptTemplateResponseDto> {
+  return this.withDomainExceptionMapping(async () => {
+    const archived = await this.service.archive(id, {
+      force: dto.force,
+      actor: user.username,
+    });
+    return PromptTemplateResponseDto.fromDomain(archived);
+  });
+}
+```
+
+Extend `withDomainExceptionMapping` to map `CannotArchivePublishedTemplateException → ConflictException (409)`. Import `CannotArchivePublishedTemplateException` from `@openlinker/core/ai` and `ConflictException` from `@nestjs/common`.
+
+### 2.6 Controller spec
+
+**File**: `apps/api/src/ai/http/prompt-templates.controller.spec.ts` (likely exists — verify and extend; if it doesn't exist, this is the file path to add).
+
+Cases:
+- 200 happy path on draft archive.
+- 200 happy path on published archive with `force: true`.
+- 409 when archiving published without force (`CannotArchivePublishedTemplateException` → `ConflictException`).
+- 404 when service throws `PromptTemplateNotFoundException`.
+
+---
+
+## 3 · Frontend — #488 (New template dialog)
+
+### 3.1 Schema
+
+**File**: `apps/web/src/features/prompt-templates/components/new-prompt-template.schema.ts` (new)
+
+Zod schema mirroring `CreatePromptTemplateDto`:
+
+```typescript
+import { z } from 'zod';
+import {
+  PromptTemplateChannelValues,
+  PromptTemplateVariableTypeValues,
+} from '../api/prompt-templates.types';
+
+const KEY_PATTERN = /^[a-z0-9]+(?:[.-][a-z0-9]+)*$/;
+
+const variableSchema = z.object({
+  name: z.string().trim().min(1, 'Variable name is required').max(128),
+  type: z.enum(PromptTemplateVariableTypeValues),
+  required: z.boolean(),
+  description: z.string().trim().max(256).optional(),
+});
+
+export const newPromptTemplateSchema = z.object({
+  key: z
+    .string()
+    .trim()
+    .min(1, 'Key is required')
+    .max(128)
+    .regex(KEY_PATTERN, 'Use lowercase letters, digits, dots and dashes only'),
+  // 'master' is the dialog-side label that maps to channel: null.
+  channel: z.enum(['master', ...PromptTemplateChannelValues]),
+  systemPrompt: z.string().trim().min(1, 'System prompt is required').max(65536),
+  userPromptTemplate: z.string().trim().min(1, 'User prompt is required').max(65536),
+  variables: z.array(variableSchema).max(64, 'At most 64 variables allowed'),
+});
+
+export type NewPromptTemplateFormValues = z.input<typeof newPromptTemplateSchema>;
+export type NewPromptTemplateSubmission = z.output<typeof newPromptTemplateSchema>;
+```
+
+### 3.2 Dialog component
+
+**File**: `apps/web/src/features/prompt-templates/components/new-prompt-template-dialog.tsx` (new)
+
+Shape:
+- Wraps `Dialog` + `DialogContent` from `shared/ui/dialog`.
+- React Hook Form + `zodResolver(newPromptTemplateSchema)`.
+- Fields: `Input` for key, `Select` for channel (`Master (generic)` + `prestashop` + `allegro`), `Textarea` x2 for system + user prompts.
+- **Variables editor**: keep deliberately simple — JSON textarea, parsed on submit. Reusing the rich `VariablesEditor` from `prompt-template-detail-page.tsx` is overkill for the on-ramp; the detail page is the editor, the dialog is the on-ramp (per #488 acceptance: "Keep the dialog deliberately simple").
+- Inline `Alert` at top of form for `mutation.error` (per `frontend.md` form patterns).
+- `FormErrorSummary` after first submit if validation errors exist.
+- Submit calls `useCreatePromptTemplateMutation`. On success: invalidate list query (already wired in the hook), navigate to `/ai/prompt-templates/{newId}` via `useNavigate`, close dialog, toast success.
+- `noValidate` on `<form>`.
+
+Channel-mapping helper:
+
+```typescript
+function channelToApi(channel: 'master' | PromptTemplateChannel): PromptTemplateChannel | null {
+  return channel === 'master' ? null : channel;
+}
+```
+
+### 3.3 List page integration (#488)
+
+**File**: `apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx`
+
+- Local state `[newOpen, setNewOpen]`.
+- `<PageLayout actions={<Button tone="primary" onClick={() => setNewOpen(true)}>New template</Button>}>` — only when `session.user?.role === 'admin'` (mirrors the existing admin gate in this page).
+- Render `<NewPromptTemplateDialog open={newOpen} onOpenChange={setNewOpen} />`.
+
+---
+
+## 4 · Frontend — #489 (Archive flow)
+
+### 4.1 FE API + mutation
+
+**File**: `apps/web/src/features/prompt-templates/api/prompt-templates.api.ts`
+
+Add `archive(id, opts?)` to `PromptTemplatesApi`:
+
+```typescript
+archive: (id: string, opts?: { force?: boolean }) => Promise<PromptTemplate>;
+// implementation:
+archive(id, opts): Promise<PromptTemplate> {
+  return request<PromptTemplate>(`/prompt-templates/${id}/archive`, {
+    method: 'POST',
+    body: JSON.stringify(opts ?? {}),
+  });
+},
+```
+
+**File**: `apps/web/src/features/prompt-templates/hooks/use-archive-prompt-template-mutation.ts` (new) — pattern mirrors the existing hooks in `use-prompt-template-mutations.ts`. Return the full `UseMutationResult`. Invalidate `promptTemplatesQueryKeys.all` on success.
+
+### 4.2 Archive dialog component
+
+**File**: `apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.tsx` (new)
+
+- Wraps `Dialog`. NOT `ConfirmDialog` because we need a `force` checkbox + dynamic copy when the row is `published`.
+- Props: `{ row: PromptTemplateSummary | null; open: boolean; onOpenChange(open): void }`.
+- Body copy adapts on `row.latestState`:
+  - draft: "Archive draft v{N}? It will be hidden from the list but kept in history."
+  - published: "Archive published v{N}? Pass force to bypass the safety guard. Active suggestions for `(key, channel)` will fail until you publish a replacement." + force checkbox.
+- Submit calls `useArchivePromptTemplateMutation`. Toast success, close on success.
+- Inline `Alert` for mutation error (e.g., 409 on force=false).
+
+### 4.3 Per-row trigger + status filter on list page
+
+**File**: `apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx`
+
+**Per-row action**: add a final column `actions` rendering a `Button tone="ghost"` "Archive" — visible only when `row.latestState !== 'archived'`. Click sets local state `[archiveTarget, setArchiveTarget]: PromptTemplateSummary | null` and opens the archive dialog.
+
+DataTable's `rowHref` would conflict with row-level button clicks — the existing setup navigates the whole row. The archive button needs to stop event propagation (or use `event.preventDefault()` + `event.stopPropagation()` in its onClick) so clicking it doesn't also navigate to the detail page.
+
+**Status filter**: add a second `<Select>` next to the existing channel filter:
+- `Active` (default) — shows rows where `hasDraft || publishedVersion !== null`.
+- `Archived` — shows rows where `!hasDraft && publishedVersion === null`.
+- `All` — no filter.
+
+URL state: `?status=active|archived|all`. Default is `active` (omitted from URL). Same pattern as the existing channel filter.
+
+### 4.4 List page tests (extend)
+
+**File**: `apps/web/src/pages/prompt-templates/prompt-templates-list-page.test.tsx`
+
+Add cases:
+- "New template" button visible for admin, opens dialog.
+- "New template" button NOT in DOM for viewer (existing admin-gate test already covers most of this; verify the button isn't rendered).
+- Archive button visible for admin on a non-archived row, opens dialog.
+- Status filter "Active" hides a fully-archived summary row (where `hasDraft=false && publishedVersion === null && latestState === 'archived'`).
+
+### 4.5 New dialog tests
+
+**Files** (new):
+- `apps/web/src/features/prompt-templates/components/new-prompt-template-dialog.test.tsx`
+- `apps/web/src/features/prompt-templates/components/archive-prompt-template-dialog.test.tsx`
+
+For new-template dialog:
+- Renders all fields.
+- Validation error on empty key shows inline.
+- "Master (generic)" channel → submission sends `channel: null`.
+- Success: `apiClient.promptTemplates.create` called with the right payload, navigate fired (mock `useNavigate`), dialog closes.
+- API error → `Alert` rendered with the message; dialog stays open.
+
+For archive dialog:
+- Draft target: shows draft copy, no force checkbox; confirm calls `archive(id)` without `force`.
+- Published target: shows force checkbox; confirm without force calls `archive(id, { force: false })`; with force calls `archive(id, { force: true })`.
+- 409 from API → `Alert` rendered; dialog stays open.
+
+---
+
+## 5 · Quality gate
+
+After implementation:
+
+```bash
+pnpm lint        # 0 errors
+pnpm type-check  # clean across all 8 workspaces
+pnpm test        # all unit tests pass; new BE + FE tests included
+pnpm --filter @openlinker/api migration:show   # NO new migrations expected
+```
+
+No DB schema changes — `state='archived'` is already supported by the table CHECK constraint and the partial unique index.
+
+---
+
+## 6 · Self-review checklist (Phase 5)
+
+- **Architecture**: domain port additions are minimal (`archiveById` only), service depends on port, controller maps domain exceptions → HTTP. ✅
+- **Naming**: `CannotArchivePublishedTemplateException`, `archiveById`, `PromptTemplateService.archive`, `useArchivePromptTemplateMutation`, `ArchivePromptTemplateDialog`, `NewPromptTemplateDialog` — all match documented patterns. ✅
+- **Symbol token**: reuses existing `PROMPT_TEMPLATE_SERVICE_TOKEN` and `PROMPT_TEMPLATE_REPOSITORY_TOKEN`. ✅
+- **Type definitions**: Zod schema in `*.schema.ts`, types kept colocated. ✅
+- **No `any`**: enforced. ✅
+- **CSS tokens**: any new styles use existing `--status-*` / spacing tokens. ✅
+- **Tests**: BE service spec + controller spec extended; FE dialog tests + list page extension. ✅
+- **Audit log**: archive emits `{ templateId, key, channel, version, actor, action: archive, forced }` per `architecture-overview.md §13` telemetry contract. ✅
+- **Authorization**: every new endpoint carries `@Roles('admin')` matching the existing controller convention. ✅
+
+---
+
+## 7 · Open questions / risks
+
+1. **Re-archiving an already-archived row**: the plan throws `PromptTemplateStateException` (already archived). The issue doesn't specify; this matches the existing pattern (`updateDraft` + `publish` reject non-draft / wrong-state rows). If we'd rather make it idempotent (no-op), flip in the service before merge. **Default: throw.**
+2. **`force=true` on a non-published row**: ignored (no effect — archiving a draft is unconditional). The DTO accepts it for forward-compatibility / consistency. No test coverage needed for this branch beyond confirming it doesn't break.
+3. **Status filter on the BE**: I'm doing it client-side because the list endpoint already returns one summary per `(key, channel)` and the filter compose-logic is small. If we later need server-side pagination the filter should move to BE — out of scope for this PR.
+4. **Archive button vs row-click navigation**: the existing `rowHref` pattern wraps the whole row. The new per-row Archive button must `stopPropagation` to avoid double action. Will verify during implementation.

--- a/libs/core/src/ai/application/services/prompt-template.service.interface.ts
+++ b/libs/core/src/ai/application/services/prompt-template.service.interface.ts
@@ -61,4 +61,18 @@ export interface IPromptTemplateService {
 
   /** Delete a draft row. Rejects if state ≠ `draft`. */
   deleteDraft(id: string): Promise<void>;
+
+  /**
+   * Archive a `draft` or `published` row. Idempotent — re-archiving an
+   * already-archived row is a no-op that returns the row unchanged. The
+   * `force` flag is required to archive a `published` row, since the
+   * partial unique index on `(key, channel, state='published')` makes it
+   * the only published version for that pair; archiving leaves the
+   * suggestion service with no template to render until a replacement is
+   * published.
+   */
+  archive(
+    id: string,
+    opts: { force?: boolean; actor?: string | null },
+  ): Promise<PromptTemplate>;
 }

--- a/libs/core/src/ai/application/services/prompt-template.service.spec.ts
+++ b/libs/core/src/ai/application/services/prompt-template.service.spec.ts
@@ -9,6 +9,7 @@
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { PromptTemplate } from '../../domain/entities/prompt-template.entity';
+import { CannotArchivePublishedTemplateException } from '../../domain/exceptions/cannot-archive-published-template.exception';
 import { PromptTemplateNotFoundException } from '../../domain/exceptions/prompt-template-not-found.exception';
 import { PromptTemplateRenderException } from '../../domain/exceptions/prompt-template-render.exception';
 import { PromptTemplateStateException } from '../../domain/exceptions/prompt-template-state.exception';
@@ -54,6 +55,7 @@ describe('PromptTemplateService', () => {
       insert: jest.fn(),
       updateContent: jest.fn(),
       publishTransition: jest.fn(),
+      archiveById: jest.fn(),
       nextVersion: jest.fn(),
       deleteById: jest.fn(),
     };
@@ -343,6 +345,98 @@ describe('PromptTemplateService', () => {
         PromptTemplateStateException,
       );
       expect(repository.deleteById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('archive', () => {
+    it('should archive a draft row without requiring force', async () => {
+      const draft = makeTemplate({ state: 'draft' });
+      const archived = makeTemplate({ state: 'archived' });
+      repository.findById.mockResolvedValue(draft);
+      repository.archiveById.mockResolvedValue(archived);
+
+      const result = await service.archive('tmpl-1', { actor: 'admin' });
+
+      expect(result).toBe(archived);
+      expect(repository.archiveById).toHaveBeenCalledWith('tmpl-1', 'draft');
+    });
+
+    it('should archive a published row when force=true', async () => {
+      const published = makeTemplate({ state: 'published' });
+      const archived = makeTemplate({ state: 'archived' });
+      repository.findById.mockResolvedValue(published);
+      repository.archiveById.mockResolvedValue(archived);
+
+      const result = await service.archive('tmpl-1', { force: true, actor: 'admin' });
+
+      expect(result).toBe(archived);
+      expect(repository.archiveById).toHaveBeenCalledWith('tmpl-1', 'published');
+    });
+
+    it('should refuse to archive a published row without force', async () => {
+      repository.findById.mockResolvedValue(makeTemplate({ state: 'published' }));
+
+      await expect(
+        service.archive('tmpl-1', { actor: 'admin' }),
+      ).rejects.toBeInstanceOf(CannotArchivePublishedTemplateException);
+      expect(repository.archiveById).not.toHaveBeenCalled();
+    });
+
+    it('should be idempotent for already-archived rows (no-op)', async () => {
+      const alreadyArchived = makeTemplate({ state: 'archived' });
+      repository.findById.mockResolvedValue(alreadyArchived);
+
+      const result = await service.archive('tmpl-1', { actor: 'admin' });
+
+      expect(result).toBe(alreadyArchived);
+      expect(repository.archiveById).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFound when the template does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.archive('missing', { actor: 'admin' }),
+      ).rejects.toBeInstanceOf(PromptTemplateNotFoundException);
+      expect(repository.archiveById).not.toHaveBeenCalled();
+    });
+
+    it('should pass through state-exception from the repo (concurrent modification)', async () => {
+      const draft = makeTemplate({ state: 'draft' });
+      repository.findById.mockResolvedValue(draft);
+      repository.archiveById.mockRejectedValue(
+        new PromptTemplateStateException({
+          templateId: 'tmpl-1',
+          actualState: 'published',
+          requiredState: 'draft',
+          operation: 'be archived (concurrent modification — refresh and retry)',
+        }),
+      );
+
+      await expect(
+        service.archive('tmpl-1', { actor: 'admin' }),
+      ).rejects.toBeInstanceOf(PromptTemplateStateException);
+    });
+
+    it('should emit a structured archive log line with key/channel/version/actor/forced', async () => {
+      const published = makeTemplate({ state: 'published', version: 7 });
+      const archived = makeTemplate({ state: 'archived', version: 7 });
+      repository.findById.mockResolvedValue(published);
+      repository.archiveById.mockResolvedValue(archived);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const logSpy = jest.spyOn((service as unknown as { logger: { log: (m: string) => void } }).logger, 'log');
+
+      await service.archive('tmpl-1', { force: true, actor: 'admin' });
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('templateId=tmpl-1'),
+      );
+      const message = logSpy.mock.calls[0][0];
+      expect(message).toContain('archived');
+      expect(message).toContain('priorState=published');
+      expect(message).toContain('version=7');
+      expect(message).toContain('actor=admin');
+      expect(message).toContain('forced=true');
     });
   });
 });

--- a/libs/core/src/ai/application/services/prompt-template.service.ts
+++ b/libs/core/src/ai/application/services/prompt-template.service.ts
@@ -11,6 +11,7 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
+import { CannotArchivePublishedTemplateException } from '../../domain/exceptions/cannot-archive-published-template.exception';
 import { PromptTemplateNotFoundException } from '../../domain/exceptions/prompt-template-not-found.exception';
 import { PromptTemplateStateException } from '../../domain/exceptions/prompt-template-state.exception';
 import type { PromptTemplate } from '../../domain/entities/prompt-template.entity';
@@ -185,6 +186,42 @@ export class PromptTemplateService implements IPromptTemplateService {
       });
     }
     await this.repository.deleteById(id);
+  }
+
+  async archive(
+    id: string,
+    opts: { force?: boolean; actor?: string | null },
+  ): Promise<PromptTemplate> {
+    const existing = await this.repository.findById(id);
+    if (existing === null) {
+      throw new PromptTemplateNotFoundException({ templateId: id });
+    }
+    // Idempotent — re-archiving an already-archived row is a no-op.
+    // The FE gates the Archive button on non-archived rows, so this branch
+    // is defensive-only; permissive semantics keep the API simple for
+    // scripts that retry.
+    if (existing.state === 'archived') {
+      return existing;
+    }
+    // The partial unique index on (key, channel, state='published') makes
+    // a published target the only published row for that pair — archiving
+    // it leaves the suggestion service with no template to render until a
+    // replacement is published. `force=true` bypasses the guard.
+    if (existing.state === 'published' && opts.force !== true) {
+      throw new CannotArchivePublishedTemplateException({
+        templateId: id,
+        key: existing.key,
+        channel: existing.channel,
+      });
+    }
+
+    const archived = await this.repository.archiveById(id, existing.state);
+    this.logger.log(
+      `[prompt-template] archived templateId=${archived.id} key=${archived.key} channel=${
+        archived.channel ?? 'master'
+      } version=${archived.version} priorState=${existing.state} actor=${opts.actor ?? 'system'} forced=${opts.force === true}`,
+    );
+    return archived;
   }
 
   private renderFromEntity(

--- a/libs/core/src/ai/domain/exceptions/cannot-archive-published-template.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/cannot-archive-published-template.exception.ts
@@ -1,0 +1,38 @@
+/**
+ * Cannot Archive Published Template Exception
+ *
+ * Thrown when an admin attempts to archive a `published` row without
+ * `{ force: true }`. The partial unique index on the `prompt_templates`
+ * table enforces at most one published row per `(key, channel)` — so the
+ * target row is by definition the only published version, and archiving
+ * it would leave the suggestion service with no template to render for
+ * that pair until a replacement is published.
+ *
+ * The API surfaces this as **HTTP 409** so callers can either pick a
+ * different row, publish a replacement first, or retry with `force: true`.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+import type { PromptTemplateChannel } from '../types/prompt-template.types';
+
+export class CannotArchivePublishedTemplateException extends Error {
+  public readonly templateId: string;
+  public readonly key: string;
+  public readonly channel: PromptTemplateChannel | null;
+
+  constructor(args: {
+    templateId: string;
+    key: string;
+    channel: PromptTemplateChannel | null;
+  }) {
+    const channelLabel = args.channel ?? 'master';
+    super(
+      `Cannot archive published template ${args.templateId} (key=${args.key}, channel=${channelLabel}): no other published version exists for this (key, channel) pair. Publish a replacement first, or pass { "force": true } to bypass.`,
+    );
+    this.name = 'CannotArchivePublishedTemplateException';
+    this.templateId = args.templateId;
+    this.key = args.key;
+    this.channel = args.channel;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/ai/domain/ports/prompt-template-repository.port.ts
+++ b/libs/core/src/ai/domain/ports/prompt-template-repository.port.ts
@@ -87,6 +87,20 @@ export interface PromptTemplateRepositoryPort {
    * target row inside the transaction — callers just pass the id.
    */
   publishTransition(id: string): Promise<PromptTemplate>;
+  /**
+   * Set state to `archived`, guarded by an expected prior state. Closes the
+   * race-window between the service-level state check and the write — if
+   * the row's state changed in the meantime (e.g. a concurrent publish),
+   * the UPDATE matches zero rows and the repo throws
+   * `PromptTemplateStateException` so the caller can re-fetch and retry.
+   *
+   * Mirrors the safety posture of `publishTransition` without the multi-
+   * statement transaction (archive is a single UPDATE).
+   */
+  archiveById(
+    id: string,
+    expectedPriorState: PromptTemplateState,
+  ): Promise<PromptTemplate>;
   nextVersion(key: string, channel: PromptTemplateChannel | null): Promise<number>;
   deleteById(id: string): Promise<void>;
 }

--- a/libs/core/src/ai/index.ts
+++ b/libs/core/src/ai/index.ts
@@ -30,6 +30,7 @@ export * from './domain/ports/prompt-template-repository.port';
 export * from './domain/exceptions/prompt-template-not-found.exception';
 export * from './domain/exceptions/prompt-template-state.exception';
 export * from './domain/exceptions/prompt-template-render.exception';
+export * from './domain/exceptions/cannot-archive-published-template.exception';
 
 export * from './application/services/prompt-template.service.interface';
 export * from './application/types/prompt-template-commands.types';

--- a/libs/core/src/ai/infrastructure/persistence/repositories/prompt-template.repository.ts
+++ b/libs/core/src/ai/infrastructure/persistence/repositories/prompt-template.repository.ts
@@ -303,6 +303,44 @@ export class PromptTemplateRepository implements PromptTemplateRepositoryPort {
     });
   }
 
+  async archiveById(
+    id: string,
+    expectedPriorState: PromptTemplateState,
+  ): Promise<PromptTemplate> {
+    // State-conditional UPDATE — closes the race-window between the
+    // service-level guard and the write. If the row's state changed (e.g.
+    // a concurrent publish), `affected` is 0 and we surface a state
+    // exception so the caller refreshes and retries.
+    const result = await this.ormRepository
+      .createQueryBuilder()
+      .update(PromptTemplateOrmEntity)
+      .set({ state: 'archived' })
+      .where('id = :id AND state = :expectedPriorState', {
+        id,
+        expectedPriorState,
+      })
+      .execute();
+
+    if (result.affected === 0) {
+      const refreshed = await this.ormRepository.findOne({ where: { id } });
+      if (refreshed === null) {
+        throw new PromptTemplateNotFoundException({ templateId: id });
+      }
+      throw new PromptTemplateStateException({
+        templateId: id,
+        actualState: refreshed.state as PromptTemplateState,
+        requiredState: expectedPriorState,
+        operation: 'be archived (concurrent modification — refresh and retry)',
+      });
+    }
+
+    const updated = await this.ormRepository.findOne({ where: { id } });
+    if (updated === null) {
+      throw new PromptTemplateNotFoundException({ templateId: id });
+    }
+    return this.toDomain(updated);
+  }
+
   async nextVersion(
     key: string,
     channel: PromptTemplateChannel | null,


### PR DESCRIPTION
## Summary

Closes the two operator-facing gaps on the `/ai/prompt-templates` admin page:

- **#488** — admins can author new draft templates from the UI (the BE endpoint already existed; only the dialog + page button were missing).
- **#489** — admins can soft-archive draft and published rows. Archiving a published row requires `{ force: true }` because the partial unique index makes it the only published version for its `(key, channel)` pair.

### Backend (#489)

- New domain exception `CannotArchivePublishedTemplateException` → HTTP 409 via `withDomainExceptionMapping`.
- New repository port method `archiveById(id, expectedPriorState)` — state-conditional UPDATE closes the race between the service guard and the write (mirrors the safety posture of `publishTransition` without a transaction since archive is a single statement).
- New `PromptTemplateService.archive(id, { force, actor })` — idempotent for already-archived rows, refuses `published` without `force`, emits a structured archive log line per the `architecture-overview.md §13` telemetry contract.
- New `POST /prompt-templates/:id/archive` endpoint with `ArchivePromptTemplateDto { force?: boolean }`.

### Frontend (#488 + #489)

- New `NewPromptTemplateDialog` — RHF + Zod, `superRefine` validates the variables-JSON inline so invalid shapes never round-trip to the API. Channel `master` maps to `null` at submit. Live JSON-status indicator below the variables textarea (`✓ valid JSON · N variables` / `✗ invalid`) gives instant feedback. Success → toast + navigate to detail editor.
- New `ArchivePromptTemplateDialog` — body uses `KeyValueList` (cockpit pattern: scan-able operational metadata, not prose). Force-archive path renders as a danger-zone block (warning-tinted + thicker top border + concise checkbox: "Confirm: this is the only published version"). Confirm button copy adapts: `Archive v2` / `Archive published v2` / `Archive published v2 (force)`.
- New `useArchivePromptTemplateMutation` + `apiClient.promptTemplates.archive`.
- Page-header **New template** button (admin-only) and per-row **Archive** action with `stopPropagation` to avoid the row-click navigation. Client-side `?status=active|archived|all` filter hides fully-retired rows from the default Active view.

No DB migration — `state='archived'` already in the table CHECK constraint.

## Test plan

- [x] BE unit: 7 new service-spec cases (happy / idempotent / refused / force / not-found / race / log shape) — `libs/core/src/ai/application/services/prompt-template.service.spec.ts`
- [x] BE unit: 5 new controller-spec cases (happy / force passthrough / 409 / 404 / 400 race) — `apps/api/src/ai/http/prompt-templates.controller.spec.ts`
- [x] FE unit: 6 new-template-dialog cases + 6 archive-dialog cases + 6 list-page extensions (button visibility, dialog opens, status filter, Archive trigger doesn't navigate)
- [x] Quality gate: `pnpm lint` (0 errors), `pnpm type-check` (clean across 8 workspaces), `pnpm test` (2415 tests passing — 30 new from this PR)
- [x] No DB migration required
- [ ] Manual QA: open `/ai/prompt-templates` as admin → click **New template** → fill the form → verify navigate to detail editor + new draft appears in list on return
- [ ] Manual QA: hover a draft row → click **Archive** → verify dialog body shows `KeyValueList` metadata + confirm copy reads `Archive draft v{N}` → verify row vanishes from Active filter, appears under Archived
- [ ] Manual QA: archive the only published row → verify danger-zone copy appears, button disabled until force checkbox is checked, confirm copy reads `Archive published v{N} (force)`
- [ ] Manual QA: try the variables JSON live status — paste valid `[]`, valid `[{...}]`, then invalid JSON, verify the inline status line flips between ✓ and ✗ in real time

Closes #488
Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)