### PR TITLE
feat(api): expose category resolution as HTTP endpoint (#631)

### DIFF
--- a/apps/api/src/listings/http/dto/resolve-category.dto.ts
+++ b/apps/api/src/listings/http/dto/resolve-category.dto.ts
@@ -1,0 +1,61 @@
+/**
+ * Resolve Category DTOs
+ *
+ * Request and response DTOs for the category-resolution endpoint (#631).
+ * Mirrors `CategoryResolutionInput` / `CategoryResolutionResult` from
+ * `@openlinker/core/listings` — the controller delegates straight to the
+ * service; this file is the validated boundary.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+import {
+  CategoryResolutionMethodValues,
+  type CategoryResolutionMethod,
+} from '@openlinker/core/listings';
+
+export class ResolveCategoryRequestDto {
+  @ApiPropertyOptional({
+    description: 'EAN or GTIN barcode for auto-detect (step 1). Omit to skip auto-detect.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  barcode?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Source platform category IDs for mapping fallback (step 2), ordered deepest-first. Omit to skip mapping.',
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @ArrayMaxSize(32)
+  sourceCategoryIds?: string[];
+}
+
+export class ResolveCategoryResponseDto {
+  @ApiProperty({
+    description: 'Resolved marketplace category ID, or null if the operator must pick manually.',
+    nullable: true,
+  })
+  allegroCategoryId!: string | null;
+
+  @ApiProperty({
+    description: 'Which step of the 3-step fallback produced the result.',
+    enum: CategoryResolutionMethodValues,
+  })
+  method!: CategoryResolutionMethod;
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -8,9 +8,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import type { CategoryParameter, OfferManagerPort, SellerPolicies } from '@openlinker/core/listings';
 import { CategoryNotFoundException } from '@openlinker/core/listings';
-import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
-import { OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, OFFER_CREATION_RECORD_REPOSITORY_TOKEN, OFFER_MAPPING_REPOSITORY_TOKEN, OfferCreationRecord, SELLER_POLICIES_SERVICE_TOKEN } from '@openlinker/core/listings';
-import type { IOfferCreationEnqueueService, ISellerPoliciesService, OfferCreationRecordRepositoryPort, OfferMappingRepositoryPort } from '@openlinker/core/listings';
+import { ConnectionNotFoundException, IdentifierMapping } from '@openlinker/core/identifier-mapping';
+import { CATEGORY_RESOLUTION_SERVICE_TOKEN, OFFER_CREATION_ENQUEUE_SERVICE_TOKEN, OFFER_CREATION_RECORD_REPOSITORY_TOKEN, OFFER_MAPPING_REPOSITORY_TOKEN, OfferCreationRecord, SELLER_POLICIES_SERVICE_TOKEN } from '@openlinker/core/listings';
+import type { ICategoryResolutionService, IOfferCreationEnqueueService, ISellerPoliciesService, OfferCreationRecordRepositoryPort, OfferMappingRepositoryPort } from '@openlinker/core/listings';
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
 import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
@@ -29,6 +29,7 @@ describe('ListingsController', () => {
   let sellerPolicies: jest.Mocked<ISellerPoliciesService>;
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let productVariantRepository: jest.Mocked<ProductVariantRepositoryPort>;
+  let categoryResolution: jest.Mocked<ICategoryResolutionService>;
 
   const mockMapping = new IdentifierMapping(
     'uuid-1',
@@ -89,6 +90,9 @@ describe('ListingsController', () => {
       upsertMany: jest.fn(),
       findMany: jest.fn(),
     };
+    categoryResolution = {
+      resolveCategory: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ListingsController],
@@ -100,6 +104,7 @@ describe('ListingsController', () => {
         { provide: SELLER_POLICIES_SERVICE_TOKEN, useValue: sellerPolicies },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
         { provide: PRODUCT_VARIANT_REPOSITORY_TOKEN, useValue: productVariantRepository },
+        { provide: CATEGORY_RESOLUTION_SERVICE_TOKEN, useValue: categoryResolution },
       ],
     }).compile();
 
@@ -619,6 +624,84 @@ describe('ListingsController', () => {
       await expect(controller.getCategoryParameters('conn-1', '257933')).rejects.toThrow(
         'upstream-503',
       );
+    });
+  });
+
+  describe('resolveCategory (#631)', () => {
+    // Opaque adapter — the integration-service mock returns it just to satisfy
+    // the pre-flight connection-validity check; the resolveCategory service
+    // is fully mocked, so the adapter's actual surface doesn't matter here.
+    const opaqueAdapter = { updateOfferQuantity: jest.fn() } as unknown as OfferManagerPort;
+
+    it('returns method=auto_detect when the barcode resolves', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(opaqueAdapter);
+      categoryResolution.resolveCategory.mockResolvedValue({
+        allegroCategoryId: '257933',
+        method: 'auto_detect',
+      });
+
+      const result = await controller.resolveCategory('conn-1', {
+        barcode: '5901234567890',
+      });
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith('conn-1', 'OfferManager');
+      expect(categoryResolution.resolveCategory).toHaveBeenCalledWith({
+        connectionId: 'conn-1',
+        barcode: '5901234567890',
+        sourceCategoryIds: undefined,
+      });
+      expect(result).toEqual({ allegroCategoryId: '257933', method: 'auto_detect' });
+    });
+
+    it('returns method=category_mapping when sourceCategoryIds resolve', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(opaqueAdapter);
+      categoryResolution.resolveCategory.mockResolvedValue({
+        allegroCategoryId: '12345',
+        method: 'category_mapping',
+      });
+
+      const result = await controller.resolveCategory('conn-1', {
+        sourceCategoryIds: ['ps-cat-99', 'ps-cat-7'],
+      });
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith('conn-1', 'OfferManager');
+      expect(categoryResolution.resolveCategory).toHaveBeenCalledWith({
+        connectionId: 'conn-1',
+        barcode: null,
+        sourceCategoryIds: ['ps-cat-99', 'ps-cat-7'],
+      });
+      expect(result).toEqual({ allegroCategoryId: '12345', method: 'category_mapping' });
+    });
+
+    it('returns method=manual with null allegroCategoryId when nothing resolves', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue(opaqueAdapter);
+      categoryResolution.resolveCategory.mockResolvedValue({
+        allegroCategoryId: null,
+        method: 'manual',
+      });
+
+      const result = await controller.resolveCategory('conn-1', {});
+
+      // `manual` is a normal outcome — the controller surfaces it as a 200
+      // response (decorator-level @HttpCode is implicit) with the null id.
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith('conn-1', 'OfferManager');
+      expect(result).toEqual({ allegroCategoryId: null, method: 'manual' });
+    });
+
+    it('propagates ConnectionNotFoundException from the pre-flight without calling resolveCategory', async () => {
+      // The domain exception the integrations service actually throws; the
+      // global filter maps it to a 404. The pre-flight is the value-add of
+      // this controller — without it, an unknown connection would silently
+      // fall through to method=manual inside the service.
+      integrationsService.getCapabilityAdapter.mockRejectedValue(
+        new ConnectionNotFoundException('conn-missing'),
+      );
+
+      await expect(
+        controller.resolveCategory('conn-missing', { barcode: '5901234567890' }),
+      ).rejects.toBeInstanceOf(ConnectionNotFoundException);
+
+      expect(categoryResolution.resolveCategory).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -30,6 +30,7 @@ import { randomUUID } from 'crypto';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import {
   CategoryNotFoundException,
+  CATEGORY_RESOLUTION_SERVICE_TOKEN,
   isCategoryParametersReader,
   isOfferReader,
   OFFER_CREATION_ENQUEUE_SERVICE_TOKEN,
@@ -39,6 +40,7 @@ import {
 } from '@openlinker/core/listings';
 import type {
   CategoryParameter,
+  ICategoryResolutionService,
   IOfferCreationEnqueueService,
   ISellerPoliciesService,
   OfferCreationRecord,
@@ -68,6 +70,10 @@ import {
   CategoryParametersListResponseDto,
   CategoryParameterResponseDto,
 } from './dto/category-parameter-response.dto';
+import {
+  ResolveCategoryRequestDto,
+  ResolveCategoryResponseDto,
+} from './dto/resolve-category.dto';
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -89,6 +95,8 @@ export class ListingsController {
     private readonly integrationsService: IIntegrationsService,
     @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
     private readonly productVariantRepository: ProductVariantRepositoryPort,
+    @Inject(CATEGORY_RESOLUTION_SERVICE_TOKEN)
+    private readonly categoryResolution: ICategoryResolutionService,
   ) {}
 
   @Get()
@@ -399,6 +407,54 @@ export class ListingsController {
     }
 
     return { parameters: parameters.map((p) => this.toCategoryParameterResponseDto(p)) };
+  }
+
+  @Post('connections/:connectionId/categories/resolve')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiOperation({
+    summary: 'Resolve marketplace category (EAN auto-match + mapping fallback) (#631)',
+    description:
+      'Runs the 3-step category-resolution chain — auto-detect by barcode → configured ' +
+      'source→marketplace mapping → manual — and returns the first hit. Mirrors the in-process ' +
+      'flow already used by OfferCreationExecutionService. Returns method=manual with ' +
+      'allegroCategoryId=null when nothing resolves (200, not 404 — manual is a normal outcome).',
+  })
+  @ApiResponse({ status: 200, description: 'Resolution result.', type: ResolveCategoryResponseDto })
+  @ApiResponse({ status: 404, description: 'Connection not found.' })
+  @ApiResponse({ status: 409, description: 'Connection disabled.' })
+  @ApiResponse({
+    status: 422,
+    description: 'Connection does not support OfferManager.',
+  })
+  async resolveCategory(
+    @Param('connectionId') connectionId: string,
+    @Body() dto: ResolveCategoryRequestDto,
+  ): Promise<ResolveCategoryResponseDto> {
+    // Validate the connection is a real, active marketplace before delegating.
+    // The `OfferManager` capability is the "is this a marketplace connection"
+    // gate — not a hard runtime requirement of the resolution algorithm. Step-2
+    // (category mapping) doesn't actually need an adapter (`mappingConfig` is a
+    // pure DB lookup); the pre-flight is here so unknown/disabled connections
+    // surface as 404/409 instead of silently falling through to `method=manual`
+    // inside the service. Matches the `categories/:categoryId/parameters` route.
+    // Throws ConnectionNotFoundException (404) / ConnectionDisabledException (409) /
+    // CapabilityNotSupportedException (422).
+    await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      connectionId,
+      'OfferManager',
+    );
+
+    const result = await this.categoryResolution.resolveCategory({
+      connectionId,
+      barcode: dto.barcode ?? null,
+      sourceCategoryIds: dto.sourceCategoryIds,
+    });
+
+    return {
+      allegroCategoryId: result.allegroCategoryId,
+      method: result.method,
+    };
   }
 
   private toCategoryParameterResponseDto(p: CategoryParameter): CategoryParameterResponseDto {

--- a/docs/plans/implementation-plan-631-category-resolution-endpoint.md
+++ b/docs/plans/implementation-plan-631-category-resolution-endpoint.md
@@ -1,0 +1,266 @@
+# Implementation Plan — #631 BE: Category Resolution HTTP endpoint
+
+## 1. Goal
+
+Expose `CategoryResolutionService.resolveCategory` via a new HTTP endpoint so the FE `CreateOfferWizard` can pre-fill the Allegro category from a variant's EAN (and from configured source→marketplace category mappings) before the operator hits the picker.
+
+**Layer:** Interface (HTTP). No CORE, application, or infrastructure changes.
+
+**Endpoint:**
+```
+POST /listings/connections/:connectionId/categories/resolve
+```
+
+**Non-goals:**
+- No domain or service changes — `CategoryResolutionService` stays untouched.
+- No new resolution algorithm — the existing 3-step fallback (auto-detect → mapping → manual) is exposed as-is.
+- No ambiguous-match list (Allegro can return multiple categories for a barcode; the service today returns at most one). If FE later needs the list, that's a follow-up touching the adapter, port, and service — out of scope here.
+- No batch endpoint (single resolution per call).
+
+## 2. Research notes
+
+### Service surface (already wired)
+`CategoryResolutionService` (`libs/core/src/listings/application/services/category-resolution.service.ts:35`) implements `ICategoryResolutionService.resolveCategory(input): Promise<CategoryResolutionResult>`. Token: `CATEGORY_RESOLUTION_SERVICE_TOKEN`, re-exported from `@openlinker/core/listings` (`libs/core/src/listings/index.ts:27`). Bound in `ListingsModule` and already injectable.
+
+Input shape (`libs/core/src/listings/application/types/category-resolution.types.ts:19`):
+```ts
+{
+  connectionId: string;       // path param, not body
+  barcode?: string | null;    // body
+  sourceCategoryIds?: string[]; // body, ordered deepest-first
+}
+```
+
+Result shape:
+```ts
+{
+  allegroCategoryId: string | null;
+  method: 'auto_detect' | 'category_mapping' | 'manual'; // CategoryResolutionMethodValues
+}
+```
+
+### Auth pattern in `ListingsController`
+The controller uses `@Roles('admin')` at class level. `JwtAuthGuard` is registered as a global `APP_GUARD` in `auth.module.ts:51`, so class-level `@Roles('admin')` is sufficient — no per-route `@UseGuards(JwtAuthGuard)` needed. The issue's "guard with `@UseGuards(JwtAuthGuard)`" is satisfied by the global JWT guard + the class-level `@Roles('admin')`.
+
+### Connection validation
+The existing `categories/:categoryId/parameters` route (lines 351-403) validates the connection by calling `integrationsService.getCapabilityAdapter<OfferManagerPort>(connectionId, 'OfferManager')` — which throws `ConnectionNotFoundException` (404) / `ConnectionDisabledException` (409) / `CapabilityNotSupportedException` (422) through the global filter. I'll do the same in `resolveCategory` BEFORE calling the service, so a missing/disabled/non-OfferManager connection short-circuits with the right HTTP status.
+
+Note that `CategoryResolutionService.tryAutoDetect` already catches adapter-resolve errors and falls through to mapping (line 80-85). If I relied on the service alone, an unknown connection would silently return `{ allegroCategoryId: null, method: 'manual' }` instead of 404 — which contradicts the acceptance criterion. The pre-flight `getCapabilityAdapter` call is the fix.
+
+### DTO conventions
+Request DTOs colocated under `apps/api/src/listings/http/dto/` use `class-validator` decorators (`@IsOptional`, `@IsString`, `@IsArray`, `@ArrayMaxSize` where appropriate) and Swagger annotations (`@ApiPropertyOptional`). Response DTOs use `@ApiProperty({ enum: ... })` for enum values. The `auto-match-variants.dto.ts` file is the closest precedent — same file holds the request and response classes.
+
+## 3. Step-by-step implementation
+
+### Step 1 — Create the request + response DTOs
+
+**File:** `apps/api/src/listings/http/dto/resolve-category.dto.ts` (new)
+
+Filename follows the verb-resource form used by `auto-match-variants.dto.ts` and `update-offer-fields.dto.ts` in the same folder. Two classes in one file (same precedent):
+
+```ts
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+import {
+  CategoryResolutionMethodValues,
+  type CategoryResolutionMethod,
+} from '@openlinker/core/listings';
+
+export class ResolveCategoryRequestDto {
+  @ApiPropertyOptional({
+    description: 'EAN or GTIN barcode for auto-detect (step 1). Omit to skip auto-detect.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  barcode?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Source platform category IDs for mapping fallback (step 2), ordered deepest-first. Omit to skip mapping.',
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @ArrayMaxSize(32)
+  sourceCategoryIds?: string[];
+}
+
+export class ResolveCategoryResponseDto {
+  @ApiProperty({
+    description: 'Resolved marketplace category ID, or null if the operator must pick manually.',
+    nullable: true,
+  })
+  allegroCategoryId!: string | null;
+
+  @ApiProperty({
+    description: 'Which step of the 3-step fallback produced the result.',
+    enum: CategoryResolutionMethodValues,
+  })
+  method!: CategoryResolutionMethod;
+}
+```
+
+**Why `MaxLength(64)` / `ArrayMaxSize(32)` / `@IsNotEmpty({ each: true })`:** lightweight bounds — EAN-13 is 13 chars, GTIN-14 is 14; 64 covers any practical barcode plus a margin. Source category paths are deepest-first lists; 32 is generous for any real tree depth and prevents accidental DoS. `@IsNotEmpty({ each: true })` rejects empty-string array elements at the boundary so a bad client doesn't fan out into no-op DB lookups inside `mappingConfig.resolveAllegroCategory`.
+
+(`CategoryResolutionMethodValues` and `CategoryResolutionMethod` are re-exported from `@openlinker/core/listings` at `libs/core/src/listings/index.ts:46-48` — confirmed.)
+
+### Step 2 — Add the controller route
+
+**File:** `apps/api/src/listings/http/listings.controller.ts`
+
+Imports — add to the existing groups:
+
+```ts
+// Add to existing @openlinker/core/listings imports:
+import { CATEGORY_RESOLUTION_SERVICE_TOKEN } from '@openlinker/core/listings';
+import type { ICategoryResolutionService } from '@openlinker/core/listings';
+
+// Add to existing local DTO imports:
+import {
+  ResolveCategoryRequestDto,
+  ResolveCategoryResponseDto,
+} from './dto/resolve-category.dto';
+```
+
+Inject — add a new constructor param at the end of the existing list:
+
+```ts
+@Inject(CATEGORY_RESOLUTION_SERVICE_TOKEN)
+private readonly categoryResolution: ICategoryResolutionService,
+```
+
+Route — place immediately after the existing `getCategoryParameters` route (line 351 block), keeping the categories-themed endpoints together:
+
+```ts
+@Post('connections/:connectionId/categories/resolve')
+@HttpCode(HttpStatus.OK)
+@ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+@ApiOperation({
+  summary: 'Resolve marketplace category (EAN auto-match + mapping fallback) (#631)',
+  description:
+    'Runs the 3-step category-resolution chain — auto-detect by barcode → configured ' +
+    'source→marketplace mapping → manual — and returns the first hit. Mirrors the in-process ' +
+    'flow already used by OfferCreationExecutionService. Returns method=manual with ' +
+    'allegroCategoryId=null when nothing resolves (200, not 404 — manual is a normal outcome).',
+})
+@ApiResponse({ status: 200, description: 'Resolution result.', type: ResolveCategoryResponseDto })
+@ApiResponse({ status: 404, description: 'Connection not found.' })
+@ApiResponse({ status: 409, description: 'Connection disabled.' })
+@ApiResponse({
+  status: 422,
+  description: 'Connection does not support OfferManager.',
+})
+async resolveCategory(
+  @Param('connectionId') connectionId: string,
+  @Body() dto: ResolveCategoryRequestDto,
+): Promise<ResolveCategoryResponseDto> {
+  // Validate the connection is a real, active marketplace before delegating.
+  // The `OfferManager` capability is the "is this a marketplace connection"
+  // gate — not a hard runtime requirement of the resolution algorithm. Step-2
+  // (category mapping) doesn't actually need an adapter (`mappingConfig` is a
+  // pure DB lookup); the pre-flight is here so unknown/disabled connections
+  // surface as 404/409 instead of silently falling through to `method=manual`
+  // inside the service. Matches the `categories/:categoryId/parameters` route.
+  // Throws ConnectionNotFoundException (404) / ConnectionDisabledException (409) /
+  // CapabilityNotSupportedException (422).
+  await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+    connectionId,
+    'OfferManager',
+  );
+
+  const result = await this.categoryResolution.resolveCategory({
+    connectionId,
+    barcode: dto.barcode ?? null,
+    sourceCategoryIds: dto.sourceCategoryIds,
+  });
+
+  return {
+    allegroCategoryId: result.allegroCategoryId,
+    method: result.method,
+  };
+}
+```
+
+### Step 3 — Controller spec
+
+**File:** `apps/api/src/listings/http/listings.controller.spec.ts`
+
+Add mock at the top alongside the existing service mocks:
+
+```ts
+let categoryResolution: jest.Mocked<ICategoryResolutionService>;
+```
+
+In `beforeEach`:
+```ts
+categoryResolution = { resolveCategory: jest.fn() };
+// ...
+{ provide: CATEGORY_RESOLUTION_SERVICE_TOKEN, useValue: categoryResolution },
+```
+
+New `describe('resolveCategory (#631)', …)` block at the end, with 4 cases per the issue acceptance criteria:
+
+1. `'returns method=auto_detect when the barcode resolves'`
+   - `integrationsService.getCapabilityAdapter.mockResolvedValue(/* anything */)`
+   - `categoryResolution.resolveCategory.mockResolvedValue({ allegroCategoryId: '257933', method: 'auto_detect' })`
+   - Call `controller.resolveCategory('conn-1', { barcode: '5901234567890' })`
+   - Assert: response shape, service called with `{ connectionId: 'conn-1', barcode: '5901234567890', sourceCategoryIds: undefined }`
+   - Assert: `integrationsService.getCapabilityAdapter` called with `('conn-1', 'OfferManager')`
+
+2. `'returns method=category_mapping when sourceCategoryIds resolve'`
+   - Service mock returns `{ allegroCategoryId: '12345', method: 'category_mapping' }`
+   - Call with `{ sourceCategoryIds: ['ps-cat-99', 'ps-cat-7'] }`
+   - Assert response method matches
+
+3. `'returns method=manual with null allegroCategoryId when nothing resolves'`
+   - Service mock returns `{ allegroCategoryId: null, method: 'manual' }`
+   - Call with `{}`
+   - Assert HTTP status is 200 (not 404) by virtue of the returned shape — verify `result.allegroCategoryId === null && result.method === 'manual'`. The `@HttpCode(HttpStatus.OK)` is decorator-level so unit tests can't observe it directly without `@nestjs/testing` HTTP boot; covering the shape is the testable invariant.
+
+4. `'propagates the 404 when the connection is not found (does not call resolveCategory)'`
+   - `integrationsService.getCapabilityAdapter.mockRejectedValue(new ConnectionNotFoundException('conn-missing'))`
+   - Expect `controller.resolveCategory('conn-missing', { barcode: '5901234567890' })` to reject
+   - Assert: `categoryResolution.resolveCategory` was NOT called (this is the value-add of the pre-flight check)
+
+Optional 5th case if it adds clarity: `'maps barcode=null when the body omits it'` — but the controller's `dto.barcode ?? null` is trivial enough that case 3 (empty body) already covers it.
+
+Use the same `OfferManagerPort` mock plumbing as `getCategoryParameters` already does — a stub that satisfies the type but doesn't need to implement any specific capability for `resolveCategory`. The service-resolve path is mocked, so the adapter object the integration service returns is essentially opaque for these tests.
+
+### Step 4 — Quality gate
+
+```bash
+pnpm lint        # 0 errors
+pnpm type-check  # clean across all packages
+pnpm test        # all unit suites pass; +4 new controller tests
+```
+
+## 4. Acceptance check vs issue
+
+- [x] `POST /listings/connections/:connectionId/categories/resolve` exists.
+- [x] Guarded by `JwtAuthGuard` via global `APP_GUARD` + class-level `@Roles('admin')`.
+- [x] Request DTO validates `barcode?: string` and `sourceCategoryIds?: string[]` with `class-validator`.
+- [x] Response shape matches `CategoryResolutionResult`.
+- [x] Delegates to `ICategoryResolutionService.resolveCategory` via `CATEGORY_RESOLUTION_SERVICE_TOKEN`; no business logic in the controller.
+- [x] 404 when connection is missing / disabled (via `getCapabilityAdapter` pre-flight).
+- [x] 200 with `method: 'manual'` and `allegroCategoryId: null` when nothing resolves.
+- [x] Swagger annotations present (`@ApiOperation`, `@ApiResponse`, `@ApiParam`, `@ApiProperty`).
+- [x] Spec covers auto-detect hit, mapping hit, manual outcome, missing connection 404.
+- [x] No CORE / application changes.
+
+## 5. Risks / notes
+
+- **Mass-assignment via DTO:** `class-validator` only rejects unknown properties when `ValidationPipe` is configured with `whitelist: true`. The wider API already runs validation pipes (this is consistent with every other DTO here), so extra fields are stripped or rejected per global config — not something this endpoint needs to re-configure.
+- **`barcode` length cap (64):** Defensive only. Real Allegro `matchCategoryByBarcode` calls have an upstream cap of their own; this just prevents the FE from sending unbounded strings before the adapter is asked.
+- **Manual-outcome HTTP status:** Returning 200 for `method: 'manual'` is explicit in the spec and matches the in-process service behaviour. A 404 here would conflate "connection missing" (a real configuration error) with "EAN not found in Allegro's catalog AND no mapping configured" (a normal flow that triggers the picker on the FE).


### PR DESCRIPTION
## Summary

- Adds `POST /listings/connections/:connectionId/categories/resolve` that delegates straight to the existing `CategoryResolutionService` — auto-detect by barcode → configured source→marketplace mapping → manual.
- Pure Interface-layer addition; no domain or application changes. `CategoryResolutionService` and `CATEGORY_RESOLUTION_SERVICE_TOKEN` were already wired in `ListingsModule`.
- Unblocks #632 (FE pre-fill Allegro category from EAN in CreateOfferWizard).

Closes #631

## What changed

| File | Change |
|---|---|
| `apps/api/src/listings/http/dto/resolve-category.dto.ts` (new) | `ResolveCategoryRequestDto` + `ResolveCategoryResponseDto`. Filename mirrors the verb-resource form of `auto-match-variants.dto.ts`. |
| `apps/api/src/listings/http/listings.controller.ts` | Inject `ICategoryResolutionService` via `CATEGORY_RESOLUTION_SERVICE_TOKEN`. Add `resolveCategory` route with pre-flight `getCapabilityAdapter('OfferManager')` validation. |
| `apps/api/src/listings/http/listings.controller.spec.ts` | New `describe('resolveCategory (#631)')` with 4 tests covering auto-detect, mapping, manual, and the `ConnectionNotFoundException` propagation path. |

## Behaviour contract

| Outcome | HTTP | Body |
|---|---|---|
| Barcode auto-detect hit | `200` | `{ allegroCategoryId, method: 'auto_detect' }` |
| Source→marketplace mapping hit | `200` | `{ allegroCategoryId, method: 'category_mapping' }` |
| Nothing resolves (operator picks manually) | `200` | `{ allegroCategoryId: null, method: 'manual' }` |
| Connection not found | `404` | (global filter) |
| Connection disabled | `409` | (global filter) |
| Connection missing `OfferManager` capability | `422` | (global filter) |

`method: 'manual'` is a **normal outcome**, not an error — the FE picker takes over from there.

## Design note: pre-flight connection check

The controller validates the connection with `integrationsService.getCapabilityAdapter('OfferManager')` *before* calling `resolveCategory`. Without it, an unknown connection would silently fall through to `method: 'manual'` inside the service (the service catches adapter-resolve errors in `tryAutoDetect` and returns `null`), which contradicts the acceptance criterion ("404 when connection not found"). The `OfferManager` capability is the "is this a real marketplace connection" gate — not a hard runtime requirement of the resolution algorithm (step-2 mapping is a pure DB lookup). Matches the existing `categories/:categoryId/parameters` route's connection-handling. Rationale captured in a 7-line comment inline.

## DTO validation bounds

- `barcode`: optional string, `@MaxLength(64)` (EAN-13 is 13 chars, GTIN-14 is 14; 64 covers any practical barcode with headroom).
- `sourceCategoryIds`: optional `string[]`, `@IsNotEmpty({ each: true })` to reject empty-string elements, `@ArrayMaxSize(32)` defensive cap.

## Test plan

- [x] `pnpm lint` — 0 errors (2 pre-existing warnings in unrelated `password-reset.service.spec.ts`)
- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm test` — all green; controller spec went 29 → 33 (+4 new resolveCategory tests)
- [ ] Manual smoke: hit `POST /listings/connections/{allegro-conn-id}/categories/resolve` with an EAN — assert `method: 'auto_detect'` and a valid Allegro category id when the EAN matches.
- [ ] Manual smoke: hit with `sourceCategoryIds: [ps-category-with-mapping]` — assert `method: 'category_mapping'`.
- [ ] Manual smoke: empty body — assert `200` with `method: 'manual'`, `allegroCategoryId: null`.
- [ ] Manual smoke: unknown connection — assert `404`.

## Notes for reviewer

- No new domain logic. The 3-step resolution algorithm stays in `CategoryResolutionService` untouched.
- No ambiguous-match list. Allegro's `/sale/matching-categories` can return multiple matches; the existing service returns at most one. If the FE later needs the ambiguous-match list, that's a follow-up touching the adapter, port, and service — explicitly out of scope.
- `POST` (not `GET`) — `sourceCategoryIds` is a list and this is a resolution operation against a connection, not a cacheable resource read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
