### PR TITLE
refactor(worker): drop allegro-only filter in inventory propagate handler

### DIFF
--- a/apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts
@@ -165,9 +165,8 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
 
       await handler.execute(job);
 
-      // Both platforms produce enqueue calls — per-platform behaviour belongs
-      // in the downstream adapter via the OfferManagerPort capability resolver,
-      // not here. The handler is platform-agnostic.
+      // Per-platform capability narrowing happens downstream via
+      // `IntegrationsService.getCapabilityAdapter`, not here.
       expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(2);
       expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts
@@ -135,7 +135,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
       expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
     });
 
-    it('should filter to only Allegro mappings', async () => {
+    it('should enqueue jobs for every offer mapping regardless of platform (#582)', async () => {
       const job = createJob({ productId: 'product-id' });
       const inventory = new InventoryItemEntity(
         'inventory-id',
@@ -151,27 +151,34 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
         {
           entityType: 'Offer',
           platformType: 'allegro',
-          connectionId: 'connection-id',
-          externalId: 'offer-id',
+          connectionId: 'allegro-connection',
+          externalId: 'allegro-offer',
         },
         {
           entityType: 'Offer',
           platformType: 'amazon',
-          connectionId: 'connection-id',
-          externalId: 'offer-id',
+          connectionId: 'amazon-connection',
+          externalId: 'amazon-offer',
         },
       ]);
       jobEnqueue.enqueueJob.mockResolvedValue({ jobId: 'enqueued-job-id', isExisting: false });
 
       await handler.execute(job);
 
-      expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(1);
+      // Both platforms produce enqueue calls — per-platform behaviour belongs
+      // in the downstream adapter via the OfferManagerPort capability resolver,
+      // not here. The handler is platform-agnostic.
+      expect(jobEnqueue.enqueueJob).toHaveBeenCalledTimes(2);
       expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
         expect.objectContaining({
-          connectionId: 'connection-id',
-          payload: expect.objectContaining({
-            offerId: 'offer-id',
-          }),
+          connectionId: 'allegro-connection',
+          payload: expect.objectContaining({ offerId: 'allegro-offer' }),
+        }),
+      );
+      expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connectionId: 'amazon-connection',
+          payload: expect.objectContaining({ offerId: 'amazon-offer' }),
         }),
       );
     });
@@ -294,7 +301,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
       await expect(handler.execute(job)).rejects.toThrow(SyncJobExecutionError);
     });
 
-    it('should handle multiple mappings', async () => {
+    it('should handle multiple mappings across mixed platforms', async () => {
       const job = createJob({ productId: 'product-id' });
       const inventory = new InventoryItemEntity(
         'inventory-id',
@@ -307,6 +314,9 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
       );
 
       inventoryService.getInventory.mockResolvedValue(inventory);
+      // Mix platforms across connections so the multi-mapping path explicitly
+      // exercises the capability-agnostic loop, not just multiple Allegro
+      // connections (#582).
       identifierMapping.getExternalIds.mockResolvedValue([
         {
           entityType: 'Offer',
@@ -316,7 +326,7 @@ describe('InventoryPropagateToMarketplacesHandler', () => {
         },
         {
           entityType: 'Offer',
-          platformType: 'allegro',
+          platformType: 'shopify',
           connectionId: 'connection-2',
           externalId: 'offer-2',
         },

--- a/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
+++ b/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
@@ -20,7 +20,6 @@ import {
 import {
   IIdentifierMappingService,
   IDENTIFIER_MAPPING_SERVICE_TOKEN,
-  ExternalIdMapping,
 } from '@openlinker/core/identifier-mapping';
 import { IInventoryService, INVENTORY_SERVICE_TOKEN } from '@openlinker/core/inventory';
 
@@ -105,19 +104,14 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
         `Found ${mappings.length} offer mapping(s) for product ${payload.productId}. Enqueuing quantity update jobs.`,
       );
 
-      // Step 4: For each mapping, enqueue marketplace.offerQuantity.update job
-      // Filter to only Allegro mappings for MVP (platformType === 'allegro')
-      const allegroMappings = mappings.filter((m: ExternalIdMapping) => m.platformType === 'allegro');
-
-      if (allegroMappings.length === 0) {
-        this.logger.debug(
-          `No Allegro offer mappings found for product ${payload.productId}. Skipping propagation.`,
-        );
-        return { outcome: 'ok' };
-      }
-
+      // Step 4: For each mapping, enqueue marketplace.offerQuantity.update job.
+      // Per-platform behaviour belongs in the adapter, not in this thin handler
+      // (#582). The downstream MarketplaceOfferQuantityUpdateHandler resolves
+      // `OfferManager` via `IntegrationsService.getCapabilityAdapter` and
+      // surfaces a missing-capability connection as a clean domain error, so a
+      // capability check at enqueue time would duplicate that policy.
       const writeEventToken = payload.inventoryUpdatedAt || 'legacy';
-      const enqueuePromises = allegroMappings.map(async (mapping) => {
+      const enqueuePromises = mappings.map(async (mapping) => {
         // Include write-event token to avoid suppressing legitimate quantity oscillations (e.g. 5->6->5).
         const idempotencyKey = `inventory:${mapping.connectionId}:${payload.productId}:${payload.variantId || 'base'}:${availableQuantity}:${writeEventToken}`;
 
@@ -145,7 +139,7 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
       await Promise.all(enqueuePromises);
 
       this.logger.log(
-        `Successfully enqueued ${allegroMappings.length} offer quantity update job(s) for product ${payload.productId}`,
+        `Successfully enqueued ${mappings.length} offer quantity update job(s) for product ${payload.productId}`,
       );
 
       return { outcome: 'ok' };

--- a/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
+++ b/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
@@ -106,10 +106,12 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
 
       // Step 4: For each mapping, enqueue marketplace.offerQuantity.update job.
       // Per-platform behaviour belongs in the adapter, not in this thin handler
-      // (#582). The downstream MarketplaceOfferQuantityUpdateHandler resolves
-      // `OfferManager` via `IntegrationsService.getCapabilityAdapter` and
-      // surfaces a missing-capability connection as a clean domain error, so a
-      // capability check at enqueue time would duplicate that policy.
+      // (#582). The downstream MarketplaceOfferQuantityUpdateHandler delegates
+      // to `InventorySyncService.updateOfferQuantity`
+      // (`libs/core/src/inventory/application/services/inventory-sync.service.ts:41-43`),
+      // which resolves `OfferManager` via `IntegrationsService.getCapabilityAdapter`
+      // and surfaces a missing-capability connection as a clean domain error —
+      // so a capability check at enqueue time would duplicate that policy.
       const writeEventToken = payload.inventoryUpdatedAt || 'legacy';
       const enqueuePromises = mappings.map(async (mapping) => {
         // Include write-event token to avoid suppressing legitimate quantity oscillations (e.g. 5->6->5).

--- a/docs/plans/implementation-plan-582-inventory-propagate-drop-allegro-filter.md
+++ b/docs/plans/implementation-plan-582-inventory-propagate-drop-allegro-filter.md
@@ -1,0 +1,59 @@
+# Implementation plan — #582 Drop `platformType === 'allegro'` filter from inventory-propagate handler
+
+## 1. Understand
+
+**Goal**: `InventoryPropagateToMarketplacesHandler` (`apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts:108-117`) currently filters offer mappings to Allegro-only before enqueuing `marketplace.offerQuantity.update` jobs. Non-Allegro mappings (Amazon, Shopify, future plugins) are silently dropped. Drop the filter — the handler is a thin orchestrator and per-platform behavior belongs in the downstream adapter (`OfferManagerPort.updateOfferQuantity`), not here.
+
+**Layer**: worker handler (sync orchestration). No CORE port change. No FE.
+
+**Non-goals**:
+- **No** connection-capability check inside the handler. Mappings are stored as `entityType='Offer'`, which is set by adapters that already implement `OfferManager`; if a stray non-OfferManager mapping somehow gets there, the downstream `marketplace.offerQuantity.update` runner's adapter resolution surfaces the failure cleanly. **Verified**: `MarketplaceOfferQuantityUpdateHandler.execute` → `InventorySyncService.updateOfferQuantity` calls `IntegrationsService.getCapabilityAdapter<OfferManagerPort>(connectionId, 'OfferManager')` (`libs/core/src/inventory/application/services/inventory-sync.service.ts:41-43`); a missing capability throws a clean domain error. Adding a defensive check at the handler would duplicate that policy.
+- **No** broader refactor of inventory-propagation orchestration into a core application service. The arch doc (`architecture-overview.md §7`) says "sync orchestration policies live in core application services, not in worker handlers"; the issue itself acknowledges this ("the handler is supposed to be a thin shell"). This PR removes the platform discrimination but leaves the orchestration policy in the worker handler — the deeper handler-vs-service refactor is a thread-E follow-up, not this PR.
+- **No** idempotency-key shape change.
+- **No** error-handling change.
+- **No** change to the no-inventory or no-mappings short-circuits.
+
+## 2. Research
+
+| Concern | Finding |
+|---|---|
+| Where the filter lives | Lines 108-117: `mappings.filter((m) => m.platformType === 'allegro')`. |
+| Why it was added | `// MVP` comment on line 109. |
+| Type currently used in filter | `ExternalIdMapping` from `@openlinker/core/identifier-mapping`. Becomes unused once filter goes. |
+| Existing test that asserts the filter | `'should filter to only Allegro mappings'` at spec line 138-177 — explicitly asserts an `amazon` mapping gets dropped. Needs to invert. |
+| Handler structure | Two pre-existing short-circuits (no inventory at line 79, no mappings at line 97) cover the legitimate "skip" cases. The filter's matching short-circuit at line 112-117 becomes dead code once the filter is removed. |
+
+## 3. Design
+
+- Replace `const allegroMappings = mappings.filter(...)` with using `mappings` directly.
+- Delete the "No Allegro offer mappings found" warn + early-return — already covered by the upstream "no offer mappings" branch.
+- Update the success log's count source from `allegroMappings.length` to `mappings.length` (variable rename only — the log copy itself is already platform-agnostic).
+- Drop the now-unused `ExternalIdMapping` import.
+
+No user-facing log copy changes needed — every existing log line is already platform-neutral; only the deleted `'No Allegro offer mappings found...'` warn at line 113 disappears with its dead-code branch.
+
+## 4. Steps
+
+| # | File | Change | AC |
+|---|---|---|---|
+| 1 | `apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts` | Drop filter + dead-code branch + unused `ExternalIdMapping` import. Variable rename `allegroMappings` → `mappings` in the iteration site and success log. | `pnpm type-check` clean; logic flow preserved. |
+| 2 | `apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts` | (a) Invert `'should filter to only Allegro mappings'` → `'should enqueue jobs for every offer mapping regardless of platform'`; assert both Allegro and non-Allegro mappings enqueue. (b) Extend the existing `'should handle multiple mappings'` to mix platforms across connections so the multi-mapping path explicitly exercises the capability-agnostic loop. | All specs green; multi-platform branch covered without leaving an outdated test name. |
+| 3 | Quality gate | `pnpm lint && pnpm type-check && pnpm test` | Zero errors / failures. |
+| 4 | Self-review + commit + PR | Conventional commit `fix(worker)` or `refactor(worker)`. | PR with `Closes #582`. |
+
+## 5. Validate
+
+- ✅ Hexagonal: change stays in `apps/worker/src/sync/handlers/`. No CORE / Integration / Interface change.
+- ✅ Naming: no new files, no naming-convention drift.
+- ✅ Logging: structured log strings updated to drop the platform-specific noun.
+- ✅ Tests: invert one spec, add one new case for multi-platform. Mocks the port `IIdentifierMappingService` (per `code-review-guide.md §Mocking Ports`).
+- ✅ Security: no new input surface, no secret handling.
+- ✅ Backwards compat: connections that today only have Allegro mappings see identical behavior. Connections with non-Allegro mappings (Amazon/Shopify/plugin) now also receive quantity-update jobs — this is the behavior the issue says they *should* have had all along. Allegro is currently the only `OfferManager` adapter (per `architecture-overview.md §6`), so non-Allegro `Offer` rows shouldn't exist on any production connection. **PR description should call this out** so reviewers can sanity-check their own dev/staging envs (a stray Shopify-prototype `Offer` row from an exploration branch would suddenly enqueue dead jobs that fail downstream when the Shopify adapter isn't registered).
+
+## 6. AC mapping
+
+| Issue AC | Met by |
+|---|---|
+| Drop the filter | Step 1 |
+| Per-platform behaviour stays in the adapter | Already true downstream; handler now hands jobs to the adapter unconditionally. |
+| Capability check handled by per-connection metadata or `OfferManagerPort` guard | Downstream `marketplace.offerQuantity.update` runner handles this; this PR doesn't add a redundant check. |


### PR DESCRIPTION
Closes #582.

## Summary

`InventoryPropagateToMarketplacesHandler` had an MVP-era filter dropping every non-Allegro offer mapping before enqueueing `marketplace.offerQuantity.update` jobs. With the adapter registry now pluggable (#570/#571), that filter became the single architectural reason a Shopify or future-plugin connection's mappings would be silently ignored even though `OfferManagerPort` is the documented capability.

This PR drops the filter and its dead-code "no Allegro mappings" early-return. Per the issue's recommendation: per-platform behaviour belongs in the downstream adapter, not in this thin orchestrator.

## Why no defensive capability check at enqueue time

The downstream `MarketplaceOfferQuantityUpdateHandler` → `InventorySyncService.updateOfferQuantity` (`libs/core/src/inventory/application/services/inventory-sync.service.ts:41-43`) already calls `IntegrationsService.getCapabilityAdapter<OfferManagerPort>(connectionId, 'OfferManager')`. A connection without `OfferManager` capability throws a clean domain error there. Adding a check at the handler would duplicate that policy.

## Out of scope

- **No** broader refactor of inventory-propagation orchestration into a core application service. `architecture-overview.md §7` says sync orchestration policies live in core application services, not in worker handlers — this PR removes the platform discrimination but leaves the orchestration policy in the worker handler. The deeper handler-vs-service refactor is a separate thread-E follow-up.

## Test plan

- [x] `pnpm lint` clean (0 errors; pre-existing warnings on `password-reset.service.spec.ts` only)
- [x] `pnpm type-check` clean
- [x] `pnpm test` — 1639 unit tests pass; worker suite still at 118 (one spec inverted, one extended, no net new specs)
- [x] Inverted `'should filter to only Allegro mappings'` → `'should enqueue jobs for every offer mapping regardless of platform (#582)'`; asserts both the Allegro and Amazon mapping enqueue
- [x] Extended `'should handle multiple mappings'` to mix Allegro + Shopify so the multi-mapping path explicitly exercises the capability-agnostic loop

## Backwards-compat note for reviewers

Allegro is currently the only `OfferManager` adapter (`architecture-overview.md §6`), so non-Allegro `entityType='Offer'` rows shouldn't exist on production. **If your dev/staging env has stray Shopify/Amazon-prototype `Offer` rows from an exploration branch, this PR will start enqueueing quantity-update jobs for them**, which then fail downstream when no matching `OfferManager` adapter is registered. Quick sanity-check query:

```sql
SELECT platform_type, COUNT(*) FROM identifier_mappings WHERE entity_type='Offer' GROUP BY platform_type;
```

Expect only `allegro` rows. If you see anything else, clean it up before merge or coordinate.

## Files

- `apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts` — drop filter + dead-code branch + unused `ExternalIdMapping` import; rename `allegroMappings` → `mappings` in iteration site and success log
- `apps/worker/src/sync/handlers/__tests__/inventory-propagate-to-marketplaces.handler.spec.ts` — inverted filter spec + extended multi-mapping spec
- `docs/plans/implementation-plan-582-inventory-propagate-drop-allegro-filter.md` — the plan that drove the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)