### PR TITLE
refactor(sync): route retry classification via core port + registry (#581)

### DIFF
--- a/apps/worker/src/sync/__tests__/sync-job.runner.spec.ts
+++ b/apps/worker/src/sync/__tests__/sync-job.runner.spec.ts
@@ -11,12 +11,25 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { SyncJobRunner } from '../sync-job.runner';
 import { SyncJobRepositoryPort } from '@openlinker/core/sync/domain/ports/sync-job-repository.port';
-import { SYNC_JOB_REPOSITORY_TOKEN } from '@openlinker/core/sync';
+import {
+  SYNC_JOB_REPOSITORY_TOKEN,
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  RetryClassifierRegistryService,
+} from '@openlinker/core/sync';
 import { SyncJobHandlerRegistry } from '../handlers/sync-job-handler.registry';
 import { SyncJobHandler } from '@openlinker/core/sync/domain/ports/sync-job-handler.port';
 import { SyncJob } from '@openlinker/core/sync/domain/entities/sync-job.entity';
 import { SyncJobExecutionError } from '@openlinker/core/sync/domain/exceptions/sync-job-execution.error';
-import { AllegroApiException, AllegroNetworkException } from '@openlinker/integrations-allegro';
+// The runner's *production* code is now platform-neutral (#581) — it
+// asks the retry-classifier registry instead of `instanceof`-ing Allegro
+// classes directly. The runner *spec* still uses the real Allegro
+// classifier wired into a real registry to verify end-to-end behaviour;
+// these imports don't follow the runner's deletions.
+import {
+  AllegroApiException,
+  AllegroNetworkException,
+  AllegroRetryClassifierAdapter,
+} from '@openlinker/integrations-allegro';
 import { OfferCreationInvariantException } from '@openlinker/core/listings';
 import { randomUUID } from 'crypto';
 
@@ -49,6 +62,15 @@ describe('SyncJobRunner', () => {
       getRegisteredJobTypes: jest.fn(),
     } as unknown as jest.Mocked<SyncJobHandlerRegistry>;
 
+    // Real registry + real Allegro classifier — the runner's behaviour
+    // under each Allegro exception type is what these tests verify, and
+    // we want the production registration path exercised end-to-end.
+    const retryClassifierRegistry = new RetryClassifierRegistryService();
+    retryClassifierRegistry.register(
+      'allegro.publicapi.v1',
+      new AllegroRetryClassifierAdapter(),
+    );
+
     moduleRef = await Test.createTestingModule({
       providers: [
         SyncJobRunner,
@@ -68,6 +90,10 @@ describe('SyncJobRunner', () => {
               return process.env[key] ?? defaultValue ?? 'true';
             }),
           },
+        },
+        {
+          provide: RETRY_CLASSIFIER_REGISTRY_TOKEN,
+          useValue: retryClassifierRegistry,
         },
       ],
     }).compile();

--- a/apps/worker/src/sync/__tests__/sync-job.runner.spec.ts
+++ b/apps/worker/src/sync/__tests__/sync-job.runner.spec.ts
@@ -64,7 +64,15 @@ describe('SyncJobRunner', () => {
 
     // Real registry + real Allegro classifier — the runner's behaviour
     // under each Allegro exception type is what these tests verify, and
-    // we want the production registration path exercised end-to-end.
+    // we want the production registration path exercised end-to-end
+    // rather than mocking the registry's `isNonRetryable` aggregation.
+    //
+    // FUTURE: when more platforms ship retry classifiers (Shopify,
+    // WooCommerce, etc.), each one needs to be registered here and
+    // covered by at least one behavioural assertion. Otherwise the
+    // runner-spec invariant "all platforms classify retry the same way
+    // they did before this PR" silently weakens. Track parallel work in
+    // Thread E follow-ups.
     const retryClassifierRegistry = new RetryClassifierRegistryService();
     retryClassifierRegistry.register(
       'allegro.publicapi.v1',

--- a/apps/worker/src/sync/sync-job.runner.ts
+++ b/apps/worker/src/sync/sync-job.runner.ts
@@ -14,20 +14,12 @@ import {
   SYNC_JOB_REPOSITORY_TOKEN,
   SyncJobEntity,
   SyncJobExecutionError,
+  RetryClassifierRegistryService,
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
 } from '@openlinker/core/sync';
 import { OfferCreationInvariantException } from '@openlinker/core/listings';
-import {
-  AllegroApiException,
-  AllegroAuthenticationException,
-} from '@openlinker/integrations-allegro';
 import { SyncJobHandlerRegistry } from './handlers/sync-job-handler.registry';
 import { Logger } from '@openlinker/shared/logging';
-
-// Deterministic Allegro 4xx — retrying never helps.
-// Excludes 408/425 (transient by spec), 429 (raised as AllegroRateLimitException
-// and handled with Retry-After inside the HTTP client), and 401 (handled below
-// via AllegroAuthenticationException + token refresh).
-const NON_RETRYABLE_ALLEGRO_STATUS_CODES = new Set([400, 403, 404, 405, 409, 415, 422]);
 
 @Injectable()
 export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
@@ -54,6 +46,8 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
     private readonly jobRepository: SyncJobRepositoryPort,
     private readonly handlerRegistry: SyncJobHandlerRegistry,
     private readonly configService: ConfigService,
+    @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly retryClassifierRegistry: RetryClassifierRegistryService,
   ) {}
 
   onModuleInit(): void {
@@ -326,25 +320,30 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Check if error is non-retryable (requires manual intervention or a code change).
+   * Check if error is non-retryable (requires manual intervention or a
+   * code change).
    *
-   * Non-retryable cases:
-   * - AllegroAuthenticationException (401) — needs token refresh, not retry.
-   * - AllegroApiException with a status in NON_RETRYABLE_ALLEGRO_STATUS_CODES —
-   *   deterministic 4xx (e.g., 415 unsupported content type, 422 validation) where
-   *   retrying burns worker capacity and masks the real issue.
+   * Two paths:
+   *   1. `OfferCreationInvariantException` — kept inline. Core exception
+   *      from `@openlinker/core/listings`, no platform coupling. It's a
+   *      code bug (orchestrator returned with a record still in 'pending'),
+   *      retries cannot fix it. See issue #400 (Plan B for #391).
+   *   2. Everything else — delegated to `RetryClassifierRegistryService`,
+   *      which OR's across registered platform classifiers (#581). The
+   *      Allegro classifier owns Allegro's exception hierarchy
+   *      (`AllegroAuthenticationException`, deterministic 4xx via
+   *      `AllegroApiException`); future Shopify / WooCommerce plugins
+   *      register their own.
    *
-   * Retryable cases intentionally left out:
-   * - MissingOrderItemMappingError — offer→variant mappings are created by a separate
-   *   sync cadence and may simply not exist yet when the order job first fires.
-   * - AllegroApiException with 5xx / 408 / 425 — transient; the HTTP client already
-   *   retries internally, and the runner gives the job more attempts.
-   * - AllegroNetworkException — network-level failure during token refresh / API
-   *   request (DNS / TLS / connection refused / `TypeError: fetch failed`). Always
-   *   transient: the runner MUST retry with backoff. Do NOT add this class here.
-   *   Pre-#499 these failures were swallowed by `refreshOnUnauthorized` and
-   *   re-classified as `AllegroAuthenticationException`, which killed jobs on
-   *   attempt 1/10 the moment `auth.allegro.pl` had a 1-second blip.
+   * The runner unwraps `SyncJobExecutionError.cause` once before either
+   * path, so per-platform classifiers see the original platform exception
+   * directly.
+   *
+   * Retryable cases intentionally left out (registry classifiers must
+   * also leave them out):
+   *   - `MissingOrderItemMappingError` — offer→variant mappings are
+   *     created by a separate sync cadence and may simply not exist yet
+   *     when the order job first fires.
    *
    * @param error - Error to check
    * @returns True if error is non-retryable
@@ -353,29 +352,11 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
     const cause =
       error instanceof SyncJobExecutionError && error.cause ? error.cause : error;
 
-    // OfferCreationInvariantException is a code bug (orchestrator returned with a
-    // record still in 'pending'). Retries cannot fix it — the next attempt would
-    // hit the same code path. Mark dead immediately so the operator can see it.
-    // See issue #400 (Plan B for #391).
     if (cause instanceof OfferCreationInvariantException) {
       return true;
     }
 
-    // AllegroAuthenticationException extends Error directly (not AllegroApiException),
-    // so the two branches are disjoint: a 401 never reaches the status-code set below.
-    if (cause instanceof AllegroAuthenticationException) {
-      return true;
-    }
-
-    if (
-      cause instanceof AllegroApiException &&
-      cause.statusCode !== undefined &&
-      NON_RETRYABLE_ALLEGRO_STATUS_CODES.has(cause.statusCode)
-    ) {
-      return true;
-    }
-
-    return false;
+    return this.retryClassifierRegistry.isNonRetryable(cause);
   }
 
   /**

--- a/docs/plans/implementation-plan-581-decouple-retry-classification-from-allegro.md
+++ b/docs/plans/implementation-plan-581-decouple-retry-classification-from-allegro.md
@@ -1,0 +1,163 @@
+# Implementation Plan — Decouple Retry Classification from Allegro (#581)
+
+**Parent**: Modularity Thread E (#551). Sibling already shipped: #582 (PR #620, dropped the `platformType === 'allegro'` filter in inventory propagation), #583 (PR #619, webhook-provisioning registry).
+**Layer**: CORE (sync) + adapter (Allegro) + worker runner.
+**Branch**: `581-decouple-retry-classification-from-allegro`.
+
+---
+
+## 1. Goal
+
+`SyncJobRunner` imports `AllegroApiException` / `AllegroAuthenticationException` and a `NON_RETRYABLE_ALLEGRO_STATUS_CODES` set to decide which jobs are non-retryable (`apps/worker/src/sync/sync-job.runner.ts:19-30, 352-378`). A Shopify plugin can't extend the runner without a core PR; the worker has an architectural inversion against `@openlinker/integrations-allegro`.
+
+Replace the hardcoded sniffing with a `RetryClassifierPort` + registry that integrations self-register against in `onModuleInit`. The runner asks the registry "is this error non-retryable?" — adapters answer for their own exception hierarchies. Identical behaviour for Allegro after the change.
+
+## 2. Non-goals
+
+- **Not** rewriting the retry policy itself (exponential backoff, max attempts, etc.). The runner keeps everything except the platform-specific exception sniffing.
+- **Not** introducing per-platform `Retry-After` semantics — that's a follow-up; this plan only solves "is this error non-retryable?", not "when to retry next?".
+- **Not** broadening the registry to handle anything beyond "should this error kill the job?". A future port may grow `getRetryDelay(error)` etc.; out of scope here.
+- **Not** touching `OfferCreationInvariantException` handling — it's a CORE exception (`@openlinker/core/listings`), which is fine to keep referenced directly from the runner.
+- **Not** moving the runner itself into core. It stays in `apps/worker`.
+- **Not** anything in `inventory-propagate-to-marketplaces.handler.ts` — #582 already shipped (PR #620).
+
+## 3. Design
+
+### 3.1 — #581 — `RetryClassifierPort` + registry
+
+**Pattern**: mirror `ConnectionTesterRegistryService` and `WebhookProvisioningRegistryService` (sibling registries, both shipped via #570/#571 and #583). Map keyed by `adapterKey`, registered in `onModuleInit`, queried by the runner.
+
+**Port** (`libs/core/src/sync/domain/ports/retry-classifier.port.ts`):
+```ts
+export interface RetryClassifierPort {
+  /**
+   * Returns true if the cause is a deterministic, non-retryable failure
+   * (auth, deterministic 4xx, etc.) for this platform's exception
+   * hierarchy. The runner OR's the answers across registered classifiers.
+   * Unknown errors return false — i.e., default-retryable.
+   */
+  isNonRetryable(cause: unknown): boolean;
+}
+```
+
+**Registry** (`libs/core/src/sync/infrastructure/adapters/retry-classifier-registry.service.ts`):
+```ts
+@Injectable()
+export class RetryClassifierRegistryService {
+  private readonly classifiers: Map<string, RetryClassifierPort> = new Map();
+
+  register(adapterKey: string, classifier: RetryClassifierPort): void;
+  get(adapterKey: string): RetryClassifierPort | undefined;
+  has(adapterKey: string): boolean;
+
+  /** Iterate registered classifiers; return true if any reports non-retryable. */
+  isNonRetryable(cause: unknown): boolean;
+}
+```
+
+The `isNonRetryable(cause)` aggregation method is the only behavioural difference from the connection-tester / webhook-provisioning registries (which look up by adapterKey because dispatch is connection-bound). Retry classification doesn't have an adapterKey at hand — the runner just has the raw error — so the registry walks all classifiers. Each classifier's `isNonRetryable` is an O(1) `instanceof` check, so iterating ~handful of platforms is free.
+
+**Note on the registry shape**: like its siblings (`ConnectionTesterRegistryService`, `WebhookProvisioningRegistryService`), `RetryClassifierRegistryService` does **not** have an `IRetryClassifierRegistryService` interface. This bends `.claude/rules/backend.md` "all services must implement an interface", but registries are containers (not application services in the application-layer sense), and the sibling pattern is well-established. Consistency wins.
+
+**Token**: `RETRY_CLASSIFIER_REGISTRY_TOKEN = Symbol('RetryClassifierRegistryService')` — exported from `libs/core/src/sync/sync.tokens.ts` and the sync barrel.
+
+**Wiring**: provided + bound + exported by `SyncModule` alongside `SyncJobRepositoryPort`, etc.
+
+**Allegro adapter** (`libs/integrations/allegro/src/infrastructure/adapters/allegro-retry-classifier.adapter.ts`):
+```ts
+export class AllegroRetryClassifierAdapter implements RetryClassifierPort {
+  private static readonly NON_RETRYABLE_STATUS_CODES = new Set([400, 403, 404, 405, 409, 415, 422]);
+
+  isNonRetryable(cause: unknown): boolean {
+    if (cause instanceof AllegroAuthenticationException) return true;
+    if (
+      cause instanceof AllegroApiException &&
+      cause.statusCode !== undefined &&
+      AllegroRetryClassifierAdapter.NON_RETRYABLE_STATUS_CODES.has(cause.statusCode)
+    ) {
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+**Self-registration** in `AllegroIntegrationModule.onModuleInit`, alongside the existing metadata + factory + connection-tester registrations:
+```ts
+this.retryClassifierRegistry.register(
+  'allegro.publicapi.v1',
+  new AllegroRetryClassifierAdapter(),
+);
+```
+
+**Runner change** (`apps/worker/src/sync/sync-job.runner.ts`):
+- Drop the imports of `AllegroApiException`, `AllegroAuthenticationException`, and `NON_RETRYABLE_ALLEGRO_STATUS_CODES`.
+- Inject `RetryClassifierRegistryService` via `@Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)`.
+- **The runner owns the `SyncJobExecutionError.cause` unwrap**: the existing `const cause = error instanceof SyncJobExecutionError && error.cause ? error.cause : error;` line stays in `isNonRetryableError`. The unwrapped `cause` is what gets passed to `registry.isNonRetryable(cause)`. Each platform classifier sees the unwrapped value — no per-classifier unwrap dance.
+- `isNonRetryableError(error)` keeps its `OfferCreationInvariantException` short-circuit (core, no platform coupling), then delegates the rest to `this.retryClassifierRegistry.isNonRetryable(cause)`.
+- The lengthy comment block explaining each Allegro branch moves to the adapter.
+
+After this change, `apps/worker` imports nothing from `@openlinker/integrations-allegro` for retry classification — the only remaining static import is in `sync-worker.module.ts` (`AllegroIntegrationModule`), which is part of the Thread C work tracked separately by #572 and out of scope here.
+
+### 3.2 — Behaviour preservation matrix
+
+| Scenario | Before | After |
+|---|---|---|
+| Allegro auth failure (401) | dead immediately | dead immediately (via `AllegroRetryClassifierAdapter`) |
+| Allegro deterministic 4xx (422) | dead immediately | dead immediately (via classifier) |
+| Allegro 5xx / 408 / 425 | retry with backoff | retry (no classifier returns true) |
+| Allegro `AllegroNetworkException` | retry | retry (not classified non-retryable) |
+| `OfferCreationInvariantException` | dead immediately | dead immediately (kept inline in runner — core exception) |
+| Unrelated error (`new Error('boom')`) | retry | retry |
+
+## 4. Step-by-step plan
+
+> **Cross-cutting**: every new file in this PR ships with a JSDoc file header following `engineering-standards.md` §"File Headers" (purpose + context + `@module` + `@see` to siblings). Spec files included.
+
+### CORE — port, registry, wiring
+
+1. **Add port** `libs/core/src/sync/domain/ports/retry-classifier.port.ts` with `RetryClassifierPort.isNonRetryable(cause)`.
+2. **Add registry** `libs/core/src/sync/infrastructure/adapters/retry-classifier-registry.service.ts` with register / get / has + aggregating `isNonRetryable`.
+3. **Add token** `RETRY_CLASSIFIER_REGISTRY_TOKEN` to `libs/core/src/sync/sync.tokens.ts`.
+4. **Wire** in `libs/core/src/sync/sync.module.ts`: register `RetryClassifierRegistryService` as a provider, bind `RETRY_CLASSIFIER_REGISTRY_TOKEN` via `useExisting`, and **export both the class and the token** in `SyncModule.exports`. The token export is what lets `AllegroIntegrationModule.onModuleInit` `@Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)` — without it the integration module can't resolve the dependency. Mirror of how `IntegrationsModule` exports `CONNECTION_TESTER_REGISTRY_TOKEN` alongside the class.
+5. **Export** from `libs/core/src/sync/index.ts` — port, registry, token.
+6. **Add unit spec** for the registry in `libs/core/src/sync/infrastructure/adapters/__tests__/retry-classifier-registry.service.spec.ts` — register / get / has, plus the `isNonRetryable` aggregation across multiple classifiers (none match → false; one matches → true).
+
+### Allegro adapter
+
+7. **Add `AllegroRetryClassifierAdapter`** at `libs/integrations/allegro/src/infrastructure/adapters/allegro-retry-classifier.adapter.ts`.
+8. **Add unit spec** at `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-retry-classifier.adapter.spec.ts` — branches: auth exception, API non-retryable status (415, 422), API retryable status (503, 408), unrelated error, network exception (must NOT be classified — preserves the #499 cure).
+9. **Register** in `AllegroIntegrationModule.onModuleInit`, mirroring the existing connection-tester registration. Inject `RETRY_CLASSIFIER_REGISTRY_TOKEN`. Update the `Registering Allegro adapter (metadata + factory + tester)` log line to mention the retry classifier. **Note the new cross-package import**: the Allegro module currently imports from `@openlinker/core/integrations` only; this PR adds a second import from `@openlinker/core/sync` for the registry + token. Architecturally fine (integrations may depend on core), but flag in the imports list during review.
+10. **Export** the adapter from `libs/integrations/allegro/src/index.ts` alongside the connection tester.
+
+### Worker — runner
+
+11. **Update `apps/worker/src/sync/sync-job.runner.ts`**:
+    - Drop imports of `AllegroApiException`, `AllegroAuthenticationException`, `NON_RETRYABLE_ALLEGRO_STATUS_CODES` constant.
+    - Inject `RetryClassifierRegistryService` via `RETRY_CLASSIFIER_REGISTRY_TOKEN` (alongside the existing token injections).
+    - In `isNonRetryableError`: keep `OfferCreationInvariantException` check, delegate the rest to `this.retryClassifierRegistry.isNonRetryable(cause)`.
+    - Update the JSDoc on `isNonRetryableError` to point at the registry instead of listing Allegro branches.
+12. **Update `apps/worker/src/sync/__tests__/sync-job.runner.spec.ts`**:
+    - Provide a real `RetryClassifierRegistryService` with the real `AllegroRetryClassifierAdapter` registered, so the existing Allegro behavioural tests pass unchanged.
+    - Existing tests stay green: auth exception, API 415, API 503, network exception, `OfferCreationInvariantException`.
+    - **The spec keeps its existing `@openlinker/integrations-allegro` import** (`AllegroApiException`, `AllegroNetworkException`). The runner *production* code becomes platform-neutral; the runner *spec* still wires Allegro into a real registry to verify end-to-end retry classification. Don't follow the runner's import deletion into the spec — they're decoupled by design.
+
+### Quality gate + ship
+
+13. Run `pnpm lint && pnpm type-check && pnpm test`. Fix anything that surfaces.
+14. Commit with `refactor(sync): route retry classification via core port + registry (#581)`.
+15. Self-review (architecture, hexagonal compliance, naming, tests). Push, open PR, `Closes #581`.
+
+## 5. Architecture compliance
+
+- **Boundary**: `RetryClassifierPort` lives in `libs/core/src/sync/domain/ports/`; registry in `libs/core/src/sync/infrastructure/adapters/`. Allegro classifier in `libs/integrations/allegro/src/infrastructure/adapters/`. No platform names in core after this lands.
+- **Dependency direction**: runner (apps/worker) → core port → core registry. Allegro adapter implements the core port. Mirror of the #570/#571/#583 pattern.
+- **Naming**: `*.port.ts` / `{Capability}Port`; `*.adapter.ts` / `{Platform}{Capability}Adapter`. Symbol DI token. Match existing standards.
+- **Domain purity**: the port is a pure interface (one method, no framework deps). The registry is `@Injectable` and lives in infrastructure.
+- **Testing**: every new file gets a `*.spec.ts` mocking the port. The runner spec uses a real registry + real Allegro classifier (the Allegro classifier is itself a deterministic adapter with no I/O).
+
+## 6. Risks & open questions
+
+- **Risk: registry-aggregation order matters?** No — each classifier owns disjoint exception hierarchies (`AllegroApiException` vs hypothetical `ShopifyApiException`). Aggregation is OR; one match wins. No ordering dependency.
+- **Open question: should `apps/api` also consume the registry?** The runner is the only consumer today. `apps/api` doesn't classify retry — out of scope.
+- **Open question: where does the `OfferCreationInvariantException` short-circuit ultimately belong?** It could become a `CoreRetryClassifier` registered by `SyncModule` itself, removing the inline import. That's cosmetic — the runner is in `apps/worker` and importing from `@openlinker/core/listings` is allowed (apps → core). Leave it inline for this PR. Track as cleanup if it ever feels worth it.

--- a/libs/core/src/sync/domain/ports/retry-classifier.port.ts
+++ b/libs/core/src/sync/domain/ports/retry-classifier.port.ts
@@ -1,0 +1,35 @@
+/**
+ * Retry Classifier Port
+ *
+ * Per-platform contract for classifying whether an error caught by the
+ * `SyncJobRunner` is non-retryable — i.e., a deterministic failure where
+ * retrying burns worker capacity and masks the real issue
+ * (auth failure, deterministic 4xx, etc.). Implemented by integration
+ * adapters (e.g., `AllegroRetryClassifierAdapter`) that own their own
+ * exception hierarchies.
+ *
+ * Resolved by the runner via `RetryClassifierRegistryService`, which
+ * aggregates answers across registered classifiers — the runner has the
+ * raw error in hand, not an `adapterKey`, so dispatch is OR-across-all
+ * rather than indexed by key (#581).
+ *
+ * Implementations should return `false` for unknown errors — i.e., the
+ * default is "retryable". A classifier never sees errors from other
+ * platforms because each owns disjoint exception hierarchies, so the
+ * unknown-error branch is purely a safety net.
+ *
+ * @module libs/core/src/sync/domain/ports
+ * @see {@link RetryClassifierRegistryService} for the registry that
+ *   aggregates implementations.
+ */
+export interface RetryClassifierPort {
+  /**
+   * Returns `true` if the cause is a deterministic, non-retryable failure
+   * for this platform's exception hierarchy. Returns `false` otherwise
+   * (transient errors, unknown errors).
+   *
+   * The runner unwraps `SyncJobExecutionError.cause` before calling, so
+   * implementations see the original platform exception directly.
+   */
+  isNonRetryable(cause: unknown): boolean;
+}

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -12,6 +12,7 @@ export { JobEnqueuePort } from './domain/ports/job-enqueue.port';
 export { SyncJobRepositoryPort } from './domain/ports/sync-job-repository.port';
 export { SyncJobHandler } from './domain/ports/sync-job-handler.port';
 export { ConnectionCursorRepositoryPort } from './domain/ports/connection-cursor-repository.port';
+export { RetryClassifierPort } from './domain/ports/retry-classifier.port';
 export { SyncJobQueuePort, EnqueueJobRequest, EnqueueJobOptions } from './application/ports/sync-job-queue.port';
 export { SyncLockPort, SyncLockToken } from './application/ports/sync-lock.port';
 
@@ -73,6 +74,7 @@ export { SyncJobNotFoundError } from './domain/exceptions/sync-job-not-found.err
 
 // Infrastructure exports (for testing/mocking)
 export { RedisStreamsJobEnqueueService } from './infrastructure/adapters/redis-streams-job-enqueue.service';
+export { RetryClassifierRegistryService } from './infrastructure/adapters/retry-classifier-registry.service';
 
 // Application Services (interfaces)
 export type { ISyncJobRetryService } from './application/services/sync-job-retry.service.interface';
@@ -88,6 +90,7 @@ export {
   SYNC_LOCK_TOKEN,
   SYNC_JOB_RETRY_SERVICE_TOKEN,
   SYNC_JOB_BULK_RETRY_SERVICE_TOKEN,
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
 } from './sync.tokens';
 
 // ORM Entities (exported for testing and TypeORM CLI usage)

--- a/libs/core/src/sync/infrastructure/adapters/__tests__/retry-classifier-registry.service.spec.ts
+++ b/libs/core/src/sync/infrastructure/adapters/__tests__/retry-classifier-registry.service.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Retry Classifier Registry Service — Unit Tests
+ *
+ * Pins the registry's contract: register / get / has + the OR-aggregating
+ * `isNonRetryable`. Sibling registries (`ConnectionTesterRegistryService`,
+ * `WebhookProvisioningRegistryService`) are similarly pinned. Regressions
+ * here would silently re-classify retry behaviour for every adapter, so
+ * the spec exists even though the surface is small (#581).
+ *
+ * @module libs/core/src/sync/infrastructure/adapters/__tests__
+ */
+import { RetryClassifierRegistryService } from '../retry-classifier-registry.service';
+import { RetryClassifierPort } from '../../../domain/ports/retry-classifier.port';
+
+describe('RetryClassifierRegistryService', () => {
+  let registry: RetryClassifierRegistryService;
+
+  const makeClassifier = (
+    matches: (cause: unknown) => boolean,
+  ): RetryClassifierPort => ({
+    isNonRetryable: jest.fn(matches),
+  });
+
+  beforeEach(() => {
+    registry = new RetryClassifierRegistryService();
+  });
+
+  describe('register / get / has', () => {
+    it('returns the registered classifier by adapterKey', () => {
+      const classifier = makeClassifier(() => false);
+      registry.register('foo.v1', classifier);
+
+      expect(registry.get('foo.v1')).toBe(classifier);
+      expect(registry.has('foo.v1')).toBe(true);
+    });
+
+    it('returns undefined / false for unknown adapterKey', () => {
+      expect(registry.get('not-registered')).toBeUndefined();
+      expect(registry.has('not-registered')).toBe(false);
+    });
+
+    it('overwrites silently when the same adapterKey is registered twice', () => {
+      // Mirrors ConnectionTesterRegistryService — integration modules
+      // register exactly once at boot, so a collision is a programming
+      // bug, not a runtime concern. Last writer wins.
+      const first = makeClassifier(() => false);
+      const second = makeClassifier(() => true);
+      registry.register('foo.v1', first);
+      registry.register('foo.v1', second);
+
+      expect(registry.get('foo.v1')).toBe(second);
+    });
+  });
+
+  describe('isNonRetryable aggregation', () => {
+    class FooError extends Error {}
+    class BarError extends Error {}
+
+    it('returns false when no classifiers are registered', () => {
+      expect(registry.isNonRetryable(new Error('boom'))).toBe(false);
+    });
+
+    it('returns false when no classifier matches', () => {
+      registry.register('foo.v1', makeClassifier((cause) => cause instanceof FooError));
+      registry.register('bar.v1', makeClassifier((cause) => cause instanceof BarError));
+
+      expect(registry.isNonRetryable(new Error('unknown'))).toBe(false);
+    });
+
+    it('returns true when any classifier matches', () => {
+      registry.register('foo.v1', makeClassifier((cause) => cause instanceof FooError));
+      registry.register('bar.v1', makeClassifier((cause) => cause instanceof BarError));
+
+      expect(registry.isNonRetryable(new FooError())).toBe(true);
+      expect(registry.isNonRetryable(new BarError())).toBe(true);
+    });
+
+    it('passes the raw cause through to each classifier', () => {
+      const fooMatcher = jest.fn((cause: unknown) => cause instanceof FooError);
+      registry.register('foo.v1', { isNonRetryable: fooMatcher });
+
+      const cause = new FooError('specific message');
+      registry.isNonRetryable(cause);
+
+      expect(fooMatcher).toHaveBeenCalledWith(cause);
+    });
+  });
+});

--- a/libs/core/src/sync/infrastructure/adapters/retry-classifier-registry.service.ts
+++ b/libs/core/src/sync/infrastructure/adapters/retry-classifier-registry.service.ts
@@ -1,0 +1,57 @@
+/**
+ * Retry Classifier Registry Service
+ *
+ * Holds `RetryClassifierPort` implementations keyed by `adapterKey`.
+ * Integration modules register their classifiers at bootstrap alongside
+ * their adapter factory + connection tester, mirroring the shape of
+ * `ConnectionTesterRegistryService` and `WebhookProvisioningRegistryService`.
+ *
+ * Consumed by `SyncJobRunner` to answer "is this error non-retryable?"
+ * without importing platform-specific exception classes. The runner has
+ * the raw error in hand (not an `adapterKey`), so dispatch differs from
+ * the sibling registries: `isNonRetryable(cause)` walks every registered
+ * classifier and OR's the answers — each classifier owns disjoint
+ * exception hierarchies, so at most one matches in practice. Iteration
+ * is O(handful) and each classifier's check is O(1) `instanceof`.
+ *
+ * Silent overwrite on duplicate `adapterKey` mirrors the sister registries;
+ * integration modules register exactly once at boot so collisions are
+ * near-impossible by construction (#581).
+ *
+ * @module libs/core/src/sync/infrastructure/adapters
+ * @see {@link RetryClassifierPort} for the port interface.
+ */
+import { Injectable } from '@nestjs/common';
+import { RetryClassifierPort } from '../../domain/ports/retry-classifier.port';
+
+@Injectable()
+export class RetryClassifierRegistryService {
+  private readonly classifiers: Map<string, RetryClassifierPort> = new Map();
+
+  register(adapterKey: string, classifier: RetryClassifierPort): void {
+    this.classifiers.set(adapterKey, classifier);
+  }
+
+  get(adapterKey: string): RetryClassifierPort | undefined {
+    return this.classifiers.get(adapterKey);
+  }
+
+  has(adapterKey: string): boolean {
+    return this.classifiers.has(adapterKey);
+  }
+
+  /**
+   * Aggregate non-retryable classification across registered classifiers.
+   * Returns `true` as soon as any classifier reports the cause as
+   * non-retryable; `false` if no classifier matches (the default —
+   * unknown errors are retryable).
+   */
+  isNonRetryable(cause: unknown): boolean {
+    for (const classifier of this.classifiers.values()) {
+      if (classifier.isNonRetryable(cause)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/libs/core/src/sync/sync.module.ts
+++ b/libs/core/src/sync/sync.module.ts
@@ -11,6 +11,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventsModule } from '@openlinker/core/events';
 import { RedisStreamsJobEnqueueService } from './infrastructure/adapters/redis-streams-job-enqueue.service';
+import { RetryClassifierRegistryService } from './infrastructure/adapters/retry-classifier-registry.service';
 import { SyncJobOrmEntity } from './infrastructure/persistence/entities/sync-job.orm-entity';
 import { SyncJobRepository } from './infrastructure/persistence/repositories/sync-job.repository';
 import { ConnectionCursorOrmEntity } from './infrastructure/persistence/entities/connection-cursor.orm-entity';
@@ -27,6 +28,7 @@ import {
   SYNC_LOCK_TOKEN,
   SYNC_JOB_RETRY_SERVICE_TOKEN,
   SYNC_JOB_BULK_RETRY_SERVICE_TOKEN,
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
 } from './sync.tokens';
 
 // Re-export tokens for convenience
@@ -38,6 +40,7 @@ export {
   SYNC_LOCK_TOKEN,
   SYNC_JOB_RETRY_SERVICE_TOKEN,
   SYNC_JOB_BULK_RETRY_SERVICE_TOKEN,
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
 } from './sync.tokens';
 
 @Module({
@@ -92,6 +95,15 @@ export {
       provide: SYNC_LOCK_TOKEN,
       useExisting: RedisSyncLockService,
     },
+
+    // Retry classifier registry — integration modules self-register their
+    // platform-specific classifiers in `onModuleInit`; the runner queries
+    // the registry instead of importing exception classes by name (#581).
+    RetryClassifierRegistryService,
+    {
+      provide: RETRY_CLASSIFIER_REGISTRY_TOKEN,
+      useExisting: RetryClassifierRegistryService,
+    },
   ],
   exports: [
     JOB_ENQUEUE_TOKEN,
@@ -108,6 +120,8 @@ export {
     SyncJobRetryService,
     SYNC_JOB_BULK_RETRY_SERVICE_TOKEN,
     SyncJobBulkRetryService,
+    RETRY_CLASSIFIER_REGISTRY_TOKEN,
+    RetryClassifierRegistryService,
   ],
 })
 export class SyncModule {}

--- a/libs/core/src/sync/sync.tokens.ts
+++ b/libs/core/src/sync/sync.tokens.ts
@@ -16,6 +16,7 @@ export const SYNC_JOB_QUEUE_TOKEN = Symbol('SyncJobQueuePort');
 export const SYNC_LOCK_TOKEN = Symbol('SyncLockPort');
 export const SYNC_JOB_RETRY_SERVICE_TOKEN = Symbol('SyncJobRetryServicePort');
 export const SYNC_JOB_BULK_RETRY_SERVICE_TOKEN = Symbol('SyncJobBulkRetryServicePort');
+export const RETRY_CLASSIFIER_REGISTRY_TOKEN = Symbol('RetryClassifierRegistryService');
 
 
 

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -23,8 +23,17 @@ import {
   INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
   IntegrationCredentialRepositoryPort,
 } from '@openlinker/core/integrations';
+// New cross-package import (#581): the retry-classifier registry lives in
+// `@openlinker/core/sync` (the runner's package). Architecturally fine —
+// integrations may depend on core — and mirrors how this module already
+// depends on `@openlinker/core/integrations`.
+import {
+  RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  RetryClassifierRegistryService,
+} from '@openlinker/core/sync';
 import { AllegroConnectionTesterAdapter } from './infrastructure/adapters/allegro-connection-tester.adapter';
 import { AllegroEmailNormalizerAdapter } from './infrastructure/adapters/allegro-email-normalizer.adapter';
+import { AllegroRetryClassifierAdapter } from './infrastructure/adapters/allegro-retry-classifier.adapter';
 import { RedisClientType } from 'redis';
 import { CustomersModule, CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN, CustomerIdentityResolverPort } from '@openlinker/core/customers';
 import { AllegroAdapterFactoryWrapper } from './infrastructure/adapters/allegro-adapter-factory-wrapper';
@@ -85,6 +94,8 @@ export class AllegroIntegrationModule implements OnModuleInit {
     private readonly connectionTesterRegistry: ConnectionTesterRegistryService,
     @Inject(EMAIL_NORMALIZER_REGISTRY_TOKEN)
     private readonly emailNormalizerRegistry: EmailNormalizerRegistryService,
+    @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly retryClassifierRegistry: RetryClassifierRegistryService,
     @Inject(CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN)
     private readonly customerIdentityResolver: CustomerIdentityResolverPort,
     @Optional()
@@ -107,7 +118,9 @@ export class AllegroIntegrationModule implements OnModuleInit {
   ) {}
 
   onModuleInit(): void {
-    this.logger.log('Registering Allegro adapter (metadata + factory + tester)...');
+    this.logger.log(
+      'Registering Allegro adapter (metadata + factory + tester + email normalizer + retry classifier)...',
+    );
     // Register metadata first — what this adapter is and what it can do.
     // Mirrors the inline literal previously hardcoded in core's
     // AdapterRegistryService (#570). isDefault: true means
@@ -143,6 +156,15 @@ export class AllegroIntegrationModule implements OnModuleInit {
     this.emailNormalizerRegistry.register(
       'allegro.publicapi.v1',
       new AllegroEmailNormalizerAdapter(),
+    );
+    // Retry classifier — replaces the runner's hardcoded `instanceof
+    // AllegroApiException` / `AllegroAuthenticationException` sniffing
+    // (#581). The classifier owns Allegro's exception hierarchy; the
+    // runner asks the registry "is this non-retryable?" without importing
+    // platform-specific classes.
+    this.retryClassifierRegistry.register(
+      'allegro.publicapi.v1',
+      new AllegroRetryClassifierAdapter(),
     );
     this.logger.log('Allegro adapter registered successfully');
   }

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -26,8 +26,13 @@ import {
 // New cross-package import (#581): the retry-classifier registry lives in
 // `@openlinker/core/sync` (the runner's package). Architecturally fine —
 // integrations may depend on core — and mirrors how this module already
-// depends on `@openlinker/core/integrations`.
+// depends on `@openlinker/core/integrations`. The `SyncModule` import
+// below is what brings `RETRY_CLASSIFIER_REGISTRY_TOKEN` into DI scope;
+// without it Nest can't resolve the constructor argument when the host
+// (apps/api or apps/worker) boots, because tokens flow only through
+// `imports`/`exports`, never via direct package imports.
 import {
+  SyncModule,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
   RetryClassifierRegistryService,
 } from '@openlinker/core/sync';
@@ -48,6 +53,7 @@ import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared';
 @Module({
   imports: [
     IntegrationsModule,
+    SyncModule, // Brings RETRY_CLASSIFIER_REGISTRY_TOKEN into DI scope (#581)
     CustomersModule, // Import CustomersModule to access CustomerIdentityResolverPort
     TypeOrmModule.forFeature([AllegroQuantityCommandOrmEntity]),
   ],

--- a/libs/integrations/allegro/src/index.ts
+++ b/libs/integrations/allegro/src/index.ts
@@ -63,6 +63,12 @@ export {
   ALLEGRO_SAFETY_ATTACHMENT_MIME_PATTERN,
 } from './domain/types/allegro-safety-attachments.types';
 
+// Adapters (exposed for test-wiring scenarios — production wiring goes
+// through `AllegroIntegrationModule.onModuleInit` registration, not this
+// barrel. The runner spec imports the retry classifier here to register
+// it against a real registry without going through the full Nest module.)
+export { AllegroRetryClassifierAdapter } from './infrastructure/adapters/allegro-retry-classifier.adapter';
+
 // Module
 export { AllegroIntegrationModule } from './allegro-integration.module';
 

--- a/libs/integrations/allegro/src/index.ts
+++ b/libs/integrations/allegro/src/index.ts
@@ -63,10 +63,22 @@ export {
   ALLEGRO_SAFETY_ATTACHMENT_MIME_PATTERN,
 } from './domain/types/allegro-safety-attachments.types';
 
-// Adapters (exposed for test-wiring scenarios — production wiring goes
-// through `AllegroIntegrationModule.onModuleInit` registration, not this
-// barrel. The runner spec imports the retry classifier here to register
-// it against a real registry without going through the full Nest module.)
+// Adapters exposed for end-to-end behavioural test wiring.
+//
+// Production wiring goes through `AllegroIntegrationModule.onModuleInit`
+// registration, not this barrel. We export the retry classifier because
+// the worker's runner spec (`apps/worker/src/sync/__tests__/sync-job.runner.spec.ts`)
+// constructs a real `RetryClassifierRegistryService` and registers the
+// real adapter against it to verify behaviour preservation across the
+// #581 refactor. Going via the barrel keeps the test's import on the
+// alias path (per `engineering-standards.md` §"Import Aliases") rather
+// than reaching into the package's internal structure.
+//
+// `AllegroConnectionTesterAdapter` is intentionally NOT exported because
+// no external spec needs it — its host module is the only consumer.
+// If a future runner-spec-shaped behavioural test ever needs it, this
+// asymmetry should be reconsidered (export both, or move both behind
+// deep paths).
 export { AllegroRetryClassifierAdapter } from './infrastructure/adapters/allegro-retry-classifier.adapter';
 
 // Module

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-retry-classifier.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-retry-classifier.adapter.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Allegro Retry Classifier Adapter — Unit Tests
+ *
+ * Pins which Allegro exceptions are non-retryable. The Allegro classifier
+ * is the only consumer of these branches (the `SyncJobRunner` was the
+ * previous home — moved here in #581) so this spec is the contract.
+ *
+ * The `AllegroNetworkException` test is load-bearing: pre-#499 these
+ * failures were re-classified as auth errors and killed jobs on attempt
+ * 1/10 during transient `auth.allegro.pl` blips. Don't relax it.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/adapters/__tests__
+ */
+import { AllegroRetryClassifierAdapter } from '../allegro-retry-classifier.adapter';
+import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
+import { AllegroAuthenticationException } from '../../../domain/exceptions/allegro-authentication.exception';
+import { AllegroNetworkException } from '../../../domain/exceptions/allegro-network.exception';
+
+describe('AllegroRetryClassifierAdapter', () => {
+  const adapter = new AllegroRetryClassifierAdapter();
+  const url = 'https://api.allegro.pl/some/path';
+
+  describe('non-retryable (returns true)', () => {
+    it('classifies AllegroAuthenticationException as non-retryable', () => {
+      expect(
+        adapter.isNonRetryable(new AllegroAuthenticationException('401 Unauthorized', 401, url)),
+      ).toBe(true);
+    });
+
+    it.each([400, 403, 404, 405, 409, 415, 422])(
+      'classifies AllegroApiException with deterministic %i as non-retryable',
+      (status) => {
+        expect(
+          adapter.isNonRetryable(new AllegroApiException('deterministic', status, 'body', url)),
+        ).toBe(true);
+      },
+    );
+  });
+
+  describe('retryable (returns false)', () => {
+    it.each([500, 502, 503, 408, 425])(
+      'does NOT classify AllegroApiException with transient %i as non-retryable',
+      (status) => {
+        expect(
+          adapter.isNonRetryable(new AllegroApiException('transient', status, 'body', url)),
+        ).toBe(false);
+      },
+    );
+
+    // Load-bearing — see #499. Network-level failures are transient and
+    // MUST stay retryable. Pre-#499 they were re-classified as auth
+    // errors and killed jobs on attempt 1/10 during transient blips.
+    it('does NOT classify AllegroNetworkException as non-retryable', () => {
+      expect(
+        adapter.isNonRetryable(new AllegroNetworkException('fetch failed', url)),
+      ).toBe(false);
+    });
+
+    it('does NOT classify a plain Error as non-retryable', () => {
+      expect(adapter.isNonRetryable(new Error('boom'))).toBe(false);
+    });
+
+    it('does NOT classify a non-Error value as non-retryable', () => {
+      expect(adapter.isNonRetryable('string error')).toBe(false);
+      expect(adapter.isNonRetryable(undefined)).toBe(false);
+      expect(adapter.isNonRetryable(null)).toBe(false);
+    });
+
+    it('does NOT classify AllegroApiException with no statusCode as non-retryable', () => {
+      // statusCode is optional on the constructor; guard against the undefined branch.
+      expect(adapter.isNonRetryable(new AllegroApiException('no status', undefined, 'body', url))).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-retry-classifier.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-retry-classifier.adapter.ts
@@ -1,0 +1,68 @@
+/**
+ * Allegro Retry Classifier Adapter
+ *
+ * Implements `RetryClassifierPort` (#581) for the Allegro platform — answers
+ * the runner's "is this error non-retryable?" question for Allegro's own
+ * exception hierarchy. Self-registered by `AllegroIntegrationModule.onModuleInit`
+ * against `RetryClassifierRegistryService` alongside the adapter factory and
+ * connection tester.
+ *
+ * Non-retryable cases (return `true`):
+ *   - `AllegroAuthenticationException` (401) — needs token refresh, not retry.
+ *   - `AllegroApiException` with a status in `NON_RETRYABLE_STATUS_CODES` —
+ *     deterministic 4xx (e.g., 415 unsupported content type, 422 validation)
+ *     where retrying burns worker capacity and masks the real issue.
+ *
+ * Retryable cases intentionally left out (return `false`):
+ *   - `AllegroApiException` with 5xx / 408 / 425 — transient; the HTTP client
+ *     already retries internally, and the runner gives the job more attempts.
+ *   - `AllegroNetworkException` — network-level failure during token refresh
+ *     or API request (DNS / TLS / connection refused / `TypeError: fetch
+ *     failed`). Always transient: the runner MUST retry with backoff. Do
+ *     NOT add this class to the non-retryable set — pre-#499 these failures
+ *     were swallowed by `refreshOnUnauthorized` and re-classified as
+ *     `AllegroAuthenticationException`, killing jobs on attempt 1/10 the
+ *     moment `auth.allegro.pl` had a 1-second blip.
+ *   - 429 — raised as `AllegroRateLimitException` and handled with
+ *     Retry-After inside the HTTP client.
+ *   - Anything not recognized — default-retryable.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/adapters
+ * @implements {RetryClassifierPort}
+ */
+import { RetryClassifierPort } from '@openlinker/core/sync';
+import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
+import { AllegroAuthenticationException } from '../../domain/exceptions/allegro-authentication.exception';
+
+/**
+ * Deterministic Allegro 4xx status codes — retrying never helps.
+ *
+ * Excludes:
+ *   - 401 (handled separately via `AllegroAuthenticationException` + token refresh)
+ *   - 408 / 425 (transient by spec)
+ *   - 429 (raised as `AllegroRateLimitException` with Retry-After in the HTTP client)
+ */
+const NON_RETRYABLE_STATUS_CODES: ReadonlySet<number> = new Set([
+  400, 403, 404, 405, 409, 415, 422,
+]);
+
+export class AllegroRetryClassifierAdapter implements RetryClassifierPort {
+  isNonRetryable(cause: unknown): boolean {
+    // AllegroAuthenticationException extends Error directly (not
+    // AllegroApiException), so the two branches are disjoint: a 401 never
+    // reaches the status-code check below.
+    if (cause instanceof AllegroAuthenticationException) {
+      return true;
+    }
+
+    if (
+      cause instanceof AllegroApiException &&
+      cause.statusCode !== undefined &&
+      NON_RETRYABLE_STATUS_CODES.has(cause.statusCode)
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Closes the Modularity Thread E issue E1 (#581): `SyncJobRunner` no longer imports `AllegroApiException` / `AllegroAuthenticationException` for retry classification. Replaced with a `RetryClassifierPort` that integrations self-register against in `onModuleInit`, mirroring the established pattern from `ConnectionTesterRegistryService` (#570) and `WebhookProvisioningRegistryService` (#583).

After this change, `apps/worker/src/sync/sync-job.runner.ts` imports nothing from `@openlinker/integrations-allegro` — a Shopify plugin can now ship its own retry classifier without a core PR.

## Changes

**CORE (`libs/core/src/sync/`)**
- `domain/ports/retry-classifier.port.ts` — new `RetryClassifierPort` with `isNonRetryable(cause: unknown): boolean`. Returns `false` (retryable) for unknown errors.
- `infrastructure/adapters/retry-classifier-registry.service.ts` — new `RetryClassifierRegistryService` keyed by `adapterKey` with register / get / has + an aggregating `isNonRetryable(cause)` that walks every registered classifier and OR's their answers. The aggregating method is the one shape difference from sibling registries — the runner has the raw error in hand, not an adapterKey, so dispatch is OR-across-all rather than indexed.
- `RETRY_CLASSIFIER_REGISTRY_TOKEN` Symbol token wired into `SyncModule` providers/exports (both the class and the token).
- Standalone unit spec for the registry pinning the OR-aggregation contract.

**Allegro integration (`libs/integrations/allegro/src/`)**
- `infrastructure/adapters/allegro-retry-classifier.adapter.ts` — implements `RetryClassifierPort`. Holds the Allegro non-retryable-status-codes set (typed as `ReadonlySet<number>`) and the auth-exception short-circuit. The lengthy comment block explaining each branch (and what's intentionally left out — `AllegroNetworkException` per #499) moves from the runner into the adapter where it belongs.
- `AllegroIntegrationModule.onModuleInit` self-registers the adapter against the registry alongside the existing metadata / factory / connection-tester registrations. New cross-package import from `@openlinker/core/sync` (architecturally fine — integrations may depend on core).
- Unit spec covering all branches: auth / non-retryable status / retryable status / network / unrelated / no-status. The `AllegroNetworkException` test is load-bearing per #499.

**Worker (`apps/worker/src/sync/`)**
- `sync-job.runner.ts` — drops the Allegro imports and the `NON_RETRYABLE_ALLEGRO_STATUS_CODES` constant. Injects `RETRY_CLASSIFIER_REGISTRY_TOKEN`. `isNonRetryableError` keeps its `OfferCreationInvariantException` short-circuit (CORE exception, no platform coupling) and the `SyncJobExecutionError.cause` unwrap, then delegates the rest to `registry.isNonRetryable(cause)`.
- Runner spec wires a real `RetryClassifierRegistryService` with the real `AllegroRetryClassifierAdapter` registered, so all 37 existing Allegro behavioural tests pass unchanged. The spec keeps its `@openlinker/integrations-allegro` imports — the runner production code is platform-neutral, the runner spec verifies end-to-end classification with the real adapter.

## Behaviour-preservation matrix

| Scenario | Before | After |
|---|---|---|
| Allegro auth failure (401) | dead immediately | dead immediately |
| Allegro deterministic 4xx (415, 422) | dead immediately | dead immediately |
| Allegro 5xx / 408 / 425 | retry | retry |
| `AllegroNetworkException` | retry | retry (load-bearing per #499) |
| `OfferCreationInvariantException` | dead immediately | dead immediately |
| Unrelated error | retry | retry |

## Test plan

- [x] `pnpm lint` — zero errors
- [x] `pnpm type-check` — zero errors
- [x] `pnpm test` — 25 shared / 586 core / 34 ai / 255 prestashop / 315 allegro / 339 api / 118 worker tests pass
- [x] All 37 existing `sync-job.runner.spec.ts` tests pass unchanged (behaviour preservation)
- [x] New registry + adapter specs cover the contract end-to-end

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)
