### PR TITLE
docs(prestashop): runbook for openlinkerwebhooks→openlinker rename migration

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,6 +42,8 @@ pnpm dev:stack:seed-prestashop
 ```
 
 > If you're upgrading from a pre-#525 dev stack, the entrypoint change requires a one-time `docker compose down && docker compose up -d prestashop` (Compose's `restart` doesn't recreate containers on entrypoint change).
+>
+> If you're upgrading from a pre-#514 install (where the bind-mount module was named `openlinkerwebhooks`), follow [`docs/operations/prestashop-module-rename-migration.md`](./operations/prestashop-module-rename-migration.md) **once** before continuing — it walks the uninstall-old / recreate-container / install-new / re-configure-cron sequence.
 
 Log in to the PrestaShop admin at **http://localhost:8080/admin-dev/** with the default credentials (set in `docker-compose.yml`):
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ pnpm dev:stack:seed-prestashop
 
 > If you're upgrading from a pre-#525 dev stack, the entrypoint change requires a one-time `docker compose down && docker compose up -d prestashop` (Compose's `restart` doesn't recreate containers on entrypoint change).
 >
-> If you're upgrading from a pre-#514 install (where the bind-mount module was named `openlinkerwebhooks`), follow [`docs/operations/prestashop-module-rename-migration.md`](./operations/prestashop-module-rename-migration.md) **once** before continuing — it walks the uninstall-old / recreate-container / install-new / re-configure-cron sequence.
+> If your `ps_module` table still has a row with `name='openlinkerwebhooks'` (a pre-#514 install), follow [`docs/operations/prestashop-module-rename-migration.md`](./operations/prestashop-module-rename-migration.md) **once** before continuing — it walks the uninstall-old / recreate-container / install-new / re-configure-cron sequence.
 
 Log in to the PrestaShop admin at **http://localhost:8080/admin-dev/** with the default credentials (set in `docker-compose.yml`):
 

--- a/docs/operations/prestashop-module-rename-migration.md
+++ b/docs/operations/prestashop-module-rename-migration.md
@@ -33,15 +33,21 @@ docker compose exec prestashop sh -c \
    "SELECT status, COUNT(*) FROM ps_openlinker_webhook_outbox GROUP BY status;" 2>/dev/null'
 ```
 
-If `pending` > 0, jump to **Drain the backlog FIRST** before continuing — uninstall drops the outbox table.
+A non-zero `pending` count is informational only — both migration paths below preserve the outbox table and any rows in it (see "Backlog handling" below).
 
-## Drain the backlog FIRST
+## Backlog handling
 
-⚠️ The `uninstall()` hook in `openlinker.php` **drops** `ps_openlinker_webhook_outbox` and `ps_openlinker_cart_shipping`. Pending events are destroyed if you uninstall before draining.
+The `uninstall()` hook in `openlinker.php` **preserves** `ps_openlinker_webhook_outbox` and `ps_openlinker_cart_shipping` — both `dropOutboxTable()` and `dropCartShippingTable()` calls are commented out by design (see `openlinker.php:171,177`, "kept commented to match the conservative outbox default"). The install hook re-creates each table with `CREATE TABLE IF NOT EXISTS`, so existing rows survive uninstall + reinstall.
 
-If your old module is still loadable (path A in the next section), open its Configure page and click **Run Delivery Now** until `Pending Events` reaches 0.
+Practical implication: any pending events queued during the broken-cron window stay in place. After step 5 finishes, the new cron URL resumes delivering them on the next tick — no manual drain needed.
 
-If your old module is in the stale-directory state (path B — files missing on disk), the cron URL has been 404ing for some time and the events were never going anywhere. Accept the loss; nothing has been delivered, but nothing critical was queued either (any new events from product/order/inventory hooks would simply re-fire on the next sync run after migration).
+If you'd rather start fresh and discard the backlog (e.g., the events are stale and you want a clean slate), run this opt-in cleanup at any point during the migration:
+
+```bash
+docker compose exec prestashop sh -c \
+  'mysql -h mysql -u prestashop -pprestashop prestashop -e \
+   "DROP TABLE IF EXISTS ps_openlinker_webhook_outbox; DROP TABLE IF EXISTS ps_openlinker_cart_shipping;"'
+```
 
 ## Migration steps
 
@@ -49,7 +55,7 @@ If your old module is in the stale-directory state (path B — files missing on 
 
 **Path A — module loadable** (`/var/www/html/modules/openlinkerwebhooks/openlinkerwebhooks.php` exists on disk):
 
-PS admin → **Modules → Module Manager → openlinkerwebhooks → Uninstall**. The uninstall hook drops the outbox + cart_shipping tables and removes hooks cleanly.
+PS admin → **Modules → Module Manager → openlinkerwebhooks → Uninstall**. The uninstall hook removes hooks, deletes the admin tab, soft-deletes the OL Dynamic carrier, and clears `OPENLINKER_*` configuration keys. It does **not** drop the outbox or cart_shipping tables — they survive the uninstall (and the reinstall, since `CREATE TABLE IF NOT EXISTS` is a no-op when the tables already exist).
 
 **Path B — module stale** (directory exists but is empty post-#514; common case if you skipped this migration when #514 shipped):
 
@@ -79,14 +85,16 @@ DELETE FROM ps_authorization_role
 DELETE FROM ps_tab_lang WHERE id_tab IN (SELECT id_tab FROM ps_tab WHERE module = "openlinkerwebhooks");
 DELETE FROM ps_tab WHERE module = "openlinkerwebhooks";
 
-DROP TABLE IF EXISTS ps_openlinker_webhook_outbox;
-DROP TABLE IF EXISTS ps_openlinker_cart_shipping;
+-- Outbox + cart_shipping tables are intentionally NOT dropped here. The
+-- install hook in step 3 uses CREATE TABLE IF NOT EXISTS, so existing
+-- rows survive into the new module. See "Backlog handling" above for the
+-- opt-in cleanup snippet if you want a clean slate.
 SELECT "Uninstall complete" AS status;
 SQL
 '
 ```
 
-This recipe leaves `ps_configuration` untouched, so `OPENLINKER_BASE_URL` / `..._CONNECTION_ID` / `..._WEBHOOK_SECRET` / `..._CRON_TOKEN` are preserved across the migration.
+This recipe leaves `ps_configuration` rows intact on disk, but the install hook in step 3 calls `setDefaultConfiguration()` and **resets all four `OPENLINKER_*` keys** regardless: `OPENLINKER_BASE_URL` / `..._CONNECTION_ID` / `..._WEBHOOK_SECRET` are reset to empty strings, and `OPENLINKER_CRON_TOKEN` is regenerated. Plan to re-enter every config value in step 4.
 
 ### 2. Recreate the container to apply the new bind-mount
 
@@ -106,11 +114,11 @@ docker compose exec prestashop ls -la /var/www/html/modules/openlinker/openlinke
 
 **Recommended: PS admin GUI** → **Modules → Module Manager → search "openlinker" → Install**. The legacy install hook fires reliably via this path and:
 
-- Creates `ps_openlinker_webhook_outbox` empty.
-- Creates `ps_openlinker_cart_shipping` empty.
+- Ensures `ps_openlinker_webhook_outbox` exists (`CREATE TABLE IF NOT EXISTS` — preserves any pre-existing rows).
+- Ensures `ps_openlinker_cart_shipping` exists (same idempotent create).
 - Seeds the OL Dynamic carrier (per #515) — visible as `OpenLinker Dynamic` in the carrier-mapping picker; persists `OPENLINKER_DYNAMIC_CARRIER_ID` to `ps_configuration`.
 - Registers the standard hook set (`actionProductSave`, `actionValidateOrderAfter`, `actionOrderHistoryAddAfter`, `actionUpdateQuantity`, `actionCarrierUpdate`).
-- Generates a fresh `OPENLINKER_CRON_TOKEN` (a 64-char hex secret).
+- Calls `setDefaultConfiguration()`, which resets `OPENLINKER_BASE_URL` / `..._CONNECTION_ID` / `..._WEBHOOK_SECRET` to empty strings and generates a fresh `OPENLINKER_CRON_TOKEN` (64-char hex).
 
 **CLI alternative (for automation only):**
 ```bash
@@ -130,7 +138,7 @@ Open the module's Configure page (Module Manager → openlinker → Configure) a
 - `OPENLINKER_CONNECTION_ID` — the PrestaShop connection's UUID from the OpenLinker app
 - `OPENLINKER_WEBHOOK_SECRET` — the HMAC shared secret (must match `OL_WEBHOOK_SECRET` on the OpenLinker side)
 
-⚠️ **`OPENLINKER_CRON_TOKEN` is regenerated on every install path** — the GUI install, `bin/console install`, and the SQL recipe → install sequence all generate a fresh hex token via `parent::install()`. The path B SQL recipe **preserves** the old token in `ps_configuration` (it only deletes `ps_module` rows), but the **install hook then overwrites it** with a new value. Practical implication: **always copy the new token from the Configure page after install and update host crontabs in step 5** — there's no operator path that preserves the original token across uninstall/install.
+⚠️ **All four `OPENLINKER_*` configuration keys are reset by every install path.** The GUI install, `bin/console install`, and the SQL recipe → install sequence all run `setDefaultConfiguration()` (`openlinker.php:124`), which unconditionally calls `Configuration::updateValue()` for `OPENLINKER_BASE_URL`, `OPENLINKER_CONNECTION_ID`, `OPENLINKER_WEBHOOK_SECRET` (all reset to `''`) and `OPENLINKER_CRON_TOKEN` (regenerated to a fresh 64-char hex). The path B SQL recipe leaves the underlying `ps_configuration` rows intact, but the install hook overwrites them anyway. Practical implication: **always copy the new token from the Configure page after install and update host crontabs in step 5** — there's no operator path that preserves the original token across uninstall/install.
 
 ### 5. Update host crontab(s)
 

--- a/docs/operations/prestashop-module-rename-migration.md
+++ b/docs/operations/prestashop-module-rename-migration.md
@@ -1,0 +1,192 @@
+# PrestaShop Module Rename Migration (#519)
+
+One-time operator runbook for shops with a pre-#514 install of the bind-mount module. PR for #514 renamed `openlinkerwebhooks → openlinker`; the `module=` slug in the cron URL changed correspondingly. If your shop wasn't migrated when #514 shipped, the cron silently 404s and webhook events stop being delivered until the migration is applied.
+
+## Symptom check
+
+Run from the host that runs the PS container:
+
+```bash
+# 1. Is the old module still registered as active?
+docker compose exec prestashop sh -c \
+  'mysql -h mysql -u prestashop -pprestashop prestashop -e \
+   "SELECT id_module, name, active FROM ps_module WHERE name LIKE \"openlinker%\";"'
+```
+
+| Output | Diagnosis |
+|---|---|
+| Empty / no rows | Module never installed — no migration needed; install fresh per `docs/getting-started.md`. |
+| `name='openlinker', active=1` | Already migrated. Verify cron URL uses `module=openlinker` and you're done. |
+| `name='openlinkerwebhooks', active=1` | **Migration needed.** Continue below. |
+
+```bash
+# 2. Are the module files where the new bind-mount points?
+docker compose exec prestashop ls -la /var/www/html/modules/openlinker/openlinker.php
+```
+
+If the file doesn't exist, the bind-mount hasn't been applied. The compose recreate in step 3.2 below will fix this.
+
+```bash
+# 3. How many events are pending?
+docker compose exec prestashop sh -c \
+  'mysql -h mysql -u prestashop -pprestashop prestashop -e \
+   "SELECT status, COUNT(*) FROM ps_openlinker_webhook_outbox GROUP BY status;" 2>/dev/null'
+```
+
+If `pending` > 0, jump to **Drain the backlog FIRST** before continuing — uninstall drops the outbox table.
+
+## Drain the backlog FIRST
+
+⚠️ The `uninstall()` hook in `openlinker.php` **drops** `ps_openlinker_webhook_outbox` and `ps_openlinker_cart_shipping`. Pending events are destroyed if you uninstall before draining.
+
+If your old module is still loadable (path A in the next section), open its Configure page and click **Run Delivery Now** until `Pending Events` reaches 0.
+
+If your old module is in the stale-directory state (path B — files missing on disk), the cron URL has been 404ing for some time and the events were never going anywhere. Accept the loss; nothing has been delivered, but nothing critical was queued either (any new events from product/order/inventory hooks would simply re-fire on the next sync run after migration).
+
+## Migration steps
+
+### 1. Uninstall the old module
+
+**Path A — module loadable** (`/var/www/html/modules/openlinkerwebhooks/openlinkerwebhooks.php` exists on disk):
+
+PS admin → **Modules → Module Manager → openlinkerwebhooks → Uninstall**. The uninstall hook drops the outbox + cart_shipping tables and removes hooks cleanly.
+
+**Path B — module stale** (directory exists but is empty post-#514; common case if you skipped this migration when #514 shipped):
+
+The GUI uninstall fails because PS can't autoload the missing PHP class. Use the SQL fallback:
+
+```bash
+docker compose exec prestashop sh -c '
+mysql -h mysql -u prestashop -pprestashop prestashop <<SQL
+SET @id_module := (SELECT id_module FROM ps_module WHERE name = "openlinkerwebhooks");
+DELETE FROM ps_hook_module WHERE id_module = @id_module;
+DELETE FROM ps_module_shop WHERE id_module = @id_module;
+DELETE FROM ps_module WHERE id_module = @id_module;
+
+-- Authorization roles are keyed by slug, not module-id FK. Two slug families
+-- per module: ROLE_MOD_MODULE_<UPPER>_<CRUD> and ROLE_MOD_TAB_<UPPER>_<CRUD>.
+DELETE FROM ps_module_access
+  WHERE id_authorization_role IN (
+    SELECT id_authorization_role FROM ps_authorization_role
+    WHERE slug LIKE "ROLE_MOD_MODULE_OPENLINKERWEBHOOKS_%"
+       OR slug LIKE "ROLE_MOD_TAB_ADMINOPENLINKERWEBHOOKS_%"
+  );
+DELETE FROM ps_authorization_role
+  WHERE slug LIKE "ROLE_MOD_MODULE_OPENLINKERWEBHOOKS_%"
+     OR slug LIKE "ROLE_MOD_TAB_ADMINOPENLINKERWEBHOOKS_%";
+
+-- Admin tab created by the module install hook
+DELETE FROM ps_tab_lang WHERE id_tab IN (SELECT id_tab FROM ps_tab WHERE module = "openlinkerwebhooks");
+DELETE FROM ps_tab WHERE module = "openlinkerwebhooks";
+
+DROP TABLE IF EXISTS ps_openlinker_webhook_outbox;
+DROP TABLE IF EXISTS ps_openlinker_cart_shipping;
+SELECT "Uninstall complete" AS status;
+SQL
+'
+```
+
+This recipe leaves `ps_configuration` untouched, so `OPENLINKER_BASE_URL` / `..._CONNECTION_ID` / `..._WEBHOOK_SECRET` / `..._CRON_TOKEN` are preserved across the migration.
+
+### 2. Recreate the container to apply the new bind-mount
+
+```bash
+docker compose down
+docker compose up -d prestashop
+```
+
+`docker compose restart` is **not** sufficient — Compose only refreshes volume mounts on container creation, not restart (same constraint #525's entrypoint change documented). Verify the new path is live:
+
+```bash
+docker compose exec prestashop ls -la /var/www/html/modules/openlinker/openlinker.php
+# expect: -rw-r--r-- ... openlinker.php
+```
+
+### 3. Install the new module
+
+**Recommended: PS admin GUI** → **Modules → Module Manager → search "openlinker" → Install**. The legacy install hook fires reliably via this path and:
+
+- Creates `ps_openlinker_webhook_outbox` empty.
+- Creates `ps_openlinker_cart_shipping` empty.
+- Seeds the OL Dynamic carrier (per #515) — visible as `OpenLinker Dynamic` in the carrier-mapping picker; persists `OPENLINKER_DYNAMIC_CARRIER_ID` to `ps_configuration`.
+- Registers the standard hook set (`actionProductSave`, `actionValidateOrderAfter`, `actionOrderHistoryAddAfter`, `actionUpdateQuantity`, `actionCarrierUpdate`).
+- Generates a fresh `OPENLINKER_CRON_TOKEN` (a 64-char hex secret).
+
+**CLI alternative (for automation only):**
+```bash
+docker compose exec prestashop sh -c 'cd /var/www/html && php bin/console prestashop:module install openlinker'
+# verify tables were created — if SHOW TABLES LIKE "%openlinker%" returns nothing,
+# `bin/console install` registered the module but skipped the legacy install hook.
+# Workaround: uninstall + reinstall to force the hook:
+docker compose exec prestashop sh -c 'cd /var/www/html && php bin/console prestashop:module uninstall openlinker && php bin/console prestashop:module install openlinker'
+```
+The reinstall cycle is needed because PS 9.x's Symfony module-installer occasionally bypasses the legacy `install()` method's table-creation step on the first invocation (verified on `prestashop:9.0.2-2.0-classic-8.4`). The GUI path doesn't have this gotcha.
+
+### 4. Re-enter operator config keys
+
+Open the module's Configure page (Module Manager → openlinker → Configure) and set:
+
+- `OPENLINKER_BASE_URL` — your OpenLinker API base, e.g. `http://host.docker.internal:3000`
+- `OPENLINKER_CONNECTION_ID` — the PrestaShop connection's UUID from the OpenLinker app
+- `OPENLINKER_WEBHOOK_SECRET` — the HMAC shared secret (must match `OL_WEBHOOK_SECRET` on the OpenLinker side)
+
+⚠️ **`OPENLINKER_CRON_TOKEN` is regenerated on every install path** — the GUI install, `bin/console install`, and the SQL recipe → install sequence all generate a fresh hex token via `parent::install()`. The path B SQL recipe **preserves** the old token in `ps_configuration` (it only deletes `ps_module` rows), but the **install hook then overwrites it** with a new value. Practical implication: **always copy the new token from the Configure page after install and update host crontabs in step 5** — there's no operator path that preserves the original token across uninstall/install.
+
+### 5. Update host crontab(s)
+
+Replace `module=openlinkerwebhooks` with `module=openlinker` in every crontab entry. The rest of the URL is unchanged:
+
+```diff
+- 0 * * * * curl -s "https://shop.example.com/index.php?fc=module&module=openlinkerwebhooks&controller=cron&token=$TOKEN"
++ 0 * * * * curl -s "https://shop.example.com/index.php?fc=module&module=openlinker&controller=cron&token=$TOKEN"
+```
+
+Same `controller=cron`, same `token=...`. HMAC behaviour is unchanged.
+
+### 6. Optional — clean up the stale directory
+
+The empty `openlinkerwebhooks/` directory still lives in the volume after path B. Functionally inert but cosmetic clutter:
+
+```bash
+docker compose exec prestashop rm -rf /var/www/html/modules/openlinkerwebhooks
+```
+
+## Verification
+
+```bash
+# 1. ps_module shows openlinker active, no openlinkerwebhooks row
+docker compose exec prestashop sh -c \
+  'mysql -h mysql -u prestashop -pprestashop prestashop -e \
+   "SELECT id_module, name, active FROM ps_module WHERE name LIKE \"openlinker%\";"'
+# expect: one row, name='openlinker', active=1
+```
+
+```bash
+# 2. Cron URL responds with delivery JSON (substitute YOUR_CRON_TOKEN)
+curl -s "http://localhost:8080/index.php?fc=module&module=openlinker&controller=cron&token=YOUR_CRON_TOKEN"
+# expect: {"ok":true,"delivered":N,...}  with 200 status, N=0 if outbox is empty
+```
+
+```bash
+# 3. After the next cron tick (or a manual cron call above), Last Delivery is non-NULL
+docker compose exec prestashop sh -c \
+  'mysql -h mysql -u prestashop -pprestashop prestashop -e \
+   "SELECT MAX(delivered_at) AS last_delivery FROM ps_openlinker_webhook_outbox;"'
+```
+
+If your shop had a backlog before migration and you drained it (or accepted the loss), `Pending Events` should now sit at its steady-state baseline (≈0 under normal load). The Configure page's Statistics panel surfaces this in real time.
+
+## Rollback
+
+If the migration goes wrong, the dev-phase contract (no back-compat shims, per #514) means there's no two-version-coexist mode. Recovery is straightforward in dev because there's nothing to lose:
+
+```bash
+docker compose down
+docker volume rm openlinker_prestashop_data
+docker compose up -d prestashop
+# wait ~2-3 min for auto-install + post-install hooks (per #525)
+```
+
+This wipes the PS DB and reinstalls the upstream image from scratch, then the entrypoint wrapper from #525 runs the post-install scripts (rename admin → set PLN currency → seed fixtures from #521). You'll re-create the OpenLinker connection in the OL app.
+
+For production / customer installs, take a MySQL backup before step 1.

--- a/docs/plans/implementation-plan-519-ps-module-cron-rename-followup.md
+++ b/docs/plans/implementation-plan-519-ps-module-cron-rename-followup.md
@@ -47,11 +47,11 @@ Operator-facing one-shot runbook. Sections:
    - `mysql ... -e "SELECT name, active FROM ps_module WHERE name LIKE 'openlinker%'"` — if you see `openlinkerwebhooks` instead of `openlinker`, you have the old registration.
    - `ls /var/www/html/modules/openlinker/` — if missing, the bind-mount didn't apply.
 
-2. **Drain the backlog FIRST** (only if `Pending Events` > 0). The `uninstall()` hook in `openlinker.php` **drops** `ps_openlinker_webhook_outbox` and `ps_openlinker_cart_shipping` tables, destroying any pending events. Operators with backlog should hit "Run Delivery Now" on the (still-loadable) old module's Configure page until `Pending Events` reaches 0 — or accept the loss if the events are no longer relevant.
+2. **Backlog handling**. The `uninstall()` hook in `openlinker.php` **preserves** `ps_openlinker_webhook_outbox` and `ps_openlinker_cart_shipping` — both `dropOutboxTable()` and `dropCartShippingTable()` calls are commented out by design (`openlinker.php:171,177`). The install hook re-creates each table with `CREATE TABLE IF NOT EXISTS`, so existing rows survive uninstall + reinstall. No drain step is required; the new cron URL resumes delivery on the next tick. The runbook documents an opt-in cleanup snippet for operators who explicitly want a clean slate.
 
 3. **Migration steps**:
    1. **Uninstall the old module.** Two paths:
-      - **(A) Module loadable** (`/var/www/html/modules/openlinkerwebhooks/openlinkerwebhooks.php` exists): use PS admin → `Module Manager → Modules → openlinkerwebhooks → Uninstall`. The uninstall hook drops the outbox + cart_shipping tables and removes hooks cleanly.
+      - **(A) Module loadable** (`/var/www/html/modules/openlinkerwebhooks/openlinkerwebhooks.php` exists): use PS admin → `Module Manager → Modules → openlinkerwebhooks → Uninstall`. The uninstall hook removes hooks, deletes the admin tab, soft-deletes the OL Dynamic carrier, and clears `OPENLINKER_*` configuration keys; it does **not** drop the outbox or cart_shipping tables.
       - **(B) Module stale** (directory empty post-#514, like the dev shop today): the GUI uninstall fails because PS can't autoload the missing class. Use the SQL fallback recipe:
         ```sql
         SET @id_module := (SELECT id_module FROM ps_module WHERE name = 'openlinkerwebhooks');

--- a/docs/plans/implementation-plan-519-ps-module-cron-rename-followup.md
+++ b/docs/plans/implementation-plan-519-ps-module-cron-rename-followup.md
@@ -1,0 +1,121 @@
+# Implementation Plan — #519 PS Module Cron-Rename Operator Followup
+
+## 1. Understand the task
+
+**Goal.** Close the operator-side gap left by #514 (the `openlinkerwebhooks → openlinker` PS module rename). The cron URL exposed by the module's front controller now requires `module=openlinker` instead of `module=openlinkerwebhooks`, but a PS install registered under the old name keeps that registration in `ps_module` until it's actively uninstalled — so the new URL silently 404s and `ps_openlinker_webhook_outbox` events pile up undelivered.
+
+**Layer.** OPS / DX. Issue body explicitly says "**File(s)**: None in this repo — purely external crontab + runbook updates" — but our investigation found the dev shop has the old registration leftover, so the deliverable shifts a touch:
+
+1. **Repo deliverable** — write a one-shot operator-facing migration runbook covering the uninstall-old / recreate-container / install-new / re-configure-cron sequence. Avoids the next operator (or the next dev-shop reset) hitting the same trap blind.
+2. **Dev-shop verification** — apply the runbook against the live dev shop to prove it works end-to-end. Capture the verified output in the PR description.
+
+**Non-goals (carried from #519 issue body):**
+
+- A back-compat shim (`module=openlinkerwebhooks` → `module=openlinker` redirect). #514 explicitly opted out of back-compat per the dev-phase contract.
+- Wiring an alert if `Pending Events` exceeds a threshold. Useful but distinct issue if desired.
+
+**Repo-wide sweep (verified):**
+
+- `grep openlinkerwebhooks` → 0 hits across the repo (excluding `node_modules`/`.git`/`.claude`).
+- `docs/prestashop-module-testing-guide.md` already uses the new `module=openlinker` cron URL throughout.
+- `apps/prestashop-module/openlinker/` is the only module directory.
+
+So #514's repo-side rename was thorough. The remaining work is purely operator-facing.
+
+## 2. Research the dev shop state (live)
+
+Captured in the prior investigation step. Summary:
+
+| Aspect | State |
+|---|---|
+| `/var/www/html/modules/openlinker/` | does not exist — new bind-mount path hasn't been applied (container needs recreate) |
+| `/var/www/html/modules/openlinkerwebhooks/` | empty stale directory (old bind-mount removed by #514) |
+| `ps_module` row | `id_module=53, name='openlinkerwebhooks', active=1` — never re-installed |
+| `ps_configuration` keys | `OPENLINKER_BASE_URL` / `..._CONNECTION_ID` / `..._WEBHOOK_SECRET` all `NULL`; `OPENLINKER_CRON_TOKEN` set |
+| `ps_openlinker_webhook_outbox` | exists, 0 rows |
+| `ps_cronjobs` | not installed (no `prestashop/ps_cronjobs` module) → operator uses host crontab if any |
+
+The dev shop is the only "operator install" that exists today (dev phase, no customer installs yet). So this issue's verification scope reduces to a single shop.
+
+## 3. Design the solution
+
+### `docs/operations/prestashop-module-rename-migration.md` (new)
+
+Operator-facing one-shot runbook. Sections:
+
+1. **Symptom check** — single SQL/CLI commands to detect the broken state:
+   - `mysql ... -e "SELECT name, active FROM ps_module WHERE name LIKE 'openlinker%'"` — if you see `openlinkerwebhooks` instead of `openlinker`, you have the old registration.
+   - `ls /var/www/html/modules/openlinker/` — if missing, the bind-mount didn't apply.
+
+2. **Drain the backlog FIRST** (only if `Pending Events` > 0). The `uninstall()` hook in `openlinker.php` **drops** `ps_openlinker_webhook_outbox` and `ps_openlinker_cart_shipping` tables, destroying any pending events. Operators with backlog should hit "Run Delivery Now" on the (still-loadable) old module's Configure page until `Pending Events` reaches 0 — or accept the loss if the events are no longer relevant.
+
+3. **Migration steps**:
+   1. **Uninstall the old module.** Two paths:
+      - **(A) Module loadable** (`/var/www/html/modules/openlinkerwebhooks/openlinkerwebhooks.php` exists): use PS admin → `Module Manager → Modules → openlinkerwebhooks → Uninstall`. The uninstall hook drops the outbox + cart_shipping tables and removes hooks cleanly.
+      - **(B) Module stale** (directory empty post-#514, like the dev shop today): the GUI uninstall fails because PS can't autoload the missing class. Use the SQL fallback recipe:
+        ```sql
+        SET @id_module := (SELECT id_module FROM ps_module WHERE name = 'openlinkerwebhooks');
+        DELETE FROM ps_hook_module WHERE id_module = @id_module;
+        DELETE FROM ps_module_shop WHERE id_module = @id_module;
+        DELETE FROM ps_module_access WHERE id_module = @id_module;
+        DELETE FROM ps_module WHERE id_module = @id_module;
+        DROP TABLE IF EXISTS ps_openlinker_webhook_outbox;
+        DROP TABLE IF EXISTS ps_openlinker_cart_shipping;
+        ```
+   2. `docker compose down && docker compose up -d prestashop` — required to pick up the renamed bind-mount path. (Compose's `restart` doesn't refresh volume mounts; same constraint as #525's entrypoint change.) Verify `/var/www/html/modules/openlinker/openlinker.php` exists after up.
+   3. Install the new module from PS admin (`Module Manager → Modules → openlinker → Install`). Install hook recreates outbox + cart_shipping tables empty and seeds the OL Dynamic carrier (per #515).
+   4. Re-enter operator config keys via the module's Configure page: `OPENLINKER_BASE_URL`, `OPENLINKER_CONNECTION_ID`, `OPENLINKER_WEBHOOK_SECRET`. **Reuse the existing `OPENLINKER_CRON_TOKEN`** (it's preserved across uninstall in the SQL recipe path because we only delete the module rows, not the configuration row); regenerate only if you suspect leakage.
+   5. Update any host crontab pointing at the old cron URL — replace `module=openlinkerwebhooks` with `module=openlinker`. Same `controller=cron`, same `token=...`.
+   6. **Optional**: `docker compose exec prestashop rm -rf /var/www/html/modules/openlinkerwebhooks` to clean up the empty stale directory.
+
+3. **Verification commands**:
+   - `mysql ... -e "SELECT name, active FROM ps_module WHERE name LIKE 'openlinker%'"` — should now show `openlinker, 1`, no `openlinkerwebhooks` row.
+   - `curl "http://localhost:8080/index.php?fc=module&module=openlinker&controller=cron&token=$TOKEN"` — should return JSON with `"delivered": N` (N=0 if backlog is empty, which is normal on a fresh dev install).
+   - Module Configure page → **Statistics** panel shows `Last Delivery` non-NULL after the next cron tick.
+
+4. **Backlog drain** (only if events accumulated during the broken window) — the configure page's "Run Delivery Now" button processes the pending backlog in batches of `BATCH_SIZE` (default 50). Click repeatedly until `Pending Events` reaches 0.
+
+### `docs/getting-started.md` — one-line cross-reference
+
+Add to the existing PrestaShop section: "If you're upgrading from a pre-#514 install (where the module was named `openlinkerwebhooks`), follow [the rename migration runbook](./operations/prestashop-module-rename-migration.md) once before continuing."
+
+### Branch / files
+
+```
+docs/operations/prestashop-module-rename-migration.md     (new)
+docs/getting-started.md                                    (edit — one-line cross-reference)
+```
+
+No code changes. No tests (operator runbook).
+
+## 4. Step-by-step implementation plan
+
+1. **Verify the install/uninstall SQL hooks** (`apps/prestashop-module/openlinker/sql/install.sql` + `uninstall.sql`) actually preserve the outbox table on uninstall — informs the runbook copy.
+2. **Write the runbook** (`docs/operations/prestashop-module-rename-migration.md`) with the symptom check / migration steps / verification commands / backlog drain section.
+3. **Update `docs/getting-started.md`** with the one-line cross-reference.
+4. **Apply the runbook to the dev shop** to prove it works:
+   - Uninstall `openlinkerwebhooks` from PS admin
+   - `docker compose down && docker compose up -d prestashop`
+   - Install `openlinker`
+   - Verify via the runbook's verification commands
+   - Capture before/after `mysql` output to paste into the PR description
+5. **PR body** documents: (a) repo-wide sweep showed 0 lingering `openlinkerwebhooks` references in code, (b) runbook added + cross-referenced, (c) dev-shop migration verified end-to-end.
+
+## 5. Validate against architecture & standards
+
+- ✅ **Layer**: OPS / DX only. No CORE / Integration / Interface / Frontend / migration code touched. No port-contract changes.
+- ✅ **Naming**: runbook lives under `docs/operations/` — new directory but matches the implicit convention (every doc-grouping in `docs/` is a flat folder by topic).
+- ✅ **No secrets**: runbook uses `$TOKEN` placeholder; operators substitute their actual `OPENLINKER_CRON_TOKEN` value.
+- ✅ **Tests**: not applicable for a doc + verification PR.
+- ✅ **Acceptance criteria from the issue body**:
+  - "Every known operator crontab pointing at `module=openlinkerwebhooks` has been identified and updated" — repo grep + dev-shop crontab check.
+  - "Every operator-facing runbook / wiki snippet referencing the old URL has been updated" — repo grep returned 0 hits.
+  - "For each affected shop, `Pending Events` returned to its steady-state baseline" — dev shop verified post-migration.
+  - "`Last Delivery` timestamp is within the expected cron interval" — dev shop verified post-migration.
+
+## Risks & open questions
+
+1. **Operator unfamiliarity with PS module install/uninstall**. The runbook walks through the GUI steps; not much we can do beyond clear copy.
+2. **Outbox table preservation across uninstall**. The runbook claims `uninstall.sql` preserves the table. Need to verify by reading the SQL before writing the claim — step 1 of the implementation plan.
+3. **Operator forgets to restart the container**. The runbook calls this out explicitly (step 2 of migration). Without recreate, install fails because module files aren't on disk.
+4. **External customers**. None today (dev phase). If any appear before this issue closes, they need to follow the same runbook.


### PR DESCRIPTION
Closes #519

## Summary

- Adds an operator-facing one-shot runbook (`docs/operations/prestashop-module-rename-migration.md`) for migrating any pre-#514 PrestaShop install where the bind-mount module was named `openlinkerwebhooks`. Without the migration the new cron URL silently 404s and `ps_openlinker_webhook_outbox` events pile up undelivered.
- Cross-references the runbook from `docs/getting-started.md`, triggered on `ps_module.name='openlinkerwebhooks'` (the runbook's own symptom check) so devs hitting a stale install are routed to it before continuing.
- Includes the implementation plan in `docs/plans/`.

#519's issue body claimed *"File(s): None in this repo — purely external crontab + runbook updates"*. Investigation found the dev shop itself was still in the broken post-#514 state (old `openlinkerwebhooks` row in `ps_module`, empty stale bind-mount directory), so the deliverable expanded to: write the runbook **and** apply it end-to-end against the live dev shop to prove it works.

## Dev-shop verification

Migration applied end-to-end. Identifiers below match what an operator can observe via the runbook's verification commands; auto-incremented `id_module` and `id_carrier` values are shop-specific and intentionally elided.

| Aspect | Before | After |
|---|---|---|
| `ps_module` row | `name='openlinkerwebhooks', active=1` | `name='openlinker', active=1` (no `openlinkerwebhooks` row) |
| `/var/www/html/modules/openlinker/` | missing (stale `openlinkerwebhooks/` empty) | populated, `openlinker.php` present |
| `ps_openlinker_webhook_outbox` | preserved | preserved (`CREATE TABLE IF NOT EXISTS` is a no-op when present) |
| `ps_openlinker_cart_shipping` | preserved | preserved (same idempotent create) |
| `OPENLINKER_DYNAMIC_CARRIER_ID` | unset | seeded by install hook (per #515), value shop-specific |
| Cron URL | 404 (stale `module=openlinkerwebhooks`) | 200 with `{"ok":true,"delivered":N,...}` |

## Behaviour notes captured during verification

These came up in the live run and tech review and are documented in the runbook so the next operator doesn't re-discover them blind:

1. **GUI uninstall fails on stale empty directory** (PHP can't autoload the missing module class). The runbook's path B provides a complete SQL fallback covering `ps_module` / `ps_hook_module` / `ps_module_shop` / `ps_module_access` / `ps_authorization_role` (slug-based; the table doesn't have `id_module`) / `ps_tab` / `ps_tab_lang`.

2. **`uninstall()` preserves the outbox + cart_shipping tables** by design — both `dropOutboxTable()` and `dropCartShippingTable()` calls in `apps/prestashop-module/openlinker/openlinker.php:171,177` are commented out ("kept commented to match the conservative outbox default"). Combined with the install hook's `CREATE TABLE IF NOT EXISTS`, pending events queued during the broken-cron window survive the migration and resume delivery on the next tick after step 5. The runbook documents an opt-in DROP snippet for operators who explicitly want a clean slate.

3. **PS 9.x `bin/console prestashop:module install` skips the legacy `install()` table-creation on first invocation.** `SHOW TABLES LIKE "%openlinker%"` returns empty after a clean CLI install. The runbook documents the uninstall + reinstall workaround. The GUI install path doesn't have this gotcha — recommended as canonical.

4. **All four `OPENLINKER_*` configuration keys are reset on every install path** by `setDefaultConfiguration()` (`openlinker.php:124`), which calls `Configuration::updateValue()` for `OPENLINKER_BASE_URL` / `..._CONNECTION_ID` / `..._WEBHOOK_SECRET` (reset to `''`) and `OPENLINKER_CRON_TOKEN` (regenerated to fresh 64-char hex). Operators must re-enter all four in step 4 and copy the new token to host crontabs after install.

## Tech-review fixes (commit `b89fc70`)

The first revision of the runbook claimed `uninstall()` drops the outbox + cart_shipping tables and led with a "Drain the backlog FIRST" warning. Tech review caught this as a factual error against the actual code (the DROP calls are commented out by design). Fixed:

- BLOCKING — replace "Drain the backlog FIRST" with "Backlog handling": both paths preserve the tables; the new cron URL resumes delivery on the next tick. Document an opt-in cleanup snippet for operators who want a clean slate.
- IMPORTANT — remove the two `DROP TABLE` lines from path B's SQL recipe (they destroyed data the install hook is happy to keep).
- IMPORTANT — reword path B's "preserved across migration" claim: the SQL recipe leaves `ps_configuration` rows on disk, but the install hook's `setDefaultConfiguration()` resets all four `OPENLINKER_*` keys regardless. Step 4 is required.
- SUGGESTION — attribute the token regeneration to `setDefaultConfiguration()` (`openlinker.php:124`), not `parent::install()`.
- SUGGESTION — `getting-started.md` cross-reference triggers on `ps_module.name='openlinkerwebhooks'` (the symptom check itself) rather than the bind-mount path.

## Non-goals (carried from the issue body)

- A back-compat shim (`module=openlinkerwebhooks` → `module=openlinker` redirect). #514 explicitly opted out per the dev-phase contract.
- An alert if `Pending Events` exceeds a threshold. Distinct issue if desired.

## Test plan

- [x] Repo-wide grep for `openlinkerwebhooks` (excluding `node_modules`/`.git`/`.claude`) — returns 0 hits across code; only references are inside the new runbook itself.
- [x] Migration applied end-to-end against the dev shop — table above documents observable before/after state.
- [x] Cron URL responds 200 with delivery JSON post-migration.
- [x] Runbook claims cross-checked against the actual `apps/prestashop-module/openlinker/openlinker.php` (uninstall body at lines 144–180, `setDefaultConfiguration` at lines 978–991, `clearConfiguration` at lines 998–1009, `createOutboxTable` at lines 686–714, `createCartShippingTable` at lines 736–748).
- [x] `pnpm lint` + `pnpm type-check` pass via pre-commit hook (docs/config-only change, tests skipped per hook policy).

## Files

- `docs/operations/prestashop-module-rename-migration.md` (new)
- `docs/getting-started.md` (one-line cross-reference)
- `docs/plans/implementation-plan-519-ps-module-cron-rename-followup.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
