### PR TITLE
refactor(integrations): make adapter registries pluggable via register()

### DIFF
--- a/apps/api/test/integration/app-boot.int-spec.ts
+++ b/apps/api/test/integration/app-boot.int-spec.ts
@@ -9,6 +9,10 @@
  */
 import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
 import { IntegrationTestHarness } from './setup';
+import {
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterRegistryPort,
+} from '@openlinker/core/integrations';
 
 describe('App Boot Integration', () => {
   let harness: IntegrationTestHarness;
@@ -48,6 +52,30 @@ describe('App Boot Integration', () => {
     const response = await http.get('/health').expect(200);
 
     expect(response.body).toBeDefined();
+  });
+
+  it('should self-register the bundled integration adapters at boot', async () => {
+    // After #570/#571, AdapterRegistryService starts empty and each
+    // *IntegrationModule.onModuleInit() registers its metadata. If a
+    // future change breaks the boot-time registration call, this assertion
+    // surfaces it directly rather than letting connection-scoped int-specs
+    // fail with cryptic "no default adapter" errors downstream.
+    const adapterRegistry = harness
+      .getApp()
+      .get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+
+    const adapters = await adapterRegistry.listAdapters();
+    const adapterKeys = adapters.map((a) => a.adapterKey);
+
+    expect(adapterKeys).toEqual(
+      expect.arrayContaining(['prestashop.webservice.v1', 'allegro.publicapi.v1']),
+    );
+    expect(await adapterRegistry.getDefaultAdapterKey('prestashop')).toBe(
+      'prestashop.webservice.v1',
+    );
+    expect(await adapterRegistry.getDefaultAdapterKey('allegro')).toBe(
+      'allegro.publicapi.v1',
+    );
   });
 
   it('should have database tables created', async () => {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1147,23 +1147,35 @@ OpenLinker uses **implicit capabilities**: capabilities are declared in code via
 ```
 
 **Adapter Registry** (Code-Level):
-```typescript
-// Adapters declare their capabilities in code
-{
-  adapterKey: 'prestashop.webservice.v1',
-  platformType: 'prestashop',
-  supportedCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager'],
-  displayName: 'PrestaShop WebService v1',
-  version: '1.0.0'
-}
 
-{
+Each integration module self-registers its adapter metadata via
+`adapterRegistry.register({...})` in `onModuleInit` (#570/#571), mirroring
+how `AdapterFactoryResolverService.registerFactory` works. `libs/core`
+no longer carries platform-specific knowledge of which adapters exist —
+the registry is empty on construct and populated by integration modules
+at boot. The `isDefault: true` flag marks the platform-default adapterKey
+for connections without an explicit `adapterKey` field.
+
+```typescript
+// In AllegroIntegrationModule.onModuleInit():
+this.adapterRegistry.register({
   adapterKey: 'allegro.publicapi.v1',
   platformType: 'allegro',
   supportedCapabilities: ['OrderSource', 'OfferManager'],
   displayName: 'Allegro Public API v1',
-  version: '1.0.0'
-}
+  version: '1.0.0',
+  isDefault: true,
+});
+
+// In PrestashopIntegrationModule.onModuleInit():
+this.adapterRegistry.register({
+  adapterKey: 'prestashop.webservice.v1',
+  platformType: 'prestashop',
+  supportedCapabilities: ['ProductMaster', 'InventoryMaster', 'OrderSource', 'OrderProcessorManager'],
+  displayName: 'PrestaShop WebService v1',
+  version: '1.0.0',
+  isDefault: true,
+});
 ```
 
 **Service Usage** (Per-Connection):

--- a/docs/plans/implementation-plan-570-571-pluggable-adapter-registry.md
+++ b/docs/plans/implementation-plan-570-571-pluggable-adapter-registry.md
@@ -1,0 +1,302 @@
+# Implementation Plan — #570 + #571 Pluggable adapter registry
+
+## 1. Goal
+
+Close two BLOCKER findings from Modularity Thread C:
+
+- **#570** — `AdapterRegistryService` is a hardcoded inline `Map` literal. No
+  `register()` method, no DB backing, no manifest discovery. An out-of-tree
+  plugin (e.g. `@third-party/openlinker-plugin-shopify`) cannot register
+  itself; even an in-tree contributor must edit `libs/core` to add a
+  platform.
+- **#571** — `IntegrationsService.deriveAdapterKey` carries a private
+  `Record<platformType, adapterKey>` that hardcodes `'prestashop' →
+  'prestashop.webservice.v1'` and `'allegro' → 'allegro.publicapi.v1'`. Any
+  new platform requires editing core.
+
+The asymmetry between these two registries and the already-pluggable
+`AdapterFactoryResolverService` (which has `registerFactory(...)` and is
+populated by `*IntegrationModule.onModuleInit()`) is the bug. After this
+change, all three artefacts an integration contributes — metadata, factory,
+and platform default — are registered the same way, by the integration
+module itself.
+
+Layer: **CORE infrastructure + Integration self-registration**.
+Non-goals (left for follow-up tickets):
+- #574 Placeholder `getAdapter` return shape — keep as-is.
+- #575 Static manifest export from adapter packages — separate ticket.
+- DB-backed registry — defer to when a real use case lands.
+- Capability open-union (#576) and EntityType open-union (#577) — separate
+  tickets in the same epic.
+
+## 2. Design
+
+### 2.1 Port surface — `AdapterRegistryPort`
+
+Add **two** new methods, sized to mirror `AdapterFactoryResolverService`:
+
+```typescript
+export interface AdapterRegistryPort {
+  /** Existing — unchanged. */
+  getAdapter(adapterKey: string): Promise<AdapterInstance>;
+  getAdapterMetadata(adapterKey: string): Promise<AdapterMetadata>;
+  listAdapters(): Promise<AdapterMetadata[]>;
+
+  /**
+   * Register an adapter's metadata (#570).
+   *
+   * Sync (returns `void`) — deliberately mirrors the sister
+   * `AdapterFactoryResolverService.registerFactory` so contributors
+   * can reason about both registries the same way at boot time. The
+   * read-side methods above stay async because they may grow IO
+   * (DB-backed registry) in the future; registration is in-process.
+   *
+   * Throws `DuplicateAdapterKeyException` if `adapterKey` is already
+   * registered (loud-fail per `code-review-guide.md` "fail fast on
+   * configuration errors"). If `metadata.isDefault === true`, also
+   * registers the adapter as the platform default — throws
+   * `DuplicatePlatformDefaultException` if another adapter is already
+   * the default for the same `platformType`.
+   */
+  register(metadata: AdapterMetadata): void;
+
+  /**
+   * Resolve the default adapterKey for a platformType (#571).
+   * Replaces `IntegrationsService.deriveAdapterKey`. Async to match
+   * the read-side methods above. Throws `AdapterNotFoundException`
+   * if no default is registered for the platformType.
+   */
+  getDefaultAdapterKey(platformType: string): Promise<string>;
+}
+```
+
+**Domain exceptions** (`libs/core/src/integrations/domain/exceptions/`):
+
+- `DuplicateAdapterKeyException` — extends `Error`, named per the existing `AdapterNotFoundException` / `CapabilityNotSupportedException` shape in the same directory.
+- `DuplicatePlatformDefaultException` — same.
+
+Per `engineering-standards.md` §Error Handling, every integrations-bounded-context error is a typed domain exception under `domain/exceptions/`; plain `throw new Error(...)` would break that convention.
+
+### 2.2 `AdapterMetadata` — add optional `isDefault`
+
+```typescript
+// libs/core/src/integrations/domain/types/adapter.types.ts
+export interface AdapterMetadata {
+  adapterKey: string;
+  platformType: string;
+  supportedCapabilities: Capability[];
+  displayName?: string;
+  version?: string;
+  /**
+   * When true, this adapter is the default for its platformType — i.e.
+   * `IntegrationsService` resolves an unspecified `connection.adapterKey`
+   * to this adapter's key. At most one default per platformType is
+   * permitted; the registry rejects a second default registration.
+   */
+  isDefault?: boolean;
+}
+```
+
+This field is the simpler half of #571's recommendation: "register an
+`isDefault: true` flag on `register()`, or expose
+`registerPlatformDefault(platformType, adapterKey)`". The flag wins
+because it keeps registration to a single call.
+
+### 2.3 `AdapterRegistryService` — rewrite
+
+```typescript
+@Injectable()
+export class AdapterRegistryService implements AdapterRegistryPort {
+  private readonly logger = new Logger(AdapterRegistryService.name);
+  private readonly registry = new Map<string, AdapterMetadata>();
+  private readonly defaultsByPlatform = new Map<string, string>();
+
+  register(metadata: AdapterMetadata): void {
+    if (this.registry.has(metadata.adapterKey)) {
+      throw new DuplicateAdapterKeyException(metadata.adapterKey);
+    }
+    if (metadata.isDefault === true) {
+      const existing = this.defaultsByPlatform.get(metadata.platformType);
+      if (existing) {
+        throw new DuplicatePlatformDefaultException(
+          metadata.platformType,
+          existing,
+          metadata.adapterKey,
+        );
+      }
+      this.defaultsByPlatform.set(metadata.platformType, metadata.adapterKey);
+    }
+    this.registry.set(metadata.adapterKey, metadata);
+    this.logger.log(`Registered adapter: ${metadata.adapterKey}` +
+      (metadata.isDefault ? ` (default for ${metadata.platformType})` : ''));
+  }
+
+  async getDefaultAdapterKey(platformType: string): Promise<string> {
+    const adapterKey = this.defaultsByPlatform.get(platformType);
+    if (!adapterKey) {
+      throw new AdapterNotFoundException(
+        `No default adapter registered for platformType: ${platformType}. ` +
+          `Available platforms: ${Array.from(this.defaultsByPlatform.keys()).join(', ')}`,
+      );
+    }
+    return adapterKey;
+  }
+
+  // ... existing getAdapter / getAdapterMetadata / listAdapters unchanged
+}
+```
+
+The inline metadata literal is **deleted** — empty registry on construct.
+
+**File header update**: the existing JSDoc on `adapter-registry.service.ts:1-12`
+describes the registry as "in-memory static registry... Future versions
+may support dynamic registration." That sentence becomes false when the
+literal is removed, so rewrite the header to describe the new shape:
+"registry populated at boot by integration modules via `register()`,
+replacing the previous static literal." Per `engineering-standards.md`
+§File Headers, the header is part of the contract.
+
+### 2.4 `IntegrationsService` — drop `deriveAdapterKey`
+
+Three call sites currently call `this.deriveAdapterKey(...)`:
+- `getAdapter()` line 70
+- `resolveAdapterMetadata()` line 159
+- `listCapabilityAdapters()` line 198
+
+All three replaced with:
+
+```typescript
+const adapterKey = connection.adapterKey
+  ?? await this.adapterRegistry.getDefaultAdapterKey(connection.platformType);
+```
+
+The private `deriveAdapterKey` method (lines 288–315) is **deleted**.
+
+### 2.5 Integration modules self-register metadata
+
+Both `AllegroIntegrationModule` and `PrestashopIntegrationModule` already
+self-register their factory in `onModuleInit`. Add an
+`AdapterRegistryService` injection and one `register({...})` call alongside
+the existing `factoryResolver.registerFactory(...)`. Same call site, same
+log line cluster — keeps the contributor mental model "everything an
+integration registers, it does in `onModuleInit`".
+
+```typescript
+// AllegroIntegrationModule
+constructor(
+  @Inject(ADAPTER_REGISTRY_TOKEN)
+  private readonly adapterRegistry: AdapterRegistryPort,
+  // ...existing
+) {}
+
+onModuleInit(): void {
+  this.adapterRegistry.register({
+    adapterKey: 'allegro.publicapi.v1',
+    platformType: 'allegro',
+    supportedCapabilities: ['OrderSource', 'OfferManager'],
+    displayName: 'Allegro Public API v1',
+    version: '1.0.0',
+    isDefault: true,
+  });
+  this.factoryResolver.registerFactory('allegro.publicapi.v1', factory);
+  // ...existing
+}
+```
+
+`PrestashopIntegrationModule` mirrors this with the prestashop metadata
+that's currently inline in the service literal (capabilities `ProductMaster`,
+`InventoryMaster`, `OrderSource`, `OrderProcessorManager`).
+
+NestJS guarantees `onModuleInit` runs in import-graph order; both
+integration modules import `IntegrationsModule` (which provides the
+registry), so the registry is constructed before the integration tries to
+register into it. Already validated empirically by the existing
+`registerFactory` flow that uses the same shape.
+
+## 3. Step-by-step
+
+| # | File | Change | Acceptance |
+|---|------|--------|------------|
+| 1 | `libs/core/src/integrations/domain/types/adapter.types.ts` | Add optional `isDefault?: boolean` to `AdapterMetadata` | Type-checks |
+| 2 | `libs/core/src/integrations/domain/ports/adapter-registry.port.ts` | Add `register()` + `getDefaultAdapterKey()` to interface | Type-checks |
+| 3 | `libs/core/src/integrations/infrastructure/adapters/adapter-registry.service.ts` | Drop inline Map literal; implement `register()` + `getDefaultAdapterKey()` with duplicate guards | Empty-registry tests pass |
+| 4 | `libs/core/src/integrations/infrastructure/adapters/adapter-registry.service.spec.ts` | Rewrite for empty-registry-with-register flow; cover register, duplicate, getDefault, duplicate-default, listAdapters | All new tests pass |
+| 5 | `libs/core/src/integrations/application/services/integrations.service.ts` | Replace 3× `deriveAdapterKey(...)` with `await this.adapterRegistry.getDefaultAdapterKey(...)`; delete the private method | Lint clean; `IntegrationsService.spec` passes |
+| 6 | `libs/core/src/integrations/application/services/integrations.service.spec.ts` | Add `getDefaultAdapterKey: jest.fn()` to mock; default mock to resolve `'prestashop.webservice.v1'`; ensure existing tests still cover the resolution path | Existing 30+ tests pass |
+| 7 | `libs/integrations/allegro/src/allegro-integration.module.ts` | Inject `ADAPTER_REGISTRY_TOKEN`; call `adapterRegistry.register({ ..., isDefault: true })` in `onModuleInit` | Boot succeeds, `IntegrationsService.getAdapter('allegro-conn')` resolves |
+| 8 | `libs/integrations/prestashop/src/prestashop-integration.module.ts` | Same pattern — register prestashop metadata in `onModuleInit` | Boot succeeds, `IntegrationsService.getAdapter('ps-conn')` resolves |
+| 9 | `libs/core/src/integrations/domain/exceptions/duplicate-adapter-key.exception.ts` (new) + `duplicate-platform-default.exception.ts` (new) | Two domain exceptions following the existing `AdapterNotFoundException` shape | Compile clean; thrown from `register()` |
+| 10 | `docs/architecture-overview.md:1149-1167` | Add one sentence: "Each integration module self-registers its adapter metadata via `adapterRegistry.register({...})` in `onModuleInit`." Closes the doc-vs-code drift this audit was meant to expose. | Doc reflects new wiring |
+| 11 | (verify) | Existing api-app integration tests (`app-boot.int-spec.ts`, `connection-capabilities.int-spec.ts`) still pass | Both green |
+
+## 4. Validation
+
+### Architecture compliance
+
+- ✅ CORE owns `AdapterRegistryService` + `AdapterRegistryPort`.
+- ✅ Integrations only call the published port methods — no deep imports.
+- ✅ `register()` is sync (mirrors `registerFactory`); `getDefaultAdapterKey`
+  is async (mirrors `getAdapterMetadata`).
+- ✅ No domain-layer changes (only types added).
+
+### Naming
+
+- `AdapterRegistryPort`, `AdapterRegistryService` — per
+  `engineering-standards.md` "Ports vs Concrete Implementations".
+- New port methods follow camelCase verb-first convention.
+
+### Error handling
+
+- Duplicate `adapterKey` registration: throw `Error` (configuration error,
+  fail-fast at boot).
+- Duplicate default per platformType: throw `Error` (same).
+- Missing default for a connection's platformType: throw
+  `AdapterNotFoundException` (existing domain exception, preserves the
+  current `IntegrationsService.deriveAdapterKey` semantics).
+
+### Testing strategy
+
+- **Unit**: rewrite `adapter-registry.service.spec.ts` to construct a fresh
+  empty registry and exercise `register` + `getDefaultAdapterKey`.
+  Cover: register-then-get, duplicate adapterKey throws
+  `DuplicateAdapterKeyException`, duplicate-default throws
+  `DuplicatePlatformDefaultException`, getDefaultAdapterKey throws
+  `AdapterNotFoundException` when unknown, listAdapters reflects
+  registered set.
+- **Unit**: extend `integrations.service.spec.ts` mock to include
+  `getDefaultAdapterKey: jest.fn().mockResolvedValue('prestashop.webservice.v1')`.
+  Existing 30+ tests carry forward unchanged because they pass
+  `mockConnection` with no `adapterKey`, hitting the derive path — now
+  via mock. Add **one** explicit assertion in a "no explicit adapterKey"
+  test case: `expect(adapterRegistry.getDefaultAdapterKey).toHaveBeenCalledWith('prestashop')`
+  — documents the contract a future contributor needs to preserve, since
+  the implicit-via-mock coverage is invisible to anyone reading the test
+  list.
+- **Integration**: `app-boot.int-spec.ts` already boots the full Nest
+  graph; if `onModuleInit` registration is broken, that spec fails at
+  startup. No new int-spec needed for #570/#571 specifically.
+
+### Security / blast radius
+
+- Single boot path. If an integration module's `onModuleInit` throws
+  (duplicate registration or similar), the API/worker fails to boot at
+  startup with a precise error message — same fail-mode as today's
+  `registerFactory` would have, just on a different line.
+- No data migration; no schema change.
+
+## 5. Risks & open questions
+
+- **Boot-time ordering across multiple workers/processes**: registration
+  is in-process. Each NestJS process registers independently at boot —
+  same as today. No coordination needed.
+- **Tests that previously relied on the live registry implicitly returning
+  `prestashop.webservice.v1` and `allegro.publicapi.v1`**: any
+  unit test that constructs `AdapterRegistryService` directly without
+  registering anything will see an empty registry. The only such test is
+  `adapter-registry.service.spec.ts`, which we're rewriting.
+- **Future `register()` ordering between metadata and factory**: today the
+  module registers factory first, then connection-tester. After this
+  change, also metadata. Order doesn't matter — the registry and the
+  factory resolver are independent maps. Adopt convention "metadata →
+  factory → tester" for readability; document as a comment in the first
+  module.

--- a/libs/core/src/ai/domain/exceptions/duplicate-ai-provider.exception.ts
+++ b/libs/core/src/ai/domain/exceptions/duplicate-ai-provider.exception.ts
@@ -1,0 +1,29 @@
+/**
+ * Duplicate AI Provider Exception
+ *
+ * Thrown when two adapters attempt to register themselves under the same
+ * `AiProvider` key on the multi-provider router. Each provider must have at
+ * most one registered completion adapter — a collision is a configuration
+ * error (typically a copy-paste in `AiIntegrationModule.register()`), so
+ * the router fails loudly at boot rather than silently overwriting.
+ *
+ * Mirrors the integrations-bounded-context pattern introduced in #570 for
+ * `AdapterRegistryService.register()` (`DuplicateAdapterKeyException`).
+ * Class suffix is `Error` to match the local AI-module convention
+ * (`AiCompletionError`); file suffix is `.exception.ts` per
+ * `engineering-standards.md` §Naming.
+ *
+ * @module libs/core/src/ai/domain/exceptions
+ */
+import type { AiProvider } from '../types/ai-completion.types';
+
+export class DuplicateAiProviderError extends Error {
+  constructor(provider: AiProvider) {
+    super(
+      `AI completion adapter for provider '${provider}' is already registered. ` +
+        `Each provider must have exactly one registered adapter.`,
+    );
+    this.name = 'DuplicateAiProviderError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/ai/index.ts
+++ b/libs/core/src/ai/index.ts
@@ -23,6 +23,7 @@ export * from './domain/exceptions/ai-completion.exception';
 export * from './domain/exceptions/ai-rate-limit.exception';
 export * from './domain/exceptions/ai-timeout.exception';
 export * from './domain/exceptions/ai-invalid-response.exception';
+export * from './domain/exceptions/duplicate-ai-provider.exception';
 
 export * from './domain/entities/prompt-template.entity';
 export * from './domain/types/prompt-template.types';

--- a/libs/core/src/integrations/application/services/integrations.service.spec.ts
+++ b/libs/core/src/integrations/application/services/integrations.service.spec.ts
@@ -67,6 +67,12 @@ describe('IntegrationsService', () => {
       getAdapter: jest.fn(),
       getAdapterMetadata: jest.fn(),
       listAdapters: jest.fn(),
+      register: jest.fn(),
+      // Default to resolving prestashop's default adapterKey — most tests
+      // pass `mockConnection` with `platformType: 'prestashop'` and no
+      // explicit adapterKey, hitting this path. Tests that need a different
+      // platform override per-test.
+      getDefaultAdapterKey: jest.fn().mockResolvedValue('prestashop.webservice.v1'),
     } as unknown as jest.Mocked<AdapterRegistryPort>;
 
     const mockFactoryResolver = {
@@ -157,6 +163,10 @@ describe('IntegrationsService', () => {
       const result = await service.getAdapter('connection-123');
 
       expect(result.connection).toEqual(mockConnection);
+      // Documents the contract: when connection.adapterKey is unset,
+      // IntegrationsService asks the registry for the platform default
+      // (#571 — replaces the hardcoded deriveAdapterKey map).
+      expect(adapterRegistry.getDefaultAdapterKey).toHaveBeenCalledWith('prestashop');
       expect(adapterRegistry.getAdapterMetadata).toHaveBeenCalledWith(
         'prestashop.webservice.v1',
       );

--- a/libs/core/src/integrations/application/services/integrations.service.ts
+++ b/libs/core/src/integrations/application/services/integrations.service.ts
@@ -67,7 +67,8 @@ export class IntegrationsService implements IIntegrationsService {
     }
 
     // Determine adapterKey
-    const adapterKey = connection.adapterKey ?? this.deriveAdapterKey(connection.platformType);
+    const adapterKey =
+      connection.adapterKey ?? (await this.adapterRegistry.getDefaultAdapterKey(connection.platformType));
     this.logger.debug(
       `Resolved adapterKey: ${adapterKey}${connection.adapterKey ? ' (explicit)' : ` (derived from platformType: ${connection.platformType})`}`,
     );
@@ -156,7 +157,8 @@ export class IntegrationsService implements IIntegrationsService {
     platformType: string;
     adapterKey?: string;
   }): Promise<AdapterMetadata> {
-    const adapterKey = params.adapterKey ?? this.deriveAdapterKey(params.platformType);
+    const adapterKey =
+      params.adapterKey ?? (await this.adapterRegistry.getDefaultAdapterKey(params.platformType));
     return this.adapterRegistry.getAdapterMetadata(adapterKey);
   }
 
@@ -195,7 +197,8 @@ export class IntegrationsService implements IIntegrationsService {
     for (const connection of connections) {
       try {
         const adapterKey =
-          connection.adapterKey ?? this.deriveAdapterKey(connection.platformType);
+          connection.adapterKey ??
+          (await this.adapterRegistry.getDefaultAdapterKey(connection.platformType));
 
         const metadata = await this.adapterRegistry.getAdapterMetadata(adapterKey);
 
@@ -285,33 +288,5 @@ export class IntegrationsService implements IIntegrationsService {
     return results;
   }
 
-  /**
-   * Derives adapterKey from platformType if not explicitly set.
-   *
-   * Hardcoded for MVP, but extracted to enable easy configuration later.
-   * Future: Can be replaced with:
-   * - Configuration service injection
-   * - Database lookup
-   * - Environment variable mapping
-   *
-   * @param platformType - The platform type (e.g., 'prestashop', 'allegro')
-   * @returns The default adapter key for the platform type
-   * @throws AdapterNotFoundException if no default adapter key found
-   */
-  private deriveAdapterKey(platformType: string): string {
-    const mapping: Record<string, string> = {
-      prestashop: 'prestashop.webservice.v1',
-      allegro: 'allegro.publicapi.v1',
-    };
-
-    const adapterKey = mapping[platformType];
-    if (!adapterKey) {
-      throw new AdapterNotFoundException(
-        `No default adapterKey found for platformType: ${platformType}`,
-      );
-    }
-
-    return adapterKey;
-  }
 }
 

--- a/libs/core/src/integrations/domain/exceptions/duplicate-adapter-key.exception.ts
+++ b/libs/core/src/integrations/domain/exceptions/duplicate-adapter-key.exception.ts
@@ -1,0 +1,21 @@
+/**
+ * Duplicate Adapter Key Exception
+ *
+ * Domain exception thrown when two integration modules attempt to register
+ * the same `adapterKey` with the registry. Each adapterKey must be unique
+ * across the system — a collision is a configuration error, not a runtime
+ * condition, so the registry fails loudly at boot rather than silently
+ * overwriting. (#570)
+ *
+ * @module libs/core/src/integrations/domain/exceptions
+ */
+export class DuplicateAdapterKeyException extends Error {
+  constructor(adapterKey: string) {
+    super(
+      `Adapter ${adapterKey} already registered. Each adapterKey must be ` +
+        `unique across all integration modules.`,
+    );
+    this.name = 'DuplicateAdapterKeyException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/integrations/domain/exceptions/duplicate-platform-default.exception.ts
+++ b/libs/core/src/integrations/domain/exceptions/duplicate-platform-default.exception.ts
@@ -1,0 +1,22 @@
+/**
+ * Duplicate Platform Default Exception
+ *
+ * Domain exception thrown when a second adapter for the same `platformType`
+ * tries to register itself as the default (`isDefault: true`). At most one
+ * default adapter per platformType is permitted — `IntegrationsService`
+ * resolves an unspecified `connection.adapterKey` through it, so two defaults
+ * would make the resolution non-deterministic. (#571)
+ *
+ * @module libs/core/src/integrations/domain/exceptions
+ */
+export class DuplicatePlatformDefaultException extends Error {
+  constructor(platformType: string, existingAdapterKey: string, conflictingAdapterKey: string) {
+    super(
+      `Default adapter for platformType '${platformType}' already registered ` +
+        `as ${existingAdapterKey}; cannot also register ${conflictingAdapterKey} ` +
+        `as default. At most one isDefault adapter is permitted per platformType.`,
+    );
+    this.name = 'DuplicatePlatformDefaultException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/integrations/domain/ports/adapter-registry.port.ts
+++ b/libs/core/src/integrations/domain/ports/adapter-registry.port.ts
@@ -30,6 +30,36 @@ export interface AdapterRegistryPort {
    * @returns Array of all adapter metadata
    */
   listAdapters(): Promise<AdapterMetadata[]>;
+
+  /**
+   * Register an adapter's metadata at boot. Called by each integration
+   * module's `onModuleInit`, mirroring `AdapterFactoryResolverService.registerFactory`.
+   *
+   * Sync (returns `void`) — deliberately mirrors the sister factory
+   * resolver so contributors can reason about both registries the same
+   * way at boot time. The read-side methods above stay async because
+   * they may grow IO (DB-backed registry) in the future; registration
+   * is in-process. (#570)
+   *
+   * @param metadata - Adapter metadata; `metadata.adapterKey` must be unique.
+   *   When `metadata.isDefault === true`, also marks this adapter as the
+   *   default for its `platformType` (resolution target for connections
+   *   without an explicit `adapterKey`).
+   * @throws DuplicateAdapterKeyException if `metadata.adapterKey` is already registered
+   * @throws DuplicatePlatformDefaultException if a default already exists for this platformType
+   */
+  register(metadata: AdapterMetadata): void;
+
+  /**
+   * Resolve the default adapterKey for a platformType. Called by
+   * `IntegrationsService` when a connection has no explicit `adapterKey`. (#571)
+   *
+   * @param platformType - Platform type identifier (e.g., 'prestashop', 'allegro')
+   * @returns The adapterKey of the integration module that registered
+   *   itself as `isDefault: true` for this platformType
+   * @throws AdapterNotFoundException if no default is registered for the platformType
+   */
+  getDefaultAdapterKey(platformType: string): Promise<string>;
 }
 
 

--- a/libs/core/src/integrations/domain/types/adapter.types.ts
+++ b/libs/core/src/integrations/domain/types/adapter.types.ts
@@ -64,6 +64,15 @@ export interface AdapterMetadata {
    * Optional adapter version
    */
   version?: string;
+
+  /**
+   * When true, this adapter is the default for its platformType — i.e.
+   * `IntegrationsService` resolves an unspecified `connection.adapterKey`
+   * to this adapter's key. At most one default per platformType is
+   * permitted; the registry rejects a second default registration with
+   * `DuplicatePlatformDefaultException`. (#571)
+   */
+  isDefault?: boolean;
 }
 
 /**

--- a/libs/core/src/integrations/infrastructure/adapters/adapter-factory-resolver.service.spec.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/adapter-factory-resolver.service.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Adapter Factory Resolver Service Unit Tests
+ *
+ * Focused on the registration surface — `createCapabilityAdapter` is
+ * exercised through `IntegrationsService.spec.ts` and the live integration
+ * modules at boot. This spec covers the duplicate-fail guard added in
+ * #570, which mirrors `AdapterRegistryService.register()`.
+ *
+ * @module libs/core/src/integrations/infrastructure/adapters
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdapterFactoryResolverService } from './adapter-factory-resolver.service';
+import { AdapterFactoryPort } from '@openlinker/core/integrations/domain/ports/adapter-factory.port';
+import { DuplicateAdapterKeyException } from '@openlinker/core/integrations/domain/exceptions/duplicate-adapter-key.exception';
+
+const buildFactoryStub = (): jest.Mocked<AdapterFactoryPort> => ({
+  createCapabilityAdapter: jest.fn(),
+});
+
+describe('AdapterFactoryResolverService', () => {
+  let service: AdapterFactoryResolverService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdapterFactoryResolverService],
+    }).compile();
+
+    service = module.get(AdapterFactoryResolverService);
+  });
+
+  describe('registerFactory', () => {
+    it('registers a factory and exposes it via hasFactory', () => {
+      service.registerFactory('prestashop.webservice.v1', buildFactoryStub());
+
+      expect(service.hasFactory('prestashop.webservice.v1')).toBe(true);
+    });
+
+    it('throws DuplicateAdapterKeyException when the same adapterKey is registered twice', () => {
+      service.registerFactory('prestashop.webservice.v1', buildFactoryStub());
+
+      expect(() =>
+        service.registerFactory('prestashop.webservice.v1', buildFactoryStub()),
+      ).toThrow(DuplicateAdapterKeyException);
+    });
+
+    it('allows different adapterKeys to coexist', () => {
+      expect(() => {
+        service.registerFactory('prestashop.webservice.v1', buildFactoryStub());
+        service.registerFactory('allegro.publicapi.v1', buildFactoryStub());
+      }).not.toThrow();
+      expect(service.hasFactory('prestashop.webservice.v1')).toBe(true);
+      expect(service.hasFactory('allegro.publicapi.v1')).toBe(true);
+    });
+  });
+
+  describe('hasFactory', () => {
+    it('returns false for an unregistered adapterKey', () => {
+      expect(service.hasFactory('unknown.adapter.v1')).toBe(false);
+    });
+  });
+});

--- a/libs/core/src/integrations/infrastructure/adapters/adapter-factory-resolver.service.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/adapter-factory-resolver.service.ts
@@ -13,6 +13,7 @@ import { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CredentialsResolverPort } from '@openlinker/core/integrations/domain/ports/credentials-resolver.port';
 import { Capability } from '@openlinker/core/integrations/domain/types/adapter.types';
 import { AdapterNotFoundException } from '@openlinker/core/integrations/domain/exceptions/adapter-not-found.exception';
+import { DuplicateAdapterKeyException } from '@openlinker/core/integrations/domain/exceptions/duplicate-adapter-key.exception';
 import { Logger } from '@openlinker/shared/logging';
 
 /**
@@ -28,10 +29,19 @@ export class AdapterFactoryResolverService {
   /**
    * Register an adapter factory
    *
+   * Throws `DuplicateAdapterKeyException` on a second registration for the
+   * same adapterKey — fail-loud at boot rather than silently overwrite.
+   * Mirrors `AdapterRegistryService.register()` (#570) so duplicate-key
+   * semantics are consistent across both registries.
+   *
    * @param adapterKey - Adapter key (e.g., 'prestashop.webservice.v1')
    * @param factory - Factory implementation
+   * @throws DuplicateAdapterKeyException if `adapterKey` is already registered
    */
   registerFactory(adapterKey: string, factory: AdapterFactoryPort): void {
+    if (this.factories.has(adapterKey)) {
+      throw new DuplicateAdapterKeyException(adapterKey);
+    }
     this.logger.debug(`Registering adapter factory: ${adapterKey}`);
     this.factories.set(adapterKey, factory);
   }

--- a/libs/core/src/integrations/infrastructure/adapters/adapter-registry.service.spec.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/adapter-registry.service.spec.ts
@@ -1,14 +1,42 @@
 /**
  * Adapter Registry Service Unit Tests
  *
- * Unit tests for AdapterRegistryService, verifying adapter lookup,
- * metadata retrieval, and error handling.
+ * Verifies the empty-registry-with-register flow added in #570/#571.
+ * Each test constructs a fresh service (zero pre-registered adapters)
+ * and exercises the public port surface — no test depends on the previous
+ * inline literal that was deleted with the modularity audit.
  *
  * @module libs/core/src/integrations/infrastructure/adapters
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { AdapterRegistryService } from './adapter-registry.service';
+import { AdapterMetadata } from '@openlinker/core/integrations/domain/types/adapter.types';
 import { AdapterNotFoundException } from '@openlinker/core/integrations/domain/exceptions/adapter-not-found.exception';
+import { DuplicateAdapterKeyException } from '@openlinker/core/integrations/domain/exceptions/duplicate-adapter-key.exception';
+import { DuplicatePlatformDefaultException } from '@openlinker/core/integrations/domain/exceptions/duplicate-platform-default.exception';
+
+const prestashopMetadata: AdapterMetadata = {
+  adapterKey: 'prestashop.webservice.v1',
+  platformType: 'prestashop',
+  supportedCapabilities: [
+    'ProductMaster',
+    'InventoryMaster',
+    'OrderSource',
+    'OrderProcessorManager',
+  ],
+  displayName: 'PrestaShop WebService v1',
+  version: '1.0.0',
+  isDefault: true,
+};
+
+const allegroMetadata: AdapterMetadata = {
+  adapterKey: 'allegro.publicapi.v1',
+  platformType: 'allegro',
+  supportedCapabilities: ['OrderSource', 'OfferManager'],
+  displayName: 'Allegro Public API v1',
+  version: '1.0.0',
+  isDefault: true,
+};
 
 describe('AdapterRegistryService', () => {
   let service: AdapterRegistryService;
@@ -21,43 +49,81 @@ describe('AdapterRegistryService', () => {
     service = module.get<AdapterRegistryService>(AdapterRegistryService);
   });
 
-  describe('getAdapterMetadata', () => {
-    it('should return metadata for prestashop adapter', async () => {
-      const metadata = await service.getAdapterMetadata('prestashop.webservice.v1');
+  describe('register', () => {
+    it('persists metadata and returns it via getAdapterMetadata', async () => {
+      service.register(prestashopMetadata);
 
-      expect(metadata).toBeDefined();
-      expect(metadata.adapterKey).toBe('prestashop.webservice.v1');
-      expect(metadata.platformType).toBe('prestashop');
-      expect(metadata.supportedCapabilities).toContain('ProductMaster');
-      expect(metadata.supportedCapabilities).toContain('InventoryMaster');
-      expect(metadata.supportedCapabilities).toContain('OrderSource');
+      const fetched = await service.getAdapterMetadata('prestashop.webservice.v1');
+      expect(fetched).toEqual(prestashopMetadata);
     });
 
-    it('should return metadata for allegro adapter', async () => {
-      const metadata = await service.getAdapterMetadata('allegro.publicapi.v1');
+    it('throws DuplicateAdapterKeyException when the same adapterKey is registered twice', () => {
+      service.register(prestashopMetadata);
 
-      expect(metadata).toBeDefined();
-      expect(metadata.adapterKey).toBe('allegro.publicapi.v1');
-      expect(metadata.platformType).toBe('allegro');
-      expect(metadata.supportedCapabilities).toContain('OfferManager');
+      expect(() => service.register(prestashopMetadata)).toThrow(DuplicateAdapterKeyException);
     });
 
-    it('should throw AdapterNotFoundException for unknown adapter', async () => {
-      await expect(
-        service.getAdapterMetadata('unknown.adapter.v1'),
-      ).rejects.toThrow(AdapterNotFoundException);
+    it('throws DuplicatePlatformDefaultException when two adapters claim the same platform default', () => {
+      service.register(prestashopMetadata);
+
+      const conflicting: AdapterMetadata = {
+        ...prestashopMetadata,
+        adapterKey: 'prestashop.alternative.v1',
+        isDefault: true,
+      };
+
+      expect(() => service.register(conflicting)).toThrow(DuplicatePlatformDefaultException);
+    });
+
+    it('allows multiple adapters per platformType when only one is the default', () => {
+      service.register(prestashopMetadata);
+      // Same platform, different adapterKey, isDefault omitted — no conflict.
+      const altPrestashop: AdapterMetadata = {
+        ...prestashopMetadata,
+        adapterKey: 'prestashop.alternative.v1',
+        isDefault: false,
+      };
+      expect(() => service.register(altPrestashop)).not.toThrow();
+    });
+  });
+
+  describe('getDefaultAdapterKey', () => {
+    it('returns the adapterKey registered with isDefault: true', async () => {
+      service.register(prestashopMetadata);
+      service.register(allegroMetadata);
+
+      expect(await service.getDefaultAdapterKey('prestashop')).toBe('prestashop.webservice.v1');
+      expect(await service.getDefaultAdapterKey('allegro')).toBe('allegro.publicapi.v1');
+    });
+
+    it('throws AdapterNotFoundException for an unknown platformType', async () => {
+      service.register(prestashopMetadata);
+
+      await expect(service.getDefaultAdapterKey('shopify')).rejects.toThrow(
+        AdapterNotFoundException,
+      );
+    });
+
+    it('does not register a default when isDefault is omitted or false', async () => {
+      service.register({ ...prestashopMetadata, isDefault: false });
+
+      await expect(service.getDefaultAdapterKey('prestashop')).rejects.toThrow(
+        AdapterNotFoundException,
+      );
     });
   });
 
   describe('getAdapter', () => {
-    it('should return adapter instance for valid adapter key', async () => {
+    it('returns adapter placeholder for a registered adapterKey', async () => {
+      service.register(prestashopMetadata);
+
       const adapter = await service.getAdapter('prestashop.webservice.v1');
 
       expect(adapter).toBeDefined();
       expect((adapter as { adapterKey: string }).adapterKey).toBe('prestashop.webservice.v1');
     });
 
-    it('should throw AdapterNotFoundException for unknown adapter', async () => {
+    it('throws AdapterNotFoundException for an unknown adapterKey', async () => {
       await expect(service.getAdapter('unknown.adapter.v1')).rejects.toThrow(
         AdapterNotFoundException,
       );
@@ -65,46 +131,23 @@ describe('AdapterRegistryService', () => {
   });
 
   describe('listAdapters', () => {
-    it('should return all registered adapters', async () => {
+    it('returns an empty array when no adapters are registered', async () => {
+      const adapters = await service.listAdapters();
+
+      expect(adapters).toEqual([]);
+    });
+
+    it('returns every registered adapter, in registration order', async () => {
+      service.register(prestashopMetadata);
+      service.register(allegroMetadata);
+
       const adapters = await service.listAdapters();
 
       expect(adapters).toHaveLength(2);
-      expect(adapters.map((a) => a.adapterKey)).toContain(
+      expect(adapters.map((a) => a.adapterKey)).toEqual([
         'prestashop.webservice.v1',
-      );
-      expect(adapters.map((a) => a.adapterKey)).toContain('allegro.publicapi.v1');
-    });
-
-    it('should return adapters with all required metadata fields', async () => {
-      const adapters = await service.listAdapters();
-
-      adapters.forEach((adapter) => {
-        expect(adapter).toHaveProperty('adapterKey');
-        expect(adapter).toHaveProperty('platformType');
-        expect(adapter).toHaveProperty('supportedCapabilities');
-        expect(adapter.supportedCapabilities.length).toBeGreaterThan(0);
-      });
-    });
-  });
-
-  describe('capability support', () => {
-    it('should verify prestashop supports ProductMaster', async () => {
-      const metadata = await service.getAdapterMetadata('prestashop.webservice.v1');
-      expect(metadata.supportedCapabilities).toContain('ProductMaster');
-    });
-
-    it('should verify allegro supports Marketplace', async () => {
-      const metadata = await service.getAdapterMetadata('allegro.publicapi.v1');
-      expect(metadata.supportedCapabilities).toContain('OfferManager');
-    });
-
-    it('should verify prestashop supports OrderSource and allegro supports Marketplace', async () => {
-      const prestashop = await service.getAdapterMetadata('prestashop.webservice.v1');
-      const allegro = await service.getAdapterMetadata('allegro.publicapi.v1');
-
-      expect(prestashop.supportedCapabilities).toContain('OrderSource');
-      expect(allegro.supportedCapabilities).toContain('OfferManager');
+        'allegro.publicapi.v1',
+      ]);
     });
   });
 });
-

--- a/libs/core/src/integrations/infrastructure/adapters/adapter-registry.service.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/adapter-registry.service.ts
@@ -1,54 +1,66 @@
 /**
  * Adapter Registry Service
  *
- * In-memory static registry of adapters and their capabilities. Provides
- * adapter lookup and metadata retrieval for the integrations service.
- * In MVP, this uses a static in-memory registry. Future versions may
- * support dynamic registration or database-backed registry.
+ * In-memory registry of adapters and their metadata. Populated at boot by
+ * each `*IntegrationModule.onModuleInit()` calling `register(...)`, replacing
+ * the previous static inline literal that lived in this file (#570). Mirrors
+ * the sister `AdapterFactoryResolverService.registerFactory` pattern — both
+ * registries are populated by the integration modules they describe, and
+ * `libs/core` no longer carries platform-specific knowledge of which
+ * adapters exist. Also tracks the per-platform default adapterKey, replacing
+ * the hardcoded `IntegrationsService.deriveAdapterKey` map (#571).
+ *
+ * Future versions may swap the in-memory map for DB-backed persistence; the
+ * port keeps `getAdapter` / `getAdapterMetadata` / `listAdapters` /
+ * `getDefaultAdapterKey` async to leave that door open.
  *
  * @module libs/core/src/integrations/infrastructure/adapters
  * @implements {AdapterRegistryPort}
  * @see {@link AdapterRegistryPort} for the port interface
  */
 import { Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
 import { AdapterRegistryPort } from '@openlinker/core/integrations/domain/ports/adapter-registry.port';
 import {
   AdapterMetadata,
   AdapterInstance,
-  Capability,
 } from '@openlinker/core/integrations/domain/types/adapter.types';
 import { AdapterNotFoundException } from '@openlinker/core/integrations/domain/exceptions/adapter-not-found.exception';
+import { DuplicateAdapterKeyException } from '@openlinker/core/integrations/domain/exceptions/duplicate-adapter-key.exception';
+import { DuplicatePlatformDefaultException } from '@openlinker/core/integrations/domain/exceptions/duplicate-platform-default.exception';
 
 @Injectable()
 export class AdapterRegistryService implements AdapterRegistryPort {
-  // Static in-memory registry (MVP approach)
-  private readonly registry: Map<string, AdapterMetadata> = new Map(
-    [
-      {
-        adapterKey: 'prestashop.webservice.v1',
-        platformType: 'prestashop',
-        supportedCapabilities: [
-          'ProductMaster',
-          'InventoryMaster',
-          'OrderSource',
-          'OrderProcessorManager',
-        ] as Capability[],
-        displayName: 'PrestaShop WebService v1',
-        version: '1.0.0',
-      },
-      {
-        adapterKey: 'allegro.publicapi.v1',
-        platformType: 'allegro',
-        supportedCapabilities: ['OrderSource', 'OfferManager'] as Capability[],
-        displayName: 'Allegro Public API v1',
-        version: '1.0.0',
-      },
-    ].map((meta) => [meta.adapterKey, meta]),
-  );
+  private readonly logger = new Logger(AdapterRegistryService.name);
+  private readonly registry: Map<string, AdapterMetadata> = new Map();
+  private readonly defaultsByPlatform: Map<string, string> = new Map();
+
+  register(metadata: AdapterMetadata): void {
+    if (this.registry.has(metadata.adapterKey)) {
+      throw new DuplicateAdapterKeyException(metadata.adapterKey);
+    }
+    if (metadata.isDefault === true) {
+      const existing = this.defaultsByPlatform.get(metadata.platformType);
+      if (existing) {
+        throw new DuplicatePlatformDefaultException(
+          metadata.platformType,
+          existing,
+          metadata.adapterKey,
+        );
+      }
+      this.defaultsByPlatform.set(metadata.platformType, metadata.adapterKey);
+    }
+    this.registry.set(metadata.adapterKey, metadata);
+    this.logger.log(
+      `Registered adapter: ${metadata.adapterKey}` +
+        (metadata.isDefault === true ? ` (default for ${metadata.platformType})` : ''),
+    );
+  }
 
   async getAdapter(adapterKey: string): Promise<AdapterInstance> {
     const metadata = await this.getAdapterMetadata(adapterKey);
-    // Return placeholder/mock instance for MVP
+    // Return placeholder/mock instance for MVP — full instances come from
+    // AdapterFactoryResolverService. (#574 tracks deleting this fallback.)
     return { adapterKey: metadata.adapterKey } as AdapterInstance;
   }
 
@@ -63,5 +75,21 @@ export class AdapterRegistryService implements AdapterRegistryPort {
   listAdapters(): Promise<AdapterMetadata[]> {
     return Promise.resolve(Array.from(this.registry.values()));
   }
-}
 
+  // Mirrors `getAdapterMetadata` shape — returns a Promise without `async`
+  // so eslint's `require-await` doesn't flag a sync body. The port keeps
+  // the signature async-shaped to leave the door open for a future
+  // DB-backed registry without changing every call site.
+  getDefaultAdapterKey(platformType: string): Promise<string> {
+    const adapterKey = this.defaultsByPlatform.get(platformType);
+    if (!adapterKey) {
+      return Promise.reject(
+        new AdapterNotFoundException(
+          `No default adapter registered for platformType: ${platformType}. ` +
+            `Available platforms: [${Array.from(this.defaultsByPlatform.keys()).join(', ')}]`,
+        ),
+      );
+    }
+    return Promise.resolve(adapterKey);
+  }
+}

--- a/libs/integrations/ai/src/ai-integration.module.ts
+++ b/libs/integrations/ai/src/ai-integration.module.ts
@@ -36,17 +36,17 @@ import type { AiCompletionPort } from '@openlinker/core/ai/domain/ports/ai-compl
 import type { AiProviderCredentialsPort } from '@openlinker/core/ai/domain/ports/ai-provider-credentials.port';
 import type { IAiProviderActiveSettingsService } from '@openlinker/core/ai/application/services/ai-provider-active-settings.service.interface';
 import { FakeAiCompletionAdapter } from './infrastructure/adapters/fake-ai-completion.adapter';
-import {
-  ANTHROPIC_AI_COMPLETION_ADAPTER_TOKEN,
-  FAKE_AI_COMPLETION_ADAPTER_TOKEN,
-  MultiProviderAiCompletionAdapter,
-  OPENAI_AI_COMPLETION_ADAPTER_TOKEN,
-} from './infrastructure/adapters/multi-provider-ai-completion.adapter';
+import { MultiProviderAiCompletionAdapter } from './infrastructure/adapters/multi-provider-ai-completion.adapter';
 import {
   VERCEL_GENERATE_TEXT_FN_TOKEN,
   VercelAiCompletionAdapter,
   type VercelGenerateTextFn,
 } from './infrastructure/adapters/vercel-ai-completion.adapter';
+import {
+  ANTHROPIC_AI_COMPLETION_ADAPTER_TOKEN,
+  FAKE_AI_COMPLETION_ADAPTER_TOKEN,
+  OPENAI_AI_COMPLETION_ADAPTER_TOKEN,
+} from './ai-integration.tokens';
 
 @Module({})
 export class AiIntegrationModule {
@@ -100,7 +100,12 @@ export class AiIntegrationModule {
       },
       // Router: AI_COMPLETION_PORT_TOKEN resolves to this; it dispatches
       // per-call to the right per-provider adapter based on the active
-      // selection.
+      // selection. The router starts empty and the module registers each
+      // provider here — mirrors the #570/#571 pluggable-registry pattern
+      // for the connection-scoped `AdapterRegistryService`. Adding a new
+      // provider (Cohere, Mistral, …) means: extend `AiProviderValues`,
+      // add a per-provider adapter provider above with its own token, and
+      // add one `router.register(...)` line here.
       {
         provide: MultiProviderAiCompletionAdapter,
         useFactory: (
@@ -108,13 +113,13 @@ export class AiIntegrationModule {
           openaiAdapter: AiCompletionPort,
           fakeAdapter: AiCompletionPort,
           activeSettings: IAiProviderActiveSettingsService,
-        ) =>
-          new MultiProviderAiCompletionAdapter(
-            anthropicAdapter,
-            openaiAdapter,
-            fakeAdapter,
-            activeSettings,
-          ),
+        ) => {
+          const router = new MultiProviderAiCompletionAdapter(activeSettings);
+          router.register('anthropic', anthropicAdapter);
+          router.register('openai', openaiAdapter);
+          router.register('fake', fakeAdapter);
+          return router;
+        },
         inject: [
           ANTHROPIC_AI_COMPLETION_ADAPTER_TOKEN,
           OPENAI_AI_COMPLETION_ADAPTER_TOKEN,

--- a/libs/integrations/ai/src/ai-integration.tokens.ts
+++ b/libs/integrations/ai/src/ai-integration.tokens.ts
@@ -1,0 +1,15 @@
+/**
+ * AI Integration Module — DI Tokens
+ *
+ * Per-provider adapter DI tokens used by `AiIntegrationModule.register()` to
+ * wire each provider's `VercelAiCompletionAdapter` (or `FakeAiCompletionAdapter`)
+ * into the multi-provider router. Lives in its own file so adding a new
+ * provider (Cohere, Mistral, …) is a one-token addition without touching the
+ * router itself — mirrors the registry pattern in #570/#571.
+ *
+ * @module libs/integrations/ai/src
+ */
+
+export const ANTHROPIC_AI_COMPLETION_ADAPTER_TOKEN = Symbol('AnthropicAiCompletionAdapter');
+export const OPENAI_AI_COMPLETION_ADAPTER_TOKEN = Symbol('OpenAiAiCompletionAdapter');
+export const FAKE_AI_COMPLETION_ADAPTER_TOKEN = Symbol('FakeAiCompletionAdapter');

--- a/libs/integrations/ai/src/index.ts
+++ b/libs/integrations/ai/src/index.ts
@@ -15,9 +15,9 @@ export {
   VERCEL_GENERATE_TEXT_FN_TOKEN,
   type VercelGenerateTextFn,
 } from './infrastructure/adapters/vercel-ai-completion.adapter';
+export { MultiProviderAiCompletionAdapter } from './infrastructure/adapters/multi-provider-ai-completion.adapter';
 export {
-  MultiProviderAiCompletionAdapter,
   ANTHROPIC_AI_COMPLETION_ADAPTER_TOKEN,
   OPENAI_AI_COMPLETION_ADAPTER_TOKEN,
   FAKE_AI_COMPLETION_ADAPTER_TOKEN,
-} from './infrastructure/adapters/multi-provider-ai-completion.adapter';
+} from './ai-integration.tokens';

--- a/libs/integrations/ai/src/infrastructure/adapters/multi-provider-ai-completion.adapter.spec.ts
+++ b/libs/integrations/ai/src/infrastructure/adapters/multi-provider-ai-completion.adapter.spec.ts
@@ -1,10 +1,12 @@
 /**
  * Multi-Provider AI Completion Adapter — Unit Tests
  *
- * The router holds a static map of per-provider adapters and resolves the
- * active provider on every call through `IAiProviderActiveSettingsService`.
- * Tests cover: dispatch to each branch, propagation of input/output, and
- * the defensive "no adapter for provider" path.
+ * After #570/#571 the router is empty on construction; per-provider adapters
+ * are added via `register(provider, adapter)`, then `complete()` reads the
+ * active provider on every call and dispatches to the matching registered
+ * adapter. Tests cover: registration (happy + duplicate-fail), dispatch to
+ * each branch, propagation of input/output, and the "no adapter for active
+ * provider" defensive path.
  *
  * @module libs/integrations/ai/infrastructure/adapters
  */
@@ -16,6 +18,7 @@ import type {
 } from '@openlinker/core/ai/domain/types/ai-completion.types';
 import type { AiCompletionPort } from '@openlinker/core/ai/domain/ports/ai-completion.port';
 import { AiCompletionError } from '@openlinker/core/ai/domain/exceptions/ai-completion.exception';
+import { DuplicateAiProviderError } from '@openlinker/core/ai/domain/exceptions/duplicate-ai-provider.exception';
 import { MultiProviderAiCompletionAdapter } from './multi-provider-ai-completion.adapter';
 
 const buildResult = (text: string): AiCompletionResult => ({
@@ -43,94 +46,117 @@ const sampleInput: AiCompletionInput = {
   requestId: 'req-1',
 };
 
+/**
+ * Build a router pre-populated with anthropic/openai/fake adapters — the
+ * standard module-wired shape. Returns the router and the underlying stubs
+ * so dispatch assertions can probe each branch.
+ */
+function buildRouter(activeProvider: AiProvider): {
+  router: MultiProviderAiCompletionAdapter;
+  anthropic: AiCompletionPort & { complete: jest.Mock };
+  openai: AiCompletionPort & { complete: jest.Mock };
+  fake: AiCompletionPort & { complete: jest.Mock };
+  activeSettings: jest.Mocked<IAiProviderActiveSettingsService>;
+} {
+  const anthropic = buildAdapterStub('A');
+  const openai = buildAdapterStub('O');
+  const fake = buildAdapterStub('F');
+  const activeSettings = buildActiveSettings(activeProvider);
+  const router = new MultiProviderAiCompletionAdapter(activeSettings);
+  router.register('anthropic', anthropic);
+  router.register('openai', openai);
+  router.register('fake', fake);
+  return { router, anthropic, openai, fake, activeSettings };
+}
+
 describe('MultiProviderAiCompletionAdapter', () => {
-  it('routes to the anthropic adapter when active=anthropic', async () => {
-    const anthropic = buildAdapterStub('A');
-    const openai = buildAdapterStub('O');
-    const fake = buildAdapterStub('F');
-    const router = new MultiProviderAiCompletionAdapter(
-      anthropic,
-      openai,
-      fake,
-      buildActiveSettings('anthropic'),
-    );
+  describe('register', () => {
+    it('accepts a per-provider adapter and dispatches to it on complete()', async () => {
+      const adapter = buildAdapterStub('X');
+      const activeSettings = buildActiveSettings('anthropic');
+      const router = new MultiProviderAiCompletionAdapter(activeSettings);
 
-    const result = await router.complete(sampleInput);
+      router.register('anthropic', adapter);
+      const result = await router.complete(sampleInput);
 
-    expect(result.text).toBe('A');
-    expect(anthropic.complete).toHaveBeenCalledWith(sampleInput);
-    expect(openai.complete).not.toHaveBeenCalled();
-    expect(fake.complete).not.toHaveBeenCalled();
+      expect(result.text).toBe('X');
+      expect(adapter.complete).toHaveBeenCalledWith(sampleInput);
+    });
+
+    it('throws DuplicateAiProviderError when the same provider is registered twice', () => {
+      const router = new MultiProviderAiCompletionAdapter(buildActiveSettings('anthropic'));
+
+      router.register('anthropic', buildAdapterStub('A1'));
+
+      expect(() => router.register('anthropic', buildAdapterStub('A2'))).toThrow(
+        DuplicateAiProviderError,
+      );
+    });
+
+    it('allows registering different providers independently', () => {
+      const router = new MultiProviderAiCompletionAdapter(buildActiveSettings('anthropic'));
+
+      expect(() => {
+        router.register('anthropic', buildAdapterStub('A'));
+        router.register('openai', buildAdapterStub('O'));
+        router.register('fake', buildAdapterStub('F'));
+      }).not.toThrow();
+    });
   });
 
-  it('routes to the openai adapter when active=openai', async () => {
-    const anthropic = buildAdapterStub('A');
-    const openai = buildAdapterStub('O');
-    const fake = buildAdapterStub('F');
-    const router = new MultiProviderAiCompletionAdapter(
-      anthropic,
-      openai,
-      fake,
-      buildActiveSettings('openai'),
-    );
+  describe('complete', () => {
+    it('routes to the anthropic adapter when active=anthropic', async () => {
+      const { router, anthropic, openai, fake } = buildRouter('anthropic');
 
-    const result = await router.complete(sampleInput);
+      const result = await router.complete(sampleInput);
 
-    expect(result.text).toBe('O');
-    expect(openai.complete).toHaveBeenCalledWith(sampleInput);
-  });
+      expect(result.text).toBe('A');
+      expect(anthropic.complete).toHaveBeenCalledWith(sampleInput);
+      expect(openai.complete).not.toHaveBeenCalled();
+      expect(fake.complete).not.toHaveBeenCalled();
+    });
 
-  it('routes to the fake adapter when active=fake', async () => {
-    const anthropic = buildAdapterStub('A');
-    const openai = buildAdapterStub('O');
-    const fake = buildAdapterStub('F');
-    const router = new MultiProviderAiCompletionAdapter(
-      anthropic,
-      openai,
-      fake,
-      buildActiveSettings('fake'),
-    );
+    it('routes to the openai adapter when active=openai', async () => {
+      const { router, openai } = buildRouter('openai');
 
-    const result = await router.complete(sampleInput);
+      const result = await router.complete(sampleInput);
 
-    expect(result.text).toBe('F');
-    expect(fake.complete).toHaveBeenCalledWith(sampleInput);
-  });
+      expect(result.text).toBe('O');
+      expect(openai.complete).toHaveBeenCalledWith(sampleInput);
+    });
 
-  it('reads the active provider on every call (no cache)', async () => {
-    const anthropic = buildAdapterStub('A');
-    const openai = buildAdapterStub('O');
-    const fake = buildAdapterStub('F');
-    const activeSettings = buildActiveSettings('anthropic');
-    const router = new MultiProviderAiCompletionAdapter(
-      anthropic,
-      openai,
-      fake,
-      activeSettings,
-    );
+    it('routes to the fake adapter when active=fake', async () => {
+      const { router, fake } = buildRouter('fake');
 
-    await router.complete(sampleInput);
-    activeSettings.getActive.mockResolvedValueOnce('openai');
-    await router.complete(sampleInput);
+      const result = await router.complete(sampleInput);
 
-    expect(activeSettings.getActive).toHaveBeenCalledTimes(2);
-    expect(anthropic.complete).toHaveBeenCalledTimes(1);
-    expect(openai.complete).toHaveBeenCalledTimes(1);
-  });
+      expect(result.text).toBe('F');
+      expect(fake.complete).toHaveBeenCalledWith(sampleInput);
+    });
 
-  it('throws AiCompletionError if the active-settings service returns an unknown provider', async () => {
-    const anthropic = buildAdapterStub('A');
-    const openai = buildAdapterStub('O');
-    const fake = buildAdapterStub('F');
-    const activeSettings = buildActiveSettings('anthropic');
-    activeSettings.getActive.mockResolvedValueOnce('cohere' as AiProvider);
-    const router = new MultiProviderAiCompletionAdapter(
-      anthropic,
-      openai,
-      fake,
-      activeSettings,
-    );
+    it('reads the active provider on every call (no cache)', async () => {
+      const { router, anthropic, openai, activeSettings } = buildRouter('anthropic');
 
-    await expect(router.complete(sampleInput)).rejects.toBeInstanceOf(AiCompletionError);
+      await router.complete(sampleInput);
+      activeSettings.getActive.mockResolvedValueOnce('openai');
+      await router.complete(sampleInput);
+
+      expect(activeSettings.getActive).toHaveBeenCalledTimes(2);
+      expect(anthropic.complete).toHaveBeenCalledTimes(1);
+      expect(openai.complete).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws AiCompletionError if the active-settings service returns an unregistered provider', async () => {
+      const { router, activeSettings } = buildRouter('anthropic');
+      activeSettings.getActive.mockResolvedValueOnce('cohere' as AiProvider);
+
+      await expect(router.complete(sampleInput)).rejects.toBeInstanceOf(AiCompletionError);
+    });
+
+    it('throws AiCompletionError if no providers are registered yet', async () => {
+      const router = new MultiProviderAiCompletionAdapter(buildActiveSettings('anthropic'));
+
+      await expect(router.complete(sampleInput)).rejects.toBeInstanceOf(AiCompletionError);
+    });
   });
 });

--- a/libs/integrations/ai/src/infrastructure/adapters/multi-provider-ai-completion.adapter.ts
+++ b/libs/integrations/ai/src/infrastructure/adapters/multi-provider-ai-completion.adapter.ts
@@ -1,10 +1,18 @@
 /**
  * Multi-Provider AI Completion Adapter (router)
  *
- * Bound to `AI_COMPLETION_PORT_TOKEN`. Holds a static map of every
- * registered provider adapter (anthropic Vercel, openai Vercel, fake) and,
- * on each `complete()` call, reads the active provider through
+ * Bound to `AI_COMPLETION_PORT_TOKEN`. Holds a registry of every registered
+ * provider adapter (anthropic Vercel, openai Vercel, fake) and, on each
+ * `complete()` call, reads the active provider through
  * `IAiProviderActiveSettingsService` and delegates to the matching adapter.
+ *
+ * Empty on construction — `AiIntegrationModule.register()` populates the
+ * registry via `register(provider, adapter)`. Mirrors the pattern introduced
+ * in #570/#571 for `AdapterRegistryService`: integration modules own
+ * registration; the router carries no platform-specific knowledge of which
+ * providers exist. A community plugin can add a new provider (Cohere,
+ * Mistral) by extending `AiProviderValues` and calling `register()` from
+ * its own module — no constructor surgery required.
  *
  * **No cache.** The active-provider lookup is a singleton-row PK query
  * against an indexed primary key — sub-millisecond. Compared to the
@@ -31,43 +39,44 @@ import type {
   AiProvider,
 } from '@openlinker/core/ai/domain/types/ai-completion.types';
 import { AiCompletionError } from '@openlinker/core/ai/domain/exceptions/ai-completion.exception';
+import { DuplicateAiProviderError } from '@openlinker/core/ai/domain/exceptions/duplicate-ai-provider.exception';
 import type { IAiProviderActiveSettingsService } from '@openlinker/core/ai/application/services/ai-provider-active-settings.service.interface';
-
-export const ANTHROPIC_AI_COMPLETION_ADAPTER_TOKEN = Symbol('AnthropicAiCompletionAdapter');
-export const OPENAI_AI_COMPLETION_ADAPTER_TOKEN = Symbol('OpenAiAiCompletionAdapter');
-export const FAKE_AI_COMPLETION_ADAPTER_TOKEN = Symbol('FakeAiCompletionAdapter');
 
 @Injectable()
 export class MultiProviderAiCompletionAdapter implements AiCompletionPort {
   private readonly logger = new Logger(MultiProviderAiCompletionAdapter.name);
-  private readonly adapters: Map<AiProvider, AiCompletionPort>;
+  private readonly adapters: Map<AiProvider, AiCompletionPort> = new Map();
 
   constructor(
-    @Inject(ANTHROPIC_AI_COMPLETION_ADAPTER_TOKEN)
-    anthropicAdapter: AiCompletionPort,
-    @Inject(OPENAI_AI_COMPLETION_ADAPTER_TOKEN)
-    openaiAdapter: AiCompletionPort,
-    @Inject(FAKE_AI_COMPLETION_ADAPTER_TOKEN)
-    fakeAdapter: AiCompletionPort,
     @Inject(AI_PROVIDER_ACTIVE_SETTINGS_SERVICE_TOKEN)
     private readonly activeSettings: IAiProviderActiveSettingsService,
-  ) {
-    this.adapters = new Map<AiProvider, AiCompletionPort>([
-      ['anthropic', anthropicAdapter],
-      ['openai', openaiAdapter],
-      ['fake', fakeAdapter],
-    ]);
+  ) {}
+
+  /**
+   * Register a per-provider AI completion adapter on this router. Called by
+   * `AiIntegrationModule.register()` once per provider at boot. Throws
+   * `DuplicateAiProviderError` on a second registration for the same
+   * provider — fail-loud at boot rather than silently overwrite.
+   */
+  register(provider: AiProvider, adapter: AiCompletionPort): void {
+    if (this.adapters.has(provider)) {
+      throw new DuplicateAiProviderError(provider);
+    }
+    this.adapters.set(provider, adapter);
+    this.logger.log(`Registered AI completion adapter for provider: ${provider}`);
   }
 
   async complete(input: AiCompletionInput): Promise<AiCompletionResult> {
     const provider = await this.activeSettings.getActive();
     const adapter = this.adapters.get(provider);
     if (!adapter) {
-      // Defensive — should be unreachable given the value-set guard at the
-      // service layer. If we add a provider to `AiProviderValues` and forget
-      // to register an adapter here, this surfaces it immediately.
+      // Defensive — should be unreachable when `AiIntegrationModule.register()`
+      // covers every member of `AiProviderValues`. If we add a provider to
+      // the value set and forget to register an adapter for it, this surfaces
+      // it immediately.
       throw new AiCompletionError(
-        `No AI completion adapter registered for active provider '${provider}'`,
+        `No AI completion adapter registered for active provider '${provider}'. ` +
+          `Registered: [${Array.from(this.adapters.keys()).join(', ')}]`,
       );
     }
     this.logger.debug(`[ai] route requestId=${input.requestId ?? '-'} provider=${provider}`);

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -10,7 +10,17 @@
 import { Module, OnModuleInit, Inject, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { IntegrationsModule, ADAPTER_FACTORY_RESOLVER_TOKEN, AdapterFactoryResolverService, CONNECTION_TESTER_REGISTRY_TOKEN, ConnectionTesterRegistryService, INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN, IntegrationCredentialRepositoryPort } from '@openlinker/core/integrations';
+import {
+  IntegrationsModule,
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  AdapterFactoryResolverService,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterRegistryPort,
+  CONNECTION_TESTER_REGISTRY_TOKEN,
+  ConnectionTesterRegistryService,
+  INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
+  IntegrationCredentialRepositoryPort,
+} from '@openlinker/core/integrations';
 import { AllegroConnectionTesterAdapter } from './infrastructure/adapters/allegro-connection-tester.adapter';
 import { RedisClientType } from 'redis';
 import { CustomersModule, CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN, CustomerIdentityResolverPort } from '@openlinker/core/customers';
@@ -64,6 +74,8 @@ export class AllegroIntegrationModule implements OnModuleInit {
   private readonly logger = new Logger(AllegroIntegrationModule.name);
 
   constructor(
+    @Inject(ADAPTER_REGISTRY_TOKEN)
+    private readonly adapterRegistry: AdapterRegistryPort,
     @Inject(ADAPTER_FACTORY_RESOLVER_TOKEN)
     private readonly factoryResolver: AdapterFactoryResolverService,
     @Inject(CONNECTION_TESTER_REGISTRY_TOKEN)
@@ -90,7 +102,21 @@ export class AllegroIntegrationModule implements OnModuleInit {
   ) {}
 
   onModuleInit(): void {
-    this.logger.log('Registering Allegro adapter factory...');
+    this.logger.log('Registering Allegro adapter (metadata + factory + tester)...');
+    // Register metadata first — what this adapter is and what it can do.
+    // Mirrors the inline literal previously hardcoded in core's
+    // AdapterRegistryService (#570). isDefault: true means
+    // `IntegrationsService` resolves connections without an explicit
+    // adapterKey to this adapter for the 'allegro' platformType (#571).
+    this.adapterRegistry.register({
+      adapterKey: 'allegro.publicapi.v1',
+      platformType: 'allegro',
+      supportedCapabilities: ['OrderSource', 'OfferManager'],
+      displayName: 'Allegro Public API v1',
+      version: '1.0.0',
+      isDefault: true,
+    });
+    // Then the factory + connection tester — runtime instantiation surface.
     const factory = new AllegroAdapterFactoryWrapper(
       this.customerIdentityResolver,
       this.tokenRefreshService,
@@ -104,7 +130,7 @@ export class AllegroIntegrationModule implements OnModuleInit {
       'allegro.publicapi.v1',
       new AllegroConnectionTesterAdapter(),
     );
-    this.logger.log('Allegro adapter factory registered successfully');
+    this.logger.log('Allegro adapter registered successfully');
   }
 
   private readQuantityPollConfig(): Record<string, number> | undefined {

--- a/libs/integrations/prestashop/src/prestashop-integration.module.ts
+++ b/libs/integrations/prestashop/src/prestashop-integration.module.ts
@@ -12,6 +12,8 @@ import {
   IntegrationsModule,
   ADAPTER_FACTORY_RESOLVER_TOKEN,
   AdapterFactoryResolverService,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterRegistryPort,
   CONNECTION_TESTER_REGISTRY_TOKEN,
   ConnectionTesterRegistryService,
   WEBHOOK_SECRET_PROVIDER_TOKEN,
@@ -57,6 +59,8 @@ export class PrestashopIntegrationModule implements OnModuleInit {
   private readonly logger = new Logger(PrestashopIntegrationModule.name);
 
   constructor(
+    @Inject(ADAPTER_REGISTRY_TOKEN)
+    private readonly adapterRegistry: AdapterRegistryPort,
     @Inject(ADAPTER_FACTORY_RESOLVER_TOKEN)
     private readonly factoryResolver: AdapterFactoryResolverService,
     @Inject(CONNECTION_TESTER_REGISTRY_TOKEN)
@@ -72,7 +76,26 @@ export class PrestashopIntegrationModule implements OnModuleInit {
   ) {}
 
   onModuleInit(): void {
-    this.logger.log('Registering PrestaShop adapter factory...');
+    this.logger.log('Registering PrestaShop adapter (metadata + factory + tester)...');
+    // Register metadata first — what this adapter is and what it can do.
+    // Mirrors the inline literal previously hardcoded in core's
+    // AdapterRegistryService (#570). isDefault: true means
+    // `IntegrationsService` resolves connections without an explicit
+    // adapterKey to this adapter for the 'prestashop' platformType (#571).
+    this.adapterRegistry.register({
+      adapterKey: 'prestashop.webservice.v1',
+      platformType: 'prestashop',
+      supportedCapabilities: [
+        'ProductMaster',
+        'InventoryMaster',
+        'OrderSource',
+        'OrderProcessorManager',
+      ],
+      displayName: 'PrestaShop WebService v1',
+      version: '1.0.0',
+      isDefault: true,
+    });
+    // Then the factory + connection tester — runtime instantiation surface.
     const factory = new PrestashopAdapterFactoryWrapper(
       this.customerProvisioner,
       this.addressProvisioner,
@@ -85,7 +108,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
       'prestashop.webservice.v1',
       new PrestashopConnectionTesterAdapter(),
     );
-    this.logger.log('PrestaShop adapter factory registered successfully');
+    this.logger.log('PrestaShop adapter registered successfully');
   }
 }
 


### PR DESCRIPTION
## Summary

Closes the two BLOCKER findings from Modularity Thread C (#549) plus an
analogous AI-module gap surfaced during tech review:

- **#570** — `AdapterRegistryService` was a hardcoded inline `Map` literal
  with no `register()` method. Plugins couldn't register; in-tree
  contributors had to edit `libs/core` to add a platform.
- **#571** — `IntegrationsService.deriveAdapterKey` carried a private
  `Record<platformType, adapterKey>` hardcoding `prestashop` and `allegro`.
  Any new platform required editing core.
- **AI module** (per tech review) — `MultiProviderAiCompletionAdapter`
  had the same hardcoded-inline-map anti-pattern (`new Map([['anthropic',
  ...], ['openai', ...], ['fake', ...]])`); the inline comment even
  acknowledged it. Shipping #570/#571 without fixing this would leave the
  AI module as the only adapter-side registry not aligned with the new
  standard.

After this PR, every adapter-side registry in the repo follows the same
pattern: empty on construct, `register(...)` method called from each
integration module's `onModuleInit` (or `useFactory`), fail-loud on
duplicate registration via domain exceptions.

## Changes

### Core (`libs/core/src/integrations`)

- `AdapterRegistryPort` adds `register(metadata)` (sync) and
  `getDefaultAdapterKey(platformType)` (async).
- `AdapterMetadata` gains optional `isDefault?: boolean` — at most one
  per `platformType`.
- `AdapterRegistryService` is empty on construct; tracks a
  `defaultsByPlatform` map for the new resolution path.
- `AdapterFactoryResolverService.registerFactory` now also throws
  `DuplicateAdapterKeyException` on a second registration for the same
  key (symmetric semantics across both registries).
- `IntegrationsService.deriveAdapterKey` deleted; three call sites
  switch to `await this.adapterRegistry.getDefaultAdapterKey(...)`.
- New domain exceptions: `DuplicateAdapterKeyException`,
  `DuplicatePlatformDefaultException`,
  `DuplicateAiProviderError` (last under `libs/core/src/ai/domain/exceptions/`).

### Allegro + PrestaShop integrations

`onModuleInit` now self-registers metadata + factory + connection-tester
in that order. Capability sets that were inline in core's literal are
now declared next to the package that owns them, with `isDefault: true`.

### AI integration (`libs/integrations/ai`)

- `MultiProviderAiCompletionAdapter` exposes
  `register(provider, adapter)`. Empty on construct; throws
  `DuplicateAiProviderError` on collision.
- `AiIntegrationModule.register()` owns the per-provider wiring inside
  the router's `useFactory`: `router.register('anthropic', anthropicAdapter)`
  etc.
- Per-provider DI tokens move to `ai-integration.tokens.ts` so adding a
  new provider (Cohere/Mistral) means: extend `AiProviderValues`, add a
  per-provider provider in the module, add one `router.register(...)`
  line. No router-internals surgery.

### Tests + docs

- New `adapter-factory-resolver.service.spec.ts` (4 tests covering
  registration + duplicate-fail).
- `adapter-registry.service.spec.ts` rewritten for the empty-with-register
  flow (12 tests covering register, duplicate adapterKey,
  duplicate-default, getDefaultAdapterKey resolution and rejection).
- `integrations.service.spec.ts` mock extended with
  `getDefaultAdapterKey`; explicit assertion documents the contract a
  future contributor needs to preserve.
- `multi-provider-ai-completion.adapter.spec.ts` rewritten to use the
  new register-then-dispatch flow (10 tests).
- `app-boot.int-spec.ts` gains an explicit assertion that registry
  self-registration succeeded — surfaces a broken `onModuleInit` directly
  instead of via downstream int-spec failures.
- `architecture-overview.md` updated to describe the new wiring (closes
  the doc-vs-code drift the audit was meant to expose).

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — all 1620+ unit tests pass (libs/core 559, libs/shared 25, libs/integrations/ai 34, libs/integrations/prestashop 256, libs/integrations/allegro 293, apps/api 335, apps/worker 118)
- [x] `pnpm test:integration -- app-boot` — passes including the new
  registry self-registration assertion
- [x] `pnpm test:integration -- connection-capabilities` — passes
- [ ] Manual smoke against dev stack: API boots, Allegro + PrestaShop
  connections resolve adapters via `getDefaultAdapterKey` instead of the
  deleted `deriveAdapterKey`, AI completion still routes correctly.

Closes #570
Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)