### PR TITLE
feat(prestashop): HMAC sidecar write for OL Dynamic carrier shipping

### DIFF
--- a/docs/plans/implementation-plan-516-ps-adapter-sidecar-write.md
+++ b/docs/plans/implementation-plan-516-ps-adapter-sidecar-write.md
@@ -1,0 +1,399 @@
+# Implementation Plan — #516: PS Adapter Sidecar Write + Reconcile Removal
+
+**Issue**: [#516](https://github.com/SilkSoftwareHouse/openlinker/issues/516) — _PS adapter: sidecar write for OL carrier; remove reconcile workaround_
+**Epic**: [#513](https://github.com/SilkSoftwareHouse/openlinker/issues/513) — _PrestaShop dynamic shipping via OL carrier module_
+**Depends on**: #515 (PS module CarrierModule capability — landed via PR #524)
+**Unblocks**: #517 (FE picker exposes OL Dynamic carrier), #518 (closes #510 / #511, rescopes #506)
+
+---
+
+## 1. Understand the Task
+
+### Goal
+
+Replace the post-create reconcile workarounds (`PUT /order_carriers/{id}` + the `PUT /orders/{id}` work in #510) with a **pre-create sidecar write** to the OL PS module's new endpoint (`POST ?module=openlinker&controller=cartshipping`, landed in #524). When the resolved PS carrier id equals the OL Dynamic carrier id, the adapter writes the buyer-paid amount into the sidecar table; PS then reads it via `getOrderShippingCostExternal()` at order-create time and the totals are correct on first POST. Result: no `current_state=8` (Payment error) badge, no reconcile, no double-write.
+
+### Layer classification
+
+**Integration** — pure changes inside `libs/integrations/prestashop/`. Two new files (HMAC-signed module client + a small types extension), one modified adapter, one modified mapper, one modified spec, plus deletions. Zero CORE / Frontend / Migration work.
+
+### Explicit non-goals (carried from issue + epic)
+
+- **No changes to the carrier-mapping data model** (`CarrierMapping` keeps `(allegroMethodId, psCarrierId)` shape; no mode/discriminator field).
+- **No frontend changes** — #517 owns the carrier-mapping picker UI changes that surface OL Dynamic.
+- **No backfill of orders synced under the reconcile-PUT path** (left at `current_state=8`; one-shot SQL is straightforward if needed).
+- **No multistore / per-shop OL-carrier discovery** — single-store assumption matches #515's install pattern.
+- **Carrier-id caching is deferred** — see §5 R3. Per-order GET to PS is the v1 simplification; revisit if it becomes a perf concern.
+
+---
+
+## 2. Research the Codebase
+
+### Existing structures to reuse
+
+| Surface | Location | How #516 reuses it |
+|---|---|---|
+| `MappingConfigService.resolveCarrierMapping(sourceConnId, methodId)` | `libs/core/src/mappings/application/services/mapping-config.service.ts` | Already wired into `resolveExternalCarrierId` at adapter line 602; keep this branch |
+| `connection.config.defaultCarrierId` | `libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts:123` | Already documented as fallback; keep semantics, just delete the carrier-1 hardcoded final fallback below it |
+| `WebhookSecretProviderPort` / `WEBHOOK_SECRET_PROVIDER_TOKEN` | `libs/core/src/integrations/domain/ports/webhook-secret-provider.port.ts` | Used by the inbound webhook receiver to resolve `(provider, connectionId) → secret`. Reuse for **outbound** HMAC signing — same secret bytes the PS module uses to verify |
+| `IPrestashopWebserviceClient` (Axios via `@nestjs/axios`) | `libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts` | Sibling pattern for the new `PrestashopOpenLinkerModuleClient` — same HTTP transport, same logging, same error-handling shape |
+| `IdentifierMappingPort.getExternalIds('Cart', internalCartId)` | `libs/core/src/identifier-mapping/` | Used to resolve internal → external cart id at sidecar-write time. Cart already has its mapping persisted by `customer-and-cart` provisioning |
+| Existing reconcile call site + method | adapter lines 101 (self-heal) + 478 (main path) + 521-581 (impl) | **Delete entirely.** Self-heal becomes a no-op return-existing |
+
+### Inbound HMAC contract (mirror for outbound)
+
+The PS module's `HmacRequestVerifier` (`apps/prestashop-module/openlinker/classes/HmacRequestVerifier.php`) verifies:
+- `X-OpenLinker-Timestamp: <unix ms>` (numeric string)
+- `X-OpenLinker-Signature: sha256=<64-char hex>`
+- HMAC-SHA256 of `timestamp + "." + rawBody` with the connection's webhook secret
+- ±5 min skew window
+- `hash_equals` constant-time comparison
+
+The TS sender (this PR) must produce the identical wire format. The inbound TS receiver at `apps/api/src/webhooks/application/services/webhook-auth.service.ts:34-129` already proves this contract works end-to-end — we mirror its `signedPayload = Buffer.concat([Buffer.from(timestamp), Buffer.from('.'), rawBody])` build, just on the outbound side.
+
+### Code paths to delete (cleanup half of the issue)
+
+1. `prestashop-order-processor-manager.adapter.ts:101-105` — self-heal call to `reconcileShippingCost`.
+2. `prestashop-order-processor-manager.adapter.ts:473-478` — main-path call to `reconcileShippingCost`.
+3. `prestashop-order-processor-manager.adapter.ts:521-581` — `reconcileShippingCost` private method.
+4. `prestashop-order-processor-manager.adapter.ts:642-647` — the carrier-1 hardcoded fallback warn + `return undefined` path. Replaced by a `throw` with operator-actionable message.
+5. `prestashop-order.mapper.ts:272-274` — `total_shipping`, `total_shipping_tax_incl`, `total_shipping_tax_excl` on the create-order body (PS recomputes from carrier regardless; leaving them was always cargo-cult).
+6. `prestashop-order.mapper.ts:319-322` — comment block that documents the `id_carrier=0` reconcile path becomes stale; rewrite for the new flow or delete.
+7. `prestashop-order-processor-manager.adapter.spec.ts` — the `'shipping cost reconciliation (#467)'` `describe` block tests for the deleted method. Replaced by the 6 new branches.
+8. `IPrestashopWebserviceClient.put` if it exists ONLY for `order_carriers`. Verify via grep before deletion — likely retained for future use, in which case leave it in.
+
+### Related docs / standards consulted
+
+- `docs/architecture-overview.md §10 Plugin Manager / Integrations` — adapter resolution is per-connection; the new module client also resolves per-connection (HMAC secret is connection-scoped).
+- `docs/engineering-standards.md §Naming Conventions` — adapters are `*-adapter.ts` / `{Platform}{Capability}Adapter`; the new HTTP helper is *not* an adapter (it doesn't implement a port), it's an HTTP client like `PrestashopWebserviceClient` — file naming `*.client.ts` matches the existing sibling.
+- `docs/engineering-standards.md §Validation` — input validation belongs at interface layer, not in adapters; the cart-shipping payload is internally generated, no DTO validation needed.
+- `.claude/rules/backend.md` — services implement interfaces in separate `*.service.interface.ts` files. The new module client follows the same pattern as `IPrestashopWebserviceClient`: interface in a `.interface.ts` file, implementation in the `.client.ts` file. Mock the interface in the adapter spec.
+
+---
+
+## 3. Design
+
+### Data flow (this PR's scope)
+
+```
+OrderCreate (Allegro→PS sync, post-#516)
+    │
+    ▼
+PrestashopOrderProcessorManagerAdapter.createOrder(order)
+    │
+    │ 1. Resolve customer (existing path, unchanged)
+    │ 2. Resolve addresses (existing path, unchanged)
+    │ 3. Resolve carrier:
+    │       psCarrierId = await resolveExternalCarrierId(order, config)
+    │         └─ mapping → defaultCarrierId → THROW (no carrier-1 fallback)
+    │ 4. Discover OL Dynamic carrier id:
+    │       olCarrierId = await openlinkerModuleClient.discoverDynamicCarrierId()
+    │         └─ GET /api/carriers?filter[external_module_name]=openlinker&filter[active]=1&filter[deleted]=0
+    │         └─ THROW if no row (operator hasn't installed/activated #515's module)
+    │ 5. Create cart (existing path, unchanged) → externalCartId
+    │ 6. IF psCarrierId === olCarrierId:
+    │       await openlinkerModuleClient.writeCartShipping({
+    │         externalCartId,
+    │         amountTaxExcl: order.totals.shipping,
+    │         amountTaxIncl: order.totals.shipping,
+    │         source: `${order.source.platformType}:${order.source.externalOrderId}`,
+    │       })
+    │       └─ POST /index.php?fc=module&module=openlinker&controller=cartshipping
+    │       └─ HMAC-signed; throws on non-2xx (NOT best-effort like reconcile was)
+    │ 7. POST /orders (existing path, BUT mapper drops total_shipping* fields)
+    │ 8. (DELETED) reconcileShippingCost
+    │
+    ▼
+OrderRef (orderId, orderNumber)
+
+PS-side (already shipped in #515):
+  PS Cart::getOrderTotal(cart, with-shipping)
+    → Carrier::getOrderShippingCost(cart, ..., $module = OpenLinker)
+       → OpenLinker::getOrderShippingCostExternal($cart)
+          → Db::getRow('SELECT amount_tax_incl FROM …openlinker_cart_shipping WHERE id_cart=?')
+          → return (float) amount_tax_incl    ← authoritative
+```
+
+### File-level design
+
+```
+libs/integrations/prestashop/src/
+├── infrastructure/
+│   ├── adapters/
+│   │   └── prestashop-order-processor-manager.adapter.ts        [MODIFIED]
+│   │       - delete reconcileShippingCost (lines 521-581)
+│   │       - delete self-heal reconcile call (lines 101-105)
+│   │       - delete main-path reconcile call (lines 473-478)
+│   │       - resolveExternalCarrierId: throw instead of returning undefined
+│   │       - createOrder: discover OL carrier id, conditional sidecar write
+│   │       - constructor: inject IPrestashopOpenLinkerModuleClient
+│   ├── http/
+│   │   ├── prestashop-openlinker-module.client.ts                [NEW]
+│   │   │   - PrestashopOpenLinkerModuleClient implements IPrestashopOpenLinkerModuleClient
+│   │   │   - Axios POST to module endpoint with HMAC headers
+│   │   │   - discoverDynamicCarrierId() via WS GET /carriers
+│   │   │   - writeCartShipping(input) → throws on non-2xx
+│   │   └── prestashop-openlinker-module.client.interface.ts      [NEW]
+│   │       - interface only (per backend.md naming rule)
+│   └── mappers/
+│       └── prestashop-order.mapper.ts                            [MODIFIED]
+│           - drop total_shipping / total_shipping_tax_incl / total_shipping_tax_excl
+│             from the create-order body (PS computes via the carrier module
+│             regardless; leaving them was vestigial)
+├── domain/
+│   └── types/
+│       └── prestashop-config.types.ts                            [MODIFIED]
+│           - clarify defaultCarrierId doc: "should default to the OL Dynamic
+│             carrier id at connection-create for the most common shape"
+│           - no schema change
+└── infrastructure/
+    └── adapters/__tests__/
+        └── prestashop-order-processor-manager.adapter.spec.ts    [MODIFIED]
+            - delete the 'shipping cost reconciliation (#467)' describe block
+            - add the 6 new test branches per §4 S6
+```
+
+### Class/interface shapes
+
+**`IPrestashopOpenLinkerModuleClient`** (new port — write-only, refined per tech-review IMP-2):
+
+The interface owns ONLY the HMAC-signed write path. Carrier discovery is a small private helper on the adapter that uses the existing `IPrestashopWebserviceClient` — different transport (WS XML vs. JSON HTTP), different auth (Basic vs. HMAC), so they don't belong on the same client.
+
+```ts
+export interface IPrestashopOpenLinkerModuleClient {
+  /**
+   * Write a per-cart shipping cost into the OL module's sidecar table via
+   * its HMAC-authed front controller. Idempotent: re-writing the same
+   * (idCart, amounts) tuple is a no-op modulo `updated_at`.
+   *
+   * @throws PrestashopOlModuleException on non-2xx response (NOT best-effort —
+   *         order creation must abort so we don't ship at zero).
+   */
+  writeCartShipping(input: WriteCartShippingInput): Promise<void>;
+}
+
+export interface WriteCartShippingInput {
+  idCart: number;
+  amountTaxExcl: number;
+  amountTaxIncl: number;
+  source?: string;
+}
+```
+
+**Adapter helper for carrier discovery (private method, not a separate client):**
+
+```ts
+// In PrestashopOrderProcessorManagerAdapter, private method:
+private async discoverDynamicCarrierId(): Promise<number> {
+  // Filter only by external_module_name. PS issue #28424 has reported
+  // inverted-result bugs on filter[active] in some 8.x versions, so we fetch
+  // all rows for this module and post-filter in TS.
+  const rows = await this.webserviceClient.listResources<PrestashopCarrierRow>(
+    'carriers',
+    { custom: { external_module_name: 'openlinker' } },
+  );
+  const live = (rows ?? []).filter(
+    (r) => Number(r.active) === 1 && Number(r.deleted) === 0,
+  );
+  if (live.length === 0) {
+    throw new PrestashopOlCarrierMissingException(this.connection.id);
+  }
+  if (live.length > 1) {
+    // Defensive log per tech-review SUGGESTION. Pathological case after a
+    // module reinstall without uninstall (#515 R6); the post-filter takes
+    // the first match.
+    this.logger.warn(
+      `OpenLinker: multiple live OL Dynamic carriers found on connection ` +
+      `${this.connection.id} (count=${live.length}); using first id=${live[0].id}. ` +
+      `Operator should soft-delete the duplicates from PS admin.`,
+    );
+  }
+  return Number.parseInt(live[0].id, 10);
+}
+```
+
+**`PrestashopOpenLinkerModuleClient`** (impl):
+
+```ts
+@Injectable()
+export class PrestashopOpenLinkerModuleClient implements IPrestashopOpenLinkerModuleClient {
+  // Three deps after IMP-2 split (down from 5). Discovery and WS-Basic-auth
+  // path lives on the adapter, not here.
+  constructor(
+    private readonly connectionId: string,           // injected per-connection via factory
+    private readonly baseUrl: string,                // PS storefront URL (no /api suffix)
+    private readonly httpService: HttpService,
+    @Inject(WEBHOOK_SECRET_PROVIDER_TOKEN)
+    private readonly secretProvider: WebhookSecretProviderPort,
+  ) {}
+
+  async writeCartShipping(input: WriteCartShippingInput): Promise<void> {
+    const secret = await this.secretProvider.getSecret('prestashop', this.connectionId);
+    const body = JSON.stringify({
+      id_cart: input.idCart,
+      amount_tax_excl: input.amountTaxExcl,
+      amount_tax_incl: input.amountTaxIncl,
+      source: input.source ?? null,
+    });
+    const timestamp = String(Date.now());
+    const signature = 'sha256=' + createHmac('sha256', secret)
+      .update(timestamp + '.' + body)
+      .digest('hex');
+
+    const url = `${this.baseUrl.replace(/\/$/, '')}/index.php?fc=module&module=openlinker&controller=cartshipping`;
+    const response = await firstValueFrom(
+      this.httpService.post(url, body, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-OpenLinker-Timestamp': timestamp,
+          'X-OpenLinker-Signature': signature,
+        },
+        validateStatus: () => true,  // we read status ourselves to surface PS-side reasons
+      }),
+    );
+
+    if (response.status >= 200 && response.status < 300) {
+      return;
+    }
+    throw new PrestashopOlModuleException(
+      this.connectionId,
+      input.idCart,
+      response.status,
+      typeof response.data === 'object' ? (response.data as { error?: string }).error : undefined,
+    );
+  }
+}
+```
+
+**Adapter changes (skeleton)**:
+
+```ts
+// In createOrder, the OL Dynamic carrier id is discovered up front so it's
+// available for both the resolution-chain fallback (IMP-1) and the
+// sidecar-write decision. Single discovery per createOrder call; per-order
+// network cost is one extra GET (R3 — acceptable v1 trade-off).
+const olCarrierId = await this.discoverDynamicCarrierId();
+// throws PrestashopOlCarrierMissingException if module not installed/active
+
+const psCarrierId = await this.resolveExternalCarrierId(order, config, olCarrierId);
+// New 4-step chain (IMP-1):
+//   1. Mapping → return mapped id
+//   2. defaultCarrierId if set → return it
+//   3. olCarrierId (passed in, already discovered) → return it as fallback
+//   4. unreachable: discoverDynamicCarrierId() already threw if no live row
+// Existing operator shops with un-set defaultCarrierId no longer get the
+// silent id_carrier=1 fallback — they fall through to the OL Dynamic carrier
+// (the recommended default per S8 doc), preserving sync correctness.
+
+// ... cart creation (unchanged) → externalCartId comes from the cart-create
+// return value (NOT a mapping lookup), so the sidecar-write below uses the
+// freshly-created id without racing against mapping persistence.
+
+if (psCarrierId === olCarrierId) {
+  await this.openlinkerModuleClient.writeCartShipping({
+    idCart: Number.parseInt(externalCartId, 10),
+    amountTaxExcl: order.totals.shipping,
+    amountTaxIncl: order.totals.shipping,
+    source: order.source ? `${order.source.platformType}:${order.source.externalOrderId}` : undefined,
+  });
+  // throws on non-2xx — order creation aborts BEFORE POST /orders to avoid
+  // shipping-at-zero outcomes
+}
+
+// ... POST /orders (mapper now drops total_shipping* fields)
+// (DELETED) reconcileShippingCost
+```
+
+---
+
+## 4. Step-by-Step Implementation Plan
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| **S1** | `libs/integrations/prestashop/src/domain/exceptions/prestashop-ol-module.exception.ts` (NEW) | Two new domain exceptions: `PrestashopOlCarrierMissingException(connectionId)` and `PrestashopOlModuleException(connectionId, idCart, status, reason?)`. Both extend `Error`, set `name`, `Error.captureStackTrace`. | Files compile; thrown instances carry the documented properties. |
+| **S2** | `libs/integrations/prestashop/src/infrastructure/http/prestashop-openlinker-module.client.interface.ts` (NEW) | `IPrestashopOpenLinkerModuleClient` interface + `WriteCartShippingInput` type. | TypeScript compiles; spec can `jest.Mocked<IPrestashopOpenLinkerModuleClient>`. |
+| **S3** | `libs/integrations/prestashop/src/infrastructure/http/prestashop-openlinker-module.client.ts` (NEW) | Implementation per §3. Constructor takes connectionId + baseUrl + HttpService + webserviceClient + secretProvider. `discoverDynamicCarrierId` via PS WS `listResources('carriers', {filter})`. `writeCartShipping` posts HMAC-signed JSON, throws on non-2xx. | Unit-tested via §S6.5 (new spec file alongside the client) — see §S6 below for the full test list. |
+| **S4** | `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts` | (a) Delete `reconcileShippingCost` method (lines 521-581). (b) Delete the two call sites (line 101 self-heal + line 478 main path). (c) Add private `discoverDynamicCarrierId()` helper using existing `webserviceClient.listResources('carriers', …)` with post-filter `active=1 && deleted=0`; warn on multi-row case; throw `PrestashopOlCarrierMissingException` on empty. (d) `resolveExternalCarrierId` now takes `olCarrierId: number` as param and uses it as the third resolution step (after mapping and `defaultCarrierId`); only throws if the discovery itself failed earlier (which already happens upstream). The carrier-1 hardcoded fallback is gone entirely. (e) Inject `IPrestashopOpenLinkerModuleClient` via constructor. (f) In `createOrder`: discover OL carrier first, pass to `resolveExternalCarrierId`, then after cart creation, conditionally call `writeCartShipping` when `psCarrierId === olCarrierId`. | Adapter file compiles; reconcile method gone; resolution chain has 3 functional fallbacks (mapping → defaultCarrierId → OL) before any throw; sidecar write happens iff resolved carrier matches OL; multi-row OL discovery emits warn-level log. |
+| **S5** | `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts` | Delete `total_shipping`, `total_shipping_tax_incl`, `total_shipping_tax_excl` from the create-order POST body builder (lines 272-274). Update the surrounding doc-comment block (lines 319-322) — drop the now-stale "id_carrier=0 / reconcileShippingCost" explanation, replace with "Shipping totals are computed PS-side via the resolved carrier (range tables for static carriers, OL sidecar for the dynamic carrier)". The `total_shipping*` entries in the field-strip list at line 462-464 stay (they apply on the read/parse path). | Mapper unit tests (`prestashop-order.mapper.spec.ts`) still pass after deletion — assertion that the body **does not** include `total_shipping*` is added. |
+| **S6** | `libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts` | (a) Delete the entire `'shipping cost reconciliation (#467)'` describe block. (b) Add the 6 new branches per the refined matrix (post IMP-1): 1. **OL carrier mapped** → sidecar POST made, no reconcile, cart `id_carrier`=OL. 2. **Static PS carrier (id=2) mapped** → no sidecar POST, cart `id_carrier`=2. 3. **Unmapped, defaultCarrierId set to static carrier** → cart `id_carrier`=`defaultCarrierId`; no sidecar POST. 4. **Unmapped, no defaultCarrierId, OL module installed** → cart `id_carrier`=OL Dynamic (auto-fallback); sidecar POST happens. 5. **Sidecar POST fails (non-2xx)** → order create aborts, error surfaced (NOT best-effort). 6. **OL module not installed (discovery returns empty)** → order create aborts with `PrestashopOlCarrierMissingException` BEFORE any cart/order write. (c) Mock `IPrestashopOpenLinkerModuleClient` per `.claude/rules/backend.md` (mock the port interface, not the concrete client). Mock `IPrestashopWebserviceClient.listResources` for the carrier-discovery path. | All 6 branches green; 0 calls to the old `webserviceClient.put('order_carriers', …)` from the adapter; no carrier-1 hardcoded fallback in any test path; the new "unmapped → OL Dynamic auto-fallback" branch (#4) is exercised. |
+| **S6.5** | `libs/integrations/prestashop/src/infrastructure/http/prestashop-openlinker-module.client.spec.ts` (NEW) | Unit tests for `PrestashopOpenLinkerModuleClient` with mocked `HttpService` + `WebhookSecretProviderPort` (no `IPrestashopWebserviceClient` after IMP-2 split): (a) `writeCartShipping` posts to the documented URL with the documented headers + body shape. (b) HMAC signature is computed over `timestamp + '.' + body` (assert via captured header value). (c) signature uses sha256 hex format with `sha256=` prefix. (d) `writeCartShipping` throws `PrestashopOlModuleException` on 401 with reason string surfaced. (e) `writeCartShipping` throws `PrestashopOlModuleException` on 500. (f) `writeCartShipping` succeeds (no throw) on 200. | All 6 tests green. |
+| **S7** | `libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts` (and its module wiring) | Wire the new `PrestashopOpenLinkerModuleClient` per-connection: pull connection's PS storefront baseUrl + connectionId, inject `WebhookSecretProviderPort` + `HttpService` + the per-connection `PrestashopWebserviceClient`. Pass into `PrestashopOrderProcessorManagerAdapter` constructor. | Factory builds an adapter that owns a working module client. Existing factory tests (if any) updated to cover the new dependency. |
+| **S8** | `libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts` + `libs/core/src/integrations/domain/ports/webhook-secret-provider.port.ts` | (a) Update `defaultCarrierId` JSDoc to reflect the new resolution chain (mapping → defaultCarrierId → OL Dynamic auto-fallback → throw). Note the operator-impact: setting `defaultCarrierId` to a static carrier id is now a deliberate opt-out from OL Dynamic auto-fallback. (b) Update `WebhookSecretProviderPort` JSDoc with the bidirectional note: "Used both for verifying inbound HMAC signatures AND for resolving the secret used to sign outbound requests to platform module endpoints (e.g. PS module's cartshipping endpoint per #516)." No port rename, no type-shape change. | Doc reads correctly; no compile churn elsewhere. |
+
+### Quality gate
+
+```bash
+pnpm lint        # zero errors
+pnpm type-check  # zero errors
+pnpm test        # all 1557+ tests green; the new branches added in S6/S6.5 included
+```
+
+### Manual verification (per acceptance criteria)
+
+On the dev shop after PR merge + module redeploy:
+1. Sync a fresh Allegro order through the dynamic-carrier path.
+2. Confirm `ps_orders.total_shipping = buyer-paid amount`, `total_paid = total_paid_real`, `current_state ≠ 8`.
+3. Confirm no `PUT /order_carriers` or `PUT /orders` calls in the OL log for that sync (only `POST /cartshipping` then `POST /orders`).
+4. Map an Allegro method to a static PS carrier, sync another order — confirm sidecar POST is **not** made; PS recomputes shipping from the carrier's price ranges.
+5. Trigger the "no mapping, no defaultCarrierId" case (temporarily remove both) — confirm sync aborts cleanly with the operator-actionable error and **no partial PS state** (no orphan cart, no order_carriers row).
+
+PR description carries the verification log.
+
+---
+
+## 5. Validate
+
+### Architecture compliance
+
+✅ **CORE / Integration boundary**: change is entirely within `libs/integrations/prestashop/`. `WebhookSecretProviderPort` consumed via DI per `.claude/rules/backend.md` (port-not-concrete). No CORE changes.
+✅ **Service interface separation**: `IPrestashopOpenLinkerModuleClient` lives in a separate `.interface.ts` per backend.md.
+✅ **Mocking ports not adapters**: spec mocks the new port interface, not the concrete client (per `engineering-standards.md §Mocking Ports`).
+✅ **Domain exceptions in `domain/exceptions/`**: new exceptions live in `libs/integrations/prestashop/src/domain/exceptions/` (existing convention for the package — see `prestashop-authentication.exception.ts` etc.).
+✅ **No `any` types**: all new code typed; `response.data` cast narrowed via type guard.
+✅ **No deep relative imports**: `WebhookSecretProviderPort` + token come via `@openlinker/core/integrations` alias.
+
+### Naming
+
+✅ Client file: `prestashop-openlinker-module.client.ts` matches existing `prestashop-webservice.client.ts` sibling convention.
+✅ Interface file: `prestashop-openlinker-module.client.interface.ts` matches `prestashop-webservice.client.interface.ts` sibling.
+✅ Exception files: `prestashop-ol-module.exception.ts` matches existing `prestashop-*.exception.ts` pattern in the package.
+
+### Testing strategy
+
+- **Adapter spec**: 6 new branches covering the documented matrix. Mock the new port; assert call/no-call on sidecar POST; assert thrown exception types for failure branches.
+- **Module-client spec**: 6 unit tests for the new client itself (HTTP shape, HMAC contract, error mapping). Mock `HttpService`, `IPrestashopWebserviceClient`, `WebhookSecretProviderPort` — three distinct concerns at the client's boundary.
+- **Mapper spec**: assert the create-order body **does not** include `total_shipping*` fields (regression guard for the deletion).
+- **No integration test added here** — #506 owns the real-PS coverage of the carrier-mapping vertical slice once #515 + #516 + #517 all land.
+
+### Security
+
+- **HMAC contract** mirrors the inbound TS receiver (proven; live in production for the webhook-outbox direction). Same secret bytes via `WebhookSecretProviderPort` — single source of truth for `(provider, connectionId) → secret`.
+- **No new secret to manage** — operators who configured the webhook outbox secret have the same value installed in the PS module's `OPENLINKER_WEBHOOK_SECRET` config, which is what the PHP receiver verifies against.
+- **Sidecar write is fail-loud, not best-effort.** Old `reconcileShippingCost` swallowed errors and proceeded; the new write throws and aborts order creation. Better failure mode: no order created at zero shipping cost vs. orphan order with wrong totals.
+- **No SQL or OS-injection surface** — all module-client inputs are typed primitives serialized via `JSON.stringify`; HMAC headers built from controlled timestamp + computed signature.
+
+### Risks / open questions
+
+- **R1 — `discoverDynamicCarrierId` filter syntax (refined after market research).** PS WS expects `filter[field]=[value]` (brackets around the value) for string-field exact match per [the official tutorial](https://devdocs.prestashop-project.org/8/webservice/tutorials/advanced-use/additional-list-parameters/). The existing `PrestashopQueryBuilder` (line 130) already emits this shape correctly via the `custom` filter option, so passing `{ external_module_name: 'openlinker' }` as `custom` produces `filter[external_module_name]=[openlinker]` automatically. **However**, [PS GitHub issue #28424 reports inverted-result bugs on `filter[active]`](https://github.com/PrestaShop/PrestaShop/issues/28424) in some 8.x versions. To dodge that landmine the plan filters **only** by `external_module_name` at the WS layer and post-filters `active=1, deleted=0` in TypeScript. Two-row case (soft-deleted predecessor + current active carrier after a BO edit per #515 R6) is the common shape and the post-filter handles it cleanly.
+- **R2 — Carrier id changes via BO edit.** PS duplicates the carrier row + assigns new id on every BO edit (#515 R6). Our discovery filters `active=1, deleted=0` — the new active row is found, the old soft-deleted row is filtered out. **No cache means no stale-id risk.** If we add caching later (R3) we need to subscribe to a refresh signal.
+- **R3 — Cache deferred to v2.** Per-order `GET /carriers?filter=…` is one extra HTTP call per order create. For Allegro→PS sync at typical SMB volumes (10s-100s of orders/day) this is negligible. If a high-volume operator hits perf concerns, add an in-memory TTL cache (5 min) keyed by connectionId. Not gating.
+- **R4 — Self-heal path no longer reconciles.** After the deletion, the `metadataInternalOrderId` early-return path simply returns the existing order ref. Orders that landed pre-#516 with `current_state=8` stay broken until manually reconciled (operator runs the SQL backfill from the epic non-goals). Acceptable — matches the explicit "no backfill" out-of-scope item.
+- **R5 — `connection.config.defaultCarrierId` semantics shift (refined after tech-review IMP-1).** Pre-#516 the chain ended with `id_carrier=1` hardcoded fallback (PS's first carrier — a common cause of wrong totals). Post-#516 the chain is **mapping → defaultCarrierId → OL Dynamic auto-fallback → throw**. The OL Dynamic carrier (already discovered for the sidecar-write path; zero extra cost) acts as the runtime fallback when `defaultCarrierId` is unset. Existing shops with un-configured `defaultCarrierId` keep working — unmapped methods now route through the dynamic-pricing path (correct behaviour) instead of the carrier-1 wrong-totals path (broken behaviour). The only hard-failure path is "no mapping AND no `defaultCarrierId` AND OL module not installed", which throws `PrestashopOlCarrierMissingException` from discovery itself — operator-actionable.
+
+- **R8 — Cart-id source (tech-review SUGGESTION).** The sidecar write must use the cart's external id from the cart-create return value, NOT from a `getExternalIds('Cart', …)` mapping lookup. Reason: the mapping write happens AFTER `cartProvisioner.createCart` returns, and a mapping-lookup at sidecar-write time would race against persistence. The existing adapter already returns the external id directly from the provisioner; #516 just propagates that value forward to `writeCartShipping`.
+
+- **R9 — BO-edit-during-sync race (tech-review SUGGESTION).** Operator edits the OL Dynamic carrier in PS BO mid-sync: discovery returns `id=A`, BO edit makes `A` deleted=1 and assigns new `id=B`, then OL POSTs the cart with `id_carrier=A`. PS still resolves the carrier-module to OpenLinker via `external_module_name='openlinker'` (which now matches `B`), and the sidecar lookup is keyed by `id_cart` not `id_carrier`, so `getOrderShippingCostExternal` finds the row regardless. **The race is benign** in this code path. If POST /orders fails for any unrelated reason, the runner retries with a fresh discovery — natural self-healing. No cache-invalidation hook needed.
+
+- **R6 — Architecture-novelty acknowledgement (research output).** Cross-referenced the PS shipping ecosystem (Colissimo, Mondial Relay, FedEx, ShipStation, BelVG tutorial). **No precedent for the OL pattern** of "external backend POSTs HMAC-signed JSON to a custom PS module endpoint that writes a sidecar table that PS reads at order-total time." All real-world shipping integrations either (a) install the carrier module *inside* PS and call out from there, or (b) post-process via PS WS after order-create (the reconcile pattern we're removing). The OL deviation is deliberate: PS's silent override of `total_shipping` makes (b) leak `current_state=8`, and (a) doesn't fit OpenLinker's role as an aggregator that doesn't own the carrier's shipping computation. The HMAC contract itself is well-trodden in PS (Stripe-style webhooks); what's novel is the *direction of use* (cart-shipping pre-write rather than event notification). No red flags surfaced; the design is sound but worth calling out in the PR description so future contributors understand why we don't just "install a module like everyone else does".
+
+### Out-of-scope follow-ups (parking lot)
+
+- Per-connection cache for `discoverDynamicCarrierId` (R3). File only if a real perf problem appears.
+- Backfill SQL for orders synced under the reconcile-PUT path (epic non-goal). One-shot job; file when an operator asks.
+- Generalize the OL-module-client pattern beyond the cartshipping endpoint — once the module grows a third capability beyond webhook outbox + carrier sidecar, consider extracting a `PrestashopModuleApiClient` that handles HMAC + URL building generically.
+
+---
+
+## Estimated diff size
+
+≈ 350-450 LOC across 10 files: 3 new (HMAC client, interface, exception module), 1 new spec, 5 modified (adapter, mapper, factory, types doc, port-doc), 1 modified spec. Net deletion ≈ 100 LOC (reconcile method + tests). Zero TypeORM migrations, zero PS module changes (module side already shipped in #515 / PR #524). The discovery method is on the adapter itself per IMP-2 split, so it doesn't need a separate file.

--- a/libs/core/src/integrations/domain/ports/webhook-secret-provider.port.ts
+++ b/libs/core/src/integrations/domain/ports/webhook-secret-provider.port.ts
@@ -7,6 +7,21 @@
  * the core domain to verify webhook signatures without depending on specific
  * credential storage.
  *
+ * Used in BOTH directions of HMAC-authenticated traffic for a connection:
+ *   - **Inbound** — webhook receivers (e.g. `WebhookController`) call
+ *     `getSecret(provider, connectionId)` to verify `X-OpenLinker-Signature`
+ *     on incoming requests.
+ *   - **Outbound** — adapters that POST HMAC-signed bodies to a partner's
+ *     module endpoints (e.g. `PrestashopOpenLinkerModuleClient` writing to
+ *     the OL PS module's `cartshipping` controller, #516) call
+ *     `getSecret(...)` to *sign* outgoing requests. Same secret bytes;
+ *     used to compute the signature instead of verifying it.
+ *
+ * The bidirectional reuse is intentional: rotating the shared secret on
+ * either side automatically invalidates BOTH the inbound verification and
+ * the outbound signing, keeping them consistent. Don't introduce a separate
+ * "outbound" port for this — same secret, same key, opposite verb.
+ *
  * @module libs/core/src/integrations/domain/ports
  * @see {@link CredentialsWebhookSecretAdapter} for the production implementation
  */

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -9,12 +9,13 @@
  */
 import { IPrestashopAdapterFactory, PrestashopAdapters } from './interfaces/prestashop-adapter.factory.interface';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
-import { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { CredentialsResolverPort, WebhookSecretProviderPort } from '@openlinker/core/integrations';
 import { IMappingConfigService } from '@openlinker/core/mappings';
 import { PrestashopConnectionConfig } from '../domain/types/prestashop-config.types';
 import { PrestashopCredentials } from '../domain/types/prestashop-credentials.types';
 import { PrestashopConfigException } from '../domain/exceptions/prestashop-config.exception';
 import { PrestashopWebserviceClient } from '../infrastructure/http/prestashop-webservice.client';
+import { PrestashopOpenLinkerModuleClient } from '../infrastructure/http/prestashop-openlinker-module.client';
 import { PrestashopProductMapper } from '../infrastructure/mappers/prestashop-product.mapper';
 import { PrestashopInventoryMapper } from '../infrastructure/mappers/prestashop-inventory.mapper';
 import { PrestashopOrderMapper } from '../infrastructure/mappers/prestashop-order.mapper';
@@ -42,12 +43,18 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
     private readonly addressProvisioner?: PrestashopAddressProvisioner,
     private readonly customerProjectionRepository?: CustomerProjectionRepositoryPort,
     private readonly mappingConfigService?: IMappingConfigService,
+    // Outbound HMAC signer for the OL PS module endpoints (#516). Required
+    // when the orderProcessorManager adapter is wired up — we only build a
+    // module client when both the secret provider and the customer-side
+    // dependencies (`customerProvisioner`, `customerProjectionRepository`)
+    // are present.
+    private readonly webhookSecretProvider?: WebhookSecretProviderPort,
   ) {
     // Validate that if orderProcessorManager is needed, dependencies are provided
     // Note: Dependencies are optional to allow factory creation without customer provisioning
     // The adapter will fail at runtime if dependencies are missing when needed
     // `mappingConfigService` is optional too — when absent the destination adapter
-    // skips carrier resolution and falls back to `defaultCarrierId` / `1`.
+    // skips carrier resolution and falls back to `defaultCarrierId` / OL Dynamic carrier.
   }
 
   async createAdapters(
@@ -101,14 +108,31 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       connection,
     );
 
-    // Create orderProcessorManager only if customer provisioning dependencies are provided
+    // Create orderProcessorManager only if customer provisioning dependencies
+    // and the outbound webhook-secret provider (#516) are provided.
     let orderProcessorManager: PrestashopOrderProcessorManagerAdapter | undefined;
-    if (this.customerProvisioner && this.customerProjectionRepository) {
+    if (
+      this.customerProvisioner &&
+      this.customerProjectionRepository &&
+      this.webhookSecretProvider
+    ) {
       // Create provisioners (if not provided, create new instances)
       const countryResolver = new PrestashopCountryResolver();
       const currencyResolver = new PrestashopCurrencyResolver();
       const addressProvisioner =
         this.addressProvisioner || new PrestashopAddressProvisioner(null, countryResolver);
+
+      // Per-connection HMAC client for the OL PS module's storefront
+      // endpoints. Same secret bytes as the inbound webhook receiver — the
+      // shared `WebhookSecretProviderPort` is used in both directions
+      // (outbound signing here, inbound verification in the webhook
+      // controller). Storefront base URL falls back to the webservice URL
+      // when unset, matching the mappers.
+      const openlinkerModuleClient = new PrestashopOpenLinkerModuleClient(
+        connection.id,
+        config.storefrontBaseUrl ?? config.baseUrl,
+        this.webhookSecretProvider,
+      );
 
       orderProcessorManager = new PrestashopOrderProcessorManagerAdapter(
         httpClient,
@@ -119,12 +143,13 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
         addressProvisioner,
         currencyResolver,
         this.customerProjectionRepository,
+        openlinkerModuleClient,
         this.mappingConfigService,
       );
     } else {
       this.logger.warn(
         `OrderProcessorManager adapter not created for connection ${connection.id}: ` +
-          `customerProvisioner or customerProjectionRepository not provided. ` +
+          `customerProvisioner, customerProjectionRepository, or webhookSecretProvider not provided. ` +
           `This adapter is required for order processing.`,
       );
     }

--- a/libs/integrations/prestashop/src/domain/exceptions/prestashop-ol-module.exception.ts
+++ b/libs/integrations/prestashop/src/domain/exceptions/prestashop-ol-module.exception.ts
@@ -1,0 +1,70 @@
+/**
+ * PrestaShop OpenLinker Module Exceptions
+ *
+ * Domain exceptions for the OpenLinker PrestaShop module integration path
+ * (#516, building on #515). Two distinct failure modes:
+ *
+ *   - PrestashopOlCarrierMissingException — the OL Dynamic carrier row
+ *     cannot be located on the connection's PrestaShop instance. Operator
+ *     hasn't installed or activated the openlinker module, or all matching
+ *     rows are soft-deleted. Order create must abort.
+ *
+ *   - PrestashopOlModuleException — an HMAC-authed call to the OL module's
+ *     front-controller endpoint (e.g. cartshipping) returned a non-2xx
+ *     response. NOT best-effort: order creation must abort rather than
+ *     proceed with potentially-wrong shipping totals.
+ *
+ * @module libs/integrations/prestashop/src/domain/exceptions
+ * @see {@link PrestashopOpenLinkerModuleClient} for the call site that throws PrestashopOlModuleException
+ */
+
+/**
+ * Thrown when no live OpenLinker Dynamic carrier exists on the PrestaShop
+ * instance. PrestaShop returns no row matching
+ * `external_module_name='openlinker' AND active=1 AND deleted=0`.
+ *
+ * Recovery: operator must install + activate the OL PrestaShop module
+ * (#515 / PR #524). After install, retry the sync.
+ */
+export class PrestashopOlCarrierMissingException extends Error {
+  constructor(public readonly connectionId: string) {
+    super(
+      `OpenLinker Dynamic carrier not found on connection ${connectionId} ` +
+        `(no row matching external_module_name='openlinker', active=1, deleted=0). ` +
+        `Install + activate the OL PrestaShop module on the dev shop, then retry.`,
+    );
+    this.name = 'PrestashopOlCarrierMissingException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/**
+ * Thrown when an HMAC-authed POST to the OL PrestaShop module's front
+ * controller (e.g. `?fc=module&module=openlinker&controller=cartshipping`)
+ * returns a non-2xx response. The reason string from the module's JSON
+ * error body is surfaced via the `reason` property when present.
+ *
+ * Recovery depends on the reason:
+ *   - 'invalid-signature' / 'misconfigured': operator must reconcile the
+ *     OPENLINKER_WEBHOOK_SECRET between PS module config and OL connection
+ *     credentials.
+ *   - 'invalid-body' / 'invalid-fields': bug in the OL adapter — the wire
+ *     contract drifted; surface to engineering.
+ *   - 'persist-failed': PS-side DB write failed; check PS log for SQL error.
+ */
+export class PrestashopOlModuleException extends Error {
+  constructor(
+    public readonly connectionId: string,
+    public readonly idCart: number,
+    public readonly status: number,
+    public readonly reason?: string,
+  ) {
+    super(
+      `OpenLinker module call failed for connection=${connectionId} idCart=${idCart}: ` +
+        `HTTP ${status}` +
+        (reason ? ` (reason: ${reason})` : ''),
+    );
+    this.name = 'PrestashopOlModuleException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts
+++ b/libs/integrations/prestashop/src/domain/types/prestashop-config.types.ts
@@ -111,14 +111,21 @@ export interface PrestashopConnectionConfig {
    * Default PrestaShop carrier ID applied to incoming orders when no
    * connection-level carrier mapping resolves for the source delivery method.
    *
-   * Resolution chain at order-create time:
+   * Resolution chain at order-create time (#516):
    *   1. Per-method carrier mapping (`MappingConfigService.resolveCarrierMapping`)
    *   2. This `defaultCarrierId`
-   *   3. PrestaShop's hardcoded `id_carrier=1` (first carrier)
+   *   3. The OpenLinker Dynamic carrier installed by the OL PS module —
+   *      discovered per-order via `external_module_name=openlinker`. The
+   *      adapter writes the buyer-paid amount into the OL module's sidecar
+   *      table BEFORE `POST /orders`, so PS reads the authoritative shipping
+   *      total via `getOrderShippingCostExternal()` at order-total time.
    *
-   * Both fallbacks are logged at `warn` so unmapped methods are observable.
-   * Must be a positive integer; `0` and negatives are rejected at config-validation
-   * time.
+   * The fallback to `id_carrier=1` and the post-create `order_carriers`
+   * reconcile (#467) were both removed in #516.
+   *
+   * Both step-2 and step-3 fallbacks are logged at `warn` so unmapped
+   * methods are observable. Must be a positive integer; `0` and negatives
+   * are rejected at config-validation time.
    */
   defaultCarrierId?: number;
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -13,6 +13,8 @@ import { createMockIdentifierMapping } from '../../../__tests__/mocks/mock-ident
 import { createTestConnection } from '../../../__tests__/fixtures/connection.fixture';
 import { PrestashopApiException } from '@openlinker/integrations-prestashop';
 import { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
+import { IPrestashopOpenLinkerModuleClient } from '../../http/prestashop-openlinker-module.client.interface';
+import { PrestashopOlModuleException } from '../../../domain/exceptions/prestashop-ol-module.exception';
 import { IPrestashopOrderMapper, PrestashopOrder } from '../../mappers/prestashop.mapper.interface';
 import {
   IdentifierMappingPort,
@@ -25,6 +27,15 @@ import { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
 import { PrestashopCustomerProvisioner } from '../../provisioners/prestashop-customer-provisioner';
 import { PrestashopAddressProvisioner } from '../../provisioners/prestashop-address-provisioner';
 
+/**
+ * The numeric `id_carrier` returned by the OL module's discovery row in
+ * these tests. Picked so it doesn't collide with any other carrier id used
+ * in the suite (#455 mapping tests use 4, fixture defaultCarrierId tests
+ * use 7). Tests that need to assert the OL Dynamic fallback compare against
+ * this constant.
+ */
+const OL_DYNAMIC_CARRIER_ID = 99;
+
 describe('PrestashopOrderProcessorManagerAdapter', () => {
   let adapter: PrestashopOrderProcessorManagerAdapter;
   let mockHttpClient: jest.Mocked<IPrestashopWebserviceClient>;
@@ -34,6 +45,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
   let mockCustomerProjectionRepository: jest.Mocked<CustomerProjectionRepositoryPort>;
   let mockCustomerProvisioner: jest.Mocked<PrestashopCustomerProvisioner>;
   let mockAddressProvisioner: jest.Mocked<PrestashopAddressProvisioner>;
+  let mockOpenLinkerModuleClient: jest.Mocked<IPrestashopOpenLinkerModuleClient>;
   let connection: ReturnType<typeof createTestConnection>;
 
   const METADATA_INTERNAL_ORDER_ID = 'ol_order_allegro_abc123';
@@ -108,6 +120,33 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       resolveOrCreateAddress: jest.fn(),
     } as unknown as jest.Mocked<PrestashopAddressProvisioner>;
 
+    mockOpenLinkerModuleClient = {
+      writeCartShipping: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<IPrestashopOpenLinkerModuleClient>;
+
+    // Default OL Dynamic carrier discovery: every createOrder call invokes
+    // `discoverDynamicCarrierId()` early, which calls
+    // `httpClient.listResources('carriers', { custom: { external_module_name: 'openlinker' } }, …)`.
+    // Tests in this suite that reassign `listResources` must remember to
+    // re-mock this path (none in createOrder do; the listCarriers /
+    // listOrderStatuses / listPaymentMethods describes don't go through
+    // createOrder, so they're unaffected).
+    mockHttpClient.listResources = jest
+      .fn()
+      .mockImplementation(
+        (resource: string, params?: { custom?: Record<string, unknown> }) => {
+          if (
+            resource === 'carriers' &&
+            params?.custom?.external_module_name === 'openlinker'
+          ) {
+            return Promise.resolve([
+              { id: OL_DYNAMIC_CARRIER_ID, active: '1', deleted: '0' },
+            ]);
+          }
+          return Promise.resolve([]);
+        },
+      );
+
     adapter = new PrestashopOrderProcessorManagerAdapter(
       mockHttpClient,
       mockIdentifierMapping,
@@ -117,6 +156,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       mockAddressProvisioner,
       mockCurrencyResolver,
       mockCustomerProjectionRepository,
+      mockOpenLinkerModuleClient,
     );
   });
 
@@ -214,7 +254,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         undefined,
         1, // currencyId
         1, // langId
-        undefined, // externalCarrierId — no mapping configured; mapper falls back to id_carrier=1
+        OL_DYNAMIC_CARRIER_ID, // #516: no mapping/default → OL Dynamic carrier fallback
       );
       expect(mockOrderMapper.mapOrderCreate).toHaveBeenCalledWith(
         order,
@@ -225,7 +265,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         undefined,
         1, // currencyId
         1, // langId
-        undefined, // externalCarrierId — no mapping configured, no defaultCarrierId; mapper falls back to 1
+        OL_DYNAMIC_CARRIER_ID, // #516: no mapping/default → OL Dynamic carrier fallback
       );
       expect(mockHttpClient.createResource).toHaveBeenCalledWith('carts', expect.any(Object));
       expect(mockHttpClient.createResource).toHaveBeenCalledWith('orders', prestashopOrderData);
@@ -810,6 +850,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockAddressProvisioner,
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
+        mockOpenLinkerModuleClient,
         mockMappingConfig,
       );
 
@@ -861,6 +902,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockAddressProvisioner,
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
+        mockOpenLinkerModuleClient,
         mockMappingConfig,
       );
 
@@ -879,12 +921,12 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       );
     });
 
-    it('ignores invalid defaultCarrierId (0, negative, NaN) so the cart never lands at id_carrier=0 (#503 follow-up)', async () => {
+    it('ignores invalid defaultCarrierId (0, negative, NaN) and falls back to OL Dynamic carrier (#503 / #516)', async () => {
       // Operator sets defaultCarrierId=0 (or negative, or non-numeric) in
       // connection config. Without the guard, the mapper writes id_carrier=0
       // to the cart and PS reproduces the #503 failure mode through a
       // different door — `??` doesn't fall back on 0, only null/undefined.
-      // Adapter must filter and let the mapper apply its DEFAULT_CARRIER_ID=1.
+      // Adapter must filter and use the OL Dynamic carrier id (#516).
       wireSuccessfulMappings('42');
       const connWithBadDefault = createTestConnection();
       (connWithBadDefault.config as Record<string, unknown>).defaultCarrierId = 0;
@@ -901,12 +943,12 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockAddressProvisioner,
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
+        mockOpenLinkerModuleClient,
         mockMappingConfig,
       );
 
       await adapterWithMapping.createOrder(buildOrderWithShipping());
 
-      // Adapter returns undefined (not 0); mappers fall back to DEFAULT_CARRIER_ID=1.
       expect(mockOrderMapper.mapCartCreate).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
@@ -916,7 +958,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         undefined,
         1,
         1,
-        undefined,
+        OL_DYNAMIC_CARRIER_ID,
       );
       expect(mockOrderMapper.mapOrderCreate).toHaveBeenCalledWith(
         expect.anything(),
@@ -927,11 +969,11 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         undefined,
         1,
         1,
-        undefined,
+        OL_DYNAMIC_CARRIER_ID,
       );
     });
 
-    it('passes undefined externalCarrierId when neither mapping nor defaultCarrierId is set (mapper falls back to 1)', async () => {
+    it('falls back to OL Dynamic carrier when neither mapping nor defaultCarrierId is set (#516)', async () => {
       wireSuccessfulMappings('42');
       const mockMappingConfig = {
         resolveCarrierMapping: jest.fn().mockResolvedValue(null),
@@ -945,6 +987,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         mockAddressProvisioner,
         mockCurrencyResolver,
         mockCustomerProjectionRepository,
+        mockOpenLinkerModuleClient,
         mockMappingConfig,
       );
 
@@ -959,18 +1002,20 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         undefined,
         1,
         1,
-        undefined,
+        OL_DYNAMIC_CARRIER_ID,
       );
     });
   });
 
-  describe('shipping cost reconciliation (#467)', () => {
-    const EXTERNAL_ORDER_ID = '999';
-    const EXTERNAL_ORDER_CARRIER_ID = '5001';
-    const EXTERNAL_ORDER_NUMBER = 'TEST-ORDER-001';
+  describe('OL module sidecar write (#516)', () => {
+    const ALLEGRO_CONNECTION_ID = 'conn-allegro-1';
+    const ALLEGRO_METHOD_ID = 'method-courier';
+    const STATIC_CARRIER_ID = 4;
 
-    const buildOrderWithShippingTotal = (shipping: number): OrderCreate => ({
+    const buildOrderForSidecar = (shipping = 12.5): OrderCreate => ({
       ...createTestOrder(),
+      shipping: { methodId: ALLEGRO_METHOD_ID, methodName: 'InPost Paczkomat' },
+      source: { connectionId: ALLEGRO_CONNECTION_ID },
       totals: {
         subtotal: 109.97,
         tax: 10.0,
@@ -980,13 +1025,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       },
     });
 
-    /**
-     * Wire mocks for a happy-path first-time order create so the only
-     * variable across these tests is the order_carriers reconcile path.
-     */
-    const wireFirstTimeCreatePath = (): void => {
-      // Step 0: no existing destination mapping → falls through to create.
-      // Steps 1-5: customer / product / variant resolutions all succeed.
+    const wireSuccessfulCreatePath = (): void => {
       mockIdentifierMapping.getExternalIds = jest
         .fn()
         .mockImplementation((entityType: string) => {
@@ -1005,7 +1044,6 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
               { connectionId: connection.id, externalId: '300', entityType: 'ProductVariant' },
             ]);
           }
-          // 'Order' lookup at Step 0 — return empty so we don't short-circuit.
           return Promise.resolve([]);
         });
 
@@ -1015,154 +1053,156 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
         associations: { order_rows: { order_row: [] } },
       });
 
-      // createResource is called twice: cart, then order.
       mockHttpClient.createResource = jest
         .fn()
         .mockResolvedValueOnce({ id: '123' }) // cart
-        .mockResolvedValueOnce({
-          id: EXTERNAL_ORDER_ID,
-          reference: EXTERNAL_ORDER_NUMBER,
-        } as PrestashopOrder);
+        .mockResolvedValueOnce({ id: '999', reference: 'TEST-ORDER-001' } as PrestashopOrder);
 
       mockIdentifierMapping.createMapping = jest.fn().mockResolvedValue(undefined);
     };
 
-    it('should write shipping_cost_* via order_carriers PUT when totals.shipping > 0', async () => {
-      wireFirstTimeCreatePath();
-      mockHttpClient.listResources = jest
-        .fn()
-        .mockResolvedValueOnce([{ id: EXTERNAL_ORDER_CARRIER_ID, id_order: EXTERNAL_ORDER_ID, id_carrier: '1' }]);
-      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce({
-        id: EXTERNAL_ORDER_CARRIER_ID,
-        id_order: EXTERNAL_ORDER_ID,
-        id_carrier: '1',
-        weight: '0.000',
-        shipping_cost_tax_excl: '0.000000',
-        shipping_cost_tax_incl: '0.000000',
-        tracking_number: '',
-      });
-      mockHttpClient.updateResource = jest.fn().mockResolvedValueOnce(undefined);
-
-      await adapter.createOrder(buildOrderWithShippingTotal(10.95));
-
-      expect(mockHttpClient.listResources).toHaveBeenCalledWith(
-        'order_carriers',
-        { custom: { id_order: EXTERNAL_ORDER_ID } },
-        1,
-        0,
+    it('writes the sidecar row when the resolved carrier is the OL Dynamic carrier (mapping branch)', async () => {
+      wireSuccessfulCreatePath();
+      const mockMappingConfig = {
+        // Mapping resolves to the OL Dynamic carrier id — adapter must write the sidecar.
+        resolveCarrierMapping: jest.fn().mockResolvedValue(String(OL_DYNAMIC_CARRIER_ID)),
+      } as unknown as IMappingConfigService;
+      const adapterUnderTest = new PrestashopOrderProcessorManagerAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        mockOrderMapper,
+        connection,
+        mockCustomerProvisioner,
+        mockAddressProvisioner,
+        mockCurrencyResolver,
+        mockCustomerProjectionRepository,
+        mockOpenLinkerModuleClient,
+        mockMappingConfig,
       );
-      expect(mockHttpClient.getResource).toHaveBeenCalledWith(
-        'order_carriers',
-        EXTERNAL_ORDER_CARRIER_ID,
-      );
-      expect(mockHttpClient.updateResource).toHaveBeenCalledWith(
-        'order_carriers',
-        EXTERNAL_ORDER_CARRIER_ID,
+
+      await adapterUnderTest.createOrder(buildOrderForSidecar(12.5));
+
+      expect(mockOpenLinkerModuleClient.writeCartShipping).toHaveBeenCalledTimes(1);
+      expect(mockOpenLinkerModuleClient.writeCartShipping).toHaveBeenCalledWith(
         expect.objectContaining({
-          // Existing fields are spread through (full-resource PUT contract).
-          id: EXTERNAL_ORDER_CARRIER_ID,
-          id_order: EXTERNAL_ORDER_ID,
-          id_carrier: '1',
-          weight: '0.000',
-          tracking_number: '',
-          // Cost fields are overwritten with the order's shipping total.
-          shipping_cost_tax_excl: '10.95',
-          shipping_cost_tax_incl: '10.95',
+          idCart: 123,
+          amountTaxExcl: 12.5,
+          amountTaxIncl: 12.5,
+          source: expect.stringContaining(`connection:${ALLEGRO_CONNECTION_ID}`),
         }),
       );
     });
 
-    it('should skip the order_carriers round-trip when totals.shipping is zero', async () => {
-      wireFirstTimeCreatePath();
-      mockHttpClient.listResources = jest.fn();
-      mockHttpClient.getResource = jest.fn();
-      mockHttpClient.updateResource = jest.fn();
+    it('does NOT write the sidecar when a static carrier id is resolved via mapping', async () => {
+      wireSuccessfulCreatePath();
+      const mockMappingConfig = {
+        resolveCarrierMapping: jest.fn().mockResolvedValue(String(STATIC_CARRIER_ID)),
+      } as unknown as IMappingConfigService;
+      const adapterUnderTest = new PrestashopOrderProcessorManagerAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        mockOrderMapper,
+        connection,
+        mockCustomerProvisioner,
+        mockAddressProvisioner,
+        mockCurrencyResolver,
+        mockCustomerProjectionRepository,
+        mockOpenLinkerModuleClient,
+        mockMappingConfig,
+      );
 
-      const ref = await adapter.createOrder(buildOrderWithShippingTotal(0));
+      await adapterUnderTest.createOrder(buildOrderForSidecar());
 
-      expect(ref.orderId).toBe(METADATA_INTERNAL_ORDER_ID);
-      expect(mockHttpClient.listResources).not.toHaveBeenCalled();
-      expect(mockHttpClient.getResource).not.toHaveBeenCalled();
-      expect(mockHttpClient.updateResource).not.toHaveBeenCalled();
+      expect(mockOpenLinkerModuleClient.writeCartShipping).not.toHaveBeenCalled();
     });
 
-    it('should warn and skip the PUT when no order_carrier row is found', async () => {
-      wireFirstTimeCreatePath();
-      mockHttpClient.listResources = jest.fn().mockResolvedValueOnce([]);
-      mockHttpClient.getResource = jest.fn();
-      mockHttpClient.updateResource = jest.fn();
+    it('does NOT write the sidecar when defaultCarrierId resolves to a static carrier', async () => {
+      wireSuccessfulCreatePath();
+      const connWithStaticDefault = createTestConnection();
+      (connWithStaticDefault.config as Record<string, unknown>).defaultCarrierId = STATIC_CARRIER_ID;
+      const mockMappingConfig = {
+        resolveCarrierMapping: jest.fn().mockResolvedValue(null),
+      } as unknown as IMappingConfigService;
+      const adapterUnderTest = new PrestashopOrderProcessorManagerAdapter(
+        mockHttpClient,
+        mockIdentifierMapping,
+        mockOrderMapper,
+        connWithStaticDefault,
+        mockCustomerProvisioner,
+        mockAddressProvisioner,
+        mockCurrencyResolver,
+        mockCustomerProjectionRepository,
+        mockOpenLinkerModuleClient,
+        mockMappingConfig,
+      );
 
-      const ref = await adapter.createOrder(buildOrderWithShippingTotal(10.95));
+      await adapterUnderTest.createOrder(buildOrderForSidecar());
 
-      expect(ref.orderId).toBe(METADATA_INTERNAL_ORDER_ID);
-      expect(mockHttpClient.listResources).toHaveBeenCalledTimes(1);
-      expect(mockHttpClient.getResource).not.toHaveBeenCalled();
-      expect(mockHttpClient.updateResource).not.toHaveBeenCalled();
+      expect(mockOpenLinkerModuleClient.writeCartShipping).not.toHaveBeenCalled();
     });
 
-    it('should swallow and log when the order_carriers update throws', async () => {
-      wireFirstTimeCreatePath();
-      mockHttpClient.listResources = jest
-        .fn()
-        .mockResolvedValueOnce([{ id: EXTERNAL_ORDER_CARRIER_ID, id_order: EXTERNAL_ORDER_ID, id_carrier: '1' }]);
-      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce({
-        id: EXTERNAL_ORDER_CARRIER_ID,
-        id_order: EXTERNAL_ORDER_ID,
-        id_carrier: '1',
-      });
-      mockHttpClient.updateResource = jest
-        .fn()
-        .mockRejectedValueOnce(new PrestashopApiException('boom', 500, 'server error'));
+    it('writes the sidecar when no mapping/default resolves and falls back to OL Dynamic', async () => {
+      // No MappingConfigService and no defaultCarrierId — adapter falls
+      // back to the OL Dynamic carrier and must therefore write the sidecar.
+      wireSuccessfulCreatePath();
 
-      // The whole createOrder must still resolve and return the OrderRef —
-      // the order is already created in PS, only the cost reconcile failed.
-      const ref = await adapter.createOrder(buildOrderWithShippingTotal(10.95));
+      await adapter.createOrder(buildOrderForSidecar(8.0));
 
-      expect(ref.orderId).toBe(METADATA_INTERNAL_ORDER_ID);
-      expect(ref.orderNumber).toBe(EXTERNAL_ORDER_NUMBER);
-      expect(mockHttpClient.updateResource).toHaveBeenCalledTimes(1);
+      expect(mockOpenLinkerModuleClient.writeCartShipping).toHaveBeenCalledTimes(1);
+      expect(mockOpenLinkerModuleClient.writeCartShipping).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idCart: 123,
+          amountTaxExcl: 8.0,
+          amountTaxIncl: 8.0,
+        }),
+      );
     });
 
-    it('should reconcile shipping cost on retry when the destination order mapping already exists', async () => {
-      // Step 0 short-circuits: getExternalIds('Order', ...) returns an
-      // existing PS order. The reconcile step must STILL run so that a
-      // partial first run (mapping committed but reconcile crashed) can
-      // self-heal on retry.
-      mockIdentifierMapping.getExternalIds = jest
-        .fn()
-        .mockImplementation((entityType: string) => {
-          if (entityType === 'Order') {
-            return Promise.resolve([
-              { connectionId: connection.id, externalId: EXTERNAL_ORDER_ID, entityType: 'Order' },
-            ]);
+    it('aborts order creation (does NOT POST /orders) when the sidecar write throws', async () => {
+      wireSuccessfulCreatePath();
+      const sidecarError = new PrestashopOlModuleException(
+        connection.id,
+        123,
+        500,
+        'persist-failed',
+      );
+      mockOpenLinkerModuleClient.writeCartShipping.mockRejectedValueOnce(sidecarError);
+
+      // Adapter wraps non-domain errors in PrestashopApiException ("Failed to
+      // create PrestaShop order: …"); the underlying reason is preserved in
+      // the message.
+      await expect(adapter.createOrder(buildOrderForSidecar())).rejects.toThrow(
+        PrestashopApiException,
+      );
+
+      // createResource was called once (cart), never twice (cart + order).
+      expect(mockHttpClient.createResource).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.createResource).toHaveBeenCalledWith('carts', expect.anything());
+    });
+
+    it('aborts before any PS write when the OL module is not installed (carrier discovery empty)', async () => {
+      wireSuccessfulCreatePath();
+      // Override the discovery default with an empty result — operator
+      // hasn't installed/activated the OL module.
+      mockHttpClient.listResources = jest.fn().mockImplementation(
+        (resource: string, params?: { custom?: Record<string, unknown> }) => {
+          if (
+            resource === 'carriers' &&
+            params?.custom?.external_module_name === 'openlinker'
+          ) {
+            return Promise.resolve([]);
           }
           return Promise.resolve([]);
-        });
-
-      mockHttpClient.listResources = jest
-        .fn()
-        .mockResolvedValueOnce([{ id: EXTERNAL_ORDER_CARRIER_ID, id_order: EXTERNAL_ORDER_ID, id_carrier: '1' }]);
-      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce({
-        id: EXTERNAL_ORDER_CARRIER_ID,
-        id_order: EXTERNAL_ORDER_ID,
-        id_carrier: '1',
-      });
-      mockHttpClient.updateResource = jest.fn().mockResolvedValueOnce(undefined);
-
-      const ref = await adapter.createOrder(buildOrderWithShippingTotal(10.95));
-
-      expect(ref.orderId).toBe(METADATA_INTERNAL_ORDER_ID);
-      // No order create was attempted — Step 0 returned early — but the
-      // reconcile path was still exercised.
-      expect(mockHttpClient.createResource).not.toHaveBeenCalled();
-      expect(mockHttpClient.updateResource).toHaveBeenCalledWith(
-        'order_carriers',
-        EXTERNAL_ORDER_CARRIER_ID,
-        expect.objectContaining({
-          shipping_cost_tax_excl: '10.95',
-          shipping_cost_tax_incl: '10.95',
-        }),
+        },
       );
+
+      await expect(adapter.createOrder(buildOrderForSidecar())).rejects.toThrow(
+        PrestashopApiException,
+      );
+
+      // No cart, no order, no sidecar — discovery threw before any write.
+      expect(mockHttpClient.createResource).not.toHaveBeenCalled();
+      expect(mockOpenLinkerModuleClient.writeCartShipping).not.toHaveBeenCalled();
     });
   });
 
@@ -1320,6 +1360,7 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
           mockAddressProvisioner,
           mockCurrencyResolver,
           mockCustomerProjectionRepository,
+          mockOpenLinkerModuleClient,
         );
       }
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -1180,6 +1180,76 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       expect(mockHttpClient.createResource).toHaveBeenCalledWith('carts', expect.anything());
     });
 
+    it('warns and uses the first live row when multiple OL Dynamic carriers exist', async () => {
+      // Operator cloned the OL Dynamic carrier in BO (or a botched migration
+      // double-inserted). The adapter must keep working but warn so the
+      // operator notices and cleans up.
+      wireSuccessfulCreatePath();
+      const warnSpy = jest
+        .spyOn((adapter as unknown as { logger: { warn: jest.Mock } }).logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      mockHttpClient.listResources = jest.fn().mockImplementation(
+        (resource: string, params?: { custom?: Record<string, unknown> }) => {
+          if (
+            resource === 'carriers' &&
+            params?.custom?.external_module_name === 'openlinker'
+          ) {
+            return Promise.resolve([
+              { id: OL_DYNAMIC_CARRIER_ID, active: '1', deleted: '0' },
+              { id: OL_DYNAMIC_CARRIER_ID + 1, active: '1', deleted: '0' },
+            ]);
+          }
+          return Promise.resolve([]);
+        },
+      );
+
+      await adapter.createOrder(buildOrderForSidecar(8.0));
+
+      // First-row id was used for both the cart's id_carrier and the sidecar.
+      expect(mockOrderMapper.mapCartCreate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(Map),
+        expect.any(Map),
+        undefined,
+        undefined,
+        1,
+        1,
+        OL_DYNAMIC_CARRIER_ID,
+      );
+      expect(mockOpenLinkerModuleClient.writeCartShipping).toHaveBeenCalledTimes(1);
+      // Operator-visible warn naming the duplicate set.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Multiple live OL Dynamic carrier rows'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('aborts when the OL Dynamic carrier row returns a non-positive id (PS WS trust-boundary guard)', async () => {
+      // PS WS edge: the row exists but `id` decodes to NaN / 0 / negative
+      // (operator BO edit, schema drift). Adapter must NOT propagate
+      // id_carrier=NaN into the cart mapper — treat as missing instead.
+      wireSuccessfulCreatePath();
+      mockHttpClient.listResources = jest.fn().mockImplementation(
+        (resource: string, params?: { custom?: Record<string, unknown> }) => {
+          if (
+            resource === 'carriers' &&
+            params?.custom?.external_module_name === 'openlinker'
+          ) {
+            return Promise.resolve([{ id: 'not-a-number', active: '1', deleted: '0' }]);
+          }
+          return Promise.resolve([]);
+        },
+      );
+
+      await expect(adapter.createOrder(buildOrderForSidecar())).rejects.toThrow(
+        PrestashopApiException,
+      );
+      expect(mockHttpClient.createResource).not.toHaveBeenCalled();
+      expect(mockOpenLinkerModuleClient.writeCartShipping).not.toHaveBeenCalled();
+    });
+
     it('aborts before any PS write when the OL module is not installed (carrier discovery empty)', async () => {
       wireSuccessfulCreatePath();
       // Override the discovery default with an empty result — operator

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-adapter-factory-wrapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-adapter-factory-wrapper.ts
@@ -8,7 +8,12 @@
  * @module libs/integrations/prestashop/src/infrastructure/adapters
  * @implements {AdapterFactoryPort}
  */
-import { AdapterFactoryPort, CredentialsResolverPort, Capability } from '@openlinker/core/integrations';
+import {
+  AdapterFactoryPort,
+  CredentialsResolverPort,
+  Capability,
+  WebhookSecretProviderPort,
+} from '@openlinker/core/integrations';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { IMappingConfigService } from '@openlinker/core/mappings';
 import { PrestashopAdapterFactory } from '../../application/prestashop-adapter.factory';
@@ -31,12 +36,14 @@ export class PrestashopAdapterFactoryWrapper implements AdapterFactoryPort {
     private readonly _addressProvisioner?: PrestashopAddressProvisioner,
     private readonly _customerProjectionRepository?: CustomerProjectionRepositoryPort,
     private readonly _mappingConfigService?: IMappingConfigService,
+    private readonly _webhookSecretProvider?: WebhookSecretProviderPort,
   ) {
     this.factory = new PrestashopAdapterFactory(
       this._customerProvisioner,
       this._addressProvisioner,
       this._customerProjectionRepository,
       this._mappingConfigService,
+      this._webhookSecretProvider,
     );
   }
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -28,10 +28,10 @@ import {
 } from '@openlinker/core/identifier-mapping';
 import { IMappingConfigService } from '@openlinker/core/mappings';
 import { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
+import { IPrestashopOpenLinkerModuleClient } from '../http/prestashop-openlinker-module.client.interface';
 import {
   IPrestashopOrderMapper,
   PrestashopOrder,
-  PrestashopOrderCarrier,
 } from '../mappers/prestashop.mapper.interface';
 import {
   PrestashopCarrier,
@@ -49,7 +49,19 @@ import { PrestashopAddressProvisioner } from '../provisioners/prestashop-address
 import { PrestashopCurrencyResolver } from '../provisioners/prestashop-currency-resolver';
 import { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
 import { PrestashopConnectionConfig } from '../../domain/types/prestashop-config.types';
+import { PrestashopOlCarrierMissingException } from '../../domain/exceptions/prestashop-ol-module.exception';
 import { hashEmail } from '@openlinker/shared/config';
+
+/**
+ * Subset of PS `/api/carriers` row fields used by `discoverDynamicCarrierId`.
+ * Only `id`, `active`, `deleted` are inspected; the rest of the row (name,
+ * delay, etc.) is ignored.
+ */
+interface PrestashopCarrierRow {
+  id: string | number;
+  active?: string | number;
+  deleted?: string | number;
+}
 
 /**
  * PrestaShop Order Processor Manager Adapter
@@ -69,6 +81,8 @@ export class PrestashopOrderProcessorManagerAdapter
     private readonly addressProvisioner: PrestashopAddressProvisioner,
     private readonly currencyResolver: PrestashopCurrencyResolver,
     private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
+    // OL PrestaShop module client for HMAC-signed sidecar writes (#516).
+    private readonly openlinkerModuleClient: IPrestashopOpenLinkerModuleClient,
     private readonly mappingConfigService?: IMappingConfigService,
   ) {}
 
@@ -94,18 +108,11 @@ export class PrestashopOrderProcessorManagerAdapter
           this.logger.log(
             `Order already exists in PrestaShop: internalOrderId=${metadataInternalOrderId}, externalOrderId=${existingPrestashopOrder.externalId}`,
           );
-          // Self-heal a partial first run (#467): if the previous invocation
-          // created the order + mapping but crashed before reconciling the
-          // shipping cost, reconcile it now. Best-effort; no-ops when the
-          // cost is already correct.
-          await this.reconcileShippingCost(
-            order,
-            existingPrestashopOrder.externalId,
-            metadataInternalOrderId,
-          );
-          // Return existing order reference
-          // Note: We don't have the order number from the mapping, so we'll use the external ID
-          // metadataInternalOrderId is guaranteed to be string here because of the if check above
+          // No reconcile here post-#516 — totals are correct on first POST
+          // via the OL Dynamic carrier sidecar path (#515). Orders that
+          // landed under the pre-#516 reconcile-PUT path stay at their
+          // original totals (current_state may be 8); see epic #513
+          // out-of-scope: backfill SQL.
           return {
             orderId: metadataInternalOrderId,
             orderNumber: order.orderNumber || String(existingPrestashopOrder.externalId),
@@ -278,8 +285,21 @@ export class PrestashopOrderProcessorManagerAdapter
       const externalLangId: number = configLangId ?? 1; // Default to 1 if not specified
       this.logger.debug(`Using language ID: ${externalLangId} (from connection config)`);
 
-      // Step 5b: Resolve carrier id for #455 — carrier mapping at the destination.
-      const externalCarrierId = await this.resolveExternalCarrierId(order, config);
+      // Step 5b: Discover the OL Dynamic carrier id up front (#516). It's
+      // used for two things in the new flow: (1) as the runtime fallback in
+      // the resolution chain when neither mapping nor defaultCarrierId
+      // resolves (R5 / IMP-1), and (2) to decide whether to write the
+      // sidecar row before POST /orders. Discovery throws
+      // PrestashopOlCarrierMissingException if the OL module isn't installed
+      // — operator-actionable, aborts the sync cleanly before any PS write.
+      const olDynamicCarrierId = await this.discoverDynamicCarrierId();
+
+      // Step 5c: Resolve carrier id for #455 — carrier mapping at the destination.
+      const externalCarrierId = await this.resolveExternalCarrierId(
+        order,
+        config,
+        olDynamicCarrierId,
+      );
 
       // Step 6: Create cart in PrestaShop (required for order creation).
       // The carrier MUST be set on the cart, not just the order body — PS
@@ -308,6 +328,39 @@ export class PrestashopOrderProcessorManagerAdapter
         this.logger.error(`Failed to create cart in PrestaShop: ${errorMessage}`);
         throw new PrestashopProvisioningException(
           `Failed to create cart in PrestaShop: ${errorMessage}`,
+        );
+      }
+
+      // Step 6.5: Sidecar write for the OL Dynamic carrier path (#516).
+      // When the resolved carrier matches the OL Dynamic carrier id, write
+      // the buyer-paid amount into the module's sidecar table BEFORE
+      // POST /orders so PS can read the authoritative value via
+      // getOrderShippingCostExternal() at order-total time. Static PS
+      // carriers don't need this — PS computes shipping from their own
+      // range tables. Throws PrestashopOlModuleException on non-2xx
+      // (NOT best-effort; abort before order create rather than ship at
+      // zero).
+      if (externalCarrierId === olDynamicCarrierId) {
+        const idCart = Number.parseInt(String(externalCartId), 10);
+        // Free-text debug label — not load-bearing. We don't know the source
+        // platform type from OrderSourceRef (only `connectionId` + `eventId`),
+        // so the label leans on whichever neutral identifier is available.
+        const sourceLabel = order.source
+          ? `connection:${order.source.connectionId}` +
+            (order.source.eventId ? `:event:${order.source.eventId}` : '') +
+            (order.orderNumber ? `:order:${order.orderNumber}` : '')
+          : order.orderNumber
+            ? `order:${order.orderNumber}`
+            : undefined;
+        await this.openlinkerModuleClient.writeCartShipping({
+          idCart,
+          amountTaxExcl: order.totals.shipping,
+          amountTaxIncl: order.totals.shipping,
+          source: sourceLabel,
+        });
+        this.logger.debug(
+          `OL sidecar written: idCart=${idCart} amountTaxIncl=${order.totals.shipping} ` +
+            `source=${sourceLabel ?? '<none>'}`,
         );
       }
 
@@ -470,12 +523,10 @@ export class PrestashopOrderProcessorManagerAdapter
         `Order mapping created: externalOrderId=${externalOrderId}, internalOrderId=${internalOrderId}`,
       );
 
-      // Step 6.5: Reconcile shipping cost on order_carriers (#467).
-      // PS silently zeros total_shipping on POST /orders when id_carrier
-      // doesn't resolve to a zone-priced carrier; PUT /order_carriers/{id}
-      // honours per-order cost regardless. Best-effort — failures are logged
-      // but never fail the order, which is already created and mapped.
-      await this.reconcileShippingCost(order, externalOrderId, internalOrderId);
+      // Order created; PS computed shipping totals via the resolved carrier
+      // — no reconcile needed post-#516. The OL Dynamic carrier path wrote
+      // its sidecar row at Step 6.5; static carriers price from PS's own
+      // zone tables.
 
       // Step 7: Return order reference
       return {
@@ -502,99 +553,73 @@ export class PrestashopOrderProcessorManagerAdapter
   }
 
   /**
-   * Reconcile per-order shipping cost on `order_carriers` (#467).
+   * Discover the PrestaShop `id_carrier` of the OpenLinker Dynamic carrier
+   * row installed by the OL PS module (#515 / PR #524).
    *
-   * Background: PrestaShop's WebService silently zeroes `total_shipping`
-   * when the carrier on `POST /orders` doesn't resolve to a zone-priced
-   * carrier (a common situation when `defaultCarrierId` isn't configured
-   * and we fall back to `id_carrier=1`). The fix is a follow-up
-   * `PUT /order_carriers/{id}` that writes the per-order
-   * `shipping_cost_tax_excl` / `shipping_cost_tax_incl` directly. PS WS
-   * honours these regardless of carrier zone configuration.
+   * Filters on `external_module_name=openlinker` via PS WS `filter[…]=[…]`
+   * (handled by the http client's `custom` option). We deliberately do NOT
+   * filter `active`/`deleted` server-side — PrestaShop has a documented bug
+   * (forge issue #28424) where `filter[active]` returns inverted results;
+   * the safer fix is to fetch the (small, single-digit) result set keyed by
+   * `external_module_name` and post-filter `active=1, deleted=0` in TS.
    *
-   * Contract: best-effort. The order is already created and the identifier
-   * mapping is durable; a reconcile failure is logged at warn level and
-   * swallowed. Re-running with the same inputs is a no-op (idempotent PUT).
-   *
-   * Skipped when `order.totals.shipping <= 0` to save a round-trip.
+   * Throws PrestashopOlCarrierMissingException if no live row exists —
+   * surfaces operator-actionable installation/activation issues fast and
+   * aborts the sync before any PS-side write. Logs a warning if multiple
+   * live rows exist (operator likely cloned the carrier in BO) and uses
+   * the first; this is a benign-but-noisy state that the operator should
+   * resolve.
    */
-  private async reconcileShippingCost(
-    order: OrderCreate,
-    externalOrderId: string,
-    internalOrderId: string,
-  ): Promise<void> {
-    const shipping = order.totals.shipping;
-    // Skip the round-trip for zero, negative, or non-finite shipping.
-    // OrderTotals doesn't model negative shipping today; if that changes,
-    // revisit whether refunds/discounts should also write back through here.
-    if (!Number.isFinite(shipping) || shipping <= 0) {
-      return;
+  private async discoverDynamicCarrierId(): Promise<number> {
+    const rows = await this.httpClient.listResources<PrestashopCarrierRow>(
+      'carriers',
+      { custom: { external_module_name: 'openlinker' } },
+      100,
+      0,
+    );
+    const live = rows.filter(
+      (r) => Number(r.active) === 1 && Number(r.deleted) === 0,
+    );
+
+    if (live.length === 0) {
+      throw new PrestashopOlCarrierMissingException(this.connection.id);
     }
 
-    try {
-      // 1. Find the auto-created order_carrier row for this order.
-      const rows = await this.httpClient.listResources<PrestashopOrderCarrier>(
-        'order_carriers',
-        { custom: { id_order: externalOrderId } },
-        1,
-        0,
-      );
-      if (rows.length === 0) {
-        this.logger.warn(
-          `Shipping cost reconcile: no order_carrier row found for externalOrderId=${externalOrderId} (internalOrderId=${internalOrderId}). PS may have failed to attach a carrier — verify carrier mapping for connection ${this.connection.id}.`,
-        );
-        return;
-      }
-
-      const orderCarrierId = rows[0].id;
-
-      // 2. Read the full row — PS WS PUT requires the complete resource body.
-      const full = await this.httpClient.getResource<PrestashopOrderCarrier>(
-        'order_carriers',
-        orderCarrierId,
-      );
-
-      // 3. Overlay the cost fields and write back. Same value for tax-incl
-      //    and tax-excl mirrors the existing OrderTotals tax-included
-      //    assumption in the mapper (revisit when OrderTotals grows a
-      //    shippingTax field).
-      const shippingCost = shipping.toFixed(2);
-      await this.httpClient.updateResource<PrestashopOrderCarrier>(
-        'order_carriers',
-        orderCarrierId,
-        {
-          ...full,
-          shipping_cost_tax_excl: shippingCost,
-          shipping_cost_tax_incl: shippingCost,
-        },
-      );
-
-      this.logger.log(
-        `Shipping cost reconciled: externalOrderId=${externalOrderId}, orderCarrierId=${String(orderCarrierId)}, shipping=${shippingCost}`,
-      );
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+    if (live.length > 1) {
       this.logger.warn(
-        `Shipping cost reconcile failed for internalOrderId=${internalOrderId} externalOrderId=${externalOrderId}: ${errorMessage}`,
+        `Multiple live OL Dynamic carrier rows on connection ${this.connection.id} ` +
+          `(count=${live.length}, ids=[${live.map((r) => String(r.id)).join(',')}]). ` +
+          `Using first; operator should remove duplicates in PS Back Office.`,
       );
     }
+
+    const id = Number(live[0].id);
+    this.logger.debug(
+      `Resolved OL Dynamic carrier on connection ${this.connection.id}: id_carrier=${id}`,
+    );
+    return id;
   }
 
   /**
-   * Resolve the PrestaShop `id_carrier` to use when creating an order (#455).
+   * Resolve the PrestaShop `id_carrier` to use when creating an order (#455 / #516).
    *
    * Resolution chain:
    *   1. `MappingConfigService.resolveCarrierMapping(sourceConnectionId, methodId)`
    *   2. `connection.config.defaultCarrierId`
-   *   3. `undefined` — mapper falls back to its hardcoded `1`
+   *   3. `olDynamicCarrierId` — runtime fallback so unmapped methods still
+   *      get a working carrier without an operator config write. The OL
+   *      Dynamic carrier writes the buyer-paid amount via the sidecar at
+   *      Step 6.5.
    *
-   * Returns `undefined` to defer the final hardcoded default to the mapper,
-   * keeping the "every fallback gets a warn" semantics in one place.
+   * No throw path — `discoverDynamicCarrierId` already threw upstream if
+   * the OL module isn't installed, so this method always returns a
+   * positive integer.
    */
   private async resolveExternalCarrierId(
     order: OrderCreate,
     config: PrestashopConnectionConfig,
-  ): Promise<number | undefined> {
+    olDynamicCarrierId: number,
+  ): Promise<number> {
     const sourceConnectionId = order.source?.connectionId;
     const methodId = order.shipping?.methodId;
     const methodName = order.shipping?.methodName;
@@ -624,7 +649,7 @@ export class PrestashopOrderProcessorManagerAdapter
       // Defend against operator-misconfigured defaults (0, negative, NaN).
       // Without this guard the mapper writes id_carrier=0 to the cart and
       // we reproduce the #503 failure mode through a different door — `??`
-      // doesn't fall back on 0, only null/undefined. Log and ignore.
+      // doesn't fall back on 0, only null/undefined.
       if (Number.isFinite(config.defaultCarrierId) && config.defaultCarrierId > 0) {
         this.logger.warn(
           `No carrier mapping for methodId=${methodId ?? '<none>'} (methodName=${methodName ?? '<none>'}, ` +
@@ -635,16 +660,16 @@ export class PrestashopOrderProcessorManagerAdapter
       }
       this.logger.warn(
         `Connection config has invalid defaultCarrierId=${String(config.defaultCarrierId)} (must be a positive integer) ` +
-          `for connection ${this.connection.id} — ignoring; falling back to PrestaShop's first carrier (id_carrier=1).`,
+          `for connection ${this.connection.id} — ignoring; falling back to OL Dynamic carrier id_carrier=${olDynamicCarrierId}.`,
       );
     }
 
     this.logger.warn(
       `No carrier mapping for methodId=${methodId ?? '<none>'} (methodName=${methodName ?? '<none>'}, ` +
         `sourceConnectionId=${sourceConnectionId ?? '<none>'}, destinationConnectionId=${this.connection.id}) ` +
-        `and no defaultCarrierId on connection config. Falling back to PrestaShop's first carrier (id_carrier=1).`,
+        `and no defaultCarrierId on connection config. Falling back to OL Dynamic carrier id_carrier=${olDynamicCarrierId}.`,
     );
-    return undefined;
+    return olDynamicCarrierId;
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -593,7 +593,20 @@ export class PrestashopOrderProcessorManagerAdapter
       );
     }
 
+    // PS WS is a trust boundary — `id` is typed `string | number` but the wire
+    // payload is operator-controlled (PS BO edits) and could in theory deliver
+    // garbage that coerces to NaN or a non-positive integer. Treat that as
+    // "module not installed" rather than letting NaN propagate into the cart
+    // mapper as `id_carrier=NaN` and reproduce #503 through a different door.
     const id = Number(live[0].id);
+    if (!Number.isFinite(id) || id <= 0) {
+      this.logger.warn(
+        `OL Dynamic carrier row on connection ${this.connection.id} has invalid id=${String(live[0].id)} ` +
+          `(must be a positive integer). Treating as missing; aborting order create.`,
+      );
+      throw new PrestashopOlCarrierMissingException(this.connection.id);
+    }
+
     this.logger.debug(
       `Resolved OL Dynamic carrier on connection ${this.connection.id}: id_carrier=${id}`,
     );

--- a/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-openlinker-module.client.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-openlinker-module.client.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * PrestaShop OpenLinker Module Client Tests
+ *
+ * Unit tests for PrestashopOpenLinkerModuleClient — HMAC signing, URL
+ * construction, header shape, and error mapping. Mocks `fetch` globally
+ * (matches the existing PrestashopWebserviceClient spec pattern in this
+ * package) and the WebhookSecretProviderPort.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/http/__tests__
+ */
+import { createHmac } from 'crypto';
+
+import { WebhookSecretProviderPort } from '@openlinker/core/integrations';
+
+import { PrestashopOpenLinkerModuleClient } from '../prestashop-openlinker-module.client';
+import { PrestashopOlModuleException } from '../../../domain/exceptions/prestashop-ol-module.exception';
+
+// Mock fetch globally — matches existing PrestashopWebserviceClient spec.
+global.fetch = jest.fn();
+
+describe('PrestashopOpenLinkerModuleClient', () => {
+  const connectionId = 'conn-uuid-1';
+  const baseUrl = 'https://shop.example.com';
+  const secret = 'shared-test-secret';
+  const idCart = 42;
+
+  let client: PrestashopOpenLinkerModuleClient;
+  let secretProvider: jest.Mocked<WebhookSecretProviderPort>;
+
+  beforeEach(() => {
+    secretProvider = {
+      getSecret: jest.fn().mockResolvedValue(secret),
+      invalidate: jest.fn(),
+    };
+    client = new PrestashopOpenLinkerModuleClient(connectionId, baseUrl, secretProvider);
+    jest.clearAllMocks();
+  });
+
+  describe('writeCartShipping', () => {
+    it('should POST to the cartshipping module endpoint with the documented body shape', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue({ ok: true, id_cart: idCart }),
+      });
+
+      // Act
+      await client.writeCartShipping({
+        idCart,
+        amountTaxExcl: 12.2,
+        amountTaxIncl: 15.0,
+        source: 'allegro:order:abc',
+      });
+
+      // Assert
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      expect(url).toBe(
+        'https://shop.example.com/index.php?fc=module&module=openlinker&controller=cartshipping',
+      );
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).toEqual({
+        id_cart: idCart,
+        amount_tax_excl: 12.2,
+        amount_tax_incl: 15.0,
+        source: 'allegro:order:abc',
+      });
+    });
+
+    it('should sign the request with HMAC-SHA256 over timestamp + "." + body', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue({ ok: true, id_cart: idCart }),
+      });
+
+      // Act
+      await client.writeCartShipping({
+        idCart,
+        amountTaxExcl: 12.2,
+        amountTaxIncl: 15.0,
+      });
+
+      // Assert — recompute the expected signature from the captured body + timestamp
+      const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      const headers = init.headers as Record<string, string>;
+      const timestamp = headers['X-OpenLinker-Timestamp'];
+      const body = init.body as string;
+      const expectedHex = createHmac('sha256', secret)
+        .update(timestamp + '.' + body)
+        .digest('hex');
+      expect(headers['X-OpenLinker-Signature']).toBe('sha256=' + expectedHex);
+      expect(headers['X-OpenLinker-Signature']).toMatch(/^sha256=[0-9a-f]{64}$/);
+      expect(secretProvider.getSecret).toHaveBeenCalledWith('prestashop', connectionId);
+    });
+
+    it('should serialize source as null when omitted', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue({ ok: true, id_cart: idCart }),
+      });
+
+      // Act
+      await client.writeCartShipping({ idCart, amountTaxExcl: 1, amountTaxIncl: 1 });
+
+      // Assert
+      const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      const parsedBody = JSON.parse(init.body as string) as { source: unknown };
+      expect(parsedBody.source).toBeNull();
+    });
+
+    it('should throw PrestashopOlModuleException when the module returns 401', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 401,
+        json: jest.fn().mockResolvedValue({ ok: false, error: 'invalid-signature' }),
+      });
+
+      // Act & Assert
+      await expect(
+        client.writeCartShipping({ idCart, amountTaxExcl: 1, amountTaxIncl: 1 }),
+      ).rejects.toMatchObject({
+        name: 'PrestashopOlModuleException',
+        connectionId,
+        idCart,
+        status: 401,
+        reason: 'invalid-signature',
+      });
+    });
+
+    it('should throw PrestashopOlModuleException when the module returns 500', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 500,
+        json: jest.fn().mockResolvedValue({ ok: false, error: 'persist-failed' }),
+      });
+
+      // Act & Assert
+      await expect(
+        client.writeCartShipping({ idCart, amountTaxExcl: 1, amountTaxIncl: 1 }),
+      ).rejects.toBeInstanceOf(PrestashopOlModuleException);
+    });
+
+    it('should resolve cleanly on 2xx response', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue({ ok: true, id_cart: idCart }),
+      });
+
+      // Act & Assert — should not throw
+      await expect(
+        client.writeCartShipping({ idCart, amountTaxExcl: 1, amountTaxIncl: 1 }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should map a fetch network failure to PrestashopOlModuleException with status=0', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:443'));
+
+      // Act & Assert
+      await expect(
+        client.writeCartShipping({ idCart, amountTaxExcl: 1, amountTaxIncl: 1 }),
+      ).rejects.toMatchObject({
+        name: 'PrestashopOlModuleException',
+        connectionId,
+        idCart,
+        status: 0,
+      });
+    });
+
+    it('should normalize trailing slash on baseUrl', async () => {
+      // Arrange
+      const slashClient = new PrestashopOpenLinkerModuleClient(
+        connectionId,
+        'https://shop.example.com/',
+        secretProvider,
+      );
+      (global.fetch as jest.Mock).mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue({ ok: true, id_cart: idCart }),
+      });
+
+      // Act
+      await slashClient.writeCartShipping({ idCart, amountTaxExcl: 1, amountTaxIncl: 1 });
+
+      // Assert
+      const [url] = (global.fetch as jest.Mock).mock.calls[0] as [
+        string,
+        RequestInit,
+      ];
+      expect(url).toBe(
+        'https://shop.example.com/index.php?fc=module&module=openlinker&controller=cartshipping',
+      );
+    });
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-openlinker-module.client.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-openlinker-module.client.interface.ts
@@ -1,0 +1,57 @@
+/**
+ * PrestaShop OpenLinker Module Client Interface
+ *
+ * Defines the contract for HMAC-signed write operations against the
+ * OpenLinker PrestaShop module's front-controller endpoints (#515 / PR #524).
+ * Used by the order processor adapter (#516) to write per-cart shipping
+ * costs into the module's sidecar table BEFORE order create, so PS can
+ * read the authoritative amount via getOrderShippingCostExternal() at
+ * order-total time.
+ *
+ * Scope: write-only. Read operations against the OL module's PS-side data
+ * (e.g. discovering the OL Dynamic carrier id) go through the regular
+ * IPrestashopWebserviceClient since they use PS WS Basic auth, not HMAC.
+ * Keeping this interface focused on HMAC writes avoids mixing transport /
+ * auth concerns on a single client.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/http
+ * @see {@link PrestashopOpenLinkerModuleClient} for the implementation
+ */
+
+/**
+ * Input shape for `writeCartShipping` — per-cart shipping cost row written
+ * into the OL module's sidecar table.
+ *
+ * The OL backend's `amount_tax_incl` is treated as authoritative on the
+ * wire; the PS module installs the OL Dynamic carrier with
+ * `id_tax_rules_group=0` so PS does NOT add tax on top.
+ */
+export interface WriteCartShippingInput {
+  /** PrestaShop cart id (integer; the cart row must already exist in PS). */
+  idCart: number;
+  /** Tax-exclusive shipping amount. Stored alongside tax-incl for future use. */
+  amountTaxExcl: number;
+  /** Tax-inclusive shipping amount — what PS actually returns at order-total. */
+  amountTaxIncl: number;
+  /**
+   * Free-text diagnostic label for the source of this row, e.g.
+   * `allegro:order:abc123`. Optional; persisted as-is for debugging.
+   */
+  source?: string;
+}
+
+/**
+ * Client contract for HMAC-signed writes to the OpenLinker PS module.
+ */
+export interface IPrestashopOpenLinkerModuleClient {
+  /**
+   * Write a per-cart shipping cost into the OL module's sidecar table via
+   * its HMAC-authed front controller. Idempotent: re-writing the same
+   * (idCart, amounts) tuple is a no-op modulo `updated_at`.
+   *
+   * @param input — cart id + tax-incl/tax-excl amounts + optional source
+   * @throws PrestashopOlModuleException on non-2xx response. NOT best-effort —
+   *         order creation must abort so we don't ship at zero.
+   */
+  writeCartShipping(input: WriteCartShippingInput): Promise<void>;
+}

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-openlinker-module.client.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-openlinker-module.client.ts
@@ -1,0 +1,144 @@
+/**
+ * PrestaShop OpenLinker Module Client
+ *
+ * HTTP client implementation for HMAC-signed writes to the OpenLinker
+ * PrestaShop module's front-controller endpoints (#515 / PR #524). Mirrors
+ * the inbound HMAC contract verified by the module's HmacRequestVerifier
+ * bit-for-bit:
+ *
+ *   - Header X-OpenLinker-Timestamp: unix milliseconds, numeric string
+ *   - Header X-OpenLinker-Signature: "sha256=<64-char hex>"
+ *   - Signed payload:                 timestamp + "." + rawBody
+ *   - HMAC algorithm:                 SHA-256
+ *
+ * Uses native `fetch` (Node 18+) to match the existing PrestashopWebservice-
+ * Client transport pattern in this package. The shared webhook secret is
+ * resolved via WebhookSecretProviderPort — same bytes the inbound webhook
+ * receiver uses to verify signatures, just used in the outbound direction
+ * here (#516 / tech-review reuse-vs-rename note).
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/http
+ * @implements {IPrestashopOpenLinkerModuleClient}
+ * @see apps/prestashop-module/openlinker/classes/HmacRequestVerifier.php (PHP receiver)
+ * @see apps/prestashop-module/openlinker/controllers/front/cartshipping.php (cartshipping endpoint)
+ */
+import { createHmac } from 'crypto';
+
+import { Logger } from '@openlinker/shared/logging';
+import { WebhookSecretProviderPort } from '@openlinker/core/integrations';
+
+import {
+  IPrestashopOpenLinkerModuleClient,
+  WriteCartShippingInput,
+} from './prestashop-openlinker-module.client.interface';
+import { PrestashopOlModuleException } from '../../domain/exceptions/prestashop-ol-module.exception';
+
+/**
+ * Provider identifier passed to WebhookSecretProviderPort.getSecret. Matches
+ * the `provider` value used by the inbound webhook receiver for the same
+ * connection, so both directions resolve the same secret bytes.
+ */
+const PROVIDER = 'prestashop';
+
+/**
+ * Module endpoint URL relative to the PS storefront base URL. Hardcoded
+ * because it's part of the wire contract — PS resolves front-controller
+ * routes via `?fc=module&module=<name>&controller=<name>`.
+ */
+const CARTSHIPPING_PATH = '/index.php?fc=module&module=openlinker&controller=cartshipping';
+
+export class PrestashopOpenLinkerModuleClient implements IPrestashopOpenLinkerModuleClient {
+  private readonly logger = new Logger(PrestashopOpenLinkerModuleClient.name);
+
+  /**
+   * @param connectionId       OpenLinker connection id (UUID); resolves the secret + identifies logs
+   * @param baseUrl            PS storefront URL with no trailing slash (e.g. `https://shop.example.com`)
+   * @param secretProvider     Resolves `(provider, connectionId) → secret` — see port JSDoc for bidirectional use
+   */
+  constructor(
+    private readonly connectionId: string,
+    private readonly baseUrl: string,
+    private readonly secretProvider: WebhookSecretProviderPort,
+  ) {}
+
+  async writeCartShipping(input: WriteCartShippingInput): Promise<void> {
+    const body = JSON.stringify({
+      id_cart: input.idCart,
+      amount_tax_excl: input.amountTaxExcl,
+      amount_tax_incl: input.amountTaxIncl,
+      source: input.source ?? null,
+    });
+
+    const timestamp = String(Date.now());
+    const secret = await this.secretProvider.getSecret(PROVIDER, this.connectionId);
+    const signedPayload = timestamp + '.' + body;
+    const signatureHex = createHmac('sha256', secret).update(signedPayload).digest('hex');
+    const signatureHeader = 'sha256=' + signatureHex;
+
+    const url = this.baseUrl.replace(/\/$/, '') + CARTSHIPPING_PATH;
+
+    this.logger.debug(
+      `OpenLinker module: POST cartshipping connection=${this.connectionId} ` +
+        `idCart=${input.idCart} amountTaxIncl=${input.amountTaxIncl}`,
+    );
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-OpenLinker-Timestamp': timestamp,
+          'X-OpenLinker-Signature': signatureHeader,
+        },
+        body,
+      });
+    } catch (err) {
+      // Network-level failure (DNS, connection refused, TLS, abort).
+      throw new PrestashopOlModuleException(
+        this.connectionId,
+        input.idCart,
+        0,
+        `network: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
+    }
+
+    if (response.status >= 200 && response.status < 300) {
+      return;
+    }
+
+    const reason = await this.extractReason(response);
+    this.logger.warn(
+      `OpenLinker module: cartshipping write failed connection=${this.connectionId} ` +
+        `idCart=${input.idCart} status=${response.status} reason=${reason ?? 'unknown'}`,
+    );
+    throw new PrestashopOlModuleException(
+      this.connectionId,
+      input.idCart,
+      response.status,
+      reason,
+    );
+  }
+
+  /**
+   * Best-effort extraction of the `error` reason string from the module's
+   * JSON error body. Falls back to undefined on any parse failure — the
+   * status code alone is enough information for the caller.
+   */
+  private async extractReason(response: Response): Promise<string | undefined> {
+    try {
+      const data: unknown = await response.json();
+      if (
+        typeof data === 'object' &&
+        data !== null &&
+        'error' in data &&
+        typeof (data as { error: unknown }).error === 'string'
+      ) {
+        return (data as { error: string }).error;
+      }
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
@@ -329,7 +329,12 @@ describe('PrestashopOrderMapper', () => {
       expect(result.total_paid_real).toBe('88.96');
       expect(result.total_products).toBe('69.97');
       expect(result.total_products_wt).toBe('83.96'); // 69.97 + 13.99
-      expect(result.total_shipping).toBe('5.00');
+      // total_shipping[_tax_incl|_tax_excl] removed in #516 — PS computes
+      // shipping from the resolved carrier (OL Dynamic via sidecar / static
+      // via zone tables) at order-create time.
+      expect(result.total_shipping).toBeUndefined();
+      expect(result.total_shipping_tax_incl).toBeUndefined();
+      expect(result.total_shipping_tax_excl).toBeUndefined();
       expect(result.conversion_rate).toBe('1.000000');
       expect(result.id_address_delivery).toBe('200');
       expect(result.id_address_invoice).toBe('201');
@@ -468,9 +473,10 @@ describe('PrestashopOrderMapper', () => {
       expect(result.total_paid_tax_excl).toBeDefined();
       expect(result.total_products).toBeDefined();
       expect(result.total_products_wt).toBeDefined();
-      expect(result.total_shipping).toBeDefined();
-      expect(result.total_shipping_tax_incl).toBeDefined();
-      expect(result.total_shipping_tax_excl).toBeDefined();
+      // total_shipping[_tax_incl|_tax_excl] omitted post-#516.
+      expect(result.total_shipping).toBeUndefined();
+      expect(result.total_shipping_tax_incl).toBeUndefined();
+      expect(result.total_shipping_tax_excl).toBeUndefined();
       expect(result.conversion_rate).toBeDefined();
       expect(result.associations).toBeDefined();
     });

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -227,17 +227,15 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
     const totalProductsWt = orderCreate.totals.subtotal + orderCreate.totals.tax;
 
     /**
-     * Calculate shipping totals for PrestaShop order
-     *
-     * PrestaShop requires separate fields for shipping with and without tax:
-     * - total_shipping_tax_excl: Shipping cost without tax
-     * - total_shipping_tax_incl: Shipping cost with tax
-     *
-     * Note: For now, we assume shipping tax is 0 (shipping tax is not provided in OrderCreate.totals).
-     * Future enhancement: Add shippingTax field to OrderTotals if needed.
+     * Shipping totals are intentionally omitted from the create-order body
+     * post-#516. PrestaShop computes them from the resolved carrier at
+     * POST /orders time:
+     *   - OL Dynamic carrier: reads `getOrderShippingCostExternal()` from
+     *     the OL module's sidecar table written at Step 6.5 (#515 / #524).
+     *   - Static carriers: priced from the carrier's own zone/range tables.
+     * Writing total_shipping[_tax_incl|_tax_excl] here either gets ignored
+     * by PS or fights the carrier's own computation — both bad.
      */
-    const totalShippingTaxExcl = orderCreate.totals.shipping;
-    const totalShippingTaxIncl = orderCreate.totals.shipping; // Assuming no tax on shipping for now
 
     /**
      * Currency conversion rate
@@ -269,9 +267,9 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
       total_paid_tax_excl: orderCreate.totals.subtotal.toFixed(2),
       total_products: totalProducts.toFixed(2), // Products total without tax
       total_products_wt: totalProductsWt.toFixed(2), // Products total with tax
-      total_shipping: orderCreate.totals.shipping.toFixed(2),
-      total_shipping_tax_incl: totalShippingTaxIncl.toFixed(2), // Shipping with tax
-      total_shipping_tax_excl: totalShippingTaxExcl.toFixed(2), // Shipping without tax
+      // total_shipping[_tax_incl|_tax_excl] intentionally omitted post-#516.
+      // PS computes shipping from the resolved carrier (OL Dynamic via sidecar
+      // or static via zone tables) at order-create time.
       conversion_rate: conversionRate.toFixed(6), // Currency conversion rate (6 decimals)
       // PrestaShop requires associations for order_rows
       associations: {
@@ -459,9 +457,7 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
       'total_paid_tax_excl',
       'total_products',
       'total_products_wt',
-      'total_shipping',
-      'total_shipping_tax_incl',
-      'total_shipping_tax_excl',
+      // total_shipping[_tax_incl|_tax_excl] removed post-#516 — see mapOrderCreate JSDoc.
       'conversion_rate',
       'associations',
     ];

--- a/libs/integrations/prestashop/src/prestashop-integration.module.ts
+++ b/libs/integrations/prestashop/src/prestashop-integration.module.ts
@@ -7,7 +7,15 @@
  * @module libs/integrations/prestashop/src
  */
 import { Module, OnModuleInit, Inject } from '@nestjs/common';
-import { IntegrationsModule, ADAPTER_FACTORY_RESOLVER_TOKEN, AdapterFactoryResolverService, CONNECTION_TESTER_REGISTRY_TOKEN, ConnectionTesterRegistryService } from '@openlinker/core/integrations';
+import {
+  IntegrationsModule,
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  AdapterFactoryResolverService,
+  CONNECTION_TESTER_REGISTRY_TOKEN,
+  ConnectionTesterRegistryService,
+  WEBHOOK_SECRET_PROVIDER_TOKEN,
+  WebhookSecretProviderPort,
+} from '@openlinker/core/integrations';
 import {
   MappingsModule,
   MAPPING_CONFIG_SERVICE_TOKEN,
@@ -44,6 +52,8 @@ export class PrestashopIntegrationModule implements OnModuleInit {
     private readonly customerProjectionRepository: CustomerProjectionRepositoryPort,
     @Inject(MAPPING_CONFIG_SERVICE_TOKEN)
     private readonly mappingConfigService: IMappingConfigService,
+    @Inject(WEBHOOK_SECRET_PROVIDER_TOKEN)
+    private readonly webhookSecretProvider: WebhookSecretProviderPort,
   ) {}
 
   onModuleInit(): void {
@@ -53,6 +63,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
       this.addressProvisioner,
       this.customerProjectionRepository,
       this.mappingConfigService,
+      this.webhookSecretProvider,
     );
     this.factoryResolver.registerFactory('prestashop.webservice.v1', factory);
     this.connectionTesterRegistry.register(


### PR DESCRIPTION
## Summary

- Adapter writes per-cart shipping into the OL PS module's HMAC-authed `cartshipping` controller (#515 / #524) **before** `POST /orders` so PS reads the buyer-paid amount via `getOrderShippingCostExternal()` at order-total time.
- Removes the post-create `order_carriers` reconcile (#467) and the carrier-1 hardcoded fallback. Unmapped methods now fall back to the discovered OL Dynamic carrier instead, which carries its own shipping cost via the sidecar — no zero-shipping landings, no `current_state=8`.
- New `IPrestashopOpenLinkerModuleClient` (write-only) signs `timestamp + "." + body` with HMAC-SHA256 using `WebhookSecretProviderPort` (same secret bytes as inbound webhook verification — bidirectional reuse documented on the port).

## Architecture

- **CORE**: `WebhookSecretProviderPort` JSDoc updated to document outbound HMAC signing as a first-class use of the same port.
- **Integration**: New HMAC client + new domain exceptions (`PrestashopOlCarrierMissingException`, `PrestashopOlModuleException`). Carrier discovery lives as an adapter helper — uses the existing PS WS client (Basic auth, not HMAC) so the new client stays focused on the HMAC-write contract.
- Resolution chain at order-create: mapping → `defaultCarrierId` → OL Dynamic carrier (discovered per-order). Sidecar write fires only when the resolved carrier matches the OL Dynamic id.

## Risks / out-of-scope

- Per-order discovery (no cache) — keeps v1 simple; easy to add a per-connection TTL cache later if PS WS becomes a hot spot.
- BO-edit race acknowledged: sidecar lookup is keyed by `id_cart`, not `id_carrier`, so even if the operator edits the carrier between OL's discovery call and `POST /orders`, the sidecar row is still found. Pre-#516 orders that landed via the reconcile-PUT path keep their original totals (backfill SQL is out-of-scope for #513).

## Test plan

- [x] Unit tests for `PrestashopOpenLinkerModuleClient` — HMAC computation, URL/body shape, 2xx/4xx/5xx mapping, network failures, trailing-slash normalization (8 tests).
- [x] Adapter spec covers the new branches: OL mapped/sidecar; static mapped/no sidecar; unmapped + static default/no sidecar; unmapped + no default + OL/sidecar; sidecar fail/abort; OL discovery empty/abort (6 new branches under `OL module sidecar write (#516)`).
- [x] Existing `carrier resolution (#455)` tests updated to assert the OL Dynamic fallback (not `undefined`).
- [x] Mapper spec updated — `total_shipping[_tax_incl|_tax_excl]` no longer in the order body; PS computes from the resolved carrier.
- [x] Quality gate: `pnpm lint && pnpm type-check && pnpm test` all green (243 PS tests, 1817 total).
- [ ] Manual: end-to-end Allegro → PS sync on dev shop with the OL module installed; verify cart shipping persists and the order's total reflects the buyer-paid amount.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)