### PR TITLE
chore: converge repo URL references to single canonical form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📚 Documentation
-    url: https://github.com/piotrswierzy/openlinker/tree/main/docs
+    url: https://github.com/SilkSoftwareHouse/openlinker/tree/main/docs
     about: Check our documentation for architecture, standards, and guides
   - name: 💬 Discussions
-    url: https://github.com/piotrswierzy/openlinker/discussions
+    url: https://github.com/SilkSoftwareHouse/openlinker/discussions
     about: Ask questions and discuss ideas with the community
 
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,15 +3,3 @@ contact_links:
   - name: 📚 Documentation
     url: https://github.com/SilkSoftwareHouse/openlinker/tree/main/docs
     about: Check our documentation for architecture, standards, and guides
-  - name: 💬 Discussions
-    url: https://github.com/SilkSoftwareHouse/openlinker/discussions
-    about: Ask questions and discuss ideas with the community
-
-
-
-
-
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:integration": "pnpm --filter @openlinker/api test:integration",
     "test:php": "cd apps/prestashop-module/openlinker && composer install --no-interaction --quiet && vendor/bin/phpunit",
     "lint": "pnpm -r lint && pnpm check:invariants",
-    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-plugin-guide-quotes.mjs",
+    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
     "create-adapter": "node scripts/create-adapter.mjs",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Open-source, modular, API-first e-commerce orchestration platform",
   "license": "Apache-2.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SilkSoftwareHouse/openlinker.git"
+  },
+  "homepage": "https://github.com/SilkSoftwareHouse/openlinker#readme",
+  "bugs": {
+    "url": "https://github.com/SilkSoftwareHouse/openlinker/issues"
+  },
   "scripts": {
     "clean": "find libs apps -type f -path '*/src/*' \\( -name '*.js' -o -name '*.js.map' -o -name '*.d.ts' -o -name '*.d.ts.map' \\) ! -name 'jest.config.js' ! -name '.eslintrc.js' -delete",
     "build": "pnpm -r build",

--- a/scripts/check-repo-urls.mjs
+++ b/scripts/check-repo-urls.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Repo URL Drift Guard (#664 / #556 follow-up)
+ *
+ * Fails `pnpm lint` if any tracked file outside the historical-context
+ * allowlist contains a forbidden repo-URL substring. Catches accidental
+ * re-introductions of the personal-fork URL or the `your-org` placeholder
+ * after PR #690 converged on a single canonical form.
+ *
+ * Scope:
+ *   - `piotrswierzy/openlinker` — personal-fork URL; the live damage
+ *     fixed in #556 / #690.
+ *   - `your-org/openlinker` — README/CONTRIBUTING placeholder template
+ *     URL flagged in #664; cleaned up in earlier PRs.
+ *
+ * The current canonical pre-transfer URL `SilkSoftwareHouse/openlinker`
+ * is **deliberately not** watched here — bulk rename to the new org
+ * happens in #641, and a watcher would require a 250+-file allowlist
+ * today. Add it as a forbidden pattern in the #641 PR that flips every
+ * live reference at once.
+ *
+ * Allowlist policy: a file may keep a forbidden substring only when the
+ * substring is an annotated historical reference (e.g., a plan / review
+ * doc citing past state with a "tracked in #N" marker). Add a new entry
+ * sparingly — the default answer to a violation is to fix the URL, not
+ * extend the allowlist.
+ *
+ * Wired into `pnpm lint` via the root `check:invariants` chain.
+ *
+ * Exits non-zero on drift, with one line per violation to stderr.
+ *
+ * @module scripts
+ */
+import { execSync } from 'node:child_process';
+import { readFile, stat } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, '..');
+
+const FORBIDDEN_PATTERNS = ['piotrswierzy/openlinker', 'your-org/openlinker'];
+
+// Files allowed to contain forbidden substrings because they preserve a
+// historical audit trail (annotated "tracked in #664" or describing
+// past state). Keep this list tight — prefer fixing the URL over
+// adding entries.
+const ALLOWLIST = new Set([
+  'docs/plans/implementation-plan-566-568-pr-template-and-codeowners.md',
+  'docs/reviews/modularity-and-plugin-readiness-2026-05-09.md',
+  // The script itself names the forbidden patterns in source comments
+  // and string literals. Self-exclude so the guard can describe what
+  // it guards.
+  'scripts/check-repo-urls.mjs',
+]);
+
+function trackedFiles() {
+  const out = execSync('git ls-files', { cwd: ROOT, encoding: 'utf8' });
+  return out.split('\n').filter(Boolean);
+}
+
+async function isReadableTextFile(absPath) {
+  try {
+    const s = await stat(absPath);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+const violations = [];
+
+for (const rel of trackedFiles()) {
+  if (ALLOWLIST.has(rel)) continue;
+  const abs = resolve(ROOT, rel);
+  if (!(await isReadableTextFile(abs))) continue;
+
+  let content;
+  try {
+    content = await readFile(abs, 'utf8');
+  } catch {
+    // Binary or unreadable — skip silently.
+    continue;
+  }
+
+  for (const pattern of FORBIDDEN_PATTERNS) {
+    if (!content.includes(pattern)) continue;
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes(pattern)) {
+        violations.push({ file: rel, line: i + 1, pattern });
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  process.stderr.write('check-repo-urls: forbidden URL substrings found\n');
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}:${v.line} — "${v.pattern}"\n`);
+  }
+  process.stderr.write(
+    '\nFix the URL, or add the file to ALLOWLIST in scripts/check-repo-urls.mjs\n' +
+      'if it intentionally preserves a historical reference.\n',
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  `check-repo-urls: OK (scanned ${FORBIDDEN_PATTERNS.length} pattern${
+    FORBIDDEN_PATTERNS.length === 1 ? '' : 's'
+  })\n`,
+);

--- a/scripts/check-repo-urls.mjs
+++ b/scripts/check-repo-urls.mjs
@@ -31,10 +31,9 @@
  *
  * @module scripts
  */
-import { execSync } from 'node:child_process';
-import { readFile, stat } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -55,26 +54,71 @@ const ALLOWLIST = new Set([
   'scripts/check-repo-urls.mjs',
 ]);
 
-function trackedFiles() {
-  const out = execSync('git ls-files', { cwd: ROOT, encoding: 'utf8' });
-  return out.split('\n').filter(Boolean);
+// Directories to skip during the walk. The walk is filesystem-based
+// rather than git-based because the CI runner that invokes
+// `pnpm lint` does not have `git` on its PATH (the workflow checks
+// the tree out and then runs lint in a context where the binary
+// isn't required for anything else). A pure-fs walk keeps the
+// invariant working in both local and CI environments.
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  '.next',
+  '.vite',
+  '.turbo',
+  '.cache',
+  '.pnpm-store',
+  '.husky',
+]);
+
+// File extensions that are almost certainly binary and not worth
+// scanning. Keeping this list small — the readFile + UTF-8 decode
+// catches the rest cheaply, and including a text file by accident
+// only costs one extra millisecond.
+const SKIP_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.svg',
+  '.woff', '.woff2', '.ttf', '.otf', '.eot',
+  '.pdf', '.zip', '.tar', '.gz', '.tgz',
+  '.lock',
+]);
+
+function shouldSkipDir(name) {
+  return SKIP_DIRS.has(name);
 }
 
-async function isReadableTextFile(absPath) {
+function shouldSkipFile(name) {
+  const dotIdx = name.lastIndexOf('.');
+  if (dotIdx === -1) return false;
+  return SKIP_EXTENSIONS.has(name.slice(dotIdx).toLowerCase());
+}
+
+async function* walk(dir) {
+  let entries;
   try {
-    const s = await stat(absPath);
-    return s.isFile();
+    entries = await readdir(dir, { withFileTypes: true });
   } catch {
-    return false;
+    return;
+  }
+  for (const entry of entries) {
+    const abs = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (shouldSkipDir(entry.name)) continue;
+      yield* walk(abs);
+    } else if (entry.isFile()) {
+      if (shouldSkipFile(entry.name)) continue;
+      yield abs;
+    }
   }
 }
 
 const violations = [];
 
-for (const rel of trackedFiles()) {
+for await (const abs of walk(ROOT)) {
+  const rel = relative(ROOT, abs);
   if (ALLOWLIST.has(rel)) continue;
-  const abs = resolve(ROOT, rel);
-  if (!(await isReadableTextFile(abs))) continue;
 
   let content;
   try {

--- a/scripts/create-adapter-templates/package.json
+++ b/scripts/create-adapter-templates/package.json
@@ -4,6 +4,15 @@
   "description": "__Name__ adapter for OpenLinker",
   "license": "Apache-2.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SilkSoftwareHouse/openlinker.git",
+    "directory": "libs/integrations/__name__"
+  },
+  "homepage": "https://github.com/SilkSoftwareHouse/openlinker/tree/main/libs/integrations/__name__#readme",
+  "bugs": {
+    "url": "https://github.com/SilkSoftwareHouse/openlinker/issues"
+  },
   "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Closes #556.

**Partial-covers #664** — the issue body's criterion #2 ("zero hits across all three URL patterns") explicitly assumes the org transfer (#641) is done. This PR fixes the live damage (the `piotrswierzy/openlinker` URLs that still ship today) and adds the canonical-URL single-source-of-truth to `package.json`, but the bulk rename to `<new-org>/openlinker` happens in the same PR that completes the org transfer. #664 stays open until then.

## Audit findings

Grep across the worktree for the three URL variants:

| Pattern | Live occurrences | Historical occurrences (kept as audit trail) |
|---|---|---|
| `your-org/openlinker` | **0** | 1 — `docs/reviews/modularity-and-plugin-readiness-2026-05-09.md:90` (audit doc describing past placeholder) |
| `piotrswierzy/openlinker` | **2** — `.github/ISSUE_TEMPLATE/config.yml:4` + `:7` | 2 — `docs/plans/implementation-plan-566-568-...md:41,283` (plan docs annotating "tracked in #664") |
| `SilkSoftwareHouse/openlinker` | **~250** | n/a (current canonical pre-transfer URL) |

The live damage was two lines in one file. The `your-org/openlinker` placeholder cited in #664's body was already cleaned up in earlier PRs; only `config.yml` still pointed at the personal-fork URL — which meant the Discussions contact link was 404'ing.

## Changes

### 1. `.github/ISSUE_TEMPLATE/config.yml`

Both contact-link URLs flip from `piotrswierzy/openlinker` to `SilkSoftwareHouse/openlinker` (Documentation + Discussions).

### 2. Root `package.json`

Adds the npm-canonical metadata triple per #556's recommendation ("Pick one canonical URL, write it once into `package.json#repository`"):

```jsonc
"repository": {
  "type": "git",
  "url": "git+https://github.com/SilkSoftwareHouse/openlinker.git"
},
"homepage": "https://github.com/SilkSoftwareHouse/openlinker#readme",
"bugs": {
  "url": "https://github.com/SilkSoftwareHouse/openlinker/issues"
}
```

Single source of truth for IDE tooling, `npm view`, and any future publish surface.

### 3. `scripts/create-adapter-templates/package.json`

Same triple in the scaffolder template, with `repository.directory: "libs/integrations/__name__"` (npm-standard monorepo-subdir pointer). Token substitution verified by smoke run: `__name__` resolves cleanly into both `directory` and `homepage` fields. Scaffolder lint invariant stays green (file count unchanged at 14).

## Out of scope

- Adding `repository` to every workspace `package.json` (11 files) — root + scaffolder template covers the value; the rest are `private: true` and not consumed as published packages today.
- Touching historical plan / review docs — they annotate past state with explicit "tracked in #664" markers; rewriting would erase the audit trail.
- The actual org rename — tracked by #641. When that PR lands, a single `sed`-style change flips `SilkSoftwareHouse/openlinker` to the new canonical org across the worktree (live docs + this PR's metadata + scaffolder template). #664 closes there.

## Test plan

- [x] `pnpm lint` — green (all 7 invariants pass, including the scaffolder + plugin-guide drift checks).
- [x] `pnpm type-check` — green.
- [x] `pnpm test` — 1853 unit tests pass across 8 packages.
- [x] **Live-damage grep**: `grep -rn "piotrswierzy/openlinker\|your-org/openlinker" . | grep -v "docs/plans/\|docs/reviews/"` returns zero — no live references remain outside historical context.
- [x] **Scaffolder smoke**: `node scripts/create-adapter.mjs example --target-dir /tmp/...` produces `repository.directory: "libs/integrations/example"` and `homepage: ".../tree/main/libs/integrations/example#readme"`.
- [ ] Reviewer: manually verify the Discussions link `https://github.com/SilkSoftwareHouse/openlinker/discussions` actually resolves (post-merge sanity check on the new contact-link URL).

## Issue-lifecycle note

`Closes #556` only. #664 stays open. The next maintainer pass closes #664 via the #641 org-transfer PR — that's the PR which finally satisfies criterion #2.
