### PR TITLE
feat(dx): add new-integration issue template + adapter scaffolder

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_integration.md
+++ b/.github/ISSUE_TEMPLATE/new_integration.md
@@ -1,0 +1,118 @@
+---
+name: 🧩 Add a New Integration
+about: Propose a new platform integration (Shopify, WooCommerce, BigCommerce, …)
+title: '[INTEGRATION] '
+labels: ['enhancement', 'documentation']
+assignees: ''
+---
+
+Use this template for proposals to add a **new platform adapter** under `libs/integrations/`. For changes to an existing adapter, use the Feature Request template instead.
+
+Before filing, please skim:
+
+- [`docs/plugin-author-guide.md`](../../docs/plugin-author-guide.md) — the contributor walkthrough.
+- [`docs/architecture-overview.md` § Capability Abstractions](../../docs/architecture-overview.md#capability-abstractions-business-roles) — what the five built-in capability ports are.
+
+---
+
+## Platform
+
+- **Name**:
+- **Website / company**:
+- **Why OpenLinker should support it** (one-line rationale, e.g., user demand, market position, gap in current adapter set):
+
+## Proposed adapter key
+
+Format is `<platform>.<transport>.v<n>` — lowercase, dot-separated. Examples in the tree: `prestashop.webservice.v1`, `allegro.publicapi.v1`. The `v<n>` suffix lets a v2 ship alongside a v1.
+
+- **Adapter key**:
+
+## Vendor API documentation
+
+- **API reference URL**:
+- **OpenAPI / Swagger spec** (URL or "none"):
+- **SDK** (official client library, or "none"):
+- **Sandbox / test environment** (URL, signup link, or "none"):
+- **API versioning model** (semver / dated / none):
+
+## Target capabilities
+
+Which OpenLinker capability ports will this adapter implement? Tick all that apply. New capability names beyond the built-in five are allowed at the registry boundary (#576) — discuss with maintainers before claiming a new one.
+
+- [ ] `ProductMaster` — source of truth for product catalog (read/write)
+- [ ] `InventoryMaster` — source of truth for stock levels
+- [ ] `OrderSource` — cursor-based order-event ingestion
+- [ ] `OrderProcessorManager` — order lifecycle on the destination shop
+- [ ] `OfferManager` — marketplace offer/listing management (split into sub-capabilities — see [`docs/architecture-overview.md`](../../docs/architecture-overview.md))
+- [ ] Other / new capability:
+
+## Authentication model
+
+Tick **one**:
+
+- [ ] API key (static, header or query param)
+- [ ] OAuth 2.0 + refresh token
+- [ ] OAuth 2.0 client-credentials (machine-to-machine)
+- [ ] mTLS
+- [ ] Request signing (HMAC / similar)
+- [ ] Other:
+
+**Token / credential lifecycle notes** (refresh interval, rotation policy, anything unusual):
+
+## Rate limits
+
+- **Known caps** (requests/second, requests/day, burst rules):
+- **Retry-after / 429 behavior**:
+- **Per-credential or per-IP**:
+
+## Webhook support
+
+Tick **one**:
+
+- [ ] Push (vendor sends webhooks)
+- [ ] Pull-only (no webhook support — polling required)
+- [ ] Partial (webhooks for some event types, polling for others)
+
+If push or partial, **which events does the vendor emit?**
+
+## Identifier model
+
+- **Product ID type** (numeric / UUID / SKU-based / external):
+- **Order ID type**:
+- **Customer ID type**:
+- **Barcodes (EAN/GTIN) as first-class identifiers?** (yes / no / variant-only):
+- **Tenant / shop ID required for any request?** (yes / no / sometimes):
+
+## Inbound order semantics
+
+Only if you ticked `OrderSource` above:
+
+- **Cursor model** (event journal with `since`/`from` cursor / polling watermark like `date_upd` / both):
+- **Idempotency surface** (does the API expose a stable per-event identifier?):
+- **Latency expectation** (real-time push, ~5 min poll, hourly batch, …):
+
+## Maturity target
+
+What ship state is realistic for v1 of this adapter? Tick **one**:
+
+- [ ] Alpha — partial capability coverage, hand-driven, not for production
+- [ ] Beta — all declared capabilities work, edge cases acknowledged, opt-in
+- [ ] Stable — production-ready, full test coverage, default-on
+
+**What blocks promotion to the next stage?**
+
+## Reference reading for the implementer
+
+- [`docs/plugin-author-guide.md`](../../docs/plugin-author-guide.md) — package layout, port selection, factory wiring, credentials/OAuth, testing, host enablement.
+- [`docs/architecture-overview.md`](../../docs/architecture-overview.md) — hexagonal architecture, capability ports, identifier mapping.
+- [`libs/integrations/prestashop/`](../../libs/integrations/prestashop/) — the OpenLinker reference adapter.
+- [`libs/integrations/allegro/`](../../libs/integrations/allegro/) — OAuth + plugin-owned migration example.
+
+## Acceptance criteria
+
+- [ ] Adapter implements every capability ticked above
+- [ ] Connection-config and credentials shape validators registered (see plugin author guide § Step 7)
+- [ ] Connection tester registered against `ConnectionTesterRegistryService`
+- [ ] Unit tests cover request shape, response parsing, and error mapping for each capability
+- [ ] Adapter package `README.md` + a one-paragraph entry in `docs/integrations/<name>/` (if operator-facing setup is non-trivial)
+- [ ] Adapter registered in `apps/api/src/plugins.ts`

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,11 @@ pnpm-lock.yaml
 package-lock.json
 yarn.lock
 
+# Scaffolder templates contain unresolved placeholder tokens (__name__,
+# __Name__, __BRAND__) that aren't valid TS — prettier would fail to
+# parse them. They're substituted at scaffold time, not at format time.
+scripts/create-adapter-templates/
+
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,12 @@ at `libs/integrations/allegro/` for the OAuth pattern. Read the guide
 alongside the reference adapter's code — the code is the spec, the
 guide is the map.
 
+**Tip**: skip the manual file-shuffle. Run
+`pnpm create-adapter <name>` to scaffold a compilable, lint-clean
+plugin skeleton at `libs/integrations/<name>/` with the contract
+surface (plugin descriptor, integration module, adapter factory,
+barrel) already in place. Then follow the guide to add capabilities.
+
 ## Pull Request Process
 
 1. Create a feature branch from `main` named after the issue

--- a/docs/plans/implementation-plan-567-564-integration-template-and-scaffolding.md
+++ b/docs/plans/implementation-plan-567-564-integration-template-and-scaffolding.md
@@ -1,0 +1,316 @@
+# Implementation Plan — #567 + #564: Integration Issue Template & Adapter Scaffolding
+
+**Branch**: `567-564-integration-template-and-scaffolding`
+**Status**: Draft — pending user sign-off
+
+Closes Modularity Thread B (#548) by shipping the two onboarding affordances deferred from #562 / #563:
+
+- **#567** — `.github/ISSUE_TEMPLATE/new_integration.md`
+- **#564** — `scripts/create-adapter.mjs` (Stage 1, **Option B: curated skeleton**)
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+1. A new GitHub issue template that funnels "I want to add platform X" proposals into a structured shape (capabilities, auth, rate-limits, webhook, vendor-doc links, proposed adapter key).
+2. A `pnpm create-adapter <name>` command that scaffolds a compilable, lint-clean plugin package at `libs/integrations/<name>/` with the contract surface in place (plugin descriptor, NestJS module, adapter factory, barrel, workspace config). Contributor adds capabilities by following `docs/plugin-author-guide.md`.
+3. Wire-ups: root `package.json` script, CONTRIBUTING.md note, plugin-author-guide § Step 3 mention.
+
+### Non-goals (deferred)
+
+- Stage 2 from #564: published `@openlinker/create-integration` npm package or Nest schematic. Locked behind Modularity Thread F (#552) / npm publishing readiness.
+- Generating capability-adapter stubs (e.g., a half-implemented `OrderSource` adapter). The skeleton stops at the factory surface; capability authoring follows the guide.
+- Automated post-scaffold verification (compile/lint) beyond manual smoke tests during development. The scaffolder script itself doesn't ship with a unit test — see §6 for the reasoning.
+
+---
+
+## 2. Layer classification
+
+**DX / repo tooling.** No CORE, Integration, Interface, or Frontend code changes. Touches:
+
+- `.github/ISSUE_TEMPLATE/` (new file)
+- `scripts/` (new file)
+- `package.json` (one new script entry)
+- `CONTRIBUTING.md` (mention `pnpm create-adapter`)
+- `docs/plugin-author-guide.md` (Step 3 callout for the scaffolder)
+- `libs/integrations/` (no source changes — only the test artifact produced during manual verification, which gets deleted before commit)
+
+---
+
+## 3. Research summary
+
+### Reference adapters surveyed
+
+- `libs/integrations/prestashop/` — 68 files, ~14k LOC, 4 capabilities + 2 provisioners + full HTTP/XML stack. Per the plugin-author-guide we just shipped, this is the **canonical reference** contributors copy by hand.
+- `libs/integrations/allegro/` — adds OAuth + plugin-owned migration on top of the PS shape.
+- `libs/integrations/ai/` — stateless port-router (dynamic module). Not a per-connection plugin; not a model for new adapters.
+
+### Existing template conventions
+
+- `.github/ISSUE_TEMPLATE/feature_request.md` — frontmatter + markdown sections; checkbox lists for "Affected Components"; an "Architecture Considerations" prompt; closing "Acceptance Criteria" checklist. The new-integration template will mirror that shape.
+
+### Existing script conventions
+
+- `scripts/` contains five tools today: 1 bash invariant (`check-fixture-purity.sh`), 4 Node `.mjs` invariants. None ship a test. None are interactive. All are chained into `pnpm lint` via `check:invariants`.
+- The scaffolder breaks this pattern in one direction (it's interactive — takes a CLI arg) but matches it in the other (Node `.mjs`, no test, ESM with `import.meta.url` for path resolution).
+
+### Reference adapter file inventory (what the skeleton ships vs omits)
+
+Files the skeleton **ships** (~15 files, all compilable, all stubs/templates):
+
+| File | Role |
+|---|---|
+| `package.json` | workspace pkg, `@openlinker/integrations-<name>`, peer-dep on `@nestjs/common` |
+| `tsconfig.json` | composite TS project, references `../../core`, `../../shared`, `../../plugin-sdk` |
+| `tsconfig.spec.json` | jest-only config: `module: Node16` + jest/node types |
+| `jest.config.mjs` | ts-jest + module-name-mapper for sibling packages |
+| `README.md` | pinned content (see §4): heading + scaffolded-status callout + one-line pointer to the plugin author guide |
+| `src/index.ts` | minimal barrel: plugin factory + manifest + module |
+| `src/<name>-plugin.ts` | `createXPlugin(deps)` + `xAdapterManifest` (empty `supportedCapabilities`) + brand label |
+| `src/<name>-integration.module.ts` | **`createNestAdapterModule(plugin)` helper form** — 5-line NestJS module that wraps the descriptor (decision: §4 *Module template — helper pattern by default*) |
+| `src/application/<name>-adapter.factory.ts` | factory class, `createAdapters` stub that throws "not implemented" |
+| `src/application/interfaces/<name>-adapter.factory.interface.ts` | factory interface |
+| `src/domain/types/<name>-config.types.ts` | `XConnectionConfig` interface stub |
+| `src/domain/types/<name>-credentials.types.ts` | `XCredentials` interface stub |
+| `src/domain/exceptions/.gitkeep` | empty dir marker |
+| `src/infrastructure/adapters/.gitkeep` | empty dir marker |
+
+Files the skeleton **omits** (contributor adds as they implement capabilities):
+
+- HTTP client (`infrastructure/http/`)
+- Mappers (`infrastructure/mappers/`)
+- Provisioners (`infrastructure/provisioners/`)
+- Shape validators (`infrastructure/adapters/<name>-connection-config-shape-validator.adapter.ts` + credentials variant)
+- Connection tester (`infrastructure/adapters/<name>-connection-tester.adapter.ts`)
+- Webhook provisioner (`infrastructure/adapters/<name>-webhook-provisioning.adapter.ts`)
+- Capability adapters (`infrastructure/adapters/<name>-{product-master,inventory-master,order-source,order-processor-manager}.adapter.ts`)
+- DTOs (`application/dto/`)
+- Tests (`__tests__/`, `src/**/__tests__/`)
+- Per-package `.eslintrc.js` — none of the existing in-tree plugins carry one; they inherit the root config.
+- Plugin-owned `migrations/` — opt-in per #599; skeleton author adds when needed
+
+### Token scheme
+
+The scaffolder needs three tokens to substitute across templates:
+
+| Token | Example for `--name shopify` | Use |
+|---|---|---|
+| `__name__` | `shopify` | filenames, paths, `platformType`, adapterKey prefix |
+| `__Name__` | `Shopify` | class names (PascalCase) |
+| `__BRAND__` | `Shopify` | short label for `xBrand` const + exception prefixes — same as `__Name__` by default; surfaced separately so a contributor can rename without grepping |
+
+Templates carry these tokens literally; the scaffolder does a single-pass string replace per file.
+
+### Template storage — external files
+
+Templates live as **external files** under `scripts/create-adapter-templates/`, mirroring the target tree under `libs/integrations/<name>/` 1:1. File extensions match the destination (`.ts`, `.json`, `.mjs`, `.md`) so prettier formats them under `pnpm format` and the eye treats them as code, not stringly-typed payloads. The scaffolder reads each template, applies the three-token substitution, and writes the output to the target dir.
+
+Rationale: inline-string templates inside `create-adapter.mjs` forfeit prettier coverage and make the most-edited part of the script opaque to a reviewer's diff. External files keep templates legible and lint-able. The trade-off — template files would be picked up by TypeScript `tsc --noEmit` and fail because they contain `__name__` / `__Name__` tokens — is mitigated by listing `scripts/create-adapter-templates/` in every workspace `tsconfig`'s `exclude` AND adding a top-level `.eslintignore` entry. The templates aren't real source.
+
+---
+
+## 4. Design
+
+### #567 — Issue template
+
+Single file: `.github/ISSUE_TEMPLATE/new_integration.md`. Frontmatter follows existing templates' shape. **Single-selection sections use checkboxes with a "mark one" instruction** — GitHub markdown issue templates don't have native radio inputs, and the existing six templates (`feature_request.md`, `bug_report.md`, …) all use the same checkbox convention. Body sections, in order:
+
+1. **Platform** — name + canonical website
+2. **Proposed adapter key** — `<platform>.<transport>.v<n>` with a hint at the convention
+3. **Vendor API documentation** — links to vendor docs, OpenAPI spec if available, sandbox/test environment availability
+4. **Target capabilities** — checkboxes for the 5 `CoreCapabilityValues` + "Other / new capability" with a sub-prompt (multi-select)
+5. **Authentication model** — checkboxes (mark one): API key, OAuth 2.0 + refresh, OAuth 2.0 client-credentials, mTLS, signed requests, other
+6. **Rate limits** — known caps, burst rules, retry-after support
+7. **Webhook support** — checkboxes (mark one): push / pull only / partial — plus a free-text prompt for events
+8. **Identifier model** — what IDs the platform exposes for products/orders/customers; whether barcodes (EAN/GTIN) are first-class
+9. **Inbound order semantics** — for `OrderSource`: event-journal cursor or polling watermark; idempotency surface
+10. **Maturity target** — checkboxes (mark one): alpha / beta / stable — plus a free-text prompt for what blocks promotion
+11. **Reference reading** — link to `docs/plugin-author-guide.md`, `docs/architecture-overview.md § Capability Abstractions`
+12. **Acceptance criteria** — checkbox list (4–6 items: adapter implements declared capabilities, shape validators registered, connection-tester registered, unit tests, docs)
+
+### #564 — Scaffolder script
+
+**Entry point**: `scripts/create-adapter.mjs` (Node ESM, `node:` imports only — no external deps).
+
+**Invocation surface**:
+
+```bash
+pnpm create-adapter <name>
+pnpm create-adapter <name> --target-dir /tmp/scaffold-smoke   # for verification runs
+# or
+node scripts/create-adapter.mjs <name> [--target-dir <dir>]
+```
+
+`<name>` is the platform slug — lowercase ASCII, 2–32 chars, leading letter, allows internal hyphens. Same character class as npm package-name (sans scope).
+
+The `--target-dir <dir>` flag (default: `libs/integrations`) lets the scaffolder write into a tmp dir for verification runs without polluting the worktree. The target package always lands at `<target-dir>/<name>/`.
+
+**Validation rules** (fail-fast, exit 1):
+
+- `<name>` missing → print usage + exit
+- `<name>` matches regex `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/` AND length 2–32 (rejects underscores, capital letters, leading/trailing hyphens, double hyphens, too short, too long)
+- `<name>` ∈ {`prestashop`, `allegro`, `ai`} → reject (clash with shipped plugins) — only enforced when `--target-dir` points inside the repo's `libs/integrations/`
+- `<name>` ∈ reserved list {`core`, `shared`, `plugin-sdk`, `web`, `api`, `worker`} → reject (workspace-name collision)
+- `<target-dir>/<name>/` already exists → reject
+- Repo root not found (no `pnpm-workspace.yaml`) → reject (defends against running from somewhere unexpected) — only when `--target-dir` is default; with explicit `--target-dir` the script trusts the caller
+
+**Output**: writes the 15-file skeleton listed in §3. After success, prints a 4-line next-steps block:
+
+```
+✓ Scaffolded libs/integrations/<name>/
+Next:
+  1. Run `pnpm install`
+  2. Read docs/plugin-author-guide.md
+  3. Pick a capability port and implement your first adapter
+```
+
+**Module structure**:
+
+The script is a single file with three sections:
+
+1. **Validation** (`validateName`, `assertSlug`)
+2. **Template resolution** (walks `scripts/create-adapter-templates/` via `fs.readdir({ recursive: true })`, applies the three-token substitution to filenames and contents — see §3 *Template storage*)
+3. **Scaffolding** (`scaffoldAdapter({ name, targetDir, repoRoot, templatesDir })` exported for future reuse / testing; `main()` parses argv and calls it)
+
+Exported `scaffoldAdapter` keeps the door open for a future test or a follow-up `--dry-run` flag without restructuring the script.
+
+### Module template — helper pattern by default
+
+The scaffolder produces an `<name>-integration.module.ts` using the `createNestAdapterModule(plugin)` helper from `@openlinker/plugin-sdk`. Whole template body is ~10 lines:
+
+```typescript
+import { createNestAdapterModule } from '@openlinker/plugin-sdk';
+import { create__Name__Plugin } from './__name__-plugin';
+
+export const __Name__IntegrationModule = createNestAdapterModule({
+  plugin: create__Name__Plugin({}),
+});
+```
+
+Rationale: a fresh plugin has zero plugin-specific `@Injectable`s — repositories, provisioners, refresh services all show up later as the contributor implements capabilities. The helper covers exactly that case. The plugin-author guide already documents how to graduate to the inline-from-module pattern (the PrestaShop / Allegro shape) when the plugin grows its first plugin-specific provider.
+
+The skeleton's `README.md` includes a one-line breadcrumb to that graduation path so the contributor doesn't get stuck when their first `@Injectable` doesn't fit the helper.
+
+### `<name>-plugin.ts` template — empty-deps shape
+
+`CreateXPluginDeps` is `Record<string, never>` in the skeleton. `createXPlugin({})` returns a descriptor with `supportedCapabilities: []` and a `createCapabilityAdapter` that throws "not implemented" with a guide link. Registering against `host.adapterRegistry` succeeds; the runtime `getCapabilityAdapter(connectionId, '<anything>')` call would fail at capability-match time, which is the correct behavior for a no-capability scaffold.
+
+When the contributor adds their first capability, they widen the deps interface (or add factory closure args) and grow `supportedCapabilities`. The empty-deps starting point keeps the diff focused.
+
+### Skeleton `README.md` content (pinned)
+
+The scaffolded `README.md` ships with this exact shape (no more, no less):
+
+```markdown
+# @openlinker/integrations-__name__
+
+> **Status: scaffolded — capabilities not yet implemented.**
+
+This package implements the OpenLinker capability ports for `__name__`.
+See [`docs/plugin-author-guide.md`](../../../docs/plugin-author-guide.md) for the walkthrough — what files to add, which port to implement, and how the host picks up your adapter.
+
+The integration module is currently the `createNestAdapterModule` helper form. When you add your first plugin-specific `@Injectable` provider (a repository, provisioner, HTTP client, refresh service), swap to the inline-from-module pattern documented in the guide § Step 6 *Two authoring patterns*.
+```
+
+Token substitution flips `__name__` to the platform slug. The status line is a deliberate signal the contributor edits when capabilities land.
+
+### #564 — Plugin-author-guide § Step 3 update
+
+The guide currently opens Step 3 with *"Copy this tree as your starting point (`libs/integrations/<platform>/`):"* — keep that as the manual path, but add a one-paragraph callout above pointing at the scaffolder as the fast path. The two paths converge: scaffolder produces the same tree the guide tells the reader to copy.
+
+### #564 — CONTRIBUTING § Building a New Integration update
+
+Currently reads: *"Adding a platform integration (e.g., Shopify, …) is a separate workflow…The walkthrough lives in the [Plugin Author Guide]…"* — add a one-line "Tip: run `pnpm create-adapter <name>` to scaffold the package skeleton, then follow the guide."
+
+### #564 — Root `package.json` script
+
+Add one entry:
+
+```json
+"create-adapter": "node scripts/create-adapter.mjs"
+```
+
+No other root-level changes. `check:invariants` is unchanged — the scaffolder isn't an invariant.
+
+---
+
+## 5. Implementation steps
+
+| # | File | Action | Acceptance |
+|---|---|---|---|
+| 1 | `.github/ISSUE_TEMPLATE/new_integration.md` | Create | 12-section markdown template per §4. Frontmatter has `name: 🧩 Add a New Integration`, `title: '[INTEGRATION] '`, `labels: ['enhancement', 'documentation']`. Single-selection sections use checkboxes with "mark one" instruction |
+| 2 | `scripts/create-adapter-templates/` | Create | ~15 template files under this directory, mirroring the skeleton tree per §3. Files carry `__name__` / `__Name__` / `__BRAND__` tokens literally |
+| 3 | `scripts/create-adapter.mjs` | Create | Node ESM, ~200-300 LOC. Validates `<name>`, walks `scripts/create-adapter-templates/`, applies three-token substitution, writes to `<target-dir>/<name>/`. `node scripts/create-adapter.mjs foo` from repo root produces `libs/integrations/foo/`. Supports `--target-dir <dir>` |
+| 4 | `package.json` (root) | Edit | Add `"create-adapter": "node scripts/create-adapter.mjs"` under `scripts:` |
+| 5 | Workspace `tsconfig` files | Edit | Add `scripts/create-adapter-templates/**` to `exclude` (root `tsconfig.json`) so templates don't fail TS check |
+| 6 | `.eslintignore` (root, create if missing) | Create/Edit | Ensure `scripts/create-adapter-templates/` is ignored by ESLint |
+| 7 | `CONTRIBUTING.md` | Edit | Append a tip line to the *Building a New Integration* section about `pnpm create-adapter <name>` |
+| 8 | `docs/plugin-author-guide.md` | Edit | Insert a callout above the Step 3 *"Copy this tree…"* paragraph mentioning the scaffolder as the fast path |
+| 9 | **Manual verification** | Run | `mkdir -p /tmp/openlinker-scaffold-smoke && node scripts/create-adapter.mjs example --target-dir /tmp/openlinker-scaffold-smoke` → scaffold to `/tmp/openlinker-scaffold-smoke/example/`. Then `cd` there and run a tsc smoke check against the templates. Tmp dir is outside the worktree — no risk of accidentally committing the artifact |
+
+---
+
+## 6. Validation strategy
+
+### Architecture compliance
+
+- The scaffolder is a build-time DX tool. No port / adapter / domain code introduced or modified — just template authoring. Hexagonal architecture is unaffected.
+- Templates produce a skeleton that **respects** the architecture: domain types under `domain/`, factory under `application/`, NestJS wiring in the module, top-level barrel imports (`@openlinker/core/...`, never deep paths).
+
+### Naming
+
+- Template file names follow `engineering-standards.md § Naming Conventions`: `<name>-plugin.ts`, `<name>-integration.module.ts`, `<name>-adapter.factory.ts`, `*.types.ts`. Class names match `{Platform}Capability` shape where applicable.
+- Adapter-key suggested in the template comment: `<name>.publicapi.v1`. Contributor adjusts during their first PR.
+
+### Testing strategy
+
+**The scaffolder script does not ship with an automated unit test in this PR. A follow-up issue tracks the lint-time smoke check.** Rationale:
+
+1. The script is exercised by manual verification (§5 step 9) during development — `node scripts/create-adapter.mjs example --target-dir /tmp/openlinker-scaffold-smoke` followed by `tsc --noEmit` against the output. That's a strong end-to-end smoke check at author time.
+2. Adding a `.mjs` test runner under `scripts/` (where no tests live today) introduces infra cost. The other invariant scripts under `scripts/` ship without tests.
+3. Co-locating a test inside `apps/api/test/` would be a category error — the scaffolder isn't part of the API.
+4. Stage 2 from #564 (npm package / schematic) will live in its own package with its own test setup. That's the right home for invested test infrastructure.
+
+**Follow-up tracking**: at PR-creation time, open a follow-up issue (analogous to #680 for the plugin-author-guide quote drift) for `scripts/check-create-adapter.mjs` — a lint-time invariant that scaffolds into a tmp dir via the exported `scaffoldAdapter`, asserts the expected file list, and runs `tsc --noEmit`. Chained into `check:invariants`. Honest framing: this PR ships the scaffolder; the drift guard is a separate, smaller follow-up. Cross-link from the PR body.
+
+### Security
+
+- Scaffolder reads no secrets, writes no creds. The only filesystem mutation is creating files under `libs/integrations/<name>/`.
+- `<name>` validation defends against path traversal (regex bounds it to a single segment, no `..`, no `/`).
+- Template strings contain no executable content — pure data. No `eval`, no `require(<dynamic>)`.
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Template drift — reference adapter evolves, scaffolder output goes stale | Medium | Tracked openly as a known limitation. Eventual hardening: structural-shape CI check (out of scope). Inline templates keep all drift visible in one file (`scripts/create-adapter.mjs`). |
+| Contributor scaffolds, then doesn't read the guide | Low | Skeleton's `README.md` and the post-scaffold console output both link the guide. Adapter-factory `createAdapters` throws a "not implemented" with a guide-link error message — runtime failure leads the contributor to the docs. |
+| Scaffolder produces output that doesn't compile after a future TypeScript or dep bump | Low | Manual verification (§5 step 6) catches this every time the scaffolder is touched. If a contributor hits it months later, they file a bug; we re-verify and patch templates. |
+
+### Open questions
+
+None blocking. One soft choice:
+
+1. **Issue template emoji prefix**: chose `🧩 Add a New Integration` to visually distinguish from the existing 6 templates. Drop if the reviewer pushes back.
+
+---
+
+## 7. Out of scope
+
+- Scaffolding sub-flavors (`--from-prestashop` to literal-clone PS; `--with-oauth` to seed OAuth scaffolding from Allegro). Easy to add later if demand emerges.
+- A "delete adapter" complement script.
+- Automatic `apps/api/src/plugins.ts` registration — the contributor edits one line by hand; that's explicitly the single edit point per `docs/architecture-overview.md`.
+- The lint-time quote-drift invariant for `plugin-author-guide.md` (tracked separately in #680).
+- Wider issue-template ergonomics (form-style YAML templates rather than markdown). Existing templates are markdown; matching that.
+
+---
+
+## 8. PR shape
+
+Single PR. Commit grouping: one commit. Conventional-commit prefix `feat(dx)` since the scaffolder is a new feature surface; `docs:` doesn't fit because it ships executable code.
+
+Body: `Closes #567`, `Closes #564`.
+
+Expected diff stat: ~600 LOC added (~250 LOC scaffolder + ~120 LOC issue template + ~30 LOC of template inline strings + ~10 LOC root package.json + small CONTRIBUTING/guide touches). Zero deletions.

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -132,6 +132,14 @@ For everything else, PrestaShop is the canonical template.
 
 ## Step 3 — Package layout
 
+> **Fast path**: `pnpm create-adapter <name>` scaffolds a compilable,
+> lint-clean version of the tree below — workspace config, barrel,
+> plugin descriptor, integration module (helper form), adapter factory,
+> empty config/credentials types, and `.gitkeep` markers for the
+> exception/adapter dirs. ~15 files; you fill in capabilities on top.
+> The manual walk-through below is still the canonical reference for
+> what each file is for.
+
 Copy this tree as your starting point (`libs/integrations/<platform>/`):
 
 ```text

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
+    "create-adapter": "node scripts/create-adapter.mjs",
     "type-check": "pnpm -r --filter \"./libs/**\" build && pnpm -r type-check",
     "start:dev": "pnpm --filter api start:dev",
     "start:dev:api": "pnpm --filter @openlinker/api exec nest start --watch",

--- a/scripts/create-adapter-templates/README.md
+++ b/scripts/create-adapter-templates/README.md
@@ -1,0 +1,8 @@
+# @openlinker/integrations-__name__
+
+> **Status: scaffolded — capabilities not yet implemented.**
+
+This package implements the OpenLinker capability ports for `__name__`.
+See [`docs/plugin-author-guide.md`](../../../docs/plugin-author-guide.md) for the walkthrough — what files to add, which port to implement, and how the host picks up your adapter.
+
+The integration module is currently the `createNestAdapterModule` helper form. When you add your first plugin-specific `@Injectable` provider (a repository, provisioner, HTTP client, refresh service), swap to the inline-from-module pattern documented in the guide § Step 6 *Two authoring patterns*.

--- a/scripts/create-adapter-templates/jest.config.mjs
+++ b/scripts/create-adapter-templates/jest.config.mjs
@@ -1,0 +1,33 @@
+export default {
+  testEnvironment: 'node',
+  rootDir: '.',
+
+  // Avoid running fixtures/mocks as "tests"
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+
+  // ESM + TS support for Node16 module resolution
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@openlinker/integrations-__name__$': '<rootDir>/src/index.ts',
+    '^@openlinker/integrations-__name__/(.*)$': '<rootDir>/src/$1',
+    '^@openlinker/core/(.*)$': '<rootDir>/../../core/src/$1',
+    '^@openlinker/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+  },
+
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '<rootDir>/coverage',
+  clearMocks: true,
+  testTimeout: 30000,
+};

--- a/scripts/create-adapter-templates/package.json
+++ b/scripts/create-adapter-templates/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@openlinker/integrations-__name__",
+  "version": "0.1.0",
+  "description": "__Name__ adapter for OpenLinker",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --config ./jest.config.mjs",
+    "test:watch": "jest --watch --config ./jest.config.mjs",
+    "test:cov": "jest --coverage --config ./jest.config.mjs",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@openlinker/core": "workspace:*",
+    "@openlinker/plugin-sdk": "workspace:*",
+    "@openlinker/shared": "workspace:*",
+    "class-validator": "0.14.1"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "20.11.30",
+    "@typescript-eslint/eslint-plugin": "7.3.1",
+    "@typescript-eslint/parser": "7.3.1",
+    "eslint": "8.57.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.2",
+    "typescript": "5.4.3"
+  }
+}

--- a/scripts/create-adapter-templates/src/__name__-integration.module.ts
+++ b/scripts/create-adapter-templates/src/__name__-integration.module.ts
@@ -1,0 +1,25 @@
+/**
+ * __Name__ Integration Module
+ *
+ * NestJS host wrapper for the __Name__ plugin descriptor. Uses the
+ * `createNestAdapterModule` helper from `@openlinker/plugin-sdk` — the
+ * simple authoring pattern (#593) for plugins that don't yet need their
+ * own NestJS providers.
+ *
+ * **When to graduate to the inline-from-module pattern**: as soon as
+ * your plugin needs its own `@Injectable` providers — a TypeORM
+ * repository, a provisioner, an HTTP client, a refresh service — swap
+ * this file for the explicit `@Module() / onModuleInit` shape used by
+ * `libs/integrations/prestashop/src/prestashop-integration.module.ts`
+ * and `libs/integrations/allegro/src/allegro-integration.module.ts`.
+ *
+ * See `docs/plugin-author-guide.md` § Step 6 *Two authoring patterns*.
+ *
+ * @module libs/integrations/__name__/src
+ */
+import { createNestAdapterModule } from '@openlinker/plugin-sdk';
+import { create__Name__Plugin } from './__name__-plugin';
+
+export const __Name__IntegrationModule = createNestAdapterModule({
+  plugin: create__Name__Plugin({}),
+});

--- a/scripts/create-adapter-templates/src/__name__-plugin.ts
+++ b/scripts/create-adapter-templates/src/__name__-plugin.ts
@@ -1,0 +1,105 @@
+/**
+ * __Name__ Plugin Descriptor
+ *
+ * Framework-neutral `AdapterPlugin` describing the __Name__ integration.
+ * Scaffolded with no capabilities and no side-registrations — this is a
+ * starting point. As you implement capabilities, add adapter classes
+ * under `infrastructure/adapters/`, wire them into the factory's
+ * `createAdapters`, expand `supportedCapabilities` here, and route the
+ * adapter through `createCapabilityAdapter` via `dispatchCapability`.
+ *
+ * See `docs/plugin-author-guide.md` § Step 6 for the full descriptor
+ * shape and the `AdapterPlugin` contract spec at
+ * `libs/plugin-sdk/src/adapter-plugin.ts:42-110`.
+ *
+ * @module libs/integrations/__name__/src
+ */
+import { type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
+import type { AdapterMetadata } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+
+/**
+ * When you wire your first capability adapter through
+ * `createCapabilityAdapter` below, import the factory:
+ *
+ *   import { __Name__AdapterFactory } from './application/__name__-adapter.factory';
+ *
+ * The factory class itself is already scaffolded under `application/`.
+ */
+
+/**
+ * Plugin-specific cross-package dependencies passed via factory closure
+ * (not through the curated `HostServices` bag). Empty for the scaffold;
+ * widen as your plugin grows — see PrestaShop's
+ * `CreatePrestashopPluginDeps` for the canonical shape.
+ */
+export type Create__Name__PluginDeps = Record<string, never>;
+
+/**
+ * Static plugin manifest (#575).
+ *
+ * Exported as a top-level `const` so consumers can read manifest fields
+ * without instantiating the full plugin. The runtime path
+ * (`create__Name__Plugin({}).manifest`) returns this same reference, so
+ * there's no drift between static and runtime views.
+ *
+ * `supportedCapabilities` starts empty. As you implement capability
+ * adapters, add their names here AND extend the dispatch table in
+ * `createCapabilityAdapter` below.
+ */
+export const __name__AdapterManifest: AdapterMetadata = {
+  adapterKey: '__name__.publicapi.v1',
+  platformType: '__name__',
+  supportedCapabilities: [],
+  displayName: '__Name__',
+  version: '0.1.0',
+  isDefault: true,
+};
+
+/**
+ * Short brand label used as the user-facing prefix when this plugin's
+ * adapters raise domain exceptions (`InvalidConnectionConfigException`,
+ * `InvalidCredentialsShapeException`). Co-located with the manifest so
+ * a rebrand touches one line.
+ */
+const __NAME___BRAND = '__BRAND__';
+
+export function create__Name__Plugin(
+  _deps: Create__Name__PluginDeps,
+): AdapterPlugin {
+  return {
+    manifest: __name__AdapterManifest,
+
+    // No side-registrations yet. As you add a connection tester, shape
+    // validators, webhook provisioner, etc., uncomment and register them
+    // here. See the plugin author guide § Step 7 (shape validators) and
+    // § Step 8 (credentials / OAuth).
+    register(_host: HostServices): void {
+      // host.connectionTesterRegistry.register(
+      //   __name__AdapterManifest.adapterKey,
+      //   new __Name__ConnectionTesterAdapter(),
+      // );
+      // host.connectionConfigShapeValidatorRegistry.register(
+      //   __name__AdapterManifest.adapterKey,
+      //   new __Name__ConnectionConfigShapeValidatorAdapter(__NAME___BRAND),
+      // );
+    },
+
+    createCapabilityAdapter<T>(
+      _connection: Connection,
+      capability: string,
+      _host: HostServices,
+    ): Promise<T> {
+      // Once you implement capability adapters, swap this for a
+      // `dispatchCapability<T>(capability, { ... }, BRAND)` call — see
+      // PrestaShop and Allegro plugin descriptors for the canonical shape.
+      return Promise.reject(
+        new Error(
+          `${__NAME___BRAND} adapter does not yet implement any capabilities. ` +
+            `Requested: "${capability}". ` +
+            `See docs/plugin-author-guide.md § Step 4 for how to implement one.`,
+        ),
+      );
+    },
+  };
+}

--- a/scripts/create-adapter-templates/src/application/__name__-adapter.factory.ts
+++ b/scripts/create-adapter-templates/src/application/__name__-adapter.factory.ts
@@ -1,0 +1,57 @@
+/**
+ * __Name__ Adapter Factory
+ *
+ * Per-connection factory for __Name__ capability adapters. Implements
+ * the plugin's `I__Name__AdapterFactory` interface; called by
+ * `create__Name__Plugin`'s `createCapabilityAdapter` once you wire your
+ * first capability.
+ *
+ * Scaffolded as a stub. As you implement capabilities:
+ *   1. Add per-capability adapter classes under `infrastructure/adapters/`.
+ *   2. Resolve `Connection.config` via a class-validator DTO (see
+ *      PrestaShop's `prestashop-connection-config.dto.ts` for the
+ *      canonical pattern).
+ *   3. Resolve credentials via `credentialsResolver.get<__Name__Credentials>(
+ *      connection.credentialsRef)` inside `createAdapters` — per-connection,
+ *      NOT in the factory constructor.
+ *   4. Construct each capability adapter with the resolved config + creds.
+ *
+ * See `docs/plugin-author-guide.md` § Step 5 and
+ * `libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts`
+ * for a worked example.
+ *
+ * @module libs/integrations/__name__/src/application
+ */
+import { Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import type {
+  I__Name__AdapterFactory,
+  __Name__Adapters,
+} from './interfaces/__name__-adapter.factory.interface';
+
+@Injectable()
+export class __Name__AdapterFactory implements I__Name__AdapterFactory {
+  private readonly logger = new Logger(__Name__AdapterFactory.name);
+
+  createAdapters(
+    connection: Connection,
+    _identifierMapping: IdentifierMappingPort,
+    _credentialsResolver: CredentialsResolverPort,
+  ): Promise<__Name__Adapters> {
+    this.logger.debug(
+      `Creating __Name__ adapters for connection: ${connection.id}`,
+    );
+    // Replace this rejection with the real implementation as you wire
+    // capabilities. See PrestaShop's factory for the canonical async/await
+    // shape (config validation → credentials resolution → adapter
+    // construction).
+    return Promise.reject(
+      new Error(
+        '__Name__AdapterFactory.createAdapters is not implemented. ' +
+          'See docs/plugin-author-guide.md § Step 5 for the implementation recipe.',
+      ),
+    );
+  }
+}

--- a/scripts/create-adapter-templates/src/application/interfaces/__name__-adapter.factory.interface.ts
+++ b/scripts/create-adapter-templates/src/application/interfaces/__name__-adapter.factory.interface.ts
@@ -1,0 +1,34 @@
+/**
+ * __Name__ Adapter Factory Interface
+ *
+ * Public contract for the per-connection __Name__ adapter factory.
+ * Implementations live under `application/__name__-adapter.factory.ts`.
+ *
+ * Co-locates the factory's input contract (`I__Name__AdapterFactory`)
+ * with its output shape (`__Name__Adapters`) — matches the PrestaShop
+ * reference adapter at
+ * `libs/integrations/prestashop/src/application/interfaces/prestashop-adapter.factory.interface.ts`.
+ *
+ * @module libs/integrations/__name__/src/application/interfaces
+ */
+import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+
+/**
+ * Empty adapter bundle. Widen this shape as you add capabilities — one
+ * field per capability adapter, keyed by lowercase camel-cased
+ * capability name (e.g. `productMaster: __Name__ProductMasterAdapter`).
+ */
+export interface __Name__Adapters {
+  // productMaster?: __Name__ProductMasterAdapter;
+  // inventoryMaster?: __Name__InventoryMasterAdapter;
+  // orderSource?: __Name__OrderSourceAdapter;
+}
+
+export interface I__Name__AdapterFactory {
+  createAdapters(
+    connection: Connection,
+    identifierMapping: IdentifierMappingPort,
+    credentialsResolver: CredentialsResolverPort,
+  ): Promise<__Name__Adapters>;
+}

--- a/scripts/create-adapter-templates/src/domain/types/__name__-config.types.ts
+++ b/scripts/create-adapter-templates/src/domain/types/__name__-config.types.ts
@@ -1,0 +1,23 @@
+/**
+ * __Name__ Connection Config Types
+ *
+ * Shape of the `Connection.config` JSONB blob operators submit when they
+ * create a __Name__ connection (e.g., base URL, shop ID, language code,
+ * any platform-specific feature flags).
+ *
+ * Scaffolded with the typical "API base URL" field. Widen as your plugin
+ * grows. Validate the shape at create-time with a `class-validator` DTO
+ * + a `ConnectionConfigShapeValidatorPort` adapter — see the plugin
+ * author guide § Step 7 and PrestaShop's
+ * `prestashop-connection-config.dto.ts` for the canonical pattern.
+ *
+ * @module libs/integrations/__name__/src/domain/types
+ */
+
+export interface __Name__ConnectionConfig {
+  /**
+   * Base URL of the __Name__ instance the adapter talks to.
+   * Must include scheme (`https://...`) and exclude trailing slash.
+   */
+  readonly baseUrl: string;
+}

--- a/scripts/create-adapter-templates/src/domain/types/__name__-credentials.types.ts
+++ b/scripts/create-adapter-templates/src/domain/types/__name__-credentials.types.ts
@@ -1,0 +1,22 @@
+/**
+ * __Name__ Credentials Types
+ *
+ * Shape of the credentials payload encrypted at rest in
+ * `integration_credentials`. The factory pulls it via
+ * `credentialsResolver.get<__Name__Credentials>(connection.credentialsRef)`
+ * inside `createAdapters` — see the plugin author guide § Step 8.
+ *
+ * Scaffolded with a single `apiKey` field — replace with whatever the
+ * vendor's auth model needs (API key, OAuth tokens, mTLS cert paths).
+ * Validate the shape with a `ConnectionCredentialsShapeValidatorPort`
+ * adapter — see PrestaShop's
+ * `prestashop-connection-credentials-shape-validator.adapter.ts` for the
+ * canonical pattern.
+ *
+ * @module libs/integrations/__name__/src/domain/types
+ */
+
+export interface __Name__Credentials {
+  /** Static API key issued by __Name__'s admin UI. */
+  readonly apiKey: string;
+}

--- a/scripts/create-adapter-templates/src/index.ts
+++ b/scripts/create-adapter-templates/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * __Name__ Integration — Public API
+ *
+ * Barrel for `@openlinker/integrations-__name__`. Exports the plugin
+ * descriptor factory, the static manifest, and the NestJS module the
+ * host imports via `apps/api/src/plugins.ts`.
+ *
+ * As capabilities, exceptions, and types are added, re-export them here
+ * if external consumers (host integration tests, sibling plugins) need
+ * them. Keep the surface narrow by default.
+ *
+ * @module libs/integrations/__name__/src
+ */
+
+export {
+  create__Name__Plugin,
+  __name__AdapterManifest,
+  type Create__Name__PluginDeps,
+} from './__name__-plugin';
+
+export { __Name__IntegrationModule } from './__name__-integration.module';
+
+export type { __Name__ConnectionConfig } from './domain/types/__name__-config.types';
+export type { __Name__Credentials } from './domain/types/__name__-credentials.types';

--- a/scripts/create-adapter-templates/tsconfig.json
+++ b/scripts/create-adapter-templates/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../../core" },
+    { "path": "../../shared" },
+    { "path": "../../plugin-sdk" }
+  ]
+}

--- a/scripts/create-adapter-templates/tsconfig.spec.json
+++ b/scripts/create-adapter-templates/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/create-adapter.mjs
+++ b/scripts/create-adapter.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * create-adapter — scaffolds a new OpenLinker plugin package.
+ *
+ * Usage:
+ *   pnpm create-adapter <name>
+ *   pnpm create-adapter <name> --target-dir /tmp/scaffold-smoke
+ *   node scripts/create-adapter.mjs <name> [--target-dir <dir>]
+ *
+ * Produces a minimal compilable skeleton at `<target-dir>/<name>/` using
+ * the `createNestAdapterModule` authoring pattern. The contributor adds
+ * capabilities by following `docs/plugin-author-guide.md`.
+ *
+ * Templates live under `scripts/create-adapter-templates/`, mirroring the
+ * target tree 1:1. Filenames and contents carry three substitution tokens:
+ *
+ *   __name__   — lowercase platform slug      (e.g. `shopify`)
+ *   __Name__   — PascalCase class identifier  (e.g. `Shopify`)
+ *   __BRAND__  — short user-facing label      (defaults to PascalCase)
+ *
+ * The `--target-dir <dir>` flag (default: `libs/integrations`) lets the
+ * scaffolder write into a tmp dir for verification runs without polluting
+ * the worktree.
+ *
+ * @module scripts
+ */
+import { mkdir, readdir, readFile, writeFile, access } from 'node:fs/promises';
+import { dirname, join, resolve, basename } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = join(SCRIPT_DIR, 'create-adapter-templates');
+const REPO_ROOT = resolve(SCRIPT_DIR, '..');
+const DEFAULT_TARGET_DIR = join(REPO_ROOT, 'libs/integrations');
+
+const NAME_PATTERN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+const NAME_MIN_LEN = 2;
+const NAME_MAX_LEN = 32;
+
+// Names that would clash with in-repo packages. Only enforced when scaffolding
+// into the repo's libs/integrations/ — external `--target-dir` skips this so a
+// throwaway smoke run into /tmp can use any slug.
+const SHIPPED_PLUGIN_NAMES = new Set(['prestashop', 'allegro', 'ai']);
+const RESERVED_WORKSPACE_NAMES = new Set([
+  'core',
+  'shared',
+  'plugin-sdk',
+  'web',
+  'api',
+  'worker',
+]);
+
+function printUsage() {
+  process.stderr.write(
+    [
+      'Usage: pnpm create-adapter <name> [--target-dir <dir>]',
+      '',
+      '  <name>           Platform slug. Lowercase ASCII, 2-32 chars, leading',
+      '                   letter, internal hyphens allowed (e.g. shopify, woo-commerce).',
+      '  --target-dir     Destination parent dir for the new package.',
+      '                   Default: libs/integrations (relative to repo root).',
+      '',
+      'Examples:',
+      '  pnpm create-adapter shopify',
+      '  pnpm create-adapter woo-commerce',
+      '  node scripts/create-adapter.mjs example --target-dir /tmp/smoke',
+      '',
+    ].join('\n'),
+  );
+}
+
+function parseArgs(argv) {
+  const args = { name: null, targetDir: null };
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === '--target-dir') {
+      args.targetDir = argv[i + 1];
+      i++;
+    } else if (token === '--help' || token === '-h') {
+      args.help = true;
+    } else if (token.startsWith('--')) {
+      throw new Error(`Unknown flag: ${token}`);
+    } else if (args.name === null) {
+      args.name = token;
+    } else {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+  }
+  return args;
+}
+
+function validateName(name) {
+  if (!name) {
+    throw new Error('Missing required argument: <name>');
+  }
+  if (name.length < NAME_MIN_LEN || name.length > NAME_MAX_LEN) {
+    throw new Error(
+      `<name> must be ${NAME_MIN_LEN}-${NAME_MAX_LEN} characters; got ${name.length}.`,
+    );
+  }
+  if (!NAME_PATTERN.test(name)) {
+    throw new Error(
+      `<name> "${name}" is invalid. Must be lowercase ASCII, leading letter, ` +
+        `internal hyphens allowed, no trailing/double hyphens, no underscores.`,
+    );
+  }
+}
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function toPascalCase(slug) {
+  return slug
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function applyTokens(text, tokens) {
+  // Single-pass replace — order doesn't matter, the tokens are
+  // non-overlapping by construction.
+  return text
+    .split('__name__')
+    .join(tokens.name)
+    .split('__Name__')
+    .join(tokens.Name)
+    .split('__BRAND__')
+    .join(tokens.BRAND);
+}
+
+async function listTemplateFiles(dir) {
+  const files = [];
+  const stack = [dir];
+  while (stack.length) {
+    const current = stack.pop();
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(abs);
+      } else if (entry.isFile()) {
+        files.push(abs);
+      }
+    }
+  }
+  return files.sort();
+}
+
+/**
+ * Scaffold a new plugin package.
+ *
+ * Exported so a future smoke test or `--dry-run` flag can call into the
+ * same code path without re-parsing argv. See the tracked follow-up for
+ * the lint-time invariant.
+ */
+export async function scaffoldAdapter({
+  name,
+  targetDir,
+  templatesDir = TEMPLATES_DIR,
+}) {
+  validateName(name);
+
+  // Reserved-name checks only apply when scaffolding into the repo's
+  // libs/integrations/ — a `--target-dir /tmp/...` smoke run can use any slug.
+  const isDefaultTarget = targetDir === DEFAULT_TARGET_DIR;
+  if (isDefaultTarget && SHIPPED_PLUGIN_NAMES.has(name)) {
+    throw new Error(
+      `<name> "${name}" matches a shipped plugin; choose a different slug.`,
+    );
+  }
+  if (isDefaultTarget && RESERVED_WORKSPACE_NAMES.has(name)) {
+    throw new Error(
+      `<name> "${name}" collides with a reserved workspace name ` +
+        `(${[...RESERVED_WORKSPACE_NAMES].join(', ')}).`,
+    );
+  }
+
+  const targetPkgDir = join(targetDir, name);
+  if (await pathExists(targetPkgDir)) {
+    throw new Error(`Target directory already exists: ${targetPkgDir}`);
+  }
+
+  const tokens = {
+    name,
+    Name: toPascalCase(name),
+    BRAND: toPascalCase(name),
+  };
+
+  const templateFiles = await listTemplateFiles(templatesDir);
+  if (templateFiles.length === 0) {
+    throw new Error(`No template files found under ${templatesDir}`);
+  }
+
+  const written = [];
+  for (const templatePath of templateFiles) {
+    const relPath = templatePath.slice(templatesDir.length + 1);
+    const targetRelPath = applyTokens(relPath, tokens);
+    const targetAbsPath = join(targetPkgDir, targetRelPath);
+    await mkdir(dirname(targetAbsPath), { recursive: true });
+
+    if (basename(templatePath) === '.gitkeep') {
+      // Preserve empty-dir markers verbatim.
+      await writeFile(targetAbsPath, '');
+    } else {
+      const raw = await readFile(templatePath, 'utf8');
+      await writeFile(targetAbsPath, applyTokens(raw, tokens));
+    }
+    written.push(targetRelPath);
+  }
+
+  return { targetPkgDir, written };
+}
+
+async function main() {
+  let parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`Error: ${err.message}\n\n`);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (parsed.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const targetDir = parsed.targetDir
+    ? resolve(parsed.targetDir)
+    : DEFAULT_TARGET_DIR;
+
+  // When using the default target, sanity-check the repo root.
+  if (!parsed.targetDir) {
+    const workspaceMarker = join(REPO_ROOT, 'pnpm-workspace.yaml');
+    if (!(await pathExists(workspaceMarker))) {
+      process.stderr.write(
+        `Error: pnpm-workspace.yaml not found at ${workspaceMarker}.\n` +
+          `Run from the OpenLinker repo root, or pass --target-dir.\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  try {
+    const { targetPkgDir, written } = await scaffoldAdapter({
+      name: parsed.name,
+      targetDir,
+    });
+    process.stdout.write(
+      [
+        `✓ Scaffolded ${targetPkgDir} (${written.length} files)`,
+        '',
+        'Next:',
+        '  1. Run `pnpm install` from the repo root',
+        '  2. Read docs/plugin-author-guide.md',
+        '  3. Pick a capability port and implement your first adapter',
+        '  4. Add the new module to `apps/api/src/plugins.ts`',
+        '',
+      ].join('\n'),
+    );
+  } catch (err) {
+    process.stderr.write(`Error: ${err.message}\n`);
+    process.exit(1);
+  }
+}
+
+// Only run main() when invoked as a script (not when imported by a test).
+// `pathToFileURL` handles spaces / escaping / Windows paths that the naive
+// `\`file://${process.argv[1]}\`` template breaks on.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}


### PR DESCRIPTION
Closes #567
Closes #564

Follow-up tracking: #684 (lint-time smoke invariant for scaffolded output).

## Summary

Two pieces closing out Modularity Thread B (#548), companion to the plugin author guide that landed in #681:

- **#567** — `.github/ISSUE_TEMPLATE/new_integration.md` funnels "I want OpenLinker to support platform X" proposals into a structured shape (platform, adapter key, vendor docs, target capabilities, auth model, rate limits, webhook support, identifier model, inbound-order semantics, maturity target).
- **#564** — `pnpm create-adapter <name>` scaffolds a compilable, lint-clean plugin skeleton at `libs/integrations/<name>/`. Stage 1 per the issue (Stage 2 — published npm package / Nest schematic — is gated on #552).

## Scaffolder shape

Per the plan's **Option B** (curated skeleton, not a literal PrestaShop clone), the output is **~14 files** covering the contract surface:

- Workspace config: `package.json`, `tsconfig.json`, `tsconfig.spec.json`, `jest.config.mjs`, `README.md`
- Code: `src/index.ts` barrel, `src/<name>-plugin.ts` (manifest + `createXPlugin`), `src/<name>-integration.module.ts` (`createNestAdapterModule` helper form), `src/application/<name>-adapter.factory.ts` + interface, `src/domain/types/<name>-{config,credentials}.types.ts`
- Empty-dir markers: `.gitkeep` in `domain/exceptions/` and `infrastructure/adapters/`

Output **compiles and lints clean** out of the box. `createAdapters` and `createCapabilityAdapter` return `Promise.reject(...)` with guide-link error messages until the contributor wires their first capability.

Templates live as **external files** under `scripts/create-adapter-templates/`, mirroring the target tree 1:1. Three substitution tokens:

| Token | Example for `--name shopify` |
|---|---|
| `__name__` | `shopify` (slug, paths, manifest fields) |
| `__Name__` | `Shopify` (class names) |
| `__BRAND__` | `Shopify` (user-facing label for exception prefixes) |

## Scaffolder CLI

```bash
pnpm create-adapter shopify                              # default → libs/integrations/
pnpm create-adapter example --target-dir /tmp/smoke      # verification runs
node scripts/create-adapter.mjs woo-commerce             # direct invocation
```

Validation: lowercase ASCII, 2–32 chars, leading letter, internal hyphens only (regex `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/`). Reserved-name and shipped-plugin checks fire only when scaffolding into the default repo target.

## Wire-ups

- Root `package.json` — new `create-adapter` script entry.
- `CONTRIBUTING.md` § *Building a New Integration* — tip line pointing at the scaffolder as the fast path.
- `docs/plugin-author-guide.md` § Step 3 — callout above the *"copy this tree"* paragraph; the manual recipe stays as the canonical reference.
- `.prettierignore` — excludes `scripts/create-adapter-templates/` so the `__name__` tokens don't break `pnpm format`.

## Self-review fixes (after tech-review)

- Moved `__Name__Adapters` result-shape type from the factory implementation into the factory interface file — matches the PrestaShop reference adapter's layout.
- Switched the main-module check to `pathToFileURL(process.argv[1]).href === import.meta.url` (handles spaces / Windows / symlinks).
- Scoped `RESERVED_WORKSPACE_NAMES` validation to the default-target case (parity with `SHIPPED_PLUGIN_NAMES`).
- Added `class-validator` to the template `package.json` (matches PS / Allegro, ready for the contributor's first shape-validator DTO).
- Promoted the commented-out factory-import line to a JSDoc breadcrumb.

## Test plan

- [x] `pnpm lint` — passes (templates excluded from format check; invariant scripts all green).
- [x] `pnpm type-check` — passes.
- [x] `pnpm test` — 1826 unit tests pass across 8 packages.
- [x] Manual smoke: `node scripts/create-adapter.mjs example` → `pnpm install --filter @openlinker/integrations-example && pnpm --filter @openlinker/integrations-example build && pnpm --filter @openlinker/integrations-example lint` — all green; smoke artifact deleted before commit.
- [ ] Reviewer: skim the scaffolded output by running `node scripts/create-adapter.mjs shopify --target-dir /tmp/scaffold-smoke` and inspecting the 14-file tree.
- [ ] Reviewer: open the new issue template at `.github/ISSUE_TEMPLATE/new_integration.md` via the GitHub "New issue" flow to verify the rendered form.

## Out of scope (deferred)

- Stage 2 from #564 — published `@openlinker/create-integration` npm package or Nest schematic. Gated on Modularity Thread F (#552).
- Capability-adapter stubs — skeleton stops at the factory surface; capability authoring follows the guide.
- Lint-time smoke invariant verifying scaffolded output still compiles — tracked in #684.
