### PR TITLE
feat(testing): publish in-memory fakes for plugin-author specs

### DIFF
--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -1234,12 +1234,15 @@ import { Logger } from '../../../shared/logging';
 - **Short relative for same-context cross-layer**: avoids the `ERR_PACKAGE_PATH_NOT_EXPORTED` runtime trap and keeps intra-context refactors local.
 - **Enforceable**: ESLint guards at `.eslintrc.js` (port files, integration packages, host apps) reject deep aliases at lint time; package.json `exports` reject them at Node runtime.
 
-**Sub-barrels** are the narrow exception to "top-level-barrel-only". They exist to expose a host-only seam that would otherwise pollute the contract surface plugins consume. Two exist today:
+**Sub-barrels** are the narrow exception to "top-level-barrel-only". They exist to expose a host-only seam that would otherwise pollute the contract surface plugins consume. Three exist today:
 
 - `@openlinker/core/listings/services` — the `ListingsModule` + the 7 `@Injectable` service classes. Kept off the main `@openlinker/core/listings` barrel to prevent runtime circular requires when sibling packages value-import the contract from the main barrel (#337/#359).
 - `@openlinker/core/<ctx>/orm-entities` — TypeORM-decorated ORM entities for each context that has cross-context consumers (today: `products`, `inventory`, `orders`, `sync`, `identifier-mapping`, `integrations`, `content`). Kept off the main barrel because TypeORM entities are infrastructure detail; exposing them would couple plugins to TypeORM (#594). Consumed only by integration-test fixtures/helpers in `apps/{api,worker}/test/` and by core orchestration modules that need to register a sibling context's entity (today: `listings.module.ts`). The TypeORM CLI itself discovers entities via a filesystem glob in `apps/api/src/database/data-source.ts`, not through these sub-barrels.
+- `@openlinker/<package>/<ctx>/testing` — in-memory fake adapters for plugin-author `*.spec.ts` consumption (#601). Today: `@openlinker/core/identifier-mapping/testing`, `@openlinker/core/integrations/testing`, `@openlinker/core/events/testing`, `@openlinker/shared/cache/testing`. Each fake implements the corresponding `*.port.ts` interface and lives at `<ctx>/testing/in-memory-{capability}.adapter.ts`. Kept off the main barrel because (1) plugin authors consume them only from test files, never from runtime code, and (2) keeping them on a dedicated subpath prevents accidental imports from production paths that would pull test-only logic into the runtime bundle.
 
 Add a new `<ctx>/orm-entities` sub-barrel only when an external consumer needs a context's ORM entity — same-module registrations should keep using relative paths into `infrastructure/persistence/entities/`. Plugin packages (`libs/integrations/**`) and core port files are ESLint-blocked from importing any `orm-entities` sub-barrel.
+
+Add a new `<ctx>/testing` sub-barrel when a port's mocking surface is large or stateful enough that hand-rolling it in every spec is high-friction (the four ports listed above qualify; trivial ports with one or two methods do not). The fake class implements the port interface verbatim and exposes a small set of `clear()` / `seed(...)` test helpers; plugin authors consume them via the package-exports subpath.
 
 **Import Order**:
 1. External packages (NestJS, TypeORM, etc.)

--- a/docs/plans/implementation-plan-601-in-memory-fakes.md
+++ b/docs/plans/implementation-plan-601-in-memory-fakes.md
@@ -1,0 +1,186 @@
+# Implementation Plan — #601 In-memory fakes for plugin authors
+
+| Layer | Scope | Risk |
+|---|---|---|
+| DX (testing helpers across two existing workspaces) + docs | 4 fakes published from `@openlinker/core` and `@openlinker/shared` via `./testing` sub-barrels + plugin-author-guide section | Low — pure additive surface; production paths unchanged. |
+
+## 1. Problem framing
+
+Every adapter spec today hand-rolls its own mock of `IdentifierMappingPort`, `CredentialsResolverPort`, `CachePort`, `EventPublisherPort`. The repo has zero `testing/` or `fakes/` directories on the core/shared side; the only in-memory fake anywhere is `libs/integrations/ai/.../fake-ai-completion.adapter.ts` (PS-private fixtures aside). Per #601, this is high friction for OSS plugin authors and the hand-rolled fakes drift from production semantics.
+
+The four targets the issue calls out:
+
+| Port | Location | Why a fake helps |
+|---|---|---|
+| `IdentifierMappingPort` | `libs/core/src/identifier-mapping/` | Most-mocked port in the codebase (every adapter spec touches it). Replicating the `ol_{prefix}_{uuid}` ID format + conflict semantics by hand is error-prone. |
+| `CredentialsResolverPort` | `libs/core/src/integrations/` | Plugin specs need a seedable resolver — current production adapter is env-backed; a Map-backed fake lets specs declare credentials inline. |
+| `CachePort` | `libs/shared/src/cache/` | Honor TTL semantics correctly. Lets specs assert on key/value writes without spinning Redis. |
+| `EventPublisherPort` | `libs/core/src/events/` | Record published events for assertion; returns synthetic monotonic IDs that look like real Redis Streams IDs. |
+
+## 2. Architecture decisions
+
+**Placement**: Each fake lives in `<port-context>/testing/` — co-located with the port it satisfies. Aligns with the issue's recommendation ("`libs/core/src/identifier-mapping/testing/in-memory-identifier-mapping.ts`") and with the existing `libs/integrations/ai/src/infrastructure/adapters/fake-ai-completion.adapter.ts` precedent (the only in-tree fake today).
+
+**Naming**: align to engineering-standards § Adapters and the existing fake precedent (`libs/integrations/ai/.../fake-ai-completion.adapter.ts` → `FakeAiCompletionAdapter`). The issue body's `in-memory-identifier-mapping.ts` is loose phrasing, not a standards override.
+- File: `in-memory-{capability}.adapter.ts`
+- Class: `InMemory{Capability}Adapter`
+- Spec: `__tests__/in-memory-{capability}.adapter.spec.ts`
+
+**Sub-barrel exports**: New entries in each workspace's `package.json` `exports` field:
+
+```jsonc
+// libs/core/package.json — add three subpaths
+"./identifier-mapping/testing": { ... → dist/identifier-mapping/testing/index.js ... }
+"./integrations/testing":       { ... → dist/integrations/testing/index.js ... }
+"./events/testing":             { ... → dist/events/testing/index.js ... }
+
+// libs/shared/package.json — add one subpath
+"./cache/testing":              { ... → dist/cache/testing/index.js ... }
+```
+
+Plus `tsconfig.base.json` `paths` entries for each so consumers can `import { InMemoryIdentifierMapping } from '@openlinker/core/identifier-mapping/testing';` and have TS resolve at typecheck time.
+
+**Sub-barrel index files**: each `testing/index.ts` re-exports the fake class + its config/seed types. Mirrors the existing two-sub-barrel pattern (`@openlinker/core/listings/services`, `@openlinker/core/<ctx>/orm-entities`) — the runtime-constraint doc (`engineering-standards.md § Import Aliases`) explicitly allows new `./testing` sub-barrels under this same precedent.
+
+**Peer-dependency hygiene**: The issue body's "Mark these as peerDependencies-free" is paraphrased; the fakes still flow through the host package's existing peer-deps (the imported port types pull `@nestjs/common` transitively). What's actually true: **no new peer-deps are added for the fakes specifically**, and the fakes need no runtime dependencies beyond Node built-ins (`crypto.randomUUID()` from `node:crypto`, Node ≥ 18). No additions to `package.json` `dependencies` or `peerDependencies` arrays.
+
+## 3. Fakes
+
+### 3.1 `InMemoryIdentifierMappingAdapter`
+
+`libs/core/src/identifier-mapping/testing/in-memory-identifier-mapping.adapter.ts`
+
+Implements `IdentifierMappingPort` (the combined Query + Command union). Key semantics to replicate from the production service:
+
+- Internal-ID format: `ol_{prefix}_{uuid}` where `prefix` is `ENTITY_TYPE_ID_PREFIX[entityType]` if present else `entityType.toLowerCase()` (matches `identifier-mapping.service.ts:333-343`). UUIDs are `crypto.randomUUID()` with dashes stripped.
+- `getOrCreateInternalId`: idempotent — same `(entityType, externalId, connectionId)` returns the same internal ID across calls.
+- `getOrCreateExactMapping`: idempotent on match; throws `IdentifierMappingConflictException` when the external ID is mapped to a *different* internal ID.
+- `createMapping`: throws `DuplicateIdentifierMappingError` (the domain exception) when a duplicate is inserted.
+- `getExternalIds(entityType, internalId)`: returns all `ExternalIdMapping` entries with the given internal ID, across all connections.
+
+**Constructor**: optional `connectionPlatformMap?: Record<string, string>` — lets specs supply `platformType` per connection. When absent, `platformType` defaults to `''` in returned `ExternalIdMapping`s (the field is denormalization for query convenience; plugin specs rarely assert on it).
+
+**Helpers**:
+- `clear(): void` — reset state between tests.
+- `seed(input: { entityType: string; externalId: string; connectionId: string; internalId: string }): void` — pre-populate without going through `getOrCreateInternalId`.
+
+Spec: round-trip happy path, idempotent re-call, conflict on `getOrCreateExactMapping`, ID-format check, `clear()` + `seed()` semantics. ~10 tests.
+
+### 3.2 `InMemoryCredentialsResolverAdapter`
+
+`libs/core/src/integrations/testing/in-memory-credentials-resolver.adapter.ts`
+
+Implements `CredentialsResolverPort`. Backed by a `Map<string, unknown>`. Constructor accepts `Record<string, unknown>` for inline seeding.
+
+**Helpers**:
+- `clear(): void`
+- `seed(ref: string, credentials: unknown): void`
+
+Spec: get-by-ref happy path, throws on missing ref (matches the production contract `@throws Error if credentials cannot be resolved`), type-parameter narrowing (`get<MyShape>(ref)`). ~5 tests.
+
+### 3.3 `InMemoryCacheAdapter`
+
+`libs/shared/src/cache/testing/in-memory-cache.adapter.ts`
+
+Implements `CachePort`. Backed by `Map<string, { value: unknown; expiresAt: number }>`. TTL honored by storing `Date.now() + ttlSec * 1000` and checking against `Date.now()` on each `get` — expired entries return `null` AND are deleted lazily (cleans up over time).
+
+**Helpers**:
+- `clear(): void`
+- `size(): number` — for assertion (e.g., asserting an LRU-style eviction in higher-level code).
+- `seed<T>(key: string, value: T, ttlSec: number): void` — pre-populate without going through `set`. Same TTL semantics as `set`.
+
+No fake timer dependency — TTL works against the real clock; specs that need to test TTL expiry can use `jest.useFakeTimers()` themselves (documented in the plugin-author guide).
+
+Spec: get/set/delete, miss returns null, TTL respected (with `jest.useFakeTimers()` in one test), `clear()` + `seed()` semantics. ~7 tests.
+
+### 3.4 `InMemoryEventPublisherAdapter`
+
+`libs/core/src/events/testing/in-memory-event-publisher.adapter.ts`
+
+Implements `EventPublisherPort`. Stores published events in a `Map<streamName, EventEnvelope[]>`. Returns synthetic message IDs in the Redis Streams `<ms>-<seq>` shape — e.g. `'1715690400000-0'` — so consumers that assert on ID format don't break.
+
+**Helpers**:
+- `clear(): void`
+- `getPublishedEvents(streamName: string): EventEnvelope[]` — events published to a single stream.
+- `published(): Array<{ streamName: string; event: EventEnvelope; id: string }>` — flat list across all streams, in publish order.
+
+Spec: publish + assert, multi-stream isolation, monotonic ID format, `clear()` semantics. ~5 tests.
+
+## 4. Files
+
+```
+libs/core/src/identifier-mapping/testing/
+├── in-memory-identifier-mapping.adapter.ts
+├── index.ts                                                # re-export
+└── __tests__/
+    └── in-memory-identifier-mapping.adapter.spec.ts
+
+libs/core/src/integrations/testing/
+├── in-memory-credentials-resolver.adapter.ts
+├── index.ts
+└── __tests__/
+    └── in-memory-credentials-resolver.adapter.spec.ts
+
+libs/core/src/events/testing/
+├── in-memory-event-publisher.adapter.ts
+├── index.ts
+└── __tests__/
+    └── in-memory-event-publisher.adapter.spec.ts
+
+libs/shared/src/cache/testing/
+├── in-memory-cache.adapter.ts
+├── index.ts
+└── __tests__/
+    └── in-memory-cache.adapter.spec.ts
+
+# Subpath wiring
+libs/core/package.json        — +3 exports entries
+libs/shared/package.json      — +1 exports entry
+tsconfig.base.json            — +4 paths entries
+
+# Docs
+docs/engineering-standards.md  — § Sub-barrels — add a third bullet documenting the `./testing` pattern
+docs/plugin-author-guide.md    — § Step 10 — Tests — new sub-section for in-memory fakes
+```
+
+## 5. Architecture compliance check
+
+- **Hexagonal layering**: each fake implements a *port interface* — that's the canonical adapter shape (engineering-standards § Adapters). Lives at `<context>/testing/` rather than `<context>/infrastructure/adapters/` because these are **test-time-only** adapters, never wired into production module graphs. Every fake's file header carries a one-line rationale on this placement choice so the next reader doesn't "fix" it back into `infrastructure/adapters/`. The split from the AI precedent (`fake-ai-completion.adapter.ts` lives in `infrastructure/adapters/` because it IS wired into production when `OL_AI_PROVIDER=fake`) is intentional.
+- **Domain-layer purity**: the fakes don't live in `domain/`; they sit in their own `testing/` directories. No framework deps — pure TS + Node `crypto`.
+- **Naming**: `InMemory{Capability}` class, `in-memory-{capability}.ts` file, `__tests__/*.spec.ts` for unit tests. ✓
+- **File headers**: every new file gets the standard `@module` JSDoc header per § File Headers.
+- **No `any`**: type-parameterize `CachePort.get<T>` correctly; use `unknown` for `CredentialsResolverPort` get-return until the caller specifies the type.
+- **Logger**: fakes do NOT log — they're test infrastructure, callers don't need log noise. (Same rationale as test-kit's `console.warn`-only decision — keep dep graph tight.)
+- **Imports**: each fake imports only from same-package sources (`../domain/ports/...port`, `../domain/types/...types`) via short relative paths (≤ `../..`). Each `testing/index.ts` does `export * from './in-memory-{capability}';`.
+
+## 6. Step-by-step implementation
+
+1. **Scaffold sub-barrels** — create the four `testing/` directories with placeholder `index.ts` and the fake class skeletons. Add file headers per the project standard.
+2. **Implement `InMemoryIdentifierMapping`** (most complex — replicates ID format + conflict semantics). Write spec first to drive contract.
+3. **Implement `InMemoryCredentialsResolver`** + spec.
+4. **Implement `InMemoryCache`** + spec (TTL test uses `jest.useFakeTimers()`).
+5. **Implement `InMemoryEventPublisher`** + spec.
+6. **Wire `exports` field** in `libs/core/package.json` (+3) and `libs/shared/package.json` (+1). Add the four `tsconfig.base.json` `paths` entries.
+7. **Update `docs/plugin-author-guide.md`** § Step 10 — Tests with a "Testing without containers — in-memory fakes" sub-section. Show one copy-pasteable spec example using `InMemoryIdentifierMapping`.
+8. **Run quality gate**: `pnpm lint && pnpm type-check && pnpm test`. Verify the new sub-barrels typecheck across consumer surfaces (apps/api, libs/integrations/*).
+9. **Commit + self-review + PR**. Body: `Closes #601`; note follow-up surface (the issue also mentions `CustomerIdentityResolverPort` as a candidate — deferred unless trivial, since it's plugin-only and not in the four-item list at the bottom of the issue).
+
+## 7. Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+Optional sanity check after subpath wiring: `pnpm --filter @openlinker/core build && pnpm --filter @openlinker/shared build` to verify the `tsc -b` output produces the `dist/<context>/testing/index.{js,d.ts}` files that the `exports` field references.
+
+## 8. Validation checklist
+
+- [ ] Four fakes live under `<context>/testing/` with `__tests__/*.spec.ts` siblings.
+- [ ] Each fake's spec exercises happy-path, idempotency where applicable, conflict/error semantics, and helper methods (`clear`, `seed`).
+- [ ] `libs/core/package.json` carries 3 new `./*/testing` subpath exports; `libs/shared/package.json` carries 1.
+- [ ] `tsconfig.base.json` `paths` has 4 new entries for the testing sub-barrels.
+- [ ] `pnpm lint && pnpm type-check && pnpm test` green.
+- [ ] `docs/plugin-author-guide.md` § Step 10 has a "Testing without containers" sub-section with a working code example.
+- [ ] PR body carries `Closes #601` and explicitly notes which ports were in-scope (4) vs deferred.

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -722,6 +722,69 @@ the system under test, in which case you mock everything *it* depends on).
 PrestaShop's adapter specs:
 [`libs/integrations/prestashop/src/infrastructure/adapters/__tests__/`](../libs/integrations/prestashop/src/infrastructure/adapters/__tests__/).
 
+#### Testing without containers — in-memory fakes (#601)
+
+For the four ports plugin authors mock most often, core publishes
+ready-made in-memory fakes via dedicated `*/testing` subpaths. Each
+fake implements the corresponding port verbatim, replicates the
+production semantics (ID format, conflict exceptions, TTL behaviour,
+…), and exposes a small set of `clear()` / `seed(...)` test helpers:
+
+| Port | Fake | Subpath |
+|---|---|---|
+| `IdentifierMappingPort` | `InMemoryIdentifierMappingAdapter` | `@openlinker/core/identifier-mapping/testing` |
+| `CredentialsResolverPort` | `InMemoryCredentialsResolverAdapter` | `@openlinker/core/integrations/testing` |
+| `EventPublisherPort` | `InMemoryEventPublisherAdapter` | `@openlinker/core/events/testing` |
+| `CachePort` | `InMemoryCacheAdapter` | `@openlinker/shared/cache/testing` |
+
+Typical adapter spec — no Postgres, no Redis, no fixture files:
+
+```typescript
+import { InMemoryIdentifierMappingAdapter } from '@openlinker/core/identifier-mapping/testing';
+import { InMemoryCredentialsResolverAdapter } from '@openlinker/core/integrations/testing';
+import { YourPlatformOrderSourceAdapter } from '../your-platform-order-source.adapter';
+
+describe('YourPlatformOrderSourceAdapter', () => {
+  let identifierMapping: InMemoryIdentifierMappingAdapter;
+  let credentials: InMemoryCredentialsResolverAdapter;
+
+  beforeEach(() => {
+    identifierMapping = new InMemoryIdentifierMappingAdapter({
+      'conn-1': 'your-platform',
+    });
+    credentials = new InMemoryCredentialsResolverAdapter({
+      'env:YOUR_PLATFORM_TOKEN': { token: 'test-token' },
+    });
+    // Pre-seed any mappings the spec expects to already exist:
+    identifierMapping.seed({
+      entityType: 'Order',
+      externalId: 'platform-order-1',
+      connectionId: 'conn-1',
+      internalId: 'ol_order_seeded',
+    });
+  });
+
+  it('should map external order IDs through IdentifierMapping', async () => {
+    const adapter = new YourPlatformOrderSourceAdapter(identifierMapping, credentials, /* ... */);
+    // … exercise the adapter; the in-memory fakes back the port calls.
+  });
+});
+```
+
+**TTL testing with `InMemoryCacheAdapter`**: TTL is honored against the
+real clock. To assert expiry behaviour, wrap the test in
+`jest.useFakeTimers()` and call `jest.advanceTimersByTime(...)` past
+the configured TTL. See
+[`libs/shared/src/cache/testing/__tests__/in-memory-cache.adapter.spec.ts`](../libs/shared/src/cache/testing/__tests__/in-memory-cache.adapter.spec.ts)
+for the reference shape.
+
+**When to use a hand-rolled mock instead**: ports outside the four-fake
+list above (most capability ports — `OfferManagerPort`,
+`OrderSourcePort`, `OfferLister`, …) are typically narrow enough that a
+`jest.fn()` per method is the cleanest spec — no shared state, no
+semantics to replicate. The fakes exist specifically for ports whose
+mock-by-hand cost is high enough to justify a shared abstraction.
+
 ### Integration tests (`*.int-spec.ts`)
 
 Optional but high-value for a new plugin. The integration-test harness

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -23,6 +23,11 @@
       "require": "./dist/integrations/orm-entities.js",
       "default": "./dist/integrations/orm-entities.js"
     },
+    "./integrations/testing": {
+      "types": "./dist/integrations/testing/index.d.ts",
+      "require": "./dist/integrations/testing/index.js",
+      "default": "./dist/integrations/testing/index.js"
+    },
     "./identifier-mapping": {
       "types": "./dist/identifier-mapping/index.d.ts",
       "require": "./dist/identifier-mapping/index.js",
@@ -32,6 +37,11 @@
       "types": "./dist/identifier-mapping/orm-entities.d.ts",
       "require": "./dist/identifier-mapping/orm-entities.js",
       "default": "./dist/identifier-mapping/orm-entities.js"
+    },
+    "./identifier-mapping/testing": {
+      "types": "./dist/identifier-mapping/testing/index.d.ts",
+      "require": "./dist/identifier-mapping/testing/index.js",
+      "default": "./dist/identifier-mapping/testing/index.js"
     },
     "./mappings": {
       "types": "./dist/mappings/index.d.ts",
@@ -72,6 +82,11 @@
       "types": "./dist/events/index.d.ts",
       "require": "./dist/events/index.js",
       "default": "./dist/events/index.js"
+    },
+    "./events/testing": {
+      "types": "./dist/events/testing/index.d.ts",
+      "require": "./dist/events/testing/index.js",
+      "default": "./dist/events/testing/index.js"
     },
     "./sync": {
       "types": "./dist/sync/index.d.ts",

--- a/libs/core/src/events/testing/__tests__/in-memory-event-publisher.adapter.spec.ts
+++ b/libs/core/src/events/testing/__tests__/in-memory-event-publisher.adapter.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * InMemoryEventPublisherAdapter Tests
+ *
+ * @module libs/core/src/events/testing
+ */
+import type { EventEnvelope } from '../../domain/types/event.types';
+import { InMemoryEventPublisherAdapter } from '../in-memory-event-publisher.adapter';
+
+function buildEnvelope(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
+  return {
+    eventId: 'evt-1',
+    eventType: 'test.event',
+    payloadJson: '{}',
+    occurredAt: '2026-05-14T12:00:00.000Z',
+    publishedAt: '2026-05-14T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('InMemoryEventPublisherAdapter', () => {
+  it('should return a Redis-Streams-shaped ID on publish', async () => {
+    const publisher = new InMemoryEventPublisherAdapter();
+
+    const id = await publisher.publish('events.inbound.webhooks', buildEnvelope());
+
+    expect(id).toMatch(/^\d+-\d+$/);
+  });
+
+  it('should record the published event for assertion via getPublishedEvents', async () => {
+    const publisher = new InMemoryEventPublisherAdapter();
+    const envelope = buildEnvelope({ eventId: 'evt-recorded' });
+
+    await publisher.publish('events.inbound.webhooks', envelope);
+
+    expect(publisher.getPublishedEvents('events.inbound.webhooks')).toEqual([envelope]);
+  });
+
+  it('should isolate events by stream name', async () => {
+    const publisher = new InMemoryEventPublisherAdapter();
+    const a = buildEnvelope({ eventId: 'a' });
+    const b = buildEnvelope({ eventId: 'b' });
+
+    await publisher.publish('stream.A', a);
+    await publisher.publish('stream.B', b);
+
+    expect(publisher.getPublishedEvents('stream.A')).toEqual([a]);
+    expect(publisher.getPublishedEvents('stream.B')).toEqual([b]);
+    expect(publisher.getPublishedEvents('stream.empty')).toEqual([]);
+  });
+
+  it('should expose a flat, in-publish-order list via published()', async () => {
+    const publisher = new InMemoryEventPublisherAdapter();
+    const a = buildEnvelope({ eventId: 'a' });
+    const b = buildEnvelope({ eventId: 'b' });
+    const c = buildEnvelope({ eventId: 'c' });
+
+    await publisher.publish('stream.A', a);
+    await publisher.publish('stream.B', b);
+    await publisher.publish('stream.A', c);
+
+    const flat = publisher.published();
+    expect(flat).toHaveLength(3);
+    expect(flat.map((entry) => entry.event.eventId)).toEqual(['a', 'b', 'c']);
+    expect(flat.map((entry) => entry.streamName)).toEqual(['stream.A', 'stream.B', 'stream.A']);
+    // IDs must be strictly monotonic in sequence suffix.
+    const sequences = flat.map((entry) => Number(entry.id.split('-')[1]));
+    expect(sequences).toEqual([0, 1, 2]);
+  });
+
+  it('should reset all state on clear()', async () => {
+    const publisher = new InMemoryEventPublisherAdapter();
+    await publisher.publish('stream.A', buildEnvelope());
+
+    publisher.clear();
+
+    expect(publisher.getPublishedEvents('stream.A')).toEqual([]);
+    expect(publisher.published()).toEqual([]);
+    // Sequence counter resets too — next publish should start from suffix 0.
+    const nextId = await publisher.publish('stream.A', buildEnvelope());
+    expect(nextId.split('-')[1]).toBe('0');
+  });
+});

--- a/libs/core/src/events/testing/in-memory-event-publisher.adapter.ts
+++ b/libs/core/src/events/testing/in-memory-event-publisher.adapter.ts
@@ -1,0 +1,69 @@
+/**
+ * In-Memory Event-Publisher Adapter
+ *
+ * Test-time-only adapter implementing `EventPublisherPort`. Records published
+ * events in an internal `Map<streamName, Array<{ event, id }>>` so specs can
+ * assert on the publish side-effects without running Redis. Returns synthetic
+ * message IDs in the Redis Streams `<ms>-<seq>` shape (e.g. `1715690400000-0`)
+ * so consumers that introspect the ID format don't surprise-fail.
+ *
+ * **Placement**: lives at `<context>/testing/` rather than
+ * `<context>/infrastructure/adapters/` because it is never wired into a
+ * production module graph — only consumed by `*.spec.ts` files in plugin
+ * packages.
+ *
+ * @module libs/core/src/events/testing
+ * @see {@link EventPublisherPort} for the port contract
+ */
+import type { EventPublisherPort } from '../domain/ports/event-publisher.port';
+import type { EventEnvelope } from '../domain/types/event.types';
+
+interface PublishedEntry {
+  event: EventEnvelope;
+  id: string;
+}
+
+interface FlatPublishedEntry {
+  streamName: string;
+  event: EventEnvelope;
+  id: string;
+}
+
+export class InMemoryEventPublisherAdapter implements EventPublisherPort {
+  private readonly streams = new Map<string, PublishedEntry[]>();
+  private readonly publishOrder: FlatPublishedEntry[] = [];
+  private sequence = 0;
+
+  publish(streamName: string, event: EventEnvelope): Promise<string> {
+    const id = `${Date.now()}-${this.sequence++}`;
+    const bucket = this.streams.get(streamName) ?? [];
+    bucket.push({ event, id });
+    this.streams.set(streamName, bucket);
+    this.publishOrder.push({ streamName, event, id });
+    return Promise.resolve(id);
+  }
+
+  // ----- test helpers (not part of the port contract) -----
+
+  clear(): void {
+    this.streams.clear();
+    this.publishOrder.length = 0;
+    this.sequence = 0;
+  }
+
+  /**
+   * Events published to a single stream, in publish order. Returns an empty
+   * array when nothing has been published to the stream.
+   */
+  getPublishedEvents(streamName: string): EventEnvelope[] {
+    return (this.streams.get(streamName) ?? []).map((entry) => entry.event);
+  }
+
+  /**
+   * Flat list of all published entries across every stream, in publish order.
+   * Use when asserting on cross-stream sequencing or total counts.
+   */
+  published(): ReadonlyArray<FlatPublishedEntry> {
+    return this.publishOrder;
+  }
+}

--- a/libs/core/src/events/testing/index.ts
+++ b/libs/core/src/events/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Events Testing Sub-Barrel
+ *
+ * Public surface for the in-memory event-publisher fake. Consumed via the
+ * `@openlinker/core/events/testing` package-exports subpath.
+ *
+ * @module libs/core/src/events/testing
+ */
+export { InMemoryEventPublisherAdapter } from './in-memory-event-publisher.adapter';

--- a/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
+++ b/libs/core/src/identifier-mapping/application/services/identifier-mapping.service.ts
@@ -31,7 +31,7 @@ import type {
   IdentifierMappingRequest,
   ExternalIdMapping,
 } from '../../domain/types/identifier-mapping.types';
-import { ENTITY_TYPE_ID_PREFIX } from '../../domain/types/identifier-mapping.types';
+import { formatInternalId } from '../../domain/types/identifier-mapping.types';
 import {
   IDENTIFIER_MAPPING_REPOSITORY_TOKEN,
   CONNECTION_PORT_TOKEN,
@@ -331,14 +331,6 @@ export class IdentifierMappingService implements IIdentifierMappingService {
   }
 
   private generateInternalId(entityType: string): string {
-    // Format: ol_{prefix}_{uuid} — prefix defaults to entityType.toLowerCase()
-    // unless overridden in ENTITY_TYPE_ID_PREFIX (e.g. ProductVariant → 'variant').
-    // The override map is keyed by CoreEntityType; widen to a string index here
-    // so plugin-registered entity types (#577) fall through to the default
-    // lowercased prefix instead of failing the indexed access.
-    const overrides: Record<string, string | undefined> = ENTITY_TYPE_ID_PREFIX;
-    const uuid = randomUUID().replace(/-/g, '');
-    const prefix = overrides[entityType] ?? entityType.toLowerCase();
-    return `ol_${prefix}_${uuid}`;
+    return formatInternalId(entityType);
   }
 }

--- a/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/identifier-mapping.types.ts
@@ -2,11 +2,12 @@
  * Identifier Mapping Types
  *
  * Type definitions for identifier mapping operations. Defines the well-known
- * core entity types, mapping context, request structures, and external ID
- * mapping structures.
+ * core entity types, mapping context, request structures, external ID
+ * mapping structures, and the shared `formatInternalId` helper.
  *
  * @module libs/core/src/identifier-mapping/domain/types
  */
+import { randomUUID } from 'node:crypto';
 
 /**
  * Well-known core entity types — the documented set OpenLinker ships with.
@@ -61,6 +62,29 @@ export type CoreEntityType = (typeof CoreEntityTypeValues)[number];
 export const ENTITY_TYPE_ID_PREFIX: Partial<Record<CoreEntityType, string>> = {
   ProductVariant: 'variant',
 };
+
+/**
+ * Format an internal identifier for an entity.
+ *
+ * Format: `ol_{prefix}_{uuid_no_dashes}` where `prefix` defaults to
+ * `entityType.toLowerCase()` unless overridden in {@link ENTITY_TYPE_ID_PREFIX}
+ * (e.g. `ProductVariant` → `'variant'` → `ol_variant_<uuid>`).
+ *
+ * **Single source of truth.** Used by both the production
+ * `IdentifierMappingService` and the in-memory test fake
+ * (`InMemoryIdentifierMappingAdapter`). Any change to the on-disk ID shape
+ * must land here so production and tests stay in lockstep.
+ *
+ * @param entityType - well-known {@link CoreEntityType} or a plugin-registered
+ *   entity-type string (#577). The override-map lookup is widened to a
+ *   string index so plugin types fall through to the lowercased default.
+ */
+export function formatInternalId(entityType: string): string {
+  const overrides: Record<string, string | undefined> = ENTITY_TYPE_ID_PREFIX;
+  const uuid = randomUUID().replace(/-/g, '');
+  const prefix = overrides[entityType] ?? entityType.toLowerCase();
+  return `ol_${prefix}_${uuid}`;
+}
 
 export interface MappingContext {
   parentEntityType?: string;

--- a/libs/core/src/identifier-mapping/testing/__tests__/in-memory-identifier-mapping.adapter.spec.ts
+++ b/libs/core/src/identifier-mapping/testing/__tests__/in-memory-identifier-mapping.adapter.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * InMemoryIdentifierMappingAdapter Tests
+ *
+ * Unit specs for the in-memory fake. Covers the ID-format contract, idempotency,
+ * conflict semantics, and the `seed` / `clear` helpers.
+ *
+ * @module libs/core/src/identifier-mapping/testing
+ */
+import { DuplicateIdentifierMappingError } from '../../domain/exceptions/duplicate-identifier-mapping.error';
+import { IdentifierMappingConflictException } from '../../domain/exceptions/identifier-mapping-conflict.exception';
+import { InMemoryIdentifierMappingAdapter } from '../in-memory-identifier-mapping.adapter';
+
+describe('InMemoryIdentifierMappingAdapter', () => {
+  describe('getOrCreateInternalId', () => {
+    it('should return a new ol_{prefix}_{uuid} internal ID on first call', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+
+      const id = await adapter.getOrCreateInternalId('Product', 'ext-1', 'conn-1');
+
+      expect(id).toMatch(/^ol_product_[0-9a-f]{32}$/);
+    });
+
+    it('should be idempotent — return the same internal ID for the same (entityType, externalId, connectionId)', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+      const first = await adapter.getOrCreateInternalId('Product', 'ext-1', 'conn-1');
+
+      const second = await adapter.getOrCreateInternalId('Product', 'ext-1', 'conn-1');
+
+      expect(second).toBe(first);
+    });
+
+    it('should honor the ENTITY_TYPE_ID_PREFIX override for ProductVariant', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+
+      const id = await adapter.getOrCreateInternalId('ProductVariant', 'ext-v1', 'conn-1');
+
+      expect(id).toMatch(/^ol_variant_[0-9a-f]{32}$/);
+    });
+
+    it('should mint distinct IDs for distinct (externalId, connectionId) pairs', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+
+      const a = await adapter.getOrCreateInternalId('Product', 'ext-1', 'conn-A');
+      const b = await adapter.getOrCreateInternalId('Product', 'ext-1', 'conn-B');
+      const c = await adapter.getOrCreateInternalId('Product', 'ext-2', 'conn-A');
+
+      expect(new Set([a, b, c]).size).toBe(3);
+    });
+  });
+
+  describe('getInternalId', () => {
+    it('should return null when no mapping exists', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+
+      const id = await adapter.getInternalId('Product', 'ext-missing', 'conn-1');
+
+      expect(id).toBeNull();
+    });
+
+    it('should return the internal ID when a mapping exists', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+      const created = await adapter.getOrCreateInternalId('Product', 'ext-1', 'conn-1');
+
+      const looked = await adapter.getInternalId('Product', 'ext-1', 'conn-1');
+
+      expect(looked).toBe(created);
+    });
+  });
+
+  describe('getExternalIds', () => {
+    it('should return all external IDs mapped to a given internal ID across connections', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter({
+        'conn-A': 'allegro',
+        'conn-B': 'prestashop',
+      });
+      adapter.seed({ entityType: 'Product', externalId: 'ext-A', connectionId: 'conn-A', internalId: 'ol_product_x' });
+      adapter.seed({ entityType: 'Product', externalId: 'ext-B', connectionId: 'conn-B', internalId: 'ol_product_x' });
+
+      const externals = await adapter.getExternalIds('Product', 'ol_product_x');
+
+      expect(externals).toHaveLength(2);
+      expect(externals).toEqual(
+        expect.arrayContaining([
+          { externalId: 'ext-A', platformType: 'allegro', connectionId: 'conn-A', entityType: 'Product' },
+          { externalId: 'ext-B', platformType: 'prestashop', connectionId: 'conn-B', entityType: 'Product' },
+        ]),
+      );
+    });
+
+    it('should default platformType to empty string when no connectionPlatformMap entry exists', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+      adapter.seed({ entityType: 'Product', externalId: 'ext-1', connectionId: 'conn-1', internalId: 'ol_product_x' });
+
+      const [external] = await adapter.getExternalIds('Product', 'ol_product_x');
+
+      expect(external.platformType).toBe('');
+    });
+  });
+
+  describe('getOrCreateExactMapping', () => {
+    it('should be idempotent when the existing mapping matches the requested internalId', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+      adapter.seed({ entityType: 'Product', externalId: 'ext-1', connectionId: 'conn-1', internalId: 'ol_product_x' });
+
+      const returned = await adapter.getOrCreateExactMapping(
+        'Product',
+        'ext-1',
+        'ol_product_x',
+        'conn-1',
+      );
+
+      expect(returned).toBe('ext-1');
+    });
+
+    it('should throw IdentifierMappingConflictException when the externalId is mapped to a different internalId', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+      adapter.seed({ entityType: 'Product', externalId: 'ext-1', connectionId: 'conn-1', internalId: 'ol_product_existing' });
+
+      await expect(
+        adapter.getOrCreateExactMapping('Product', 'ext-1', 'ol_product_requested', 'conn-1'),
+      ).rejects.toBeInstanceOf(IdentifierMappingConflictException);
+    });
+  });
+
+  describe('createMapping', () => {
+    it('should throw DuplicateIdentifierMappingError on second insert with the same composite key', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+      await adapter.createMapping('Product', 'ext-1', 'conn-1', 'ol_product_x');
+
+      await expect(
+        adapter.createMapping('Product', 'ext-1', 'conn-1', 'ol_product_y'),
+      ).rejects.toBeInstanceOf(DuplicateIdentifierMappingError);
+    });
+  });
+
+  describe('listExternalIdsByConnection', () => {
+    it('should return all external IDs of an entityType for a single connection', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+      adapter.seed({ entityType: 'Product', externalId: 'ext-1', connectionId: 'conn-A', internalId: 'ol_product_1' });
+      adapter.seed({ entityType: 'Product', externalId: 'ext-2', connectionId: 'conn-A', internalId: 'ol_product_2' });
+      adapter.seed({ entityType: 'Product', externalId: 'ext-3', connectionId: 'conn-B', internalId: 'ol_product_3' });
+      adapter.seed({ entityType: 'Order', externalId: 'ord-1', connectionId: 'conn-A', internalId: 'ol_order_1' });
+
+      const externals = await adapter.listExternalIdsByConnection('Product', 'conn-A');
+
+      expect(externals.sort()).toEqual(['ext-1', 'ext-2']);
+    });
+  });
+
+  describe('helpers', () => {
+    it('should drop all rows on clear()', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+      await adapter.getOrCreateInternalId('Product', 'ext-1', 'conn-1');
+
+      adapter.clear();
+
+      expect(await adapter.getInternalId('Product', 'ext-1', 'conn-1')).toBeNull();
+    });
+
+    it('should pre-populate without minting a new ID when seed() is used', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter();
+
+      adapter.seed({ entityType: 'Product', externalId: 'ext-1', connectionId: 'conn-1', internalId: 'ol_product_pre_seeded' });
+
+      expect(await adapter.getInternalId('Product', 'ext-1', 'conn-1')).toBe('ol_product_pre_seeded');
+    });
+  });
+});

--- a/libs/core/src/identifier-mapping/testing/__tests__/in-memory-identifier-mapping.adapter.spec.ts
+++ b/libs/core/src/identifier-mapping/testing/__tests__/in-memory-identifier-mapping.adapter.spec.ts
@@ -95,6 +95,14 @@ describe('InMemoryIdentifierMappingAdapter', () => {
 
       expect(external.platformType).toBe('');
     });
+
+    it('should throw on unknown connectionId in strict mode (non-empty connectionPlatformMap)', async () => {
+      const adapter = new InMemoryIdentifierMappingAdapter({ 'conn-known': 'allegro' });
+
+      await expect(
+        adapter.getOrCreateInternalId('Product', 'ext-1', 'conn-unknown'),
+      ).rejects.toThrow(/unknown connectionId 'conn-unknown'/);
+    });
   });
 
   describe('getOrCreateExactMapping', () => {

--- a/libs/core/src/identifier-mapping/testing/in-memory-identifier-mapping.adapter.ts
+++ b/libs/core/src/identifier-mapping/testing/in-memory-identifier-mapping.adapter.ts
@@ -1,0 +1,251 @@
+/**
+ * In-Memory Identifier-Mapping Adapter
+ *
+ * Test-time-only adapter implementing `IdentifierMappingPort` for plugin
+ * authors and unit specs that need to exercise identifier-mapping flows
+ * without spinning Postgres. Replicates the production service's semantics:
+ * `ol_{prefix}_{uuid}` internal-ID format (via `ENTITY_TYPE_ID_PREFIX`),
+ * idempotent `getOrCreateInternalId`, and the domain exception types
+ * (`DuplicateIdentifierMappingError`, `IdentifierMappingConflictException`).
+ *
+ * **Placement**: lives at `<context>/testing/` rather than
+ * `<context>/infrastructure/adapters/` because it is never wired into a
+ * production module graph — only consumed by `*.spec.ts` files in plugin
+ * packages. The AI fake (`fake-ai-completion.adapter.ts`) lives at
+ * `infrastructure/adapters/` because it IS wired into production when
+ * `OL_AI_PROVIDER=fake`; that's a different role.
+ *
+ * @module libs/core/src/identifier-mapping/testing
+ * @see {@link IdentifierMappingPort} for the port contract
+ * @see {@link IdentifierMappingService} for the production implementation
+ */
+import { randomUUID } from 'node:crypto';
+import type {
+  IdentifierMappingPort,
+} from '../domain/ports/identifier-mapping.port';
+import type {
+  ExternalIdMapping,
+  IdentifierMappingRequest,
+  MappingContext,
+} from '../domain/types/identifier-mapping.types';
+import { ENTITY_TYPE_ID_PREFIX } from '../domain/types/identifier-mapping.types';
+import { DuplicateIdentifierMappingError } from '../domain/exceptions/duplicate-identifier-mapping.error';
+import { IdentifierMappingConflictException } from '../domain/exceptions/identifier-mapping-conflict.exception';
+
+/**
+ * Stored row shape. The composite key `(entityType, externalId, connectionId)`
+ * is enforced by the `Map`'s key derivation (`keyOf` below). `internalId` and
+ * `platformType` are denormalized for the reverse-lookup path.
+ */
+interface Row {
+  readonly entityType: string;
+  readonly externalId: string;
+  readonly connectionId: string;
+  readonly internalId: string;
+  readonly platformType: string;
+  readonly context: MappingContext | null;
+}
+
+/**
+ * Seed input for {@link InMemoryIdentifierMappingAdapter.seed}.
+ */
+export interface InMemoryIdentifierMappingSeed {
+  entityType: string;
+  externalId: string;
+  connectionId: string;
+  internalId: string;
+  context?: MappingContext;
+}
+
+export class InMemoryIdentifierMappingAdapter implements IdentifierMappingPort {
+  private readonly rows = new Map<string, Row>();
+
+  /**
+   * @param connectionPlatformMap optional map of `connectionId` →
+   *   `platformType`. Used to populate the `platformType` field on returned
+   *   `ExternalIdMapping`s. Absent connection IDs default to `''`.
+   */
+  constructor(private readonly connectionPlatformMap: Readonly<Record<string, string>> = {}) {}
+
+  getInternalId(
+    entityType: string,
+    externalId: string,
+    connectionId: string,
+  ): Promise<string | null> {
+    const row = this.rows.get(keyOf(entityType, externalId, connectionId));
+    return Promise.resolve(row?.internalId ?? null);
+  }
+
+  getExternalIds(entityType: string, internalId: string): Promise<ExternalIdMapping[]> {
+    const result: ExternalIdMapping[] = [];
+    for (const row of this.rows.values()) {
+      if (row.entityType === entityType && row.internalId === internalId) {
+        result.push({
+          externalId: row.externalId,
+          platformType: row.platformType,
+          connectionId: row.connectionId,
+          entityType: row.entityType,
+        });
+      }
+    }
+    return Promise.resolve(result);
+  }
+
+  listExternalIdsByConnection(entityType: string, connectionId: string): Promise<string[]> {
+    const result: string[] = [];
+    for (const row of this.rows.values()) {
+      if (row.entityType === entityType && row.connectionId === connectionId) {
+        result.push(row.externalId);
+      }
+    }
+    return Promise.resolve(result);
+  }
+
+  getOrCreateInternalId(
+    entityType: string,
+    externalId: string,
+    connectionId: string,
+    context?: MappingContext,
+  ): Promise<string> {
+    const key = keyOf(entityType, externalId, connectionId);
+    const existing = this.rows.get(key);
+    if (existing) {
+      return Promise.resolve(existing.internalId);
+    }
+    const internalId = this.generateInternalId(entityType);
+    this.rows.set(key, this.buildRow(entityType, externalId, connectionId, internalId, context));
+    return Promise.resolve(internalId);
+  }
+
+  createMapping(
+    entityType: string,
+    externalId: string,
+    connectionId: string,
+    internalId: string,
+    context?: MappingContext,
+  ): Promise<void> {
+    const key = keyOf(entityType, externalId, connectionId);
+    if (this.rows.has(key)) {
+      return Promise.reject(
+        new DuplicateIdentifierMappingError(
+          entityType,
+          externalId,
+          this.platformTypeFor(connectionId),
+          connectionId,
+        ),
+      );
+    }
+    this.rows.set(key, this.buildRow(entityType, externalId, connectionId, internalId, context));
+    return Promise.resolve();
+  }
+
+  async batchGetOrCreateInternalIds(
+    requests: IdentifierMappingRequest[],
+  ): Promise<Map<string, string>> {
+    const result = new Map<string, string>();
+    for (const req of requests) {
+      const internalId = await this.getOrCreateInternalId(
+        req.entityType,
+        req.externalId,
+        req.connectionId,
+        req.context,
+      );
+      result.set(`${req.externalId}:${req.connectionId}`, internalId);
+    }
+    return result;
+  }
+
+  getOrCreateExactMapping(
+    entityType: string,
+    externalId: string,
+    internalId: string,
+    connectionId: string,
+    context?: MappingContext,
+  ): Promise<string> {
+    const key = keyOf(entityType, externalId, connectionId);
+    const existing = this.rows.get(key);
+    if (existing) {
+      if (existing.internalId === internalId) {
+        return Promise.resolve(externalId);
+      }
+      return Promise.reject(
+        new IdentifierMappingConflictException(
+          entityType,
+          externalId,
+          connectionId,
+          existing.internalId,
+          internalId,
+        ),
+      );
+    }
+    this.rows.set(key, this.buildRow(entityType, externalId, connectionId, internalId, context));
+    return Promise.resolve(externalId);
+  }
+
+  deleteMapping(entityType: string, externalId: string, connectionId: string): Promise<void> {
+    this.rows.delete(keyOf(entityType, externalId, connectionId));
+    return Promise.resolve();
+  }
+
+  // ----- test helpers (not part of the port contract) -----
+
+  /**
+   * Reset all stored mappings. Typical use: `beforeEach(() => adapter.clear())`.
+   */
+  clear(): void {
+    this.rows.clear();
+  }
+
+  /**
+   * Pre-populate a mapping without going through `getOrCreateInternalId`.
+   * Overwrites any existing row at the same `(entityType, externalId, connectionId)` key.
+   */
+  seed(input: InMemoryIdentifierMappingSeed): void {
+    this.rows.set(
+      keyOf(input.entityType, input.externalId, input.connectionId),
+      this.buildRow(
+        input.entityType,
+        input.externalId,
+        input.connectionId,
+        input.internalId,
+        input.context,
+      ),
+    );
+  }
+
+  // ----- internals -----
+
+  private buildRow(
+    entityType: string,
+    externalId: string,
+    connectionId: string,
+    internalId: string,
+    context: MappingContext | undefined,
+  ): Row {
+    return {
+      entityType,
+      externalId,
+      connectionId,
+      internalId,
+      platformType: this.platformTypeFor(connectionId),
+      context: context ?? null,
+    };
+  }
+
+  private platformTypeFor(connectionId: string): string {
+    return this.connectionPlatformMap[connectionId] ?? '';
+  }
+
+  private generateInternalId(entityType: string): string {
+    // Mirrors `IdentifierMappingService.generateInternalId` — keep both shapes
+    // in sync if the production format changes.
+    const overrides: Record<string, string | undefined> = ENTITY_TYPE_ID_PREFIX;
+    const uuid = randomUUID().replace(/-/g, '');
+    const prefix = overrides[entityType] ?? entityType.toLowerCase();
+    return `ol_${prefix}_${uuid}`;
+  }
+}
+
+function keyOf(entityType: string, externalId: string, connectionId: string): string {
+  return `${entityType}\x00${externalId}\x00${connectionId}`;
+}

--- a/libs/core/src/identifier-mapping/testing/in-memory-identifier-mapping.adapter.ts
+++ b/libs/core/src/identifier-mapping/testing/in-memory-identifier-mapping.adapter.ts
@@ -4,7 +4,8 @@
  * Test-time-only adapter implementing `IdentifierMappingPort` for plugin
  * authors and unit specs that need to exercise identifier-mapping flows
  * without spinning Postgres. Replicates the production service's semantics:
- * `ol_{prefix}_{uuid}` internal-ID format (via `ENTITY_TYPE_ID_PREFIX`),
+ * `ol_{prefix}_{uuid}` internal-ID format (via the shared `formatInternalId`
+ * helper — single source of truth shared with `IdentifierMappingService`),
  * idempotent `getOrCreateInternalId`, and the domain exception types
  * (`DuplicateIdentifierMappingError`, `IdentifierMappingConflictException`).
  *
@@ -19,7 +20,6 @@
  * @see {@link IdentifierMappingPort} for the port contract
  * @see {@link IdentifierMappingService} for the production implementation
  */
-import { randomUUID } from 'node:crypto';
 import type {
   IdentifierMappingPort,
 } from '../domain/ports/identifier-mapping.port';
@@ -28,7 +28,7 @@ import type {
   IdentifierMappingRequest,
   MappingContext,
 } from '../domain/types/identifier-mapping.types';
-import { ENTITY_TYPE_ID_PREFIX } from '../domain/types/identifier-mapping.types';
+import { formatInternalId } from '../domain/types/identifier-mapping.types';
 import { DuplicateIdentifierMappingError } from '../domain/exceptions/duplicate-identifier-mapping.error';
 import { IdentifierMappingConflictException } from '../domain/exceptions/identifier-mapping-conflict.exception';
 
@@ -61,9 +61,19 @@ export class InMemoryIdentifierMappingAdapter implements IdentifierMappingPort {
   private readonly rows = new Map<string, Row>();
 
   /**
-   * @param connectionPlatformMap optional map of `connectionId` →
-   *   `platformType`. Used to populate the `platformType` field on returned
-   *   `ExternalIdMapping`s. Absent connection IDs default to `''`.
+   * @param connectionPlatformMap optional map of `connectionId` → `platformType`.
+   *
+   * **Strictness mode** — chosen by whether the map is empty:
+   * - **Empty (default)**: `platformType` denormalises to `''` on every row.
+   *   Use this when the spec does not assert on `ExternalIdMapping.platformType`.
+   * - **Non-empty**: every `connectionId` passed to a write method MUST be a
+   *   key of the map. An unknown `connectionId` throws an `Error` — matching
+   *   the production FK-violation that the real repository would surface
+   *   when the `connections` row does not exist.
+   *
+   * This split avoids two failure modes: (a) specs that don't care about
+   * `platformType` getting noise from a strict check, and (b) specs that do
+   * care getting silent `''` values that diverge from the production adapter.
    */
   constructor(private readonly connectionPlatformMap: Readonly<Record<string, string>> = {}) {}
 
@@ -107,6 +117,8 @@ export class InMemoryIdentifierMappingAdapter implements IdentifierMappingPort {
     connectionId: string,
     context?: MappingContext,
   ): Promise<string> {
+    const guard = this.checkConnectionKnown(connectionId);
+    if (guard) return Promise.reject(guard);
     const key = keyOf(entityType, externalId, connectionId);
     const existing = this.rows.get(key);
     if (existing) {
@@ -124,6 +136,8 @@ export class InMemoryIdentifierMappingAdapter implements IdentifierMappingPort {
     internalId: string,
     context?: MappingContext,
   ): Promise<void> {
+    const guard = this.checkConnectionKnown(connectionId);
+    if (guard) return Promise.reject(guard);
     const key = keyOf(entityType, externalId, connectionId);
     if (this.rows.has(key)) {
       return Promise.reject(
@@ -162,6 +176,8 @@ export class InMemoryIdentifierMappingAdapter implements IdentifierMappingPort {
     connectionId: string,
     context?: MappingContext,
   ): Promise<string> {
+    const guard = this.checkConnectionKnown(connectionId);
+    if (guard) return Promise.reject(guard);
     const key = keyOf(entityType, externalId, connectionId);
     const existing = this.rows.get(key);
     if (existing) {
@@ -199,8 +215,14 @@ export class InMemoryIdentifierMappingAdapter implements IdentifierMappingPort {
   /**
    * Pre-populate a mapping without going through `getOrCreateInternalId`.
    * Overwrites any existing row at the same `(entityType, externalId, connectionId)` key.
+   *
+   * Honours strict mode: throws synchronously when `connectionPlatformMap`
+   * is non-empty and `connectionId` is missing — `seed` is a test helper
+   * (not part of the port contract), so a sync throw is the right shape.
    */
   seed(input: InMemoryIdentifierMappingSeed): void {
+    const guard = this.checkConnectionKnown(input.connectionId);
+    if (guard) throw guard;
     this.rows.set(
       keyOf(input.entityType, input.externalId, input.connectionId),
       this.buildRow(
@@ -232,17 +254,38 @@ export class InMemoryIdentifierMappingAdapter implements IdentifierMappingPort {
     };
   }
 
+  /**
+   * Always-safe `platformType` lookup. Returns `''` for unknown ids in both
+   * modes. Callers wanting strict-mode behaviour MUST call
+   * {@link checkConnectionKnown} first and short-circuit on a non-null result.
+   */
   private platformTypeFor(connectionId: string): string {
     return this.connectionPlatformMap[connectionId] ?? '';
   }
 
+  /**
+   * Strict-mode guard. Returns an `Error` describing the unknown id when the
+   * `connectionPlatformMap` is non-empty AND the id is missing; returns `null`
+   * otherwise. Returned (not thrown) so public methods can `return Promise.reject(err)`
+   * and the port's `Promise<T>` contract isn't violated by a synchronous throw.
+   */
+  private checkConnectionKnown(connectionId: string): Error | null {
+    if (this.connectionPlatformMap[connectionId] !== undefined) {
+      return null;
+    }
+    if (Object.keys(this.connectionPlatformMap).length === 0) {
+      return null;
+    }
+    return new Error(
+      `InMemoryIdentifierMappingAdapter: unknown connectionId '${connectionId}'. ` +
+        `Seed it in the constructor's connectionPlatformMap or omit the map to opt into lax mode.`,
+    );
+  }
+
   private generateInternalId(entityType: string): string {
-    // Mirrors `IdentifierMappingService.generateInternalId` — keep both shapes
-    // in sync if the production format changes.
-    const overrides: Record<string, string | undefined> = ENTITY_TYPE_ID_PREFIX;
-    const uuid = randomUUID().replace(/-/g, '');
-    const prefix = overrides[entityType] ?? entityType.toLowerCase();
-    return `ol_${prefix}_${uuid}`;
+    // Delegates to the shared `formatInternalId` helper so the test fake and
+    // the production `IdentifierMappingService` can never drift on ID shape.
+    return formatInternalId(entityType);
   }
 }
 

--- a/libs/core/src/identifier-mapping/testing/index.ts
+++ b/libs/core/src/identifier-mapping/testing/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Identifier-Mapping Testing Sub-Barrel
+ *
+ * Public surface for the in-memory fake. Consumed via the
+ * `@openlinker/core/identifier-mapping/testing` package-exports subpath
+ * (see `libs/core/package.json`). Plugin authors import from this barrel
+ * in their `*.spec.ts` files; production code never reaches in here.
+ *
+ * @module libs/core/src/identifier-mapping/testing
+ */
+export { InMemoryIdentifierMappingAdapter } from './in-memory-identifier-mapping.adapter';
+export type { InMemoryIdentifierMappingSeed } from './in-memory-identifier-mapping.adapter';

--- a/libs/core/src/integrations/testing/__tests__/in-memory-credentials-resolver.adapter.spec.ts
+++ b/libs/core/src/integrations/testing/__tests__/in-memory-credentials-resolver.adapter.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * InMemoryCredentialsResolverAdapter Tests
+ *
+ * @module libs/core/src/integrations/testing
+ */
+import { InMemoryCredentialsResolverAdapter } from '../in-memory-credentials-resolver.adapter';
+
+describe('InMemoryCredentialsResolverAdapter', () => {
+  it('should return the seeded credentials for a known ref', async () => {
+    const resolver = new InMemoryCredentialsResolverAdapter({
+      'env:ALLEGRO_TOKEN': { token: 'abc123' },
+    });
+
+    const credentials = await resolver.get<{ token: string }>('env:ALLEGRO_TOKEN');
+
+    expect(credentials).toEqual({ token: 'abc123' });
+  });
+
+  it('should narrow the return type via the generic parameter', async () => {
+    interface PrestashopCreds {
+      apiKey: string;
+      baseUrl: string;
+    }
+    const resolver = new InMemoryCredentialsResolverAdapter({
+      'env:PS_CREDS': { apiKey: 'k', baseUrl: 'https://shop.example' } satisfies PrestashopCreds,
+    });
+
+    const creds = await resolver.get<PrestashopCreds>('env:PS_CREDS');
+
+    expect(creds.apiKey).toBe('k');
+    expect(creds.baseUrl).toBe('https://shop.example');
+  });
+
+  it('should throw with a descriptive message when the ref is missing', async () => {
+    const resolver = new InMemoryCredentialsResolverAdapter();
+
+    await expect(resolver.get('env:MISSING')).rejects.toThrow(
+      /Credentials not found for ref: env:MISSING/,
+    );
+  });
+
+  it('should pick up credentials seeded via seed() after construction', async () => {
+    const resolver = new InMemoryCredentialsResolverAdapter();
+
+    resolver.seed('env:LATER', 'value-added-later');
+
+    expect(await resolver.get('env:LATER')).toBe('value-added-later');
+  });
+
+  it('should make subsequent get() calls throw after clear()', async () => {
+    const resolver = new InMemoryCredentialsResolverAdapter({ 'env:X': 'y' });
+
+    resolver.clear();
+
+    await expect(resolver.get('env:X')).rejects.toThrow(/not found/);
+  });
+});

--- a/libs/core/src/integrations/testing/in-memory-credentials-resolver.adapter.ts
+++ b/libs/core/src/integrations/testing/in-memory-credentials-resolver.adapter.ts
@@ -1,0 +1,48 @@
+/**
+ * In-Memory Credentials-Resolver Adapter
+ *
+ * Test-time-only adapter implementing `CredentialsResolverPort`. Backed by an
+ * internal `Map<string, unknown>`; specs seed credentials inline rather than
+ * setting environment variables or mocking a vault.
+ *
+ * **Placement**: lives at `<context>/testing/` rather than
+ * `<context>/infrastructure/adapters/` because it is never wired into a
+ * production module graph — only consumed by `*.spec.ts` files in plugin
+ * packages. See the identifier-mapping fake header for the placement
+ * rationale.
+ *
+ * @module libs/core/src/integrations/testing
+ * @see {@link CredentialsResolverPort} for the port contract
+ */
+import type { CredentialsResolverPort } from '../domain/ports/credentials-resolver.port';
+
+export class InMemoryCredentialsResolverAdapter implements CredentialsResolverPort {
+  private readonly store = new Map<string, unknown>();
+
+  /**
+   * @param initial optional map of `credentialsRef` → credentials object. Seeded
+   *   on construction. Specs can also call {@link seed} later.
+   */
+  constructor(initial: Readonly<Record<string, unknown>> = {}) {
+    for (const [ref, credentials] of Object.entries(initial)) {
+      this.store.set(ref, credentials);
+    }
+  }
+
+  get<T = unknown>(credentialsRef: string): Promise<T> {
+    if (!this.store.has(credentialsRef)) {
+      return Promise.reject(new Error(`Credentials not found for ref: ${credentialsRef}`));
+    }
+    return Promise.resolve(this.store.get(credentialsRef) as T);
+  }
+
+  // ----- test helpers (not part of the port contract) -----
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  seed(ref: string, credentials: unknown): void {
+    this.store.set(ref, credentials);
+  }
+}

--- a/libs/core/src/integrations/testing/index.ts
+++ b/libs/core/src/integrations/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Integrations Testing Sub-Barrel
+ *
+ * Public surface for the in-memory credentials-resolver fake. Consumed via
+ * the `@openlinker/core/integrations/testing` package-exports subpath.
+ *
+ * @module libs/core/src/integrations/testing
+ */
+export { InMemoryCredentialsResolverAdapter } from './in-memory-credentials-resolver.adapter';

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -43,6 +43,10 @@
     "./cache": {
       "types": "./dist/cache/index.d.ts",
       "require": "./dist/cache/index.js"
+    },
+    "./cache/testing": {
+      "types": "./dist/cache/testing/index.d.ts",
+      "require": "./dist/cache/testing/index.js"
     }
   },
   "files": [

--- a/libs/shared/src/cache/testing/__tests__/in-memory-cache.adapter.spec.ts
+++ b/libs/shared/src/cache/testing/__tests__/in-memory-cache.adapter.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * InMemoryCacheAdapter Tests
+ *
+ * @module libs/shared/src/cache/testing
+ */
+import { InMemoryCacheAdapter } from '../in-memory-cache.adapter';
+
+describe('InMemoryCacheAdapter', () => {
+  it('should return null on a miss', async () => {
+    const cache = new InMemoryCacheAdapter();
+
+    expect(await cache.get('missing')).toBeNull();
+  });
+
+  it('should round-trip set + get', async () => {
+    const cache = new InMemoryCacheAdapter();
+
+    await cache.set('k', { hello: 'world' }, 60);
+
+    expect(await cache.get<{ hello: string }>('k')).toEqual({ hello: 'world' });
+  });
+
+  it('should delete the entry on delete()', async () => {
+    const cache = new InMemoryCacheAdapter();
+    await cache.set('k', 'v', 60);
+
+    await cache.delete('k');
+
+    expect(await cache.get('k')).toBeNull();
+  });
+
+  it('should respect TTL — expired entries return null and are lazily evicted', async () => {
+    jest.useFakeTimers();
+    try {
+      const cache = new InMemoryCacheAdapter();
+      await cache.set('k', 'v', 30); // 30s TTL
+      expect(cache.size()).toBe(1);
+
+      jest.advanceTimersByTime(31_000); // jump past expiry
+
+      expect(await cache.get('k')).toBeNull();
+      // get() lazily evicts on miss
+      expect(cache.size()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should drop all entries on clear()', async () => {
+    const cache = new InMemoryCacheAdapter();
+    await cache.set('a', 1, 60);
+    await cache.set('b', 2, 60);
+
+    cache.clear();
+
+    expect(cache.size()).toBe(0);
+    expect(await cache.get('a')).toBeNull();
+  });
+
+  it('should pre-populate without going through set when seed() is used', async () => {
+    const cache = new InMemoryCacheAdapter();
+
+    cache.seed('k', 'pre-seeded', 60);
+
+    expect(await cache.get('k')).toBe('pre-seeded');
+  });
+
+  it('should report size() across all entries (expired or not, until lazy eviction)', async () => {
+    const cache = new InMemoryCacheAdapter();
+    expect(cache.size()).toBe(0);
+
+    await cache.set('a', 1, 60);
+    await cache.set('b', 2, 60);
+
+    expect(cache.size()).toBe(2);
+  });
+});

--- a/libs/shared/src/cache/testing/in-memory-cache.adapter.ts
+++ b/libs/shared/src/cache/testing/in-memory-cache.adapter.ts
@@ -12,8 +12,13 @@
  * `infrastructure/` split there) and this adapter is never wired into a
  * production module graph anyway — only consumed by `*.spec.ts` files.
  *
- * **TTL testing**: works against the real clock; specs that need to assert
- * TTL expiry can use `jest.useFakeTimers()` themselves.
+ * **TTL testing**: the adapter reads `Date.now()` directly. Jest 29's modern
+ * fake timers (the default since Jest 27) mock `Date.now()`, so a spec can
+ * call `jest.useFakeTimers()` + `jest.advanceTimersByTime(ms)` to step past
+ * an entry's expiry without sleeping. To pin to an absolute wall-clock time
+ * instead (e.g. to test boundary semantics around midnight), use
+ * `jest.setSystemTime(new Date(...))` or `useFakeTimers({ now: <ms> })`.
+ * See `in-memory-cache.adapter.spec.ts` for a worked example.
  *
  * @module libs/shared/src/cache/testing
  * @see {@link CachePort} for the port contract

--- a/libs/shared/src/cache/testing/in-memory-cache.adapter.ts
+++ b/libs/shared/src/cache/testing/in-memory-cache.adapter.ts
@@ -1,0 +1,75 @@
+/**
+ * In-Memory Cache Adapter
+ *
+ * Test-time-only adapter implementing `CachePort`. Backed by an internal
+ * `Map<string, { value: unknown; expiresAt: number }>`. TTL is honored by
+ * storing `Date.now() + ttlSec * 1000` and checking against `Date.now()` on
+ * each `get` — expired entries return `null` and are deleted lazily.
+ *
+ * **Placement**: lives at `cache/testing/` rather than
+ * `cache/infrastructure/adapters/` because `libs/shared` does not use the
+ * full hexagonal layered structure (no `domain/`, `application/`,
+ * `infrastructure/` split there) and this adapter is never wired into a
+ * production module graph anyway — only consumed by `*.spec.ts` files.
+ *
+ * **TTL testing**: works against the real clock; specs that need to assert
+ * TTL expiry can use `jest.useFakeTimers()` themselves.
+ *
+ * @module libs/shared/src/cache/testing
+ * @see {@link CachePort} for the port contract
+ */
+import type { CachePort } from '../cache.port';
+
+interface Entry {
+  value: unknown;
+  expiresAt: number;
+}
+
+export class InMemoryCacheAdapter implements CachePort {
+  private readonly store = new Map<string, Entry>();
+
+  get<T>(key: string): Promise<T | null> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return Promise.resolve(null);
+    }
+    if (entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(entry.value as T);
+  }
+
+  set<T>(key: string, value: T, ttlSec: number): Promise<void> {
+    this.store.set(key, { value, expiresAt: Date.now() + ttlSec * 1000 });
+    return Promise.resolve();
+  }
+
+  delete(key: string): Promise<void> {
+    this.store.delete(key);
+    return Promise.resolve();
+  }
+
+  // ----- test helpers (not part of the port contract) -----
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  /**
+   * Number of entries currently held (including any expired ones not yet
+   * lazily evicted). Useful for asserting on cache pressure in higher-level
+   * code without exposing the internal `Map`.
+   */
+  size(): number {
+    return this.store.size;
+  }
+
+  /**
+   * Pre-populate without going through `set`. Same TTL semantics —
+   * `ttlSec` is the lifetime in seconds from the moment `seed` is called.
+   */
+  seed<T>(key: string, value: T, ttlSec: number): void {
+    this.store.set(key, { value, expiresAt: Date.now() + ttlSec * 1000 });
+  }
+}

--- a/libs/shared/src/cache/testing/index.ts
+++ b/libs/shared/src/cache/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Cache Testing Sub-Barrel
+ *
+ * Public surface for the in-memory cache fake. Consumed via the
+ * `@openlinker/shared/cache/testing` package-exports subpath.
+ *
+ * @module libs/shared/src/cache/testing
+ */
+export { InMemoryCacheAdapter } from './in-memory-cache.adapter';


### PR DESCRIPTION
## Summary

Modularity Thread G · **G2 · MEDIUM**. Adapter specs in the repo today hand-roll a `jest.Mocked<IdentifierMappingPort>` (or similar) in every suite — replicating the production semantics (`ol_{prefix}_{uuid}` ID format, conflict exceptions, TTL behaviour) ad hoc and drifting from the real contract over time. Per the issue body, third-party plugin authors face the same friction.

This PR publishes four in-memory fake adapters, each exposed via a dedicated `./testing` subpath and consumable from any `*.spec.ts` file:

| Port | Fake | Subpath |
|---|---|---|
| `IdentifierMappingPort` | `InMemoryIdentifierMappingAdapter` | `@openlinker/core/identifier-mapping/testing` |
| `CredentialsResolverPort` | `InMemoryCredentialsResolverAdapter` | `@openlinker/core/integrations/testing` |
| `EventPublisherPort` | `InMemoryEventPublisherAdapter` | `@openlinker/core/events/testing` |
| `CachePort` | `InMemoryCacheAdapter` | `@openlinker/shared/cache/testing` |

Each fake:

- Implements the corresponding port verbatim.
- Replicates production semantics. The IdentifierMapping fake delegates to the **same `formatInternalId` helper** as `IdentifierMappingService` (single source of truth — fakes can't drift on ID shape) and throws the canonical domain exceptions (`DuplicateIdentifierMappingError`, `IdentifierMappingConflictException`). The Cache fake honours TTL against the real clock with `Date.now()` checks + lazy eviction. EventPublisher returns synthetic Redis-Streams-shaped IDs (`<ms>-<seq>`).
- Exposes a small set of test helpers — `clear()` for cross-test reset, `seed(...)` for pre-population, plus `size()` / `getPublishedEvents()` / `published()` where useful for assertions.
- Carries no new runtime dependencies — `crypto.randomUUID()` from `node:crypto` is the only new import.

**Strict mode** on the IdentifierMapping fake: passing a non-empty `connectionPlatformMap` to the constructor opts every write into strict-mode validation — unknown `connectionId`s surface as a rejected `Promise<Error>` instead of silently denormalising to `''`. Empty map (default) keeps lax semantics so no-care specs work unchanged. Closes the test/prod gap where the production adapter would FK-fail on an unknown connection.

**Placement**: each fake lives at `<context>/testing/` (rather than `<context>/infrastructure/adapters/`) because these are test-time-only adapters — never wired into a production module graph. The existing AI fake (`fake-ai-completion.adapter.ts`) lives in `infrastructure/adapters/` because it IS wired into production when `OL_AI_PROVIDER=fake`; that's a different role and warrants the different placement.

## Subpath wiring

- `libs/core/package.json` `exports` — 3 new `./*/testing` entries alongside the existing `./*/orm-entities` ones.
- `libs/shared/package.json` `exports` — 1 new `./cache/testing` entry.
- `tsconfig.base.json` paths already cover via existing `@openlinker/core/*` and `@openlinker/shared/*` wildcards.

## Docs

- `docs/engineering-standards.md § Sub-barrels` — third bullet added documenting the `<ctx>/testing` pattern alongside `listings/services` and `<ctx>/orm-entities`, with guidance on when to add a new one.
- `docs/plugin-author-guide.md § Step 10 — Tests` — new "Testing without containers — in-memory fakes" sub-section with a copy-pasteable spec example and the four-fake reference table.

## Commits

1. `29833fe` — initial four fakes + subpath wiring + docs (1138 insertions, 17 files)
2. `bb122f9` — tech-review follow-ups: extract `formatInternalId` to a shared helper (single source of truth), tighten strict-mode validation, clarify Cache TTL header

## Test plan

- [x] `pnpm lint` — clean (0 errors, 7 invariants pass)
- [x] `pnpm type-check` — clean across all 11 workspaces
- [x] `pnpm test` — 1870 unit tests across 8 packages (+31 from new fakes, +1 strict-mode regression test; zero regressions)
- [ ] `pnpm test:integration` — requires Docker, deferred to CI

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)