### PR TITLE
docs: OSS launch baseline — LICENSE, SECURITY.md, CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,39 @@
 # Contributing to OpenLinker
 
-Thank you for your interest in contributing to OpenLinker! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to OpenLinker! This document
+provides guidelines and instructions for contributing.
+
+## Setup Checklist
+
+The fastest path from a fresh clone to a green test run:
+
+```bash
+git clone https://github.com/SilkSoftwareHouse/openlinker.git
+cd openlinker
+pnpm install
+cp apps/api/.env.example apps/api/.env
+pnpm dev:stack:up
+pnpm --filter @openlinker/api migration:run
+pnpm test
+```
+
+If any step fails, the sections below cover prerequisites, setup, and
+troubleshooting in more detail.
 
 ## Prerequisites
 
 - Node.js 18+ (LTS recommended)
-- pnpm 8+
-- PostgreSQL 14+
-- Redis 7+
+- pnpm 10+
+- Docker (for the dev stack and integration tests)
+
+The dev stack (`pnpm dev:stack:up`) starts PostgreSQL, Redis, MySQL, and
+PrestaShop in containers — you do not need any of those installed locally.
 
 ## Development Setup
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/your-org/openlinker.git
+   git clone https://github.com/SilkSoftwareHouse/openlinker.git
    cd openlinker
    ```
 
@@ -28,59 +48,77 @@ Thank you for your interest in contributing to OpenLinker! This document provide
    # Edit .env with your configuration
    ```
 
-4. **Start services with Docker Compose**
+4. **Start the development stack**
    ```bash
-   docker-compose up -d postgres redis
+   pnpm dev:stack:up
    ```
+   This brings up PostgreSQL, Redis, MySQL, and PrestaShop. See
+   [Development Environment Guide](./docs/dev-environment.md) for details.
 
-5. **Run database migrations** (when available)
+5. **Run database migrations**
    ```bash
-   pnpm migration:run
+   pnpm --filter @openlinker/api migration:run
    ```
+   See [Database Migrations](./docs/migrations.md) for the full workflow.
 
-6. **Start the development server**
+6. **Start the application**
+
+   Run whichever process(es) you need; each binds its own port:
    ```bash
-   pnpm start:dev
+   pnpm start:dev:api      # NestJS API on :3000
+   pnpm start:dev:worker   # Background job worker
+   pnpm start:dev:web      # React frontend on :5173
    ```
 
 ## Git Hooks
 
 This project uses Husky for git hooks. The pre-commit hook runs:
+
 - Linting (`pnpm lint`)
 - Type checking (`pnpm type-check`)
 - Tests (`pnpm test`)
 
-Husky is automatically installed when you run `pnpm install` (via the `prepare` script).
+Husky is installed automatically by `pnpm install` (via the `prepare`
+script).
 
 ## Code Style
 
-- Follow the [Engineering Standards](./docs/engineering-standards.md)
-- Use Prettier for formatting: `pnpm format`
-- Run ESLint: `pnpm lint`
+- Follow the [Engineering Standards](./docs/engineering-standards.md).
+- Format with Prettier: `pnpm format`.
+- Lint with ESLint: `pnpm lint`.
 
 ## Testing
 
-- Write tests for new features
-- Run tests: `pnpm test`
-- Run tests in watch mode: `pnpm test:watch`
-- Check coverage: `pnpm test:cov`
+- Write tests for new features.
+- Run unit tests: `pnpm test`.
+- Run unit tests in watch mode: `pnpm test:watch`.
+- Run with coverage: `pnpm test:cov`.
+- Run integration tests (requires Docker): `pnpm test:integration`.
+
+See the [Testing Guide](./docs/testing-guide.md) for the full testing
+approach, including the Testcontainers setup.
 
 ## Architecture
 
-Please review the [Architecture Overview](./docs/architecture-overview.md) before making significant changes.
+Please review the [Architecture Overview](./docs/architecture-overview.md)
+before making significant changes. OpenLinker follows Hexagonal
+Architecture (Ports and Adapters); CORE and Integration packages have
+strict boundaries that contributions must respect.
 
 ## Pull Request Process
 
-1. Create a feature branch from `develop`
-2. Make your changes following the coding standards
-3. Write or update tests
-4. Ensure all tests pass and linting is clean
-5. Update documentation if needed
-6. Submit a pull request with a clear description
+1. Create a feature branch from `main` named after the issue
+   (e.g., `657-658-660-oss-launch-docs`).
+2. Make your changes following the coding standards.
+3. Write or update tests.
+4. Ensure `pnpm lint`, `pnpm type-check`, and `pnpm test` all pass.
+5. Update documentation if needed.
+6. Submit a pull request with a clear description and `Closes #N` in the
+   body — issues should be closed by the merged PR, not manually.
 
-## Commit Messages
+## Commits
 
-Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+OpenLinker uses [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
 <type>(<scope>): <subject>
@@ -90,17 +128,36 @@ Use [Conventional Commits](https://www.conventionalcommits.org/) format:
 <footer>
 ```
 
-Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`.
+
+### Developer Certificate of Origin (DCO)
+
+OpenLinker uses the [Developer Certificate of Origin](https://developercertificate.org/)
+instead of a Contributor License Agreement (CLA). By contributing, you
+certify the statements in the DCO — in short, that you have the right to
+submit the work under the project's [Apache 2.0](./LICENSE) license.
+
+Sign off your commits with `git commit -s` so each commit ends with a
+`Signed-off-by:` trailer:
+
+```
+feat(inventory): add inventory sync service
+
+Signed-off-by: Your Name <you@example.com>
+```
+
+Automated DCO enforcement will be turned on once the repository transfer
+([#641](https://github.com/SilkSoftwareHouse/openlinker/issues/641))
+completes; in the interim, please sign off your commits anyway so the
+history is consistent when enforcement starts.
+
+## Security
+
+**Do not file security vulnerabilities as public GitHub issues or pull
+requests.** See [SECURITY.md](./SECURITY.md) for the responsible-disclosure
+process.
 
 ## Questions?
 
-Feel free to open an issue for questions or discussions.
-
-
-
-
-
-
-
-
-
+Open a GitHub issue for questions or discussion. For security topics,
+follow the process in [SECURITY.md](./SECURITY.md) instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@ troubleshooting in more detail.
 
 The dev stack (`pnpm dev:stack:up`) starts PostgreSQL, Redis, MySQL, and
 PrestaShop in containers — you do not need any of those installed locally.
+Running against a locally-installed Postgres / Redis instead is possible
+but undocumented; the supported path is Docker.
 
 ## Development Setup
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ OpenLinker is designed to synchronize and orchestrate e-commerce operations acro
 ## Prerequisites
 
 - Node.js 18+ (LTS recommended)
-- pnpm 8+
-- PostgreSQL 14+
-- Redis 7+
+- pnpm 10+
+- Docker (for the dev stack and integration tests)
+
+The dev stack (`pnpm dev:stack:up`) starts PostgreSQL, Redis, MySQL, and
+PrestaShop in containers — you do not need any of those installed locally.
 
 ## Installation
 
@@ -47,23 +49,27 @@ OpenLinker is designed to synchronize and orchestrate e-commerce operations acro
    
    This starts PostgreSQL, Redis, MySQL, and PrestaShop. For detailed setup instructions, see [Development Environment Guide](./docs/dev-environment.md).
 
-5. **Start the development server**
-   ```bash
-   pnpm start:dev
-   ```
+5. **Start the application**
 
-The API will be available at `http://localhost:3000`
+   Run whichever process(es) you need; each binds its own port:
+   ```bash
+   pnpm start:dev:api      # NestJS API on :3000
+   pnpm start:dev:worker   # Background job worker
+   pnpm start:dev:web      # React frontend on :5173
+   ```
 
 ## Development
 
 ### Running the Application
 
 ```bash
-# Development mode (with hot reload)
-pnpm start:dev
+# Development mode (with hot reload) — pick the process(es) you need
+pnpm start:dev:api      # NestJS API on :3000
+pnpm start:dev:worker   # Background job worker
+pnpm start:dev:web      # React frontend on :5173
 
-# Production mode
-pnpm start:prod
+# Production mode (API)
+pnpm start:prod:api
 ```
 
 ### Testing
@@ -177,11 +183,15 @@ See `.github/workflows/` for details.
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details on the development workflow, coding standards, and pull-request process.
+
+## Security
+
+Found a vulnerability? Please follow the responsible-disclosure process in [SECURITY.md](./SECURITY.md) — do not open a public issue.
 
 ## License
 
-[Add your license here]
+OpenLinker is released under the Apache License 2.0. See the [LICENSE](./LICENSE) file for details.
 
 ## Related Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,114 @@
+# Security Policy
+
+OpenLinker handles OAuth tokens, marketplace API credentials, and customer
+PII. We take security reports seriously and appreciate responsible
+disclosure from the security research community.
+
+## Supported Versions
+
+Until the first tagged release, only the `main` branch receives security
+fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | ✅        |
+
+Once the project ships tagged releases, this table will be updated to
+reflect the supported release lines.
+
+## Reporting a Vulnerability
+
+**Please do not file public GitHub issues or pull requests for security
+vulnerabilities.** Public disclosure before a fix is available puts every
+OpenLinker operator at risk.
+
+**Preferred channel — GitHub Security Advisories:**
+
+1. Navigate to the [Security tab](https://github.com/SilkSoftwareHouse/openlinker/security)
+   on this repository.
+2. Click **Report a vulnerability**.
+3. Fill in the advisory form. The report stays private to the maintainers
+   and yourself until a fix is published.
+
+GitHub Security Advisories give you a private, auditable thread with the
+maintainers and an automatic CVE issuance path once a fix lands.
+
+> **TODO (depends on [#642](https://github.com/SilkSoftwareHouse/openlinker/issues/642)):**
+> once the `openlinker.io` domain is operational, a `security@openlinker.io`
+> email alias will be added as a secondary channel. GitHub Security
+> Advisories will remain the primary channel.
+
+When reporting, please include:
+
+- A description of the vulnerability and its impact.
+- Reproduction steps, proof-of-concept, or a minimal failing test case.
+- Affected versions / commits.
+- Any suggested mitigation, if you have one.
+
+## Response SLA
+
+We aim to meet the following timelines:
+
+| Stage                          | Target                  |
+| ------------------------------ | ----------------------- |
+| Initial acknowledgement        | within 72 hours         |
+| Triage + severity assessment   | within 7 days           |
+| Fix for critical vulnerability | within 14 days          |
+| Fix for non-critical           | within 30 days          |
+| Coordinated public disclosure  | after fix is published  |
+
+Severity follows [CVSS v3.1](https://www.first.org/cvss/) — anything rated
+**Critical** or **High** is treated as critical for SLA purposes.
+
+If the timelines above slip, we will keep you updated on the advisory
+thread with reasons and a revised target.
+
+## Scope
+
+**In scope** — every package maintained in this repository:
+
+- `apps/api` — the NestJS HTTP API.
+- `apps/worker` — the background job worker.
+- `apps/web` — the operator admin SPA.
+- `libs/core` — domain logic and ports (`@openlinker/core/*`).
+- `libs/shared` — cross-cutting utilities (`@openlinker/shared/*`).
+- `libs/plugin-sdk` — the plugin contract surface (`@openlinker/plugin-sdk`).
+- `libs/integrations/*` — the bundled adapters (Allegro, PrestaShop, AI).
+
+**Out of scope:**
+
+- Third-party plugins not maintained in this repository — please contact
+  the plugin author directly.
+- Vulnerabilities in upstream services (Allegro, PrestaShop, etc.) —
+  please report those to the upstream vendor directly. We are happy to
+  coordinate disclosure if the vulnerability has cross-impact.
+- Vulnerabilities in third-party dependencies — first check whether a fix
+  has been published upstream. If yes, an upgrade PR is welcome via the
+  normal contribution flow. If no, report to the upstream project; we will
+  pick up the fix when available.
+
+## Safe Harbor
+
+We support security research conducted in good faith. As long as you:
+
+- Make a good-faith effort to avoid privacy violations, destruction of
+  data, and degradation of our services.
+- Only test against your own data / accounts, or against test accounts
+  you've created yourself.
+- Give us reasonable time to investigate and remediate before any public
+  disclosure.
+- Do not exploit a vulnerability beyond what is necessary to demonstrate
+  it.
+
+…we consider your research authorized, will not initiate legal action
+against you, and will work with you on coordinated disclosure.
+
+This safe harbor does not extend to attacks against OpenLinker operators
+(production instances run by third parties) — please research against your
+own local installation only.
+
+## Acknowledgements
+
+We will publicly credit reporters on the published advisory unless you
+prefer to remain anonymous. Please indicate your preference in the
+report.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,13 @@ maintainers and an automatic CVE issuance path once a fix lands.
 > email alias will be added as a secondary channel. GitHub Security
 > Advisories will remain the primary channel.
 
+> **TODO (depends on [#641](https://github.com/SilkSoftwareHouse/openlinker/issues/641)):**
+> the Security-tab URL above resolves to the canonical repo URL today. Once
+> the org transfer completes, update the link (and any other references in
+> this doc) to the post-transfer URL. Tracked alongside the broader URL
+> convergence work in
+> [#664](https://github.com/SilkSoftwareHouse/openlinker/issues/664).
+
 When reporting, please include:
 
 - A description of the vulnerability and its impact.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/api",
   "version": "0.1.0",
   "description": "OpenLinker API Application",
+  "license": "Apache-2.0",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/web",
   "version": "0.1.0",
   "description": "OpenLinker frontend application",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/worker",
   "version": "0.1.0",
   "description": "OpenLinker Worker Application",
+  "license": "Apache-2.0",
   "private": true,
   "type": "commonjs",
   "scripts": {
@@ -48,4 +49,3 @@
     "typescript": "5.4.3"
   }
 }
-

--- a/docs/plans/implementation-plan-657-658-660-oss-launch-baseline.md
+++ b/docs/plans/implementation-plan-657-658-660-oss-launch-baseline.md
@@ -1,0 +1,273 @@
+# Implementation Plan — OSS Launch Baseline Docs (#657, #658, #660)
+
+Bundled docs/governance pass to clear the three BLOCKING items from epic #670
+before the OpenLinker repo is flipped public.
+
+## Goals
+
+- **#657** — Add Apache 2.0 `LICENSE` file at repo root; update README license
+  section; set `"license": "Apache-2.0"` on every `package.json` in the
+  workspace.
+- **#658** — Add `SECURITY.md` with a responsible-disclosure path, covering
+  the five required sections (supported versions, reporting channel, SLA,
+  scope, safe harbor). Link from README + CONTRIBUTING.
+- **#660** — Fix `CONTRIBUTING.md`: replace placeholder clone URL, swap
+  `docker-compose up` for `pnpm dev:stack:up`, fix the migration command,
+  align rest of the file with `package.json` scripts and CLAUDE.md.
+
+## Non-goals
+
+- **Domain / org transfer.** Issues #641 (org transfer) and #642 (domain
+  purchase) are explicit dependencies for the *final* URLs and email aliases.
+  This PR uses the interim values (`SilkSoftwareHouse/openlinker` URL, a
+  placeholder reporting channel) and tags them so they can be batch-updated
+  when #641/#642 land. The issues themselves call out this interim approach.
+- **Enabling GitHub Private Vulnerability Reporting** in repo settings. That
+  is a settings-page toggle, not a code change — it gets done by a repo admin
+  during the launch flip. SECURITY.md will document the intended channel.
+- **DCO enforcement workflow.** #657 explicitly defers enforcement until
+  after the org transfer; this PR records the DCO decision in the PR
+  description only.
+- **Other items from #670** (#656, #659, #662, #663, #664, #665) — separate
+  PRs.
+
+## Layer classification
+
+Pure **DX / Governance / Docs**. No code, no architecture impact, no
+migrations, no tests required.
+
+## Open decisions (please flag in review)
+
+1. **Reporting channel placeholder in SECURITY.md.** Pre-#642 we don't own
+   `security@openlinker.io`. Two reasonable interim options:
+   - **(A — recommended)** Direct researchers to GitHub Security Advisories
+     ("Report a vulnerability" tab on the repo) once Private Vulnerability
+     Reporting is enabled. Zero email dependency, works the day we flip
+     public, GitHub handles the audit trail.
+   - **(B)** Direct researchers to a personal/maintainer email
+     (`p.j.swierzy@gmail.com`) with a TODO to switch once `security@openlinker.io`
+     exists.
+   I'm going with **(A)** in the draft and adding a TODO to add the
+   `security@openlinker.io` alias as a secondary channel once #642 lands.
+2. **DCO vs CLA.** #657 recommends DCO; not enforced this PR. I'll note the
+   decision in the PR body and add a one-line stub to CONTRIBUTING.md
+   covering `Signed-off-by:` as the expected mechanism so contributors aren't
+   surprised when enforcement turns on.
+3. **README "Prerequisites".** Says `pnpm 8+`, but the lockfile shows `pnpm
+   10.11.1` and CLAUDE.md targets pnpm 10. Same drift in CONTRIBUTING.md.
+   I'll bump both to `pnpm 10+` (the floor that actually works) — this is a
+   trivial fix and otherwise the CONTRIBUTING.md "audit the rest of the file"
+   acceptance criterion isn't met.
+4. **`develop` branch reference in CONTRIBUTING.md line 74.** The repo has
+   no `develop` branch — the trunk is `main` (confirmed in CLAUDE.md). I'll
+   fix this as part of the "audit the rest of the file" sweep.
+
+## Implementation steps
+
+### Step 1 — LICENSE (#657)
+
+**File:** `/LICENSE` (new)
+
+Add the verbatim Apache License 2.0 text from
+`https://www.apache.org/licenses/LICENSE-2.0.txt`. No `[yyyy]` /
+`[name of copyright owner]` placeholders in the appendix boilerplate
+section — those are templates, not part of the license. Per Apache
+guidance, ship the text-only license file (the `APPENDIX` block at the
+bottom of the canonical file describes *how* to apply it; teams typically
+omit it from the LICENSE file itself, but keeping it is also fine. I'll
+keep it verbatim for "no surprises" review).
+
+**Acceptance:** `diff <(curl -s https://www.apache.org/licenses/LICENSE-2.0.txt) LICENSE` → empty.
+
+### Step 2 — README license section (#657)
+
+**File:** `README.md` (edit line 182-184)
+
+Replace:
+```
+## License
+
+[Add your license here]
+```
+with:
+```
+## License
+
+OpenLinker is released under the Apache License 2.0. See the
+[LICENSE](./LICENSE) file for details.
+```
+
+### Step 3 — `license` field on every workspace package.json (#657)
+
+Set `"license": "Apache-2.0"` on:
+- `package.json` (root)
+- `apps/api/package.json`
+- `apps/web/package.json`
+- `apps/worker/package.json`
+- `libs/core/package.json`
+- `libs/integrations/ai/package.json`
+- `libs/integrations/allegro/package.json`
+- `libs/integrations/prestashop/package.json`
+- `libs/plugin-sdk/package.json`
+- `libs/shared/package.json`
+
+`license` is a standard metadata field for every `package.json`, publishable
+or not, per npm convention. Setting it everywhere removes ambiguity and
+matches the rest of the ecosystem regardless of whether the workspace is an
+end app (`apps/*`) or a future-publishable library (`libs/*`).
+
+### Step 4 — SECURITY.md (#658)
+
+**File:** `/SECURITY.md` (new)
+
+Sections (must cover all five per acceptance criteria):
+
+1. **Supported versions** — `main` only until the first tagged release. Add
+   a table with one row.
+2. **Reporting a vulnerability** — point to GitHub Security Advisories
+   ("Report a vulnerability" tab); add a TODO line for the
+   `security@openlinker.io` secondary channel once #642 lands.
+3. **Response SLA** — 72h initial acknowledgement; 14 days for critical,
+   30 days for non-critical. Patch + coordinated disclosure timing.
+4. **Scope** — in-scope: every package maintained in this repo
+   (`apps/{api,worker,web}` + every `libs/**` package — including the
+   plugin contract surfaces `@openlinker/core/*`, `@openlinker/shared/*`,
+   `@openlinker/plugin-sdk`, and the bundled adapters). Out-of-scope:
+   third-party plugins not maintained in this repo; vulnerabilities in
+   external services (Allegro, PrestaShop, etc.) — please report those to
+   the upstream vendors directly.
+5. **Safe harbor** — research-in-good-faith language; explicit "we will not
+   pursue legal action."
+
+### Step 5 — Reference SECURITY.md from README (#658)
+
+**File:** `README.md` (insert near License section, line ~178)
+
+Add a `## Security` section above `## Contributing` with a one-line
+pointer to `SECURITY.md`.
+
+### Step 6 — Reference SECURITY.md from CONTRIBUTING.md (#658)
+
+**File:** `CONTRIBUTING.md` (under "Pull Request Process" or new section)
+
+Add a one-line "Do not file security vulnerabilities as public issues — see
+[SECURITY.md](./SECURITY.md)" pointer.
+
+### Step 7 — Fix CONTRIBUTING.md (#660)
+
+**File:** `CONTRIBUTING.md`
+
+Concrete edits:
+- **Line 8** prerequisites: `pnpm 8+` → `pnpm 10+`.
+- **Line 16**: clone URL placeholder → `https://github.com/SilkSoftwareHouse/openlinker.git`.
+- **Line 33**: `docker-compose up -d postgres redis` → `pnpm dev:stack:up`.
+- **Line 36-39**: replace the conditional "when available" migration block
+  with a real, working command: `pnpm --filter @openlinker/api migration:run`
+  (per CLAUDE.md). Drop the "when available" caveat — migrations exist.
+- **Line 41-44**: replace `pnpm start:dev` with the three commands actually
+  documented in CLAUDE.md: `pnpm start:dev:api`, `pnpm start:dev:worker`,
+  `pnpm start:dev:web`. Note which port each binds.
+- **Line 74**: "Create a feature branch from `develop`" → "Create a feature
+  branch from `main`" (no `develop` branch exists; CLAUDE.md uses `main`).
+- **Trailing blank lines (100-107)**: trim.
+- **New "Setup checklist" block** at the top — the exact zero-to-green
+  sequence:
+  ```bash
+  pnpm install
+  cp apps/api/.env.example apps/api/.env
+  pnpm dev:stack:up
+  pnpm --filter @openlinker/api migration:run
+  pnpm test
+  ```
+- **Add Security pointer** (per Step 6).
+- **Record DCO decision** in a new "Commits" sub-section: state explicitly
+  that the project has chosen DCO over CLA, that `Signed-off-by:` is the
+  attestation mechanism, and that automated enforcement is deferred until
+  after the org transfer (#641 / #657). The decision belongs in the file
+  itself — not only in the PR body — so future contributors discover it
+  without diving into PR history.
+
+### Step 7b — Fix README.md drift
+
+**File:** `README.md`
+
+Same drift exists in README.md (audit-quality concern surfaced in tech
+review). Without this, the PR ships a direct contradiction between two
+adjacent files:
+
+- **Line 19** prerequisites: `pnpm 8+` → `pnpm 10+`.
+- **Lines 51–53** "Start the development server": replace `pnpm start:dev`
+  with the three real commands (`pnpm start:dev:api` / `:worker` / `:web`)
+  noting which port each binds.
+- **Lines 64–67** Testing block: drop `pnpm start:prod` reference if it
+  appears; verify the testing commands match `package.json` scripts.
+
+(License section + Security pointer for README.md are already covered by
+Steps 2 and 5.)
+
+### Step 8 — Quality gate
+
+In order:
+
+1. `pnpm format` (write mode) on the new/edited files only — pre-normalize
+   so the check pass surfaces real issues, not formatter noise.
+2. `pnpm format:check`
+3. `pnpm lint` (runs `check:invariants` — migration timestamps, design
+   tokens, etc.)
+4. `pnpm type-check`
+5. `pnpm test`
+
+Per CLAUDE.md's "run before every commit" rule — no skipping just because
+this is docs-only.
+
+### Step 9 — Self-review pass
+
+Walk the file diff against the acceptance criteria in each of #657, #658,
+#660. Confirm:
+- LICENSE present and byte-identical to canonical Apache 2.0 text.
+- README license section updated; new Security section linking to SECURITY.md.
+- All ten `package.json` files have `"license": "Apache-2.0"`.
+- SECURITY.md covers all five required sections.
+- CONTRIBUTING.md: every command runs against the actual `package.json`
+  scripts and matches CLAUDE.md.
+- No placeholder URLs, no `docker-compose up -d postgres redis`, no
+  `pnpm migration:run` left in the diff.
+
+## Risks
+
+- **Trademark gate (#657 references #642).** The LICENSE itself is the
+  same regardless of trademark status — the gate is on going public, not on
+  committing the file. The PR can merge into a private repo today; the
+  public flip is a separate decision tied to #642 clearing.
+- **README/CONTRIBUTING drift from `dev-environment.md`.** I'll scan
+  `dev-environment.md` for setup commands and surface any further drift in
+  the PR description (out of scope to fix here, but worth flagging).
+- **SECURITY.md SLA values** are recommendations, not negotiated with
+  maintainers. The PR will explicitly call this out and ask for sign-off on
+  the numbers before merge (per #658 acceptance: "SLA targets discussed and
+  agreed with maintainers before publishing").
+
+## PR body checklist (drafted now to keep this honest)
+
+- [ ] LICENSE is verbatim Apache 2.0 text
+- [ ] README license section updated; Security section added
+- [ ] All 10 `package.json` files set `license: Apache-2.0`
+- [ ] SECURITY.md covers supported-versions, reporting channel, SLA, scope, safe harbor
+- [ ] CONTRIBUTING.md commands all match `package.json` scripts
+- [ ] No `develop` branch references remain
+- [ ] DCO decision recorded (planned mechanism: `Signed-off-by:` once #641 transfers)
+- [ ] Third-party code requiring Apache § 4 attribution: none identified
+- [ ] Closes #657, #658, #660
+
+## Out-of-PR follow-ups to record
+
+- Enable GitHub Private Vulnerability Reporting in repo settings (admin
+  toggle, post-merge).
+- Once #642 lands `openlinker.io`: set up `security@openlinker.io` forward
+  and **replace** (not just augment) the SECURITY.md reporting section
+  — GH Security Advisories stays as the primary channel, email becomes the
+  secondary. A TODO anchored to #642 lives in SECURITY.md itself so the
+  edit is discoverable.
+- Once #641 lands the org transfer: update repo URL in CONTRIBUTING.md /
+  README.md and any other references (tracked in #664).
+- Add DCO check workflow once on the new org (out of scope per #657).

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/core",
   "version": "0.1.0",
   "description": "OpenLinker Core Bounded Contexts",
+  "license": "Apache-2.0",
   "private": true,
   "type": "commonjs",
   "main": "./dist/index.js",
@@ -123,7 +124,9 @@
       "default": "./dist/content/orm-entities.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "jest",
@@ -151,4 +154,3 @@
     "typescript": "5.4.3"
   }
 }
-

--- a/libs/integrations/ai/package.json
+++ b/libs/integrations/ai/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/integrations-ai",
   "version": "0.1.0",
   "description": "AI completion adapter for OpenLinker (Vercel AI SDK + Anthropic)",
+  "license": "Apache-2.0",
   "private": true,
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/libs/integrations/allegro/package.json
+++ b/libs/integrations/allegro/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/integrations-allegro",
   "version": "0.1.0",
   "description": "Allegro Public API v1 adapter for OpenLinker",
+  "license": "Apache-2.0",
   "private": true,
   "type": "commonjs",
   "main": "./dist/index.js",
@@ -12,7 +13,9 @@
       "require": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "jest --config ./jest.config.mjs",
@@ -43,6 +46,3 @@
     "typescript": "5.4.3"
   }
 }
-
-
-

--- a/libs/integrations/prestashop/package.json
+++ b/libs/integrations/prestashop/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/integrations-prestashop",
   "version": "0.1.0",
   "description": "PrestaShop WebService v1 adapter for OpenLinker",
+  "license": "Apache-2.0",
   "private": true,
   "type": "commonjs",
   "main": "./dist/index.js",
@@ -12,7 +13,9 @@
       "require": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "jest --config ./jest.config.mjs",
@@ -43,4 +46,3 @@
     "typescript": "5.4.3"
   }
 }
-

--- a/libs/plugin-sdk/package.json
+++ b/libs/plugin-sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/plugin-sdk",
   "version": "0.1.0",
   "description": "Plugin SDK for OpenLinker — AdapterPlugin contract + NestJS adapter for per-connection integration plugins (#593, #597).",
+  "license": "Apache-2.0",
   "private": true,
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -2,6 +2,7 @@
   "name": "@openlinker/shared",
   "version": "0.1.0",
   "description": "OpenLinker Shared Utilities",
+  "license": "Apache-2.0",
   "private": true,
   "type": "commonjs",
   "main": "./dist/index.js",
@@ -44,7 +45,9 @@
       "require": "./dist/cache/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "jest --passWithNoTests",
@@ -75,4 +78,3 @@
     "typescript": "5.4.3"
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "openlinker",
   "version": "0.1.0",
   "description": "Open-source, modular, API-first e-commerce orchestration platform",
+  "license": "Apache-2.0",
   "private": true,
   "scripts": {
     "clean": "find libs apps -type f -path '*/src/*' \\( -name '*.js' -o -name '*.js.map' -o -name '*.d.ts' -o -name '*.d.ts.map' \\) ! -name 'jest.config.js' ! -name '.eslintrc.js' -delete",


### PR DESCRIPTION
Three BLOCKING items from the OSS launch readiness epic (#670) bundled into one docs/governance pass.

## Summary

- **#657** — Apache 2.0 `LICENSE` at repo root (verbatim text, md5 matches canonical Apache distribution); README license section updated; `"license": "Apache-2.0"` set on every `package.json` across the workspace (root + 3 apps + 6 libs); DCO recorded as the contributor-attestation mechanism in `CONTRIBUTING.md`.
- **#658** — New top-level `SECURITY.md` covering all five required sections (supported versions, reporting channel, SLA, scope, safe harbor). Reporting routes through GitHub Security Advisories — no domain dependency. Linked from both README and CONTRIBUTING.md.
- **#660** — `CONTRIBUTING.md` rewritten: placeholder clone URL replaced, `docker-compose up` swapped for `pnpm dev:stack:up`, migration command fixed to `pnpm --filter @openlinker/api migration:run`, `develop` → `main`, `pnpm 8+` → `pnpm 10+`, single `pnpm start:dev` split into the three real commands, Setup checklist added at the top. The same drift is fixed in README.md.

## ⚠️ Pre-merge / pre-public-flip requirement

**Enable GitHub Private Vulnerability Reporting in repo settings** (Settings → Code security and analysis → Private vulnerability reporting → Enable). `SECURITY.md`'s primary reporting channel points contributors at the Security-tab "Report a vulnerability" form, which only works once this toggle is on. The doc is correct; the admin action is the precondition.

## Acceptance — #657

- [x] `/LICENSE` exists with verbatim Apache 2.0 text (md5 `3b83ef96387f14655fc854ddc3c6bd57` matches canonical).
- [x] README license section updated.
- [x] `package.json` `license` field set on root + every workspace.
- [x] DCO check decision recorded — `CONTRIBUTING.md § Commits` documents DCO over CLA; this PR is signed off with `Signed-off-by:` to demonstrate the mechanism. Automated enforcement deferred to post-#641 per the issue.
- [x] Third-party code requiring Apache 2.0 § 4 attribution: none identified.

## Acceptance — #658

- [x] `/SECURITY.md` exists, covers all five required sections (+ a bonus Acknowledgements section).
- [x] Linked from README (new `## Security` section) and CONTRIBUTING.md (`## Security` near the bottom).
- [ ] **Private Vulnerability Reporting enabled in repo settings** — admin task, see above.
- [ ] **Dedicated security email alias** (`security@openlinker.io`) — depends on #642; TODO anchor in SECURITY.md.
- [ ] **SLA targets agreed with maintainers** — proposed values are conventional defaults (72h ack / 14d critical / 30d non-critical). Please confirm before merge or propose adjustments.

## Acceptance — #660

- [x] Cloning the URL from `CONTRIBUTING.md` works (`SilkSoftwareHouse/openlinker.git`).
- [x] Every command in the doc matches an actual script in `package.json` (verified by grep against root + workspace scripts).
- [x] Doc is consistent with README — same prereq/command drift fixed in both files.
- [x] Setup Checklist at the top gives the exact zero-to-green sequence.
- [x] Will need a follow-up edit when #641 transfers the repo URL — tracked in #664.

## Out-of-PR follow-ups

Already noted in the implementation plan (`docs/plans/implementation-plan-657-658-660-oss-launch-baseline.md`):

- Enable GitHub Private Vulnerability Reporting (admin toggle).
- Replace `SECURITY.md` reporting section once `openlinker.io` lands (#642).
- Update repo URLs in `SECURITY.md` / `CONTRIBUTING.md` / `README.md` once the org transfer completes (#641, tracked in #664).
- Add an automated DCO check workflow on the new org (out of scope per #657's explicit deferral).

## Test plan

- [x] `pnpm lint` — passes (0 errors; pre-existing warnings only).
- [x] `pnpm type-check` — passes.
- [x] `pnpm test` — passes (357 + 118 unit tests across apps/api and apps/worker; web suite passed independently; one transient flake in `webhook-deliveries-page.test.tsx` resolved on rerun).
- [x] `diff <(curl -s https://www.apache.org/licenses/LICENSE-2.0.txt) LICENSE` — empty (byte-identical).
- [x] `grep -E "your-org|docker-compose up|pnpm migration:run\b|from \`develop\`" CONTRIBUTING.md` — empty (no placeholders or drift remain).
- [x] `grep "Add your license\|pnpm 8\+" README.md` — empty (same drift fixed).
- [x] Manually walk the Setup Checklist from a hypothetical fresh clone (eyeball check; the commands match `package.json` scripts).

## Notes for reviewers

- This PR is signed off with `git commit -s` to demonstrate the documented DCO mechanism. Future contributors should do the same; automated enforcement will be added post-#641.
- Two commits to make the review easier: the bulk PR (`698e59a`) and a small tech-review polish (`f8052ae`) adding a sibling `#641` TODO anchor in `SECURITY.md` and clarifying the Docker-vs-local-Postgres path in `CONTRIBUTING.md`.

Closes #657
Closes #658
Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)
