### PR TITLE
docs(getting-started): trim to what works today + drop WIP banner (#569)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -237,6 +237,6 @@ Repeat for each category you intend to list products in on Allegro.
 With both connections active, products discovered, and at least one category mapped, you're ready to:
 
 - **Create your first Allegro offer from a PrestaShop product.** Walkthrough in progress — tracked in [#429](https://github.com/SilkSoftwareHouse/openlinker/issues/429) (Allegro offer-creation epic). The flow is functional today; the screenshot-level guide is the next doc to land.
-- **Watch an Allegro order land in PrestaShop.** End-to-end sandbox walkthrough tracked in [#152](https://github.com/SilkSoftwareHouse/openlinker/issues/152) (clean-state E2E epic). The ingestion path is exercised by the carrier-mapping vertical-slice int-spec ([#535](https://github.com/SilkSoftwareHouse/openlinker/pull/671)) — the user-facing walkthrough is the missing piece.
+- **Watch an Allegro order land in PrestaShop.** End-to-end sandbox walkthrough tracked in [#152](https://github.com/SilkSoftwareHouse/openlinker/issues/152) (clean-state E2E epic). The ingestion path is exercised today by the carrier-mapping vertical-slice int-spec (landed in [PR #671](https://github.com/SilkSoftwareHouse/openlinker/pull/671), closing [#535](https://github.com/SilkSoftwareHouse/openlinker/issues/535)) — the user-facing walkthrough is the missing piece.
 
-Until those walkthroughs land, the **Jobs & Logs** page in the OpenLinker web app (`http://localhost:4173/jobs`) is the best place to watch sync activity, and the **Orders** page surfaces orders as they ingest.
+Until those walkthroughs land, the **Jobs & Logs** page in the OpenLinker web app (`http://localhost:4173/jobs-logs`) is the best place to watch sync activity, and the **Orders** page (`http://localhost:4173/orders`) surfaces orders as they ingest.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,6 @@
 # Getting Started
 
-End-to-end walkthrough: from a clean machine to a first Allegro order synced into PrestaShop via OpenLinker.
-
-> **Status:** work in progress. Built incrementally as part of [#152](https://github.com/SilkSoftwareHouse/openlinker/issues/152). Sections marked _TBD_ are not yet documented.
+End-to-end walkthrough: from a clean machine to a fully-configured OpenLinker instance with PrestaShop and Allegro connected, catalog synced, and categories mapped — ready to start creating offers and ingesting orders.
 
 ## Prerequisites
 
@@ -234,10 +232,11 @@ Category mapping connects your PrestaShop categories to Allegro's category tree 
 
 Repeat for each category you intend to list products in on Allegro.
 
-## 8. First offer
+## What's next
 
-_TBD_
+With both connections active, products discovered, and at least one category mapped, you're ready to:
 
-## 9. First order end-to-end
+- **Create your first Allegro offer from a PrestaShop product.** Walkthrough in progress — tracked in [#429](https://github.com/SilkSoftwareHouse/openlinker/issues/429) (Allegro offer-creation epic). The flow is functional today; the screenshot-level guide is the next doc to land.
+- **Watch an Allegro order land in PrestaShop.** End-to-end sandbox walkthrough tracked in [#152](https://github.com/SilkSoftwareHouse/openlinker/issues/152) (clean-state E2E epic). The ingestion path is exercised by the carrier-mapping vertical-slice int-spec ([#535](https://github.com/SilkSoftwareHouse/openlinker/pull/671)) — the user-facing walkthrough is the missing piece.
 
-_TBD_
+Until those walkthroughs land, the **Jobs & Logs** page in the OpenLinker web app (`http://localhost:4173/jobs`) is the best place to watch sync activity, and the **Orders** page surfaces orders as they ingest.

--- a/docs/plans/implementation-plan-569-getting-started-trim.md
+++ b/docs/plans/implementation-plan-569-getting-started-trim.md
@@ -1,0 +1,126 @@
+# Implementation Plan — #569 `docs/getting-started.md` is WIP and ends mid-flow
+
+| Layer | Scope | Risk |
+|---|---|---|
+| DX / docs | Single-file edit | Low — pure docs |
+
+## 1. Decision: trim, don't fabricate
+
+The issue lists both options ("complete §§ 8-9" or "trim to what works today") but
+explicitly favours trimming: *"The first 7 sections are excellent and shouldn't
+be hidden behind a 'this doc is incomplete' warning."*
+
+Reasons to trim, not fill:
+
+- The `_TBD_` sections cover live behaviours (offer creation on Allegro, full
+  Allegro→PrestaShop order sync) that require a running dev stack to verify.
+  Writing them blind risks #660-style breakage where docs promise commands /
+  flows that don't actually work.
+- The doc through §7 is verified and useful as-is; the WIP banner makes
+  contributors hesitate to follow it.
+- The end-to-end-order walkthrough is already tracked in #152 (the E2E
+  clean-state test epic) and the offer-creation flow in #429 (Allegro
+  offer-creation epic). Pointing at those forward-looking issues is more honest
+  than two `_TBD_` headings.
+
+## 2. Cross-doc scan
+
+Grep results for `getting-started`:
+
+- `docs/plans/*.md` — historical plan docs only, no link rot.
+- `docs/operations/prestashop-module-rename-migration.md:18` — generic pointer
+  to "install fresh per `docs/getting-started.md`"; no anchor reference.
+- `docs/reviews/modularity-and-plugin-readiness-2026-05-09.md` — the source
+  audit; references this issue's line numbers, not user-facing.
+
+README and CONTRIBUTING contain **no references** to `getting-started.md` today,
+so no anchor rot to worry about.
+
+## 3. Three edits
+
+### 3.1 Lead paragraph (line 3)
+
+Adjust scope to match what's documented:
+
+```diff
+- End-to-end walkthrough: from a clean machine to a first Allegro order synced into PrestaShop via OpenLinker.
++ End-to-end walkthrough: from a clean machine to a fully-configured OpenLinker instance with PrestaShop and Allegro connected, catalog synced, and categories mapped — ready to start creating offers and ingesting orders.
+```
+
+Honest framing: the doc gets you to "ready to use", not "first order synced".
+
+### 3.2 Drop WIP banner (lines 5-6)
+
+Remove entirely:
+
+```diff
+-
+- > **Status:** work in progress. Built incrementally as part of [#152](https://github.com/SilkSoftwareHouse/openlinker/issues/152). Sections marked _TBD_ are not yet documented.
+-
+```
+
+The banner exists to warn readers about `_TBD_` sections; once those sections
+are removed, the banner has nothing to flag.
+
+### 3.3 Replace §§ 8-9 (lines 237-243) with `## What's next`
+
+```diff
+- ## 8. First offer
+-
+- _TBD_
+-
+- ## 9. First order end-to-end
+-
+- _TBD_
++ ## What's next
++
++ With both connections active, products discovered, and at least one category
++ mapped, you're ready to:
++
++ - **Create your first Allegro offer from a PrestaShop product.** Walkthrough
++   in progress — tracked in [#429](https://github.com/SilkSoftwareHouse/openlinker/issues/429)
++   (Allegro offer-creation epic). The flow is functional today; the screenshot-
++   level guide is the next doc to land.
++ - **Watch an Allegro order land in PrestaShop.** End-to-end sandbox walkthrough
++   tracked in [#152](https://github.com/SilkSoftwareHouse/openlinker/issues/152)
++   (clean-state E2E epic). The ingestion path is exercised by the carrier-
++   mapping vertical-slice int-spec
++   ([#535](https://github.com/SilkSoftwareHouse/openlinker/pull/671)) — the
++   user-facing walkthrough is the missing piece.
++
++ Until those walkthroughs land, the **Jobs & Logs** page in the OpenLinker web
++ app (`http://localhost:4173/jobs`) is the best place to watch sync activity,
++ and the **Orders** page surfaces orders as they ingest.
+```
+
+Result: the doc now ends with a forward-looking pointer, not an empty
+`_TBD_` cliff.
+
+## 4. Quality gate
+
+Pure docs — no `pnpm test` impact. Run:
+
+```bash
+npx prettier --check docs/getting-started.md docs/plans/implementation-plan-569-getting-started-trim.md
+pnpm lint
+```
+
+`pnpm type-check` and `pnpm test` are no-ops on these files but should still
+pass — the pre-commit hook runs the full triad anyway.
+
+## 5. Commit
+
+Single conventional-commit:
+
+```
+docs(getting-started): trim to what works today + drop WIP banner (#569)
+```
+
+## 6. Acceptance — #569
+
+- [x] WIP banner removed.
+- [x] `_TBD_` sections removed.
+- [x] Doc reads cleanly end-to-end through §7.
+- [x] Forward pointers to #152 and #429 land the deferred work in tracked
+      epics, not in a "doc incomplete" warning.
+- [x] Lead paragraph honestly describes what the doc covers.


### PR DESCRIPTION
Closes #569 (B8 from the modularity-and-plugin-readiness audit).

## Decision: trim, not fabricate

The issue lists both options ("complete §§ 8-9" or "trim to what works today") and explicitly favours trimming: *"The first 7 sections are excellent and shouldn't be hidden behind a 'this doc is incomplete' warning."*

Filling `## 8. First offer` and `## 9. First order end-to-end` blind would require writing two end-to-end walkthroughs against the live dev stack — exactly the failure mode of CONTRIBUTING.md before #672 (placeholder URLs, wrong `pnpm migration:run` command, `develop` branch reference). Better to trim now, complete those sections in dedicated PRs once the flows are exercised on a real stack.

## Three edits to `docs/getting-started.md`

1. **Lead paragraph** — adjust scope to match what's documented. The doc gets you to a fully-configured OpenLinker instance with both connections, catalog synced, and category mapping in place — not "first Allegro order synced", which was never written.
2. **WIP banner removed** (lines 5-6) — the banner existed to warn about `_TBD_` sections; once those are gone, the banner has nothing to flag.
3. **Replace `## 8. First offer` and `## 9. First order end-to-end` (both `_TBD_`) with `## What's next`** — forward-looking pointer to:
   - **#429** — Allegro offer-creation epic (the missing offer-creation walkthrough).
   - **#152** — clean-state E2E epic (the missing order-sync walkthrough), with a note that the ingestion path is exercised today by the carrier-mapping vertical-slice int-spec from PR #671 (`Closes #535`).
   - Interim guidance: **Jobs & Logs** at `/jobs-logs` to watch sync activity, **Orders** at `/orders` to see ingest results.

## Self-review fix (commit `fafcd9a`)

The first commit (`36ec014`) had two issues caught in self-review:

1. **Wrong route URL** — I wrote `http://localhost:4173/jobs`, but `apps/web/src/app/routes/jobs-logs.route.tsx:12` declares `path: 'jobs-logs'`. Following the doc would 404. Exactly the failure mode the trim approach was meant to avoid. Fixed to `/jobs-logs`; added `/orders` URL for the Orders pointer too.
2. **Link label/URL mismatch** — `[#535](.../pull/671)` displayed "#535" but linked at PR #671. Rewrote as `[PR #671](.../pull/671), closing [#535](.../issues/535)` so GitHub's auto-linker behaviour matches the rendered text.

Two commits to make the review story explicit (mirrors the pattern #672 / #674 used).

## Cross-doc impact: zero

- `README.md` and `CONTRIBUTING.md` contain no references to `docs/getting-started.md` today (verified via grep).
- `docs/operations/prestashop-module-rename-migration.md:18` references the file generically ("install fresh per `docs/getting-started.md`") — no anchor reference, no breakage.
- `docs/reviews/modularity-and-plugin-readiness-2026-05-09.md` references the line numbers we're touching but is the source audit doc, not a load-bearing pointer.

## Acceptance — #569

- [x] WIP banner removed.
- [x] `_TBD_` sections removed.
- [x] First 7 sections preserved verbatim (verified by diff line ranges — only lines 1-6 and 237-243 of the old file changed).
- [x] Forward pointers to #152, #429, and PR #671 land deferred work in tracked epics, not behind a `_TBD_` cliff.
- [x] Lead paragraph honestly describes what the doc covers.
- [x] All URLs in new content verified against `apps/web/src/app/routes/*`.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [x] `pnpm type-check` — clean (no-op for docs but verifies no incidental breakage).
- [x] `pnpm test` — full unit-test triad green (the pre-commit hook detected docs-only changes and skipped tests on the actual commit, but the manual triad ran clean before that).
- [x] `npx prettier --check docs/getting-started.md docs/plans/implementation-plan-569-getting-started-trim.md` — both files pass.
- [x] `grep -c "TBD\|work in progress" docs/getting-started.md` — `0`.
- [x] Routes verified — `apps/web/src/app/routes/jobs-logs.route.tsx` declares `path: 'jobs-logs'`; `apps/web/src/app/routes/orders.route.tsx` declares `path: 'orders'`.

## Notes for reviewers

- Implementation plan committed at `docs/plans/implementation-plan-569-getting-started-trim.md` per the precedent #672 and #676 established.
- Signed off with `git commit -s` (DCO).
- The `_TBD_` cliff was the audit's specific complaint at `docs/getting-started.md:5,239,243` — all three line references are addressed.

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)