### PR TITLE
test(inventory): add unit tests for inventory application services

### DIFF
--- a/docs/plans/implementation-plan-667-inventory-services-unit-tests.md
+++ b/docs/plans/implementation-plan-667-inventory-services-unit-tests.md
@@ -1,0 +1,103 @@
+# Implementation Plan — #667 Add unit tests for inventory application services
+
+| Layer | Scope | Risk |
+|---|---|---|
+| CORE / tests | Two `*.spec.ts` files in `libs/core/src/inventory/application/services/__tests__/` | Low — pure tests, no production-code change |
+
+## 1. Scope reality check
+
+The issue says three services have "no co-located `*.spec.ts`" but research shows only one is actually missing:
+
+| Service | LoC | Existing spec | Real gap |
+|---|---|---|---|
+| `inventory-query.service.ts` | 98 | 9 tests, 200 LoC — list/get composition, dedup, null handling, filter passthrough, ordering | **No gap** — well-covered. |
+| `inventory-sync.service.ts` | 91 | 2 tests, 78 LoC — batch happy path + per-item-fallback partial failure | Four narrow branches missing: single-item delegate, empty-items early return, non-batch-capable adapter, deterministic idempotency-key generation. |
+| `master-inventory-sync.service.ts` | 97 | **none** | Whole file uncovered — the actual gap. |
+
+Also: the issue describes `inventory-sync` as orchestrating "master-slave" inventory propagation, but the actual code propagates **offer quantities to a marketplace** via `OfferManagerPort`. The master→canonical responsibility lives in `MasterInventorySyncService`. The issue conflated the two; the implementation follows the code, not the issue text.
+
+## 2. Layout decision
+
+Existing specs in this module live in `__tests__/`, not as `*.spec.ts` siblings. Match local precedent — the issue's "co-located" wording is loose (per engineering-standards.md the test-file pattern is `*.spec.ts`; layout is mixed across the repo).
+
+## 3. Files
+
+### 3.1 `__tests__/master-inventory-sync.service.spec.ts` (new)
+
+Mocks (per `engineering-standards.md § Mocking Ports`):
+
+- `IIntegrationsService` (port mock — `getCapabilityAdapter` returns `InventoryMasterPort`)
+- `IIdentifierMappingService` (port mock — `getOrCreateInternalId`)
+- `IInventoryService` (port mock — `getInventory` + `setInventory`)
+- `InventoryMasterPort` (port mock — `getInventory`)
+
+Coverage plan (test names follow `should [behaviour] when [condition]`):
+
+- `should resolve external→internal ID and set inventory when adapter returns a complete inventory record` — happy-path: identifier-mapping resolves, adapter returns `Inventory` with `available`/`reserved`/`updatedAt`, `inventoryService.setInventory` is called with a domain `InventoryItem` carrying the right quantities; result echoes the canonical IDs.
+- `should derive available from quantity minus reserved when adapter omits available` — exercises the `available ?? quantity - reserved` fallback in `toDomainInventoryItem` (line 82-84).
+- `should preserve existing inventory item ID when an InventoryItem already exists for the (product, variant, location)` — `inventoryService.getInventory` returns a pre-existing entity → `setInventory` is called with the *same* `inventoryItemId`. Tests the identity preservation that prevents duplicate rows.
+- `should mint a fresh inventory item ID when no existing record matches` — `inventoryService.getInventory` returns null → `setInventory` receives a freshly generated UUID. Sister branch to the previous.
+- `should propagate getCapabilityAdapter failures` — `integrationsService.getCapabilityAdapter` rejects (e.g. unsupported capability) → the error bubbles to the caller, no inventory write happens.
+- `should propagate adapter.getInventory failures and skip the local write` — adapter fetch throws → no `inventoryService.setInventory` call, error bubbles. Confirms partial-failure safety (no half-written state).
+- `should default updatedAt to now when adapter omits it` — adapter returns inventory without `updatedAt` → domain entity gets a current `Date`. Asserts via `expect.any(Date)`.
+
+Total: 7 focused tests. ~150-180 LoC.
+
+### 3.2 `__tests__/inventory-sync.service.spec.ts` (extend existing)
+
+Add four tests covering the missing branches. Keep the two existing tests untouched (they work).
+
+- `should return empty result without resolving the adapter when items is empty` — verifies the `if (!cmd.items || cmd.items.length === 0)` early return at line 37. Asserts `integrationsService.getCapabilityAdapter` was NOT called.
+- `should delegate updateOfferQuantity to updateOfferQuantities` — single-command path: assert single-item batch is invoked end-to-end and the result shape matches.
+- `should issue per-item updates when the adapter is not OfferQuantityBatchUpdater-capable` — mock `OfferManagerPort` *without* the `updateOfferQuantitiesBatch` method → forces per-item path via the `isOfferQuantityBatchUpdater` guard. Confirms `updateOfferQuantity` called N times, `updateOfferQuantitiesBatch` never called.
+- `should auto-generate a deterministic idempotency key when an item omits one` — call with `{ offerId, quantity }` only (no `idempotencyKey`). Inspect the argument passed to `updateOfferQuantity` and assert it carries an `idempotencyKey` matching `/^inv:[a-f0-9]{16}$/`. Second call with the same shape produces the same key (deterministic SHA-256 truncation per `buildIdempotencyKey` at line 84-89).
+
+Total: +4 tests. ~80-100 LoC delta on the file.
+
+### 3.3 `inventory-query.service.spec.ts` — no changes
+
+Already at 9 tests covering every branch. Touching it would be busywork.
+
+## 4. Architecture compliance check
+
+- **Mock ports, not concrete adapters**: ✓ All four mocks above target port/interface types (`InventoryMasterPort`, `IIntegrationsService`, `IIdentifierMappingService`, `IInventoryService`, `OfferManagerPort`).
+- **Cross-context imports through top-level barrels** (`engineering-standards.md § Import Aliases`): ✓ Existing specs use `@openlinker/core/integrations`, `@openlinker/core/listings`, `@openlinker/core/identifier-mapping`, `@openlinker/core/products` — match.
+- **Same-context cross-layer relative**: ✓ `../master-inventory-sync.service`, `../../../domain/...` (≤ `../..` rule).
+- **No `any`**: any `as unknown as jest.Mocked<...>` cast is the established repo pattern (see existing inventory-sync spec line 16, 32) — used only at mock-construction boundaries.
+- **Test names**: `should [behaviour] when [condition]` per the existing inventory-query spec and `engineering-standards.md § Test Naming`. ✓
+
+## 5. Quality gate
+
+```bash
+pnpm lint                # 0 errors
+pnpm type-check          # clean
+pnpm test                # all suites green + new tests visible
+```
+
+Coverage check (informational — verify ≥80% on the three target files):
+
+```bash
+pnpm --filter @openlinker/core test:cov -- \
+  --collectCoverageFrom='src/inventory/application/services/{inventory-query,inventory-sync,master-inventory-sync}.service.ts'
+```
+
+## 6. Commit + PR
+
+Single conventional-commit:
+
+```
+test(inventory): add master-inventory-sync spec + close inventory-sync branch gaps (#667)
+```
+
+PR description notes:
+- Issue's "three services missing specs" claim was partially out of date — only `master-inventory-sync` was truly uncovered.
+- `inventory-query` already at 9 tests, intentionally untouched.
+- Layout matches local `__tests__/` precedent.
+
+## 7. Validation checklist
+
+- [ ] `master-inventory-sync.service.spec.ts` exists with 7 tests covering: happy-path, available-fallback derivation, existing-ID preservation, fresh-ID minting, adapter-not-supported error, adapter-fetch error, updatedAt default.
+- [ ] `inventory-sync.service.spec.ts` extended with 4 tests: empty-items early return, single-item delegate, non-batch-capable adapter, deterministic idempotency key.
+- [ ] `pnpm lint && pnpm type-check && pnpm test` green.
+- [ ] All mocks target port/interface types; no concrete-adapter instantiation.
+- [ ] Test names match the `should [behaviour] when [condition]` pattern.

--- a/libs/core/src/inventory/application/services/__tests__/inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory-sync.service.spec.ts
@@ -126,7 +126,8 @@ describe('InventorySyncService', () => {
 
   it('should auto-generate a deterministic idempotency key when an item omits one', async () => {
     // Single-item path (length === 1) forces per-item loop, which lets us inspect the
-    // normalized item passed to updateOfferQuantity.
+    // normalized item passed to updateOfferQuantity. The key is a SHA-256 truncation
+    // of (connectionId, offerId, quantity) — same tuple → same key, distinct tuple → distinct key.
     marketplace.updateOfferQuantity.mockResolvedValue(undefined);
 
     await service.updateOfferQuantities(connectionId, {

--- a/libs/core/src/inventory/application/services/__tests__/inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory-sync.service.spec.ts
@@ -74,5 +74,83 @@ describe('InventorySyncService', () => {
       { offerId: 'o2', errorCode: 'unknown', message: 'boom' },
     ]);
   });
+
+  it('should short-circuit with an empty result when items is empty (no adapter resolution)', async () => {
+    const result = await service.updateOfferQuantities(connectionId, { items: [] });
+
+    expect(result).toEqual({ succeeded: [], failed: [] });
+    expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+    expect(marketplace.updateOfferQuantitiesBatch).not.toHaveBeenCalled();
+    expect(marketplace.updateOfferQuantity).not.toHaveBeenCalled();
+  });
+
+  it('should delegate updateOfferQuantity to updateOfferQuantities for the single-item path', async () => {
+    // Single item path: never batched (batch is gated to length > 1), goes through per-item loop.
+    marketplace.updateOfferQuantity.mockResolvedValueOnce(undefined);
+
+    const result = await service.updateOfferQuantity(connectionId, {
+      offerId: 'o1',
+      quantity: 7,
+      idempotencyKey: 'k1',
+    });
+
+    expect(marketplace.updateOfferQuantitiesBatch).not.toHaveBeenCalled();
+    expect(marketplace.updateOfferQuantity).toHaveBeenCalledTimes(1);
+    expect(marketplace.updateOfferQuantity).toHaveBeenCalledWith({
+      offerId: 'o1',
+      quantity: 7,
+      idempotencyKey: 'k1',
+    });
+    expect(result).toEqual({ succeeded: ['o1'], failed: [] });
+  });
+
+  it('should force per-item updates when the adapter does not implement OfferQuantityBatchUpdater', async () => {
+    // Construct a marketplace adapter that lacks updateOfferQuantitiesBatch entirely —
+    // isOfferQuantityBatchUpdater() checks `typeof obj.updateOfferQuantitiesBatch === 'function'`,
+    // so omitting the key makes the guard return false and forces the per-item path.
+    const minimalMarketplace = {
+      updateOfferQuantity: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<OfferManagerPort>;
+    integrationsService.getCapabilityAdapter.mockResolvedValueOnce(minimalMarketplace);
+
+    const result = await service.updateOfferQuantities(connectionId, {
+      items: [
+        { offerId: 'o1', quantity: 1, idempotencyKey: 'k1' },
+        { offerId: 'o2', quantity: 2, idempotencyKey: 'k2' },
+      ],
+    });
+
+    expect(minimalMarketplace.updateOfferQuantity).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ succeeded: ['o1', 'o2'], failed: [] });
+  });
+
+  it('should auto-generate a deterministic idempotency key when an item omits one', async () => {
+    // Single-item path (length === 1) forces per-item loop, which lets us inspect the
+    // normalized item passed to updateOfferQuantity.
+    marketplace.updateOfferQuantity.mockResolvedValue(undefined);
+
+    await service.updateOfferQuantities(connectionId, {
+      items: [{ offerId: 'o1', quantity: 7 }],
+    });
+    await service.updateOfferQuantities(connectionId, {
+      items: [{ offerId: 'o1', quantity: 7 }],
+    });
+
+    expect(marketplace.updateOfferQuantity).toHaveBeenCalledTimes(2);
+    const firstCallArg = marketplace.updateOfferQuantity.mock.calls[0][0];
+    const secondCallArg = marketplace.updateOfferQuantity.mock.calls[1][0];
+
+    expect(firstCallArg.idempotencyKey).toMatch(/^inv:[a-f0-9]{16}$/);
+    // Same (connectionId, offerId, quantity) tuple → same key. Deterministic SHA-256 truncation.
+    expect(secondCallArg.idempotencyKey).toBe(firstCallArg.idempotencyKey);
+
+    // Distinct quantity → distinct key.
+    await service.updateOfferQuantities(connectionId, {
+      items: [{ offerId: 'o1', quantity: 8 }],
+    });
+    const thirdCallArg = marketplace.updateOfferQuantity.mock.calls[2][0];
+    expect(thirdCallArg.idempotencyKey).toMatch(/^inv:[a-f0-9]{16}$/);
+    expect(thirdCallArg.idempotencyKey).not.toBe(firstCallArg.idempotencyKey);
+  });
 });
 

--- a/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * Master Inventory Sync Service Tests
+ *
+ * Unit tests for MasterInventorySyncService. Covers the read-from-master →
+ * map-to-domain → upsert-canonical pipeline, the available-quantity fallback
+ * derivation, inventory-item ID preservation across upserts, and failure-mode
+ * propagation from each external collaborator.
+ *
+ * Logger is left as-is (class-constructed at line 29 of the service); the
+ * neutral `@openlinker/shared/logging` console default handles output during
+ * tests. Same precedent as `inventory-sync.service.spec.ts`.
+ *
+ * @module libs/core/src/inventory/application/services/__tests__
+ */
+
+import { MasterInventorySyncService } from '../master-inventory-sync.service';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
+import type { IInventoryService } from '../inventory.service.interface';
+import type {
+  InventoryMasterPort,
+  Inventory as InventoryPortInterface,
+} from '../../../domain/ports/inventory-master.port';
+import { InventoryItem } from '../../../domain/entities/inventory-item.entity';
+
+describe('MasterInventorySyncService', () => {
+  let service: MasterInventorySyncService;
+  let integrationsService: jest.Mocked<IIntegrationsService>;
+  let identifierMapping: jest.Mocked<IIdentifierMappingService>;
+  let inventoryService: jest.Mocked<IInventoryService>;
+  let inventoryAdapter: jest.Mocked<InventoryMasterPort>;
+
+  const connectionId = 'connection-123';
+  const externalId = 'ext-product-9';
+  const internalProductId = 'ol_product_abc';
+
+  beforeEach(() => {
+    inventoryAdapter = {
+      getInventory: jest.fn(),
+      adjustInventory: jest.fn(),
+      reserveInventory: jest.fn(),
+      releaseInventory: jest.fn(),
+      getAvailableQuantity: jest.fn(),
+    } as unknown as jest.Mocked<InventoryMasterPort>;
+
+    integrationsService = {
+      getCapabilityAdapter: jest.fn().mockResolvedValue(inventoryAdapter),
+      getAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    identifierMapping = {
+      getOrCreateInternalId: jest.fn().mockResolvedValue(internalProductId),
+      getInternalId: jest.fn(),
+      getExternalIds: jest.fn(),
+      createMapping: jest.fn(),
+      batchGetOrCreateInternalIds: jest.fn(),
+      getOrCreateExactMapping: jest.fn(),
+      deleteMapping: jest.fn(),
+      listExternalIdsByConnection: jest.fn(),
+    } as unknown as jest.Mocked<IIdentifierMappingService>;
+
+    inventoryService = {
+      setInventory: jest.fn().mockImplementation((item: InventoryItem) => Promise.resolve(item)),
+      getInventory: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<IInventoryService>;
+
+    service = new MasterInventorySyncService(
+      integrationsService,
+      identifierMapping,
+      inventoryService,
+    );
+  });
+
+  describe('syncFromMasterByExternalId', () => {
+    it('should resolve external→internal ID and set canonical inventory when the adapter returns a complete inventory record', async () => {
+      const adapterInventory: InventoryPortInterface = {
+        id: 'adapter-inv-1',
+        productId: internalProductId,
+        variantId: 'var-1',
+        locationId: 'loc-1',
+        quantity: 12,
+        reserved: 3,
+        available: 9,
+        updatedAt: new Date('2026-05-01T10:00:00Z'),
+      };
+      inventoryAdapter.getInventory.mockResolvedValue(adapterInventory);
+
+      const result = await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(identifierMapping.getOrCreateInternalId).toHaveBeenCalledWith(
+        'Product',
+        externalId,
+        connectionId,
+      );
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+        connectionId,
+        'InventoryMaster',
+      );
+      expect(inventoryAdapter.getInventory).toHaveBeenCalledWith(internalProductId, undefined);
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          productId: internalProductId,
+          productVariantId: 'var-1',
+          availableQuantity: 9,
+          reservedQuantity: 3,
+          locationId: 'loc-1',
+          updatedAt: adapterInventory.updatedAt,
+        }),
+      );
+      expect(result).toEqual({
+        internalProductId,
+        availableQuantity: 9,
+        reservedQuantity: 3,
+      });
+    });
+
+    it('should derive availableQuantity from quantity minus reserved when the adapter omits available', async () => {
+      const adapterInventory = {
+        id: 'adapter-inv-2',
+        productId: internalProductId,
+        variantId: undefined,
+        locationId: undefined,
+        quantity: 20,
+        reserved: 5,
+        updatedAt: new Date('2026-05-01T10:00:00Z'),
+        // available intentionally omitted — exercises the `?? (quantity - reserved)` fallback
+      } as unknown as InventoryPortInterface;
+      inventoryAdapter.getInventory.mockResolvedValue(adapterInventory);
+
+      const result = await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          availableQuantity: 15,
+          reservedQuantity: 5,
+        }),
+      );
+      expect(result.availableQuantity).toBe(15);
+      expect(result.reservedQuantity).toBe(5);
+    });
+
+    it('should preserve the existing inventory item ID when an InventoryItem already exists for the (product, variant, location)', async () => {
+      const existing = new InventoryItem(
+        'preserved-inv-id',
+        internalProductId,
+        'var-1',
+        0,
+        0,
+        'loc-1',
+        new Date('2026-04-01T00:00:00Z'),
+      );
+      inventoryService.getInventory.mockResolvedValue(existing);
+      inventoryAdapter.getInventory.mockResolvedValue({
+        id: 'adapter-inv-3',
+        productId: internalProductId,
+        variantId: 'var-1',
+        locationId: 'loc-1',
+        quantity: 12,
+        reserved: 2,
+        available: 10,
+        updatedAt: new Date('2026-05-01T10:00:00Z'),
+      });
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.getInventory).toHaveBeenCalledWith(internalProductId, 'var-1', 'loc-1');
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'preserved-inv-id' }),
+      );
+    });
+
+    it('should mint a fresh inventory item ID when no existing record matches', async () => {
+      inventoryService.getInventory.mockResolvedValue(null);
+      inventoryAdapter.getInventory.mockResolvedValue({
+        id: 'adapter-inv-4',
+        productId: internalProductId,
+        // no variantId / locationId — both null in the getInventory lookup
+        quantity: 5,
+        reserved: 0,
+        available: 5,
+        updatedAt: new Date('2026-05-01T10:00:00Z'),
+      });
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.getInventory).toHaveBeenCalledWith(internalProductId, null, null);
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.stringMatching(/^[0-9a-f-]{36}$/i),
+          productVariantId: null,
+          locationId: null,
+        }),
+      );
+    });
+
+    it('should default updatedAt to the current Date when the adapter omits it', async () => {
+      inventoryAdapter.getInventory.mockResolvedValue({
+        id: 'adapter-inv-5',
+        productId: internalProductId,
+        quantity: 1,
+        reserved: 0,
+        available: 1,
+        // updatedAt intentionally omitted
+      } as unknown as InventoryPortInterface);
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({ updatedAt: expect.any(Date) }),
+      );
+    });
+
+    it('should propagate identifierMapping.getOrCreateInternalId failures and skip downstream calls', async () => {
+      const boom = new Error('identifier-mapping unavailable');
+      identifierMapping.getOrCreateInternalId.mockRejectedValueOnce(boom);
+
+      await expect(
+        service.syncFromMasterByExternalId(connectionId, externalId),
+      ).rejects.toBe(boom);
+
+      expect(integrationsService.getCapabilityAdapter).not.toHaveBeenCalled();
+      expect(inventoryAdapter.getInventory).not.toHaveBeenCalled();
+      expect(inventoryService.setInventory).not.toHaveBeenCalled();
+    });
+
+    it('should propagate getCapabilityAdapter failures when the connection does not support InventoryMaster', async () => {
+      const boom = new Error('Capability InventoryMaster not supported by connection');
+      integrationsService.getCapabilityAdapter.mockRejectedValueOnce(boom);
+
+      await expect(
+        service.syncFromMasterByExternalId(connectionId, externalId),
+      ).rejects.toBe(boom);
+
+      expect(inventoryAdapter.getInventory).not.toHaveBeenCalled();
+      expect(inventoryService.setInventory).not.toHaveBeenCalled();
+    });
+
+    it('should propagate adapter.getInventory failures and skip the canonical write', async () => {
+      const boom = new Error('master inventory fetch failed');
+      inventoryAdapter.getInventory.mockRejectedValueOnce(boom);
+
+      await expect(
+        service.syncFromMasterByExternalId(connectionId, externalId),
+      ).rejects.toBe(boom);
+
+      expect(inventoryService.setInventory).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
@@ -17,11 +17,11 @@ import { MasterInventorySyncService } from '../master-inventory-sync.service';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 import type { IInventoryService } from '../inventory.service.interface';
-import type {
+import {
   InventoryMasterPort,
   Inventory as InventoryPortInterface,
-} from '../../../domain/ports/inventory-master.port';
-import { InventoryItem } from '../../../domain/entities/inventory-item.entity';
+  InventoryItemEntity as InventoryItem,
+} from '@openlinker/core/inventory';
 
 describe('MasterInventorySyncService', () => {
   let service: MasterInventorySyncService;
@@ -187,7 +187,7 @@ describe('MasterInventorySyncService', () => {
       expect(inventoryService.getInventory).toHaveBeenCalledWith(internalProductId, null, null);
       expect(inventoryService.setInventory).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: expect.stringMatching(/^[0-9a-f-]{36}$/i),
+          id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i),
           productVariantId: null,
           locationId: null,
         }),


### PR DESCRIPTION
## Summary

- Adds a new spec for `MasterInventorySyncService` (8 tests) covering the read-from-master → map-to-domain → upsert-canonical pipeline, the `available ?? quantity - reserved` fallback, inventory-item ID preservation vs minting, the default-`updatedAt`-to-now branch, and propagation from each external collaborator (`identifierMapping`, `getCapabilityAdapter`, `adapter.getInventory`).
- Extends `InventorySyncService` spec with 4 missing-branch tests: empty-items early return, single-item delegate, non-`OfferQuantityBatchUpdater`-capable adapter forced per-item, and deterministic auto-generated idempotency key (`inv:<sha-256 of (connectionId, offerId, quantity)>`).
- Leaves `InventoryQueryService` spec untouched — already at 9 tests / 200 LoC / every branch covered. The issue's "three services missing specs" claim was partially out of date.

## Scope reality check

The issue text described `InventorySyncService` as orchestrating "master-slave" inventory propagation. The actual code propagates **offer quantities to a marketplace** via `OfferManagerPort`; the master→canonical path lives in `MasterInventorySyncService`. Implementation follows the code, not the issue text.

## Test plan

- [x] `pnpm --filter @openlinker/core lint` — 0 errors (8 pre-existing warnings in unrelated specs)
- [x] `pnpm --filter @openlinker/core type-check` — clean
- [x] `pnpm test` — libs/core 627 → 639 tests (+12), all green
- [x] Coverage on the three target files (`jest --coverage`):
  - `inventory-query.service.ts` — 100 / 100 / 100 / 100 (stmts / branch / funcs / lines)
  - `inventory-sync.service.ts` — 100 / 90 / 100 / 100
  - `master-inventory-sync.service.ts` — 100 / 85 / 100 / 100
  - all clear the 80% threshold per `engineering-standards.md` § Test Coverage

## Architecture compliance

- Mocks target port interfaces, not concrete adapters (`Mocking Ports` rule).
- Test names follow `should [behaviour] when [condition]` (`Test Naming`).
- Cross-context imports route through `@openlinker/core/*` barrels — including `InventoryMasterPort`, `Inventory`, and `InventoryItemEntity` from `@openlinker/core/inventory` (no `../../../domain/...` deep-relatives per `Import Aliases` rule 2).
- Layout matches the existing `__tests__/` precedent in this module.

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)