### PR TITLE
docs(core): cross-context coupling policy + lint-time invariant

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -6,9 +6,10 @@
 2. [Core Bounded Contexts](#core-bounded-contexts)
 3. [Capability Abstractions (Business Roles)](#capability-abstractions-business-roles)
 4. [Hexagonal Architecture Structure](#hexagonal-architecture-structure)
-5. [Module Organization](#module-organization)
-6. [Data Flow](#data-flow)
-7. [Technology Stack](#technology-stack)
+5. [Cross-context dependencies in core](#cross-context-dependencies-in-core)
+6. [Module Organization](#module-organization)
+7. [Data Flow](#data-flow)
+8. [Technology Stack](#technology-stack)
 
 ---
 
@@ -1075,6 +1076,100 @@ catch (error) {
   }
 }
 ```
+
+---
+
+## Cross-context dependencies in core
+
+Each bounded context in `libs/core/src/<ctx>` is an independently testable hexagonal cell, but contexts legitimately depend on each other — `orders` needs `customers` and `identifier-mapping` for identity resolution, `content` needs `ai` for suggestions, `listings` needs `products` to walk variant catalogs. The architecture supports those dependencies via a **single, narrow contract surface** between contexts. This section names that contract.
+
+### The rule
+
+A file in `libs/core/src/<ctx-A>/**` may import from `@openlinker/core/<ctx-B>` (the top-level barrel of any sibling context) **only** the following kinds of symbols:
+
+| Allowed | Pattern | Example |
+|---|---|---|
+| Service interfaces | `I*Service` | `IIntegrationsService`, `IIdentifierMappingService` |
+| DI tokens (Symbol) | `*_TOKEN` | `INTEGRATIONS_SERVICE_TOKEN`, `EVENT_PUBLISHER_TOKEN` |
+| Capability ports | `*Port` (single `Port` suffix) | `OfferManagerPort`, `OrderSourcePort`, `EventPublisherPort` |
+| Capability type-guards | `is*` | `isOfferCreator`, `isCategoryBarcodeMatcher` |
+| Domain entities, value objects, type aliases | published in the barrel | `Connection`, `Product`, `Order`, `MarketplaceCursor` |
+| Domain exceptions | `*Exception`, `*Error` | `ConnectionNotFoundException`, `DuplicateIdentifierMappingError` |
+| Other `as const` value constants | `UPPER_SNAKE_CASE` | `CORE_ENTITY_TYPE`, `OFFER_CREATION_STATUS` |
+| NestJS module classes | `*Module` — **for `imports: [...]` only, never injected into services** | `CustomersModule` in `orders.module.ts` |
+
+The cross-context contract is **explicitly forbidden** for these symbol shapes:
+
+| Forbidden | Pattern | Why |
+|---|---|---|
+| Repository ports | `*RepositoryPort` | Intra-context contract — exposes persistence concerns the source context controls. Cross-context callers go through `I*Service`. |
+| ORM entities | `*OrmEntity` | TypeORM-decorated infrastructure detail (and ESLint-guarded under `@openlinker/core/<ctx>/orm-entities` separately). |
+| Adapter classes | `*Adapter` | Concrete infrastructure; sibling contexts see behaviour through `I*Service` or capability ports, never the adapter directly. |
+| Application DTOs | `*Dto` | Owned by the source context's interface layer. |
+| Default imports | `import X from '@openlinker/core/<ctx>'` | Barrels have no default export. |
+| Namespace imports | `import * as X from '@openlinker/core/<ctx>'` | Reserved for barrel-purity tests; cross-context callers use named imports so the surface they touch is explicit. |
+
+The rule applies only to imports from the bare top-level barrel `@openlinker/core/<ctx>`. The three documented sub-barrel exceptions (`/services`, `/orm-entities`, `/testing`) are governed by their own ESLint rules — see `docs/engineering-standards.md § Import Aliases`.
+
+### Why each rule exists
+
+- **Service interfaces are the seam.** A context's `I*Service` shape is the *only* thing sibling contexts can rely on staying stable. When `products` reorganises its repository layout, the consumers in `orders` / `listings` / `inventory` don't break — they kept asking `IProductsService` for what they needed, and `products` is free to change how it answers internally.
+- **Capability ports are part of the published contract.** `OfferManagerPort`, `ProductMasterPort`, `OrderSourcePort` — these are the abstractions adapters implement. They cross context boundaries because they're how the marketplace integrations express themselves to the rest of core. Repository ports, by contrast, are persistence concerns that no sibling has business reaching into.
+- **Domain entities cross by value.** When `orders` imports `Product` from `@openlinker/core/products`, it binds to the published shape — `products` can evolve internals freely, and any breaking shape change surfaces at type-check time. Value imports of entities are intentionally allowed (services construct, return, and pattern-match on them); the contract surface is what's published from the barrel, not the import kind.
+- **NestJS module classes cross only at the module-graph layer.** `orders.module.ts` imports `CustomersModule` to compose providers. A service constructor must never type-hint `CustomersModule` directly — that's the wrong layer.
+
+### Current dependency map
+
+Audited 2026-05-15 from `libs/core/src/**`:
+
+```mermaid
+graph LR
+  orders --> customers
+  orders --> identifier-mapping
+  orders --> integrations
+  orders --> mappings
+  orders --> products
+  orders --> sync
+  customers --> identifier-mapping
+  customers --> integrations
+  customers --> orders
+  content --> ai
+  content --> integrations
+  content --> listings
+  content --> products
+  listings --> identifier-mapping
+  listings --> integrations
+  listings --> mappings
+  listings --> products
+  listings --> sync
+  inventory --> identifier-mapping
+  inventory --> integrations
+  inventory --> listings
+  inventory --> products
+  inventory --> sync
+  products --> identifier-mapping
+  products --> integrations
+  products --> listings
+  sync --> events
+  sync --> listings
+  sync --> orders
+  ai --> integrations
+  integrations --> identifier-mapping
+```
+
+`identifier-mapping`, `integrations`, and `events` form the most-depended-upon "infrastructure spine" (each used by 5+ siblings). `users`, `webhooks`, and `mappings` have minimal outbound coupling.
+
+The `orders ↔ customers` pair shows up as a cycle at the barrel level. It's safe at runtime because the cross-context surface is interfaces, Symbol tokens, and type imports — there's no value-level cycle between concrete classes. The same shape would be true of any future cyclic pair: cycle safety is a property of the contract surface, not the file-level dependency graph.
+
+### Enforcement
+
+`scripts/check-cross-context-imports.mjs` runs under `pnpm check:invariants` (chained into `pnpm lint`). On any cross-context import that doesn't match the allow shapes — or that matches a deny shape — it fails the build with a file:line and the rule that fired.
+
+Pre-existing cross-context repository-port couplings (10 production files + 10 spec mocks, 20 `(file, symbol)` entries total) are tracked in **[#718](https://github.com/SilkSoftwareHouse/openlinker/issues/718)** and allow-listed in the script's `ALLOW_LIST` map by `(file, symbol)` pair until they're rewired through service interfaces. The per-symbol gate means new deny-pattern imports added to an already-listed file still fail the build — only the specific repository-port name listed against the path is silenced. When a rewire ships, its allow-list entries drop alongside.
+
+### Scope
+
+Today the rule applies to `libs/core/src/<ctx>/**` only — that matches the boundary the policy was audited against. Extending the same shape to `libs/integrations/<plugin>/src/**` and `apps/{api,worker}/src/**` is tracked in **[#719](https://github.com/SilkSoftwareHouse/openlinker/issues/719)** — the symmetry would mirror the existing Symbol-DI-token convention's reach, and the same script's matcher works against either tree with a small scope change.
 
 ---
 

--- a/docs/plans/implementation-plan-713-cross-context-coupling-policy.md
+++ b/docs/plans/implementation-plan-713-cross-context-coupling-policy.md
@@ -1,0 +1,176 @@
+# Implementation Plan — #713 Cross-context coupling policy in core
+
+## 1. Understand the task
+
+**Goal.** Make the cross-context coupling pattern that already exists in `libs/core/src/**` a documented, enforced architectural policy, not tribal knowledge. New contributors and AI assistants should be able to answer "is this cross-context import allowed?" without reading 60-line audit comments.
+
+**Layer classification.** DX / Docs / CI. Two artefacts:
+1. **Docs** — a new section in `docs/architecture-overview.md` that names the rule, the allow/deny set, the dependency map, and the rationale.
+2. **Lint-time invariant** — a `scripts/check-cross-context-imports.mjs` chained into `pnpm check:invariants`, matching the existing pattern (`check-repo-urls.mjs`, `check-create-adapter.mjs`, etc.).
+
+**Explicit non-goals.**
+- Refactoring sibling cross-context coupling to events. The policy is a *clarification* of the existing dependency-inversion seam — not a re-architecture.
+- Adding the policy to FE (`apps/web`). Out of scope; the issue is specifically about `libs/core/src/<ctx>`.
+- Touching ESLint config beyond what's already there (the issue suggests either ESLint *or* an invariant script; I'm picking the script — it's cheaper, matches the existing pattern, and the error messages are richer).
+- Building runtime telemetry on imports. Static analysis only.
+
+## 2. Research findings
+
+### 2a. Actual cross-context dependency map (audited 2026-05-15)
+
+```
+ai           → integrations
+content      → ai, integrations, listings, products
+customers    → identifier-mapping, integrations, orders
+integrations → identifier-mapping
+inventory    → identifier-mapping, integrations, listings, products, sync
+listings     → identifier-mapping, integrations, mappings, products, sync
+orders       → customers, identifier-mapping, integrations, mappings, products, sync
+products     → identifier-mapping, integrations, listings
+sync         → events, listings, orders
+```
+
+`identifier-mapping`, `integrations`, and `events` are the most-depended-upon contexts (each used by 5+ siblings) — they form the "infrastructure spine" of the core. `users`, `webhooks`, `mappings` have minimal outbound coupling.
+
+### 2b. Symbols that legitimately cross context boundaries today
+
+Confirmed in `grep -rE "from '@openlinker/core/[a-z-]+'" libs/core/src/`:
+
+- **Service interfaces**: `IIdentifierMappingService`, `IIntegrationsService`, `IMappingConfigService`, `IPromptTemplateService`, `IInventorySyncService`, `IListingsService` (and more — anything named `I*Service`).
+- **Symbol DI tokens**: `IDENTIFIER_MAPPING_SERVICE_TOKEN`, `CONNECTION_PORT_TOKEN`, `EVENT_PUBLISHER_TOKEN`, `INTEGRATIONS_SERVICE_TOKEN`, etc. — uniformly suffixed `_TOKEN`.
+- **Domain entities used as read-only types**: `Connection`, `Product`, `ProductVariant`, `IdentifierMapping`, `Order`, etc. Always `import type` (or treated as DTO-like shapes).
+- **Capability types and type-guards**: `OfferManagerPort`, `OrderSourcePort`, `ProductMasterPort` (the capability *contracts*, not adapter classes), plus their co-located `isOfferCreator` / `isCategoryBarcodeMatcher` / `isSellerPoliciesReader` predicates.
+- **`as const` value types and enums**: `CoreEntityType`, `JobOutcome`, `JobType`, `PromptTemplateChannel`, `OFFER_CREATION_STATUS`, `CORE_ENTITY_TYPE`.
+- **Domain exceptions**: `ConnectionNotFoundException`, `ConnectionDisabledException`, `DuplicateIdentifierMappingError`, `CredentialNotFoundException`, etc.
+- **NestJS module classes** (cross-module wiring at the module-graph level, not inside services): `CustomersModule`, `EventsModule`, etc.
+
+### 2c. Current violations to be flagged
+
+Three production-code files import a **repository port** from a sibling context — exactly the pattern the proposed policy disallows:
+
+| File | Cross-context port imported | Should go through |
+|---|---|---|
+| `inventory/application/services/inventory-query.service.ts` | `ProductRepositoryPort` from `products` | `IProductsService` |
+| `orders/application/services/order-item-ref-resolver.service.ts` | `ProductVariantRepositoryPort` from `products` | `IProductsService` (a `findVariantById` method) |
+| `content/application/services/content-state-reader.service.ts` | `OfferMappingRepositoryPort` from `listings` | `IListingsService` (or a narrower `IOfferMappingQueryService`) |
+
+Multiple test files (`*.spec.ts`) also import these cross-context repository ports — they're constructing mock instances of the same ports the production code imports. They'll be caught by the same rule once the policy lands; fix follows the production fix.
+
+### 2d. Existing invariant-script pattern
+
+Scripts in `scripts/check-*.mjs` follow a uniform shape:
+- Pure-Node, no external deps.
+- Use `fs/promises` `readdir` (recursive) to walk the tree.
+- SKIP_DIRS deny-list (`node_modules`, `dist`, `coverage`, `.git`, etc.).
+- File-extension allow-list (`.ts`, sometimes `.tsx`).
+- Print clear "✗ Violation:" lines with file path and column when a match hits.
+- Exit code 1 on any violation, 0 otherwise.
+- Chained into `pnpm check:invariants` via `&&` in package.json.
+
+`scripts/check-repo-urls.mjs` (added in PR #690) is the closest precedent: pattern-grep for banned substrings, deny-list skip dirs, sub-200-line implementation.
+
+## 3. Design
+
+### 3a. The policy text
+
+To live in `docs/architecture-overview.md` as a new top-level **`## Cross-context dependencies in core`** section, placed right after `### Repository Ports Pattern` (line ~1077) and before `## Module Organization` — that's the natural sequence (intra-context layering → intra-context repository contract → cross-context contract → module composition).
+
+Content outline:
+
+1. **The rule.** Cross-context calls in `libs/core/src/<ctx>` go through the **service interface + Symbol token + top-level barrel** of the target context. No other shape is allowed.
+2. **Allowed cross-context exposures** (table):
+   - `I{Service}Service` interfaces
+   - `*_TOKEN` Symbols (DI tokens)
+   - Domain entities, value objects, exceptions
+   - `as const` value types / enums
+   - Capability port *interfaces* and `is{Capability}` guards (these are part of the published port contract, not adapter internals)
+   - NestJS Module classes (for module-graph composition only — `@Module imports: [...]`, not for service injection)
+3. **Forbidden cross-context exposures** (table):
+   - Repository ports (`*RepositoryPort`)
+   - ORM entities (`*OrmEntity`)
+   - Infrastructure adapter classes (`*Adapter`)
+   - Application DTOs (`*Dto`)
+   - Internal types from `domain/types/` not re-exported by the barrel (caught at runtime by package `exports` anyway, but stated explicitly)
+4. **Dependency map** (from 2a above).
+5. **Rationale.** Three bullets:
+   - **Dependency inversion via the service-interface seam** keeps each context independently testable — swap any sibling's `IXService` impl with a stub.
+   - **Logical dependencies should be explicit, not hidden in events.** Calling `IProductsService.getVariant(id)` is clearer than emitting a request event and awaiting a response.
+   - **Refactor safety.** When a sibling context restructures its internals (entities split, adapters rename), the contract — interface, entity types, exceptions, Symbol tokens — is the only surface that has to stay stable.
+6. **Pointer** to the lint-time invariant script.
+
+### 3b. The invariant script
+
+`scripts/check-cross-context-imports.mjs`. Walks `libs/core/src/<ctx>/**/*.ts`; for every cross-context import (`from '@openlinker/core/<other-ctx>'`), inspects the imported symbol names.
+
+**Allow rules** (any of these makes the import legal):
+- Named import matches `/^I[A-Z][A-Za-z]*Service$/` (e.g., `IIntegrationsService`).
+- Named import matches `/^[A-Z_]+_TOKEN$/` (e.g., `IDENTIFIER_MAPPING_SERVICE_TOKEN`).
+- Named import matches `/^is[A-Z][A-Za-z]+$/` (capability type-guard).
+- Named import matches `/Module$/` for module-graph composition (e.g., `CustomersModule`).
+- Named import ends `Exception` or `Error` (domain exceptions).
+- Named import ends `Port` AND the import is `import type` only AND the port name does **not** end `RepositoryPort` (capability ports like `OfferManagerPort` are fine; repository ports are blocked).
+- Anything in a curated `ALLOWED_VALUE_TYPES` list (capability constants: `CORE_ENTITY_TYPE`, `OFFER_CREATION_STATUS`, etc. — small, growable when something new gets surfaced).
+- Bare `import type {Entity, ValueObject, …}` is allowed by default — domain entities/value objects are part of the published surface. Specifically, anything `import type` that doesn't match a deny pattern.
+
+**Deny rules** (any of these is a violation):
+- Named import ends `RepositoryPort`.
+- Named import ends `OrmEntity`.
+- Named import ends `Adapter`.
+- Named import ends `Dto`.
+- Default import (`import X from '@openlinker/core/...'`) — barrels don't have defaults; if it parses, it's a misuse.
+- Wildcard import (`import * as foo from '@openlinker/core/...'`) — exception: explicitly allowed in `**/__tests__/barrel-purity.spec.ts` files via a file-path allow-list (barrel-purity tests legitimately introspect the entire namespace).
+
+**Output shape.** On violation:
+```
+✗ Cross-context coupling violation: libs/core/src/orders/application/services/order-item-ref-resolver.service.ts:11
+    import: { ProductVariantRepositoryPort } from '@openlinker/core/products'
+    rule: repository ports must not cross context boundaries
+    fix: go through IProductsService instead
+    docs: docs/architecture-overview.md#cross-context-dependencies-in-core
+```
+
+Exit 1 on any hit; exit 0 with `✓ N cross-context imports checked across M files. All conform.` otherwise.
+
+**Edge cases.**
+- Multi-line imports: parse-friendly — script reads each `.ts` file and pulls every `import ... from '@openlinker/core/<x>'` statement via regex with `s`-flag.
+- Same-context imports (e.g., `libs/core/src/listings/x.ts` importing `@openlinker/core/listings`): skip — the rule only applies *across* contexts.
+- `import` *types* — both `import type {…}` and `import {type Foo}` modifiers parsed.
+
+### 3c. Handling the three existing violations
+
+The proposed policy turns them red the moment the invariant script lands. Two options per the issue:
+- **Fix in this PR** — adds 3 service-interface methods (`findVariantById`, `getProductById`, `findOfferMappingsForVariant`) and rewires the call sites. Net diff probably ~150 lines.
+- **Fix in a follow-up** — land the docs + invariant with the three production violations explicitly allow-listed by file path, plus a follow-up issue tracking the rewire.
+
+**My recommendation:** fix in a follow-up. Reasoning:
+- The three violations each need careful service-interface design (what's the right method shape?) and ripple into test setup.
+- Mixing "policy + invariant script + 3 service-interface refactors" in one PR fattens it past the issue's own effort estimate ("small for docs, medium with lint enforcement").
+- Allow-listing is honest — the file path + the rule it violates is visible; future readers can see exactly what's outstanding.
+
+I'll file a follow-up issue and reference it in both the docs section and the script's allow-list comment.
+
+## 4. Step-by-step plan
+
+1. **`docs/architecture-overview.md`** — add `## Cross-context dependencies in core` section between `### Repository Ports Pattern` and `## Module Organization` (≈100 lines: rule + 2 tables + dependency map + rationale + link to invariant script). Update Table of Contents.
+2. **`scripts/check-cross-context-imports.mjs`** — implement per 3b. Pure-Node, follows `check-repo-urls.mjs` pattern. ~200 LOC.
+3. **`package.json`** — append `&& node scripts/check-cross-context-imports.mjs` to the `check:invariants` script.
+4. **File the follow-up issue** for the three production-code violations. Reference the issue number in both `architecture-overview.md` and the script's allow-list comment.
+5. **Run the quality gate** — `pnpm lint && pnpm type-check && pnpm test`. The new invariant must pass after the allow-list captures the three known violations.
+
+## 5. Validation
+
+- **Architecture compliance**: docs-only + lint-time script. No runtime code touched. No new ports, services, or modules.
+- **Naming**: script follows existing `check-*.mjs` convention. New doc section title is plain English.
+- **Testing**: invariant script is its own test — running it on the audited tree must produce 3 known violations (the allow-listed ones) and 0 unexpected ones. No unit tests needed for a one-shot CI script; precedent: `check-repo-urls.mjs` doesn't have its own tests either.
+- **Security**: none of the changes touch auth, secrets, or input handling.
+- **Quality gate**: must pass after the changes land.
+
+## Open questions
+
+- **Capability ports vs. repository ports** — both end in `Port`. The deny rule keys on `RepositoryPort` suffix; capability ports like `OfferManagerPort` stay allowed. Is the suffix convention firm enough? Audit says yes — all repository ports today end in `RepositoryPort`, all capability ports in single `Port`. New repository ports added later that diverge from the convention will fail invisibly. **Mitigation:** the script comment will spell out the convention so anyone adding a `*RepositoryPort` in the future understands the rule.
+- **Capability constants** — `CORE_ENTITY_TYPE`, `OFFER_CREATION_STATUS` etc. are pattern-matched as `[A-Z_]+`. That overlaps the `*_TOKEN` rule but doesn't conflict. The script's matcher orders the rules so `_TOKEN` matches first, then the bare ALL_CAPS allow.
+
+## Risks
+
+- **False positives.** The pattern-matching script may reject a legitimate cross-context import I haven't yet seen. The follow-up: any contributor can add to the allow-list with a one-line rationale in the script's comments.
+- **Follow-up debt.** Filing the three violations as a separate issue means they may linger if not prioritised. **Mitigation:** the script's allow-list lists them by name; every time someone touches it the violations are right there.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:integration": "pnpm --filter @openlinker/api test:integration",
     "test:php": "cd apps/prestashop-module/openlinker && composer install --no-interaction --quiet && vendor/bin/phpunit",
     "lint": "pnpm -r lint && pnpm check:invariants",
-    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-libs-build-scripts.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs",
+    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-libs-build-scripts.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs && node scripts/check-cross-context-imports.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
     "create-adapter": "node scripts/create-adapter.mjs",

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+/**
+ * check-cross-context-imports.mjs
+ *
+ * Lint-time invariant for the cross-context coupling policy documented at
+ * docs/architecture-overview.md § Cross-context dependencies in core.
+ *
+ * Rule. Inside `libs/core/src/<ctx>/**`, when a file imports from
+ * `@openlinker/core/<other-ctx>` (i.e. across a context boundary), the
+ * imported symbols MUST be on the published-contract surface:
+ *
+ *   - `I*Service` service interfaces                  (e.g. IIntegrationsService)
+ *   - `is*` capability type-guards                    (e.g. isOfferCreator)
+ *   - `*Port` capability ports                        (e.g. OfferManagerPort)
+ *   - `*Module` NestJS module classes                 (for `imports: [...]` only)
+ *   - `*Exception` / `*Error` domain exceptions       (e.g. ConnectionNotFoundException)
+ *   - `UPPER_SNAKE_CASE` constants (incl. *_TOKEN)    (e.g. CORE_ENTITY_TYPE, EVENT_PUBLISHER_TOKEN)
+ *   - any other identifier (domain entities, value objects, plain types) —
+ *     these are part of the contract surface and may be value-imported.
+ *
+ * Deny patterns (always rejected, including for value imports):
+ *
+ *   - `*RepositoryPort` — repository ports are intra-context; cross-context
+ *     callers go through the service interface seam.
+ *   - `*OrmEntity`      — TypeORM-decorated; infrastructure detail.
+ *   - `*Adapter`        — adapter classes are infrastructure; sibling
+ *                         contexts get behaviour via service interfaces.
+ *   - `*Dto`            — application DTOs are owned by the source context.
+ *   - default imports, namespace imports — barrels don't have defaults;
+ *     wildcard introspection is reserved for the barrel-purity spec.
+ *
+ * The matcher fires ONLY on bare `@openlinker/core/<ctx>` (no subpath).
+ * Documented sub-barrels (`/services`, `/orm-entities`, `/testing`) are
+ * governed by separate ESLint rules in `.eslintrc.js` and are out of
+ * scope here.
+ *
+ * Scope. Today the rule applies to `libs/core/src/<ctx>/**` only — that
+ * matches the audit. Extending the same gate to `libs/integrations/**`
+ * and `apps/{api,worker}/src/**` is tracked in #719.
+ *
+ * Allow-list. Pre-existing cross-context repository-port couplings
+ * (10 production files + 10 spec mocks = 20 (file, symbol) entries) are
+ * allow-listed here BY (file, symbol) pair until they're rewired through
+ * the proper service-interface seam. Tracked in #718. Allow-listing a
+ * path only silences the specific repository-port name listed against
+ * it — any new deny-pattern import added to the same file still fails
+ * the build. When a rewire ships, drop its entries together.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(__dirname, '..');
+const coreSrc = join(repoRoot, 'libs', 'core', 'src');
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'coverage',
+  '.git',
+  '.turbo',
+]);
+
+const VALID_EXTS = new Set(['.ts', '.tsx']);
+
+/**
+ * Per-(file, symbol) allow-list. Each entry exempts a single repository
+ * port name on a single file. New deny-pattern imports added to one of
+ * these files still fail the build — the gate is the specific name, not
+ * the path. Grouped by rewire target so each rewire's entries drop
+ * together when #718 lands its corresponding PR.
+ */
+const ALLOW_LIST = new Map([
+  // inventory → products.ProductRepositoryPort — rewire via IProductsService
+  [
+    'libs/core/src/inventory/application/services/inventory-query.service.ts',
+    new Set(['ProductRepositoryPort']),
+  ],
+  [
+    'libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts',
+    new Set(['ProductRepositoryPort']),
+  ],
+
+  // orders → products.ProductVariantRepositoryPort — rewire via IProductsService
+  [
+    'libs/core/src/orders/application/services/order-item-ref-resolver.service.ts',
+    new Set(['ProductVariantRepositoryPort']),
+  ],
+  [
+    'libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts',
+    new Set(['ProductVariantRepositoryPort']),
+  ],
+
+  // listings → products.ProductVariantRepositoryPort — rewire via IProductsService
+  [
+    'libs/core/src/listings/application/services/offer-mapping-sync.service.ts',
+    new Set(['ProductVariantRepositoryPort']),
+  ],
+  [
+    'libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts',
+    new Set(['ProductVariantRepositoryPort']),
+  ],
+  [
+    'libs/core/src/listings/application/services/offer-builder.service.ts',
+    new Set(['ProductVariantRepositoryPort']),
+  ],
+  [
+    'libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts',
+    new Set(['ProductVariantRepositoryPort']),
+  ],
+
+  // listings → sync.SyncJobRepositoryPort — rewire via ISyncJobsService
+  [
+    'libs/core/src/listings/application/services/offer-status-poll.service.ts',
+    new Set(['SyncJobRepositoryPort']),
+  ],
+  [
+    'libs/core/src/listings/application/services/__tests__/offer-status-poll.service.spec.ts',
+    new Set(['SyncJobRepositoryPort']),
+  ],
+
+  // content → listings.OfferMappingRepositoryPort — rewire via IListingsService
+  [
+    'libs/core/src/content/application/services/content-state-reader.service.ts',
+    new Set(['OfferMappingRepositoryPort']),
+  ],
+  [
+    'libs/core/src/content/application/services/content-state-reader.service.spec.ts',
+    new Set(['OfferMappingRepositoryPort']),
+  ],
+  [
+    'libs/core/src/content/application/services/integrations-content-publisher.service.ts',
+    new Set(['OfferMappingRepositoryPort']),
+  ],
+  [
+    'libs/core/src/content/application/services/integrations-content-publisher.service.spec.ts',
+    new Set(['OfferMappingRepositoryPort']),
+  ],
+
+  // ai → integrations.IntegrationCredentialRepositoryPort — rewire via ICredentialsService
+  [
+    'libs/core/src/ai/application/services/ai-provider-key.service.ts',
+    new Set(['IntegrationCredentialRepositoryPort']),
+  ],
+  [
+    'libs/core/src/ai/application/services/ai-provider-key.service.spec.ts',
+    new Set(['IntegrationCredentialRepositoryPort']),
+  ],
+  [
+    'libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.ts',
+    new Set(['IntegrationCredentialRepositoryPort']),
+  ],
+  [
+    'libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts',
+    new Set(['IntegrationCredentialRepositoryPort']),
+  ],
+
+  // orders → sync.ConnectionCursorRepositoryPort — rewire via ISyncCursorsService
+  [
+    'libs/core/src/orders/application/services/order-ingestion.service.ts',
+    new Set(['ConnectionCursorRepositoryPort']),
+  ],
+  [
+    'libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts',
+    new Set(['ConnectionCursorRepositoryPort']),
+  ],
+]);
+
+const DENY_PATTERNS = [
+  /RepositoryPort$/,
+  /OrmEntity$/,
+  /Adapter$/,
+  /Dto$/,
+];
+
+const ALLOW_PATTERNS = [
+  /^I[A-Z][A-Za-z]*Service$/, // I*Service interfaces
+  /^is[A-Z][A-Za-z]+$/, // is* capability guards
+  /Port$/, // *Port (capability ports). Deny *RepositoryPort cases already short-circuited.
+  /Module$/, // NestJS *Module
+  /(Exception|Error)$/, // domain exceptions
+  /^[A-Z][A-Z0-9_]+$/, // UPPER_SNAKE_CASE constants (incl. *_TOKEN)
+];
+
+/**
+ * Parse all cross-context imports in a single file. Returns an array of
+ * `{ line, source, kind, names }` records. Multi-line imports are
+ * handled by reading the whole file and matching on the joined content,
+ * then re-resolving line numbers from the match offset.
+ */
+function parseImports(content) {
+  const records = [];
+  const lineStartOffsets = [0];
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === '\n') lineStartOffsets.push(i + 1);
+  }
+  const offsetToLine = (offset) => {
+    let lo = 0;
+    let hi = lineStartOffsets.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (lineStartOffsets[mid] <= offset) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo + 1;
+  };
+
+  // The `<ctx>` capture's `[a-z-]+` between `/core/` and the closing
+  // quote enforces the bare `@openlinker/core/<ctx>` shape — sub-barrels
+  // like `/services`, `/orm-entities`, `/testing` (which carry an extra
+  // `/` segment) are excluded by construction and governed by separate
+  // ESLint rules in `.eslintrc.js`.
+  const pattern =
+    /import\s+(?<kind>type\s+)?(?:(?<default>[A-Za-z_$][\w$]*)|\*\s+as\s+(?<ns>[A-Za-z_$][\w$]*)|\{(?<named>[^}]+)\})\s*(?:from\s+)?['"](?<source>@openlinker\/core\/[a-z-]+)['"]/gs;
+
+  let m;
+  while ((m = pattern.exec(content)) !== null) {
+    const line = offsetToLine(m.index);
+    const source = m.groups.source;
+    if (m.groups.named !== undefined) {
+      const names = m.groups.named
+        .split(',')
+        .map((n) => n.trim())
+        .filter(Boolean)
+        .map((n) => n.replace(/^type\s+/, '').split(/\s+as\s+/)[0].trim());
+      records.push({ line, source, kind: m.groups.kind ? 'type-named' : 'named', names });
+    } else if (m.groups.default !== undefined) {
+      records.push({ line, source, kind: 'default', names: [m.groups.default] });
+    } else if (m.groups.ns !== undefined) {
+      records.push({ line, source, kind: 'namespace', names: [m.groups.ns] });
+    }
+  }
+  return records;
+}
+
+/**
+ * Classify a single imported name. Deny patterns are checked first, then
+ * allow patterns. Unrecognized names are default-allowed — they're
+ * treated as domain entities / value objects / plain types, which are
+ * part of the published contract surface and may be value-imported.
+ */
+function classifyName(name) {
+  for (const pat of DENY_PATTERNS) {
+    if (pat.test(name)) return { allowed: false, reason: `matches deny pattern ${pat.source}` };
+  }
+  for (const pat of ALLOW_PATTERNS) {
+    if (pat.test(name)) return { allowed: true };
+  }
+  return { allowed: true };
+}
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      files.push(...(await walk(join(dir, entry.name))));
+    } else if (entry.isFile()) {
+      if (VALID_EXTS.has('.' + entry.name.split('.').pop())) {
+        files.push(join(dir, entry.name));
+      }
+    }
+  }
+  return files;
+}
+
+function importerContext(repoRelPath) {
+  // libs/core/src/<ctx>/...
+  const parts = repoRelPath.split(sep);
+  if (parts.length < 4 || parts[0] !== 'libs' || parts[1] !== 'core' || parts[2] !== 'src') return null;
+  return parts[3];
+}
+
+function targetContext(source) {
+  return source.replace(/^@openlinker\/core\//, '');
+}
+
+async function main() {
+  const files = await walk(coreSrc);
+  let totalImports = 0;
+  let checkedFiles = 0;
+  const violations = [];
+
+  for (const file of files) {
+    const repoRel = relative(repoRoot, file);
+    const myCtx = importerContext(repoRel);
+    if (!myCtx) continue;
+    checkedFiles += 1;
+
+    const content = await readFile(file, 'utf8');
+    const imports = parseImports(content);
+
+    for (const imp of imports) {
+      const tgtCtx = targetContext(imp.source);
+      if (tgtCtx === myCtx) continue; // same-context, not a cross-context import
+      totalImports += 1;
+
+      // Default / namespace imports are denied outright (no allow-list
+      // exception today — barrel-purity tests live outside libs/core/src).
+      if (imp.kind === 'default') {
+        violations.push({
+          file: repoRel,
+          line: imp.line,
+          source: imp.source,
+          symbol: imp.names[0],
+          reason: 'default imports are not part of the cross-context contract surface (barrels have no default export)',
+        });
+        continue;
+      }
+      if (imp.kind === 'namespace') {
+        violations.push({
+          file: repoRel,
+          line: imp.line,
+          source: imp.source,
+          symbol: `* as ${imp.names[0]}`,
+          reason: 'wildcard imports are reserved for barrel-purity tests; everywhere else use named imports',
+        });
+        continue;
+      }
+
+      const allowedForFile = ALLOW_LIST.get(repoRel);
+      for (const name of imp.names) {
+        const cls = classifyName(name);
+        if (!cls.allowed) {
+          if (allowedForFile?.has(name)) continue; // pre-existing, tracked in #718
+          violations.push({
+            file: repoRel,
+            line: imp.line,
+            source: imp.source,
+            symbol: name,
+            reason: cls.reason,
+          });
+        }
+      }
+    }
+  }
+
+  const allowListEntryCount = Array.from(ALLOW_LIST.values()).reduce(
+    (sum, set) => sum + set.size,
+    0,
+  );
+
+  if (violations.length === 0) {
+    console.log(
+      `✓ check-cross-context-imports: ${totalImports} cross-context import(s) across ${checkedFiles} file(s). All conform.`,
+    );
+    if (allowListEntryCount > 0) {
+      console.log(
+        `  (${allowListEntryCount} pre-existing (file, symbol) entries allow-listed across ${ALLOW_LIST.size} file(s); see script header and #718.)`,
+      );
+    }
+    process.exit(0);
+  }
+
+  console.error(`✗ check-cross-context-imports: ${violations.length} violation(s).\n`);
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}`);
+    console.error(`    import: { ${v.symbol} } from '${v.source}'`);
+    console.error(`    rule:   ${v.reason}`);
+    console.error(`    docs:   docs/architecture-overview.md#cross-context-dependencies-in-core`);
+    console.error('');
+  }
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('check-cross-context-imports: fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a new **`## Cross-context dependencies in core`** section to `docs/architecture-overview.md` that names the contract sibling contexts in `libs/core/src/<ctx>` use between each other — allowed shapes (`I*Service`, `*_TOKEN`, `*Port` capability ports, `is*` guards, domain entities/exceptions, `*Module` for module-graph composition, `UPPER_SNAKE_CASE` constants) and forbidden shapes (`*RepositoryPort`, `*OrmEntity`, `*Adapter`, `*Dto`, default and namespace imports).
- Ships `scripts/check-cross-context-imports.mjs` (chained into `pnpm check:invariants` → `pnpm lint`) which walks `libs/core/src/**`, parses every `@openlinker/core/<ctx>` import, and fails the build on any cross-context import that violates the policy.
- Pre-existing repository-port couplings (10 production + 10 spec mocks, 20 `(file, symbol)` entries) are allow-listed by `(file, symbol)` pair — tracked in #718 for rewire through service interfaces. New deny-pattern imports added to an allow-listed file still fail the build.
- Includes a Mermaid dependency map of the current cross-context coupling (with a note on the `orders ↔ customers` cycle being safe at the contract-surface level).
- Extending the same gate to `libs/integrations/**` and `apps/{api,worker}/src/**` is tracked in #719.

Closes #713

## Test plan

- [x] `node scripts/check-cross-context-imports.mjs` reports `✓ 189 cross-context import(s) across 469 file(s). All conform.` with 20 entries allow-listed across 20 files.
- [x] `pnpm lint` (which includes `check:invariants`) is green.
- [x] `pnpm type-check` is green.
- [x] `pnpm test` is green (also ran via the pre-commit hook — 364 tests passed).
- [ ] Manual verification of the docs section renders the Mermaid diagram correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
