### PR TITLE
fix(scaffolder): hyphen-safe identifier emission + lint-time bug-class guard

### DIFF
--- a/.github/workflows/scaffold-smoke.yml
+++ b/.github/workflows/scaffold-smoke.yml
@@ -9,7 +9,7 @@
 # compilability. Runs on ubuntu-latest so fork PRs see the signal too —
 # orthogonal to #557 (the five existing self-hosted jobs).
 #
-# The smoke scaffolds into `libs/integrations/smoketest/` rather than a literal
+# The smoke scaffolds into `libs/integrations/smoke-test/` rather than a literal
 # tmp dir because the template `tsconfig.json` uses relative project references
 # (`../../core`) and the template `package.json` uses `workspace:*` deps —
 # neither resolves outside the workspace. Cleanup runs unconditionally.
@@ -65,10 +65,10 @@ jobs:
       # leftover from a partial previous run would otherwise fail the scaffolder
       # ("Target directory already exists").
       - name: Cleanup any leftover scaffold dir
-        run: rm -rf libs/integrations/smoketest
+        run: rm -rf libs/integrations/smoke-test
 
       - name: Scaffold smoke adapter
-        run: node scripts/create-adapter.mjs smoketest
+        run: node scripts/create-adapter.mjs smoke-test
 
       # The scaffolded package didn't exist when pnpm-lock.yaml was committed,
       # so --frozen-lockfile would refuse here. The mutation stays on the
@@ -79,8 +79,8 @@ jobs:
       # tsc -b walks the composite project references and builds
       # @openlinker/{shared,core,plugin-sdk} on the way — no pre-build needed.
       - name: Build scaffolded adapter (tsc -b)
-        run: pnpm --filter @openlinker/integrations-smoketest build
+        run: pnpm --filter @openlinker/integrations-smoke-test build
 
       - name: Cleanup scaffold dir
         if: always()
-        run: rm -rf libs/integrations/smoketest
+        run: rm -rf libs/integrations/smoke-test

--- a/docs/plans/implementation-plan-698-684-adapter-scaffolder-hyphens.md
+++ b/docs/plans/implementation-plan-698-684-adapter-scaffolder-hyphens.md
@@ -1,0 +1,228 @@
+# Implementation Plan — #698 + #684 final: adapter scaffolder hyphen-safe + drift guard locks it in
+
+**Branch:** `698-684-adapter-scaffolder-hyphens`
+**Base:** `main` (5fe7c0d)
+**Scope:** Modularity Thread B (#548) — plugin author scaffolding.
+
+---
+
+## 1 — Understand
+
+### Goal
+
+Make `scripts/create-adapter.mjs` produce compilable TypeScript for hyphenated slugs (`smoke-test`, `woo-commerce`, …), and extend `scripts/check-create-adapter.mjs` to scaffold a hyphenated slug at lint-time so this drift class cannot return.
+
+### Layer
+
+DX / tooling — no runtime code, no API surface, no migration. All edits in `scripts/` and `.github/workflows/` (the latter optional).
+
+### Non-goals
+
+- **No tsc-noEmit in lint** — explicitly deferred from #684's original ask; the CI workflow `.github/workflows/scaffold-smoke.yml` (shipped via #695) is the right place for that and already exists.
+- **No regex tightening to ban hyphens** — issue body's option 2. The help text advertises hyphens; preserving them is the better contract.
+- **No changes to the shipped plugins** (`prestashop`, `allegro`, `ai`) — their slugs are non-hyphenated, so they sidestep the bug.
+
+---
+
+## 2 — Research
+
+### Bug surface
+
+`scripts/create-adapter.mjs` ships three substitution tokens:
+
+| Token | Form | Example for `smoke-test` |
+|---|---|---|
+| `__name__` | raw lowercase slug | `smoke-test` |
+| `__Name__` | PascalCase | `SmokeTest` |
+| `__BRAND__` | defaults to `__Name__` | `SmokeTest` |
+
+The `__name__` token is correct for **filenames** (the directory IS hyphenated), **string literals** (`adapterKey: '__name__.publicapi.v1'`), and **module paths in comments**. It is **wrong for TypeScript identifier positions** — `smoke-testAdapterManifest` parses as subtraction.
+
+### Affected template positions (verified via `grep`)
+
+Six identifier positions across two template files:
+
+- `scripts/create-adapter-templates/src/__name__-plugin.ts:50` — `export const __name__AdapterManifest`
+- `scripts/create-adapter-templates/src/__name__-plugin.ts:71` — `manifest: __name__AdapterManifest`
+- `scripts/create-adapter-templates/src/__name__-plugin.ts:79` — commented example: `__name__AdapterManifest.adapterKey`
+- `scripts/create-adapter-templates/src/__name__-plugin.ts:83` — commented example: same
+- `scripts/create-adapter-templates/src/index.ts:17` — `__name__AdapterManifest,` (re-export)
+- `scripts/create-adapter-templates/src/index.ts:19` — `} from './__name__-plugin';` ← this one is the FILENAME path (correct as `__name__`, stays put)
+
+So 5 of the 6 positions need a token change. (Position 19 is a path string, stays `__name__`.)
+
+### Existing convention
+
+`libs/integrations/allegro/src/allegro-plugin.ts:72` — `export const allegroAdapterManifest`.
+`libs/integrations/prestashop/src/prestashop-plugin.ts:55` — `export const prestashopAdapterManifest`.
+
+Convention is **camelCase identifier** (`<camelName>AdapterManifest`). For hyphenated `smoke-test` the expected identifier is `smokeTestAdapterManifest`.
+
+### Existing safety net
+
+- `scripts/check-create-adapter.mjs` already does shape + token-leftover + count checks at lint-time (header says "#684, partial"). Today it scaffolds **one** slug (`lintcheck`, non-hyphenated), so the bug class slipped through.
+- `.github/workflows/scaffold-smoke.yml` (PR #695) does the full `tsc -b` smoke in CI, also on a non-hyphenated slug (`smoketest`). Updating it to hyphenated is the second safety net.
+
+---
+
+## 3 — Design
+
+### Token change
+
+Introduce a fourth substitution token:
+
+| Token | Form | Example for `smoke-test` |
+|---|---|---|
+| `__camelName__` | lowerCamelCase | `smokeTest` |
+
+Same `split-hyphen → PascalCase parts → join` derivation as `toPascalCase`, but with the first character of the FIRST part left lowercase.
+
+```js
+function toCamelCase(slug) {
+  const parts = slug.split('-');
+  return parts
+    .map((part, i) =>
+      i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1),
+    )
+    .join('');
+}
+```
+
+For non-hyphenated slugs (`shopify`), `__camelName__` resolves to the same value as `__name__` (`shopify`). No regression — existing in-tree usage of `__name__` in identifier positions only ever ran against non-hyphenated slugs.
+
+### Template edits
+
+Replace the 5 identifier-position occurrences of `__name__AdapterManifest` with `__camelName__AdapterManifest`. Leave the path-string occurrence at `index.ts:19` alone.
+
+After substitution for `smoke-test`:
+```ts
+// __name__-plugin.ts → smoke-test-plugin.ts
+export const smokeTestAdapterManifest: AdapterMetadata = { ... };
+//          ^^^^^^^^^ — identifier, valid
+```
+
+### Drift guard
+
+Extend `scripts/check-create-adapter.mjs` to scaffold **two** slugs per run:
+
+1. `lintcheck` (existing, non-hyphenated — keeps the trivial sanity check)
+2. `smoke-test` (new, hyphenated — exercises the camelName path)
+
+Both runs go through the same assertion suite (shape + token-leftover + count). The token-leftover check picks up `__camelName__` as a fourth must-be-substituted token.
+
+This locks in the bug class: if anyone ever reintroduces `__name__AdapterManifest` in a template, the hyphenated-slug run will produce a file containing `smoke-testAdapterManifest`, and either:
+- the new check-create-adapter assertion will spot the `-` in the file contents via a (light) syntax check, OR
+- (defense in depth) the CI `scaffold-smoke.yml` will catch it via real `tsc -b`.
+
+The simpler win is just covering the hyphenated path — the existing token-leftover check doesn't catch this regression (`__name__` is correctly substituted; the problem is *where* it was substituted to). Adding a quick "no `-` in TS identifier positions" smoke is more brittle than valuable. The lint shape check + the CI tsc smoke together cover the bug class, with the CI smoke being the authoritative compile check.
+
+### CI workflow update (optional)
+
+`.github/workflows/scaffold-smoke.yml` currently scaffolds the non-hyphenated `smoketest`. Bumping to `smoke-test` makes the CI smoke exercise the hyphenated code path on every relevant PR. Low-risk edit (one slug change in the workflow file).
+
+---
+
+## 4 — Implementation steps
+
+### Step 1 — Add `__camelName__` token to scaffolder
+
+**File:** `scripts/create-adapter.mjs`
+
+- Add `toCamelCase(slug)` helper next to `toPascalCase`.
+- Extend the `tokens` object in `scaffoldAdapter` to include `camelName: toCamelCase(name)`.
+- Extend `applyTokens` to substitute `__camelName__` → `tokens.camelName`.
+
+**Acceptance:** running `node scripts/create-adapter.mjs --help` still works; the token list in the file's header docblock is updated to list four tokens.
+
+### Step 2 — Update templates to use `__camelName__` in identifier positions
+
+**Files:**
+- `scripts/create-adapter-templates/src/__name__-plugin.ts` (4 positions)
+- `scripts/create-adapter-templates/src/index.ts` (1 position; the path-string at `:19` stays)
+
+**Acceptance:** scaffolding `smoke-test` with the new scaffolder produces `libs/integrations/smoke-test/src/smoke-test-plugin.ts` containing `export const smokeTestAdapterManifest`, and `src/index.ts` containing `smokeTestAdapterManifest,` in the re-export block.
+
+### Step 3 — Extend check-create-adapter.mjs to cover hyphenated slug
+
+**File:** `scripts/check-create-adapter.mjs`
+
+- Hoist the per-slug logic into a function `runScaffoldCheck(slug)` that does the existing scaffold + shape + token-leftover + count checks.
+- Call it twice: once with `'lintcheck'`, once with `'smoke-test'`.
+- Add `__camelName__` to the `TOKENS` must-be-substituted list.
+- Update `applyExpectedSubstitution` to apply `__camelName__` substitution (mirroring the scaffolder).
+- The `EXPECTED_FILE_COUNT` constant stays at 14 — the file count is per-run, identical for both slugs.
+- The OK-line summary becomes `check-create-adapter: OK (2 slugs × 14 files)` to make the doubled coverage visible.
+
+**Acceptance:** `pnpm lint` includes a check-create-adapter step that exits 0 on a clean tree; if the camelName substitution is broken (e.g. a future PR replaces `__camelName__` with `__name__` in an identifier position), the second slug's run produces a file with a `-` in the identifier and the token-leftover or extended sanity check fails. Pre-commit budget impact: ~2× sub-second (still well under the lint budget).
+
+### Step 4 — CI workflow: switch to hyphenated slug
+
+**File:** `.github/workflows/scaffold-smoke.yml`
+
+- Change the scaffold slug from `smoketest` to `smoke-test`.
+- Verify the workflow's existing `pnpm --filter @openlinker/integrations-<slug> build` invocation still resolves with the new slug.
+
+**Acceptance:** workflow YAML still parses; the slug appears only in the script-block and the cleanup step. (Verifying the workflow runs green is a post-merge concern — the workflow's `pull_request` trigger means the PR for THIS work will run it as its own validation.)
+
+### Step 5 — Docs touch-up
+
+**File:** `scripts/create-adapter.mjs` header docblock.
+
+Add `__camelName__` to the 3-token list in the header comment. Update the contents of any inline help that lists tokens (currently the header is the only such surface).
+
+**File:** `docs/plugin-author-guide.md`
+
+Scan for any mention of the template token set. If the guide enumerates `__name__` / `__Name__` / `__BRAND__`, add `__camelName__` to the list. (If the guide refers only to the slug → output transformation conceptually, no edit needed.)
+
+### Step 6 — Local smoke
+
+- `node scripts/create-adapter.mjs smoke-test --target-dir /tmp/scaffold-698-check`
+- `cd /tmp/scaffold-698-check/smoke-test && grep -n smokeTestAdapterManifest src/smoke-test-plugin.ts src/index.ts` — both files should print the identifier.
+- `pnpm --filter @openlinker/integrations-smoke-test build` (after symlinking into the workspace) — should compile. *(Skipped if the workspace symlink dance is fragile — the CI `scaffold-smoke.yml` re-run on the resulting PR is the authoritative check.)*
+
+---
+
+## 5 — Validation
+
+### Architecture compliance
+
+DX / tooling layer only. No CORE ↔ Integration boundary crossings, no runtime code, no DI wiring, no domain logic. The `scripts/` directory is the established home for these invariants (4 sibling scripts: `check-design-tokens.mjs`, `check-migration-timestamps.mjs`, `check-render-template-fixture-drift.mjs`, `check-create-adapter.mjs`).
+
+### Naming compliance
+
+`toCamelCase` matches the existing `toPascalCase` convention. `__camelName__` matches the existing token style (`__name__` / `__Name__` / `__BRAND__`). No new file names introduced.
+
+### Testing strategy
+
+The lint-time `check-create-adapter` itself IS the test for the scaffolder. Running it against a hyphenated slug is the regression coverage. No `*.spec.ts` needed — `scripts/` is not under Jest's test glob.
+
+### Security
+
+No new attack surface. The scaffolder writes to `targetDir` (default `libs/integrations/`); `--target-dir` already supports tmp-dir override. No shell-out, no file ops outside the tree.
+
+### Risks
+
+- **Risk:** unforeseen template position using `__name__` in an identifier slot we missed. **Mitigation:** Step 3 adds the hyphenated-slug coverage; any miss would fail the lint check on this PR's own run.
+- **Risk:** the CI workflow change in Step 4 conflicts with concurrent edits to `scaffold-smoke.yml`. **Mitigation:** `git fetch origin main` immediately before commit; the workflow file has no other open PR touching it.
+- **Risk:** `pnpm install` warns on the changed package.json (none expected — we don't touch package.json). **Mitigation:** none needed; quality gate would catch.
+
+---
+
+## 6 — Open questions
+
+- **Close #684?** Its original ask was tsc-noEmit in lint. That was explicitly deferred and shipped as CI in #695. The shape check is already in main. After this PR adds hyphenated coverage, #684 is functionally complete — its full scope (drift guard for scaffolder output) is satisfied between the lint shape check + CI tsc smoke + hyphenated-slug coverage. Recommendation: include `Closes #684` in the PR body alongside `Closes #698`. If the user wants tsc-noEmit moved back into lint anyway, that's a separate follow-up that explicitly diverges from the #695 design decision.
+- **Bump `EXPECTED_FILE_COUNT` to count both runs?** The count is per-run, and asserting `14` twice is cleaner than asserting `28` once. Plan keeps it as-is — per-run, single constant.
+
+---
+
+## File list
+
+| File | Action | Reason |
+|---|---|---|
+| `scripts/create-adapter.mjs` | edit | Add `__camelName__` token + helper |
+| `scripts/create-adapter-templates/src/__name__-plugin.ts` | edit | 4 identifier positions → `__camelName__` |
+| `scripts/create-adapter-templates/src/index.ts` | edit | 1 identifier position → `__camelName__` |
+| `scripts/check-create-adapter.mjs` | edit | Cover hyphenated slug + `__camelName__` in TOKENS |
+| `.github/workflows/scaffold-smoke.yml` | edit | Hyphenated slug in CI smoke |
+| `docs/plugin-author-guide.md` | maybe-edit | If token list is enumerated |
+| `docs/plans/implementation-plan-698-684-adapter-scaffolder-hyphens.md` | new | This plan |

--- a/scripts/check-create-adapter.mjs
+++ b/scripts/check-create-adapter.mjs
@@ -131,7 +131,7 @@ function applyExpectedSubstitution(relPath, tokens) {
 }
 
 /**
- * Identifier-syntax check for the hyphenated-slug run (#698).
+ * Identifier-syntax check (#698).
  *
  * Catches the bug class where `__name__` is mistakenly used in a TypeScript
  * identifier slot — for a hyphenated slug the substitution produces e.g.
@@ -145,18 +145,28 @@ function applyExpectedSubstitution(relPath, tokens) {
  * package names (`@openlinker/integrations-smoke-test`), and file paths
  * inside import strings (`from './smoke-test-plugin'`).
  *
+ * **Anchor convention**: every pattern must use a trailing-context anchor
+ * (`,`, `}`, `)`, or end of statement) and/or a leading-context anchor
+ * (`export const`, `{`, `:`) to bind the hyphenated capture to an actual
+ * identifier slot. Without anchors, the patterns would over-match
+ * (e.g. fire on hyphens inside string literals or URL paths). Future
+ * pattern additions must follow this convention; verify by extending the
+ * `SELF_TESTS` block below and re-running the check.
+ *
  * The CI `scaffold-smoke.yml` workflow runs `tsc -b` on the same output as
  * the authoritative compile check; this heuristic catches the bug class
  * at lint-time without spending the 15s+ a real build would cost.
  */
 const IDENTIFIER_HYPHEN_PATTERNS = [
-  // `export const <id-with-hyphen>:` or `= ...`
+  // `export const <id-with-hyphen>:` or `= ...` (leading: `export const`)
   /\bexport\s+const\s+([a-z][a-zA-Z0-9]*-[a-zA-Z][a-zA-Z0-9-]*)\b/,
   // Re-export list: `{ <id-with-hyphen>, ... }` — match a name inside
   // brace-delimited list followed by `,` or `}`. Excludes `from '...'`
   // string positions because those aren't followed by `,` or `}`.
+  // (leading: `{` or `,`; trailing: `,` or `}`)
   /[{,]\s*([a-z][a-zA-Z0-9]*-[a-zA-Z][a-zA-Z0-9-]*)\s*[,}]/,
-  // Object literal value: `<key>: <id-with-hyphen>` followed by `,` or `}`
+  // Object literal value: `<key>: <id-with-hyphen>` followed by `,`,
+  // `)`, or `}`. (leading: `<id>:`; trailing: `,`/`)`/`}`)
   /[a-zA-Z_$][a-zA-Z0-9_$]*\s*:\s*([a-z][a-zA-Z0-9]*-[a-zA-Z][a-zA-Z0-9-]*)\s*[,)}]/,
 ];
 
@@ -254,12 +264,11 @@ async function runScaffoldCheck(slug) {
         }
       }
 
-      // 7. Identifier-syntax check — only on the hyphenated slug, where
-      //    a stray `__name__` in an identifier slot surfaces as a `-`
-      //    inside what TS expects to be a single identifier.
-      if (slug.includes('-')) {
-        checkHyphenatedIdentifierSyntax(absFile, contents, rel);
-      }
+      // 7. Identifier-syntax check — runs on every slug. A hardcoded
+      //    hyphen identifier in a template would surface here too,
+      //    regardless of whether the hyphen came from substitution or
+      //    from the template itself.
+      checkHyphenatedIdentifierSyntax(absFile, contents, rel);
     }
   } finally {
     // Best-effort cleanup. force:true tolerates partial-write states.
@@ -267,7 +276,48 @@ async function runScaffoldCheck(slug) {
   }
 }
 
+/**
+ * Self-test for `IDENTIFIER_HYPHEN_PATTERNS`. Runs before the real
+ * scaffold-check so a regex regression surfaces immediately, even on a
+ * clean tree where no scaffolded output would yet trip the patterns.
+ *
+ * Each entry is `[label, input, shouldMatch]`. `shouldMatch=true` asserts
+ * the patterns DO fire; `false` asserts they DO NOT (false-positive guard).
+ * Extend whenever adding or modifying a pattern in
+ * `IDENTIFIER_HYPHEN_PATTERNS`.
+ */
+const SELF_TESTS = [
+  // Positives — the #698 bug class.
+  ['export const w/ hyphen', 'export const smoke-testAdapterManifest = {};', true],
+  ['re-export list w/ hyphen', '{ createPlugin, smoke-testAdapterManifest } from "./x"', true],
+  ['object value w/ hyphen', '{ manifest: smoke-testAdapterManifest, }', true],
+  // Negatives — legitimate hyphens that must NOT fire.
+  ['hyphen in string literal', "adapterKey: 'smoke-test.publicapi.v1',", false],
+  ['hyphen in package name string', "import x from '@openlinker/integrations-smoke-test';", false],
+  ['hyphen in import path', "} from './smoke-test-plugin';", false],
+  ['hyphen in module-path comment', ' * @module libs/integrations/smoke-test/src', false],
+  ['valid camelCase identifier', 'export const smokeTestAdapterManifest = {};', false],
+];
+
+function runSelfTests() {
+  for (const [label, input, shouldMatch] of SELF_TESTS) {
+    // Strip comments the same way the real check does.
+    const stripped = input
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    const matched = IDENTIFIER_HYPHEN_PATTERNS.some((p) => p.test(stripped));
+    if (matched !== shouldMatch) {
+      fail(
+        `check-create-adapter[self-test]: pattern self-test "${label}" failed — ` +
+          `expected match=${shouldMatch}, got match=${matched}. Input: ${input}`,
+      );
+    }
+  }
+}
+
 async function main() {
+  runSelfTests();
+
   for (const slug of SCAFFOLD_SLUGS) {
     await runScaffoldCheck(slug);
   }

--- a/scripts/check-create-adapter.mjs
+++ b/scripts/check-create-adapter.mjs
@@ -1,25 +1,33 @@
 #!/usr/bin/env node
 /**
- * Adapter Scaffolder Output Drift Guard (#684, partial)
+ * Adapter Scaffolder Output Drift Guard (#684)
  *
  * Imports the exported `scaffoldAdapter` from `scripts/create-adapter.mjs`,
- * scaffolds into `os.tmpdir()`, and asserts:
+ * scaffolds into `os.tmpdir()` for two slugs per run (one non-hyphenated,
+ * one hyphenated), and asserts:
  *
  *   1. The set of files produced equals the expected substituted-name set
  *      derived from `scripts/create-adapter-templates/` (no missing, no
- *      unexpected).
- *   2. Every output file is clean of the three substitution tokens
- *      (`__name__`, `__Name__`, `__BRAND__`) — catches forgotten-spot bugs.
- *   3. The expected file count (constant `EXPECTED_FILE_COUNT`) matches the
- *      actual output count — catches "template added but invariant not
- *      bumped" drift.
+ *      unexpected). Per-run, both slugs must produce the same file count.
+ *   2. Every output file is clean of the four substitution tokens
+ *      (`__name__`, `__Name__`, `__camelName__`, `__BRAND__`) — catches
+ *      forgotten-spot bugs.
+ *   3. The expected file count (constant `EXPECTED_FILE_COUNT`) matches
+ *      the actual output count — catches "template added but invariant
+ *      not bumped" drift.
+ *   4. **Hyphenated-slug syntax check**: for every `*.ts` file in the
+ *      hyphenated-slug run, fail if a top-level `export const`, re-export
+ *      list, or right-hand-side identifier reference contains a `-`
+ *      (which would parse as the subtraction operator). Catches the #698
+ *      bug class — `__name__` accidentally re-used in a TypeScript
+ *      identifier slot where `__camelName__` is required. Heuristic
+ *      (regex-based, not a real parser); CI `scaffold-smoke.yml` runs the
+ *      authoritative `tsc -b` check on the same hyphenated output.
  *
- * Out of scope (tracked separately as a follow-up to #684): full
- * `tsc --noEmit` smoke on the scaffolded output. Pre-commit budget for
- * existing invariants is sub-second; the install + tsc dance would push
- * that to ~15s, which is the wrong trade for catching the rare core-API-
- * rename drift class. The shape check here catches the common drift
- * (token substitution, file-shape changes).
+ * Out of scope (intentionally — covered by CI `scaffold-smoke.yml`,
+ * shipped via #686 / #695): full `tsc --noEmit` smoke. Pre-commit budget
+ * for existing invariants is sub-second; the install + tsc dance would
+ * push that to ~15s.
  *
  * Wired into `pnpm lint` via the root `check:invariants` chain.
  *
@@ -44,7 +52,18 @@ const TEMPLATES_DIR = resolve(ROOT, 'scripts/create-adapter-templates');
 // the templates-dir walk alone wouldn't.
 const EXPECTED_FILE_COUNT = 14;
 
-const SCAFFOLD_NAME = 'lintcheck';
+/**
+ * The two slugs exercised per run.
+ *  - `lintcheck` — non-hyphenated sanity case. For this slug
+ *    `__camelName__` resolves to the same string as `__name__`, so the
+ *    leftover-token check still exercises all four tokens but the
+ *    identifier-syntax check (assertion 4) does nothing — `-` cannot
+ *    appear in the output.
+ *  - `smoke-test` — hyphenated. Specifically exercises the
+ *    `__camelName__` path; this is the run that the identifier-syntax
+ *    check guards.
+ */
+const SCAFFOLD_SLUGS = ['lintcheck', 'smoke-test'];
 
 /**
  * Mirror of `toPascalCase` in `scripts/create-adapter.mjs`. Kept inline so
@@ -59,12 +78,22 @@ function toPascalCase(slug) {
     .join('');
 }
 
-const SCAFFOLD_NAME_PASCAL = toPascalCase(SCAFFOLD_NAME);
+/**
+ * Mirror of `toCamelCase` in `scripts/create-adapter.mjs`. Inline-duplicated
+ * for the same reason as `toPascalCase` — if the scaffolder's helper drifts,
+ * this check exercises the same logic and catches it.
+ */
+function toCamelCase(slug) {
+  const parts = slug.split('-');
+  return parts
+    .map((part, i) => (i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+    .join('');
+}
 
 // Tokens that MUST be substituted out of every output file. Mirrored from
-// `scripts/create-adapter.mjs`. The 3-token set was finalized in #685 —
-// `__NAME__` was dropped during tech-review there.
-const TOKENS = ['__name__', '__Name__', '__BRAND__'];
+// `scripts/create-adapter.mjs`. The 4-token set finalized in #698 — added
+// `__camelName__` so hyphenated slugs produce valid TS identifiers.
+const TOKENS = ['__name__', '__Name__', '__camelName__', '__BRAND__'];
 
 const errors = [];
 
@@ -97,28 +126,89 @@ function applyExpectedSubstitution(relPath, tokens) {
   return relPath
     .split('__name__').join(tokens.name)
     .split('__Name__').join(tokens.Name)
+    .split('__camelName__').join(tokens.camelName)
     .split('__BRAND__').join(tokens.Name);
 }
 
-async function main() {
+/**
+ * Identifier-syntax check for the hyphenated-slug run (#698).
+ *
+ * Catches the bug class where `__name__` is mistakenly used in a TypeScript
+ * identifier slot — for a hyphenated slug the substitution produces e.g.
+ * `smoke-testAdapterManifest`, which TS parses as subtraction. This is
+ * exactly what #698 surfaced.
+ *
+ * Heuristic patterns — each looks for a hyphen sitting between identifier
+ * characters in a position where TS expects a single identifier. The set
+ * is intentionally narrow to avoid false positives on legitimate hyphens
+ * in strings (`'__name__.publicapi.v1'` → `'smoke-test.publicapi.v1'`),
+ * package names (`@openlinker/integrations-smoke-test`), and file paths
+ * inside import strings (`from './smoke-test-plugin'`).
+ *
+ * The CI `scaffold-smoke.yml` workflow runs `tsc -b` on the same output as
+ * the authoritative compile check; this heuristic catches the bug class
+ * at lint-time without spending the 15s+ a real build would cost.
+ */
+const IDENTIFIER_HYPHEN_PATTERNS = [
+  // `export const <id-with-hyphen>:` or `= ...`
+  /\bexport\s+const\s+([a-z][a-zA-Z0-9]*-[a-zA-Z][a-zA-Z0-9-]*)\b/,
+  // Re-export list: `{ <id-with-hyphen>, ... }` — match a name inside
+  // brace-delimited list followed by `,` or `}`. Excludes `from '...'`
+  // string positions because those aren't followed by `,` or `}`.
+  /[{,]\s*([a-z][a-zA-Z0-9]*-[a-zA-Z][a-zA-Z0-9-]*)\s*[,}]/,
+  // Object literal value: `<key>: <id-with-hyphen>` followed by `,` or `}`
+  /[a-zA-Z_$][a-zA-Z0-9_$]*\s*:\s*([a-z][a-zA-Z0-9]*-[a-zA-Z][a-zA-Z0-9-]*)\s*[,)}]/,
+];
+
+function checkHyphenatedIdentifierSyntax(absFile, contents, rel) {
+  if (!absFile.endsWith('.ts')) return;
+  // Strip line and block comments to avoid false positives on commented
+  // examples that include hyphens. Strings are not stripped — the
+  // assumption is that legitimate hyphenated strings (package names,
+  // URLs, file paths in import specifiers) won't match the narrow
+  // identifier-context patterns above.
+  const stripped = contents
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  const lines = stripped.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    for (const pattern of IDENTIFIER_HYPHEN_PATTERNS) {
+      const m = lines[i].match(pattern);
+      if (m) {
+        fail(
+          `check-create-adapter: hyphen in TypeScript identifier slot in ${rel}:${i + 1} — ` +
+            `"${m[0].trim()}". Likely a __name__ token used where __camelName__ is required (#698).`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Run the full assertion suite once for a single slug.
+ */
+async function runScaffoldCheck(slug) {
+  const tokens = {
+    name: slug,
+    Name: toPascalCase(slug),
+    camelName: toCamelCase(slug),
+  };
+
   // 1. Compute expected output file list by walking the templates dir
   //    and applying the same token substitution the scaffolder applies.
   const templateFiles = await listFilesRecursive(TEMPLATES_DIR);
   const expectedRelPaths = new Set(
     templateFiles.map((absPath) =>
-      applyExpectedSubstitution(
-        relative(TEMPLATES_DIR, absPath),
-        { name: SCAFFOLD_NAME, Name: SCAFFOLD_NAME_PASCAL },
-      ),
+      applyExpectedSubstitution(relative(TEMPLATES_DIR, absPath), tokens),
     ),
   );
 
   // 2. Scaffold into a unique tmp dir.
-  const tmpRoot = await mkdtemp(join(tmpdir(), 'openlinker-create-adapter-check-'));
+  const tmpRoot = await mkdtemp(join(tmpdir(), `openlinker-create-adapter-check-${slug}-`));
   let scaffoldResult;
   try {
     scaffoldResult = await scaffoldAdapter({
-      name: SCAFFOLD_NAME,
+      name: slug,
       targetDir: tmpRoot,
     });
 
@@ -132,22 +222,22 @@ async function main() {
     for (const expected of expectedRelPaths) {
       if (!actualRelPaths.has(expected)) {
         fail(
-          `check-create-adapter: expected file missing from scaffolder output: ${expected}`,
+          `check-create-adapter[${slug}]: expected file missing from scaffolder output: ${expected}`,
         );
       }
     }
     for (const actual of actualRelPaths) {
       if (!expectedRelPaths.has(actual)) {
         fail(
-          `check-create-adapter: unexpected file in scaffolder output (not in templates dir): ${actual}`,
+          `check-create-adapter[${slug}]: unexpected file in scaffolder output (not in templates dir): ${actual}`,
         );
       }
     }
 
-    // 5. Count sanity check.
+    // 5. Count sanity check (per-run).
     if (actualRelPaths.size !== EXPECTED_FILE_COUNT) {
       fail(
-        `check-create-adapter: file count mismatch — expected ${EXPECTED_FILE_COUNT}, got ${actualRelPaths.size} ` +
+        `check-create-adapter[${slug}]: file count mismatch — expected ${EXPECTED_FILE_COUNT}, got ${actualRelPaths.size} ` +
           `(bump EXPECTED_FILE_COUNT after verifying the scaffolder still works end to end)`,
       );
     }
@@ -159,14 +249,27 @@ async function main() {
       for (const token of TOKENS) {
         if (contents.includes(token)) {
           fail(
-            `check-create-adapter: substitution token "${token}" leaked into output file: ${rel}`,
+            `check-create-adapter[${slug}]: substitution token "${token}" leaked into output file: ${rel}`,
           );
         }
+      }
+
+      // 7. Identifier-syntax check — only on the hyphenated slug, where
+      //    a stray `__name__` in an identifier slot surfaces as a `-`
+      //    inside what TS expects to be a single identifier.
+      if (slug.includes('-')) {
+        checkHyphenatedIdentifierSyntax(absFile, contents, rel);
       }
     }
   } finally {
     // Best-effort cleanup. force:true tolerates partial-write states.
     await rm(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  for (const slug of SCAFFOLD_SLUGS) {
+    await runScaffoldCheck(slug);
   }
 
   if (errors.length > 0) {
@@ -177,7 +280,7 @@ async function main() {
   }
 
   process.stdout.write(
-    `check-create-adapter: OK (${EXPECTED_FILE_COUNT} files)\n`,
+    `check-create-adapter: OK (${SCAFFOLD_SLUGS.length} slugs × ${EXPECTED_FILE_COUNT} files)\n`,
   );
 }
 

--- a/scripts/create-adapter-templates/src/__name__-plugin.ts
+++ b/scripts/create-adapter-templates/src/__name__-plugin.ts
@@ -47,7 +47,7 @@ export type Create__Name__PluginDeps = Record<string, never>;
  * adapters, add their names here AND extend the dispatch table in
  * `createCapabilityAdapter` below.
  */
-export const __name__AdapterManifest: AdapterMetadata = {
+export const __camelName__AdapterManifest: AdapterMetadata = {
   adapterKey: '__name__.publicapi.v1',
   platformType: '__name__',
   supportedCapabilities: [],
@@ -68,7 +68,7 @@ export function create__Name__Plugin(
   _deps: Create__Name__PluginDeps,
 ): AdapterPlugin {
   return {
-    manifest: __name__AdapterManifest,
+    manifest: __camelName__AdapterManifest,
 
     // No side-registrations yet. As you add a connection tester, shape
     // validators, webhook provisioner, etc., uncomment and register them
@@ -76,11 +76,11 @@ export function create__Name__Plugin(
     // § Step 8 (credentials / OAuth).
     register(_host: HostServices): void {
       // host.connectionTesterRegistry.register(
-      //   __name__AdapterManifest.adapterKey,
+      //   __camelName__AdapterManifest.adapterKey,
       //   new __Name__ConnectionTesterAdapter(),
       // );
       // host.connectionConfigShapeValidatorRegistry.register(
-      //   __name__AdapterManifest.adapterKey,
+      //   __camelName__AdapterManifest.adapterKey,
       //   new __Name__ConnectionConfigShapeValidatorAdapter(__NAME___BRAND),
       // );
     },

--- a/scripts/create-adapter-templates/src/index.ts
+++ b/scripts/create-adapter-templates/src/index.ts
@@ -14,7 +14,7 @@
 
 export {
   create__Name__Plugin,
-  __name__AdapterManifest,
+  __camelName__AdapterManifest,
   type Create__Name__PluginDeps,
 } from './__name__-plugin';
 

--- a/scripts/create-adapter.mjs
+++ b/scripts/create-adapter.mjs
@@ -12,11 +12,18 @@
  * capabilities by following `docs/plugin-author-guide.md`.
  *
  * Templates live under `scripts/create-adapter-templates/`, mirroring the
- * target tree 1:1. Filenames and contents carry three substitution tokens:
+ * target tree 1:1. Filenames and contents carry four substitution tokens:
  *
- *   __name__   — lowercase platform slug      (e.g. `shopify`)
- *   __Name__   — PascalCase class identifier  (e.g. `Shopify`)
- *   __BRAND__  — short user-facing label      (defaults to PascalCase)
+ *   __name__        — lowercase platform slug      (e.g. `smoke-test`)
+ *   __Name__        — PascalCase class identifier  (e.g. `SmokeTest`)
+ *   __camelName__   — lowerCamelCase identifier    (e.g. `smokeTest`)
+ *   __BRAND__       — short user-facing label      (defaults to PascalCase)
+ *
+ * Use `__camelName__` for TypeScript identifier positions where the existing
+ * convention is lowercase (e.g. `<camelName>AdapterManifest` matching the
+ * shipped `allegroAdapterManifest` / `prestashopAdapterManifest`). The
+ * raw `__name__` token would substitute hyphenated slugs (`smoke-test`)
+ * into identifier slots and produce uncompilable output (#698).
  *
  * The `--target-dir <dir>` flag (default: `libs/integrations`) lets the
  * scaffolder write into a tmp dir for verification runs without polluting
@@ -122,14 +129,26 @@ function toPascalCase(slug) {
     .join('');
 }
 
+// First segment stays lowercase, subsequent segments PascalCase.
+// `smoke-test` → `smokeTest`; non-hyphenated slugs are unchanged.
+function toCamelCase(slug) {
+  const parts = slug.split('-');
+  return parts
+    .map((part, i) => (i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+    .join('');
+}
+
 function applyTokens(text, tokens) {
   // Single-pass replace — order doesn't matter, the tokens are
-  // non-overlapping by construction.
+  // non-overlapping by construction (`__camelName__` doesn't contain
+  // `__name__` / `__Name__` / `__BRAND__` as a substring and vice versa).
   return text
     .split('__name__')
     .join(tokens.name)
     .split('__Name__')
     .join(tokens.Name)
+    .split('__camelName__')
+    .join(tokens.camelName)
     .split('__BRAND__')
     .join(tokens.BRAND);
 }
@@ -189,6 +208,7 @@ export async function scaffoldAdapter({
   const tokens = {
     name,
     Name: toPascalCase(name),
+    camelName: toCamelCase(name),
     BRAND: toPascalCase(name),
   };
 


### PR DESCRIPTION
## Summary

#698 surfaced a template bug: `scripts/create-adapter.mjs` accepts hyphenated slugs (`smoke-test`, `woo-commerce`), but the templates substituted the raw `__name__` token into TypeScript identifier positions. For hyphenated slugs the result was `smoke-testAdapterManifest`, which TS parses as subtraction. Non-hyphenated slugs (`shopify`, `prestashop`, `allegro`) sidestepped the bug, so it slipped through until #695's scaffold-smoke CI workflow surfaced it during local dry-run.

This PR fixes the template bug AND locks in the bug class on both safety nets (lint-time + CI).

## Template fix

Introduces a fourth substitution token `__camelName__` (lowerCamelCase — `smoke-test` → `smokeTest`). Used in TS identifier positions where the existing convention is camelCase, matching shipped plugins (`allegroAdapterManifest`, `prestashopAdapterManifest`). Filenames, string literals, and module paths in comments continue to use the raw `__name__` token (hyphens are valid there).

5 template positions migrated to `__camelName__AdapterManifest`. For non-hyphenated slugs `__camelName__` resolves to the same string as `__name__`, so zero behaviour change for `shopify` / `prestashop` / `allegro` / `lintcheck`.

## Lint-time guard (#684, final piece)

`scripts/check-create-adapter.mjs` was already in main as "#684 partial" — shape + token-leftover + count checks against a single non-hyphenated slug (`lintcheck`). This PR extends it to:

1. **Scaffold two slugs per run** — `lintcheck` (existing) + `smoke-test` (NEW hyphenated). Doubles the coverage axis.
2. **Add `__camelName__` to the `TOKENS` leftover-check list** (4-token set total).
3. **Identifier-syntax check** — for every `*.ts` file, fail if a top-level `export const`, re-export list, or right-hand-side identifier reference contains a `-`. Three regex patterns with a documented anchor convention (leading and/or trailing context binds the capture to an actual identifier slot, avoiding false positives on legitimate hyphens in strings / package names / paths).
4. **Self-tests for the regex patterns** — 8 cases (3 positive, 5 negative) run on every `pnpm lint` invocation. A regression to the patterns surfaces immediately on a clean tree, not when someone reintroduces the bug.

Pre-commit budget impact: still well within the sub-second invariant budget. `check-create-adapter: OK (2 slugs × 14 files)` after the change.

## CI guard

`.github/workflows/scaffold-smoke.yml` previously scaffolded `smoketest` (non-hyphenated). Bumped to `smoke-test` so the authoritative `tsc -b` check also exercises the hyphenated code path on every PR.

## #684 closure framing

#684's original ask was tsc-noEmit in `pnpm lint`. That goal was explicitly redirected during the #686 / #695 design discussion: full tsc smoke moved to CI (right tool for the job — install + tsc costs are too high for pre-commit). The lint-time check kept the cheap drift guards and now adds the bug-class-specific identifier-syntax check + regex self-tests. The drift-guard suite is functionally complete between the in-lint check + the CI tsc smoke + this PR's hyphenated-slug coverage. Closing #684 as designed-and-delivered, not literally verbatim.

## Commits

1. `e6489ae` — template flip + scaffolder helper + check-create-adapter extension + CI workflow + plan doc
2. `b848989` — tech-review follow-ups: regex self-tests, widen syntax check to both slugs, anchor-convention documentation

## Test plan

- [x] `pnpm lint` — clean (0 errors, 8 invariants pass)
- [x] `pnpm type-check` — clean across 11 workspaces
- [x] `pnpm test` — 1870 unit tests pass, zero regressions
- [x] Local smoke: `node scripts/create-adapter.mjs woo-commerce` → `wooCommerceAdapterManifest` in identifier slots, `woo-commerce` in strings + filenames. Both `plugin.ts` and `index.ts` parse as valid TypeScript.
- [x] Failure path verified: temporarily reverted `__name__-plugin.ts:50` to `__name__AdapterManifest` — lint reports `"export const smoke-testAdapterManifest"` with file + line + actionable hint, restored cleanly.
- [x] Regex self-tests: 3 positive cases fire, 5 negative cases do not. Self-tests run on every `pnpm lint`.
- [ ] CI scaffold-smoke workflow on this PR's own validation run (`pull_request` trigger on the workflow file).

Closes #698
Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)