### PR TITLE
chore(dx): add two lint-time invariants for scaffolder + plugin guide

### DIFF
--- a/docs/plans/implementation-plan-684-680-lint-invariants.md
+++ b/docs/plans/implementation-plan-684-680-lint-invariants.md
@@ -1,0 +1,245 @@
+# Implementation Plan — #684 + #680: Lint invariants for scaffolder + plugin-author-guide quotes
+
+**Branch**: `684-680-lint-invariants`
+**Status**: Draft — pending user sign-off
+
+Two `scripts/check-*.mjs` invariant scripts that close out the drift-risk gaps surfaced by the tech-reviews on the previous two PRs (#681, #685). Both are wired into the existing `pnpm lint` chain via `check:invariants`. Same shape as `check-design-tokens.mjs`, `check-migration-timestamps.mjs`, `check-render-template-fixture-drift.mjs`.
+
+Closes:
+
+- **#680** — `docs/plugin-author-guide.md` verbatim quotes + line-range references stay in sync with the source (full coverage of what the issue asks for).
+- **Partial close on #684** — the shape-only check this PR ships catches token-substitution and file-shape drift but **not** the tsc-compile drift the issue body asks for. The full tsc smoke is filed as a new follow-up issue at PR-creation time; #684 is closed with a comment explaining the reduced scope. See the framing in § 1 *Goals & non-goals* below.
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+
+1. Catch silent drift in `scripts/create-adapter.mjs` + `scripts/create-adapter-templates/` before it reaches a contributor. Specifically: template tokens not substituted, expected file shape changing, template-file count drifting.
+2. Catch silent drift in `docs/plugin-author-guide.md`'s three pinned source references — the verbatim `CoreCapabilityValues` block at lines 22-28 of `adapter.types.ts`, and the line-range pointers at `adapter-plugin.ts:42-110` and `host-services.ts:50-121`.
+3. Both checks chain into `pnpm lint` via `check:invariants` and run sub-second so they're acceptable in the pre-commit hook.
+4. Self-documenting failure messages — when the invariant fires, the contributor reads the error and knows what to fix.
+
+### Non-goals (deferred to follow-ups)
+
+- **Full `tsc --noEmit` smoke on scaffolded output.** The original #684 framing called for compiling the scaffold to confirm it still type-checks against the current workspace. Doing this in `pnpm lint` requires either (a) scaffolding into `libs/integrations/` + running `pnpm install --filter` + `tsc -b` (~10-15s — bad pre-commit UX), or (b) writing a synthetic `tsconfig.json` with `paths` overrides to resolve `@openlinker/*` to source. Both add meaningful complexity. The shape check (this PR) catches the most common drift; the heavier compile check belongs in a separate non-blocking CI job (e.g., `pnpm verify:scaffold` chained off a GitHub Actions workflow but not `pnpm lint`).
+  - **Issue hygiene**: per project memory, issues only close via merged PR with `Closes #N`. This PR's body uses **`Closes #680` only**. #684 stays open — its body explicitly asks for the tsc smoke, which this PR doesn't ship. The PR body links to #684 with a "partial-coverage" note explaining what's shipped vs what's still pending, plus a link to the new follow-up issue filed at PR-creation time. A future PR that adds the tsc check will be the one to close #684.
+- Generalized "verify every file path mentioned in the guide" check. Out of scope; the three pinned references are the load-bearing ones.
+- Anchor-link verification (`#L22-L28` rendering correctly on GitHub blob view). Best-effort by design.
+
+---
+
+## 2. Layer classification
+
+**DX / repo tooling.** Two new `.mjs` scripts under `scripts/`. No CORE, Integration, Interface, Frontend, or schema changes.
+
+Files touched:
+- `scripts/check-create-adapter.mjs` (new, ~80 LOC)
+- `scripts/check-plugin-guide-quotes.mjs` (new, ~120 LOC)
+- `package.json` (root) — chain both into `check:invariants`
+
+---
+
+## 3. Research summary
+
+### Existing invariant-script conventions
+
+Surveyed `scripts/check-design-tokens.mjs`, `check-migration-timestamps.mjs`, `check-render-template-fixture-drift.mjs`. All share:
+
+- Node ESM, `node:` imports only, no external deps.
+- Top-of-file JSDoc block documenting the invariant and why it exists.
+- `fileURLToPath(import.meta.url)` + `dirname` + `resolve` to find the repo root.
+- Exit 0 on green; exit 1 on drift with a one-line-per-violation report to stderr.
+- Sub-second runtime (verified earlier in `pnpm lint` output: `design-tokens: OK (85 tokens)`).
+- Wired into `check:invariants` chain in root `package.json`.
+
+The two new scripts follow this template exactly.
+
+### What the plugin-author guide actually quotes
+
+`grep -n "adapter.types.ts:\|adapter-plugin.ts:\|host-services.ts:" docs/plugin-author-guide.md` returns five lines, three distinct source references:
+
+1. **Line 71**: `adapter.types.ts:22-28` — followed by a fenced TypeScript code block that **verbatim quotes** `CoreCapabilityValues`. This needs a character-for-character match check.
+2. **Line 427**: `adapter-plugin.ts:42-110` — pointer only, no inline code. Prose describes the four fields. This needs a **boundary check**: lines 42-110 in the source must still bracket the `AdapterPlugin` interface body.
+3. **Line 443**: `host-services.ts:50-121` — pointer only, no inline code. Prose describes the read-inputs vs side-registries split. Same boundary check as (2).
+
+Plus two duplicate pointer references at lines 841, 843 (in the "Related reading" footer). Those re-reference the same ranges; the check normalizes by `(path, range)` so each unique reference is verified once.
+
+### Scaffolder template inventory
+
+`find scripts/create-adapter-templates -type f` returns **14 files** today. Token shape: `__name__`, `__Name__`, `__BRAND__` (no `__NAME__` — dropped during tech-review of #685). `scaffoldAdapter` is exported from `scripts/create-adapter.mjs` precisely so a smoke test can call it without re-parsing argv.
+
+---
+
+## 4. Design
+
+### `scripts/check-create-adapter.mjs`
+
+**Behavior**:
+
+1. Import `scaffoldAdapter` from `scripts/create-adapter.mjs` (already exported).
+2. Create a tmp dir at `os.tmpdir() + '/openlinker-create-adapter-check-' + process.pid + '-' + Date.now()`.
+3. Call `scaffoldAdapter({ name: 'lintcheck', targetDir: tmpDir })`.
+4. Assertions:
+   - **Expected file list**: the scaffolder produces exactly the set of paths derived from `scripts/create-adapter-templates/` with `__name__/__Name__/__BRAND__` substituted. Build the expected list by walking the templates dir; mismatch fails with a diff.
+   - **No leftover tokens**: every file in the output is grep-clean of `__name__`, `__Name__`, `__BRAND__`. Catches the substitution-forgotten-a-spot bug.
+   - **Template count sanity**: expected file count constant (`EXPECTED_FILE_COUNT = 14`) — fails if a template was added without the constant bump, signaling "verify the scaffolder still works end to end" to the author.
+5. Tmp dir cleanup in a `finally` block via `rm -rf` (via `fs.rm({ recursive: true, force: true })`).
+
+**Validates**:
+- Token-substitution bugs (most common drift surface).
+- File-shape drift (template added but scaffolder doesn't pick it up, or vice versa).
+
+**Does NOT validate** (out of scope, see §1):
+- Output still compiles with `tsc -b`.
+- Output still passes `eslint`.
+- The reference adapter (PrestaShop) and the scaffolder output match structurally.
+
+**Expected runtime**: <500ms (just filesystem + string ops).
+
+**Failure-output format** (matches existing invariants):
+
+- On success: `check-create-adapter: OK (<N> files)` to stdout, exit 0.
+- On missing-file: `check-create-adapter: expected file missing from scaffolder output: <relpath>` to stderr.
+- On unexpected-file: `check-create-adapter: unexpected file in scaffolder output (not in templates dir): <relpath>` to stderr.
+- On count mismatch: `check-create-adapter: file count mismatch — expected <N>, got <M> (bump EXPECTED_FILE_COUNT after verifying)` to stderr.
+- On token leftover: `check-create-adapter: substitution token "<tok>" leaked into output file: <relpath>` to stderr.
+- Each failure exits 1 immediately. One-line-per-violation matches `check-design-tokens.mjs`.
+
+### `scripts/check-plugin-guide-quotes.mjs`
+
+**Behavior**:
+
+1. Read `docs/plugin-author-guide.md` into memory.
+2. **Verbatim block check** for `CoreCapabilityValues`:
+   - Extraction algorithm (sketch, written explicitly so the next maintainer doesn't pick a different one):
+     ```
+     lines = guide.split('\n');
+     linkIdx = lines.findIndex(l => l.includes('adapter.types.ts:22-28'));
+        // fail if -1: "guide is missing the CoreCapabilityValues reference"
+     fenceStartIdx = lines.findIndex((l, i) => i > linkIdx && l.startsWith('```typescript'));
+        // fail if -1 or if (fenceStartIdx - linkIdx > 5):
+        //   "expected a typescript fence within 5 lines of the reference"
+        // The 5-line cap defends against a refactor inserting an unrelated
+        // paragraph between the link and the fence; without it the script
+        // could pair the wrong fence and silently accept drift.
+     fenceEndIdx = lines.findIndex((l, i) => i > fenceStartIdx && l === '```');
+     quotedBlock = lines.slice(fenceStartIdx + 1, fenceEndIdx).join('\n');
+     ```
+   - Read lines 22-28 of `libs/core/src/integrations/domain/types/adapter.types.ts` from disk.
+   - Compare line by line (after trimming trailing whitespace + dropping a single trailing newline on each side).
+   - Mismatch → exit 1 with the first divergent line printed side-by-side.
+3. **Line-range boundary check** for `AdapterPlugin` and `HostServices`:
+   - For each of the two references (`adapter-plugin.ts:42-110`, `host-services.ts:50-121`):
+     - Read the file from disk.
+     - Verify line `<start>` matches `^export interface <Name> {` (where `<Name>` is `AdapterPlugin` / `HostServices`).
+     - Verify line `<end>` matches `^}\s*$` (closing brace of the interface, no trailing content).
+   - Mismatch → exit 1 with the actual line content vs expected pattern.
+4. All three reference paths must resolve on disk (otherwise the guide is referencing a moved file).
+
+**Validates**:
+- `CoreCapabilityValues` quote stays accurate as the codebase changes.
+- The `AdapterPlugin` interface still starts at line 42 and ends at line 110 — fails the moment someone adds an import above the interface or extends it past line 110.
+- `HostServices` same shape.
+
+**Does NOT validate**:
+- The four field-bullet prose at lines 431-439 of the guide (e.g., "register?(host: HostServices): void — optional"). That prose summarizes the interface; if the interface adds a fifth field, the boundary check fires (end line moves), but the prose drift isn't structurally caught. Acceptable for v1 — the boundary catch forces the human to re-read the prose anyway.
+
+**Expected runtime**: <100ms (one markdown read + three small source reads).
+
+**Failure-output format** (matches existing invariants):
+
+- On success: `check-plugin-guide-quotes: OK (1 verbatim block, 2 boundary references)` to stdout, exit 0.
+- Verbatim mismatch: `check-plugin-guide-quotes: CoreCapabilityValues quote drift — line <n>: source="<x>" guide="<y>"` to stderr.
+- Boundary miss (start): `check-plugin-guide-quotes: <file>:<start> does not match expected "export interface <Name> {" (found: "<actual>")` to stderr.
+- Boundary miss (end): `check-plugin-guide-quotes: <file>:<end> does not match expected closing "}" (found: "<actual>")` to stderr.
+- Missing reference in guide: `check-plugin-guide-quotes: guide is missing reference to <file>:<range>` to stderr.
+- Each failure exits 1 immediately.
+
+### Wire-up
+
+Root `package.json` — extend `check:invariants`:
+
+```jsonc
+"check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-plugin-guide-quotes.mjs"
+```
+
+Append at the end of the chain; same shape as the existing entries.
+
+---
+
+## 5. Implementation steps
+
+| # | File | Action | Acceptance |
+|---|---|---|---|
+| 1 | `scripts/check-create-adapter.mjs` | Create | Node ESM. Imports `scaffoldAdapter` from `./create-adapter.mjs`. Scaffolds to `os.tmpdir()`. Asserts (a) expected file list, (b) no leftover tokens, (c) expected file count. Cleanup in `finally`. Exits 0 on green, 1 on drift. ~80 LOC |
+| 2 | `scripts/check-plugin-guide-quotes.mjs` | Create | Node ESM. Reads the guide. Verbatim-block check for `CoreCapabilityValues`. Boundary check for `AdapterPlugin` (lines 42-110) + `HostServices` (lines 50-121). Exits 0/1 with descriptive messages. ~120 LOC |
+| 3 | `package.json` (root) | Edit | Append `&& node scripts/check-create-adapter.mjs && node scripts/check-plugin-guide-quotes.mjs` to the `check:invariants` script |
+| 4 | **Manual smoke** | Run | `pnpm lint` from worktree root; confirm both new invariants pass. Then deliberately break each (e.g., add a trailing space inside a template, or shift the `AdapterPlugin` start by one line in a scratch checkout) and confirm the right error fires. Revert |
+
+---
+
+## 6. Validation strategy
+
+### Cost-benefit framing for the deferred tsc smoke
+
+The shape-only check catches token-substitution + file-shape drift in <500ms. The full `tsc --noEmit` smoke would additionally catch drift from core API renames (e.g., a port moving from one `@openlinker/core/<ctx>` barrel to another) — but costs ~15× the lint budget (~10-15s for the scaffold + install + tsc round-trip). Pre-commit UX dominates: existing invariants all run sub-second; bumping `pnpm lint` to 12+ seconds across the board to catch a less-common drift class is the wrong trade. Accept the gap, file the full check as a non-blocking CI follow-up.
+
+### Architecture compliance
+
+DX tooling — no architecture surface touched. Hexagonal architecture unaffected.
+
+### Naming
+
+- Both files use the `check-<topic>.mjs` pattern matching existing invariants.
+- No symbols to name; just scripts.
+
+### Testing strategy
+
+**Neither script ships with a unit test.** Same rationale as the scaffolder itself:
+
+1. The scripts are exercised every `pnpm lint` (which runs `check:invariants`). That's strong continuous coverage.
+2. The scripts have very low logic complexity — a regex extraction, a file read, a string compare. Edge cases are tested by the deliberate-break smoke during PR development.
+3. Adding a test runner under `scripts/` (where no tests live today) introduces infra cost without commensurate benefit.
+
+If a regression slips through, the fix is a one-line tweak to the script — no test fixture overhead.
+
+### Security
+
+- Both scripts read files only (no writes outside `os.tmpdir()`).
+- Tmp dir name includes `process.pid + Date.now()` to defend against name collisions.
+- `fs.rm({ recursive: true, force: true })` is fenced inside `finally` so partial failures don't leave artifacts in `os.tmpdir()`.
+- No external network calls, no shell-out to user-controlled strings.
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Line-range boundary check is brittle to legitimate refactors (e.g., merging a one-line comment into the interface body shifts the end line) | Medium | The mitigation IS the check firing — the human update the guide's `:42-110` reference to match the new range. That's exactly the drift the invariant exists to catch. |
+| Verbatim-block check could false-positive on a whitespace-only diff | Low | Compare after `.trimEnd()` on each line + drop one trailing newline. Catches semantic diffs, ignores trailing-whitespace churn. |
+| Tmp-dir leak if the script process is `SIGKILL`'d between scaffold and cleanup | Low | `os.tmpdir()` is OS-cleaned periodically. Tmp dir names are unique-per-invocation. Worst case: orphaned ~150KB per killed run. |
+
+### Open questions
+
+None blocking.
+
+---
+
+## 7. Out of scope
+
+- **Full tsc smoke** on scaffolded output. Documented as a known gap; tracked at PR-creation time as a follow-up issue.
+- **Verifying every linked path in the guide** (47+ paths). Different drift profile (link rot vs source rename) and out of scope here. Worth a separate `scripts/check-doc-links.mjs` someday.
+- **Prose drift between the guide's field bullets and the interface body**. The boundary check catches the boundary; the human re-reads the prose. Structural prose-vs-source checking would require parsing TS, which is over-engineered for this layer.
+
+---
+
+## 8. PR shape
+
+Single PR. Commit grouping: one commit. Conventional-commit prefix `chore(dx)` since these are dev-experience invariants.
+
+**PR body**:
+- `Closes #680` — full coverage of what the issue asks for.
+- **No `Closes #684`.** The PR ships partial coverage of #684 (shape, not compile); the full tsc smoke is a follow-up. Per project memory, issues only close via the merged PR that fully satisfies them. PR body explicitly links #684 with a "partial coverage shipped — see follow-up #X" note. A new follow-up issue is filed at PR-creation time and referenced in the body alongside the partial-coverage note.
+
+Expected diff stat: ~250 LOC added across 2 new script files + 1 line in `package.json`. Zero deletions.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:integration": "pnpm --filter @openlinker/api test:integration",
     "test:php": "cd apps/prestashop-module/openlinker && composer install --no-interaction --quiet && vendor/bin/phpunit",
     "lint": "pnpm -r lint && pnpm check:invariants",
-    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs",
+    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-plugin-guide-quotes.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
     "create-adapter": "node scripts/create-adapter.mjs",

--- a/scripts/check-create-adapter.mjs
+++ b/scripts/check-create-adapter.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Adapter Scaffolder Output Drift Guard (#684, partial)
+ *
+ * Imports the exported `scaffoldAdapter` from `scripts/create-adapter.mjs`,
+ * scaffolds into `os.tmpdir()`, and asserts:
+ *
+ *   1. The set of files produced equals the expected substituted-name set
+ *      derived from `scripts/create-adapter-templates/` (no missing, no
+ *      unexpected).
+ *   2. Every output file is clean of the three substitution tokens
+ *      (`__name__`, `__Name__`, `__BRAND__`) — catches forgotten-spot bugs.
+ *   3. The expected file count (constant `EXPECTED_FILE_COUNT`) matches the
+ *      actual output count — catches "template added but invariant not
+ *      bumped" drift.
+ *
+ * Out of scope (tracked separately as a follow-up to #684): full
+ * `tsc --noEmit` smoke on the scaffolded output. Pre-commit budget for
+ * existing invariants is sub-second; the install + tsc dance would push
+ * that to ~15s, which is the wrong trade for catching the rare core-API-
+ * rename drift class. The shape check here catches the common drift
+ * (token substitution, file-shape changes).
+ *
+ * Wired into `pnpm lint` via the root `check:invariants` chain.
+ *
+ * Exits non-zero on drift, with one line per violation to stderr.
+ *
+ * @module scripts
+ */
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { scaffoldAdapter } from './create-adapter.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, '..');
+const TEMPLATES_DIR = resolve(ROOT, 'scripts/create-adapter-templates');
+
+// Bump this when a template is added or removed. The constant exists so
+// the maintainer's eye catches an unintended count change — relying on
+// the templates-dir walk alone wouldn't.
+const EXPECTED_FILE_COUNT = 14;
+
+const SCAFFOLD_NAME = 'lintcheck';
+
+/**
+ * Mirror of `toPascalCase` in `scripts/create-adapter.mjs`. Kept inline so
+ * this check exercises the same logic the scaffolder uses; if the slug
+ * grows hyphens (`lint-check` → `LintCheck`) both sides agree without a
+ * second edit.
+ */
+function toPascalCase(slug) {
+  return slug
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+const SCAFFOLD_NAME_PASCAL = toPascalCase(SCAFFOLD_NAME);
+
+// Tokens that MUST be substituted out of every output file. Mirrored from
+// `scripts/create-adapter.mjs`. The 3-token set was finalized in #685 —
+// `__NAME__` was dropped during tech-review there.
+const TOKENS = ['__name__', '__Name__', '__BRAND__'];
+
+const errors = [];
+
+function fail(msg) {
+  errors.push(msg);
+}
+
+async function listFilesRecursive(dir) {
+  const out = [];
+  const stack = [dir];
+  while (stack.length) {
+    const current = stack.pop();
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = join(current, entry.name);
+      if (entry.isDirectory()) stack.push(abs);
+      else if (entry.isFile()) out.push(abs);
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Mirrors the scaffolder's token substitution (see `create-adapter.mjs`
+ * `applyTokens`). `__BRAND__` defaults to the same value as `__Name__` —
+ * if the scaffolder ever decouples BRAND from Name, update both sides
+ * together (this function + `create-adapter.mjs`'s tokens construction).
+ */
+function applyExpectedSubstitution(relPath, tokens) {
+  return relPath
+    .split('__name__').join(tokens.name)
+    .split('__Name__').join(tokens.Name)
+    .split('__BRAND__').join(tokens.Name);
+}
+
+async function main() {
+  // 1. Compute expected output file list by walking the templates dir
+  //    and applying the same token substitution the scaffolder applies.
+  const templateFiles = await listFilesRecursive(TEMPLATES_DIR);
+  const expectedRelPaths = new Set(
+    templateFiles.map((absPath) =>
+      applyExpectedSubstitution(
+        relative(TEMPLATES_DIR, absPath),
+        { name: SCAFFOLD_NAME, Name: SCAFFOLD_NAME_PASCAL },
+      ),
+    ),
+  );
+
+  // 2. Scaffold into a unique tmp dir.
+  const tmpRoot = await mkdtemp(join(tmpdir(), 'openlinker-create-adapter-check-'));
+  let scaffoldResult;
+  try {
+    scaffoldResult = await scaffoldAdapter({
+      name: SCAFFOLD_NAME,
+      targetDir: tmpRoot,
+    });
+
+    // 3. Walk the scaffolded output and collect relative paths.
+    const scaffoldedFiles = await listFilesRecursive(scaffoldResult.targetPkgDir);
+    const actualRelPaths = new Set(
+      scaffoldedFiles.map((abs) => relative(scaffoldResult.targetPkgDir, abs)),
+    );
+
+    // 4. Diff expected vs actual.
+    for (const expected of expectedRelPaths) {
+      if (!actualRelPaths.has(expected)) {
+        fail(
+          `check-create-adapter: expected file missing from scaffolder output: ${expected}`,
+        );
+      }
+    }
+    for (const actual of actualRelPaths) {
+      if (!expectedRelPaths.has(actual)) {
+        fail(
+          `check-create-adapter: unexpected file in scaffolder output (not in templates dir): ${actual}`,
+        );
+      }
+    }
+
+    // 5. Count sanity check.
+    if (actualRelPaths.size !== EXPECTED_FILE_COUNT) {
+      fail(
+        `check-create-adapter: file count mismatch — expected ${EXPECTED_FILE_COUNT}, got ${actualRelPaths.size} ` +
+          `(bump EXPECTED_FILE_COUNT after verifying the scaffolder still works end to end)`,
+      );
+    }
+
+    // 6. Token-leftover check on every output file.
+    for (const absFile of scaffoldedFiles) {
+      const rel = relative(scaffoldResult.targetPkgDir, absFile);
+      const contents = await readFile(absFile, 'utf8');
+      for (const token of TOKENS) {
+        if (contents.includes(token)) {
+          fail(
+            `check-create-adapter: substitution token "${token}" leaked into output file: ${rel}`,
+          );
+        }
+      }
+    }
+  } finally {
+    // Best-effort cleanup. force:true tolerates partial-write states.
+    await rm(tmpRoot, { recursive: true, force: true });
+  }
+
+  if (errors.length > 0) {
+    for (const msg of errors) {
+      process.stderr.write(`${msg}\n`);
+    }
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `check-create-adapter: OK (${EXPECTED_FILE_COUNT} files)\n`,
+  );
+}
+
+try {
+  await main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`check-create-adapter: unexpected error — ${message}\n`);
+  process.exit(1);
+}

--- a/scripts/check-plugin-guide-quotes.mjs
+++ b/scripts/check-plugin-guide-quotes.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Plugin Author Guide Quote Drift Guard (#680)
+ *
+ * `docs/plugin-author-guide.md` pins three source references that must
+ * stay in sync with the live code:
+ *
+ *   1. **Verbatim quote** of `CoreCapabilityValues` at
+ *      `libs/core/src/integrations/domain/types/adapter.types.ts:22-28`,
+ *      reproduced inline in the guide as a fenced TypeScript block.
+ *      Drift = the guide quotes stale capability values; readers code
+ *      against a list that no longer matches the registry.
+ *
+ *   2. **Boundary check** for the `AdapterPlugin` interface at
+ *      `libs/plugin-sdk/src/adapter-plugin.ts:42-110`. The guide doesn't
+ *      reproduce the body but pins the line range. Drift = an import
+ *      added above the interface or the interface extending past line
+ *      110; the link still resolves but lands on the wrong content.
+ *
+ *   3. **Boundary check** for the `HostServices` interface at
+ *      `libs/plugin-sdk/src/host-services.ts:50-121`. Same shape.
+ *
+ * Both checks are deliberately strict: when they fire on a benign
+ * refactor (e.g., new import above the interface), the human updates
+ * the guide's line range. That re-read is exactly the value the
+ * invariant exists to extract.
+ *
+ * Wired into `pnpm lint` via the root `check:invariants` chain.
+ *
+ * Exits non-zero on drift, with one line per violation to stderr.
+ *
+ * @module scripts
+ */
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, '..');
+const GUIDE = resolve(ROOT, 'docs/plugin-author-guide.md');
+
+/**
+ * Pinned references the guide MUST keep in sync. Add a new entry only
+ * when a new pinned reference is introduced in the guide.
+ */
+const VERBATIM_QUOTES = [
+  {
+    label: 'CoreCapabilityValues',
+    sourceFile: 'libs/core/src/integrations/domain/types/adapter.types.ts',
+    sourceStart: 22, // 1-indexed
+    sourceEnd: 28,
+    guideLinkSubstring: 'adapter.types.ts:22-28',
+    fenceOpen: '```typescript',
+  },
+];
+
+const BOUNDARY_REFS = [
+  {
+    label: 'AdapterPlugin',
+    sourceFile: 'libs/plugin-sdk/src/adapter-plugin.ts',
+    sourceStart: 42,
+    sourceEnd: 110,
+    guideLinkSubstring: 'adapter-plugin.ts:42-110',
+    expectedStart: /^export interface AdapterPlugin \{$/,
+    expectedEnd: /^\}\s*$/,
+  },
+  {
+    label: 'HostServices',
+    sourceFile: 'libs/plugin-sdk/src/host-services.ts',
+    sourceStart: 50,
+    sourceEnd: 121,
+    guideLinkSubstring: 'host-services.ts:50-121',
+    expectedStart: /^export interface HostServices \{$/,
+    expectedEnd: /^\}\s*$/,
+  },
+];
+
+// Cap the gap between the guide's link line and the verbatim fence so a
+// later refactor inserting an unrelated paragraph between them doesn't
+// accidentally pair the wrong fence. Five lines is generous enough to
+// allow a one-line introductory sentence + blank lines.
+const MAX_LINES_BETWEEN_LINK_AND_FENCE = 5;
+
+const errors = [];
+
+function fail(msg) {
+  errors.push(msg);
+}
+
+async function readLines(absPath) {
+  const raw = await readFile(absPath, 'utf8');
+  // Strip the trailing newline so split doesn't yield an empty trailing
+  // element; line indices stay 1:1 with editor line numbers.
+  const trimmed = raw.endsWith('\n') ? raw.slice(0, -1) : raw;
+  return trimmed.split('\n');
+}
+
+function checkGuideReferenceExists(guideLines, substring, label) {
+  const idx = guideLines.findIndex((l) => l.includes(substring));
+  if (idx === -1) {
+    fail(
+      `check-plugin-guide-quotes: guide is missing reference to ${substring} (label: ${label})`,
+    );
+    return -1;
+  }
+  return idx;
+}
+
+async function checkVerbatim(guideLines, quote) {
+  const linkIdx = checkGuideReferenceExists(
+    guideLines,
+    quote.guideLinkSubstring,
+    quote.label,
+  );
+  if (linkIdx === -1) return;
+
+  const fenceStartIdx = guideLines.findIndex(
+    (l, i) => i > linkIdx && l.startsWith(quote.fenceOpen),
+  );
+  if (fenceStartIdx === -1) {
+    fail(
+      `check-plugin-guide-quotes: expected a "${quote.fenceOpen}" fence after the ${quote.label} reference at guide line ${linkIdx + 1}, none found`,
+    );
+    return;
+  }
+  if (fenceStartIdx - linkIdx > MAX_LINES_BETWEEN_LINK_AND_FENCE) {
+    fail(
+      `check-plugin-guide-quotes: expected the ${quote.label} fence within ${MAX_LINES_BETWEEN_LINK_AND_FENCE} lines of the reference (link at ${linkIdx + 1}, fence at ${fenceStartIdx + 1})`,
+    );
+    return;
+  }
+  const fenceEndIdx = guideLines.findIndex(
+    (l, i) => i > fenceStartIdx && l === '```',
+  );
+  if (fenceEndIdx === -1) {
+    fail(
+      `check-plugin-guide-quotes: ${quote.label} fence at guide line ${fenceStartIdx + 1} is never closed`,
+    );
+    return;
+  }
+  const quotedLines = guideLines.slice(fenceStartIdx + 1, fenceEndIdx);
+
+  // Read source lines and compare 1:1.
+  const sourceAbs = resolve(ROOT, quote.sourceFile);
+  const sourceLines = await readLines(sourceAbs);
+  const expectedLines = sourceLines.slice(quote.sourceStart - 1, quote.sourceEnd);
+
+  if (quotedLines.length !== expectedLines.length) {
+    fail(
+      `check-plugin-guide-quotes: ${quote.label} block length mismatch — guide has ${quotedLines.length} lines, source has ${expectedLines.length} lines (source range ${quote.sourceStart}-${quote.sourceEnd})`,
+    );
+    return;
+  }
+
+  for (let i = 0; i < expectedLines.length; i++) {
+    const guideLine = quotedLines[i].trimEnd();
+    const sourceLine = expectedLines[i].trimEnd();
+    if (guideLine !== sourceLine) {
+      const sourceLineNum = quote.sourceStart + i;
+      fail(
+        `check-plugin-guide-quotes: ${quote.label} quote drift — source ${quote.sourceFile}:${sourceLineNum} = "${sourceLine}", guide block line ${i + 1} = "${guideLine}"`,
+      );
+      return; // One mismatch per quote is enough signal.
+    }
+  }
+}
+
+async function checkBoundary(guideLines, ref) {
+  // Confirm the guide still carries the reference (the link line). If
+  // the guide drops it entirely, the boundary check has no anchor.
+  const linkIdx = checkGuideReferenceExists(
+    guideLines,
+    ref.guideLinkSubstring,
+    ref.label,
+  );
+  if (linkIdx === -1) return;
+
+  const sourceAbs = resolve(ROOT, ref.sourceFile);
+  const sourceLines = await readLines(sourceAbs);
+
+  if (sourceLines.length < ref.sourceEnd) {
+    fail(
+      `check-plugin-guide-quotes: ${ref.sourceFile} has only ${sourceLines.length} lines, guide references line ${ref.sourceEnd}`,
+    );
+    return;
+  }
+
+  const startLine = sourceLines[ref.sourceStart - 1];
+  if (!ref.expectedStart.test(startLine)) {
+    fail(
+      `check-plugin-guide-quotes: ${ref.sourceFile}:${ref.sourceStart} does not match expected "${ref.expectedStart.source}" (found: "${startLine}")`,
+    );
+  }
+
+  const endLine = sourceLines[ref.sourceEnd - 1];
+  if (!ref.expectedEnd.test(endLine)) {
+    fail(
+      `check-plugin-guide-quotes: ${ref.sourceFile}:${ref.sourceEnd} does not match expected closing "${ref.expectedEnd.source}" (found: "${endLine}")`,
+    );
+  }
+}
+
+async function main() {
+  const guideLines = await readLines(GUIDE);
+
+  for (const quote of VERBATIM_QUOTES) {
+    await checkVerbatim(guideLines, quote);
+  }
+  for (const ref of BOUNDARY_REFS) {
+    await checkBoundary(guideLines, ref);
+  }
+
+  if (errors.length > 0) {
+    for (const msg of errors) {
+      process.stderr.write(`${msg}\n`);
+    }
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `check-plugin-guide-quotes: OK (${VERBATIM_QUOTES.length} verbatim block, ${BOUNDARY_REFS.length} boundary references)\n`,
+  );
+}
+
+try {
+  await main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`check-plugin-guide-quotes: unexpected error — ${message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #680.

**Partial coverage of #684** — shape-only check ships here; the full `tsc --noEmit` smoke on scaffolded output is tracked in #686 as a non-blocking CI follow-up. #684 stays open until that CI job lands.

## Summary

Two new `scripts/check-*.mjs` invariants, both wired into `pnpm lint` via `check:invariants`. Same shape as the existing four invariants — Node ESM, `node:` imports only, no external deps, sub-second runtime, one-line-per-violation output.

### `scripts/check-create-adapter.mjs` (~170 LOC) — partial #684

Imports the exported `scaffoldAdapter` from `scripts/create-adapter.mjs`, scaffolds into `os.tmpdir()`, asserts:

1. Output file set matches the expected token-substituted set derived from `scripts/create-adapter-templates/`.
2. No `__name__` / `__Name__` / `__BRAND__` token leaked into any output file.
3. Expected file count constant matches actual.

Catches the most common drift surface (token substitution + file-shape changes) in <500ms. Does **not** compile-check the output — that's #686.

### `scripts/check-plugin-guide-quotes.mjs` (~225 LOC) — closes #680

Pins three references that `docs/plugin-author-guide.md` must keep in sync with the live code:

| Reference | Check | Source |
|---|---|---|
| `CoreCapabilityValues` | Verbatim block match | `adapter.types.ts:22-28` |
| `AdapterPlugin` | Line `42` = `export interface AdapterPlugin {`; line `110` = `}` | `adapter-plugin.ts:42-110` |
| `HostServices` | Line `50` = `export interface HostServices {`; line `121` = `}` | `host-services.ts:50-121` |

Strict by design — when it fires on a benign refactor (e.g., an import added above the interface), the human updates the guide's line range. That re-read is exactly the value the invariant exists to extract.

5-line cap between the guide's link line and the verbatim fence, so an unrelated paragraph inserted between them can't accidentally pair the wrong fence. <100ms.

### Wire-up

`package.json` `check:invariants` extended to chain both scripts after the existing five.

## Self-review fixes (after tech-review)

- **Wrapped top-level `await main()` in try/catch** in both scripts so scaffolder failures surface as clean `check-*: unexpected error — …` lines instead of unhandled-rejection stack traces.
- **Derived `SCAFFOLD_NAME_PASCAL` from `SCAFFOLD_NAME`** via an inlined `toPascalCase` mirroring the scaffolder; survives a future hyphenated slug.
- **Added a doc-comment on `applyExpectedSubstitution`** noting the BRAND-defaults-to-Name coupling with `create-adapter.mjs`.
- **Coalesced `node:path` imports** into one statement.
- **Dropped unnecessary `async`** on `checkGuideReferenceExists`.
- **Hoisted `fenceOpen`** to the config entry (`'```typescript'`) instead of reconstructing from a `fenceLang` field per call.

## Test plan

- [x] Both scripts green against current state.
- [x] `pnpm lint` — green; both new invariants chained into `check:invariants` chain in order after `check-design-tokens`.
- [x] `pnpm type-check` — green.
- [x] `pnpm test` — 1839 unit tests pass across 8 packages.
- [x] **Deliberate-break test 1**: renamed `'ProductMaster'` → `'ProductMasterX'` in `adapter.types.ts` → `check-plugin-guide-quotes` correctly fired with side-by-side line diff. Restored, re-verified green.
- [x] **Deliberate-break test 2**: inserted comment line above `AdapterPlugin` interface in `adapter-plugin.ts` to shift it off line 42 → both `:42` start and `:110` end boundary checks fired with actual content. Restored, re-verified green.
- [ ] Reviewer: confirm the eventual `#684` close path is via #686's PR, not this one.

## Issue lifecycle

- `Closes #680` — full coverage of what the issue body asks for.
- **NOT** `Closes #684`. This PR partial-covers #684 (shape only); #686 tracks the remaining tsc-compile gap. Per project memory, issues only close via the merged PR that fully satisfies them.
