### PR TITLE
fix(dx): add @openlinker/integrations-prestashop to tsconfig paths

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,7 +36,9 @@
       "@openlinker/integrations-allegro": ["libs/integrations/allegro/src/index.ts"],
       "@openlinker/integrations-allegro/*": ["libs/integrations/allegro/src/*"],
       "@openlinker/integrations-ai": ["libs/integrations/ai/src/index.ts"],
-      "@openlinker/integrations-ai/*": ["libs/integrations/ai/src/*"]
+      "@openlinker/integrations-ai/*": ["libs/integrations/ai/src/*"],
+      "@openlinker/integrations-prestashop": ["libs/integrations/prestashop/src/index.ts"],
+      "@openlinker/integrations-prestashop/*": ["libs/integrations/prestashop/src/*"]
     }
   }
 }


### PR DESCRIPTION
Closes #532

## Summary

- Adds the missing `@openlinker/integrations-prestashop` (and `/*` wildcard) entries to `tsconfig.base.json` `paths`. Every other workspace package already had aliases — prestashop was the lone gap.
- Without the alias, the import resolved via `node_modules/@openlinker/integrations-prestashop/package.json` → `"types": "./dist/index.d.ts"`, which doesn't exist in dev/CI. The whole import surface typed as `any`, producing 4 ESLint errors at the only use site (`apps/api/src/integrations/http/connection.controller.ts:264-268`, introduced in #168) and blocking `pnpm lint` on `main`.

## Quality gate

| Check | Before | After |
|---|---|---|
| `pnpm lint` | 4 errors, 21 warnings | **0 errors**, 21 warnings |
| `pnpm type-check` | passes | passes |
| `pnpm test` | passes | **1605 / 1605** across 8 packages |

The four resolved errors (all in `apps/api/src/integrations/http/connection.controller.ts`):

```
264:3   error  Async method 'installWebhooks' has no 'await' expression  @typescript-eslint/require-await
268:5   error  Unsafe return of an `any` typed value                     @typescript-eslint/no-unsafe-return
268:12  error  Unsafe call of an `any` typed value                       @typescript-eslint/no-unsafe-call
268:44  error  Unsafe member access .install on an `any` value           @typescript-eslint/no-unsafe-member-access
```

All four disappear once TS resolves `IPrestashopWebhookProvisioningService` properly via the new alias — the field declaration was correct all along, only the import was unresolved.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — all 1605 unit tests pass
- [x] Verified `connection.controller.ts:264-268` no longer produces any errors
- [x] Verified no other usages of `@openlinker/integrations-prestashop` regress

## Discovered while

Working on #519 (PS module rename followup). The pre-commit hook on a docs-only PR caught these errors on `main`. Filing this fix first unblocks `pnpm lint` for everyone before #519 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
