### PR TITLE
feat(security): encrypt integration credentials at rest (#709)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -120,6 +120,41 @@ This safe harbor does not extend to attacks against OpenLinker operators
 (production instances run by third parties) — please research against your
 own local installation only.
 
+## Threat Model
+
+OpenLinker stores third-party platform credentials — OAuth refresh
+tokens, webhook signing secrets, AI provider API keys, marketplace API
+keys — in the `integration_credentials` Postgres table. Since #709 every
+row is wrapped in an AES-256-GCM envelope keyed off
+`OPENLINKER_CREDENTIALS_ENCRYPTION_KEY`; the table holds no plaintext.
+
+**The control protects against:**
+
+- **Database dump leakage** — logical backups, replica snapshots, or
+  exfiltration of `pg_dump` output. Without the encryption key the
+  envelopes are opaque.
+- **Read-only DBA / support access** — operators inspecting the table
+  for debugging see ciphertext, not credentials.
+
+**It does not protect against:**
+
+- **App-server compromise** — the running process holds the key in
+  memory and can decrypt at will. Hardening the host is out of scope
+  for this control.
+- **Joint key + DB leakage** — if the key file and a DB dump leak
+  together the envelopes are recoverable. Independent rotation of every
+  upstream credential is the only remediation; see
+  [`docs/operations/credentials-rotation.md`](./docs/operations/credentials-rotation.md).
+- **Plaintext leakage through logs, metrics, or error responses** —
+  adapters and services that handle decrypted values must not log them.
+  Reviewers should reject PRs that log credential fields.
+
+The plaintext env-var credentials backend
+(`CredentialsResolverService.getFromEnvironment`) and the env-var
+encryption-key fallback (`loadEncryptionKey`) are both **disabled under
+`NODE_ENV=production`**. A misconfigured deploy fails fast at boot
+rather than silently writing plaintext credentials.
+
 ## Acknowledgements
 
 We will publicly credit reporters on the published advisory unless you

--- a/apps/api/src/integrations/application/services/allegro-oauth.service.ts
+++ b/apps/api/src/integrations/application/services/allegro-oauth.service.ts
@@ -327,13 +327,12 @@ export class AllegroOAuthService implements IAllegroOAuthService {
       clientSecret: stateData.clientSecret,
     };
 
-    // Store credentials in database
+    // Store credentials in database — repository handles encryption-at-rest (#709).
     try {
       await this.credentialRepository.create({
         ref: credentialRef,
         platformType: 'allegro',
         credentialsJson: credentials as unknown as Record<string, unknown>,
-        encrypted: false, // For MVP, credentials are stored unencrypted. Encryption can be added later.
       });
       this.logger.log(`Credentials stored in database: ${credentialRef}`);
     } catch (error) {

--- a/apps/api/src/integrations/application/services/connection.service.spec.ts
+++ b/apps/api/src/integrations/application/services/connection.service.spec.ts
@@ -124,7 +124,6 @@ describe('ConnectionService', () => {
               ref: payload.ref,
               platformType: payload.platformType,
               credentialsJson: payload.credentialsJson,
-              encrypted: false,
               createdAt: new Date(),
               updatedAt: new Date(),
             })

--- a/apps/api/src/migrations/1795000000000-encrypt-integration-credentials.ts
+++ b/apps/api/src/migrations/1795000000000-encrypt-integration-credentials.ts
@@ -1,0 +1,134 @@
+/**
+ * Encrypt Integration Credentials Migration (#709)
+ *
+ * One-way data migration. Replaces the `credentialsJson jsonb` + `encrypted boolean`
+ * columns with a single `credentialsCiphertext varchar` column containing the
+ * AES-256-GCM envelope of `JSON.stringify(credentialsJson)`. Collapses the
+ * inner-envelope pattern used by `WebhookSecretService` and `AiProviderKeyService`
+ * (where `credentialsJson = { ciphertext: <inner-encrypted> }`) into the unified
+ * outer-encryption shape so the runtime read path no longer carries a
+ * special-case "decrypt inner ciphertext" branch.
+ *
+ * ⚠️  `down()` IS DATA-IRREVERSIBLE. Running it after `up()` restores the legacy
+ * schema (`credentialsJson jsonb`, `encrypted boolean`) but leaves
+ * `credentialsJson = {}` on every previously-encrypted row. Recovering plaintext
+ * is intentionally impossible — the entire point of encryption-at-rest is that
+ * the DB does not contain plaintext. Operators who need to roll back MUST take
+ * a fresh DB backup BEFORE running this migration and restore from backup
+ * instead of `migration:revert`. This aligns with `docs/migrations.md` § Best
+ * Practices "implement both up() and down()": `down()` is structurally
+ * reversible (schema) but data-irreversible by intent.
+ *
+ * @module apps/api/src/migrations
+ * @see libs/shared/src/crypto/crypto-primitives.ts — pure crypto primitives
+ *      shared with the runtime `CryptoService`. One source of truth for the
+ *      envelope shape and key-loading semantics.
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+import {
+  decryptWithKey,
+  encryptWithKey,
+  loadEncryptionKey,
+} from '@openlinker/shared';
+import { AI_PROVIDER_CREDENTIALS_REF_PREFIX } from '@openlinker/core/ai';
+import { WEBHOOK_SECRET_REF_PREFIX } from '@openlinker/core/integrations';
+
+interface LegacyRow {
+  id: string;
+  ref: string;
+  credentialsJson: Record<string, unknown>;
+  encrypted: boolean;
+}
+
+export class EncryptIntegrationCredentials1795000000000 implements MigrationInterface {
+  name = 'EncryptIntegrationCredentials1795000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Fail-closed under NODE_ENV=production when the encryption key is unset.
+    // Operators MUST set OPENLINKER_CREDENTIALS_ENCRYPTION_KEY before running.
+    const { key } = loadEncryptionKey(process.env);
+
+    // 1. Add new column (nullable initially so the backfill can populate it).
+    await queryRunner.query(
+      `ALTER TABLE "integration_credentials" ADD "credentialsCiphertext" varchar`,
+    );
+
+    // 2. Backfill every existing row.
+    const rows = (await queryRunner.query(
+      `SELECT id, ref, "credentialsJson", encrypted FROM "integration_credentials"`,
+    )) as LegacyRow[];
+
+    for (const row of rows) {
+      const plain = unwrapPlaintext(row, key);
+      const ciphertext = encryptWithKey(key, JSON.stringify(plain));
+      await queryRunner.query(
+        `UPDATE "integration_credentials" SET "credentialsCiphertext" = $1 WHERE id = $2`,
+        [ciphertext, row.id],
+      );
+    }
+
+    // 3. Enforce NOT NULL and drop the legacy columns.
+    await queryRunner.query(
+      `ALTER TABLE "integration_credentials" ALTER COLUMN "credentialsCiphertext" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "integration_credentials" DROP COLUMN "credentialsJson"`,
+    );
+    await queryRunner.query(`ALTER TABLE "integration_credentials" DROP COLUMN encrypted`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Structural revert only. Plaintext is NOT recoverable — see file header.
+    await queryRunner.query(
+      `ALTER TABLE "integration_credentials" ADD "credentialsJson" jsonb`,
+    );
+    await queryRunner.query(
+      `UPDATE "integration_credentials" SET "credentialsJson" = '{}'::jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "integration_credentials" ALTER COLUMN "credentialsJson" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "integration_credentials" ADD "encrypted" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "integration_credentials" DROP COLUMN "credentialsCiphertext"`,
+    );
+  }
+}
+
+/**
+ * Convert a legacy row into the outer-encryption plaintext shape.
+ *
+ * - Rows already in the inner-envelope shape (`{ ciphertext: <inner> }` + encrypted=true)
+ *   get the inner value decrypted, then re-wrapped as a typed plaintext object
+ *   keyed by the writer that produced them (`{ webhookSecret }` or `{ apiKey }`).
+ * - All other rows pass through as-is — they're plaintext JSON objects that the
+ *   outer encryption will protect for the first time.
+ *
+ * An inner-envelope row at an unknown ref prefix is a regression: a fourth
+ * credential writer was added without updating this migration. Throw with an
+ * actionable diagnostic instead of silently corrupting the row.
+ */
+function unwrapPlaintext(row: LegacyRow, key: Buffer): Record<string, unknown> {
+  const innerCiphertext = row.credentialsJson?.ciphertext;
+  const isInnerEnvelope = row.encrypted && typeof innerCiphertext === 'string';
+  if (!isInnerEnvelope) {
+    return row.credentialsJson;
+  }
+
+  const innerPlain = decryptWithKey(key, innerCiphertext);
+  if (row.ref.startsWith(WEBHOOK_SECRET_REF_PREFIX)) {
+    return { webhookSecret: innerPlain };
+  }
+  if (row.ref.startsWith(AI_PROVIDER_CREDENTIALS_REF_PREFIX)) {
+    return { apiKey: innerPlain };
+  }
+  throw new Error(
+    `[1795000000000-encrypt-integration-credentials] inner-envelope row ${row.id} ` +
+      `(ref=${row.ref}) does not match any known inner-envelope ref prefix. ` +
+      `Expected one of: '${WEBHOOK_SECRET_REF_PREFIX}', '${AI_PROVIDER_CREDENTIALS_REF_PREFIX}'. ` +
+      `A new inner-envelope writer was added without updating this migration.`,
+  );
+}

--- a/apps/api/test/integration/ai-provider-settings.int-spec.ts
+++ b/apps/api/test/integration/ai-provider-settings.int-spec.ts
@@ -25,7 +25,6 @@ import {
   IntegrationCredentialRepositoryPort,
 } from '@openlinker/core/integrations';
 import { aiProviderCredentialsRef } from '@openlinker/core/ai';
-import { CryptoService } from '@openlinker/shared';
 import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
 import type { IntegrationTestHarness } from './setup';
 import { loginAsAdmin } from './helpers/test-auth.helper';
@@ -284,35 +283,38 @@ describe('AI Provider Settings Integration', () => {
   });
 
   describe('storage round-trip against real Postgres', () => {
-    it('encrypts → stores → retrieves → decrypts to the original key (provider-agnostic)', async () => {
+    it('writes plaintext via the repo; raw column stores ciphertext; getByRef round-trips (#709)', async () => {
       const app = harness.getApp();
       const repository = app.get<IntegrationCredentialRepositoryPort>(
         INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
       );
-      const crypto = app.get(CryptoService);
+      const dataSource = harness.getDataSource();
 
       const ref = aiProviderCredentialsRef('openai');
       const plaintext = 'sk-openai-real-shape-but-fake-value-abc123';
-      const ciphertext = crypto.encrypt(plaintext);
-
-      expect(ciphertext).not.toBe(plaintext);
-      expect(ciphertext.length).toBeGreaterThan(plaintext.length);
 
       const created = await repository.create({
         ref,
         platformType: 'openai',
-        credentialsJson: { ciphertext },
-        encrypted: true,
+        credentialsJson: { apiKey: plaintext },
       });
 
       expect(created.ref).toBe(ref);
-      expect(created.encrypted).toBe(true);
+      expect(created.credentialsJson).toEqual({ apiKey: plaintext });
 
+      // Raw column must not contain the plaintext (TypeORM keeps the camelCase
+      // column name when no `name:` is set on the @Column decorator).
+      const rawRows = await dataSource.query<Array<{ credentialsCiphertext: string }>>(
+        `SELECT "credentialsCiphertext" FROM integration_credentials WHERE ref = $1`,
+        [ref],
+      );
+      expect(rawRows).toHaveLength(1);
+      expect(rawRows[0].credentialsCiphertext).not.toContain(plaintext);
+      expect(rawRows[0].credentialsCiphertext.length).toBeGreaterThan(plaintext.length);
+
+      // getByRef decrypts transparently.
       const retrieved = await repository.getByRef(ref);
-      const retrievedCipher = retrieved.credentialsJson?.ciphertext;
-      expect(typeof retrievedCipher).toBe('string');
-      const decrypted = crypto.decrypt(retrievedCipher as string);
-      expect(decrypted).toBe(plaintext);
+      expect(retrieved.credentialsJson).toEqual({ apiKey: plaintext });
 
       await repository.delete(ref);
       await expect(repository.getByRef(ref)).rejects.toBeInstanceOf(CredentialNotFoundException);

--- a/apps/api/test/integration/connection-credentials.int-spec.ts
+++ b/apps/api/test/integration/connection-credentials.int-spec.ts
@@ -9,6 +9,10 @@
  * @module apps/api/test/integration
  */
 import { DataSource } from 'typeorm';
+import {
+  IntegrationCredentialRepositoryPort,
+  INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
+} from '@openlinker/core/integrations';
 import { IntegrationCredentialOrmEntity } from '@openlinker/core/integrations/orm-entities';
 import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
 import { IntegrationTestHarness } from './setup';
@@ -19,7 +23,7 @@ import {
 import { getConnectionById } from './helpers/test-database.helper';
 import { loginAsAdmin } from './helpers/test-auth.helper';
 
-async function findCredentialByRef(
+async function findRawCredentialByRef(
   dataSource: DataSource,
   ref: string,
 ): Promise<IntegrationCredentialOrmEntity | null> {
@@ -59,10 +63,20 @@ describe('Connection Credentials Integration', () => {
       expect(connection?.credentialsRef.startsWith('db:')).toBe(true);
 
       const ref = connection!.credentialsRef.slice('db:'.length);
-      const credential = await findCredentialByRef(dataSource, ref);
-      expect(credential).toBeDefined();
-      expect(credential?.platformType).toBe('prestashop');
-      expect(credential?.credentialsJson).toEqual({ webserviceApiKey: 'WS_KEY_TEST' });
+
+      // The raw row stores the AES-256-GCM envelope, not plaintext (#709).
+      const raw = await findRawCredentialByRef(dataSource, ref);
+      expect(raw).toBeDefined();
+      expect(raw?.platformType).toBe('prestashop');
+      expect(raw?.credentialsCiphertext).not.toContain('WS_KEY_TEST');
+      expect(raw?.credentialsCiphertext.length).toBeGreaterThan(20);
+
+      // The domain repository decrypts transparently.
+      const repository = harness
+        .getApp()
+        .get<IntegrationCredentialRepositoryPort>(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN);
+      const decrypted = await repository.getByRef(ref);
+      expect(decrypted.credentialsJson).toEqual({ webserviceApiKey: 'WS_KEY_TEST' });
     });
 
     it('rejects raw-key credentialsRef without db: prefix', async () => {
@@ -139,8 +153,15 @@ describe('Connection Credentials Integration', () => {
       expect(after!.credentialsRef).toBe(refBefore);
 
       const ref = refBefore.slice('db:'.length);
-      const credential = await findCredentialByRef(dataSource, ref);
-      expect(credential?.credentialsJson).toEqual({ webserviceApiKey: 'ROTATED_KEY' });
+      const repository = harness
+        .getApp()
+        .get<IntegrationCredentialRepositoryPort>(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN);
+      const credential = await repository.getByRef(ref);
+      expect(credential.credentialsJson).toEqual({ webserviceApiKey: 'ROTATED_KEY' });
+
+      // Ciphertext does not leak the rotated plaintext into raw bytes.
+      const raw = await findRawCredentialByRef(dataSource, ref);
+      expect(raw?.credentialsCiphertext).not.toContain('ROTATED_KEY');
     });
 
     it('returns 400 when the connection has a non-db credentials reference', async () => {

--- a/apps/api/test/integration/helpers/test-connection.helper.ts
+++ b/apps/api/test/integration/helpers/test-connection.helper.ts
@@ -12,6 +12,7 @@
  */
 import { randomUUID } from 'crypto';
 import { DataSource } from 'typeorm';
+import { encryptWithKey, loadEncryptionKey } from '@openlinker/shared';
 import { ConnectionOrmEntity } from '@openlinker/core/identifier-mapping/orm-entities';
 import { IntegrationCredentialOrmEntity } from '@openlinker/core/integrations/orm-entities';
 import { MAPPING_CONFIG_SERVICE_TOKEN, IMappingConfigService } from '@openlinker/core/mappings';
@@ -159,8 +160,9 @@ export async function createTestPrestashopDestinationConnection(
 }
 
 /**
- * Seed an `integration_credentials` row directly. Bypasses the encrypted-write
- * path on purpose — test credentials never need to go through encryption.
+ * Seed an `integration_credentials` row directly. Encrypts the payload with
+ * the same primitive the production repository uses (#709) so that downstream
+ * decryption through `IntegrationCredentialRepository.getByRef` round-trips.
  */
 async function seedIntegrationCredential(
   dataSource: DataSource,
@@ -170,13 +172,13 @@ async function seedIntegrationCredential(
     credentialsJson: Record<string, unknown>;
   },
 ): Promise<void> {
+  const { key } = loadEncryptionKey(process.env);
   const repo = dataSource.getRepository(IntegrationCredentialOrmEntity);
   await repo.save(
     repo.create({
       ref: args.ref,
       platformType: args.platformType,
-      credentialsJson: args.credentialsJson,
-      encrypted: false,
+      credentialsCiphertext: encryptWithKey(key, JSON.stringify(args.credentialsJson)),
     }),
   );
 }

--- a/docs/operations/credentials-rotation.md
+++ b/docs/operations/credentials-rotation.md
@@ -1,0 +1,103 @@
+# Credentials Rotation
+
+Per-environment runbook for the AES-256-GCM credentials-at-rest envelope
+introduced in #709. The same envelope protects every row in the
+`integration_credentials` table — OAuth tokens, webhook secrets, AI provider
+keys, and platform API keys all share the same key.
+
+## Encryption key
+
+The key is a 32-byte hex string supplied via:
+
+```
+OPENLINKER_CREDENTIALS_ENCRYPTION_KEY=<64 hex chars>
+```
+
+Generate one:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+### Production gate
+
+Under `NODE_ENV=production` the encryption key is **mandatory**.
+`loadEncryptionKey` throws at boot (and inside the migration) if it is
+unset, so a misconfigured deploy fails fast rather than silently falling
+back to a deterministic dev fallback.
+
+The plaintext env-var credentials backend (`getFromEnvironment`) is also
+disabled in production for the same reason — see
+`CredentialsResolverService.getFromEnvironment`.
+
+### Dev/test fallback
+
+In `NODE_ENV !== 'production'` (i.e. local dev, CI), `loadEncryptionKey`
+falls back to a deterministic key when the env var is unset, so
+`pnpm test` / `pnpm test:integration` work zero-config. The fallback is
+**not safe** for any environment that handles real credentials.
+
+## Rotation procedure
+
+Rotating the encryption key today is a manual two-step:
+
+1. **Stop every API + worker process.** Both keys cannot be live in the
+   same process; if rotation runs while a process is still serving
+   traffic, half the rows end up keyed under the old envelope and half
+   under the new envelope and the only recovery is a backup restore.
+2. **Decrypt-all** under the *old* key (write plaintext snapshots to a
+   protected, ephemeral location).
+3. **Re-encrypt-all** under the *new* key, then start the processes back
+   up with `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` pointing at the new
+   value.
+
+There is no in-tree CLI for this yet. The recommended path while one
+doesn't exist:
+
+```ts
+import { CryptoService } from '@openlinker/shared';
+import { IntegrationCredentialRepository } from '@openlinker/core/integrations';
+
+// Read every row with the old key, write every row with the new key.
+// CryptoService reads OPENLINKER_CREDENTIALS_ENCRYPTION_KEY once at
+// instantiation — run a dedicated one-shot script with the old env,
+// then a second one-shot with the new env. Never flip the env on a
+// long-running process.
+```
+
+A `pnpm rotate-credentials-key` CLI is tracked as a follow-up to #709.
+
+## Compromise response
+
+If the encryption key is suspected compromised:
+
+1. Issue a fresh key (`OPENLINKER_CREDENTIALS_ENCRYPTION_KEY`).
+2. Run the rotation procedure above.
+3. **Independently** rotate each upstream credential — OAuth refresh
+   tokens, PrestaShop webservice API keys, Allegro client secrets,
+   Anthropic/OpenAI API keys. The envelope only protects rest; if a key
+   leaked, the plaintext it was wrapping must be assumed compromised too.
+
+## Migration safety
+
+The #709 data migration (`1795000000000-encrypt-integration-credentials`)
+backfills the new `credentialsCiphertext` column from the legacy
+`credentialsJson` + `encrypted` columns, then drops them. `down()`
+restores the schema only — the plaintext is *not* recoverable from
+ciphertext during a revert. **Always take a fresh database backup before
+running this migration in any environment you cannot afford to lose.**
+
+## Threat model
+
+The envelope mitigates:
+
+- DB dump leakage (logical backup, replica snapshot, exfiltration).
+- Read-only DBA / support access without the encryption key.
+
+It does **not** mitigate:
+
+- App-server compromise (the app must hold the key in process memory).
+- Key + DB joint leakage (encryption is moot at that point — independent
+  rotation of upstream credentials is the only remediation).
+- Plaintext leakage through logs, metrics, error responses. Adapters and
+  services that handle decrypted values must not log them.

--- a/docs/plans/implementation-plan-encrypt-integration-credentials.md
+++ b/docs/plans/implementation-plan-encrypt-integration-credentials.md
@@ -1,0 +1,267 @@
+# Implementation plan — #709 Encrypt integration credentials at rest
+
+**Layer**: Backend / Infrastructure (persistence) + small Allegro/AI/webhook-secret call-site updates.
+**Severity**: CRITICAL (security)
+**Issue**: #709
+
+## Problem
+
+`integration_credentials.credentialsJson` (jsonb) stores third-party API credentials (Allegro OAuth refresh tokens, PrestaShop API keys) as **plaintext**. `CryptoService` (AES-256-GCM, prod-fail-closed, dev-fallback) already lives at `libs/shared/src/crypto/` and is wired into the `IntegrationsModule` — it's just not injected into `IntegrationCredentialRepository`.
+
+Two services have worked around this with an **inner-envelope** pattern: `WebhookSecretService` and `AiProviderKeyService` encrypt their secret inline as `{ciphertext: encrypted(raw)}` and set `encrypted: true`. Allegro OAuth + PrestaShop credentials store everything plaintext.
+
+## Goal
+
+Single, consistent encryption-at-rest at the repository layer:
+
+- `credentialsJson jsonb` (plaintext map) → `credentialsCiphertext varchar` (base64 envelope of `JSON.stringify(credentialsJson)`).
+- `encrypted: boolean` column dropped (always-encrypted; no flag needed).
+- Repository encrypts on write, decrypts on read. Domain entity exposes `credentialsJson` (decrypted JS object) — callers continue to work with object shapes.
+- Inner-envelope writers (`WebhookSecretService`, `AiProviderKeyService`) drop the inline `crypto.encrypt` + `{ciphertext}` wrap; they store `{webhookSecret}` / `{apiKey}` and the repo layer handles encryption transparently.
+
+## Non-goals
+
+- Secret-manager backends (Vault / AWS SM / GCP SM) — out of scope.
+- Per-tenant key derivation — defer until tenancy work lands.
+- Removing the env-fallback `CredentialsResolverService.getFromEnvironment` entirely — only gate it to non-production in this PR.
+- Zero-downtime multi-deploy migration sequence — OpenLinker is pre-1.0, no live tenants. **Single migration** that adds the new column, backfills (in the same TX), drops the old. Documented in this plan.
+
+## Layer
+
+Backend. New migration in `apps/api/src/migrations/`.
+
+## Changes
+
+### 0. Precursors — extract shared primitives
+
+Two cross-cutting concerns the migration shares with runtime code. Land these in the **same PR but before the migration step** in the diff order so the migration's imports resolve to stable, typed symbols.
+
+#### 0a. Crypto primitives — shared pure-function module
+
+New file: `libs/shared/src/crypto/crypto-primitives.ts`. Pure functions, no NestJS, no DI:
+
+```typescript
+export function encryptWithKey(key: Buffer, plaintext: string): string { /* AES-256-GCM */ }
+export function decryptWithKey(key: Buffer, envelope: string): string { /* AES-256-GCM */ }
+export function loadEncryptionKey(env: NodeJS.ProcessEnv): Buffer { /* OPENLINKER_CREDENTIALS_ENCRYPTION_KEY + NODE_ENV=production fail-closed; dev/test deterministic fallback with warning */ }
+```
+
+Refactor `CryptoService` (`libs/shared/src/crypto/crypto.service.ts`):
+- `onModuleInit()` calls `this.key = loadEncryptionKey(process.env)` (delegating fail-closed + dev-fallback semantics + warning emission).
+- `encrypt(plaintext)` → `encryptWithKey(this.key, plaintext)`.
+- `decrypt(envelope)` → `decryptWithKey(this.key, envelope)`.
+
+Service-level behavior unchanged; algorithm now has one source of truth. Existing `crypto.service.spec.ts` continues to pass.
+
+Eliminates the drift risk between the runtime service and the migration's encryption logic.
+
+#### 0b. Ref-prefix constants — exported alongside the ref helpers
+
+Today prefix strings live as inline literals inside two ref-builder functions:
+- `libs/core/src/integrations/domain/ports/webhook-secret-provider.port.ts:50` → `webhookSecretRef(id) = 'webhook-secret:' + id`
+- `libs/core/src/ai/domain/ports/ai-provider-credentials.port.ts:30` → `aiProviderCredentialsRef(provider) = 'ai-provider:' + provider`
+
+Add exported constants in the same files:
+
+```typescript
+// webhook-secret-provider.port.ts
+export const WEBHOOK_SECRET_REF_PREFIX = 'webhook-secret:';
+export const webhookSecretRef = (connectionId: string): string =>
+  `${WEBHOOK_SECRET_REF_PREFIX}${connectionId}`;
+
+// ai-provider-credentials.port.ts
+export const AI_PROVIDER_CREDENTIALS_REF_PREFIX = 'ai-provider:';
+export const aiProviderCredentialsRef = (provider: AiProvider): string =>
+  `${AI_PROVIDER_CREDENTIALS_REF_PREFIX}${provider}`;
+```
+
+Re-export both constants through the `@openlinker/core/integrations` and `@openlinker/core/ai` barrels (additive). The migration imports them via the barrels, not via deep paths.
+
+**Pre-merge grep check** (acceptance criterion): run
+```bash
+grep -rn "credentialRepository\.create\|credentialRepository\.update" libs/core libs/integrations apps/api --include='*.ts' | grep -v ".spec.ts" | grep -v ".test.ts"
+```
+to enumerate every credential writer. Expected: `WebhookSecretService`, `AiProviderKeyService`, `AllegroOauthService` — exactly three production writers, plus the test helper. A fourth writer at an unknown ref prefix would break the migration's inner-envelope inference (and the migration file's JSDoc says so).
+
+### 1. Migration
+
+`apps/api/src/migrations/1789000000000-encrypt-integration-credentials.ts` (single transactional migration):
+
+```typescript
+import { encryptWithKey, decryptWithKey, loadEncryptionKey } from '@openlinker/shared';
+import { WEBHOOK_SECRET_REF_PREFIX } from '@openlinker/core/integrations';
+import { AI_PROVIDER_CREDENTIALS_REF_PREFIX } from '@openlinker/core/ai';
+
+public async up(queryRunner: QueryRunner): Promise<void> {
+  const key = loadEncryptionKey(process.env);  // throws under NODE_ENV=production when unset
+
+  // 1. Add new column
+  await queryRunner.query(
+    `ALTER TABLE "integration_credentials" ADD "credentialsCiphertext" varchar`,
+  );
+
+  // 2. Backfill
+  const rows: Array<{ id: string; ref: string; credentialsJson: Record<string, unknown>; encrypted: boolean }> =
+    await queryRunner.query(
+      `SELECT id, ref, "credentialsJson", encrypted FROM "integration_credentials"`,
+    );
+
+  for (const row of rows) {
+    let plain: Record<string, unknown>;
+    // Collapse inner-envelope rows into the new outer shape.
+    // Before: { ciphertext: <encrypted(secret)> } + encrypted=true
+    // After:  { webhookSecret: <secret> } / { apiKey: <secret> } — plaintext object,
+    //         OUTER encryption handles confidentiality.
+    if (row.encrypted && typeof row.credentialsJson?.ciphertext === 'string') {
+      const innerPlain = decryptWithKey(key, row.credentialsJson.ciphertext);
+      if (row.ref.startsWith(WEBHOOK_SECRET_REF_PREFIX)) {
+        plain = { webhookSecret: innerPlain };
+      } else if (row.ref.startsWith(AI_PROVIDER_CREDENTIALS_REF_PREFIX)) {
+        plain = { apiKey: innerPlain };
+      } else {
+        throw new Error(
+          `[1789000000000-encrypt-integration-credentials] inner-envelope row ${row.id} (ref=${row.ref}) ` +
+            `does not match any known inner-envelope ref prefix. ` +
+            `Expected one of: '${WEBHOOK_SECRET_REF_PREFIX}', '${AI_PROVIDER_CREDENTIALS_REF_PREFIX}'. ` +
+            `A new inner-envelope writer was added without updating this migration.`,
+        );
+      }
+    } else {
+      plain = row.credentialsJson;
+    }
+
+    const ciphertext = encryptWithKey(key, JSON.stringify(plain));
+    await queryRunner.query(
+      `UPDATE "integration_credentials" SET "credentialsCiphertext" = $1 WHERE id = $2`,
+      [ciphertext, row.id],
+    );
+  }
+
+  // 3. Enforce NOT NULL + drop old columns
+  await queryRunner.query(
+    `ALTER TABLE "integration_credentials" ALTER COLUMN "credentialsCiphertext" SET NOT NULL`,
+  );
+  await queryRunner.query(`ALTER TABLE "integration_credentials" DROP COLUMN "credentialsJson"`);
+  await queryRunner.query(`ALTER TABLE "integration_credentials" DROP COLUMN encrypted`);
+}
+```
+
+The migration uses the shared primitive functions extracted in step 0a, and ref-prefix constants from step 0b. Unknown ref prefixes on inner-envelope rows throw with an actionable diagnostic.
+
+**Down-migration** (`down()`) restores the schema structurally (re-creates `credentialsJson jsonb NOT NULL` + `encrypted boolean DEFAULT false`) but the column will be empty `{}` on previously-encrypted rows. This is **intentional and data-irreversible** by design — decrypting back to plaintext is exactly the breach this migration prevents. The migration file's JSDoc header MUST explicitly call this out:
+
+```typescript
+/**
+ * Encrypt Integration Credentials Migration (#709)
+ *
+ * One-way data migration: existing plaintext + inner-envelope rows are
+ * re-encrypted under the outer-envelope shape and the legacy columns
+ * are dropped.
+ *
+ * ⚠️  `down()` IS DATA-IRREVERSIBLE: running it after `up()` has executed
+ * restores the legacy schema (credentialsJson jsonb, encrypted boolean) but
+ * leaves `credentialsJson = {}` on every previously-encrypted row.
+ * Recovering plaintext is intentionally impossible — the entire point of
+ * encryption-at-rest is that the DB does not contain plaintext. Operators
+ * who need to roll back MUST take a fresh DB backup BEFORE running this
+ * migration and restore from backup instead of `migration:revert`.
+ *
+ * Aligns with `docs/migrations.md` § Best Practices "implement both up()
+ * and down()": this `down()` is structurally reversible (schema) but
+ * data-irreversible by intent.
+ */
+```
+
+### 2. ORM entity
+
+`libs/core/src/integrations/infrastructure/persistence/entities/integration-credential.orm-entity.ts`:
+
+```typescript
+@Column({ type: 'varchar' })
+credentialsCiphertext!: string;
+// drop credentialsJson + encrypted
+```
+
+### 3. Domain entity + port
+
+`libs/core/src/integrations/domain/entities/integration-credential.entity.ts` — drop `encrypted: boolean`. Keep `credentialsJson: Record<string, unknown>` (this is the decrypted JS object exposed to callers — the on-disk envelope is repository-internal).
+
+`libs/core/src/integrations/domain/ports/integration-credential-repository.port.ts`:
+- `CredentialCreate` — drop `encrypted?: boolean`.
+- `CredentialUpdate` — drop `encrypted?: boolean`.
+
+### 4. Repository
+
+`libs/core/src/integrations/infrastructure/persistence/repositories/integration-credential.repository.ts`:
+
+```typescript
+@Injectable()
+export class IntegrationCredentialRepository implements IntegrationCredentialRepositoryPort {
+  constructor(
+    @InjectRepository(IntegrationCredentialOrmEntity)
+    private readonly repository: Repository<IntegrationCredentialOrmEntity>,
+    private readonly crypto: CryptoService,
+  ) {}
+
+  // toOrm: entity.credentialsCiphertext = crypto.encrypt(JSON.stringify(payload.credentialsJson))
+  // toDomain: credentialsJson = JSON.parse(crypto.decrypt(entity.credentialsCiphertext))
+  // update: re-encrypt the full patched object (read-modify-write on the JS object)
+}
+```
+
+### 5. Call-site updates (drop the inner-envelope workaround)
+
+- **`libs/core/src/integrations/application/services/webhook-secret.service.ts`** — drop `crypto.encrypt(secret)` + `{ciphertext}` wrap; store `{webhookSecret: secret}` + drop `encrypted: true`. The service no longer needs `CryptoService` injected (the repo handles encryption).
+- **`libs/core/src/ai/application/services/ai-provider-key.service.ts`** — same pattern; store `{apiKey: apiKey}` + drop `encrypted: true`. Drop the `CryptoService` injection.
+- **`libs/core/src/integrations/infrastructure/adapters/credentials-webhook-secret.adapter.ts`** — drop the inner `decrypt(credential.credentialsJson.ciphertext)` chain; read `credential.credentialsJson.webhookSecret` directly. Drop `CryptoService` injection.
+- **`libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.ts`** — same pattern. Drop the env-fallback's deprecated-warning narrative since the inner-envelope pattern is gone.
+- **`apps/api/src/integrations/application/services/allegro-oauth.service.ts:336`** — drop `encrypted: false` from the credential-create payload. Update the misleading "For MVP, credentials are stored unencrypted" comment — they ARE encrypted now.
+- **`apps/api/test/integration/helpers/test-connection.helper.ts:179`** — drop `encrypted: false`.
+
+### 6. Production env-fallback gate
+
+`libs/core/src/integrations/infrastructure/credentials/credentials-resolver.service.ts:getFromEnvironment`: throw when `NODE_ENV=production`. Helpful error message pointing to `db:` refs as the production-supported backend. Dev/test untouched.
+
+### 7. Tests
+
+**Unit tests**:
+- `integration-credential.repository.spec.ts` (new) — mock `CryptoService` + the typeorm repository, assert `toOrm` writes `crypto.encrypt(JSON.stringify(payload))` and `toDomain` round-trips through `crypto.decrypt → JSON.parse`. Pin the contract.
+- Update existing `webhook-secret.service.spec.ts` and `credentials-webhook-secret.adapter.spec.ts` to reflect the new shape (`{webhookSecret}` no inner ciphertext).
+- Update existing `ai-provider-key.service`-related specs.
+
+**Integration test** (the key acceptance criterion):
+- `apps/api/test/integration/connection-credentials.int-spec.ts` — extend the existing spec with: write a credential containing a unique sentinel string (e.g. `'SENTINEL_PLAINTEXT_MUST_NOT_LEAK'`), `SELECT credentialsCiphertext FROM integration_credentials WHERE ref = ?`, assert the persisted bytes do NOT contain the sentinel. Then `getByRef` and assert the decrypted round-trip returns the original.
+- **Helper split**: keep the existing `findCredentialByRef` returning the **raw OrmEntity** (now reading `credentialsCiphertext` not `credentialsJson`) — that's the seam that powers the sentinel-not-in-persisted-bytes assertion (the load-bearing security AC). Add a parallel assertion that routes through `repository.getByRef(ref)` for the decrypted round-trip equality check. Two distinct things being asserted, two distinct paths through the spec.
+
+### 8. Docs
+
+- `docs/operations/credentials-rotation.md` (new) — how to rotate `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY`. Single-key today, so rotation = re-encrypt every row + restart. Document the dual-key transition pattern as a follow-up.
+- `SECURITY.md` — file already exists (covers Security Policy + Reporting + Supported Versions); has **no** "Threat model" section today. This PR adds a new top-level "## Threat Model" section describing the credentials-at-rest control (algorithm, envelope format, key source, fail-closed semantics under `NODE_ENV=production`, the env-fallback non-prod gate). Sized as a new section, not an edit to existing content.
+
+## Acceptance criteria
+
+- `libs/shared/src/crypto/crypto-primitives.ts` exists; `CryptoService` delegates to it; no algorithm duplication between runtime and migration paths.
+- `WEBHOOK_SECRET_REF_PREFIX` / `AI_PROVIDER_CREDENTIALS_REF_PREFIX` are exported constants the ref-builder helpers compose against; both are re-exported from `@openlinker/core/integrations` and `@openlinker/core/ai` barrels.
+- Pre-merge grep enumerates exactly the expected three credential writers (`WebhookSecretService`, `AiProviderKeyService`, `AllegroOauthService`); a fourth writer at an unknown ref prefix would have failed the migration in CI.
+- `IntegrationCredentialOrmEntity` has `credentialsCiphertext: string` and no `credentialsJson` / `encrypted` columns.
+- `IntegrationCredentialRepository.create/update` writes only ciphertext. Unit test pins this.
+- `getByRef` returns the decrypted JS object (`credential.credentialsJson` is the unwrapped object).
+- **Integration test**: SELECT raw `credentialsCiphertext` bytes via `findCredentialByRef` (raw OrmEntity) — assert sentinel-plaintext is NOT present. Then `repository.getByRef(ref)` — assert decrypted round-trip equality.
+- Inner-envelope pattern removed from `WebhookSecretService` + `AiProviderKeyService` + their adapters. The `{ciphertext}` shape no longer appears anywhere in the code.
+- `CredentialsResolverService.getFromEnvironment` throws under `NODE_ENV=production`.
+- `docs/operations/credentials-rotation.md` exists.
+- `SECURITY.md` has a new `## Threat Model` section describing the credentials-at-rest control.
+- Migration file's JSDoc explicitly warns that `down()` is data-irreversible and operators must restore from backup, not `migration:revert`.
+- Migration runs idempotently on a clean DB (covered by Testcontainers boot in int-spec) and on a seeded DB (manual smoke if practical).
+- `pnpm lint` / `pnpm type-check` / `pnpm test` / `pnpm --filter @openlinker/api migration:show` green.
+
+## Risks
+
+- **Migration backfill fails closed if `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` is unset in production.** Operators MUST set the key before running migrations. Documented in `credentials-rotation.md` and emitted as a clear error if missing.
+- **Inner-envelope rows in production**: webhook-secret + AI-key rows already have inner-encrypted ciphertext. The migration decrypts that inner value once (using the same key), then re-wraps + re-encrypts with the outer envelope. Same key for both layers; migration owns the unwrap path.
+- **Allegro OAuth refresh tokens** are the highest-value target. The OAuth flow stores them plaintext today. Post-migration they're encrypted at rest; the OAuth service no longer needs (and can't request) the `encrypted: false` flag.
+- **Down-migration is irreversible** in the data sense (we can't decrypt back to plaintext if the goal is to revert encryption-at-rest — that defeats the purpose). Structural revert is supported but rows are not retrievable as plaintext JSON. Document.
+
+## Estimated size
+
+~17 files modified + 1 new migration + 1 new shared-primitives file + 1 new doc + new section in `SECURITY.md`. Net LOC slightly positive (the shared crypto-primitives module is genuinely new code, even though it's a refactor-extraction; +~50 LOC there counterbalances the encrypt/decrypt-replaces-plaintext deltas elsewhere).

--- a/libs/core/src/ai/application/services/ai-provider-key.service.spec.ts
+++ b/libs/core/src/ai/application/services/ai-provider-key.service.spec.ts
@@ -1,14 +1,13 @@
 /**
  * AI Provider Key Service — Unit Tests
  *
- * Mocks the credentials port + credential repo + crypto. Asserts: per-provider
- * upsert+create paths encrypt and persist; clear deletes; both invalidate the
- * port for that provider only; rejecting writes for providers that don't
- * require a key.
+ * Mocks the credentials port + credential repo. Asserts: per-provider
+ * upsert+create paths persist plaintext (the repo encrypts); clear deletes;
+ * both invalidate the port for that provider only; rejecting writes for
+ * providers that don't require a key.
  *
  * @module libs/core/src/ai/application/services
  */
-import type { CryptoService } from '@openlinker/shared';
 import { Logger as SharedLogger } from '@openlinker/shared/logging';
 import type { IntegrationCredentialRepositoryPort } from '@openlinker/core/integrations';
 import { CredentialNotFoundException } from '@openlinker/core/integrations';
@@ -18,24 +17,15 @@ import { AiProviderSettingsNotApplicableError } from '../../domain/exceptions/ai
 import { AiProviderKeyService } from './ai-provider-key.service';
 
 const sampleCredential = (ref: string): IntegrationCredential =>
-  new IntegrationCredential(
-    'cred-id',
-    ref,
-    'anthropic',
-    { ciphertext: 'cipher' },
-    true,
-    new Date(),
-    new Date()
-  );
+  new IntegrationCredential('cred-id', ref, 'anthropic', { apiKey: 'plain-key' }, new Date(), new Date());
 
 describe('AiProviderKeyService', () => {
   let credentialsPort: jest.Mocked<AiProviderCredentialsPort>;
   let repository: jest.Mocked<IntegrationCredentialRepositoryPort>;
-  let crypto: jest.Mocked<Pick<CryptoService, 'encrypt' | 'decrypt'>>;
   let logSpy: jest.SpyInstance;
 
   const buildService = (): AiProviderKeyService =>
-    new AiProviderKeyService(credentialsPort, repository, crypto as unknown as CryptoService);
+    new AiProviderKeyService(credentialsPort, repository);
 
   beforeEach(() => {
     credentialsPort = {
@@ -50,10 +40,6 @@ describe('AiProviderKeyService', () => {
       update: jest.fn().mockResolvedValue(sampleCredential('ai-provider:anthropic')),
       delete: jest.fn().mockResolvedValue(true),
     };
-    crypto = {
-      encrypt: jest.fn().mockReturnValue('cipher'),
-      decrypt: jest.fn(),
-    };
     logSpy = jest.spyOn(SharedLogger.prototype, 'log').mockImplementation(() => undefined);
   });
 
@@ -62,13 +48,11 @@ describe('AiProviderKeyService', () => {
   });
 
   describe('setKey', () => {
-    it('encrypts the key and updates the existing credential row when present', async () => {
+    it('updates the existing credential row with plaintext apiKey', async () => {
       await buildService().setKey('anthropic', 'plain-key', 'admin-1');
 
-      expect(crypto.encrypt).toHaveBeenCalledWith('plain-key');
       expect(repository.update).toHaveBeenCalledWith('ai-provider:anthropic', {
-        credentialsJson: { ciphertext: 'cipher' },
-        encrypted: true,
+        credentialsJson: { apiKey: 'plain-key' },
       });
       expect(repository.create).not.toHaveBeenCalled();
       expect(credentialsPort.invalidate).toHaveBeenCalledWith('anthropic');
@@ -82,8 +66,7 @@ describe('AiProviderKeyService', () => {
       expect(repository.create).toHaveBeenCalledWith({
         ref: 'ai-provider:openai',
         platformType: 'openai',
-        credentialsJson: { ciphertext: 'cipher' },
-        encrypted: true,
+        credentialsJson: { apiKey: 'plain-key' },
       });
       expect(credentialsPort.invalidate).toHaveBeenCalledWith('openai');
     });

--- a/libs/core/src/ai/application/services/ai-provider-key.service.ts
+++ b/libs/core/src/ai/application/services/ai-provider-key.service.ts
@@ -14,7 +14,7 @@
  * @implements {IAiProviderKeyService}
  */
 import { Inject, Injectable } from '@nestjs/common';
-import { Logger, CryptoService } from '@openlinker/shared';
+import { Logger } from '@openlinker/shared';
 import {
   IntegrationCredentialRepositoryPort,
   INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
@@ -42,7 +42,6 @@ export class AiProviderKeyService implements IAiProviderKeyService {
     private readonly credentialsPort: AiProviderCredentialsPort,
     @Inject(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN)
     private readonly credentialRepository: IntegrationCredentialRepositoryPort,
-    private readonly crypto: CryptoService,
   ) {}
 
   describe(provider: AiProvider): Promise<AiProviderSettingsView> {
@@ -56,21 +55,19 @@ export class AiProviderKeyService implements IAiProviderKeyService {
   async setKey(provider: AiProvider, apiKey: string, actorUserId?: string): Promise<void> {
     this.assertProviderRequiresKey(provider);
 
-    const ciphertext = this.crypto.encrypt(apiKey);
     const ref = aiProviderCredentialsRef(provider);
 
+    // Plaintext at this layer — the repository encrypts on write (#709).
     try {
       await this.credentialRepository.update(ref, {
-        credentialsJson: { ciphertext },
-        encrypted: true,
+        credentialsJson: { apiKey },
       });
     } catch (error) {
       if (error instanceof CredentialNotFoundException) {
         await this.credentialRepository.create({
           ref,
           platformType: provider,
-          credentialsJson: { ciphertext },
-          encrypted: true,
+          credentialsJson: { apiKey },
         });
       } else {
         throw error;

--- a/libs/core/src/ai/domain/ports/ai-provider-credentials.port.ts
+++ b/libs/core/src/ai/domain/ports/ai-provider-credentials.port.ts
@@ -21,6 +21,16 @@ import type { AiProvider } from '../types/ai-completion.types';
 import type { AiProviderSettingsView } from '../types/ai-provider-credentials.types';
 
 /**
+ * Canonical credential ref prefix for per-provider AI keys.
+ *
+ * Exported separately from `aiProviderCredentialsRef` (#709) so the
+ * credentials-encryption migration can dispatch on
+ * `row.ref.startsWith(prefix)` against a typed constant rather than a
+ * hardcoded string literal.
+ */
+export const AI_PROVIDER_CREDENTIALS_REF_PREFIX = 'ai-provider:';
+
+/**
  * Build the credential `ref` for a given provider. Single source of truth
  * shared between the write side (`AiProviderKeyService`) and the read side
  * (`CredentialsAiProviderAdapter`). Lives in the domain layer so both
@@ -28,7 +38,7 @@ import type { AiProviderSettingsView } from '../types/ai-provider-credentials.ty
  * file — never on each other.
  */
 export const aiProviderCredentialsRef = (provider: AiProvider): string =>
-  `ai-provider:${provider}`;
+  `${AI_PROVIDER_CREDENTIALS_REF_PREFIX}${provider}`;
 
 export interface AiProviderCredentialsPort {
   /**

--- a/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts
+++ b/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts
@@ -1,17 +1,18 @@
 /**
  * Credentials AI Provider Adapter — Unit Tests
  *
- * Mocks the credential repo, crypto service, and ConfigService. Asserts:
- * per-provider DB hit (decrypts), DB miss → env fallback (warns once per
- * provider), both missing → AiProviderKeyMissingError, per-provider cache
- * hit, invalidate(provider) clears that provider's slot, describe() reports
- * the resolution source per provider, provider=fake short-circuits without
- * DB/env lookups, env reads go via ConfigService (not process.env).
+ * Mocks the credential repo and ConfigService. The adapter sees plaintext
+ * domain entities (encryption-at-rest lives in the repository layer, #709).
+ * Asserts: per-provider DB hit (returns plaintext apiKey), DB miss → env
+ * fallback (warns once per provider), both missing → AiProviderKeyMissingError,
+ * per-provider cache hit, invalidate(provider) clears that provider's slot,
+ * describe() reports the resolution source per provider, provider=fake
+ * short-circuits without DB/env lookups, env reads go via ConfigService
+ * (not process.env).
  *
  * @module libs/core/src/ai/infrastructure/adapters
  */
 import type { ConfigService } from '@nestjs/config';
-import type { CryptoService } from '@openlinker/shared';
 import { Logger as SharedLogger } from '@openlinker/shared/logging';
 import type { IntegrationCredentialRepositoryPort } from '@openlinker/core/integrations';
 import { CredentialNotFoundException } from '@openlinker/core/integrations';
@@ -28,20 +29,11 @@ const buildConfigService = (overrides: Record<string, string | undefined>): Conf
     }),
   }) as unknown as ConfigService;
 
-const dbCredential = (ref: string, ciphertext: string, encrypted = true): IntegrationCredential =>
-  new IntegrationCredential(
-    'cred-id',
-    ref,
-    'anthropic',
-    { ciphertext },
-    encrypted,
-    new Date(),
-    new Date()
-  );
+const dbCredential = (ref: string, apiKey: string): IntegrationCredential =>
+  new IntegrationCredential('cred-id', ref, 'anthropic', { apiKey }, new Date(), new Date());
 
 describe('CredentialsAiProviderAdapter', () => {
   let repository: jest.Mocked<IntegrationCredentialRepositoryPort>;
-  let crypto: jest.Mocked<Pick<CryptoService, 'encrypt' | 'decrypt'>>;
   let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -50,10 +42,6 @@ describe('CredentialsAiProviderAdapter', () => {
       create: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
-    };
-    crypto = {
-      encrypt: jest.fn(),
-      decrypt: jest.fn(),
     };
     warnSpy = jest.spyOn(SharedLogger.prototype, 'warn').mockImplementation(() => undefined);
   });
@@ -66,22 +54,18 @@ describe('CredentialsAiProviderAdapter', () => {
   const buildAdapter = (
     config: Record<string, string | undefined> = {}
   ): CredentialsAiProviderAdapter =>
-    new CredentialsAiProviderAdapter(
-      repository,
-      crypto as unknown as CryptoService,
-      buildConfigService(config)
-    );
+    new CredentialsAiProviderAdapter(repository, buildConfigService(config));
 
   describe('getApiKey', () => {
-    it('returns the decrypted DB key when present for the given provider', async () => {
-      repository.getByRef.mockResolvedValue(dbCredential('ai-provider:anthropic', 'cipher'));
-      crypto.decrypt.mockReturnValue('plaintext-key');
+    it('returns the plaintext DB apiKey when present for the given provider', async () => {
+      repository.getByRef.mockResolvedValue(
+        dbCredential('ai-provider:anthropic', 'plaintext-key')
+      );
 
       const result = await buildAdapter().getApiKey('anthropic');
 
       expect(result).toBe('plaintext-key');
       expect(repository.getByRef).toHaveBeenCalledWith('ai-provider:anthropic');
-      expect(crypto.decrypt).toHaveBeenCalledWith('cipher');
     });
 
     it('falls back to ConfigService env (with one-shot warning per provider) when no DB row', async () => {
@@ -95,13 +79,11 @@ describe('CredentialsAiProviderAdapter', () => {
       const a2 = await adapter.getApiKey('anthropic');
       expect(a1).toBe('anthropic-env-key');
       expect(a2).toBe('anthropic-env-key');
-      // Only one warning emitted for anthropic so far
       expect(warnSpy).toHaveBeenCalledTimes(1);
       const firstWarn = String((warnSpy.mock.calls[0] as unknown as [unknown])[0] ?? '');
       expect(firstWarn).toContain('ANTHROPIC_API_KEY');
       expect(firstWarn).toContain('deprecated');
 
-      // OpenAI key resolves separately and triggers its own one-shot warning
       const o1 = await adapter.getApiKey('openai');
       expect(o1).toBe('openai-env-key');
       expect(warnSpy).toHaveBeenCalledTimes(2);
@@ -119,20 +101,21 @@ describe('CredentialsAiProviderAdapter', () => {
     });
 
     it('caches the resolved key per provider and avoids re-reading the DB on the next call', async () => {
-      repository.getByRef.mockResolvedValue(dbCredential('ai-provider:anthropic', 'cipher'));
-      crypto.decrypt.mockReturnValue('plaintext-key');
+      repository.getByRef.mockResolvedValue(
+        dbCredential('ai-provider:anthropic', 'plaintext-key')
+      );
       const adapter = buildAdapter();
 
       await adapter.getApiKey('anthropic');
       await adapter.getApiKey('anthropic');
 
       expect(repository.getByRef).toHaveBeenCalledTimes(1);
-      expect(crypto.decrypt).toHaveBeenCalledTimes(1);
     });
 
     it('re-reads the DB for that provider after invalidate(provider)', async () => {
-      repository.getByRef.mockResolvedValue(dbCredential('ai-provider:anthropic', 'cipher'));
-      crypto.decrypt.mockReturnValue('plaintext-key');
+      repository.getByRef.mockResolvedValue(
+        dbCredential('ai-provider:anthropic', 'plaintext-key')
+      );
       const adapter = buildAdapter();
 
       await adapter.getApiKey('anthropic');
@@ -145,11 +128,10 @@ describe('CredentialsAiProviderAdapter', () => {
     it("keeps each provider's cache slot independent — invalidating openai does not bust anthropic", async () => {
       repository.getByRef.mockImplementation((ref: string) => {
         if (ref === 'ai-provider:anthropic') {
-          return Promise.resolve(dbCredential('ai-provider:anthropic', 'a-cipher'));
+          return Promise.resolve(dbCredential('ai-provider:anthropic', 'a-plain'));
         }
-        return Promise.resolve(dbCredential('ai-provider:openai', 'o-cipher'));
+        return Promise.resolve(dbCredential('ai-provider:openai', 'o-plain'));
       });
-      crypto.decrypt.mockImplementation((ct: string) => `plain-${ct}`);
       const adapter = buildAdapter();
 
       await adapter.getApiKey('anthropic');
@@ -169,23 +151,13 @@ describe('CredentialsAiProviderAdapter', () => {
       );
       expect(repository.getByRef).not.toHaveBeenCalled();
     });
-
-    it('treats a stored unencrypted credential as raw plaintext (does not call decrypt)', async () => {
-      repository.getByRef.mockResolvedValue(
-        dbCredential('ai-provider:anthropic', 'plaintext-stored', false)
-      );
-
-      const result = await buildAdapter().getApiKey('anthropic');
-
-      expect(result).toBe('plaintext-stored');
-      expect(crypto.decrypt).not.toHaveBeenCalled();
-    });
   });
 
   describe('describe', () => {
     it('reports source=db when a DB row exists', async () => {
-      repository.getByRef.mockResolvedValue(dbCredential('ai-provider:anthropic', 'cipher'));
-      crypto.decrypt.mockReturnValue('plaintext-key');
+      repository.getByRef.mockResolvedValue(
+        dbCredential('ai-provider:anthropic', 'plaintext-key')
+      );
 
       expect(await buildAdapter().describe('anthropic')).toEqual({
         provider: 'anthropic',
@@ -200,7 +172,6 @@ describe('CredentialsAiProviderAdapter', () => {
       const view = await buildAdapter({ ANTHROPIC_API_KEY: 'env-key' }).describe('anthropic');
 
       expect(view).toEqual({ provider: 'anthropic', configured: true, source: 'env' });
-      // describe() must not emit the deprecation warning — only getApiKey() does
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
@@ -243,11 +214,7 @@ describe('CredentialsAiProviderAdapter', () => {
     it('routes the env lookup through ConfigService.get', async () => {
       repository.getByRef.mockRejectedValue(new CredentialNotFoundException('x'));
       const config = buildConfigService({ ANTHROPIC_API_KEY: 'env-key' });
-      const adapter = new CredentialsAiProviderAdapter(
-        repository,
-        crypto as unknown as CryptoService,
-        config
-      );
+      const adapter = new CredentialsAiProviderAdapter(repository, config);
 
       await adapter.getApiKey('anthropic');
 

--- a/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.ts
+++ b/libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.ts
@@ -6,6 +6,9 @@
  * encrypted `integration_credentials` table) and its own 60 s in-process
  * cache. Resolution priority per provider: DB → env → throw.
  *
+ * Encryption-at-rest is handled by the repository layer (#709) — this adapter
+ * only sees plaintext domain entities.
+ *
  * The adapter is independent of which provider is currently *active* — that
  * resolution lives in `AiProviderActiveSettingsService`. This split lets
  * the `MultiProviderAiCompletionAdapter` route to the right Vercel adapter
@@ -21,7 +24,7 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Logger, CryptoService } from '@openlinker/shared';
+import { Logger } from '@openlinker/shared';
 import {
   IntegrationCredentialRepositoryPort,
   INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN,
@@ -54,7 +57,6 @@ export class CredentialsAiProviderAdapter implements AiProviderCredentialsPort {
   constructor(
     @Inject(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN)
     private readonly credentialRepository: IntegrationCredentialRepositoryPort,
-    private readonly crypto: CryptoService,
     private readonly configService: ConfigService
   ) {}
 
@@ -125,18 +127,12 @@ export class CredentialsAiProviderAdapter implements AiProviderCredentialsPort {
     const ref = aiProviderCredentialsRef(provider);
     try {
       const credential = await this.credentialRepository.getByRef(ref);
-      const ciphertext = credential.credentialsJson?.ciphertext;
-      if (typeof ciphertext !== 'string') {
-        this.logger.error(`AI provider credential ${ref} is missing a ciphertext field`);
+      const apiKey = credential.credentialsJson?.apiKey;
+      if (typeof apiKey !== 'string') {
+        this.logger.error(`AI provider credential ${ref} is missing an apiKey field`);
         return null;
       }
-      if (!credential.encrypted) {
-        this.logger.warn(
-          `AI provider credential ${ref} is not marked encrypted — returning raw value`
-        );
-        return ciphertext;
-      }
-      return this.crypto.decrypt(ciphertext);
+      return apiKey;
     } catch (error) {
       if (error instanceof CredentialNotFoundException) {
         return null;

--- a/libs/core/src/integrations/application/services/webhook-secret.service.spec.ts
+++ b/libs/core/src/integrations/application/services/webhook-secret.service.spec.ts
@@ -3,7 +3,6 @@
  *
  * @module libs/core/src/integrations/application/services
  */
-import type { CryptoService } from '@openlinker/shared';
 import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
 import { Connection } from '@openlinker/core/identifier-mapping';
 import { WebhookSecretService } from './webhook-secret.service';
@@ -29,7 +28,6 @@ describe('WebhookSecretService', () => {
 
   let connectionPort: jest.Mocked<ConnectionPort>;
   let repository: jest.Mocked<IntegrationCredentialRepositoryPort>;
-  let crypto: jest.Mocked<Pick<CryptoService, 'encrypt' | 'decrypt'>>;
   let secretProvider: jest.Mocked<WebhookSecretProviderPort>;
   let subject: WebhookSecretService;
 
@@ -38,7 +36,6 @@ describe('WebhookSecretService', () => {
     `webhook-secret:${connectionId}`,
     'prestashop',
     {},
-    true,
     new Date(),
     new Date()
   );
@@ -51,25 +48,17 @@ describe('WebhookSecretService', () => {
       update: jest.fn().mockResolvedValue(sampleCredential),
       delete: jest.fn(),
     };
-    crypto = { encrypt: jest.fn().mockReturnValue('cipher'), decrypt: jest.fn() } as never;
     secretProvider = { getSecret: jest.fn(), invalidate: jest.fn() } as never;
 
-    subject = new WebhookSecretService(
-      connectionPort,
-      repository,
-      crypto as unknown as CryptoService,
-      secretProvider
-    );
+    subject = new WebhookSecretService(connectionPort, repository, secretProvider);
   });
 
-  it('updates existing credential when present and returns plaintext once', async () => {
+  it('updates existing credential with plaintext secret and returns it once', async () => {
     const result = await subject.rotate('prestashop', connectionId, 'user-1');
 
     expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
-    expect(crypto.encrypt).toHaveBeenCalledWith(result.secret);
     expect(repository.update).toHaveBeenCalledWith(`webhook-secret:${connectionId}`, {
-      credentialsJson: { ciphertext: 'cipher' },
-      encrypted: true,
+      credentialsJson: { webhookSecret: result.secret },
     });
     expect(secretProvider.invalidate).toHaveBeenCalledWith('prestashop', connectionId);
   });
@@ -77,13 +66,12 @@ describe('WebhookSecretService', () => {
   it('creates the credential when missing', async () => {
     repository.update.mockRejectedValueOnce(new CredentialNotFoundException('x'));
 
-    await subject.rotate('prestashop', connectionId);
+    const result = await subject.rotate('prestashop', connectionId);
 
     expect(repository.create).toHaveBeenCalledWith({
       ref: `webhook-secret:${connectionId}`,
       platformType: 'prestashop',
-      credentialsJson: { ciphertext: 'cipher' },
-      encrypted: true,
+      credentialsJson: { webhookSecret: result.secret },
     });
   });
 

--- a/libs/core/src/integrations/application/services/webhook-secret.service.ts
+++ b/libs/core/src/integrations/application/services/webhook-secret.service.ts
@@ -10,7 +10,7 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { randomBytes } from 'crypto';
-import { Logger, CryptoService } from '@openlinker/shared';
+import { Logger } from '@openlinker/shared';
 import { ConnectionPort, CONNECTION_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
 import {
   WebhookSecretProviderPort,
@@ -38,7 +38,6 @@ export class WebhookSecretService implements IWebhookSecretService {
     private readonly connectionPort: ConnectionPort,
     @Inject(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN)
     private readonly credentialRepository: IntegrationCredentialRepositoryPort,
-    private readonly crypto: CryptoService,
     @Inject(WEBHOOK_SECRET_PROVIDER_TOKEN)
     private readonly secretProvider: WebhookSecretProviderPort
   ) {}
@@ -51,21 +50,19 @@ export class WebhookSecretService implements IWebhookSecretService {
     const connection = await this.connectionPort.get(connectionId);
 
     const secret = randomBytes(SECRET_BYTES).toString('hex');
-    const ciphertext = this.crypto.encrypt(secret);
     const ref = webhookSecretRef(connectionId);
 
+    // Plaintext at this layer — the repository encrypts on write (#709).
     try {
       await this.credentialRepository.update(ref, {
-        credentialsJson: { ciphertext },
-        encrypted: true,
+        credentialsJson: { webhookSecret: secret },
       });
     } catch (error) {
       if (error instanceof CredentialNotFoundException) {
         await this.credentialRepository.create({
           ref,
           platformType: connection.platformType,
-          credentialsJson: { ciphertext },
-          encrypted: true,
+          credentialsJson: { webhookSecret: secret },
         });
       } else {
         throw error;

--- a/libs/core/src/integrations/domain/entities/integration-credential.entity.ts
+++ b/libs/core/src/integrations/domain/entities/integration-credential.entity.ts
@@ -2,9 +2,10 @@
  * Integration Credential Domain Entity
  *
  * Represents stored credentials for an integration. Credentials are stored
- * separately from connections and referenced via credentialsRef. This allows
- * credentials to be managed independently and supports multiple credential
- * storage backends (database, vault, etc.).
+ * separately from connections and referenced via `credentialsRef`. The
+ * `credentialsJson` field on this domain entity is **always plaintext** —
+ * the encryption-at-rest envelope (#709) is repository-internal and the
+ * domain entity is only constructed after decryption.
  *
  * @module libs/core/src/integrations/domain/entities
  */
@@ -14,10 +15,7 @@ export class IntegrationCredential {
     public readonly ref: string,
     public readonly platformType: string,
     public readonly credentialsJson: Record<string, unknown>,
-    public readonly encrypted: boolean,
     public readonly createdAt: Date,
     public readonly updatedAt: Date,
   ) {}
 }
-
-

--- a/libs/core/src/integrations/domain/ports/integration-credential-repository.port.ts
+++ b/libs/core/src/integrations/domain/ports/integration-credential-repository.port.ts
@@ -2,8 +2,13 @@
  * Integration Credential Repository Port
  *
  * Defines the contract for IntegrationCredential persistence operations.
- * Implemented by IntegrationCredentialRepository to provide credential storage
- * capabilities for the credentials resolver service.
+ * Implemented by IntegrationCredentialRepository to provide credential
+ * storage capabilities for the credentials resolver service.
+ *
+ * The `encrypted` field that previously parameterized create/update was
+ * removed in #709 — credentials are now ALWAYS encrypted at rest. Callers
+ * pass plaintext `credentialsJson` and the repository handles encryption
+ * internally via `CryptoService`.
  *
  * @module libs/core/src/integrations/domain/ports
  * @see {@link IntegrationCredentialRepository} for the implementation
@@ -11,21 +16,21 @@
 import type { IntegrationCredential } from '../entities/integration-credential.entity';
 
 /**
- * Credential creation payload
+ * Credential creation payload. `credentialsJson` is plaintext at this layer —
+ * the repository encrypts it before persistence.
  */
 export interface CredentialCreate {
   ref: string;
   platformType: string;
   credentialsJson: Record<string, unknown>;
-  encrypted?: boolean;
 }
 
 /**
- * Credential update payload
+ * Credential update payload. Same plaintext-at-this-layer rule as
+ * `CredentialCreate`.
  */
 export interface CredentialUpdate {
   credentialsJson?: Record<string, unknown>;
-  encrypted?: boolean;
 }
 
 /**
@@ -35,31 +40,27 @@ export interface CredentialUpdate {
  */
 export interface IntegrationCredentialRepositoryPort {
   /**
-   * Get credential by reference
-   * @param ref - The credential reference (e.g., 'db:allegro_123')
-   * @returns Credential entity or throws if not found
+   * Get credential by reference.
+   * @param ref - The credential reference (e.g., 'webhook-secret:123')
+   * @returns Decrypted credential entity, or throws if not found.
    */
   getByRef(ref: string): Promise<IntegrationCredential>;
 
   /**
-   * Create a new credential
-   * @param payload - Credential creation payload
-   * @returns Created credential entity
+   * Create a new credential. `payload.credentialsJson` is plaintext at this
+   * layer; the implementation encrypts it before persistence.
    */
   create(payload: CredentialCreate): Promise<IntegrationCredential>;
 
   /**
-   * Update an existing credential
-   * @param ref - The credential reference
-   * @param patch - Partial update payload
-   * @returns Updated credential entity or throws if not found
+   * Update an existing credential. Returns the decrypted post-update entity
+   * or throws if the ref is unknown.
    */
   update(ref: string, patch: CredentialUpdate): Promise<IntegrationCredential>;
 
   /**
-   * Delete a credential by reference
-   * @param ref - The credential reference
-   * @returns True if deleted, false if not found
+   * Delete a credential by reference.
+   * @returns True if deleted, false if not found.
    */
   delete(ref: string): Promise<boolean>;
 }

--- a/libs/core/src/integrations/domain/ports/webhook-secret-provider.port.ts
+++ b/libs/core/src/integrations/domain/ports/webhook-secret-provider.port.ts
@@ -44,11 +44,23 @@ export interface WebhookSecretProviderPort {
 }
 
 /**
+ * Canonical credential ref prefix for per-connection webhook secrets.
+ *
+ * Exported separately from `webhookSecretRef` (#709) so the credentials-
+ * encryption migration can dispatch on `row.ref.startsWith(prefix)` against
+ * a typed constant rather than a hardcoded string literal — the migration
+ * has to identify inner-envelope writers when unwrapping them into the
+ * new outer-envelope shape, and a future helper rename must not silently
+ * skip that branch.
+ */
+export const WEBHOOK_SECRET_REF_PREFIX = 'webhook-secret:';
+
+/**
  * Canonical credential ref key for a per-connection webhook secret.
  * Defined here so both the adapter and application layer share one source of truth.
  */
 export const webhookSecretRef = (connectionId: string): string =>
-  `webhook-secret:${connectionId}`;
+  `${WEBHOOK_SECRET_REF_PREFIX}${connectionId}`;
 
 
 

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -26,7 +26,11 @@ export { WebhookProvisioningPort } from './domain/ports/webhook-provisioning.por
 export { EmailNormalizerPort } from './domain/ports/email-normalizer.port';
 export { ConnectionConfigShapeValidatorPort } from './domain/ports/connection-config-shape-validator.port';
 export { ConnectionCredentialsShapeValidatorPort } from './domain/ports/connection-credentials-shape-validator.port';
-export { WebhookSecretProviderPort, webhookSecretRef } from './domain/ports/webhook-secret-provider.port';
+export {
+  WebhookSecretProviderPort,
+  webhookSecretRef,
+  WEBHOOK_SECRET_REF_PREFIX,
+} from './domain/ports/webhook-secret-provider.port';
 export {
   IntegrationCredentialRepositoryPort,
   CredentialCreate,

--- a/libs/core/src/integrations/infrastructure/adapters/credentials-webhook-secret.adapter.spec.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/credentials-webhook-secret.adapter.spec.ts
@@ -4,7 +4,6 @@
  * @module libs/core/src/integrations/infrastructure/adapters
  */
 import type { ConfigService } from '@nestjs/config';
-import type { CryptoService } from '@openlinker/shared';
 import { CredentialsWebhookSecretAdapter } from './credentials-webhook-secret.adapter';
 import type { IntegrationCredentialRepositoryPort } from '../../domain/ports/integration-credential-repository.port';
 import { CredentialNotFoundException } from '../../domain/exceptions/credential-not-found.exception';
@@ -15,7 +14,6 @@ describe('CredentialsWebhookSecretAdapter', () => {
   const provider = 'prestashop';
   let repository: jest.Mocked<IntegrationCredentialRepositoryPort>;
   let config: jest.Mocked<Pick<ConfigService, 'get'>>;
-  let crypto: jest.Mocked<Pick<CryptoService, 'encrypt' | 'decrypt'>>;
   let subject: CredentialsWebhookSecretAdapter;
 
   beforeEach(() => {
@@ -26,43 +24,33 @@ describe('CredentialsWebhookSecretAdapter', () => {
       delete: jest.fn(),
     };
     config = { get: jest.fn() } as never;
-    crypto = { encrypt: jest.fn(), decrypt: jest.fn() } as never;
-    subject = new CredentialsWebhookSecretAdapter(
-      repository,
-      crypto as unknown as CryptoService,
-      config as unknown as ConfigService
-    );
+    subject = new CredentialsWebhookSecretAdapter(repository, config as unknown as ConfigService);
   });
 
-  const credential = (ciphertext: unknown, encrypted = true): IntegrationCredential =>
+  const credential = (webhookSecret: unknown): IntegrationCredential =>
     new IntegrationCredential(
       'id',
       `webhook-secret:${connectionId}`,
       provider,
-      { ciphertext },
-      encrypted,
+      { webhookSecret },
       new Date(),
       new Date()
     );
 
-  it('returns decrypted secret from DB', async () => {
-    repository.getByRef.mockResolvedValue(credential('ENV'));
-    crypto.decrypt.mockReturnValue('plain');
+  it('returns plaintext secret from DB', async () => {
+    repository.getByRef.mockResolvedValue(credential('plain'));
 
     const secret = await subject.getSecret(provider, connectionId);
 
     expect(secret).toBe('plain');
     expect(repository.getByRef).toHaveBeenCalledWith(`webhook-secret:${connectionId}`);
-    expect(crypto.decrypt).toHaveBeenCalledWith('ENV');
   });
 
-  it('returns raw ciphertext when credential.encrypted is false', async () => {
-    repository.getByRef.mockResolvedValue(credential('raw-value', false));
+  it('returns null when webhookSecret field is missing', async () => {
+    repository.getByRef.mockResolvedValue(credential(undefined));
+    config.get.mockReturnValue(undefined);
 
-    const secret = await subject.getSecret(provider, connectionId);
-
-    expect(secret).toBe('raw-value');
-    expect(crypto.decrypt).not.toHaveBeenCalled();
+    await expect(subject.getSecret(provider, connectionId)).rejects.toThrow(/not found/);
   });
 
   it('falls back to env with a deprecation warning on DB miss', async () => {
@@ -100,21 +88,28 @@ describe('CredentialsWebhookSecretAdapter', () => {
 
   it('resolves distinct secrets per connection', async () => {
     repository.getByRef.mockImplementation((ref: string) =>
-      Promise.resolve(credential(`cipher-${ref}`))
+      Promise.resolve(
+        new IntegrationCredential(
+          'id',
+          ref,
+          provider,
+          { webhookSecret: `plain-${ref}` },
+          new Date(),
+          new Date()
+        )
+      )
     );
-    crypto.decrypt.mockImplementation((c: string) => `plain-${c}`);
 
     const a = await subject.getSecret(provider, 'A');
     const b = await subject.getSecret(provider, 'B');
 
-    expect(a).toBe('plain-cipher-webhook-secret:A');
-    expect(b).toBe('plain-cipher-webhook-secret:B');
+    expect(a).toBe('plain-webhook-secret:A');
+    expect(b).toBe('plain-webhook-secret:B');
     expect(a).not.toEqual(b);
   });
 
   it('caches resolved secrets and invalidate() clears them', async () => {
-    repository.getByRef.mockResolvedValue(credential('ENV'));
-    crypto.decrypt.mockReturnValue('plain');
+    repository.getByRef.mockResolvedValue(credential('plain'));
 
     await subject.getSecret(provider, connectionId);
     await subject.getSecret(provider, connectionId);

--- a/libs/core/src/integrations/infrastructure/adapters/credentials-webhook-secret.adapter.ts
+++ b/libs/core/src/integrations/infrastructure/adapters/credentials-webhook-secret.adapter.ts
@@ -3,8 +3,9 @@
  *
  * Production implementation of WebhookSecretProviderPort backed by the
  * encrypted integration_credentials table. Per-connection secrets are stored
- * with ref = `webhook-secret:<connectionId>` and encrypted at rest using
- * CryptoService (AES-256-GCM).
+ * with ref = `webhook-secret:<connectionId>`. Encryption-at-rest is handled
+ * by the repository layer (#709) — this adapter only sees plaintext domain
+ * entities.
  *
  * Env-variable-based secrets (legacy stub behavior) are
  * supported as a deprecated read-through fallback for one release — callers
@@ -15,7 +16,7 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Logger, CryptoService } from '@openlinker/shared';
+import { Logger } from '@openlinker/shared';
 import type { WebhookSecretProviderPort } from '../../domain/ports/webhook-secret-provider.port';
 import { webhookSecretRef } from '../../domain/ports/webhook-secret-provider.port';
 import { IntegrationCredentialRepositoryPort } from '../../domain/ports/integration-credential-repository.port';
@@ -41,7 +42,6 @@ export class CredentialsWebhookSecretAdapter implements WebhookSecretProviderPor
   constructor(
     @Inject(INTEGRATION_CREDENTIAL_REPOSITORY_TOKEN)
     private readonly credentialRepository: IntegrationCredentialRepositoryPort,
-    private readonly crypto: CryptoService,
     private readonly configService: ConfigService
   ) {}
 
@@ -76,21 +76,14 @@ export class CredentialsWebhookSecretAdapter implements WebhookSecretProviderPor
   private async tryLoadFromDb(connectionId: string): Promise<string | null> {
     try {
       const credential = await this.credentialRepository.getByRef(webhookSecretRef(connectionId));
-      const ciphertext = credential.credentialsJson?.ciphertext;
-      if (typeof ciphertext !== 'string') {
+      const webhookSecret = credential.credentialsJson?.webhookSecret;
+      if (typeof webhookSecret !== 'string') {
         this.logger.error(
-          `Webhook secret credential ${credential.ref} is missing a ciphertext field`
+          `Webhook secret credential ${credential.ref} is missing a webhookSecret field`
         );
         return null;
       }
-      // Honor the encrypted flag: only decrypt when the credential was stored encrypted.
-      if (!credential.encrypted) {
-        this.logger.warn(
-          `Webhook secret credential ${credential.ref} is not marked encrypted — returning raw value`
-        );
-        return ciphertext;
-      }
-      return this.crypto.decrypt(ciphertext);
+      return webhookSecret;
     } catch (error) {
       if (error instanceof CredentialNotFoundException) {
         return null;

--- a/libs/core/src/integrations/infrastructure/credentials/credentials-resolver.service.ts
+++ b/libs/core/src/integrations/infrastructure/credentials/credentials-resolver.service.ts
@@ -79,9 +79,17 @@ export class CredentialsResolverService implements CredentialsResolverPort {
   /**
    * Get credentials from environment variable
    *
-   * MVP implementation for development and testing.
+   * Dev/test only. Fail-closed under NODE_ENV=production so a deploy that
+   * accidentally relies on plaintext env credentials is caught at boot (#709).
    */
   private async getFromEnvironment<T = unknown>(credentialsRef: string): Promise<T> {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        `Plaintext env-var credentials backend is disabled in production. ` +
+          `Reference: ${credentialsRef}. Store credentials encrypted via 'db:{ref}'.`
+      );
+    }
+
     // Pattern: CREDENTIALS_{credentialsRef}
     // Example: credentialsRef='prestashop_123' → env var 'CREDENTIALS_prestashop_123'
     const envKey = `CREDENTIALS_${credentialsRef.toUpperCase().replace(/[^A-Z0-9_]/g, '_')}`;

--- a/libs/core/src/integrations/infrastructure/persistence/entities/integration-credential.orm-entity.ts
+++ b/libs/core/src/integrations/infrastructure/persistence/entities/integration-credential.orm-entity.ts
@@ -1,19 +1,21 @@
 /**
  * Integration Credential ORM Entity
  *
- * TypeORM entity representing the integration_credentials table in PostgreSQL.
- * Stores encrypted or unencrypted credentials for integrations. Credentials are
- * stored as JSONB to support platform-specific credential structures.
+ * TypeORM entity for the `integration_credentials` table. Stores the
+ * AES-256-GCM-encrypted base64 envelope of the credential payload in
+ * `credentialsCiphertext` (#709). The repository is responsible for
+ * encryption on write and decryption on read; application services and
+ * adapters only ever see the decrypted domain entity.
  *
  * @module libs/core/src/integrations/infrastructure/persistence/entities
  */
 import {
-  Entity,
-  PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
-  UpdateDateColumn,
+  Entity,
   Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 
 @Entity('integration_credentials')
@@ -29,11 +31,13 @@ export class IntegrationCredentialOrmEntity {
   @Column()
   platformType!: string;
 
-  @Column({ type: 'jsonb' })
-  credentialsJson!: Record<string, unknown>;
-
-  @Column({ type: 'boolean', default: false })
-  encrypted!: boolean;
+  /**
+   * Base64-encoded AES-256-GCM envelope: `nonce[12] || ciphertext || authTag[16]`.
+   * Wraps `JSON.stringify(credentialsJson)`. Decrypted to a `Record<string, unknown>`
+   * by `IntegrationCredentialRepository.toDomain()`.
+   */
+  @Column({ type: 'varchar' })
+  credentialsCiphertext!: string;
 
   @CreateDateColumn()
   createdAt!: Date;
@@ -41,5 +45,3 @@ export class IntegrationCredentialOrmEntity {
   @UpdateDateColumn()
   updatedAt!: Date;
 }
-
-

--- a/libs/core/src/integrations/infrastructure/persistence/repositories/integration-credential.repository.spec.ts
+++ b/libs/core/src/integrations/infrastructure/persistence/repositories/integration-credential.repository.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration Credential Repository — Unit Tests
+ *
+ * Pins the encryption boundary: `toOrm` writes ciphertext into
+ * `credentialsCiphertext`, `toDomain` round-trips through
+ * `crypto.decrypt + JSON.parse`. Mocks the TypeORM repository so the spec
+ * is fast and independent of Postgres — the int-spec
+ * `ai-provider-settings.int-spec.ts` and `connection-credentials.int-spec.ts`
+ * cover the real-DB round-trip.
+ *
+ * @module libs/core/src/integrations/infrastructure/persistence/repositories
+ */
+import type { Repository } from 'typeorm';
+import type { CryptoService } from '@openlinker/shared';
+import { IntegrationCredentialRepository } from './integration-credential.repository';
+import type { IntegrationCredentialOrmEntity } from '../entities/integration-credential.orm-entity';
+import { CredentialNotFoundException } from '../../../domain/exceptions/credential-not-found.exception';
+
+describe('IntegrationCredentialRepository', () => {
+  let ormRepo: jest.Mocked<Pick<Repository<IntegrationCredentialOrmEntity>, 'findOne' | 'save' | 'delete'>>;
+  let crypto: jest.Mocked<Pick<CryptoService, 'encrypt' | 'decrypt'>>;
+  let subject: IntegrationCredentialRepository;
+
+  beforeEach(() => {
+    ormRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
+    crypto = {
+      encrypt: jest.fn().mockImplementation((p: string) => `cipher(${p})`),
+      decrypt: jest.fn().mockImplementation((c: string) => c.replace(/^cipher\((.+)\)$/, '$1')),
+    };
+    subject = new IntegrationCredentialRepository(
+      ormRepo as unknown as Repository<IntegrationCredentialOrmEntity>,
+      crypto as unknown as CryptoService,
+    );
+  });
+
+  const ormRow = (overrides: Partial<IntegrationCredentialOrmEntity> = {}): IntegrationCredentialOrmEntity => ({
+    id: 'cred-1',
+    ref: 'webhook-secret:c1',
+    platformType: 'prestashop',
+    credentialsCiphertext: 'cipher({"webhookSecret":"plain"})',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  });
+
+  describe('create', () => {
+    it('encrypts JSON.stringify(credentialsJson) into credentialsCiphertext', async () => {
+      ormRepo.save.mockImplementation((entity) =>
+        Promise.resolve({ ...ormRow(), ...(entity as IntegrationCredentialOrmEntity) }),
+      );
+
+      await subject.create({
+        ref: 'ai-provider:openai',
+        platformType: 'openai',
+        credentialsJson: { apiKey: 'plain-key' },
+      });
+
+      expect(crypto.encrypt).toHaveBeenCalledWith(JSON.stringify({ apiKey: 'plain-key' }));
+      const saved = ormRepo.save.mock.calls[0][0] as IntegrationCredentialOrmEntity;
+      expect(saved.credentialsCiphertext).toBe('cipher({"apiKey":"plain-key"})');
+    });
+
+    it('returns a decrypted domain entity', async () => {
+      ormRepo.save.mockResolvedValue(ormRow({ credentialsCiphertext: 'cipher({"apiKey":"k"})' }));
+
+      const created = await subject.create({
+        ref: 'ai-provider:openai',
+        platformType: 'openai',
+        credentialsJson: { apiKey: 'k' },
+      });
+
+      expect(created.credentialsJson).toEqual({ apiKey: 'k' });
+    });
+  });
+
+  describe('getByRef', () => {
+    it('round-trips via crypto.decrypt + JSON.parse', async () => {
+      ormRepo.findOne.mockResolvedValue(
+        ormRow({ credentialsCiphertext: 'cipher({"webhookSecret":"plain"})' }),
+      );
+
+      const credential = await subject.getByRef('webhook-secret:c1');
+
+      expect(crypto.decrypt).toHaveBeenCalledWith('cipher({"webhookSecret":"plain"})');
+      expect(credential.credentialsJson).toEqual({ webhookSecret: 'plain' });
+    });
+
+    it('throws CredentialNotFoundException when missing', async () => {
+      ormRepo.findOne.mockResolvedValue(null);
+      await expect(subject.getByRef('nope')).rejects.toBeInstanceOf(CredentialNotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('re-encrypts the patched JSON when credentialsJson is provided', async () => {
+      const existing = ormRow();
+      ormRepo.findOne.mockResolvedValue(existing);
+      ormRepo.save.mockImplementation((entity) =>
+        Promise.resolve(entity as IntegrationCredentialOrmEntity),
+      );
+
+      await subject.update('webhook-secret:c1', {
+        credentialsJson: { webhookSecret: 'rotated' },
+      });
+
+      expect(crypto.encrypt).toHaveBeenCalledWith(JSON.stringify({ webhookSecret: 'rotated' }));
+      expect(existing.credentialsCiphertext).toBe('cipher({"webhookSecret":"rotated"})');
+    });
+
+    it('throws CredentialNotFoundException when ref is unknown', async () => {
+      ormRepo.findOne.mockResolvedValue(null);
+      await expect(subject.update('nope', { credentialsJson: {} })).rejects.toBeInstanceOf(
+        CredentialNotFoundException,
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('returns true when a row was affected', async () => {
+      ormRepo.delete.mockResolvedValue({ affected: 1, raw: [] });
+      expect(await subject.delete('r')).toBe(true);
+    });
+
+    it('returns false when no row matched', async () => {
+      ormRepo.delete.mockResolvedValue({ affected: 0, raw: [] });
+      expect(await subject.delete('r')).toBe(false);
+    });
+  });
+});

--- a/libs/core/src/integrations/infrastructure/persistence/repositories/integration-credential.repository.ts
+++ b/libs/core/src/integrations/infrastructure/persistence/repositories/integration-credential.repository.ts
@@ -1,28 +1,31 @@
 /**
  * Integration Credential Repository
  *
- * Repository implementation for IntegrationCredential persistence operations.
- * Provides data access methods for CRUD operations on credentials, with conversion
- * between domain entities and ORM entities. Implements IntegrationCredentialRepositoryPort
- * interface for use by the credentials resolver service.
+ * Persistence implementation of `IntegrationCredentialRepositoryPort`.
+ * Encrypts the credential payload via `CryptoService` on write and
+ * decrypts on read so callers (`CredentialsResolverService`,
+ * `CredentialsWebhookSecretAdapter`, `CredentialsAiProviderAdapter`) only
+ * ever see plaintext domain entities (#709). The encrypted-at-rest envelope
+ * lives in `IntegrationCredentialOrmEntity.credentialsCiphertext`.
  *
  * @module libs/core/src/integrations/infrastructure/persistence/repositories
  * @implements {IntegrationCredentialRepositoryPort}
- * @see {@link IntegrationCredentialOrmEntity} for the database entity
- * @see {@link IntegrationCredentialRepositoryPort} for the port interface
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { IntegrationCredentialOrmEntity } from '../entities/integration-credential.orm-entity';
+
+import { CryptoService } from '@openlinker/shared';
+import { Logger } from '@openlinker/shared/logging';
+
 import { IntegrationCredential } from '../../../domain/entities/integration-credential.entity';
+import { CredentialNotFoundException } from '../../../domain/exceptions/credential-not-found.exception';
 import type {
-  IntegrationCredentialRepositoryPort,
   CredentialCreate,
   CredentialUpdate,
+  IntegrationCredentialRepositoryPort,
 } from '../../../domain/ports/integration-credential-repository.port';
-import { CredentialNotFoundException } from '../../../domain/exceptions/credential-not-found.exception';
-import { Logger } from '@openlinker/shared/logging';
+import { IntegrationCredentialOrmEntity } from '../entities/integration-credential.orm-entity';
 
 @Injectable()
 export class IntegrationCredentialRepository implements IntegrationCredentialRepositoryPort {
@@ -30,18 +33,15 @@ export class IntegrationCredentialRepository implements IntegrationCredentialRep
 
   constructor(
     @InjectRepository(IntegrationCredentialOrmEntity)
-    private readonly repository: Repository<IntegrationCredentialOrmEntity>
+    private readonly repository: Repository<IntegrationCredentialOrmEntity>,
+    private readonly crypto: CryptoService,
   ) {}
 
   async getByRef(ref: string): Promise<IntegrationCredential> {
-    const entity = await this.repository.findOne({
-      where: { ref },
-    });
-
+    const entity = await this.repository.findOne({ where: { ref } });
     if (!entity) {
       throw new CredentialNotFoundException(ref);
     }
-
     return this.toDomain(entity);
   }
 
@@ -55,21 +55,13 @@ export class IntegrationCredentialRepository implements IntegrationCredentialRep
   }
 
   async update(ref: string, patch: CredentialUpdate): Promise<IntegrationCredential> {
-    // Load existing entity
-    const existing = await this.repository.findOne({
-      where: { ref },
-    });
-
+    const existing = await this.repository.findOne({ where: { ref } });
     if (!existing) {
       throw new CredentialNotFoundException(ref);
     }
 
-    // Apply patch
     if (patch.credentialsJson !== undefined) {
-      existing.credentialsJson = patch.credentialsJson;
-    }
-    if (patch.encrypted !== undefined) {
-      existing.encrypted = patch.encrypted;
+      existing.credentialsCiphertext = this.crypto.encrypt(JSON.stringify(patch.credentialsJson));
     }
 
     const saved = await this.repository.save(existing);
@@ -87,30 +79,24 @@ export class IntegrationCredentialRepository implements IntegrationCredentialRep
     return deleted;
   }
 
-  /**
-   * Convert ORM entity to domain entity
-   */
   private toDomain(entity: IntegrationCredentialOrmEntity): IntegrationCredential {
+    const plaintext = this.crypto.decrypt(entity.credentialsCiphertext);
+    const credentialsJson = JSON.parse(plaintext) as Record<string, unknown>;
     return new IntegrationCredential(
       entity.id,
       entity.ref,
       entity.platformType,
-      entity.credentialsJson,
-      entity.encrypted,
+      credentialsJson,
       entity.createdAt,
-      entity.updatedAt
+      entity.updatedAt,
     );
   }
 
-  /**
-   * Convert creation payload to ORM entity
-   */
   private toOrm(payload: CredentialCreate): IntegrationCredentialOrmEntity {
     const entity = new IntegrationCredentialOrmEntity();
     entity.ref = payload.ref;
     entity.platformType = payload.platformType;
-    entity.credentialsJson = payload.credentialsJson;
-    entity.encrypted = payload.encrypted ?? false;
+    entity.credentialsCiphertext = this.crypto.encrypt(JSON.stringify(payload.credentialsJson));
     return entity;
   }
 }

--- a/libs/shared/src/crypto/crypto-primitives.ts
+++ b/libs/shared/src/crypto/crypto-primitives.ts
@@ -1,0 +1,100 @@
+/**
+ * Crypto Primitives
+ *
+ * Pure functions implementing the AES-256-GCM credentials-at-rest envelope
+ * used by `CryptoService` (runtime, NestJS-injected) AND by the
+ * `1789000000000-encrypt-integration-credentials` migration (one-shot, no
+ * DI). One source of truth for the algorithm + key-loading semantics so the
+ * two callers cannot drift (#709).
+ *
+ * **Envelope format**: `base64(nonce[12] || ciphertext || authTag[16])`.
+ *
+ * **Key source**: `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` (base64, 32 bytes
+ * decoded). In production the key is required; missing/invalid values throw.
+ * In development/test a deterministic fallback key is used with a warning so
+ * local setups keep working without manual configuration.
+ *
+ * @module libs/shared/src/crypto
+ */
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_BYTES = 32;
+const NONCE_BYTES = 12;
+const TAG_BYTES = 16;
+const DEV_KEY_SEED = 'openlinker-dev-credentials-key-do-not-use-in-production';
+const ENV_VAR_NAME = 'OPENLINKER_CREDENTIALS_ENCRYPTION_KEY';
+
+/**
+ * Result of loading the encryption key. The `usedDevFallback` flag lets the
+ * caller emit a one-time warning via its own logger (the primitive module
+ * intentionally has no logging dependency).
+ */
+export interface LoadedEncryptionKey {
+  key: Buffer;
+  usedDevFallback: boolean;
+}
+
+/**
+ * Read the credentials-encryption key from the supplied env map.
+ *
+ * Behavior:
+ *   - `NODE_ENV=production` + key unset → throws.
+ *   - `NODE_ENV=production` + key set but malformed → throws.
+ *   - `NODE_ENV` in {development, test} + key unset → deterministic dev
+ *     fallback, `usedDevFallback=true` so the caller can warn.
+ *   - Key set with valid 32-byte base64 → returns the decoded buffer.
+ */
+export function loadEncryptionKey(env: NodeJS.ProcessEnv): LoadedEncryptionKey {
+  const raw = env[ENV_VAR_NAME];
+  const nodeEnv = env.NODE_ENV ?? 'development';
+
+  if (!raw) {
+    if (nodeEnv === 'development' || nodeEnv === 'test') {
+      return {
+        key: createHash('sha256').update(DEV_KEY_SEED).digest(),
+        usedDevFallback: true,
+      };
+    }
+    throw new Error(
+      `${ENV_VAR_NAME} is required. Set it to a base64-encoded 32-byte key.`,
+    );
+  }
+
+  const decoded = Buffer.from(raw, 'base64');
+  if (decoded.length !== KEY_BYTES) {
+    throw new Error(
+      `${ENV_VAR_NAME} must decode to ${KEY_BYTES} bytes (got ${decoded.length}).`,
+    );
+  }
+  return { key: decoded, usedDevFallback: false };
+}
+
+/**
+ * Encrypt `plaintext` under `key` using AES-256-GCM. Returns the base64
+ * envelope.
+ */
+export function encryptWithKey(key: Buffer, plaintext: string): string {
+  const nonce = randomBytes(NONCE_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, nonce);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([nonce, ciphertext, tag]).toString('base64');
+}
+
+/**
+ * Decrypt a base64 envelope produced by `encryptWithKey`. Throws on auth-tag
+ * mismatch or malformed envelope.
+ */
+export function decryptWithKey(key: Buffer, envelope: string): string {
+  const buf = Buffer.from(envelope, 'base64');
+  if (buf.length < NONCE_BYTES + TAG_BYTES) {
+    throw new Error('Invalid ciphertext envelope: too short');
+  }
+  const nonce = buf.subarray(0, NONCE_BYTES);
+  const tag = buf.subarray(buf.length - TAG_BYTES);
+  const ciphertext = buf.subarray(NONCE_BYTES, buf.length - TAG_BYTES);
+  const decipher = createDecipheriv(ALGORITHM, key, nonce);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}

--- a/libs/shared/src/crypto/crypto.service.ts
+++ b/libs/shared/src/crypto/crypto.service.ts
@@ -1,27 +1,22 @@
 /**
  * Crypto Service
  *
- * AES-256-GCM symmetric encryption for credential data at rest.
- * Envelope format: base64(nonce[12] || ciphertext || authTag[16]).
+ * NestJS-injectable façade over the pure `crypto-primitives` module
+ * (`encryptWithKey` / `decryptWithKey` / `loadEncryptionKey`). The primitives
+ * are shared with the `1789000000000-encrypt-integration-credentials`
+ * migration (#709) so runtime + migration paths cannot drift on algorithm
+ * or key-loading semantics.
  *
- * Key source: OPENLINKER_CREDENTIALS_ENCRYPTION_KEY (base64, 32 bytes decoded).
- * In production the key is required; missing/invalid values throw on startup.
- * In development/test a deterministic fallback key is used with a warning so
- * local setups keep working without manual configuration.
+ * Envelope format: base64(nonce[12] || ciphertext || authTag[16]).
+ * Key source: `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` (base64, 32 bytes).
  *
  * @module libs/shared/src/crypto
  */
 import type { OnModuleInit } from '@nestjs/common';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'crypto';
 import { Logger } from '../logging/logger';
-
-const ALGORITHM = 'aes-256-gcm';
-const KEY_BYTES = 32;
-const NONCE_BYTES = 12;
-const TAG_BYTES = 16;
-const DEV_KEY_SEED = 'openlinker-dev-credentials-key-do-not-use-in-production';
+import { decryptWithKey, encryptWithKey, loadEncryptionKey } from './crypto-primitives';
 
 @Injectable()
 export class CryptoService implements OnModuleInit {
@@ -31,51 +26,29 @@ export class CryptoService implements OnModuleInit {
   constructor(private readonly configService: ConfigService) {}
 
   onModuleInit(): void {
-    const raw = this.configService.get<string>('OPENLINKER_CREDENTIALS_ENCRYPTION_KEY');
-    const nodeEnv = this.configService.get<string>('NODE_ENV') ?? 'development';
-
-    if (!raw) {
-      if (nodeEnv === 'development' || nodeEnv === 'test') {
-        this.key = createHash('sha256').update(DEV_KEY_SEED).digest();
-        this.logger.warn(
-          'OPENLINKER_CREDENTIALS_ENCRYPTION_KEY not set — using deterministic dev fallback. ' +
-            'Never use this in production.'
-        );
-        return;
-      }
-      throw new Error(
-        'OPENLINKER_CREDENTIALS_ENCRYPTION_KEY is required. ' +
-          'Set it to a base64-encoded 32-byte key.'
+    // `ConfigService.get` mirrors process.env semantics — wrap it in a
+    // ProcessEnv-shaped record so the primitive sees a plain map.
+    const env: NodeJS.ProcessEnv = {
+      OPENLINKER_CREDENTIALS_ENCRYPTION_KEY: this.configService.get<string>(
+        'OPENLINKER_CREDENTIALS_ENCRYPTION_KEY',
+      ),
+      NODE_ENV: this.configService.get<string>('NODE_ENV') ?? 'development',
+    };
+    const { key, usedDevFallback } = loadEncryptionKey(env);
+    this.key = key;
+    if (usedDevFallback) {
+      this.logger.warn(
+        'OPENLINKER_CREDENTIALS_ENCRYPTION_KEY not set — using deterministic dev fallback. ' +
+          'Never use this in production.',
       );
     }
-
-    const decoded = Buffer.from(raw, 'base64');
-    if (decoded.length !== KEY_BYTES) {
-      throw new Error(
-        `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY must decode to ${KEY_BYTES} bytes (got ${decoded.length}).`
-      );
-    }
-    this.key = decoded;
   }
 
   encrypt(plaintext: string): string {
-    const nonce = randomBytes(NONCE_BYTES);
-    const cipher = createCipheriv(ALGORITHM, this.key, nonce);
-    const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    return Buffer.concat([nonce, ciphertext, tag]).toString('base64');
+    return encryptWithKey(this.key, plaintext);
   }
 
   decrypt(envelope: string): string {
-    const buf = Buffer.from(envelope, 'base64');
-    if (buf.length < NONCE_BYTES + TAG_BYTES) {
-      throw new Error('Invalid ciphertext envelope: too short');
-    }
-    const nonce = buf.subarray(0, NONCE_BYTES);
-    const tag = buf.subarray(buf.length - TAG_BYTES);
-    const ciphertext = buf.subarray(NONCE_BYTES, buf.length - TAG_BYTES);
-    const decipher = createDecipheriv(ALGORITHM, this.key, nonce);
-    decipher.setAuthTag(tag);
-    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+    return decryptWithKey(this.key, envelope);
   }
 }

--- a/libs/shared/src/crypto/index.ts
+++ b/libs/shared/src/crypto/index.ts
@@ -4,3 +4,9 @@
  * @module libs/shared/src/crypto
  */
 export * from './crypto.service';
+export {
+  encryptWithKey,
+  decryptWithKey,
+  loadEncryptionKey,
+  type LoadedEncryptionKey,
+} from './crypto-primitives';


### PR DESCRIPTION
## Summary

Wire `CryptoService` into the `IntegrationCredentialRepository` write/read path so every row in `integration_credentials` is stored as an AES-256-GCM envelope. Collapses the inner-envelope workaround used by `WebhookSecretService` and `AiProviderKeyService` into the unified outer encryption — call sites now store plaintext domain entities and the repository handles encryption.

- **Production gates** — `loadEncryptionKey()` throws under `NODE_ENV=production` when `OPENLINKER_CREDENTIALS_ENCRYPTION_KEY` is unset; the plaintext env-var credentials backend (`CredentialsResolverService.getFromEnvironment`) throws under prod when called at all. Dev/test deterministic fallback unchanged so `pnpm test` works zero-config.
- **Migration `1795000000000`** — backfills every row, unwrapping inner-envelope rows on the `webhook-secret:` / `ai-provider:` ref prefixes, then drops the legacy `credentialsJson jsonb` + `encrypted boolean` columns. `down()` is data-irreversible by intent (documented in the migration header + new `docs/operations/credentials-rotation.md` runbook). Backups are required before running this in any environment that can't tolerate loss.
- **Inner-envelope collapse** — `WebhookSecretService` + `AiProviderKeyService` write plain `{webhookSecret}` / `{apiKey}`; matching adapters read the field directly. `CryptoService` injection dropped from those four call sites.
- **Shared primitives** — encryption split into `libs/shared/src/crypto/crypto-primitives.ts` (`encryptWithKey` / `decryptWithKey` / `loadEncryptionKey`) so the runtime `CryptoService` and the TypeORM migration consume one source of truth (migrations have no DI).
- **Threat model** — new `SECURITY.md § Threat Model` section + `docs/operations/credentials-rotation.md` runbook covering rotation, compromise response, and what the envelope does / doesn't protect.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 1,895 unit tests pass (161 suites). New `integration-credential.repository.spec.ts` pins the encryption boundary; specs across `webhook-secret.service`, `credentials-webhook-secret.adapter`, `ai-provider-key.service`, `credentials-ai-provider.adapter`, and `connection.service` updated to the new shape.
- [x] `pnpm --filter @openlinker/api test:integration --testPathPatterns="ai-provider-settings"` — 154/154 pass against real Postgres + Testcontainers (the migration runs cleanly during harness setup; raw column round-trip confirms sentinel-not-in-bytes).
- [x] `pnpm --filter @openlinker/api test:integration --testPathPatterns="connection-credentials"` — 6/6 pass (encrypt-on-write + raw-row sentinel + domain-repo round-trip).
- [x] `pnpm --filter @openlinker/api migration:show` — `EncryptIntegrationCredentials1795000000000` queued at end of chain, no timestamp collisions.

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)