### PR TITLE
fix(identifier-mapping): close concurrency race via pure insert-then-recover

### DIFF
--- a/apps/api/test/integration/identifier-mapping/identifier-mapping-concurrency.int-spec.ts
+++ b/apps/api/test/integration/identifier-mapping/identifier-mapping-concurrency.int-spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Identifier Mapping Concurrency Integration Spec
+ *
+ * Real-DB regression test for issue #656 (concurrency race in
+ * `getOrCreateInternalId`). Complements the unit spec, which only proves the
+ * application-layer recovery given a stubbed `DuplicateIdentifierMappingError`.
+ * This spec exercises the full seam: the repository's PG `23505` →
+ * `DuplicateIdentifierMappingError` translation against a real Postgres
+ * unique index, plus the service's insert-then-recover convergence under
+ * concurrent insert load.
+ *
+ * @module apps/api/test/integration/identifier-mapping
+ */
+import { DataSource } from 'typeorm';
+import {
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  IIdentifierMappingService,
+} from '@openlinker/core/identifier-mapping';
+import { IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping/orm-entities';
+import {
+  getTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+  IntegrationTestHarness,
+} from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+
+describe('IdentifierMappingService — concurrency (real Postgres)', () => {
+  let harness: IntegrationTestHarness;
+  let dataSource: DataSource;
+  let service: IIdentifierMappingService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    dataSource = harness.getDataSource();
+    service = harness.getApp().get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);
+  }, 60_000);
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('converges on a single mapping row when N callers race on the same external key', async () => {
+    const connection = await createTestConnection(dataSource);
+    const N = 16;
+
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        service.getOrCreateInternalId('Product', 'external-race', connection.id),
+      ),
+    );
+
+    // Every caller resolves to the same internalId.
+    const unique = new Set(results);
+    expect(unique.size).toBe(1);
+    expect(results[0]).toMatch(/^ol_product_[a-f0-9]{32}$/);
+
+    // Exactly one row persists in the database for the external key.
+    const mappings = await dataSource.getRepository(IdentifierMappingOrmEntity).find({
+      where: {
+        entityType: 'Product',
+        connectionId: connection.id,
+        externalId: 'external-race',
+      },
+    });
+    expect(mappings).toHaveLength(1);
+    expect(mappings[0].internalId).toBe(results[0]);
+  });
+
+  it('isolates races per (entityType, externalId, connectionId) triple', async () => {
+    const connection = await createTestConnection(dataSource);
+    const externalIds = ['ext-a', 'ext-b', 'ext-c'];
+    const callersPerKey = 6;
+
+    const calls = externalIds.flatMap((externalId) =>
+      Array.from({ length: callersPerKey }, () => ({
+        externalId,
+        promise: service.getOrCreateInternalId('Product', externalId, connection.id),
+      })),
+    );
+
+    const resolved = await Promise.all(calls.map(({ externalId, promise }) => promise.then((id) => ({ externalId, id }))));
+
+    // Each externalId produced exactly one internalId across its callers.
+    const idByExternal = new Map<string, Set<string>>();
+    for (const { externalId, id } of resolved) {
+      const set = idByExternal.get(externalId) ?? new Set<string>();
+      set.add(id);
+      idByExternal.set(externalId, set);
+    }
+    for (const externalId of externalIds) {
+      expect(idByExternal.get(externalId)?.size).toBe(1);
+    }
+
+    // The three external keys minted three distinct internal IDs.
+    const distinctInternalIds = new Set(resolved.map((r) => r.id));
+    expect(distinctInternalIds.size).toBe(externalIds.length);
+
+    // The database carries exactly three rows.
+    const mappings = await dataSource.getRepository(IdentifierMappingOrmEntity).find({
+      where: { entityType: 'Product', connectionId: connection.id },
+    });
+    expect(mappings).toHaveLength(externalIds.length);
+  });
+});

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -90,7 +90,7 @@ All TypeScript projects must use strict mode:
 #### Test Files
 
 - **Unit Tests**: `*.spec.ts` (e.g., `product.service.spec.ts`)
-- **Integration Tests**: `*.integration.spec.ts` (e.g., `product.integration.spec.ts`)
+- **Integration Tests**: `*.int-spec.ts` (e.g., `product.int-spec.ts`) — see [Testing Guide](./testing-guide.md) for the harness pattern
 - **E2E Tests**: `*.e2e-spec.ts` (e.g., `product.e2e-spec.ts`)
 
 ### Class Names

--- a/docs/plans/implementation-plan-identifier-mapping-race.md
+++ b/docs/plans/implementation-plan-identifier-mapping-race.md
@@ -1,0 +1,356 @@
+# Implementation Plan — Fix concurrency race in `IdentifierMappingService`
+
+**Issue:** #656 — [BUG] Concurrency race in `IdentifierMappingService.getOrCreateInternalId`
+**Branch:** `656-identifier-mapping-race`
+**Layer:** CORE / Application service (`libs/core/src/identifier-mapping/`)
+**Owner:** Piotr Swierzy
+
+---
+
+## 1. Goal
+
+Eliminate the read-before-write race window in `IdentifierMappingService` by switching all get-or-create paths to a pure **insert-then-recover** pattern, per `docs/engineering-standards.md` § _Error handling in concurrent operations_. Remove the long-standing TODO at `identifier-mapping.service.ts:316`.
+
+### Non-goals
+
+- No port/interface signature changes.
+- No new public methods.
+- No persistence/schema changes (existing unique index `(entityType, platformType, connectionId, externalId)` is already sufficient and confirmed present on `IdentifierMappingOrmEntity`).
+- No batch-size chunking changes for `batchGetOrCreateInternalIds` (the existing concurrency note remains correct; fixing the helper is enough).
+
+---
+
+## 2. Where the race actually is
+
+Three call sites currently mix check-then-insert:
+
+| Method | Read-before-write? | Recovery on race? | Notes |
+|---|---|---|---|
+| `getOrCreateInternalIdWithPlatform` (private helper, used by `getOrCreateInternalId` + batch) | Yes (fast-path `findByExternalKey`) | Yes (catches `DuplicateIdentifierMappingError`) | Race already *closed* by recovery, but the upfront read still violates the "no read-before-write race window" acceptance criterion. |
+| `createMapping` (public) | Yes | **No** — `repository.create()` does plain `.save()` and surfaces raw `QueryFailedError` | Real race; concurrent callers see infrastructure error leak. |
+| `getOrCreateExactMapping` (public) | Yes (twice — once directly, then again inside `createMapping`) | **No** — same as `createMapping` | Real race; carries the TODO at line 316 explicitly acknowledging the bug. |
+
+`batchGetOrCreateInternalIds` delegates to the helper, so it inherits whatever the helper does. No separate fix needed.
+
+`repository.insertMapping` already translates PG `23505` → `DuplicateIdentifierMappingError` (confirmed at `identifier-mapping.repository.ts:92-113`). `repository.create` does **not**.
+
+---
+
+## 3. Design — pure insert-then-recover
+
+Apply the canonical pattern from `docs/engineering-standards.md`:
+
+```ts
+try {
+  await this.repository.insertMapping(mapping);   // unconditional insert
+  return internalId;
+} catch (error) {
+  if (error instanceof DuplicateIdentifierMappingError) {
+    const winner = await this.repository.findByExternalKey(...);
+    if (winner) return winner.internalId;
+  }
+  throw error;   // re-throw if not a duplicate, or if winner vanished
+}
+```
+
+Apply with method-specific tweaks:
+
+- **`getOrCreateInternalIdWithPlatform`**: drop the upfront `findByExternalKey`. Always generate an internalId, always try `insertMapping`, recover on duplicate. Same external contract: returns the winning `internalId`.
+- **`createMapping`** (public — keeps "explicit create, fail if duplicate" semantics): drop the upfront `findByExternalKey`. Always try `insertMapping`. On duplicate → SELECT winner → throw `MappingAlreadyExistsError(... winner.internalId)`. This preserves the existing public contract: callers still see `MappingAlreadyExistsError`, not a raw infrastructure error.
+- **`getOrCreateExactMapping`** (public — explicit-mapping with "existing-equal is OK" semantics): drop both upfront reads. Always try `insertMapping` with the *provided* internalId. On duplicate → SELECT winner → if `winner.internalId === requestedInternalId` return success, else throw `IdentifierMappingConflictException`. Remove the TODO.
+
+The pattern is consistent everywhere: insert → catch `DuplicateIdentifierMappingError` → SELECT winner → translate the winner into whatever the public method's contract demands.
+
+### Cost note (deliberate trade-off)
+
+Removing the fast-path read is a **deliberate performance regression on the dominant workload** (sync jobs re-hitting known external IDs). Two readings of the issue's acceptance criterion ("no read-before-write race window") are defensible:
+
+- **Strict reading** — eliminate the read-before-write code path entirely. This plan follows this reading.
+- **Lenient reading** — close the *race* in the read-before-write path. The existing catch on `DuplicateIdentifierMappingError` already does this.
+
+The strict reading wins here because (a) the engineering-standards.md sample is pure insert-then-recover with no upfront read, (b) following the documented pattern verbatim means the next reader of this code can't conclude "the fast-path is fine to add back" without first revisiting the standard, and (c) the cost is small: an insert against a unique index that already has the row is a single PG `23505` failure — no WAL extension, returns immediately.
+
+The PR description must call this out explicitly so future "perf optimization" PRs don't silently reintroduce the fast-path and undo the work. Adapters that legitimately need raw-read performance should call `getInternalId` directly — that path is unchanged and remains a pure read.
+
+---
+
+## 4. Step-by-step implementation
+
+### Step 4.1 — Refactor `getOrCreateInternalIdWithPlatform`
+
+**File:** `libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts`
+
+Replace the body of `getOrCreateInternalIdWithPlatform` with pure insert-then-recover:
+
+```ts
+private async getOrCreateInternalIdWithPlatform(
+  entityType: string,
+  externalId: string,
+  connectionId: string,
+  platformType: string,
+  context?: MappingContext,
+): Promise<string> {
+  const internalId = this.generateInternalId(entityType);
+  const mapping = new IdentifierMapping(
+    randomUUID(),
+    entityType,
+    internalId,
+    externalId,
+    platformType,
+    connectionId,
+    context ?? null,
+    new Date(),
+    new Date(),
+  );
+
+  try {
+    await this.repository.insertMapping(mapping);
+    this.logger.log(
+      `Created new mapping for ${entityType}:${externalId}@${connectionId} -> ${internalId}`,
+    );
+    return internalId;
+  } catch (error) {
+    if (error instanceof DuplicateIdentifierMappingError) {
+      const winner = await this.repository.findByExternalKey(
+        entityType, platformType, connectionId, externalId,
+      );
+      if (winner) {
+        this.logger.debug(
+          `Mapping already exists for ${entityType}:${externalId}@${connectionId} -> ${winner.internalId}`,
+        );
+        return winner.internalId;
+      }
+    }
+    throw error;
+  }
+}
+```
+
+**Acceptance:**
+- No upfront `findByExternalKey` call in this helper.
+- JSDoc updated: the "handles `DuplicateIdentifierMappingError` (concurrent insert)" parenthetical is widened to "handles duplicate mappings — pre-existing or from concurrent insert", since the duplicate path now covers both cases.
+- Existing JSDoc note about `InternalIdCollisionError` is retained.
+
+### Step 4.2 — Refactor `createMapping` (public)
+
+Same file.
+
+```ts
+async createMapping(
+  entityType: string,
+  externalId: string,
+  connectionId: string,
+  internalId: string,
+  context?: MappingContext,
+): Promise<void> {
+  const connection = await this.connectionPort.get(connectionId);
+  const platformType = connection.platformType;
+
+  const mapping = new IdentifierMapping(
+    randomUUID(),
+    entityType,
+    internalId,
+    externalId,
+    platformType,
+    connectionId,
+    context ?? null,
+    new Date(),
+    new Date(),
+  );
+
+  try {
+    await this.repository.insertMapping(mapping);
+  } catch (error) {
+    if (error instanceof DuplicateIdentifierMappingError) {
+      const winner = await this.repository.findByExternalKey(
+        entityType, platformType, connectionId, externalId,
+      );
+      if (winner) {
+        throw new MappingAlreadyExistsError(
+          entityType, externalId, connectionId, winner.internalId,
+        );
+      }
+    }
+    throw error;
+  }
+}
+```
+
+**Acceptance:**
+- Public contract preserved for the common case: `MappingAlreadyExistsError` still thrown when a duplicate exists (whether pre-existing or from concurrent insert).
+- Switches from `repository.create()` to `repository.insertMapping()` (the duplicate-translating variant).
+- **Documented contract drift in the corner case**: if `insertMapping` throws `DuplicateIdentifierMappingError` AND the follow-up `findByExternalKey` returns `null` (concurrent insert + concurrent delete window — microsecond-wide), the method re-throws the underlying `DuplicateIdentifierMappingError` instead of synthesizing a fake `MappingAlreadyExistsError`. The JSDoc on `createMapping` documents this: `@throws MappingAlreadyExistsError` in the normal duplicate case, `@throws DuplicateIdentifierMappingError` if the winner row has been deleted between the insert failure and the SELECT.
+
+### Step 4.3 — Refactor `getOrCreateExactMapping` and remove the TODO
+
+Same file. Inline the logic rather than calling the now-changed `createMapping` (since this method has different "existing-equal is OK" semantics):
+
+```ts
+async getOrCreateExactMapping(
+  entityType: string,
+  externalId: string,
+  internalId: string,
+  connectionId: string,
+  context?: MappingContext,
+): Promise<string> {
+  const connection = await this.connectionPort.get(connectionId);
+  const platformType = connection.platformType;
+
+  const mapping = new IdentifierMapping(
+    randomUUID(),
+    entityType,
+    internalId,
+    externalId,
+    platformType,
+    connectionId,
+    context ?? null,
+    new Date(),
+    new Date(),
+  );
+
+  try {
+    await this.repository.insertMapping(mapping);
+    this.logger.debug(
+      `Created mapping: ${entityType}:${externalId}@${connectionId} -> ${internalId}`,
+    );
+    return externalId;
+  } catch (error) {
+    if (error instanceof DuplicateIdentifierMappingError) {
+      const winner = await this.repository.findByExternalKey(
+        entityType, platformType, connectionId, externalId,
+      );
+      if (winner) {
+        if (winner.internalId === internalId) {
+          this.logger.debug(
+            `Mapping already exists: ${entityType}:${externalId}@${connectionId} -> ${internalId}`,
+          );
+          return externalId;
+        }
+        throw new IdentifierMappingConflictException(
+          entityType, externalId, connectionId, winner.internalId, internalId,
+        );
+      }
+    }
+    throw error;
+  }
+}
+```
+
+**Acceptance:**
+- TODO comment at the old line 316 is gone.
+- Same public behaviour: perfect-match no-op returns `externalId`; mismatch throws `IdentifierMappingConflictException`.
+
+### Step 4.4 — Update existing unit tests
+
+**File:** `libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts`
+
+Two existing tests assume the old fast-path read:
+
+1. `'should return existing internal ID if mapping exists'` (around line 78). Rewrite expectations: `insertMapping` IS called, throws `DuplicateIdentifierMappingError`, then `findByExternalKey` returns the existing mapping. Assert returned internalId equals the existing one.
+2. `'should create mapping when it does not exist'` under `describe('createMapping')` (around line 356). Switch the mocked successful path from `repository.create` to `repository.insertMapping`. Likewise update `'should throw error if mapping already exists'` to drive the path via `insertMapping.mockRejectedValue(duplicateError)` + `findByExternalKey.mockResolvedValue(existing)`.
+
+The "concurrent insert detected" tests and "should re-throw … when winner cannot be found" tests carry over unchanged.
+
+### Step 4.5 — Add a `Promise.all` concurrency unit test
+
+Same spec file. Drive N parallel `getOrCreateInternalId` calls; mock `insertMapping` so the first call resolves and the rest reject with `DuplicateIdentifierMappingError`; mock `findByExternalKey` to return the winning mapping. Assert all N callers return the same internalId and `insertMapping` was called N times (one success + N-1 duplicates).
+
+```ts
+it('should converge on a single internalId when N concurrent callers race', async () => {
+  const N = 10;
+  let savedMapping: IdentifierMapping | null = null;
+
+  repository.insertMapping.mockImplementation(async (mapping) => {
+    if (!savedMapping) {
+      savedMapping = mapping;
+      return mapping;
+    }
+    throw new DuplicateIdentifierMappingError(
+      mapping.entityType, mapping.externalId, mapping.platformType, mapping.connectionId,
+    );
+  });
+  repository.findByExternalKey.mockImplementation(async () => savedMapping);
+
+  const results = await Promise.all(
+    Array.from({ length: N }, () =>
+      service.getOrCreateInternalId('Product', 'external-race', connectionId),
+    ),
+  );
+
+  expect(new Set(results).size).toBe(1);                  // all converged
+  expect(results[0]).toMatch(/^ol_product_[a-f0-9]{32}$/);
+  expect(repository.insertMapping).toHaveBeenCalledTimes(N);
+});
+```
+
+### Step 4.6 — Add a real-DB concurrency integration test
+
+**New file:** `apps/api/test/integration/identifier-mapping/identifier-mapping-concurrency.int-spec.ts`
+
+The unit test in Step 4.5 only proves the recovery logic *given* `DuplicateIdentifierMappingError`. It cannot catch a regression where the repository stops translating PG `23505` correctly (e.g., TypeORM version bump changes the `QueryFailedError` shape). The translation seam at `identifier-mapping.repository.ts:92-113` is currently un-tested.
+
+Add a Testcontainers-backed int-spec that:
+
+1. Uses `getTestHarness()` to spin up real Postgres + run migrations.
+2. Inserts a real `Connection` row (so the connection-port resolution path is real, not mocked).
+3. Drives N concurrent `service.getOrCreateInternalId(...)` calls with the same `(entityType, externalId, connectionId)` via `Promise.all`.
+4. Asserts: exactly one `identifier_mappings` row persists, and every caller resolves to the same `internalId`.
+5. `resetTestHarness()` between cases so the table is clean per test.
+
+This belongs alongside any future identifier-mapping int-specs; if no folder exists yet, create `apps/api/test/integration/identifier-mapping/` — the testing-guide.md pattern allows per-context folders.
+
+### Step 4.7 — Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All must pass with zero errors. No migration step needed (no schema change).
+
+---
+
+## 5. Validation
+
+### 5.1 Architecture
+
+- ✅ Domain layer untouched (no framework imports added).
+- ✅ Application service still depends only on ports (`IdentifierMappingRepositoryPort`, `ConnectionPort`).
+- ✅ Public method signatures unchanged → no caller updates needed across the repo.
+- ✅ Repository contract unchanged.
+
+### 5.2 Naming / conventions
+
+- ✅ No new files, no renames.
+- ✅ No new types or constants.
+
+### 5.3 Testing strategy
+
+- **Unit spec** (Step 4.5) covers the application-layer recovery logic given a stubbed `DuplicateIdentifierMappingError`.
+- **Integration spec** (Step 4.6) covers the repository's PG `23505` → `DuplicateIdentifierMappingError` translation seam against a real Postgres unique index, plus the end-to-end concurrent-insert convergence. This catches regressions the unit spec is blind to (TypeORM error-shape drift, unique-index name drift, migration-state mismatch).
+- Both are needed because they cover different layers of the same guarantee — the unit spec gives fast feedback, the int-spec is the regression backstop at the seam that matters.
+
+### 5.4 Security / performance
+
+- No security impact.
+- Performance trade-off (extra insert attempt per repeat lookup) acknowledged above; acceptable for correctness.
+
+### 5.5 Open questions
+
+None known. The repository port already exposes everything needed (`insertMapping` + `findByExternalKey`).
+
+---
+
+## 6. Acceptance checklist (from issue #656 + scope additions)
+
+- [ ] `getOrCreateInternalId` follows the insert-then-recover pattern; no read-before-write race window.
+- [ ] Concurrency test (unit): spawn N parallel calls with the same `(entityType, externalId, connectionId)` — exactly one mapping persists, all callers return the same `internalId`. Added as a unit spec with `Promise.all`.
+- [ ] Concurrency test (integration): same shape against a real Postgres + Connection row, also covering the repository's `23505` → `DuplicateIdentifierMappingError` translation seam.
+- [ ] TODO at line 316 removed.
+- [ ] `batchGetOrCreateInternalIds` reviewed for the same pattern; fix flows through the shared helper (no separate change needed).
+- [ ] **Scope addition**: `createMapping` switched from `repository.create()` to `repository.insertMapping()`. Public exception contract documented in JSDoc: `MappingAlreadyExistsError` in the normal duplicate case, `DuplicateIdentifierMappingError` in the rare insert-fails-then-winner-deleted window.
+- [ ] **Scope addition**: `getOrCreateExactMapping` rewritten to the same pattern; behaviour preserved for both perfect-match (no-op) and mismatch (`IdentifierMappingConflictException`) branches.
+- [ ] Helper JSDoc on `getOrCreateInternalIdWithPlatform` updated: "concurrent insert" → "duplicate mappings — pre-existing or from concurrent insert".
+- [ ] PR description explicitly calls out the fast-path-read removal as a deliberate trade-off (not just literal spec compliance) so future "perf optimization" PRs don't silently reintroduce it.
+- [ ] `pnpm lint && pnpm type-check && pnpm test` pass; `pnpm test:integration` passes the new concurrency spec.

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts
@@ -75,7 +75,7 @@ describe('IdentifierMappingService', () => {
       connectionPort.get.mockResolvedValue(connection);
     });
 
-    it('should return existing internal ID if mapping exists', async () => {
+    it('should return existing internalId when mapping already exists (recovered via duplicate-insert path)', async () => {
       const existingMapping = new IdentifierMapping(
         'id-1',
         'Product',
@@ -88,6 +88,14 @@ describe('IdentifierMappingService', () => {
         new Date(),
       );
 
+      // Pure insert-then-recover: insert attempt fails on duplicate, SELECT returns the existing row.
+      const duplicateError = new DuplicateIdentifierMappingError(
+        'Product',
+        'external-123',
+        platformType,
+        connectionId,
+      );
+      repository.insertMapping.mockRejectedValue(duplicateError);
       repository.findByExternalKey.mockResolvedValue(existingMapping);
 
       const result = await service.getOrCreateInternalId(
@@ -98,17 +106,17 @@ describe('IdentifierMappingService', () => {
 
       expect(result).toBe('ol_product_abc123');
       expect(connectionPort.get).toHaveBeenCalledWith(connectionId);
+      expect(repository.insertMapping).toHaveBeenCalledTimes(1);
+      expect(repository.findByExternalKey).toHaveBeenCalledTimes(1);
       expect(repository.findByExternalKey).toHaveBeenCalledWith(
         'Product',
         platformType,
         connectionId,
         'external-123',
       );
-      expect(repository.insertMapping).not.toHaveBeenCalled();
     });
 
     it('should create new mapping if it does not exist', async () => {
-      repository.findByExternalKey.mockResolvedValue(null);
       const newMapping = new IdentifierMapping(
         'id-1',
         'Product',
@@ -131,6 +139,8 @@ describe('IdentifierMappingService', () => {
       expect(result).toMatch(/^ol_product_/);
       expect(connectionPort.get).toHaveBeenCalledWith(connectionId);
       expect(repository.insertMapping).toHaveBeenCalled();
+      // No upfront read — insert is attempted unconditionally.
+      expect(repository.findByExternalKey).not.toHaveBeenCalled();
     });
 
     it('should return existing internalId when concurrent insert is detected', async () => {
@@ -146,11 +156,6 @@ describe('IdentifierMappingService', () => {
         new Date(),
       );
 
-      // First call: no mapping yet (triggers insert); second call: winner row after race
-      repository.findByExternalKey
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(winnerMapping);
-
       const duplicateError = new DuplicateIdentifierMappingError(
         'Product',
         'external-123',
@@ -158,16 +163,17 @@ describe('IdentifierMappingService', () => {
         connectionId,
       );
       repository.insertMapping.mockRejectedValue(duplicateError);
+      repository.findByExternalKey.mockResolvedValue(winnerMapping);
 
       const result = await service.getOrCreateInternalId('Product', 'external-123', connectionId);
 
       expect(result).toBe('ol_product_winner');
       expect(repository.insertMapping).toHaveBeenCalledTimes(1);
-      expect(repository.findByExternalKey).toHaveBeenCalledTimes(2);
+      expect(repository.findByExternalKey).toHaveBeenCalledTimes(1);
     });
 
     it('should re-throw DuplicateIdentifierMappingError when winner cannot be found after concurrent insert', async () => {
-      // Both findByExternalKey calls return null (insert failed AND winner disappeared)
+      // Insert fails with duplicate AND the winner row has vanished (delete-during-race window)
       repository.findByExternalKey.mockResolvedValue(null);
 
       const duplicateError = new DuplicateIdentifierMappingError(
@@ -182,11 +188,10 @@ describe('IdentifierMappingService', () => {
         service.getOrCreateInternalId('Product', 'external-123', connectionId),
       ).rejects.toThrow(DuplicateIdentifierMappingError);
 
-      expect(repository.findByExternalKey).toHaveBeenCalledTimes(2);
+      expect(repository.findByExternalKey).toHaveBeenCalledTimes(1);
     });
 
     it('should resolve platformType from Connection', async () => {
-      repository.findByExternalKey.mockResolvedValue(null);
       repository.insertMapping.mockResolvedValue(
         new IdentifierMapping(
           'id-1',
@@ -204,17 +209,55 @@ describe('IdentifierMappingService', () => {
       await service.getOrCreateInternalId('Product', 'external-123', connectionId);
 
       expect(connectionPort.get).toHaveBeenCalledWith(connectionId);
-      expect(repository.findByExternalKey).toHaveBeenCalledWith(
-        'Product',
-        platformType,
-        connectionId,
-        'external-123',
+      // platformType propagates into the mapping passed to insertMapping
+      expect(repository.insertMapping).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: 'Product',
+          externalId: 'external-123',
+          platformType,
+          connectionId,
+        }),
       );
+    });
+
+    it('should converge on a single internalId when N concurrent callers race', async () => {
+      // Drives N parallel getOrCreateInternalId calls against a simulated DB.
+      // Only the first insertMapping succeeds; the rest throw DuplicateIdentifierMappingError.
+      // findByExternalKey always returns the saved row (the "winner") after that.
+      const N = 10;
+      let savedMapping: IdentifierMapping | null = null;
+
+      repository.insertMapping.mockImplementation((mapping) => {
+        if (!savedMapping) {
+          savedMapping = mapping;
+          return Promise.resolve(mapping);
+        }
+        return Promise.reject(
+          new DuplicateIdentifierMappingError(
+            mapping.entityType,
+            mapping.externalId,
+            mapping.platformType,
+            mapping.connectionId,
+          ),
+        );
+      });
+      repository.findByExternalKey.mockImplementation(() => Promise.resolve(savedMapping));
+
+      const results = await Promise.all(
+        Array.from({ length: N }, () =>
+          service.getOrCreateInternalId('Product', 'external-race', connectionId),
+        ),
+      );
+
+      expect(new Set(results).size).toBe(1);
+      expect(results[0]).toMatch(/^ol_product_[a-f0-9]{32}$/);
+      expect(repository.insertMapping).toHaveBeenCalledTimes(N);
+      // N - 1 duplicate-recoveries each do one SELECT; the winner does zero.
+      expect(repository.findByExternalKey).toHaveBeenCalledTimes(N - 1);
     });
 
     describe('internal ID prefix', () => {
       beforeEach(() => {
-        repository.findByExternalKey.mockResolvedValue(null);
         repository.insertMapping.mockImplementation((mapping) => Promise.resolve(mapping));
       });
 
@@ -354,7 +397,6 @@ describe('IdentifierMappingService', () => {
     });
 
     it('should create mapping when it does not exist', async () => {
-      repository.findByExternalKey.mockResolvedValue(null);
       const newMapping = new IdentifierMapping(
         'id-1',
         'Product',
@@ -366,7 +408,7 @@ describe('IdentifierMappingService', () => {
         new Date(),
         new Date(),
       );
-      repository.create.mockResolvedValue(newMapping);
+      repository.insertMapping.mockResolvedValue(newMapping);
 
       await service.createMapping(
         'Product',
@@ -376,10 +418,12 @@ describe('IdentifierMappingService', () => {
       );
 
       expect(connectionPort.get).toHaveBeenCalledWith(connectionId);
-      expect(repository.create).toHaveBeenCalled();
+      expect(repository.insertMapping).toHaveBeenCalled();
+      // No upfront read — insert is attempted unconditionally.
+      expect(repository.findByExternalKey).not.toHaveBeenCalled();
     });
 
-    it('should throw error if mapping already exists', async () => {
+    it('should throw MappingAlreadyExistsError if mapping already exists (recovered via duplicate-insert path)', async () => {
       const existingMapping = new IdentifierMapping(
         'id-1',
         'Product',
@@ -391,11 +435,40 @@ describe('IdentifierMappingService', () => {
         new Date(),
         new Date(),
       );
+      const duplicateError = new DuplicateIdentifierMappingError(
+        'Product',
+        'external-123',
+        platformType,
+        connectionId,
+      );
+      repository.insertMapping.mockRejectedValue(duplicateError);
       repository.findByExternalKey.mockResolvedValue(existingMapping);
 
       await expect(
         service.createMapping('Product', 'external-123', connectionId, 'ol_product_new'),
       ).rejects.toThrow(MappingAlreadyExistsError);
+
+      expect(repository.findByExternalKey).toHaveBeenCalledWith(
+        'Product',
+        platformType,
+        connectionId,
+        'external-123',
+      );
+    });
+
+    it('should re-throw DuplicateIdentifierMappingError when winner cannot be found after concurrent insert', async () => {
+      const duplicateError = new DuplicateIdentifierMappingError(
+        'Product',
+        'external-123',
+        platformType,
+        connectionId,
+      );
+      repository.insertMapping.mockRejectedValue(duplicateError);
+      repository.findByExternalKey.mockResolvedValue(null);
+
+      await expect(
+        service.createMapping('Product', 'external-123', connectionId, 'ol_product_new'),
+      ).rejects.toThrow(DuplicateIdentifierMappingError);
     });
   });
 

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.spec.ts
@@ -26,7 +26,6 @@ describe('IdentifierMappingService', () => {
     const mockRepository = {
       findByExternalKey: jest.fn(),
       findByInternalId: jest.fn(),
-      create: jest.fn(),
       insertMapping: jest.fn(),
       deleteByExternalKey: jest.fn(),
       findByEntityTypeAndConnection: jest.fn(),
@@ -75,7 +74,7 @@ describe('IdentifierMappingService', () => {
       connectionPort.get.mockResolvedValue(connection);
     });
 
-    it('should return existing internalId when mapping already exists (recovered via duplicate-insert path)', async () => {
+    it('should return existing internalId when mapping already exists', async () => {
       const existingMapping = new IdentifierMapping(
         'id-1',
         'Product',
@@ -423,7 +422,7 @@ describe('IdentifierMappingService', () => {
       expect(repository.findByExternalKey).not.toHaveBeenCalled();
     });
 
-    it('should throw MappingAlreadyExistsError if mapping already exists (recovered via duplicate-insert path)', async () => {
+    it('should throw MappingAlreadyExistsError if mapping already exists', async () => {
       const existingMapping = new IdentifierMapping(
         'id-1',
         'Product',

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
@@ -92,6 +92,18 @@ export class IdentifierMappingService implements IIdentifierMappingService {
     }));
   }
 
+  /**
+   * Create an explicit mapping. Concurrency-safe via insert-then-recover.
+   *
+   * @throws MappingAlreadyExistsError when a mapping already exists for the
+   *   `(entityType, externalId, connectionId)` triple — whether pre-existing
+   *   or inserted concurrently.
+   * @throws DuplicateIdentifierMappingError in the rare insert-fails-then-
+   *   winner-deleted window: `insertMapping` raises a unique-violation but
+   *   the follow-up `findByExternalKey` returns null because the winner row
+   *   was deleted between the two calls. Callers that only catch
+   *   `MappingAlreadyExistsError` should let this propagate.
+   */
   async createMapping(
     entityType: string,
     externalId: string,
@@ -99,19 +111,8 @@ export class IdentifierMappingService implements IIdentifierMappingService {
     internalId: string,
     context?: MappingContext,
   ): Promise<void> {
-    // Resolve Connection and derive platformType
     const connection = await this.connectionPort.get(connectionId);
     const platformType = connection.platformType;
-
-    const existing = await this.repository.findByExternalKey(
-      entityType,
-      platformType,
-      connectionId,
-      externalId,
-    );
-    if (existing) {
-      throw new MappingAlreadyExistsError(entityType, externalId, connectionId, existing.internalId);
-    }
 
     const mapping = new IdentifierMapping(
       randomUUID(),
@@ -125,7 +126,27 @@ export class IdentifierMappingService implements IIdentifierMappingService {
       new Date(),
     );
 
-    await this.repository.create(mapping);
+    try {
+      await this.repository.insertMapping(mapping);
+    } catch (error) {
+      if (error instanceof DuplicateIdentifierMappingError) {
+        const winner = await this.repository.findByExternalKey(
+          entityType,
+          platformType,
+          connectionId,
+          externalId,
+        );
+        if (winner) {
+          throw new MappingAlreadyExistsError(
+            entityType,
+            externalId,
+            connectionId,
+            winner.internalId,
+          );
+        }
+      }
+      throw error;
+    }
   }
 
   async deleteMapping(
@@ -202,9 +223,17 @@ export class IdentifierMappingService implements IIdentifierMappingService {
    * Internal helper for get-or-create with resolved platformType.
    * Used by batch operations to avoid redundant connection lookups.
    *
-   * Note: this helper handles DuplicateIdentifierMappingError (concurrent insert) but
-   * does NOT retry on InternalIdCollisionError. Internal ID collisions are astronomically
-   * rare with UUID generation; if one occurs here the error propagates to the caller.
+   * Pure insert-then-recover: always attempts insert (no upfront read), and
+   * handles duplicate mappings — pre-existing or from concurrent insert — by
+   * SELECTing the winner. Pattern matches docs/engineering-standards.md §
+   * "Error handling in concurrent operations". Eliminating the upfront read
+   * is a deliberate trade-off — repeat lookups now pay one insert attempt
+   * against a unique index in exchange for closing the race-window contract
+   * literally. Callers that need raw-read performance should use
+   * `getInternalId` directly.
+   *
+   * Does NOT retry on internal-id collisions. UUID collisions are
+   * astronomically rare; if one occurs the error propagates to the caller.
    * @private
    */
   private async getOrCreateInternalIdWithPlatform(
@@ -214,24 +243,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
     platformType: string,
     context?: MappingContext,
   ): Promise<string> {
-    // Check if mapping already exists
-    const existing = await this.repository.findByExternalKey(
-      entityType,
-      platformType,
-      connectionId,
-      externalId,
-    );
-    if (existing) {
-      this.logger.debug(
-        `Found existing mapping for ${entityType}:${externalId}@${connectionId} -> ${existing.internalId}`,
-      );
-      return existing.internalId;
-    }
-
-    // Generate new internal ID
     const internalId = this.generateInternalId(entityType);
-
-    // Create mapping with concurrency-safe insert
     const mapping = new IdentifierMapping(
       randomUUID(),
       entityType,
@@ -251,9 +263,7 @@ export class IdentifierMappingService implements IIdentifierMappingService {
       );
       return internalId;
     } catch (error) {
-      // Handle unique violation (concurrency case)
       if (error instanceof DuplicateIdentifierMappingError) {
-        // Retry: select and return winner
         const winner = await this.repository.findByExternalKey(
           entityType,
           platformType,
@@ -262,19 +272,24 @@ export class IdentifierMappingService implements IIdentifierMappingService {
         );
         if (winner) {
           this.logger.debug(
-            `Concurrent insert detected, returning existing mapping for ${entityType}:${externalId}@${connectionId} -> ${winner.internalId}`,
+            `Mapping already exists for ${entityType}:${externalId}@${connectionId} -> ${winner.internalId}`,
           );
           return winner.internalId;
         }
       }
-      // Re-throw if not a duplicate error or if winner not found
       throw error;
     }
   }
 
   /**
-   * Get or create exact mapping between external and internal identifiers
-   * Returns the external ID if mapping exists or was created successfully
+   * Get or create an exact mapping between an external identifier and a
+   * caller-supplied internal identifier. Concurrency-safe via insert-then-
+   * recover.
+   *
+   * @returns the external ID when the mapping was created or already exists
+   *   with the requested internal ID.
+   * @throws IdentifierMappingConflictException when the external ID is
+   *   already mapped to a *different* internal ID.
    */
   async getOrCreateExactMapping(
     entityType: string,
@@ -283,46 +298,53 @@ export class IdentifierMappingService implements IIdentifierMappingService {
     connectionId: string,
     context?: MappingContext,
   ): Promise<string> {
-    // Resolve Connection and derive platformType
     const connection = await this.connectionPort.get(connectionId);
     const platformType = connection.platformType;
 
-    // Check if mapping already exists
-    const existing = await this.repository.findByExternalKey(
+    const mapping = new IdentifierMapping(
+      randomUUID(),
       entityType,
+      internalId,
+      externalId,
       platformType,
       connectionId,
-      externalId,
+      context ?? null,
+      new Date(),
+      new Date(),
     );
-    if (existing) {
-      if (existing.internalId === internalId) {
-        // Perfect match - mapping already exists
-        this.logger.debug(
-          `Mapping already exists: ${entityType}:${externalId}@${connectionId} -> ${internalId}`,
-        );
-        return externalId;
-      }
-      // Conflict: external ID mapped to different internal ID
-      throw new IdentifierMappingConflictException(
-        entityType,
-        externalId,
-        connectionId,
-        existing.internalId,
-        internalId,
+
+    try {
+      await this.repository.insertMapping(mapping);
+      this.logger.debug(
+        `Created mapping: ${entityType}:${externalId}@${connectionId} -> ${internalId}`,
       );
+      return externalId;
+    } catch (error) {
+      if (error instanceof DuplicateIdentifierMappingError) {
+        const winner = await this.repository.findByExternalKey(
+          entityType,
+          platformType,
+          connectionId,
+          externalId,
+        );
+        if (winner) {
+          if (winner.internalId === internalId) {
+            this.logger.debug(
+              `Mapping already exists: ${entityType}:${externalId}@${connectionId} -> ${internalId}`,
+            );
+            return externalId;
+          }
+          throw new IdentifierMappingConflictException(
+            entityType,
+            externalId,
+            connectionId,
+            winner.internalId,
+            internalId,
+          );
+        }
+      }
+      throw error;
     }
-
-    // Create mapping (createMapping already checks for duplicates and throws if exists).
-    // TODO: this path is not concurrency-safe — concurrent calls can race between the
-    // findByExternalKey check above and repository.create() below, producing a raw
-    // QueryFailedError instead of a domain error. Fix if concurrent createMapping calls
-    // become a realistic scenario.
-    await this.createMapping(entityType, externalId, connectionId, internalId, context);
-    this.logger.debug(
-      `Created mapping: ${entityType}:${externalId}@${connectionId} -> ${internalId}`,
-    );
-    return externalId;
-
   }
 
   private generateInternalId(entityType: string): string {

--- a/libs/core/src/identifier-mapping/domain/ports/identifier-mapping-repository.port.ts
+++ b/libs/core/src/identifier-mapping/domain/ports/identifier-mapping-repository.port.ts
@@ -33,13 +33,10 @@ export interface IdentifierMappingRepositoryPort {
   findByInternalId(entityType: string, internalId: string): Promise<IdentifierMapping[]>;
 
   /**
-   * Create mapping (standard save operation)
-   */
-  create(mapping: IdentifierMapping): Promise<IdentifierMapping>;
-
-  /**
-   * Insert mapping with unique violation detection
-   * Used for concurrency-safe get-or-create operations
+   * Insert mapping with unique violation detection.
+   * Used for concurrency-safe get-or-create operations — the only write path
+   * the service uses, since plain `save()` does not translate PG `23505` to a
+   * domain error.
    * @throws DuplicateIdentifierMappingError if unique constraint violation occurs
    */
   insertMapping(mapping: IdentifierMapping): Promise<IdentifierMapping>;

--- a/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts
+++ b/libs/core/src/identifier-mapping/infrastructure/persistence/repositories/identifier-mapping.repository.ts
@@ -73,15 +73,6 @@ export class IdentifierMappingRepository implements IdentifierMappingRepositoryP
   }
 
   /**
-   * Create mapping (standard save operation)
-   */
-  async create(mapping: IdentifierMapping): Promise<IdentifierMapping> {
-    const entity = this.toOrmEntity(mapping);
-    const saved = await this.repository.save(entity);
-    return this.toDomain(saved);
-  }
-
-  /**
    * Insert mapping with unique violation detection.
    * Used for concurrency-safe get-or-create operations.
    * The only unique constraint on this table is the external key index


### PR DESCRIPTION
## Summary

Closes #656.

`IdentifierMappingService` had three check-then-insert paths that could race under concurrent load (parallel order ingestion, retried jobs, batch sync). The TODO at `identifier-mapping.service.ts:316` acknowledged the unhandled race. This PR rewrites all three to pure insert-then-recover per `docs/engineering-standards.md` § _Error handling in concurrent operations_, plus drops the now-dead `repository.create()` method that was only there to feed the old check-then-insert flow.

## What changed

**`getOrCreateInternalIdWithPlatform`** (private helper feeding `getOrCreateInternalId` + `batchGetOrCreateInternalIds`):
Dropped the upfront `findByExternalKey`. Always attempt `insertMapping`. On `DuplicateIdentifierMappingError` → SELECT winner → return its `internalId`. If the winner has vanished (deletion race), re-throw the duplicate error.

**`createMapping`** (public):
Switched from `repository.create()` (no PG-error translation, leaked raw `QueryFailedError` on concurrent insert) to `repository.insertMapping()` (translates `23505` → `DuplicateIdentifierMappingError`). Recover from duplicates and throw `MappingAlreadyExistsError` with the *winner's* `internalId`. Contract drift documented inline: the rare insert-fails-then-winner-deleted window now re-throws `DuplicateIdentifierMappingError` instead of synthesizing a `MappingAlreadyExistsError` with a stale id.

**`getOrCreateExactMapping`** (public):
Rewritten to the same pattern. Preserves perfect-match no-op and mismatch → `IdentifierMappingConflictException` branches. TODO at line 316 removed.

**`IdentifierMappingRepositoryPort.create()`**:
Removed (port + impl + spec mock). After the migration above, it had zero live callers — all writes go through `insertMapping`, which is the PG-error-translating variant.

## Trade-off note

Removing the upfront `findByExternalKey` is a **deliberate performance regression on the dominant workload** (sync jobs re-hitting known external IDs). Two readings of the issue's acceptance criterion are defensible:

- **Strict** — eliminate the read-before-write code path entirely (this PR's choice).
- **Lenient** — close the *race* in the read-before-write path; the existing `catch (DuplicateIdentifierMappingError)` already did this.

The strict reading wins because (a) `docs/engineering-standards.md` shows pure insert-then-recover with no upfront read, (b) following the documented pattern verbatim means a future reader can't re-add the fast-path "for performance" without first revisiting the standard, and (c) the cost is small: an insert against a unique index that already has the row is a single PG `23505` failure with no WAL extension. Adapters that need raw-read performance should call `getInternalId` directly — that path is unchanged.

**Future "perf optimization" PRs that try to reintroduce the fast-path must first revisit the engineering standard.**

## Out-of-scope follow-up

`libs/core/src/listings/application/services/offer-creation-execution.service.ts:134-140` catches only `DuplicateIdentifierMappingError` on its `createMapping` call. That catch was non-functional before this PR (the old `repository.create()` threw raw `QueryFailedError`, not the domain error). This PR is neutral for that caller — the catch is still dead — but it now sees `MappingAlreadyExistsError` propagated in the common pre-existing-mapping case rather than a raw infrastructure error. Worth a follow-up to widen the catch; not blocking on this PR.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 2890 tests pass across 9 packages, including a new `Promise.all` unit spec that drives N=10 concurrent callers and asserts they all converge on a single `internalId`
- [ ] `pnpm test:integration` — Docker not available locally; CI will run the new int-spec at `apps/api/test/integration/identifier-mapping/identifier-mapping-concurrency.int-spec.ts`. That spec covers the repository's `23505` → `DuplicateIdentifierMappingError` translation seam against a real Postgres unique index plus end-to-end convergence with N=16 callers on the same key and an isolation case with 3 keys × 6 callers each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)