### PR TITLE
refactor(web): introduce build-time plugin registry + open ApiClient

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,8 +69,8 @@ module.exports = {
           {
             patterns: [
               {
-                group: ['**/features/**', '**/pages/**', '**/app/**'],
-                message: 'Shared modules must not import feature, page, or app modules.',
+                group: ['**/features/**', '**/pages/**', '**/app/**', '**/plugins/**'],
+                message: 'Shared modules must not import feature, page, app, or plugin modules.',
               },
             ],
           },
@@ -92,8 +92,8 @@ module.exports = {
           {
             patterns: [
               {
-                group: ['**/pages/**'],
-                message: 'Feature modules must not import page modules.',
+                group: ['**/pages/**', '**/plugins/**'],
+                message: 'Feature modules must not import page or plugin modules.',
               },
               {
                 group: ['@radix-ui/*', '@tanstack/react-table', '@tanstack/react-virtual'],
@@ -128,8 +128,8 @@ module.exports = {
           {
             patterns: [
               {
-                group: ['**/app/**'],
-                message: 'Page modules must not import app modules.',
+                group: ['**/app/**', '**/plugins/**'],
+                message: 'Page modules must not import app or plugin modules.',
               },
               {
                 group: ['@radix-ui/*', '@tanstack/react-table', '@tanstack/react-virtual'],
@@ -162,6 +162,52 @@ module.exports = {
                   'Headless UI libraries are wrapped by primitives in shared/ui/. Import the project primitive instead of the library directly.',
               },
             ],
+          },
+        ],
+      },
+    },
+    {
+      // Plugin boundary (#604): plugins compose pages/features/shared and may
+      // reference the public type seam at `app/api/api-client` only. Importing
+      // any other `app/` path would couple plugins to host internals (router,
+      // layouts, app-shell) and defeat the seam introduced for OSS plugin
+      // contribution. Enumerated explicitly because the `ignore`-style glob
+      // negation we'd normally use ('**/app/**', '!**/app/api/api-client') is
+      // unreliable across `ignore` versions; an explicit list is shorter than
+      // arguing about it and reads honestly in the diff.
+      files: ['apps/web/src/plugins/**/*.{ts,tsx}'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: [
+                  '**/app/router*',
+                  '**/app/app',
+                  '**/app/app.tsx',
+                  '**/app/layouts/**',
+                  '**/app/routes/**',
+                  '**/app/hooks/**',
+                  '**/app/providers/**',
+                  '**/app/api/api-client-provider*',
+                ],
+                message:
+                  'Plugin modules must not import host internals (router, routes, layouts, hooks, providers, the API client provider hook). The public surface plugins may consume is app/api/api-client (types) and app/app-shell (NavGroup types) — anything else couples plugins to host implementation.',
+              },
+              {
+                group: ['@radix-ui/*', '@tanstack/react-table', '@tanstack/react-virtual'],
+                message:
+                  'Headless UI libraries are wrapped by primitives in shared/ui/. Import the project primitive instead of the library directly.',
+              },
+            ],
+          },
+        ],
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'fetch',
+            message: 'Use API client modules from shared/api instead of raw fetch().',
           },
         ],
       },

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -1,9 +1,28 @@
+/**
+ * API client — composition of feature API factories
+ *
+ * Owns the typed `ApiClient` interface and the `createApiClient` factory.
+ * Split into two surfaces (#605):
+ *
+ *   - `CoreApiClient` — namespaces every host needs (auth, health, generic
+ *     resource CRUD). Closed and shipped with the host.
+ *   - `PluginApiNamespaces` — empty by default; plugins extend it via TS
+ *     declaration merging (see `apps/web/src/plugins/<name>/index.ts`).
+ *
+ *   `ApiClient = CoreApiClient & PluginApiNamespaces`.
+ *
+ * Composition order in `createApiClient`: build core namespaces → iterate
+ * `plugins` and merge each plugin's `apiNamespaces(request)` result. Caller
+ * overrides (test-utils only) merge last; see `apps/web/src/test/test-utils.tsx`.
+ *
+ * @module app/api
+ * @see apps/web/src/plugins/plugin.types.ts — the WebPlugin contract
+ */
 import { createAdaptersApi, type AdaptersApi } from '../../features/adapters/api/adapters.api';
 import {
   createAiProviderSettingsApi,
   type AiProviderSettingsApi,
 } from '../../features/ai-provider-settings/api/ai-provider-settings.api';
-import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/allegro.api';
 import { createAuthApi, type AuthApi } from '../../features/auth/api/auth.api';
 import { createConnectionsApi, type ConnectionsApi } from '../../features/connections/api/connections.api';
 import { createContentApi, type ContentApi } from '../../features/content/api/content.api';
@@ -24,6 +43,7 @@ import {
   createWebhookDeliveriesApi,
   type WebhookDeliveriesApi,
 } from '../../features/webhook-deliveries/api/webhook-deliveries.api';
+import { plugins } from '../../plugins';
 import { ApiError } from '../../shared/api/api-error';
 import type { SessionAdapter } from '../../shared/auth/session-adapter';
 
@@ -36,10 +56,26 @@ interface ApiClientConfig {
   sessionAdapter: SessionAdapter;
 }
 
-export interface ApiClient {
+/**
+ * The bound `request` function plugins receive from `createApiClient`.
+ * Already wraps auth-header injection, timeout, and error normalisation.
+ * Exposed as a named export so plugin types have a stable import target.
+ */
+export type ApiRequest = <T>(path: string, init?: RequestInit) => Promise<T>;
+
+/**
+ * Plugin-augmentable surface. Empty by default; each plugin extends it
+ * via `declare module '../../app/api/api-client'` (see the allegro plugin
+ * for the canonical pattern). The empty form is the documented TS shape
+ * for declaration-merging seams — the lint disable below is intentional
+ * and load-bearing.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface -- canonical declaration-merging seam; plugins extend via `declare module`
+export interface PluginApiNamespaces {}
+
+export interface CoreApiClient {
   adapters: AdaptersApi;
   aiProviderSettings: AiProviderSettingsApi;
-  allegro: AllegroApi;
   auth: AuthApi;
   connections: ConnectionsApi;
   content: ContentApi;
@@ -52,10 +88,12 @@ export interface ApiClient {
   products: ProductsApi;
   promptTemplates: PromptTemplatesApi;
   mappings: MappingsApi;
-  request: <T>(path: string, init?: RequestInit) => Promise<T>;
+  request: ApiRequest;
   syncJobs: SyncJobsApi;
   webhookDeliveries: WebhookDeliveriesApi;
 }
+
+export type ApiClient = CoreApiClient & PluginApiNamespaces;
 
 function buildUrl(baseUrl: string, path: string): string {
   return new URL(path, `${baseUrl.replace(/\/$/, '')}/`).toString();
@@ -81,7 +119,7 @@ export function createApiClient({
   requestTimeoutMs = DEFAULT_TIMEOUT_MS,
   sessionAdapter,
 }: ApiClientConfig): ApiClient {
-  const request = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
+  const request: ApiRequest = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
     const accessToken = await sessionAdapter.getAccessToken();
     const headers = new Headers(init.headers);
 
@@ -133,10 +171,9 @@ export function createApiClient({
     }
   };
 
-  return {
+  const core: CoreApiClient = {
     adapters: createAdaptersApi(request),
     aiProviderSettings: createAiProviderSettingsApi(request),
-    allegro: createAllegroApi(request),
     auth: createAuthApi(request),
     connections: createConnectionsApi(request),
     content: createContentApi(request),
@@ -153,4 +190,13 @@ export function createApiClient({
     syncJobs: createSyncJobsApi(request),
     webhookDeliveries: createWebhookDeliveriesApi(request),
   };
+
+  const pluginNamespaces: Partial<PluginApiNamespaces> = {};
+  for (const plugin of plugins) {
+    if (plugin.apiNamespaces) {
+      Object.assign(pluginNamespaces, plugin.apiNamespaces(request));
+    }
+  }
+
+  return { ...core, ...pluginNamespaces } as ApiClient;
 }

--- a/apps/web/src/app/api/api-client.ts
+++ b/apps/web/src/app/api/api-client.ts
@@ -67,10 +67,11 @@ export type ApiRequest = <T>(path: string, init?: RequestInit) => Promise<T>;
  * Plugin-augmentable surface. Empty by default; each plugin extends it
  * via `declare module '../../app/api/api-client'` (see the allegro plugin
  * for the canonical pattern). The empty form is the documented TS shape
- * for declaration-merging seams — the lint disable below is intentional
- * and load-bearing.
+ * for declaration-merging seams. `@typescript-eslint/no-empty-interface`
+ * is not enabled in the repo's eslint config (verified 2026-05-11), so no
+ * inline disable is needed; if the rule is added later, this is the line
+ * to exempt.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface -- canonical declaration-merging seam; plugins extend via `declare module`
 export interface PluginApiNamespaces {}
 
 export interface CoreApiClient {
@@ -198,5 +199,13 @@ export function createApiClient({
     }
   }
 
+  // Single boundary cast. The structural shape is guaranteed by the union of
+  // CoreApiClient (built above) and PluginApiNamespaces (augmented at compile
+  // time). Caveat the cast hides: declaration merging makes TS believe every
+  // augmented key is present, but the runtime presence depends on each plugin
+  // returning the right shape from `apiNamespaces`. A plugin that declares
+  // `allegro: AllegroApi` but forgets to return `{ allegro: … }` produces a
+  // type-checking `client.allegro` that is actually `undefined` at runtime —
+  // surfaces only at the call site.
   return { ...core, ...pluginNamespaces } as ApiClient;
 }

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -22,6 +22,8 @@ import {
 } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useSession } from '../shared/auth/use-session';
+import { mergePluginNavContributions } from '../plugins/merge-nav-contributions';
+import { plugins } from '../plugins';
 import { useNavCounts, type NavCounts } from './hooks/use-nav-counts';
 import { Button } from '../shared/ui/button';
 import { EnvironmentBadge } from '../shared/ui/environment-badge';
@@ -38,7 +40,7 @@ import { useToast } from '../shared/ui/toast-provider';
 
 type NavCountKey = Exclude<keyof NavCounts, never>;
 
-interface LiveNavItem {
+export interface LiveNavItem {
   countKey?: NavCountKey;
   end?: boolean;
   label: string;
@@ -50,7 +52,7 @@ interface PlannedNavItem {
   reason?: string;
 }
 
-interface LiveNavGroup {
+export interface LiveNavGroup {
   items: LiveNavItem[];
   kind: 'live';
   label: string;
@@ -62,7 +64,7 @@ interface PlannedNavGroup {
   label: string;
 }
 
-type NavGroup = LiveNavGroup | PlannedNavGroup;
+export type NavGroup = LiveNavGroup | PlannedNavGroup;
 
 interface NavGroupOptions {
   isAdmin: boolean;
@@ -342,7 +344,11 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
   const counts = useNavCounts();
   const isAdmin =
     isReady && session.status === 'authenticated' && session.user?.role === 'admin';
-  const groups = useMemo(() => buildNavGroups({ isAdmin }), [isAdmin]);
+  const groups = useMemo(() => {
+    const baseGroups = buildNavGroups({ isAdmin });
+    const contributions = plugins.flatMap((plugin) => plugin.navItems ?? []);
+    return mergePluginNavContributions(baseGroups, contributions);
+  }, [isAdmin]);
 
   const closeDrawer = useCallback((): void => {
     drawerRef.current?.close();

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -1,8 +1,19 @@
+/**
+ * Root authenticated route
+ *
+ * Composes the operator-facing route tree: a fixed core set + every route
+ * contributed by the plugin registry. React Router resolves matches by path
+ * specificity, not array position, so appending plugin routes is safe — a
+ * plugin can only "shadow" a core path by declaring an identical path.
+ *
+ * @module app/routes
+ * @see apps/web/src/plugins/index.ts — single edit point for plugin routes
+ */
 import type { RouteObject } from 'react-router-dom';
+
+import { plugins } from '../../plugins';
 import { AuthenticatedAppLayout } from '../layouts/authenticated-app-layout';
 import { adaptersRoute } from './adapters.route';
-import { allegroCallbackRoute } from './allegro-callback.route';
-import { allegroSetupRoute } from './allegro-setup.route';
 import { connectionDetailRoute } from './connection-detail.route';
 import { connectionCategoryMappingsRoute } from './connection-category-mappings.route';
 import { connectionMappingsRoute } from './connection-mappings.route';
@@ -16,7 +27,6 @@ import { aiProviderSettingsRoute } from './ai-provider-settings.route';
 import { inventoryRoute } from './inventory.route';
 import { jobsLogsRoute } from './jobs-logs.route';
 import { newConnectionRoute } from './new-connection.route';
-import { prestashopSetupRoute } from './prestashop-setup.route';
 import { advancedNewConnectionRoute } from './advanced-new-connection.route';
 import { ordersRoute } from './orders.route';
 import { productsRoute } from './products.route';
@@ -29,35 +39,36 @@ import {
 import { settingsRoute } from './settings.route';
 import { webhookDeliveriesRoute } from './webhook-deliveries.route';
 
+const coreChildren: RouteObject[] = [
+  dashboardRoute,
+  ordersRoute,
+  productsRoute,
+  inventoryRoute,
+  cursorsRoute,
+  customersRoute,
+  listingsRoute,
+  connectionsRoute,
+  adaptersRoute,
+  newConnectionRoute,
+  advancedNewConnectionRoute,
+  connectionDetailRoute,
+  connectionCategoryMappingsRoute,
+  connectionMappingsRoute,
+  editConnectionRoute,
+  jobsLogsRoute,
+  webhookDeliveriesRoute,
+  settingsRoute,
+  promptTemplatesListRoute,
+  promptTemplateDetailRoute,
+  promptTemplatesLegacyListRedirectRoute,
+  promptTemplateLegacyDetailRedirectRoute,
+  aiProviderSettingsRoute,
+];
+
+const pluginChildren: RouteObject[] = plugins.flatMap((plugin) => plugin.routes ?? []);
+
 export const rootRoute: RouteObject = {
   path: '/',
   element: <AuthenticatedAppLayout />,
-  children: [
-    dashboardRoute,
-    ordersRoute,
-    productsRoute,
-    inventoryRoute,
-    cursorsRoute,
-    customersRoute,
-    listingsRoute,
-    connectionsRoute,
-    adaptersRoute,
-    newConnectionRoute,
-    prestashopSetupRoute,
-    advancedNewConnectionRoute,
-    allegroSetupRoute,
-    connectionDetailRoute,
-    connectionCategoryMappingsRoute,
-    connectionMappingsRoute,
-    editConnectionRoute,
-    allegroCallbackRoute,
-    jobsLogsRoute,
-    webhookDeliveriesRoute,
-    settingsRoute,
-    promptTemplatesListRoute,
-    promptTemplateDetailRoute,
-    promptTemplatesLegacyListRedirectRoute,
-    promptTemplateLegacyDetailRedirectRoute,
-    aiProviderSettingsRoute,
-  ],
+  children: [...coreChildren, ...pluginChildren],
 };

--- a/apps/web/src/plugins/allegro/allegro-callback.route.tsx
+++ b/apps/web/src/plugins/allegro/allegro-callback.route.tsx
@@ -1,4 +1,10 @@
+/**
+ * Route: `/integrations/allegro/connect/callback` — OAuth2 callback landing.
+ *
+ * @module plugins/allegro
+ */
 import type { RouteObject } from 'react-router-dom';
+
 import { AllegroConnectCallbackPage } from '../../pages/integrations/allegro-connect-callback-page';
 
 export const allegroCallbackRoute: RouteObject = {

--- a/apps/web/src/plugins/allegro/allegro-plugin.test.ts
+++ b/apps/web/src/plugins/allegro/allegro-plugin.test.ts
@@ -1,0 +1,32 @@
+/**
+ * allegroPlugin smoke test
+ *
+ * Asserts the plugin's static surface (id, routes, apiNamespaces factory
+ * shape). The behavior of `createAllegroApi` is covered by feature tests.
+ *
+ * @module plugins/allegro
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiRequest } from '../../app/api/api-client';
+
+import { allegroPlugin } from './index';
+
+describe('allegroPlugin', () => {
+  it('has the stable kebab-case id', () => {
+    expect(allegroPlugin.id).toBe('allegro');
+  });
+
+  it('contributes the OAuth callback and setup routes', () => {
+    const paths = (allegroPlugin.routes ?? []).map((route) => route.path);
+    expect(paths).toContain('integrations/allegro/connect/callback');
+    expect(paths).toContain('connections/new/allegro');
+  });
+
+  it('contributes the `allegro` API namespace when its factory is called', () => {
+    const stubRequest: ApiRequest = vi.fn();
+    const namespaces = allegroPlugin.apiNamespaces?.(stubRequest);
+    expect(namespaces).toBeDefined();
+    expect(namespaces && 'allegro' in namespaces).toBe(true);
+  });
+});

--- a/apps/web/src/plugins/allegro/allegro-setup.route.tsx
+++ b/apps/web/src/plugins/allegro/allegro-setup.route.tsx
@@ -1,4 +1,10 @@
+/**
+ * Route: `/connections/new/allegro` — guided Allegro wizard.
+ *
+ * @module plugins/allegro
+ */
 import type { RouteObject } from 'react-router-dom';
+
 import { AllegroSetupPage } from '../../pages/connections/allegro-setup-page';
 
 export const allegroSetupRoute: RouteObject = {

--- a/apps/web/src/plugins/allegro/index.ts
+++ b/apps/web/src/plugins/allegro/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Allegro plugin
+ *
+ * Contributes the Allegro typed API namespace (`apiClient.allegro`) and the
+ * two Allegro-specific routes (OAuth callback + setup wizard). The actual
+ * API factory and page components stay in `features/allegro/` and `pages/`
+ * for this MVP — this file is the thin shim that wires them into the
+ * registry.
+ *
+ * @module plugins/allegro
+ */
+import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/allegro.api';
+import { definePlugin } from '../define-plugin';
+import { allegroCallbackRoute } from './allegro-callback.route';
+import { allegroSetupRoute } from './allegro-setup.route';
+
+declare module '../../app/api/api-client' {
+  interface PluginApiNamespaces {
+    allegro: AllegroApi;
+  }
+}
+
+export const allegroPlugin = definePlugin({
+  id: 'allegro',
+  routes: [allegroCallbackRoute, allegroSetupRoute],
+  apiNamespaces: (request) => ({ allegro: createAllegroApi(request) }),
+});

--- a/apps/web/src/plugins/assert-unique-plugin-ids.ts
+++ b/apps/web/src/plugins/assert-unique-plugin-ids.ts
@@ -1,0 +1,27 @@
+/**
+ * assertUniquePluginIds
+ *
+ * Boot-time invariant: plugin ids must be unique across the registry.
+ * Extracted as a pure helper so the failure path is exercisable from
+ * tests without dynamic-import gymnastics — the barrel calls it at
+ * module load with the static `plugins` array.
+ *
+ * @module plugins
+ */
+import type { WebPlugin } from './plugin.types';
+
+export function assertUniquePluginIds(plugins: readonly WebPlugin[]): void {
+  const seen = new Set<string>();
+  for (const plugin of plugins) {
+    if (seen.has(plugin.id)) {
+      const duplicateIds = plugins
+        .filter((p) => p.id === plugin.id)
+        .map((_, i) => `plugins[${i}]`)
+        .join(', ');
+      throw new Error(
+        `Duplicate plugin id: "${plugin.id}" appears multiple times in the registry (${duplicateIds}). Plugin ids must be unique.`,
+      );
+    }
+    seen.add(plugin.id);
+  }
+}

--- a/apps/web/src/plugins/define-plugin.ts
+++ b/apps/web/src/plugins/define-plugin.ts
@@ -1,0 +1,15 @@
+/**
+ * definePlugin
+ *
+ * Identity helper for authoring a `WebPlugin`. Exists purely for type-checked
+ * ergonomics — plugin authors get full IntelliSense on the slot shape without
+ * having to annotate the export themselves. Mirrors the pattern of Vite's
+ * `defineConfig` and similar.
+ *
+ * @module plugins
+ */
+import type { WebPlugin } from './plugin.types';
+
+export function definePlugin(plugin: WebPlugin): WebPlugin {
+  return plugin;
+}

--- a/apps/web/src/plugins/index.ts
+++ b/apps/web/src/plugins/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Plugin registry — single edit point
+ *
+ * Lists every in-tree plugin the FE host should compose. To enable a new
+ * plugin, drop a directory under `apps/web/src/plugins/<name>/` exporting
+ * a `WebPlugin` (built via `definePlugin({...})`) and append it here.
+ *
+ * Mirrors `apps/api/src/plugins.ts` (BE counterpart, #572). Same intent:
+ * the OSS contributor never has to edit core composition files.
+ *
+ * @module plugins
+ */
+import { allegroPlugin } from './allegro';
+import { prestashopPlugin } from './prestashop';
+import type { WebPlugin } from './plugin.types';
+
+export const plugins: WebPlugin[] = [allegroPlugin, prestashopPlugin];
+
+// Boot-time invariant: plugin ids must be unique. Catches forks/copies that
+// forget to rename. Runs once at module load — empty static array passes,
+// duplicates fail loudly in dev + CI.
+const seen = new Set<string>();
+for (const plugin of plugins) {
+  if (seen.has(plugin.id)) {
+    throw new Error(`Duplicate plugin id: "${plugin.id}". Plugin ids must be unique.`);
+  }
+  seen.add(plugin.id);
+}

--- a/apps/web/src/plugins/index.ts
+++ b/apps/web/src/plugins/index.ts
@@ -5,24 +5,25 @@
  * plugin, drop a directory under `apps/web/src/plugins/<name>/` exporting
  * a `WebPlugin` (built via `definePlugin({...})`) and append it here.
  *
+ * **Both runtime composition AND TS declaration-merging require the plugin
+ * to be in this array.** Each plugin's `declare module '../../app/api/api-client'`
+ * block is only picked up by the compiler when the plugin file is in the
+ * import graph — and the only path that puts it there is being referenced
+ * from this barrel. A plugin that exists on disk but isn't listed here
+ * contributes nothing at runtime AND its type augmentation silently has
+ * no effect at compile time. There is no warning for this; assume your
+ * augmented `apiClient.<plugin>` field is missing if you forgot the entry.
+ *
  * Mirrors `apps/api/src/plugins.ts` (BE counterpart, #572). Same intent:
  * the OSS contributor never has to edit core composition files.
  *
  * @module plugins
  */
 import { allegroPlugin } from './allegro';
+import { assertUniquePluginIds } from './assert-unique-plugin-ids';
 import { prestashopPlugin } from './prestashop';
 import type { WebPlugin } from './plugin.types';
 
 export const plugins: WebPlugin[] = [allegroPlugin, prestashopPlugin];
 
-// Boot-time invariant: plugin ids must be unique. Catches forks/copies that
-// forget to rename. Runs once at module load — empty static array passes,
-// duplicates fail loudly in dev + CI.
-const seen = new Set<string>();
-for (const plugin of plugins) {
-  if (seen.has(plugin.id)) {
-    throw new Error(`Duplicate plugin id: "${plugin.id}". Plugin ids must be unique.`);
-  }
-  seen.add(plugin.id);
-}
+assertUniquePluginIds(plugins);

--- a/apps/web/src/plugins/merge-nav-contributions.test.ts
+++ b/apps/web/src/plugins/merge-nav-contributions.test.ts
@@ -1,0 +1,101 @@
+/**
+ * mergePluginNavContributions tests
+ *
+ * Pins the merge semantics: append to matching live group; create a new
+ * group at the end when no match; preserve `planned` groups untouched.
+ *
+ * @module plugins
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { NavGroup } from '../app/app-shell';
+import { mergePluginNavContributions } from './merge-nav-contributions';
+import type { NavContribution } from './plugin.types';
+
+function baseGroups(): NavGroup[] {
+  return [
+    {
+      kind: 'live',
+      label: 'Operations',
+      items: [{ to: '/', label: 'Dashboard', end: true }],
+    },
+    {
+      kind: 'live',
+      label: 'Platform',
+      items: [{ to: '/connections', label: 'Connections' }],
+    },
+    {
+      kind: 'planned',
+      label: 'Planned',
+      items: [{ label: 'Automations', reason: 'Coming soon' }],
+    },
+  ];
+}
+
+describe('mergePluginNavContributions', () => {
+  it('returns the same array reference when there are no contributions', () => {
+    const groups = baseGroups();
+    expect(mergePluginNavContributions(groups, [])).toBe(groups);
+  });
+
+  it('appends a contribution to a matching live group', () => {
+    const contribution: NavContribution = {
+      groupLabel: 'Platform',
+      to: '/connections/new/shopify',
+      label: 'Connect Shopify',
+    };
+
+    const result = mergePluginNavContributions(baseGroups(), [contribution]);
+
+    const platform = result.find((g) => g.label === 'Platform');
+    expect(platform?.kind).toBe('live');
+    expect(platform?.kind === 'live' && platform.items).toEqual([
+      { to: '/connections', label: 'Connections' },
+      { to: '/connections/new/shopify', label: 'Connect Shopify', end: undefined },
+    ]);
+  });
+
+  it('creates a new live group at the end when groupLabel is unknown', () => {
+    const contribution: NavContribution = {
+      groupLabel: 'Reporting',
+      to: '/reports/sales',
+      label: 'Sales',
+    };
+
+    const result = mergePluginNavContributions(baseGroups(), [contribution]);
+
+    expect(result).toHaveLength(4);
+    const last = result.at(-1);
+    expect(last).toMatchObject({
+      kind: 'live',
+      label: 'Reporting',
+      items: [{ to: '/reports/sales', label: 'Sales', end: undefined }],
+    });
+  });
+
+  it('does not mutate the input groups array or its items', () => {
+    const groups = baseGroups();
+    const snapshot = JSON.parse(JSON.stringify(groups)) as NavGroup[];
+
+    mergePluginNavContributions(groups, [
+      { groupLabel: 'Operations', to: '/x', label: 'X' },
+    ]);
+
+    expect(groups).toEqual(snapshot);
+  });
+
+  it('appends multiple contributions in registry order within the same group', () => {
+    const contributions: NavContribution[] = [
+      { groupLabel: 'Platform', to: '/a', label: 'A' },
+      { groupLabel: 'Platform', to: '/b', label: 'B' },
+    ];
+
+    const result = mergePluginNavContributions(baseGroups(), contributions);
+    const platform = result.find((g) => g.label === 'Platform');
+    expect(platform?.kind === 'live' && platform.items.map((i) => i.label)).toEqual([
+      'Connections',
+      'A',
+      'B',
+    ]);
+  });
+});

--- a/apps/web/src/plugins/merge-nav-contributions.ts
+++ b/apps/web/src/plugins/merge-nav-contributions.ts
@@ -1,0 +1,58 @@
+/**
+ * mergePluginNavContributions
+ *
+ * Pure helper that folds plugin nav contributions into the host's static
+ * nav groups. For each contribution: find a `LiveNavGroup` whose `label`
+ * matches `groupLabel` and append; otherwise create a new live group at
+ * the end of the list. Group order is stable; within a group, contributions
+ * are appended in registry order.
+ *
+ * Exported as a standalone module so the merge logic stays unit-testable
+ * without booting the app shell.
+ *
+ * @module plugins
+ */
+import type { LiveNavGroup, LiveNavItem, NavGroup } from '../app/app-shell';
+import type { NavContribution } from './plugin.types';
+
+function toLiveNavItem(contribution: NavContribution): LiveNavItem {
+  return {
+    to: contribution.to,
+    label: contribution.label,
+    end: contribution.end,
+  };
+}
+
+export function mergePluginNavContributions(
+  groups: NavGroup[],
+  contributions: NavContribution[],
+): NavGroup[] {
+  if (contributions.length === 0) {
+    return groups;
+  }
+
+  const result: NavGroup[] = groups.map((group) =>
+    group.kind === 'live' ? { ...group, items: [...group.items] } : group,
+  );
+
+  for (const contribution of contributions) {
+    const item = toLiveNavItem(contribution);
+    const target = result.find(
+      (group): group is LiveNavGroup =>
+        group.kind === 'live' && group.label === contribution.groupLabel,
+    );
+
+    if (target) {
+      target.items.push(item);
+      continue;
+    }
+
+    result.push({
+      kind: 'live',
+      label: contribution.groupLabel,
+      items: [item],
+    });
+  }
+
+  return result;
+}

--- a/apps/web/src/plugins/plugin-registry.test.ts
+++ b/apps/web/src/plugins/plugin-registry.test.ts
@@ -4,9 +4,10 @@
  * Pins the contract a plugin author depends on:
  *   - `createApiClient` merges every plugin's `apiNamespaces` into the
  *     returned client (with the bound `request` function).
- *   - Route slot flows through (covered indirectly here; route precedence
- *     is React Router's job).
- *   - Duplicate plugin ids fail loudly at module load time.
+ *   - Caller overrides in `createMockApiClient` win over plugin contributions
+ *     so existing tests that stub a plugin namespace keep working.
+ *   - Duplicate plugin ids throw at module load (failure path verified
+ *     directly against the `assertUniquePluginIds` helper).
  *
  * @module plugins
  */
@@ -14,7 +15,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createApiClient, type ApiRequest, type PluginApiNamespaces } from '../app/api/api-client';
 import { createNoopSessionAdapter } from '../shared/auth/noop-session-adapter';
+import { createMockApiClient } from '../test/test-utils';
 
+import { assertUniquePluginIds } from './assert-unique-plugin-ids';
 import { definePlugin } from './define-plugin';
 import { plugins } from './index';
 
@@ -48,11 +51,14 @@ describe('plugin registry', () => {
     });
   });
 
-  describe('apiNamespaces factory contract', () => {
-    it('receives the bound request function from createApiClient', () => {
-      // Verify the seam by inspecting an inline plugin's factory result. We
-      // can't easily intercept the real registry from inside createApiClient,
-      // so we exercise the plugin's factory directly with a stub.
+  describe('WebPlugin contract', () => {
+    it("definePlugin's apiNamespaces factory receives the request it is invoked with", () => {
+      // Narrow contract test: a `definePlugin` author can rely on the
+      // `request` argument being the one the host passes in. We don't go
+      // through `createApiClient` here — the registry barrel is static, so
+      // there's no clean way to inject a fixture plugin without mutating
+      // module state. Verifying the plugin's own factory contract is the
+      // right level: createApiClient just calls this contract.
       const stubRequest: ApiRequest = vi.fn();
       const shopifyPlugin = definePlugin({
         id: 'shopify-test-fixture',
@@ -67,10 +73,49 @@ describe('plugin registry', () => {
     });
   });
 
-  describe('id uniqueness', () => {
-    it('the in-tree plugins barrel has no duplicate ids', () => {
+  describe('createMockApiClient merge order', () => {
+    it('caller overrides win over plugin contributions', () => {
+      // Documents the merge order spelled out in test-utils.tsx:
+      //   hardcoded defaults → caller overrides.
+      // Existing tests that pass `{ allegro: { startOAuth: vi.fn(...) } }`
+      // rely on this — if the order ever flips, every Allegro-flow test
+      // silently starts hitting the default mock instead of the caller's.
+      const callerOverride = vi.fn().mockResolvedValue({
+        authorizationUrl: 'http://override',
+        state: 'override-state',
+      });
+
+      const client = createMockApiClient({
+        allegro: {
+          startOAuth: callerOverride,
+        },
+      });
+
+      expect(client.allegro.startOAuth).toBe(callerOverride);
+    });
+  });
+
+  describe('id uniqueness invariant', () => {
+    it('the live plugins barrel has no duplicate ids', () => {
       const ids = plugins.map((p) => p.id);
       expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('assertUniquePluginIds throws when two plugins share an id', () => {
+      const duplicates = [
+        definePlugin({ id: 'duplicate-fixture' }),
+        definePlugin({ id: 'duplicate-fixture' }),
+      ];
+
+      expect(() => {
+        assertUniquePluginIds(duplicates);
+      }).toThrow(/Duplicate plugin id: "duplicate-fixture"/);
+    });
+
+    it('assertUniquePluginIds accepts an empty array', () => {
+      expect(() => {
+        assertUniquePluginIds([]);
+      }).not.toThrow();
     });
   });
 });

--- a/apps/web/src/plugins/plugin-registry.test.ts
+++ b/apps/web/src/plugins/plugin-registry.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Plugin registry composition tests
+ *
+ * Pins the contract a plugin author depends on:
+ *   - `createApiClient` merges every plugin's `apiNamespaces` into the
+ *     returned client (with the bound `request` function).
+ *   - Route slot flows through (covered indirectly here; route precedence
+ *     is React Router's job).
+ *   - Duplicate plugin ids fail loudly at module load time.
+ *
+ * @module plugins
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { createApiClient, type ApiRequest, type PluginApiNamespaces } from '../app/api/api-client';
+import { createNoopSessionAdapter } from '../shared/auth/noop-session-adapter';
+
+import { definePlugin } from './define-plugin';
+import { plugins } from './index';
+
+interface ShopifyPing {
+  ping: () => string;
+}
+
+// Augment the plugin namespace surface for the duration of this test file so
+// the fixture below type-checks against the same seam real plugins use.
+declare module '../app/api/api-client' {
+  interface PluginApiNamespaces {
+    shopify?: ShopifyPing;
+  }
+}
+
+describe('plugin registry', () => {
+  describe('createApiClient with the real registry', () => {
+    it('exposes every namespace contributed by registered plugins', () => {
+      // `fetchFn` is optional and defaults to the global fetch. The test
+      // never invokes any namespace method, so the default is fine.
+      const client = createApiClient({
+        baseUrl: 'http://example.test',
+        sessionAdapter: createNoopSessionAdapter(),
+      });
+
+      // allegroPlugin contributes the `allegro` namespace via declaration merging.
+      // The real factory wires `createAllegroApi(request)` — we don't invoke it,
+      // we only assert presence so the test stays offline.
+      expect(client.allegro).toBeDefined();
+      expect(typeof client.allegro.startOAuth).toBe('function');
+    });
+  });
+
+  describe('apiNamespaces factory contract', () => {
+    it('receives the bound request function from createApiClient', () => {
+      // Verify the seam by inspecting an inline plugin's factory result. We
+      // can't easily intercept the real registry from inside createApiClient,
+      // so we exercise the plugin's factory directly with a stub.
+      const stubRequest: ApiRequest = vi.fn();
+      const shopifyPlugin = definePlugin({
+        id: 'shopify-test-fixture',
+        apiNamespaces: (request): Partial<PluginApiNamespaces> => {
+          expect(request).toBe(stubRequest);
+          return { shopify: { ping: () => 'pong' } };
+        },
+      });
+
+      const result = shopifyPlugin.apiNamespaces?.(stubRequest);
+      expect(result?.shopify?.ping()).toBe('pong');
+    });
+  });
+
+  describe('id uniqueness', () => {
+    it('the in-tree plugins barrel has no duplicate ids', () => {
+      const ids = plugins.map((p) => p.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+});

--- a/apps/web/src/plugins/plugin.types.ts
+++ b/apps/web/src/plugins/plugin.types.ts
@@ -1,0 +1,73 @@
+/**
+ * WebPlugin types
+ *
+ * Type definitions for the FE build-time plugin registry. A `WebPlugin` is a
+ * plain object contributed by a sibling package (an in-tree plugin under
+ * `apps/web/src/plugins/<name>/`) and collected in `plugins/index.ts`. The
+ * host iterates the registry to compose routes, nav items, and API client
+ * namespaces — no runtime DI, no dynamic imports.
+ *
+ * Named `WebPlugin` (not `Plugin`) to disambiguate from the BE `PluginEntry`,
+ * which is a NestJS module class — same intent, structurally different.
+ *
+ * @module plugins
+ * @see apps/api/src/plugins.ts — BE counterpart that this design mirrors
+ */
+import type { RouteObject } from 'react-router-dom';
+
+import type { ApiRequest, PluginApiNamespaces } from '../app/api/api-client';
+
+/**
+ * One nav-link contribution from a plugin. `groupLabel` is an open string:
+ * a contribution whose label matches an existing nav group is appended to
+ * that group; an unknown label creates a new group at the end of the sidebar.
+ *
+ * Soft contract: contributors should prefer matching one of the existing
+ * groups ("Operations", "Diagnostics", "Platform"). Tightening to a closed
+ * union is a follow-up if group sprawl becomes a problem.
+ *
+ * Note: `countKey` is intentionally omitted — count badges are wired to
+ * internal queries via a closed key set (`NavCountKey`), not a plugin
+ * concern in MVP.
+ */
+export interface NavContribution {
+  groupLabel: string;
+  to: string;
+  label: string;
+  end?: boolean;
+}
+
+/**
+ * Factory called once at `createApiClient` composition time. Receives the
+ * core `request` function (already wrapped with auth + error normalisation)
+ * and returns the namespaces this plugin wants to expose on `ApiClient`.
+ *
+ * Plugins extend `PluginApiNamespaces` via TS declaration merging:
+ *
+ * ```ts
+ * declare module '../../app/api/api-client' {
+ *   interface PluginApiNamespaces {
+ *     allegro: AllegroApi;
+ *   }
+ * }
+ * ```
+ */
+export type PluginApiNamespacesFactory = (
+  request: ApiRequest,
+) => Partial<PluginApiNamespaces>;
+
+/**
+ * A build-time plugin contributing routes, nav items, and/or API namespaces.
+ * Authored via `definePlugin({...})` for type-checked ergonomics; collected
+ * in `apps/web/src/plugins/index.ts`.
+ */
+export interface WebPlugin {
+  /** Stable id, kebab-case. Must be unique across the registry. */
+  id: string;
+  /** React Router route objects appended to the root route's children. */
+  routes?: RouteObject[];
+  /** Sidebar nav items merged into the existing nav groups by label. */
+  navItems?: NavContribution[];
+  /** Factory that produces typed API client namespaces. */
+  apiNamespaces?: PluginApiNamespacesFactory;
+}

--- a/apps/web/src/plugins/prestashop/index.ts
+++ b/apps/web/src/plugins/prestashop/index.ts
@@ -1,0 +1,16 @@
+/**
+ * PrestaShop plugin
+ *
+ * Contributes the PrestaShop setup-wizard route. Routes-only plugin — no
+ * API namespace yet (PrestaShop access goes through generic core APIs like
+ * `connections`, not a dedicated `prestashop.*` surface).
+ *
+ * @module plugins/prestashop
+ */
+import { definePlugin } from '../define-plugin';
+import { prestashopSetupRoute } from './prestashop-setup.route';
+
+export const prestashopPlugin = definePlugin({
+  id: 'prestashop',
+  routes: [prestashopSetupRoute],
+});

--- a/apps/web/src/plugins/prestashop/prestashop-setup.route.tsx
+++ b/apps/web/src/plugins/prestashop/prestashop-setup.route.tsx
@@ -1,7 +1,10 @@
 /**
  * Route: `/connections/new/prestashop` — guided PrestaShop wizard.
+ *
+ * @module plugins/prestashop
  */
 import type { RouteObject } from 'react-router-dom';
+
 import { PrestashopSetupPage } from '../../pages/connections/prestashop-setup-page';
 
 export const prestashopSetupRoute: RouteObject = {

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -43,7 +43,16 @@ export const sampleConnection: Connection = {
  * automatically a valid override slot here.
  *
  * Merge order in `createMockApiClient`: hardcoded vi.fn defaults → caller
- * overrides. Caller overrides always win.
+ * overrides. Caller overrides always win. (See `plugin-registry.test.ts`
+ * "caller overrides win over plugin contributions" — pinned.)
+ *
+ * Note on divergence from runtime composition: `createApiClient` iterates
+ * the real plugin registry and merges `plugin.apiNamespaces(request)`. The
+ * mock factory deliberately does NOT — invoking real plugin factories with
+ * a stubbed `request` would call through to feature-side fetchers in tests
+ * that don't override. Instead, the factory hardcodes plugin-namespace
+ * defaults inline (e.g. the `allegro` block below) with vi.fn defaults.
+ * Keep that block in sync with the runtime contributions of `apps/web/src/plugins/`.
  */
 type DeepPartialApiClient = {
   [K in keyof ApiClient]?: ApiClient[K] extends (...args: never[]) => unknown

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -35,25 +35,20 @@ export const sampleConnection: Connection = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
+/**
+ * Per-namespace partial of `ApiClient`. Function fields (e.g. `request`)
+ * stay as-is; object namespaces become `Partial<...>` so tests can override
+ * a subset of methods. The mapped form auto-tracks `PluginApiNamespaces` —
+ * when a plugin extends `ApiClient` via declaration merging, the new key is
+ * automatically a valid override slot here.
+ *
+ * Merge order in `createMockApiClient`: hardcoded vi.fn defaults → caller
+ * overrides. Caller overrides always win.
+ */
 type DeepPartialApiClient = {
-  request?: ApiClient['request'];
-  adapters?: Partial<ApiClient['adapters']>;
-  aiProviderSettings?: Partial<ApiClient['aiProviderSettings']>;
-  allegro?: Partial<ApiClient['allegro']>;
-  auth?: Partial<ApiClient['auth']>;
-  connections?: Partial<ApiClient['connections']>;
-  content?: Partial<ApiClient['content']>;
-  cursors?: Partial<ApiClient['cursors']>;
-  customers?: Partial<ApiClient['customers']>;
-  health?: Partial<ApiClient['health']>;
-  inventory?: Partial<ApiClient['inventory']>;
-  listings?: Partial<ApiClient['listings']>;
-  orders?: Partial<ApiClient['orders']>;
-  products?: Partial<ApiClient['products']>;
-  promptTemplates?: Partial<ApiClient['promptTemplates']>;
-  mappings?: Partial<ApiClient['mappings']>;
-  syncJobs?: Partial<ApiClient['syncJobs']>;
-  webhookDeliveries?: Partial<ApiClient['webhookDeliveries']>;
+  [K in keyof ApiClient]?: ApiClient[K] extends (...args: never[]) => unknown
+    ? ApiClient[K]
+    : Partial<ApiClient[K]>;
 };
 
 export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiClient {

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -42,6 +42,7 @@ The `apps/web/src` folder is organized as:
 - `app/`: application shell, providers, router, layouts, and route registration
 - `pages/`: route-level page composition
 - `features/`: vertical slices with feature-specific API hooks, mutations, and UI
+- `plugins/`: build-time plugin registry — named extension points (routes, nav items, typed API namespaces) iterated by the host. The barrel at `plugins/index.ts` is the **single edit point** an OSS contributor touches to enable a new in-tree plugin. Mirrors the BE `apps/api/src/plugins.ts` shape (#604/#605).
 - `shared/`: reusable UI, utilities, config, and cross-feature types
 - `test/`: shared frontend test setup and helpers
 
@@ -283,12 +284,13 @@ See [`docs/ui-audit/library-analysis.md`](./ui-audit/library-analysis.md) for th
 
 Dependency direction must remain simple and enforceable:
 
-- `app` may import `pages`, `features`, and `shared`
+- `app` may import `pages`, `features`, `plugins`, and `shared`
 - `pages` may import `features` and `shared`
 - `features` may import `shared`
-- `shared` must not import `features` or `pages`
+- `plugins` may import `pages`, `features`, `shared`, and type-only from `app/api/api-client` and `app/app-shell` (the public type seam). Plugins must not import host internals — router, routes, layouts, hooks, providers, the API client provider hook.
+- `shared` must not import `features`, `pages`, or `plugins`
 
-These boundaries are enforced by ESLint `no-restricted-imports` rules in `.eslintrc.js` — violations fail `pnpm lint`. Raw `fetch()` calls are also blocked in `shared/`, `features/`, and `pages/` via `no-restricted-globals` to ensure all HTTP calls go through shared API client modules.
+These boundaries are enforced by ESLint `no-restricted-imports` rules in `.eslintrc.js` — violations fail `pnpm lint`. Raw `fetch()` calls are also blocked in `shared/`, `features/`, `pages/`, and `plugins/` via `no-restricted-globals` to ensure all HTTP calls go through shared API client modules.
 
 > **Note:** Features may import `useApiClient` from `app/api/` — this is the designed dependency-injection boundary for API access. A future refactor may move the hook to `shared/`, but the current crossing is intentional and not restricted by lint.
 

--- a/docs/plans/implementation-plan-fe-plugin-registry-open-apiclient.md
+++ b/docs/plans/implementation-plan-fe-plugin-registry-open-apiclient.md
@@ -1,0 +1,467 @@
+# Implementation Plan: FE Plugin Registry + Open ApiClient (#604, #605)
+
+**Date**: 2026-05-11
+**Status**: Ready for implementation (tech-review fixes applied)
+**Estimated Effort**: ~1–1.5 days
+
+---
+
+## 1. Task Summary
+
+**Objective**: Introduce a minimal, build-time **frontend plugin registry** with named extension points (routes, nav items, API namespaces) and break the closed `ApiClient` interface into a core surface plus a typed plugin-augmentable surface. Migrate the two currently platform-specific seams (`allegro`, `prestashop`) into reference plugins to prove the mechanism.
+
+**Context**: Both #604 and #605 are BLOCKER tech-debt items in **Modularity Thread H** (frontend OSS-readiness). A third-party plugin currently has nowhere to attach: every UI surface (routes, nav, API methods) is statically imported, and `ApiClient` is a single closed interface listing every feature by name. Mirrors the backend `PluginRegistryModule.forRoot({ plugins })` shape that landed in #572.
+
+**Classification**: Frontend (`apps/web`).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- A `WebPlugin` shape with three extension slots: `routes`, `navItems`, `apiNamespaces` (named `WebPlugin` to disambiguate from the BE `PluginEntry`, which is a NestJS module class — same word, different shape).
+- A `definePlugin()` identity helper for ergonomic, type-checked authoring.
+- A `plugins` barrel (`apps/web/src/plugins/index.ts`) — the **single edit point** an OSS contributor touches to enable a new plugin (mirrors `apps/api/src/plugins.ts`).
+- Splitting `ApiClient` into `CoreApiClient` + a `PluginApiNamespaces` interface that plugins extend via TypeScript declaration merging.
+- Refactoring `createApiClient()`, `app/routes/root.route.tsx`, and `app/app-shell.tsx` to iterate the registry.
+- **Relocating** Allegro and PrestaShop route files (`allegro-callback.route.tsx`, `allegro-setup.route.tsx`, `prestashop-setup.route.tsx`) from `apps/web/src/app/routes/` into `apps/web/src/plugins/<name>/`. The recommendation explicitly states a third-party plugin must have "nowhere to attach" turned into "somewhere to drop a file" — keeping platform routes in `app/routes/` would only half-resolve the BLOCKER.
+- Migrating the `allegro` API namespace into `allegroPlugin`.
+- Updating `apps/web/src/test/test-utils.tsx` so the mock `ApiClient` follows the same Core + plugin shape, with an explicit **merge order** spec (see §6 Step 6).
+- A new lint rule keeping `apps/web/src/plugins/` to a tight boundary (allowed to import `pages/`, `features/`, `shared/`, and the public types from `app/api/api-client`; forbidden from importing anything else in `app/`).
+- Tests proving registry composition for all three slots, plus a **boot-time `id` uniqueness assertion**.
+- Updating `docs/frontend-architecture.md` so the new top-level `plugins/` folder and its dependency direction are documented alongside `app/`, `pages/`, `features/`, `shared/`.
+
+### Out of Scope
+- Wizard registries (`connectionSetupWizards`, `offerCreationWizards`, `connectionConfigSections`) — tied to FE-5 / FE-7 (#608, #610). The `WebPlugin` shape will be **extensible to add them later** without breaking existing plugins.
+- Lazy-loading / dynamic route registration (FE-3 / #606).
+- Moving entire `features/allegro/` and `features/connections/.../prestashop-setup-form` directories into `plugins/<name>/`. The plugin shim re-exports the API factory and form component from the existing feature module; only the **route module** (already platform-specific and currently misplaced in `app/routes/`) moves.
+- Any backend changes.
+- i18n, design tokens, theme contract (other H-thread issues).
+- Full rewrite of `buildNavGroups` — only add a contribution merge point; existing static groups stay.
+
+### Constraints
+- Must compile and pass `pnpm lint`, `pnpm type-check`, `pnpm test`.
+- Cannot break the current operator UX (every existing route + API call must keep working).
+- Must not introduce `any` types or string-keyed registries that defeat TS inference.
+- FE uses **relative imports** (no `@/` alias is configured); all new files follow that convention.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: `apps/web/src/` — adds a new top-level `plugins/` folder peer to the documented `app/`, `pages/`, `features/`, `shared/`.
+
+**New dependency rules** (to be added to `docs/frontend-architecture.md` §Dependency Rules):
+- `plugins/` may import `pages/`, `features/`, `shared/`, and **type-only** from `app/api/api-client` (the public type seam for plugin authors).
+- `plugins/` must not import from any other path under `app/` (router internals, layouts, app-shell).
+- `app/` may import `plugins/` (the barrel) — same direction it already imports `pages/`.
+- `pages/`, `features/`, `shared/` must not import `plugins/`.
+
+Cross-boundary contract: `app/api/api-client.ts` exposes `ApiRequest` and `PluginApiNamespaces` as the **public extension API** for plugins. Plugins augment `PluginApiNamespaces` via `declare module '../../app/api/api-client'`.
+
+**Existing services reused**:
+- `createAllegroApi(request)` factory in `apps/web/src/features/allegro/api/allegro.api.ts` — re-used by `allegroPlugin` without modification.
+- `PrestashopSetupForm` component and any feature-side mutations under `apps/web/src/features/connections/` — re-used by `prestashopPlugin` without modification (only the route module relocates).
+- The 16 existing feature `*.api.ts` factories — all stay in `features/` and are still composed by `createApiClient`; only `allegro` moves into the plugin-augmented surface.
+
+**New components required**:
+- `apps/web/src/plugins/plugin.types.ts` — type definitions
+- `apps/web/src/plugins/define-plugin.ts` — identity helper
+- `apps/web/src/plugins/index.ts` — barrel listing in-tree plugins (the OSS contributor seam)
+- `apps/web/src/plugins/merge-nav-contributions.ts` — pure helper, exported for testability
+- `apps/web/src/plugins/allegro/index.ts` — first reference plugin
+- `apps/web/src/plugins/allegro/allegro-callback.route.tsx` — relocated from `app/routes/`
+- `apps/web/src/plugins/allegro/allegro-setup.route.tsx` — relocated from `app/routes/`
+- `apps/web/src/plugins/prestashop/index.ts` — second reference plugin
+- `apps/web/src/plugins/prestashop/prestashop-setup.route.tsx` — relocated from `app/routes/`
+- Module augmentation snippet in `plugins/allegro/index.ts` extending `PluginApiNamespaces`
+
+**Plugin vs core justification**:
+- Routes/APIs that are **platform-shaped** (Allegro OAuth callback, PrestaShop WebService setup, the Allegro typed API client) belong in plugins.
+- Routes/APIs that are **capability-generic** (Dashboard, Orders, Products, Inventory, Customers, Listings, generic Connections list, Adapters, Jobs/Logs, Settings, Mappings, Prompt Templates, AI provider settings) stay in core because every plugin needs them as a host service.
+
+---
+
+## 4. External / Domain Research
+
+### External system
+N/A.
+
+### Internal patterns
+- **Backend mirror** — `apps/api/src/plugins.ts` (`export const apiPlugins: PluginEntry[]`) consumed by `PluginRegistryModule.forRoot({ plugins })` at `libs/core/src/integrations/plugin-registry.module.ts`. The FE registry uses the same "single edit point + iterate at composition time" shape, adapted to React (no Nest DI; plain composition).
+- **Existing factory pattern** — every feature already exports a `create*Api(request)` factory that returns a typed namespace object. The plugin `apiNamespaces` slot just calls these factories — zero rework on the feature side.
+- **Existing route module pattern** — each route file exports a `RouteObject` constant. The plugin `routes` slot just collects them.
+- **Existing ESLint boundary pattern** — `.eslintrc.js` at the repo root enforces `shared/` → no features/pages/app, `features/` → no pages, `pages/` → no app. The new `plugins/` block follows the same shape.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open questions
+- None blocking. All design decisions have safe defaults below.
+
+### Assumptions
+1. **Static barrel is sufficient for #604/#605.** The issue body explicitly endorses "Even a static, build-time `definePlugin({...})` collected from a `plugins/index.ts` barrel would unblock in-tree contribution and make the runtime path a later refactor, not a rewrite." Dynamic registration is FE-3/#606.
+2. **Type-level extension via declaration merging is the right shape for `ApiClient`.** The issue body lists this as option (a) and is more idiomatic in TypeScript than option (b) (a generic `apiClient.plugin('shopify')` accessor that returns `unknown`). Declaration merging keeps full IntelliSense.
+3. **Allegro and PrestaShop feature dirs stay in `features/`; only thin shims and the platform-specific route modules move to `plugins/`.** Physically relocating `features/allegro/` and the entire prestashop setup form belongs in a follow-up that tackles H6 (#609).
+4. **`PluginApiNamespaces` augmentation is per-plugin local.** Each plugin file declares `declare module '../../app/api/api-client' { interface PluginApiNamespaces { allegro: AllegroApi } }`. Importing the plugin's barrel entry activates the typing — exactly what we want.
+5. **Nav contributions are append-only and group-keyed by an open string `groupLabel`.** Open (not a closed union) so future plugins are not constrained by the current IA. Documented as a soft contract: contributors should prefer matching an existing group (`Operations` / `Diagnostics` / `Platform` / `Planned`); unknown labels create a new group at the end. If group sprawl becomes a problem, tighten to a closed union in a follow-up.
+6. **`navItems` slot is wired and tested by a fixture plugin in unit tests; no in-tree plugin contributes a nav item in MVP.** First real consumer will be a follow-up plugin. The slot is intentional future-proofing for #608/#610.
+7. **Mock merge order is `core → plugin namespaces → caller overrides`.** Spelled out in Step 6 so existing tests that override `allegro` continue to win against the plugin contribution.
+8. **Route matching follows React Router specificity, not array order.** The Phase 3 implementation appends plugin routes to the children array; this controls which route appears first in the children list, but React Router resolves matches by path specificity, not order. Plugins cannot accidentally override an existing core path unless they declare the same exact path.
+
+### Documentation gaps
+- `docs/frontend-architecture.md` does not currently document `plugins/`. This plan adds it as part of the implementation diff so the doc and the code stay consistent on the same PR.
+
+---
+
+## 6. Proposed Implementation Plan
+
+> **Conventions for every new file:** standard JSDoc header per `engineering-standards.md` §File Headers (Purpose + Context + optional `@module`). Kebab-case filenames; PascalCase types; camelCase values. No `any`. No `console.log`. No `eslint-disable` without an inline rationale.
+
+### Phase 1 — Registry primitives (no host changes)
+
+**Goal**: Land the `WebPlugin` shape, helper, and empty barrel. All existing code keeps compiling unchanged.
+
+1. **Create `plugin.types.ts`**
+   - **File**: `apps/web/src/plugins/plugin.types.ts`
+   - **Action**: Define `WebPlugin`, `NavContribution`, `PluginApiNamespacesFactory`. Type-import `ApiRequest` and `PluginApiNamespaces` from `../app/api/api-client` (relative path — no `@/` alias). Shape:
+     ```ts
+     import type { RouteObject } from 'react-router-dom';
+     import type { ApiRequest, PluginApiNamespaces } from '../app/api/api-client';
+
+     export interface NavContribution {
+       groupLabel: string;
+       to: string;
+       label: string;
+       end?: boolean;
+       countKey?: string;
+     }
+
+     export type PluginApiNamespacesFactory = (
+       request: ApiRequest,
+     ) => Partial<PluginApiNamespaces>;
+
+     export interface WebPlugin {
+       /** Stable id used in logs and the uniqueness assertion — kebab-case. */
+       id: string;
+       routes?: RouteObject[];
+       navItems?: NavContribution[];
+       apiNamespaces?: PluginApiNamespacesFactory;
+     }
+     ```
+   - **Acceptance**: Compiles. No runtime change.
+
+2. **Create `define-plugin.ts`**
+   - **File**: `apps/web/src/plugins/define-plugin.ts`
+   - **Action**: `export function definePlugin(plugin: WebPlugin): WebPlugin { return plugin; }` — identity helper for ergonomic, type-checked authoring.
+   - **Acceptance**: Importable; passes lint.
+
+3. **Create `merge-nav-contributions.ts` (pure helper, no host change yet)**
+   - **File**: `apps/web/src/plugins/merge-nav-contributions.ts`
+   - **Action**: Export pure function `mergePluginNavContributions(groups: NavGroup[], contributions: NavContribution[]): NavGroup[]`. For each contribution: find a group whose `label === groupLabel` and append; otherwise create a new `{ kind: 'live', label: groupLabel, items: [...] }` group at the end. Import `NavGroup` from `../app/app-shell` (or wherever the type currently lives — verify during implementation; relocate the type to a co-located `*.types.ts` file if it's defined inline in `app-shell.tsx`).
+   - **Acceptance**: Pure helper, fully unit-testable; no app behaviour change.
+
+4. **Create empty plugin barrel + boot-time id-uniqueness assertion**
+   - **File**: `apps/web/src/plugins/index.ts`
+   - **Action**:
+     ```ts
+     export const plugins: WebPlugin[] = [];
+
+     // Boot-time invariant: plugin ids must be unique. Catches forks/copies
+     // that forget to rename. Runs at module load (effectively dev/CI only —
+     // the array is static, so this either passes once or fails CI).
+     const ids = new Set<string>();
+     for (const p of plugins) {
+       if (ids.has(p.id)) {
+         throw new Error(`Duplicate plugin id: "${p.id}". Plugin ids must be unique.`);
+       }
+       ids.add(p.id);
+     }
+     ```
+   - **Acceptance**: Compiles; no behaviour change for an empty array.
+
+### Phase 2 — Split `ApiClient` into core + plugin-augmentable surface
+
+**Goal**: Type-level mechanism for plugins to contribute API namespaces, with `createApiClient()` iterating the registry. No namespaces actually move yet — that happens in Phase 5.
+
+5. **Refactor `api-client.ts`**
+   - **File**: `apps/web/src/app/api/api-client.ts`
+   - **Action**:
+     - Export `type ApiRequest = <T>(path: string, init?: RequestInit) => Promise<T>;` (named export so plugin types have a stable import target).
+     - Add an empty augmentable surface:
+       ```ts
+       // eslint-disable-next-line @typescript-eslint/no-empty-interface -- canonical declaration-merging seam; plugins extend via `declare module`
+       export interface PluginApiNamespaces {}
+       ```
+     - Rename the current `ApiClient` interface to `CoreApiClient` (16 namespaces unchanged for now).
+     - Export `export type ApiClient = CoreApiClient & PluginApiNamespaces;`.
+     - In `createApiClient()`, build the core namespaces object, then iterate `plugins` from `../../plugins`. For each plugin with an `apiNamespaces` factory, call it with `request` and `Object.assign` the result onto the api client. Return as `ApiClient` (single boundary cast; do not propagate `as ApiClient` deeper).
+     - Merge order: **core → plugin contributions** (caller overrides do not apply here — they're a test-utils concern handled in Step 6).
+   - **Acceptance**: `pnpm type-check` passes; `useApiClient()` consumers see no type change since `PluginApiNamespaces` is empty.
+
+6. **Mirror the split in `test-utils.tsx`**
+   - **File**: `apps/web/src/test/test-utils.tsx`
+   - **Action**: Restructure the mock factory so it produces a client in this order:
+     1. Build the core mock namespaces (existing 15 namespaces minus `allegro`, which moves in Step 11; for this step keep all 16 — Step 11 will delete `allegro` from the core mock).
+     2. Merge plugin contributions from real `plugins` (using stubbed `request`).
+     3. Merge caller overrides last so test-specific stubs always win.
+     - Strip the explicit `allegro?: Partial<...>` field from the type; the union `Partial<CoreApiClient & PluginApiNamespaces>` already lets callers override allegro via declaration merging.
+   - **Acceptance**: All existing tests still pass with no changes. Document the merge order in a short comment at the merge site.
+
+### Phase 3 — Route extension point
+
+**Goal**: Host iterates `plugin.routes` and appends them to the root route's children.
+
+7. **Refactor `root.route.tsx`**
+   - **File**: `apps/web/src/app/routes/root.route.tsx`
+   - **Action**: Import `plugins` from `../../plugins` (relative). Build the children array by concatenating the existing core children list with `plugins.flatMap((p) => p.routes ?? [])`. Comment explains: "core operator routes first; plugin-contributed routes appended in registry order; React Router resolves matches by path specificity, not array position."
+   - **Acceptance**: All current routes still resolve; type stays `RouteObject`.
+
+### Phase 4 — Nav extension point
+
+**Goal**: Host iterates `plugin.navItems` and merges them into nav groups.
+
+8. **Wire `mergePluginNavContributions` into `app-shell.tsx`**
+   - **File**: `apps/web/src/app/app-shell.tsx`
+   - **Action**:
+     - Import `plugins` from `../plugins` and `mergePluginNavContributions` from `../plugins/merge-nav-contributions`.
+     - After `buildNavGroups({ isAdmin })` returns its static groups, pass them through `mergePluginNavContributions(groups, plugins.flatMap(p => p.navItems ?? []))`.
+   - **Acceptance**: With zero plugin nav contributions, output is byte-for-byte identical to today.
+
+### Phase 5 — `allegroPlugin`: API namespace + relocated routes
+
+**Goal**: Move Allegro from "hardcoded in core" to "contributed by allegroPlugin." Primary correctness check for the registry.
+
+9. **Relocate Allegro route files**
+   - **Move (`git mv`)**:
+     - `apps/web/src/app/routes/allegro-callback.route.tsx` → `apps/web/src/plugins/allegro/allegro-callback.route.tsx`
+     - `apps/web/src/app/routes/allegro-setup.route.tsx` → `apps/web/src/plugins/allegro/allegro-setup.route.tsx`
+   - **Fixup**: Adjust relative imports inside those files (paths to `pages/`, `features/`, `shared/` change by one level since the file moved deeper).
+   - **Acceptance**: Routes still type as `RouteObject`; imports resolve.
+
+10. **Create `plugins/allegro/index.ts`**
+    - **File**: `apps/web/src/plugins/allegro/index.ts`
+    - **Action**:
+      ```ts
+      import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/allegro.api';
+      import { definePlugin } from '../define-plugin';
+      import { allegroCallbackRoute } from './allegro-callback.route';
+      import { allegroSetupRoute } from './allegro-setup.route';
+
+      declare module '../../app/api/api-client' {
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface -- declaration-merging augmentation
+        interface PluginApiNamespaces {
+          allegro: AllegroApi;
+        }
+      }
+
+      export const allegroPlugin = definePlugin({
+        id: 'allegro',
+        routes: [allegroCallbackRoute, allegroSetupRoute],
+        apiNamespaces: (request) => ({ allegro: createAllegroApi(request) }),
+      });
+      ```
+    - **Acceptance**: Compiles.
+
+11. **Remove allegro from core; register the plugin**
+    - **Files**:
+      - `apps/web/src/app/api/api-client.ts` — delete `allegro: AllegroApi;` from `CoreApiClient`, the `allegro: createAllegroApi(request),` line in the factory, and the now-unused `createAllegroApi`/`AllegroApi` imports.
+      - `apps/web/src/plugins/index.ts` — `import { allegroPlugin } from './allegro';` and add to the `plugins` array.
+      - `apps/web/src/app/routes/root.route.tsx` — delete the explicit `allegroCallbackRoute` and `allegroSetupRoute` imports and their entries in the hardcoded children list (the plugin's routes are appended via Phase 3).
+      - `apps/web/src/test/test-utils.tsx` — delete the explicit `allegro?: Partial<...>` mock branch (typing still works via the augmented `PluginApiNamespaces`; the mock-factory plugin-merge step ensures the namespace is present unless overridden).
+    - **Acceptance**:
+      - `apiClient.allegro.startOAuth(…)` still type-checks at every call site.
+      - `/integrations/allegro/connect/callback` and `/connections/new/allegro` still resolve in the running app.
+      - Existing tests that override allegro continue to pass (merge order: plugin → caller override).
+      - `pnpm type-check`, `pnpm lint`, `pnpm test` all pass.
+
+### Phase 6 — `prestashopPlugin`: routes-only contribution
+
+**Goal**: Validate that a routes-only plugin (no API namespace) works.
+
+12. **Relocate the PrestaShop setup route and create the plugin**
+    - **Move**: `apps/web/src/app/routes/prestashop-setup.route.tsx` → `apps/web/src/plugins/prestashop/prestashop-setup.route.tsx` (fix up relative imports).
+    - **File**: `apps/web/src/plugins/prestashop/index.ts`
+      ```ts
+      import { definePlugin } from '../define-plugin';
+      import { prestashopSetupRoute } from './prestashop-setup.route';
+
+      export const prestashopPlugin = definePlugin({
+        id: 'prestashop',
+        routes: [prestashopSetupRoute],
+      });
+      ```
+    - **Then**:
+      - `apps/web/src/plugins/index.ts` — add `prestashopPlugin` to the array.
+      - `apps/web/src/app/routes/root.route.tsx` — delete the `prestashopSetupRoute` explicit import and child entry.
+    - **Acceptance**: `/connections/new/prestashop` still resolves; type surface unchanged (no api namespace to declare).
+
+### Phase 7 — Tests + lint guardrail + doc
+
+**Goal**: Lock the design with tests, prevent boundary regressions, and document the new top-level folder.
+
+13. **Test: registry composition**
+    - **File**: `apps/web/src/plugins/plugin-registry.test.ts`
+    - **Cases** (Vitest):
+      - A fixture plugin whose `apiNamespaces` factory returns `{ shopify: { ping: () => 'pong' } }`, when wired through `createApiClient` with a stubbed `request`, yields a client where `client.shopify.ping()` returns `'pong'`.
+      - `mergePluginNavContributions` appends to a matching group, creates a new group when unmatched.
+      - A fixture plugin with `routes: [{ path: '/__test__/fixture', element: null }]` flows through the root-route children flattening.
+      - **Caller-override wins**: a mock client with `{ allegro: { startOAuth: vi.fn() } }` produces a `startOAuth` reference equal to the caller's stub, not the real plugin contribution.
+      - **Id uniqueness**: importing a `plugins/index.ts`-shaped module with two plugins sharing an id throws at module load (test via dynamic import of an inline fixture).
+    - **Acceptance**: All cases pass.
+
+14. **Test: allegroPlugin wiring**
+    - **File**: `apps/web/src/plugins/allegro/allegro-plugin.test.ts`
+    - **Action**: Smoke test that `allegroPlugin.routes` contains both expected route objects and that `allegroPlugin.apiNamespaces?.(stubRequest)` returns an object with an `allegro` key. No need to re-test `createAllegroApi` internals — covered by feature tests.
+    - **Acceptance**: Test passes.
+
+15. **Lint guardrail**
+    - **File**: `.eslintrc.js` (repo root)
+    - **Action**: Add a new override block for `apps/web/src/plugins/**/*.{ts,tsx}` forbidding imports from `app/**` **except** the `app/api/api-client` module. Also extend the existing `shared/` block to forbid `plugins/`, and add `plugins/` to the forbidden list in the `features/` and `pages/` blocks.
+    - Concretely:
+      ```js
+      // New override
+      {
+        files: ['apps/web/src/plugins/**/*.{ts,tsx}'],
+        rules: {
+          'no-restricted-imports': [
+            'error',
+            {
+              patterns: [
+                {
+                  group: ['**/app/**', '!**/app/api/api-client', '!**/app/api/api-client.ts'],
+                  message:
+                    'Plugin modules may only import from app/api/api-client (the public type seam). Other app/ paths are not part of the plugin contract.',
+                },
+              ],
+            },
+          ],
+        },
+      }
+      ```
+    - **Verify**: A contrived `import { router } from '../../app/router'` from a plugin file is rejected; `import type { ApiRequest } from '../../app/api/api-client'` is allowed.
+
+16. **Documentation update**
+    - **File**: `docs/frontend-architecture.md`
+    - **Action**: In §Folder Conventions, add `plugins/`: "build-time plugin registry; named extension points iterated by the host." In §Dependency Rules, add: "`app` may import `plugins`; `plugins` may import `pages`, `features`, `shared`, and type-only from `app/api/api-client`; `pages`/`features`/`shared` must not import `plugins`."
+    - **Acceptance**: The doc and the lint rules agree on every directional arrow.
+
+### Phase 8 — Quality gate
+
+17. **Run the full gate**
+    - `pnpm lint` — zero errors.
+    - `pnpm type-check` — zero errors.
+    - `pnpm test` (Vitest in `apps/web`, Jest in everything else) — all green.
+    - Manually start the FE (`pnpm start:dev:web`) and confirm `/`, `/connections/new/allegro`, `/connections/new/prestashop`, and the Allegro OAuth callback URL all render without console errors. (UI / frontend changes require a real browser smoke per CLAUDE.md.)
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1 — Generic `apiClient.plugin('shopify')` accessor
+- **Description**: Instead of declaration merging, `ApiClient` exposes a `plugin<T>(name: string): T` method that returns an opaque slice the plugin provides.
+- **Why rejected**: Loses IntelliSense (`apiClient.allegro.startOAuth(...)` is far more discoverable than `apiClient.plugin<AllegroApi>('allegro').startOAuth(...)`). Forces every call site to either know a generic parameter or accept `unknown`. The issue body lists module augmentation as the preferred option (a).
+- **Trade-offs**: Slightly simpler runtime; significantly worse DX.
+
+### Alternative 2 — Runtime/dynamic plugin loading
+- **Description**: Plugins ship as separate npm packages; the host reads a runtime manifest and dynamically imports them.
+- **Why rejected**: FE-3/#606 territory (lazy loading) plus would require a per-plugin npm publishing pipeline before the static seam even exists. The issue explicitly endorses "static, build-time `definePlugin({...})` … make the runtime path a later refactor, not a rewrite."
+- **Trade-offs**: True OSS distributability vs. simpler diff and faster unblock. We pick the unblock.
+
+### Alternative 3 — Leave platform-specific routes in `app/routes/` and have the plugin barrel re-export them
+- **Description**: `apps/web/src/plugins/allegro/index.ts` would `import { allegroCallbackRoute } from '../../app/routes/allegro-callback.route'` and contribute it.
+- **Why rejected**: Half-resolves the BLOCKER. A contributor adding a Shopify plugin would still have to drop the route file inside `app/routes/` — i.e., "no plugin/extension registry exists in the FE" stays partly true. The cost of relocating two `allegro-*.route.tsx` files and one `prestashop-setup.route.tsx` is small (`git mv` + adjust relative imports); the payoff is that platform-specific code finally has a home.
+- **Trade-offs**: Slightly bigger diff vs. cleaner long-term layout. We pick clean.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture compliance
+- ✅ New `plugins/` folder is documented in §3 above and (per Phase 7 Step 16) added to `docs/frontend-architecture.md` in the same PR. Lint rules and doc agree.
+- ✅ Frontend conventions: kebab-case file names; types in a `*.types.ts` file; explicit React Router route modules; one `createApiClient()` entrypoint.
+- ✅ All new files include JSDoc headers per `engineering-standards.md` §File Headers.
+
+### Naming conventions
+- ✅ Files: `plugin.types.ts`, `define-plugin.ts`, `merge-nav-contributions.ts`, `allegro-plugin.test.ts`, `plugin-registry.test.ts` — kebab-case.
+- ✅ Exports: `WebPlugin`, `NavContribution`, `definePlugin`, `allegroPlugin`, `prestashopPlugin` — PascalCase types, camelCase values.
+- ✅ `WebPlugin` is named distinctly from BE `PluginEntry` (assumption #note in §5) to avoid the trap of contributors expecting symmetry between two structurally different things.
+
+### Existing patterns
+- ✅ Plugin slot shape (`routes`, `navItems`, `apiNamespaces`) mirrors what `apps/api/src/plugins.ts` does for the backend.
+- ✅ `definePlugin` identity helper mirrors common patterns (e.g. Vite's `defineConfig`).
+- ✅ Module augmentation of `PluginApiNamespaces` is canonical TS plugin-extension shape.
+
+### Risks
+- **R1 — Module augmentation requires the file to be in the import graph.** Mitigation: including the plugin in `plugins/index.ts` (imported by `api-client.ts`, `root.route.tsx`, and `app-shell.tsx`) guarantees the file is loaded.
+- **R2 — Plugin route precedence.** React Router resolves by path specificity, not array position. A plugin declaring the same exact path as a core route can override it (last child wins for ambiguous matches). Mitigation: documented in the merge-site comment; revisit only if a real plugin needs override semantics.
+- **R3 — Mock client surface drift.** Tests using `createMockApiClient({ allegro: { … } })` rely on caller overrides winning over plugin contributions. Mitigation: Step 6 spells out the merge order (`core → plugin → caller override`) and a Step 13 test pins it.
+- **R4 — Circular import between `plugins/index.ts` and `app/api/api-client.ts`.** The api-client imports `plugins` to iterate them; each plugin file imports types from `app/api/api-client` for `ApiRequest` and to declaration-merge `PluginApiNamespaces`. Mitigation: those `app/api/api-client` references use `import type` (TS-only, no runtime cycle).
+- **R5 — `@typescript-eslint/no-empty-interface` flags `interface PluginApiNamespaces {}`.** Mitigation: inline `eslint-disable-next-line @typescript-eslint/no-empty-interface -- canonical declaration-merging seam; plugins extend via 'declare module'` on the interface and on each plugin's augmentation block.
+
+### Edge cases
+- **Plugin with empty slots** — handled: `plugin.routes ?? []`, `plugin.navItems ?? []`, `plugin.apiNamespaces?.(request) ?? {}`.
+- **Two plugins contributing the same `groupLabel`** — both append to the same group in registry order. Documented.
+- **Two plugins contributing the same API namespace key** — last-write-wins (`Object.assign`). Acceptable for MVP; a future runtime-aware version can throw on conflict.
+- **Two plugins sharing the same `id`** — boot-time assertion throws. Covered by Step 13.
+
+### Backward compatibility
+- ✅ Every existing route, API call, and nav item continues to render identically.
+- ✅ `ApiClient` stays structurally identical at every consumer site (Core + augmented Plugin = the same 16 namespaces in the running app).
+- ✅ No data migration; no API surface change to the backend.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit tests
+- `apps/web/src/plugins/plugin-registry.test.ts` — composition of all three extension points using fixture plugins, mock merge-order, and id-uniqueness assertion.
+- `apps/web/src/plugins/allegro/allegro-plugin.test.ts` — smoke test that `allegroPlugin` exposes the expected `routes` and `apiNamespaces`.
+- Existing `*.test.tsx` files using `createMockApiClient({ allegro: { … } })` continue to pass without modification.
+
+### Integration tests
+- N/A for FE — Vitest + Testing Library is the FE equivalent.
+
+### Mocking strategy
+- Real `createApiClient` is used in tests where the `request` function is stubbed. Fixture plugins are built inline. No networked code under test.
+
+### Acceptance criteria
+- [ ] `apps/web/src/plugins/{plugin.types.ts, define-plugin.ts, merge-nav-contributions.ts, index.ts, allegro/index.ts, allegro/allegro-callback.route.tsx, allegro/allegro-setup.route.tsx, prestashop/index.ts, prestashop/prestashop-setup.route.tsx}` exist and compile.
+- [ ] `ApiClient = CoreApiClient & PluginApiNamespaces`; the explicit `allegro` field is gone from `CoreApiClient`.
+- [ ] `apiClient.allegro.startOAuth(...)` type-checks at every call site and works at runtime exactly as before.
+- [ ] `root.route.tsx` no longer explicitly imports `allegroCallbackRoute`, `allegroSetupRoute`, or `prestashopSetupRoute`; those routes are contributed by the respective plugins.
+- [ ] `apps/web/src/app/routes/allegro-callback.route.tsx`, `allegro-setup.route.tsx`, `prestashop-setup.route.tsx` no longer exist (relocated into `plugins/`).
+- [ ] `pnpm lint`, `pnpm type-check`, `pnpm test` all green.
+- [ ] All Vitest cases in `plugin-registry.test.ts` and `allegro-plugin.test.ts` pass.
+- [ ] `.eslintrc.js` rejects a `plugins/` file that imports from `app/router` or any other non-public `app/` path.
+- [ ] `docs/frontend-architecture.md` documents `plugins/` in Folder Conventions and Dependency Rules.
+- [ ] FE smoke (browser): `/`, `/connections/new/allegro`, `/connections/new/prestashop`, `/integrations/allegro/connect/callback` all render without console errors.
+- [ ] No `any` introduced; no `console.log`; no `eslint-disable` without an inline rationale.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows the architecture documented in `docs/frontend-architecture.md` (and updates the doc to reflect the new boundary)
+- [x] Respects `app → pages → features → shared`; adds `plugins/` as a new boundary with explicit, lint-enforced dependency direction
+- [x] Uses existing patterns (`*.api.ts` factories, `RouteObject` route modules, identity-fn helpers)
+- [x] Idempotent at build time (plugin barrel is a const array)
+- [x] No event-driven concerns (frontend)
+- [x] No backend rate-limit / retry concerns
+- [x] Error handling: registry merge is total; id-uniqueness throws at load
+- [x] Testing strategy complete (Vitest unit tests for registry + plugin wiring + browser smoke)
+- [x] Naming conventions followed
+- [x] File structure matches existing FE conventions + new documented `plugins/` boundary
+- [x] Plan is execution-ready
+- [x] Plan saved as markdown file
+
+---
+
+## Related Documentation
+- `docs/frontend-architecture.md` — FE folder structure, dependency rules, ApiClient conventions (updated as part of this PR)
+- `docs/engineering-standards.md` — file headers, type separation, naming, error handling
+- `docs/architecture-overview.md` §10 — BE `PluginRegistryModule` reference (the shape this plan mirrors)
+- Issue #604 — H1 BLOCKER: No FE plugin/extension registry
+- Issue #605 — H2 BLOCKER: Typed `ApiClient` is a closed enum
+- PR #572 (merged) — backend `PluginRegistryModule.forRoot({ plugins })`


### PR DESCRIPTION
## Summary

Closes #604
Closes #605

Lands the two Modularity-Thread-H BLOCKERs together. Mirrors the BE `PluginRegistryModule` shape (#572) for the FE.

- **`apps/web/src/plugins/`** — new top-level boundary with three extension slots (`routes`, `navItems`, `apiNamespaces`). The barrel at `plugins/index.ts` is the **single edit point** an OSS contributor touches to enable a new in-tree plugin.
- **`ApiClient = CoreApiClient & PluginApiNamespaces`** — plugins extend the surface via TypeScript declaration merging, so `apiClient.allegro.startOAuth(...)` keeps full IntelliSense at every call site without listing every plugin namespace in the host interface.
- **Two reference plugins** prove the mechanism:
  - `allegroPlugin` — contributes the `allegro` API namespace + OAuth callback + setup routes (exercises every slot).
  - `prestashopPlugin` — contributes only the PrestaShop setup route (proves routes-only plugins work).
- **Platform-specific route files relocated** from `apps/web/src/app/routes/` into `apps/web/src/plugins/<name>/` — `allegro-callback.route.tsx`, `allegro-setup.route.tsx`, `prestashop-setup.route.tsx`. The feature directories (`features/allegro/`, the PrestaShop setup form components) stay where they are; the plugin shims re-export.
- **Lint guardrail** added to `.eslintrc.js`: `plugins/` may import `pages/`, `features/`, `shared/`, and the public type seam (`app/api/api-client`, `app/app-shell` for NavGroup types). Host internals (router, routes, layouts, hooks, providers, the API client provider hook) are forbidden. The `plugins/` boundary is also added to the existing `shared/`/`features/`/`pages/` override blocks so nothing depends on `plugins/` in reverse.
- **`docs/frontend-architecture.md`** is updated in the same diff so the folder convention and dependency-rules sections reflect the new `plugins/` boundary — docs and lint agree.
- **Implementation plan** at `docs/plans/implementation-plan-fe-plugin-registry-open-apiclient.md` captures the design that this PR was built against.

Static, build-time only — runtime/dynamic plugin loading is FE-3 (#606). Wizard registries (`connectionSetupWizards`, `offerCreationWizards`, `connectionConfigSections`) are out of scope here and tied to FE-5/#608 and FE-7/#610; the slot shape is extensible to add them later without breaking existing plugins.

## Test plan

- [x] `pnpm lint` — 0 errors (19 pre-existing warnings)
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 885 passing in `apps/web` (up from 882: caller-override-wins, `assertUniquePluginIds` throws on duplicates, empty-array baseline). API: 339/339, worker: 118/118 — all green.
- [x] `pnpm --filter @openlinker/web build` — Vite production build succeeds
- [x] Browser smoke (Chrome DevTools MCP): `/`, `/connections/new/allegro`, `/connections/new/prestashop`, `/integrations/allegro/connect/callback` all load with zero console errors (all redirect to `/login` as expected for an unauthenticated session)
- [x] Pre-commit hook ran the full quality gate on the fix-up commit

## Commits

1. `refactor(web): introduce build-time plugin registry + open ApiClient` — main implementation
2. `refactor(web): apply tech-review fixes` — extracted `assertUniquePluginIds` helper, added the three missing tests called out in the plan (caller-override-wins, duplicate-throws failure path, empty-array baseline), renamed the misleading factory-contract test, documented the import-graph requirement and runtime-cast invariant inline

## Notes for reviewers

- **Type-space pollution from test fixture**: `plugin-registry.test.ts` adds `shopify?: ShopifyPing` to `PluginApiNamespaces` via `declare module`. `apps/web/tsconfig.app.json` includes test files, so this is visible to dev type-check (optional, harmless). Vite excludes test files from prod builds, so no runtime impact.
- **The `as ApiClient` cast** in `createApiClient` is a single boundary cast over the spread of `CoreApiClient` + plugin contributions. The cast doesn't enforce that a plugin actually returns the namespaces it declares via `declare module` — if a plugin declares `allegro: AllegroApi` but forgets to return `{ allegro: ... }` from `apiNamespaces`, `client.allegro` will be `undefined` at runtime even though TS thinks it's present. Surfaces only at the call site; commented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)