### PR TITLE
docs: add Plugin Author Guide + designate PrestaShop as reference adapter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,18 @@ before making significant changes. OpenLinker follows Hexagonal
 Architecture (Ports and Adapters); CORE and Integration packages have
 strict boundaries that contributions must respect.
 
+## Building a New Integration
+
+Adding a platform integration (e.g., Shopify, WooCommerce,
+BigCommerce) is a separate workflow with its own port-selection,
+package-layout, factory-wiring, credentials/OAuth, and host-enablement
+steps. The walkthrough lives in the
+[Plugin Author Guide](./docs/plugin-author-guide.md). It uses
+`libs/integrations/prestashop/` as the reference adapter and points
+at `libs/integrations/allegro/` for the OAuth pattern. Read the guide
+alongside the reference adapter's code — the code is the spec, the
+guide is the map.
+
 ## Pull Request Process
 
 1. Create a feature branch from `main` named after the issue

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ See `.github/workflows/` for details.
 
 Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details on the development workflow, coding standards, and pull-request process.
 
+**Building a new integration?** See the [Plugin Author Guide](./docs/plugin-author-guide.md) — a walkthrough of port selection, package layout, registry wiring, OAuth, testing, and host enablement.
+
 ## License
 
 OpenLinker is released under the Apache License 2.0. See the [LICENSE](./LICENSE) file for details.

--- a/apps/api/src/plugins.ts
+++ b/apps/api/src/plugins.ts
@@ -5,6 +5,11 @@
  * `PluginRegistryModule.forRoot({ plugins: apiPlugins })` inside
  * `apps/api/src/integrations/integrations.module.ts`.
  *
+ * Adding a new integration? See `docs/plugin-author-guide.md` for the
+ * full walkthrough (package layout, capability ports, factory wiring,
+ * credentials/OAuth, tests). This file is the host-side enablement
+ * step.
+ *
  * To enable a third-party plugin:
  *
  *   1. `pnpm add @third-party/openlinker-plugin-<name>` in `apps/api`.

--- a/docs/connections-and-adapter-resolution.md
+++ b/docs/connections-and-adapter-resolution.md
@@ -166,22 +166,10 @@ export interface AdapterRegistryPort {
 
 ### Adding New Adapters
 
-To add a new adapter, update `AdapterRegistryService`:
-
-```typescript
-private readonly registry: Map<string, AdapterMetadata> = new Map([
-  // ... existing adapters
-  {
-    adapterKey: 'shopify.restapi.v1',
-    platformType: 'shopify',
-    supportedCapabilities: ['ProductMaster', 'InventoryMaster'],
-    displayName: 'Shopify REST API v1',
-    version: '1.0.0',
-  },
-].map((meta) => [meta.adapterKey, meta]));
-```
-
-**Future Enhancement**: Dynamic registration or database-backed registry.
+See [`docs/plugin-author-guide.md`](./plugin-author-guide.md) for the
+full walkthrough of adding a new integration adapter — package layout,
+port selection, factory wiring, credentials/OAuth, plugin-owned
+migrations, tests, and host enablement.
 
 ---
 

--- a/docs/plans/implementation-plan-562-563-plugin-author-guide.md
+++ b/docs/plans/implementation-plan-562-563-plugin-author-guide.md
@@ -1,0 +1,455 @@
+# Implementation Plan — Plugin author guide + reference adapter signpost (#562, #563)
+
+Two BLOCKER findings from Modularity Thread B (#548 / #546):
+
+- **#562** — No "Building a plugin / Adding a new integration" guide.
+  External contributors who have read the README and architecture-overview
+  still cannot answer *"where do my files go, which port do I implement,
+  how does the registry pick up my adapter, how do I expose credentials,
+  how do I write the tests."*
+- **#563** — No reference adapter signposted. Three in-tree integrations
+  (`allegro`, `prestashop`, `ai`) with no README in any of them. A
+  first-time contributor has to read all three to figure out the canonical
+  shape.
+
+## Goals
+
+- **#562** — Add `docs/plugin-author-guide.md`, a self-contained walk
+  from "I want to add Platform X" to merging a working adapter. Covers
+  port selection, package layout, factory wiring, registry registration,
+  credentials/OAuth, connection-config shape validation, plugin-owned
+  migrations, testing, and module wiring in the host.
+- **#563** — Designate `libs/integrations/prestashop/` as the
+  reference adapter by adding a short `README.md` to that package,
+  pointing at the guide.
+- Cross-link from `README.md`, `CONTRIBUTING.md`, and (informational)
+  the existing `docs/connections-and-adapter-resolution.md` so anyone
+  arriving at the repo finds the path.
+
+## Non-goals
+
+- **Scaffolding / `pnpm create-adapter`** (#564 — separate HIGH issue).
+  #562's recommendation mentions it as step 2 of the proposed flow, but
+  the scaffolding tool is its own piece of work. The guide will note
+  that #564 is the future shortcut and document the manual-copy path
+  today.
+- **Add-integration issue template** (#567 — separate HIGH). The guide
+  will cross-link to the existing `bug_report.md` / `developer_task.md`
+  templates and note that an integration-specific template is on the
+  way.
+- **Pluralising guides for AI and Allegro plugins.** The guide names
+  PrestaShop as the canonical reference per #563's recommendation
+  ("designate prestashop explicitly"), with brief callouts pointing at
+  `allegro` for the OAuth path and `ai` for the stateless-port-router
+  shape. No separate per-platform README beyond the PrestaShop one.
+- **Rewriting the rest of `docs/connections-and-adapter-resolution.md`.**
+  Only the obsolete "Adding New Adapters" subsection (lines 167–184) is
+  deleted by this PR — it's stale (claims you add to a static `Map` in
+  `AdapterRegistryService`, but real registration is plugin
+  self-registration in `onModuleInit`). The rest of that doc (adapter
+  resolution semantics, connection entity, registry port shape) stays
+  unchanged.
+- **Plugin-SDK contract docs.** The contract is documented in
+  `libs/plugin-sdk/src/adapter-plugin.ts` and `host-services.ts`
+  header comments (verified during research). The author guide will
+  *link to* those header comments, not duplicate them.
+- **Semver / npm publishing guidance.** Every plugin package is
+  `"private": true` today; npm publishing is gated on Modularity
+  Thread F (#552). The guide will note the current state and point at
+  #596 for the future.
+
+## Layer classification
+
+Pure **DX / Documentation**. No code, no tests, no architecture impact,
+no migrations.
+
+## Research findings (already validated)
+
+Verified against the working tree at `f2cf874`:
+
+- **No README** exists in any `libs/integrations/<x>/` package today.
+- **Plugin-SDK structure** matches the `Explore` agent's report:
+  `libs/plugin-sdk/src/{adapter-plugin.ts, host-services.ts,
+  create-nest-adapter-module.ts, dispatch-capability.ts, index.ts}`.
+- **`AdapterPlugin`** has 4 fields: required `manifest` + required
+  `createCapabilityAdapter`, optional `register?(host)` + optional
+  `migrations?`. Verbatim from `libs/plugin-sdk/src/adapter-plugin.ts`.
+- **`HostServices`** splits into two blocks: *read inputs* (logger,
+  identifierMapping, credentialsResolver, optional cache) and
+  *side registries* (8 entries — adapterRegistry, factoryResolver,
+  connectionTesterRegistry, emailNormalizerRegistry,
+  retryClassifierRegistry, schedulerTaskRegistry,
+  webhookProvisioningRegistry, connectionConfigShapeValidatorRegistry,
+  connectionCredentialsShapeValidatorRegistry). Verbatim from
+  `libs/plugin-sdk/src/host-services.ts`.
+- **Plugin-specific cross-package deps** (e.g.,
+  `CustomerProjectionRepositoryPort`, `IMappingConfigService`) are
+  *not* in `HostServices` — passed via the plugin's
+  `create<Platform>Plugin(deps)` factory constructor instead. This is
+  the conservative cut documented inline in `host-services.ts:18–22`.
+- **PrestaShop is the recommended reference**: 4 capabilities
+  (ProductMaster, InventoryMaster, OrderSource, OrderProcessorManager),
+  no OAuth complexity, full set of side registrations (connection
+  tester, webhook provisioner, config + credentials shape validators).
+  See `libs/integrations/prestashop/src/prestashop-plugin.ts:55–68`.
+- **Allegro is the OAuth reference**: token refresh, scheduler tasks
+  (quantity polling), email normalizer (for masked emails), retry
+  classifier, plugin-owned migration (`1767900000000-add-allegro-quantity-commands-table.ts`).
+- **AI is the stateless-router reference**: no per-connection
+  adapter; dynamic module via `AiIntegrationModule.register()`.
+- **Host enablement**: `apps/api/src/plugins.ts` is the single edit
+  point; `PluginRegistryModule.forRoot({ plugins: apiPlugins })`
+  composes them.
+- **Plugin-owned migrations (#599)** require TWO host-side edits:
+  `apps/api/src/plugin-migrations.ts` + `scripts/plugin-migration-dirs.json`.
+  Drift fails `pnpm lint` via `scripts/check-migration-timestamps.mjs`.
+
+## Open decisions (please flag in review)
+
+1. **Guide length / scope.** I'm aiming for ~600 lines — enough to
+   cover the 11 sections concretely without padding. If you'd prefer
+   a tighter "quick start" doc with separate "deep dive" sub-docs,
+   single-line revert. Defaulting to one-file-comprehensive because
+   that's what an external contributor wants on first read.
+
+2. **PrestaShop as reference vs Allegro.** #563's recommendation says
+   PrestaShop explicitly. My research agrees: it has the most ports,
+   no OAuth complexity, and the broadest set of side registrations.
+   Allegro gets a callout for OAuth; AI gets a callout for the
+   stateless-router shape.
+
+3. **Worked example: full adapter or excerpts?** Defaulting to
+   structured excerpts (factory shape, plugin descriptor, integration
+   module skeleton) with verbatim quotes from the PrestaShop adapter
+   for the canonical bits. Writing a fictional "Shopify" worked
+   example end-to-end would double the doc size and drift the moment
+   the SDK contract evolves.
+
+4. **Cross-link surface.** Add a one-line pointer in:
+   - `README.md` § Contributing (above the existing
+     CONTRIBUTING.md pointer)
+   - `CONTRIBUTING.md` § Pull Request Process (after the existing
+     branch-naming step)
+   - `docs/connections-and-adapter-resolution.md` § Adding New Adapters
+     (note: the new guide supersedes this section; cleanup deferred)
+
+## Implementation steps
+
+### Step 1 — `docs/plugin-author-guide.md` (#562)
+
+**File:** `docs/plugin-author-guide.md` (new, ~600 lines)
+
+Top-to-bottom outline:
+
+1. **Title + framing** — "This guide is for an external contributor
+   who wants to add a new platform integration (e.g., Shopify,
+   WooCommerce, BigCommerce) to OpenLinker." One-paragraph TL;DR with
+   "the 7-step path" inline. Explicit expectation-setting paragraph:
+   *"This guide is a map for reading `libs/integrations/prestashop/`,
+   not a copy-paste tutorial. The canonical reference is the code;
+   this guide is the map to read it by."*
+
+2. **Prerequisites** — pnpm 10+, Node 18+, Docker (for the dev
+   stack), familiarity with `docs/architecture-overview.md` § *Core
+   Bounded Contexts* and § *Capability Abstractions*. Link to
+   `CONTRIBUTING.md` setup checklist.
+
+3. **Pick a capability port** — quote `CoreCapabilityValues`
+   **verbatim** from `libs/core/src/integrations/domain/types/adapter.types.ts:22-28`
+   (don't restate in prose; drift risk). One-line description of each
+   capability port and where its interface lives in CORE. Note the
+   open-set rule (#576): plugins can declare new capability names if
+   the target platform doesn't fit one of the existing ones.
+   Recommend starting with one capability and adding more
+   incrementally.
+
+4. **Use PrestaShop as your starting point** — short paragraph
+   designating it. List the 4 capabilities it implements, note that
+   it's the most port-rich adapter and the recommended template.
+   Cross-link to `libs/integrations/prestashop/README.md` (added in
+   Step 2 below).
+
+5. **Package layout** — annotated tree of
+   `libs/integrations/prestashop/src/` showing where each layer
+   lives:
+   - `application/` — adapter factory, DTOs, interfaces
+   - `domain/` — types, exceptions
+   - `infrastructure/adapters/` — port implementations + HTTP client
+   - `infrastructure/provisioners/` — cross-cutting side effects
+   - `infrastructure/http/` — HTTP client + auth glue
+   - `infrastructure/mappers/` — wire-format ↔ domain mappers
+   - `migrations/` — plugin-owned migrations (if any; PrestaShop has
+     none, Allegro has one — cross-reference)
+   - `__tests__/` — mocks + fixtures + unit specs (colocated
+     `__tests__/` dirs are the convention)
+   Verbatim `package.json` shape (from PrestaShop), `tsconfig.json`
+   note, barrel `src/index.ts` shape.
+
+6. **The `AdapterPlugin` contract** — quote the interface fields with
+   one-paragraph explanations of each. Link to the *exact line ranges*
+   of the header comments rather than the bare file path:
+   - `libs/plugin-sdk/src/adapter-plugin.ts:42-110` — `AdapterPlugin`
+     interface
+   - `libs/plugin-sdk/src/host-services.ts:50-121` — `HostServices`
+     bag (read-inputs vs side-registries split)
+   GitHub's `.ts` blob view skips JSDoc rendering; the line range
+   lands the reader inside the relevant block instead of at the top
+   of the file. Explain the two authoring patterns:
+   - **`createNestAdapterModule(plugin)` helper** — for plugins
+     with no plugin-specific Nest providers. Single-line module file.
+   - **Inline-from-module pattern (Allegro/PrestaShop)** — for
+     plugins with their own `@Injectable` providers (repositories,
+     provisioners, HTTP clients). Show the `onModuleInit` recipe
+     from PrestaShop. Note this is the more common pattern in
+     practice.
+
+7. **Implementing a capability port** — using
+   `PrestashopOrderProcessorManagerAdapter` as the worked example.
+   Cover:
+   - Where the port interface lives in CORE (`@openlinker/core/<ctx>`
+     barrel import — *never* deep paths, link to engineering-standards
+     § *Import Aliases*).
+   - Class signature: `implements OrderProcessorManagerPort`.
+   - Constructor: inject HTTP client + `IdentifierMappingPort` + plugin-
+     internal helpers.
+   - Method shape: validate inputs, call the platform API, map
+     response, translate errors to domain exceptions.
+   - Throwing for unsupported operations — example pattern.
+
+8. **Adapter factory + registry** — `PrestashopAdapterFactory.createAdapters`
+   walkthrough. Cover:
+   - When the factory is constructed (once at boot) vs invoked
+     (per `createCapabilityAdapter` call).
+   - How config is validated (`validateAndParseConfig(connection.config)`).
+   - How credentials are resolved
+     (`credentialsResolver.get<T>(connection.credentialsRef)`).
+   - How adapters are assembled into the per-capability map and
+     returned.
+   - `adapterKey` naming (`<platform>.<api-version>.<version>` —
+     e.g., `prestashop.webservice.v1`, `allegro.publicapi.v1`).
+   - `manifest` static export (named `<platform>AdapterManifest`)
+     and why it exists as both a top-level `const` and as `plugin.manifest`
+     (same reference — no drift; #575).
+
+9. **Connection-config and credentials shape validation** —
+   `class-validator` DTO pattern in
+   `application/dto/<platform>-connection-config.dto.ts` plus the
+   adapter wrapping it. Show the validator-registry registration in
+   `register(host)`. Note that shape validation is separate from
+   *"do these credentials actually authenticate"* — the latter is
+   `ConnectionTesterPort` against the live API.
+
+10. **Credentials / OAuth** — bump to ~40 lines covering both shapes
+    concretely; a one-paragraph callout is too thin for someone
+    implementing their first OAuth flow.
+    - **Non-OAuth (PrestaShop):** simple `{ apiKey: string }` payload,
+      validated at create-time via the credentials shape validator,
+      encrypted in `integration_credentials`. Path to the validator
+      file. Where the API key is read on each request.
+    - **OAuth (Allegro):** cover the *shape* before pointing at the
+      code:
+      - **Token tables** — plugin-private migration creates the
+        token row; pre-#599 shape with example schema.
+      - **Token-refresh service** — `AllegroTokenRefreshService`
+        signature, when it's called (constructor or per-request
+        callback).
+      - **Shared state** — `AllegroConnectionTokenState` is the
+        in-memory token + expiry, shared between the OAuth and
+        webservice HTTP clients so a refresh updates both. Pattern
+        an external plugin author needs to replicate.
+      - **401 → refresh → retry** — handler signature in the HTTP
+        client.
+      - **Where the live code lives** —
+        `libs/integrations/allegro/src/infrastructure/http/` for the
+        full walkthrough. The guide gives shape; code is spec.
+
+11. **Plugin-owned migrations** — when you need them, the recipe
+    from `docs/migrations.md § Plugin-Owned Migrations (#599)`. Three
+    edits: (a) write the migration in
+    `libs/integrations/<platform>/src/migrations/`, (b) add the dir
+    to `apps/api/src/plugin-migrations.ts`, (c) add the same dir to
+    `scripts/plugin-migration-dirs.json`. Cross-link to migrations
+    doc for the timestamp-uniqueness rule. Allegro's existing
+    migration is the worked example.
+
+12. **Tests** — unit and integration patterns:
+    - **Unit specs** (`__tests__/<name>.spec.ts`): mock the HTTP
+      client + `IdentifierMappingPort` via the existing factory
+      helpers; test request shape, parsing, error mapping, port
+      contract. Cross-link the existing `testing-guide.md`.
+    - **Integration specs** (`apps/api/test/integration/**/*.int-spec.ts`):
+      Testcontainers-based; opt-in PrestaShop container helper for
+      adapter-shape verification. Cross-link to
+      `docs/testing-guide.md § PrestaShop Testcontainer Pattern (#506)`.
+    - **Vertical slice** (`apps/api/test/integration/orders/allegro-prestashop-carrier-mapping.int-spec.ts`)
+      as the reference for end-to-end adapter integration tests.
+
+13. **Wiring the plugin into the host** — `apps/api/src/plugins.ts`
+    is the single edit point. Show the existing
+    `apiPlugins` array; explain that adding your `MyIntegrationModule`
+    to that array is the host-enablement step.
+
+14. **Gotchas / things to know** —
+    - Import-aliases rule (#591): top-level barrel for cross-package,
+      never deep paths into `@openlinker/core/<ctx>/...`.
+    - `orm-entities` sub-barrels are off-limits to plugin packages
+      (#594, ESLint-enforced).
+    - Plugin packages are `"private": true` today (npm publishing
+      depends on Modularity Thread F, #552/#596).
+    - Capability is open at the registry boundary (#576).
+    - Plugin migrations require the TWO-edit host wire-up (drift
+      surfaces as `relation "..." does not exist` at runtime).
+
+15. **Where to ask questions** — open a discussion or an issue using
+    the existing `bug_report.md` / `developer_task.md` templates;
+    note that an integration-specific template is planned (#567).
+
+16. **Related reading** — links to:
+    - `docs/architecture-overview.md`
+    - `docs/engineering-standards.md`
+    - `docs/connections-and-adapter-resolution.md`
+    - `docs/migrations.md`
+    - `docs/testing-guide.md`
+    - `libs/plugin-sdk/src/adapter-plugin.ts` (header comment is the
+      contract spec)
+    - `libs/plugin-sdk/src/host-services.ts` (HostServices spec)
+
+### Step 2 — `libs/integrations/prestashop/README.md` (#563)
+
+**File:** `libs/integrations/prestashop/README.md` (new, ~30 lines)
+
+Short and focused. Sections:
+
+- One-paragraph "This is the OpenLinker reference adapter" header.
+  States that it implements ProductMaster, InventoryMaster,
+  OrderSource, OrderProcessorManager via the PrestaShop WebService v1
+  API.
+- "New adapter authors should copy this package's layout as your
+  starting point. See [`docs/plugin-author-guide.md`](../../../docs/plugin-author-guide.md)
+  for the full walkthrough."
+- Brief callouts of what's *not* in this adapter — *"OAuth and
+  token refresh: see `libs/integrations/allegro/` for that pattern.
+  Stateless port-router: see `libs/integrations/ai/`."*
+- One-line capability-port list with file links into the package.
+- Pointer to operator docs at `docs/integrations/prestashop/{setup,runbook,manual-testing}.md`
+  (those exist; this README is for *building* an adapter, the operator
+  docs are for *running* one).
+
+### Step 3 — Cross-links + obsolete-section delete
+
+- **`README.md`** — add one bullet under `## Contributing` (currently
+  one-line pointer to CONTRIBUTING.md): *"Building a plugin? See the
+  [Plugin Author Guide](./docs/plugin-author-guide.md)."*
+- **`CONTRIBUTING.md`** — add a new top-level section
+  `## Building a New Integration` between `## Architecture` and
+  `## Pull Request Process` (workflow surface, not a PR step). One
+  short paragraph linking to the guide. Discoverable in the TOC and
+  in the rendered doc's section list.
+- **`docs/connections-and-adapter-resolution.md`** — **delete** the
+  obsolete `### Adding New Adapters` subsection (lines 167–184). The
+  stale code snippet there (claims you edit a static `Map` in
+  `AdapterRegistryService`) is exactly what #562 was filed against;
+  carrying it forward as cruft re-creates the drift the new guide is
+  meant to solve. Replace with a one-line pointer:
+  `See [Plugin Author Guide](./plugin-author-guide.md) for the full
+  walkthrough of adding a new integration adapter.`
+- **`apps/api/src/plugins.ts`** — add a one-line header comment at
+  the top of the file: `// Adding a new integration? See
+  docs/plugin-author-guide.md.` This is where contributors land when
+  they're ready to enable their plugin; the comment costs nothing and
+  meets them at the right moment.
+
+### Step 4 — Quality gate
+
+Per CLAUDE.md, run in order:
+
+1. `pnpm lint` — confirms no broken markdown links or invariant drift.
+2. `pnpm type-check` — sanity (no code changes, should no-op).
+3. `pnpm test` — sanity.
+
+None of the gate steps directly exercise the new files. The real
+verification is:
+
+- Manual re-read of `plugin-author-guide.md` against the actual files
+  it references — every code path it quotes (factory shape, plugin
+  descriptor, registration calls) must match what's in
+  `libs/integrations/prestashop/src/`.
+- Grep for any path in the guide that doesn't resolve.
+
+### Step 5 — Self-review
+
+Walk the diff against #562 / #563 acceptance criteria:
+
+- **#562 acceptance** — guide covers all 7 points in the issue's
+  recommendation: (1) port pick, (2) scaffolding note (deferred to
+  #564), (3) port + factory, (4) registry registration, (5)
+  credentials/OAuth, (6) testing pattern, (7) doc expectations. ✓
+- **#563 acceptance** — PrestaShop README exists, designates the
+  package as reference, points at the plugin author guide. ✓
+- Cross-links present in README, CONTRIBUTING, and the existing
+  connections-and-adapter-resolution doc.
+- Every file path quoted in the guide resolves against the working
+  tree.
+
+## Risks
+
+- **Doc drift over time.** A 600-line doc that references concrete
+  paths, class names, and registry-method signatures will go stale
+  the next time someone refactors the plugin SDK. Mitigations:
+  - Keep code excerpts short and link to the live file for the long
+    form.
+  - The `AdapterPlugin` and `HostServices` contracts already have
+    rich header comments — link to those rather than duplicating
+    (with explicit line ranges per Section 6 above).
+  - Footer with *"Last verified at commit `<sha>`. If you spot
+    drift, please open an issue or PR."* — honest framing that it's
+    a hint, not a guarantee. Lower-effort than a lint invariant and
+    sets reader expectations correctly.
+  - **Future hardening (out of scope today):** `pnpm lint` invariant
+    grep-checking key claims against live code, or doc-test-style
+    code snippets that import the actual types. Tracked for a
+    follow-up if drift becomes a real problem.
+- **Path conflicts with parallel work (PR #678 / #665).** PR #678
+  is editing `libs/core/src/listings/application/services/`. My doc
+  references the listings package as one of the capability port
+  homes (`OfferManagerPort`). No file conflict — my changes are all
+  under `docs/` and `libs/integrations/prestashop/README.md` — but
+  the guide's pointer text to `OfferManagerPort` should be a
+  *capability-name* reference, not a *file-path* reference, to be
+  immune to the cleanup in #678.
+- **Adapter-as-source-of-truth risk.** The guide tells contributors to
+  copy PrestaShop. If PrestaShop drifts from the documented patterns
+  (e.g., starts using a deprecated registry method), the guide becomes
+  misleading. Mitigation: the guide cites *patterns* with PrestaShop
+  paths as examples, not as the spec — the spec is in
+  `engineering-standards.md` and the SDK header comments.
+
+## PR body checklist
+
+- [ ] `docs/plugin-author-guide.md` exists, ~600 lines, covers the 7
+      points in #562's recommendation.
+- [ ] `libs/integrations/prestashop/README.md` exists, designates
+      PrestaShop as reference, points at the guide.
+- [ ] Cross-link in `README.md` § Contributing.
+- [ ] Cross-link in `CONTRIBUTING.md` § Pull Request Process.
+- [ ] Cross-link prepended to `docs/connections-and-adapter-resolution.md`
+      § Adding New Adapters.
+- [ ] All file paths referenced in the guide resolve against the
+      current working tree.
+- [ ] `pnpm lint` + `pnpm type-check` + `pnpm test` pass.
+- [ ] Closes #562, #563.
+
+## Out-of-PR follow-ups
+
+- **#564** — `pnpm create-adapter <name>` scaffolding tool. The guide
+  notes this is the future shortcut; until then, contributors do
+  manual copy-from-PrestaShop.
+- **#567** — Add-integration GitHub issue template. The guide notes
+  this is planned; for now, contributors use the existing templates.
+- **#569** — Resume / finish `docs/getting-started.md` (currently
+  ends mid-flow). Independent of the plugin guide; mentioned only as
+  related work.
+- **Cleanup of `docs/connections-and-adapter-resolution.md` § Adding
+  New Adapters**. The new guide supersedes that 15-line section; once
+  the guide is reviewed, the old section can be deleted in a follow-up
+  PR (not this one).

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -16,22 +16,30 @@ the API host.
 > **What this guide is not.** A from-zero copy-paste tutorial. Expect
 > to read the reference adapter alongside this doc and assemble pieces.
 
-## The seven-step path
+## The path
 
 1. **Pick a capability port** in `libs/core/src/<context>/domain/ports/`.
-2. **Create the package** under `libs/integrations/<platform>/` (start
-   by copying the PrestaShop layout).
-3. **Implement the port** as an adapter class.
-4. **Write a factory** that builds per-connection adapter instances and
-   resolves credentials.
-5. **Wire up the plugin descriptor + NestJS module** with the
-   `AdapterPlugin` contract.
-6. **Add tests** — unit specs colocated with the adapter, optional
-   integration spec under `apps/api/test/integration/`.
-7. **Enable the plugin** in the API host (`apps/api/src/plugins.ts` —
-   a single-line edit).
+2. **Use PrestaShop as your starting point** — copy
+   `libs/integrations/prestashop/` as your reference adapter.
+3. **Package layout** — set up `libs/integrations/<platform>/` with the
+   standard tree.
+4. **Implement a capability port** as an adapter class.
+5. **Write the adapter factory** that builds per-connection instances
+   and resolves credentials.
+6. **Wire up the `AdapterPlugin` descriptor + NestJS module** with the
+   plugin SDK contract.
+7. **Register connection-config and credentials shape validators** at
+   boot.
+8. **Handle credentials and OAuth** — static API key (PrestaShop) or
+   token refresh-and-retry (Allegro).
+9. **Add plugin-owned migrations** if your plugin owns any tables
+   (optional, #599).
+10. **Add tests** — unit specs colocated with the adapter, optional
+    integration spec under `apps/api/test/integration/`.
+11. **Enable the plugin** in the API host (`apps/api/src/plugins.ts` —
+    a single-line edit).
 
-Each step is one section below.
+Each numbered item is one section below.
 
 ---
 
@@ -84,10 +92,12 @@ export const CoreCapabilityValues = [
 the type-system level (`CoreCapability` union). At the registry
 boundary it's open: a plugin's
 [`AdapterMetadata.supportedCapabilities`](../libs/core/src/integrations/domain/types/adapter.types.ts)
-field accepts `string[]`. You can declare a new capability name if
-your platform doesn't fit one of the existing ports — coordinate with
-the maintainers first, since a new capability isn't useful until
-something in CORE consumes it.
+field accepts the well-known `CoreCapability` members *and* any other
+string, so the registry can carry capability names that core doesn't
+declare yet. If your platform doesn't fit one of the existing ports
+you can declare a new capability name — coordinate with the maintainers
+first, since a new capability isn't useful until something in CORE
+consumes it.
 
 **Recommendation: start with one capability and add more
 incrementally.** PrestaShop ships four; you don't need to match that
@@ -442,6 +452,13 @@ closure — see `CreatePrestashopPluginDeps` at
 
 ### Two authoring patterns
 
+**Default to the inline-from-module pattern (below).** Most real-world
+plugins land there because they have at least one plugin-specific
+`@Injectable` — a repository, provisioner, HTTP client, or refresh
+service. Allegro and PrestaShop both use it. The
+`createNestAdapterModule` helper covered first is the easy path for
+truly thin plugins; don't fight it if your plugin grows beyond that.
+
 **Simple case (no plugin-specific Nest providers).** Use the
 [`createNestAdapterModule(plugin)`](../libs/plugin-sdk/src/create-nest-adapter-module.ts)
 helper. The whole module file becomes:
@@ -493,11 +510,6 @@ export class XIntegrationModule implements OnModuleInit {
 
 Concrete worked example:
 [`libs/integrations/prestashop/src/prestashop-integration.module.ts`](../libs/integrations/prestashop/src/prestashop-integration.module.ts).
-
-Note: most real-world plugins land on the inline-from-module pattern
-because they have at least one plugin-specific `@Injectable`. The
-`createNestAdapterModule` helper is the easy path for thin plugins;
-don't fight it if your plugin grows beyond that.
 
 ### `dispatchCapability` helper
 
@@ -829,5 +841,7 @@ boot and self-registers against the host registries.
 <sub>**Last verified at commit `f2cf874`** (`bbca59d` series merged
 2026-05-13). If you spot drift between this guide and the live code —
 or hit a step that's wrong or unclear — please open an issue or PR.
+A lint-time invariant that checks the verbatim quotes against the
+source is tracked in [#680](https://github.com/SilkSoftwareHouse/openlinker/issues/680).
 The code is the spec; this guide is the map. Maps go stale; the
 code can't.</sub>

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -1,0 +1,833 @@
+# Plugin Author Guide
+
+This guide walks an external contributor through *"I want to add a new
+platform integration to OpenLinker"* — say Shopify, WooCommerce, or
+BigCommerce. By the end you'll know where your files go, which port to
+implement, how the registry picks up your adapter, how credentials and
+OAuth fit in, how to write the tests, and how to enable the plugin in
+the API host.
+
+> **What this guide is.** A map for reading
+> [`libs/integrations/prestashop/`](../libs/integrations/prestashop/) —
+> the project's reference adapter. The canonical reference is the code;
+> this guide is the map to read it by. Copy-paste excerpts will go
+> stale faster than the code does.
+
+> **What this guide is not.** A from-zero copy-paste tutorial. Expect
+> to read the reference adapter alongside this doc and assemble pieces.
+
+## The seven-step path
+
+1. **Pick a capability port** in `libs/core/src/<context>/domain/ports/`.
+2. **Create the package** under `libs/integrations/<platform>/` (start
+   by copying the PrestaShop layout).
+3. **Implement the port** as an adapter class.
+4. **Write a factory** that builds per-connection adapter instances and
+   resolves credentials.
+5. **Wire up the plugin descriptor + NestJS module** with the
+   `AdapterPlugin` contract.
+6. **Add tests** — unit specs colocated with the adapter, optional
+   integration spec under `apps/api/test/integration/`.
+7. **Enable the plugin** in the API host (`apps/api/src/plugins.ts` —
+   a single-line edit).
+
+Each step is one section below.
+
+---
+
+## Prerequisites
+
+- Node.js 18+ (LTS), pnpm 10+, Docker (for the dev stack and
+  integration tests).
+- Familiarity with
+  [`docs/architecture-overview.md`](./architecture-overview.md) —
+  especially the *Hexagonal Architecture* and *Capability
+  Abstractions (Business Roles)* sections.
+- Familiarity with
+  [`docs/engineering-standards.md`](./engineering-standards.md) —
+  especially *Naming Conventions*, *Type Definitions in Separate
+  Files*, *Service Interface Implementation*, and *Import Aliases*.
+- A working dev stack — see
+  [`CONTRIBUTING.md § Setup Checklist`](../CONTRIBUTING.md#setup-checklist)
+  for the zero-to-green sequence.
+
+---
+
+## Step 1 — Pick a capability port
+
+OpenLinker's CORE defines a small closed set of "business capability"
+port interfaces in `libs/core/src/<context>/domain/ports/`. An adapter
+implements one or more of them.
+
+The well-known set is `CoreCapabilityValues`, declared verbatim at
+[`libs/core/src/integrations/domain/types/adapter.types.ts:22-28`](../libs/core/src/integrations/domain/types/adapter.types.ts#L22-L28):
+
+```typescript
+export const CoreCapabilityValues = [
+  'ProductMaster',
+  'InventoryMaster',
+  'OrderProcessorManager',
+  'OrderSource',
+  'OfferManager',
+] as const;
+```
+
+| Capability             | What it does                                              | Port file                                                                                                                          |
+| ---------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `ProductMaster`        | Source of truth for product catalog (read/write).         | [`libs/core/src/products/domain/ports/product-master.port.ts`](../libs/core/src/products/domain/ports/product-master.port.ts)      |
+| `InventoryMaster`      | Source of truth for stock levels.                         | [`libs/core/src/inventory/domain/ports/inventory-master.port.ts`](../libs/core/src/inventory/domain/ports/inventory-master.port.ts) |
+| `OrderProcessorManager`| Order lifecycle on the destination shop (create / status).| [`libs/core/src/orders/domain/ports/order-processor-manager.port.ts`](../libs/core/src/orders/domain/ports/order-processor-manager.port.ts) |
+| `OrderSource`          | Cursor-based order-event ingestion.                       | [`libs/core/src/orders/domain/ports/order-source.port.ts`](../libs/core/src/orders/domain/ports/order-source.port.ts)               |
+| `OfferManager`         | Marketplace offer/listing management (split into sub-capabilities). | [`libs/core/src/listings/domain/ports/offer-manager.port.ts`](../libs/core/src/listings/domain/ports/offer-manager.port.ts)         |
+
+**Open at the registry boundary (#576).** The set above is closed at
+the type-system level (`CoreCapability` union). At the registry
+boundary it's open: a plugin's
+[`AdapterMetadata.supportedCapabilities`](../libs/core/src/integrations/domain/types/adapter.types.ts)
+field accepts `string[]`. You can declare a new capability name if
+your platform doesn't fit one of the existing ports — coordinate with
+the maintainers first, since a new capability isn't useful until
+something in CORE consumes it.
+
+**Recommendation: start with one capability and add more
+incrementally.** PrestaShop ships four; you don't need to match that
+on day one.
+
+---
+
+## Step 2 — Use PrestaShop as your starting point
+
+[`libs/integrations/prestashop/`](../libs/integrations/prestashop/) is
+the **reference adapter**. It implements four capabilities, has no
+OAuth complexity, registers the full set of side-services
+(connection tester, webhook provisioner, shape validators), and is the
+most port-rich plugin in the tree. New plugin authors should copy this
+layout.
+
+Two pointers for special cases:
+
+- **OAuth flow** — see
+  [`libs/integrations/allegro/`](../libs/integrations/allegro/). It
+  adds token tables, refresh handling, scheduler tasks, and email
+  normalisation on top of the PrestaShop shape.
+- **Stateless port-router (no per-connection adapter)** — see
+  [`libs/integrations/ai/`](../libs/integrations/ai/). Uses a dynamic
+  module (`AiIntegrationModule.register()`) and routes calls to
+  per-provider instances at runtime. Reference only if your platform
+  is provider-switched rather than per-connection.
+
+For everything else, PrestaShop is the canonical template.
+
+---
+
+## Step 3 — Package layout
+
+Copy this tree as your starting point (`libs/integrations/<platform>/`):
+
+```text
+libs/integrations/<platform>/
+├── jest.config.mjs
+├── tsconfig.json
+├── package.json
+├── .eslintrc.js
+└── src/
+    ├── index.ts                          # Barrel — see "Barrel exports" below
+    ├── <platform>-plugin.ts              # createXPlugin() + adapter manifest
+    ├── <platform>-integration.module.ts  # NestJS module + onModuleInit registration
+    ├── application/
+    │   ├── <platform>-adapter.factory.ts # Per-connection factory
+    │   ├── dto/
+    │   │   └── <platform>-connection-config.dto.ts
+    │   ├── interfaces/                   # Factory contract (optional)
+    │   └── __tests__/
+    ├── domain/
+    │   ├── types/                        # Connection-config + credentials + domain types
+    │   └── exceptions/                   # Plugin-specific domain exceptions
+    ├── infrastructure/
+    │   ├── adapters/                     # Capability-port implementations + side adapters
+    │   ├── http/                         # HTTP client + auth glue
+    │   ├── mappers/                      # Wire-format ↔ domain mappers
+    │   ├── provisioners/                 # Cross-cutting side effects (e.g. PS customer/address)
+    │   └── __tests__/
+    ├── migrations/                       # Plugin-owned migrations (optional, #599)
+    └── __tests__/
+        ├── fixtures/                     # Test fixtures
+        └── mocks/                        # Mock factories
+```
+
+PrestaShop has no `migrations/` because it doesn't own any tables;
+Allegro has one (the `allegro_quantity_commands` table). The rest of
+the layout is the same.
+
+### `package.json` shape
+
+Copy from
+[`libs/integrations/prestashop/package.json`](../libs/integrations/prestashop/package.json):
+
+```jsonc
+{
+  "name": "@openlinker/integrations-<platform>",
+  "version": "0.1.0",
+  "description": "<platform> <API name> adapter for OpenLinker",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "require": "./dist/index.js" }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --config ./jest.config.mjs",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.ts\" --fix"
+  },
+  "dependencies": {
+    "@openlinker/core": "workspace:*",
+    "@openlinker/plugin-sdk": "workspace:*",
+    "@openlinker/shared": "workspace:*",
+    "class-validator": "0.14.1"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0"
+  }
+}
+```
+
+All packages are `"private": true` today. npm publishing is gated on
+Modularity Thread F (#552 / #596); until that lands, plugins consume
+each other via the pnpm workspace, not via the registry.
+
+### Barrel exports (`src/index.ts`)
+
+The barrel is the package's public surface. Export only what the host
+or test fixtures need:
+
+- The plugin factory: `createXPlugin` + `xAdapterManifest` + the
+  `CreateXPluginDeps` type.
+- The shape validator adapters (test fixtures sometimes need them).
+- The NestJS integration module (the host imports this).
+- Domain types and exceptions other packages legitimately need
+  (rare).
+
+See
+[`libs/integrations/prestashop/src/index.ts`](../libs/integrations/prestashop/src/index.ts)
+for the verbatim shape.
+
+---
+
+## Step 4 — Implement a capability port
+
+Where the port lives in CORE drives where the adapter lives in your
+plugin:
+
+```text
+CORE  → libs/core/src/orders/domain/ports/order-processor-manager.port.ts
+PLUGIN → libs/integrations/<platform>/src/infrastructure/adapters/<platform>-order-processor-manager.adapter.ts
+```
+
+### Import the port through the barrel
+
+Per
+[`docs/engineering-standards.md § Import Aliases`](./engineering-standards.md#import-aliases),
+**plugins cross-import via the top-level barrel only** — never deep
+paths into `@openlinker/core/<ctx>/domain/...`:
+
+```typescript
+// ✅ Top-level barrel (works at runtime, passes ESLint)
+import { OrderProcessorManagerPort } from '@openlinker/core/orders';
+
+// ❌ Deep import — fails at Node runtime with ERR_PACKAGE_PATH_NOT_EXPORTED
+import { OrderProcessorManagerPort } from '@openlinker/core/orders/domain/ports/order-processor-manager.port';
+```
+
+The same rule applies to ORM-entity sub-barrels — they're host-only
+(#594). Plugin packages are ESLint-blocked from importing any
+`@openlinker/core/<ctx>/orm-entities` path. If you find yourself
+wanting to, stop: you're reaching for an infrastructure detail that
+shouldn't cross the port boundary.
+
+### Adapter shape
+
+Naming: `{Platform}{Capability}Adapter` (PascalCase), one file per
+adapter, filename `<platform>-<capability>.adapter.ts`. See the
+naming rules in
+[`docs/engineering-standards.md § Class Names — Adapters`](./engineering-standards.md#adapters).
+
+```typescript
+// libs/integrations/<platform>/src/infrastructure/adapters/<platform>-order-processor-manager.adapter.ts
+
+import { Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import type {
+  OrderProcessorManagerPort,
+  OrderCreate,
+  Order,
+  OrderStatus,
+} from '@openlinker/core/orders';
+import type { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import type { XHttpClient } from '../http/x-http-client';
+
+@Injectable()
+export class XOrderProcessorManagerAdapter implements OrderProcessorManagerPort {
+  private readonly logger = new Logger(XOrderProcessorManagerAdapter.name);
+
+  constructor(
+    private readonly httpClient: XHttpClient,
+    private readonly identifierMapping: IdentifierMappingPort,
+    // ... other plugin-internal deps
+  ) {}
+
+  async createOrder(order: OrderCreate): Promise<Order> {
+    // 1. Translate internal IDs → external IDs via identifierMapping
+    // 2. Call the platform API
+    // 3. Map response → unified Order
+    // 4. Translate platform errors → domain exceptions
+  }
+
+  async updateOrderStatus(orderId: string, status: OrderStatus): Promise<Order> {
+    // ...
+  }
+
+  // Throw for unsupported operations rather than returning a half-baked result.
+}
+```
+
+Concrete worked example:
+[`libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts`](../libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts).
+
+### Error handling
+
+Adapters must translate platform errors into domain exceptions. Per
+[`docs/engineering-standards.md § Error Handling`](./engineering-standards.md#error-handling),
+domain exceptions live in `<plugin>/src/domain/exceptions/`. Never
+leak platform HTTP status codes or SDK error types through the port
+return.
+
+---
+
+## Step 5 — Write the adapter factory
+
+A plugin has many ports per capability, but adapters are
+**per-connection** — same plugin, different `Connection.config` and
+credentials means different adapter instances. The factory is what
+builds them at runtime.
+
+```typescript
+// libs/integrations/<platform>/src/application/<platform>-adapter.factory.ts
+
+import { Injectable } from '@nestjs/common';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type {
+  IdentifierMappingPort,
+  CredentialsResolverPort,
+} from '@openlinker/core/integrations';
+import type { XConnectionConfig } from '../domain/types/x-config.types';
+import type { XCredentials } from '../domain/types/x-credentials.types';
+
+@Injectable()
+export class XAdapterFactory {
+  constructor(/* plugin-internal deps — provisioners, repositories, refreshers */) {}
+
+  async createAdapters(
+    connection: Connection,
+    identifierMapping: IdentifierMappingPort,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<XAdapters> {
+    // 1. Validate + parse Connection.config (JSONB blob from operator).
+    const config = this.validateAndParseConfig(connection.config);
+
+    // 2. Resolve credentials at adapter-construction time, NOT in the
+    //    factory constructor. Credentials are per-connection; the
+    //    factory is process-wide.
+    const credentials = await credentialsResolver.get<XCredentials>(
+      connection.credentialsRef,
+    );
+
+    // 3. Build the HTTP client(s) with config + credentials.
+    const http = new XHttpClient(config.baseUrl, credentials, ...);
+
+    // 4. Construct each capability adapter and return them keyed by
+    //    capability name.
+    return {
+      productMaster: new XProductMasterAdapter(http, identifierMapping, ...),
+      inventoryMaster: new XInventoryMasterAdapter(http, identifierMapping, ...),
+      orderSource: new XOrderSourceAdapter(http, identifierMapping, ...),
+      orderProcessorManager: new XOrderProcessorManagerAdapter(http, identifierMapping, ...),
+    };
+  }
+
+  private validateAndParseConfig(raw: unknown): XConnectionConfig {
+    // Use the same DTO + class-validator pipeline as Step 6.
+  }
+}
+```
+
+Concrete worked example:
+[`libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts`](../libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts).
+
+### `adapterKey` naming
+
+Format: `<platform>.<api-name>.v<version>` (lowercase, dot-separated).
+Examples in the tree:
+
+- `prestashop.webservice.v1`
+- `allegro.publicapi.v1`
+
+The version suffix lets you ship a v2 alongside the v1 for the same
+`platformType` without a breaking-change PR.
+
+### Static manifest export (#575)
+
+Export the manifest as a top-level `const` co-located with the plugin
+factory, so consumers can read it without booting NestJS:
+
+```typescript
+// libs/integrations/<platform>/src/<platform>-plugin.ts
+import type { AdapterMetadata } from '@openlinker/core/integrations';
+
+export const xAdapterManifest: AdapterMetadata = {
+  adapterKey: 'x.publicapi.v1',
+  platformType: 'x',
+  supportedCapabilities: ['ProductMaster', 'InventoryMaster'],
+  displayName: 'X Public API v1',
+  version: '1.0.0',
+  isDefault: true,
+};
+```
+
+The runtime `plugin.manifest` returns this same object reference, so
+static and runtime views can't drift.
+
+---
+
+## Step 6 — Wire up the `AdapterPlugin` descriptor
+
+The plugin contract lives in
+[`libs/plugin-sdk/src/adapter-plugin.ts:42-110`](../libs/plugin-sdk/src/adapter-plugin.ts#L42-L110)
+(the header comment is the contract spec — read it in full before
+authoring your plugin). Its four fields:
+
+- `manifest: AdapterMetadata` — required; the static export from
+  Step 5.
+- `register?(host: HostServices): void` — optional; side-registrations
+  beyond the base manifest + factory. Called once at boot.
+- `createCapabilityAdapter<T>(connection, capability, host)` —
+  required; the per-connection factory entry point.
+- `migrations?: readonly string[]` — optional; informational pointer
+  to plugin-owned migration globs (host enablement is separate — see
+  Step 8).
+
+The `HostServices` bag passed into `register` and `createCapabilityAdapter`
+is defined at
+[`libs/plugin-sdk/src/host-services.ts:50-121`](../libs/plugin-sdk/src/host-services.ts#L50-L121).
+It splits into two blocks:
+
+- **Read inputs** (use): `logger`, `identifierMapping`,
+  `credentialsResolver`, optional `cache`.
+- **Side registries** (register into at boot): `adapterRegistry`,
+  `factoryResolver`, `connectionTesterRegistry`,
+  `emailNormalizerRegistry`, `retryClassifierRegistry`,
+  `schedulerTaskRegistry`, `webhookProvisioningRegistry`,
+  `connectionConfigShapeValidatorRegistry`,
+  `connectionCredentialsShapeValidatorRegistry`.
+
+**Plugin-specific cross-package deps** (your customer-projection
+repository, mapping-config service, etc.) are *not* in the
+`HostServices` bag. Plugins pass them via the factory constructor
+closure — see `CreatePrestashopPluginDeps` at
+[`libs/integrations/prestashop/src/prestashop-plugin.ts`](../libs/integrations/prestashop/src/prestashop-plugin.ts).
+
+### Two authoring patterns
+
+**Simple case (no plugin-specific Nest providers).** Use the
+[`createNestAdapterModule(plugin)`](../libs/plugin-sdk/src/create-nest-adapter-module.ts)
+helper. The whole module file becomes:
+
+```typescript
+// libs/integrations/<platform>/src/x-integration.module.ts
+import { createNestAdapterModule } from '@openlinker/plugin-sdk';
+import { createXPlugin } from './x-plugin';
+
+export const XIntegrationModule = createNestAdapterModule({
+  plugin: createXPlugin({ /* deps */ }),
+});
+```
+
+**Inline-from-module (the common case — Allegro + PrestaShop).** When
+your plugin needs its own `@Injectable` providers (repositories,
+provisioners, HTTP clients), write an explicit `OnModuleInit` module:
+
+```typescript
+// libs/integrations/<platform>/src/x-integration.module.ts
+@Module({
+  imports: [IntegrationsModule, /* plugin-specific imports */],
+  providers: [
+    XCustomerProvisioner,
+    XAddressProvisioner,
+    /* … your @Injectable providers */
+  ],
+})
+export class XIntegrationModule implements OnModuleInit {
+  constructor(
+    @Inject(ADAPTER_REGISTRY_TOKEN) private adapterRegistry: AdapterRegistryPort,
+    @Inject(ADAPTER_FACTORY_RESOLVER_TOKEN) private factoryResolver: AdapterFactoryResolverService,
+    /* + the rest of HostServices registries you need + your plugin-specific deps */
+  ) {}
+
+  onModuleInit(): void {
+    const plugin = createXPlugin({
+      customerProvisioner: this.customerProvisioner,
+      // ... rest of CreateXPluginDeps
+    });
+    const host: HostServices = { /* build from @Inject'd fields */ };
+
+    this.adapterRegistry.register(plugin.manifest);
+    this.factoryResolver.registerFactory(plugin.manifest.adapterKey, /* … */);
+    plugin.register?.(host);
+  }
+}
+```
+
+Concrete worked example:
+[`libs/integrations/prestashop/src/prestashop-integration.module.ts`](../libs/integrations/prestashop/src/prestashop-integration.module.ts).
+
+Note: most real-world plugins land on the inline-from-module pattern
+because they have at least one plugin-specific `@Injectable`. The
+`createNestAdapterModule` helper is the easy path for thin plugins;
+don't fight it if your plugin grows beyond that.
+
+### `dispatchCapability` helper
+
+Inside `createCapabilityAdapter`, use
+[`dispatchCapability`](../libs/plugin-sdk/src/dispatch-capability.ts)
+to dispatch the `capability: string` argument to the right adapter.
+It hardens against prototype-pollution and produces a uniform error
+message format across plugins:
+
+```typescript
+return dispatchCapability<T>(
+  capability,
+  {
+    ProductMaster: () => adapters.productMaster,
+    InventoryMaster: () => adapters.inventoryMaster,
+    OrderSource: () => adapters.orderSource,
+    OrderProcessorManager: () => adapters.orderProcessorManager,
+  },
+  'X',
+);
+```
+
+---
+
+## Step 7 — Connection-config and credentials shape validation
+
+Operators submit `Connection.config` (a JSONB blob) and credentials
+when they create a connection. Two ports (#586, #587) let the plugin
+validate the shape of each before encryption / persistence:
+
+- `ConnectionConfigShapeValidatorPort` — validates the structure of
+  `Connection.config`. *"Are the required fields present, are URLs
+  parseable, are enum values in range?"*
+- `ConnectionCredentialsShapeValidatorPort` — validates the structure
+  of the raw credentials payload. *"Does the API-key string match the
+  expected length / charset?"* — **shape only**, not authentication.
+
+Both are plugin-private. Register them in your plugin's `register(host)`:
+
+```typescript
+host.connectionConfigShapeValidatorRegistry.register(
+  'x.publicapi.v1',
+  new XConnectionConfigShapeValidatorAdapter('X'),
+);
+host.connectionCredentialsShapeValidatorRegistry.register(
+  'x.publicapi.v1',
+  new XConnectionCredentialsShapeValidatorAdapter('X'),
+);
+```
+
+The adapter implementation wraps a `class-validator` DTO and returns
+shape errors as domain exceptions. See:
+
+- [`libs/integrations/prestashop/src/application/dto/prestashop-connection-config.dto.ts`](../libs/integrations/prestashop/src/application/dto/prestashop-connection-config.dto.ts)
+- [`libs/integrations/prestashop/src/infrastructure/adapters/prestashop-connection-config-shape-validator.adapter.ts`](../libs/integrations/prestashop/src/infrastructure/adapters/prestashop-connection-config-shape-validator.adapter.ts)
+- [`libs/integrations/prestashop/src/infrastructure/adapters/prestashop-connection-credentials-shape-validator.adapter.ts`](../libs/integrations/prestashop/src/infrastructure/adapters/prestashop-connection-credentials-shape-validator.adapter.ts)
+
+**Shape validation ≠ live-credentials test.** "Do these credentials
+actually authenticate against the live API?" is a *connection test*,
+handled by `ConnectionTesterPort` — a separate registry, also
+registered in your plugin's `register(host)`. The shape validator
+runs synchronously at create-time; the connection tester runs against
+the live API and is triggered by the operator.
+
+---
+
+## Step 8 — Credentials and OAuth
+
+Credentials are encrypted at rest in the `integration_credentials`
+table (core schema). Your plugin doesn't read that table directly;
+the `CredentialsResolverPort` decrypts and returns the payload typed
+to your plugin's credentials type:
+
+```typescript
+const credentials = await credentialsResolver.get<XCredentials>(
+  connection.credentialsRef,
+);
+```
+
+`XCredentials` is a plugin-private type in `<plugin>/src/domain/types/`.
+Two shapes are common:
+
+### Non-OAuth (PrestaShop)
+
+A static API key. The shape is `{ apiKey: string }` (or similar);
+the operator provides it at create-time, the shape validator (Step 7)
+validates it before encryption, the factory pulls it on every
+adapter construction. No refresh, no token state — just read once
+per `createAdapters` call.
+
+See:
+- [`libs/integrations/prestashop/src/domain/types/prestashop-credentials.types.ts`](../libs/integrations/prestashop/src/domain/types/prestashop-credentials.types.ts)
+- The factory's `credentialsResolver.get<...>` call at
+  [`libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts`](../libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts).
+
+### OAuth (Allegro)
+
+OAuth is more involved. The shape your plugin needs to replicate:
+
+- **Token tables** — a plugin-owned migration creates a token-state
+  table (Allegro has `allegro_quantity_commands` for its work-queue;
+  tokens themselves are stored in `integration_credentials` and
+  refreshed in place). Example migration:
+  [`libs/integrations/allegro/src/migrations/1767900000000-add-allegro-quantity-commands-table.ts`](../libs/integrations/allegro/src/migrations/1767900000000-add-allegro-quantity-commands-table.ts).
+- **Token-refresh service** — encapsulates the refresh-token flow.
+  Allegro's lives in `libs/integrations/allegro/src/application/`
+  and exposes a method the HTTP client calls when it gets a 401.
+- **Shared token state** — Allegro's
+  [`AllegroConnectionTokenState`](../libs/integrations/allegro/src/infrastructure/http/allegro-connection-token-state.ts)
+  is an in-memory token + expiry, shared between the OAuth HTTP
+  client and the webservice HTTP client. When a refresh succeeds,
+  it updates this state, and *both* clients see the new token on
+  their next call. External plugin authors need to replicate this
+  pattern if they have multiple HTTP clients per connection.
+- **401 → refresh → retry handler** — the HTTP client wraps each
+  request: on 401, it calls the refresh service, updates the shared
+  state, and retries the original request exactly once. Lives in
+  [`libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts`](../libs/integrations/allegro/src/infrastructure/http/allegro-http-client.ts).
+- **OAuth callback handler** — the redirect-back leg of the OAuth
+  flow is handled at the API layer
+  (`apps/api/src/integrations/...`), not in the plugin. Your plugin
+  exposes the authorise-URL builder; the host wires it into a
+  controller. PrestaShop has no equivalent because it's static-key
+  auth.
+
+For the long-form walkthrough, read the Allegro HTTP layer end to end:
+[`libs/integrations/allegro/src/infrastructure/http/`](../libs/integrations/allegro/src/infrastructure/http/).
+The header comments in `allegro-http-client.ts` carry the full
+sequence diagram in prose.
+
+---
+
+## Step 9 — Plugin-owned migrations (optional, #599)
+
+Skip this step if your plugin doesn't own any tables. Read
+[`docs/migrations.md § Plugin-Owned Migrations (#599)`](./migrations.md#plugin-owned-migrations-599)
+end-to-end if it does.
+
+The recipe in three edits:
+
+1. **Create the migration file** under
+   `libs/integrations/<platform>/src/migrations/`. Same
+   `MigrationInterface` shape as core migrations; class name + filename
+   timestamp must match the 13-digit-prefix invariant
+   (`scripts/check-migration-timestamps.mjs` fails `pnpm lint` on
+   collision or drift).
+
+2. **Declare the migration glob** on your plugin descriptor
+   (informational — the TypeORM CLI does not read plugin descriptors,
+   the host enablement file in step 3 is the canonical seam):
+
+   ```typescript
+   // libs/integrations/<platform>/src/x-plugin.ts
+   import { resolve } from 'node:path';
+   export function createXPlugin(deps): AdapterPlugin {
+     return {
+       manifest: xAdapterManifest,
+       migrations: [resolve(__dirname, 'migrations/**/*{.ts,.js}')],
+       // ...
+     };
+   }
+   ```
+
+3. **Enable in the host** — two parallel edits (both required):
+   - Append the plugin dir to `PLUGIN_MIGRATION_DIRS_FROM_REPO_ROOT`
+     in [`apps/api/src/plugin-migrations.ts`](../apps/api/src/plugin-migrations.ts).
+   - Append the same dir to the `directories` array in
+     [`scripts/plugin-migration-dirs.json`](../scripts/plugin-migration-dirs.json).
+   - `scripts/check-migration-timestamps.mjs` cross-checks the two
+     lists; drift fails `pnpm lint`.
+
+A plugin in `plugins.ts` whose migration globs are *not* also in
+`plugin-migrations.ts` will boot, register its adapter, and then crash
+on the first attempt to use its tables with `relation "..." does not
+exist`. Keep the two lists aligned.
+
+---
+
+## Step 10 — Tests
+
+Two layers, both required for a production-ready adapter.
+
+### Unit tests (`*.spec.ts`)
+
+Colocated with the adapter — `__tests__/<name>.spec.ts` next to the
+file under test. Each capability adapter should have a spec covering:
+
+- Request shape — what bytes go on the wire, what headers, what
+  encoding.
+- Response parsing — happy-path + error responses, edge cases (empty
+  arrays, null fields, missing optional sections).
+- Error mapping — platform error → domain exception.
+- Port contract — every method on the interface is exercised.
+
+Mock the HTTP client and `IdentifierMappingPort` via the fixture /
+mock factories under `<plugin>/src/__tests__/{fixtures,mocks}/`. See
+[`docs/engineering-standards.md § Testing Standards`](./engineering-standards.md#testing-standards)
+for naming and the mock-ports rule (mock the *port interface*, not
+the concrete adapter — except in this case where the adapter *is*
+the system under test, in which case you mock everything *it* depends on).
+
+PrestaShop's adapter specs:
+[`libs/integrations/prestashop/src/infrastructure/adapters/__tests__/`](../libs/integrations/prestashop/src/infrastructure/adapters/__tests__/).
+
+### Integration tests (`*.int-spec.ts`)
+
+Optional but high-value for a new plugin. Live under
+`apps/api/test/integration/`, opt into the PrestaShop Testcontainer
+helper if your test depends on a real PrestaShop response (see
+[`docs/testing-guide.md § PrestaShop Testcontainer Pattern (#506)`](./testing-guide.md#prestashop-testcontainer-pattern-506)).
+
+Reference vertical-slice spec:
+[`apps/api/test/integration/orders/allegro-prestashop-carrier-mapping.int-spec.ts`](../apps/api/test/integration/orders/allegro-prestashop-carrier-mapping.int-spec.ts).
+It exercises `OrderIngestionService.syncOrderFromSource` end-to-end
+with a stubbed Allegro source and a real PrestaShop destination. Copy
+its shape for cross-adapter integration tests.
+
+### Quality gate
+
+Before pushing, run from the repo root:
+
+```bash
+pnpm lint        # zero errors
+pnpm type-check  # zero errors
+pnpm test        # all unit specs pass
+```
+
+The pre-commit hook (`husky`) runs the same triple — push will fail
+if any of the three fails.
+
+---
+
+## Step 11 — Enable the plugin in the host
+
+Edit [`apps/api/src/plugins.ts`](../apps/api/src/plugins.ts) — append
+your `XIntegrationModule` to the `apiPlugins` array. That's the entire
+host-enablement step.
+
+```typescript
+import { XIntegrationModule } from '@openlinker/integrations-x';
+
+export const apiPlugins: PluginEntry[] = [
+  PrestashopIntegrationModule,
+  AllegroIntegrationModule,
+  AiIntegrationModule.register(),
+  XIntegrationModule, // ← your plugin
+];
+```
+
+`PluginRegistryModule.forRoot({ plugins: apiPlugins })` (in
+[`apps/api/src/integrations/integrations.module.ts`](../apps/api/src/integrations/integrations.module.ts))
+imports every plugin module; each plugin's `onModuleInit` runs at
+boot and self-registers against the host registries.
+
+---
+
+## Things plugin authors trip on
+
+- **Top-level barrel only** for cross-package imports (#591). ESLint
+  rejects deep imports into `@openlinker/core/<ctx>/domain/...` and
+  Node fails them at runtime with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+- **No `orm-entities` sub-barrel imports from plugins** (#594).
+  TypeORM entities are infrastructure detail; if you find yourself
+  reaching for `@openlinker/core/<ctx>/orm-entities`, you're crossing
+  the port boundary — back off.
+- **Plugin packages are `private: true` today.** npm publishing
+  depends on Modularity Thread F (#552, #596). Until then, plugins
+  are workspace-only.
+- **Migrations need two-edit host wire-up.** `apps/api/src/plugin-migrations.ts`
+  + `scripts/plugin-migration-dirs.json` must agree. Drift fails
+  `pnpm lint`. Missing migration-dir entry surfaces as `relation "..."
+  does not exist` at runtime.
+- **Credentials are per-connection, factory is process-wide.** Call
+  `credentialsResolver.get()` inside `createAdapters()`, not in the
+  factory constructor.
+- **Capability is open at the registry boundary (#576).** You can
+  declare a new capability name beyond `CoreCapabilityValues`, but
+  it's not useful until something in CORE consumes it. Talk to the
+  maintainers first.
+- **OAuth shared state.** If your plugin has multiple HTTP clients
+  per connection, share the token state via a module-scoped object
+  (see `AllegroConnectionTokenState`), not via per-client copies.
+- **Plugin-specific cross-package deps are not in `HostServices`.**
+  Pass them through your `createXPlugin(deps)` factory closure. See
+  `CreatePrestashopPluginDeps` for the canonical shape.
+
+---
+
+## Where to ask questions
+
+- **General questions or discussion.** Open a GitHub issue using the
+  existing templates at `.github/ISSUE_TEMPLATE/`. An
+  integration-specific template is planned (#567); until it lands,
+  the developer-task template fits.
+- **Security or vulnerability disclosure.** Follow
+  [`SECURITY.md`](../SECURITY.md) — never open a public issue for a
+  security report.
+- **Architecture questions about a new capability port or a CORE
+  change.** Open a proposal issue first per
+  [`GOVERNANCE.md § Decision-making`](../GOVERNANCE.md#decision-making).
+  Major changes to `docs/architecture-overview.md` /
+  `docs/engineering-standards.md` need maintainer alignment before
+  the PR.
+
+---
+
+## Related reading
+
+- [`docs/architecture-overview.md`](./architecture-overview.md) — the
+  big picture.
+- [`docs/engineering-standards.md`](./engineering-standards.md) —
+  naming conventions, import-aliases rules, type-definition rules,
+  service-interface separation.
+- [`docs/connections-and-adapter-resolution.md`](./connections-and-adapter-resolution.md)
+  — how the registry resolves an adapter for a given
+  `(connection, capability)` pair at request time.
+- [`docs/migrations.md`](./migrations.md) — full migration workflow
+  including the plugin-owned-migrations recipe (#599).
+- [`docs/testing-guide.md`](./testing-guide.md) — Testcontainers,
+  vertical-slice patterns, the PrestaShop opt-in helper.
+- [`libs/plugin-sdk/src/adapter-plugin.ts:42-110`](../libs/plugin-sdk/src/adapter-plugin.ts#L42-L110)
+  — the `AdapterPlugin` contract spec, header-comment form.
+- [`libs/plugin-sdk/src/host-services.ts:50-121`](../libs/plugin-sdk/src/host-services.ts#L50-L121)
+  — the `HostServices` bag, fields split into read-inputs vs side
+  registries.
+
+---
+
+<sub>**Last verified at commit `f2cf874`** (`bbca59d` series merged
+2026-05-13). If you spot drift between this guide and the live code —
+or hit a step that's wrong or unclear — please open an issue or PR.
+The code is the spec; this guide is the map. Maps go stale; the
+code can't.</sub>

--- a/libs/integrations/prestashop/README.md
+++ b/libs/integrations/prestashop/README.md
@@ -1,0 +1,62 @@
+# @openlinker/integrations-prestashop
+
+PrestaShop WebService v1 adapter for OpenLinker.
+
+## This is the OpenLinker reference adapter
+
+If you're here to **build a new integration** (Shopify, WooCommerce,
+BigCommerce, …), start by copying this package's layout — it implements
+the broadest set of capabilities (`ProductMaster`, `InventoryMaster`,
+`OrderSource`, `OrderProcessorManager`) and registers the full
+side-service set (connection tester, webhook provisioner, two shape
+validators). The walkthrough lives at
+[`docs/plugin-author-guide.md`](../../../docs/plugin-author-guide.md) —
+read it alongside this code, not before.
+
+Two pointers for special cases this package doesn't demonstrate:
+
+- **OAuth + token refresh** — see
+  [`libs/integrations/allegro/`](../allegro/). Adds token-state
+  sharing across HTTP clients, refresh-on-401 retry, and a
+  plugin-owned migration.
+- **Stateless port-router** (single dynamic-module shape, no
+  per-connection adapter) — see
+  [`libs/integrations/ai/`](../ai/). Reference only if your platform
+  is provider-switched rather than per-connection.
+
+## What this package contains
+
+| Capability                | Adapter file                                                                                                                                                                              |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ProductMaster`           | [`infrastructure/adapters/prestashop-product-master.adapter.ts`](./src/infrastructure/adapters/prestashop-product-master.adapter.ts)                                                       |
+| `InventoryMaster`         | [`infrastructure/adapters/prestashop-inventory-master.adapter.ts`](./src/infrastructure/adapters/prestashop-inventory-master.adapter.ts)                                                   |
+| `OrderSource`             | [`infrastructure/adapters/prestashop-order-source.adapter.ts`](./src/infrastructure/adapters/prestashop-order-source.adapter.ts)                                                           |
+| `OrderProcessorManager`   | [`infrastructure/adapters/prestashop-order-processor-manager.adapter.ts`](./src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts)                                     |
+
+Plus the registered side services:
+
+- Connection tester — [`prestashop-connection-tester.adapter.ts`](./src/infrastructure/adapters/prestashop-connection-tester.adapter.ts)
+- Webhook provisioner — [`prestashop-webhook-provisioning.adapter.ts`](./src/infrastructure/adapters/prestashop-webhook-provisioning.adapter.ts)
+- Connection-config shape validator — [`prestashop-connection-config-shape-validator.adapter.ts`](./src/infrastructure/adapters/prestashop-connection-config-shape-validator.adapter.ts)
+- Credentials shape validator — [`prestashop-connection-credentials-shape-validator.adapter.ts`](./src/infrastructure/adapters/prestashop-connection-credentials-shape-validator.adapter.ts)
+
+The plugin descriptor and NestJS module are at
+[`src/prestashop-plugin.ts`](./src/prestashop-plugin.ts) and
+[`src/prestashop-integration.module.ts`](./src/prestashop-integration.module.ts)
+respectively. Both are referenced in the
+[plugin author guide](../../../docs/plugin-author-guide.md) as the
+canonical examples.
+
+## Operator / runtime docs
+
+For setting up a PrestaShop connection in production (PHP module
+install, WebService API key creation, webhook configuration), see the
+operator-facing docs:
+
+- [`docs/prestashop-module-testing-guide.md`](../../../docs/prestashop-module-testing-guide.md)
+  — testing the OpenLinker PHP module against a live PrestaShop.
+- [`docs/connections-and-adapter-resolution.md`](../../../docs/connections-and-adapter-resolution.md)
+  — how a connection resolves to this adapter at request time.
+
+(A dedicated `docs/integrations/prestashop/` subdir comparable to
+Allegro's is not yet authored — contributions welcome.)

--- a/libs/integrations/prestashop/README.md
+++ b/libs/integrations/prestashop/README.md
@@ -57,6 +57,3 @@ operator-facing docs:
   — testing the OpenLinker PHP module against a live PrestaShop.
 - [`docs/connections-and-adapter-resolution.md`](../../../docs/connections-and-adapter-resolution.md)
   — how a connection resolves to this adapter at request time.
-
-(A dedicated `docs/integrations/prestashop/` subdir comparable to
-Allegro's is not yet authored — contributions welcome.)


### PR DESCRIPTION
Closes #562
Closes #563

## Summary

Two BLOCKER findings from Modularity Thread B (#548 / #546) — the plugin-author onboarding gap. An external contributor who has read the README and the architecture doc still can't answer "where do my files go, which port do I implement, how does the registry pick up my adapter, how do I expose credentials, how do I write the tests." This PR closes that gap.

## What's new

### #562 — Plugin Author Guide
- **`docs/plugin-author-guide.md`** (~860 lines, 11 numbered steps) walking from *"pick a capability port"* through *"implement adapter, write factory, wire plugin descriptor + NestJS module, register shape validators, handle credentials/OAuth, write tests, enable in host."* Treats `libs/integrations/prestashop/` as the canonical reference; signposts Allegro for OAuth and AI for the stateless port-router pattern.
- Framed explicitly as *"a map for reading the reference adapter, not a copy-paste tutorial"* — sets reader expectations and acknowledges the code-is-spec limit.
- Expanded OAuth section covers token tables, `AllegroConnectionTokenState` shared-state pattern, refresh service, 401-retry handler. Concrete enough to anchor a new OAuth adapter author before they read the live code.
- Verbatim quotes carry explicit line ranges (`adapter-plugin.ts:42-110`, `host-services.ts:50-121`, `adapter.types.ts:22-28`) so GitHub blob view lands the reader inside the relevant block. Drift-check lint invariant tracked in #680.

### #563 — Reference adapter signpost
- **`libs/integrations/prestashop/README.md`** (~60 lines). Designates the package as the OpenLinker reference adapter. Lists the four capabilities it implements with file links, calls out what's not here (OAuth → Allegro; stateless router → AI), and points at the plugin author guide for the walkthrough.

### Cross-links + obsolete-section delete
- `README.md` § Contributing — new "Building a new integration?" bullet linking to the guide.
- `CONTRIBUTING.md` — new top-level `## Building a New Integration` section between `## Architecture` and `## Pull Request Process` (the guide is a workflow surface, not a PR step).
- `docs/connections-and-adapter-resolution.md` § Adding New Adapters — obsolete 15-line subsection deleted (claimed you edit a static `Map` in `AdapterRegistryService`; real registration is plugin self-registration in `onModuleInit`). Replaced with a one-line pointer to the new guide.
- `apps/api/src/plugins.ts` header — one-line comment pointing at the guide. Lands in front of contributors at the right moment (the file they edit to enable their plugin).

## Self-review fixes (commit `505d764`)

Tech-review pass after the initial commit:

- **IMPORTANT** — renumbered the intro "seven-step path" to match the actual eleven `Step N —` section headings. The previous overview promised 7 items but the body ran to 11; Steps 8 (Credentials/OAuth) and 9 (Plugin-owned migrations) were never surfaced in the TOC.
- Reworded the "Open at the registry boundary (#576)" callout — `AdapterMetadata.supportedCapabilities` doesn't literally accept `string[]`; the new wording says "accepts the well-known `CoreCapability` members and any other string."
- Steered Step 6 readers to the inline-from-module pattern by default (most real plugins land there).
- Dropped an orphan "contributions welcome" parenthetical from the PrestaShop README.
- Wired the lint-invariant follow-up (#680) into the footer.

## Research validated

- Every file path / class name / line range quoted in the guide resolves against the working tree (47 paths spot-checked).
- `AdapterPlugin` contract quoted from `libs/plugin-sdk/src/adapter-plugin.ts:42-110` verbatim.
- `HostServices` fields quoted from `libs/plugin-sdk/src/host-services.ts:50-121` verbatim.
- `CoreCapabilityValues` quoted from `libs/core/src/integrations/domain/types/adapter.types.ts:22-28` verbatim — no prose restatement to drift.

## Scope discipline

- Plugin-author scaffolding (`pnpm create-adapter`) — deferred to #564.
- Add-integration GitHub issue template — deferred to #567.
- `docs/getting-started.md` WIP — independent, tracked in #569.
- Per-platform READMEs for Allegro and AI — out of scope; PrestaShop is the canonical reference per #563.
- Lint-time invariant that re-validates the verbatim quotes against the live source — tracked in #680.

## Test plan

- [x] `pnpm lint` — passes
- [x] `pnpm type-check` — passes
- [x] Manual review of every link target in the guide (47 paths)
- [ ] Reviewer: skim the eleven-step flow and confirm the section numbering is now coherent
- [ ] Reviewer: skim `libs/integrations/prestashop/README.md` and confirm the "reference adapter" framing reads cleanly
