### PR TITLE
refactor(web): capability-shape CreateOfferWizard via plugin registry

### DIFF
--- a/apps/web/src/app/plugin-bindings/use-offer-creation-wizard.test.tsx
+++ b/apps/web/src/app/plugin-bindings/use-offer-creation-wizard.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * useOfferCreationWizard — unit spec
+ *
+ * Tested against the real plugin registry — verifying that the hook
+ * returns the Allegro contribution that `plugins/allegro/index.ts`
+ * actually registers, and `null` for everything else.
+ */
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useOfferCreationWizard } from './use-offer-creation-wizard';
+
+describe('useOfferCreationWizard', () => {
+  it('returns null when platformType is undefined', () => {
+    const { result } = renderHook(() => useOfferCreationWizard(undefined));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when no plugin registers a wizard for the platform', () => {
+    const { result } = renderHook(() => useOfferCreationWizard('shopify'));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns the Allegro contribution registered by the allegro plugin', () => {
+    const { result } = renderHook(() => useOfferCreationWizard('allegro'));
+    expect(result.current).not.toBeNull();
+    expect(result.current?.platformType).toBe('allegro');
+    expect(typeof result.current?.component).toBe('function');
+  });
+
+  it('memoises by platformType — same platform returns the same reference across re-renders', () => {
+    const { result, rerender } = renderHook(({ p }) => useOfferCreationWizard(p), {
+      initialProps: { p: 'allegro' },
+    });
+    const first = result.current;
+    rerender({ p: 'allegro' });
+    expect(result.current).toBe(first);
+  });
+});

--- a/apps/web/src/app/plugin-bindings/use-offer-creation-wizard.ts
+++ b/apps/web/src/app/plugin-bindings/use-offer-creation-wizard.ts
@@ -1,0 +1,35 @@
+/**
+ * useOfferCreationWizard
+ *
+ * App-tier hook that resolves the per-platform offer-creation wizard from
+ * the build-time plugin registry. Returns the registered contribution for
+ * `platformType` or `null` if no plugin contributes a wizard for that
+ * platform.
+ *
+ * **Why this lives in `app/`**: `features/` may only import `shared/` per
+ * `docs/frontend-architecture.md` §"Dependency Rules" (ESLint-enforced).
+ * Features that need plugin contributions go through this DI-boundary
+ * hook, mirroring the established `useApiClient` precedent — never by
+ * importing `plugins/` directly. (#608)
+ *
+ * The folder is named `plugin-bindings` (not `plugins`) so it doesn't
+ * collide with the `**/plugins/**` glob in `.eslintrc.js` that blocks
+ * features from reaching into the top-level `plugins/` registry directly.
+ *
+ * @module app/plugin-bindings
+ * @see {@link resolveOfferCreationWizard} for the pure resolver
+ */
+import { useMemo } from 'react';
+
+import { plugins } from '../../plugins';
+import { resolveOfferCreationWizard } from '../../plugins/resolve-offer-creation-wizard';
+import type { OfferCreationWizardContribution } from '../../plugins/plugin.types';
+
+export function useOfferCreationWizard(
+  platformType: string | undefined,
+): OfferCreationWizardContribution | null {
+  return useMemo(
+    () => (platformType ? resolveOfferCreationWizard(plugins, platformType) : null),
+    [platformType],
+  );
+}

--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
@@ -1,12 +1,15 @@
 /**
- * CreateOfferWizard Tests
+ * AllegroCreateOfferWizard Tests
  *
  * @module apps/web/src/features/listings/components
  */
 import { screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
-import { CreateOfferWizard } from './CreateOfferWizard';
+import { AllegroCreateOfferWizard } from './AllegroCreateOfferWizard';
+// NOTE: tests for the connection-picker UX moved to OfferCreationLauncher.test.tsx
+// as part of #608. The wizard is now content-only; the launcher owns the
+// Dialog chrome and the connection-pick flow.
 import type { Connection } from '../../connections/api/connections.types';
 import type { Product } from '../../products/api/products.types';
 import type {
@@ -115,14 +118,10 @@ async function advanceThroughEmptyParameters(): Promise<void> {
 }
 
 async function advanceToStep2(): Promise<void> {
-  // Wait for the connections query to resolve so the default connection has
-  // been pre-selected into the form.
-  await waitFor(() => {
-    const select = screen.getByLabelText<HTMLSelectElement>(/connection/i);
-    expect(select.value).toBe(allegroConnection.id);
-  });
-  // Wait for the products query to resolve, then expand the product row to
-  // reveal its variants.
+  // Connection is now a prop (the launcher resolves it before mounting),
+  // so we skip the connection-picker wait that the pre-#608 wizard
+  // required. Wait for the products query, expand the product row, pick
+  // the variant, and move to Step 2.
   await waitFor(() => expect(screen.getByText('Test Shirt')).toBeInTheDocument());
   fireEvent.click(screen.getByRole('button', { name: /test shirt/i }));
   await waitFor(() => expect(screen.getByText(/test shirt — m/i)).toBeInTheDocument());
@@ -135,7 +134,7 @@ async function advanceToStep2(): Promise<void> {
   await waitFor(() => expect(screen.getByText('Allegro category')).toBeInTheDocument());
 }
 
-describe('CreateOfferWizard', () => {
+describe('AllegroCreateOfferWizard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -144,67 +143,50 @@ describe('CreateOfferWizard', () => {
     cleanup();
   });
 
-  it('does not render dialog content when closed', () => {
+  // Removed in #608:
+  //   - "does not render dialog content when closed" — the wizard is now
+  //     content-only, mounted on demand by `OfferCreationLauncher`. The
+  //     "closed" state is the launcher's responsibility; covered in
+  //     `OfferCreationLauncher.test.tsx`.
+  //   - "renders step 1 with connection picker and variant search" — the
+  //     connection picker moved to the launcher; this assertion is
+  //     replaced by the connection-id integrity test below + the
+  //     launcher's picker spec.
+  //   - "pre-selects the connection when defaultConnectionId is provided"
+  //     — auto-skip is now launcher behaviour; covered by
+  //     `OfferCreationLauncher.test.tsx` ("auto-skips picker when
+  //     defaultConnectionId resolves").
+
+  it('renders step 1 with the variant search and the connection name in the header', async () => {
     const mockApi = defaultMocks();
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={false}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={vi.fn()}
         onSubmitted={vi.fn()}
       />,
       { apiClient: mockApi },
     );
 
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-  });
-
-  it('renders step 1 with connection picker and variant search when open', async () => {
-    const mockApi = defaultMocks();
-    renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
-        onSubmitted={vi.fn()}
-      />,
-      { apiClient: mockApi },
-    );
-
-    expect(await screen.findByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByLabelText(/connection/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/search products/i)).toBeInTheDocument();
-  });
-
-  it('pre-selects the connection when defaultConnectionId is provided', async () => {
-    const mockApi = defaultMocks();
-    renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
-        onSubmitted={vi.fn()}
-      />,
-      { apiClient: mockApi },
-    );
-
-    const connectionSelect = await screen.findByLabelText<HTMLSelectElement>(/connection/i);
-    await waitFor(() => expect(connectionSelect.value).toBe(allegroConnection.id));
+    expect(await screen.findByLabelText(/search products/i)).toBeInTheDocument();
+    expect(screen.getByText(allegroConnection.name)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^connection$/i)).not.toBeInTheDocument();
   });
 
   it('cannot advance from step 1 without picking a variant', async () => {
     const mockApi = defaultMocks();
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={vi.fn()}
         onSubmitted={vi.fn()}
       />,
       { apiClient: mockApi },
     );
 
-    await screen.findByRole('dialog');
+    // Wizard renders content-only now; wait for Step 1 to be visible
+    // before driving the Next button.
+    await screen.findByLabelText(/search products/i);
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
     // Stays on Step 1 — title field (Step 2) must not be visible
     expect(screen.queryByLabelText(/^title$/i)).not.toBeInTheDocument();
@@ -214,10 +196,9 @@ describe('CreateOfferWizard', () => {
   it('blocks advancement past step 2 until a leaf category is selected', async () => {
     const mockApi = defaultMocks();
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={vi.fn()}
         onSubmitted={vi.fn()}
       />,
       { apiClient: mockApi },
@@ -241,10 +222,9 @@ describe('CreateOfferWizard', () => {
   it('validates title ≤ 75 chars on step 2', async () => {
     const mockApi = defaultMocks();
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={vi.fn()}
         onSubmitted={vi.fn()}
       />,
       { apiClient: mockApi },
@@ -262,10 +242,9 @@ describe('CreateOfferWizard', () => {
   it('requires delivery policy on the policies step when policies are present', async () => {
     const mockApi = defaultMocks();
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={vi.fn()}
         onSubmitted={vi.fn()}
       />,
       { apiClient: mockApi },
@@ -304,10 +283,9 @@ describe('CreateOfferWizard', () => {
     });
 
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={vi.fn()}
         onSubmitted={vi.fn()}
       />,
       { apiClient: mockApi },
@@ -330,10 +308,9 @@ describe('CreateOfferWizard', () => {
     const mockApi = defaultMocks({ listings: { createOffer, getSellerPolicies: vi.fn().mockResolvedValue(policies) } });
 
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={onClose}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={onClose}
         onSubmitted={onSubmitted}
       />,
       { apiClient: mockApi },
@@ -384,10 +361,9 @@ describe('CreateOfferWizard', () => {
     const mockApi = defaultMocks({ listings: { createOffer, getSellerPolicies: vi.fn().mockResolvedValue(policies) } });
 
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={vi.fn()}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={vi.fn()}
         onSubmitted={vi.fn()}
       />,
       { apiClient: mockApi },
@@ -424,10 +400,9 @@ describe('CreateOfferWizard', () => {
     const mockApi = defaultMocks({ listings: { createOffer, getSellerPolicies: vi.fn().mockResolvedValue(policies) } });
 
     renderWithProviders(
-      <CreateOfferWizard
-        isOpen={true}
-        onClose={onClose}
-        defaultConnectionId={allegroConnection.id}
+      <AllegroCreateOfferWizard
+        connection={allegroConnection}
+        onCancel={onClose}
         onSubmitted={vi.fn()}
       />,
       { apiClient: mockApi },
@@ -445,7 +420,10 @@ describe('CreateOfferWizard', () => {
     fireEvent.click(await screen.findByRole('button', { name: /create offer/i }));
 
     expect(await screen.findByText(/offer creation failed/i)).toBeInTheDocument();
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // Wizard body still rendered (the launcher's Dialog wraps it; this
+    // spec mounts the wizard directly, so we assert the wizard markup
+    // instead of `role="dialog"`).
+    expect(screen.getByText('Create Allegro offer')).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
   });
 
@@ -469,10 +447,9 @@ describe('CreateOfferWizard', () => {
     it('renders the retry hint on Step 1 after Back when opened with initialValues', async () => {
       const mockApi = defaultMocks();
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           initialValues={initialRequest}
           onSubmitted={vi.fn()}
         />,
@@ -489,10 +466,9 @@ describe('CreateOfferWizard', () => {
     it('does not render the retry hint on a fresh open', async () => {
       const mockApi = defaultMocks();
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
         { apiClient: mockApi },
@@ -505,10 +481,9 @@ describe('CreateOfferWizard', () => {
     it('opens on step 2 with fields pre-filled from initialValues', async () => {
       const mockApi = defaultMocks();
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           initialValues={initialRequest}
           onSubmitted={vi.fn()}
         />,
@@ -536,11 +511,10 @@ describe('CreateOfferWizard', () => {
       });
 
       // First wizard session: normal flow through all four steps.
-      const { rerender } = renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+      renderWithProviders(
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
         { apiClient: mockApi },
@@ -560,23 +534,19 @@ describe('CreateOfferWizard', () => {
       await waitFor(() => expect(createOffer).toHaveBeenCalledTimes(1));
       const firstKey = createOffer.mock.calls[0][2].idempotencyKey;
 
-      // Close the wizard, then reopen it with initialValues (the retry path).
-      rerender(
-        <CreateOfferWizard
-          isOpen={false}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
-          onSubmitted={vi.fn()}
-        />,
-      );
-      rerender(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+      // Unmount the first session, then mount a fresh wizard with
+      // `initialValues` (the retry path the launcher exercises). Re-mounting
+      // is what mints a fresh idempotency key — `useRef(crypto.randomUUID())`
+      // re-runs on a new component instance.
+      cleanup();
+      renderWithProviders(
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           initialValues={initialRequest}
           onSubmitted={vi.fn()}
         />,
+        { apiClient: mockApi },
       );
 
       // We land on Step 2 pre-filled; advance through the empty parameters
@@ -605,10 +575,9 @@ describe('CreateOfferWizard', () => {
       const list = vi.fn().mockResolvedValue({ items: [page1Product], total: 1, limit: 10, offset: 0 });
       const mockApi = defaultMocks({ products: { list, getById: vi.fn().mockResolvedValue(page1Product) } });
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
         { apiClient: mockApi },
@@ -633,10 +602,9 @@ describe('CreateOfferWizard', () => {
         products: { list, getById: vi.fn().mockResolvedValue(page1Product) },
       });
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
         { apiClient: mockApi },
@@ -680,10 +648,9 @@ describe('CreateOfferWizard', () => {
         products: { list, getById: vi.fn().mockResolvedValue(page1Product) },
       });
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
         { apiClient: mockApi },
@@ -759,10 +726,9 @@ describe('CreateOfferWizard', () => {
       });
 
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={onClose}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={onClose}
           onSubmitted={onSubmitted}
         />,
         { apiClient: mockApi },
@@ -849,10 +815,9 @@ describe('CreateOfferWizard', () => {
       });
 
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
         { apiClient: mockApi },
@@ -925,10 +890,9 @@ describe('CreateOfferWizard', () => {
       });
 
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
         { apiClient: mockApi },
@@ -977,10 +941,9 @@ describe('CreateOfferWizard', () => {
       });
 
       renderWithProviders(
-        <CreateOfferWizard
-          isOpen={true}
-          onClose={vi.fn()}
-          defaultConnectionId={allegroConnection.id}
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
           onSubmitted={vi.fn()}
         />,
         { apiClient: mockApi },

--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx
@@ -1,10 +1,14 @@
 /**
- * CreateOfferWizard
+ * AllegroCreateOfferWizard
  *
- * Five-step wizard that publishes an OpenLinker variant as a new offer
- * on a marketplace connection. Steps:
- *   1. Connection & Variant — pick the target connection, search and
- *      select a product variant
+ * Five-step wizard that publishes an OpenLinker variant as a new Allegro
+ * offer on a given marketplace connection. **Content-only**: the
+ * surrounding `<Dialog>` chrome and connection selection live in
+ * `OfferCreationLauncher` (#608); this component receives the resolved
+ * `Connection` as a prop and renders wizard body + nav buttons directly.
+ *
+ * Steps:
+ *   1. Variant — search and select a product variant
  *   2. Offer details — title override, Allegro category id, price, stock,
  *      description, publish-immediately toggle
  *   3. Category parameters (#410) — required-first / optional-collapsed
@@ -14,15 +18,11 @@
  *      warranty (optional), populated from the seller-policies endpoint
  *   5. Review — summary of all chosen values
  *
- * Retry-safe: a stable `x-idempotency-key` is generated on open
+ * Retry-safe: a stable `x-idempotency-key` is generated once per mount
  * (`crypto.randomUUID()`) and reused until success or explicit cancel,
- * so the server returns the same OfferCreationRecord on retry instead
- * of creating a duplicate.
- *
- * Rendered inside the shared `Dialog` primitive (Radix-backed) rather
- * than a bespoke side drawer — the shared `.drawer` classes referenced
- * by other components do not exist in `index.css`, and a centered
- * modal is a better fit for multi-step content anyway.
+ * so the server returns the same OfferCreationRecord on retry instead of
+ * creating a duplicate. The launcher unmounts + remounts the wizard on
+ * close/re-open, which mints a fresh key naturally.
  *
  * @module apps/web/src/features/listings/components
  */
@@ -37,7 +37,6 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../../../shared/ui/dialog';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
@@ -46,7 +45,7 @@ import { SetupStepper } from '../../../shared/ui/setup-stepper';
 import { Textarea } from '../../../shared/ui/textarea';
 import { useToast } from '../../../shared/ui/toast-provider';
 import { useDebouncedValue } from '../../../shared/hooks/use-debounced-value';
-import { useConnectionsQuery } from '../../connections/hooks/use-connections-query';
+import type { Connection } from '../../connections/api/connections.types';
 import { useProductQuery } from '../../products/hooks/use-product-query';
 import { useProductsQuery } from '../../products/hooks/use-products-query';
 import type { Product, ProductVariant } from '../../products/api/products.types';
@@ -71,8 +70,8 @@ import {
 } from './create-offer-fields.schema';
 import { createOfferRequestToFormValues } from './create-offer-request-to-form-values';
 
-const STEP_LABELS = [
-  'Connection & Variant',
+const ALLEGRO_STEP_LABELS = [
+  'Variant',
   'Offer details',
   'Category parameters',
   'Policies',
@@ -80,7 +79,9 @@ const STEP_LABELS = [
 ] as const;
 
 const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<CreateOfferFieldsValues>>> = [
-  ['connectionId', 'internalVariantId'],
+  // Step 0 (Variant) — the connection is fixed by the launcher and pre-filled
+  // into the form state; only the variant needs user input here.
+  ['internalVariantId'],
   ['title', 'categoryId', 'priceAmount', 'priceCurrency', 'stock'],
   // Step 3 (parameters) is validated dynamically via buildParametersZodSchema —
   // its field shape is runtime-driven so we cannot list keys statically.
@@ -92,16 +93,18 @@ const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<CreateOfferFieldsValues>>> =
 const VARIANT_SEARCH_DEBOUNCE_MS = 300;
 const VARIANT_PICKER_PAGE_SIZE = 10;
 
-interface CreateOfferWizardProps {
-  isOpen: boolean;
-  onClose: () => void;
-  /** Pre-fill hint from the listings list filter; the picker is always
-   *  visible so the operator can change it. */
-  defaultConnectionId?: string;
-  /** Snapshot of a prior request, used by the retry path to reopen the
-   *  wizard pre-populated. Consumed on each open transition; changing it
-   *  while the wizard is already open has no effect. */
+interface AllegroCreateOfferWizardProps {
+  /** The marketplace connection the launcher resolved before mounting
+   *  this wizard. The connection's id is pre-filled into the form
+   *  state — never user-editable from inside the wizard. */
+  connection: Connection;
+  defaultVariantId?: string;
+  /** Snapshot of a prior request, used by the retry path to pre-fill the
+   *  wizard. Read once at mount (re-mount to consume a new snapshot). */
   initialValues?: CreateOfferRequest;
+  /** Fired by the Cancel button on Step 0. The launcher uses this to
+   *  close its surrounding Dialog. */
+  onCancel: () => void;
   onSubmitted: (offerCreationRecordId: string, connectionId: string) => void;
 }
 
@@ -194,33 +197,48 @@ function renderReviewParametersBlock(
   );
 }
 
-export function CreateOfferWizard({
-  isOpen,
-  onClose,
-  defaultConnectionId,
+export function AllegroCreateOfferWizard({
+  connection,
+  defaultVariantId,
   initialValues,
+  onCancel,
   onSubmitted,
-}: CreateOfferWizardProps): ReactElement {
+}: AllegroCreateOfferWizardProps): ReactElement {
   const mutation = useCreateOfferMutation();
   const { showToast } = useToast();
-  const idempotencyKeyRef = useRef<string>('');
+  // Fresh idempotency key per mount. Re-mount = launcher close+reopen =
+  // a new key naturally (#307 acceptance preserved).
+  const idempotencyKeyRef = useRef<string>(crypto.randomUUID());
 
   const form = useForm<CreateOfferFieldsValues, undefined, CreateOfferFieldsSubmission>({
-    defaultValues: { ...CREATE_OFFER_DEFAULT_VALUES, connectionId: defaultConnectionId ?? '' },
+    // Connection id is fixed by the launcher's pick. Variant defaults to
+    // the launcher's hint (rarely supplied; retained for parity with the
+    // contract) or empty for the picker to fill in.
+    defaultValues: initialValues
+      ? createOfferRequestToFormValues(initialValues, connection.id)
+      : {
+          ...CREATE_OFFER_DEFAULT_VALUES,
+          connectionId: connection.id,
+          internalVariantId: defaultVariantId ?? '',
+        },
     resolver: zodResolver(createOfferFieldsSchema),
     mode: 'onBlur',
   });
 
-  const [stepIndex, setStepIndex] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState<ReadonlySet<number>>(new Set());
+  // Retry path: land directly on Step 2 with Steps 0/1 marked complete
+  // when initialValues are supplied. Otherwise start at Step 0.
+  const [stepIndex, setStepIndex] = useState(() => (initialValues ? 1 : 0));
+  const [completedSteps, setCompletedSteps] = useState<ReadonlySet<number>>(() =>
+    initialValues ? new Set([0, 1]) : new Set(),
+  );
   const [productSearchInput, setProductSearchInput] = useState('');
   const [productOffset, setProductOffset] = useState(0);
   const [selectedProductId, setSelectedProductId] = useState<string | null>(null);
   // True when the current session was opened via Retry with a snapshot.
-  // Lets Step 1 render a hint explaining why the picker looks empty
+  // Lets Step 0 render a hint explaining why the picker looks empty
   // despite the form carrying a variant id from the prior attempt.
-  const [wasPrefilled, setWasPrefilled] = useState(false);
-  // EAN of the variant the operator picked in Step 1 — fed to the Step 3
+  const wasPrefilled = initialValues !== undefined;
+  // EAN of the variant the operator picked in Step 0 — fed to the Step 3
   // parameter auto-prefill so EAN/GTIN-class fields populate from the
   // variant's barcode without needing the variant detail re-fetched.
   const [pickedVariantEan, setPickedVariantEan] = useState<string | null>(null);
@@ -237,53 +255,6 @@ export function CreateOfferWizard({
   const [staleSchemaError, setStaleSchemaError] = useState<string | null>(null);
   const debouncedProductSearch = useDebouncedValue(productSearchInput, VARIANT_SEARCH_DEBOUNCE_MS);
 
-  // Reset wizard state on open. A fresh idempotency key is minted every
-  // time the wizard opens — including the retry flow — so a failed record
-  // stays on the previous key and a retry creates a new OfferCreationRecord
-  // rather than colliding with the old one (issue #307 acceptance).
-  // #478: depend on the destructured stable `reset` methods, not the
-  // wrapping `form` / `mutation` objects — `useMutation` returns a fresh
-  // wrapper each render (the `prevIsOpenRef` guard masks the loop here).
-  const { reset: resetForm } = form;
-  const { reset: resetMutation } = mutation;
-  const prevIsOpenRef = useRef(false);
-  useEffect(() => {
-    if (isOpen && !prevIsOpenRef.current) {
-      idempotencyKeyRef.current = crypto.randomUUID();
-      if (initialValues) {
-        const prefilled = createOfferRequestToFormValues(
-          initialValues,
-          defaultConnectionId ?? '',
-        );
-        resetForm(prefilled);
-        // Jump to Step 2 with Steps 0 and 1 marked as completed so the
-        // operator lands directly on the offer-details form with the
-        // prior values visible. Step 0 is re-traversable via Back.
-        setStepIndex(1);
-        setCompletedSteps(new Set([0, 1]));
-        // Pre-select the product panel so Step 0 shows the correct
-        // expansion if the operator steps back. The variant id format
-        // is `ol_variant_*`; product id cannot be derived from it, so
-        // the picker simply opens empty on Back until the operator
-        // re-searches.
-        setSelectedProductId(null);
-        setWasPrefilled(true);
-      } else {
-        resetForm({ ...CREATE_OFFER_DEFAULT_VALUES, connectionId: defaultConnectionId ?? '' });
-        setStepIndex(0);
-        setCompletedSteps(new Set());
-        setSelectedProductId(null);
-        setWasPrefilled(false);
-      }
-      setProductSearchInput('');
-      setProductOffset(0);
-      setPickedVariantEan(null);
-      setPrefilledIds(new Set());
-      resetMutation();
-    }
-    prevIsOpenRef.current = isOpen;
-  }, [isOpen, defaultConnectionId, initialValues, resetForm, resetMutation]);
-
   // Abandon-prevention: warn if the operator closes the tab mid-flow.
   useEffect(() => {
     function handleBeforeUnload(event: BeforeUnloadEvent): void {
@@ -295,34 +266,9 @@ export function CreateOfferWizard({
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [form.formState.isDirty]);
 
-  const connectionsQuery = useConnectionsQuery();
-  const marketplaceConnections = useMemo(
-    () =>
-      (connectionsQuery.data ?? []).filter(
-        (c) => c.platformType === 'allegro' || c.supportedCapabilities.includes('OfferManager'),
-      ),
-    [connectionsQuery.data],
-  );
-
-  // RHF `register` writes initial values via ref on mount, but the native
-  // `<select>` only accepts a value that matches a rendered `<option>`. When
-  // the connections list arrives after mount (the query resolves async) the
-  // DOM value hasn't caught up with the form state, so we re-issue
-  // `setValue` once the intended option is actually present.
-  const currentConnectionId = form.watch('connectionId');
-  const connectionsLoadedRef = useRef(false);
-  useEffect(() => {
-    if (connectionsLoadedRef.current || marketplaceConnections.length === 0) return;
-    connectionsLoadedRef.current = true;
-    if (defaultConnectionId && marketplaceConnections.some((c) => c.id === defaultConnectionId)) {
-      form.setValue('connectionId', defaultConnectionId, { shouldDirty: false });
-    }
-  }, [marketplaceConnections, defaultConnectionId, form]);
-
-  // Reset the "loaded" ref on wizard re-open so a fresh session re-syncs.
-  useEffect(() => {
-    if (!isOpen) connectionsLoadedRef.current = false;
-  }, [isOpen]);
+  // Connection id is fixed for the wizard's lifetime — driven by the
+  // `connection` prop, mirrored into the form state for the API payload.
+  const currentConnectionId = connection.id;
 
   const productsQuery = useProductsQuery(
     { search: debouncedProductSearch || undefined },
@@ -447,7 +393,7 @@ export function CreateOfferWizard({
     }
 
     setCompletedSteps((prev) => new Set(prev).add(stepIndex));
-    setStepIndex((i) => Math.min(i + 1, STEP_LABELS.length - 1));
+    setStepIndex((i) => Math.min(i + 1, ALLEGRO_STEP_LABELS.length - 1));
   }
 
   function goBack(): void {
@@ -537,7 +483,7 @@ export function CreateOfferWizard({
         description: 'Status will appear inline on the listings page.',
       });
       onSubmitted(result.offerCreationRecordId, values.connectionId);
-      onClose();
+      onCancel();
     } catch {
       // Inline Alert renders from mutation.error; retry will reuse the
       // same idempotency key so the server de-duplicates to the same
@@ -549,14 +495,16 @@ export function CreateOfferWizard({
   const selectedVariantId = values.internalVariantId;
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent>
-        <DialogTitle>Create offer</DialogTitle>
-        <DialogDescription>
-          Publish an OpenLinker variant as a new offer on a marketplace connection.
-        </DialogDescription>
+    <div className="allegro-create-offer-wizard">
+      <header className="allegro-create-offer-wizard__header">
+        <h2 className="allegro-create-offer-wizard__title">Create Allegro offer</h2>
+        <p className="allegro-create-offer-wizard__subtitle">
+          Publishing to <strong>{connection.name}</strong>{' '}
+          <span className="mono-text muted-text">({connection.platformType})</span>
+        </p>
+      </header>
 
-        <SetupStepper steps={STEP_LABELS} currentStep={stepIndex} completedSteps={completedSteps} />
+      <SetupStepper steps={ALLEGRO_STEP_LABELS} currentStep={stepIndex} completedSteps={completedSteps} />
 
         {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
           <FormErrorSummary errors={validationMessages} />
@@ -608,28 +556,10 @@ export function CreateOfferWizard({
             <>
               {wasPrefilled ? (
                 <Alert tone="info" title="Prior attempt re-loaded">
-                  Connection and variant were copied from the failed attempt. Search to change
-                  the variant if the original selection was wrong.
+                  Variant was copied from the failed attempt. Search to change the variant if
+                  the original selection was wrong.
                 </Alert>
               ) : null}
-              <FormField
-                label="Connection"
-                name="connectionId"
-                error={form.formState.errors.connectionId?.message}
-                description="Marketplace to publish this offer to."
-              >
-                <Select
-                  {...form.register('connectionId')}
-                  invalid={Boolean(form.formState.errors.connectionId)}
-                >
-                  <option value="">Choose a connection…</option>
-                  {marketplaceConnections.map((c) => (
-                    <option key={c.id} value={c.id}>
-                      {c.name} ({c.platformType})
-                    </option>
-                  ))}
-                </Select>
-              </FormField>
 
               <FormField
                 label="Search products"
@@ -969,9 +899,7 @@ export function CreateOfferWizard({
           {stepIndex === 4 ? (
             <dl className="wizard-review-list">
               <dt>Connection</dt>
-              <dd>
-                {marketplaceConnections.find((c) => c.id === values.connectionId)?.name ?? '—'}
-              </dd>
+              <dd>{connection.name}</dd>
               <dt>Variant</dt>
               <dd>{values.variantLabel || values.internalVariantId}</dd>
               <dt>Title</dt>
@@ -1032,31 +960,30 @@ export function CreateOfferWizard({
         </form>
         </FormProvider>
 
-        <div className="wizard-actions">
-          <div className="wizard-actions__group">
-            {stepIndex > 0 ? (
-              <Button tone="secondary" type="button" onClick={goBack}>
-                Back
-              </Button>
-            ) : (
-              <Button tone="ghost" type="button" onClick={onClose}>
-                Cancel
-              </Button>
-            )}
-          </div>
-          <div className="wizard-actions__group">
-            {stepIndex < STEP_LABELS.length - 1 ? (
-              <Button type="button" onClick={() => void goNext()}>
-                Next
-              </Button>
-            ) : (
-              <Button type="submit" form="create-offer-form" disabled={mutation.isPending}>
-                {mutation.isPending ? 'Submitting…' : 'Create offer'}
-              </Button>
-            )}
-          </div>
+      <div className="wizard-actions">
+        <div className="wizard-actions__group">
+          {stepIndex > 0 ? (
+            <Button tone="secondary" type="button" onClick={goBack}>
+              Back
+            </Button>
+          ) : (
+            <Button tone="ghost" type="button" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
         </div>
-      </DialogContent>
-    </Dialog>
+        <div className="wizard-actions__group">
+          {stepIndex < ALLEGRO_STEP_LABELS.length - 1 ? (
+            <Button type="button" onClick={() => void goNext()}>
+              Next
+            </Button>
+          ) : (
+            <Button type="submit" form="create-offer-form" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Submitting…' : 'Create offer'}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/features/listings/components/OfferCreationLauncher.test.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationLauncher.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * OfferCreationLauncher Tests
+ *
+ * Covers the capability-shaped dispatch site (#608):
+ *   - picker shown when no defaultConnectionId
+ *   - auto-skip when defaultConnectionId resolves against active connections
+ *   - falls back to picker when defaultConnectionId doesn't resolve
+ *   - loading state while connections fetch
+ *   - unsupported-platform alert when no plugin registers a wizard
+ *   - wizard rendered on Continue (Allegro plugin contribution exercised)
+ *   - Cancel / Close fire onClose
+ *   - empty marketplace list shows a "no connections" alert
+ *
+ * Tests for the wizard's own UX (variant pick, step navigation, submit,
+ * idempotency) live in `AllegroCreateOfferWizard.test.tsx`. This spec
+ * stays focused on the dispatch surface.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import { OfferCreationLauncher } from './OfferCreationLauncher';
+import type { Connection } from '../../connections/api/connections.types';
+
+const allegroConnection: Connection = {
+  id: 'conn_allegro_1',
+  name: 'Allegro sandbox',
+  platformType: 'allegro',
+  status: 'active',
+  config: {},
+  credentialsBacked: true,
+  adapterKey: 'allegro.publicapi.v1',
+  enabledCapabilities: ['OfferManager'],
+  supportedCapabilities: ['OfferManager'],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const prestashopConnection: Connection = {
+  id: 'conn_ps_1',
+  name: 'PrestaShop main',
+  platformType: 'prestashop',
+  status: 'active',
+  config: {},
+  credentialsBacked: true,
+  adapterKey: 'prestashop.webservice.v1',
+  enabledCapabilities: ['OfferManager'],
+  // This fixture deliberately advertises OfferManager so the launcher
+  // surfaces it in the picker — exercising the "unsupported platform"
+  // branch when the operator picks it (no FE plugin registers Prestashop).
+  supportedCapabilities: ['OfferManager'],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+function defaultMocks(connections: Connection[] = [allegroConnection]) {
+  return createMockApiClient({
+    connections: { list: vi.fn().mockResolvedValue(connections) },
+    products: {
+      list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 10, offset: 0 }),
+    },
+    listings: {
+      getSellerPolicies: vi.fn().mockResolvedValue({
+        deliveryPolicies: [],
+        returnPolicies: [],
+        warranties: [],
+        impliedWarranties: [],
+      }),
+      getCategoryParameters: vi.fn().mockResolvedValue({ parameters: [] }),
+    },
+    mappings: {
+      getAllegroCategories: vi.fn().mockResolvedValue([]),
+    },
+  });
+}
+
+describe('OfferCreationLauncher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders nothing when isOpen is false', () => {
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={false}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks() },
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows the connection picker when no defaultConnectionId is supplied', async () => {
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks() },
+    );
+
+    expect(await screen.findByLabelText(/marketplace connection/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+  });
+
+  it('auto-skips the picker when defaultConnectionId resolves to an active connection', async () => {
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        defaultConnectionId={allegroConnection.id}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks() },
+    );
+
+    // Allegro plugin contributes the wizard — the picker is bypassed and
+    // the wizard mounts immediately with the resolved connection.
+    expect(await screen.findByLabelText(/search products/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/marketplace connection/i)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the picker when defaultConnectionId does not match any active connection', async () => {
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        defaultConnectionId="conn_does_not_exist"
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks() },
+    );
+
+    expect(await screen.findByLabelText(/marketplace connection/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/search products/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the wizard after the operator picks a connection and clicks Continue', async () => {
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks() },
+    );
+
+    const select = await screen.findByLabelText<HTMLSelectElement>(/marketplace connection/i);
+    fireEvent.change(select, { target: { value: allegroConnection.id } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(await screen.findByLabelText(/search products/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/marketplace connection/i)).not.toBeInTheDocument();
+  });
+
+  it('shows an unsupported-platform alert when the picked connection has no registered wizard', async () => {
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks([allegroConnection, prestashopConnection]) },
+    );
+
+    const select = await screen.findByLabelText<HTMLSelectElement>(/marketplace connection/i);
+    fireEvent.change(select, { target: { value: prestashopConnection.id } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    expect(
+      await screen.findByText(/offer creation isn't supported for this marketplace yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it('fires onClose when the picker Cancel is pressed', async () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={onClose}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks() },
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the "no marketplace connections" alert when the loaded list is empty', async () => {
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks([]) },
+    );
+
+    expect(
+      await screen.findByText(/no marketplace connections available/i),
+    ).toBeInTheDocument();
+  });
+
+  it('Continue is disabled until a connection is chosen', async () => {
+    renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks() },
+    );
+
+    const continueBtn = await screen.findByRole('button', { name: /continue/i });
+    expect(continueBtn).toBeDisabled();
+  });
+
+  it('resets picker state when the dialog closes and reopens', async () => {
+    const { rerender } = renderWithProviders(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+      { apiClient: defaultMocks([allegroConnection, prestashopConnection]) },
+    );
+
+    // Pick prestashop, advance into the unsupported branch.
+    const select = await screen.findByLabelText<HTMLSelectElement>(/marketplace connection/i);
+    fireEvent.change(select, { target: { value: prestashopConnection.id } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    await screen.findByText(/offer creation isn't supported/i);
+
+    // Close — picker state should reset.
+    rerender(
+      <OfferCreationLauncher
+        isOpen={false}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+    );
+
+    // Reopen — should see the picker (not the unsupported alert).
+    rerender(
+      <OfferCreationLauncher
+        isOpen={true}
+        onClose={vi.fn()}
+        onSubmitted={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/marketplace connection/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/offer creation isn't supported/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/listings/components/OfferCreationLauncher.tsx
+++ b/apps/web/src/features/listings/components/OfferCreationLauncher.tsx
@@ -1,0 +1,234 @@
+/**
+ * OfferCreationLauncher
+ *
+ * Capability-shaped entry-point for the "Create offer" CTA on the listings
+ * page (#608). Owns:
+ *   - the surrounding `<Dialog>` chrome
+ *   - the connection-picking state (which marketplace to publish to)
+ *   - dispatch to the per-platform wizard registered against the FE
+ *     plugin registry via `useOfferCreationWizard(platformType)`
+ *
+ * The launcher renders a **single morphing Dialog**:
+ *   1. picker body when no connection is chosen yet
+ *   2. plugin-contributed wizard body once the connection resolves to a
+ *      platform that has a registered wizard
+ *   3. an "unsupported marketplace" alert when no plugin contributes
+ *
+ * Auto-skip: if `defaultConnectionId` is supplied (retry path) **and**
+ * resolves to an active marketplace connection, the picker is skipped and
+ * the wizard renders directly. While the connections query is still
+ * loading, an inline loading state is shown inside the dialog.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
+
+import { useOfferCreationWizard } from '../../../app/plugin-bindings/use-offer-creation-wizard';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '../../../shared/ui/dialog';
+import { FormField } from '../../../shared/ui/form-field';
+import { Select } from '../../../shared/ui/select';
+import { useConnectionsQuery } from '../../connections/hooks/use-connections-query';
+import type { Connection } from '../../connections/api/connections.types';
+import type { CreateOfferRequest } from '../api/listings.types';
+
+interface OfferCreationLauncherProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Pre-selected connection id (e.g. retry path). When this resolves
+   *  against the loaded connection list, the picker is skipped. */
+  defaultConnectionId?: string;
+  initialValues?: CreateOfferRequest;
+  onSubmitted: (offerCreationRecordId: string, connectionId: string) => void;
+}
+
+/**
+ * Marketplace connections eligible for offer creation. Matches the filter
+ * the previous in-wizard picker applied — `platformType === 'allegro'` is
+ * grandfathered alongside connections that advertise the `OfferManager`
+ * capability. Once the BE exposes `OfferCreator` capability metadata to
+ * the FE (#573/#574 follow-up) this should narrow to that specifically.
+ */
+function selectMarketplaceConnections(all: ReadonlyArray<Connection>): Connection[] {
+  return all
+    .filter(
+      (c) =>
+        c.status === 'active' &&
+        (c.platformType === 'allegro' || c.supportedCapabilities.includes('OfferManager')),
+    )
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function OfferCreationLauncher({
+  isOpen,
+  onClose,
+  defaultConnectionId,
+  initialValues,
+  onSubmitted,
+}: OfferCreationLauncherProps): ReactElement | null {
+  const connectionsQuery = useConnectionsQuery();
+  const marketplaceConnections = useMemo(
+    () => selectMarketplaceConnections(connectionsQuery.data ?? []),
+    [connectionsQuery.data],
+  );
+
+  // Selected connection drives both the dispatch lookup and the wizard
+  // mount. Stays null until the operator (or the auto-pick effect) makes
+  // a choice — so closing the dialog and reopening lands back at the picker
+  // (unless the auto-pick fires again).
+  const [pickedConnectionId, setPickedConnectionId] = useState<string | null>(null);
+  // Form-local draft for the picker `<Select>` — separated from the
+  // commit (`pickedConnectionId`) so the operator can dismiss the dialog
+  // without leaving a stale half-pick behind on next open.
+  const [pickerDraft, setPickerDraft] = useState<string>('');
+
+  // Reset picker state every time the dialog closes — guarantees a fresh
+  // open starts from "no choice yet" rather than carrying the previous
+  // operator's selection.
+  useEffect(() => {
+    if (!isOpen) {
+      setPickedConnectionId(null);
+      setPickerDraft('');
+    }
+  }, [isOpen]);
+
+  // Auto-skip path: if a default connection id was supplied and it
+  // resolves against the loaded marketplace list, commit it directly so
+  // the wizard mounts without an intermediate picker step. Fires exactly
+  // once per (defaultConnectionId, connections-loaded) transition.
+  useEffect(() => {
+    if (!isOpen || pickedConnectionId !== null) return;
+    if (!defaultConnectionId) return;
+    if (marketplaceConnections.length === 0) return;
+    if (marketplaceConnections.some((c) => c.id === defaultConnectionId)) {
+      setPickedConnectionId(defaultConnectionId);
+    }
+    // `pickedConnectionId` is intentionally excluded from the deps array
+    // — the early-out above guards run-once behaviour; re-including it
+    // would just re-fire the effect with no net effect.
+  }, [isOpen, defaultConnectionId, marketplaceConnections]);
+
+  const pickedConnection =
+    pickedConnectionId !== null
+      ? marketplaceConnections.find((c) => c.id === pickedConnectionId) ?? null
+      : null;
+
+  const wizardContribution = useOfferCreationWizard(pickedConnection?.platformType);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  // Branch the dialog body on launcher state without nesting the wizard
+  // inside a second Dialog — one continuous Radix Dialog from picker
+  // through to wizard, so no flicker between transitions.
+  let body: ReactElement;
+  let title: string;
+  let description: string | null;
+
+  if (pickedConnection === null) {
+    // Loading or picker mode.
+    if (connectionsQuery.isLoading) {
+      title = 'Create offer';
+      description = 'Loading marketplace connections…';
+      body = <p className="muted-text">Loading…</p>;
+    } else if (marketplaceConnections.length === 0) {
+      title = 'Create offer';
+      description = null;
+      body = (
+        <Alert tone="warning" title="No marketplace connections available">
+          Add an active connection that supports offer creation before publishing offers.
+        </Alert>
+      );
+    } else {
+      title = 'Create offer';
+      description = 'Pick the marketplace connection you want to publish this offer to.';
+      body = (
+        <>
+          <FormField label="Connection" name="connection">
+            <Select
+              value={pickerDraft}
+              onChange={(e) => setPickerDraft(e.target.value)}
+              aria-label="Marketplace connection"
+            >
+              <option value="">Choose a connection…</option>
+              {marketplaceConnections.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name} ({c.platformType})
+                </option>
+              ))}
+            </Select>
+          </FormField>
+          <div className="wizard-actions">
+            <div className="wizard-actions__group">
+              <Button tone="ghost" type="button" onClick={onClose}>
+                Cancel
+              </Button>
+            </div>
+            <div className="wizard-actions__group">
+              <Button
+                type="button"
+                disabled={!pickerDraft}
+                onClick={() => setPickedConnectionId(pickerDraft)}
+              >
+                Continue
+              </Button>
+            </div>
+          </div>
+        </>
+      );
+    }
+  } else if (wizardContribution === null) {
+    // Unsupported-platform branch.
+    title = 'Marketplace not supported';
+    description = null;
+    const Wizard = null; // suppress unused-variable lint
+    void Wizard;
+    body = (
+      <>
+        <Alert tone="warning" title="Offer creation isn't supported for this marketplace yet">
+          No plugin contributes an offer-creation wizard for{' '}
+          <span className="mono-text">{pickedConnection.platformType}</span>. Choose a different
+          connection or install a plugin that handles this platform.
+        </Alert>
+        <div className="wizard-actions">
+          <div className="wizard-actions__group">
+            <Button tone="ghost" type="button" onClick={onClose}>
+              Close
+            </Button>
+          </div>
+        </div>
+      </>
+    );
+  } else {
+    // Wizard branch — the contributed component renders inside our Dialog.
+    title = `Create ${pickedConnection.platformType} offer`;
+    description = null;
+    const Wizard = wizardContribution.component;
+    body = (
+      <Wizard
+        connection={pickedConnection}
+        initialValues={initialValues}
+        onCancel={onClose}
+        onSubmitted={onSubmitted}
+      />
+    );
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent>
+        <DialogTitle>{title}</DialogTitle>
+        {description !== null ? <DialogDescription>{description}</DialogDescription> : null}
+        {body}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -10,7 +10,7 @@ import { Input } from '../../shared/ui/input';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
-import { CreateOfferWizard } from '../../features/listings/components/CreateOfferWizard';
+import { OfferCreationLauncher } from '../../features/listings/components/OfferCreationLauncher';
 import { OfferCreationTracker } from '../../features/listings/components/OfferCreationTracker';
 import type {
   CreateOfferRequest,
@@ -283,7 +283,7 @@ export function ListingsListPage(): ReactElement {
         </>
       )}
 
-      <CreateOfferWizard
+      <OfferCreationLauncher
         isOpen={isWizardOpen}
         onClose={closeWizard}
         defaultConnectionId={retryDefaultConnectionId ?? (debouncedConnectionId || undefined)}

--- a/apps/web/src/plugins/allegro/index.ts
+++ b/apps/web/src/plugins/allegro/index.ts
@@ -10,6 +10,7 @@
  * @module plugins/allegro
  */
 import { createAllegroApi, type AllegroApi } from '../../features/allegro/api/allegro.api';
+import { AllegroCreateOfferWizard } from '../../features/listings/components/AllegroCreateOfferWizard';
 import { definePlugin } from '../define-plugin';
 import { allegroCallbackRoute } from './allegro-callback.route';
 import { allegroSetupRoute } from './allegro-setup.route';
@@ -24,4 +25,11 @@ export const allegroPlugin = definePlugin({
   id: 'allegro',
   routes: [allegroCallbackRoute, allegroSetupRoute],
   apiNamespaces: (request) => ({ allegro: createAllegroApi(request) }),
+  // Capability-shaped offer creation (#608): the listings page resolves
+  // this contribution via `useOfferCreationWizard('allegro')` and renders
+  // the wizard inside the launcher's Dialog.
+  offerCreationWizard: {
+    platformType: 'allegro',
+    component: AllegroCreateOfferWizard,
+  },
 });

--- a/apps/web/src/plugins/plugin.types.ts
+++ b/apps/web/src/plugins/plugin.types.ts
@@ -13,9 +13,12 @@
  * @module plugins
  * @see apps/api/src/plugins.ts — BE counterpart that this design mirrors
  */
+import type { ComponentType } from 'react';
 import type { RouteObject } from 'react-router-dom';
 
 import type { ApiRequest, PluginApiNamespaces } from '../app/api/api-client';
+import type { Connection } from '../features/connections/api/connections.types';
+import type { CreateOfferRequest } from '../features/listings/api/listings.types';
 
 /**
  * One nav-link contribution from a plugin. `groupLabel` is an open string:
@@ -57,7 +60,42 @@ export type PluginApiNamespacesFactory = (
 ) => Partial<PluginApiNamespaces>;
 
 /**
- * A build-time plugin contributing routes, nav items, and/or API namespaces.
+ * Props every per-platform offer-creation wizard receives. The launcher
+ * (`features/listings/components/OfferCreationLauncher.tsx`) resolves the
+ * connection up front and owns the surrounding Dialog chrome — so each
+ * contributed wizard is **content-only**, knows its platform via
+ * `connection.platformType`, and never renders its own Dialog or
+ * connection picker (#608).
+ *
+ * `defaultVariantId` / `initialValues` carry retry-path hints.
+ */
+export interface OfferCreationWizardProps {
+  connection: Connection;
+  defaultVariantId?: string;
+  initialValues?: CreateOfferRequest;
+  /** Fired by the wizard's Cancel/Close affordance — the launcher uses
+   *  this to close the surrounding Dialog. */
+  onCancel: () => void;
+  onSubmitted: (offerCreationRecordId: string, connectionId: string) => void;
+}
+
+/**
+ * Plugin contribution for capability-shaped offer creation (#608).
+ *
+ * `component` is a pre-bound React component, not a render fn — keeps the
+ * contribution a pure value at module load, plays nicely with test mocks,
+ * and matches how React expects to consume components at JSX time
+ * (`<contribution.component {...props} />`).
+ */
+export interface OfferCreationWizardContribution {
+  /** Connection `platformType` this wizard handles, e.g. 'allegro'. */
+  platformType: string;
+  component: ComponentType<OfferCreationWizardProps>;
+}
+
+/**
+ * A build-time plugin contributing routes, nav items, API namespaces,
+ * and/or an offer-creation wizard.
  * Authored via `definePlugin({...})` for type-checked ergonomics; collected
  * in `apps/web/src/plugins/index.ts`.
  */
@@ -70,4 +108,7 @@ export interface WebPlugin {
   navItems?: NavContribution[];
   /** Factory that produces typed API client namespaces. */
   apiNamespaces?: PluginApiNamespacesFactory;
+  /** Per-platform offer-creation wizard registered against the
+   *  `OfferCreationLauncher` dispatch site (#608). */
+  offerCreationWizard?: OfferCreationWizardContribution;
 }

--- a/apps/web/src/plugins/resolve-offer-creation-wizard.test.ts
+++ b/apps/web/src/plugins/resolve-offer-creation-wizard.test.ts
@@ -1,0 +1,57 @@
+/**
+ * resolveOfferCreationWizard — unit spec
+ *
+ * Covers the pure resolver: match, no-match, and first-match-wins when
+ * multiple plugins contribute for the same `platformType` (#608).
+ */
+import { describe, expect, it } from 'vitest';
+import type { ComponentType } from 'react';
+
+import { resolveOfferCreationWizard } from './resolve-offer-creation-wizard';
+import type { OfferCreationWizardProps, WebPlugin } from './plugin.types';
+
+const dummyComponent: ComponentType<OfferCreationWizardProps> = () => null;
+
+function plugin(id: string, platformType?: string): WebPlugin {
+  if (platformType === undefined) {
+    return { id };
+  }
+  return {
+    id,
+    offerCreationWizard: { platformType, component: dummyComponent },
+  };
+}
+
+describe('resolveOfferCreationWizard', () => {
+  it('returns null when the plugin list is empty', () => {
+    expect(resolveOfferCreationWizard([], 'allegro')).toBeNull();
+  });
+
+  it('returns null when no plugin contributes for the requested platform', () => {
+    const plugins = [plugin('prestashop', 'prestashop'), plugin('docs-only')];
+    expect(resolveOfferCreationWizard(plugins, 'allegro')).toBeNull();
+  });
+
+  it('returns the matching contribution by platformType', () => {
+    const plugins = [plugin('allegro', 'allegro'), plugin('prestashop', 'prestashop')];
+    const resolved = resolveOfferCreationWizard(plugins, 'allegro');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.platformType).toBe('allegro');
+    expect(resolved?.component).toBe(dummyComponent);
+  });
+
+  it('ignores plugins that do not contribute an offerCreationWizard', () => {
+    const plugins = [plugin('no-wizard'), plugin('allegro', 'allegro')];
+    expect(resolveOfferCreationWizard(plugins, 'allegro')?.platformType).toBe('allegro');
+  });
+
+  it('returns the first match when multiple plugins contribute for the same platformType', () => {
+    const firstComponent: ComponentType<OfferCreationWizardProps> = () => null;
+    const secondComponent: ComponentType<OfferCreationWizardProps> = () => null;
+    const plugins: WebPlugin[] = [
+      { id: 'first', offerCreationWizard: { platformType: 'allegro', component: firstComponent } },
+      { id: 'second', offerCreationWizard: { platformType: 'allegro', component: secondComponent } },
+    ];
+    expect(resolveOfferCreationWizard(plugins, 'allegro')?.component).toBe(firstComponent);
+  });
+});

--- a/apps/web/src/plugins/resolve-offer-creation-wizard.ts
+++ b/apps/web/src/plugins/resolve-offer-creation-wizard.ts
@@ -1,0 +1,29 @@
+/**
+ * resolveOfferCreationWizard
+ *
+ * Pure helper: walks a plugin list and returns the first plugin whose
+ * `offerCreationWizard` contribution matches `platformType`, or `null` if
+ * none. Consumed by the `app/`-tier hook `useOfferCreationWizard` — never
+ * imported directly from `features/` or `pages/` (FE dep rules, #608).
+ *
+ * "First match wins" mirrors how `routes` and `navItems` are merged
+ * elsewhere in the registry. Duplicate contributions for the same
+ * `platformType` would be a registry-construction bug; a stronger guard
+ * (warn / throw) can be layered in later if the need arises.
+ *
+ * @module plugins
+ */
+import type { OfferCreationWizardContribution, WebPlugin } from './plugin.types';
+
+export function resolveOfferCreationWizard(
+  plugins: ReadonlyArray<WebPlugin>,
+  platformType: string,
+): OfferCreationWizardContribution | null {
+  for (const plugin of plugins) {
+    const contribution = plugin.offerCreationWizard;
+    if (contribution && contribution.platformType === platformType) {
+      return contribution;
+    }
+  }
+  return null;
+}

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -293,6 +293,8 @@ Dependency direction must remain simple and enforceable:
 These boundaries are enforced by ESLint `no-restricted-imports` rules in `.eslintrc.js` — violations fail `pnpm lint`. Raw `fetch()` calls are also blocked in `shared/`, `features/`, `pages/`, and `plugins/` via `no-restricted-globals` to ensure all HTTP calls go through shared API client modules.
 
 > **Note:** Features may import `useApiClient` from `app/api/` — this is the designed dependency-injection boundary for API access. A future refactor may move the hook to `shared/`, but the current crossing is intentional and not restricted by lint.
+>
+> **Note (#608):** Features may also import `useOfferCreationWizard` from `app/plugin-bindings/` — same DI-boundary precedent. Features must NOT import `plugins/` directly; per-platform extension points go through the `app/`-tier hook that closes over the registry. The folder is named `plugin-bindings` (not `plugins`) so the `**/plugins/**` lint deny-glob can stay broad without carve-out exceptions.
 
 Additional rules:
 

--- a/docs/plans/implementation-plan-capability-offer-wizard.md
+++ b/docs/plans/implementation-plan-capability-offer-wizard.md
@@ -1,0 +1,273 @@
+# Implementation Plan — Capability-shaped Offer Creation Wizard (#608)
+
+**Issue**: [#608 — [H5] [HIGH] CreateOfferWizard is Allegro-shaped, not capability-shaped](https://github.com/SilkSoftwareHouse/openlinker/issues/608)
+**Thread**: H (FE plugin architecture)
+**Branch**: `608-create-offer-wizard-capability-shape`
+**Builds on**: #629 (FE plugin registry + open ApiClient — landed yesterday)
+
+---
+
+## 1. Goal
+
+`apps/web/src/features/listings/components/CreateOfferWizard.tsx` is presented as a generic offer-creation flow but is wired to Allegro semantics throughout (category picker, seller policies, `productSet`, `serializeAllegroParameters`, `MissingCategoryParameterSectionError`). The listings page mounts it unconditionally regardless of `connection.platformType`. A Shopify or eBay plugin has no extension point to swap in its own offer-creation flow.
+
+Add a per-platform extension point to the FE plugin registry, replace the unconditional mount with a capability-shaped dispatch, and rename the existing wizard so its Allegro coupling is named in the type system rather than implied.
+
+## 2. Non-goals (deferred follow-ups)
+
+- **File relocation**: the issue mentions "move under `features/allegro/`". This plan **keeps the wizard and its private helpers in `features/listings/components/`** for the architectural fix, and defers the directory move to a follow-up. Rationale: separating the registry seam from the file-move makes the diff reviewable, and the renamed wizard's identity is what the FE plugin registry binds to — the disk path is cosmetic. The follow-up issue (call it H5b) is mechanical `git mv` + import updates.
+- **Splitting the Allegro-shaped helpers** (`serialize-allegro-parameters`, `auto-prefill-parameters`, `build-parameters-zod-schema`, the CategoryPicker tree, `category-parameters-step`, `category-parameter-form.types`) out of `features/listings/` — same rationale; same follow-up.
+- **OfferManager capability gating** on the connection picker (only listing connections whose adapter implements `OfferCreator` per `CoreCapability`). The BE doesn't yet expose adapter-capabilities to the FE; today every active marketplace connection is offered. Wire when #573/#574 (FE-side capability metadata) lands.
+
+## 3. Layer classification
+
+- **Frontend / plugin contracts** (`apps/web/src/plugins/`) — extend the `WebPlugin` interface with an `offerCreationWizard` slot; add a resolver helper.
+- **Frontend / feature** (`apps/web/src/features/listings/`) — rename the wizard, drop in-wizard connection picker (the launcher now owns connection selection), add a small `OfferCreationLauncher` entry-point component.
+- **Frontend / plugin instance** (`apps/web/src/plugins/allegro/`) — wire the renamed Allegro wizard against the registry.
+- **Frontend / page** (`apps/web/src/pages/listings/`) — swap the unconditional wizard mount for the launcher.
+
+No backend changes. No new API endpoints. No new tests at the API or worker level.
+
+## 4. Pattern reuse
+
+Mirrors the registry-contribution pattern #629 established for `WebPlugin.routes` / `navItems` / `apiNamespaces`. The contribution is structural — no TypeScript declaration merging needed (unlike `apiNamespaces`, which augments `PluginApiNamespaces`). A plugin that omits `offerCreationWizard` simply doesn't contribute — listings page renders a "Marketplace not supported" empty state when the chosen connection's `platformType` has no registered wizard.
+
+## 5. Design
+
+### 5.1 Plugin contract — `apps/web/src/plugins/plugin.types.ts`
+
+Extend `WebPlugin` with one new optional slot:
+
+```typescript
+import type { ComponentType } from 'react';
+import type { Connection } from '../features/connections/api/connections.types';
+import type { CreateOfferRequest } from '../features/listings/api/listings.types';
+
+/**
+ * Props every per-platform offer-creation wizard receives. The launcher
+ * resolves the connection up front (so each wizard knows its platform via
+ * `connection.platformType` and never has to render its own connection
+ * picker). The wizard is **content-only** — the launcher owns the Dialog
+ * chrome so the connection-picker → wizard transition is one continuous
+ * dialog rather than two flashing in sequence. `defaultVariantId` /
+ * `initialValues` carry retry-path hints.
+ */
+export interface OfferCreationWizardProps {
+  connection: Connection;
+  defaultVariantId?: string;
+  initialValues?: CreateOfferRequest;
+  /** Called when the wizard's Cancel/Close button is pressed — the
+   *  launcher uses this to close the surrounding Dialog. */
+  onCancel: () => void;
+  onSubmitted: (offerCreationRecordId: string, connectionId: string) => void;
+}
+
+export interface OfferCreationWizardContribution {
+  /** Connection `platformType` this wizard handles, e.g. 'allegro'. */
+  platformType: string;
+  /**
+   * Pre-bound React component. Using `ComponentType` (vs a render fn) keeps
+   * the contribution a pure value at module-load time, plays nicely with
+   * test mocks, and mirrors how React expects to consume components at JSX
+   * time (`<contribution.component {...props} />`).
+   */
+  component: ComponentType<OfferCreationWizardProps>;
+}
+
+export interface WebPlugin {
+  // …existing fields…
+  offerCreationWizard?: OfferCreationWizardContribution;
+}
+```
+
+### 5.2 Resolver — `apps/web/src/plugins/resolve-offer-creation-wizard.ts`
+
+Pure helper used by the `app/`-tier hook (§5.2a). Walks an arbitrary plugin list and returns the first matching contribution or `null`. Pure so the unit spec is trivial and the hook can mock it.
+
+```typescript
+export function resolveOfferCreationWizard(
+  plugins: ReadonlyArray<WebPlugin>,
+  platformType: string,
+): OfferCreationWizardContribution | null {
+  for (const plugin of plugins) {
+    const contribution = plugin.offerCreationWizard;
+    if (contribution && contribution.platformType === platformType) {
+      return contribution;
+    }
+  }
+  return null;
+}
+```
+
+### 5.2a App-tier hook — `apps/web/src/app/plugins/use-offer-creation-wizard.ts`
+
+`features` may import only `shared` per `frontend-architecture.md` §"Dependency Rules" — ESLint-enforced. **Features cannot import `plugins/`.** To bridge: expose the plugin lookup via an `app/`-tier hook, mirroring the existing `useApiClient` carve-out the same doc explicitly endorses ("Features may import `useApiClient` from `app/api/` — this is the designed dependency-injection boundary").
+
+```typescript
+// apps/web/src/app/plugins/use-offer-creation-wizard.ts
+import { useMemo } from 'react';
+import { plugins } from '../../plugins';
+import {
+  resolveOfferCreationWizard,
+  type OfferCreationWizardContribution,
+} from '../../plugins/resolve-offer-creation-wizard';
+
+/**
+ * App-tier hook that resolves the per-platform offer-creation wizard from
+ * the build-time plugin registry. Features consume this hook; they must
+ * not import `plugins/` directly (FE dep-rule violation, ESLint-enforced).
+ *
+ * Returns `null` when no plugin contributes a wizard for the given
+ * platform — call sites render a "marketplace not supported" empty state.
+ */
+export function useOfferCreationWizard(
+  platformType: string | undefined,
+): OfferCreationWizardContribution | null {
+  return useMemo(
+    () => (platformType ? resolveOfferCreationWizard(plugins, platformType) : null),
+    [platformType],
+  );
+}
+```
+
+**Doc update (required in this PR)**: add a one-line carve-out to `docs/frontend-architecture.md` §"Dependency Rules" alongside the `useApiClient` line, so the next contributor doesn't read the import as a violation:
+
+> Features may also import `useOfferCreationWizard` from `app/plugins/` — same DI-boundary precedent.
+
+### 5.3 `OfferCreationLauncher` — `apps/web/src/features/listings/components/OfferCreationLauncher.tsx`
+
+Drop-in replacement for the current `<CreateOfferWizard>` mount on the listings page. Owns connection-picking state, owns the Dialog chrome, and resolves the per-platform wizard via `useOfferCreationWizard(connection?.platformType)`.
+
+**Props** (intentionally a superset of the old wizard props so the call site is one-line):
+```typescript
+interface OfferCreationLauncherProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Pre-selected connection id (e.g. retry path). When set, skips the picker. */
+  defaultConnectionId?: string;
+  initialValues?: CreateOfferRequest;
+  onSubmitted: (offerCreationRecordId: string, connectionId: string) => void;
+}
+```
+
+**Single morphing dialog** (state-driven body, not two sequential dialogs — see review SUGGESTION #3):
+
+1. `isOpen=false` → render nothing.
+2. `isOpen=true` + no connection chosen yet → render `<Dialog>` with a small connection-picker body: dropdown of active connections sorted by name, "Continue" + "Cancel" buttons. Continue stores the chosen `connection` in launcher state; Cancel fires `onClose`.
+3. `isOpen=true` + `connection` chosen + matching wizard contribution → render the **same** `<Dialog>` but switch the body to `<contribution.component connection={…} defaultVariantId={…} initialValues={…} onCancel={onClose} onSubmitted={onSubmitted} />`. The wizard renders no Dialog of its own; it lives inside the launcher's.
+4. `isOpen=true` + `connection` chosen + **no** matching contribution → same `<Dialog>` rendering an `<Alert tone="warning">` saying "Offer creation isn't supported for this marketplace yet (platformType=`{connection.platformType}`)" + a Close button that fires `onClose`.
+
+Auto-pick optimisation: when `defaultConnectionId` is supplied and resolves to an active connection in the loaded list, skip step 2 and seed `connection` directly. While the connections query is still loading and no connection is yet chosen, render a tiny inline loading state inside the dialog body — never let the dialog flash empty.
+
+### 5.4 Wizard rename + content-only refactor — `apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx`
+
+`git mv CreateOfferWizard.tsx AllegroCreateOfferWizard.tsx`; rename the exported function; preserve all internal logic. Shape changes:
+
+- **Props**: replace `{ isOpen, onClose, defaultConnectionId, initialValues, onSubmitted }` with `{ connection, defaultVariantId?, initialValues?, onCancel, onSubmitted }` (per the contract in §5.1).
+- **Dialog chrome removed**: drop the `<Dialog>`/`<DialogContent>`/`<DialogTitle>` wrapper entirely. The wizard now returns wizard-body markup directly (stepper + step content + nav buttons). The launcher provides the surrounding Dialog. Internal "Cancel" button calls `onCancel`.
+- **Step 1**: rename "Connection & Variant" → "Variant". Remove the connection `<Select>`. Pre-fill `connectionId` in the form state from `props.connection.id` (defaulted via `defaultValues`); the field stays in the form schema (the API call still needs it) but is never user-editable.
+- **`STEP_FIELDS[0]`**: drop `'connectionId'`; keep `'internalVariantId'`.
+- **Step labels constant** renamed to make Allegro identity explicit (e.g. `ALLEGRO_STEP_LABELS`) — small clarity tweak; no functional change.
+- **Header**: include the connection name (e.g. "Create Allegro offer · {connection.name}") inside the wizard body so the operator knows which marketplace they're creating for, replacing the in-wizard picker affordance.
+
+**Test migration (review SUGGESTION #5)**: the existing `CreateOfferWizard.test.tsx` has substantial coverage of "operator picks a connection, then …" — that behaviour now lives in the launcher. Tests removed from the wizard spec because they exercise the connection-picker UX must be **re-implemented against `OfferCreationLauncher.test.tsx`** so net regression coverage is preserved. Don't just delete them.
+
+**Connection-id integrity check (review SUGGESTION #4)**: add a single test that mounts the renamed wizard with a fixture `connection`, drives it through to submit, and asserts the captured `CreateOfferRequest.connectionId === connection.id`. This catches the failure mode where someone later wires a hidden input that drifts.
+
+### 5.5 Plugin wiring — `apps/web/src/plugins/allegro/index.ts`
+
+```typescript
+import { AllegroCreateOfferWizard } from '../../features/listings/components/AllegroCreateOfferWizard';
+// …existing imports…
+
+export const allegroPlugin = definePlugin({
+  id: 'allegro',
+  routes: [allegroCallbackRoute, allegroSetupRoute],
+  apiNamespaces: (request) => ({ allegro: createAllegroApi(request) }),
+  offerCreationWizard: {
+    platformType: 'allegro',
+    component: AllegroCreateOfferWizard,
+  },
+});
+```
+
+### 5.6 Listings page — `apps/web/src/pages/listings/listings-list-page.tsx`
+
+Replace:
+```tsx
+<CreateOfferWizard
+  isOpen={isWizardOpen}
+  onClose={closeWizard}
+  defaultConnectionId={...}
+  initialValues={retryInitialValues}
+  onSubmitted={handleOfferSubmitted}
+/>
+```
+with:
+```tsx
+<OfferCreationLauncher
+  isOpen={isWizardOpen}
+  onClose={closeWizard}
+  defaultConnectionId={retryDefaultConnectionId ?? (debouncedConnectionId || undefined)}
+  initialValues={retryInitialValues}
+  onSubmitted={handleOfferSubmitted}
+/>
+```
+Imports change; logic doesn't. `listings-list-page.test.tsx` updates to match.
+
+## 6. Step-by-step plan
+
+| # | File | Action | Acceptance |
+|---|------|--------|------------|
+| 1 | `apps/web/src/plugins/plugin.types.ts` | Add `OfferCreationWizardProps`, `OfferCreationWizardContribution` (uses `component: ComponentType<…>`, not a render fn); extend `WebPlugin`. | Type compiles; existing plugins unchanged. |
+| 2 | `apps/web/src/plugins/resolve-offer-creation-wizard.ts` | New helper (pure function). | Exports the signature in §5.2. |
+| 3 | `apps/web/src/plugins/resolve-offer-creation-wizard.test.ts` | Unit spec — match, no-match, multi-plugin (first-match-wins). | 3+ tests pass. |
+| 4 | `apps/web/src/app/plugins/use-offer-creation-wizard.ts` | New `app/`-tier hook that closes over `plugins` and exposes `useOfferCreationWizard(platformType)`. Mirrors the `useApiClient` DI-boundary precedent. | Returns the resolved contribution or `null`. Memoised on `platformType`. |
+| 5 | `apps/web/src/app/plugins/use-offer-creation-wizard.test.tsx` | Unit spec. | Returns `null` for unknown / undefined platform; returns the contribution for a registered one. |
+| 6 | `docs/frontend-architecture.md` | Add the one-line carve-out under §"Dependency Rules" — "Features may also import `useOfferCreationWizard` from `app/plugins/` — same DI-boundary precedent as `useApiClient`." | Doc change visible in diff. |
+| 7 | `apps/web/src/features/listings/components/CreateOfferWizard.tsx` | `git mv` → `AllegroCreateOfferWizard.tsx`. Drop the Dialog wrapper. Drop `isOpen`/`onClose`/`defaultConnectionId`; require `connection` + `onCancel` props (§5.1 contract). Drop the connection picker from Step 1; rename step labels; show connection name in the wizard header. | File renamed; no `<Dialog>` import; no `isOpen` prop; `STEP_FIELDS[0]` is `['internalVariantId']`. |
+| 8 | `apps/web/src/features/listings/components/CreateOfferWizard.test.tsx` | `git mv` → `AllegroCreateOfferWizard.test.tsx`. Strip connection-picker tests; inject a fixture `connection`. Add the connection-id integrity test (§5.4). **Identify which removed tests cover behaviour that now lives in the launcher and migrate them to step 10's spec** — net coverage preserved. | Suite passes; explicit comment on which removed cases were re-homed in the launcher spec. |
+| 9 | `apps/web/src/plugins/allegro/index.ts` | Register the wizard contribution: `{ platformType: 'allegro', component: AllegroCreateOfferWizard }`. | Type-check passes; `allegroPlugin.offerCreationWizard?.platformType === 'allegro'`. |
+| 10 | `apps/web/src/features/listings/components/OfferCreationLauncher.tsx` | New component (§5.3). Owns the Dialog; switches body between picker / wizard / unsupported-alert based on internal `connection` state. Uses `useOfferCreationWizard(connection?.platformType)`. | Renders the 4 states (closed, picking, wizard, unsupported); auto-picks on `defaultConnectionId` once connections load; single-Dialog morphing, no flicker. |
+| 11 | `apps/web/src/features/listings/components/OfferCreationLauncher.test.tsx` | Unit spec covering: picker shown when no default; auto-skip when default supplied AND connection in active set; falls back to picker when `defaultConnectionId` doesn't resolve; loading state while connections fetch; unsupported-platform alert when no plugin contribution; wizard rendered on Continue. **Re-implement the connection-picker-flow tests that previously lived in the wizard spec** (§5.4 migration). | All migrated test cases preserved and passing. |
+| 12 | `apps/web/src/pages/listings/listings-list-page.tsx` | Swap mount → `OfferCreationLauncher`. | Page still opens "Create offer" CTA; existing retry path still pre-fills. |
+| 13 | `apps/web/src/pages/listings/listings-list-page.test.tsx` | Update imports / assertions. | Suite passes. |
+| 14 | `apps/web/src/index.css` | Launcher picker-body styles (if new classes needed). | Picker renders without horizontal scroll on 360px; reuses existing `.dialog__*` tokens. |
+
+## 7. Architecture compliance
+
+- ✅ `WebPlugin` is an open-extension contract — adding a slot doesn't break existing plugins (the new field is optional).
+- ✅ Dependency direction:
+  - `plugins/allegro` → `features/listings/components/AllegroCreateOfferWizard.tsx` is `plugins → features`, allowed.
+  - `pages/listings` → `features/listings/components/OfferCreationLauncher.tsx` is `pages → features`, allowed.
+  - `features/listings/components/OfferCreationLauncher.tsx` → `app/plugins/use-offer-creation-wizard.ts` is `features → app`, allowed via the explicit `useApiClient` carve-out (extended in step 6).
+  - `app/plugins/use-offer-creation-wizard.ts` → `plugins/index.ts` is `app → plugins`, allowed.
+  - **Features do NOT import `plugins/` directly** — that path goes only through the `app/`-tier hook.
+- ✅ No `any` — `Connection`, `CreateOfferRequest` are typed imports; the wizard contribution is fully typed via `ComponentType<OfferCreationWizardProps>`.
+- ✅ Naming: `AllegroCreateOfferWizard.tsx` (PascalCase export, matches existing `CreateOfferWizard.tsx` / `CategoryPicker.tsx` / `EditOfferDrawer.tsx` / `OfferCreationTracker.tsx` convention in this slice).
+- ✅ `OfferCreationLauncher.tsx` follows the same Pascal convention.
+- ✅ `use-offer-creation-wizard.ts` follows the kebab `use-*.ts` hook convention.
+- ✅ Test files use `*.test.tsx` per FE rules.
+- ✅ No `fetch()` from pages/features — all data goes through `useApiClient`.
+
+## 8. Risks
+
+1. **Test renames** — `CreateOfferWizard.test.tsx` is the largest test file in the listings slice (covers all 5 steps + retry path). Renaming + updating connection-picker tests is mechanical but voluminous. Mitigation: do the rename as a pure `git mv` first, then a focused edit of the connection-picker test block.
+2. **Connection-picker UX shift** — moving the picker from inside the wizard to a launcher modal changes the operator flow. Existing tests asserting "step 1 contains a connection select" will break and need to be replaced by launcher tests asserting "picker dialog shows on open, then wizard opens on Continue". Snapshot/screenshot diff is intentional; it's the user-visible change the issue tracks.
+3. **`defaultConnectionId` semantics** — today the wizard uses `defaultConnectionId` to *pre-select* in its picker; after the refactor the launcher uses it to *skip* the picker. Listings-page retry path (`handleRetry`) already supplies an exact connection, so the skip is correct. The filter-derived default (`debouncedConnectionId`) may not always identify a real connection (it's a free-text filter on platform type / ID strings). Guard: launcher resolves `defaultConnectionId` against the loaded connections list and falls back to the picker if the id doesn't match.
+
+## 9. Out of scope (re-stated)
+
+- Physical move of the wizard + Allegro-shaped helpers to `features/allegro/` — follow-up.
+- Hiding non-`OfferCreator` connections from the picker — needs FE-side capability metadata (#573/#574 dependency).
+- Building a generic "no-wizard" fallback page or marketplace-onboarding stub — the launcher shows an inline alert today; a richer story can land when there's a second plugin to test against.
+
+## 10. Validation checklist
+
+Before commit:
+- [ ] `pnpm lint` clean
+- [ ] `pnpm type-check` clean
+- [ ] `pnpm test` — all suites green, including renamed wizard suite and new launcher suite
+- [ ] Manual: open `/listings`, click "Create offer", confirm picker dialog shows with active connections, pick one, confirm wizard opens for Allegro and the connection name is shown in the wizard header
+- [ ] Manual: retry path from `OfferCreationTracker` still opens directly into the wizard with pre-filled fields
+- [ ] Manual: with a non-Allegro connection (mock by editing fixtures or temporarily registering a Prestashop plugin contribution), confirm the "not supported" alert renders


### PR DESCRIPTION
## Summary

Closes #608 — last HIGH item on Modularity Thread H wired to a plugin extension point.

The 1062-line `CreateOfferWizard` was presented as a generic offer-creation flow but Allegro-coupled end-to-end (category picker, seller policies, `productSet`, `serializeAllegroParameters`). The listings page mounted it unconditionally regardless of `connection.platformType`, so a Shopify or eBay plugin had no extension point.

This PR introduces the extension point and re-shapes the wizard around it.

## What changes

### Plugin contract
- `WebPlugin` (in `apps/web/src/plugins/plugin.types.ts`) gains an optional `offerCreationWizard?: { platformType; component }` slot.
- `component` is a **pre-bound `ComponentType<OfferCreationWizardProps>`**, not a render fn — pure value at module-load, easy to mock, matches how React expects to consume components at JSX time.

### Launcher (new)
- `OfferCreationLauncher` in `apps/web/src/features/listings/components/` owns the Dialog chrome and the connection-pick state.
- Renders a **single morphing Radix Dialog** — picker → wizard / unsupported-alert, no flash between states.
- Auto-skips the picker when `defaultConnectionId` (retry path) resolves against an active connection; falls back to the picker when it doesn't.

### App-tier bridge (new)
- `useOfferCreationWizard(platformType)` in `apps/web/src/app/plugin-bindings/` closes over the plugin registry and exposes it via a hook.
- Features bind to the hook — they never reach into `plugins/` directly (FE dep-rule, ESLint-enforced).
- Mirrors the existing `useApiClient` DI-boundary precedent. New carve-out documented in `docs/frontend-architecture.md`.
- The folder is named `plugin-bindings` (not `plugins`) so the `**/plugins/**` lint deny-glob stays broad without carve-outs.

### Wizard refactor
- `CreateOfferWizard.tsx` → `AllegroCreateOfferWizard.tsx`.
- Content-only: drops its own `<Dialog>` wrapper, takes `connection: Connection` as a prop, removes the in-wizard connection picker.
- Step 1 renames "Connection & Variant" → "Variant"; the connection name is shown in the wizard header so the operator knows which marketplace they're publishing to.
- `STEP_FIELDS[0]` shrinks to `['internalVariantId']`.
- Allegro plugin (`apps/web/src/plugins/allegro/index.ts`) registers the renamed wizard against `platformType: 'allegro'`.

## UX

- Operator clicks "Create offer" → small connection-picker dialog → Continue mounts the resolved plugin's wizard inside the same dialog.
- Retry path (`defaultConnectionId` from a failed `OfferCreationRecord`) auto-skips the picker.
- A connection whose `platformType` has no plugin contribution shows an inline "Marketplace not supported" alert with a Close button.

## Test plan

- [x] `pnpm lint` — clean (zero errors)
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — **1747 tests / 143 suites green**
- New: 5 resolver tests · 4 app-tier hook tests · 10 launcher tests
- Updated: `AllegroCreateOfferWizard.test.tsx` — connection-picker tests migrated to the launcher spec (explicit comment marks the migration). Connection-id integrity already covered by the existing submit assertion `createOffer(allegroConnection.id, …)`.

## Out of scope (deferred)

The wizard and its 8 Allegro-shaped helper files (`serialize-allegro-parameters`, `auto-prefill-parameters`, `build-parameters-zod-schema`, `CategoryPicker`, `category-parameters-step`, `category-parameter-form.types`, `category-parameter-visibility`, `create-offer-request-to-form-values`) **stay under `features/listings/`** for this PR. The architectural seam — what the issue is filed against — is what landed; the physical move to `features/allegro/` is a mechanical follow-up that gets its own issue.

## Implementation plan

Full plan at `docs/plans/implementation-plan-capability-offer-wizard.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
