### PR TITLE
fix(prestashop): drop double-wrap on configurations WS payload

### DIFF
--- a/apps/api/test/integration/helpers/prestashop-fixture.helper.ts
+++ b/apps/api/test/integration/helpers/prestashop-fixture.helper.ts
@@ -67,6 +67,10 @@ const WS_RESOURCES = [
   'languages',
   'countries',
   'states',
+  // Used by PrestashopWebhookProvisioningService to write OPENLINKER_*
+  // rows (#168 / #541). Carrier-mapping smoke spec doesn't touch this
+  // resource, so adding it here is purely additive.
+  'configurations',
 ] as const;
 
 /**

--- a/apps/api/test/integration/prestashop/prestashop-webhook-provisioning.int-spec.ts
+++ b/apps/api/test/integration/prestashop/prestashop-webhook-provisioning.int-spec.ts
@@ -1,0 +1,226 @@
+/**
+ * PrestaShop Webhook Provisioning — Integration Test (#541)
+ *
+ * End-to-end guard for the install-webhooks flow: routes through the public
+ * `PrestashopWebhookProvisioningService.install()` method against a real
+ * PrestaShop 9.0.2 instance (booted via the #506 Phase 1 Testcontainer
+ * harness) with stubbed ports for connection / secret-rotation / credentials
+ * resolution.
+ *
+ * Catches the #541 regression class:
+ *   - Wrong WS body shape (the original double-wrap that 400'd in production
+ *     while green at the unit-test layer because the unit spec asserted the
+ *     buggy shape).
+ *   - Partial-body PUT contract on `configurations`: `upsertConfiguration`
+ *     sends only `{ id, name, value }` on update — this spec proves PS
+ *     accepts that subset by re-running install (which exercises the
+ *     update-existing branch).
+ *
+ * Suite-scoped: PS container starts in `beforeAll` (60-90s warm cache) and
+ * stops in `afterAll`. Not wired into the global Postgres+Redis harness so
+ * the existing fast int-specs are unaffected.
+ *
+ * @module apps/api/test/integration/prestashop
+ */
+import { Connection, ConnectionPort } from '@openlinker/core/identifier-mapping';
+import type {
+  CredentialsResolverPort,
+  IWebhookSecretService,
+} from '@openlinker/core/integrations';
+import { PrestashopWebhookProvisioningService } from '@openlinker/integrations-prestashop';
+import {
+  PrestashopTestContainer,
+  startPrestashopContainer,
+} from '../helpers/prestashop-container.helper';
+
+interface PrestashopConfigurationRow {
+  id: string | number;
+  name?: string;
+  value?: string;
+}
+
+/**
+ * Read PS configurations by name via raw WS GET. Used to verify what
+ * `install()` actually wrote on the PS side, independently of the
+ * `PrestashopWebserviceClient` the service uses (so a bug in the read path
+ * wouldn't mask a bug in the write path).
+ */
+async function fetchConfigurationByName(
+  baseUrl: string,
+  apiKey: string,
+  name: string,
+): Promise<PrestashopConfigurationRow | null> {
+  const url = new URL(`${baseUrl.replace(/\/$/, '')}/api/configurations`);
+  url.searchParams.set('display', 'full');
+  url.searchParams.set('output_format', 'JSON');
+  url.searchParams.set('filter[name]', name);
+
+  const auth = Buffer.from(`${apiKey}:`).toString('base64');
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Authorization: `Basic ${auth}` },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `PS WS GET /api/configurations?filter[name]=${name} failed: ` +
+        `${response.status} ${response.statusText} — ${body.slice(0, 200)}`,
+    );
+  }
+  const data = (await response.json()) as { configurations?: PrestashopConfigurationRow[] };
+  const rows = Array.isArray(data.configurations) ? data.configurations : [];
+  return rows[0] ?? null;
+}
+
+describe('PrestaShop webhook provisioning — install() against real PS (#541)', () => {
+  let container: PrestashopTestContainer;
+  let service: PrestashopWebhookProvisioningService;
+
+  // Stub state — a fresh secret is generated per `install()` call so we can
+  // assert the second call rotated it. `connectionPort.update` captures the
+  // patches the service applies; we assert on those, not on real DB state.
+  let connectionPort: jest.Mocked<ConnectionPort>;
+  let webhookSecretService: jest.Mocked<IWebhookSecretService>;
+  let credentialsResolver: jest.Mocked<CredentialsResolverPort>;
+  let baseConnection: Connection;
+  let lastRotatedSecret: string;
+
+  const TEST_CONNECTION_ID = 'test-conn-541';
+  const TEST_CALLBACK_URL = 'http://test-callback.local';
+
+  beforeAll(async () => {
+    container = await startPrestashopContainer();
+  }, 15 * 60_000);
+
+  afterAll(async () => {
+    if (container) {
+      await container.cleanup();
+    }
+  });
+
+  beforeEach(() => {
+    baseConnection = new Connection(
+      TEST_CONNECTION_ID,
+      'prestashop',
+      'Test PS Shop',
+      'active',
+      {
+        baseUrl: container.baseUrl,
+        openlinkerCallbackBaseUrl: TEST_CALLBACK_URL,
+      },
+      'db:test-cred-541',
+      new Date(),
+      new Date(),
+      undefined,
+      [],
+    );
+
+    connectionPort = {
+      get: jest.fn().mockResolvedValue(baseConnection),
+      list: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn().mockResolvedValue(baseConnection),
+      disable: jest.fn(),
+    } as unknown as jest.Mocked<ConnectionPort>;
+
+    webhookSecretService = {
+      rotate: jest.fn().mockImplementation(async () => {
+        // Secret content is opaque to PS — but the service writes it verbatim
+        // into `OPENLINKER_WEBHOOK_SECRET`, so we assert round-trip equality.
+        // Fresh per-call so the second `install()` produces a different value
+        // and we can prove the update branch ran (vs. a no-op).
+        lastRotatedSecret = `test-secret-541-${Math.random().toString(36).slice(2, 10)}`;
+        return { secret: lastRotatedSecret };
+      }),
+    } as unknown as jest.Mocked<IWebhookSecretService>;
+
+    credentialsResolver = {
+      get: jest.fn().mockResolvedValue({
+        webserviceApiKey: container.webserviceApiKey,
+      }),
+    } as unknown as jest.Mocked<CredentialsResolverPort>;
+
+    service = new PrestashopWebhookProvisioningService(
+      connectionPort,
+      webhookSecretService,
+      credentialsResolver,
+    );
+  });
+
+  it('writes the three OPENLINKER_* configurations into PS on first install', async () => {
+    const result = await service.install(TEST_CONNECTION_ID, 'actor-541');
+
+    // The WS push is the part this test guards. The synchronous ping is
+    // best-effort and the OL PS module is not installed in this harness,
+    // but PS's storefront still returns a 2xx for `/module/openlinker/ping`
+    // (it falls through to a generic page), so `testPingTriggered` is
+    // non-deterministic from the outside — we don't assert on it.
+    expect(result.webhooksConfigured).toBe(true);
+
+    expect(connectionPort.update).toHaveBeenCalledWith(
+      TEST_CONNECTION_ID,
+      expect.objectContaining({
+        config: expect.objectContaining({ webhooksConfigured: true }),
+      }),
+    );
+
+    // PS-side proof — read the rows back via a separate raw fetch (different
+    // code path from the one the service uses to write). All three keys
+    // must be present with the values the service wrote.
+    const baseUrlRow = await fetchConfigurationByName(
+      container.baseUrl,
+      container.webserviceApiKey,
+      'OPENLINKER_BASE_URL',
+    );
+    expect(baseUrlRow).not.toBeNull();
+    expect(baseUrlRow?.value).toBe(TEST_CALLBACK_URL);
+
+    const connectionIdRow = await fetchConfigurationByName(
+      container.baseUrl,
+      container.webserviceApiKey,
+      'OPENLINKER_CONNECTION_ID',
+    );
+    expect(connectionIdRow).not.toBeNull();
+    expect(connectionIdRow?.value).toBe(TEST_CONNECTION_ID);
+
+    const secretRow = await fetchConfigurationByName(
+      container.baseUrl,
+      container.webserviceApiKey,
+      'OPENLINKER_WEBHOOK_SECRET',
+    );
+    expect(secretRow).not.toBeNull();
+    expect(secretRow?.value).toBe(lastRotatedSecret);
+  });
+
+  it('updates rows in place on a second install (idempotent + partial-body PUT)', async () => {
+    // First install creates the rows — fixture for the update path.
+    await service.install(TEST_CONNECTION_ID, 'actor-541');
+    const firstSecretRow = await fetchConfigurationByName(
+      container.baseUrl,
+      container.webserviceApiKey,
+      'OPENLINKER_WEBHOOK_SECRET',
+    );
+    expect(firstSecretRow).not.toBeNull();
+    const firstId = firstSecretRow!.id;
+    const firstSecret = firstSecretRow!.value;
+
+    // Second install — the secret rotates to a new value, the WS list-by-name
+    // returns the existing row, and `upsertConfiguration` takes the
+    // `updateResource` branch with a flat `{ id, name, value }` body. If PS
+    // rejected partial-body PUTs (the conservative reading of the WS client
+    // interface JSDoc), this call would 400 and the test would fail.
+    await service.install(TEST_CONNECTION_ID, 'actor-541');
+
+    const secondSecretRow = await fetchConfigurationByName(
+      container.baseUrl,
+      container.webserviceApiKey,
+      'OPENLINKER_WEBHOOK_SECRET',
+    );
+    expect(secondSecretRow).not.toBeNull();
+    // Same row (no duplicate insert) — same id_configuration.
+    expect(String(secondSecretRow!.id)).toBe(String(firstId));
+    // New value — proves the update branch ran end-to-end against PS.
+    expect(secondSecretRow!.value).toBe(lastRotatedSecret);
+    expect(secondSecretRow!.value).not.toBe(firstSecret);
+  });
+});

--- a/docs/plans/implementation-plan-541-ps-webhook-config-double-wrap.md
+++ b/docs/plans/implementation-plan-541-ps-webhook-config-double-wrap.md
@@ -1,0 +1,187 @@
+# Implementation Plan — #541 PS webhook auto-provisioning double-wrap fix
+
+## 1. Goal
+
+Fix `PrestashopWebhookProvisioningService.upsertConfiguration` so the "Install
+webhooks" action against a real PrestaShop shop succeeds end-to-end. Today
+every call 400s because the WS payload is wrapped twice (`prestashop ›
+configuration › configuration › { id, name, value }`).
+
+Layer: **Integration** (PrestaShop adapter, application service).
+Non-goals: multi-store retry-with-defaults (already a TODO at line 198), any
+change to the WS client's wrapping behaviour, any change to other PS adapter
+call sites (orders/carts/customers/addresses already pass flat payloads).
+
+## 2. Root cause (verified)
+
+- `prestashop-webhook-provisioning.service.ts:211-218` passes
+  `{ configuration: { id, name, value } }` as the `data` argument.
+- `prestashop-webservice.client.ts:217-221` (`writeResource`) already wraps
+  `data` as `{ prestashop: { [resourceKey]: data } }` where
+  `resourceKey = 'configuration'` (singularised from `configurations`).
+- Net XML body: `<prestashop><configuration><configuration>…</configuration></configuration></prestashop>`.
+- PS strips the outer `<prestashop>` wrapper, then sees a `<configuration>`
+  child where it expects `<id>`, and rejects with HTTP 400 / error code 90:
+  `"id is required when modifying a resource"`.
+
+Every other adapter caller passes flat fields (e.g.
+`createResource('orders', prestashopOrderData)` where `prestashopOrderData`
+has flat `id_cart`, `id_customer`, etc.).
+
+The unit spec at
+`prestashop-webhook-provisioning.service.spec.ts:118-128` and `:152-167`
+asserts the buggy shape (`body.configuration.name`), so green CI never caught
+the bug.
+
+## 3. Fix
+
+### 3.1 Source code
+
+`libs/integrations/prestashop/src/application/services/prestashop-webhook-provisioning.service.ts:209-218`
+
+Replace:
+
+```ts
+if (existing.length > 0) {
+  const id = existing[0].id;
+  await wsClient.updateResource('configurations', id, {
+    configuration: { id: String(id), name, value },
+  });
+  return;
+}
+await wsClient.createResource('configurations', {
+  configuration: { name, value },
+});
+```
+
+With:
+
+```ts
+if (existing.length > 0) {
+  const id = existing[0].id;
+  await wsClient.updateResource('configurations', id, {
+    id: String(id),
+    name,
+    value,
+  });
+  return;
+}
+await wsClient.createResource('configurations', { name, value });
+```
+
+The `id: String(id)` on update is preserved because the PS WS PUT contract
+(`prestashop-webservice.client.interface.ts:75-96`) requires it in the body —
+PS validates body-id against the path-id.
+
+### 3.2 Unit spec
+
+`libs/integrations/prestashop/src/application/services/__tests__/prestashop-webhook-provisioning.service.spec.ts`
+
+Two changes — both replace assertions on the wrong shape:
+
+- `:118-128` (happy path) — `body.configuration.name` → `body.name`.
+- `:158-167` (update path) — drop the nested `configuration:` matcher, assert
+  flat `id`, `name`, `value` directly.
+
+### 3.3 New integration test (regression guard)
+
+`apps/api/test/integration/prestashop/prestashop-webhook-provisioning.int-spec.ts`
+
+Suite-scoped (uses the heavy PS Testcontainer harness from #506 Phase 1).
+Routes through the public `install()` method with stubbed ports — exercises
+**the actual `upsertConfiguration` code path** (not just the WS client) so a
+future re-introduction of the wrap or any other shape regression in the
+service is caught at the int-spec layer too.
+
+**Layered coverage:**
+- Unit spec → asserts the service builds the **correct call shape** for
+  `createResource` / `updateResource` (mocks the WS client).
+- Int-spec → asserts the **end-to-end install flow** writes the expected
+  rows into a real PS 9.0.2 `ps_configuration` table, with the real WS
+  client speaking real XML to real PS.
+
+Flow:
+
+1. `beforeAll`: `startPrestashopContainer()` — boots PS + MySQL.
+2. Construct stub ports:
+   - `ConnectionPort.get()` → returns a `Connection` with
+     `config.baseUrl = prestashop.baseUrl`,
+     `config.openlinkerCallbackBaseUrl = 'http://test-callback.local'`.
+   - `ConnectionPort.update()` → resolves (captures the
+     `webhooksConfigured: true` patch for assertion).
+   - `IWebhookSecretService.rotate()` → returns
+     `{ secret: 'test-secret-541-<random>' }` (a fresh per-run secret).
+   - `CredentialsResolverPort.get()` → returns
+     `{ webserviceApiKey: prestashop.webserviceApiKey }`.
+3. Instantiate `PrestashopWebhookProvisioningService` with the stubs and
+   call `install('test-conn-541')`.
+4. `it('writes the three OPENLINKER_* configurations into PS via upsertConfiguration')`:
+   - `result.webhooksConfigured` is `true`.
+   - `result.testPingTriggered` is `false` and
+     `result.warning === 'ping-not-received'` (PS doesn't have the OL
+     module installed in the harness, so the synchronous ping legitimately
+     misses; the install's accept-and-surface policy returns the
+     warning — exactly the partial-state path the service was designed to
+     handle).
+   - `connectionPort.update` called with
+     `expect.objectContaining({ config: expect.objectContaining({ webhooksConfigured: true }) })`.
+   - Read PS WS `/api/configurations?filter[name]=OPENLINKER_BASE_URL` (and
+     the other two keys) directly via raw `fetch` + Basic-auth, assert all
+     three rows exist with the expected values. **This is also the
+     partial-body PUT proof** — `upsertConfiguration` sends only
+     `{ id, name, value }` on update; if PS didn't accept that subset for
+     `configurations`, the second `install()` call (step 5) would 400.
+5. `it('UPDATE path: re-running install upserts existing rows in place')`:
+   - Call `service.install('test-conn-541')` a second time. The first call
+     created the rows; the second hits the list-by-name → `updateResource`
+     branch in `upsertConfiguration`. Assert PS still returns exactly the
+     same three rows (no duplicates, idempotent), and that the secret
+     value updates to the new rotated secret.
+
+Naming the keys with the canonical `OPENLINKER_*` prefix is intentional —
+they're the production keys, and using anything else would mean the int-spec
+isn't actually exercising what production writes. The PS Testcontainer
+boots fresh per test run, so there's no cross-run collision.
+
+### 3.4 Harness change — grant `configurations` to the test WS API key
+
+`apps/api/test/integration/helpers/prestashop-fixture.helper.ts:55-70`
+
+The existing `WS_RESOURCES` list (carrier-mapping focus) doesn't include
+`configurations`. Add it. Justification: the webhook-provisioning service is
+the only OL caller that touches `configurations`, and once the int-spec lands
+the harness needs to support it. Existing carrier-mapping spec is unaffected.
+
+## 4. Step-by-step
+
+| # | File | Change | Acceptance |
+|---|------|--------|------------|
+| 1 | `prestashop-webhook-provisioning.service.ts:209-218` | Drop redundant `configuration:` wrapper at both call sites | Code passes flat `{ id, name, value }` and `{ name, value }` |
+| 2 | `prestashop-webhook-provisioning.service.spec.ts:118-128` | Assert `body.name` (flat) | Test still passes after step 1 |
+| 3 | `prestashop-webhook-provisioning.service.spec.ts:158-167` | Drop nested `configuration:` matcher | Test still passes after step 1 |
+| 4 | `prestashop-fixture.helper.ts:55-70` | Add `'configurations'` to `WS_RESOURCES` | Smoke spec still passes; new int-spec can read/write configurations |
+| 5 | `apps/api/test/integration/prestashop/prestashop-webhook-provisioning.int-spec.ts` (new) | End-to-end `install()` against real PS via stubbed ports; create + update paths via re-run | All three `OPENLINKER_*` rows present in PS after first call; idempotent on second call |
+| 6 | `docs/testing-guide.md` (PrestaShop Testcontainer Pattern section) | One-line note that PS-Testcontainer int-specs live under `apps/api/test/integration/prestashop/` going forward | Documented placement convention |
+
+## 5. Validation
+
+- **Unit**: `pnpm test -- prestashop-webhook-provisioning` — both happy-path
+  and update-path specs pass with flat assertions.
+- **Lint + type-check**: `pnpm lint && pnpm type-check`.
+- **Integration**: `pnpm test:integration -- prestashop-webhook-provisioning`
+  — Docker required, ~60-90s warm cache.
+- **Architecture**: no boundaries crossed. The change lives entirely in the
+  PrestaShop integration package; no CORE port or interface changed.
+- **Naming**: int-spec follows `*.int-spec.ts` convention.
+- **Security**: no auth/credential surface change. Webhook secret rotation
+  semantics unchanged.
+
+## 6. Risks & open questions
+
+- **Multi-store**: The TODO at `:198-202` flags that some PS 8.2+ multi-store
+  hosts may need explicit `id_shop_group` / `id_shop` on the body. Out of
+  scope for #541 — that's a separate failure mode not covered by either the
+  unit or integration test today. Track when a multi-store user reports it.
+- **Old offers**: rows with the mistakenly-shaped XML are already rejected
+  pre-write, so there is no stale state to migrate. Re-running install is
+  safe and idempotent (the existing comment at `:144` already promises this).

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -304,6 +304,14 @@ completion signal (HTTP probes race the install). Default deadline is 12 min.
 When the dev-stack PS image is bumped, this helper must follow — keep the
 two pins aligned to avoid version-drift bugs that would only surface in CI.
 
+### File placement
+
+PS-Testcontainer int-specs live under `apps/api/test/integration/prestashop/`.
+The carrier-mapping smoke spec at `apps/api/test/integration/orders/` predates
+this convention and stays where it is for now (it's an orders-flow assertion
+that happens to use the harness); new specs whose primary subject is the PS
+adapter belong under `prestashop/`.
+
 ---
 
 ## Running Tests

--- a/libs/integrations/prestashop/src/application/services/__tests__/prestashop-webhook-provisioning.service.spec.ts
+++ b/libs/integrations/prestashop/src/application/services/__tests__/prestashop-webhook-provisioning.service.spec.ts
@@ -115,10 +115,12 @@ describe('PrestashopWebhookProvisioningService', () => {
       expect(mockWsClient.listResources).toHaveBeenCalledTimes(3);
       expect(mockWsClient.createResource).toHaveBeenCalledTimes(3);
 
+      // PS WS body must be flat (`{ name, value }`) — the WS client adds the
+      // `{ prestashop: { configuration: ... } }` wrapper itself. (#541)
       const namesPushed = mockWsClient.createResource.mock.calls.map(
         (call: unknown[]) => {
-          const body = call[1] as { configuration: { name: string } };
-          return body.configuration.name;
+          const body = call[1] as { name: string };
+          return body.name;
         },
       );
       expect(namesPushed).toEqual([
@@ -126,6 +128,15 @@ describe('PrestashopWebhookProvisioningService', () => {
         'OPENLINKER_CONNECTION_ID',
         'OPENLINKER_WEBHOOK_SECRET',
       ]);
+      // Defensive: assert the body is flat, not `{ configuration: {...} }`.
+      // Catches the #541 double-wrap regression at the unit-test layer.
+      const createCalls = mockWsClient.createResource.mock.calls as unknown[][];
+      for (const call of createCalls) {
+        const body = call[1] as Record<string, unknown>;
+        expect(body).not.toHaveProperty('configuration');
+        expect(body).toHaveProperty('name');
+        expect(body).toHaveProperty('value');
+      }
 
       // Connection.config.webhooksConfigured set true.
       expect(connectionPort.update).toHaveBeenCalledWith(
@@ -155,16 +166,19 @@ describe('PrestashopWebhookProvisioningService', () => {
 
       await service.install('connection-123');
 
+      // PS WS PUT body is flat, with `id` stringified to match the path id.
+      // No `configuration:` wrapper — the WS client adds it. (#541)
       expect(mockWsClient.updateResource).toHaveBeenCalledWith(
         'configurations',
         42,
         expect.objectContaining({
-          configuration: expect.objectContaining({
-            id: '42',
-            name: 'OPENLINKER_BASE_URL',
-          }),
+          id: '42',
+          name: 'OPENLINKER_BASE_URL',
         }),
       );
+      const updateCalls = mockWsClient.updateResource.mock.calls as unknown[][];
+      const updateBody = updateCalls[0][1] as Record<string, unknown>;
+      expect(updateBody).not.toHaveProperty('configuration');
       expect(mockWsClient.createResource).toHaveBeenCalledTimes(2); // remaining two
     });
   });

--- a/libs/integrations/prestashop/src/application/services/prestashop-webhook-provisioning.service.ts
+++ b/libs/integrations/prestashop/src/application/services/prestashop-webhook-provisioning.service.ts
@@ -208,14 +208,18 @@ export class PrestashopWebhookProvisioningService
     );
     if (existing.length > 0) {
       const id = existing[0].id;
+      // PS WS PUT requires `id` in the body to match the path id; the
+      // singular-resource wrapper (`{ prestashop: { configuration: ... } }`)
+      // is added by `writeResource` in the WS client — callers must pass
+      // flat fields. (#541)
       await wsClient.updateResource('configurations', id, {
-        configuration: { id: String(id), name, value },
+        id: String(id),
+        name,
+        value,
       });
       return;
     }
-    await wsClient.createResource('configurations', {
-      configuration: { name, value },
-    });
+    await wsClient.createResource('configurations', { name, value });
   }
 
   /**


### PR DESCRIPTION
## Summary

`PrestashopWebhookProvisioningService.upsertConfiguration` was passing
`{ configuration: { id, name, value } }` as the WS write payload, but
`PrestashopWebserviceClient.writeResource` already wraps in
`{ prestashop: { configuration: ... } }`. Net result was
`{ prestashop: { configuration: { configuration: {...} } } }` — PS strips
the outer wrapper, sees a child `<configuration>` where it expects
`<id>`, and rejects with HTTP 400 / error code 90 (`"id is required when
modifying a resource"`).

End-to-end effect: #168 / #529 looked complete but the install-webhooks
action 400'd on every real shop, forcing operators back to the
manual-paste form #168 was meant to retire. The unit spec at the time
codified the bug-shape (`body.configuration.name`), which is why green
CI shipped the regression.

- **Source** (`prestashop-webhook-provisioning.service.ts`): pass flat
  `{ name, value }` to `createResource` and `{ id, name, value }` to
  `updateResource`. Aligns with how every other PS adapter call site
  (orders, carts, customers, addresses) invokes the WS client.
- **Unit spec**: assert flat shape; add defensive
  `not.toHaveProperty('configuration')` guards on both create and
  update mock calls so a re-introduction fails at the unit-test layer.
- **Integration test**: new suite-scoped int-spec under
  `apps/api/test/integration/prestashop/` routes through the public
  `install()` method against the #506 Phase 1 PS Testcontainer harness,
  reads PS state back via a separate raw fetch, and covers both the
  create-new-row and update-existing-row paths. Doubles as the
  partial-body PUT proof for `configurations` (the WS client JSDoc
  conservatively claims PUT requires the full row; PS in fact accepts
  `{ id, name, value }` for this resource).
- **Harness** (`prestashop-fixture.helper.ts`): add `'configurations'`
  to `WS_RESOURCES` so the test WS API key has permission. Carrier-mapping
  smoke spec (#506) unaffected.
- **Docs**: testing-guide placement convention for new
  PS-Testcontainer int-specs.

## Test plan

- [x] `pnpm test` — 335 api + 118 worker tests pass; 9 unit tests in
  `prestashop-webhook-provisioning.service.spec.ts` pass with the
  flat-shape assertions.
- [x] `pnpm lint && pnpm type-check` — zero errors.
- [x] `pnpm test:integration -- prestashop-webhook-provisioning` against
  PS 9.0.2 — both `it()` blocks pass; XML body in the WS log shows the
  fix landing as expected (`<configuration><id/><name/><value/></configuration>`,
  no double wrap).
- [x] `pnpm test:integration -- prestashop-harness-smoke` (#506 Phase 1)
  still passes after the `WS_RESOURCES` addition.
- [ ] Manual smoke against a clean dev PrestaShop: click "Install
  webhooks" on a connection → expect 200, `webhooksConfigured: true`,
  and the three `OPENLINKER_*` rows in `ps_configuration`.

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)