### PR TITLE
refactor(core): use identifier-mapping barrel in port files + lint guard

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -200,6 +200,32 @@ module.exports = {
         'no-restricted-imports': 'off',
       },
     },
+    {
+      // Port and capability files form the public contract surface plugin
+      // adapters implement. They must import cross-context types via the
+      // top-level package barrel — never deep sub-paths — so plugin authors
+      // can model their imports on the contract without copying brittle
+      // internal paths (#592).
+      files: ['libs/core/src/**/domain/ports/**/*.{port,capability}.ts'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: [
+                  '@openlinker/core/*/domain/**',
+                  '@openlinker/core/*/application/**',
+                  '@openlinker/core/*/infrastructure/**',
+                ],
+                message:
+                  "Port and capability files must import cross-context types via the top-level package barrel — e.g. `import { Connection } from '@openlinker/core/identifier-mapping'` — never via deep sub-paths. Ports are the contract surface plugin authors implement; the deep-path pattern leaks unstable internals.",
+              },
+            ],
+          },
+        ],
+      },
+    },
   ],
 };
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -201,12 +201,13 @@ module.exports = {
       },
     },
     {
-      // Port and capability files form the public contract surface plugin
-      // adapters implement. They must import cross-context types via the
-      // top-level package barrel — never deep sub-paths — so plugin authors
-      // can model their imports on the contract without copying brittle
-      // internal paths (#592).
-      files: ['libs/core/src/**/domain/ports/**/*.{port,capability}.ts'],
+      // Port, capability, and port-local type files form the public contract
+      // surface plugin adapters implement. They must import cross-context
+      // types via the top-level package barrel — never deep sub-paths — so
+      // plugin authors can model their imports on the contract without
+      // copying brittle internal paths. Importing from an integration
+      // package at all would invert the dependency direction (#592).
+      files: ['libs/core/src/**/domain/ports/**/*.{port,capability,types}.ts'],
       rules: {
         'no-restricted-imports': [
           'error',
@@ -217,9 +218,10 @@ module.exports = {
                   '@openlinker/core/*/domain/**',
                   '@openlinker/core/*/application/**',
                   '@openlinker/core/*/infrastructure/**',
+                  '@openlinker/integrations-*/**',
                 ],
                 message:
-                  "Port and capability files must import cross-context types via the top-level package barrel — e.g. `import { Connection } from '@openlinker/core/identifier-mapping'` — never via deep sub-paths. Ports are the contract surface plugin authors implement; the deep-path pattern leaks unstable internals.",
+                  "Port and capability files must import cross-context types via the top-level package barrel — e.g. `import { Connection } from '@openlinker/core/identifier-mapping'` — never via deep sub-paths. Ports are the contract surface plugin authors implement; deep-path imports leak unstable internals, and integration-package imports invert the dependency direction.",
               },
             ],
           },

--- a/docs/plans/implementation-plan-592-adapter-factory-port-barrel-import.md
+++ b/docs/plans/implementation-plan-592-adapter-factory-port-barrel-import.md
@@ -1,0 +1,121 @@
+# Implementation plan — #592 Barrel-only imports in CORE domain ports
+
+## 1. Understand
+
+**Goal**: Replace deep cross-context imports in CORE port files with the top-level barrel (`@openlinker/core/<context>`), and prevent regressions with an ESLint guard scoped to `libs/core/src/**/domain/ports/*.port.ts`.
+
+**Layer**: CORE domain ports + DX (lint config). No FE, no migration, no port-contract change.
+
+**Non-goals**:
+- **No** changes to `connection.entity.ts`. The issue text references a `Capability` deep import there ("connection.entity.ts:19"), but #576/#577 already widened `enabledCapabilities` to `string[]` and dropped the `Capability` import — the file now imports only from a local relative `./types/connection.types`. Verified via grep.
+- **No** widening of the lint rule beyond ports. Ports are the surface plugin authors implement; the rest of CORE can be tightened in a future thread-F pass.
+- **No** behavioural change in `AdapterFactoryPort` or `ConnectionTesterPort` themselves. Imports only.
+
+## 2. Research
+
+Grep across `libs/core/src/**/*.{port,capability}.ts` for `@openlinker/core/*/{domain,application,infrastructure}/` imports:
+
+```bash
+grep -rn "from '@openlinker/core/[^']*/domain/" libs/core/src \
+  --include='*.port.ts' --include='*.capability.ts'
+```
+
+Result — exactly two hits, no false negatives elsewhere:
+
+| File | Line | Current |
+|---|---|---|
+| `libs/core/src/integrations/domain/ports/adapter-factory.port.ts` | 9 | `import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';` |
+| `libs/core/src/integrations/domain/ports/connection-tester.port.ts` | 14 | `import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';` |
+
+The 12 sub-capability files in `libs/core/src/listings/domain/ports/capabilities/` all import via relative paths or the top-level barrel — already compliant. Folding them into the lint glob below is a guard for future regressions, not a fix.
+
+The issue cites only the first; the second has the identical shape and same root cause (a port file teaching the deep-path pattern). In scope by the issue's own framing ("the port file's *own* import shape teaches plugin authors that deep paths are acceptable").
+
+Barrel sanity check (`libs/core/src/identifier-mapping/index.ts`): `export * from './domain/entities/connection.entity';` — confirmed `Connection` is exported from the top-level barrel.
+
+ESLint config inventory (`.eslintrc.js`):
+- Base `no-restricted-imports` is `'warn'`, targeting deep relative paths (`../../domain/*` etc.).
+- Existing override at lines 191-202 turns the rule **off** for `**/infrastructure/**`, `**/persistence/**`, and `**/application/**` files (intentional, documented). That override does **not** match port files (they live in `domain/ports/`).
+- No existing override targets `**/domain/ports/**`. The new override is placed **last** in `overrides[]` so its more-specific glob is applied after the infrastructure-disable override — avoids future surprises if globs are broadened.
+
+## 3. Design
+
+### Import fixes
+
+```diff
+- import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';
++ import { Connection } from '@openlinker/core/identifier-mapping';
+```
+
+Applied to both port files. Pure import-path change; types resolve identically through the barrel.
+
+### Lint guard
+
+Add a new ESLint override (placed **last** in `overrides[]`) targeting both port files and sub-capability files in CORE — these together form the public contract surface plugin adapters implement (per `architecture-overview.md` § OfferManagerPort, the sub-capability split #337/#359):
+
+```js
+{
+  // Port and capability files form the public contract surface plugin
+  // adapters implement. They must import cross-context types via the
+  // top-level package barrel — never deep sub-paths — so plugin authors
+  // can model their imports on the contract without copying brittle
+  // internal paths (#592).
+  files: ['libs/core/src/**/domain/ports/**/*.{port,capability}.ts'],
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: [
+              '@openlinker/core/*/domain/**',
+              '@openlinker/core/*/application/**',
+              '@openlinker/core/*/infrastructure/**',
+            ],
+            message:
+              "Port and capability files must import cross-context types via the top-level package barrel — e.g. `import { Connection } from '@openlinker/core/identifier-mapping'` — never via deep sub-paths. Ports are the contract surface plugin authors implement; the deep-path pattern leaks unstable internals.",
+          },
+        ],
+      },
+    ],
+  },
+},
+```
+
+Severity `'error'`: this is a structural contract on the public-surface files, not a stylistic warning, and the codebase pattern for documented dependency rules is `'error'` (see the FE `shared/` override at lines 65-77).
+
+The pattern allows:
+- `@openlinker/core/<context>` (top-level barrel) — the desired path.
+- `@openlinker/core/<context>/services` (e.g. the `listings/services` documented sub-barrel) — only restricted sub-paths are `/domain/`, `/application/`, `/infrastructure/`.
+- Relative imports to sibling files (e.g. `./credentials-resolver.port`).
+- External packages (`@nestjs/common` etc.).
+
+## 4. Steps
+
+| # | File | Change | AC |
+|---|---|---|---|
+| 1 | `libs/core/src/integrations/domain/ports/adapter-factory.port.ts` | Swap line 9 deep import to barrel. | Import resolves; `pnpm type-check` clean. |
+| 2 | `libs/core/src/integrations/domain/ports/connection-tester.port.ts` | Swap line 14 deep import to barrel. | Same as step 1. |
+| 3 | `.eslintrc.js` | Append the port/capability-files override described above (last entry in `overrides[]`). | `pnpm lint` clean on current tree. |
+| 4 | Smoke-test the lint rule | Temporarily restore the deep import in `adapter-factory.port.ts`, run `pnpm lint`, confirm a `no-restricted-imports` error fires at that line, then revert. | Rule fires on bad input; passes on good input. |
+| 5 | Quality gate | `pnpm lint && pnpm type-check && pnpm test`. | Zero errors / failures. |
+| 6 | Commit + PR | Conventional `refactor(core)`. `Closes #592` in body. Note stale `Capability` reference in issue body. | PR opened against `main`. |
+
+## 5. Validate
+
+- ✅ Hexagonal: change is fully in `libs/core/src/integrations/domain/ports/` + DX config. No infrastructure touched.
+- ✅ Naming: no new files. No rename. The port classes' names unchanged.
+- ✅ Type safety: re-routing through the barrel preserves the exact `Connection` type — same symbol re-exported.
+- ✅ No runtime impact: TypeScript imports erased at compile time; the emitted `require()` shifts from `@openlinker/core/identifier-mapping/domain/entities/connection.entity` to `@openlinker/core/identifier-mapping`, both of which the `@openlinker/core` package's `exports` field already serves.
+- ✅ Backwards compat: any external consumer importing `Connection` via the deep path continues to work — the deep path remains exported. We only change the *port file's own* import; we don't remove the deep export.
+- ✅ Test changes: none required. The fix is pure code-path-equivalent, and lint is enforced by the quality gate.
+
+## 6. AC mapping (issue #592)
+
+| Issue AC | Met by |
+|---|---|
+| Replace line 9 in `adapter-factory.port.ts` with the barrel import | Step 1 |
+| Apply the same fix to `connection.entity.ts:19` (Capability deep import) | **Already resolved** by #576/#577 — verified in research. Will note in PR body. |
+| Add a barrel-only import lint rule for `libs/core/src/**/domain/ports/*.port.ts` | Step 3 |
+
+Bonus finding: `connection-tester.port.ts:14` has the same deep-import problem the issue describes for the factory port. Fixed in the same PR (step 2) — same root cause, same fix.

--- a/libs/core/src/integrations/domain/ports/adapter-factory.port.ts
+++ b/libs/core/src/integrations/domain/ports/adapter-factory.port.ts
@@ -6,8 +6,7 @@
  *
  * @module libs/core/src/integrations/domain/ports
  */
-import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';
-import { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { CredentialsResolverPort } from './credentials-resolver.port';
 
 /**

--- a/libs/core/src/integrations/domain/ports/connection-tester.port.ts
+++ b/libs/core/src/integrations/domain/ports/connection-tester.port.ts
@@ -11,7 +11,7 @@
  *
  * @module libs/core/src/integrations/domain/ports
  */
-import { Connection } from '@openlinker/core/identifier-mapping/domain/entities/connection.entity';
+import { Connection } from '@openlinker/core/identifier-mapping';
 import { CredentialsResolverPort } from './credentials-resolver.port';
 import { ConnectionTestResult } from '../types/connection-test.types';
 


### PR DESCRIPTION
## Summary

- Swap deep cross-context imports in CORE port files to the top-level `@openlinker/core/identifier-mapping` barrel — `adapter-factory.port.ts:9` and `connection-tester.port.ts:14` both reached into `identifier-mapping/domain/entities/connection.entity`, teaching plugin authors that deep paths are the contract surface. The barrel re-exports `Connection`, so type identity is preserved.
- Add an ESLint `no-restricted-imports` override scoped to `libs/core/src/**/domain/ports/**/*.{port,capability,types}.ts` that errors on `@openlinker/core/*/{domain,application,infrastructure}/**` *and* `@openlinker/integrations-*/**` imports. Ports are the contract surface plugin adapters implement; deep-path imports leak unstable internals and integration-package imports invert the dependency direction.

## Issue scope notes

The issue body also cites `connection.entity.ts:19` (a `Capability` deep import). That site is **already clean** — #576/#577 widened `enabledCapabilities` to `string[]` and dropped the `Capability` import while opening the capability union at the registry boundary. No action needed on that file.

Bonus finding: `connection-tester.port.ts:14` had the same deep-import shape as the cited `adapter-factory.port.ts:9`. Same root cause, same fix — included in this PR.

## Test plan

- [x] `pnpm lint` — clean (only pre-existing `explicit-function-return-type` warnings)
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 339 + 118 = 457 unit tests passing
- [x] Lint rule smoke-test — temporarily restored the deep import in `adapter-factory.port.ts`, confirmed the new rule errors at line 9 with the expected message, then reverted

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)