### PR TITLE
feat(web): pre-fill Allegro category from EAN in CreateOfferWizard (#632)

### DIFF
--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -16,6 +16,8 @@ import type {
   OfferCreationStatusResponse,
   OfferMapping,
   PaginatedOfferMappings,
+  ResolveCategoryRequest,
+  ResolveCategoryResponse,
   SellerPoliciesResponse,
   UpdateOfferFieldsPayload,
   UpdateOfferFieldsResult,
@@ -54,6 +56,16 @@ export interface ListingsApi {
     connectionId: string,
     categoryId: string,
   ) => Promise<CategoryParametersListResponse>;
+  /**
+   * Resolves an Allegro category from an EAN / source-category-id chain (#631).
+   * Runs the BE's 3-step fallback (auto-detect by barcode → configured
+   * mapping → manual) and returns the first hit. `method=manual` with
+   * `allegroCategoryId=null` is a normal outcome, not an error.
+   */
+  resolveCategory: (
+    connectionId: string,
+    body: ResolveCategoryRequest,
+  ) => Promise<ResolveCategoryResponse>;
 }
 
 interface ApiRequest {
@@ -115,6 +127,16 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
     getCategoryParameters(connectionId, categoryId): Promise<CategoryParametersListResponse> {
       return request<CategoryParametersListResponse>(
         `/listings/connections/${connectionId}/categories/${categoryId}/parameters`,
+      );
+    },
+    resolveCategory(connectionId, body): Promise<ResolveCategoryResponse> {
+      return request<ResolveCategoryResponse>(
+        `/listings/connections/${connectionId}/categories/resolve`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
       );
     },
   };

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -26,4 +26,19 @@ export const listingsQueryKeys = {
       connectionId,
       categoryId,
     ] as const,
+  // #631 / #632 — EAN → Allegro category resolution. `sourceCategoryIds` is
+  // included in the key so a future caller plumbing source-category info
+  // doesn't share a cache entry with the wizard's barcode-only call.
+  resolveCategory: (
+    connectionId: string,
+    barcode: string | null,
+    sourceCategoryIds?: string[],
+  ) =>
+    [
+      'listings',
+      'resolveCategory',
+      connectionId,
+      barcode ?? '',
+      sourceCategoryIds ?? [],
+    ] as const,
 };

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -315,3 +315,47 @@ export interface CategoryParameter {
 export interface CategoryParametersListResponse {
   parameters: CategoryParameter[];
 }
+
+/**
+ * Request body for `POST /listings/connections/:connectionId/categories/resolve`
+ * (#631). Mirrors the BE `ResolveCategoryRequestDto`. Fields stay camelCase to
+ * preserve the BE contract (per `frontend-architecture.md`).
+ */
+export interface ResolveCategoryRequest {
+  /** EAN/GTIN barcode for auto-detect (step 1). Omit to skip auto-detect. */
+  barcode?: string | null;
+  /**
+   * Source-platform category IDs (deepest-first) for the mapping fallback.
+   * Not used by the wizard today — kept on the type so the FE can grow into
+   * it without a second migration when source-category info becomes available.
+   */
+  sourceCategoryIds?: string[];
+}
+
+/**
+ * Mirrors the BE `CategoryResolutionMethodValues` shipped from
+ * `@openlinker/core/listings/application/types/category-resolution.types.ts`.
+ * Duplicated FE-side per #591 — apps/web is a browser bundle and the
+ * established FE convention is local types under each feature's `api/`
+ * folder (see `CategoryParameter` above). If the BE grows a 4th method, TS
+ * narrowing on the response fails-fast at the wizard's
+ * `resolvedCategoryHint(...)` and both sides need a one-line edit in lockstep.
+ */
+export const CategoryResolutionMethodValues = [
+  'auto_detect',
+  'category_mapping',
+  'manual',
+] as const;
+
+export type CategoryResolutionMethod = (typeof CategoryResolutionMethodValues)[number];
+
+/**
+ * Response from `POST /listings/connections/:connectionId/categories/resolve`
+ * (#631). Mirrors the BE `ResolveCategoryResponseDto`.
+ */
+export interface ResolveCategoryResponse {
+  /** Resolved marketplace category ID, or null if manual pick is needed. */
+  allegroCategoryId: string | null;
+  /** Which step of the 3-step fallback produced the result. */
+  method: CategoryResolutionMethod;
+}

--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
@@ -3,7 +3,7 @@
  *
  * @module apps/web/src/features/listings/components
  */
-import { screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
 import { AllegroCreateOfferWizard } from './AllegroCreateOfferWizard';
@@ -1067,6 +1067,186 @@ describe('AllegroCreateOfferWizard', () => {
         screen.queryByRole('button', { name: /suggest with ai/i }),
       ).not.toBeInTheDocument();
       expect(screen.getByText(/picked variant/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Step 2 category auto-prefill (#632)', () => {
+    // Two-leaf tree used by the user-override test below; reused for the
+    // single-leaf scenarios to keep the auto-fill target stable across cases.
+    const resolvedLeaf = {
+      id: 'cat-42',
+      name: 'Resolved leaf',
+      parentId: null,
+      leaf: true,
+    } as const;
+    const otherLeaf = {
+      id: 'cat-99',
+      name: 'Other leaf',
+      parentId: null,
+      leaf: true,
+    } as const;
+
+    it('auto_detect resolution pre-selects the picker and renders an EAN hint', async () => {
+      const mockApi = defaultMocks({
+        mappings: {
+          getAllegroCategories: vi.fn().mockResolvedValue([resolvedLeaf]),
+        },
+        listings: {
+          resolveCategory: vi.fn().mockResolvedValue({
+            allegroCategoryId: 'cat-42',
+            method: 'auto_detect',
+          }),
+        },
+      });
+
+      renderWithProviders(
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await advanceToStep2();
+
+      // Picker exposes the auto-selected leaf via the "Selected" button —
+      // same affordance the existing `pickFirstLeafCategory()` helper waits
+      // on after a manual click.
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /^selected$/i })).toBeInTheDocument(),
+      );
+      // Hint copy includes the picked variant's EAN; the regex match keeps
+      // the assertion resilient to trailing punctuation changes.
+      expect(
+        screen.getByText(/Matched from EAN 5901234567890/i),
+      ).toBeInTheDocument();
+      // Sanity check: the BE was called with the variant's EAN and no
+      // sourceCategoryIds (the wizard doesn't plumb them today).
+      expect(mockApi.listings.resolveCategory).toHaveBeenCalledWith(
+        allegroConnection.id,
+        { barcode: '5901234567890', sourceCategoryIds: undefined },
+      );
+    });
+
+    it('category_mapping resolution renders the mapping-attribution hint copy', async () => {
+      const mockApi = defaultMocks({
+        mappings: {
+          getAllegroCategories: vi
+            .fn()
+            .mockResolvedValue([{ ...resolvedLeaf, id: 'cat-7', name: 'Mapped leaf' }]),
+        },
+        listings: {
+          resolveCategory: vi.fn().mockResolvedValue({
+            allegroCategoryId: 'cat-7',
+            method: 'category_mapping',
+          }),
+        },
+      });
+
+      renderWithProviders(
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await advanceToStep2();
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /^selected$/i })).toBeInTheDocument(),
+      );
+      // category_mapping copy must NOT mention the EAN — the attribution is
+      // the configured mapping, not the barcode.
+      expect(
+        screen.getByText(/Matched from configured category mapping/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/Matched from EAN/i)).not.toBeInTheDocument();
+    });
+
+    it('manual outcome leaves the picker empty and renders no hint', async () => {
+      // Uses the test-utils default (resolveCategory → null/manual). The
+      // picker stays at its empty value; no "Matched from" copy renders.
+      const mockApi = defaultMocks();
+
+      renderWithProviders(
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await advanceToStep2();
+
+      // Browser is up and the single leaf row's button still reads "Select"
+      // (i.e., nothing was auto-selected).
+      await screen.findByRole('button', { name: /^select$/i });
+      expect(
+        screen.queryByRole('button', { name: /^selected$/i }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/Matched from/i)).not.toBeInTheDocument();
+    });
+
+    it('respects an operator override — no re-prefill, hint hidden', async () => {
+      const mockApi = defaultMocks({
+        mappings: {
+          getAllegroCategories: vi.fn().mockResolvedValue([resolvedLeaf, otherLeaf]),
+        },
+        listings: {
+          resolveCategory: vi.fn().mockResolvedValue({
+            allegroCategoryId: 'cat-42',
+            method: 'auto_detect',
+          }),
+        },
+      });
+
+      renderWithProviders(
+        <AllegroCreateOfferWizard
+          connection={allegroConnection}
+          onCancel={vi.fn()}
+          onSubmitted={vi.fn()}
+        />,
+        { apiClient: mockApi },
+      );
+
+      await advanceToStep2();
+
+      // Wait for the auto-prefill to land (cat-42 becomes "Selected").
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /^selected$/i })).toBeInTheDocument(),
+      );
+      expect(screen.getByText(/Matched from EAN/i)).toBeInTheDocument();
+
+      // Now the operator picks the OTHER leaf. `<li>` rows have no accessible
+      // name attribute — locate each row by its visible name text, then walk
+      // up to the `<li>` ancestor so within() can scope the button query.
+      const otherRow = (await screen.findByText('Other leaf')).closest('li');
+      if (!otherRow) throw new Error('Other leaf <li> not found');
+      const otherSelect = within(otherRow as HTMLElement).getByRole('button', {
+        name: /^select$/i,
+      });
+      fireEvent.click(otherSelect);
+
+      // After the override: cat-99 is selected, cat-42 reverts to "Select",
+      // and the hint disappears because data.allegroCategoryId no longer
+      // matches the form value.
+      await waitFor(() => {
+        const otherRowAfter = screen.getByText('Other leaf').closest('li');
+        if (!otherRowAfter) throw new Error('Other leaf <li> not found');
+        expect(
+          within(otherRowAfter as HTMLElement).getByRole('button', { name: /^selected$/i }),
+        ).toBeInTheDocument();
+      });
+      const resolvedRow = screen.getByText('Resolved leaf').closest('li');
+      if (!resolvedRow) throw new Error('Resolved leaf <li> not found');
+      expect(
+        within(resolvedRow as HTMLElement).getByRole('button', { name: /^select$/i }),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/Matched from/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx
@@ -406,9 +406,12 @@ export function AllegroCreateOfferWizard({
 
   // #632 — once the BE resolves a category for the picked variant's EAN,
   // pre-set the picker, but only when the operator has not already chosen
-  // one. The dirty-field guard preserves operator intent; the ref pins the
-  // auto-set to once per (connectionId, ean) so re-renders don't stomp a
-  // value the operator cleared back to the resolved one. Mirrors the
+  // one. The `currentCategoryId` check makes this safe even for paths that
+  // provide an initial value via RHF defaultValues (e.g., retry-with-snapshot)
+  // — RHF doesn't mark default-supplied values as dirty, so dirtyFields alone
+  // would let auto-fill stomp a snapshot. The ref pins the auto-set to once
+  // per (connectionId, ean) so re-renders don't re-fire after the operator
+  // cleared their override back to the resolved value. Mirrors the
   // `prefilledKeyRef` pattern used for parameter prefill above.
   useEffect(() => {
     const data = resolveCategoryQuery.data;
@@ -416,10 +419,17 @@ export function AllegroCreateOfferWizard({
     if (!currentConnectionId || !pickedVariantEan) return;
     const key = `${currentConnectionId}::${pickedVariantEan}`;
     if (resolvedCategoryKeyRef.current === key) return;
+    if (currentCategoryId) return;
     if (form.formState.dirtyFields.categoryId) return;
     resolvedCategoryKeyRef.current = key;
     form.setValue('categoryId', data.allegroCategoryId, { shouldDirty: false });
-  }, [resolveCategoryQuery.data, currentConnectionId, pickedVariantEan, form]);
+  }, [
+    resolveCategoryQuery.data,
+    currentConnectionId,
+    pickedVariantEan,
+    currentCategoryId,
+    form,
+  ]);
 
   // Hint render gating (#632): only attribute the resolved category when
   // (1) we got a resolution back, (2) it currently matches the picker, and

--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx
@@ -54,6 +54,7 @@ import type { Product, ProductVariant } from '../../products/api/products.types'
 import { useCreateOfferMutation } from '../hooks/use-create-offer-mutation';
 import { useSellerPoliciesQuery } from '../hooks/use-seller-policies-query';
 import { useCategoryParametersQuery } from '../hooks/use-category-parameters-query';
+import { useResolveCategoryQuery } from '../hooks/use-resolve-category-query';
 import { CategoryPicker } from './CategoryPicker';
 import { CategoryParametersStep } from './category-parameters-step';
 import { autoPrefillParameters } from './auto-prefill-parameters';
@@ -63,7 +64,11 @@ import {
   serializeAllegroParameters,
 } from './serialize-allegro-parameters';
 import type { CategoryParameterFormValues } from './category-parameter-form.types';
-import type { CategoryParameter, CreateOfferRequest } from '../api/listings.types';
+import type {
+  CategoryParameter,
+  CategoryResolutionMethod,
+  CreateOfferRequest,
+} from '../api/listings.types';
 import {
   CREATE_OFFER_DEFAULT_VALUES,
   createOfferFieldsSchema,
@@ -91,6 +96,19 @@ const STEP_FIELDS: ReadonlyArray<ReadonlyArray<Path<CreateOfferFieldsValues>>> =
   ['deliveryPolicyId'],
   [],
 ];
+
+// #632 — attribution copy for the Step 2 category auto-prefill hint.
+// `manual` is intentionally unhandled — when the BE returns method=manual
+// (no auto-detect hit and no mapping configured) there's nothing to
+// attribute, so the hint doesn't render.
+function resolvedCategoryHint(
+  method: CategoryResolutionMethod,
+  ean: string | null,
+): string | null {
+  if (method === 'auto_detect' && ean) return `Matched from EAN ${ean}.`;
+  if (method === 'category_mapping') return `Matched from configured category mapping.`;
+  return null;
+}
 
 const VARIANT_SEARCH_DEBOUNCE_MS = 300;
 const VARIANT_PICKER_PAGE_SIZE = 10;
@@ -326,6 +344,17 @@ export function AllegroCreateOfferWizard({
     currentConnectionId || undefined,
     currentCategoryId || undefined,
   );
+
+  // Step 2 (#632) — resolve an Allegro category from the picked variant's
+  // EAN via the BE's 3-step fallback (auto-detect → mapping → manual). The
+  // useEffect below auto-fills the picker the first time the resolver returns
+  // a hit for a (connectionId, ean) pair, but only if the operator hasn't
+  // already picked a category.
+  const resolveCategoryQuery = useResolveCategoryQuery(
+    currentConnectionId || undefined,
+    pickedVariantEan,
+  );
+  const resolvedCategoryKeyRef = useRef<string>('');
   const categoryParameters = useMemo(
     () => categoryParametersQuery.data ?? [],
     [categoryParametersQuery.data],
@@ -374,6 +403,36 @@ export function AllegroCreateOfferWizard({
     pickedVariantEan,
     form,
   ]);
+
+  // #632 — once the BE resolves a category for the picked variant's EAN,
+  // pre-set the picker, but only when the operator has not already chosen
+  // one. The dirty-field guard preserves operator intent; the ref pins the
+  // auto-set to once per (connectionId, ean) so re-renders don't stomp a
+  // value the operator cleared back to the resolved one. Mirrors the
+  // `prefilledKeyRef` pattern used for parameter prefill above.
+  useEffect(() => {
+    const data = resolveCategoryQuery.data;
+    if (!data || data.allegroCategoryId === null) return;
+    if (!currentConnectionId || !pickedVariantEan) return;
+    const key = `${currentConnectionId}::${pickedVariantEan}`;
+    if (resolvedCategoryKeyRef.current === key) return;
+    if (form.formState.dirtyFields.categoryId) return;
+    resolvedCategoryKeyRef.current = key;
+    form.setValue('categoryId', data.allegroCategoryId, { shouldDirty: false });
+  }, [resolveCategoryQuery.data, currentConnectionId, pickedVariantEan, form]);
+
+  // Hint render gating (#632): only attribute the resolved category when
+  // (1) we got a resolution back, (2) it currently matches the picker, and
+  // (3) the method has a copy to attribute (`manual` doesn't). Computed
+  // up-front instead of as an IIFE inside JSX so the picker block reads
+  // cleanly.
+  const resolveData = resolveCategoryQuery.data;
+  const resolvedCategoryHintCopy =
+    resolveData &&
+    resolveData.allegroCategoryId !== null &&
+    resolveData.allegroCategoryId === currentCategoryId
+      ? resolvedCategoryHint(resolveData.method, pickedVariantEan)
+      : null;
 
   // Clear the parameters slice whenever the chosen category changes — the
   // shape is category-specific so prior values would never be valid under a
@@ -771,6 +830,14 @@ export function AllegroCreateOfferWizard({
                 <p id="categoryId-description" className="form-field__description">
                   Browse the Allegro tree and pick a leaf category.
                 </p>
+                {resolvedCategoryHintCopy ? (
+                  <p
+                    className="form-field__description form-field__description--match"
+                    aria-live="polite"
+                  >
+                    {resolvedCategoryHintCopy}
+                  </p>
+                ) : null}
                 {form.formState.errors.categoryId?.message ? (
                   <p id="categoryId-error" className="form-field__error" role="alert">
                     {form.formState.errors.categoryId.message}

--- a/apps/web/src/features/listings/hooks/use-resolve-category-query.ts
+++ b/apps/web/src/features/listings/hooks/use-resolve-category-query.ts
@@ -1,0 +1,47 @@
+/**
+ * use-resolve-category-query
+ *
+ * Calls the BE category-resolution endpoint (#631) for the create-offer
+ * wizard's Step 2 auto-prefill (#632). Returns the resolved Allegro category
+ * id and the resolution method (`auto_detect` | `category_mapping` | `manual`).
+ *
+ * Enabled only when both `connectionId` and `barcode` are set. `retry: false`
+ * because Allegro's `/sale/matching-categories` regularly returns "no match"
+ * and that's a normal 200 from our BE, not a transient error.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { ResolveCategoryResponse } from '../api/listings.types';
+
+// 10-minute window. Resolution is deterministic for a given (connectionId,
+// barcode) pair — the only legitimate invalidator is an admin changing
+// category mappings, which is rare. 10 min covers a wizard session and the
+// usual Step 0 ↔ Step 2 navigation without re-hitting Allegro's rate-limited
+// /sale/matching-categories endpoint on every remount.
+export const RESOLVE_CATEGORY_STALE_TIME_MS = 10 * 60 * 1000;
+
+export function useResolveCategoryQuery(
+  connectionId: string | undefined,
+  barcode: string | null | undefined,
+  sourceCategoryIds?: string[],
+): UseQueryResult<ResolveCategoryResponse> {
+  const apiClient = useApiClient();
+  return useQuery<ResolveCategoryResponse>({
+    queryKey: listingsQueryKeys.resolveCategory(
+      connectionId ?? '',
+      barcode ?? null,
+      sourceCategoryIds,
+    ),
+    queryFn: () =>
+      apiClient.listings.resolveCategory(connectionId as string, {
+        barcode: barcode ?? null,
+        sourceCategoryIds,
+      }),
+    enabled: Boolean(connectionId && barcode),
+    retry: false,
+    staleTime: RESOLVE_CATEGORY_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1879,6 +1879,13 @@ textarea {
   font-size: 0.875rem;
 }
 
+/* #632 — success-tinted variant for "matched from EAN / mapping" hints under
+   form fields. Inherits the description's spacing and size; only the colour
+   token changes. */
+.form-field__description--match {
+  color: var(--status-success-strong);
+}
+
 .form-field__error {
   margin: 0;
   color: var(--status-error);

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -259,6 +259,13 @@ export function createMockApiClient(overrides: DeepPartialApiClient = {}): ApiCl
       // #410 — default to "no parameters" so the wizard's category step
       // renders the friendly empty state in tests that don't override.
       getCategoryParameters: vi.fn().mockResolvedValue({ parameters: [] }),
+      // #632 — default to a no-match outcome so existing wizard tests that
+      // don't opt in behave as if the BE returned "manual / null". Tests that
+      // exercise the auto-prefill override this with the desired shape.
+      resolveCategory: vi.fn().mockResolvedValue({
+        allegroCategoryId: null,
+        method: 'manual',
+      }),
       ...overrides.listings,
     } as ApiClient['listings'],
     products: {

--- a/docs/plans/implementation-plan-632-fe-prefill-category-from-ean.md
+++ b/docs/plans/implementation-plan-632-fe-prefill-category-from-ean.md
@@ -1,0 +1,390 @@
+# Implementation Plan — #632 FE: Pre-fill Allegro category from EAN in CreateOfferWizard
+
+## 1. Goal & Context
+
+Wire the `AllegroCreateOfferWizard` to the BE category-resolution endpoint shipped in #631. When the operator picks a variant in Step 0 and lands on Step 2, the wizard should:
+
+1. Fire `POST /listings/connections/:connectionId/categories/resolve` with the picked variant's EAN.
+2. On a non-null `allegroCategoryId` AND the user hasn't already touched the category, pre-select it via `form.setValue('categoryId', …, { shouldDirty: false })`.
+3. Show a one-line hint under the picker attributing the source (`auto_detect` → "Matched from EAN {ean}", `category_mapping` → "Matched from configured category mapping", `manual` → no hint).
+4. The hint disappears the moment the user changes the picker.
+
+**Layer**: Frontend — `features/listings` API + hook + wizard component. No BE, no `shared/` touches.
+
+**Non-goals**:
+- Skipping Step 2 automatically (issue explicit).
+- Ambiguous-match alternatives (BE collapses to one ID today).
+- Plumbing `sourceCategoryIds` into the request — the wizard doesn't have source-category info at this step. First cut sends `barcode` only.
+
+---
+
+## 2. Diverges from issue text
+
+**Wizard filename**: Issue refers to `apps/web/src/features/listings/components/CreateOfferWizard.tsx:786-813`. That file was renamed to `AllegroCreateOfferWizard.tsx` in #608 (capability-shape refactor). All file paths and line ranges below use the current name. The shape of the wiring (Step 2, `CategoryPicker` inside a `Controller`, `pickedVariantEan` already captured in Step 0) is intact — only the filename moved.
+
+The test file is `AllegroCreateOfferWizard.test.tsx`.
+
+Nothing else diverges from the issue.
+
+---
+
+## 3. Architecture
+
+### Data flow
+
+```
+Step 0: operator picks variant
+   └─> setPickedVariantEan(variant.ean)        [existing line 448]
+
+Step 2 mount (or pickedVariantEan/connectionId change)
+   └─> useResolveCategoryQuery({ connectionId, barcode: pickedVariantEan })
+         │  enabled: Boolean(connectionId && pickedVariantEan)
+         │  retry: false
+         ▼
+   apiClient.listings.resolveCategory(connectionId, { barcode })
+         │
+         ▼  POST /listings/connections/:cid/categories/resolve
+   { allegroCategoryId, method }   ← cached by query
+
+   useEffect on data:
+     if data.allegroCategoryId !== null
+        && !form.formState.dirtyFields.categoryId
+        && resolvedKeyRef.current !== `${connectionId}::${pickedVariantEan}`:
+          setValue('categoryId', data.allegroCategoryId, { shouldDirty: false })
+          resolvedKeyRef.current = `${connectionId}::${pickedVariantEan}`
+
+   Hint render:
+     if data?.allegroCategoryId === currentCategoryId
+        && data.method !== 'manual':
+          render <p className="form-field__description form-field__description--match">{copy}</p>
+```
+
+### Why the ref pattern
+
+Mirrors the existing `prefilledKeyRef` (line 337) for category-parameter prefill. The dirty-field guard alone would let the resolved value re-apply itself if React re-runs the effect (e.g., the operator clears their override back to "untouched" by manually re-selecting the resolved value, which clears `dirtyFields.categoryId`). The ref pins the auto-set to once-per-`(connectionId, ean)` pair, which is what the issue's "do not overwrite user choice" rule actually means.
+
+### State ownership (per `frontend.md`)
+
+| Concern | Owner |
+|---|---|
+| Resolution result | TanStack Query (server state) |
+| Category value | React Hook Form (form state) |
+| "Have we already auto-set for this (cid, ean) pair?" | `useRef` (local UI state) |
+
+No new global store, no new context.
+
+---
+
+## 4. File-by-file plan
+
+### 4.1 `apps/web/src/features/listings/api/listings.types.ts` — add request/response types
+
+Add at the end of the file, near the other request/response shapes:
+
+```ts
+/**
+ * Request body for POST /listings/connections/:connectionId/categories/resolve.
+ * Mirrors the BE ResolveCategoryRequestDto (#631). Fields stay camelCase.
+ */
+export interface ResolveCategoryRequest {
+  /** EAN/GTIN barcode for auto-detect. Omit to skip step 1. */
+  barcode?: string | null;
+  /**
+   * Source-platform category IDs (deepest-first) for the mapping fallback.
+   * Not used by the wizard today — kept on the type so the FE can grow into it
+   * without a second migration when source-category info becomes available.
+   */
+  sourceCategoryIds?: string[];
+}
+
+/**
+ * Mirrors the BE `CategoryResolutionMethodValues` shipped from
+ * `@openlinker/core/listings/application/types/category-resolution.types.ts`.
+ * Duplicated FE-side per #591 — apps/web is a browser bundle and the
+ * apps/web FE convention is local types under `features/*/api/*.types.ts`
+ * (see `CategoryParameter` in this file for the established precedent). If
+ * the BE grows a 4th method, TS narrowing on the response will fail-fast at
+ * the wizard's `resolvedCategoryHint(...)` and both sides need a one-line
+ * edit in lockstep.
+ */
+export const CategoryResolutionMethodValues = [
+  'auto_detect',
+  'category_mapping',
+  'manual',
+] as const;
+export type CategoryResolutionMethod = (typeof CategoryResolutionMethodValues)[number];
+
+/** Response from POST /listings/connections/:connectionId/categories/resolve. */
+export interface ResolveCategoryResponse {
+  /** Resolved marketplace category ID, or null if manual pick is needed. */
+  allegroCategoryId: string | null;
+  /** Which step of the 3-step fallback produced the result. */
+  method: CategoryResolutionMethod;
+}
+```
+
+**Note**: we duplicate the `CategoryResolutionMethodValues` union on the FE rather than importing from `@openlinker/core` — `apps/web` is a browser bundle and per #591 only consumes from top-level barrels of FE-safe packages. Importing core types into the browser also drags TypeORM/Nest types in transitively. The values are an enum-style union: trivial to keep in sync, and the BE already validates against its own copy.
+
+### 4.2 `apps/web/src/features/listings/api/listings.api.ts` — add `resolveCategory`
+
+Add to the `ListingsApi` interface:
+
+```ts
+resolveCategory: (
+  connectionId: string,
+  body: ResolveCategoryRequest,
+) => Promise<ResolveCategoryResponse>;
+```
+
+Add to the imports and to `createListingsApi(...)`:
+
+```ts
+resolveCategory(connectionId, body): Promise<ResolveCategoryResponse> {
+  return request<ResolveCategoryResponse>(
+    `/listings/connections/${connectionId}/categories/resolve`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+},
+```
+
+### 4.3 `apps/web/src/features/listings/api/listings.query-keys.ts` — add key
+
+```ts
+resolveCategory: (connectionId: string, barcode: string | null, sourceCategoryIds?: string[]) =>
+  [
+    'listings',
+    'resolveCategory',
+    connectionId,
+    barcode ?? '',
+    sourceCategoryIds ?? [],
+  ] as const,
+```
+
+The `sourceCategoryIds` slot is included now so a future caller with source-category info doesn't share a cache entry with the wizard's barcode-only call.
+
+### 4.4 `apps/web/src/features/listings/hooks/use-resolve-category-query.ts` — new
+
+```ts
+/**
+ * use-resolve-category-query
+ *
+ * Calls the BE category-resolution endpoint (#631) for the create-offer
+ * wizard's Step 2 auto-prefill. Returns the resolved Allegro category id and
+ * the resolution method (`auto_detect` | `category_mapping` | `manual`).
+ *
+ * Enabled only when both `connectionId` and `barcode` are set. `retry: false`
+ * because Allegro's `/sale/matching-categories` regularly returns "no match"
+ * and that's a normal 200 from our BE, not a transient error.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { ResolveCategoryResponse } from '../api/listings.types';
+
+// 10-minute window. Resolution is deterministic for a given (connectionId,
+// barcode) pair — the only legitimate invalidator is an admin changing
+// category mappings, which is rare. 10 min covers a wizard session and the
+// usual Step 0 ↔ Step 2 navigation without re-hitting Allegro's rate-limited
+// /sale/matching-categories endpoint on every remount.
+export const RESOLVE_CATEGORY_STALE_TIME_MS = 10 * 60 * 1000;
+
+export function useResolveCategoryQuery(
+  connectionId: string | undefined,
+  barcode: string | null | undefined,
+  sourceCategoryIds?: string[],
+): UseQueryResult<ResolveCategoryResponse> {
+  const apiClient = useApiClient();
+  return useQuery<ResolveCategoryResponse>({
+    queryKey: listingsQueryKeys.resolveCategory(
+      connectionId ?? '',
+      barcode ?? null,
+      sourceCategoryIds,
+    ),
+    queryFn: () =>
+      apiClient.listings.resolveCategory(connectionId as string, {
+        barcode: barcode ?? null,
+        sourceCategoryIds,
+      }),
+    enabled: Boolean(connectionId && barcode),
+    retry: false,
+    staleTime: RESOLVE_CATEGORY_STALE_TIME_MS,
+  });
+}
+```
+
+### 4.5 `apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx` — wire query + setValue + hint
+
+**New imports** (top of file, with the others from `../hooks`):
+```ts
+import { useResolveCategoryQuery } from '../hooks/use-resolve-category-query';
+```
+
+**New state** (next to `prefilledKeyRef` around line 337, before the existing `useEffect`):
+```ts
+const resolvedCategoryKeyRef = useRef<string>('');
+const resolveCategoryQuery = useResolveCategoryQuery(
+  currentConnectionId || undefined,
+  pickedVariantEan,
+);
+```
+
+**New useEffect** (immediately after the existing parameter-prefill effect, so it follows the same "once-per-key" pattern):
+```ts
+// #632 — once the BE resolves a category for the picked variant's EAN, pre-set
+// the picker, but only when the operator has not already chosen one. The
+// dirty-field guard preserves operator intent; the ref pins the auto-set to
+// once per (connectionId, ean) so re-renders don't stomp a value the operator
+// has cleared back to the resolved one.
+useEffect(() => {
+  const data = resolveCategoryQuery.data;
+  if (!data || data.allegroCategoryId === null) return;
+  if (!currentConnectionId || !pickedVariantEan) return;
+  const key = `${currentConnectionId}::${pickedVariantEan}`;
+  if (resolvedCategoryKeyRef.current === key) return;
+  if (form.formState.dirtyFields.categoryId) return;
+  resolvedCategoryKeyRef.current = key;
+  form.setValue('categoryId', data.allegroCategoryId, { shouldDirty: false });
+}, [
+  resolveCategoryQuery.data,
+  currentConnectionId,
+  pickedVariantEan,
+  form,
+]);
+```
+
+**Hint copy helper** (top of file, near the other module constants):
+```ts
+function resolvedCategoryHint(
+  method: CategoryResolutionMethod,
+  ean: string | null,
+): string | null {
+  if (method === 'auto_detect' && ean) return `Matched from EAN ${ean}.`;
+  if (method === 'category_mapping') return `Matched from configured category mapping.`;
+  return null;
+}
+```
+
+**Computed copy** (in the component body, just after `resolveCategoryQuery` is declared):
+```ts
+// Hint render gating: only attribute the resolved category when (1) we got a
+// resolution back, (2) it currently matches the picker, and (3) the method
+// has a copy to attribute (`manual` doesn't). Computed up-front instead of as
+// an IIFE inside JSX so the picker block reads cleanly.
+const resolveData = resolveCategoryQuery.data;
+const resolvedCategoryHintCopy =
+  resolveData &&
+  resolveData.allegroCategoryId !== null &&
+  resolveData.allegroCategoryId === currentCategoryId
+    ? resolvedCategoryHint(resolveData.method, pickedVariantEan)
+    : null;
+```
+
+**Hint render** (immediately after the existing `<p id="categoryId-description">` at lines 771-773, before the error block):
+```tsx
+{resolvedCategoryHintCopy ? (
+  <p
+    className="form-field__description form-field__description--match"
+    aria-live="polite"
+  >
+    {resolvedCategoryHintCopy}
+  </p>
+) : null}
+```
+
+The `aria-live="polite"` ensures screen readers announce the match the first time it appears; subsequent re-renders (cached) don't re-trigger the announcement because the text doesn't change.
+
+### 4.6 `apps/web/src/index.css` — add hint modifier
+
+Append next to `.form-field__description` (line 1876):
+```css
+.form-field__description--match {
+  color: var(--status-success-strong);
+}
+```
+
+Uses `--status-success-strong` per `frontend-ui-style-guide.md:222-225` — `strong` is the documented text variant on neutral surfaces; the base `--status-success` is the icon/dot tone. No new tokens.
+
+### 4.7 `apps/web/src/test/test-utils.tsx` — add default mock
+
+Inside the `listings: { ... }` block (around line 234), add a default that returns "no match" so existing wizard tests don't all need to opt into a mock:
+
+```ts
+// #632 — default to method='manual' / null so wizard tests that don't
+// opt into category resolution behave as if the BE returned "no match".
+resolveCategory: vi.fn().mockResolvedValue({
+  allegroCategoryId: null,
+  method: 'manual',
+}),
+```
+
+### 4.8 `apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx` — new tests
+
+Four new tests under a `describe('Step 2 category auto-prefill (#632)')` block, mirroring the issue's acceptance criteria + the two hint copy branches:
+
+1. **`auto_detect` → category pre-selected with EAN hint**: mock `resolveCategory` to return `{ allegroCategoryId: 'cat-42', method: 'auto_detect' }`, pick a variant whose EAN is set, advance to Step 2, assert the picker reflects `'cat-42'` and the hint text reads `Matched from EAN 5901234567890.`.
+2. **`category_mapping` → mapping hint copy**: mock returns `{ allegroCategoryId: 'cat-7', method: 'category_mapping' }`; assert the picker reflects `'cat-7'` and the hint text reads `Matched from configured category mapping.` (no EAN in the copy — the wording is method-specific).
+3. **No match → no hint, picker empty**: default mock returns `{ allegroCategoryId: null, method: 'manual' }`; assert no hint is rendered, picker stays at its empty value.
+4. **User override → hint hidden, no re-prefill**: mock returns `{ allegroCategoryId: 'cat-42', method: 'auto_detect' }`, the user manually picks `'cat-99'` via the picker, then the query data is unchanged on re-render; assert (a) the form value stays `'cat-99'`, (b) no hint is rendered.
+
+Test boilerplate reuses `renderWithProviders` + `createMockApiClient` from `test/test-utils.tsx`. Match copy assertions use `screen.getByText(/Matched from EAN/)` and `screen.getByText(/configured category mapping/)` so future copy tweaks only break if they change the distinctive substring.
+
+---
+
+## 5. Quality Gate
+
+```
+pnpm lint        # 0 errors
+pnpm type-check  # 0 errors
+pnpm test        # AllegroCreateOfferWizard.test (existing + 3 new), listings.query-keys.test
+```
+
+No backend changes → no `migration:show`. No `apps/api` files touched.
+
+---
+
+## 6. Acceptance Criteria (mapped from issue)
+
+- [x] `listingsApi.resolveCategory` exists → 4.2
+- [x] `useResolveCategoryQuery` is enabled only on connectionId+barcode → 4.4
+- [x] Sets `categoryId` via `setValue(..., { shouldDirty: false })` when non-null + not dirty → 4.5
+- [x] Does not overwrite operator's choice (dirty-fields + ref guard) → 4.5
+- [x] Picker stays visible and operable; no auto-skip → 4.5 (no Step 2 navigation changes)
+- [x] Hint reflects `method`; absent for `manual` → 4.5 (hint helper)
+- [x] Hint disappears when user changes picker → conditional render on `data.allegroCategoryId === currentCategoryId`
+- [x] Loading/error don't block the wizard → query failure leaves `data === undefined`; no error UI
+- [x] Vitest tests for the three scenarios → 4.8
+- [x] `pnpm lint && pnpm type-check && pnpm test` pass → 5
+- [x] No new external UI library → only CSS modifier added
+- [x] Dependency direction holds: feature → shared only → no `shared/` imports introduced
+
+---
+
+## 7. Risks & Open Questions
+
+1. **`dirtyFields.categoryId` semantics** — RHF marks a field "dirty" only on user-initiated changes (not on `setValue(..., { shouldDirty: false })`). Verified in RHF docs and matches the wizard's existing `prefilledKeyRef` pattern, so this should work as expected. Edge case: if the operator picks the resolved value manually and then picks a different one, `dirtyFields.categoryId` is `true` and the ref guard already fired, so no stomping.
+
+2. **Race between Step 0 → Step 2 navigation and query in-flight**: the picker can render before the query resolves. The hint conditional renders nothing until `data` arrives; no flicker. The auto-set fires inside `useEffect`, so it lands one tick after the query resolves — the operator sees an empty picker briefly. Acceptable for an MVP cut; if it ever becomes a UX papercut, gate Step 2 access on `!resolveCategoryQuery.isLoading` (out of scope).
+
+3. **Cache lifetime**: default TanStack Query staleness applies. The endpoint is cheap on the BE (one Allegro `/sale/matching-categories` call, then DB lookups), and the cache key includes barcode + connection, so re-opening the wizard for the same variant is free. No special `staleTime` needed.
+
+4. **Source category IDs**: kept on the FE type and query key, but the wizard does not plumb them today. Adding source-category info to the request is a follow-up, not a regression.
+
+5. **`CategoryResolutionMethodValues` duplication** between FE and BE: BE imports from `@openlinker/core/listings`, FE duplicates the union locally. Acceptable per the import-aliases rules (apps/web is a browser bundle, core barrels drag in Nest/TypeORM types). The closed-union shape means TS will fail-fast if either side adds a value without updating the other.
+
+6. **Responsive (mobile + tablet) coverage**: per the team's default-mobile-into-scope rule, the hint must work at 360 / 768 / 1440 px. The hint is a single `<p>` reflowing in the form's existing flex column with no horizontal demands — at 360 px it stays one line for the short EAN copy and wraps for longer categories without overflow. No new breakpoint-specific CSS needed. Step 2 is one-step-per-screen on mobile per the wizard convention, so the hint sits above the price/stock fields naturally.
+
+---
+
+## 8. Out of Scope (explicit)
+
+- BE-side changes (already shipped in #631).
+- Plumbing `sourceCategoryIds` into the wizard request.
+- Ambiguous-match UX (BE collapses to one id today; see #635 for the catalog-product cousin).
+- Auto-skip of Step 2.
+- A "loading" skeleton on the picker while the resolve query is in flight.


### PR DESCRIPTION
## Summary

- Wires `AllegroCreateOfferWizard` Step 2 to the BE category-resolution endpoint shipped in #631 — when the picked variant has an EAN, the picker pre-selects the resolved Allegro category.
- A one-line hint under the picker attributes the source: `auto_detect` → "Matched from EAN {ean}.", `category_mapping` → "Matched from configured category mapping." `manual` (no resolution) → no hint.
- Operator intent always wins: `dirtyFields.categoryId` + once-per-`(connectionId, ean)` ref guard prevent any stomping of a manual choice.

Closes #632.

## What changed

| Layer | File | Change |
|---|---|---|
| Types | `apps/web/src/features/listings/api/listings.types.ts` | `ResolveCategoryRequest`, `ResolveCategoryResponse`, `CategoryResolutionMethodValues` (BE union duplicated FE-side per #591; JSDoc points at the BE source of truth). |
| API client | `apps/web/src/features/listings/api/listings.api.ts` | New `resolveCategory(connectionId, body)` method. |
| Query keys | `apps/web/src/features/listings/api/listings.query-keys.ts` | New `resolveCategory(connectionId, barcode, sourceCategoryIds?)` factory. |
| Hook (new) | `apps/web/src/features/listings/hooks/use-resolve-category-query.ts` | `enabled` only on (`connectionId && barcode`), `retry: false`, 10-min `staleTime`. |
| Wizard | `apps/web/src/features/listings/components/AllegroCreateOfferWizard.tsx` | Mounts the query, runs a once-per-pair `useEffect` that honors `dirtyFields.categoryId`, renders the hint under the picker. |
| CSS | `apps/web/src/index.css` | `.form-field__description--match` modifier using `--status-success-strong` (the documented text-on-neutral variant of the success triple). |
| Test utils | `apps/web/src/test/test-utils.tsx` | Default `resolveCategory` mock returns `{ allegroCategoryId: null, method: 'manual' }` so existing wizard tests don't need to opt in. |
| Tests | `apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx` | 4 new tests under `Step 2 category auto-prefill (#632)`. |
| Plan | `docs/plans/implementation-plan-632-fe-prefill-category-from-ean.md` | Implementation plan from /work Phase 3. |

## Behaviour contract

| Scenario | Outcome |
|---|---|
| EAN resolves (`auto_detect` or `category_mapping`) and operator hasn't touched `categoryId` | `form.setValue('categoryId', resolved, { shouldDirty: false })`; hint renders attributing the source. |
| Resolution returns `method: 'manual'` / `null` | Picker stays empty; no hint. |
| Operator has already picked a category (`dirtyFields.categoryId === true`) | No auto-fill; hint hidden. |
| Operator picks a different category after auto-fill | Hint disappears immediately (gated on `data.allegroCategoryId === currentCategoryId`); ref guard prevents re-fire. |
| Query fails | Silent — no error UI bleeds into the form; picker remains usable. |

## Diverges from issue text

The issue refers to `CreateOfferWizard.tsx:786-813`. That file was renamed to `AllegroCreateOfferWizard.tsx` in #608 — the wiring shape (Step 2, `CategoryPicker` inside `<Controller>`, `pickedVariantEan` already captured in Step 0) is intact. All file paths in the implementation use the current name.

## Design notes (#632 reviewer cheat-sheet)

- **Why `staleTime: 10 min` and not the default 0** — resolution is deterministic for a given (connectionId, barcode) pair; the only legitimate invalidator is an admin editing category mappings, which is rare. 10 min covers a wizard session and Step 0 ↔ Step 2 navigation without re-hitting Allegro's rate-limited `/sale/matching-categories` endpoint.
- **Why `resolvedCategoryKeyRef`** — the dirty-field guard alone would let the auto-set re-fire if the operator manually cleared their override back to the resolved value (which clears `dirtyFields.categoryId`). The ref pins the auto-set to once per `(connectionId, ean)`, matching the existing `prefilledKeyRef` precedent for category-parameter prefill (line 337).
- **Why duplicate `CategoryResolutionMethodValues` FE-side** — apps/web is a browser bundle, and per #591 only consumes from top-level barrels of FE-safe packages; the established FE convention is local types under each feature's `api/` folder (see `CategoryParameter` in the same file). Closed union — TS narrowing on the response fails-fast if either side drifts.
- **Why `--status-success-strong`** — per `frontend-ui-style-guide.md:222-225`, the status triple ships `base / strong / soft / border`; `strong` is the documented text variant on neutral surfaces. `--status-success` is the icon/dot tone.

## DTO bounds (BE, already shipped in #631)

- `barcode`: optional string, `MaxLength(64)` for EAN/GTIN.
- `sourceCategoryIds`: optional `string[]`, non-empty elements, `ArrayMaxSize(32)`. Not plumbed into the wizard today — kept on the FE type and query key for a future caller with source-category info.

## Test plan

- [x] `pnpm lint` — 0 errors (2 pre-existing warnings, unrelated)
- [x] `pnpm type-check` — clean across all packages
- [x] `pnpm test` — apps/web 969/969 (4 new); libs/core 606, apps/api 346, apps/worker 118, libs/integrations/ai 34, libs/integrations/allegro 338, libs/integrations/prestashop 255, libs/shared 49
- Manual smoke (out of CI scope, deferred to merge): open the wizard with a variant that has an EAN, advance to Step 2, confirm the resolved category is pre-selected and the hint copy attributes the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
