### PR TITLE
refactor(shared): decouple Logger from NestJS via LoggerPort (#589)

### DIFF
--- a/apps/api/src/auth/bootstrap-admin.service.spec.ts
+++ b/apps/api/src/auth/bootstrap-admin.service.spec.ts
@@ -39,11 +39,11 @@ describe('BootstrapAdminService', () => {
   beforeEach(() => {
     warnMessages = [];
     logMessages = [];
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation((msg: string) => {
-      warnMessages.push(msg);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation((msg: unknown) => {
+      warnMessages.push(String(msg));
     });
-    jest.spyOn(Logger.prototype, 'log').mockImplementation((msg: string) => {
-      logMessages.push(msg);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation((msg: unknown) => {
+      logMessages.push(String(msg));
     });
   });
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -11,10 +11,15 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as express from 'express';
+import { installNestLogger } from '@openlinker/shared/logging/nest';
 import { AppModule } from './app.module';
 import { CapabilityNotSupportedFilter } from './common/filters/capability-not-supported.filter';
 
 async function bootstrap(): Promise<void> {
+  // Route shared `Logger` calls through @nestjs/common before any other work,
+  // so module-init logs land in Nest's formatter from the very first emission.
+  installNestLogger();
+
   // Disable Nest's default body parser so we can control parser order
   // This ensures webhook routes capture raw body before JSON parsing
   const app = await NestFactory.create(AppModule, {

--- a/apps/worker/jest.config.js
+++ b/apps/worker/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
   testTimeout: 10000,
   moduleNameMapper: {
     '^@openlinker/core/(.*)$': path.resolve(__dirname, '../../libs/core/src/$1'),
+    '^@openlinker/shared$': path.resolve(__dirname, '../../libs/shared/src/index.ts'),
     '^@openlinker/shared/(.*)$': path.resolve(__dirname, '../../libs/shared/src/$1'),
     '^@openlinker/integrations-prestashop/(.*)$': path.resolve(__dirname, '../../libs/integrations/prestashop/src/$1'),
     '^@openlinker/integrations-allegro$': path.resolve(__dirname, '../../libs/integrations/allegro/src/index.ts'),

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -9,10 +9,15 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { Logger } from '@openlinker/shared/logging';
+import { installNestLogger } from '@openlinker/shared/logging/nest';
 
 const logger = new Logger('WorkerBootstrap');
 
 async function bootstrap(): Promise<void> {
+  // Route shared `Logger` calls through @nestjs/common before any other work,
+  // so even pre-Nest-init failures from this bootstrap land in Nest's formatter.
+  installNestLogger();
+
   const app = await NestFactory.createApplicationContext(AppModule, {
     logger: ['error', 'warn', 'log', 'debug', 'verbose'],
   });

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -213,8 +213,10 @@ The system is organized into the following core bounded contexts:
 
 ### 11. Logging & Monitoring
 - **Responsibility**: Structured logging, metrics, tracing
-- **Technology**: NestJS Logger, OpenTelemetry (future)
-- **Location**: `libs/shared/src/logging/`
+- **Contract**: `LoggerPort` (`log/debug/warn/error`) shipped from `@openlinker/shared/logging`. The consumer-facing `Logger` factory (`new Logger(ClassName.name)`) delegates to a process-wide active backend.
+- **Backends**: `ConsoleLoggerAdapter` is the zero-dependency default that ships in the same package, so plugins compiled against `@openlinker/shared` get working logs without any host wiring. The NestJS-backed `NestLoggerAdapter` lives on the host-only subpath `@openlinker/shared/logging/nest`; hosts call `installNestLogger()` at the top of `bootstrap()` to swap it in (#589). Plugins never transitively pull `@nestjs/common` through the logger.
+- **Tracing**: OpenTelemetry (future).
+- **Location**: `libs/shared/src/logging/` (port + default + factory); `libs/shared/src/logging/nest/` (Nest-backed adapter, host-only).
 
 ### 12. Content
 - **Responsibility**: Per-product, per-channel (or master) content fields with draft write-through and conflict detection. First field key: `description`.
@@ -1488,7 +1490,7 @@ Future: Worker processes jobs
 - **Events**: `@nestjs/event-emitter` (in-memory), Redis Streams (distributed)
 - **Authentication**: JWT (`@nestjs/jwt`, `@nestjs/passport`)
 - **Validation**: `class-validator`, `class-transformer`
-- **Logging**: NestJS Logger (wrapped in shared library)
+- **Logging**: framework-neutral `LoggerPort` (`@openlinker/shared/logging`) with a console default; host apps install the NestJS-backed adapter at boot via `installNestLogger()` from `@openlinker/shared/logging/nest`
 
 ### Development Tools
 

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -1020,7 +1020,7 @@ async getProduct(productId: string): Promise<Product> {
 
 ### Logging
 
-**Use NestJS Logger wrapper** from shared library:
+**Use the `Logger` factory** from `@openlinker/shared/logging`. It implements the framework-neutral `LoggerPort` contract; the active backend is swapped at host boot (Nest in apps, console default everywhere else).
 
 ```typescript
 import { Logger } from '@openlinker/shared/logging';
@@ -1035,18 +1035,31 @@ export class ProductService {
       // ...
       this.logger.log(`Product synced successfully: ${productId}`);
     } catch (error) {
-      this.logger.error(`Failed to sync product: ${productId}`, error.stack);
+      this.logger.error(`Failed to sync product: ${productId}`, (error as Error).stack);
       throw error;
     }
   }
 }
 ```
 
-**Log levels**:
+**Host wiring** (apps/api, apps/worker only):
+
+```typescript
+import { installNestLogger } from '@openlinker/shared/logging/nest';
+
+async function bootstrap() {
+  installNestLogger(); // first statement — routes every Logger call through @nestjs/common
+  // ...
+}
+```
+
+Library code and plugins must NOT import from `@openlinker/shared/logging/nest`. The neutral `@openlinker/shared/logging` ships its own console-based default, so `new Logger(ctx)` works zero-config.
+
+**Log levels** (from `LogLevelValues` / `LogLevel`):
 - `log()`: General information
 - `debug()`: Detailed debugging information
 - `warn()`: Warnings
-- `error()`: Errors with stack traces
+- `error(message, stack?, context?)`: Errors with optional stack traces
 
 ### Async/Await
 

--- a/docs/plans/implementation-plan-shared-logger-port.md
+++ b/docs/plans/implementation-plan-shared-logger-port.md
@@ -1,0 +1,247 @@
+# Implementation Plan — Shared Logger Port (#589)
+
+**Issue**: [#589 — [F2] [HIGH] @openlinker/shared Logger is a NestJS Logger subclass — locks plugins to a Nest version](https://github.com/SilkSoftwareHouse/openlinker/issues/589)
+**Thread**: Modularity Thread F · Catalog SDK-4
+**Layer**: SDK / Shared infrastructure (cross-cutting backend)
+
+---
+
+## 1 · Goal
+
+Decouple `@openlinker/shared/logging` from `@nestjs/common`. Adapters and core services should depend on a neutral `LoggerPort` shipped from `@openlinker/shared/logging`; the NestJS-backed implementation moves to a host-only `@openlinker/shared/logging/nest` subpath. A plugin compiled against `@openlinker/shared` must not transitively pull `@nestjs/common` through the logger.
+
+## 2 · Non-goals
+
+- Migrating the 91 call sites from `new Logger(ClassName.name)` to DI-based logger injection. The current factory-style API is preserved verbatim — this is a backend swap, not a consumer migration.
+- Removing `@nestjs/common` from `libs/shared` peerDependencies. Other shared modules (cache, database, errors) still legitimately use Nest. The fix is scoped to `logging`.
+- Adding structured-log fields, log levels beyond `log/debug/warn/error`, or transport plug-points beyond a single global backend setter. Anything richer is out of scope and would be a follow-up.
+
+## 3 · Constraints
+
+- **Preserve `new Logger(context)` ergonomics.** 91 import sites use this exact shape; no consumer-side changes.
+- **Preserve prod log output.** Apps (API, worker) currently print via NestJS' Logger; output formatting must remain visually unchanged.
+- **No new runtime deps in the default path.** A plugin must work with `@openlinker/shared/logging` alone — no requirement to wire anything to get logs.
+- **Backend rules**: domain layer stays framework-free; `Logger` is already only used from application/infrastructure layers, so no boundary changes required.
+
+## 4 · Research summary
+
+- **Consumer pattern** (uniform across 91 files): `private readonly logger = new Logger(ClassName.name);` followed by `.log/.error/.warn/.debug` calls. No DI, no extension, no `verbose`.
+- **Method-call tally** (libs/core + libs/integrations): debug=358, warn=227, log=148, error=83. Four methods is the right port surface.
+- **Signature shape of `.error`**: both `logger.error(msg)` and `logger.error(msg, error)`/`logger.error(msg, error.stack)` patterns are in use. Port must accept an optional second arg.
+- **Reference pattern in this codebase**: `libs/shared/src/cache/` already follows port-in-shared-core + adapter-in-subpath, but uses NestJS DI. We adopt the *layering* (port in main path, default impl ships, Nest-specific impl segregated to its own subpath) but keep the **factory-style API** the existing 91 sites depend on.
+- **Workspace layout**: `libs/shared/package.json` `exports` field gates Node-runtime resolution; tsconfig path alias `@openlinker/shared/*` already wildcards into `libs/shared/src/*`, so a new `/nest` subpath needs only a `package.json` exports entry.
+- **Apps**: `apps/api/src/main.ts` (NestFactory.create) and `apps/worker/src/main.ts` (NestFactory.createApplicationContext) are the only places that need `installNestLogger()`.
+
+## 5 · Design
+
+### Layering
+
+```
+libs/shared/src/logging/
+├── index.ts                     # Public surface (current path)
+├── logger.port.ts               # LoggerPort interface
+├── logger.types.ts              # LogLevel + LogLevelValues (as const)
+├── logger.ts                    # Logger class (context-bound) + module-level backend registry
+├── console-logger.adapter.ts    # ConsoleLoggerAdapter — default, zero deps
+├── format-body-for-log.ts       # unchanged
+├── format-body-for-log.spec.ts  # unchanged
+├── logger.spec.ts               # new — colocated per local convention
+└── nest/
+    ├── index.ts                 # Public surface for /nest subpath
+    ├── nest-logger.adapter.ts   # NestLoggerAdapter (wraps @nestjs/common Logger)
+    └── install.ts               # installNestLogger() — one-liner for hosts
+```
+
+File split mirrors `libs/shared/src/cache/` precedent (`cache.port.ts` + `cache.types.ts`). Spec is colocated next to `logger.ts` to match the sibling `format-body-for-log.spec.ts` — no `__tests__/` subfolder.
+
+### `LoggerPort` (in `logger.port.ts`)
+
+```ts
+export interface LoggerPort {
+  log(message: unknown, context?: string): void;
+  debug(message: unknown, context?: string): void;
+  warn(message: unknown, context?: string): void;
+  error(message: unknown, stack?: unknown, context?: string): void;
+}
+```
+
+Adapters implement `LoggerPort` directly — the project's documented adapter pattern (`{System}{Capability}Adapter`). The earlier draft introduced a separate `LoggerBackend` interface aliased to `LoggerPort`; that was no-op signal noise and has been dropped per tech-review SUGGESTION.
+
+### `LogLevel` (in `logger.types.ts`)
+
+Follows the documented `as const + union` pattern (engineering-standards "Union Types: `as const` Pattern (Default)"):
+
+```ts
+export const LogLevelValues = ['log', 'debug', 'warn', 'error'] as const;
+export type LogLevel = (typeof LogLevelValues)[number];
+```
+
+Runtime array is exported so future validation/filtering code (or a Swagger surface) can enumerate levels without re-declaring them.
+
+### `Logger` class (in `logger.ts`)
+
+- Module-level mutable `activeBackend: LoggerPort` initialised to a `ConsoleLoggerAdapter` instance.
+- `setLoggerBackend(backend: LoggerPort): void` — swap (used by host wiring + tests).
+- `getLoggerBackend(): LoggerPort` — exported for advanced use / tests.
+- `class Logger implements LoggerPort` — constructor stores `context`. Each method delegates: `this.log(m, ctx?) => activeBackend.log(m, ctx ?? this.context)`.
+
+This preserves the existing 91-site call shape exactly.
+
+### `ConsoleLoggerAdapter`
+
+- Pure TypeScript, zero deps.
+- Formats as `[OL] <ISO timestamp> <LEVEL> [<context>] <message>`. (Approximates Nest's "Nest" prefix shape but isn't presented as Nest output.)
+- `error(message, stack?, context?)`: writes message via `console.error`; if `stack` is provided, writes it on the next line.
+- Uses `console.log` / `console.warn` / `console.error` / `console.debug` per level.
+- ESLint `no-console` exemption is local to this file via an `eslint-disable` comment with reason — this is the one legitimate place to call `console.*` in the codebase.
+
+### `NestLoggerAdapter` (in `/nest`)
+
+- Wraps `@nestjs/common`'s `Logger`. Maintains a per-context cache of `NestLogger` instances (`Map<string, NestLogger>`) to mirror Nest's per-context formatting.
+- `installNestLogger()` is the one-liner: `setLoggerBackend(new NestLoggerAdapter())`.
+- This is the only file in `libs/shared/` that imports `@nestjs/common` for logging purposes after the refactor.
+
+### Wiring
+
+- `apps/api/src/main.ts`: `installNestLogger()` is the **first statement** of `bootstrap()`, before any other work.
+- `apps/worker/src/main.ts`: same. The worker declares a module-level `const logger = new Logger('WorkerBootstrap')` and its `.catch(logger.error(...))` runs if `bootstrap()` throws — calling `installNestLogger()` as the first line of `bootstrap()` ensures even crash-path errors land in the Nest backend (and pre-init errors are still captured by the console default — visually different but never lost).
+- The existing 91 consumer sites continue to work unchanged because the `Logger` class signature is preserved.
+
+### `package.json` exports (`libs/shared/package.json`)
+
+Add:
+
+```json
+"./logging/nest": {
+  "types": "./dist/logging/nest/index.d.ts",
+  "require": "./dist/logging/nest/index.js"
+}
+```
+
+### Public surface
+
+- `@openlinker/shared/logging` exports: `LoggerPort`, `LogLevel`, `LogLevelValues`, `Logger`, `setLoggerBackend`, `getLoggerBackend`, `ConsoleLoggerAdapter`, plus the existing `formatBodyForLog`.
+- `@openlinker/shared/logging/nest` exports: `NestLoggerAdapter`, `installNestLogger`.
+- `libs/shared/src/index.ts` already does `export * from './logging'`, so `import { Logger } from '@openlinker/shared'` (used by several call sites today) continues to resolve transparently.
+
+## 6 · Step-by-step plan
+
+Each step lists files touched and acceptance criteria.
+
+### Step 1 — Add port, types, and default adapter
+
+**Files**:
+- `libs/shared/src/logging/logger.port.ts` (new) — `LoggerPort`
+- `libs/shared/src/logging/logger.types.ts` (new) — `LogLevelValues` + `LogLevel`
+- `libs/shared/src/logging/console-logger.adapter.ts` (new) — `ConsoleLoggerAdapter implements LoggerPort`
+
+**Accept**: file headers per engineering-standards; `LoggerPort` lives in `*.port.ts` with the variadic `(message: unknown, ...optionalParams: unknown[]) => void` shape (mirrors Nest's signature so structured-data + error-object 2nd args keep working); `LogLevel` follows the documented `as const + union` pattern in `*.types.ts`; `ConsoleLoggerAdapter` has the four methods and zero framework imports.
+
+### Step 2 — Rewrite `logger.ts` around the port
+
+**Files**:
+- `libs/shared/src/logging/logger.ts` (edit — remove `extends NestLogger`; add backend registry; `Logger implements LoggerPort`)
+
+**Accept**:
+- `Logger` no longer imports `@nestjs/common`.
+- `new Logger(ctx)` returns an object with `log/debug/warn/error` matching today's call shape.
+- `setLoggerBackend(b)` swaps the active backend; `getLoggerBackend()` returns it.
+- Method delegation passes the instance's bound `context` when the caller didn't override it.
+
+### Step 3 — Update logging barrel + verify root barrel
+
+**Files**:
+- `libs/shared/src/logging/index.ts` (edit — re-export the new symbols)
+
+**Accept**:
+- Barrel exports `LoggerPort`, `LogLevel`, `LogLevelValues`, `Logger`, `setLoggerBackend`, `getLoggerBackend`, `ConsoleLoggerAdapter` plus existing `formatBodyForLog`.
+- Verify `libs/shared/src/index.ts` still does `export * from './logging'` (no edit expected — pre-existing). This is the seam that keeps `import { Logger } from '@openlinker/shared'` working for the small set of call sites that go through the root barrel.
+
+### Step 4 — Add `nest/` subpath
+
+**Files**:
+- `libs/shared/src/logging/nest/nest-logger.adapter.ts` (new)
+- `libs/shared/src/logging/nest/install.ts` (new)
+- `libs/shared/src/logging/nest/index.ts` (new — barrel)
+
+**Accept**:
+- `NestLoggerAdapter` is the only place that imports `@nestjs/common` for logging.
+- `installNestLogger()` wires it via `setLoggerBackend`.
+- Per-context `NestLogger` cache avoids reallocating instances.
+
+### Step 5 — Expose `/nest` subpath in package.json
+
+**Files**:
+- `libs/shared/package.json` (edit — add `./logging/nest` exports entry)
+
+**Accept**: `pnpm --filter @openlinker/shared build` emits `dist/logging/nest/index.js` and `dist/logging/nest/index.d.ts`; consumers can `import { installNestLogger } from '@openlinker/shared/logging/nest'`.
+
+### Step 6 — Wire `installNestLogger()` in host apps
+
+**Files**:
+- `apps/api/src/main.ts` (edit — call as **first statement** of `bootstrap()`)
+- `apps/worker/src/main.ts` (edit — same)
+
+**Accept**: both apps boot and emit logs with the same `[Nest] …` format as today; worker's crash-path `logger.error(...)` in `.catch()` hits the Nest backend because `installNestLogger()` runs synchronously at the top of `bootstrap()` before any failure can occur.
+
+### Step 7 — Tests
+
+**Files**:
+- `libs/shared/src/logging/__tests__/logger.spec.ts` (new)
+
+**Cases**:
+- `new Logger('Ctx').log('hi')` calls the active backend's `log` with `('hi', 'Ctx')`.
+- `setLoggerBackend(fake)` redirects all four methods.
+- `Logger.error(msg, stack)` forwards `stack` to backend as the 2nd arg.
+- After test: restore default backend in `afterEach` to avoid cross-test pollution.
+
+**Accept**: `pnpm --filter @openlinker/shared test` passes including the new spec.
+
+### Step 8 — Documentation
+
+**Files**:
+- `docs/architecture-overview.md` (edit — §11 Logging & Monitoring; §Technology Stack > Logging)
+- `docs/engineering-standards.md` (edit — §Logging)
+
+**Updates**:
+- Point at `LoggerPort` as the contract; describe `Logger` as the consumer-facing factory.
+- Note the default backend (console) and the `/nest` opt-in.
+- Code sample uses `import { Logger } from '@openlinker/shared/logging'` (unchanged) — clarify it now resolves through a swappable backend, with `installNestLogger()` called in `apps/*/src/main.ts`.
+
+**Accept**: docs no longer describe `Logger` as a NestJS subclass.
+
+### Step 9 — Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All zero-error. Spot-check that 91 existing call sites still type-check unmodified.
+
+## 7 · Risk register
+
+| Risk | Mitigation |
+|---|---|
+| `Logger.error(message, error)` (passing an `Error` object as 2nd arg) renders differently under console backend vs. Nest backend. | Console backend handles both `string` and `unknown` for `stack`; stringifies via `String(stack)` plus best-effort `stack` field extraction. Visually different from Nest in dev, but functionally lossless. Test covers this. |
+| Tests that mock `Logger` directly (none found in grep, but possible) break. | Spec file grep before commit; the `Logger` class API is unchanged so anything mocking it via `jest.spyOn(logger, 'log')` continues to work. |
+| Subpath export not picked up by `ts-jest` in tests. | Existing `./cache` subpath uses the same exports shape and works; replicating that pattern. Verify by adding the `/nest` test step. |
+| Hot reload / dev mode picks up stale `dist/`. | Standard `pnpm install && pnpm build` after the change; tsconfig path alias `@openlinker/shared/*` resolves to `src/*` for dev so dist freshness doesn't matter at type-check time. |
+| Test pollution: module-level `activeBackend` is a process-wide singleton; a future spec that calls `setLoggerBackend(...)` without restoring it leaks state into sibling specs in the same Jest worker. | The new `logger.spec.ts` restores the default in `afterEach`. Document the pattern in the spec's header comment so anyone else writing logger-related tests follows it. |
+
+## 8 · Validation checklist
+
+- [ ] `libs/shared/src/logging/logger.ts` contains zero imports of `@nestjs/common`.
+- [ ] `grep -r "extends NestLogger" libs/` returns no results.
+- [ ] `grep -r "@nestjs/common" libs/shared/src/logging/` matches only files under `libs/shared/src/logging/nest/`.
+- [ ] `new Logger('X')` still compiles in all 91 existing import sites without edits.
+- [ ] `apps/api` and `apps/worker` `main.ts` call `installNestLogger()` before any log emission.
+- [ ] Docs updated (architecture-overview §Logging, engineering-standards §Logging).
+- [ ] Quality gate (`lint`, `type-check`, `test`) passes cleanly.
+- [ ] New unit spec covers backend swap + context forwarding.
+
+## 9 · Open questions / deferred
+
+- Should `installNestLogger()` also override Nest's own internal logger (the one Nest uses for module-init messages) via `Logger.overrideLogger`? **Decision: no** — the worker already configures Nest's internal levels via `{ logger: [...] }`; mixing concerns is out of scope. Follow-up if needed.
+- A future ticket could move per-call structured fields (`logger.log(msg, { reqId, ... })`) into the port. Not in scope for #589.

--- a/libs/core/jest.config.js
+++ b/libs/core/jest.config.js
@@ -29,6 +29,7 @@ module.exports = {
   testEnvironment: 'node',
   moduleNameMapper: {
     '^@openlinker/core/(.*)$': '<rootDir>/$1',
+    '^@openlinker/shared$': '<rootDir>/../../../libs/shared/src/index.ts',
     '^@openlinker/shared/(.*)$': '<rootDir>/../../../libs/shared/src/$1',
   },
 };

--- a/libs/core/src/ai/application/services/ai-provider-active-settings.service.spec.ts
+++ b/libs/core/src/ai/application/services/ai-provider-active-settings.service.spec.ts
@@ -9,8 +9,8 @@
  *
  * @module libs/core/src/ai/application/services
  */
-import { Logger as NestLogger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Logger as SharedLogger } from '@openlinker/shared/logging';
 import { AiProviderActiveSetting } from '../../domain/entities/ai-provider-active-setting.entity';
 import { AiProviderActiveSettingRepositoryPort } from '../../domain/ports/ai-provider-active-setting-repository.port';
 import { AiProviderCredentialsPort } from '../../domain/ports/ai-provider-credentials.port';
@@ -43,7 +43,7 @@ describe('AiProviderActiveSettingsService', () => {
       describeAll: jest.fn(),
       invalidate: jest.fn(),
     };
-    logSpy = jest.spyOn(NestLogger.prototype, 'log').mockImplementation(() => undefined);
+    logSpy = jest.spyOn(SharedLogger.prototype, 'log').mockImplementation(() => undefined);
   });
 
   afterEach(() => {

--- a/libs/core/src/ai/application/services/ai-provider-key.service.spec.ts
+++ b/libs/core/src/ai/application/services/ai-provider-key.service.spec.ts
@@ -8,8 +8,8 @@
  *
  * @module libs/core/src/ai/application/services
  */
-import { Logger as NestLogger } from '@nestjs/common';
 import { CryptoService } from '@openlinker/shared';
+import { Logger as SharedLogger } from '@openlinker/shared/logging';
 import {
   IntegrationCredentialRepositoryPort,
   CredentialNotFoundException,
@@ -56,7 +56,7 @@ describe('AiProviderKeyService', () => {
       encrypt: jest.fn().mockReturnValue('cipher'),
       decrypt: jest.fn(),
     };
-    logSpy = jest.spyOn(NestLogger.prototype, 'log').mockImplementation(() => undefined);
+    logSpy = jest.spyOn(SharedLogger.prototype, 'log').mockImplementation(() => undefined);
   });
 
   afterEach(() => {

--- a/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts
+++ b/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts
@@ -10,9 +10,9 @@
  *
  * @module libs/core/src/ai/infrastructure/adapters
  */
-import { Logger as NestLogger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CryptoService } from '@openlinker/shared';
+import { Logger as SharedLogger } from '@openlinker/shared/logging';
 import {
   IntegrationCredentialRepositoryPort,
   CredentialNotFoundException,
@@ -57,7 +57,7 @@ describe('CredentialsAiProviderAdapter', () => {
       encrypt: jest.fn(),
       decrypt: jest.fn(),
     };
-    warnSpy = jest.spyOn(NestLogger.prototype, 'warn').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(SharedLogger.prototype, 'warn').mockImplementation(() => undefined);
   });
 
   afterEach(() => {

--- a/libs/core/src/integrations/plugin-registry.module.spec.ts
+++ b/libs/core/src/integrations/plugin-registry.module.spec.ts
@@ -10,7 +10,8 @@
  *
  * @module libs/core/src/integrations
  */
-import { DynamicModule, Logger as NestLogger, Module } from '@nestjs/common';
+import { DynamicModule, Module } from '@nestjs/common';
+import { Logger as SharedLogger } from '@openlinker/shared/logging';
 import { Test } from '@nestjs/testing';
 import { PluginRegistryModule } from './plugin-registry.module';
 
@@ -81,7 +82,7 @@ describe('PluginRegistryModule', () => {
 
     it('should log the composed plugin names when the module initialises', async () => {
       const logSpy = jest
-        .spyOn(NestLogger.prototype, 'log')
+        .spyOn(SharedLogger.prototype, 'log')
         .mockImplementation(() => undefined);
 
       const moduleRef = await Test.createTestingModule({

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -15,6 +15,10 @@
       "types": "./dist/logging/index.d.ts",
       "require": "./dist/logging/index.js"
     },
+    "./logging/nest": {
+      "types": "./dist/logging/nest/index.d.ts",
+      "require": "./dist/logging/nest/index.js"
+    },
     "./config": {
       "types": "./dist/config/index.d.ts",
       "require": "./dist/config/index.js"

--- a/libs/shared/src/logging/console-logger.adapter.spec.ts
+++ b/libs/shared/src/logging/console-logger.adapter.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Console Logger Adapter Spec
+ *
+ * Covers the default zero-dependency backend: prefix shape, per-level sink
+ * dispatch, trailing-string-as-context convention, Error.stack rendering,
+ * and the JSON-stringify fallback for circular or unstringifiable values.
+ *
+ * @module libs/shared/src/logging
+ */
+import { ConsoleLoggerAdapter } from './console-logger.adapter';
+
+const firstLine = (spy: jest.SpyInstance): string =>
+  String((spy.mock.calls[0] as unknown[] | undefined)?.[0] ?? '');
+
+const lineAt = (spy: jest.SpyInstance, index: number): string =>
+  String((spy.mock.calls[index] as unknown[] | undefined)?.[0] ?? '');
+
+describe('ConsoleLoggerAdapter', () => {
+  let adapter: ConsoleLoggerAdapter;
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    adapter = new ConsoleLoggerAdapter();
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('writes log() via console.log with [OL] prefix, LEVEL, and context', () => {
+    adapter.log('hello', 'Ctx');
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(firstLine(logSpy)).toMatch(/^\[OL\] \S+ LOG \[Ctx\] hello$/);
+  });
+
+  it('writes warn() via console.warn', () => {
+    adapter.warn('careful', 'Ctx');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(firstLine(warnSpy)).toMatch(/WARN \[Ctx\] careful/);
+  });
+
+  it('writes debug() via console.debug', () => {
+    adapter.debug('trace', 'Ctx');
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(firstLine(debugSpy)).toMatch(/DEBUG \[Ctx\] trace/);
+  });
+
+  it('writes error() via console.error when called with message and context only', () => {
+    adapter.error('boom', 'Ctx');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(firstLine(errorSpy)).toMatch(/ERROR \[Ctx\] boom/);
+  });
+
+  it('emits a second console.error line carrying the stack when error has one', () => {
+    const err = new Error('boom');
+    adapter.error('failure', err, 'Ctx');
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(lineAt(errorSpy, 0)).toMatch(/ERROR \[Ctx\] failure/);
+    expect(lineAt(errorSpy, 1)).toContain('Error: boom');
+  });
+
+  it('treats a trailing string param as context, not as extra payload', () => {
+    adapter.log('hi', 'CallerCtx');
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(firstLine(logSpy)).toMatch(/LOG \[CallerCtx\] hi/);
+  });
+
+  it('renders extra payload params on additional lines after the message', () => {
+    adapter.log('event', { actor: 'alice' }, 'Ctx');
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(lineAt(logSpy, 0)).toMatch(/LOG \[Ctx\] event/);
+    expect(lineAt(logSpy, 1)).toContain('"actor":"alice"');
+  });
+
+  it('falls back to String() when JSON.stringify throws on a circular value', () => {
+    const circular: Record<string, unknown> = { self: undefined };
+    circular.self = circular;
+    adapter.log(circular, 'Ctx');
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(firstLine(logSpy)).toMatch(/LOG \[Ctx\] \[object Object\]/);
+  });
+
+  it('omits the context segment when no context is provided', () => {
+    adapter.log('hi');
+    expect(firstLine(logSpy)).toMatch(/^\[OL\] \S+ LOG hi$/);
+  });
+});

--- a/libs/shared/src/logging/console-logger.adapter.ts
+++ b/libs/shared/src/logging/console-logger.adapter.ts
@@ -1,0 +1,83 @@
+/**
+ * Console Logger Adapter
+ *
+ * Zero-dependency default `LoggerPort` implementation that writes to the
+ * standard `console.*` channels. Used automatically when no host wires a
+ * richer backend (e.g. `installNestLogger()`), so plugins importing
+ * `@openlinker/shared/logging` always have working logs without setup.
+ *
+ * Output shape: `[OL] <ISO timestamp> <LEVEL> [<context>] <message>` plus
+ * one trailing line per extra positional param (Error objects render their
+ * `.stack`, plain objects are JSON-stringified). Deliberately different
+ * from Nest's `[Nest]` prefix so "running on default backend" is visible
+ * at a glance during dev.
+ *
+ * @module libs/shared/src/logging
+ */
+/* eslint-disable no-console -- This adapter is the one legitimate caller of console.* in the codebase. */
+import { LoggerPort } from './logger.port';
+import { LogLevel } from './logger.types';
+
+export class ConsoleLoggerAdapter implements LoggerPort {
+  log(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('log', message, optionalParams);
+  }
+
+  debug(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('debug', message, optionalParams);
+  }
+
+  warn(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('warn', message, optionalParams);
+  }
+
+  error(message: unknown, ...optionalParams: unknown[]): void {
+    this.emit('error', message, optionalParams);
+  }
+
+  private emit(level: LogLevel, message: unknown, optionalParams: unknown[]): void {
+    const { context, extras } = this.splitParams(optionalParams);
+    const prefix = `[OL] ${new Date().toISOString()} ${level.toUpperCase()}${
+      context ? ` [${context}]` : ''
+    }`;
+    const sink = this.sinkFor(level);
+    sink(`${prefix} ${this.stringify(message)}`);
+    for (const extra of extras) {
+      sink(this.stringify(extra));
+    }
+  }
+
+  /**
+   * Mirror Nest's convention: trailing string param = context; everything
+   * before it = extra payload (Error, structured object, raw stack).
+   */
+  private splitParams(params: unknown[]): { context?: string; extras: unknown[] } {
+    if (params.length > 0 && typeof params[params.length - 1] === 'string') {
+      return { context: params[params.length - 1] as string, extras: params.slice(0, -1) };
+    }
+    return { extras: params };
+  }
+
+  private sinkFor(level: LogLevel): (line: string) => void {
+    switch (level) {
+      case 'error':
+        return console.error;
+      case 'warn':
+        return console.warn;
+      case 'debug':
+        return console.debug;
+      case 'log':
+        return console.log;
+    }
+  }
+
+  private stringify(value: unknown): string {
+    if (typeof value === 'string') return value;
+    if (value instanceof Error) return value.stack ?? value.message;
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+}

--- a/libs/shared/src/logging/index.ts
+++ b/libs/shared/src/logging/index.ts
@@ -1,10 +1,20 @@
 /**
  * Logging Module Exports
  *
- * Exports for the logging module, providing logger utilities.
+ * Public surface for `@openlinker/shared/logging`. Exposes the
+ * framework-neutral `LoggerPort` contract, the consumer-facing `Logger`
+ * factory, the default `ConsoleLoggerAdapter`, the backend registry
+ * (`setLoggerBackend` / `getLoggerBackend`), and the `LogLevel` enumeration.
+ *
+ * The NestJS-backed adapter is intentionally NOT re-exported here — it lives
+ * at `@openlinker/shared/logging/nest` so plugins compiled against this
+ * package don't transitively pull `@nestjs/common` through the logger.
  *
  * @module libs/shared/src/logging
  */
-export * from './logger';
+export type { LoggerPort } from './logger.port';
+export type { LogLevel } from './logger.types';
+export { LogLevelValues } from './logger.types';
+export { Logger, setLoggerBackend, getLoggerBackend } from './logger';
+export { ConsoleLoggerAdapter } from './console-logger.adapter';
 export * from './format-body-for-log';
-

--- a/libs/shared/src/logging/logger.port.ts
+++ b/libs/shared/src/logging/logger.port.ts
@@ -1,0 +1,26 @@
+/**
+ * Logger Port
+ *
+ * Framework-neutral logging contract consumed across the codebase via the
+ * `Logger` factory class. Adapters (Console default, NestJS opt-in under
+ * `./nest`) implement this port; the host swaps the active implementation
+ * via `setLoggerBackend()` at boot. Plugins compiled against
+ * `@openlinker/shared` depend only on this interface — no @nestjs/common
+ * is pulled in via the logger.
+ *
+ * Method signatures mirror NestJS' `Logger` variadic contract: the first
+ * argument is the message, and any number of optional positional params
+ * may follow. By convention (inherited from Nest), if the LAST optional
+ * param is a string, the backend treats it as the per-call context;
+ * everything else is extra payload (e.g. an Error object, a structured
+ * metadata bag, or a stack trace).
+ *
+ * @module libs/shared/src/logging
+ * @see {@link Logger} for the consumer-facing factory class.
+ */
+export interface LoggerPort {
+  log(message: unknown, ...optionalParams: unknown[]): void;
+  debug(message: unknown, ...optionalParams: unknown[]): void;
+  warn(message: unknown, ...optionalParams: unknown[]): void;
+  error(message: unknown, ...optionalParams: unknown[]): void;
+}

--- a/libs/shared/src/logging/logger.spec.ts
+++ b/libs/shared/src/logging/logger.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Logger Spec
+ *
+ * Covers the backend-registry contract and the `Logger` factory's context
+ * forwarding. The module-level `activeBackend` is process-wide singleton
+ * state, so EVERY test that calls `setLoggerBackend(...)` must restore the
+ * previous backend in `afterEach` to avoid leaking into sibling specs.
+ *
+ * @module libs/shared/src/logging
+ */
+import { ConsoleLoggerAdapter } from './console-logger.adapter';
+import { Logger, getLoggerBackend, setLoggerBackend } from './logger';
+import { LoggerPort } from './logger.port';
+
+function createFakeBackend(): jest.Mocked<LoggerPort> {
+  return {
+    log: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+describe('Logger', () => {
+  let previousBackend: LoggerPort;
+  let backend: jest.Mocked<LoggerPort>;
+
+  beforeEach(() => {
+    previousBackend = getLoggerBackend();
+    backend = createFakeBackend();
+    setLoggerBackend(backend);
+  });
+
+  afterEach(() => {
+    setLoggerBackend(previousBackend);
+  });
+
+  it('defaults to ConsoleLoggerAdapter when no backend is installed', () => {
+    setLoggerBackend(previousBackend);
+    expect(getLoggerBackend()).toBeInstanceOf(ConsoleLoggerAdapter);
+  });
+
+  it('appends the instance context when no trailing-string context is supplied', () => {
+    new Logger('Ctx').log('hello');
+    expect(backend.log).toHaveBeenCalledWith('hello', 'Ctx');
+  });
+
+  it('forwards a structured-data extra param and still appends the bound context', () => {
+    const meta = { actor: 'alice', action: 'rotate' };
+    new Logger('Ctx').log('event', meta);
+    expect(backend.log).toHaveBeenCalledWith('event', meta, 'Ctx');
+  });
+
+  it('forwards an Error as the second arg to error() and appends the bound context', () => {
+    const err = new Error('boom');
+    new Logger('Ctx').error('failure', err);
+    expect(backend.error).toHaveBeenCalledWith('failure', err, 'Ctx');
+  });
+
+  it('preserves a caller-supplied trailing-string context (no double-append)', () => {
+    new Logger('DefaultCtx').log('hi', 'OverrideCtx');
+    expect(backend.log).toHaveBeenCalledWith('hi', 'OverrideCtx');
+  });
+
+  it('preserves caller-supplied stack + context positional pair on error()', () => {
+    new Logger('DefaultCtx').error('msg', 'stack-trace', 'OverrideCtx');
+    expect(backend.error).toHaveBeenCalledWith('msg', 'stack-trace', 'OverrideCtx');
+  });
+
+  it('falls back to "Application" context when constructed without one', () => {
+    new Logger().log('hi');
+    expect(backend.log).toHaveBeenCalledWith('hi', 'Application');
+  });
+
+  it('allows setLoggerBackend to swap the implementation at runtime', () => {
+    const next = createFakeBackend();
+    setLoggerBackend(next);
+    new Logger('Ctx').log('hi');
+    expect(backend.log).not.toHaveBeenCalled();
+    expect(next.log).toHaveBeenCalledWith('hi', 'Ctx');
+  });
+});

--- a/libs/shared/src/logging/logger.ts
+++ b/libs/shared/src/logging/logger.ts
@@ -1,17 +1,75 @@
 /**
- * Logger Wrapper
+ * Logger
  *
- * Wrapper around NestJS Logger providing consistent logging interface
- * across the application. Extends NestJS Logger with additional context
- * support for structured logging.
+ * Consumer-facing factory class that all 90+ call sites use as
+ * `private readonly logger = new Logger(ClassName.name)`. The class itself
+ * is framework-neutral — it delegates every call to a process-wide active
+ * `LoggerPort` backend. The backend defaults to `ConsoleLoggerAdapter` and
+ * is swapped by host apps at boot via `setLoggerBackend()` (typically through
+ * `installNestLogger()` from `@openlinker/shared/logging/nest`).
+ *
+ * Plugins compiled against `@openlinker/shared` never transitively import
+ * `@nestjs/common` through the logger — that dependency lives only in the
+ * `./nest` subpath, loaded by host applications.
  *
  * @module libs/shared/src/logging
+ * @implements {LoggerPort}
  */
-import { Logger as NestLogger } from '@nestjs/common';
+import { ConsoleLoggerAdapter } from './console-logger.adapter';
+import { LoggerPort } from './logger.port';
 
-export class Logger extends NestLogger {
-  constructor(context?: string) {
-    super(context ?? 'Application');
-  }
+let activeBackend: LoggerPort = new ConsoleLoggerAdapter();
+
+/**
+ * Replace the active logger backend. Called by host apps at boot.
+ * Also used by tests — always restore the previous backend in `afterEach`
+ * to avoid polluting sibling specs in the same Jest worker.
+ */
+export function setLoggerBackend(backend: LoggerPort): void {
+  activeBackend = backend;
 }
 
+/**
+ * Read the active logger backend. Exposed for tests and for advanced
+ * compositions (e.g. a wrapping backend that forwards to the previous one).
+ */
+export function getLoggerBackend(): LoggerPort {
+  return activeBackend;
+}
+
+export class Logger implements LoggerPort {
+  private readonly context: string;
+
+  constructor(context?: string) {
+    this.context = context ?? 'Application';
+  }
+
+  log(message: unknown, ...optionalParams: unknown[]): void {
+    activeBackend.log(message, ...this.appendContextIfMissing(optionalParams));
+  }
+
+  debug(message: unknown, ...optionalParams: unknown[]): void {
+    activeBackend.debug(message, ...this.appendContextIfMissing(optionalParams));
+  }
+
+  warn(message: unknown, ...optionalParams: unknown[]): void {
+    activeBackend.warn(message, ...this.appendContextIfMissing(optionalParams));
+  }
+
+  error(message: unknown, ...optionalParams: unknown[]): void {
+    activeBackend.error(message, ...this.appendContextIfMissing(optionalParams));
+  }
+
+  /**
+   * Append the instance context as the trailing string param IF the caller
+   * didn't already supply a trailing-string context. Mirrors NestJS Logger
+   * semantics so existing call sites (`logger.log(msg, structuredData)` or
+   * `logger.error(msg, error.stack)`) keep working unchanged.
+   */
+  private appendContextIfMissing(params: unknown[]): unknown[] {
+    if (params.length > 0 && typeof params[params.length - 1] === 'string') {
+      return params;
+    }
+    return [...params, this.context];
+  }
+}

--- a/libs/shared/src/logging/logger.types.ts
+++ b/libs/shared/src/logging/logger.types.ts
@@ -1,0 +1,11 @@
+/**
+ * Logger Types
+ *
+ * Enumerated log levels following the documented `as const + union` pattern
+ * (engineering-standards "Union Types"). `LogLevelValues` is the runtime
+ * array; `LogLevel` is the derived union type.
+ *
+ * @module libs/shared/src/logging
+ */
+export const LogLevelValues = ['log', 'debug', 'warn', 'error'] as const;
+export type LogLevel = (typeof LogLevelValues)[number];

--- a/libs/shared/src/logging/nest/index.ts
+++ b/libs/shared/src/logging/nest/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Logging / NestJS Subpath Exports
+ *
+ * Host-only entry point that ships the NestJS-backed `LoggerPort` adapter
+ * and its `installNestLogger()` installer. Application bootstrap files
+ * (`apps/api`, `apps/worker`) import from here; library code and plugins
+ * import only from `@openlinker/shared/logging`.
+ *
+ * @module libs/shared/src/logging/nest
+ */
+export { NestLoggerAdapter } from './nest-logger.adapter';
+export { installNestLogger } from './install';

--- a/libs/shared/src/logging/nest/install.ts
+++ b/libs/shared/src/logging/nest/install.ts
@@ -1,0 +1,17 @@
+/**
+ * NestJS Logger Installer
+ *
+ * One-liner host helper that swaps the active `LoggerPort` backend to the
+ * NestJS-backed adapter. Call as the first statement of an app's
+ * `bootstrap()` so every subsequent `new Logger(ctx).log(...)` call emits
+ * via Nest's logger formatter.
+ *
+ * @module libs/shared/src/logging/nest
+ */
+import { setLoggerBackend } from '../logger';
+
+import { NestLoggerAdapter } from './nest-logger.adapter';
+
+export function installNestLogger(): void {
+  setLoggerBackend(new NestLoggerAdapter());
+}

--- a/libs/shared/src/logging/nest/nest-logger.adapter.spec.ts
+++ b/libs/shared/src/logging/nest/nest-logger.adapter.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * NestJS Logger Adapter Spec
+ *
+ * Covers the host-only Nest-backed backend: per-context instance reuse,
+ * trailing-string-as-context consumption (not double-passed as payload),
+ * and stack-as-second-arg forwarding to `NestLogger.error`.
+ *
+ * @module libs/shared/src/logging/nest
+ */
+import { Logger as NestLogger } from '@nestjs/common';
+
+import { NestLoggerAdapter } from './nest-logger.adapter';
+
+const argsOf = (spy: jest.SpyInstance, callIndex = 0): unknown[] =>
+  (spy.mock.calls[callIndex] as unknown[] | undefined) ?? [];
+
+describe('NestLoggerAdapter', () => {
+  let adapter: NestLoggerAdapter;
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    adapter = new NestLoggerAdapter();
+    logSpy = jest.spyOn(NestLogger.prototype, 'log').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(NestLogger.prototype, 'warn').mockImplementation(() => undefined);
+    debugSpy = jest.spyOn(NestLogger.prototype, 'debug').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(NestLogger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('routes log() through the NestLogger instance bound to the trailing context', () => {
+    adapter.log('hello', 'Ctx');
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(argsOf(logSpy)[0]).toBe('hello');
+  });
+
+  it('routes warn() through NestLogger.prototype.warn', () => {
+    adapter.warn('careful', 'Ctx');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(argsOf(warnSpy)[0]).toBe('careful');
+  });
+
+  it('routes debug() through NestLogger.prototype.debug', () => {
+    adapter.debug('trace', 'Ctx');
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(argsOf(debugSpy)[0]).toBe('trace');
+  });
+
+  it('forwards the stack argument to NestLogger.error and consumes the trailing context', () => {
+    adapter.error('failure', 'stack-trace', 'Ctx');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const args = argsOf(errorSpy);
+    expect(args[0]).toBe('failure');
+    expect(args[1]).toBe('stack-trace');
+    // Trailing context must NOT be passed through as a third positional arg —
+    // Nest derives the context from the per-instance NestLogger itself.
+    expect(args).toHaveLength(2);
+  });
+
+  it('reuses the same NestLogger instance across calls with the same context', () => {
+    adapter.log('one', 'CachedCtx');
+    adapter.log('two', 'CachedCtx');
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    const cache = (adapter as unknown as { instances: Map<string, NestLogger> }).instances;
+    expect(cache.size).toBe(1);
+    expect(cache.has('CachedCtx')).toBe(true);
+  });
+
+  it('falls back to the "Application" context when no trailing string is supplied', () => {
+    adapter.log('hi');
+    const cache = (adapter as unknown as { instances: Map<string, NestLogger> }).instances;
+    expect(cache.has('Application')).toBe(true);
+  });
+
+  it('does not pass the trailing context through as an extra payload arg on log()', () => {
+    adapter.log('msg', { extra: 1 }, 'Ctx');
+    const args = argsOf(logSpy);
+    expect(args[0]).toBe('msg');
+    expect(args[1]).toEqual({ extra: 1 });
+    expect(args).toHaveLength(2); // context stripped before forwarding
+  });
+});

--- a/libs/shared/src/logging/nest/nest-logger.adapter.ts
+++ b/libs/shared/src/logging/nest/nest-logger.adapter.ts
@@ -1,0 +1,83 @@
+/**
+ * NestJS Logger Adapter
+ *
+ * `LoggerPort` implementation that delegates to `@nestjs/common`'s `Logger`,
+ * preserving the existing `[Nest] <pid> - <date> <level> [<context>] <msg>`
+ * output shape in production. Maintains a per-context cache of `NestLogger`
+ * instances to match Nest's per-context formatting and to avoid reallocating
+ * loggers on every call.
+ *
+ * The `LoggerPort` contract mirrors Nest's variadic signature, so each
+ * method forwards `optionalParams` verbatim — Nest handles the
+ * trailing-string-as-context convention itself.
+ *
+ * Lives on the `@openlinker/shared/logging/nest` subpath so the
+ * `@nestjs/common` import never leaks into plugin builds that depend only on
+ * the neutral `@openlinker/shared/logging` surface.
+ *
+ * @module libs/shared/src/logging/nest
+ */
+import { Logger as NestLogger } from '@nestjs/common';
+
+import { LoggerPort } from '../logger.port';
+import { LogLevel } from '../logger.types';
+
+const DEFAULT_CONTEXT = 'Application';
+
+export class NestLoggerAdapter implements LoggerPort {
+  // Per-context `NestLogger` cache. Context should be a bounded
+  // class-name-like identifier (e.g. `ProductSyncService.name`), not a
+  // per-request handle — this Map grows monotonically for the process
+  // lifetime.
+  private readonly instances = new Map<string, NestLogger>();
+
+  log(message: unknown, ...optionalParams: unknown[]): void {
+    this.forward('log', message, optionalParams);
+  }
+
+  debug(message: unknown, ...optionalParams: unknown[]): void {
+    this.forward('debug', message, optionalParams);
+  }
+
+  warn(message: unknown, ...optionalParams: unknown[]): void {
+    this.forward('warn', message, optionalParams);
+  }
+
+  error(message: unknown, ...optionalParams: unknown[]): void {
+    this.forward('error', message, optionalParams);
+  }
+
+  /**
+   * Single forwarding seam — resolves the per-context NestLogger and invokes
+   * the matching method. The `as never` cast localises the gap between our
+   * `LoggerPort` (`message: unknown`) and Nest's overloaded `Logger` API
+   * (typed as `any` upstream) to one line instead of four.
+   */
+  private forward(level: LogLevel, message: unknown, optionalParams: unknown[]): void {
+    const { logger, payload } = this.resolve(optionalParams);
+    logger[level](message as never, ...payload);
+  }
+
+  /**
+   * Pick the per-context `NestLogger` instance and return the remaining
+   * payload to pass through. We pop the trailing-string context (if any)
+   * because Nest itself uses the `Logger` instance's context, not a
+   * trailing param — passing it through twice would render `[Ctx]` in the
+   * payload as well.
+   */
+  private resolve(params: unknown[]): { logger: NestLogger; payload: unknown[] } {
+    let context = DEFAULT_CONTEXT;
+    let payload = params;
+    if (params.length > 0 && typeof params[params.length - 1] === 'string') {
+      context = params[params.length - 1] as string;
+      payload = params.slice(0, -1);
+    }
+
+    let logger = this.instances.get(context);
+    if (!logger) {
+      logger = new NestLogger(context);
+      this.instances.set(context, logger);
+    }
+    return { logger, payload };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #589.

- Introduces a neutral `LoggerPort` (`log/debug/warn/error`, variadic to mirror Nest) in `@openlinker/shared/logging`, plus a zero-dependency default `ConsoleLoggerAdapter`. Plugins compiled against `@openlinker/shared` no longer transitively pull `@nestjs/common` through the logger.
- Moves the NestJS-backed adapter to a host-only `@openlinker/shared/logging/nest` subpath; `apps/api` and `apps/worker` call `installNestLogger()` as the first statement of `bootstrap()` so production output stays byte-identical.
- Preserves `new Logger(ClassName.name)` ergonomics across all 91 call sites — no consumer migration.

## Side-effect fixes

- `libs/core` + `apps/worker` jest configs add the bare-path `@openlinker/shared` module-name mapper (`apps/api` already had it). Without it, prod code resolved to `dist/` while specs resolved to source — different `Logger` prototypes — so `jest.spyOn(Logger.prototype, …)` silently missed.
- 4 existing specs (`plugin-registry.module`, `ai-provider-active-settings`, `ai-provider-key`, `credentials-ai-provider`) now spy on the shared `Logger.prototype` directly. The previous shape relied on `Logger extends NestLogger`.
- `engineering-standards.md` §Logging example updated to `(error as Error).stack` to match strict-mode `catch (error: unknown)`.

## Architecture

`@nestjs/common` is now imported once for logging — in `libs/shared/src/logging/nest/nest-logger.adapter.ts`. Grep confirms no other file in `libs/shared/src/logging/` references it.

```
libs/shared/src/logging/
├── logger.port.ts              # LoggerPort interface
├── logger.types.ts             # LogLevelValues + LogLevel (as const)
├── logger.ts                   # Logger factory + setLoggerBackend/getLoggerBackend
├── console-logger.adapter.ts   # Default backend (zero deps)
├── logger.spec.ts              # registry + delegation tests
├── console-logger.adapter.spec.ts
└── nest/
    ├── nest-logger.adapter.ts  # NestLoggerAdapter (only file importing @nestjs/common)
    ├── nest-logger.adapter.spec.ts
    └── install.ts              # installNestLogger() one-liner
```

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — **1718/1718** passing (+16 new from the two adapter specs)
- [x] `grep -r "@nestjs/common" libs/shared/src/logging/` matches only files under `nest/`
- [x] `grep -r "extends NestLogger" libs apps` returns nothing
- [x] 91 existing `new Logger(ctx)` call sites unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)