### PR TITLE
ci(dx): build libs via workspace glob + invariant for missing scripts (#602)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Build type definitions
-        run: |
-          # Build packages that provide types needed for type-aware linting
-          # This ensures TypeScript can resolve types across workspace packages
-          # and prevents 'any' type inference that triggers unsafe-* lint errors
-          pnpm --filter @openlinker/shared build
-          pnpm --filter @openlinker/core build
-          pnpm --filter @openlinker/integrations-prestashop build
+      - name: Build libs (workspace glob — auto-discovers new packages)
+        run: pnpm -r --filter "./libs/**" build
       - name: Run lint
         run: pnpm lint
 
@@ -67,15 +61,8 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Build dependencies
-        run: |
-          # Build shared, core, and integration packages first
-          # Tests import workspace packages directly, so required package artifacts
-          # must exist before recursive test execution.
-          pnpm --filter @openlinker/shared build
-          pnpm --filter @openlinker/core build
-          pnpm --filter @openlinker/integrations-prestashop build
-          pnpm --filter @openlinker/integrations-allegro build
+      - name: Build libs (workspace glob — auto-discovers new packages)
+        run: pnpm -r --filter "./libs/**" build
       - name: Run tests
         run: pnpm test:ci
 
@@ -100,22 +87,15 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Build dependencies
+      - name: Build libs (workspace glob — auto-discovers new packages)
+        run: pnpm -r --filter "./libs/**" build
+      - name: Verify core dist exists
+        # Past-bug guard: a build-output regression in libs/core left
+        # identifier-mapping unbuilt, breaking integration tests with cryptic
+        # errors. Fail fast with a clear message instead.
         run: |
-          # Build shared, core, and PrestaShop integration (required for integration tests)
-          # Integration tests boot the full NestJS app which imports PrestashopIntegrationModule
-          pnpm --filter @openlinker/shared build
-          pnpm --filter @openlinker/core build
-          pnpm --filter @openlinker/integrations-prestashop build
-          # Debug: Show where files are actually being emitted
-          echo "Core dist tree (top 50 files):"
-          find libs/core/dist -maxdepth 4 -type f | sort | head -50 || true
-          echo ""
-          echo "Looking for identifier-mapping index.js anywhere:"
-          find libs/core/dist -type f -path "*identifier-mapping*index.js" -print || echo "No identifier-mapping index.js found"
-          echo ""
-          # Verify core build output exists (catches missing dist files early)
-          test -f libs/core/dist/identifier-mapping/index.js || (echo "ERROR: libs/core/dist/identifier-mapping/index.js missing after build" && exit 1)
+          test -f libs/core/dist/identifier-mapping/index.js \
+            || (echo "ERROR: libs/core/dist/identifier-mapping/index.js missing after build" && exit 1)
       - name: Run integration tests
         run: pnpm --filter @openlinker/api test:integration
         timeout-minutes: 15 # Integration tests can take longer due to container startup

--- a/docs/plans/implementation-plan-602-ci-adapter-build-glob.md
+++ b/docs/plans/implementation-plan-602-ci-adapter-build-glob.md
@@ -1,0 +1,115 @@
+# #602 — CI: deterministic adapter-package builds via workspace glob
+
+Closes #602. Part of Modularity Thread G (#553).
+
+## 1. Goal
+
+Two changes that close the "I added an adapter but forgot to update CI" gap:
+
+1. **Replace the hardcoded `pnpm --filter @openlinker/integrations-<name> build` lists** in three CI jobs with a workspace-glob `pnpm -r --filter "./libs/**" build`. The glob auto-discovers any new package under `libs/`.
+2. **Add a `pnpm lint` invariant** that asserts every workspace package under `libs/` declares a non-empty `scripts.build`. Closes the silent-skip failure mode in (1) — see §4.2.
+
+## 2. Layer classification
+
+DX / CI. No application-code touch.
+
+## 3. Current state — asymmetric under-coverage
+
+Three integration packages exist (`ai`, `allegro`, `prestashop`) plus `core`, `shared`, `plugin-sdk`, and `test-kit` (#689). The current `ci.yml` pre-build steps are inconsistent:
+
+| Job (file:line) | Pre-builds today | Missing |
+|---|---|---|
+| `lint` (`ci.yml:31-33`) | shared, core, prestashop | allegro, ai, plugin-sdk, test-kit |
+| `test` (`ci.yml:75-78`) | shared, core, prestashop, allegro | ai, plugin-sdk, test-kit |
+| `test-integration` (`ci.yml:107-109`) | shared, core, prestashop | allegro, ai, plugin-sdk, test-kit |
+
+Today this works because the affected job's lint/test targets don't reach types in the missing packages. It's a latent under-coverage. `ai` is in *no* job's pre-build list despite being a real workspace package.
+
+The `type-check` and `build` jobs already use workspace-glob commands (`pnpm type-check`, `pnpm build`) and don't have this problem.
+
+## 4. Design
+
+### 4.1 The replacement command
+
+```yaml
+- name: Build dependencies
+  run: pnpm -r --filter "./libs/**" build
+```
+
+- `-r` runs the script in every workspace package.
+- `--filter "./libs/**"` scopes to packages whose directory is under `libs/` (matches all 7 today). Verified locally.
+- pnpm runs in topological order by default — `@openlinker/core` builds before its dependents.
+- Each package's `build` is `tsc -b`; composite mode walks references and short-circuits already-built deps, so the topo redundancy is bounded.
+
+### 4.2 The pnpm silent-skip failure mode — and the invariant that closes it
+
+The plan's first draft claimed pnpm would error on a missing `build` script ("Missing script: build"). Empirical test (pnpm 10.11.1, this workspace, `pnpm -r --filter "./libs/**" run nonexistent-script`):
+
+```
+Scope: 7 of 11 workspace projects
+None of the selected packages has a "nonexistent-script" script
+exit=0
+```
+
+Worse — temporarily deleting `scripts.build` from `libs/test-kit/package.json` and running the actual `build` command: pnpm builds the other 6 packages and silently skips test-kit. **Exit 0**. No warning that test-kit was missed.
+
+This means a contributor who adds `libs/integrations/shopify/package.json` with a typo'd `"buld"` (or no `build` script at all) would have it silently excluded from CI's build step. The runtime breakage surfaces somewhere downstream — exactly the failure mode #602 is trying to prevent.
+
+**Fix**: a small invariant script `scripts/check-libs-build-scripts.mjs`, chained into the `check:invariants` command (which runs on every `pnpm lint`). The script asserts every workspace package under `libs/*` and `libs/integrations/*` declares a non-empty `scripts.build`. Mirrors the shape of `check-create-adapter.mjs` and `check-migration-timestamps.mjs`.
+
+### 4.3 Trigger paths and runner choice
+
+Trigger paths are unchanged from current `ci.yml` (workflow already runs on every PR). Runner choice (`self-hosted` for the modified jobs) is unchanged — that's #557's domain.
+
+### 4.4 Test-integration verify step — split, don't inline
+
+The current `Build dependencies` step at `ci.yml:103-118` packs two concerns into one `run: |` heredoc: three `pnpm --filter` lines plus a `dist/identifier-mapping/index.js` verify check (past-bug guard). The cleanest mechanical replacement is to **split into two steps**:
+
+```yaml
+- name: Build dependencies
+  run: pnpm -r --filter "./libs/**" build
+
+- name: Verify core dist exists
+  run: |
+    test -f libs/core/dist/identifier-mapping/index.js \
+      || (echo "ERROR: libs/core/dist/identifier-mapping/index.js missing after build" && exit 1)
+```
+
+Drops the `find`/`echo` diagnostic noise (it was inline-debugging for the past incident; the `test -f` is the load-bearing guard). The verify step stays as its own concern.
+
+### 4.5 Wasted-work tradeoff
+
+Switching the pre-built set:
+
+| Job | Pre-built today | New (glob) | Net invocations added |
+|---|---|---|---|
+| `lint` | 3 | 7 | +4 |
+| `test` | 4 | 7 | +3 |
+| `test-integration` | 3 | 7 | +4 |
+
+Each added `tsc -b` against an already-built dep is fast (composite mode + incremental). Estimated overhead: 10-20s per job on cold cache; near-zero on warm.
+
+## 5. Implementation
+
+| # | File | Action |
+|---|------|--------|
+| 1 | `.github/workflows/ci.yml:26-33` (lint) | Replace 3-line hardcoded block with `pnpm -r --filter "./libs/**" build` |
+| 2 | `.github/workflows/ci.yml:70-78` (test) | Replace 4-line hardcoded block with the same glob command |
+| 3 | `.github/workflows/ci.yml:103-118` (test-integration) | Replace the whole 16-line block with two steps per §4.4: glob build + dist verify |
+| 4 | `scripts/check-libs-build-scripts.mjs` (new) | Walks `libs/*` and `libs/integrations/*`, fails if any package.json lacks non-empty `scripts.build` |
+| 5 | `package.json` `check:invariants` script | Chain in the new check |
+| 6 | local quality gate | `pnpm lint && pnpm type-check && pnpm test` — confirm no regression |
+
+Net change: ~14 LoC YAML net, ~50 LoC for the new invariant script, 1 LoC in `package.json`.
+
+## 6. Validation
+
+- **Architecture / engineering standards**: N/A (CI yml + tooling script only).
+- **Security**: no change to triggers, permissions, or secret access.
+- **Naming**: workflow file unchanged; new script follows the `check-<topic>.mjs` precedent (`check-create-adapter.mjs`, `check-design-tokens.mjs`, `check-migration-timestamps.mjs`).
+- **Tests**: the invariant script will be exercised by the next `pnpm lint` run; no separate unit test (consistent with existing invariants).
+
+## 7. Out of scope (deferred)
+
+- Moving any CI job off self-hosted — #557.
+- The `find` diagnostic lines currently in test-integration — folded into the split-step cleanup, but the `dist/identifier-mapping/index.js` verify is preserved.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:integration": "pnpm --filter @openlinker/api test:integration",
     "test:php": "cd apps/prestashop-module/openlinker && composer install --no-interaction --quiet && vendor/bin/phpunit",
     "lint": "pnpm -r lint && pnpm check:invariants",
-    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs",
+    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-libs-build-scripts.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
     "create-adapter": "node scripts/create-adapter.mjs",

--- a/scripts/check-libs-build-scripts.mjs
+++ b/scripts/check-libs-build-scripts.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Libs Build-Script Invariant (#602)
+ *
+ * Asserts every workspace package under `libs/*` and `libs/integrations/*`
+ * declares a non-empty `scripts.build`. Closes the silent-skip gap in
+ * `pnpm -r --filter "./libs/**" build`:
+ *
+ *   $ pnpm -r --filter "./libs/**" run nonexistent-script
+ *   Scope: 7 of 11 workspace projects
+ *   None of the selected packages has a "nonexistent-script" script
+ *   exit=0
+ *
+ * pnpm silently skips packages that lack the script. A contributor adding
+ * `libs/integrations/shopify/package.json` with a typo'd `"buld"` (or no
+ * build script at all) would have CI skip the build for that package — the
+ * runtime breakage surfaces somewhere downstream rather than at the build
+ * step. This invariant fails `pnpm lint` immediately on the offending
+ * package.json so the issue is caught at the same point the contributor
+ * runs their pre-commit hook.
+ *
+ * Chained into the root `check:invariants` command. Mirrors the shape of
+ * `scripts/check-create-adapter.mjs`.
+ *
+ * @module scripts
+ */
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+
+// Mirrors the pnpm-workspace.yaml `libs/*` and `libs/integrations/*` globs.
+// Order matters for the diagnostic message — top-level libs first, then
+// nested integration packages.
+const LIBS_PARENTS = ['libs', 'libs/integrations'];
+
+const errors = [];
+
+async function listChildPackageDirs(parent) {
+  const parentAbs = join(REPO_ROOT, parent);
+  const entries = await readdir(parentAbs, { withFileTypes: true });
+  const dirs = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    // Skip `libs/integrations` when scanning `libs` — the nested glob handles it.
+    if (parent === 'libs' && entry.name === 'integrations') continue;
+    dirs.push(join(parent, entry.name));
+  }
+  return dirs.sort();
+}
+
+async function main() {
+  let packagesChecked = 0;
+  for (const parent of LIBS_PARENTS) {
+    const children = await listChildPackageDirs(parent);
+    for (const child of children) {
+      const pkgPath = join(REPO_ROOT, child, 'package.json');
+      let pkg;
+      try {
+        const raw = await readFile(pkgPath, 'utf8');
+        pkg = JSON.parse(raw);
+      } catch (err) {
+        // Not a package directory (no package.json) — silently skip. Same
+        // posture as pnpm's workspace resolver, so the invariant covers
+        // exactly the set the glob targets.
+        if (err && /** @type {NodeJS.ErrnoException} */ (err).code === 'ENOENT') {
+          continue;
+        }
+        throw err;
+      }
+      packagesChecked++;
+      const buildScript = pkg.scripts?.build;
+      if (
+        !buildScript ||
+        typeof buildScript !== 'string' ||
+        buildScript.trim() === ''
+      ) {
+        errors.push(
+          `${child}/package.json: missing or empty "scripts.build" — pnpm -r --filter "./libs/**" build will silently skip this package`,
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    for (const msg of errors) {
+      process.stderr.write(`check-libs-build-scripts: ${msg}\n`);
+    }
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `check-libs-build-scripts: OK (${packagesChecked} packages)\n`,
+  );
+}
+
+try {
+  await main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(
+    `check-libs-build-scripts: unexpected error — ${message}\n`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Closes the "I added an adapter but forgot to update CI" gap from #602 (Modularity Thread G · G3).

- **CI yml**: replaces three hardcoded `pnpm --filter @openlinker/integrations-<name> build` blocks in `lint`, `test`, and `test-integration` with `pnpm -r --filter "./libs/**" build`. The glob auto-discovers any new workspace package under `libs/`. This is the same pattern the workspace's own `test:ci` and `type-check` scripts in `package.json` already use.

- **Invariant**: new `scripts/check-libs-build-scripts.mjs` wired into `check:invariants`. Empirical testing showed pnpm 10.11.1 *silently skips* packages without the script under `pnpm -r run <script>` — a contributor's typo'd `"buld"` would be excluded from CI's build step and surface as a runtime import error somewhere downstream. The invariant asserts every package under `libs/*` and `libs/integrations/*` declares a non-empty `scripts.build`, failing `pnpm lint` immediately if not.

- **test-integration cleanup**: split the existing inline build+verify block into two YAML steps. Drops the `find`/`echo` diagnostic noise (left over from a past identifier-mapping incident) but preserves the load-bearing `dist/identifier-mapping/index.js` verify check as its own step.

## Diagnosis is also a bug fix

The current hardcoded lists are asymmetric:

| Job | Pre-builds today | Missing |
|---|---|---|
| `lint` | shared, core, prestashop | allegro, ai, plugin-sdk, test-kit |
| `test` | shared, core, prestashop, allegro | ai, plugin-sdk, test-kit |
| `test-integration` | shared, core, prestashop | allegro, ai, plugin-sdk, test-kit |

`@openlinker/integrations-ai` is in **no** job's pre-build list despite being a real workspace package. The glob fixes the under-coverage as a side effect of fixing the auto-discovery bug.

## Plan

`docs/plans/implementation-plan-602-ci-adapter-build-glob.md` captures the design — including the empirical pnpm behaviour test that motivated adding the invariant (the first draft of the plan claimed the glob alone was sufficient; testing showed otherwise).

## Test plan

- [x] Local empirical test: temporarily removed `scripts.build` from `libs/test-kit/package.json` — confirmed pnpm silently skipped it with exit 0. Confirmed the new invariant catches the same scenario with a clear error message naming the offending package.
- [x] `pnpm lint` — green, includes new invariant (`check-libs-build-scripts: OK (7 packages)`)
- [x] `pnpm type-check` — clean across all 9 workspaces
- [x] `pnpm test` — 1,856 unit tests pass across api+worker+libs (357 + 118 + 653 + 34 + 364 + 266 + 11 + 49 + 4)
- [x] YAML structure validated via `js-yaml` round-trip
- [ ] `pnpm test:integration` — deferred to CI; the glob is a superset of the previous prestashop-only pre-build, so the integration tests get strictly more coverage

## Out of scope

- Moving CI jobs off self-hosted — #557
- Frontend (`apps/web`) — not affected; the glob is scoped to `libs/**`

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)