### PR TITLE
refactor: extract repeated magic strings to named constants

### DIFF
--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -23,7 +23,7 @@ import {
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { PRODUCTS_SERVICE_TOKEN, IProductsService } from '@openlinker/core/products';
-import { IDENTIFIER_MAPPING_SERVICE_TOKEN } from '@openlinker/core/identifier-mapping';
+import { IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { Product, ProductVariant } from '@openlinker/core/products';
 import { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
@@ -155,8 +155,8 @@ export class ProductsController {
 
     // Load external IDs for product and all variants in parallel
     const [productExternalIds, ...variantExternalIdResults] = await Promise.all([
-      this.identifierMapping.getExternalIds('Product', id),
-      ...variants.map((v) => this.identifierMapping.getExternalIds('Product', v.id)),
+      this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, id),
+      ...variants.map((v) => this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, v.id)),
     ]);
 
     const variantDtos = variants.map((v, i) => {

--- a/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
+++ b/apps/worker/src/sync/handlers/inventory-propagate-to-marketplaces.handler.ts
@@ -15,10 +15,7 @@ import type {
   SyncJobRequest,
 } from '@openlinker/core/sync';
 import { SyncJobExecutionError, JobEnqueuePort, JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { IInventoryService, INVENTORY_SERVICE_TOKEN } from '@openlinker/core/inventory';
 
 type SyncJob = SyncJobEntity;
@@ -89,7 +86,7 @@ export class InventoryPropagateToMarketplacesHandler implements SyncJobHandler {
       // Step 3: Find all marketplace offers mapped to this internal product
       // (Offer mappings are stored in identifier_mappings as entityType='Offer')
       const mappingTargetId = payload.variantId || payload.productId;
-      const mappings = await this.identifierMapping.getExternalIds('Offer', mappingTargetId);
+      const mappings = await this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Offer, mappingTargetId);
 
       if (mappings.length === 0) {
         this.logger.debug(

--- a/apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-field-update.handler.ts
@@ -15,10 +15,7 @@ import type {
   MarketplaceOfferFieldUpdatePayloadV1,
 } from '@openlinker/core/sync';
 import { SyncJobExecutionError } from '@openlinker/core/sync';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { OfferManagerPort } from '@openlinker/core/listings';
 import { isOfferFieldUpdater } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
@@ -45,7 +42,7 @@ export class MarketplaceOfferFieldUpdateHandler implements SyncJobHandler {
     );
 
     // Resolve internal offer ID → external (marketplace-native) offer ID
-    const externalMappings = await this.identifierMapping.getExternalIds('Offer', payload.offerId);
+    const externalMappings = await this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Offer, payload.offerId);
     const mapping = externalMappings.find((m) => m.connectionId === job.connectionId);
 
     if (!mapping) {

--- a/apps/worker/src/sync/handlers/master-inventory-sync-all.handler.ts
+++ b/apps/worker/src/sync/handlers/master-inventory-sync-all.handler.ts
@@ -23,10 +23,7 @@ import type {
   SyncJobRequest,
 } from '@openlinker/core/sync';
 import { SyncJobExecutionError, JobEnqueuePort, JOB_ENQUEUE_TOKEN } from '@openlinker/core/sync';
-import {
-  IdentifierMappingQueryPort,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+import { IdentifierMappingQueryPort, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
 
 type SyncJob = SyncJobEntity;
@@ -49,7 +46,7 @@ export class MasterInventorySyncAllHandler implements SyncJobHandler {
 
     try {
       const externalIds = await this.identifierMapping.listExternalIdsByConnection(
-        'Product',
+        CORE_ENTITY_TYPE.Product,
         job.connectionId
       );
 
@@ -78,7 +75,7 @@ export class MasterInventorySyncAllHandler implements SyncJobHandler {
           payload: {
             schemaVersion: 1,
             externalId,
-            objectType: 'Product',
+            objectType: CORE_ENTITY_TYPE.Product,
           },
           // Derive from outer job id so retries of this outer job produce the same
           // sub-job keys and dedupe against the queue.

--- a/apps/worker/src/sync/handlers/master-product-sync-all.handler.ts
+++ b/apps/worker/src/sync/handlers/master-product-sync-all.handler.ts
@@ -30,6 +30,7 @@ import { SyncJobExecutionError, JobEnqueuePort, JOB_ENQUEUE_TOKEN } from '@openl
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { ProductMasterPort } from '@openlinker/core/products';
 import { Logger } from '@openlinker/shared/logging';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 
 type SyncJob = SyncJobEntity;
 
@@ -80,7 +81,7 @@ export class MasterProductSyncAllHandler implements SyncJobHandler {
           payload: {
             schemaVersion: 1,
             externalId,
-            objectType: 'Product',
+            objectType: CORE_ENTITY_TYPE.Product,
           },
           idempotencyKey: `master:${job.connectionId}:product:sync:${externalId}:${job.id}`,
         };

--- a/libs/core/src/customers/application/services/customer-identity-resolver.service.ts
+++ b/libs/core/src/customers/application/services/customer-identity-resolver.service.ts
@@ -19,10 +19,10 @@ import type {
   CustomerIdentityMode,
 } from '../../domain/types/customer-identity.types';
 import {
-  IdentifierMappingPort,
-  ConnectionPort,
-  CONNECTION_PORT_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+  CustomerIdentityModeValues,
+  DEFAULT_CUSTOMER_IDENTITY_MODE,
+} from '../../domain/types/customer-identity.types';
+import { IdentifierMappingPort, ConnectionPort, CONNECTION_PORT_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { EmailNormalizerPort } from '@openlinker/core/integrations';
 import {
   EmailNormalizerRegistryService,
@@ -59,25 +59,23 @@ export class CustomerIdentityResolverService implements ICustomerIdentityResolve
     @Inject(EMAIL_NORMALIZER_REGISTRY_TOKEN)
     private readonly emailNormalizerRegistry: EmailNormalizerRegistryService
   ) {
-    // Read identity mode from environment (default: email_fallback)
-    const modeValue = getEnv('OL_CUSTOMER_IDENTITY_MODE', 'email_fallback');
-    if (
-      modeValue !== 'external_only' &&
-      modeValue !== 'email_fallback' &&
-      modeValue !== 'true' &&
-      modeValue !== 'false'
-    ) {
+    // Read identity mode from environment (default: email_fallback).
+    // Legacy: 'true' is accepted as an alias for 'email_fallback', 'false' for
+    // 'external_only'. Anything else falls back to the default with a warning.
+    const modeValue = getEnv('OL_CUSTOMER_IDENTITY_MODE', DEFAULT_CUSTOMER_IDENTITY_MODE);
+    const isValid =
+      CustomerIdentityModeValues.includes(modeValue as CustomerIdentityMode) ||
+      modeValue === 'true' ||
+      modeValue === 'false';
+    if (!isValid) {
       this.logger.warn(
-        `Invalid OL_CUSTOMER_IDENTITY_MODE value: ${modeValue}. Using default: email_fallback`
+        `Invalid OL_CUSTOMER_IDENTITY_MODE value: ${modeValue}. Using default: ${DEFAULT_CUSTOMER_IDENTITY_MODE}`
       );
+      this.identityMode = DEFAULT_CUSTOMER_IDENTITY_MODE;
+    } else if (modeValue === 'true' || modeValue === 'email_fallback') {
       this.identityMode = 'email_fallback';
     } else {
-      // Support legacy boolean values for backward compatibility
-      if (modeValue === 'true' || modeValue === 'email_fallback') {
-        this.identityMode = 'email_fallback';
-      } else {
-        this.identityMode = 'external_only';
-      }
+      this.identityMode = 'external_only';
     }
 
     if (this.identityMode === 'email_fallback') {
@@ -105,7 +103,7 @@ export class CustomerIdentityResolverService implements ICustomerIdentityResolve
 
     // Primary: Try external buyer ID mapping
     const existingMapping = await this.identifierMapping.getInternalId(
-      'Customer',
+      CORE_ENTITY_TYPE.Customer,
       externalBuyerId,
       sourceConnectionId
     );
@@ -141,7 +139,7 @@ export class CustomerIdentityResolverService implements ICustomerIdentityResolve
 
     // External-only mode: Create new internal customer
     const newInternalId = await this.identifierMapping.getOrCreateInternalId(
-      'Customer',
+      CORE_ENTITY_TYPE.Customer,
       externalBuyerId,
       sourceConnectionId
     );
@@ -181,7 +179,7 @@ export class CustomerIdentityResolverService implements ICustomerIdentityResolve
     if (matchingProjections.length === 0) {
       // No match: Create new internal customer
       const newInternalId = await this.identifierMapping.getOrCreateInternalId(
-        'Customer',
+        CORE_ENTITY_TYPE.Customer,
         externalBuyerId,
         sourceConnectionId
       );
@@ -206,7 +204,7 @@ export class CustomerIdentityResolverService implements ICustomerIdentityResolve
 
       try {
         await this.identifierMapping.createMapping(
-          'Customer',
+          CORE_ENTITY_TYPE.Customer,
           externalBuyerId,
           sourceConnectionId,
           existingInternalId
@@ -232,7 +230,7 @@ export class CustomerIdentityResolverService implements ICustomerIdentityResolve
       } catch (error) {
         // Mapping may already exist (concurrent request), fetch it
         const mapping = await this.identifierMapping.getInternalId(
-          'Customer',
+          CORE_ENTITY_TYPE.Customer,
           externalBuyerId,
           sourceConnectionId
         );
@@ -261,7 +259,7 @@ export class CustomerIdentityResolverService implements ICustomerIdentityResolve
     );
 
     const newInternalId = await this.identifierMapping.getOrCreateInternalId(
-      'Customer',
+      CORE_ENTITY_TYPE.Customer,
       externalBuyerId,
       sourceConnectionId
     );

--- a/libs/core/src/customers/domain/types/customer-identity.types.ts
+++ b/libs/core/src/customers/domain/types/customer-identity.types.ts
@@ -24,6 +24,13 @@ export const CustomerIdentityModeValues = ['external_only', 'email_fallback'] as
 export type CustomerIdentityMode = (typeof CustomerIdentityModeValues)[number];
 
 /**
+ * Default identity mode used when the `OL_CUSTOMER_IDENTITY_MODE` env var is
+ * absent, blank, or invalid. Exported so call sites can reference the default
+ * by name rather than repeating the bare `'email_fallback'` literal (#668).
+ */
+export const DEFAULT_CUSTOMER_IDENTITY_MODE: CustomerIdentityMode = 'email_fallback';
+
+/**
  * Customer identity resolution request
  *
  * Contains information needed to resolve customer identity from external buyer data.

--- a/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
@@ -38,6 +38,28 @@ export const CoreEntityTypeValues = [
 export type CoreEntityType = (typeof CoreEntityTypeValues)[number];
 
 /**
+ * Named-constant map for the well-known core entity types (#668).
+ *
+ * Lets call sites reference entity types by name (`CORE_ENTITY_TYPE.Product`)
+ * rather than repeating bare `'Product'` / `'Customer'` literals. The port
+ * signature deliberately stays open (`string`) so plugin adapters can register
+ * additional names; this map is only the well-known closed set.
+ *
+ * `as const satisfies Record<CoreEntityType, CoreEntityType>` ensures the keys
+ * remain in lockstep with the union (drops an entry → TS errors; types a value
+ * to a non-member literal → TS errors).
+ */
+export const CORE_ENTITY_TYPE = {
+  Product: 'Product',
+  ProductVariant: 'ProductVariant',
+  Sku: 'Sku',
+  Order: 'Order',
+  Offer: 'Offer',
+  Inventory: 'Inventory',
+  Customer: 'Customer',
+} as const satisfies Record<CoreEntityType, CoreEntityType>;
+
+/**
  * Internal-ID prefix overrides for entity types whose default lowercased
  * prefix is undesirable.
  *

--- a/libs/core/src/inventory/application/services/master-inventory-sync.service.ts
+++ b/libs/core/src/inventory/application/services/master-inventory-sync.service.ts
@@ -10,10 +10,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { INVENTORY_SERVICE_TOKEN } from '../../inventory.tokens';
 import { IInventoryService } from './inventory.service.interface';
 import type {
@@ -45,7 +42,7 @@ export class MasterInventorySyncService implements IMasterInventorySyncService {
     externalId: string
   ): Promise<MasterInventorySyncResult> {
     const internalProductId = await this.identifierMapping.getOrCreateInternalId(
-      'Product',
+      CORE_ENTITY_TYPE.Product,
       externalId,
       connectionId
     );

--- a/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-enqueue.service.ts
@@ -19,7 +19,7 @@
 import { Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
 
 import type { OfferManagerPort } from '@openlinker/core/listings';
-import { isOfferCreator } from '@openlinker/core/listings';
+import { isOfferCreator, OFFER_CREATION_STATUS } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import {
   JobEnqueuePort,
@@ -87,7 +87,7 @@ export class OfferCreationEnqueueService implements IOfferCreationEnqueueService
       internalVariantId: input.internalVariantId,
       connectionId: input.connectionId,
       externalOfferId: null,
-      status: 'pending',
+      status: OFFER_CREATION_STATUS.Pending,
       errors: null,
       publishImmediately: input.publishImmediately,
       request: requestSnapshot,

--- a/libs/core/src/listings/application/services/offer-creation-execution.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-execution.service.ts
@@ -25,13 +25,9 @@
 
 import { Inject, Injectable } from '@nestjs/common';
 
-import {
-  DuplicateIdentifierMappingError,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-  IIdentifierMappingService,
-} from '@openlinker/core/identifier-mapping';
+import { DuplicateIdentifierMappingError, IDENTIFIER_MAPPING_SERVICE_TOKEN, IIdentifierMappingService, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { OfferManagerPort } from '@openlinker/core/listings';
-import { isOfferCreator } from '@openlinker/core/listings';
+import { isOfferCreator, OFFER_CREATION_STATUS } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type {
   CreateOfferCommand,
@@ -97,7 +93,7 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
     } catch (error) {
       const terminal = this.mapBuilderException(error);
       if (terminal) {
-        const updated = await this.offerCreationRecords.updateStatus(record.id, 'failed', terminal);
+        const updated = await this.offerCreationRecords.updateStatus(record.id, OFFER_CREATION_STATUS.Failed, terminal);
         return this.buildResult(updated, input.connectionId);
       }
       throw error;
@@ -120,7 +116,7 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
       if (error instanceof OfferCreateRejectedException) {
         const updated = await this.offerCreationRecords.updateStatus(
           record.id,
-          'failed',
+          OFFER_CREATION_STATUS.Failed,
           this.mapRejectionErrors(error)
         );
         return this.buildResult(updated, input.connectionId);
@@ -130,7 +126,7 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
 
     try {
       await this.identifierMapping.createMapping(
-        'Offer',
+        CORE_ENTITY_TYPE.Offer,
         result.externalOfferId,
         input.connectionId,
         input.internalVariantId
@@ -186,14 +182,20 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
    */
   private recordToOutcome(record: OfferCreationRecord): JobOutcome {
     switch (record.status) {
-      case 'failed':
+      case OFFER_CREATION_STATUS.Failed:
         return 'business_failure';
-      case 'active':
-      case 'draft':
-      case 'validating':
+      case OFFER_CREATION_STATUS.Active:
+      case OFFER_CREATION_STATUS.Draft:
+      case OFFER_CREATION_STATUS.Validating:
         return 'ok';
-      case 'pending':
+      case OFFER_CREATION_STATUS.Pending:
         throw new OfferCreationInvariantException(record.id, record.status);
+      default: {
+        // Exhaustiveness guard: a new OfferCreationStatus member fails here at
+        // compile time, surfacing the missing case in PR review (#668).
+        const _exhaustive: never = record.status;
+        return _exhaustive;
+      }
     }
   }
 
@@ -221,7 +223,7 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
     return this.offerCreationRecords.create({
       internalVariantId: input.internalVariantId,
       connectionId: input.connectionId,
-      status: 'pending',
+      status: OFFER_CREATION_STATUS.Pending,
       publishImmediately: input.publishImmediately,
       externalOfferId: null,
       errors: null,

--- a/libs/core/src/listings/application/services/offer-mapping-sync.service.ts
+++ b/libs/core/src/listings/application/services/offer-mapping-sync.service.ts
@@ -10,11 +10,7 @@ import type { OfferManagerPort } from '@openlinker/core/listings';
 import { isOfferEventReader, isOfferLister } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { OfferFeedItem } from '@openlinker/core/listings';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-  IdentifierMappingConflictException,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, IdentifierMappingConflictException, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import {
   PRODUCT_VARIANT_REPOSITORY_TOKEN,
   ProductVariantRepositoryPort,
@@ -76,7 +72,7 @@ export class OfferMappingSyncService implements IOfferMappingSyncService {
       if (result.status === 'linked' && result.internalVariantId) {
         try {
           await this.identifierMapping.getOrCreateExactMapping(
-            'Offer',
+            CORE_ENTITY_TYPE.Offer,
             item.offerId,
             result.internalVariantId,
             connectionId,

--- a/libs/core/src/listings/application/services/offer-status-poll.service.ts
+++ b/libs/core/src/listings/application/services/offer-status-poll.service.ts
@@ -197,9 +197,9 @@ export class OfferStatusPollService implements IOfferStatusPollService {
             outcome: 'business_failure',
           };
         }
-        return { terminal: true, recordStatus: 'draft', errors: null, outcome: 'ok' };
+        return { terminal: true, recordStatus: OFFER_CREATION_STATUS.Draft, errors: null, outcome: 'ok' };
       case 'ended':
-        return { terminal: true, recordStatus: 'draft', errors: null, outcome: 'ok' };
+        return { terminal: true, recordStatus: OFFER_CREATION_STATUS.Draft, errors: null, outcome: 'ok' };
     }
   }
 

--- a/libs/core/src/listings/application/services/offer-status-poll.service.ts
+++ b/libs/core/src/listings/application/services/offer-status-poll.service.ts
@@ -25,6 +25,7 @@ import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/co
 import type { OfferManagerPort } from '@openlinker/core/listings';
 import {
   isOfferStatusReader,
+  OFFER_CREATION_STATUS,
   OfferNotFoundOnMarketplaceException,
   OfferPollNotSupportedException,
   type OfferStatusReadResult,
@@ -179,7 +180,7 @@ export class OfferStatusPollService implements IOfferStatusPollService {
       } {
     switch (result.publicationStatus) {
       case 'active':
-        return { terminal: true, recordStatus: 'active', errors: null, outcome: 'ok' };
+        return { terminal: true, recordStatus: OFFER_CREATION_STATUS.Active, errors: null, outcome: 'ok' };
       case 'activating':
       case 'inactivating':
         return { terminal: false };
@@ -187,7 +188,7 @@ export class OfferStatusPollService implements IOfferStatusPollService {
         if (result.validationErrors.length > 0) {
           return {
             terminal: true,
-            recordStatus: 'failed',
+            recordStatus: OFFER_CREATION_STATUS.Failed,
             errors: result.validationErrors.map((v) => ({
               code: v.code,
               message: v.message,
@@ -281,6 +282,6 @@ export class OfferStatusPollService implements IOfferStatusPollService {
     code: string
   ): Promise<void> {
     const error: OfferCreationError = { code, message };
-    await this.offerCreationRecords.updateStatus(recordId, 'failed', [error]);
+    await this.offerCreationRecords.updateStatus(recordId, OFFER_CREATION_STATUS.Failed, [error]);
   }
 }

--- a/libs/core/src/listings/domain/types/offer-creation-record.types.ts
+++ b/libs/core/src/listings/domain/types/offer-creation-record.types.ts
@@ -35,6 +35,23 @@ export const OfferCreationStatusValues = [
 export type OfferCreationStatus = (typeof OfferCreationStatusValues)[number];
 
 /**
+ * Named-constant map for the offer-creation lifecycle status (#668).
+ *
+ * Lets call sites reference status values by name
+ * (`OFFER_CREATION_STATUS.Pending`) rather than repeating bare
+ * `'pending'` / `'failed'` literals. The `as const satisfies` keeps the map
+ * in lockstep with the union — drop an entry → TS errors; type a value to a
+ * non-member literal → TS errors.
+ */
+export const OFFER_CREATION_STATUS = {
+  Pending: 'pending',
+  Draft: 'draft',
+  Validating: 'validating',
+  Active: 'active',
+  Failed: 'failed',
+} as const satisfies Record<string, OfferCreationStatus>;
+
+/**
  * Structured error from the platform (or validation path).
  * Persisted in `OfferCreationRecord.errors` when status is `failed`.
  */

--- a/libs/core/src/listings/domain/types/offer-creation-record.types.ts
+++ b/libs/core/src/listings/domain/types/offer-creation-record.types.ts
@@ -40,8 +40,10 @@ export type OfferCreationStatus = (typeof OfferCreationStatusValues)[number];
  * Lets call sites reference status values by name
  * (`OFFER_CREATION_STATUS.Pending`) rather than repeating bare
  * `'pending'` / `'failed'` literals. The `as const satisfies` keeps the map
- * in lockstep with the union — drop an entry → TS errors; type a value to a
- * non-member literal → TS errors.
+ * in lockstep with the union on *both* axes — drop an entry → TS errors
+ * because the key domain is `Capitalize<OfferCreationStatus>` (e.g. drop
+ * `Pending` and the satisfies check fails); type a value to a non-member
+ * literal → TS errors because the value domain is `OfferCreationStatus`.
  */
 export const OFFER_CREATION_STATUS = {
   Pending: 'pending',
@@ -49,7 +51,7 @@ export const OFFER_CREATION_STATUS = {
   Validating: 'validating',
   Active: 'active',
   Failed: 'failed',
-} as const satisfies Record<string, OfferCreationStatus>;
+} as const satisfies Record<Capitalize<OfferCreationStatus>, OfferCreationStatus>;
 
 /**
  * Structured error from the platform (or validation path).

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -59,7 +59,10 @@ export type {
   OfferFieldUpdate,
 } from './domain/types/offer-update.types';
 export { OfferCreationRecord } from './domain/entities/offer-creation-record.entity';
-export { OfferCreationStatusValues } from './domain/types/offer-creation-record.types';
+export {
+  OfferCreationStatusValues,
+  OFFER_CREATION_STATUS,
+} from './domain/types/offer-creation-record.types';
 export type {
   OfferCreationStatus,
   OfferCreationError,

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-mapping.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-mapping.repository.ts
@@ -11,6 +11,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { CoreEntityType } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { IdentifierMapping } from '@openlinker/core/identifier-mapping';
 import { IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping/orm-entities';
 import type { OfferMappingRepositoryPort } from '../../../domain/ports/offer-mapping-repository.port';
@@ -20,7 +21,7 @@ import type {
   PaginatedOfferMappings,
 } from '../../../domain/types/offer-mapping.types';
 
-const OFFER_ENTITY_TYPE: CoreEntityType = 'Offer';
+const OFFER_ENTITY_TYPE: CoreEntityType = CORE_ENTITY_TYPE.Offer;
 
 @Injectable()
 export class OfferMappingRepository implements OfferMappingRepositoryPort {

--- a/libs/core/src/orders/application/services/order-destination-retry.service.ts
+++ b/libs/core/src/orders/application/services/order-destination-retry.service.ts
@@ -15,10 +15,7 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { JobEnqueuePort, JOB_ENQUEUE_TOKEN, type SyncJobRequest } from '@openlinker/core/sync';
 import type {
   IOrderDestinationRetryService,
@@ -75,7 +72,7 @@ export class OrderDestinationRetryService implements IOrderDestinationRetryServi
       );
     }
 
-    const sourceExternalIds = await this.identifierMapping.getExternalIds('Order', internalOrderId);
+    const sourceExternalIds = await this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Order, internalOrderId);
     const sourceMapping = sourceExternalIds.find(
       (m) => m.connectionId === order.sourceConnectionId
     );

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -23,10 +23,7 @@ import {
   SyncLockPort,
   SYNC_LOCK_TOKEN,
 } from '@openlinker/core/sync';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import {
   ICustomerIdentityResolverService,
   CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN,
@@ -186,7 +183,7 @@ export class OrderIngestionService implements IOrderIngestionService {
 
     // Step 1: resolve order + customer IDs (no item mapping yet)
     const internalOrderId = await this.identifierMapping.getOrCreateInternalId(
-      'Order',
+      CORE_ENTITY_TYPE.Order,
       incoming.externalOrderId,
       connectionId
     );
@@ -326,10 +323,10 @@ export class OrderIngestionService implements IOrderIngestionService {
       return resolution.internalCustomerId;
     }
     return this.identifierMapping.getOrCreateInternalId(
-      'Customer',
+      CORE_ENTITY_TYPE.Customer,
       incoming.customerExternalId,
       connectionId,
-      { parentEntityType: 'Order', parentInternalId: internalOrderId }
+      { parentEntityType: CORE_ENTITY_TYPE.Order, parentInternalId: internalOrderId }
     );
   }
 

--- a/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
+++ b/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
@@ -6,10 +6,7 @@
  * @module libs/core/src/orders/application/services
  */
 import { Injectable, Inject } from '@nestjs/common';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
 import { ProductVariantRepositoryPort } from '@openlinker/core/products';
 import type { IncomingOrderItemRef } from '../../domain/types/incoming-order.types';
@@ -52,7 +49,7 @@ export class OrderItemRefResolverService {
     switch (productRef.type) {
       case 'offer': {
         const internalVariantId = await this.identifierMapping.getInternalId(
-          'Offer',
+          CORE_ENTITY_TYPE.Offer,
           productRef.externalId,
           connectionId
         );
@@ -75,7 +72,7 @@ export class OrderItemRefResolverService {
       }
       case 'product': {
         const internalProductId = await this.identifierMapping.getInternalId(
-          'Product',
+          CORE_ENTITY_TYPE.Product,
           productRef.externalId,
           connectionId
         );
@@ -90,7 +87,7 @@ export class OrderItemRefResolverService {
       }
       case 'variant': {
         const internalVariantId = await this.identifierMapping.getInternalId(
-          'ProductVariant',
+          CORE_ENTITY_TYPE.ProductVariant,
           productRef.externalId,
           connectionId
         );
@@ -113,7 +110,7 @@ export class OrderItemRefResolverService {
       }
       case 'sku': {
         const internalId = await this.identifierMapping.getInternalId(
-          'Sku',
+          CORE_ENTITY_TYPE.Sku,
           productRef.externalId,
           connectionId
         );

--- a/libs/core/src/products/application/services/auto-match-variant-offers.service.ts
+++ b/libs/core/src/products/application/services/auto-match-variant-offers.service.ts
@@ -15,11 +15,7 @@ import {
   type OfferFeedOutput,
 } from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-  IdentifierMappingConflictException,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, IdentifierMappingConflictException, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
 import type { IAutoMatchVariantOffersService } from './auto-match-variant-offers.service.interface';
 import type {
@@ -104,7 +100,7 @@ export class AutoMatchVariantOffersService implements IAutoMatchVariantOffersSer
 
       try {
         await this.identifierMapping.getOrCreateExactMapping(
-          'Offer',
+          CORE_ENTITY_TYPE.Offer,
           matchResult.offerId,
           variant.id,
           connectionId,

--- a/libs/core/src/products/application/services/master-product-sync.service.ts
+++ b/libs/core/src/products/application/services/master-product-sync.service.ts
@@ -9,10 +9,7 @@
 
 import { Injectable, Inject } from '@nestjs/common';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
-import {
-  IIdentifierMappingService,
-  IDENTIFIER_MAPPING_SERVICE_TOKEN,
-} from '@openlinker/core/identifier-mapping';
+import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { PRODUCTS_SERVICE_TOKEN } from '../../products.tokens';
 import { IProductsService } from './products.service.interface';
 import type { ProductMasterPort } from '../../domain/ports/product-master.port';
@@ -44,7 +41,7 @@ export class MasterProductSyncService implements IMasterProductSyncService {
   ): Promise<MasterProductSyncResult> {
     // Resolve internal product ID
     const internalProductId = await this.identifierMapping.getOrCreateInternalId(
-      'Product',
+      CORE_ENTITY_TYPE.Product,
       externalId,
       connectionId
     );

--- a/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
@@ -25,6 +25,7 @@ import type {
   PaginatedProductVariants,
 } from '../../../domain/types/product.types';
 import { normalizeBarcode, normalizeToEan13 } from '../../../domain/utils/barcode-normalization';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 
 @Injectable()
 export class ProductVariantRepository implements ProductVariantRepositoryPort {
@@ -116,7 +117,7 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
         `,
         {
           connectionId,
-          entityType: 'ProductVariant',
+          entityType: CORE_ENTITY_TYPE.ProductVariant,
         }
       )
       .where(
@@ -155,7 +156,7 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
         'identifier_mappings',
         'mapping',
         `mapping.internalId = variant.id AND mapping.connectionId = :connectionId AND mapping.entityType = :entityType`,
-        { connectionId: filters.connectionId, entityType: 'ProductVariant' }
+        { connectionId: filters.connectionId, entityType: CORE_ENTITY_TYPE.ProductVariant }
       );
     }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -52,6 +52,7 @@ import {
   OfferNotFoundOnMarketplaceException,
 } from '@openlinker/core/listings';
 import type { AllegroSellerDefaultsConfig } from '../../domain/types/allegro-seller-defaults.types';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import {
   resolveAllegroProductCardByEan,
   type ResolveProductCardResult,
@@ -478,7 +479,7 @@ export class AllegroOfferManagerAdapter
   private async isOfferMapped(offerId: string): Promise<boolean> {
     try {
       const internalId = await this.identifierMapping.getInternalId(
-        'Offer',
+        CORE_ENTITY_TYPE.Offer,
         offerId,
         this.connectionId
       );

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts
@@ -13,6 +13,7 @@ import type {
   InventoryAdjustment,
 } from '@openlinker/core/inventory';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
 import type {
   IPrestashopInventoryMapper,
@@ -45,7 +46,7 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort {
     );
 
     // Resolve internal ID → external ID
-    const externalIds = await this.identifierMapping.getExternalIds('Product', productId);
+    const externalIds = await this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, productId);
     const prestashopProductId = externalIds.find(
       (e: { connectionId: string }) => e.connectionId === this.connection.id
     );
@@ -54,7 +55,7 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
       const error = new PrestashopResourceNotFoundException(
         `Product not found: ${productId} (no external ID mapping for connection ${this.connection.id})`,
-        'Product',
+        CORE_ENTITY_TYPE.Product,
         productId,
         this.connection.id
       );
@@ -98,7 +99,7 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
       const error = new PrestashopResourceNotFoundException(
         `Inventory not found for product: ${productId}`,
-        'Inventory',
+        CORE_ENTITY_TYPE.Inventory,
         productId,
         this.connection.id
       );
@@ -113,11 +114,11 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort {
 
     // Get or create internal ID for inventory
     const internalId = await this.identifierMapping.getOrCreateInternalId(
-      'Inventory',
+      CORE_ENTITY_TYPE.Inventory,
       String(stockRecord.id),
       this.connection.id,
       {
-        parentEntityType: 'Product',
+        parentEntityType: CORE_ENTITY_TYPE.Product,
         parentInternalId: productId,
       }
     );

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -16,10 +16,7 @@
 import type { OrderProcessorManagerPort, OrderCreate, OrderRef } from '@openlinker/core/orders';
 import type { DestinationOptionsReader, MappingOption } from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
-import {
-  MappingAlreadyExistsError,
-  DuplicateIdentifierMappingError,
-} from '@openlinker/core/identifier-mapping';
+import { MappingAlreadyExistsError, DuplicateIdentifierMappingError, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IMappingConfigService } from '@openlinker/core/mappings';
 import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
 import type { IPrestashopOpenLinkerModuleClient } from '../http/prestashop-openlinker-module.client.interface';
@@ -95,7 +92,7 @@ export class PrestashopOrderProcessorManagerAdapter
       const metadataInternalOrderId = order.metadata?.internalOrderId as string | undefined;
       if (metadataInternalOrderId) {
         const existingExternalIds = await this.identifierMapping.getExternalIds(
-          'Order',
+          CORE_ENTITY_TYPE.Order,
           metadataInternalOrderId
         );
         const existingPrestashopOrder = existingExternalIds.find(
@@ -122,7 +119,7 @@ export class PrestashopOrderProcessorManagerAdapter
       let externalCustomerId: string | number;
       if (order.customerId) {
         const externalIds = await this.identifierMapping.getExternalIds(
-          'Customer',
+          CORE_ENTITY_TYPE.Customer,
           order.customerId
         );
         const prestashopCustomerId = externalIds.find(
@@ -199,7 +196,7 @@ export class PrestashopOrderProcessorManagerAdapter
       for (const item of order.items) {
         // Resolve product ID
         const productExternalIds = await this.identifierMapping.getExternalIds(
-          'Product',
+          CORE_ENTITY_TYPE.Product,
           item.productId
         );
         const prestashopProductId = productExternalIds.find(
@@ -219,7 +216,7 @@ export class PrestashopOrderProcessorManagerAdapter
         // Resolve variant ID if present
         if (item.variantId) {
           const variantExternalIds = await this.identifierMapping.getExternalIds(
-            'ProductVariant',
+            CORE_ENTITY_TYPE.ProductVariant,
             item.variantId
           );
           const prestashopVariantId = variantExternalIds.find(
@@ -495,7 +492,7 @@ export class PrestashopOrderProcessorManagerAdapter
       if (metadataInternalOrderId) {
         try {
           await this.identifierMapping.createMapping(
-            'Order',
+            CORE_ENTITY_TYPE.Order,
             externalOrderId,
             this.connection.id,
             metadataInternalOrderId,
@@ -531,7 +528,7 @@ export class PrestashopOrderProcessorManagerAdapter
           `createOrder invoked without metadata.internalOrderId for externalOrderId=${externalOrderId} connection=${this.connection.id} — idempotency check will be bypassed`
         );
         internalOrderId = await this.identifierMapping.getOrCreateInternalId(
-          'Order',
+          CORE_ENTITY_TYPE.Order,
           externalOrderId,
           this.connection.id,
           {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
@@ -19,6 +19,7 @@ import type {
   IncomingOrderAddress,
 } from '@openlinker/core/orders';
 import type { Connection } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
 import type {
   IPrestashopOrderMapper,
@@ -125,7 +126,7 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
       if (error instanceof PrestashopApiException && error.statusCode === 404) {
         throw new PrestashopResourceNotFoundException(
           `Order not found: ${externalOrderId} on connection ${this.connection.id}`,
-          'Order',
+          CORE_ENTITY_TYPE.Order,
           externalOrderId,
           this.connection.id
         );

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -19,6 +19,7 @@ import type {
 } from '@openlinker/core/products';
 import { normalizeBarcode, normalizeToEan13 } from '@openlinker/core/products';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
 import type {
   IPrestashopProductMapper,
@@ -51,7 +52,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     this.logger.debug(`Getting product: ${productId} (connection: ${this.connection.id})`);
 
     // Resolve internal ID → external ID
-    const externalIds = await this.identifierMapping.getExternalIds('Product', productId);
+    const externalIds = await this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, productId);
     const prestashopId = externalIds.find(
       (e: { connectionId: string }) => e.connectionId === this.connection.id
     );
@@ -60,7 +61,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
       const error = new PrestashopResourceNotFoundException(
         `Product not found: ${productId} (no external ID mapping for connection ${this.connection.id})`,
-        'Product',
+        CORE_ENTITY_TYPE.Product,
         productId,
         this.connection.id
       );
@@ -166,7 +167,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     );
 
     // Resolve internal ID → external ID
-    const externalIds = await this.identifierMapping.getExternalIds('Product', productId);
+    const externalIds = await this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, productId);
     const prestashopProductId = externalIds.find(
       (e: { connectionId: string }) => e.connectionId === this.connection.id
     );
@@ -175,7 +176,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- prestashop webservice response is dynamically shaped; narrowed by the surrounding mapper / parser
       const error = new PrestashopResourceNotFoundException(
         `Product not found: ${productId} (no external ID mapping for connection ${this.connection.id})`,
-        'Product',
+        CORE_ENTITY_TYPE.Product,
         productId,
         this.connection.id
       );
@@ -201,11 +202,11 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     if (combinations.length === 0) {
       const syntheticExternalId = `product:${prestashopProductId.externalId}`;
       const internalId = await this.identifierMapping.getOrCreateInternalId(
-        'ProductVariant',
+        CORE_ENTITY_TYPE.ProductVariant,
         syntheticExternalId,
         this.connection.id,
         {
-          parentEntityType: 'Product',
+          parentEntityType: CORE_ENTITY_TYPE.Product,
           parentInternalId: productId,
           metadata: {
             variantExternalId: syntheticExternalId,
@@ -232,7 +233,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     // Ensure stale synthetic variant mapping is removed once combinations exist
     const syntheticExternalId = `product:${prestashopProductId.externalId}`;
     await this.identifierMapping.deleteMapping(
-      'ProductVariant',
+      CORE_ENTITY_TYPE.ProductVariant,
       syntheticExternalId,
       this.connection.id
     );
@@ -242,7 +243,7 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
       externalId: String(c.id),
       connectionId: this.connection.id,
       context: {
-        parentEntityType: 'Product',
+        parentEntityType: CORE_ENTITY_TYPE.Product,
         parentInternalId: productId,
         metadata: {
           variantExternalId: String(c.id),

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-customer-provisioner.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-customer-provisioner.ts
@@ -10,6 +10,7 @@
 import { Injectable, Inject, Logger, Optional } from '@nestjs/common';
 import type { RedisClientType } from 'redis';
 import type { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
 import type { PrestashopConnectionConfig } from '../../domain/types/prestashop-config.types';
 import { PrestashopProvisioningException } from '../../domain/exceptions/prestashop-provisioning.exception';
@@ -157,7 +158,7 @@ export class PrestashopCustomerProvisioner {
     this.logger.debug(
       `Internal customer ID: ${internalCustomerId}, destinationConnectionId: ${destinationConnectionId}`
     );
-    const externalIds = await identifierMapping.getExternalIds('Customer', internalCustomerId);
+    const externalIds = await identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Customer, internalCustomerId);
     const prestashopMapping = externalIds.find((e) => e.connectionId === destinationConnectionId);
 
     if (prestashopMapping) {
@@ -177,7 +178,7 @@ export class PrestashopCustomerProvisioner {
       await new Promise((resolve) => setTimeout(resolve, 500)); // Wait 500ms
 
       // Re-check mapping after waiting
-      const retryMapping = await identifierMapping.getExternalIds('Customer', internalCustomerId);
+      const retryMapping = await identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Customer, internalCustomerId);
       const retryPrestashopMapping = retryMapping.find(
         (e) => e.connectionId === destinationConnectionId
       );
@@ -203,7 +204,7 @@ export class PrestashopCustomerProvisioner {
     try {
       // Step 3: Re-check mapping after lock acquisition
       const postLockMapping = await identifierMapping.getExternalIds(
-        'Customer',
+        CORE_ENTITY_TYPE.Customer,
         internalCustomerId
       );
       const postLockPrestashopMapping = postLockMapping.find(
@@ -310,7 +311,7 @@ export class PrestashopCustomerProvisioner {
       // Step 6: Create mapping with post-create re-check
       try {
         const externalId = await identifierMapping.getOrCreateExactMapping(
-          'Customer',
+          CORE_ENTITY_TYPE.Customer,
           prestashopCustomerId,
           internalCustomerId,
           destinationConnectionId
@@ -319,7 +320,7 @@ export class PrestashopCustomerProvisioner {
       } catch (error) {
         // Mapping may already exist (concurrent request), fetch it
         const duplicateMapping = await identifierMapping.getExternalIds(
-          'Customer',
+          CORE_ENTITY_TYPE.Customer,
           internalCustomerId
         );
         const duplicatePrestashopMapping = duplicateMapping.find(


### PR DESCRIPTION
## Summary

Address the three sets the modularity audit flagged in #668. All three target unions already existed (`CustomerIdentityMode`, `OfferCreationStatus`, `CoreEntityType`); this PR closes the gap between the type definition and the call sites that were still passing bare literals.

## Set 1 — Customer identity modes

- Replace the `!== 'external_only' && !== 'email_fallback'` chain in `customer-identity-resolver.service.ts` with `CustomerIdentityModeValues.includes(...)`. A typo at either literal previously fell through silently; `includes` is rename-safe.
- Add `DEFAULT_CUSTOMER_IDENTITY_MODE: CustomerIdentityMode = 'email_fallback'` to `customer-identity.types.ts` and use it for fallback paths.

## Set 2 — Offer-creation lifecycle status

- Add `OFFER_CREATION_STATUS` const map (`as const satisfies Record<string, OfferCreationStatus>`) to `offer-creation-record.types.ts` + re-export from the listings barrel.
- Replace 5 non-narrowed call-site literals across `offer-creation-enqueue.service.ts`, `offer-status-poll.service.ts`, `offer-creation-execution.service.ts`.
- Migrate the `recordToOutcome` switch in `offer-creation-execution.service.ts` from bare-literal `case` labels to `case OFFER_CREATION_STATUS.X:` and **add the explicit `const _exhaustive: never = record.status` guard** — a new `OfferCreationStatus` member now fails the switch at compile time rather than returning `undefined` at runtime (per issue acceptance criteria § "TS exhaustiveness check").

## Set 3 — Entity types

- Add `CORE_ENTITY_TYPE` const map (`as const satisfies Record<CoreEntityType, CoreEntityType>`) to `identifier-mapping.types.ts` — re-exported via the barrel's `export *`.
- Replace bare-literal entity-type arguments across 15 files (libs/core services + libs/integrations adapters + apps/worker handlers + one apps/api controller). Caught both the single-line `fn('Product', …)` shape and the multi-line standalone-arg `\n  'Customer',\n  …` shape — the latter required a second sweep pass after the first regex (line-based) missed all multi-line call sites.
- **Port signature unchanged.** `IdentifierMappingPort.getOrCreateInternalId(entityType: CoreEntityType | string, …)` is the documented plugin-runtime-extensibility seam — tightening to `CoreEntityType` alone would regress the extension point at #577. The const map gives well-known call sites rename-safety without closing the extensibility door.
- Migration file `1788000000000-promote-product-variant-entity-type.ts` intentionally NOT touched: its literals live inside SQL query template strings.

## Follow-up suggestion

The `CORE_ENTITY_TYPE` / `OFFER_CREATION_STATUS` const-map shape sits alongside the existing `XxxValues = [...] as const` + derived union pattern documented in `engineering-standards.md § Union Types`. Same `as const satisfies …` foundation, exposed via named accessors (`CORE_ENTITY_TYPE.Product`) rather than array indexing. A follow-up to codify this companion pattern in the standard is appropriate if reviewers find it useful.

## What this PR does NOT do

- Test files (~200 bare-literal occurrences) are left as-is — they pass literals as positional args to ports typed `CoreEntityType | string`; replacing them with const references gains no type safety and adds churn.
- The port signature stays `CoreEntityType | string` (extensibility-by-design).

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 1852 unit tests pass (libs/shared 49 + libs/core 653 + libs/plugin-sdk 11 + libs/integrations/ai 34 + libs/integrations/prestashop 266 + libs/integrations/allegro 364 + apps/api 357 + apps/worker 118)
- [x] Pre-commit hook (full test suite) — green
- [ ] Integration tests (`pnpm test:integration`) — Docker unavailable locally; relying on CI

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)