### PR TITLE
refactor(web): plugin-aware nav groups and route-colocated breadcrumbs (#610)

### DIFF
--- a/apps/web/src/app/app-shell.test.tsx
+++ b/apps/web/src/app/app-shell.test.tsx
@@ -7,13 +7,20 @@
  *
  * @module shared/ui
  */
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryRouter,
+  useNavigate,
+  type RouteObject,
+} from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './app-shell';
+import type { RouteCrumbHandle } from './nav-registry.types';
 import { SessionProvider } from '../shared/auth/session-provider';
 import type { SessionAdapter } from '../shared/auth/session-adapter';
 import { ToastProvider } from '../shared/ui/toast-provider';
@@ -31,6 +38,47 @@ interface RenderShellOptions {
   sessionAdapter?: SessionAdapter;
 }
 
+const PAGE_CONTENT = <div data-testid="page-content">Page content</div>;
+
+const dashboardCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Dashboard' },
+};
+const connectionsCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Platform', title: 'Connections' },
+};
+
+function ShellLayout({ children }: { children: ReactNode }): ReactElement {
+  return <AppShell>{children}</AppShell>;
+}
+
+/**
+ * Build a minimal data-router tree wrapping `AppShell`. We can't use the
+ * real `rootRoute` here — it imports lazy page modules that pull the full
+ * feature graph — but we mirror the route shape the shell expects:
+ * an outer layout route whose children carry the crumb `handle`s the test
+ * pathnames need. The wildcard `*` child has no handle so the
+ * unknown-routes fallback test exercises the `DEFAULT_CRUMB` branch.
+ */
+function buildShellRouter(pathname: string): ReturnType<typeof createMemoryRouter> {
+  const routes: RouteObject[] = [
+    {
+      path: '/',
+      element: (
+        <ShellLayout>
+          <Outlet />
+        </ShellLayout>
+      ),
+      children: [
+        { index: true, handle: dashboardCrumb, element: PAGE_CONTENT },
+        { path: 'connections', handle: connectionsCrumb, element: PAGE_CONTENT },
+        { path: 'orders', element: PAGE_CONTENT },
+        { path: '*', element: PAGE_CONTENT },
+      ],
+    },
+  ];
+  return createMemoryRouter(routes, { initialEntries: [pathname] });
+}
+
 function renderShell({
   apiClient = createMockApiClient(),
   pathname = '/',
@@ -38,6 +86,7 @@ function renderShell({
 }: RenderShellOptions = {}): ReturnType<typeof render> {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const adapter = sessionAdapter ?? createAuthenticatedSessionAdapter();
+  const router = buildShellRouter(pathname);
 
   return render(
     <ThemeProvider>
@@ -45,11 +94,7 @@ function renderShell({
         <ToastProvider>
           <ApiClientProvider client={apiClient}>
             <QueryClientProvider client={queryClient}>
-              <MemoryRouter initialEntries={[pathname]}>
-                <AppShell>
-                  <div data-testid="page-content">Page content</div>
-                </AppShell>
-              </MemoryRouter>
+              <RouterProvider router={router} />
             </QueryClientProvider>
           </ApiClientProvider>
         </ToastProvider>
@@ -241,24 +286,31 @@ describe('AppShell', () => {
     const adapter = createAuthenticatedSessionAdapter();
     const apiClient = createMockApiClient();
 
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          element: (
+            <AppShell>
+              <Outlet />
+            </AppShell>
+          ),
+          children: [
+            { index: true, handle: dashboardCrumb, element: <Redirector to="/orders" /> },
+            { path: 'orders', element: PAGE_CONTENT },
+          ],
+        },
+      ],
+      { initialEntries: ['/'] },
+    );
+
     render(
       <ThemeProvider>
         <SessionProvider adapter={adapter}>
           <ToastProvider>
             <ApiClientProvider client={apiClient}>
               <QueryClientProvider client={queryClient}>
-                <MemoryRouter initialEntries={['/']}>
-                  <Routes>
-                    <Route
-                      path="*"
-                      element={
-                        <AppShell>
-                          <Redirector to="/orders" />
-                        </AppShell>
-                      }
-                    />
-                  </Routes>
-                </MemoryRouter>
+                <RouterProvider router={router} />
               </QueryClientProvider>
             </ApiClientProvider>
           </ToastProvider>

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -20,10 +20,11 @@ import {
   type PropsWithChildren,
   type ReactElement,
 } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, useLocation, useMatches } from 'react-router-dom';
 import { useSession } from '../shared/auth/use-session';
-import { mergePluginNavContributions } from '../plugins/merge-nav-contributions';
-import { plugins } from '../plugins';
+import { resolveCrumbFromMatches } from './breadcrumbs';
+import { buildNavGroups } from './nav-registry';
+import type { NavGroup } from './nav-registry.types';
 import { useNavCounts, type NavCounts } from './hooks/use-nav-counts';
 import { Button } from '../shared/ui/button';
 import { EnvironmentBadge } from '../shared/ui/environment-badge';
@@ -37,139 +38,6 @@ import {
 } from '../shared/ui/dropdown-menu';
 import { ThemeToggle } from '../shared/ui/theme-toggle';
 import { useToast } from '../shared/ui/toast-provider';
-
-type NavCountKey = Exclude<keyof NavCounts, never>;
-
-export interface LiveNavItem {
-  countKey?: NavCountKey;
-  end?: boolean;
-  label: string;
-  to: string;
-}
-
-interface PlannedNavItem {
-  label: string;
-  reason?: string;
-}
-
-export interface LiveNavGroup {
-  items: LiveNavItem[];
-  kind: 'live';
-  label: string;
-}
-
-interface PlannedNavGroup {
-  items: PlannedNavItem[];
-  kind: 'planned';
-  label: string;
-}
-
-export type NavGroup = LiveNavGroup | PlannedNavGroup;
-
-interface NavGroupOptions {
-  isAdmin: boolean;
-}
-
-/**
- * Build the sidebar nav composition for the current session. Admin-only
- * groups (AI) are spliced in at build time so non-admin sessions never see
- * them in the DOM — no client-side permission filtering at render.
- */
-function buildNavGroups({ isAdmin }: NavGroupOptions): NavGroup[] {
-  const groups: NavGroup[] = [
-    {
-      kind: 'live',
-      label: 'Operations',
-      items: [
-        { to: '/', label: 'Dashboard', end: true },
-        { to: '/orders', label: 'Orders', countKey: 'orders' },
-        { to: '/products', label: 'Products' },
-        { to: '/inventory', label: 'Inventory', countKey: 'inventory' },
-        { to: '/customers', label: 'Customers', countKey: 'customers' },
-        { to: '/listings', label: 'Listings', countKey: 'listings' },
-      ],
-    },
-    {
-      kind: 'live',
-      label: 'Diagnostics',
-      items: [
-        { to: '/jobs-logs', label: 'Jobs & Logs', countKey: 'jobsFailed' },
-        { to: '/webhook-deliveries', label: 'Webhooks', countKey: 'webhooksFailed' },
-        { to: '/cursors', label: 'Cursors' },
-      ],
-    },
-    {
-      kind: 'live',
-      label: 'Platform',
-      items: [
-        { to: '/connections', label: 'Connections', countKey: 'connections' },
-        { to: '/adapters', label: 'Adapters' },
-        { to: '/settings', label: 'Settings' },
-      ],
-    },
-  ];
-
-  if (isAdmin) {
-    groups.push({
-      kind: 'live',
-      label: 'AI',
-      items: [
-        { to: '/ai/prompt-templates', label: 'Prompt templates' },
-        { to: '/ai/provider-settings', label: 'Provider settings' },
-      ],
-    });
-  }
-
-  groups.push({
-    kind: 'planned',
-    label: 'Planned',
-    items: [
-      { label: 'Automations', reason: 'Coming in a future release' },
-      { label: 'Shipping', reason: 'Coming in a future release' },
-      { label: 'Invoices', reason: 'Coming in a future release' },
-    ],
-  });
-
-  return groups;
-}
-
-const staticCrumbs: Record<string, { group: string; title: string }> = {
-  '/': { group: 'Operations', title: 'Dashboard' },
-  '/orders': { group: 'Operations', title: 'Orders' },
-  '/orders/failed': { group: 'Operations', title: 'Failed orders' },
-  '/products': { group: 'Operations', title: 'Products' },
-  '/inventory': { group: 'Operations', title: 'Inventory' },
-  '/customers': { group: 'Operations', title: 'Customers' },
-  '/listings': { group: 'Operations', title: 'Listings' },
-  '/jobs-logs': { group: 'Diagnostics', title: 'Jobs & Logs' },
-  '/webhook-deliveries': { group: 'Diagnostics', title: 'Webhooks' },
-  '/cursors': { group: 'Diagnostics', title: 'Cursors' },
-  '/connections': { group: 'Platform', title: 'Connections' },
-  '/connections/new': { group: 'Platform', title: 'New connection' },
-  '/connections/new/allegro': { group: 'Platform', title: 'Connect Allegro' },
-  '/connections/new/prestashop': { group: 'Platform', title: 'Connect PrestaShop' },
-  '/connections/new/advanced': { group: 'Platform', title: 'Advanced setup' },
-  '/adapters': { group: 'Platform', title: 'Adapters' },
-  '/settings': { group: 'Platform', title: 'Settings' },
-  '/ai/prompt-templates': { group: 'AI', title: 'Prompt templates' },
-  '/ai/provider-settings': { group: 'AI', title: 'Provider settings' },
-};
-
-function resolveCrumbs(pathname: string): { group: string; title: string } {
-  const exact = staticCrumbs[pathname];
-  if (exact) return exact;
-
-  if (pathname.startsWith('/orders/')) return { group: 'Operations', title: 'Order' };
-  if (pathname.startsWith('/products/')) return { group: 'Operations', title: 'Product' };
-  if (pathname.startsWith('/inventory/')) return { group: 'Operations', title: 'Inventory item' };
-  if (pathname.startsWith('/customers/')) return { group: 'Operations', title: 'Customer' };
-  if (pathname.startsWith('/listings/')) return { group: 'Operations', title: 'Listing' };
-  if (pathname.startsWith('/jobs-logs/')) return { group: 'Diagnostics', title: 'Job' };
-  if (pathname.startsWith('/connections/')) return { group: 'Platform', title: 'Connection' };
-  if (pathname.startsWith('/ai/prompt-templates/')) return { group: 'AI', title: 'Prompt template' };
-
-  return { group: 'OpenLinker', title: '' };
-}
 
 const COUNT_FORMATTER = new Intl.NumberFormat('en-US');
 
@@ -344,11 +212,8 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
   const counts = useNavCounts();
   const isAdmin =
     isReady && session.status === 'authenticated' && session.user?.role === 'admin';
-  const groups = useMemo(() => {
-    const baseGroups = buildNavGroups({ isAdmin });
-    const contributions = plugins.flatMap((plugin) => plugin.navItems ?? []);
-    return mergePluginNavContributions(baseGroups, contributions);
-  }, [isAdmin]);
+  const groups = useMemo(() => buildNavGroups({ isAdmin }), [isAdmin]);
+  const matches = useMatches();
 
   const closeDrawer = useCallback((): void => {
     drawerRef.current?.close();
@@ -369,7 +234,7 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
     })();
   }, [clearSession, showToast]);
 
-  const crumbs = resolveCrumbs(location.pathname);
+  const crumbs = resolveCrumbFromMatches(matches);
 
   return (
     <div className="shell">

--- a/apps/web/src/app/breadcrumbs.test.ts
+++ b/apps/web/src/app/breadcrumbs.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Breadcrumb resolver tests
+ *
+ * Pin the deepest-match-wins semantics of `resolveCrumbFromMatches`. Feeds
+ * synthetic `useMatches()` results and asserts the resolved crumb; covers
+ * deepest-wins, missing handle → fallback, and non-crumb-shaped handles
+ * (e.g. arbitrary strings) being ignored by the guard.
+ *
+ * @module app
+ */
+import type { UIMatch } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_CRUMB, resolveCrumbFromMatches } from './breadcrumbs';
+
+type Match = UIMatch<unknown, unknown>;
+
+function match(id: string, handle: unknown): Match {
+  return {
+    id,
+    pathname: '/' + id,
+    params: {},
+    data: undefined,
+    handle,
+    loaderData: undefined,
+  };
+}
+
+describe('resolveCrumbFromMatches', () => {
+  it('returns the default crumb when no match carries a handle', () => {
+    expect(resolveCrumbFromMatches([])).toEqual(DEFAULT_CRUMB);
+  });
+
+  it('returns the deepest match that carries a crumb-shaped handle', () => {
+    const matches: Match[] = [
+      match('root', undefined),
+      match('orders', { crumb: { group: 'Operations', title: 'Orders' } }),
+      match('order-detail', { crumb: { group: 'Operations', title: 'Order' } }),
+    ];
+
+    expect(resolveCrumbFromMatches(matches)).toEqual({
+      group: 'Operations',
+      title: 'Order',
+    });
+  });
+
+  it('walks past matches without a handle to find a deeper one', () => {
+    const matches: Match[] = [
+      match('root', undefined),
+      match('parent', { crumb: { group: 'Platform', title: 'Connections' } }),
+      match('child', undefined),
+    ];
+
+    // Deepest with a handle wins.
+    expect(resolveCrumbFromMatches(matches)).toEqual({
+      group: 'Platform',
+      title: 'Connections',
+    });
+  });
+
+  it('falls back to the default when only non-crumb-shaped handles are present', () => {
+    const matches: Match[] = [
+      match('root', 'just-a-string'),
+      match('child', { somethingElse: true }),
+    ];
+
+    expect(resolveCrumbFromMatches(matches)).toEqual(DEFAULT_CRUMB);
+  });
+
+  it('skips a non-crumb handle deeper in the chain and uses a valid one above', () => {
+    const matches: Match[] = [
+      match('root', { crumb: { group: 'Operations', title: 'Dashboard' } }),
+      match('child', 'bogus-handle'),
+    ];
+
+    expect(resolveCrumbFromMatches(matches)).toEqual({
+      group: 'Operations',
+      title: 'Dashboard',
+    });
+  });
+
+  it('returns a fresh object so callers cannot mutate the DEFAULT_CRUMB constant', () => {
+    const first = resolveCrumbFromMatches([]);
+    const second = resolveCrumbFromMatches([]);
+
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+  });
+});

--- a/apps/web/src/app/breadcrumbs.ts
+++ b/apps/web/src/app/breadcrumbs.ts
@@ -1,0 +1,40 @@
+/**
+ * Breadcrumb resolver
+ *
+ * Pure helper consumed by `AppShell` to derive the current breadcrumb from
+ * the React Router match chain. Each authenticated route module sets
+ * `handle: { crumb: { group, title } } satisfies RouteCrumbHandle` and the
+ * resolver walks the match list deepest-first, returning the first crumb
+ * it finds. When no match carries a crumb, the fallback is the same
+ * shape the legacy `resolveCrumbs()` returned for unknown paths.
+ *
+ * Extracted so the merge logic stays unit-testable without booting the
+ * shell or the React Router data-router runtime.
+ *
+ * @module app
+ * @see nav-registry.types.ts — `RouteCrumbHandle` + `isCrumbHandle` guard
+ */
+import type { useMatches } from 'react-router-dom';
+
+import { isCrumbHandle } from './nav-registry.types';
+
+export const DEFAULT_CRUMB = { group: 'OpenLinker', title: '' } as const;
+
+/**
+ * Walk the React Router match chain deepest-first and return the first
+ * crumb-shaped `handle`. Falls back to `DEFAULT_CRUMB` when nothing in the
+ * chain carries crumb metadata.
+ */
+export function resolveCrumbFromMatches(
+  matches: ReturnType<typeof useMatches>,
+): { group: string; title: string } {
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const handle = matches[i].handle;
+    if (isCrumbHandle(handle)) {
+      return handle.crumb;
+    }
+  }
+  // Spread to return a fresh object — `DEFAULT_CRUMB` is `as const`, and we
+  // don't want callers to mutate the shared constant by accident.
+  return { ...DEFAULT_CRUMB };
+}

--- a/apps/web/src/app/layouts/authenticated-app-layout.test.tsx
+++ b/apps/web/src/app/layouts/authenticated-app-layout.test.tsx
@@ -1,8 +1,19 @@
-import { screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
-import { Route, Routes } from 'react-router-dom';
 import { AuthenticatedAppLayout } from './authenticated-app-layout';
-import { createAuthenticatedSessionAdapter, renderWithProviders } from '../../test/test-utils';
+import { ApiClientProvider } from '../api/api-client-provider';
+import type { SessionAdapter } from '../../shared/auth/session-adapter';
+import { SessionProvider } from '../../shared/auth/session-provider';
+import { ThemeProvider } from '../../shared/theme/theme-provider';
+import { ToastProvider } from '../../shared/ui/toast-provider';
+import { createNoopSessionAdapter } from '../../shared/auth/noop-session-adapter';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+} from '../../test/test-utils';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 function TestChild(): React.ReactElement {
   return <div>Authenticated content</div>;
@@ -12,15 +23,37 @@ function LoginSentinel(): React.ReactElement {
   return <div>Login page</div>;
 }
 
-function renderLayout(sessionAdapter?: ReturnType<typeof createAuthenticatedSessionAdapter>): void {
-  renderWithProviders(
-    <Routes>
-      <Route path="/" element={<AuthenticatedAppLayout />}>
-        <Route index element={<TestChild />} />
-      </Route>
-      <Route path="/login" element={<LoginSentinel />} />
-    </Routes>,
-    { sessionAdapter },
+const indexCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Dashboard' },
+};
+
+function renderLayout(sessionAdapter?: SessionAdapter): void {
+  const adapter = sessionAdapter ?? createNoopSessionAdapter();
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <AuthenticatedAppLayout />,
+        children: [{ index: true, handle: indexCrumb, element: <TestChild /> }],
+      },
+      { path: '/login', element: <LoginSentinel /> },
+    ],
+    { initialEntries: ['/'] },
+  );
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  render(
+    <ThemeProvider>
+      <SessionProvider adapter={adapter}>
+        <ToastProvider>
+          <ApiClientProvider client={createMockApiClient()}>
+            <QueryClientProvider client={queryClient}>
+              <RouterProvider router={router} />
+            </QueryClientProvider>
+          </ApiClientProvider>
+        </ToastProvider>
+      </SessionProvider>
+    </ThemeProvider>,
   );
 }
 

--- a/apps/web/src/app/nav-registry.ts
+++ b/apps/web/src/app/nav-registry.ts
@@ -1,0 +1,104 @@
+/**
+ * Nav registry
+ *
+ * Static data + builder helper for the FE chrome's sidebar nav. Previously
+ * lived inside `app-shell.tsx` as an inline `buildNavGroups()` function;
+ * extracted in #610 so plugins can contribute admin-only items via
+ * `NavContribution.requiresRole` and so future extension points (a third
+ * role, a different group ordering) can grow without touching the shell.
+ *
+ * Plugin nav contributions are still merged via
+ * `mergePluginNavContributions` from `plugins/merge-nav-contributions.ts`;
+ * the only change is that this module now owns the base groups and the
+ * role-gate filter that runs before merging.
+ *
+ * @module app
+ * @see nav-registry.types.ts — the type and guard exports
+ * @see plugins/merge-nav-contributions.ts — plugin contribution merge logic
+ */
+import { mergePluginNavContributions } from '../plugins/merge-nav-contributions';
+import { plugins } from '../plugins';
+import type { NavGroup, NavRegistryGroup } from './nav-registry.types';
+
+/**
+ * Canonical sidebar composition. The shell consumes whatever this builder
+ * resolves at render time after filtering by session role and folding plugin
+ * contributions in.
+ */
+export const BASE_NAV_GROUPS: readonly NavRegistryGroup[] = [
+  {
+    kind: 'live',
+    label: 'Operations',
+    items: [
+      { to: '/', label: 'Dashboard', end: true },
+      { to: '/orders', label: 'Orders', countKey: 'orders' },
+      { to: '/products', label: 'Products' },
+      { to: '/inventory', label: 'Inventory', countKey: 'inventory' },
+      { to: '/customers', label: 'Customers', countKey: 'customers' },
+      { to: '/listings', label: 'Listings', countKey: 'listings' },
+    ],
+  },
+  {
+    kind: 'live',
+    label: 'Diagnostics',
+    items: [
+      { to: '/jobs-logs', label: 'Jobs & Logs', countKey: 'jobsFailed' },
+      { to: '/webhook-deliveries', label: 'Webhooks', countKey: 'webhooksFailed' },
+      { to: '/cursors', label: 'Cursors' },
+    ],
+  },
+  {
+    kind: 'live',
+    label: 'Platform',
+    items: [
+      { to: '/connections', label: 'Connections', countKey: 'connections' },
+      { to: '/adapters', label: 'Adapters' },
+      { to: '/settings', label: 'Settings' },
+    ],
+  },
+  {
+    kind: 'live',
+    label: 'AI',
+    requiresRole: 'admin',
+    items: [
+      { to: '/ai/prompt-templates', label: 'Prompt templates' },
+      { to: '/ai/provider-settings', label: 'Provider settings' },
+    ],
+  },
+  {
+    kind: 'planned',
+    label: 'Planned',
+    items: [
+      { label: 'Automations', reason: 'Coming in a future release' },
+      { label: 'Shipping', reason: 'Coming in a future release' },
+      { label: 'Invoices', reason: 'Coming in a future release' },
+    ],
+  },
+];
+
+export interface BuildNavGroupsInput {
+  isAdmin: boolean;
+}
+
+/**
+ * Build the sidebar nav composition for the current session.
+ *
+ * Filters the static `BASE_NAV_GROUPS` against the session role, then folds
+ * in plugin contributions via the existing `mergePluginNavContributions`
+ * helper. Admin-only items contributed by plugins are also filtered out for
+ * non-admin sessions — no client-side permission filtering at render.
+ */
+export function buildNavGroups({ isAdmin }: BuildNavGroupsInput): NavGroup[] {
+  // `mergePluginNavContributions` already deep-clones each group before
+  // mutating it, so we can pass the readonly array directly without an
+  // intermediate spread.
+  const baseGroups: NavGroup[] = BASE_NAV_GROUPS.filter((group) => {
+    if (group.kind === 'live' && group.requiresRole === 'admin' && !isAdmin) {
+      return false;
+    }
+    return true;
+  });
+
+  const contributions = plugins.flatMap((plugin) => plugin.navItems ?? []);
+  return mergePluginNavContributions(baseGroups, contributions, { isAdmin });
+}

--- a/apps/web/src/app/nav-registry.types.ts
+++ b/apps/web/src/app/nav-registry.types.ts
@@ -1,0 +1,91 @@
+/**
+ * Nav registry types
+ *
+ * Type definitions for the FE chrome's nav-group registry and route-colocated
+ * breadcrumb metadata. Plugins consume these types when declaring nav
+ * contributions (`NavContribution.requiresRole`) and routes when declaring
+ * crumb metadata (`route.handle = { crumb: { group, title } }`).
+ *
+ * Lives in a `*.types.ts` sibling of `nav-registry.ts` per the engineering-
+ * standards rule on separating type definitions from implementations.
+ *
+ * @module app
+ * @see nav-registry.ts — `BASE_NAV_GROUPS` data + `buildNavGroups` helper
+ * @see breadcrumbs.ts — `resolveCrumbFromMatches` consumes `isCrumbHandle`
+ */
+import type { NavCounts } from './hooks/use-nav-counts';
+
+/**
+ * Roles that the FE chrome gates against. Runtime array + derived union
+ * follows the `as const` pattern from engineering standards § "Union Types".
+ *
+ * Today only `'admin'` is gated; the array exists so adding another role
+ * (e.g. `'operator'`) is a single-file change rather than a type-rename
+ * propagation across the contribution surface.
+ */
+export const RoleValues = ['admin'] as const;
+export type Role = (typeof RoleValues)[number];
+
+export type NavCountKey = keyof NavCounts;
+
+/**
+ * One leaf nav item under a live nav group. Mirrors the existing shape that
+ * `app-shell.tsx` consumed inline before #610.
+ */
+export interface LiveNavItem {
+  countKey?: NavCountKey;
+  end?: boolean;
+  label: string;
+  to: string;
+}
+
+export interface PlannedNavItem {
+  label: string;
+  reason?: string;
+}
+
+export interface LiveNavGroup {
+  items: LiveNavItem[];
+  kind: 'live';
+  label: string;
+  /** Declarative role gate — admin-only groups are filtered out for non-admin sessions. */
+  requiresRole?: Role;
+}
+
+export interface PlannedNavGroup {
+  items: PlannedNavItem[];
+  kind: 'planned';
+  label: string;
+}
+
+export type NavGroup = LiveNavGroup | PlannedNavGroup;
+
+/**
+ * Registry-shaped variant of `NavGroup`. Mirrors the runtime shape but
+ * carries the optional `requiresRole` gate on every variant; the gate is
+ * applied during `buildNavGroups` and stripped before reaching the shell.
+ */
+export type NavRegistryGroup = LiveNavGroup | PlannedNavGroup;
+export type NavRegistryItem = LiveNavItem | PlannedNavItem;
+
+/**
+ * Route-colocated breadcrumb metadata. Each route module sets
+ * `handle: { crumb: { group, title } } satisfies RouteCrumbHandle` and the
+ * shell's `resolveCrumbFromMatches` walks `useMatches()` deepest-first to
+ * find the active crumb.
+ */
+export interface RouteCrumbHandle {
+  crumb: { group: string; title: string };
+}
+
+/**
+ * Type guard for `RouteObject.handle` — React Router types `handle` as
+ * `unknown`, so consumers must narrow before reading `.crumb`.
+ */
+export function isCrumbHandle(handle: unknown): handle is RouteCrumbHandle {
+  if (!handle || typeof handle !== 'object') return false;
+  const crumb = (handle as { crumb?: unknown }).crumb;
+  if (!crumb || typeof crumb !== 'object') return false;
+  const { group, title } = crumb as { group?: unknown; title?: unknown };
+  return typeof group === 'string' && typeof title === 'string';
+}

--- a/apps/web/src/app/routes/adapters.route.tsx
+++ b/apps/web/src/app/routes/adapters.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const adaptersRoute: RouteObject = {
   path: 'adapters',
+  handle: { crumb: { group: 'Platform', title: 'Adapters' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { AdaptersCatalogPage } = await import('../../pages/adapters/adapters-catalog-page');
     return { Component: AdaptersCatalogPage };

--- a/apps/web/src/app/routes/advanced-new-connection.route.tsx
+++ b/apps/web/src/app/routes/advanced-new-connection.route.tsx
@@ -2,9 +2,11 @@
  * Route: `/connections/new/advanced` — raw connection form fallback.
  */
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const advancedNewConnectionRoute: RouteObject = {
   path: 'connections/new/advanced',
+  handle: { crumb: { group: 'Platform', title: 'Advanced setup' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { AdvancedNewConnectionPage } = await import(
       '../../pages/connections/advanced-new-connection-page'

--- a/apps/web/src/app/routes/ai-provider-settings.route.tsx
+++ b/apps/web/src/app/routes/ai-provider-settings.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const aiProviderSettingsRoute: RouteObject = {
   path: 'ai/provider-settings',
+  handle: { crumb: { group: 'AI', title: 'Provider settings' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { AiProviderSettingsPage } = await import(
       '../../pages/ai-provider-settings/ai-provider-settings-page'

--- a/apps/web/src/app/routes/connection-category-mappings.route.tsx
+++ b/apps/web/src/app/routes/connection-category-mappings.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const connectionCategoryMappingsRoute: RouteObject = {
   path: 'connections/:connectionId/mappings/categories',
+  handle: { crumb: { group: 'Platform', title: 'Connection' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { ConnectionCategoryMappingsPage } = await import(
       '../../pages/connections/connection-category-mappings-page'

--- a/apps/web/src/app/routes/connection-detail.route.tsx
+++ b/apps/web/src/app/routes/connection-detail.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const connectionDetailRoute: RouteObject = {
   path: 'connections/:connectionId',
+  handle: { crumb: { group: 'Platform', title: 'Connection' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { ConnectionDetailPage } = await import(
       '../../pages/connections/connection-detail-page'

--- a/apps/web/src/app/routes/connection-mappings.route.tsx
+++ b/apps/web/src/app/routes/connection-mappings.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const connectionMappingsRoute: RouteObject = {
   path: 'connections/:connectionId/mappings',
+  handle: { crumb: { group: 'Platform', title: 'Connection' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { ConnectionMappingsPage } = await import(
       '../../pages/connections/connection-mappings-page'

--- a/apps/web/src/app/routes/connections.route.tsx
+++ b/apps/web/src/app/routes/connections.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const connectionsRoute: RouteObject = {
   path: 'connections',
+  handle: { crumb: { group: 'Platform', title: 'Connections' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { ConnectionsListPage } = await import(
       '../../pages/connections/connections-list-page'

--- a/apps/web/src/app/routes/cursors.route.tsx
+++ b/apps/web/src/app/routes/cursors.route.tsx
@@ -1,10 +1,16 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const cursorsListCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Diagnostics', title: 'Cursors' },
+};
 
 export const cursorsRoute: RouteObject = {
   path: 'cursors',
   children: [
     {
       index: true,
+      handle: cursorsListCrumb,
       lazy: async () => {
         const { CursorsListPage } = await import('../../pages/cursors/cursors-list-page');
         return { Component: CursorsListPage };

--- a/apps/web/src/app/routes/customers.route.tsx
+++ b/apps/web/src/app/routes/customers.route.tsx
@@ -1,10 +1,19 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const customersListCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Customers' },
+};
+const customerDetailCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Customer' },
+};
 
 export const customersRoute: RouteObject = {
   path: 'customers',
   children: [
     {
       index: true,
+      handle: customersListCrumb,
       lazy: async () => {
         const { CustomersListPage } = await import('../../pages/customers/customers-list-page');
         return { Component: CustomersListPage };
@@ -12,6 +21,7 @@ export const customersRoute: RouteObject = {
     },
     {
       path: ':id',
+      handle: customerDetailCrumb,
       lazy: async () => {
         const { CustomerDetailPage } = await import('../../pages/customers/customer-detail-page');
         return { Component: CustomerDetailPage };

--- a/apps/web/src/app/routes/dashboard.route.tsx
+++ b/apps/web/src/app/routes/dashboard.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const dashboardRoute: RouteObject = {
   index: true,
+  handle: { crumb: { group: 'Operations', title: 'Dashboard' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { DashboardPage } = await import('../../pages/dashboard/dashboard-page');
     return { Component: DashboardPage };

--- a/apps/web/src/app/routes/edit-connection.route.tsx
+++ b/apps/web/src/app/routes/edit-connection.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const editConnectionRoute: RouteObject = {
   path: 'connections/:connectionId/edit',
+  handle: { crumb: { group: 'Platform', title: 'Connection' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { EditConnectionPage } = await import(
       '../../pages/connections/edit-connection-page'

--- a/apps/web/src/app/routes/inventory.route.tsx
+++ b/apps/web/src/app/routes/inventory.route.tsx
@@ -1,10 +1,19 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const inventoryListCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Inventory' },
+};
+const inventoryDetailCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Inventory item' },
+};
 
 export const inventoryRoute: RouteObject = {
   path: 'inventory',
   children: [
     {
       index: true,
+      handle: inventoryListCrumb,
       lazy: async () => {
         const { InventoryListPage } = await import('../../pages/inventory/inventory-list-page');
         return { Component: InventoryListPage };
@@ -12,6 +21,7 @@ export const inventoryRoute: RouteObject = {
     },
     {
       path: ':id',
+      handle: inventoryDetailCrumb,
       lazy: async () => {
         const { InventoryDetailPage } = await import(
           '../../pages/inventory/inventory-detail-page'

--- a/apps/web/src/app/routes/jobs-logs.route.tsx
+++ b/apps/web/src/app/routes/jobs-logs.route.tsx
@@ -1,10 +1,19 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const jobsListCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Diagnostics', title: 'Jobs & Logs' },
+};
+const jobDetailCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Diagnostics', title: 'Job' },
+};
 
 export const jobsLogsRoute: RouteObject = {
   path: 'jobs-logs',
   children: [
     {
       index: true,
+      handle: jobsListCrumb,
       lazy: async () => {
         const { SyncJobsPage } = await import('../../pages/sync-jobs/sync-jobs-page');
         return { Component: SyncJobsPage };
@@ -12,6 +21,7 @@ export const jobsLogsRoute: RouteObject = {
     },
     {
       path: ':id',
+      handle: jobDetailCrumb,
       lazy: async () => {
         const { SyncJobDetailPage } = await import(
           '../../pages/sync-jobs/sync-job-detail-page'

--- a/apps/web/src/app/routes/listings.route.tsx
+++ b/apps/web/src/app/routes/listings.route.tsx
@@ -1,10 +1,19 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const listingsListCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Listings' },
+};
+const listingDetailCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Listing' },
+};
 
 export const listingsRoute: RouteObject = {
   path: 'listings',
   children: [
     {
       index: true,
+      handle: listingsListCrumb,
       lazy: async () => {
         const { ListingsListPage } = await import('../../pages/listings/listings-list-page');
         return { Component: ListingsListPage };
@@ -12,6 +21,7 @@ export const listingsRoute: RouteObject = {
     },
     {
       path: ':id',
+      handle: listingDetailCrumb,
       lazy: async () => {
         const { ListingDetailPage } = await import('../../pages/listings/listing-detail-page');
         return { Component: ListingDetailPage };

--- a/apps/web/src/app/routes/new-connection.route.tsx
+++ b/apps/web/src/app/routes/new-connection.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const newConnectionRoute: RouteObject = {
   path: 'connections/new',
+  handle: { crumb: { group: 'Platform', title: 'New connection' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { NewConnectionPage } = await import('../../pages/connections/new-connection-page');
     return { Component: NewConnectionPage };

--- a/apps/web/src/app/routes/orders.route.tsx
+++ b/apps/web/src/app/routes/orders.route.tsx
@@ -1,10 +1,22 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const ordersListCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Orders' },
+};
+const failedOrdersCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Failed orders' },
+};
+const orderDetailCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Order' },
+};
 
 export const ordersRoute: RouteObject = {
   path: 'orders',
   children: [
     {
       index: true,
+      handle: ordersListCrumb,
       lazy: async () => {
         const { OrdersListPage } = await import('../../pages/orders/orders-list-page');
         return { Component: OrdersListPage };
@@ -12,6 +24,7 @@ export const ordersRoute: RouteObject = {
     },
     {
       path: 'failed',
+      handle: failedOrdersCrumb,
       lazy: async () => {
         const { FailedOrdersPage } = await import('../../pages/orders/failed-orders-page');
         return { Component: FailedOrdersPage };
@@ -19,6 +32,7 @@ export const ordersRoute: RouteObject = {
     },
     {
       path: ':internalOrderId',
+      handle: orderDetailCrumb,
       lazy: async () => {
         const { OrderDetailPage } = await import('../../pages/orders/order-detail-page');
         return { Component: OrderDetailPage };

--- a/apps/web/src/app/routes/products.route.tsx
+++ b/apps/web/src/app/routes/products.route.tsx
@@ -1,10 +1,19 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const productsListCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Products' },
+};
+const productDetailCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Product' },
+};
 
 export const productsRoute: RouteObject = {
   path: 'products',
   children: [
     {
       index: true,
+      handle: productsListCrumb,
       lazy: async () => {
         const { ProductsListPage } = await import('../../pages/products/products-list-page');
         return { Component: ProductsListPage };
@@ -12,6 +21,7 @@ export const productsRoute: RouteObject = {
     },
     {
       path: ':id',
+      handle: productDetailCrumb,
       lazy: async () => {
         const { ProductDetailPage } = await import('../../pages/products/product-detail-page');
         return { Component: ProductDetailPage };

--- a/apps/web/src/app/routes/prompt-template-detail.route.tsx
+++ b/apps/web/src/app/routes/prompt-template-detail.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const promptTemplateDetailRoute: RouteObject = {
   path: 'ai/prompt-templates/:id',
+  handle: { crumb: { group: 'AI', title: 'Prompt template' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { PromptTemplateDetailPage } = await import(
       '../../pages/prompt-templates/prompt-template-detail-page'

--- a/apps/web/src/app/routes/prompt-templates-list.route.tsx
+++ b/apps/web/src/app/routes/prompt-templates-list.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const promptTemplatesListRoute: RouteObject = {
   path: 'ai/prompt-templates',
+  handle: { crumb: { group: 'AI', title: 'Prompt templates' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { PromptTemplatesListPage } = await import(
       '../../pages/prompt-templates/prompt-templates-list-page'

--- a/apps/web/src/app/routes/route-handle.test.ts
+++ b/apps/web/src/app/routes/route-handle.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Route handle contract test
+ *
+ * Iterates every authenticated route registered with the host (core children
+ * of `rootRoute` plus every plugin's contributed routes) and asserts each
+ * leaf carries a crumb-shaped `handle`. Parameterized so a copy-paste
+ * regression on any single file fails this test — mirrors the
+ * `route-lazy.test.ts` pattern.
+ *
+ * Guest routes (`login`, `forgot-password`, `reset-password`) render outside
+ * `AuthenticatedAppLayout` / `AppShell`, so `useMatches()` inside the shell
+ * never sees them — they are intentionally excluded.
+ *
+ * Legacy-redirect routes that render an inline `<Navigate>` element with
+ * neither `lazy` nor `children` are transient (the user is redirected before
+ * the shell renders a crumb) and are also excluded.
+ *
+ * @module app/routes
+ * @see ../breadcrumbs.ts — `resolveCrumbFromMatches` consumes `handle.crumb`
+ * @see ../nav-registry.types.ts — `RouteCrumbHandle` shape + `isCrumbHandle`
+ */
+import type { RouteObject } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { plugins } from '../../plugins';
+import { isCrumbHandle } from '../nav-registry.types';
+import { coreChildren } from './root.route';
+
+/**
+ * Walk the route tree depth-first and collect every **lazy** leaf node —
+ * defined as a node that renders content via `lazy: () => …` and has no
+ * `children` of its own (so the deepest match really is this row). The
+ * `lazy` check is load-bearing: it intentionally skips
+ *
+ *   - `<Navigate>`-element legacy redirects (no `lazy`, only `element`);
+ *   - eager-element guest routes like `loginRoute` (not in `coreChildren`
+ *     anyway, but defensive).
+ *
+ * Every authenticated page module is lazy today (#606). If a future
+ * authenticated route lands as eager `element:`, broaden this filter to
+ * `route.lazy === 'function' || route.element !== undefined` so it still
+ * gets crumb-contract coverage.
+ */
+function collectLazyAuthenticatedLeafRoutes(routes: RouteObject[]): RouteObject[] {
+  const out: RouteObject[] = [];
+  for (const route of routes) {
+    if (route.children && route.children.length > 0) {
+      out.push(...collectLazyAuthenticatedLeafRoutes(route.children));
+      continue;
+    }
+    if (typeof route.lazy === 'function') {
+      out.push(route);
+    }
+  }
+  return out;
+}
+
+const leafRoutes = collectLazyAuthenticatedLeafRoutes([
+  ...coreChildren,
+  ...plugins.flatMap((plugin) => plugin.routes ?? []),
+]);
+
+describe('route handle contract', () => {
+  it('every authenticated leaf route is discoverable', () => {
+    // Sanity check: the contract test only fires if we actually picked up
+    // routes. A regression that returns an empty array (e.g. changed route
+    // tree shape) should fail loudly here rather than silently pass.
+    expect(leafRoutes.length).toBeGreaterThan(0);
+  });
+
+  it.each(
+    leafRoutes.map((route) => [describePath(route), route] as const),
+  )('route %s declares a crumb-shaped handle', (_label, route) => {
+    expect(isCrumbHandle(route.handle)).toBe(true);
+  });
+});
+
+function describePath(route: RouteObject): string {
+  if (route.index === true) return '<index>';
+  return route.path ?? '<unknown>';
+}

--- a/apps/web/src/app/routes/settings.route.tsx
+++ b/apps/web/src/app/routes/settings.route.tsx
@@ -1,7 +1,9 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
 
 export const settingsRoute: RouteObject = {
   path: 'settings',
+  handle: { crumb: { group: 'Platform', title: 'Settings' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { SettingsPage } = await import('../../pages/settings/settings-page');
     return { Component: SettingsPage };

--- a/apps/web/src/app/routes/webhook-deliveries.route.tsx
+++ b/apps/web/src/app/routes/webhook-deliveries.route.tsx
@@ -1,10 +1,19 @@
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const webhooksListCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Diagnostics', title: 'Webhooks' },
+};
+const webhookDetailCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Diagnostics', title: 'Webhook' },
+};
 
 export const webhookDeliveriesRoute: RouteObject = {
   path: 'webhook-deliveries',
   children: [
     {
       index: true,
+      handle: webhooksListCrumb,
       lazy: async () => {
         const { WebhookDeliveriesPage } = await import(
           '../../pages/webhook-deliveries/webhook-deliveries-page'
@@ -14,6 +23,7 @@ export const webhookDeliveriesRoute: RouteObject = {
     },
     {
       path: ':id',
+      handle: webhookDetailCrumb,
       lazy: async () => {
         const { WebhookDeliveryDetailPage } = await import(
           '../../pages/webhook-deliveries/webhook-delivery-detail-page'

--- a/apps/web/src/plugins/allegro/allegro-callback.route.tsx
+++ b/apps/web/src/plugins/allegro/allegro-callback.route.tsx
@@ -4,9 +4,11 @@
  * @module plugins/allegro
  */
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../../app/nav-registry.types';
 
 export const allegroCallbackRoute: RouteObject = {
   path: 'integrations/allegro/connect/callback',
+  handle: { crumb: { group: 'Platform', title: 'Allegro callback' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { AllegroConnectCallbackPage } = await import(
       '../../pages/integrations/allegro-connect-callback-page'

--- a/apps/web/src/plugins/allegro/allegro-setup.route.tsx
+++ b/apps/web/src/plugins/allegro/allegro-setup.route.tsx
@@ -4,9 +4,11 @@
  * @module plugins/allegro
  */
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../../app/nav-registry.types';
 
 export const allegroSetupRoute: RouteObject = {
   path: 'connections/new/allegro',
+  handle: { crumb: { group: 'Platform', title: 'Connect Allegro' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { AllegroSetupPage } = await import('../../pages/connections/allegro-setup-page');
     return { Component: AllegroSetupPage };

--- a/apps/web/src/plugins/merge-nav-contributions.test.ts
+++ b/apps/web/src/plugins/merge-nav-contributions.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import type { NavGroup } from '../app/app-shell';
+import type { NavGroup } from '../app/nav-registry.types';
 import { mergePluginNavContributions } from './merge-nav-contributions';
 import type { NavContribution } from './plugin.types';
 
@@ -97,5 +97,42 @@ describe('mergePluginNavContributions', () => {
       'A',
       'B',
     ]);
+  });
+
+  it('drops admin-only contributions for non-admin sessions', () => {
+    const contributions: NavContribution[] = [
+      { groupLabel: 'Platform', to: '/secret', label: 'Secret', requiresRole: 'admin' },
+    ];
+
+    const result = mergePluginNavContributions(baseGroups(), contributions, { isAdmin: false });
+
+    const platform = result.find((g) => g.label === 'Platform');
+    expect(platform?.kind === 'live' && platform.items.map((i) => i.label)).toEqual(['Connections']);
+  });
+
+  it('keeps admin-only contributions for admin sessions', () => {
+    const contributions: NavContribution[] = [
+      { groupLabel: 'Platform', to: '/secret', label: 'Secret', requiresRole: 'admin' },
+    ];
+
+    const result = mergePluginNavContributions(baseGroups(), contributions, { isAdmin: true });
+
+    const platform = result.find((g) => g.label === 'Platform');
+    expect(platform?.kind === 'live' && platform.items.map((i) => i.label)).toEqual([
+      'Connections',
+      'Secret',
+    ]);
+  });
+
+  it('defaults to non-admin when isAdmin is omitted', () => {
+    const contributions: NavContribution[] = [
+      { groupLabel: 'Platform', to: '/secret', label: 'Secret', requiresRole: 'admin' },
+    ];
+
+    // No third arg — admin contributions must be hidden by default.
+    const result = mergePluginNavContributions(baseGroups(), contributions);
+
+    const platform = result.find((g) => g.label === 'Platform');
+    expect(platform?.kind === 'live' && platform.items.map((i) => i.label)).toEqual(['Connections']);
   });
 });

--- a/apps/web/src/plugins/merge-nav-contributions.ts
+++ b/apps/web/src/plugins/merge-nav-contributions.ts
@@ -2,17 +2,18 @@
  * mergePluginNavContributions
  *
  * Pure helper that folds plugin nav contributions into the host's static
- * nav groups. For each contribution: find a `LiveNavGroup` whose `label`
- * matches `groupLabel` and append; otherwise create a new live group at
- * the end of the list. Group order is stable; within a group, contributions
- * are appended in registry order.
+ * nav groups. For each contribution: drop it if its `requiresRole` doesn't
+ * match the session role (#610); otherwise find a `LiveNavGroup` whose
+ * `label` matches `groupLabel` and append; otherwise create a new live group
+ * at the end of the list. Group order is stable; within a group,
+ * contributions are appended in registry order.
  *
  * Exported as a standalone module so the merge logic stays unit-testable
  * without booting the app shell.
  *
  * @module plugins
  */
-import type { LiveNavGroup, LiveNavItem, NavGroup } from '../app/app-shell';
+import type { LiveNavGroup, LiveNavItem, NavGroup } from '../app/nav-registry.types';
 import type { NavContribution } from './plugin.types';
 
 function toLiveNavItem(contribution: NavContribution): LiveNavItem {
@@ -23,11 +24,25 @@ function toLiveNavItem(contribution: NavContribution): LiveNavItem {
   };
 }
 
+export interface MergeNavContributionsOptions {
+  /** Session role gate. Defaults to `false` so admin-only contributions are
+   *  hidden unless the caller opts in. */
+  isAdmin?: boolean;
+}
+
 export function mergePluginNavContributions(
   groups: NavGroup[],
   contributions: NavContribution[],
+  options: MergeNavContributionsOptions = {},
 ): NavGroup[] {
-  if (contributions.length === 0) {
+  const isAdmin = options.isAdmin ?? false;
+
+  const visibleContributions = contributions.filter((contribution) => {
+    if (contribution.requiresRole === 'admin' && !isAdmin) return false;
+    return true;
+  });
+
+  if (visibleContributions.length === 0) {
     return groups;
   }
 
@@ -35,7 +50,7 @@ export function mergePluginNavContributions(
     group.kind === 'live' ? { ...group, items: [...group.items] } : group,
   );
 
-  for (const contribution of contributions) {
+  for (const contribution of visibleContributions) {
     const item = toLiveNavItem(contribution);
     const target = result.find(
       (group): group is LiveNavGroup =>

--- a/apps/web/src/plugins/plugin.types.ts
+++ b/apps/web/src/plugins/plugin.types.ts
@@ -17,6 +17,7 @@ import type { ComponentType } from 'react';
 import type { RouteObject } from 'react-router-dom';
 
 import type { ApiRequest, PluginApiNamespaces } from '../app/api/api-client';
+import type { Role } from '../app/nav-registry.types';
 import type { Connection } from '../features/connections';
 import type { CreateOfferRequest } from '../features/listings';
 
@@ -38,6 +39,13 @@ export interface NavContribution {
   to: string;
   label: string;
   end?: boolean;
+  /**
+   * Declarative role gate (#610). When set, the contribution is dropped for
+   * sessions whose role doesn't match — same UI-hide semantics as the AI
+   * group's `requiresRole: 'admin'` on `BASE_NAV_GROUPS`. Authorization is
+   * still enforced backend-side; this only hides the nav affordance.
+   */
+  requiresRole?: Role;
 }
 
 /**

--- a/apps/web/src/plugins/prestashop/prestashop-setup.route.tsx
+++ b/apps/web/src/plugins/prestashop/prestashop-setup.route.tsx
@@ -4,9 +4,11 @@
  * @module plugins/prestashop
  */
 import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../../app/nav-registry.types';
 
 export const prestashopSetupRoute: RouteObject = {
   path: 'connections/new/prestashop',
+  handle: { crumb: { group: 'Platform', title: 'Connect PrestaShop' } } satisfies RouteCrumbHandle,
   lazy: async () => {
     const { PrestashopSetupPage } = await import(
       '../../pages/connections/prestashop-setup-page'

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -128,6 +128,40 @@ Exceptions kept intentionally eager:
 
 A parameterized test at `apps/web/src/app/routes/route-lazy.test.ts` asserts the exact lazy-route count; bump `EXPECTED_LAZY_ROUTE_COUNT` when intentionally adding or removing a lazy route.
 
+### Breadcrumb metadata on routes (#610)
+
+Each authenticated route module declares its breadcrumb metadata inline via `route.handle` using the `RouteCrumbHandle` shape from `apps/web/src/app/nav-registry.types.ts`:
+
+```ts
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+export const ordersRoute: RouteObject = {
+  path: 'orders',
+  children: [
+    {
+      index: true,
+      handle: { crumb: { group: 'Operations', title: 'Orders' } } satisfies RouteCrumbHandle,
+      lazy: async () => {
+        const { OrdersListPage } = await import('../../pages/orders/orders-list-page');
+        return { Component: OrdersListPage };
+      },
+    },
+    // … sibling children with their own handles
+  ],
+};
+```
+
+The shell resolves the active crumb by calling `useMatches()` and walking the match chain deepest-first via `resolveCrumbFromMatches` (in `apps/web/src/app/breadcrumbs.ts`). The first match carrying a crumb-shaped handle wins; if no match in the chain carries one, the shell falls back to `{ group: 'OpenLinker', title: '' }`.
+
+**Rules**:
+
+- Leaf routes (including index children like `dashboardRoute`) own their crumb metadata. Parent shells with no semantic title carry no handle — `useMatches()`'s deepest-first walk picks the right one.
+- Guest routes (`loginRoute`, `forgotPasswordRoute`, `resetPasswordRoute`) render outside `AppShell` and have no `handle.crumb`. They are excluded from the route-handle contract test.
+- Marketplace-specific breadcrumbs (e.g. `Connect Allegro`, `Connect PrestaShop`) ship with the plugin route module — never with the host shell.
+- A parameterized contract test at `apps/web/src/app/routes/route-handle.test.ts` asserts every authenticated leaf route declares a crumb. Same enforcement shape as `route-lazy.test.ts`.
+
+Plugins contribute breadcrumbs the same way: a plugin route module's `RouteObject` carries its own `handle.crumb`. See [Platform Plugins](#platform-plugins-plugins) for the build-time `WebPlugin` route contribution shape and the optional `requiresRole` gate available on `NavContribution`.
+
 ## API Client Conventions
 
 The frontend consumes the Nest REST API exposed by `apps/api`.
@@ -368,6 +402,8 @@ The in-tree plugins live in `apps/web/src/plugins/<name>/`. Two parallel concern
 2. **Runtime `PlatformPlugin`** (#578/#579) — per-platform UI affordances: setup card, callback-URL default, structured edit-form sections, extra sections, credentials panel, connection actions. Collected as the exported `IN_TREE_PLUGINS: readonly PlatformPlugin[]` array. Resolved at render time via `usePlugin(platformType)` / `usePlugins()` from `shared/plugins/`.
 
 The two contracts live side-by-side because they answer different questions ("what does this plugin contribute to the app shell?" vs "what platform-specific UI does this connection's platformType expose?"). A single per-platform directory typically contributes both: `plugins/allegro/index.ts` exports an `allegroPlugin: WebPlugin`; `plugins/allegro/allegro.plugin.tsx` exports an `allegroPlatformPlugin: PlatformPlugin`.
+
+`WebPlugin.navItems` accepts an optional `requiresRole?: Role` (today: `'admin'`) — admin-only contributions are filtered out for non-admin sessions, mirroring the declarative gate the in-tree `AI` group uses on `BASE_NAV_GROUPS` (#610). Authorization is still enforced backend-side; the gate only hides the nav affordance. Plugin route modules contribute breadcrumb metadata the same way host routes do — via `handle: { crumb: { group, title } } satisfies RouteCrumbHandle`. See [Breadcrumb metadata on routes](#breadcrumb-metadata-on-routes-610).
 
 Adding a new in-tree platform is a single edit point: drop a new directory under `plugins/` and append entries to both arrays in `plugins/index.ts`.
 

--- a/docs/plans/implementation-plan-610-fe-plugin-aware-nav.md
+++ b/docs/plans/implementation-plan-610-fe-plugin-aware-nav.md
@@ -1,0 +1,190 @@
+# Implementation Plan — FE plugin-aware navigation & breadcrumbs (#610)
+
+## Goal
+
+Close H7 / FE-8 of Modularity Thread H. Move the FE shell's nav-group definitions out of a hardcoded `buildNavGroups()` function and breadcrumb metadata out of the central `staticCrumbs` table, so plugins can contribute nav items + breadcrumbs without editing core chrome. Remove the marketplace-specific entries (`/connections/new/allegro`, `/connections/new/prestashop`) that currently leak into `app-shell.tsx`.
+
+## Layer
+
+**Frontend / DX-shaped.** No API, no data, no domain changes. Two narrow surface changes inside `apps/web/src/app/`.
+
+## Non-goals
+
+- **Dynamic breadcrumb titles** (e.g., showing the actual order ID in `/orders/:id`). Today's crumbs use static "Order" fallback labels — preserved exactly. Dynamic titles would require Query state inside the shell; out of scope.
+- **React Router data-router migration** (`createBrowserRouter` etc.). Existing `RouteObject` shape is kept.
+- **NavLink / `react-router` replacement.** Same library, same primitives.
+- **i18n of nav labels** — tracked separately by #612.
+- **Plugin migration to contribute nav items.** None of the in-tree plugins use `navItems` today; introducing usage is a separate concern. This PR opens the seam; consumers can adopt it later.
+
+## Research summary
+
+### What exists today
+
+- `apps/web/src/app/app-shell.tsx:76-134` — `buildNavGroups({ isAdmin })`: hardcoded array of 3-5 groups (Operations, Diagnostics, Platform, optional AI, Planned).
+- `app-shell.tsx:136-156` — `staticCrumbs: Record<string, { group, title }>`: 19 exact-path entries, including marketplace-specific `/connections/new/allegro` and `/connections/new/prestashop`.
+- `app-shell.tsx:158-172` — `resolveCrumbs(pathname)`: prefix-match fallback for parameterized routes (`/orders/`, `/products/`, …).
+- `apps/web/src/plugins/plugin.types.ts:108` — `WebPlugin.navItems?: NavContribution[]` already declared.
+- `apps/web/src/plugins/merge-nav-contributions.ts` — pure helper merging contributions by `groupLabel`. Has unit tests.
+- No plugin currently uses `navItems`; the contribution surface is wired but unused.
+- 27 route modules under `apps/web/src/app/routes/`; 3 plugin route modules (`plugins/allegro/{allegro-callback,allegro-setup}.route.tsx`, `plugins/prestashop/prestashop-setup.route.tsx`).
+- No existing `useMatches()` usage or `route.handle` declarations in the codebase.
+- `apps/web/src/app/routes/route-lazy.test.ts` parameterizes over every registered route + asserts `lazy` resolves to a `Component`. Useful pattern to mirror for breadcrumb coverage.
+- **Router shape verified**: `apps/web/src/app/router.tsx` exports `appRouter = createBrowserRouter([...guestRoutes, rootRoute])`, mounted via `<RouterProvider>` in `app.tsx`. The Data Router is in use, so `useMatches()` resolves matches with `handle` exposed on each entry as documented. The route-colocated breadcrumb approach is valid for this codebase.
+
+### React Router primitives we'll lean on
+
+- `RouteObject.handle` — opaque arbitrary metadata; React Router doesn't interpret it but exposes it via `useMatches()`. Standard pattern for route-colocated breadcrumb metadata (documented in React Router docs).
+- `useMatches()` — returns the matched route chain top-to-bottom; each entry exposes `handle`.
+
+## Design
+
+### Piece 1 — Move base nav groups to a registry
+
+Two new modules under `apps/web/src/app/`:
+
+- `nav-registry.types.ts` — `NavRegistryGroup`, `NavRegistryItem`, `RouteCrumbHandle`, `LiveNavGroup`, `PlannedNavGroup`, `NavGroup`, `LiveNavItem`, `PlannedNavItem`, the `RoleValues` runtime array + `Role` union, and the `isCrumbHandle` type guard.
+- `nav-registry.ts` — the `BASE_NAV_GROUPS` data and the `buildNavGroups({ isAdmin })` helper.
+
+```ts
+// nav-registry.types.ts
+export const RoleValues = ['admin'] as const;
+export type Role = (typeof RoleValues)[number];
+
+export interface NavRegistryGroup {
+  label: string;             // canonical group name; plugin `groupLabel` matches against this
+  kind: 'live' | 'planned';
+  items: NavRegistryItem[];
+  requiresRole?: Role;       // declarative gate; today only AI uses it
+}
+// LiveNavGroup / PlannedNavGroup / NavGroup move here verbatim from app-shell.tsx.
+```
+
+```ts
+// nav-registry.ts
+import { BASE_NAV_GROUPS_DATA, type NavRegistryGroup } from './nav-registry.types';
+
+export const BASE_NAV_GROUPS: readonly NavRegistryGroup[] = [
+  { label: 'Operations', kind: 'live', items: [...] },
+  { label: 'Diagnostics', kind: 'live', items: [...] },
+  { label: 'Platform', kind: 'live', items: [...] },
+  { label: 'AI', kind: 'live', requiresRole: 'admin', items: [...] },
+  { label: 'Planned', kind: 'planned', items: [...] },
+];
+```
+
+`buildNavGroups({ isAdmin })` (also in `nav-registry.ts`) reduces to a small pure helper that:
+1. Filters `BASE_NAV_GROUPS` by `requiresRole` against the session role.
+2. Hands the survivors to `mergePluginNavContributions()` (unchanged).
+
+The shell calls the helper with the resolved role; otherwise the call site stays the same. The `NavGroup` types in `app-shell.tsx` are re-exported from there for backward compatibility (e.g., `merge-nav-contributions.ts` already imports them by name) — the canonical home is now `nav-registry.types.ts`.
+
+`NavContribution` (in `plugin.types.ts`) optionally grows `requiresRole?: Role` — same declarative gate for plugin items. Pure additive; no consumer needs to set it.
+
+### Piece 2 — Route-colocated breadcrumbs
+
+New type in `nav-registry.ts`:
+
+```ts
+export interface RouteCrumbHandle {
+  crumb: { group: string; title: string };
+}
+```
+
+Each route module gains a `handle` field. Examples:
+
+```ts
+// app/routes/orders.route.tsx — outer
+export const ordersRoute: RouteObject = {
+  path: 'orders',
+  handle: { crumb: { group: 'Operations', title: 'Orders' } } satisfies RouteCrumbHandle,
+  children: [
+    // index → orders list, inherits parent crumb
+    { index: true, lazy: ... },
+    // failed → distinct title
+    { path: 'failed', handle: { crumb: { group: 'Operations', title: 'Failed orders' } }, lazy: ... },
+    // detail → static "Order" fallback today; same here
+    { path: ':internalOrderId', handle: { crumb: { group: 'Operations', title: 'Order' } }, lazy: ... },
+  ],
+};
+```
+
+Shell-side resolver (new helper in `app/breadcrumbs.ts`):
+
+```ts
+export function resolveCrumbFromMatches(
+  matches: ReturnType<typeof useMatches>,
+): { group: string; title: string } {
+  // Walk deepest-first; first match carrying `handle.crumb` wins.
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const handle = matches[i].handle;
+    if (isCrumbHandle(handle)) return handle.crumb;
+  }
+  return { group: 'OpenLinker', title: '' };
+}
+```
+
+`AppShell` replaces `resolveCrumbs(location.pathname)` with `resolveCrumbFromMatches(useMatches())`. `staticCrumbs` and the old `resolveCrumbs` are deleted.
+
+The marketplace-specific entries leave core: `plugins/allegro/allegro-setup.route.tsx` gains `handle: { crumb: { group: 'Platform', title: 'Connect Allegro' } }`; same for PrestaShop. The marketplace breadcrumb data ships with the plugin.
+
+### Why this shape
+
+- **Same composition model in both halves** — base groups are data; plugins add data; merger is pure. Breadcrumb metadata is data colocated with each route; resolver is pure.
+- **Open at the seam, closed at the trunk** — the `requiresRole` gate and the contribution merger are open to additions; the core nav-registry array and crumb resolver are small and don't grow when a new plugin lands.
+- **No new state, no new context** — everything is static-at-import-time + one `useMatches()` call.
+- **Mechanical migration** — 30 route files gain a `handle` field; no behavior change in any other code path.
+
+## Implementation steps
+
+### Step 1 — Add `nav-registry.types.ts` + `nav-registry.ts`
+- `apps/web/src/app/nav-registry.types.ts` — exports `NavRegistryGroup`, `NavRegistryItem`, `RouteCrumbHandle`, `LiveNavGroup`, `PlannedNavGroup`, `NavGroup`, `LiveNavItem`, `PlannedNavItem`, `RoleValues` runtime array + `Role` union, and the `isCrumbHandle` type guard. The `NavGroup` types move out of `app-shell.tsx`; the shell keeps a back-compat re-export so existing imports (`merge-nav-contributions.ts`) don't change.
+- `apps/web/src/app/nav-registry.ts` — exports `BASE_NAV_GROUPS` (data) and `buildNavGroups({ isAdmin })` (helper that filters by role + applies plugin contributions).
+
+### Step 2 — Extend `NavContribution` with optional `requiresRole`
+- `apps/web/src/plugins/plugin.types.ts:24-46` — add `requiresRole?: Role` to `NavContribution` (imported from `nav-registry.types`).
+- `merge-nav-contributions.ts` — drop contributions whose `requiresRole` doesn't match (new optional `isAdmin` arg, defaults to `false`).
+- Extend `merge-nav-contributions.test.ts` to cover the gate.
+
+### Step 3 — Use the registry from `app-shell.tsx`
+- Update `app-shell.tsx`: import `buildNavGroups` from `./nav-registry`; delete the inline `buildNavGroups` and its types. The `useMemo` dependency stays `[isAdmin]`.
+
+### Step 4 — Add `route.handle.crumb` to every authenticated route module
+- 27 host route modules under `apps/web/src/app/routes/` covered by `coreChildren` (every file except `route-lazy.test.ts` and the guest routes — see below).
+- 3 plugin route modules (`allegro-callback`, `allegro-setup`, `prestashop-setup`).
+- Each gets `handle: { crumb: { group, title } } satisfies RouteCrumbHandle` matching today's `staticCrumbs` + `resolveCrumbs` output.
+- **Index-route rule**: leaf routes (including index children like `dashboardRoute`) own crumb metadata. Parent shells with no semantic title (e.g. `rootRoute` itself) carry no handle; `useMatches()`'s deepest-with-handle resolution picks the right one.
+- **Guest routes are excluded**: `loginRoute`, `forgotPasswordRoute`, `resetPasswordRoute` render outside `AuthenticatedAppLayout` / `AppShell`, so `useMatches()` inside the shell never sees them. They get no `handle.crumb` and are NOT parametrized in the contract test.
+
+### Step 5 — Replace shell crumb resolution
+- New `apps/web/src/app/breadcrumbs.ts` exports `resolveCrumbFromMatches(matches)`. The `isCrumbHandle` guard lives alongside the types in `nav-registry.types.ts` and is re-imported here.
+- `app-shell.tsx` swaps `resolveCrumbs(location.pathname)` → `resolveCrumbFromMatches(useMatches())`. Delete `staticCrumbs` + the inline `resolveCrumbs`.
+
+### Step 6 — Tests
+- `apps/web/src/app/breadcrumbs.test.ts` — table-driven: feed fake `useMatches()` results and assert resolved crumb. Cover: deepest match wins, no handle → fallback, plain string handle ignored.
+- `apps/web/src/app/routes/route-handle.test.ts` — parametrized over `coreChildren` + plugin routes (NOT guest routes), asserts every leaf carries a `handle.crumb` shape. Same pattern as `route-lazy.test.ts`.
+
+### Step 7 — Documentation
+- Append a short subsection to `docs/frontend-architecture.md` under § Routing Conventions noting `route.handle.crumb` is the convention.
+- Cross-link from § Platform Plugins so plugin authors discover `requiresRole` and the nav/crumb contribution shape from one place.
+- Note: AI features (`/ai/prompt-templates`, `/ai/provider-settings`) stay in `BASE_NAV_GROUPS` with `requiresRole: 'admin'` because they're in-tree core features (`libs/core/ai`), not a plugin. If AI ever moves to its own plugin package, the AI group becomes a plugin nav contribution.
+
+## Validation
+
+- **Architecture** — all new modules live in `app/` (the layer that owns chrome). Plugins-side change is one optional field on an existing contribution type.
+- **Naming** — kebab-case files, PascalCase types, `*.test.ts` colocated.
+- **Types** — no `any`; `unknown` only where `useMatches()` exposes `handle` as `unknown`, narrowed via the `isCrumbHandle` guard.
+- **Testing** — pure helpers under unit tests; route-handle contract test mirrors the existing `route-lazy` pattern.
+- **Security** — declarative `requiresRole: 'admin'` mirrors the existing imperative `if (isAdmin)` gate; same trust boundary (UI hide, NOT authorization). Backend `@Roles('admin')` continues to gate the endpoints — unchanged.
+
+## Risks & open questions
+
+- **Index-route crumbs**: the dashboard is `{ index: true, lazy: ... }` inside `dashboardRoute`. The handle must live on the index child to surface the "Dashboard" title (otherwise the parent's handle dominates). Handled at Step 4.
+- **Plugin contribution test fixture for `requiresRole`**: existing `merge-nav-contributions.test.ts` doesn't cover the new gate — add cases.
+- **Breadcrumb regression coverage**: today's behavior is asserted only by manual visual checking. Adding `route-handle.test.ts` makes the contract explicit before the migration.
+
+## Out-of-scope follow-ups
+
+- **Dynamic crumb titles** (e.g., `Order #ol_order_abc`). Would require route loaders or a Query-driven shell. Distinct surface from this PR.
+- **i18n of nav/crumb labels** — covered by #612.
+- **Plugins contributing actual nav items in-tree** — Allegro/PrestaShop don't have user-facing routes inside the operator nav today. When that lands, it uses the now-fully-plugin-aware surface.
+- **Static-discovery of plugin nav** — today's registry is imperative; #575 tracks moving toward static discovery. Independent.


### PR DESCRIPTION
## Summary

Closes H7 / FE-8 of Modularity Thread H. Moves the FE chrome's nav-group composition out of an inline `buildNavGroups()` in `app-shell.tsx` into a typed registry, and moves breadcrumb metadata out of a central `staticCrumbs` table onto each route's `handle.crumb`. Plugins can now contribute admin-only nav items via `NavContribution.requiresRole`, and the marketplace-specific breadcrumb entries (`/connections/new/allegro`, `/connections/new/prestashop`) ship with their plugin route module instead of leaking into core chrome.

### What landed

1. **`apps/web/src/app/nav-registry.{ts,types.ts}`** — types live in `*.types.ts`, data + builder in `nav-registry.ts`. Exports `BASE_NAV_GROUPS`, the `RoleValues`/`Role` `as const` pair, `RouteCrumbHandle` + `isCrumbHandle` guard, and `buildNavGroups({ isAdmin })`.
2. **`apps/web/src/plugins/plugin.types.ts`** — `NavContribution` gains optional `requiresRole?: Role`. `mergePluginNavContributions` filters admin-only contributions when `isAdmin === false` (defaults to false).
3. **27 host route modules + 3 plugin routes** — each authenticated leaf declares `handle: { crumb: { group, title } } satisfies RouteCrumbHandle`. The shell swaps `resolveCrumbs(location.pathname)` for `resolveCrumbFromMatches(useMatches())` (a pure helper, deepest-wins, fallback to `{ OpenLinker, '' }`). `staticCrumbs` + the prefix-match `resolveCrumbs` are deleted.
4. **Two improved crumbs** (side effect, deliberate): `/integrations/allegro/connect/callback` was `{ OpenLinker, '' }` → now `{ Platform, Allegro callback }`; `/webhook-deliveries/:id` was `{ OpenLinker, '' }` → now `{ Diagnostics, Webhook }`. Both fell through the legacy fallback for lack of an entry.
5. **Test fixtures migrated to the Data Router**. `app-shell.test.tsx` and `authenticated-app-layout.test.tsx` previously used `<MemoryRouter>`; `useMatches()` requires `createMemoryRouter` + `RouterProvider`. The runtime has been on Data Router since #606 — tests now match.
6. **New tests**: `breadcrumbs.test.ts` (deepest-wins, fallback, non-crumb-handle rejection); `route-handle.test.ts` (contract test, every authenticated leaf carries a crumb); three new cases in `merge-nav-contributions.test.ts` for the `requiresRole` gate.
7. **Docs**: new `## Routing Conventions › Breadcrumb metadata on routes` subsection in `docs/frontend-architecture.md`; `## Platform Plugins` cross-links `requiresRole` and the crumb convention.

## Test plan
- [x] `pnpm lint` — zero errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 2,759 tests pass (shared 49, core 606, web 1013, ai 34, prestashop 255, allegro 338, api 346, worker 118)
- [x] AppShell tests cover: nav-group composition, admin gate, breadcrumb resolution for known and unknown routes, mobile drawer open/close on route change
- [x] Manual: deepest-wins resolution verified for nested routes (`/orders/failed`, `/orders/:id`)

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)