### PR TITLE
refactor(web): open platformType union + introduce plugin registry (#578, #579)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,6 +85,30 @@ module.exports = {
       },
     },
     {
+      // `shared/plugins/` is the FE plugin-contract surface (#578/#579). It
+      // necessarily references the `Connection` shape that plugins receive
+      // and the form-value shapes plugins compose into. The Connection type
+      // lives in `features/connections/api/` today; making this exemption
+      // narrow keeps `shared/plugins/` cleanly typed without hoisting the
+      // entire connections domain into `shared/` for one type.
+      files: ['apps/web/src/shared/plugins/**/*.{ts,tsx}'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: ['**/features/**', '**/pages/**', '**/app/**'],
+                importNamePattern: '^(?!Connection$|EditConnectionFormValues$).+',
+                message:
+                  'shared/plugins/ may only type-import `Connection` and `EditConnectionFormValues` from features/. All other feature imports remain banned.',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
       files: ['apps/web/src/features/**/*.{ts,tsx}'],
       rules: {
         'no-restricted-imports': [
@@ -198,6 +222,43 @@ module.exports = {
       ],
       rules: {
         'no-restricted-imports': 'off',
+      },
+    },
+    {
+      // FE platformType is an opaque string post-#578/#579. Literal-equality
+      // dispatch (`connection.platformType === 'allegro'`, etc.) is forbidden
+      // outside the in-tree plugin packages — use `usePlugin()` / `usePlugins()`
+      // or capability checks (`supportedCapabilities.includes('OfferManager')`)
+      // instead. The single legitimate use is inside `apps/web/src/plugins/<name>/`
+      // where each plugin keys on its own `platformType` constant.
+      //
+      // Selector scope: member-access on one side AND a string Literal on the
+      // other. Standalone-variable comparisons inside platform-specific helper
+      // fns (e.g. `if (platformType !== 'allegro') return null` at the top of
+      // `allegro-seller-panel-url.ts`) are NOT caught, and they should not be:
+      // those helpers advertise their platform in the filename and fail safe
+      // for non-matching inputs.
+      files: ['apps/web/src/{features,pages,app}/**/*.{ts,tsx}'],
+      excludedFiles: [
+        'apps/web/src/**/*.test.{ts,tsx}',
+        'apps/web/src/**/*.spec.{ts,tsx}',
+      ],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector:
+              "BinaryExpression[operator=/^(===|!==)$/][left.property.name='platformType'][right.type='Literal']",
+            message:
+              "Literal-equality dispatch on platformType is forbidden outside apps/web/src/plugins/. Use usePlugin()/usePlugins() from shared/plugins, or capability checks (supportedCapabilities.includes('…')). See #578/#579.",
+          },
+          {
+            selector:
+              "BinaryExpression[operator=/^(===|!==)$/][right.property.name='platformType'][left.type='Literal']",
+            message:
+              "Literal-equality dispatch on platformType is forbidden outside apps/web/src/plugins/. Use usePlugin()/usePlugins() from shared/plugins, or capability checks (supportedCapabilities.includes('…')). See #578/#579.",
+          },
+        ],
       },
     },
     {

--- a/apps/web/src/app/providers/app-providers.tsx
+++ b/apps/web/src/app/providers/app-providers.tsx
@@ -7,6 +7,8 @@ import { SessionProvider } from '../../shared/auth/session-provider';
 import { ToastProvider } from '../../shared/ui/toast-provider';
 import { env } from '../../shared/config/env';
 import { ThemeProvider } from '../../shared/theme';
+import { PluginRegistryProvider } from '../../shared/plugins';
+import { IN_TREE_PLUGINS } from '../../plugins';
 
 export function AppProviders({ children }: PropsWithChildren): ReactElement {
   const [queryClient] = useState(
@@ -35,13 +37,15 @@ export function AppProviders({ children }: PropsWithChildren): ReactElement {
 
   return (
     <ThemeProvider>
-      <SessionProvider adapter={sessionAdapter}>
-        <ToastProvider>
-          <ApiClientProvider client={apiClient}>
-            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-          </ApiClientProvider>
-        </ToastProvider>
-      </SessionProvider>
+      <PluginRegistryProvider plugins={IN_TREE_PLUGINS}>
+        <SessionProvider adapter={sessionAdapter}>
+          <ToastProvider>
+            <ApiClientProvider client={apiClient}>
+              <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+            </ApiClientProvider>
+          </ToastProvider>
+        </SessionProvider>
+      </PluginRegistryProvider>
     </ThemeProvider>
   );
 }

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -1,6 +1,19 @@
-export const PLATFORM_TYPES = ['prestashop', 'allegro'] as const;
+/**
+ * Well-known platform types shipped in-tree. Mirrors `CORE_CAPABILITY_VALUES`
+ * below — open at the boundary: plugin authors can register additional
+ * platform types without modifying core (#578). Use `string` where the FE
+ * consumes adapter-supplied values; use this constant only when an
+ * exhaustive in-tree list is genuinely needed (e.g. fixture defaults).
+ */
+export const CORE_PLATFORM_TYPES = ['prestashop', 'allegro'] as const;
 
-export type PlatformType = (typeof PLATFORM_TYPES)[number];
+/**
+ * Connection platform type — an opaque string. Plugins are resolved by
+ * platform key via the FE plugin registry (`apps/web/src/plugins/`).
+ * Do not literal-equality-dispatch on this value — use `usePlugin()` or
+ * `supportedCapabilities` checks instead (enforced by ESLint).
+ */
+export type PlatformType = string;
 
 export type ConnectionStatus = 'active' | 'disabled' | 'error';
 

--- a/apps/web/src/features/connections/components/ConnectionActionsPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionActionsPanel.test.tsx
@@ -41,9 +41,29 @@ describe('ConnectionActionsPanel', () => {
   });
 
   it('shows trigger sync button for non-prestashop connections too', () => {
-    const allegroConnection = { ...sampleConnection, platformType: 'allegro' as const };
+    const allegroConnection = { ...sampleConnection, platformType: 'allegro' };
     renderWithProviders(<ConnectionActionsPanel connection={allegroConnection} />);
 
+    expect(screen.getByRole('button', { name: /trigger sync/i })).toBeInTheDocument();
+  });
+
+  it('renders the PrestaShop plugin\'s "Configure webhooks" action for prestashop connections', () => {
+    renderWithProviders(<ConnectionActionsPanel connection={sampleConnection} />);
+    expect(screen.getByRole('button', { name: /configure webhooks/i })).toBeInTheDocument();
+  });
+
+  it('does not render the "Configure webhooks" action for non-prestashop connections', () => {
+    const allegroConnection = { ...sampleConnection, platformType: 'allegro' };
+    renderWithProviders(<ConnectionActionsPanel connection={allegroConnection} />);
+    expect(screen.queryByRole('button', { name: /configure webhooks/i })).not.toBeInTheDocument();
+  });
+
+  it('renders no plugin-specific actions for an unregistered platformType', () => {
+    const unknownConnection = { ...sampleConnection, platformType: 'shopify' };
+    renderWithProviders(<ConnectionActionsPanel connection={unknownConnection} />);
+    expect(screen.queryByRole('button', { name: /configure webhooks/i })).not.toBeInTheDocument();
+    // Core actions are still present.
+    expect(screen.getByRole('link', { name: 'Edit' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /trigger sync/i })).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/connections/components/ConnectionActionsPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionActionsPanel.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import type { Connection } from '../api/connections.types';
 import { useDisableConnectionMutation } from '../hooks/use-disable-connection-mutation';
 import { useTestConnectionMutation } from '../hooks/use-test-connection-mutation';
-import { useConfigureWebhooksMutation } from '../hooks/use-configure-webhooks-mutation';
+import { usePlugin } from '../../../shared/plugins';
 import { TriggerSyncDialog } from '../../sync-jobs/components/TriggerSyncDialog';
 import { Button } from '../../../shared/ui/button';
 import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
@@ -17,52 +17,13 @@ interface ConnectionActionsPanelProps {
 export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelProps): ReactElement {
   const disableConnection = useDisableConnectionMutation();
   const testConnection = useTestConnectionMutation();
-  const configureWebhooks = useConfigureWebhooksMutation();
   const { showToast } = useToast();
   const [isDisableDialogOpen, setIsDisableDialogOpen] = useState(false);
   const [isTriggerDialogOpen, setIsTriggerDialogOpen] = useState(false);
+  const plugin = usePlugin(connection.platformType);
+  const PluginActions = plugin?.ConnectionActions;
 
   const isDisabled = connection.status === 'disabled';
-  const isPrestashop = connection.platformType === 'prestashop';
-  const webhooksConfigured =
-    typeof connection.config === 'object' &&
-    connection.config !== null &&
-    (connection.config as Record<string, unknown>).webhooksConfigured === true;
-
-  async function handleConfigureWebhooks(): Promise<void> {
-    try {
-      const result = await configureWebhooks.mutateAsync(connection.id);
-      if (result.webhooksConfigured && result.testPingTriggered) {
-        showToast({
-          tone: 'success',
-          title: 'Webhooks configured',
-          description:
-            "PrestaShop module updated and verified by a test ping. You're done.",
-        });
-      } else if (result.webhooksConfigured) {
-        // Push succeeded but ping didn't make it back. Configuration is correct;
-        // verification is incomplete. Operator can retry or wait for a real event.
-        showToast({
-          tone: 'warning',
-          title: 'Webhooks configured (ping not received)',
-          description:
-            'Configuration is in place but the test ping did not arrive. Click again to retry, or wait for the next real event.',
-        });
-      } else {
-        showToast({
-          tone: 'error',
-          title: 'Configuration push failed',
-          description: result.warning ?? 'PrestaShop did not accept the configuration push.',
-        });
-      }
-    } catch (error) {
-      showToast({
-        tone: 'error',
-        title: 'Configuration push failed',
-        description: (error as Error).message,
-      });
-    }
-  }
 
   async function handleTest(): Promise<void> {
     try {
@@ -131,29 +92,7 @@ export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelPro
           </Link>
         </div>
 
-        {isPrestashop ? (
-          <div className="action-list__item">
-            <div>
-              <strong>Configure webhooks</strong>
-              <p className="muted-text">
-                Push Base URL, Connection ID, and a freshly-rotated Webhook Secret to the
-                PrestaShop module via WS. Verifies with a synchronous test ping.
-                {webhooksConfigured ? ' Currently configured ✓' : ''}
-              </p>
-            </div>
-            <Button
-              tone={webhooksConfigured ? 'secondary' : 'primary'}
-              disabled={configureWebhooks.isPending}
-              onClick={() => void handleConfigureWebhooks()}
-            >
-              {configureWebhooks.isPending
-                ? 'Configuring...'
-                : webhooksConfigured
-                  ? 'Re-configure webhooks'
-                  : 'Configure webhooks'}
-            </Button>
-          </div>
-        ) : null}
+        {PluginActions ? <PluginActions connection={connection} /> : null}
 
         {!isDisabled ? (
           <div className="action-list__item">

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactElement } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import type { Connection } from '../api/connections.types';
 import { useUpdateConnectionMutation } from '../hooks/use-update-connection-mutation';
-import { useUpdateConnectionCredentialsMutation } from '../hooks/use-update-connection-credentials-mutation';
 import { useProductMasterConnections } from '../hooks/use-product-master-connections';
 import {
   editConnectionSchema,
@@ -21,10 +20,8 @@ import { Input } from '../../../shared/ui/input';
 import { Select } from '../../../shared/ui/select';
 import { Textarea } from '../../../shared/ui/textarea';
 import { useToast } from '../../../shared/ui/toast-provider';
-import { AllegroSellerDefaultsSection } from './allegro-seller-defaults-section';
+import { usePlugin } from '../../../shared/plugins';
 import { POLISH_VOIVODESHIP_VALUES } from '../types/polish-voivodeship.types';
-import { useMappingOptions } from '../../mappings/hooks/use-mapping-options';
-import type { MappingOption } from '../../mappings/api/mappings.types';
 
 interface EditConnectionFormProps {
   connection: Connection;
@@ -37,21 +34,6 @@ type StructuredField =
   | 'openlinkerCallbackBaseUrl'
   | 'masterCatalogConnectionId'
   | 'defaultCarrierId';
-
-/**
- * Mirror of the dropdown decoration in `MappingPanel` (#517). Native
- * `<option>` is text-only so the dynamic-kind cue is encoded as a label
- * suffix; static options stay bare. Kept inline here (rather than
- * imported from `features/mappings`) to keep the cross-feature surface
- * narrow — only the `MappingOption` type is shared.
- */
-function carrierOptionLabel(option: MappingOption): string {
-  return option.kind === 'dynamic'
-    ? `${option.label} — exact Allegro cost`
-    : option.label;
-}
-
-type PlatformBranch = 'prestashop' | 'marketplace' | 'raw';
 
 function readString(config: Record<string, unknown>, key: string): string {
   const value = config[key];
@@ -145,6 +127,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const { showToast } = useToast();
   const navigate = useNavigate();
   const [showRawJson, setShowRawJson] = useState(false);
+  const plugin = usePlugin(connection.platformType);
 
   const form = useForm<EditConnectionFormValues, undefined, EditConnectionFormSubmission>({
     defaultValues: {
@@ -152,16 +135,15 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
       baseUrl: readString(connection.config, 'baseUrl'),
       shopId: readString(connection.config, 'shopId'),
       storefrontBaseUrl: readString(connection.config, 'storefrontBaseUrl'),
-      // #168 — pre-fill OL callback URL from window.location.origin when the
+      // #168 — pre-fill OL callback URL via the platform plugin when the
       // connection has none yet. Browser-context value, not server-trusted; the
       // BE doesn't derive this from request headers (host-header injection risk),
       // so the FE owns the convenience default. Operator can override for dev
       // (e.g. http://host.docker.internal:3000) by editing the field.
       openlinkerCallbackBaseUrl:
         readString(connection.config, 'openlinkerCallbackBaseUrl') ||
-        (typeof window !== 'undefined' && connection.platformType === 'prestashop'
-          ? window.location.origin
-          : ''),
+        plugin?.getCallbackUrlDefault?.() ||
+        '',
       masterCatalogConnectionId: readString(connection.config, 'masterCatalogConnectionId'),
       // PS `defaultCarrierId` is persisted as a number; the form keeps it
       // as a string so the same `<Select>` primitive serves both this
@@ -181,13 +163,16 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
     error?.message ? [String(error.message)] : [],
   );
 
-  const platformBranch: PlatformBranch =
-    connection.platformType === 'prestashop'
-      ? 'prestashop'
-      : connection.enabledCapabilities.includes('OfferManager')
-        ? 'marketplace'
-        : 'raw';
-  const hasStructuredInputs = platformBranch !== 'raw';
+  // Structured-config dispatch (#578/#579):
+  //   - A platform plugin may contribute its own structured inputs (today: PS).
+  //   - Independently, marketplace-class connections (capability `OfferManager`)
+  //     render the generic catalog picker.
+  //   - Either / both is "structured"; otherwise the operator only sees raw JSON.
+  const StructuredSection = plugin?.StructuredConfigSection;
+  const ExtraSection = plugin?.ExtraConfigSection;
+  const PluginCredentialsPanel = plugin?.CredentialsPanel;
+  const isMarketplace = connection.enabledCapabilities.includes('OfferManager');
+  const hasStructuredInputs = StructuredSection !== undefined || isMarketplace;
 
   // Tracks whether the raw JSON currently parses. When it doesn't, we lock the
   // structured inputs so typing in them can't silently drop custom keys that
@@ -255,7 +240,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const autoSelectFiredRef = useRef(false);
   useEffect(() => {
     if (autoSelectFiredRef.current) return;
-    if (platformBranch !== 'marketplace') return;
+    if (!isMarketplace) return;
     if (hasStoredMaster) return;
     if (!localAutoSelectId) return;
     if (connectionsQuery.isLoading) return;
@@ -268,7 +253,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
     localAutoSelectId,
     connectionsQuery.isLoading,
     connectionsQuery.error,
-    platformBranch,
+    isMarketplace,
     hasStoredMaster,
   ]);
 
@@ -320,7 +305,20 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
         <Input value={connection.platformType} disabled />
       </FormField>
 
-      <CredentialsPanel connection={connection} />
+      {PluginCredentialsPanel ? (
+        <PluginCredentialsPanel connection={connection} />
+      ) : (
+        <FormField label="Credentials" name="credentials">
+          <Input
+            value={
+              connection.credentialsBacked
+                ? 'Stored securely (managed by integration)'
+                : 'Environment variable (not editable via UI)'
+            }
+            disabled
+          />
+        </FormField>
+      )}
 
       <FormField
         label="Adapter key"
@@ -342,81 +340,18 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
         </Alert>
       ) : null}
 
-      {platformBranch === 'prestashop' ? (
-        <>
-          <FormField
-            label="Shop URL"
-            name="baseUrl"
-            error={form.formState.errors.baseUrl?.message}
-            description="The public URL of the PrestaShop storefront."
-          >
-            <Input
-              value={form.watch('baseUrl') ?? ''}
-              onChange={(event) => syncStructuredToJson('baseUrl', event.target.value)}
-              placeholder="https://shop.example.com"
-              disabled={!configIsParseable}
-              invalid={Boolean(form.formState.errors.baseUrl)}
-            />
-          </FormField>
-
-          <FormField
-            label="Storefront URL (optional)"
-            name="storefrontBaseUrl"
-            error={form.formState.errors.storefrontBaseUrl?.message}
-            description="Override only if your public storefront URL is different from the webservice URL. Leave blank if they're the same — defaults to Shop URL."
-          >
-            <Input
-              value={form.watch('storefrontBaseUrl') ?? ''}
-              onChange={(event) => syncStructuredToJson('storefrontBaseUrl', event.target.value)}
-              placeholder="https://shop.example.com"
-              disabled={!configIsParseable}
-              invalid={Boolean(form.formState.errors.storefrontBaseUrl)}
-            />
-          </FormField>
-
-          <FormField
-            label="Shop ID (optional)"
-            name="shopId"
-            error={form.formState.errors.shopId?.message}
-            description="Only needed for multi-shop PrestaShop installations."
-          >
-            <Input
-              value={form.watch('shopId') ?? ''}
-              onChange={(event) => syncStructuredToJson('shopId', event.target.value)}
-              placeholder="1"
-              disabled={!configIsParseable}
-              invalid={Boolean(form.formState.errors.shopId)}
-            />
-          </FormField>
-
-          <FormField
-            label="OL callback URL"
-            name="openlinkerCallbackBaseUrl"
-            error={form.formState.errors.openlinkerCallbackBaseUrl?.message}
-            description="OpenLinker's URL from PrestaShop's perspective — used by the PS module to POST webhooks back to OL. Pre-filled from your browser; override for Docker dev (e.g. http://host.docker.internal:3000) or unusual deploys. Required to use the 'Configure webhooks' action."
-          >
-            <Input
-              value={form.watch('openlinkerCallbackBaseUrl') ?? ''}
-              onChange={(event) =>
-                syncStructuredToJson('openlinkerCallbackBaseUrl', event.target.value)
-              }
-              placeholder="https://api.openlinker.example"
-              disabled={!configIsParseable}
-              invalid={Boolean(form.formState.errors.openlinkerCallbackBaseUrl)}
-            />
-          </FormField>
-
-          <PrestashopFallbackCarrierField
-            connectionId={connection.id}
-            value={form.watch('defaultCarrierId') ?? ''}
-            errorMessage={form.formState.errors.defaultCarrierId?.message}
-            disabled={!configIsParseable}
-            onChange={(value) => syncStructuredToJson('defaultCarrierId', value)}
-          />
-        </>
+      {StructuredSection ? (
+        <StructuredSection
+          connection={connection}
+          form={form}
+          configIsParseable={configIsParseable}
+          syncStructuredToJson={(field, value, options) =>
+            syncStructuredToJson(field as StructuredField, value, options)
+          }
+        />
       ) : null}
 
-      {platformBranch === 'marketplace' ? (
+      {isMarketplace ? (
         <MarketplaceCatalogPicker
           value={masterCatalogValue}
           candidates={candidates}
@@ -430,12 +365,12 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
         />
       ) : null}
 
-      {connection.platformType === 'allegro' ? (
-        <AllegroSellerDefaultsSection
-          connectionId={connection.id}
+      {ExtraSection ? (
+        <ExtraSection
+          connection={connection}
           form={form}
-          onChange={syncSellerDefaultsToJson}
-          disabled={!configIsParseable}
+          configIsParseable={configIsParseable}
+          syncSellerDefaultsToJson={syncSellerDefaultsToJson}
         />
       ) : null}
 
@@ -572,173 +507,3 @@ function MarketplaceCatalogPicker({
   );
 }
 
-interface PrestashopFallbackCarrierFieldProps {
-  connectionId: string;
-  value: string;
-  errorMessage: string | undefined;
-  disabled: boolean;
-  onChange: (value: string) => void;
-}
-
-/**
- * Fallback-carrier picker for PrestaShop connections (#517).
- *
- * Backed by the same `getMappingOptions(connectionId, 'destination', 'carriers')`
- * endpoint as the per-method mapping page, so the option set (and its
- * dynamic-kind decoration) stays in lockstep. The field is allowed to
- * stay blank: when unset, the BE adapter (#516) falls back to the
- * OpenLinker Dynamic carrier at order-create time. A save-time warning
- * banner fires only when (a) the field is blank, (b) the OL Dynamic
- * carrier is NOT among the loaded options (operator hasn't installed
- * the OL PS module on this connection) — i.e. the connection is in a
- * state where any unmapped Allegro shipping method WILL fail at sync.
- *
- * No soft-prefill: per tech-review on #517, picking the OL Dynamic
- * carrier as a phantom default would write a value the operator didn't
- * choose. The runtime fallback chain handles the unset case, and the
- * help text + warning banner make the consequence explicit.
- */
-function PrestashopFallbackCarrierField({
-  connectionId,
-  value,
-  errorMessage,
-  disabled,
-  onChange,
-}: PrestashopFallbackCarrierFieldProps): ReactElement {
-  const { options, isLoading, errors } = useMappingOptions(connectionId);
-  const carriersError = errors.prestashopCarriers ?? null;
-  const carriers = options.prestashopCarriers;
-  const hasDynamicOption = carriers.some((c) => c.kind === 'dynamic');
-  const showNoFallbackWarning = value === '' && carriersError === null && !isLoading && !hasDynamicOption;
-
-  return (
-    <>
-      <FormField
-        label="Fallback carrier (optional)"
-        name="defaultCarrierId"
-        error={errorMessage}
-        description="Used when an Allegro shipping method has no carrier mapping. Leave unset to use the OpenLinker Dynamic carrier (exact Allegro shipping cost) at sync time — works only when the OL PrestaShop module is installed."
-      >
-        {isLoading ? (
-          <Select disabled>
-            <option>Loading carriers…</option>
-          </Select>
-        ) : carriersError ? (
-          <Select disabled>
-            <option>Failed to load carriers</option>
-          </Select>
-        ) : (
-          <Select
-            value={value}
-            onChange={(event) => onChange(event.target.value)}
-            disabled={disabled}
-            invalid={Boolean(errorMessage)}
-          >
-            <option value="">None — use OpenLinker Dynamic at runtime</option>
-            {carriers.map((c) => (
-              <option key={c.value} value={c.value}>
-                {carrierOptionLabel(c)}
-              </option>
-            ))}
-          </Select>
-        )}
-      </FormField>
-
-      {showNoFallbackWarning ? (
-        <Alert tone="warning" className="edit-connection__fallback-warning">
-          No fallback carrier is set and the OpenLinker PrestaShop module isn't
-          installed on this connection. Sync will fail for any Allegro shipping
-          method without a carrier mapping until you pick a fallback or install
-          the OL PS module.
-        </Alert>
-      ) : null}
-    </>
-  );
-}
-
-function CredentialsPanel({ connection }: { connection: Connection }): ReactElement {
-  const [showRotate, setShowRotate] = useState(false);
-  const [newKey, setNewKey] = useState('');
-  const rotate = useUpdateConnectionCredentialsMutation();
-  const { showToast } = useToast();
-
-  if (!connection.credentialsBacked) {
-    return (
-      <FormField label="Credentials" name="credentials">
-        <Input value="Environment variable (not editable via UI)" disabled />
-      </FormField>
-    );
-  }
-
-  if (connection.platformType !== 'prestashop') {
-    return (
-      <FormField label="Credentials" name="credentials">
-        <Input value="Stored securely (managed by integration)" disabled />
-      </FormField>
-    );
-  }
-
-  const onRotate = async (event: FormEvent): Promise<void> => {
-    event.preventDefault();
-    if (newKey.trim().length === 0) return;
-    try {
-      await rotate.mutateAsync({
-        connectionId: connection.id,
-        credentials: { webserviceApiKey: newKey.trim() },
-      });
-      showToast({
-        tone: 'success',
-        title: 'Credentials rotated',
-        description: 'The new webservice key is now in use.',
-      });
-      setNewKey('');
-      setShowRotate(false);
-    } catch {
-      // surfaced via rotate.error
-    }
-  };
-
-  return (
-    <FormField
-      label="Webservice key"
-      name="credentials"
-      description="Stored securely on the server. Rotate to replace the key without restarting the API."
-    >
-      {showRotate ? (
-        <div className="form-grid">
-          {rotate.error ? <Alert tone="error">{rotate.error.message}</Alert> : null}
-          <Input
-            type="password"
-            autoComplete="off"
-            placeholder="New webservice key"
-            value={newKey}
-            onChange={(event) => setNewKey(event.target.value)}
-          />
-          <div className="form-actions">
-            <Button
-              type="button"
-              onClick={(event) => void onRotate(event)}
-              disabled={rotate.isPending || newKey.trim().length === 0}
-            >
-              {rotate.isPending ? 'Rotating...' : 'Save new key'}
-            </Button>
-            <Button
-              tone="secondary"
-              type="button"
-              onClick={() => {
-                setShowRotate(false);
-                setNewKey('');
-              }}
-            >
-              Cancel
-            </Button>
-          </div>
-        </div>
-      ) : (
-        <Button tone="secondary" type="button" onClick={() => setShowRotate(true)}>
-          Rotate webservice key
-        </Button>
-      )}
-    </FormField>
-  );
-}

--- a/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
+++ b/apps/web/src/features/connections/components/allegro-seller-defaults-section.tsx
@@ -45,11 +45,11 @@ interface AllegroSellerDefaultsSectionProps {
  * information — required by `POST /sale/product-offers` since the GPSR
  * rollout on 2024-12-13.
  *
- * Lives inside the existing `EditConnectionForm`; rendered only when
- * `connection.platformType === 'allegro'`. The form already syncs the
- * structured fields into a single `configText` JSON via the merge helper —
- * this section follows that pattern (every input change calls `onChange`,
- * the parent re-serializes).
+ * Rendered by the Allegro platform plugin's `EditConnectionExtraSection`
+ * slot in `apps/web/src/plugins/allegro/`. The parent `EditConnectionForm`
+ * already syncs the structured fields into a single `configText` JSON via
+ * the merge helper — this section follows that pattern (every input change
+ * calls `onChange`, the parent re-serializes).
  */
 export function AllegroSellerDefaultsSection({
   connectionId,

--- a/apps/web/src/features/connections/components/create-connection-form.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
-import { PLATFORM_TYPES } from '../api/connections.types';
+import { usePlugin, usePlugins } from '../../../shared/plugins';
 import { useCreateConnectionMutation } from '../hooks/use-create-connection-mutation';
 import {
   createConnectionSchema,
@@ -37,25 +37,24 @@ const DEFAULT_VALUES: CreateConnectionFormValues = {
   platformType: '',
 };
 
-const PLATFORM_OPTIONS = [
-  { value: PLATFORM_TYPES[0], label: 'PrestaShop' },
-  { value: PLATFORM_TYPES[1], label: 'Allegro' },
-] as const;
-
 export function CreateConnectionForm(): ReactElement {
   const createConnection = useCreateConnectionMutation();
   const { showToast } = useToast();
   const navigate = useNavigate();
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
+  const plugins = usePlugins();
+  const platformOptions = plugins.map((p) => ({ value: p.platformType, label: p.displayName }));
   const form = useForm<CreateConnectionFormValues, undefined, CreateConnectionFormSubmission>({
     defaultValues: DEFAULT_VALUES,
     resolver: zodResolver(createConnectionSchema),
   });
 
   const watchedPlatformType = form.watch('platformType');
-  // TODO: when a second OAuth platform is added, extract platform-specific
-  // form rendering into separate components rather than accumulating conditionals here.
-  const isAllegroSelected = watchedPlatformType === 'allegro';
+  // Platforms that drive the operator through an OAuth redirect (today:
+  // Allegro) suppress the inline create-submit affordances — the registered
+  // platform wizard owns the rest of the flow.
+  const selectedPlugin = usePlugin(watchedPlatformType);
+  const requiresExternalAuthRedirect = selectedPlugin?.requiresExternalAuthRedirect === true;
 
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
     error?.message ? [String(error.message)] : [],
@@ -65,7 +64,7 @@ export function CreateConnectionForm(): ReactElement {
     // Guard against Enter-key form submission while a platform-specific wizard
     // (e.g. Allegro) is selected: the schema still validates hidden fields, so
     // submission would fail silently without visible feedback.
-    if (isAllegroSelected) return;
+    if (requiresExternalAuthRedirect) return;
     try {
       const created = await createConnection.mutateAsync(toCreateConnectionInput(values));
       showToast({
@@ -110,7 +109,7 @@ export function CreateConnectionForm(): ReactElement {
           >
             <Select {...form.register('platformType')} invalid={Boolean(form.formState.errors.platformType)}>
               <option value="">Select a platform</option>
-              {PLATFORM_OPTIONS.map((platform) => (
+              {platformOptions.map((platform) => (
                 <option key={platform.value} value={platform.value}>
                   {platform.label}
                 </option>
@@ -118,7 +117,7 @@ export function CreateConnectionForm(): ReactElement {
             </Select>
           </FormField>
 
-          {isAllegroSelected ? null : (
+          {requiresExternalAuthRedirect ? null : (
             <FormField label="Credentials reference" name="credentialsRef" error={form.formState.errors.credentialsRef?.message}>
               <Input
                 {...form.register('credentialsRef')}
@@ -128,7 +127,7 @@ export function CreateConnectionForm(): ReactElement {
             </FormField>
           )}
 
-          {isAllegroSelected ? null : (
+          {requiresExternalAuthRedirect ? null : (
             <FormField
               label="Adapter key"
               name="adapterKey"
@@ -144,11 +143,17 @@ export function CreateConnectionForm(): ReactElement {
           )}
         </div>
 
-        {isAllegroSelected ? (
-          <Alert tone="info" title="Allegro uses OAuth">
-            Allegro connections require OAuth authorization.{' '}
-            <Link to="/connections/new/allegro">Use the Allegro setup wizard</Link> to connect your
-            account securely.
+        {requiresExternalAuthRedirect && selectedPlugin ? (
+          <Alert tone="info" title={`${selectedPlugin.displayName} uses OAuth`}>
+            {selectedPlugin.displayName} connections require OAuth authorization.{' '}
+            {selectedPlugin.setupCard ? (
+              <Link to={selectedPlugin.setupCard.to}>
+                Use the {selectedPlugin.displayName} setup wizard
+              </Link>
+            ) : (
+              `Use the ${selectedPlugin.displayName} setup wizard`
+            )}{' '}
+            to connect your account securely.
           </Alert>
         ) : (
           <FormField
@@ -161,7 +166,7 @@ export function CreateConnectionForm(): ReactElement {
           </FormField>
         )}
 
-        {isAllegroSelected ? null : (
+        {requiresExternalAuthRedirect ? null : (
           <div className="form-actions">
             <Button type="submit" disabled={createConnection.isPending}>
               {createConnection.isPending ? 'Creating...' : 'Create connection'}

--- a/apps/web/src/features/connections/components/create-connection.schema.ts
+++ b/apps/web/src/features/connections/components/create-connection.schema.ts
@@ -1,9 +1,16 @@
 import { z } from 'zod';
-import { PLATFORM_TYPES, type CreateConnectionInput, type PlatformType } from '../api/connections.types';
+import type { CreateConnectionInput } from '../api/connections.types';
 
+/**
+ * `platformType` is an opaque string post-#578 — membership is enforced at
+ * the registry boundary, not the schema. The schema only ensures the field
+ * is non-empty; an unknown platform falls through to a clear runtime error
+ * from `usePlugin()` consumers or the BE registry.
+ */
 export const platformTypeFormSchema = z
-  .enum([...PLATFORM_TYPES, ''] as const)
-  .refine((value): value is PlatformType => value !== '', 'Platform type is required');
+  .string()
+  .trim()
+  .min(1, 'Platform type is required');
 
 export const createConnectionSchema = z.object({
   adapterKey: z.string().trim().optional(),

--- a/apps/web/src/features/connections/components/platform-picker.test.tsx
+++ b/apps/web/src/features/connections/components/platform-picker.test.tsx
@@ -2,6 +2,7 @@ import { within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { PlatformPicker } from './platform-picker';
 import { renderWithProviders } from '../../../test/test-utils';
+import type { PlatformPlugin } from '../../../shared/plugins';
 
 describe('PlatformPicker', () => {
   it('renders a card per platform linking to its guided setup route', () => {
@@ -18,5 +19,30 @@ describe('PlatformPicker', () => {
     const view = renderWithProviders(<PlatformPicker />);
     const advanced = within(view.container).getByRole('link', { name: /advanced mode/i });
     expect(advanced).toHaveAttribute('href', '/connections/new/advanced');
+  });
+
+  it('omits plugins without a setupCard', () => {
+    const plugins: PlatformPlugin[] = [
+      {
+        platformType: 'with-card',
+        displayName: 'With Card',
+        setupCard: {
+          title: 'With Card',
+          description: 'Has guided setup.',
+          to: '/connections/new/with-card',
+          badge: 'Test',
+        },
+      },
+      // No setupCard — must not render.
+      { platformType: 'headless', displayName: 'Headless' },
+    ];
+    const view = renderWithProviders(<PlatformPicker />, { plugins });
+
+    expect(
+      within(view.container).getByRole('link', { name: /With Card/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(view.container).queryByRole('link', { name: /Headless/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/connections/components/platform-picker.tsx
+++ b/apps/web/src/features/connections/components/platform-picker.tsx
@@ -1,61 +1,38 @@
 /**
  * Platform Picker
  *
- * Step 1 of the connection setup flow. Renders one card per supported
- * platform and links to that platform's guided wizard route. The
- * metadata table is indexed by PlatformType so the compiler fails if a
- * new platform type is added to PLATFORM_TYPES without a corresponding
- * card entry.
+ * Step 1 of the connection setup flow. Renders one card per registered
+ * platform plugin that exposes a `setupCard`. Cards are sourced from the
+ * plugin registry (`shared/plugins`) — adding a new platform plugin is
+ * the single edit point; this component picks it up automatically.
  */
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { PLATFORM_TYPES, type PlatformType } from '../api/connections.types';
-
-interface PlatformCard {
-  title: string;
-  description: string;
-  to: string;
-  badge: string;
-}
-
-const PLATFORM_CARDS: Record<PlatformType, PlatformCard> = {
-  prestashop: {
-    title: 'PrestaShop',
-    description:
-      'Connect a PrestaShop store via the Webservice API. You will need the shop URL and a webservice key.',
-    to: '/connections/new/prestashop',
-    badge: 'Webservice API',
-  },
-  allegro: {
-    title: 'Allegro',
-    description:
-      'Connect an Allegro seller account. Authorization uses OAuth 2.0 — no manual token paste.',
-    to: '/connections/new/allegro',
-    badge: 'OAuth 2.0',
-  },
-};
+import { usePlugins } from '../../../shared/plugins';
 
 export function PlatformPicker(): ReactElement {
+  const plugins = usePlugins();
+  const cards = plugins
+    .filter((p) => p.setupCard !== undefined)
+    .map((p) => ({ platformType: p.platformType, ...p.setupCard! }));
+
   return (
     <div className="platform-picker">
       <ul className="platform-picker__list">
-        {PLATFORM_TYPES.map((platformType) => {
-          const card = PLATFORM_CARDS[platformType];
-          return (
-            <li key={platformType}>
-              <Link to={card.to} className="platform-picker__card">
-                <div className="platform-picker__card-header">
-                  <h3 className="platform-picker__card-title">{card.title}</h3>
-                  <span className="toolbar-chip">{card.badge}</span>
-                </div>
-                <p className="platform-picker__card-description">{card.description}</p>
-                <span className="platform-picker__card-cta" aria-hidden="true">
-                  Continue →
-                </span>
-              </Link>
-            </li>
-          );
-        })}
+        {cards.map((card) => (
+          <li key={card.platformType}>
+            <Link to={card.to} className="platform-picker__card">
+              <div className="platform-picker__card-header">
+                <h3 className="platform-picker__card-title">{card.title}</h3>
+                <span className="toolbar-chip">{card.badge}</span>
+              </div>
+              <p className="platform-picker__card-description">{card.description}</p>
+              <span className="platform-picker__card-cta" aria-hidden="true">
+                Continue →
+              </span>
+            </Link>
+          </li>
+        ))}
       </ul>
       <p className="platform-picker__advanced">
         Need to configure a raw adapter key or bespoke config JSON?{' '}

--- a/apps/web/src/features/listings/components/CreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/CreateOfferWizard.tsx
@@ -296,10 +296,14 @@ export function CreateOfferWizard({
   }, [form.formState.isDirty]);
 
   const connectionsQuery = useConnectionsQuery();
+  // Filter by capability only (#578/#579). The previous `platformType === 'allegro'`
+  // arm was a transitional backstop for connections that pre-dated the
+  // adapter-registry capability metadata in #570/#571 — every Allegro connection
+  // now reports `OfferManager` in `supportedCapabilities`.
   const marketplaceConnections = useMemo(
     () =>
-      (connectionsQuery.data ?? []).filter(
-        (c) => c.platformType === 'allegro' || c.supportedCapabilities.includes('OfferManager'),
+      (connectionsQuery.data ?? []).filter((c) =>
+        c.supportedCapabilities.includes('OfferManager'),
       ),
     [connectionsQuery.data],
   );

--- a/apps/web/src/pages/connections/connections-list-page.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
-import type { Connection, ConnectionFilters, ConnectionStatus, PlatformType } from '../../features/connections/api/connections.types';
-import { PLATFORM_TYPES } from '../../features/connections/api/connections.types';
+import type { Connection, ConnectionFilters, ConnectionStatus } from '../../features/connections/api/connections.types';
+import { usePlugins } from '../../shared/plugins';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { useTableSort } from '../../shared/ui/use-table-sort';
 import { ErrorState, LoadingState, EmptyState } from '../../shared/ui/feedback-state';
@@ -12,10 +12,6 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { Select } from '../../shared/ui/select';
 
 const CONNECTION_STATUSES = ['active', 'disabled', 'error'] as const;
-
-function isValidPlatformType(value: string): value is PlatformType {
-  return PLATFORM_TYPES.includes(value as PlatformType);
-}
 
 function isValidStatus(value: string): value is ConnectionStatus {
   return CONNECTION_STATUSES.includes(value as ConnectionStatus);
@@ -69,12 +65,14 @@ const COLUMNS: DataTableColumn<Connection>[] = [
 export function ConnectionsListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const { sort, setSort } = useTableSort([{ id: 'name', desc: false }]);
+  const plugins = usePlugins();
 
   const platformType = searchParams.get('platformType') ?? '';
   const status = searchParams.get('status') ?? '';
+  const isKnownPlatform = platformType !== '' && plugins.some((p) => p.platformType === platformType);
 
   const filters: ConnectionFilters = {
-    platformType: isValidPlatformType(platformType) ? platformType : undefined,
+    platformType: isKnownPlatform ? platformType : undefined,
     status: isValidStatus(status) ? status : undefined,
   };
 
@@ -123,8 +121,8 @@ export function ConnectionsListPage(): ReactElement {
             onChange={(e) => { handleFilterChange('platformType', e.target.value); }}
           >
             <option value="">All platforms</option>
-            {PLATFORM_TYPES.map((p) => (
-              <option key={p} value={p}>{p}</option>
+            {plugins.map((p) => (
+              <option key={p.platformType} value={p.platformType}>{p.displayName}</option>
             ))}
           </Select>
           <Select

--- a/apps/web/src/pages/listings/listing-detail-page.tsx
+++ b/apps/web/src/pages/listings/listing-detail-page.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../shared/ui/button';
 import { KeyValueList } from '../../shared/ui/key-value-list';
 import { RawPayloadPanel } from '../../shared/ui/raw-payload-panel';
 import { TimeDisplay } from '../../shared/ui/time-display';
+import { usePlugin } from '../../shared/plugins';
 import { useListingQuery } from '../../features/listings/hooks/use-listing-query';
 import { EditOfferDrawer } from '../../features/listings/components/EditOfferDrawer';
 import { ListingMarketplaceOfferSection } from '../../features/listings/components/listing-marketplace-offer-section';
@@ -109,6 +110,10 @@ export function ListingDetailPage(): ReactElement {
   }
 
   const mapping = query.data;
+  // Mapping `platformType` is the BE-denormalized copy of the connection's
+  // `platformType` (architecture-overview §IdentifierMappingService) — always
+  // canonical-cased, so direct lookup is safe.
+  const mappingPlugin = usePlugin(mapping.platformType);
 
   return (
     <PageLayout
@@ -116,7 +121,7 @@ export function ListingDetailPage(): ReactElement {
       eyebrow="Listings"
       title={`Mapping — ${mapping.externalId}`}
       actions={
-        mapping.platformType.toLowerCase() === 'allegro' ? (
+        mappingPlugin?.supportsListingEdit ? (
           <Button onClick={() => setIsEditDrawerOpen(true)}>
             Edit offer
           </Button>

--- a/apps/web/src/plugins/allegro/allegro.plugin.test.tsx
+++ b/apps/web/src/plugins/allegro/allegro.plugin.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Allegro Plugin Smoke Tests
+ *
+ * Asserts the registered fields are present. Behavioural coverage of each
+ * contributed component lives in the consumer-side tests
+ * (`platform-picker.test.tsx`, `EditConnectionForm.test.tsx`, etc.).
+ */
+import { describe, expect, it } from 'vitest';
+import { allegroPlugin } from './allegro.plugin';
+
+describe('allegroPlugin', () => {
+  it('declares the expected platform key + display name', () => {
+    expect(allegroPlugin.platformType).toBe('allegro');
+    expect(allegroPlugin.displayName).toBe('Allegro');
+  });
+
+  it('contributes the setup card pointing to the guided wizard', () => {
+    expect(allegroPlugin.setupCard).toBeDefined();
+    expect(allegroPlugin.setupCard?.to).toBe('/connections/new/allegro');
+  });
+
+  it('marks itself as requiring an external auth redirect (OAuth)', () => {
+    expect(allegroPlugin.requiresExternalAuthRedirect).toBe(true);
+  });
+
+  it('contributes the GPSR extra-config section and the edit-offer affordance', () => {
+    expect(allegroPlugin.ExtraConfigSection).toBeDefined();
+    expect(allegroPlugin.supportsListingEdit).toBe(true);
+  });
+
+  it('does NOT contribute structured-config / credentials / connection-actions slots', () => {
+    expect(allegroPlugin.StructuredConfigSection).toBeUndefined();
+    expect(allegroPlugin.CredentialsPanel).toBeUndefined();
+    expect(allegroPlugin.ConnectionActions).toBeUndefined();
+  });
+
+  it('does NOT contribute a callback-URL default (PS-only affordance)', () => {
+    expect(allegroPlugin.getCallbackUrlDefault).toBeUndefined();
+  });
+});

--- a/apps/web/src/plugins/allegro/allegro.plugin.tsx
+++ b/apps/web/src/plugins/allegro/allegro.plugin.tsx
@@ -1,0 +1,29 @@
+/**
+ * Allegro Platform Plugin
+ *
+ * In-tree plugin definition for the Allegro marketplace. Contributes:
+ *
+ *   - Setup card on `PlatformPicker`
+ *   - External-auth-redirect flag (the inline create form swaps in an Alert)
+ *   - GPSR seller-defaults section in `EditConnectionForm` (#430)
+ *   - "Edit offer" affordance on `ListingDetailPage`
+ *
+ * @module plugins/allegro
+ */
+import type { PlatformPlugin } from '../../shared/plugins';
+import { AllegroExtraSection } from './components/allegro-extra-section';
+
+export const allegroPlugin: PlatformPlugin = {
+  platformType: 'allegro',
+  displayName: 'Allegro',
+  setupCard: {
+    title: 'Allegro',
+    description:
+      'Connect an Allegro seller account. Authorization uses OAuth 2.0 — no manual token paste.',
+    to: '/connections/new/allegro',
+    badge: 'OAuth 2.0',
+  },
+  requiresExternalAuthRedirect: true,
+  ExtraConfigSection: AllegroExtraSection,
+  supportsListingEdit: true,
+};

--- a/apps/web/src/plugins/allegro/components/allegro-extra-section.tsx
+++ b/apps/web/src/plugins/allegro/components/allegro-extra-section.tsx
@@ -1,0 +1,29 @@
+/**
+ * Allegro Extra Edit-Connection Section
+ *
+ * Plugin slot adapter that wraps the existing `AllegroSellerDefaultsSection`
+ * with the registry-shaped prop signature. Kept thin: all GPSR / location
+ * / responsible-producer rendering still lives in the feature module —
+ * this is only the plugin-contract surface.
+ *
+ * @module plugins/allegro/components
+ */
+import { type ReactElement } from 'react';
+import { AllegroSellerDefaultsSection } from '../../../features/connections/components/allegro-seller-defaults-section';
+import type { ExtraConfigSectionProps } from '../../../shared/plugins';
+
+export function AllegroExtraSection({
+  connection,
+  form,
+  configIsParseable,
+  syncSellerDefaultsToJson,
+}: ExtraConfigSectionProps): ReactElement {
+  return (
+    <AllegroSellerDefaultsSection
+      connectionId={connection.id}
+      form={form}
+      onChange={syncSellerDefaultsToJson}
+      disabled={!configIsParseable}
+    />
+  );
+}

--- a/apps/web/src/plugins/index.ts
+++ b/apps/web/src/plugins/index.ts
@@ -1,0 +1,19 @@
+/**
+ * In-Tree Plugin Manifest
+ *
+ * Single edit point for the in-tree FE platform plugins. Mirrors
+ * `apps/api/src/plugins.ts` from #572. To add a third-party platform
+ * plugin, add an entry here — no other file in `apps/web/src/{app,features,
+ * pages,shared}` should need to change.
+ *
+ * The order in this array determines the rendering order of
+ * platform-driven UI lists (e.g. setup-card sequence on `PlatformPicker`,
+ * dropdown option order on connection filters / create-connection form).
+ *
+ * @module plugins
+ */
+import type { PlatformPlugin } from '../shared/plugins';
+import { prestashopPlugin } from './prestashop/prestashop.plugin';
+import { allegroPlugin } from './allegro/allegro.plugin';
+
+export const IN_TREE_PLUGINS: readonly PlatformPlugin[] = [prestashopPlugin, allegroPlugin];

--- a/apps/web/src/plugins/index.ts
+++ b/apps/web/src/plugins/index.ts
@@ -10,10 +10,32 @@
  * platform-driven UI lists (e.g. setup-card sequence on `PlatformPicker`,
  * dropdown option order on connection filters / create-connection form).
  *
+ * Duplicate `platformType` keys are rejected at module load time below —
+ * the same check also runs inside `PluginRegistryProvider` so fixture
+ * plugins injected by tests can't accidentally shadow each other.
+ *
  * @module plugins
  */
 import type { PlatformPlugin } from '../shared/plugins';
 import { prestashopPlugin } from './prestashop/prestashop.plugin';
 import { allegroPlugin } from './allegro/allegro.plugin';
 
-export const IN_TREE_PLUGINS: readonly PlatformPlugin[] = [prestashopPlugin, allegroPlugin];
+const PLUGINS: readonly PlatformPlugin[] = [prestashopPlugin, allegroPlugin];
+
+// Module-load validation: catches the production-manifest case before any
+// provider mounts. The provider-level guard in `plugin-registry-context.tsx`
+// covers the test-fixture case (where a non-production array is passed in).
+function assertUniquePlatformTypes(plugins: readonly PlatformPlugin[]): void {
+  const seen = new Set<string>();
+  for (const p of plugins) {
+    if (seen.has(p.platformType)) {
+      throw new Error(
+        `Duplicate plugin platformType: "${p.platformType}". Each registered plugin must have a unique \`platformType\`.`,
+      );
+    }
+    seen.add(p.platformType);
+  }
+}
+assertUniquePlatformTypes(PLUGINS);
+
+export const IN_TREE_PLUGINS: readonly PlatformPlugin[] = PLUGINS;

--- a/apps/web/src/plugins/prestashop/components/prestashop-connection-actions.tsx
+++ b/apps/web/src/plugins/prestashop/components/prestashop-connection-actions.tsx
@@ -1,0 +1,87 @@
+/**
+ * PrestaShop Connection Actions
+ *
+ * Plugin-owned action rows rendered inside `ConnectionActionsPanel` for
+ * PrestaShop connections. Today: the "Configure webhooks" action (#168 /
+ * #583). Owns its mutation hook and toast feedback — the generic
+ * actions panel only knows it's rendering a plugin sub-tree.
+ *
+ * @module plugins/prestashop/components
+ */
+import { type ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { useConfigureWebhooksMutation } from '../../../features/connections/hooks/use-configure-webhooks-mutation';
+import type { Connection } from '../../../features/connections/api/connections.types';
+
+interface PrestashopConnectionActionsProps {
+  connection: Connection;
+}
+
+export function PrestashopConnectionActions({
+  connection,
+}: PrestashopConnectionActionsProps): ReactElement {
+  const configureWebhooks = useConfigureWebhooksMutation();
+  const { showToast } = useToast();
+
+  const webhooksConfigured =
+    typeof connection.config === 'object' &&
+    connection.config !== null &&
+    (connection.config as Record<string, unknown>).webhooksConfigured === true;
+
+  async function handleConfigureWebhooks(): Promise<void> {
+    try {
+      const result = await configureWebhooks.mutateAsync(connection.id);
+      if (result.webhooksConfigured && result.testPingTriggered) {
+        showToast({
+          tone: 'success',
+          title: 'Webhooks configured',
+          description: "PrestaShop module updated and verified by a test ping. You're done.",
+        });
+      } else if (result.webhooksConfigured) {
+        showToast({
+          tone: 'warning',
+          title: 'Webhooks configured (ping not received)',
+          description:
+            'Configuration is in place but the test ping did not arrive. Click again to retry, or wait for the next real event.',
+        });
+      } else {
+        showToast({
+          tone: 'error',
+          title: 'Configuration push failed',
+          description: result.warning ?? 'PrestaShop did not accept the configuration push.',
+        });
+      }
+    } catch (error) {
+      showToast({
+        tone: 'error',
+        title: 'Configuration push failed',
+        description: (error as Error).message,
+      });
+    }
+  }
+
+  return (
+    <div className="action-list__item">
+      <div>
+        <strong>Configure webhooks</strong>
+        <p className="muted-text">
+          Push Base URL, Connection ID, and a freshly-rotated Webhook Secret to the PrestaShop
+          module via WS. Verifies with a synchronous test ping.
+          {webhooksConfigured ? ' Currently configured ✓' : ''}
+        </p>
+      </div>
+      <Button
+        tone={webhooksConfigured ? 'secondary' : 'primary'}
+        disabled={configureWebhooks.isPending}
+        onClick={() => void handleConfigureWebhooks()}
+      >
+        {configureWebhooks.isPending
+          ? 'Configuring...'
+          : webhooksConfigured
+            ? 'Re-configure webhooks'
+            : 'Configure webhooks'}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/plugins/prestashop/components/prestashop-credentials-panel.test.tsx
+++ b/apps/web/src/plugins/prestashop/components/prestashop-credentials-panel.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * PrestashopCredentialsPanel Tests
+ *
+ * Localized regression coverage for the rotate-webservice-key flow that
+ * was previously inlined in `EditConnectionForm`. The form-level test
+ * still exercises the full mount path via the plugin slot; these tests
+ * pin the plugin's own surface so future refactors land here first.
+ */
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMockApiClient,
+  findToastTitle,
+  renderWithProviders,
+  sampleConnection,
+} from '../../../test/test-utils';
+import { PrestashopCredentialsPanel } from './prestashop-credentials-panel';
+
+describe('PrestashopCredentialsPanel', () => {
+  afterEach(cleanup);
+
+  it('renders the rotate affordance for a credentials-backed connection', () => {
+    renderWithProviders(<PrestashopCredentialsPanel connection={sampleConnection} />);
+    expect(screen.getByText('Rotate webservice key')).toBeInTheDocument();
+  });
+
+  it('falls back to the env-var disabled input when credentialsBacked=false', () => {
+    const envBackedConnection = { ...sampleConnection, credentialsBacked: false };
+    renderWithProviders(<PrestashopCredentialsPanel connection={envBackedConnection} />);
+    expect(
+      screen.getByDisplayValue('Environment variable (not editable via UI)'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /rotate/i })).not.toBeInTheDocument();
+  });
+
+  it('sends the rotated key as `webserviceApiKey` and surfaces a success toast', async () => {
+    const updateCredentials = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({
+      connections: { updateCredentials },
+    });
+    renderWithProviders(<PrestashopCredentialsPanel connection={sampleConnection} />, {
+      apiClient,
+    });
+
+    fireEvent.click(screen.getByText('Rotate webservice key'));
+    const newKeyInput = screen.getByPlaceholderText('New webservice key');
+    fireEvent.change(newKeyInput, { target: { value: 'new-secret-key' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save new key' }));
+
+    await waitFor(() => {
+      expect(updateCredentials).toHaveBeenCalledWith(sampleConnection.id, {
+        webserviceApiKey: 'new-secret-key',
+      });
+    });
+    expect(await findToastTitle('Credentials rotated')).toBeInTheDocument();
+  });
+
+  it('disables save while the rotate input is empty and while the mutation is pending', () => {
+    renderWithProviders(<PrestashopCredentialsPanel connection={sampleConnection} />);
+    fireEvent.click(screen.getByText('Rotate webservice key'));
+    expect(screen.getByRole('button', { name: 'Save new key' })).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText('New webservice key'), {
+      target: { value: 'k' },
+    });
+    expect(screen.getByRole('button', { name: 'Save new key' })).toBeEnabled();
+  });
+});

--- a/apps/web/src/plugins/prestashop/components/prestashop-credentials-panel.tsx
+++ b/apps/web/src/plugins/prestashop/components/prestashop-credentials-panel.tsx
@@ -1,0 +1,105 @@
+/**
+ * PrestaShop Credentials Panel
+ *
+ * Plugin-owned credentials affordance for PrestaShop connections — rotates
+ * the stored Webservice API key in place via PUT /credentials. Owns its
+ * own toggle state, mutation, and toast feedback; the parent
+ * `EditConnectionForm` renders this only when the plugin contributes it.
+ *
+ * Lives in the plugin (not in core) because the rotation form is shaped to
+ * the PS credential model (`webserviceApiKey`) — surfacing it generically
+ * would mislabel the input for any other platform that opted in.
+ *
+ * @module plugins/prestashop/components
+ */
+import { useState, type FormEvent, type ReactElement } from 'react';
+import type { Connection } from '../../../features/connections/api/connections.types';
+import { useUpdateConnectionCredentialsMutation } from '../../../features/connections/hooks/use-update-connection-credentials-mutation';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { useToast } from '../../../shared/ui/toast-provider';
+
+export function PrestashopCredentialsPanel({
+  connection,
+}: {
+  connection: Connection;
+}): ReactElement {
+  const [showRotate, setShowRotate] = useState(false);
+  const [newKey, setNewKey] = useState('');
+  const rotate = useUpdateConnectionCredentialsMutation();
+  const { showToast } = useToast();
+
+  if (!connection.credentialsBacked) {
+    return (
+      <FormField label="Credentials" name="credentials">
+        <Input value="Environment variable (not editable via UI)" disabled />
+      </FormField>
+    );
+  }
+
+  const onRotate = async (event: FormEvent): Promise<void> => {
+    event.preventDefault();
+    if (newKey.trim().length === 0) return;
+    try {
+      await rotate.mutateAsync({
+        connectionId: connection.id,
+        credentials: { webserviceApiKey: newKey.trim() },
+      });
+      showToast({
+        tone: 'success',
+        title: 'Credentials rotated',
+        description: 'The new webservice key is now in use.',
+      });
+      setNewKey('');
+      setShowRotate(false);
+    } catch {
+      // surfaced via rotate.error
+    }
+  };
+
+  return (
+    <FormField
+      label="Webservice key"
+      name="credentials"
+      description="Stored securely on the server. Rotate to replace the key without restarting the API."
+    >
+      {showRotate ? (
+        <div className="form-grid">
+          {rotate.error ? <Alert tone="error">{rotate.error.message}</Alert> : null}
+          <Input
+            type="password"
+            autoComplete="off"
+            placeholder="New webservice key"
+            value={newKey}
+            onChange={(event) => setNewKey(event.target.value)}
+          />
+          <div className="form-actions">
+            <Button
+              type="button"
+              onClick={(event) => void onRotate(event)}
+              disabled={rotate.isPending || newKey.trim().length === 0}
+            >
+              {rotate.isPending ? 'Rotating...' : 'Save new key'}
+            </Button>
+            <Button
+              tone="secondary"
+              type="button"
+              onClick={() => {
+                setShowRotate(false);
+                setNewKey('');
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button tone="secondary" type="button" onClick={() => setShowRotate(true)}>
+          Rotate webservice key
+        </Button>
+      )}
+    </FormField>
+  );
+}

--- a/apps/web/src/plugins/prestashop/components/prestashop-structured-section.tsx
+++ b/apps/web/src/plugins/prestashop/components/prestashop-structured-section.tsx
@@ -1,0 +1,186 @@
+/**
+ * PrestaShop Structured Section
+ *
+ * Plugin-owned structured-config inputs rendered inside `EditConnectionForm`
+ * when the connection's `platformType` is `'prestashop'`. Carries:
+ *
+ *   - Shop URL
+ *   - Storefront URL (split-host override)
+ *   - Shop ID (multi-shop)
+ *   - OL callback URL (used by the webhook auto-install flow, #168)
+ *   - Fallback carrier picker (PS-only; #517)
+ *
+ * @module plugins/prestashop/components
+ */
+import { type ReactElement } from 'react';
+import { Alert } from '../../../shared/ui/alert';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
+import { useMappingOptions } from '../../../features/mappings/hooks/use-mapping-options';
+import type { MappingOption } from '../../../features/mappings/api/mappings.types';
+import type { StructuredConfigSectionProps } from '../../../shared/plugins';
+
+function carrierOptionLabel(option: MappingOption): string {
+  return option.kind === 'dynamic' ? `${option.label} — exact Allegro cost` : option.label;
+}
+
+export function PrestashopStructuredSection({
+  connection,
+  form,
+  configIsParseable,
+  syncStructuredToJson,
+}: StructuredConfigSectionProps): ReactElement {
+  return (
+    <>
+      <FormField
+        label="Shop URL"
+        name="baseUrl"
+        error={form.formState.errors.baseUrl?.message}
+        description="The public URL of the PrestaShop storefront."
+      >
+        <Input
+          value={form.watch('baseUrl') ?? ''}
+          onChange={(event) => syncStructuredToJson('baseUrl', event.target.value)}
+          placeholder="https://shop.example.com"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.baseUrl)}
+        />
+      </FormField>
+
+      <FormField
+        label="Storefront URL (optional)"
+        name="storefrontBaseUrl"
+        error={form.formState.errors.storefrontBaseUrl?.message}
+        description="Override only if your public storefront URL is different from the webservice URL. Leave blank if they're the same — defaults to Shop URL."
+      >
+        <Input
+          value={form.watch('storefrontBaseUrl') ?? ''}
+          onChange={(event) => syncStructuredToJson('storefrontBaseUrl', event.target.value)}
+          placeholder="https://shop.example.com"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.storefrontBaseUrl)}
+        />
+      </FormField>
+
+      <FormField
+        label="Shop ID (optional)"
+        name="shopId"
+        error={form.formState.errors.shopId?.message}
+        description="Only needed for multi-shop PrestaShop installations."
+      >
+        <Input
+          value={form.watch('shopId') ?? ''}
+          onChange={(event) => syncStructuredToJson('shopId', event.target.value)}
+          placeholder="1"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.shopId)}
+        />
+      </FormField>
+
+      <FormField
+        label="OL callback URL"
+        name="openlinkerCallbackBaseUrl"
+        error={form.formState.errors.openlinkerCallbackBaseUrl?.message}
+        description="OpenLinker's URL from PrestaShop's perspective — used by the PS module to POST webhooks back to OL. Pre-filled from your browser; override for Docker dev (e.g. http://host.docker.internal:3000) or unusual deploys. Required to use the 'Configure webhooks' action."
+      >
+        <Input
+          value={form.watch('openlinkerCallbackBaseUrl') ?? ''}
+          onChange={(event) =>
+            syncStructuredToJson('openlinkerCallbackBaseUrl', event.target.value)
+          }
+          placeholder="https://api.openlinker.example"
+          disabled={!configIsParseable}
+          invalid={Boolean(form.formState.errors.openlinkerCallbackBaseUrl)}
+        />
+      </FormField>
+
+      <PrestashopFallbackCarrierField
+        connectionId={connection.id}
+        value={form.watch('defaultCarrierId') ?? ''}
+        errorMessage={form.formState.errors.defaultCarrierId?.message}
+        disabled={!configIsParseable}
+        onChange={(value) => syncStructuredToJson('defaultCarrierId', value)}
+      />
+    </>
+  );
+}
+
+interface PrestashopFallbackCarrierFieldProps {
+  connectionId: string;
+  value: string;
+  errorMessage: string | undefined;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Fallback-carrier picker for PrestaShop connections (#517).
+ *
+ * Backed by the same `getMappingOptions(connectionId, 'destination', 'carriers')`
+ * endpoint as the per-method mapping page, so the option set (and its
+ * dynamic-kind decoration) stays in lockstep. The field is allowed to
+ * stay blank: when unset, the BE adapter (#516) falls back to the
+ * OpenLinker Dynamic carrier at order-create time. A save-time warning
+ * banner fires only when (a) the field is blank, (b) the OL Dynamic
+ * carrier is NOT among the loaded options (operator hasn't installed
+ * the OL PS module on this connection) — i.e. the connection is in a
+ * state where any unmapped Allegro shipping method WILL fail at sync.
+ */
+function PrestashopFallbackCarrierField({
+  connectionId,
+  value,
+  errorMessage,
+  disabled,
+  onChange,
+}: PrestashopFallbackCarrierFieldProps): ReactElement {
+  const { options, isLoading, errors } = useMappingOptions(connectionId);
+  const carriersError = errors.prestashopCarriers ?? null;
+  const carriers = options.prestashopCarriers;
+  const hasDynamicOption = carriers.some((c) => c.kind === 'dynamic');
+  const showNoFallbackWarning =
+    value === '' && carriersError === null && !isLoading && !hasDynamicOption;
+
+  return (
+    <>
+      <FormField
+        label="Fallback carrier (optional)"
+        name="defaultCarrierId"
+        error={errorMessage}
+        description="Used when an Allegro shipping method has no carrier mapping. Leave unset to use the OpenLinker Dynamic carrier (exact Allegro shipping cost) at sync time — works only when the OL PrestaShop module is installed."
+      >
+        {isLoading ? (
+          <Select disabled>
+            <option>Loading carriers…</option>
+          </Select>
+        ) : carriersError ? (
+          <Select disabled>
+            <option>Failed to load carriers</option>
+          </Select>
+        ) : (
+          <Select
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            disabled={disabled}
+            invalid={Boolean(errorMessage)}
+          >
+            <option value="">None — use OpenLinker Dynamic at runtime</option>
+            {carriers.map((c) => (
+              <option key={c.value} value={c.value}>
+                {carrierOptionLabel(c)}
+              </option>
+            ))}
+          </Select>
+        )}
+      </FormField>
+
+      {showNoFallbackWarning ? (
+        <Alert tone="warning" className="edit-connection__fallback-warning">
+          No fallback carrier is set and the OpenLinker PrestaShop module isn't installed on this
+          connection. Sync will fail for any Allegro shipping method without a carrier mapping
+          until you pick a fallback or install the OL PS module.
+        </Alert>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/plugins/prestashop/prestashop.plugin.test.tsx
+++ b/apps/web/src/plugins/prestashop/prestashop.plugin.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * PrestaShop Plugin Smoke Tests
+ *
+ * Asserts the registered fields are present and that `getCallbackUrlDefault`
+ * honours `window.location.origin` in jsdom. Behavioural coverage of each
+ * contributed component lives in the consumer-side tests
+ * (`platform-picker.test.tsx`, `ConnectionActionsPanel.test.tsx`,
+ * `EditConnectionForm.test.tsx`).
+ */
+import { describe, expect, it } from 'vitest';
+import { prestashopPlugin } from './prestashop.plugin';
+
+describe('prestashopPlugin', () => {
+  it('declares the expected platform key + display name', () => {
+    expect(prestashopPlugin.platformType).toBe('prestashop');
+    expect(prestashopPlugin.displayName).toBe('PrestaShop');
+  });
+
+  it('contributes the setup card pointing to the guided wizard', () => {
+    expect(prestashopPlugin.setupCard).toBeDefined();
+    expect(prestashopPlugin.setupCard?.to).toBe('/connections/new/prestashop');
+  });
+
+  it('contributes structured-config + credentials + actions slots', () => {
+    expect(prestashopPlugin.StructuredConfigSection).toBeDefined();
+    expect(prestashopPlugin.CredentialsPanel).toBeDefined();
+    expect(prestashopPlugin.ConnectionActions).toBeDefined();
+  });
+
+  it('does NOT contribute an extra config section (PS has no Allegro-like extra block)', () => {
+    expect(prestashopPlugin.ExtraConfigSection).toBeUndefined();
+  });
+
+  it('does NOT mark itself as external-auth-redirect (PS uses inline credentials)', () => {
+    expect(prestashopPlugin.requiresExternalAuthRedirect).toBeUndefined();
+  });
+
+  it('returns window.location.origin from getCallbackUrlDefault under jsdom', () => {
+    expect(prestashopPlugin.getCallbackUrlDefault?.()).toBe(window.location.origin);
+  });
+});

--- a/apps/web/src/plugins/prestashop/prestashop.plugin.tsx
+++ b/apps/web/src/plugins/prestashop/prestashop.plugin.tsx
@@ -1,0 +1,34 @@
+/**
+ * PrestaShop Platform Plugin
+ *
+ * In-tree plugin definition for the PrestaShop platform. Contributes:
+ *
+ *   - Setup card on `PlatformPicker`
+ *   - Structured-config inputs in `EditConnectionForm` (Shop URL, etc.)
+ *   - "Configure webhooks" action in `ConnectionActionsPanel`
+ *   - Default for the OL callback URL field (`window.location.origin`)
+ *   - Rotate-webservice-key panel in `EditConnectionForm.CredentialsPanel`
+ *
+ * @module plugins/prestashop
+ */
+import type { PlatformPlugin } from '../../shared/plugins';
+import { PrestashopStructuredSection } from './components/prestashop-structured-section';
+import { PrestashopConnectionActions } from './components/prestashop-connection-actions';
+import { PrestashopCredentialsPanel } from './components/prestashop-credentials-panel';
+
+export const prestashopPlugin: PlatformPlugin = {
+  platformType: 'prestashop',
+  displayName: 'PrestaShop',
+  setupCard: {
+    title: 'PrestaShop',
+    description:
+      'Connect a PrestaShop store via the Webservice API. You will need the shop URL and a webservice key.',
+    to: '/connections/new/prestashop',
+    badge: 'Webservice API',
+  },
+  getCallbackUrlDefault: () =>
+    typeof window !== 'undefined' ? window.location.origin : undefined,
+  StructuredConfigSection: PrestashopStructuredSection,
+  CredentialsPanel: PrestashopCredentialsPanel,
+  ConnectionActions: PrestashopConnectionActions,
+};

--- a/apps/web/src/shared/plugins/index.ts
+++ b/apps/web/src/shared/plugins/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Plugin Registry Public Surface
+ *
+ * Re-exports the registry contract (types, provider, hooks) consumed by
+ * features, pages, and the app composition root. The actual plugin
+ * instances live in `apps/web/src/plugins/` and are wired into the
+ * provider via `IN_TREE_PLUGINS` in `apps/web/src/plugins/index.ts`.
+ *
+ * @module shared/plugins
+ */
+export type {
+  PlatformPlugin,
+  PlatformSetupCard,
+  StructuredConfigSectionProps,
+  ExtraConfigSectionProps,
+} from './plugin.types';
+export { PluginRegistryProvider, PluginRegistryContext } from './plugin-registry-context';
+export { usePlugins } from './use-plugins';
+export { usePlugin } from './use-plugin';

--- a/apps/web/src/shared/plugins/plugin-registry-context.test.tsx
+++ b/apps/web/src/shared/plugins/plugin-registry-context.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Plugin Registry Context Tests
+ *
+ * Smoke coverage for the registry contract — provider missing throws, lookups
+ * hit/miss as expected. Specific plugin behavior is covered in feature-level
+ * tests (`platform-picker.test.tsx`, `ConnectionActionsPanel.test.tsx`).
+ */
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { describe, expect, it } from 'vitest';
+import { PluginRegistryProvider } from './plugin-registry-context';
+import { usePlugin } from './use-plugin';
+import { usePlugins } from './use-plugins';
+import type { PlatformPlugin } from './plugin.types';
+
+function PluginsCount(): ReactElement {
+  const plugins = usePlugins();
+  return <span data-testid="count">{plugins.length}</span>;
+}
+
+function PluginByKey({ platformType }: { platformType: string }): ReactElement {
+  const plugin = usePlugin(platformType);
+  return <span data-testid="display">{plugin?.displayName ?? 'NONE'}</span>;
+}
+
+const fixturePlugins: PlatformPlugin[] = [
+  { platformType: 'foo', displayName: 'Foo' },
+  { platformType: 'bar', displayName: 'Bar' },
+];
+
+describe('PluginRegistryContext', () => {
+  it('exposes the plugin manifest via usePlugins()', () => {
+    const { getByTestId } = render(
+      <PluginRegistryProvider plugins={fixturePlugins}>
+        <PluginsCount />
+      </PluginRegistryProvider>,
+    );
+    expect(getByTestId('count').textContent).toBe('2');
+  });
+
+  it('returns the matching plugin for a known platformType', () => {
+    const { getByTestId } = render(
+      <PluginRegistryProvider plugins={fixturePlugins}>
+        <PluginByKey platformType="bar" />
+      </PluginRegistryProvider>,
+    );
+    expect(getByTestId('display').textContent).toBe('Bar');
+  });
+
+  it('returns undefined for an unknown platformType', () => {
+    const { getByTestId } = render(
+      <PluginRegistryProvider plugins={fixturePlugins}>
+        <PluginByKey platformType="shopify" />
+      </PluginRegistryProvider>,
+    );
+    expect(getByTestId('display').textContent).toBe('NONE');
+  });
+
+  it('returns undefined when platformType is an empty string', () => {
+    const { getByTestId } = render(
+      <PluginRegistryProvider plugins={fixturePlugins}>
+        <PluginByKey platformType="" />
+      </PluginRegistryProvider>,
+    );
+    expect(getByTestId('display').textContent).toBe('NONE');
+  });
+
+  it('throws when usePlugins() is used outside the provider', () => {
+    const ConsumerSansProvider = (): ReactElement => <PluginsCount />;
+    // React swallows render-phase errors and surfaces them via error boundary
+    // or the global error handler. We assert by silencing console.error and
+    // catching the thrown error from render().
+    const originalError = console.error;
+    console.error = (): void => {};
+    try {
+      expect(() => render(<ConsumerSansProvider />)).toThrow(
+        /usePlugins\(\) must be used inside <PluginRegistryProvider>/,
+      );
+    } finally {
+      console.error = originalError;
+    }
+  });
+});

--- a/apps/web/src/shared/plugins/plugin-registry-context.tsx
+++ b/apps/web/src/shared/plugins/plugin-registry-context.tsx
@@ -1,0 +1,43 @@
+/**
+ * Plugin Registry Context
+ *
+ * React context that exposes the in-tree platform plugin manifest to any
+ * component below the provider. Consumers should use `usePlugins()` or
+ * `usePlugin(platformType)` from the sibling hook files rather than reading
+ * the context directly.
+ *
+ * @module shared/plugins
+ */
+import { createContext, useMemo, type PropsWithChildren, type ReactElement } from 'react';
+import type { PlatformPlugin } from './plugin.types';
+
+export const PluginRegistryContext = createContext<readonly PlatformPlugin[] | null>(null);
+
+interface PluginRegistryProviderProps {
+  plugins: readonly PlatformPlugin[];
+}
+
+export function PluginRegistryProvider({
+  plugins,
+  children,
+}: PropsWithChildren<PluginRegistryProviderProps>): ReactElement {
+  // Fail fast on duplicate `platformType` keys at mount time. Plugin
+  // lookup uses `Array.find`, which silently returns the first match —
+  // a duplicate key would silently shadow the second plugin and produce
+  // hard-to-debug "wrong UI" behaviour at runtime.
+  useMemo(() => {
+    const seen = new Set<string>();
+    for (const p of plugins) {
+      if (seen.has(p.platformType)) {
+        throw new Error(
+          `Duplicate plugin platformType: "${p.platformType}". Each registered plugin must have a unique key.`,
+        );
+      }
+      seen.add(p.platformType);
+    }
+  }, [plugins]);
+
+  return (
+    <PluginRegistryContext.Provider value={plugins}>{children}</PluginRegistryContext.Provider>
+  );
+}

--- a/apps/web/src/shared/plugins/plugin-registry-context.tsx
+++ b/apps/web/src/shared/plugins/plugin-registry-context.tsx
@@ -21,16 +21,18 @@ export function PluginRegistryProvider({
   plugins,
   children,
 }: PropsWithChildren<PluginRegistryProviderProps>): ReactElement {
-  // Fail fast on duplicate `platformType` keys at mount time. Plugin
-  // lookup uses `Array.find`, which silently returns the first match —
-  // a duplicate key would silently shadow the second plugin and produce
-  // hard-to-debug "wrong UI" behaviour at runtime.
+  // Fail fast on duplicate `platformType` keys when the provider mounts.
+  // The production manifest is validated at module load in
+  // `apps/web/src/plugins/index.ts`; this guard is the belt-and-suspenders
+  // for test fixtures that pass in their own plugin arrays. Plugin lookup
+  // uses `Array.find`, which silently returns the first match — without
+  // this check a duplicate would shadow its sibling at runtime.
   useMemo(() => {
     const seen = new Set<string>();
     for (const p of plugins) {
       if (seen.has(p.platformType)) {
         throw new Error(
-          `Duplicate plugin platformType: "${p.platformType}". Each registered plugin must have a unique key.`,
+          `Duplicate plugin platformType: "${p.platformType}". Each registered plugin must have a unique \`platformType\`.`,
         );
       }
       seen.add(p.platformType);

--- a/apps/web/src/shared/plugins/plugin.types.ts
+++ b/apps/web/src/shared/plugins/plugin.types.ts
@@ -1,0 +1,105 @@
+/**
+ * Platform Plugin Contract
+ *
+ * Defines the shape of an in-tree FE plugin. Each registered plugin
+ * represents one platform (e.g. PrestaShop, Allegro) and contributes the
+ * platform-specific UI affordances that the core feature surfaces dispatch
+ * to via `usePlugin(platformType)` / `usePlugins()` from this module.
+ *
+ * Mirrors `apps/api/src/plugins.ts` + `PluginRegistryModule.forRoot({ plugins })`
+ * on the backend (#572). The FE counterpart of the modularity work that
+ * landed in #570/#571/#576/#577.
+ *
+ * @module shared/plugins
+ */
+import type { ComponentType, ReactNode } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import type { Connection } from '../../features/connections/api/connections.types';
+import type { EditConnectionFormValues } from '../../features/connections/components/edit-connection.schema';
+
+/**
+ * Setup-card metadata rendered on the connection-type picker
+ * (`PlatformPicker`). Omit on plugins that don't expose a guided wizard
+ * (advanced-mode-only platforms).
+ */
+export interface PlatformSetupCard {
+  title: string;
+  description: string;
+  to: string;
+  badge: string;
+}
+
+/**
+ * Prop shape for the plugin-owned structured-config section in
+ * `EditConnectionForm`. `syncStructuredToJson` accepts a wider `string` than
+ * the parent's internal `StructuredField` union — the parent narrows at the
+ * call site. Plugins should only pass field names that exist on
+ * `EditConnectionFormValues`.
+ */
+export interface StructuredConfigSectionProps {
+  connection: Connection;
+  form: UseFormReturn<EditConnectionFormValues>;
+  configIsParseable: boolean;
+  syncStructuredToJson: (
+    field: string,
+    value: string,
+    options?: { markDirty?: boolean },
+  ) => void;
+}
+
+/**
+ * Extra section rendered below the structured/raw config inputs. Allegro
+ * uses this for the GPSR seller-defaults section. `syncSellerDefaultsToJson`
+ * is the parent form's serialize helper — the section calls it on every
+ * sub-field change so the raw `configText` stays in sync.
+ */
+export interface ExtraConfigSectionProps {
+  connection: Connection;
+  form: UseFormReturn<EditConnectionFormValues>;
+  configIsParseable: boolean;
+  syncSellerDefaultsToJson: () => void;
+}
+
+export interface PlatformPlugin {
+  /** Stable key matching `connection.platformType`. */
+  platformType: string;
+  /** Human-readable display name (dropdown labels, etc.). */
+  displayName: string;
+
+  /** Setup-card metadata for `PlatformPicker`. Omit if no guided wizard. */
+  setupCard?: PlatformSetupCard;
+  /**
+   * When true, the inline create-connection form replaces its submit
+   * affordances with an Alert linking to the guided setup wizard (today:
+   * Allegro OAuth). Named broadly so non-OAuth redirect flows (e.g. magic
+   * link, device-code) can opt into the same UX.
+   */
+  requiresExternalAuthRedirect?: boolean;
+
+  /** Edit-connection: default value for the OL callback URL field. */
+  getCallbackUrlDefault?: () => string | undefined;
+  /** Edit-connection: render the platform-specific structured config inputs. */
+  StructuredConfigSection?: ComponentType<StructuredConfigSectionProps>;
+  /** Edit-connection: render extra section below structured/raw. */
+  ExtraConfigSection?: ComponentType<ExtraConfigSectionProps>;
+  /**
+   * Edit-connection: render the credentials panel (e.g. rotate-webservice-key
+   * for PrestaShop). When omitted, the parent renders a generic read-only
+   * "Stored securely (managed by integration)" affordance. Plugins that need
+   * a custom rotation flow contribute the full panel so the form labels and
+   * mutation payload match the platform's actual credential shape.
+   */
+  CredentialsPanel?: ComponentType<{ connection: Connection }>;
+
+  /**
+   * Connection-detail: contribute extra platform-specific actions to the
+   * actions panel. Rendered as a sub-tree below the generic actions; the
+   * component owns its mutation hooks and toast feedback.
+   */
+  ConnectionActions?: ComponentType<{ connection: Connection }>;
+
+  /** Listing-detail: gate the "Edit offer" button on `ListingDetailPage`. */
+  supportsListingEdit?: boolean;
+}
+
+export type { ReactNode };

--- a/apps/web/src/shared/plugins/use-plugin.ts
+++ b/apps/web/src/shared/plugins/use-plugin.ts
@@ -1,0 +1,17 @@
+/**
+ * usePlugin Hook
+ *
+ * Looks up the registered plugin for a given `platformType`. Returns
+ * `undefined` for unknown platforms so consumers can fall through to a
+ * generic raw-config rendering path.
+ *
+ * @module shared/plugins
+ */
+import { usePlugins } from './use-plugins';
+import type { PlatformPlugin } from './plugin.types';
+
+export function usePlugin(platformType: string | undefined): PlatformPlugin | undefined {
+  const plugins = usePlugins();
+  if (!platformType) return undefined;
+  return plugins.find((p) => p.platformType === platformType);
+}

--- a/apps/web/src/shared/plugins/use-plugins.ts
+++ b/apps/web/src/shared/plugins/use-plugins.ts
@@ -1,0 +1,21 @@
+/**
+ * usePlugins Hook
+ *
+ * Returns the full in-tree platform plugin manifest. Throws if used outside
+ * a `<PluginRegistryProvider>` — every render path in `apps/web` is mounted
+ * inside the provider in `AppProviders`, so a missing provider indicates a
+ * misconfigured test, not a runtime branch.
+ *
+ * @module shared/plugins
+ */
+import { useContext } from 'react';
+import { PluginRegistryContext } from './plugin-registry-context';
+import type { PlatformPlugin } from './plugin.types';
+
+export function usePlugins(): readonly PlatformPlugin[] {
+  const ctx = useContext(PluginRegistryContext);
+  if (ctx === null) {
+    throw new Error('usePlugins() must be used inside <PluginRegistryProvider>.');
+  }
+  return ctx;
+}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -12,11 +12,20 @@ import type { SessionAdapter } from '../shared/auth/session-adapter';
 import { SessionProvider } from '../shared/auth/session-provider';
 import type { Session, SessionUser } from '../shared/auth/session.types';
 import { ToastProvider } from '../shared/ui/toast-provider';
+import type { PlatformPlugin } from '../shared/plugins';
+import { PluginRegistryProvider } from '../shared/plugins';
+import { IN_TREE_PLUGINS } from '../plugins';
 
 interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
   apiClient?: ApiClient;
   route?: string;
   sessionAdapter?: SessionAdapter;
+  /**
+   * Override the in-tree plugin manifest visible to `usePlugin()` /
+   * `usePlugins()`. Defaults to the production manifest — set this on tests
+   * that need to assert registry-absent behavior or inject a fixture plugin.
+   */
+  plugins?: readonly PlatformPlugin[];
 }
 
 export const sampleConnection: Connection = {
@@ -375,6 +384,7 @@ export function renderWithProviders(ui: ReactElement, options: RenderWithProvide
     apiClient = createMockApiClient(),
     route = '/',
     sessionAdapter = createNoopSessionAdapter(),
+    plugins = IN_TREE_PLUGINS,
     ...renderOptions
   } = options;
   const queryClient = new QueryClient({
@@ -395,13 +405,15 @@ export function renderWithProviders(ui: ReactElement, options: RenderWithProvide
   return render(ui, {
     wrapper: ({ children }) => (
       <MemoryRouter initialEntries={[route]}>
-        <SessionProvider adapter={sessionAdapter}>
-          <ToastProvider>
-            <ApiClientProvider client={apiClient}>
-              <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-            </ApiClientProvider>
-          </ToastProvider>
-        </SessionProvider>
+        <PluginRegistryProvider plugins={plugins}>
+          <SessionProvider adapter={sessionAdapter}>
+            <ToastProvider>
+              <ApiClientProvider client={apiClient}>
+                <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+              </ApiClientProvider>
+            </ToastProvider>
+          </SessionProvider>
+        </PluginRegistryProvider>
       </MemoryRouter>
     ),
     ...renderOptions,

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -307,6 +307,25 @@ The in-tree platform plugins (#578 / #579) live in `apps/web/src/plugins/<platfo
 
 Literal-equality dispatch on `platformType` (`connection.platformType === 'allegro'`) is forbidden outside `plugins/<platformType>/` — use `usePlugin()`, `usePlugins()`, or capability checks (`supportedCapabilities.includes('OfferManager')`) instead. The ESLint rule `no-restricted-syntax` enforces this.
 
+### Plugin slot reference
+
+Every slot is optional. A plugin contributes only the affordances its platform actually needs; the consuming surface falls back to a generic rendering (or hides the affordance entirely) when the slot is absent.
+
+| Slot | Type | Consumed by | Purpose |
+|---|---|---|---|
+| `platformType` | `string` | registry lookup | Stable key — matches `connection.platformType`. Required. |
+| `displayName` | `string` | dropdowns, alerts | Human-readable label. Required. |
+| `setupCard` | `PlatformSetupCard` | `PlatformPicker` (`features/connections`) | One card on `/connections/new`. Omit for advanced-only platforms. |
+| `requiresExternalAuthRedirect` | `boolean` | `CreateConnectionForm` | When true, the inline create form swaps in an Alert linking to the guided wizard (today: Allegro OAuth). Named broadly so non-OAuth redirect flows can opt in. |
+| `getCallbackUrlDefault` | `() => string \| undefined` | `EditConnectionForm` | Default for the OL callback URL field when the connection has none stored. PrestaShop uses `window.location.origin`. |
+| `StructuredConfigSection` | `ComponentType<StructuredConfigSectionProps>` | `EditConnectionForm` | Platform-specific structured-config inputs (PS: shop URL / storefront / shop ID / OL callback / fallback carrier). When absent, the form falls back to raw JSON. |
+| `ExtraConfigSection` | `ComponentType<ExtraConfigSectionProps>` | `EditConnectionForm` | Extra section below the structured/raw block (Allegro: GPSR seller defaults). |
+| `CredentialsPanel` | `ComponentType<{ connection }>` | `EditConnectionForm` | Full credentials panel including the rotate-key UI shape that fits the platform's credential model. When absent, the form renders a read-only "Stored securely (managed by integration)" / "Environment variable" affordance. |
+| `ConnectionActions` | `ComponentType<{ connection }>` | `ConnectionActionsPanel` | Extra platform-specific actions on the connection-detail page (PS: "Configure webhooks"). |
+| `supportsListingEdit` | `boolean` | `ListingDetailPage` | Gates the "Edit offer" button on the listing-detail page. |
+
+Module-load validation in `apps/web/src/plugins/index.ts` rejects duplicate `platformType` keys before any provider mounts. `PluginRegistryProvider` re-runs the same check at mount time as belt-and-suspenders for test fixtures.
+
 ## Async UX Conventions
 
 All API-driven screens should implement the same baseline UX states:

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -283,20 +283,29 @@ See [`docs/ui-audit/library-analysis.md`](./ui-audit/library-analysis.md) for th
 
 Dependency direction must remain simple and enforceable:
 
-- `app` may import `pages`, `features`, and `shared`
+- `app` may import `pages`, `features`, `plugins`, and `shared`
 - `pages` may import `features` and `shared`
+- `plugins` may import `features` and `shared` (see [Platform Plugins](#platform-plugins-plugins))
 - `features` may import `shared`
-- `shared` must not import `features` or `pages`
+- `shared` must not import `features`, `pages`, or `plugins` — with one narrow exemption documented below
 
 These boundaries are enforced by ESLint `no-restricted-imports` rules in `.eslintrc.js` — violations fail `pnpm lint`. Raw `fetch()` calls are also blocked in `shared/`, `features/`, and `pages/` via `no-restricted-globals` to ensure all HTTP calls go through shared API client modules.
 
 > **Note:** Features may import `useApiClient` from `app/api/` — this is the designed dependency-injection boundary for API access. A future refactor may move the hook to `shared/`, but the current crossing is intentional and not restricted by lint.
+
+> **Exemption — `shared/plugins/` (#578/#579):** The FE plugin contract in `shared/plugins/plugin.types.ts` is a feature-aware surface by design — plugins receive `Connection` and `UseFormReturn<EditConnectionFormValues>` shapes from the connections feature. To keep the contract fully typed without hoisting feature-private types into `shared/`, the ESLint rule allows `shared/plugins/**` to type-import `Connection` and `EditConnectionFormValues` (and nothing else) from `features/connections/`. Hoisting the types into a `shared/types/` boundary is the cleaner long-term move; it's deferred until a second consumer needs them.
 
 Additional rules:
 
 - pages compose features but should not contain raw transport logic
 - feature modules may define feature-specific types, hooks, and view-model mapping
 - shared modules must remain generic enough to be reused across features
+
+## Platform Plugins (`plugins/`)
+
+The in-tree platform plugins (#578 / #579) live in `apps/web/src/plugins/<platformType>/`. Each plugin exposes a `PlatformPlugin` object describing the platform-specific UI affordances — setup card, callback-URL default, structured edit-form sections, extra edit-form sections, connection actions, etc. The plugin registry contract (`shared/plugins/`) is consumed by core feature components via `usePlugin(platformType)` and `usePlugins()`. Adding a new platform plugin is a single edit point: drop a new directory under `plugins/` and add it to `IN_TREE_PLUGINS` in `plugins/index.ts`.
+
+Literal-equality dispatch on `platformType` (`connection.platformType === 'allegro'`) is forbidden outside `plugins/<platformType>/` — use `usePlugin()`, `usePlugins()`, or capability checks (`supportedCapabilities.includes('OfferManager')`) instead. The ESLint rule `no-restricted-syntax` enforces this.
 
 ## Async UX Conventions
 

--- a/docs/plans/implementation-plan-578-579-fe-platform-type-open-world.md
+++ b/docs/plans/implementation-plan-578-579-fe-platform-type-open-world.md
@@ -1,0 +1,531 @@
+# Implementation Plan — FE `platformType` open-world (#578 + #579)
+
+## Goal
+
+Close Modularity Thread D's two remaining HIGH items on the frontend:
+
+- **#578 (D3)** — `PLATFORM_TYPES = ['prestashop', 'allegro']` is a closed `as const` union. The platform-picker uses `Record<PlatformType, …>` which compiler-enforces exhaustiveness against the closed set. Adding `'shopify'` requires editing the core `PLATFORM_TYPES` union and touching every literal-branch site.
+- **#579 (D4)** — A dozen call sites dispatch on `connection.platformType === 'allegro' | 'prestashop'` literals to render platform-specific UI (offer-wizard filtering, seller-defaults section, edit-form branches, listing-detail rendering, connection actions).
+
+After this PR, `platformType` is an opaque string and FE behavior dispatches through:
+
+1. **Capability checks** (`c.supportedCapabilities.includes('OfferManager')`) for capability-shaped decisions.
+2. **A per-platform plugin registry** for true UI quirks that cannot be expressed as a capability (e.g., PrestaShop's `window.location.origin` default for the OL callback URL, Allegro's GPSR seller-defaults section, the "Configure webhooks" action).
+
+An ESLint rule prevents the literal-equality dispatch from coming back.
+
+This mirrors the FE counterpart of the BE pattern landed in #570/#571/#572/#576/#577 (open Capability/EntityType unions at the registry boundary, plugins self-register via `PluginRegistryModule.forRoot({ plugins })`).
+
+## Layer classification
+
+**Frontend.** No backend code touched. Public BE contracts (`connection.supportedCapabilities: string[]`, `connection.enabledCapabilities: string[]`, `connection.platformType: string`) are already open since #576/#577 — FE just consumes them.
+
+## Non-goals
+
+- **Not** opening `Capability` on the FE — already done by #576 (FE keeps `CORE_CAPABILITY_VALUES` as well-known set, `enabledCapabilities`/`supportedCapabilities` are `string[]`).
+- **Not** building an out-of-tree plugin discovery mechanism (lazy chunk loading, manifest scanning, etc.). That's Modularity Thread H — see #604/#605/#606. This PR ships the in-tree registry seam **only**; H-thread can later add discovery on top.
+- **Not** migrating `PromptTemplateChannelValues = ['prestashop', 'allegro']` (#580 D5) — different scope, lives in the AI feature.
+- **Not** addressing #607 (marketplace-specific code in `shared/`) or #608 (`CreateOfferWizard` Allegro-shaped). Those are larger refactors. This PR's `CreateOfferWizard` migration is limited to the single `platformType === 'allegro'` literal at line 302.
+- **Not** moving `allegro-seller-panel-url.ts` into the plugin folder. It's a pure helper that already fails safe for non-Allegro platforms — and it's referenced by name in tests. Leaving as-is.
+
+## Research summary
+
+### Current shape
+
+`apps/web/src/features/connections/api/connections.types.ts:1-3`:
+
+```ts
+export const PLATFORM_TYPES = ['prestashop', 'allegro'] as const;
+export type PlatformType = (typeof PLATFORM_TYPES)[number];
+```
+
+Compare to the already-open Capability type on the same file (lines 12-25): `CORE_CAPABILITY_VALUES` is the well-known set, `enabledCapabilities`/`supportedCapabilities` field types are `string[]`. Same pattern applies here.
+
+### Literal-equality dispatch sites (full inventory)
+
+| File | Line | Today | Replacement |
+|---|---|---|---|
+| `features/listings/components/CreateOfferWizard.tsx` | 302 | `c.platformType === 'allegro' \|\| c.supportedCapabilities.includes('OfferManager')` | `c.supportedCapabilities.includes('OfferManager')` (drop redundant arm — #576 guarantees `supportedCapabilities` is populated) |
+| `features/connections/components/create-connection-form.tsx` | 41-43 | `PLATFORM_OPTIONS` static array | `usePlugins()` → `plugins.map(p => …)` |
+| `features/connections/components/create-connection-form.tsx` | 58 | `watchedPlatformType === 'allegro'` (toggles OAuth-only flow) | `usePlugin(watchedPlatformType)?.requiresOAuthRedirect === true` |
+| `features/connections/components/create-connection.schema.ts` | 5-6 | `z.enum([...PLATFORM_TYPES, ''])` | `z.string().trim().min(1, 'Platform type is required')` (BE validates membership) |
+| `features/connections/components/EditConnectionForm.tsx` | 162 | `connection.platformType === 'prestashop'` (callback-URL default) | `usePlugin(connection.platformType)?.getCallbackUrlDefault?.()` |
+| `features/connections/components/EditConnectionForm.tsx` | 185 | `platformBranch = prestashop \| marketplace \| raw` via literal | `hasStructuredSection = plugin?.EditConnectionStructuredSection !== undefined`; `isMarketplace = connection.enabledCapabilities.includes('OfferManager')` |
+| `features/connections/components/EditConnectionForm.tsx` | 345 | (already replaced upstream — line moved) | n/a |
+| `features/connections/components/EditConnectionForm.tsx` | 433 | `connection.platformType === 'allegro' ? <AllegroSellerDefaultsSection /> : null` | `<plugin?.EditConnectionExtraSection ?? null />` (Allegro plugin contributes the seller-defaults section) |
+| `features/connections/components/EditConnectionForm.tsx` | 673 | `connection.platformType !== 'prestashop'` (gates credential-rotation UI) | `usePlugin(connection.platformType)?.supportsCredentialRotation === true` |
+| `features/connections/components/ConnectionActionsPanel.tsx` | 26 | `connection.platformType === 'prestashop'` (gates "Configure webhooks") | Render `usePlugin(connection.platformType)?.useConnectionActions?.(connection) ?? []` after the generic actions. PrestaShop plugin contributes the "Configure webhooks" action |
+| `pages/connections/connections-list-page.tsx` | 5,17,126 | `PLATFORM_TYPES.includes(...)` validation + dropdown | `usePlugins()` for dropdown; accept any string in URL (BE validates) |
+| `pages/listings/listing-detail-page.tsx` | 119 | `mapping.platformType.toLowerCase() === 'allegro'` gates "Edit offer" button | `usePlugin(mapping.platformType)?.supportsListingEdit === true` |
+| `features/connections/components/platform-picker.tsx` | 21-43 | `PLATFORM_CARDS: Record<PlatformType, PlatformCard>` | `usePlugins()` → `plugins.filter(p => p.setupCard).map(p => ...)` |
+
+The grep that produced this list:
+
+```bash
+grep -rn -E "(platformType|PlatformType)\s*(===|!==)" apps/web/src
+grep -rn "toLowerCase() === 'allegro'\|toLowerCase() === 'prestashop'" apps/web/src
+grep -rn "PLATFORM_TYPES" apps/web/src
+```
+
+### Existing FE provider stack
+
+`apps/web/src/main.tsx` → `AppProviders` wraps the tree in: `ThemeProvider → SessionProvider → ToastProvider → ApiClientProvider → QueryClientProvider`. Adding `PluginRegistryProvider` at the outermost level (no dependency on session/api) is safe.
+
+### Dependency rules to respect
+
+From `docs/frontend-architecture.md:284-291` (enforced by `.eslintrc.js` overrides):
+
+- `shared/` cannot import `features/`, `pages/`, or `app/`
+- `features/` cannot import `pages/`
+- `app/` is the composition root
+
+The plan therefore puts the **plugin contract** (types, hooks, provider) in `shared/plugins/` (importable from anywhere) and the **plugin instances** (which compose feature components) in a new top-level `plugins/` directory at the same level as `app/`. Only `app/providers/app-providers.tsx` imports the manifest from `plugins/`. We add `plugins/` to the ESLint `features/`-restriction list as an allowed downstream (mirrors the existing override stanza shape).
+
+## Design
+
+### File layout
+
+```
+apps/web/src/
+├── app/
+│   └── providers/app-providers.tsx       # [edit] mount PluginRegistryProvider
+├── plugins/                              # [new] in-tree plugin instances
+│   ├── index.ts                          # exports IN_TREE_PLUGINS = [allegroPlugin, prestashopPlugin]
+│   ├── allegro/
+│   │   ├── allegro.plugin.tsx            # PlatformPlugin object
+│   │   └── allegro.plugin.test.tsx
+│   └── prestashop/
+│       ├── prestashop.plugin.tsx
+│       └── prestashop.plugin.test.tsx
+├── shared/
+│   └── plugins/                          # [new] registry contract
+│       ├── plugin.types.ts
+│       ├── plugin-registry-context.tsx   # provider + context
+│       ├── use-plugin.ts                 # usePlugin(platformType) hook
+│       ├── use-plugins.ts                # usePlugins() hook
+│       ├── plugin-registry-context.test.tsx
+│       └── index.ts                      # barrel
+└── features/connections/api/connections.types.ts  # [edit] open PlatformType
+```
+
+### Plugin contract (`shared/plugins/plugin.types.ts`)
+
+```ts
+import type { ComponentType, ReactNode } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import type { Connection } from '../../features/connections/api/connections.types';
+// NOTE: this is a cross-feature type import from shared/plugins. The contract
+// is feature-aware by necessity — plugins compose feature components. We
+// intentionally import only TYPES, not runtime, so the dependency direction
+// stays one-way at runtime.
+
+export interface PlatformSetupCard {
+  title: string;
+  description: string;
+  to: string;
+  badge: string;
+}
+
+export interface PlatformConnectionAction {
+  id: string;
+  label: string;
+  description: ReactNode;
+  status?: ReactNode;
+  tone?: 'primary' | 'secondary' | 'danger' | 'ghost';
+  disabled?: boolean;
+  isPending?: boolean;
+  pendingLabel?: string;
+  onTrigger: () => void;
+}
+
+export interface EditConnectionStructuredSectionProps {
+  connection: Connection;
+  // EditConnectionFormValues is a type that lives inside features/connections/
+  // — to avoid the type leaking up into shared/, the prop typing here is
+  // intentionally `unknown`-narrowed: plugins cast via a `formAccessor` arg.
+  // See plugin-form-accessor.ts for the cast helper.
+  form: UseFormReturn<EditConnectionFormSurface>;
+  configIsParseable: boolean;
+  syncStructuredToJson: (field: string, value: string, options?: { markDirty?: boolean }) => void;
+}
+
+// Minimal projection of EditConnectionFormValues that plugins are allowed
+// to read/write. Keeps shared/plugins decoupled from feature-internal types.
+export interface EditConnectionFormSurface {
+  watch: (path: string) => string | undefined;
+  setValue: (path: string, value: unknown, opts?: { shouldDirty?: boolean }) => void;
+  register: UseFormReturn['register'];
+  formState: { errors: Record<string, unknown> };
+}
+
+export interface EditConnectionExtraSectionProps {
+  connection: Connection;
+  form: UseFormReturn;
+  configIsParseable: boolean;
+  syncSellerDefaultsToJson: () => void;
+}
+
+export interface PlatformPlugin {
+  /** Stable key matching `connection.platformType`. */
+  platformType: string;
+  /** Human-readable display name. */
+  displayName: string;
+
+  /** Setup-card metadata for `PlatformPicker`. Omit if no guided wizard. */
+  setupCard?: PlatformSetupCard;
+  /** Create-connection: skip the inline form, show OAuth-redirect Alert. */
+  requiresOAuthRedirect?: boolean;
+
+  /** Edit-connection: callback-URL default (PS only today). */
+  getCallbackUrlDefault?: () => string | undefined;
+  /** Edit-connection: render the platform-specific structured config inputs. */
+  EditConnectionStructuredSection?: ComponentType<EditConnectionStructuredSectionProps>;
+  /** Edit-connection: render extra section below structured/raw (e.g., Allegro seller defaults). */
+  EditConnectionExtraSection?: ComponentType<EditConnectionExtraSectionProps>;
+  /** Edit-connection: render rotate-key UI in CredentialsPanel. */
+  supportsCredentialRotation?: boolean;
+
+  /** Connection-detail: extra platform-specific actions on the action panel. */
+  useConnectionActions?: (connection: Connection) => PlatformConnectionAction[];
+
+  /** Listing-detail: gate the "Edit offer" button. */
+  supportsListingEdit?: boolean;
+}
+```
+
+> **Note on the form prop**: `EditConnectionFormValues` is a feature-private type that we cannot safely expose to `shared/plugins/`. Two pragmatic options:
+>
+> - **(a)** Keep the structured-section plugin slot's `form` prop as a narrow `EditConnectionFormSurface` projection (minimal Watch/SetValue/Register signature). Plugins cast as needed. **Trade-off**: weaker static typing inside plugin bodies.
+> - **(b)** Hoist `EditConnectionFormValues` (and `editConnectionSchema`) into `shared/forms/edit-connection-form-values.ts`. **Trade-off**: a feature-internal type bleeds into shared/ — but `shared/plugins/` is itself a contract surface so this isn't entirely wrong.
+>
+> **Decision: (b)** is too invasive for this PR's scope and would couple `shared/` to every feature's form schema as plugins grow. **Going with (a)**: the structured-section/extra-section props use the narrowest possible interface (`UseFormReturn` with feature-local extension via the `form as` cast in plugin bodies). Plugins are the only places that need full typing, and they're already feature-aware composition layers. Reviewer: this is the one place static-typing weakens — confirm acceptable.
+
+### Provider & hooks
+
+```ts
+// shared/plugins/plugin-registry-context.tsx
+const PluginRegistryContext = createContext<PlatformPlugin[] | null>(null);
+
+export function PluginRegistryProvider({ plugins, children }: { plugins: PlatformPlugin[]; children: ReactNode }) {
+  return <PluginRegistryContext.Provider value={plugins}>{children}</PluginRegistryContext.Provider>;
+}
+
+// shared/plugins/use-plugins.ts
+export function usePlugins(): PlatformPlugin[] {
+  const ctx = useContext(PluginRegistryContext);
+  if (ctx === null) {
+    throw new Error('usePlugins() must be used inside <PluginRegistryProvider>.');
+  }
+  return ctx;
+}
+
+// shared/plugins/use-plugin.ts
+export function usePlugin(platformType: string | undefined): PlatformPlugin | undefined {
+  const plugins = usePlugins();
+  if (!platformType) return undefined;
+  return plugins.find((p) => p.platformType === platformType);
+}
+```
+
+### In-tree plugin manifest
+
+```ts
+// apps/web/src/plugins/index.ts
+import { allegroPlugin } from './allegro/allegro.plugin';
+import { prestashopPlugin } from './prestashop/prestashop.plugin';
+import type { PlatformPlugin } from '../shared/plugins';
+
+/**
+ * In-tree plugin manifest. Mirrors `apps/api/src/plugins.ts` from #572. To add
+ * a third-party platform plugin, add an entry here — no other file in
+ * `apps/web/src/{app,features,pages,shared}` should need to change.
+ */
+export const IN_TREE_PLUGINS: PlatformPlugin[] = [prestashopPlugin, allegroPlugin];
+```
+
+### Prestashop plugin (what it contributes)
+
+```ts
+export const prestashopPlugin: PlatformPlugin = {
+  platformType: 'prestashop',
+  displayName: 'PrestaShop',
+  setupCard: {
+    title: 'PrestaShop',
+    description: 'Connect a PrestaShop store via the Webservice API…',
+    to: '/connections/new/prestashop',
+    badge: 'Webservice API',
+  },
+  getCallbackUrlDefault: () =>
+    typeof window !== 'undefined' ? window.location.origin : undefined,
+  EditConnectionStructuredSection: PrestashopStructuredSection,
+  // No EditConnectionExtraSection — PS has no Allegro-like extra block.
+  supportsCredentialRotation: true,
+  useConnectionActions: (connection) => [configureWebhooksAction(connection)],
+};
+```
+
+The `PrestashopStructuredSection` component contains: Shop URL, Storefront URL, Shop ID, OL callback URL, fallback carrier picker — moved verbatim from the inline JSX block in `EditConnectionForm.tsx`.
+
+The `configureWebhooksAction` factory composes `useConfigureWebhooksMutation` + the toast feedback that was inlined in `ConnectionActionsPanel.tsx`. It becomes a hook because it owns mutation state — so the slot is `useConnectionActions: (connection) => PlatformConnectionAction[]` (rules-of-hooks compliant by calling the hook in the registry-consumer site, not inside the registry).
+
+> **Hook usage in the registry**: `useConnectionActions` IS a hook (returns derived actions from mutation state). The consumer site (`ConnectionActionsPanel`) is the one calling it. Since each plugin's `useConnectionActions` must be called unconditionally, and there is at most one plugin per connection (`usePlugin(connection.platformType)`), the consumer always calls exactly zero-or-one such hook — but it would need to know *which* plugin's hook to call at compile-time. Since plugin lookup is dynamic, we instead make `useConnectionActions` ALWAYS execute and return `[]` for non-matching plugins, OR have a dedicated `<PluginConnectionActions />` component that the consumer renders, and that component internally calls the matching plugin's hook. **Going with the `<PluginConnectionActions connection={connection} />` component** — cleanest. The plugin exposes `ConnectionActions: ComponentType<{ connection: Connection }>` (a sub-component), not a hook. This sidesteps rules-of-hooks entirely.
+
+Updated shape:
+
+```ts
+ConnectionActions?: ComponentType<{ connection: Connection }>;  // renders zero or more actions
+```
+
+### Allegro plugin (what it contributes)
+
+```ts
+export const allegroPlugin: PlatformPlugin = {
+  platformType: 'allegro',
+  displayName: 'Allegro',
+  setupCard: {
+    title: 'Allegro',
+    description: 'Connect an Allegro seller account…',
+    to: '/connections/new/allegro',
+    badge: 'OAuth 2.0',
+  },
+  requiresOAuthRedirect: true,
+  EditConnectionExtraSection: AllegroSellerDefaultsExtraSection,
+  supportsListingEdit: true,
+};
+```
+
+`AllegroSellerDefaultsExtraSection` wraps the existing `AllegroSellerDefaultsSection` from `features/connections/components/allegro-seller-defaults-section.tsx` — pure re-export with the plugin-slot signature.
+
+### Migration sketch — `EditConnectionForm.tsx`
+
+Before (line 184-190):
+```ts
+const platformBranch: PlatformBranch =
+  connection.platformType === 'prestashop' ? 'prestashop'
+  : connection.enabledCapabilities.includes('OfferManager') ? 'marketplace'
+  : 'raw';
+const hasStructuredInputs = platformBranch !== 'raw';
+```
+
+After:
+```ts
+const plugin = usePlugin(connection.platformType);
+const StructuredSection = plugin?.EditConnectionStructuredSection;
+const isMarketplace = connection.enabledCapabilities.includes('OfferManager');
+const hasStructuredInputs = Boolean(StructuredSection) || isMarketplace;
+```
+
+Body rendering:
+```tsx
+{StructuredSection ? (
+  <StructuredSection
+    connection={connection}
+    form={form}
+    configIsParseable={configIsParseable}
+    syncStructuredToJson={syncStructuredToJson}
+  />
+) : null}
+
+{isMarketplace ? (
+  <MarketplaceCatalogPicker {...marketplaceProps} />
+) : null}
+
+{plugin?.EditConnectionExtraSection ? (
+  <plugin.EditConnectionExtraSection
+    connection={connection}
+    form={form}
+    configIsParseable={configIsParseable}
+    syncSellerDefaultsToJson={syncSellerDefaultsToJson}
+  />
+) : null}
+```
+
+### Migration sketch — `ConnectionActionsPanel.tsx`
+
+Before (line 25, 134-156):
+```ts
+const isPrestashop = connection.platformType === 'prestashop';
+// later …
+{isPrestashop ? <ConfigureWebhooksRow … /> : null}
+```
+
+After:
+```tsx
+{plugin?.ConnectionActions ? (
+  <plugin.ConnectionActions connection={connection} />
+) : null}
+```
+
+The `ConfigureWebhooks` action JSX moves into `plugins/prestashop/components/prestashop-connection-actions.tsx` — owns its mutation hook and toast handling.
+
+## Step-by-step plan
+
+### Step 1 — Open `PlatformType` (`features/connections/api/connections.types.ts`)
+
+- Rename `PLATFORM_TYPES` → `CORE_PLATFORM_TYPES` (well-known set; keeps the BE-mirror naming).
+- Change `PlatformType` to `string` (just `string`, not `CorePlatformType | string` — flat alias is simpler and the BE entity type is already `string` post-#577).
+- Change `Connection.platformType: PlatformType` → `platformType: string` (effectively the same; alias retained for code-search friendliness).
+- Same for `ConnectionFilters.platformType` and `CreateConnectionInput.platformType`.
+- **Acceptance**: `tsc --noEmit` clean. Grep `PLATFORM_TYPES` returns zero hits.
+
+### Step 2 — Build the registry contract (`shared/plugins/`)
+
+Files created:
+- `shared/plugins/plugin.types.ts` — interfaces above.
+- `shared/plugins/plugin-registry-context.tsx` — `PluginRegistryContext`, `PluginRegistryProvider`.
+- `shared/plugins/use-plugins.ts` — `usePlugins()` (throws when provider absent).
+- `shared/plugins/use-plugin.ts` — `usePlugin(platformType)` (returns `undefined` for unknown).
+- `shared/plugins/index.ts` — barrel.
+- `shared/plugins/plugin-registry-context.test.tsx` — basic provider/hook unit test.
+
+### Step 3 — Build the two in-tree plugins (`plugins/`)
+
+Files created:
+- `plugins/prestashop/prestashop.plugin.tsx` — `prestashopPlugin: PlatformPlugin`.
+- `plugins/prestashop/components/prestashop-structured-section.tsx` — the structured-config block extracted from `EditConnectionForm.tsx` (Shop URL, Storefront URL, Shop ID, OL callback URL, fallback carrier picker). Keeps the inline-JSX shape but receives props through `EditConnectionStructuredSectionProps`. The `PrestashopFallbackCarrierField` sub-component stays here; the `useMappingOptions` import path stays.
+- `plugins/prestashop/components/prestashop-connection-actions.tsx` — the "Configure webhooks" action row extracted from `ConnectionActionsPanel.tsx`.
+- `plugins/allegro/allegro.plugin.tsx` — `allegroPlugin: PlatformPlugin`.
+- `plugins/allegro/components/allegro-extra-section.tsx` — thin wrapper around the existing `AllegroSellerDefaultsSection` so the plugin slot's prop signature matches.
+- `plugins/index.ts` — `IN_TREE_PLUGINS` manifest.
+
+### Step 4 — Mount the provider
+
+Edit `app/providers/app-providers.tsx`: wrap inside `ThemeProvider` (outermost or just inside — doesn't matter, no consumer depends on session/api):
+
+```tsx
+<PluginRegistryProvider plugins={IN_TREE_PLUGINS}>
+  …existing providers…
+</PluginRegistryProvider>
+```
+
+### Step 5 — Migrate dispatch sites
+
+In order, each migration with the new code:
+
+5.1 `features/connections/components/platform-picker.tsx` — use `usePlugins()` for setup cards.
+
+5.2 `features/connections/components/create-connection-form.tsx` —
+- Replace `PLATFORM_OPTIONS` with `usePlugins().map(p => ({ value: p.platformType, label: p.displayName }))`.
+- Replace `isAllegroSelected` with `requiresOAuthRedirect`.
+
+5.3 `features/connections/components/create-connection.schema.ts` — relax `platformTypeFormSchema` to `z.string().trim().min(1, 'Platform type is required')`.
+
+5.4 `pages/connections/connections-list-page.tsx` —
+- Drop `isValidPlatformType` literal check; the URL search param is now an arbitrary string passed to BE.
+- Dropdown options come from `usePlugins()`; label shows `displayName`.
+
+5.5 `features/listings/components/CreateOfferWizard.tsx:302` — drop `c.platformType === 'allegro' ||`, leaving only the capability check.
+
+5.6 `features/connections/components/EditConnectionForm.tsx` — five sites:
+- Line 162 — `usePlugin(...)?.getCallbackUrlDefault?.() ?? ''` for the OL callback default.
+- Line 185 — derive `StructuredSection`, `isMarketplace`, `hasStructuredInputs` as in the sketch above.
+- Line 345-417 PS block — replace inline JSX with `<StructuredSection {...} />`.
+- Line 433 — replace inline Allegro check with `<plugin.EditConnectionExtraSection {...} />`.
+- Line 673 (`CredentialsPanel`) — replace `connection.platformType !== 'prestashop'` with `!plugin?.supportsCredentialRotation`. (`CredentialsPanel` becomes plugin-aware; it already takes `connection` as prop.)
+
+5.7 `features/connections/components/ConnectionActionsPanel.tsx` — replace `isPrestashop` and the inline "Configure webhooks" row with `<plugin.ConnectionActions connection={connection} />`.
+
+5.8 `pages/listings/listing-detail-page.tsx:119` — gate on `usePlugin(mapping.platformType)?.supportsListingEdit === true` (lowercase normalization no longer needed; `platformType` is opaque, but we keep `toLowerCase()` in the lookup as a defensive measure — or use the mapping's `platformType` as-is. Decision: drop the `toLowerCase()` since plugin keys are canonical strings; if production data has uppercase variants we should fix the BE rather than papering over here.).
+
+### Step 6 — ESLint guard
+
+Add a new override to `.eslintrc.js` for `apps/web/src/{features,pages,app}/`:
+
+```js
+{
+  files: ['apps/web/src/{features,pages,app}/**/*.{ts,tsx}'],
+  excludedFiles: ['apps/web/src/plugins/**'],
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector:
+          "BinaryExpression[operator=/^(===|!==)$/][left.property.name='platformType']",
+        message:
+          "Literal-equality dispatch on platformType is forbidden outside apps/web/src/plugins/. Use usePlugin()/usePlugins() or capability checks (supportedCapabilities.includes('…')).",
+      },
+      {
+        selector:
+          "BinaryExpression[operator=/^(===|!==)$/][right.property.name='platformType']",
+        message:
+          "Literal-equality dispatch on platformType is forbidden outside apps/web/src/plugins/.",
+      },
+    ],
+  },
+},
+```
+
+`apps/web/src/plugins/` is the one place where literal-equality is still legitimate (each plugin keys on its own `platformType` constant).
+
+Also extend the `features/`-restriction stanza so plugin imports are allowed from features (TypeScript would otherwise complain about layer violations only if we tried to import `pages/` from `features/`; importing `plugins/` is fine — but features should not depend on plugins either, since plugins compose feature components. **Actually** features should NOT import plugins (one-way: plugins → features). The migration sites use `usePlugin()`/`usePlugins()` from `shared/plugins/` — which is allowed. Features don't import `apps/web/src/plugins/` directly.
+
+### Step 7 — Tests
+
+7.1 `shared/plugins/plugin-registry-context.test.tsx` — provider missing throws, provider present returns plugins; lookup hit/miss.
+
+7.2 `plugins/prestashop/prestashop.plugin.test.tsx` — smoke that the plugin object has the expected fields and that `getCallbackUrlDefault()` returns origin in jsdom.
+
+7.3 `plugins/allegro/allegro.plugin.test.tsx` — smoke.
+
+7.4 Update `features/connections/components/platform-picker.test.tsx` — existing test renders both cards through provider mock. Adjust setup to wrap in `<PluginRegistryProvider plugins={[prestashopPlugin, allegroPlugin]}>` or extend `renderWithProviders` to take a `plugins?` option.
+
+7.5 Update `features/connections/components/create-connection-form.test.tsx` and `features/connections/components/EditConnectionForm.test.tsx` — same provider wrap.
+
+7.6 Update `features/connections/components/ConnectionActionsPanel.test.tsx` — add a case asserting that "Configure webhooks" renders for prestashop and NOT for allegro.
+
+7.7 Update `pages/connections/connections-list-page.test.tsx` if it exists — verify filter dropdown options come from registry.
+
+**Decision on `renderWithProviders` extension**: add an optional `plugins?: PlatformPlugin[]` parameter that defaults to `IN_TREE_PLUGINS`. Tests that need a non-default registry pass it explicitly. This minimizes per-test boilerplate.
+
+### Step 8 — Quality gate + commit
+
+```bash
+pnpm lint        # zero errors
+pnpm type-check  # zero errors
+pnpm test        # all passing
+```
+
+Conventional commit (single commit per scope):
+
+```
+refactor(web): open platformType union + introduce plugin registry (#578, #579)
+
+D3 + D4 of Modularity Thread D. PlatformType becomes an opaque string;
+platform-specific UI dispatches through a new in-tree plugin registry
+(apps/web/src/plugins/) instead of platformType === '…' literal checks.
+ESLint rule prevents the literal-equality dispatch from coming back.
+
+Mirrors the BE pattern from #572/#576/#577.
+```
+
+## Validation
+
+- **Architecture**: dependency direction unchanged. `shared/plugins/` exports types + provider/hooks; `plugins/` (new top-level) is the composition layer that imports features; `features/` consume registry via `shared/plugins/`. No cycles.
+- **Naming**: matches FE conventions (`*.tsx` PascalCase exports for components, `use-*.ts` for hooks, `*.test.tsx` colocated).
+- **Testing**: unit tests for the new registry plus updated tests for migrated components.
+- **Security**: no new request paths, no new credential handling. Same auth gates.
+- **Lint**: new `no-restricted-syntax` rule lands the cross-cutting guard suggested by #546 (FE-side only — backend-side `platformType` literal dispatch is handled by Thread E).
+
+## Risks & open questions
+
+- **Form-type leakage**: the `EditConnectionStructuredSection` plugin slot's `form` prop is the weakest static-typing point (see "Note on the form prop" above). If reviewer pushes back, alternative is to hoist `EditConnectionFormValues` into `shared/forms/`. I'd prefer to land (a) and defer (b) until plugin authors hit it in practice.
+- **Plugin import in tests**: `renderWithProviders` will now default to `IN_TREE_PLUGINS`. Tests that previously rendered components without the provider will need updating. Failure mode is a clear error message from `usePlugins()` — should be a fast fix.
+- **`mapping.platformType.toLowerCase()` on `listing-detail-page.tsx:119`**: dropping `toLowerCase()` assumes BE always returns canonical lowercase. Spot-checked the BE `IdentifierMapping.platformType` denormalization in `architecture-overview.md:747` — denormalized from `Connection.platformType` which is always lowercase. Safe to drop.
+- **Backwards compat**: dropping the `c.platformType === 'allegro'` arm in `CreateOfferWizard.tsx:302` relies on every Allegro connection having `supportedCapabilities: ['OrderSource', 'OfferManager']`. This was set in `apps/api/src/integrations/allegro/allegro-integration.module.ts` since #570/#571. Existing connections in DB inherit the metadata at request time (resolved live from `AdapterRegistryService`), so no migration is needed.
+
+## Out-of-scope follow-ups (not this PR)
+
+- #580 (D5): `PromptTemplateChannelValues` closed union — same shape, different feature.
+- #607 (H4): `shared/` contains marketplace-specific code — broader refactor.
+- #608 (H5): `CreateOfferWizard` Allegro-shaped — broader refactor.
+- Lazy-loading plugin chunks (Modularity Thread H milestone 3 — out-of-tree plugins).
+
+## Post-implementation deltas from tech-review
+
+- `CredentialsPanel` moved from a flag (`supportsCredentialRotation`) into a full plugin slot (`CredentialsPanel?: ComponentType<{ connection }>`). The rotation form was hardcoded with PrestaShop-specific labels and the `webserviceApiKey` payload — gating that UI on a generic flag would mislabel it for any future plugin opting in. The PS plugin now contributes `PrestashopCredentialsPanel` directly; the form falls back to a generic read-only affordance when no plugin contributes one.
+- `requiresOAuthRedirect` renamed to `requiresExternalAuthRedirect` — non-OAuth redirect flows (magic link, device-code) can opt into the same UX without the flag name lying.
+- Plugin slot prop names dropped the `EditConnection` prefix: `EditConnectionStructuredSectionProps` → `StructuredConfigSectionProps`, `EditConnectionExtraSectionProps` → `ExtraConfigSectionProps`. Plugin field names followed: `EditConnectionStructuredSection` → `StructuredConfigSection`, `EditConnectionExtraSection` → `ExtraConfigSection`.
+- `PluginRegistryProvider` now throws on duplicate `platformType` keys at mount time via a `useMemo` guard — silent shadowing was the previous failure mode.
+- ESLint rule for `platformType` literal-equality now carries a comment explaining the deliberate scope (member-access vs literal only; standalone-variable comparisons in platform-specific helpers are exempt).
+- Plugin smoke tests added at `plugins/{prestashop,allegro}/{name}.plugin.test.tsx`.
+- `docs/frontend-architecture.md` now explicitly documents the `shared/plugins/` → `features/connections/api/` type-import exemption alongside the dependency rules.


### PR DESCRIPTION
## Summary

Closes D3 + D4 of Modularity Thread D (#546). `PlatformType` becomes an opaque string; platform-specific UI dispatches through a new in-tree plugin registry (`apps/web/src/plugins/`) instead of `platformType === '…'` literal checks. ESLint rule prevents the literal-equality dispatch from coming back. Mirrors the BE pattern from #572/#576/#577.

Closes #578
Closes #579

## What changed

**Open union**
- `PlatformType` widened from `'prestashop' | 'allegro'` to `string`.
- `CORE_PLATFORM_TYPES` retained as the in-tree well-known set (mirrors `CORE_CAPABILITY_VALUES`).

**Plugin contract** (`apps/web/src/shared/plugins/`)
- `PlatformPlugin` interface
- `PluginRegistryProvider`, `usePlugin()`, `usePlugins()`
- Provider throws on duplicate `platformType` keys at mount time.

**In-tree plugin manifest** (`apps/web/src/plugins/`)
- `prestashop/` — setup card, `StructuredConfigSection` (shop URL / storefront / shop ID / OL callback URL / fallback carrier), `CredentialsPanel` (rotate webservice key), `ConnectionActions` (configure webhooks), `getCallbackUrlDefault`
- `allegro/` — setup card, `ExtraConfigSection` (GPSR seller defaults), `requiresExternalAuthRedirect`, `supportsListingEdit`
- `plugins/index.ts` is the single edit point — `IN_TREE_PLUGINS = [prestashopPlugin, allegroPlugin]`

**Migrated dispatch sites** (9)
| File | Before | After |
|---|---|---|
| `CreateOfferWizard.tsx:302` | `c.platformType === 'allegro' \|\| supportedCapabilities.includes('OfferManager')` | Capability check only |
| `EditConnectionForm.tsx` (callback default) | `=== 'prestashop'` ternary | `plugin?.getCallbackUrlDefault?.()` |
| `EditConnectionForm.tsx` (platform branch) | `=== 'prestashop' ? ... : enabledCapabilities.includes('OfferManager') ? ...` | Plugin `StructuredConfigSection` + capability check |
| `EditConnectionForm.tsx` (allegro block) | `=== 'allegro' ? <AllegroSellerDefaultsSection />` | Plugin `ExtraConfigSection` |
| `EditConnectionForm.tsx` (credentials) | inline `CredentialsPanel` with `=== 'prestashop'` | Plugin `CredentialsPanel` slot + generic fallback |
| `ConnectionActionsPanel.tsx:26` | `isPrestashop` gates "Configure webhooks" | Plugin `ConnectionActions` slot |
| `platform-picker.tsx` | `Record<PlatformType, PlatformCard>` | `usePlugins().filter(p => p.setupCard)` |
| `create-connection-form.tsx` | `PLATFORM_OPTIONS` static + `=== 'allegro'` | Registry-driven options + `requiresExternalAuthRedirect` |
| `connections-list-page.tsx` | `PLATFORM_TYPES.includes(...)` | Registry-driven options |
| `listing-detail-page.tsx:119` | `mapping.platformType.toLowerCase() === 'allegro'` | `plugin?.supportsListingEdit` |

**ESLint guard**
`no-restricted-syntax` bans `BinaryExpression[platformType === Literal]` outside `apps/web/src/plugins/**`. Documented why the standalone-variable case in platform-specific helpers (`allegro-seller-panel-url.ts`) is intentionally exempt.

**Docs**
`docs/frontend-architecture.md` documents the new `plugins/` layer and the narrow `shared/plugins/` → `features/connections/api/` type-import exemption.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm test` — 892 web tests pass (12 new: registry context, plugin smoke tests, plugin-routing assertions in `ConnectionActionsPanel.test.tsx` + `platform-picker.test.tsx`); all backend suites unchanged
- [ ] Manual: open `/connections/new` — see two cards (PrestaShop, Allegro)
- [ ] Manual: open a PS connection's edit page — Shop URL inputs render, rotate-webservice-key UI renders, "Configure webhooks" action renders
- [ ] Manual: open an Allegro connection's edit page — GPSR seller-defaults section renders, "Stored securely" fallback (no rotation UI) renders, no "Configure webhooks" action
- [ ] Manual: open a listing with Allegro mapping — "Edit offer" button appears; for non-Allegro mappings it does not
- [ ] Manual: `/connections?platformType=allegro` filter dropdown shows both registered plugins

## Notes for reviewer

- The plugin contract types `form: UseFormReturn<EditConnectionFormValues>`. This couples in-tree plugins to the feature's private form schema — an out-of-tree plugin (Thread H milestone 3) would need either a narrowed projection or the feature types hoisted into `shared/`. Deferred per plan scope.
- A handful of `=== 'prestashop'` literal-equality sites remain in test fixtures and one platform-specific helper (`allegro-seller-panel-url.ts`) — these are explicitly scoped out by the plan and the ESLint guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)