### PR TITLE
refactor(core,api,web): open Capability and EntityType at registry boundary

### DIFF
--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -44,7 +44,7 @@ import { ConnectionService } from '../application/services/connection.service';
 import { Connection, ConnectionUpdate, ConnectionFilters } from '@openlinker/core/identifier-mapping';
 import { SyncJobRepositoryPort } from '@openlinker/core/sync/domain/ports/sync-job-repository.port';
 import { SYNC_JOB_REPOSITORY_TOKEN } from '@openlinker/core/sync';
-import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN, Capability } from '@openlinker/core/integrations';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 
 @ApiBearerAuth()
 @ApiTags('connections')
@@ -65,7 +65,7 @@ export class ConnectionController {
   ) {}
 
   private async toResponse(connection: Connection): Promise<ConnectionResponseDto> {
-    let supported: Capability[] = [];
+    let supported: string[] = [];
     try {
       const metadata = await this.integrationsService.resolveAdapterMetadata({
         platformType: connection.platformType,

--- a/apps/api/src/integrations/http/dto/connection-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/connection-response.dto.ts
@@ -8,7 +8,7 @@
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Connection } from '@openlinker/core/identifier-mapping';
-import { Capability, CapabilityValues } from '@openlinker/core/integrations';
+import { CoreCapabilityValues } from '@openlinker/core/integrations';
 
 export class ConnectionResponseDto {
   @ApiProperty({ description: 'Connection ID (UUID)', example: '123e4567-e89b-12d3-a456-426614174000' })
@@ -36,18 +36,18 @@ export class ConnectionResponseDto {
   adapterKey?: string;
 
   @ApiProperty({
-    description: 'Capabilities enabled on this connection (operator-chosen subset of supportedCapabilities)',
+    description: 'Capabilities enabled on this connection (operator-chosen subset of supportedCapabilities). Well-known values listed in `enum`; plugin-registered capability names also accepted.',
     isArray: true,
-    enum: CapabilityValues,
+    enum: CoreCapabilityValues,
   })
-  enabledCapabilities!: Capability[];
+  enabledCapabilities!: string[];
 
   @ApiProperty({
-    description: 'Capabilities supported by the resolved adapter (derived, not persisted)',
+    description: 'Capabilities supported by the resolved adapter (derived, not persisted). Well-known values listed in `enum`; plugin-registered capability names also accepted.',
     isArray: true,
-    enum: CapabilityValues,
+    enum: CoreCapabilityValues,
   })
-  supportedCapabilities!: Capability[];
+  supportedCapabilities!: string[];
 
   @ApiProperty({ description: 'Creation timestamp' })
   createdAt!: Date;
@@ -57,7 +57,7 @@ export class ConnectionResponseDto {
 
   static fromDomain(
     connection: Connection,
-    supportedCapabilities: Capability[],
+    supportedCapabilities: string[],
   ): ConnectionResponseDto {
     const dto = new ConnectionResponseDto();
     dto.id = connection.id;

--- a/apps/api/src/integrations/http/dto/create-connection.dto.ts
+++ b/apps/api/src/integrations/http/dto/create-connection.dto.ts
@@ -29,7 +29,7 @@ import {
   ValidationArguments,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Capability, CapabilityValues } from '@openlinker/core/integrations';
+import { CoreCapability, CoreCapabilityValues } from '@openlinker/core/integrations';
 
 @ValidatorConstraint({ name: 'CredentialsXor', async: false })
 class CredentialsXorConstraint implements ValidatorConstraintInterface {
@@ -109,10 +109,10 @@ export class CreateConnectionDto {
     description:
       'Capabilities this connection should fulfil. Defaults to the adapter\u2019s full supported set when omitted. Must be a subset of supportedCapabilities.',
     isArray: true,
-    enum: CapabilityValues,
+    enum: CoreCapabilityValues,
   })
   @IsArray()
-  @IsIn(CapabilityValues, { each: true })
+  @IsIn(CoreCapabilityValues, { each: true })
   @IsOptional()
-  enabledCapabilities?: Capability[];
+  enabledCapabilities?: CoreCapability[];
 }

--- a/apps/api/src/integrations/http/dto/update-connection.dto.ts
+++ b/apps/api/src/integrations/http/dto/update-connection.dto.ts
@@ -9,7 +9,7 @@
 import { IsString, IsOptional, IsObject, IsEnum, IsArray, IsIn } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ConnectionStatusValues } from '@openlinker/core/identifier-mapping';
-import { Capability, CapabilityValues } from '@openlinker/core/integrations';
+import { CoreCapability, CoreCapabilityValues } from '@openlinker/core/integrations';
 
 export class UpdateConnectionDto {
   @ApiPropertyOptional({
@@ -48,11 +48,11 @@ export class UpdateConnectionDto {
   @ApiPropertyOptional({
     description: 'Capabilities enabled on this connection. Subset of the adapter\u2019s supportedCapabilities.',
     isArray: true,
-    enum: CapabilityValues,
+    enum: CoreCapabilityValues,
   })
   @IsArray()
-  @IsIn(CapabilityValues, { each: true })
+  @IsIn(CoreCapabilityValues, { each: true })
   @IsOptional()
-  enabledCapabilities?: Capability[];
+  enabledCapabilities?: CoreCapability[];
 }
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -48,7 +48,7 @@ import type {
 } from '@openlinker/core/listings';
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
-import type { EntityType, IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import type { CoreEntityType, IdentifierMapping } from '@openlinker/core/identifier-mapping';
 import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
 import type { ProductVariantRepositoryPort } from '@openlinker/core/products';
 import { JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
@@ -139,7 +139,7 @@ export class ListingsController {
     //   - the linked variant's productId (drives the AI-suggest flow on the
     //     edit drawer — #485 — which is keyed on product, not variant).
     // Non-Offer entity types skip both lookups entirely.
-    if (mapping.entityType === ('Offer' satisfies EntityType)) {
+    if (mapping.entityType === ('Offer' satisfies CoreEntityType)) {
       const [record, linkedVariant] = await Promise.all([
         this.offerCreationRecords.findByExternalOfferIdAndConnectionId(
           mapping.externalId,
@@ -185,7 +185,7 @@ export class ListingsController {
     // Treat non-Offer mappings as 404 rather than a separate 4xx — the
     // existence of the mapping isn't actionable for the live-offer surface
     // and the response shape is identical to "mapping doesn't exist".
-    if (mapping.entityType !== ('Offer' satisfies EntityType)) {
+    if (mapping.entityType !== ('Offer' satisfies CoreEntityType)) {
       throw new NotFoundException(
         `Offer mapping ${id} is not of entityType=Offer (got: ${mapping.entityType})`,
       );

--- a/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
+++ b/apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts
@@ -333,7 +333,7 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
    *
    * Maps webhook events to sync job requests based on event type and provider.
    * Acts as a translation layer: provider-specific terminology → canonical job types.
-   * Normalizes objectType to PascalCase to match EntityType enum values.
+   * Normalizes objectType to PascalCase to match the well-known core entity types.
    *
    * @throws Error if job type cannot be constructed or validated
    */
@@ -424,7 +424,7 @@ export class WebhookToJobHandler implements OnModuleInit, OnModuleDestroy {
   /**
    * Normalize objectType to PascalCase
    *
-   * Converts lowercase/snake_case object types to PascalCase to match EntityType enum.
+   * Converts lowercase/snake_case object types to PascalCase to match the well-known core entity types.
    * Examples:
    * - "product" -> "Product"
    * - "product_variant" -> "ProductVariant"

--- a/apps/web/src/features/adapters/api/adapters.types.ts
+++ b/apps/web/src/features/adapters/api/adapters.types.ts
@@ -1,9 +1,12 @@
-import type { Capability } from '../../connections/api/connections.types';
-
 export interface AdapterSummary {
   adapterKey: string;
   platformType: string;
-  supportedCapabilities: Capability[];
+  /**
+   * Open string set — well-known values are `CoreCapability` (see
+   * `connections.types.ts`); plugin adapters can register additional
+   * capability names (#576).
+   */
+  supportedCapabilities: string[];
   displayName?: string;
   version?: string;
 }

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -4,7 +4,12 @@ export type PlatformType = (typeof PLATFORM_TYPES)[number];
 
 export type ConnectionStatus = 'active' | 'disabled' | 'error';
 
-export const CAPABILITY_VALUES = [
+/**
+ * Well-known core capabilities — mirrors `CoreCapabilityValues` on the backend.
+ * Plugin adapters can register additional capability names; FE accepts those
+ * as plain strings without runtime narrowing failures (#576).
+ */
+export const CORE_CAPABILITY_VALUES = [
   'ProductMaster',
   'InventoryMaster',
   'OrderProcessorManager',
@@ -12,7 +17,12 @@ export const CAPABILITY_VALUES = [
   'OfferManager',
 ] as const;
 
-export type Capability = (typeof CAPABILITY_VALUES)[number];
+/**
+ * Closed type for the well-known core capabilities. Use where exhaustiveness
+ * matters (UI dropdowns, dispatch dialog gating). Use `string`
+ * where the FE consumes adapter-supplied capability names.
+ */
+export type CoreCapability = (typeof CORE_CAPABILITY_VALUES)[number];
 
 export interface Connection {
   id: string;
@@ -23,8 +33,8 @@ export interface Connection {
   /** True when credentials are stored in the database and can be rotated via PUT /credentials. */
   credentialsBacked: boolean;
   adapterKey?: string;
-  enabledCapabilities: Capability[];
-  supportedCapabilities: Capability[];
+  enabledCapabilities: string[];
+  supportedCapabilities: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -43,7 +53,13 @@ export interface CreateConnectionInput {
   /** Existing db-backed reference (must start with `db:`). Used by OAuth flows. */
   credentialsRef?: string;
   adapterKey?: string;
-  enabledCapabilities?: Capability[];
+  /**
+   * Capabilities to enable on this connection. Strict on the well-known core
+   * set today — mirrors the BE request DTO contract. Plugin-registered
+   * capabilities are out of scope for the create/update path until the
+   * runtime-aware DTO validator follow-up lands (#576).
+   */
+  enabledCapabilities?: CoreCapability[];
 }
 
 export interface UpdateConnectionInput {
@@ -51,7 +67,7 @@ export interface UpdateConnectionInput {
   status?: ConnectionStatus;
   config?: Record<string, unknown>;
   adapterKey?: string;
-  enabledCapabilities?: Capability[];
+  enabledCapabilities?: CoreCapability[];
 }
 
 export interface RecentJobSummary {

--- a/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.tsx
@@ -8,7 +8,8 @@
  * @module apps/web/src/features/connections/components
  */
 import { useState, type ReactElement } from 'react';
-import type { Capability, Connection } from '../api/connections.types';
+import type { Connection, CoreCapability } from '../api/connections.types';
+import { CORE_CAPABILITY_VALUES } from '../api/connections.types';
 import { useUpdateConnectionMutation } from '../hooks/use-update-connection-mutation';
 import { Alert } from '../../../shared/ui/alert';
 import { StatusBadge } from '../../../shared/ui/status-badge';
@@ -18,7 +19,7 @@ interface ConnectionCapabilitiesPanelProps {
   connection: Connection;
 }
 
-const CAPABILITY_HELP: Record<Capability, string> = {
+const CAPABILITY_HELP: Record<CoreCapability, string> = {
   ProductMaster: 'Read the product catalog (variants, attributes, categories) from this connection.',
   InventoryMaster: 'Read stock levels from this connection as the inventory source of truth.',
   OrderProcessorManager: 'Create and manage orders in this connection (typically the destination shop).',
@@ -26,17 +27,28 @@ const CAPABILITY_HELP: Record<Capability, string> = {
   OfferManager: 'Manage offers and listings on this marketplace connection.',
 };
 
+const CORE_CAPABILITY_SET = new Set<string>(CORE_CAPABILITY_VALUES);
+
+function isCoreCapability(value: string): value is CoreCapability {
+  return CORE_CAPABILITY_SET.has(value);
+}
+
 export function ConnectionCapabilitiesPanel({
   connection,
 }: ConnectionCapabilitiesPanelProps): ReactElement {
   const updateMutation = useUpdateConnectionMutation();
   const { showToast } = useToast();
-  const [pending, setPending] = useState<Capability | null>(null);
+  const [pending, setPending] = useState<CoreCapability | null>(null);
 
-  const supported = connection.supportedCapabilities;
-  const enabled = new Set(connection.enabledCapabilities);
+  // Today the panel only renders well-known core capabilities. Plugin-registered
+  // capabilities (#576) are valid on the connection entity but not editable from
+  // this UI yet — the backend's request DTO is still strict on CoreCapabilityValues
+  // (see plan §3.1). When the runtime-aware DTO validator follow-up lands, this
+  // narrow can be removed.
+  const supported = connection.supportedCapabilities.filter(isCoreCapability);
+  const enabled = new Set(connection.enabledCapabilities.filter(isCoreCapability));
 
-  async function handleToggle(capability: Capability, checked: boolean): Promise<void> {
+  async function handleToggle(capability: CoreCapability, checked: boolean): Promise<void> {
     const next = new Set(enabled);
     if (checked) {
       next.add(capability);
@@ -69,6 +81,11 @@ export function ConnectionCapabilitiesPanel({
           <h3 className="section-title">Enabled roles</h3>
         </div>
         <span className="panel__meta">
+          {/* Counter reflects the well-known core caps only — both sides
+           * were narrowed via `isCoreCapability` above. If a connection
+           * ever stores plugin-registered capabilities, those are
+           * excluded from both numerator and denominator until this
+           * panel grows a separate plugin-cap surface. */}
           {enabled.size} of {supported.length} enabled
         </span>
       </div>

--- a/apps/web/src/features/connections/components/prestashop-setup-form.tsx
+++ b/apps/web/src/features/connections/components/prestashop-setup-form.tsx
@@ -28,7 +28,7 @@ import {
   type PrestashopSetupFormValues,
 } from './prestashop-setup.schema';
 import { PrestashopSetupSummary } from './prestashop-setup-summary';
-import type { Capability } from '../api/connections.types';
+import { CORE_CAPABILITY_VALUES, type CoreCapability } from '../api/connections.types';
 import { useAdaptersQuery } from '../../adapters/hooks/use-adapters-query';
 import { Alert } from '../../../shared/ui/alert';
 import { BackLink } from '../../../shared/ui/back-link';
@@ -41,7 +41,7 @@ import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { WizardLayout } from '../../../shared/ui/wizard-layout';
 import { useToast } from '../../../shared/ui/toast-provider';
 
-const CAPABILITY_HELP: Record<Capability, string> = {
+const CAPABILITY_HELP: Record<CoreCapability, string> = {
   ProductMaster: 'Read the product catalog (variants, attributes, categories) from this shop.',
   InventoryMaster: 'Read stock levels from this shop as the inventory source of truth.',
   OrderProcessorManager: 'Create and manage orders in this shop (typically the order destination).',
@@ -100,8 +100,16 @@ export function PrestashopSetupForm(): ReactElement {
   }, [form.formState.isDirty]);
 
   const adapterMetadata = adaptersQuery.data?.find((a) => a.adapterKey === PRESTASHOP_ADAPTER_KEY);
-  const supportedCapabilities: Capability[] =
-    adapterMetadata?.supportedCapabilities ?? PRESTASHOP_FALLBACK_CAPABILITIES;
+  // The form's checkbox list is gated on the well-known core capabilities. Plugin
+  // adapters (#576) may register additional names, but the create-connection
+  // request DTO is still strict on `CoreCapabilityValues`, so the wizard only
+  // exposes core caps for editing today. Lift the narrow when the runtime-aware
+  // DTO validator follow-up lands.
+  const supportedCapabilities: CoreCapability[] = (
+    adapterMetadata?.supportedCapabilities ?? PRESTASHOP_FALLBACK_CAPABILITIES
+  ).filter((capability): capability is CoreCapability =>
+    (CORE_CAPABILITY_VALUES as readonly string[]).includes(capability),
+  );
 
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : []

--- a/apps/web/src/features/connections/components/prestashop-setup.schema.ts
+++ b/apps/web/src/features/connections/components/prestashop-setup.schema.ts
@@ -9,7 +9,7 @@
  * `db:<uuid>` reference automatically.
  */
 import { z } from 'zod';
-import type { Capability, CreateConnectionInput } from '../api/connections.types';
+import type { CoreCapability, CreateConnectionInput } from '../api/connections.types';
 
 export const PRESTASHOP_ADAPTER_KEY = 'prestashop.webservice.v1';
 
@@ -18,7 +18,7 @@ export const PRESTASHOP_ADAPTER_KEY = 'prestashop.webservice.v1';
  * failure, stale cache, etc.). The source of truth is the `/adapters` endpoint
  * consumed by the wizard via `useAdaptersQuery`.
  */
-export const PRESTASHOP_FALLBACK_CAPABILITIES: Capability[] = [
+export const PRESTASHOP_FALLBACK_CAPABILITIES: CoreCapability[] = [
   'ProductMaster',
   'InventoryMaster',
   'OrderProcessorManager',

--- a/apps/web/src/features/sync-jobs/components/trigger-sync-dialog.types.ts
+++ b/apps/web/src/features/sync-jobs/components/trigger-sync-dialog.types.ts
@@ -6,7 +6,7 @@
  *
  * @module apps/web/src/features/sync-jobs/components
  */
-import type { Capability, Connection } from '../../connections/api/connections.types';
+import type { CoreCapability, Connection } from '../../connections/api/connections.types';
 
 export interface PayloadField {
   name: string;
@@ -30,7 +30,7 @@ export interface TriggerableJob {
   description: string;
   payloadFields: PayloadField[];
   /** If set, only show this job when the connection supports this capability. */
-  requiredCapability?: Capability;
+  requiredCapability?: CoreCapability;
 }
 
 export interface TriggerSyncDialogProps {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -479,6 +479,8 @@ Each is an independent interface + co-located `is{Capability}(adapter)` type gua
 - **ShippingProviderManagerPort**: Orchestrates shipping and tracking
 - **PaymentProcessorPort**: Handles payment processing
 
+**Capability is open at the registry boundary** (#576). The well-known set lives in `CoreCapabilityValues` as the closed `CoreCapability` type; adapter metadata (`AdapterMetadata.supportedCapabilities`), the `IntegrationsService` resolution methods, and the connection entity's `enabledCapabilities` accept `CoreCapability | string`. Plugin adapters can register new capability names without a core PR — the runtime gate at `IntegrationsService.getCapabilityAdapter` validates against `metadata.supportedCapabilities`. The HTTP request DTOs remain strict on `CoreCapabilityValues` until a runtime-aware DTO validator follow-up lands.
+
 ---
 
 ## Identifier Mapping Service
@@ -526,7 +528,7 @@ interface IdentifierMappingService {
    * If not, generates new internal ID and creates mapping
    */
   getOrCreateInternalId(
-    entityType: 'Product' | 'Order' | 'Offer' | 'Inventory' | 'Customer' | string,
+    entityType: CoreEntityType | string,
     externalId: string,
     connectionId: string,  // ✅ Connection ID (not platform ID)
     context?: MappingContext
@@ -537,7 +539,7 @@ interface IdentifierMappingService {
    * Returns null if mapping doesn't exist
    */
   getInternalId(
-    entityType: string,
+    entityType: CoreEntityType | string,
     externalId: string,
     connectionId: string  // ✅ Connection ID
   ): Promise<string | null>;
@@ -547,7 +549,7 @@ interface IdentifierMappingService {
    * Returns all connection-specific external IDs mapped to this internal ID
    */
   getExternalIds(
-    entityType: string,
+    entityType: CoreEntityType | string,
     internalId: string
   ): Promise<ExternalIdMapping[]>;
 
@@ -556,7 +558,7 @@ interface IdentifierMappingService {
    * Used for manual mapping or when internal ID already exists
    */
   createMapping(
-    entityType: string,
+    entityType: CoreEntityType | string,
     externalId: string,
     connectionId: string,  // ✅ Connection ID
     internalId: string
@@ -578,7 +580,7 @@ interface MappingContext {
 }
 
 interface IdentifierMappingRequest {
-  entityType: string;
+  entityType: CoreEntityType | string;
   externalId: string;
   connectionId: string;  // ✅ Connection ID
   context?: MappingContext;

--- a/docs/plans/implementation-plan-open-capability-and-entity-type-unions.md
+++ b/docs/plans/implementation-plan-open-capability-and-entity-type-unions.md
@@ -1,0 +1,271 @@
+# Implementation plan — open `Capability` and `EntityType` unions (#576 + #577)
+
+Closes: #576 (D1) and #577 (D2). Tracks: #550 / #546.
+
+## 1. Goal & non-goals
+
+**Goal.** Close two doc-vs-code drifts that block plugin authors from extending OpenLinker without forking core:
+
+- **#576 D1.** `Capability` is a closed `as const` union. The architecture doc lists `PricingAuthorityPort`, `ShippingProviderManagerPort`, `PaymentProcessorPort` as future capabilities. A plugin that introduces a new capability today must edit `libs/core/src/integrations/domain/types/adapter.types.ts`.
+- **#577 D2.** `EntityType` is a closed union of seven values. The architecture doc says the port signature is `entityType: 'Product' | … | 'Customer' | string` — already documented as open. The code regressed against its own contract.
+
+The shape both issues recommend, applied literally:
+
+- Keep the well-known list as a closed `as const` + derived union, renamed `Core*` so its scope is explicit.
+- Widen the **boundary signatures** (port methods, adapter-metadata fields, registry calls) — not the type alias — by typing those parameters/fields as `CoreCapability | string` or `CoreEntityType | string`. This matches `architecture-overview.md` line 529 verbatim (`entityType: 'Product' | … | string`), and matches #576's "treat `Capability` as `string` at the registry boundary" and #577's "widen the parameter type to `EntityType | string`".
+- Validate against runtime metadata where it matters. The `IntegrationsService.getCapabilityAdapter` runtime gate already rejects unsupported capabilities; we keep it.
+- Keep the HTTP DTO surface strict on `CoreCapabilityValues` for now via `@IsIn(...)`. The DTO is the immediate-feedback validation boundary an operator sees in the UI; loosening it without a runtime-aware validator regresses UX. File a follow-up issue for the runtime-aware DTO validator.
+
+This avoids the `Core* | (string & {})` autocomplete idiom: it collapses to `string` for assignability anyway, while obscuring intent at the type level. The boundary-only widening is the architecturally honest version.
+
+**Layer.** Backend — `libs/core` (domain + application) + `apps/api` (HTTP DTOs + a couple of comments) + `apps/web` (mirrored types).
+
+**Non-goals.**
+- *No* `registerEntityType(name, { idPrefix })` extension hook — explicitly listed as an optional follow-up in #577. We close the doc-vs-code drift now; a richer extension API is its own issue.
+- *No* changes to listings sub-capabilities (`OfferLister`, `OfferCreator`, etc.). They already use the structural-typing + type-guard pattern #576 holds up as the model. Aligning the top-level `Capability` system to that same shape is a separate refactor and out of scope here.
+- *No* DB migration. `connections.enabled_capabilities` and `identifier_mappings.entity_type` are already `text[]` / `text` in Postgres; widening the TypeScript type does not change the wire shape.
+- *No* changes to FE platform-switch dispatch (`=== 'allegro'`, etc., #579 D4). The widening here makes those switches *more* likely to silently accept new strings; #579 owns the structural fix.
+
+## 2. Existing patterns we lean on
+
+- **Sub-capabilities (`libs/core/src/listings/domain/ports/capabilities/*.capability.ts`).** Each is a free-standing interface + co-located `is{Capability}(adapter)` type guard. Adapters declare `implements OfferManagerPort, OfferLister, OfferCreator, …`; call sites narrow via the guard. No central enum. This is the model #576 explicitly points at.
+- **Runtime capability check.** `IntegrationsService.getCapabilityAdapter` already verifies `metadata.supportedCapabilities.includes(capability)` and throws `CapabilityNotSupportedException` when missing. This is the canonical runtime gate — we keep it; we just stop also gating at compile time on the *registry* boundary.
+- **`as const` + union pattern.** Engineering Standards § "Union Types: `as const` Pattern" already documents the runtime-array-plus-derived-type shape. We keep it intact for the well-known set (`CoreCapabilityValues` → `CoreCapability`); we do *not* widen the type alias itself.
+- **`Partial<Record<…, …>>` for sparse override maps.** `ENTITY_TYPE_ID_PREFIX` already has the right shape (`Partial<Record<EntityType, string>>`). We keep that constraint — it correctly types `lookup[unknownKey]` as `string | undefined`, which the existing `?? entityType.toLowerCase()` fallback already handles. Plugin-registered prefixes flow through the deferred `registerEntityType` hook, not through type-system capitulation.
+
+## 3. Design
+
+### 3.1 `Capability` (#576)
+
+`libs/core/src/integrations/domain/types/adapter.types.ts`:
+
+```ts
+/** Well-known core capabilities. The published, documented set. */
+export const CoreCapabilityValues = [
+  'ProductMaster',
+  'InventoryMaster',
+  'OrderProcessorManager',
+  'OrderSource',
+  'OfferManager',
+] as const;
+
+/**
+ * Closed type for the well-known core capabilities.
+ *
+ * Use `CoreCapability` where exhaustiveness or strict validation matters
+ * (HTTP DTOs, FE dropdowns). Use `CoreCapability | string` at extension
+ * boundaries (adapter metadata, integrations service) where plugin
+ * adapters can register additional capability names.
+ */
+export type CoreCapability = (typeof CoreCapabilityValues)[number];
+
+/**
+ * Adapter metadata.
+ *
+ * `supportedCapabilities` is `(CoreCapability | string)[]` so plugin adapters
+ * can register capability names beyond the core set without editing core.
+ * The runtime gate at `IntegrationsService.getCapabilityAdapter` validates
+ * the requested capability against this array — it is the source of truth
+ * for "is this capability supported", regardless of whether the name is in
+ * `CoreCapabilityValues`.
+ */
+export interface AdapterMetadata {
+  adapterKey: string;
+  platformType: string;
+  supportedCapabilities: (CoreCapability | string)[];
+  displayName?: string;
+  version?: string;
+}
+```
+
+**Boundary signatures widen, alias stays closed.** Concretely:
+
+| Surface | Before | After |
+|---|---|---|
+| `AdapterMetadata.supportedCapabilities` | `Capability[]` | `(CoreCapability \| string)[]` |
+| `Connection.enabledCapabilities` (domain entity + types) | `Capability[]` | `(CoreCapability \| string)[]` |
+| `IntegrationsService.getCapabilityAdapter(connectionId, capability)` | `Capability` | `CoreCapability \| string` |
+| `IntegrationsService.listCapabilityAdapters({ capability })` | `Capability` | `CoreCapability \| string` |
+| `AdapterFactoryPort.createCapabilityAdapter(... capability)` | `Capability` | `CoreCapability \| string` |
+| `CapabilityNotSupportedException`, `CapabilityNotEnabledException` constructor `capability` | `Capability` | `CoreCapability \| string` |
+| HTTP request DTOs (`enabledCapabilities` field type) | `Capability[]` | `CoreCapability[]` (stays strict) |
+| HTTP request DTOs `@IsIn(...)` | `@IsIn(CapabilityValues, ...)` | `@IsIn(CoreCapabilityValues, ...)` (stays strict) |
+| HTTP response DTO `enabledCapabilities`, `supportedCapabilities` | `Capability[]` | `(CoreCapability \| string)[]` |
+| Swagger `@ApiProperty enum:` (request + response) | `enum: CapabilityValues` | `enum: CoreCapabilityValues` (rename only) |
+
+The DTOs stay `@IsIn(CoreCapabilityValues, { each: true })`. An operator typo'ing `'productMaster'` (lowercase) gets immediate API feedback today and continues to. A plugin-registered capability would hit the DTO wall first; that case does not exist today, and unblocking it is the scope of a follow-up issue ("runtime-aware DTO validator that consults the resolved adapter's `supportedCapabilities`").
+
+Swagger `enum:` stays on both request and response — the API today emits and accepts only the well-known set, and that's what the OpenAPI contract should advertise.
+
+### 3.2 `EntityType` (#577)
+
+`libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts`:
+
+```ts
+/** Well-known core entity types. The published, documented set. */
+export const CoreEntityTypeValues = [
+  'Product',
+  'ProductVariant',
+  'Sku',
+  'Order',
+  'Offer',
+  'Inventory',
+  'Customer',
+] as const;
+
+/**
+ * Closed type for the well-known core entity types.
+ *
+ * Use `CoreEntityType` where exhaustiveness matters (e.g. literal comparisons
+ * against `'Offer'` or `'Product'`). Use `CoreEntityType | string` at port
+ * boundaries (e.g. `IdentifierMappingService.getOrCreateInternalId`) where
+ * plugin adapters may map additional entity types like `Refund`,
+ * `Fulfilment`, `Subscription`.
+ */
+export type CoreEntityType = (typeof CoreEntityTypeValues)[number];
+
+/**
+ * Internal-ID prefix overrides for entity types whose default
+ * lowercased prefix is undesirable.
+ *
+ * `Partial<Record<CoreEntityType, string>>` — only well-known entity types
+ * may have prefix overrides registered here today. The lookup type is
+ * `string | undefined`, which the existing `?? entityType.toLowerCase()`
+ * fallback in `IdentifierMappingService.generateInternalId` handles.
+ *
+ * Plugin-registered entity types fall through to the lowercased default.
+ * A future `registerEntityType(name, { idPrefix? })` extension hook (see
+ * #577 follow-up) will be the supported way for plugins to register
+ * non-default prefixes.
+ */
+export const ENTITY_TYPE_ID_PREFIX: Partial<Record<CoreEntityType, string>> = {
+  ProductVariant: 'variant',
+};
+```
+
+**Boundary signatures widen, alias stays closed.** Concretely:
+
+| Surface | Before | After |
+|---|---|---|
+| `IdentifierMappingQueryPort.getInternalId(entityType, ...)` | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingQueryPort.getExternalIds(entityType, ...)` | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingQueryPort.listExternalIdsByConnection(entityType, ...)` | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingCommandPort.getOrCreateInternalId(entityType, ...)` | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingCommandPort.createMapping(entityType, ...)` | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingCommandPort.batchGetOrCreateInternalIds(requests)` (`request.entityType`) | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingCommandPort.getOrCreateExactMapping(entityType, ...)` | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingCommandPort.deleteMapping(entityType, ...)` | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingRequest.entityType` | `EntityType` | `CoreEntityType \| string` |
+| Repository port methods + `IdentifierMappingRepository` impl | `EntityType` | `CoreEntityType \| string` |
+| `IdentifierMappingService` private/public methods | `EntityType` | `CoreEntityType \| string` |
+| `OFFER_ENTITY_TYPE` constant in `offer-mapping.repository.ts` | `EntityType = 'Offer'` | `CoreEntityType = 'Offer'` |
+| `entity.entityType as EntityType` cast on the same file | `as EntityType` | `as CoreEntityType` (kept; load-bearing for downstream narrowing) |
+| `ExternalIdMapping.entityType` | already `string` | unchanged |
+
+The cast at `offer-mapping.repository.ts:110` is **kept** under the renamed name. With `EntityType` previously closed, the cast was already a documented widening from the ORM's untyped `string` column to the `EntityType` domain type; now that `CoreEntityType` is also closed, the cast still narrows from `string` to the well-known set and downstream literal comparisons (`mapping.entityType === 'Offer'`) keep working. Dropping it would require widening every downstream consumer to `CoreEntityType | string`, which is a non-goal here.
+
+`webhook-to-job.handler.ts` PascalCase normalisation comments (lines 336 and 427) get a one-line update: "match the well-known core entity types" instead of "match EntityType enum values" — the PascalCase normalisation itself is still useful; it's just no longer load-bearing for type-checking.
+
+### 3.3 Frontend mirror
+
+`apps/web/src/features/connections/api/connections.types.ts` has its own `CAPABILITY_VALUES` / `Capability`. Apply the same shape:
+
+```ts
+export const CORE_CAPABILITY_VALUES = [
+  'ProductMaster',
+  'InventoryMaster',
+  'OrderProcessorManager',
+  'OrderSource',
+  'OfferManager',
+] as const;
+
+export type CoreCapability = (typeof CORE_CAPABILITY_VALUES)[number];
+```
+
+`Connection.enabledCapabilities` and `Connection.supportedCapabilities` widen to `(CoreCapability | string)[]` — the FE displays whatever the API returns. `CreateConnectionInput.enabledCapabilities` and `UpdateConnectionInput.enabledCapabilities` stay strict (`CoreCapability[]`), mirroring the BE request DTO contract. `adapters.api.types.ts` (`supportedCapabilities`) widens. The `requiredCapability?` in `trigger-sync-dialog.types.ts` stays `CoreCapability` — it gates UI dispatch on well-known names only.
+
+The FE has no analog of `EntityType` (only the backend side maps identifiers).
+
+**Out of scope.** D4 (#579) calls out FE platform-switch dispatch (`=== 'allegro'`-style equality). The capability widening here makes that class of bug *more* likely to silently accept plugin-registered capability names; #579 owns the structural fix (capability-shaped wizard, registry-driven dispatch). Anything new written in this PR that touches `Capability` should use `CORE_CAPABILITY_VALUES.includes(...)` runtime checks rather than `=== 'OrderSource'` equality.
+
+## 4. Step-by-step plan
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| 1 | `libs/core/src/integrations/domain/types/adapter.types.ts` | Rename `CapabilityValues` → `CoreCapabilityValues`, `Capability` (alias) → `CoreCapability`. Update `AdapterMetadata.supportedCapabilities` to `(CoreCapability \| string)[]` with explanatory JSDoc. | `pnpm type-check` passes; `AdapterMetadata['supportedCapabilities']` accepts `['PricingAuthority']` literal. |
+| 2 | `libs/core/src/integrations/index.ts` | Replace `Capability, CapabilityValues` exports with `CoreCapability, CoreCapabilityValues`. | Barrel exports the new names; old names gone. |
+| 3 | `libs/core/src/integrations/application/services/integrations.service.ts` + `application/interfaces/integrations.service.interface.ts` | Replace `Capability` with `CoreCapability \| string` in method signatures (`getCapabilityAdapter`, `listCapabilityAdapters` filter, return-type `capability` field). Imports update. Behaviour unchanged. | Compiles; `getCapabilityAdapter(id, 'PricingAuthority')` typechecks. |
+| 4 | `libs/core/src/integrations/domain/ports/adapter-factory.port.ts` + `infrastructure/adapters/adapter-factory-resolver.service.ts` + `infrastructure/adapters/adapter-registry.service.ts` | Same widening at the factory + registry boundary. The two `as Capability[]` casts in `adapter-registry.service.ts:35,42` become unnecessary — drop them. | Compiles; explicit casts removed. |
+| 5 | `libs/core/src/integrations/domain/exceptions/capability-not-supported.exception.ts` + `capability-not-enabled.exception.ts` | Constructor `capability` parameter type widens to `CoreCapability \| string`. Imports update. | Compiles. |
+| 6 | `libs/core/src/identifier-mapping/domain/entities/connection.entity.ts` + `domain/types/connection.types.ts` | `Connection.enabledCapabilities: (CoreCapability \| string)[]`. `CreateConnectionParams` / `UpdateConnectionParams` `enabledCapabilities`: same. Import updates. | Compiles. |
+| 7 | `libs/core/src/identifier-mapping/infrastructure/persistence/repositories/connection.repository.ts` | Update import to `CoreCapability`. The repository already passes the array through unchanged; widening flows transparently. | Compiles. |
+| 8 | `libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts` | Rename `EntityTypeValues` → `CoreEntityTypeValues`, `EntityType` → `CoreEntityType`. Keep `ENTITY_TYPE_ID_PREFIX: Partial<Record<CoreEntityType, string>>` (constraint unchanged, just renamed). Widen `IdentifierMappingRequest.entityType` to `CoreEntityType \| string`. | Compiles. |
+| 9 | `libs/core/src/identifier-mapping/index.ts` | Replace `EntityType, EntityTypeValues` exports with `CoreEntityType, CoreEntityTypeValues`. | Barrel exports the new names. |
+| 10 | `libs/core/src/identifier-mapping/domain/ports/identifier-mapping.port.ts` + `domain/ports/identifier-mapping-repository.port.ts` | Widen every `entityType: EntityType` parameter to `entityType: CoreEntityType \| string`. Update imports. | Compiles; ports accept arbitrary strings. |
+| 11 | `libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts` + `infrastructure/persistence/repositories/identifier-mapping.repository.ts` + `domain/entities/identifier-mapping.entity.ts` | Same widening on impl + entity. `generateInternalId(entityType: CoreEntityType \| string)` — its `ENTITY_TYPE_ID_PREFIX[entityType]` lookup is now indexing a `Partial<Record<CoreEntityType, string>>` with a `CoreEntityType \| string` key. TS narrows correctly because the lookup just needs the `string` index signature; the `?? entityType.toLowerCase()` fallback covers the `undefined` branch. | Compiles; existing behaviour unchanged for well-known types; new types fall through to lowercased default. |
+| 12 | `libs/core/src/listings/infrastructure/persistence/repositories/offer-mapping.repository.ts` | Rename `EntityType` import to `CoreEntityType`. `OFFER_ENTITY_TYPE: CoreEntityType = 'Offer'`. The cast `entity.entityType as CoreEntityType` is kept (load-bearing for downstream literal narrowing). | Compiles. |
+| 13 | `apps/api/src/listings/http/listings.controller.ts` | Update the `import type { EntityType, ... }` to `CoreEntityType`. The two `('Offer' satisfies EntityType)` checks become `('Offer' satisfies CoreEntityType)`. | Compiles. |
+| 14 | `apps/api/src/webhooks/application/handlers/webhook-to-job.handler.ts` | Update the two comments referencing "EntityType enum" to "well-known core entity types". No type changes. | Comments accurate; behaviour unchanged. |
+| 15 | `apps/api/src/integrations/http/dto/create-connection.dto.ts` + `update-connection.dto.ts` | Update imports `CapabilityValues` → `CoreCapabilityValues`, `Capability` → `CoreCapability`. Keep `@IsIn(CoreCapabilityValues, { each: true })` strict. Keep `enum: CoreCapabilityValues` in `@ApiProperty`. Field type stays `CoreCapability[]`. | Compiles; DTO still rejects non-well-known capabilities at the API. |
+| 16 | `apps/api/src/integrations/http/dto/connection-response.dto.ts` | Update imports. Field types widen to `(CoreCapability \| string)[]` (mirrors the entity). Keep `enum: CoreCapabilityValues` in `@ApiProperty` — that documents what the server emits today; FE codegen pinning against it is correct. | Swagger response shape unchanged for current clients; type accepts plugin values when they exist. |
+| 17 | `apps/api/test/integration/connection-capabilities.int-spec.ts` | Update import of `CapabilityValues`/`Capability` to the new names if used. | int-spec compiles + still passes. |
+| 18 | `apps/web/src/features/connections/api/connections.types.ts` | Rename `CAPABILITY_VALUES` → `CORE_CAPABILITY_VALUES`, `Capability` → `CoreCapability`. Widen `Connection.{enabled,supported}Capabilities` to `(CoreCapability \| string)[]`. Keep `Create/UpdateConnectionInput.enabledCapabilities` strict (`CoreCapability[]`) to mirror the BE request DTO. | FE compiles. |
+| 19 | `apps/web/src/features/adapters/api/adapters.types.ts` + `connections/components/ConnectionCapabilitiesPanel.tsx` + `connections/components/prestashop-setup.schema.ts` + `connections/components/prestashop-setup-form.tsx` + `sync-jobs/components/trigger-sync-dialog.types.ts` | Sweep: rename imports. `adapters.types.ts` widens `supportedCapabilities` to `(CoreCapability \| string)[]`. `trigger-sync-dialog.types.ts` `requiredCapability?` stays `CoreCapability` (UI gates on well-known names only). `ConnectionCapabilitiesPanel` + `prestashop-setup.*` use `CoreCapability` for editor-mode strictness. | FE compiles; runtime renders unchanged. |
+| 20 | New unit test: `libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts` | Concrete behavioural assertions — see §5.2. | `pnpm test` passes. |
+| 21 | New unit test: `libs/core/src/identifier-mapping/domain/types/__tests__/identifier-mapping.types.spec.ts` | Concrete behavioural assertions — see §5.2. | `pnpm test` passes. |
+| 22 | `docs/architecture-overview.md` | Two surgical edits: (a) §"Identifier Mapping Service / Interface" — replace inline `entityType: 'Product' \| ... \| string` shape with an explicit `entityType: CoreEntityType \| string` referencing the new alias name, so doc + code use the same identifier. (b) §"Capability Abstractions / Future Capability Ports" — append a paragraph noting `Capability` is open at the registry boundary (`CoreCapability \| string`) and plugins do not need a core PR to register a new capability; HTTP DTOs remain strict on `CoreCapabilityValues` until the runtime-aware validator follow-up lands. | Doc + code use the same identifiers. |
+| 23 | Final sweep: `grep -rn '\\b(Capability\|CapabilityValues\|EntityType\|EntityTypeValues\|CAPABILITY_VALUES)\\b' apps libs \| grep -v Core` | All remaining hits should be intentional substring matches (e.g. `CapabilityNotSupportedException`, `OfferCreationCapability`, file names). Manual eyeball; no rename mistakes. | Confirmation that the rename is complete. |
+
+## 5. Validation
+
+### 5.1 Architecture & standards compliance
+
+- ✅ Domain has no framework deps — only `*.types.ts`, `*.port.ts`, `*.entity.ts` files in `domain/` are touched.
+- ✅ Engineering Standards § "Union Types: `as const` Pattern" preserved literally — `CoreCapabilityValues` + derived `CoreCapability` keeps the runtime-array-plus-derived-type shape; the type alias itself is *not* widened with `(string & {})`. The boundary widening lives on the consuming signatures, where the doc literally documents it.
+- ✅ Naming — `Core{Capability,EntityType}{Values,}` mirrors #576's literal recommendation.
+- ✅ No deprecation shims — call sites are renamed in the same PR (~30 references across ~20 files).
+- ✅ No `any`. The `CoreCapability | string` boundary is documented by name; readers see "well-known core, plus any string."
+- ✅ Repository ports / port pattern unchanged structurally — only parameter types widen.
+- ✅ Engineering Standards § "Validation" preserved — DTO validation stays strict on `CoreCapabilityValues`. Loosening it would regress operator UX (typos surface at sync-job time, not API time).
+
+### 5.2 Tests
+
+Two new spec files. **Real assertions, not `satisfies` lines.**
+
+`libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts`:
+
+- *should expose the documented five well-known capabilities in `CoreCapabilityValues`* — assert `CoreCapabilityValues` deep-equals the literal array `['ProductMaster','InventoryMaster','OrderProcessorManager','OrderSource','OfferManager']`. Regression guard against silent reordering or additions.
+- *should accept a non-well-known capability when typed as `CoreCapability \| string`* — assign a plugin-style string `'PricingAuthority'` to a `(CoreCapability | string)[]` array and assert it round-trips through `Array.includes`. The compile-time check is implicit; the runtime check makes the test meaningful in `pnpm test`.
+- *should narrow back to `CoreCapability` for well-known values via `CoreCapabilityValues.includes`* — function `isCoreCapability(c: CoreCapability | string): c is CoreCapability { return (CoreCapabilityValues as readonly string[]).includes(c); }` returns `true` for `'ProductMaster'`, `false` for `'PricingAuthority'`. This documents the runtime narrowing pattern call sites should use.
+
+`libs/core/src/identifier-mapping/domain/types/__tests__/identifier-mapping.types.spec.ts`:
+
+- *should expose the documented seven well-known entity types in `CoreEntityTypeValues`* — same shape regression guard.
+- *should override the prefix to 'variant' for ProductVariant* — assert `ENTITY_TYPE_ID_PREFIX.ProductVariant === 'variant'`.
+- *should fall back to `entityType.toLowerCase()` when `ENTITY_TYPE_ID_PREFIX` has no override* — pull the lookup logic from `IdentifierMappingService.generateInternalId` into a small pure helper or inline-test the expression: `(ENTITY_TYPE_ID_PREFIX[t] ?? t.toLowerCase())` returns `'product'` for `'Product'` (no override) and `'refund'` for `'Refund'` (plugin entity type, also no override).
+- *should accept a non-well-known entity type when typed as `CoreEntityType \| string`* — assign `'Refund'` to a `CoreEntityType | string` variable and assert it survives identity round-trips. Documents the boundary-widening intent.
+
+### 5.3 Quality gate
+
+`pnpm lint && pnpm type-check && pnpm test`. Existing unit + integration tests should be unaffected — boundary signatures get *strictly broader*, every existing call site continues to typecheck.
+
+### 5.4 Security
+
+- DTO validation stays strict (`@IsIn(CoreCapabilityValues, { each: true })`). API attack surface unchanged.
+- `EntityType` widening has no security surface; it's an in-process identifier-routing type.
+
+### 5.5 Risk
+
+- **Swagger codegen consumers** — no change. Both request and response DTOs keep `enum: CoreCapabilityValues`. External clients pinning against the OpenAPI enum continue to compile.
+- **Internal callers passing well-known values** — no change. `'OrderSource'` is still a valid `CoreCapability`, still flows into widened signatures unchanged.
+- **Internal callers passing arbitrary strings** — none today; the change unblocks future plugin registration without committing to the registration mechanism in this PR.
+- **Doc drift the other way** — step 22 closes it.
+
+## 6. Open questions / follow-ups
+
+1. ~~Deprecation aliases?~~ **Decision: deleted in this PR.**
+2. ~~Type alias mechanism?~~ **Decision: boundary widening (`CoreCapability \| string`), not type-alias widening (`CoreCapability \| (string & {})`).** Rationale: matches the literal architecture doc, matches both issues' recommendations word-for-word, doesn't fight the `as const` engineering standard.
+3. **Runtime-aware DTO validator.** Out of scope here. File a follow-up under #550 ("`@IsKnownCapabilityForAdapter` validator that consults the resolved adapter's `supportedCapabilities`"). When that lands, the DTO can drop `@IsIn(CoreCapabilityValues, ...)` cleanly.
+4. **`registerEntityType(name, { idPrefix? })` extension hook.** Explicitly listed as a follow-up in #577. File a child issue under #550.
+5. **Sub-capability pattern asymmetry.** Top-level `Capability` lands on `Core* | string` boundary widening; sub-capabilities use structural typing + `is{Capability}` guards. Both are documented patterns. Whether to unify on the structural pattern is a follow-up under #550 — out of scope here because it would touch every adapter.
+6. **FE platform-switch dispatch (#579 D4).** The widening here makes `enabledCapabilities.includes('Foo')` more meaningful and makes `=== 'OrderSource'` more brittle. #579 owns the structural fix. Out of scope here.

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
@@ -27,7 +27,6 @@ import { DuplicateIdentifierMappingError } from '../../domain/exceptions/duplica
 import { MappingAlreadyExistsError } from '../../domain/exceptions/mapping-already-exists.error';
 import { IdentifierMappingConflictException } from '../../domain/exceptions/identifier-mapping-conflict.exception';
 import {
-  EntityType,
   ENTITY_TYPE_ID_PREFIX,
   MappingContext,
   IdentifierMappingRequest,
@@ -47,7 +46,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
   ) {}
 
   async getOrCreateInternalId(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
     context?: MappingContext,
@@ -63,7 +62,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
   }
 
   async getInternalId(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
   ): Promise<string | null> {
@@ -81,7 +80,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
   }
 
   async getExternalIds(
-    entityType: EntityType,
+    entityType: string,
     internalId: string,
   ): Promise<ExternalIdMapping[]> {
     const mappings = await this.repository.findByInternalId(entityType, internalId);
@@ -94,7 +93,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
   }
 
   async createMapping(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
     internalId: string,
@@ -130,7 +129,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
   }
 
   async deleteMapping(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
   ): Promise<void> {
@@ -148,7 +147,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
   }
 
   async listExternalIdsByConnection(
-    entityType: EntityType,
+    entityType: string,
     connectionId: string,
   ): Promise<string[]> {
     const mappings = await this.repository.findByEntityTypeAndConnection(
@@ -209,7 +208,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
    * @private
    */
   private async getOrCreateInternalIdWithPlatform(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
     platformType: string,
@@ -278,7 +277,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
    * Returns the external ID if mapping exists or was created successfully
    */
   async getOrCreateExactMapping(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     internalId: string,
     connectionId: string,
@@ -326,11 +325,15 @@ export class IdentifierMappingService implements IIdentifierMappingService {
 
   }
 
-  private generateInternalId(entityType: EntityType): string {
+  private generateInternalId(entityType: string): string {
     // Format: ol_{prefix}_{uuid} — prefix defaults to entityType.toLowerCase()
     // unless overridden in ENTITY_TYPE_ID_PREFIX (e.g. ProductVariant → 'variant').
+    // The override map is keyed by CoreEntityType; widen to a string index here
+    // so plugin-registered entity types (#577) fall through to the default
+    // lowercased prefix instead of failing the indexed access.
+    const overrides: Record<string, string | undefined> = ENTITY_TYPE_ID_PREFIX;
     const uuid = randomUUID().replace(/-/g, '');
-    const prefix = ENTITY_TYPE_ID_PREFIX[entityType] ?? entityType.toLowerCase();
+    const prefix = overrides[entityType] ?? entityType.toLowerCase();
     return `ol_${prefix}_${uuid}`;
   }
 }

--- a/libs/core/src/identifier-mapping/domain/entities/connection.entity.ts
+++ b/libs/core/src/identifier-mapping/domain/entities/connection.entity.ts
@@ -16,8 +16,6 @@ import {
   ConnectionStatus,
   ConnectionConfig,
 } from '../types/connection.types';
-import type { Capability } from '@openlinker/core/integrations/domain/types/adapter.types';
-
 export class Connection {
   constructor(
     public readonly id: string,
@@ -29,6 +27,13 @@ export class Connection {
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
     public readonly adapterKey: string | undefined,
-    public readonly enabledCapabilities: Capability[],
+    /**
+     * Capabilities the operator has enabled on this connection. Subset of
+     * the resolved adapter's `supportedCapabilities`. Open string set —
+     * the well-known values are listed in the integrations module's
+     * `CoreCapability` / `CoreCapabilityValues`; plugin adapters may
+     * register additional names (#576).
+     */
+    public readonly enabledCapabilities: string[],
   ) {}
 }

--- a/libs/core/src/identifier-mapping/domain/entities/identifier-mapping.entity.ts
+++ b/libs/core/src/identifier-mapping/domain/entities/identifier-mapping.entity.ts
@@ -12,12 +12,12 @@
  *
  * @module libs/core/src/identifier-mapping/domain/entities
  */
-import { EntityType, MappingContext } from '../types/identifier-mapping.types';
+import { MappingContext } from '../types/identifier-mapping.types';
 
 export class IdentifierMapping {
   constructor(
     public readonly id: string,
-    public readonly entityType: EntityType,
+    public readonly entityType: string,
     public readonly internalId: string,
     public readonly externalId: string,
     public readonly platformType: string,

--- a/libs/core/src/identifier-mapping/domain/ports/identifier-mapping-repository.port.ts
+++ b/libs/core/src/identifier-mapping/domain/ports/identifier-mapping-repository.port.ts
@@ -13,7 +13,6 @@
  * @see {@link IdentifierMappingRepository} for the implementation
  */
 import { IdentifierMapping } from '../entities/identifier-mapping.entity';
-import { EntityType } from '../types/identifier-mapping.types';
 
 export interface IdentifierMappingRepositoryPort {
   /**
@@ -21,7 +20,7 @@ export interface IdentifierMappingRepositoryPort {
    * Used by service after resolving platformType from Connection
    */
   findByExternalKey(
-    entityType: EntityType,
+    entityType: string,
     platformType: string,
     connectionId: string,
     externalId: string,
@@ -31,7 +30,7 @@ export interface IdentifierMappingRepositoryPort {
    * Find all mappings for a given internal ID (reverse lookup)
    * Returns all external IDs mapped to this internal ID
    */
-  findByInternalId(entityType: EntityType, internalId: string): Promise<IdentifierMapping[]>;
+  findByInternalId(entityType: string, internalId: string): Promise<IdentifierMapping[]>;
 
   /**
    * Create mapping (standard save operation)
@@ -50,7 +49,7 @@ export interface IdentifierMappingRepositoryPort {
    * Idempotent: no-op if mapping does not exist.
    */
   deleteByExternalKey(
-    entityType: EntityType,
+    entityType: string,
     platformType: string,
     connectionId: string,
     externalId: string,
@@ -60,7 +59,7 @@ export interface IdentifierMappingRepositoryPort {
    * Find all mappings for a given entity type and connection.
    */
   findByEntityTypeAndConnection(
-    entityType: EntityType,
+    entityType: string,
     connectionId: string,
   ): Promise<IdentifierMapping[]>;
 }

--- a/libs/core/src/identifier-mapping/domain/ports/identifier-mapping.port.ts
+++ b/libs/core/src/identifier-mapping/domain/ports/identifier-mapping.port.ts
@@ -13,7 +13,6 @@
  * @see {@link IdentifierMappingService} for the implementation
  */
 import {
-  EntityType,
   MappingContext,
   IdentifierMappingRequest,
   ExternalIdMapping,
@@ -31,7 +30,7 @@ export interface IdentifierMappingQueryPort {
    * Returns null if mapping doesn't exist
    */
   getInternalId(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
   ): Promise<string | null>;
@@ -40,7 +39,7 @@ export interface IdentifierMappingQueryPort {
    * Get external identifier(s) for an internal ID
    * Returns all platform-specific external IDs mapped to this internal ID
    */
-  getExternalIds(entityType: EntityType, internalId: string): Promise<ExternalIdMapping[]>;
+  getExternalIds(entityType: string, internalId: string): Promise<ExternalIdMapping[]>;
 
   /**
    * List all external IDs for a given entity type and connection.
@@ -49,7 +48,7 @@ export interface IdentifierMappingQueryPort {
    * without calling the external platform API.
    */
   listExternalIdsByConnection(
-    entityType: EntityType,
+    entityType: string,
     connectionId: string,
   ): Promise<string[]>;
 }
@@ -64,7 +63,7 @@ export interface IdentifierMappingCommandPort {
    * internal ID and creates the mapping.
    */
   getOrCreateInternalId(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
     context?: MappingContext,
@@ -75,7 +74,7 @@ export interface IdentifierMappingCommandPort {
    * @throws Error if mapping already exists
    */
   createMapping(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
     internalId: string,
@@ -96,7 +95,7 @@ export interface IdentifierMappingCommandPort {
    * @throws Error on conflict (external ID mapped to different internal ID)
    */
   getOrCreateExactMapping(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     internalId: string,
     connectionId: string,
@@ -107,7 +106,7 @@ export interface IdentifierMappingCommandPort {
    * Delete mapping by external key (idempotent).
    */
   deleteMapping(
-    entityType: EntityType,
+    entityType: string,
     externalId: string,
     connectionId: string,
   ): Promise<void>;

--- a/libs/core/src/identifier-mapping/domain/types/__tests__/identifier-mapping.types.spec.ts
+++ b/libs/core/src/identifier-mapping/domain/types/__tests__/identifier-mapping.types.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Identifier Mapping Types — unit tests
+ *
+ * Regression guards for the open-`EntityType` extension axis (#577). The
+ * well-known core list (`CoreEntityTypeValues`) stays closed; port boundary
+ * signatures accept arbitrary strings. The internal-ID prefix override map
+ * keeps its `Partial<Record<CoreEntityType, string>>` shape — plugin entity
+ * types fall through to the lowercased default.
+ *
+ * @module libs/core/src/identifier-mapping/domain/types/__tests__
+ */
+import {
+  CoreEntityTypeValues,
+  ENTITY_TYPE_ID_PREFIX,
+  IdentifierMappingRequest,
+} from '../identifier-mapping.types';
+
+describe('identifier-mapping.types', () => {
+  describe('CoreEntityTypeValues', () => {
+    it('should expose the documented seven well-known entity types', () => {
+      // Guards against silent reordering or accidental additions/removals
+      // of the published well-known set. The architecture doc enumerates
+      // the same seven values at §"Internal Identifier Format".
+      expect([...CoreEntityTypeValues]).toEqual([
+        'Product',
+        'ProductVariant',
+        'Sku',
+        'Order',
+        'Offer',
+        'Inventory',
+        'Customer',
+      ]);
+    });
+  });
+
+  describe('ENTITY_TYPE_ID_PREFIX', () => {
+    it('should override the prefix to "variant" for ProductVariant', () => {
+      // Documented in architecture-overview.md §"Internal Identifier Format":
+      // ProductVariant maps to ol_variant_*, not ol_productvariant_*.
+      expect(ENTITY_TYPE_ID_PREFIX.ProductVariant).toBe('variant');
+    });
+
+    it('should not register an override for Product (default lowercased prefix wins)', () => {
+      expect(ENTITY_TYPE_ID_PREFIX.Product).toBeUndefined();
+    });
+  });
+
+  describe('prefix lookup at the open boundary', () => {
+    // Mirrors the lookup in IdentifierMappingService.generateInternalId.
+    // Documents that plugin-registered entity types (which #577 unblocks)
+    // fall through to the lowercased default cleanly — without the cast
+    // hacks the closed-set version required.
+    function resolvePrefix(entityType: string): string {
+      const overrides: Record<string, string | undefined> = ENTITY_TYPE_ID_PREFIX;
+      return overrides[entityType] ?? entityType.toLowerCase();
+    }
+
+    it('should return "variant" for the ProductVariant override', () => {
+      expect(resolvePrefix('ProductVariant')).toBe('variant');
+    });
+
+    it('should fall back to lowercased entityType for well-known types without overrides', () => {
+      expect(resolvePrefix('Product')).toBe('product');
+      expect(resolvePrefix('Offer')).toBe('offer');
+      expect(resolvePrefix('Customer')).toBe('customer');
+    });
+
+    it('should fall back to lowercased entityType for plugin-registered types', () => {
+      // The whole point of #577: a Shopify or Klarna adapter mapping a
+      // Refund / Fulfilment / Subscription doesn't need a core PR, and
+      // gets a sensible default prefix.
+      expect(resolvePrefix('Refund')).toBe('refund');
+      expect(resolvePrefix('Fulfilment')).toBe('fulfilment');
+      expect(resolvePrefix('Subscription')).toBe('subscription');
+    });
+  });
+
+  describe('IdentifierMappingRequest.entityType', () => {
+    it('should accept a well-known core entity type', () => {
+      const request: IdentifierMappingRequest = {
+        entityType: 'Product',
+        externalId: 'ext-1',
+        connectionId: 'conn-1',
+      };
+      expect(request.entityType).toBe('Product');
+    });
+
+    it('should accept a plugin-registered entity type beyond the core set', () => {
+      // Documents the open extension axis at the request boundary —
+      // matches the architecture-overview.md interface excerpt
+      // `entityType: 'Product' | … | 'Customer' | string`.
+      const request: IdentifierMappingRequest = {
+        entityType: 'Refund',
+        externalId: 'ext-2',
+        connectionId: 'conn-1',
+      };
+      expect(request.entityType).toBe('Refund');
+    });
+  });
+});

--- a/libs/core/src/identifier-mapping/domain/types/connection.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/connection.types.ts
@@ -7,8 +7,6 @@
  *
  * @module libs/core/src/identifier-mapping/domain/types
  */
-import type { Capability } from '@openlinker/core/integrations/domain/types/adapter.types';
-
 /**
  * Platform type identifier (e.g., 'prestashop', 'allegro', 'shopify')
  */
@@ -60,7 +58,7 @@ export interface ConnectionCreate {
    * supportedCapabilities. When omitted at create time, ConnectionService defaults
    * this to the adapter's full supported set (behavior-preserving).
    */
-  enabledCapabilities?: Capability[];
+  enabledCapabilities?: string[];
 }
 
 /**
@@ -79,7 +77,7 @@ export interface ConnectionUpdate {
    * here so existing callers that pass the unchanged value still type-check.
    */
   adapterKey?: string;
-  enabledCapabilities?: Capability[];
+  enabledCapabilities?: string[];
 }
 
 /**

--- a/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
@@ -1,12 +1,21 @@
 /**
  * Identifier Mapping Types
  *
- * Type definitions for identifier mapping operations. Defines entity types,
- * mapping context, request structures, and external ID mapping structures.
+ * Type definitions for identifier mapping operations. Defines the well-known
+ * core entity types, mapping context, request structures, and external ID
+ * mapping structures.
  *
  * @module libs/core/src/identifier-mapping/domain/types
  */
-export const EntityTypeValues = [
+
+/**
+ * Well-known core entity types — the documented set OpenLinker ships with.
+ *
+ * Plugin adapters can map additional entity types beyond this set (#577).
+ * Port methods accept `string`; this list stays closed and
+ * is the source of truth for "well-known."
+ */
+export const CoreEntityTypeValues = [
   'Product',
   'ProductVariant',
   'Sku',
@@ -16,18 +25,40 @@ export const EntityTypeValues = [
   'Customer',
 ] as const;
 
-export type EntityType = (typeof EntityTypeValues)[number];
+/**
+ * Closed type for the well-known core entity types.
+ *
+ * Use `CoreEntityType` where exhaustiveness matters (e.g. literal comparisons
+ * against `'Offer'` or `'Product'`). Use `string` at port
+ * boundaries (e.g. `IdentifierMappingService.getOrCreateInternalId`) where
+ * plugin adapters may map additional entity types like `Refund`,
+ * `Fulfilment`, `Subscription`. This mirrors the literal `architecture-overview.md`
+ * documentation of the port signature.
+ */
+export type CoreEntityType = (typeof CoreEntityTypeValues)[number];
 
 /**
- * Entity types whose internal-ID prefix diverges from `entityType.toLowerCase()`.
+ * Internal-ID prefix overrides for entity types whose default lowercased
+ * prefix is undesirable.
  *
  * The default format is `ol_{entityType.toLowerCase()}_{uuid}`. Entries here
- * override the prefix segment only. `ProductVariant` maps to `variant` so IDs
- * remain the documented `ol_variant_*` shape (see `docs/architecture-overview.md`
- * §"Internal Identifier Format") rather than the verbose `ol_productvariant_*`
- * that the default lowercasing would produce.
+ * override the prefix segment only. `ProductVariant` maps to `variant` so
+ * IDs remain the documented `ol_variant_*` shape (see
+ * `docs/architecture-overview.md` §"Internal Identifier Format") rather than
+ * the verbose `ol_productvariant_*` that the default lowercasing would
+ * produce.
+ *
+ * `Partial<Record<CoreEntityType, string>>` — only well-known core entity
+ * types may have prefix overrides registered statically. The lookup type is
+ * `string | undefined`, which the existing `?? entityType.toLowerCase()`
+ * fallback in `IdentifierMappingService.generateInternalId` handles.
+ *
+ * Plugin-registered entity types fall through to the lowercased default
+ * today. A future `registerEntityType(name, { idPrefix? })` extension hook
+ * (#577 follow-up) will be the supported way for plugins to register
+ * non-default prefixes.
  */
-export const ENTITY_TYPE_ID_PREFIX: Partial<Record<EntityType, string>> = {
+export const ENTITY_TYPE_ID_PREFIX: Partial<Record<CoreEntityType, string>> = {
   ProductVariant: 'variant',
 };
 
@@ -38,7 +69,12 @@ export interface MappingContext {
 }
 
 export interface IdentifierMappingRequest {
-  entityType: EntityType;
+  /**
+   * Entity type. Open string set — well-known values are in
+   * {@link CoreEntityTypeValues}; plugin adapters can register additional
+   * names (#577).
+   */
+  entityType: string;
   externalId: string;
   connectionId: string;
   context?: MappingContext;
@@ -50,4 +86,3 @@ export interface ExternalIdMapping {
   connectionId: string;
   entityType: string;
 }
-

--- a/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/connection.repository.ts
+++ b/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/connection.repository.ts
@@ -24,7 +24,6 @@ import {
 } from '../../../domain/types/connection.types';
 import { ConnectionNotFoundException } from '../../../domain/exceptions/connection-not-found.exception';
 import { Logger } from '@openlinker/shared/logging';
-import type { Capability } from '@openlinker/core/integrations/domain/types/adapter.types';
 
 @Injectable()
 export class ConnectionRepository implements ConnectionPort {
@@ -153,7 +152,7 @@ export class ConnectionRepository implements ConnectionPort {
       entity.createdAt,
       entity.updatedAt,
       entity.adapterKey,
-      (entity.enabledCapabilities ?? []) as Capability[],
+      (entity.enabledCapabilities ?? []),
     );
   }
 

--- a/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts
+++ b/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts
@@ -21,11 +21,7 @@ import { IdentifierMappingOrmEntity } from '../entities/identifier-mapping.orm-e
 import { IdentifierMappingRepositoryPort } from '../../../domain/ports/identifier-mapping-repository.port';
 import { IdentifierMapping } from '../../../domain/entities/identifier-mapping.entity';
 import { DuplicateIdentifierMappingError } from '../../../domain/exceptions/duplicate-identifier-mapping.error';
-import {
-  EntityType,
-  EntityTypeValues,
-  MappingContext,
-} from '@openlinker/core/identifier-mapping/domain/types/identifier-mapping.types';
+import { MappingContext } from '@openlinker/core/identifier-mapping/domain/types/identifier-mapping.types';
 
 @Injectable()
 export class IdentifierMappingRepository implements IdentifierMappingRepositoryPort {
@@ -39,7 +35,7 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
    * Used by service after resolving platformType from Connection
    */
   async findByExternalKey(
-    entityType: EntityType,
+    entityType: string,
     platformType: string,
     connectionId: string,
     externalId: string,
@@ -61,7 +57,7 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
   }
 
   async findByInternalId(
-    entityType: EntityType,
+    entityType: string,
     internalId: string,
   ): Promise<IdentifierMapping[]> {
     const entities = await this.repository.find({
@@ -117,7 +113,7 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
   }
 
   async findByEntityTypeAndConnection(
-    entityType: EntityType,
+    entityType: string,
     connectionId: string,
   ): Promise<IdentifierMapping[]> {
     const entities = await this.repository.find({
@@ -130,7 +126,7 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
   }
 
   async deleteByExternalKey(
-    entityType: EntityType,
+    entityType: string,
     platformType: string,
     connectionId: string,
     externalId: string,
@@ -144,12 +140,13 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
   }
 
   private toDomain(entity: IdentifierMappingOrmEntity): IdentifierMapping {
-    if (!(EntityTypeValues as readonly string[]).includes(entity.entityType)) {
-      throw new Error(`Invalid entityType in database: ${entity.entityType}`);
-    }
+    // No `entityType` validation here. Pre-#577 this method threw on values
+    // outside `EntityTypeValues`; with the boundary now widened to `string`,
+    // plugin-registered entity types (Refund, Fulfilment, Subscription, …)
+    // are legitimate ORM rows. The closed-set check would reject them.
     return new IdentifierMapping(
       entity.id,
-      entity.entityType as EntityType,
+      entity.entityType,
       entity.internalId,
       entity.externalId,
       entity.platformType,

--- a/libs/core/src/integrations/application/interfaces/integrations.service.interface.ts
+++ b/libs/core/src/integrations/application/interfaces/integrations.service.interface.ts
@@ -12,7 +12,6 @@ import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/
 import {
   AdapterMetadata,
   AdapterInstance,
-  Capability,
 } from '@openlinker/core/integrations/domain/types/adapter.types';
 
 export interface IIntegrationsService {
@@ -48,7 +47,7 @@ export interface IIntegrationsService {
    * @throws AdapterNotFoundException if adapter key not found in registry
    * @throws CapabilityNotSupportedException if adapter doesn't support the capability
    */
-  getCapabilityAdapter<T>(connectionId: string, capability: Capability): Promise<T>;
+  getCapabilityAdapter<T>(connectionId: string, capability: string): Promise<T>;
 
   /**
    * List all adapters supporting a capability
@@ -75,7 +74,7 @@ export interface IIntegrationsService {
   }): Promise<AdapterMetadata>;
 
   listCapabilityAdapters<T>(filters: {
-    capability: Capability;
+    capability: string;
     platformType?: string;
   }): Promise<
     Array<{

--- a/libs/core/src/integrations/application/services/integrations.service.ts
+++ b/libs/core/src/integrations/application/services/integrations.service.ts
@@ -18,7 +18,6 @@ import { Inject } from '@nestjs/common';
 import {
   AdapterMetadata,
   AdapterInstance,
-  Capability,
 } from '../../domain/types/adapter.types';
 import { AdapterRegistryPort } from '../../domain/ports/adapter-registry.port';
 import {
@@ -91,7 +90,7 @@ export class IntegrationsService implements IIntegrationsService {
 
   async getCapabilityAdapter<T>(
     connectionId: string,
-    capability: Capability,
+    capability: string,
   ): Promise<T> {
     this.logger.debug(`Resolving ${capability} adapter for connection: ${connectionId}`);
 
@@ -161,7 +160,7 @@ export class IntegrationsService implements IIntegrationsService {
   }
 
   async listCapabilityAdapters<T>(filters: {
-    capability: Capability;
+    capability: string;
     platformType?: string;
   }): Promise<
     Array<{

--- a/libs/core/src/integrations/domain/exceptions/capability-not-enabled.exception.ts
+++ b/libs/core/src/integrations/domain/exceptions/capability-not-enabled.exception.ts
@@ -9,14 +9,13 @@
  *
  * @module libs/core/src/integrations/domain/exceptions
  */
-import { Capability } from '../types/adapter.types';
 import { CapabilityNotSupportedException } from './capability-not-supported.exception';
 
 export class CapabilityNotEnabledException extends CapabilityNotSupportedException {
   constructor(
     public readonly connectionId: string,
     adapterKey: string,
-    capability: Capability,
+    capability: string,
   ) {
     super(adapterKey, capability);
     this.message = `Connection ${connectionId} has capability ${capability} disabled (adapter ${adapterKey} supports it)`;

--- a/libs/core/src/integrations/domain/exceptions/capability-not-supported.exception.ts
+++ b/libs/core/src/integrations/domain/exceptions/capability-not-supported.exception.ts
@@ -7,10 +7,8 @@
  *
  * @module libs/core/src/integrations/domain/exceptions
  */
-import { Capability } from '../types/adapter.types';
-
 export class CapabilityNotSupportedException extends Error {
-  constructor(adapterKey: string, capability: Capability) {
+  constructor(adapterKey: string, capability: string) {
     super(`Adapter ${adapterKey} does not support capability: ${capability}`);
     this.name = 'CapabilityNotSupportedException';
     Error.captureStackTrace(this, this.constructor);

--- a/libs/core/src/integrations/domain/ports/adapter-factory.port.ts
+++ b/libs/core/src/integrations/domain/ports/adapter-factory.port.ts
@@ -9,7 +9,6 @@
 import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';
 import { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CredentialsResolverPort } from './credentials-resolver.port';
-import { Capability } from '../types/adapter.types';
 
 /**
  * Adapter Factory Port
@@ -29,7 +28,7 @@ export interface AdapterFactoryPort {
    */
   createCapabilityAdapter<T>(
     connection: Connection,
-    capability: Capability,
+    capability: string,
     identifierMapping: IdentifierMappingPort,
     credentialsResolver: CredentialsResolverPort,
   ): Promise<T>;

--- a/libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts
+++ b/libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Adapter Types — unit tests
+ *
+ * Regression guards for the open-`Capability` extension axis (#576). The
+ * well-known core list (`CoreCapabilityValues`) stays closed; port boundary
+ * signatures accept arbitrary strings. Tests document the narrowing pattern
+ * call sites should use.
+ *
+ * @module libs/core/src/integrations/domain/types/__tests__
+ */
+import {
+  CoreCapabilityValues,
+  CoreCapability,
+  AdapterMetadata,
+} from '../adapter.types';
+
+describe('adapter.types', () => {
+  describe('CoreCapabilityValues', () => {
+    it('should expose the documented five well-known capabilities', () => {
+      // Guards against silent reordering or accidental additions/removals
+      // of the published well-known set. If this fails, either the set
+      // genuinely changed (update the test + arch doc) or someone extended
+      // the closed list when they should have used the open boundary.
+      expect([...CoreCapabilityValues]).toEqual([
+        'ProductMaster',
+        'InventoryMaster',
+        'OrderProcessorManager',
+        'OrderSource',
+        'OfferManager',
+      ]);
+    });
+  });
+
+  describe('AdapterMetadata.supportedCapabilities', () => {
+    it('should accept a well-known capability', () => {
+      const metadata: AdapterMetadata = {
+        adapterKey: 'test.v1',
+        platformType: 'test',
+        supportedCapabilities: ['ProductMaster'],
+      };
+      expect(metadata.supportedCapabilities).toEqual(['ProductMaster']);
+    });
+
+    it('should accept a plugin-registered capability name beyond the core set', () => {
+      // Documents the open extension axis: plugin adapters may register
+      // capability names not in `CoreCapabilityValues` (e.g. PricingAuthority
+      // listed in architecture-overview.md as future). The runtime gate at
+      // IntegrationsService.getCapabilityAdapter is the source of truth.
+      const metadata: AdapterMetadata = {
+        adapterKey: 'plugin.v1',
+        platformType: 'plugin',
+        supportedCapabilities: ['PricingAuthority', 'ProductMaster'],
+      };
+      expect(metadata.supportedCapabilities).toContain('PricingAuthority');
+    });
+  });
+
+  describe('isCoreCapability narrowing pattern', () => {
+    // Documented call-site pattern for narrowing back to the well-known set
+    // when exhaustiveness matters (e.g. UI dropdowns). Lifted here as a
+    // runtime test so future reorganisations don't silently break the
+    // pattern — call sites that copy this idiom should remain correct.
+    function isCoreCapability(value: string): value is CoreCapability {
+      return (CoreCapabilityValues as readonly string[]).includes(value);
+    }
+
+    it('should return true for every well-known core capability', () => {
+      for (const value of CoreCapabilityValues) {
+        expect(isCoreCapability(value)).toBe(true);
+      }
+    });
+
+    it('should return false for a plugin-registered capability', () => {
+      expect(isCoreCapability('PricingAuthority')).toBe(false);
+      expect(isCoreCapability('ShippingProvider')).toBe(false);
+    });
+
+    it('should return false for the empty string', () => {
+      expect(isCoreCapability('')).toBe(false);
+    });
+  });
+});

--- a/libs/core/src/integrations/domain/types/adapter.types.ts
+++ b/libs/core/src/integrations/domain/types/adapter.types.ts
@@ -1,21 +1,25 @@
 /**
  * Adapter Types
  *
- * Type definitions for adapter registry and capability system. Defines capability
- * types, adapter metadata structure, and adapter instance types. Used by the
- * adapter registry and integrations service for runtime adapter resolution.
+ * Type definitions for adapter registry and capability system. Defines the
+ * well-known core capability set, adapter-metadata structure, and adapter
+ * instance types. Used by the adapter registry and integrations service for
+ * runtime adapter resolution.
  *
  * @module libs/core/src/integrations/domain/types
  */
 
 /**
- * Capability values
+ * Well-known core capabilities — the documented set OpenLinker ships with.
  *
- * Runtime array of all valid capability values. Used for validation,
- * Swagger documentation, and UI dropdowns. Follows OpenLinker engineering
- * standards: `as const` + derived union type pattern.
+ * Plugin adapters can register additional capability names beyond this set
+ * (#576). The runtime gate at `IntegrationsService.getCapabilityAdapter`
+ * validates the requested capability against
+ * `AdapterMetadata.supportedCapabilities`, which is the source of truth for
+ * "is this capability supported?", regardless of whether the name appears
+ * in `CoreCapabilityValues`.
  */
-export const CapabilityValues = [
+export const CoreCapabilityValues = [
   'ProductMaster',
   'InventoryMaster',
   'OrderProcessorManager',
@@ -24,20 +28,28 @@ export const CapabilityValues = [
 ] as const;
 
 /**
- * Capability type
+ * Closed type for the well-known core capabilities.
  *
- * Represents business capabilities that adapters can support.
- * Matches capability ports in architecture. Derived from CapabilityValues
- * using the union-from-const pattern per engineering standards.
+ * Use `CoreCapability` where exhaustiveness or strict validation matters
+ * (HTTP DTOs, FE dropdowns). At extension boundaries (adapter metadata,
+ * integrations service, exception constructors) the parameter / field
+ * type is bare `string` with a JSDoc pointer back to {@link CoreCapability}.
+ * The documentation lives in JSDoc; the type system reflects what the
+ * runtime actually accepts.
  */
-export type Capability = (typeof CapabilityValues)[number];
+export type CoreCapability = (typeof CoreCapabilityValues)[number];
 
 /**
- * Adapter metadata
+ * Adapter metadata.
  *
  * Describes an adapter's capabilities and metadata. Used by AdapterRegistry
  * to resolve adapters at runtime. Each adapter must declare at least one
  * supported capability.
+ *
+ * `supportedCapabilities` is `string[]` so plugin
+ * adapters can register capability names beyond the well-known core set
+ * (#576). The runtime gate at `IntegrationsService.getCapabilityAdapter`
+ * validates the requested capability against this array.
  */
 export interface AdapterMetadata {
   /**
@@ -52,8 +64,12 @@ export interface AdapterMetadata {
 
   /**
    * Array of capabilities supported by this adapter. Must be non-empty.
+   * Open string set: well-known values come from {@link CoreCapabilityValues}
+   * / {@link CoreCapability}; plugin adapters can register additional names
+   * (#576). The runtime gate at `IntegrationsService.getCapabilityAdapter`
+   * is the source of truth for "is this capability supported".
    */
-  supportedCapabilities: Capability[];
+  supportedCapabilities: string[];
 
   /**
    * Optional human-readable display name
@@ -73,4 +89,3 @@ export interface AdapterMetadata {
  * instances. Full adapter implementations are separate epics.
  */
 export type AdapterInstance = unknown;
-

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -27,8 +27,8 @@ export {
 
 // Types
 export {
-  Capability,
-  CapabilityValues,
+  CoreCapability,
+  CoreCapabilityValues,
   AdapterMetadata,
   AdapterInstance,
 } from './domain/types/adapter.types';

--- a/libs/core/src/integrations/infrastructure/adapters/adapter-factory-resolver.service.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/adapter-factory-resolver.service.ts
@@ -11,7 +11,6 @@ import { AdapterFactoryPort } from '@openlinker/core/integrations/domain/ports/a
 import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';
 import { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CredentialsResolverPort } from '@openlinker/core/integrations/domain/ports/credentials-resolver.port';
-import { Capability } from '@openlinker/core/integrations/domain/types/adapter.types';
 import { AdapterNotFoundException } from '@openlinker/core/integrations/domain/exceptions/adapter-not-found.exception';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -50,7 +49,7 @@ export class AdapterFactoryResolverService {
   async createCapabilityAdapter<T>(
     adapterKey: string,
     connection: Connection,
-    capability: Capability,
+    capability: string,
     identifierMapping: IdentifierMappingPort,
     credentialsResolver: CredentialsResolverPort,
   ): Promise<T> {

--- a/libs/core/src/integrations/infrastructure/adapters/adapter-registry.service.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/adapter-registry.service.ts
@@ -15,7 +15,6 @@ import { AdapterRegistryPort } from '@openlinker/core/integrations/domain/ports/
 import {
   AdapterMetadata,
   AdapterInstance,
-  Capability,
 } from '@openlinker/core/integrations/domain/types/adapter.types';
 import { AdapterNotFoundException } from '@openlinker/core/integrations/domain/exceptions/adapter-not-found.exception';
 
@@ -32,14 +31,14 @@ export class AdapterRegistryService implements AdapterRegistryPort {
           'InventoryMaster',
           'OrderSource',
           'OrderProcessorManager',
-        ] as Capability[],
+        ],
         displayName: 'PrestaShop WebService v1',
         version: '1.0.0',
       },
       {
         adapterKey: 'allegro.publicapi.v1',
         platformType: 'allegro',
-        supportedCapabilities: ['OrderSource', 'OfferManager'] as Capability[],
+        supportedCapabilities: ['OrderSource', 'OfferManager'],
         displayName: 'Allegro Public API v1',
         version: '1.0.0',
       },

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-mapping.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-mapping.repository.ts
@@ -13,7 +13,7 @@ import { Repository } from 'typeorm';
 import {
   IdentifierMappingOrmEntity,
   IdentifierMapping,
-  EntityType,
+  CoreEntityType,
 } from '@openlinker/core/identifier-mapping';
 import { OfferMappingRepositoryPort } from '../../../domain/ports/offer-mapping-repository.port';
 import {
@@ -22,7 +22,7 @@ import {
   PaginatedOfferMappings,
 } from '../../../domain/types/offer-mapping.types';
 
-const OFFER_ENTITY_TYPE: EntityType = 'Offer';
+const OFFER_ENTITY_TYPE: CoreEntityType = 'Offer';
 
 @Injectable()
 export class OfferMappingRepository implements OfferMappingRepositoryPort {
@@ -107,7 +107,7 @@ export class OfferMappingRepository implements OfferMappingRepositoryPort {
   private toDomain(entity: IdentifierMappingOrmEntity): IdentifierMapping {
     return new IdentifierMapping(
       entity.id,
-      entity.entityType as EntityType,
+      entity.entityType,
       entity.internalId,
       entity.externalId,
       entity.platformType,

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-adapter-factory-wrapper.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-adapter-factory-wrapper.ts
@@ -7,7 +7,7 @@
  * @module libs/integrations/allegro/src/infrastructure/adapters
  * @implements {AdapterFactoryPort}
  */
-import { AdapterFactoryPort, CredentialsResolverPort, Capability } from '@openlinker/core/integrations';
+import { AdapterFactoryPort, CredentialsResolverPort } from '@openlinker/core/integrations';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CustomerIdentityResolverPort } from '@openlinker/core/customers';
 import type { CachePort } from '@openlinker/shared';
@@ -47,7 +47,7 @@ export class AllegroAdapterFactoryWrapper implements AdapterFactoryPort {
 
   async createCapabilityAdapter<T>(
     connection: Connection,
-    capability: Capability,
+    capability: string,
     identifierMapping: IdentifierMappingPort,
     credentialsResolver: CredentialsResolverPort,
   ): Promise<T> {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-adapter-factory-wrapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-adapter-factory-wrapper.ts
@@ -11,7 +11,6 @@
 import {
   AdapterFactoryPort,
   CredentialsResolverPort,
-  Capability,
   WebhookSecretProviderPort,
 } from '@openlinker/core/integrations';
 import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
@@ -49,7 +48,7 @@ export class PrestashopAdapterFactoryWrapper implements AdapterFactoryPort {
 
   async createCapabilityAdapter<T>(
     connection: Connection,
-    capability: Capability,
+    capability: string,
     identifierMapping: IdentifierMappingPort,
     credentialsResolver: CredentialsResolverPort,
   ): Promise<T> {


### PR DESCRIPTION
Closes #576
Closes #577

## Summary

Closes the doc-vs-code drift on two extension axes that were blocking plugin authors from extending OpenLinker without forking core. Both `Capability` and `EntityType` were closed `as const` unions; `architecture-overview.md` already documents both as open at the boundary, and the sub-capabilities pattern in `libs/core/src/listings/.../capabilities/` is the model. This PR aligns the code to that contract.

The shape applied (per #576/#577 and the architecture doc, line for line):

- **`as const` arrays stay closed.** Renamed to `CoreCapabilityValues` / `CoreEntityTypeValues`. They remain the source of truth for the well-known set, kept verbatim against the documented values.
- **Boundary signatures widen to bare `string`** with JSDoc pointers back to `CoreCapability` / `CoreEntityType`. `(CoreCapability | string)` would have been an autocomplete trick — TS collapses it to `string` for assignability and `@typescript-eslint/no-redundant-type-constituents` correctly flags it. The honest expression is `string` + JSDoc, which matches the architecture-doc literal `entityType: 'Product' | … | 'Customer' | string` (which itself reduces to `string`).
- **HTTP request DTOs stay strict** via `@IsIn(CoreCapabilityValues, { each: true })`. Operator UX is preserved — typos surface at API time, not at sync-job time. A runtime-aware DTO validator follow-up under #550 will lift this.
- **Swagger `enum: CoreCapabilityValues` retained** on both request and response. External clients pinning against the OpenAPI enum continue to compile.
- **`ENTITY_TYPE_ID_PREFIX` keeps `Partial<Record<CoreEntityType, string>>`** — no `Record<string, string>` lie. The `IdentifierMappingService.generateInternalId` lookup widens locally via a documented `Record<string, string | undefined>` view, so plugin entity types fall through to the lowercased default cleanly.
- **Removed the `toDomain` validator** in `IdentifierMappingRepository`. Plugin-registered entity types are legitimate ORM rows under #577; the closed-set check would reject them. Documented with a comment at the call site.
- **FE mirrors the renames.** `Connection.{enabled,supported}Capabilities` widen to `string[]`. The capability-edit UIs (`ConnectionCapabilitiesPanel`, `prestashop-setup-form`) narrow back to `CoreCapability` for the editor scope — plugin caps are not editable from the UI yet, mirroring the BE request-DTO contract. The `=` counter and the form's checkbox list both note this in inline comments.
- **Two unit specs** document the well-known lists (regression guard against silent reordering), the prefix-fallback for plugin entity types, and the `is{X}` runtime narrowing pattern call sites should use.
- **Architecture doc updated**: the `IdentifierMappingService` interface excerpt now references `CoreEntityType | string` literally, and the "Future Capability Ports" section gets a paragraph noting `Capability` is open at the registry boundary.

## Test plan

- [x] `pnpm lint` — 0 errors (19 pre-existing warnings in unrelated files)
- [x] `pnpm type-check` — clean across all 8 packages
- [x] `pnpm test` — 871 tests pass
- [x] New unit specs cover: `CoreCapabilityValues` shape, plugin-cap acceptance, `isCoreCapability` narrowing, `CoreEntityTypeValues` shape, `ENTITY_TYPE_ID_PREFIX.ProductVariant` override, plugin-entity-type prefix fallback, plugin-entity-type acceptance through `IdentifierMappingRequest`
- [x] Implementation plan saved to `docs/plans/implementation-plan-open-capability-and-entity-type-unions.md`

## Out of scope (deferred follow-ups under #550)

1. **Runtime-aware DTO validator** — `@IsKnownCapabilityForAdapter` that consults the resolved adapter's `supportedCapabilities`. Will let the request DTO accept plugin-registered capability names while still rejecting typos. Today's strict `@IsIn(CoreCapabilityValues, ...)` is a placeholder until that lands.
2. **`registerEntityType(name, { idPrefix? })` extension hook** — explicitly listed as a follow-up in #577. Adapter authors will use it to register prefixes without mutating the `ENTITY_TYPE_ID_PREFIX` map directly.
3. **FE platform-switch dispatch (#579 D4)** — the widening here makes `=== 'allegro'`-style switches more brittle (they silently accept new strings now). #579 owns the structural fix.
4. **Sub-capability pattern unification** — top-level `Capability` lands on the boundary-widening shape; sub-capabilities use structural typing + `is{Capability}` guards. Both are documented patterns. Whether to unify is its own refactor since it touches every adapter.