### PR TITLE
docs(prestashop): drop stale reconcileShippingCost reference in PS order mapper JSDoc

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -319,8 +319,7 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
    *
    * #503: `externalCarrierId` MUST be set on the cart, not just the order
    * body. PS resolves the order's `id_carrier` from the cart at `POST /orders`
-   * time and ignores the order body's `id_carrier` field. Consequences of
-   * skipping this are documented at the call site in the adapter.
+   * time and ignores the order body's `id_carrier` field.
    */
   mapCartCreate(
     orderCreate: OrderCreate,

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -319,10 +319,8 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
    *
    * #503: `externalCarrierId` MUST be set on the cart, not just the order
    * body. PS resolves the order's `id_carrier` from the cart at `POST /orders`
-   * time and ignores the order body's `id_carrier` field. Without this every
-   * synced order lands at `id_carrier=0`, no `order_carriers` row is created,
-   * and `reconcileShippingCost` cannot write the buyer-paid shipping cost
-   * back into PS.
+   * time and ignores the order body's `id_carrier` field. Consequences of
+   * skipping this are documented at the call site in the adapter.
    */
   mapCartCreate(
     orderCreate: OrderCreate,


### PR DESCRIPTION
## Summary

The trailing sentence in `mapCartCreate`'s JSDoc described the pre-#516 reconcile flow, which #516 deleted. The first three sentences carry the load-bearing contract (`externalCarrierId` MUST be on the cart, not the order body) and stay; consequences of skipping the contract are documented at the call site in the adapter.

Matches the proposed solution in #693 verbatim.

## Test plan

- [x] `grep -rn reconcileShippingCost libs/integrations/prestashop/src` returns zero hits
- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm --filter @openlinker/integrations-prestashop test` — 266 tests pass

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)