### PR TITLE
ci(dx): full tsc smoke on scaffolded adapter output (#686)

### DIFF
--- a/.github/workflows/scaffold-smoke.yml
+++ b/.github/workflows/scaffold-smoke.yml
@@ -1,0 +1,71 @@
+# Scaffold Smoke (#686)
+#
+# Full tsc smoke on the output of `scripts/create-adapter.mjs`. Catches the
+# drift class the in-`pnpm lint` shape check (`scripts/check-create-adapter.mjs`,
+# #684) cannot: a core API rename in `@openlinker/{core,shared,plugin-sdk}`
+# that silently breaks the scaffolded code's imports.
+#
+# Paths-filtered to changes that could plausibly affect scaffolded-output
+# compilability. Runs on ubuntu-latest so fork PRs see the signal too —
+# orthogonal to #557 (the five existing self-hosted jobs).
+#
+# The smoke scaffolds into `libs/integrations/smoketest/` rather than a literal
+# tmp dir because the template `tsconfig.json` uses relative project references
+# (`../../core`) and the template `package.json` uses `workspace:*` deps —
+# neither resolves outside the workspace. Cleanup runs unconditionally.
+
+name: Scaffold Smoke
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/create-adapter*.mjs'
+      - 'scripts/create-adapter-templates/**'
+      - 'libs/core/**'
+      - 'libs/shared/**'
+      - 'libs/plugin-sdk/**'
+      - '.github/workflows/scaffold-smoke.yml'
+
+jobs:
+  scaffold-smoke:
+    name: Scaffolded Adapter Builds
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install root dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Defensive — fresh GitHub-hosted runners shouldn't have this, but a
+      # leftover from a partial previous run would otherwise fail the scaffolder
+      # ("Target directory already exists").
+      - name: Cleanup any leftover scaffold dir
+        run: rm -rf libs/integrations/smoketest
+
+      - name: Scaffold smoke adapter
+        run: node scripts/create-adapter.mjs smoketest
+
+      # The scaffolded package didn't exist when pnpm-lock.yaml was committed,
+      # so --frozen-lockfile would refuse here. The mutation stays on the
+      # runner; we never push it.
+      - name: Re-link workspace
+        run: pnpm install --no-frozen-lockfile
+
+      # tsc -b walks the composite project references and builds
+      # @openlinker/{shared,core,plugin-sdk} on the way — no pre-build needed.
+      - name: Build scaffolded adapter (tsc -b)
+        run: pnpm --filter @openlinker/integrations-smoketest build
+
+      - name: Cleanup scaffold dir
+        if: always()
+        run: rm -rf libs/integrations/smoketest

--- a/.github/workflows/scaffold-smoke.yml
+++ b/.github/workflows/scaffold-smoke.yml
@@ -21,10 +21,25 @@ on:
     paths:
       - 'scripts/create-adapter*.mjs'
       - 'scripts/create-adapter-templates/**'
+      # libs/core, libs/shared, libs/plugin-sdk source — excluding spec/test
+      # files that can't affect scaffolded-output compilability.
       - 'libs/core/**'
+      - '!libs/core/**/*.spec.ts'
+      - '!libs/core/**/__tests__/**'
       - 'libs/shared/**'
+      - '!libs/shared/**/*.spec.ts'
+      - '!libs/shared/**/__tests__/**'
       - 'libs/plugin-sdk/**'
+      - '!libs/plugin-sdk/**/*.spec.ts'
+      - '!libs/plugin-sdk/**/__tests__/**'
       - '.github/workflows/scaffold-smoke.yml'
+
+# Read-only token — this workflow only runs compilation. No API writes,
+# commits, or comments. Belt-and-suspenders supply-chain hardening on top
+# of the `pull_request` (not `pull_request_target`) trigger that already
+# blocks secret injection from fork PRs.
+permissions:
+  contents: read
 
 jobs:
   scaffold-smoke:

--- a/docs/plans/implementation-plan-686-scaffold-smoke-ci.md
+++ b/docs/plans/implementation-plan-686-scaffold-smoke-ci.md
@@ -1,0 +1,108 @@
+# #686 — CI: full `tsc` smoke on scaffolded adapter output
+
+Closes #686. Complements the just-merged #684 (lint-time shape check).
+
+## 1. Goal
+
+Add a non-blocking, paths-filtered CI job that:
+
+1. Scaffolds a fresh plugin package via `scripts/create-adapter.mjs`.
+2. Wires it into the pnpm workspace via `pnpm install --no-frozen-lockfile`.
+3. Builds it via the scaffolded `pnpm build` (`tsc -b`).
+4. Cleans up.
+5. Fails the PR check if any step fails.
+
+Catches a drift class the existing `scripts/check-create-adapter.mjs` (shape-only, sub-second, runs in `pnpm lint`) cannot: a core API rename in `@openlinker/{core,shared,plugin-sdk}` that silently breaks the scaffolded code's imports.
+
+**Non-goals**: ESLint on scaffolded output (rare drift class, explicitly carved out in the issue body), rewriting `check-create-adapter.mjs`, adding the smoke to `pnpm lint` / pre-commit (wrong resource budget).
+
+## 2. Layer classification
+
+DX / Tooling. No application-code changes; the workflow exercises the scaffolder + the three core packages whose API surface the scaffold consumes.
+
+## 3. Design
+
+### 3.1 Scaffold into the workspace, not a literal tmp dir
+
+The issue body says "tmp dir." A literal `/tmp/...` won't compile because:
+
+- The template `tsconfig.json` uses relative project references (`../../core` etc.). Outside `libs/integrations/`, those paths point at nothing.
+- The template `package.json` declares deps via `workspace:*`. Outside the workspace, pnpm can't resolve them.
+
+Resolution: scaffold into `libs/integrations/<slug>/` (a real workspace path per `pnpm-workspace.yaml`'s `libs/integrations/*` glob), build, then remove. This is the only configuration where `tsc -b` sees the same world a real plugin would. The shape check at `scripts/check-create-adapter.mjs` can scaffold to `os.tmpdir()` because it never invokes the compiler.
+
+### 3.2 Smoke slug — `smoketest`
+
+`smoketest` matches the scaffolder's `[a-z][a-z0-9]*(-[a-z0-9]+)*` regex, isn't in `SHIPPED_PLUGIN_NAMES` or `RESERVED_WORKSPACE_NAMES`, and is consistent with the existing shape check's `lintcheck` convention (also non-hyphenated).
+
+A hyphenated slug like `smoke-test` is **deliberately not used**: a local dry-run surfaced a latent bug in `scripts/create-adapter-templates/` where `__name__` (raw slug with hyphens) gets substituted into TypeScript identifier positions like `export const __name__AdapterManifest`, producing invalid syntax (`smoke-testAdapterManifest` parses as `smoke - testAdapterManifest`). The fix belongs in the templates, not in this PR — tracked as a follow-up. The smoke remains non-hyphenated to match the shape check's working baseline.
+
+### 3.3 Trigger paths
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - 'scripts/create-adapter*.mjs'
+      - 'scripts/create-adapter-templates/**'
+      - 'libs/core/**'
+      - 'libs/shared/**'
+      - 'libs/plugin-sdk/**'
+      - '.github/workflows/scaffold-smoke.yml'
+```
+
+Matches the issue body's recommendation. The workflow file itself is included so edits to it re-trigger.
+
+### 3.4 Runner — `ubuntu-latest`
+
+Matches `test-php` (the only existing job on a public runner). Fork-PR contributors get the signal — the whole point of catching scaffold drift early is helping contributors before merge, so the gate must work on fork PRs. Orthogonal to #557, which is scoped to the five existing self-hosted jobs.
+
+### 3.5 No pre-build of `{shared,core,plugin-sdk}`
+
+A local dry-run confirmed `tsc -b` walks the composite project references in the scaffolded `tsconfig.json` and builds `@openlinker/shared`, `@openlinker/core`, `@openlinker/plugin-sdk` automatically from a clean `dist/`-empty state. Pre-building (as `ci.yml`'s lint and test jobs do) is unnecessary for this workflow — those jobs pre-build because they consume `dist/` at runtime (path-resolution via package `main`/`types`); a pure `tsc -b` against the scaffolded package doesn't.
+
+Skipping the pre-build saves ~60s per invocation.
+
+### 3.6 Step sequence
+
+```yaml
+- checkout
+- setup pnpm v9 + node 20 (matches existing CI)
+- pnpm install --frozen-lockfile      # baseline workspace install
+- defensive cleanup of any leftover scaffold dir
+- node scripts/create-adapter.mjs smoketest
+- pnpm install --no-frozen-lockfile    # re-link workspace
+- pnpm --filter @openlinker/integrations-smoketest build
+- always(): rm -rf libs/integrations/smoketest
+```
+
+`--no-frozen-lockfile` is required because the scaffolded package didn't exist when the lockfile was generated; pnpm refuses otherwise. The mutation is local to the runner and never committed.
+
+### 3.7 Coverage
+
+Catches: symbol moves out of `@openlinker/core/<ctx>` or `@openlinker/plugin-sdk` barrels; new required field on `AdapterMetadata`; `tsconfig.base.json` `compilerOptions` changes that break composite-mode builds.
+
+Doesn't catch: runtime drift (compilation only), ESLint rule changes (out of scope), template bugs that affect only hyphenated slugs (separate template bug, follow-up).
+
+## 4. Implementation
+
+| # | File | Action |
+|---|------|--------|
+| 1 | `.github/workflows/scaffold-smoke.yml` | New workflow per §3.6 |
+| 2 | local YAML validation | Parse with `python3 -c "import yaml; yaml.safe_load(...)"` before commit — catches indentation / structural issues that GitHub Actions would only report after push |
+| 3 | local end-to-end dry-run | Already executed during planning: scaffold + relink + build succeeded against a clean dist tree (~50s wall time) |
+
+No source-code changes. No test changes. Existing checks unaffected.
+
+## 5. Validation
+
+- **Architecture**: N/A (pure DX). No domain/application/infra/interface touch.
+- **Naming**: workflow file `.github/workflows/scaffold-smoke.yml` (issue body verbatim); job id `scaffold-smoke`; step names in sentence case matching `ci.yml`.
+- **Security**: `pull_request` trigger (not `pull_request_target`) — runs against the PR's checkout, no access to repo secrets. Equivalent risk profile to existing lint/test jobs.
+- **Wall time estimate**: ~2 min on `ubuntu-latest` (checkout 5s + setup 10s + install 60s + scaffold 1s + relink 30s + build 50s + cleanup 1s). Well under the 10-min timeout.
+
+## 6. Out of scope (follow-ups)
+
+- Hyphenated-slug template bug (see §3.2) — `__name__` token leaking into TS identifier positions.
+- `concurrency:` group to cancel superseded runs.
+- Caching `dist/` between runs.

--- a/docs/plans/implementation-plan-686-scaffold-smoke-ci.md
+++ b/docs/plans/implementation-plan-686-scaffold-smoke-ci.md
@@ -39,19 +39,7 @@ A hyphenated slug like `smoke-test` is **deliberately not used**: a local dry-ru
 
 ### 3.3 Trigger paths
 
-```yaml
-on:
-  pull_request:
-    paths:
-      - 'scripts/create-adapter*.mjs'
-      - 'scripts/create-adapter-templates/**'
-      - 'libs/core/**'
-      - 'libs/shared/**'
-      - 'libs/plugin-sdk/**'
-      - '.github/workflows/scaffold-smoke.yml'
-```
-
-Matches the issue body's recommendation. The workflow file itself is included so edits to it re-trigger.
+The issue body recommends `libs/{core,shared,plugin-sdk}/**` plus the scaffolder/template paths. The committed filter narrows each `libs/<pkg>/**` entry to exclude `*.spec.ts` and `__tests__/**`: spec-only changes can't affect scaffolded-output compilability, and the negation patterns keep noise bounded without changing the core trigger logic. The workflow file itself is included so edits to it re-trigger.
 
 ### 3.4 Runner — `ubuntu-latest`
 
@@ -98,8 +86,8 @@ No source-code changes. No test changes. Existing checks unaffected.
 
 - **Architecture**: N/A (pure DX). No domain/application/infra/interface touch.
 - **Naming**: workflow file `.github/workflows/scaffold-smoke.yml` (issue body verbatim); job id `scaffold-smoke`; step names in sentence case matching `ci.yml`.
-- **Security**: `pull_request` trigger (not `pull_request_target`) — runs against the PR's checkout, no access to repo secrets. Equivalent risk profile to existing lint/test jobs.
-- **Wall time estimate**: ~2 min on `ubuntu-latest` (checkout 5s + setup 10s + install 60s + scaffold 1s + relink 30s + build 50s + cleanup 1s). Well under the 10-min timeout.
+- **Security**: `pull_request` trigger (not `pull_request_target`) — runs against the PR's checkout, no access to repo secrets. Top-level `permissions: contents: read` scopes the `GITHUB_TOKEN` to read-only as belt-and-suspenders.
+- **Wall time estimate**: ~3-5 min on a `ubuntu-latest` cold cache (checkout 5-10s + Node/pnpm setup 30-60s + `pnpm install --frozen-lockfile` 60-90s + scaffold 1s + re-link 30-60s + `tsc -b` of three core packages + the scaffold 30-50s + cleanup 1s). Well under the 10-min timeout. Warm-cache subsequent runs trim install/re-link by ~half.
 
 ## 6. Out of scope (follow-ups)
 


### PR DESCRIPTION
## Summary

Complements the in-`pnpm lint` shape check (#684) with a paths-filtered CI workflow that does the part the shape check cannot: scaffold a fresh adapter, install workspace deps, and run `tsc -b` against the output. Catches a drift class the shape check can't see — a core API rename in `@openlinker/{core,shared,plugin-sdk}` that silently breaks the scaffolded code's imports.

- New workflow at `.github/workflows/scaffold-smoke.yml`. Runs on `pull_request`, paths-filtered to scaffolder + template changes and to `libs/{core,shared,plugin-sdk}/**` source files (spec/test files excluded — they can't affect compilation).
- Scaffolds into `libs/integrations/smoketest/` rather than a literal tmp dir, because the template's relative `tsconfig` project references and `workspace:*` deps don't resolve outside the workspace. Cleanup runs unconditionally via `if: always()`.
- `ubuntu-latest` so fork-PR contributors see the signal too — orthogonal to #557 (the five existing self-hosted jobs).
- No pre-build of `@openlinker/{shared,core,plugin-sdk}` is needed: `tsc -b` walks the composite project references and builds them on the way. Verified locally from a clean `dist/`-empty tree.
- `permissions: contents: read` at workflow level scopes the `GITHUB_TOKEN` to read-only.

## Bonus finding (not fixed here)

During local dry-run with `smoke-test` I hit a latent template bug: `scripts/create-adapter-templates/` substitutes `__name__` (raw slug with hyphens) into TypeScript identifier positions like `export const __name__AdapterManifest`, so any hyphenated slug fails to compile (`smoke-testAdapterManifest` parses as subtraction). Documented in the plan §3.2 / §6 — separate template fix, follow-up.

## Plan

`docs/plans/implementation-plan-686-scaffold-smoke-ci.md` captures the design tradeoffs (workspace-vs-tmp scaffolding, runner choice, pre-build redundancy verification, slug choice + the hyphen-bug carve-out).

## Test plan

- [x] Local dry-run: scaffold `smoketest` → `pnpm install --no-frozen-lockfile` → `pnpm --filter @openlinker/integrations-smoketest build` succeeds against a clean `dist/`-empty tree (~50s wall time)
- [x] Workflow YAML parses cleanly (`js-yaml` round-trip + manual structure check)
- [x] Pre-commit quality gate green (`pnpm lint` including `check-create-adapter`, `pnpm type-check`)
- [x] Full unit-test suite still passes (`pnpm test`, 475 tests across api+worker)
- [ ] First post-merge run will be the workflow's own validation against `ubuntu-latest`

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)