### PR TITLE
docs: add PR template, CODEOWNERS, GOVERNANCE.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,24 +26,24 @@
 *                                  @piotrswierzy
 
 # Core domain — hexagonal architecture, ports, application services
-libs/core/                         @piotrswierzy
+/libs/core/                        @piotrswierzy
 
 # Shared utilities — logger, types, errors used across packages
-libs/shared/                       @piotrswierzy
+/libs/shared/                      @piotrswierzy
 
 # Plugin SDK — the public contract surface plugins bind against
-libs/plugin-sdk/                   @piotrswierzy
+/libs/plugin-sdk/                  @piotrswierzy
 
 # Host applications
-apps/api/                          @piotrswierzy
-apps/worker/                       @piotrswierzy
-apps/web/                          @piotrswierzy
+/apps/api/                         @piotrswierzy
+/apps/worker/                      @piotrswierzy
+/apps/web/                         @piotrswierzy
 
 # In-tree adapters — see GOVERNANCE.md for the policy on plugin
 # authors co-maintaining their own integration package
-libs/integrations/allegro/         @piotrswierzy
-libs/integrations/prestashop/      @piotrswierzy
-libs/integrations/ai/              @piotrswierzy
+/libs/integrations/allegro/        @piotrswierzy
+/libs/integrations/prestashop/     @piotrswierzy
+/libs/integrations/ai/             @piotrswierzy
 
 # Workflows, CI, governance metadata — guarded
 /.github/                          @piotrswierzy

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,57 @@
+# OpenLinker code owners
+#
+# Each route below names the maintainer(s) responsible for reviewing
+# changes to the matching paths. GitHub uses this file to request
+# reviews automatically. See `GOVERNANCE.md` for the review SLA, merge
+# policy, and the rule that integrations (`libs/integrations/<x>/`) may
+# be co-maintained or owned outright by non-core maintainers.
+#
+# Single-owner state today
+# ------------------------
+# Every route below resolves to a single GitHub handle while the
+# project gets off the ground. The per-package structure is in place so
+# routes can be re-pointed to a `@openlinker/<team>` slug — or to a
+# specific plugin author — without rewriting the file. Adding a new
+# maintainer is a single-line edit per package.
+#
+# Branch protection
+# -----------------
+# `Require review from Code Owners` MUST stay off until a second
+# maintainer exists. With one owner, that toggle deadlocks self-merge:
+# GitHub will not let the PR author satisfy a code-owner requirement
+# for a file they themselves authored. See `GOVERNANCE.md` →
+# "Who can merge" for the recommended branch-protection combination.
+
+# Default — everything not matched below
+*                                  @piotrswierzy
+
+# Core domain — hexagonal architecture, ports, application services
+libs/core/                         @piotrswierzy
+
+# Shared utilities — logger, types, errors used across packages
+libs/shared/                       @piotrswierzy
+
+# Plugin SDK — the public contract surface plugins bind against
+libs/plugin-sdk/                   @piotrswierzy
+
+# Host applications
+apps/api/                          @piotrswierzy
+apps/worker/                       @piotrswierzy
+apps/web/                          @piotrswierzy
+
+# In-tree adapters — see GOVERNANCE.md for the policy on plugin
+# authors co-maintaining their own integration package
+libs/integrations/allegro/         @piotrswierzy
+libs/integrations/prestashop/      @piotrswierzy
+libs/integrations/ai/              @piotrswierzy
+
+# Workflows, CI, governance metadata — guarded
+/.github/                          @piotrswierzy
+
+# Architectural-direction docs — major changes here require a proposal
+# issue first per GOVERNANCE.md → "Decision-making". Same owner today,
+# routed explicitly so future re-pointing to a "core architects" team
+# is one line.
+/docs/architecture-overview.md     @piotrswierzy
+/docs/engineering-standards.md     @piotrswierzy
+/docs/frontend-architecture.md     @piotrswierzy

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,19 +37,21 @@ Closes #
 
 ## Migrations
 
-- [ ] No ORM-entity schema changes — **OR** —
-- [ ] Migration added under `apps/api/src/migrations/` (or plugin
-      package), `pnpm --filter @openlinker/api migration:show` confirms
-      it's listed, and `up()` / `down()` were tested locally. See
-      [`docs/migrations.md`](../docs/migrations.md).
+- [ ] If this PR changes an ORM entity, a migration is included under
+      `apps/api/src/migrations/` (or the plugin package), `pnpm --filter
+      @openlinker/api migration:show` confirms it's listed, and both
+      `up()` and `down()` were tested locally. See
+      [`docs/migrations.md`](../docs/migrations.md). Tick this box for
+      PRs that don't touch schemas too — it's trivially satisfied.
 
 ## DCO sign-off
 
-- [ ] All commits in this PR are signed off (`git commit -s`). DCO is
-      OpenLinker's contributor attestation per
-      [CONTRIBUTING.md → Commits](../CONTRIBUTING.md#commits). Automated
-      enforcement is deferred until after the org transfer; please sign
-      off anyway so the history is consistent when enforcement starts.
+> Sign off every commit with `git commit -s`. OpenLinker uses the
+> [Developer Certificate of Origin](https://developercertificate.org/)
+> as its contributor attestation (see
+> [CONTRIBUTING.md → Commits](../CONTRIBUTING.md#commits)). Automated
+> enforcement is deferred until after the org transfer; sign off anyway
+> so the history is consistent when enforcement starts.
 
 <details>
 <summary><strong>Adding a new integration adapter?</strong> (expand)</summary>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,91 @@
+<!--
+Thank you for contributing to OpenLinker!
+
+Title: use Conventional Commits format — `feat(scope): subject`,
+`fix(scope): subject`, `docs:`, `refactor:`, `test:`, `chore:`.
+See CONTRIBUTING.md → Commits for the full type list.
+-->
+
+## Summary
+
+<!-- 1–3 bullets: what changed and why. Focus on the why. -->
+
+-
+
+## Related issues
+
+<!-- One `Closes #N` per issue this PR resolves. Issues are closed
+     automatically when the PR merges — do not close them manually. -->
+
+Closes #
+
+## Test plan
+
+<!-- How a reviewer verifies the change. Commands to run, paths to
+     click through, edge cases to confirm. -->
+
+-
+
+## Quality gate
+
+- [ ] `pnpm lint` passes (zero errors)
+- [ ] `pnpm type-check` passes (zero errors)
+- [ ] `pnpm test` passes (all unit tests green)
+- [ ] *Optional, Docker required:* `pnpm test:integration` passes — needed
+      only if you touched `apps/api/test/integration/**` or any plugin's
+      `infrastructure/adapters/`.
+
+## Migrations
+
+- [ ] No ORM-entity schema changes — **OR** —
+- [ ] Migration added under `apps/api/src/migrations/` (or plugin
+      package), `pnpm --filter @openlinker/api migration:show` confirms
+      it's listed, and `up()` / `down()` were tested locally. See
+      [`docs/migrations.md`](../docs/migrations.md).
+
+## DCO sign-off
+
+- [ ] All commits in this PR are signed off (`git commit -s`). DCO is
+      OpenLinker's contributor attestation per
+      [CONTRIBUTING.md → Commits](../CONTRIBUTING.md#commits). Automated
+      enforcement is deferred until after the org transfer; please sign
+      off anyway so the history is consistent when enforcement starts.
+
+<details>
+<summary><strong>Adding a new integration adapter?</strong> (expand)</summary>
+
+If this PR introduces a new package under `libs/integrations/<x>/`,
+declare its status so reviewers know what bar to apply:
+
+- [ ] **alpha** — experimental; API may change, no production traffic
+      yet
+- [ ] **beta** — stable contract, real-world use ongoing, breaking
+      changes flagged in PR title
+- [ ] **stable** — production-ready; breaking changes follow semver
+
+See [`docs/architecture-overview.md`](../docs/architecture-overview.md)
+for the adapter / capability contract and
+[`GOVERNANCE.md`](../GOVERNANCE.md) for the policy on plugin authors
+co-maintaining their own adapter.
+
+</details>
+
+<details>
+<summary><strong>UI changes?</strong> Attach screenshots at three widths (expand)</summary>
+
+Per [`docs/frontend-ui-style-guide.md` § Responsive](../docs/frontend-ui-style-guide.md#responsive),
+mobile and tablet are first-class. Capture after-shots at all three
+breakpoints:
+
+- **Mobile** (360 × 812):
+- **Tablet** (768 × 1024):
+- **Desktop** (1440 × 900):
+
+</details>
+
+---
+
+<sub>By submitting this pull request, I confirm that my contributions
+are made under the terms of the [Apache License 2.0](../LICENSE), and I
+certify the [Developer Certificate of Origin](https://developercertificate.org/)
+by signing off my commits.</sub>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,18 @@ strict boundaries that contributions must respect.
 4. Ensure `pnpm lint`, `pnpm type-check`, and `pnpm test` all pass.
 5. Update documentation if needed.
 6. Submit a pull request with a clear description and `Closes #N` in the
-   body — issues should be closed by the merged PR, not manually.
+   body — issues should be closed by the merged PR, not manually. The
+   repo has a [pull-request template](./.github/PULL_REQUEST_TEMPLATE.md)
+   that prompts for the essentials.
+
+## Governance
+
+Maintainers, review SLA, who can merge, and the rule that integrations
+may be co-maintained by non-core authors are documented in
+[GOVERNANCE.md](./GOVERNANCE.md). Major changes to the architectural-
+direction docs (`docs/architecture-overview.md`,
+`docs/engineering-standards.md`, `docs/frontend-architecture.md`)
+require a proposal issue first per that policy.
 
 ## Commits
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -121,7 +121,9 @@ A maintainer may be removed by mutual agreement, by a maintainer's own
 request, or by consensus of the remaining maintainers in cases of:
 
 - Sustained inactivity (no review or commit activity for 6 months).
-- Violation of `CODE_OF_CONDUCT.md` (tracked in #659).
+- Violation of `CODE_OF_CONDUCT.md` (the CoC ships separately — tracked
+  in [#659](https://github.com/SilkSoftwareHouse/openlinker/issues/659);
+  until it lands, GitHub's default community standards apply).
 
 Removal is recorded in the Maintainers table above, in
 `.github/CODEOWNERS`, and in any other places where the handle is

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,133 @@
+# OpenLinker Governance
+
+This document covers who maintains OpenLinker, how decisions are made,
+and how an external contributor can land a change. It complements
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) (the *how* of submitting a PR)
+and [`SECURITY.md`](./SECURITY.md) (the *how* of disclosing a
+vulnerability).
+
+## Maintainers
+
+The current maintainer set is small while the project gets off the
+ground:
+
+| Handle | Role | Scope |
+| ------ | ---- | ----- |
+| [@piotrswierzy](https://github.com/piotrswierzy) | Project lead | All packages |
+
+Per-package code ownership is tracked in
+[`.github/CODEOWNERS`](./.github/CODEOWNERS). Today every route resolves
+to the project lead; the structure exists so per-package or per-team
+ownership can be added without rewriting the file.
+
+## Review SLA
+
+We aim for these timelines on every pull request:
+
+| Stage | Target |
+| ----- | ------ |
+| Initial acknowledgement (a comment, a question, or a first review) | within **2 business days** |
+| Approve, request changes, or close on a well-scoped PR | within **5 business days** |
+| Larger PRs (touching ≥ 5 files across multiple packages, or any architecture-direction doc) | longer — a holding comment within the SLA window confirms it's in flight |
+
+Business days are weekdays (Monday–Friday) in Europe. These are
+aspirational defaults, not contractual — but if a PR has been silent
+past these windows, please tag the maintainer in a comment or open a
+follow-up issue.
+
+## Who can merge
+
+Only maintainers (see above) can merge to `main`.
+
+We use GitHub's branch protection to enforce this. The combination
+recommended today, with a single maintainer, is:
+
+- `Require a pull request before merging` — **on** (no direct pushes to
+  `main`)
+- `Require approvals` — **0** (the maintainer may merge their own PR
+  via the GitHub UI; required-approvals would deadlock self-merge
+  otherwise)
+- `Require review from Code Owners` — **off** (will be turned on once a
+  second maintainer exists — see `.github/CODEOWNERS` for the
+  rationale)
+- `Require status checks to pass before merging` — **on** for `lint`,
+  `type-check`, `test`, and integration-test workflows once those
+  workflows can run reliably on fork PRs (tracked in #662)
+
+When a second maintainer is added, approvals go to `1` and code-owner
+review can be enabled in the same PR that adds them.
+
+## Adapter / plugin maintainership
+
+OpenLinker's integration packages live under `libs/integrations/<x>/`.
+**Adapter packages may be co-maintained or solely maintained by a
+non-core contributor** with demonstrated commitment to that platform.
+The intent is that a Shopify-shop operator who has built and is
+running a Shopify adapter in production should be able to own review
+of that package — they understand the platform's edge cases better
+than the core team does.
+
+Mechanically, per-adapter ownership lives in
+[`.github/CODEOWNERS`](./.github/CODEOWNERS). When a non-core
+maintainer steps up for an adapter, that adapter's CODEOWNERS route is
+re-pointed to their handle (or a `core + plugin-author` pair). The
+default until then is core-team review.
+
+The plugin contract surface (`libs/plugin-sdk/`, `@openlinker/core/*`,
+`@openlinker/shared/*`) is *not* in this category — those packages stay
+under core-team review regardless of who maintains downstream adapters,
+because changes there affect every plugin.
+
+## Decision-making
+
+- **Day-to-day decisions** — implementation choices inside a single
+  package, bug fixes, dependency bumps, test additions — are made by
+  single-maintainer review and approval on a PR.
+- **Major architectural changes** — anything that modifies
+  `docs/architecture-overview.md`, `docs/engineering-standards.md`, or
+  `docs/frontend-architecture.md` — require a **proposal issue first**.
+  Open an issue describing the change, motivation, and alternatives;
+  discuss; then open the PR. This avoids the maintainer reading 600
+  lines of code and only then disagreeing with the direction.
+- **Adding or removing a maintainer** — by invitation from the current
+  maintainer set, recorded in the Maintainers table above and in
+  `.github/CODEOWNERS`.
+- **Conflicts** — IP, contributor identity, and licensing decisions are
+  governed by [`LICENSE`](./LICENSE) (Apache 2.0) and the DCO
+  attestation in [`CONTRIBUTING.md`](./CONTRIBUTING.md). Conduct
+  decisions follow `CODE_OF_CONDUCT.md` when it lands (tracked in
+  #659); until then, GitHub's default community standards apply.
+
+## Becoming a maintainer
+
+Today the path is intentionally lightweight, because the project has
+one maintainer and "becoming a maintainer" effectively means impressing
+that one person. The current criteria:
+
+- Sustained contribution over multiple PRs (think weeks, not days).
+- Review quality — leaving useful comments on other people's PRs that
+  catch real issues.
+- An invitation from the current maintainer set.
+
+As the project grows past 2–3 maintainers, the bar will tighten —
+expect explicit metrics (e.g., a minimum number of merged substantive
+PRs over a defined window, sustained review activity, and consensus
+from the existing maintainer set). This section will be updated to
+reflect that.
+
+## Removing a maintainer
+
+A maintainer may be removed by mutual agreement, by a maintainer's own
+request, or by consensus of the remaining maintainers in cases of:
+
+- Sustained inactivity (no review or commit activity for 6 months).
+- Violation of `CODE_OF_CONDUCT.md` (tracked in #659).
+
+Removal is recorded in the Maintainers table above, in
+`.github/CODEOWNERS`, and in any other places where the handle is
+referenced.
+
+## Changes to this document
+
+`GOVERNANCE.md` is itself covered by the "architectural-direction docs"
+rule above — propose changes as an issue first, then open the PR.

--- a/docs/plans/implementation-plan-566-568-pr-template-and-codeowners.md
+++ b/docs/plans/implementation-plan-566-568-pr-template-and-codeowners.md
@@ -1,0 +1,283 @@
+# Implementation Plan — PR template + CODEOWNERS + GOVERNANCE.md (#566, #568)
+
+Two HIGH-severity findings from Modularity Thread B (#548 / #546) that
+together formalize what reviewers expect from PRs and who is responsible
+for which areas of the repo. Necessary for "we're prepared to accept PRs
+from strangers" — required before the org transfer (#641) puts the repo
+in front of external contributors.
+
+## Goals
+
+- **#566** — Add `.github/PULL_REQUEST_TEMPLATE.md` with a contributor
+  checklist (commands, tests, `Closes #N`, DCO sign-off, integration
+  status). Mirrors the workflow already documented in `CONTRIBUTING.md`
+  so contributors don't have to discover it from the conversation
+  history.
+- **#568** — Add `.github/CODEOWNERS` mapping each maintained area to
+  the responsible owner(s), and a one-page `GOVERNANCE.md` covering
+  review SLA, merge authority, and the explicit rule that integrations
+  may be owned by external maintainers.
+
+## Non-goals
+
+- **Bringing in additional maintainers today.** The repo today has a
+  single member with merge authority (`piotrswierzy`). CODEOWNERS will
+  reflect that reality with a forward-compatible structure (per-path
+  routes, ready to be split when teams exist on the new org). This PR
+  does NOT name external maintainers or grant new permissions.
+- **Enabling CODEOWNERS-required-review branch protection.** That is a
+  repo-settings toggle (admin task) and depends on `.github/CODEOWNERS`
+  existing first. The file ships here; the toggle is a post-merge admin
+  step, called out in the PR body.
+- **Drafting per-adapter maintainership.** The audit recommends mapping
+  `libs/integrations/allegro/` and `libs/integrations/prestashop/` to
+  "specific maintainers" — but today both are maintained by the same
+  person. Forward-compatible structure now, real owners after #641 lands
+  the new org's team membership.
+- **Re-enabling the disabled `cd.yml` workflow.** #568 mentions it as
+  evidence ("it's not even clear who can merge"); the fix is to document
+  who can merge in GOVERNANCE.md, not to turn the CD pipeline back on.
+- **Fixing the URL drift in `.github/ISSUE_TEMPLATE/config.yml`** (still
+  points at `piotrswierzy/openlinker`). Tracked separately in #664.
+
+## Layer classification
+
+Pure **DX / Governance / Docs**. No code, no architecture impact, no
+migrations, no tests required.
+
+## Open decisions (please flag in review)
+
+1. **Sole owner today.** CODEOWNERS today resolves to a single GitHub
+   handle (`@piotrswierzy`). The file lists per-package routes so the
+   structure is ready to receive real team membership after the org
+   transfer (#641), but every route resolves to the same person until
+   then. Confirm the handle is correct — memory has email
+   `p.j.swierzy@gmail.com` but the GitHub username is `piotrswierzy`
+   (visible on the repo's recent merge commits).
+2. **Review SLA.** I'll propose **2 business days** for first reviewer
+   acknowledgement and **5 business days** to either approve or request
+   changes on a well-scoped PR. Larger PRs may take longer. These are
+   conventional OSS defaults — adjustable.
+3. **Plugin / adapter ownership policy.** GOVERNANCE.md will explicitly
+   state that maintainership of an integration (`libs/integrations/<x>/`)
+   may sit with a non-core maintainer — i.e., a plugin author can own
+   review of their own adapter once they've proven themselves on the
+   project. This is from the #568 acceptance.
+4. **Branch protection.** Today `main` likely has no required-review
+   rule. Once CODEOWNERS exists, the admin can enable
+   "Require a pull request before merging" + "Require review from Code
+   Owners" + "Restrict who can push to matching branches" (admin task,
+   post-merge follow-up, not done in this PR).
+
+## Implementation steps
+
+### Step 1 — `.github/PULL_REQUEST_TEMPLATE.md` (#566)
+
+**File:** `.github/PULL_REQUEST_TEMPLATE.md` (new)
+
+Sections:
+- **Title reminder** at the top — Conventional Commits format
+  (`feat:`, `fix:`, `docs:`, …) per
+  `docs/engineering-standards.md § Pull Requests`. Links to
+  `CONTRIBUTING.md § Commits` for the full type list. Discoverable to
+  first-time contributors who haven't read the standards doc yet.
+- **Summary** — what changed and why, 1–3 bullets.
+- **Closes** — explicit `Closes #N` placeholder.
+- **Test plan** — how a reviewer verifies the change.
+- **Quality gate checklist** — three required checkboxes matching the
+  `pnpm lint`, `pnpm type-check`, `pnpm test` triple from CLAUDE.md,
+  plus one optional checkbox: *"If you touched integration-test paths
+  (`apps/api/test/integration/**` or any plugin's `infrastructure/
+  adapters/`), also ran `pnpm test:integration`"* — gated on Docker
+  availability so it doesn't block contributors without Docker on a
+  pure-unit PR.
+- **Migrations** — checkbox + reminder when an ORM entity changed
+  (per `docs/migrations.md`).
+- **DCO sign-off** — reminder to commit with `-s` per `CONTRIBUTING.md`.
+- **New adapter status** (collapsed `<details>` block) — for PRs that
+  introduce a new integration package: declare `alpha` / `beta` /
+  `stable` so reviewers know what bar to apply. Cribbed verbatim from
+  the #566 audit recommendation.
+- **Screenshots** (collapsed) — for UI changes. Per
+  `docs/frontend-ui-style-guide.md § Responsive`, FE PRs must attach
+  shots at **three widths**: 360×812 (mobile), 768×1024 (tablet),
+  1440×900 (desktop). Mobile + tablet are first-class per the
+  project's responsive parity matrix.
+
+Format: minimal HTML, mostly raw markdown. Keep collapsible sections
+small so the PR body stays scannable. Don't duplicate everything
+`CONTRIBUTING.md` already covers — link to it.
+
+### Step 2 — `.github/CODEOWNERS` (#568)
+
+**File:** `.github/CODEOWNERS` (new)
+
+Structure:
+```
+# Default owner — everything not matched below
+*                                  @piotrswierzy
+
+# Core domain (libs/core) — owned by the core team
+libs/core/                         @piotrswierzy
+
+# Shared utilities (libs/shared) — owned by the core team
+libs/shared/                       @piotrswierzy
+
+# Plugin SDK (libs/plugin-sdk) — public contract surface
+libs/plugin-sdk/                   @piotrswierzy
+
+# Hosts (apps/api, apps/worker, apps/web) — owned by the core team
+apps/api/                          @piotrswierzy
+apps/worker/                       @piotrswierzy
+apps/web/                          @piotrswierzy
+
+# In-tree adapters — see GOVERNANCE.md for the policy on plugin maintainers
+libs/integrations/allegro/         @piotrswierzy
+libs/integrations/prestashop/      @piotrswierzy
+libs/integrations/ai/              @piotrswierzy
+
+# Workflows and CI — guarded; changes need core-team review
+/.github/                          @piotrswierzy
+
+# Architectural-direction docs — require proposal-issue-first per
+# GOVERNANCE.md. Same owner as the catch-all today; routed explicitly
+# so future re-pointing to a "core architects" team is one-line.
+/docs/architecture-overview.md     @piotrswierzy
+/docs/engineering-standards.md     @piotrswierzy
+/docs/frontend-architecture.md     @piotrswierzy
+```
+
+With a header comment explaining:
+- Why every route currently resolves to one handle.
+- That per-adapter ownership can move to specific maintainers (see
+  GOVERNANCE.md).
+- The link between this file and CODEOWNERS-required-review branch
+  protection (admin toggle, not turned on yet).
+
+### Step 3 — `GOVERNANCE.md` (#568)
+
+**File:** `GOVERNANCE.md` (new, at repo root)
+
+Sections:
+1. **Maintainers** — who, with current handles. One person today;
+   structured so new maintainers can be added without rewriting the
+   file.
+2. **Review SLA** — 2 business days to acknowledge, 5 business days to
+   approve or request changes on a well-scoped PR. Larger work may take
+   longer, but a holding comment is expected within the SLA window.
+3. **Who can merge** — only maintainers. Branch protection (admin
+   toggle) will enforce CODEOWNERS-required-review once enabled. This
+   PR ships the file; the toggle is a post-merge admin step.
+4. **Adapter / plugin maintainership** — in-tree adapters
+   (`libs/integrations/<x>/`) may be co-maintained or solely maintained
+   by a non-core contributor with demonstrated commitment. The default
+   is core-team review; per-adapter CODEOWNERS routes can be re-pointed
+   to a non-core handle when a plugin gets its own maintainer.
+5. **Decision-making** — `LICENSE` + `CONTRIBUTING.md` cover IP. Major
+   architectural changes (touching `docs/architecture-overview.md` or
+   `docs/engineering-standards.md`) require a proposal issue first.
+   Day-to-day decisions are by single reviewer approval.
+6. **Becoming a maintainer** — short note on the path (sustained
+   contribution, demonstrated review quality, invite from current
+   maintainers). Explicitly note that *the bar is intentionally
+   lightweight today (one maintainer) and will tighten as the project
+   grows past 2–3 maintainers* — otherwise the section reads as
+   boilerplate.
+7. **Removing a maintainer** — short note (inactivity > 6 months OR
+   conduct violation per CoC). #659 will add CODE_OF_CONDUCT.md
+   separately; until then, cross-link the GitHub default standards.
+
+Length target: one screen — this is a "what's the policy" doc, not a
+constitutional document.
+
+### Step 4 — Link GOVERNANCE.md from CONTRIBUTING.md
+
+**File:** `CONTRIBUTING.md` (edit)
+
+Add a one-line pointer in the existing "Pull Request Process" or a new
+"Governance" section: "Maintainers, review SLA, and the rule that
+adapters may have non-core maintainers are documented in
+[GOVERNANCE.md](./GOVERNANCE.md)."
+
+### Step 5 — Quality gate + manual draft-PR verification
+
+In order (per CLAUDE.md — no skipping just because docs-only):
+
+1. `pnpm format` (write mode) on the new files to pre-normalize.
+2. `pnpm lint` (includes `check:invariants`)
+3. `pnpm type-check`
+4. `pnpm test`
+
+None of the gate steps actually exercise the new PR template, CODEOWNERS,
+or GOVERNANCE.md files (they're not TS, not loaded at runtime). So after
+the gate passes:
+
+5. Push the branch and open a **draft PR** against `main` — confirms the
+   PR template renders correctly in the GitHub UI before real
+   contributors see it. <2 min, catches formatting issues no
+   command-line tool can.
+
+### Step 6 — Self-review
+
+Walk diff against #566 / #568 acceptance criteria:
+- PR template includes the five contributor-checklist items from #566.
+- CODEOWNERS covers `libs/integrations/{allegro,prestashop}` and
+  `libs/core/` + `apps/api/` per #568's explicit recommendation.
+- GOVERNANCE.md covers review SLA, who can merge, and adapter-owned-
+  by-external-maintainers rule per #568.
+
+## Risks
+
+- **Single-owner CODEOWNERS today.** With every route resolving to
+  `@piotrswierzy`, the `Require review from Code Owners` branch
+  protection would require `@piotrswierzy` to review their own PRs —
+  GitHub does not let an author satisfy a CODEOWNERS requirement for a
+  file they themselves authored. Until a second maintainer exists OR
+  the org transfer (#641) creates team-based ownership, the admin
+  should **not** enable CODEOWNERS-required-review. PR body will call
+  this out explicitly.
+- **PR template friction.** A long PR template makes small PRs feel
+  heavyweight. Keep the visible body short, push optional sections into
+  collapsible `<details>` blocks so a quick docs PR isn't drowning in
+  unchecked boxes.
+- **Drift between PR template and CONTRIBUTING.md.** The template
+  duplicates a thin slice of the checklist documented in
+  `CONTRIBUTING.md § Pull Request Process`. Pin the template to *link*
+  CONTRIBUTING.md rather than restate the rules — keeps the source of
+  truth in one place.
+
+## PR body checklist
+
+- [ ] `.github/PULL_REQUEST_TEMPLATE.md` covers the #566 contributor
+      checklist items (lint/type-check/test triple, tests, migrations,
+      `Closes #N`, integration status for new adapters).
+- [ ] `.github/CODEOWNERS` covers the path mapping #568 recommends.
+- [ ] `GOVERNANCE.md` covers review SLA, who can merge, plugin-author
+      maintainership policy.
+- [ ] CONTRIBUTING.md links to GOVERNANCE.md.
+- [ ] Closes #566, #568.
+
+## Out-of-PR follow-ups to record
+
+- **Admin: enable branch protection** on `main` — but be specific about
+  *which* combination is safe today vs. which requires a second
+  maintainer. Safe to enable today:
+  - `Require a pull request before merging` ON
+  - `Require approvals: 0` (PR-based merge required, but author may
+    still self-approve via "Merge pull request")
+  - `Require review from Code Owners` **OFF** — turning this on with a
+    single owner deadlocks self-merge (GitHub refuses to let the PR
+    author satisfy a CODEOWNERS requirement for a file they authored)
+  - `Require status checks to pass before merging` ON (once CI is
+    aligned to public runners per #662)
+
+  Requires a second maintainer (or org-team membership post-#641) before
+  enabling:
+  - `Require approvals: 1`
+  - `Require review from Code Owners` ON
+- **Re-point integration-package CODEOWNERS routes** when an adapter
+  gets its own non-core maintainer (anticipated post-#641).
+- **Add CODE_OF_CONDUCT.md** (#659) so GOVERNANCE.md's "removing a
+  maintainer for conduct violations" line can link to a concrete CoC.
+- **Fix issue-template `config.yml` URL drift** (still
+  `piotrswierzy/openlinker`) — tracked in #664.


### PR DESCRIPTION
Two HIGH-severity findings from Modularity Thread B (#548 / #546) formalizing what reviewers expect from contributors and who is responsible for which areas of the repo. Necessary before the org transfer (#641) puts the repo in front of external contributors.

> **Opened as draft** to verify the new `.github/PULL_REQUEST_TEMPLATE.md` renders correctly in the GitHub UI before marking ready-for-review (per the plan's Step 5 verification). If the template renders cleanly above this body, marking ready.

## Summary

- **#566** — Pull-request template (`.github/PULL_REQUEST_TEMPLATE.md`): title-format reminder (Conventional Commits), quality-gate checklist matching CLAUDE.md, DCO sign-off banner, collapsible blocks for new-adapter status (alpha/beta/stable) and three-breakpoint UI screenshots (360×812 / 768×1024 / 1440×900).
- **#568** — CODEOWNERS (`.github/CODEOWNERS`): per-package routes for `libs/{core,shared,plugin-sdk,integrations/*}`, `apps/{api,worker,web}`, `/.github/`, plus explicit routes for the three architectural-direction docs. Every route resolves to `@piotrswierzy` today; structure is ready for per-team or per-plugin-author re-pointing post-#641.
- **#568** — `GOVERNANCE.md` (one-pager): maintainers table, review SLA (2 business days ack / 5 business days approve-or-request-changes), who can merge with the specific safe branch-protection combination, adapter/plugin maintainership policy (in-tree adapters MAY be co-maintained by non-core authors), decision-making, becoming/removing a maintainer.

## ⚠️ New rule introduced by `GOVERNANCE.md`

The Decision-making section adds a rule that **major changes to `docs/architecture-overview.md`, `docs/engineering-standards.md`, or `docs/frontend-architecture.md` require a proposal issue first**. This is a new governance policy — not previously documented elsewhere. It is consistent with #568's audit recommendation and with how the project has actually operated (Modularity-thread epics #547–#554 were proposed before the code work), but please sign off on the policy explicitly, not just on the doc shape.

The explicit CODEOWNERS routes for those three docs hook this rule into the GitHub review flow.

## Pre-merge / pre-public-flip requirements

- **Confirm GitHub username** — every CODEOWNERS route resolves to `@piotrswierzy`. Confirm this is the correct GitHub handle (memory shows email `p.j.swierzy@gmail.com`; recent merge commits show `piotrswierzy` as the GitHub username).
- **Confirm SLA values** — proposed defaults are 2 business days first acknowledgement / 5 business days to approve or request changes. Negotiable.
- **Confirm the policy intent above** — GOVERNANCE.md introduces a new rule for architectural-direction doc changes.
- **Admin: do NOT enable `Require review from Code Owners` branch protection yet.** With one maintainer, GitHub will not let the PR author satisfy a code-owner requirement for files they themselves authored — self-merge deadlocks. The CODEOWNERS file header + GOVERNANCE.md → "Who can merge" both document the safe combination today (`Require PR` ON, `Require approvals` 0, `Require code-owner review` OFF). Toggle code-owner review on once a second maintainer exists.

## Acceptance — #566

- [x] `.github/PULL_REQUEST_TEMPLATE.md` exists.
- [x] Quality-gate checklist matches CLAUDE.md's required triple (`pnpm lint`, `pnpm type-check`, `pnpm test`).
- [x] Optional `pnpm test:integration` checkbox gated on Docker availability.
- [x] Migrations conditional checkbox + link to `docs/migrations.md`.
- [x] `Closes #N` placeholder + reminder that issues close via merged PR, not manually.
- [x] Adapter status flag (alpha/beta/stable) for new-integration PRs.
- [x] Three-breakpoint screenshot rule for UI PRs.
- [x] DCO sign-off reminder (blockquote, not a self-attestation checkbox).
- [x] Title format reminder (Conventional Commits) at the top.

## Acceptance — #568

- [x] `.github/CODEOWNERS` maps `libs/integrations/{allegro,prestashop,ai}`, `libs/{core,shared,plugin-sdk}`, `apps/{api,worker,web}`, `/.github/`, and the three architectural-direction docs.
- [x] `GOVERNANCE.md` covers maintainers, review SLA, who can merge, adapter/plugin maintainership (with the explicit "non-core may own an adapter" rule from the audit), decision-making, becoming/removing a maintainer.
- [x] `CONTRIBUTING.md` links to both `PULL_REQUEST_TEMPLATE.md` and `GOVERNANCE.md`.
- [ ] **Branch protection enabled with the safe combination** — admin task, see above.

## Out-of-PR follow-ups

Recorded in the implementation plan (`docs/plans/implementation-plan-566-568-pr-template-and-codeowners.md`):

- Admin: enable safe branch protection on `main` (Require PR ON, Require approvals 0, Require code-owner review OFF).
- Re-point per-adapter CODEOWNERS routes when a plugin author steps up to co-maintain an integration package (post-#641).
- Fix the issue-template `config.yml` URL drift (still points at `piotrswierzy/openlinker`, tracked in #664).
- Once #659 lands `CODE_OF_CONDUCT.md`, replace the GitHub-default-community-standards fallback in `GOVERNANCE.md` § Removing a maintainer.

## Test plan

- [x] `pnpm lint` passes (zero errors; pre-existing warnings only).
- [x] `pnpm type-check` passes (zero errors).
- [x] `pnpm test` passes across all packages (~1,700+ tests; web alone is 1064/139 files).
- [x] **Draft PR opened** (this one) to verify `.github/PULL_REQUEST_TEMPLATE.md` renders correctly in the GitHub UI before marking ready-for-review.
- [x] CODEOWNERS file has consistent leading-slash path anchoring throughout.
- [x] Every command/path referenced in the PR template maps to a real `package.json` script or `docs/` file.

## Notes for reviewers

- Two commits to make review easier:
  - `2f16491` — bulk add PR template + CODEOWNERS + GOVERNANCE.md + CONTRIBUTING.md link
  - `893b2a4` — tech-review polish: single-checkbox migrations conditional, DCO blockquote instead of self-attestation checkbox, leading-`/` CODEOWNERS anchoring, CoC fallback note in GOVERNANCE.md
- Both commits signed off with DCO (`git commit -s`) — eating our own dog food.

Closes #566
Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
