### PR TITLE
refactor(products): rewire inventory/orders/listings callers through IProductsService (#718, slice 1 of 4)

### DIFF
--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -47,7 +47,10 @@ function createMockProductsService(): jest.Mocked<IProductsService> {
     upsertProduct: jest.fn(),
     upsertVariants: jest.fn(),
     getProduct: jest.fn(),
+    getProductsByIds: jest.fn(),
     getVariant: jest.fn(),
+    getVariantsBySkus: jest.fn(),
+    getVariantsByBarcodes: jest.fn(),
     listProducts: jest.fn(),
     listVariants: jest.fn(),
   };

--- a/docs/plans/implementation-plan-718-products-repo-port-rewire.md
+++ b/docs/plans/implementation-plan-718-products-repo-port-rewire.md
@@ -1,0 +1,261 @@
+# Implementation Plan — Rewire products repository-port callers through IProductsService (#718, slice 1 of 4)
+
+**Issue**: [#718 — Rewire cross-context repository-port couplings through service interfaces](https://github.com/SilkSoftwareHouse/openlinker/issues/718)
+**Slice**: 4 callers of `products` repository ports → `IProductsService` extensions.
+**Branch**: `718-products-repo-port-rewire`
+**Drops**: 8 of the 20 `(file, symbol)` entries from `scripts/check-cross-context-imports.mjs`.
+
+---
+
+## 0. Goal
+
+Eliminate four cross-context value-imports of `products`-owned repository ports. After this PR:
+
+- `inventory-query.service.ts` no longer imports `ProductRepositoryPort` — it calls `IProductsService` instead.
+- `order-item-ref-resolver.service.ts`, `offer-builder.service.ts`, and `offer-mapping-sync.service.ts` no longer import `ProductVariantRepositoryPort` — same.
+- The four production files + their four spec files (8 entries) drop from the cross-context-imports allow-list.
+- `pnpm check:invariants` stays green with those 8 entries removed.
+
+**Bonus**: the existing TODO at `inventory-query.service.ts:63` about replacing the N-per-call lookup with a batch method is addressed in the same PR — adding `findProductsByIds` to the products port + service is the minimal-cost shape that fits the rewire.
+
+**Non-goals** (the other three slices of #718, deferred):
+
+- Sync repository-port callers (slice 2 of #718 — `offer-status-poll.service.ts`, `order-ingestion.service.ts`).
+- Listings repository-port callers (slice 3 — `content-state-reader.service.ts`, `integrations-content-publisher.service.ts`).
+- Integrations credential-repository callers (slice 4 — `ai-provider-key.service.ts`, `credentials-ai-provider.adapter.ts`).
+
+Each slice is independent; this PR closes one source-context bucket.
+
+---
+
+## 1. Architecture mapping
+
+| Layer | What lands here |
+|---|---|
+| **CORE — Products domain** | New `findByIds(ids)` on `ProductRepositoryPort`. No new variant-port methods needed — the four call shapes are already on `ProductVariantRepositoryPort`. |
+| **CORE — Products infrastructure** | `ProductRepository.findByIds` impl (one `IN (...)` query). |
+| **CORE — Products application** | Extend `IProductsService` + `ProductsService` with four new methods that proxy to the underlying repositories: `findProductsByIds`, `findVariantsBySkuIn`, `findVariantsByEanOrGtinIn`. (`getVariant`, the fourth shape, already exists.) |
+| **CORE — Inventory application** | `inventory-query.service.ts` injects `IProductsService` instead of `ProductRepositoryPort`; `buildProductMap` becomes one `findProductsByIds(ids)` call. |
+| **CORE — Orders application** | `order-item-ref-resolver.service.ts` injects `IProductsService` instead of `ProductVariantRepositoryPort`; calls `getVariant(id)` in the four branches. |
+| **CORE — Listings application** | `offer-builder.service.ts` calls `getVariant(id)`. `offer-mapping-sync.service.ts` calls `findVariantsBySkuIn` + `findVariantsByEanOrGtinIn`. Both inject `IProductsService`. |
+| **Lint** | Drop 8 entries from `ALLOW_LIST` in `scripts/check-cross-context-imports.mjs`. |
+| **Module wiring** | Add `IProductsService`'s binding to the `forwardRef` graph wherever the four consumer modules import products (the binding already exists on `ProductsModule`; verify and adjust each consumer module's `imports`). |
+
+Why `IProductsService` (one umbrella) and not a narrower seam per consumer? The four shapes (`findProductsByIds`, `getVariant`, `findVariantsBySkuIn`, `findVariantsByEanOrGtinIn`) are all small reads on the same aggregate root family (Product + ProductVariant) and there's no operational reason to split them into narrower service interfaces. The issue body explicitly nominates `IProductsService` as the seam. Future contention (e.g. write-vs-read split) is a refactor inside the products context that won't break consumers.
+
+---
+
+## 2. Domain layer changes
+
+### 2.1 `ProductRepositoryPort.findByIds(ids: string[]): Promise<Product[]>`
+
+`libs/core/src/products/domain/ports/product-repository.port.ts`
+
+```ts
+/**
+ * Find products by internal-id list. Returns rows in arbitrary order;
+ * caller maps by id. Missing ids are silently dropped (no null fillers)
+ * — same shape as `findBySkuIn` / `findByEanOrGtinIn` on the variant port.
+ */
+findByIds(ids: string[]): Promise<Product[]>;
+```
+
+Empty-input contract: `findByIds([])` returns `[]` synchronously (no DB round-trip). Caller doesn't need to guard.
+
+---
+
+## 3. Infrastructure layer changes
+
+### 3.1 `ProductRepository.findByIds`
+
+`libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts`
+
+```ts
+async findByIds(ids: string[]): Promise<Product[]> {
+  if (ids.length === 0) return [];
+  const rows = await this.ormRepository.find({ where: { id: In(ids) } });
+  return rows.map((row) => this.toDomain(row));
+}
+```
+
+`In` already imported from `typeorm` elsewhere in the file. No new dependencies.
+
+---
+
+## 4. Application layer — IProductsService extension
+
+### 4.1 New methods on `IProductsService`
+
+`libs/core/src/products/application/services/products.service.interface.ts`
+
+Names follow the existing `get*` convention on the interface (`getProduct`, `getVariant`) — multi-key reads pluralise the noun. Mirrors the repository-port shape underneath but doesn't bleed the port's `find*` verb across the seam.
+
+```ts
+/**
+ * Batch product lookup by internal id. Missing ids are silently
+ * dropped — caller maps results by `product.id` if presence matters.
+ * Empty input returns `[]` without a DB round-trip.
+ */
+getProductsByIds(ids: string[]): Promise<Product[]>;
+
+/**
+ * Variant lookup by SKU list. Empty input returns `[]` without a
+ * DB round-trip.
+ */
+getVariantsBySkus(skus: string[]): Promise<ProductVariant[]>;
+
+/**
+ * Variant lookup by EAN or GTIN list, scoped to a master-catalog
+ * connection. Empty input returns `[]` without a DB round-trip.
+ */
+getVariantsByBarcodes(
+  connectionId: string,
+  values: string[],
+  field: 'ean' | 'gtin',
+): Promise<ProductVariant[]>;
+```
+
+`getVariant(id)` already exists and matches `variantRepository.findById(id)` — no rename needed.
+
+### 4.2 `ProductsService` impls
+
+`libs/core/src/products/application/services/products.service.ts`
+
+Each is a thin pass-through to the repository port the service already holds, **with empty-input short-circuit at the service layer** so consumers drop the `length > 0 ? ... : []` ternary:
+
+```ts
+getProductsByIds(ids) {
+  if (ids.length === 0) return Promise.resolve([]);
+  return this.productRepository.findByIds(ids);
+}
+getVariantsBySkus(skus) {
+  if (skus.length === 0) return Promise.resolve([]);
+  return this.variantRepository.findBySkuIn(skus);
+}
+getVariantsByBarcodes(connId, values, field) {
+  if (values.length === 0) return Promise.resolve([]);
+  return this.variantRepository.findByEanOrGtinIn(connId, values, field);
+}
+```
+
+The repository-port `findByIds` (§2.1) also short-circuits internally as a belt-and-braces (we're already crossing the seam there too).
+
+---
+
+## 5. Rewire the four consumers
+
+**Pre-step**: verify `ProductsModule.exports` includes `PRODUCTS_SERVICE_TOKEN` (not just `PRODUCT_REPOSITORY_TOKEN` / `PRODUCT_VARIANT_REPOSITORY_TOKEN`). If missing, add the export — one-line edit, but should be the first change in the implementation diff so the four consumer swaps don't blow up on a DI lookup miss at boot.
+
+For each consumer file:
+1. Replace the `ProductRepositoryPort` / `ProductVariantRepositoryPort` import with `IProductsService` + `PRODUCTS_SERVICE_TOKEN`.
+2. Swap the constructor injection: drop the repository port + its `@Inject(*_REPOSITORY_TOKEN)`, add `@Inject(PRODUCTS_SERVICE_TOKEN) private readonly productsService: IProductsService`.
+3. Update method call sites.
+4. **Update the file header `@see` line** — `inventory-query.service.ts:13` and the other three carry `@see {@link ProductRepositoryPort}` / `{@link ProductVariantRepositoryPort}` doc comments that go stale after the rewire. Replace with `@see {@link IProductsService}`.
+5. Update the spec to mock `IProductsService` instead of the repository port.
+6. Verify the consumer's NestJS module imports `ProductsModule` (most likely already, since they sit downstream of products in the dep graph).
+
+### 5.1 `inventory-query.service.ts`
+
+- `this.productRepository.findById(item.productId)` → `this.productsService.getProduct(item.productId)`.
+- `buildProductMap` rewrites to a single `findProductsByIds(uniqueIds)` call. The TODO comment at line 63 is deleted.
+
+Module: `apps/api/src/inventory/inventory.module.ts` — confirm `imports: [ProductsModule, ...]` (or wherever it currently pulls `PRODUCT_REPOSITORY_TOKEN` from).
+
+### 5.2 `order-item-ref-resolver.service.ts`
+
+- All four `this.variantRepository.findById(internalId)` calls → `this.productsService.getVariant(internalId)`.
+
+Module: `apps/api/src/orders/orders.module.ts` (or wherever this service is provided) — confirm `imports: [ProductsModule]`.
+
+### 5.3 `offer-builder.service.ts`
+
+- One `this.variantRepository.findById(input.internalVariantId)` → `this.productsService.getVariant(...)`.
+
+Module: listings → check.
+
+### 5.4 `offer-mapping-sync.service.ts`
+
+- `this.variantRepository.findBySkuIn(skuCandidates)` → `this.productsService.findVariantsBySkuIn(skuCandidates)`.
+- Both `this.variantRepository.findByEanOrGtinIn(...)` → `this.productsService.findVariantsByEanOrGtinIn(...)`.
+
+Module: same as 5.3.
+
+---
+
+## 6. Spec rewires
+
+Each spec currently constructs a `jest.Mocked<ProductVariantRepositoryPort>` (or `ProductRepositoryPort`) and provides it under the repository token. The rewire:
+
+1. Replace the mock type with `jest.Mocked<Pick<IProductsService, '...'>>` (use `Pick<>` so we only mock the methods the consumer touches — no need to stub all 9+ methods of `IProductsService`).
+2. Replace the `provide: PRODUCT_*_REPOSITORY_TOKEN` binding with `provide: PRODUCTS_SERVICE_TOKEN`.
+3. Update assertions: `expect(mockRepo.findById).toHaveBeenCalledWith(...)` → `expect(mockProductsService.getProduct).toHaveBeenCalledWith(...)` etc.
+
+**Per-spec mock surface** (keeps spec scope tight, protects against accidentally stubbing methods the SUT doesn't call):
+
+| Spec | `Pick<IProductsService, …>` |
+|---|---|
+| `inventory-query.service.spec.ts` | `'getProduct' \| 'getProductsByIds'` |
+| `order-item-ref-resolver.service.spec.ts` | `'getVariant'` |
+| `offer-builder.service.spec.ts` | `'getVariant'` |
+| `offer-mapping-sync.service.spec.ts` | `'getVariantsBySkus' \| 'getVariantsByBarcodes'` |
+
+Existing assertion semantics are preserved — the underlying call shape doesn't change, only the injection seam.
+
+---
+
+## 7. Allow-list cleanup
+
+`scripts/check-cross-context-imports.mjs` — remove the 8 entries grouped under the three rewire comments:
+
+```
+// inventory → products.ProductRepositoryPort — rewire via IProductsService
+// orders → products.ProductVariantRepositoryPort — rewire via IProductsService
+// listings → products.ProductVariantRepositoryPort — rewire via IProductsService
+```
+
+(Keep the remaining 12 entries — those are slices 2/3/4 of #718.)
+
+---
+
+## 8. Testing strategy
+
+| Layer | Test | What it asserts |
+|---|---|---|
+| Products repository | `product.repository.spec.ts` (extend if exists, else add) | `findByIds([])` returns `[]` without hitting DB; `findByIds([a, b])` returns rows; missing ids drop silently. Unit-level with a mocked TypeORM repo. |
+| Products service | `products.service.spec.ts` (extend) | Three new methods are pass-through — assert they call the repository with the same args. |
+| Inventory consumer | `inventory-query.service.spec.ts` | `getInventoryItem` calls `productsService.getProduct`; `listInventoryItems` calls `productsService.findProductsByIds` exactly once with the de-duped id list. |
+| Orders consumer | `order-item-ref-resolver.service.spec.ts` | Each of the four branches (offer/product/variant/sku) calls `productsService.getVariant` (where applicable). |
+| Listings consumer | `offer-builder.service.spec.ts` | Calls `productsService.getVariant(input.internalVariantId)`. |
+| Listings consumer | `offer-mapping-sync.service.spec.ts` | SKU lookup calls `findVariantsBySkuIn`; barcode lookup calls `findVariantsByEanOrGtinIn` with the `(connectionId, values, field)` args. |
+| Lint invariant | `pnpm check:invariants` | Passes with the 8 allow-list entries removed. |
+
+No integration test needed — this is a pure injection-seam refactor, no behaviour change.
+
+---
+
+## 9. Acceptance criteria (from #718, slice 1)
+
+- [ ] `inventory-query.service.ts`, `order-item-ref-resolver.service.ts`, `offer-mapping-sync.service.ts`, `offer-builder.service.ts` no longer import `ProductRepositoryPort` or `ProductVariantRepositoryPort`.
+- [ ] Their four spec files mock `IProductsService` instead of the repository ports.
+- [ ] Allow-list in `scripts/check-cross-context-imports.mjs` drops 8 entries (the three rewire blocks at the top of the list).
+- [ ] `pnpm check:invariants` stays green.
+- [ ] `IProductsService` exposes only domain types (`Product`, `ProductVariant`) — no ORM entities or raw enum types leak.
+- [ ] Existing TODO comment at `inventory-query.service.ts:63` removed (resolved by `findProductsByIds`).
+
+---
+
+## 10. Risks & open questions
+
+- **NestJS module graph** — each consumer module must import `ProductsModule` (or have it in its forward-ref chain). The current imports use `PRODUCT_REPOSITORY_TOKEN` / `PRODUCT_VARIANT_REPOSITORY_TOKEN` which are exported by `ProductsModule` already, so the import line itself is unchanged. Verify per consumer.
+- **Spec mock types**: using `Pick<IProductsService, ...>` keeps the mock scoped, but Nest's `Test.createTestingModule` is type-erased so a structural mock is fine. If a spec uses `jest.Mocked<IProductsService>` directly, all 9 methods need stubs — `Pick<>` is the smaller surface.
+- **Circular imports** — `ProductsModule` already exports `PRODUCTS_SERVICE_TOKEN`; no new module imports needed. If a consumer's module currently doesn't import `ProductsModule` (only the bare token via `@nestjs/typeorm` magic), that's a latent bug — fix in the same PR.
+- **Future shape changes** to `ProductRepositoryPort` / `ProductVariantRepositoryPort` now stop at the products context. Cross-context callers see only `IProductsService`, which is the explicit goal.
+
+---
+
+## 11. Out-of-scope follow-ups
+
+- Slice 2 (sync repository ports) — `offer-status-poll.service.ts`, `order-ingestion.service.ts`. Tracked by #718.
+- Slice 3 (listings.OfferMappingRepositoryPort callers) — `content-state-reader.service.ts`, `integrations-content-publisher.service.ts`. Tracked by #718.
+- Slice 4 (integrations credentials) — `ai-provider-key.service.ts`, `credentials-ai-provider.adapter.ts`. Tracked by #718.
+- Dropping the barrel exports of `ProductRepositoryPort` / `ProductVariantRepositoryPort` once all cross-context callers are gone. Intra-context callers (the products context itself) still need them, so the exports stay — the lint script is the gate, not the barrel.

--- a/libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts
@@ -11,12 +11,16 @@
 import { InventoryQueryService } from '../inventory-query.service';
 import { InventoryItem } from '../../../domain/entities/inventory-item.entity';
 import type { InventoryRepositoryPort } from '../../../domain/ports/inventory-repository.port';
-import type { Product, ProductRepositoryPort } from '@openlinker/core/products';
+import type { IProductsService, Product } from '@openlinker/core/products';
+
+// Only the two products-service methods the SUT actually calls — keeps the
+// mock surface tight per #718 review.
+type ProductsServiceMock = Pick<IProductsService, 'getProduct' | 'getProductsByIds'>;
 
 describe('InventoryQueryService', () => {
   let service: InventoryQueryService;
   let inventoryRepository: jest.Mocked<InventoryRepositoryPort>;
-  let productRepository: jest.Mocked<ProductRepositoryPort>;
+  let productsService: jest.Mocked<ProductsServiceMock>;
 
   const itemA = new InventoryItem(
     'inv-a',
@@ -73,17 +77,21 @@ describe('InventoryQueryService', () => {
       findMany: jest.fn(),
     };
 
-    productRepository = {
-      findById: jest.fn(),
-    } as unknown as jest.Mocked<ProductRepositoryPort>;
+    productsService = {
+      getProduct: jest.fn(),
+      getProductsByIds: jest.fn(),
+    };
 
-    service = new InventoryQueryService(inventoryRepository, productRepository);
+    service = new InventoryQueryService(
+      inventoryRepository,
+      productsService as unknown as IProductsService,
+    );
   });
 
   describe('listInventoryItems', () => {
     it('composes product details onto each item', async () => {
       inventoryRepository.findMany.mockResolvedValue({ items: [itemA], total: 1 });
-      productRepository.findById.mockResolvedValue(product1);
+      productsService.getProductsByIds.mockResolvedValue([product1]);
 
       const result = await service.listInventoryItems({}, { limit: 20, offset: 0 });
 
@@ -97,19 +105,19 @@ describe('InventoryQueryService', () => {
       });
     });
 
-    it('deduplicates product lookups when items share a productId', async () => {
+    it('deduplicates product lookups via getProductsByIds when items share a productId', async () => {
       inventoryRepository.findMany.mockResolvedValue({ items: [itemA, itemB], total: 2 });
-      productRepository.findById.mockResolvedValue(product1);
+      productsService.getProductsByIds.mockResolvedValue([product1]);
 
       await service.listInventoryItems({}, { limit: 20, offset: 0 });
 
-      expect(productRepository.findById).toHaveBeenCalledTimes(1);
-      expect(productRepository.findById).toHaveBeenCalledWith('prod-1');
+      expect(productsService.getProductsByIds).toHaveBeenCalledTimes(1);
+      expect(productsService.getProductsByIds).toHaveBeenCalledWith(['prod-1']);
     });
 
-    it('returns product: null on each view when the product lookup returns null', async () => {
+    it('returns product: null on each view when the product lookup returns []', async () => {
       inventoryRepository.findMany.mockResolvedValue({ items: [itemA, itemB], total: 2 });
-      productRepository.findById.mockResolvedValue(null);
+      productsService.getProductsByIds.mockResolvedValue([]);
 
       const result = await service.listInventoryItems({}, { limit: 20, offset: 0 });
 
@@ -120,6 +128,7 @@ describe('InventoryQueryService', () => {
 
     it('passes filters and pagination through to the repository unchanged', async () => {
       inventoryRepository.findMany.mockResolvedValue({ items: [], total: 0 });
+      productsService.getProductsByIds.mockResolvedValue([]);
 
       await service.listInventoryItems(
         { productId: 'prod-1', productVariantId: 'var-a', locationId: 'loc-1' },
@@ -134,12 +143,13 @@ describe('InventoryQueryService', () => {
 
     it('returns an empty view when the repository returns no items', async () => {
       inventoryRepository.findMany.mockResolvedValue({ items: [], total: 0 });
+      productsService.getProductsByIds.mockResolvedValue([]);
 
       const result = await service.listInventoryItems({}, { limit: 20, offset: 0 });
 
       expect(result.items).toEqual([]);
       expect(result.total).toBe(0);
-      expect(productRepository.findById).not.toHaveBeenCalled();
+      // getProductsByIds short-circuits internally on [], but the call is fine either way.
     });
 
     it('preserves repository.findMany ordering after composition', async () => {
@@ -149,11 +159,7 @@ describe('InventoryQueryService', () => {
         items: [itemC, itemA, itemB],
         total: 3,
       });
-      productRepository.findById.mockImplementation((id: string) => {
-        if (id === 'prod-1') return Promise.resolve(product1);
-        if (id === 'prod-2') return Promise.resolve(product2);
-        return Promise.resolve(null);
-      });
+      productsService.getProductsByIds.mockResolvedValue([product1, product2]);
 
       const result = await service.listInventoryItems({}, { limit: 20, offset: 0 });
 
@@ -164,7 +170,7 @@ describe('InventoryQueryService', () => {
   describe('getInventoryItem', () => {
     it('composes product details when both item and product exist', async () => {
       inventoryRepository.findById.mockResolvedValue(itemA);
-      productRepository.findById.mockResolvedValue(product1);
+      productsService.getProduct.mockResolvedValue(product1);
 
       const result = await service.getInventoryItem('inv-a');
 
@@ -175,6 +181,7 @@ describe('InventoryQueryService', () => {
         sku: 'SKU-1',
         coverImageUrl: 'https://shop.test/img/1/cover.jpg',
       });
+      expect(productsService.getProduct).toHaveBeenCalledWith('prod-1');
     });
 
     it('returns null when the inventory item does not exist and skips the product lookup', async () => {
@@ -183,12 +190,12 @@ describe('InventoryQueryService', () => {
       const result = await service.getInventoryItem('missing');
 
       expect(result).toBeNull();
-      expect(productRepository.findById).not.toHaveBeenCalled();
+      expect(productsService.getProduct).not.toHaveBeenCalled();
     });
 
     it('returns a view with product: null when the item exists but the product lookup returns null', async () => {
       inventoryRepository.findById.mockResolvedValue(itemA);
-      productRepository.findById.mockResolvedValue(null);
+      productsService.getProduct.mockResolvedValue(null);
 
       const result = await service.getInventoryItem('inv-a');
 

--- a/libs/core/src/inventory/application/services/inventory-query.service.ts
+++ b/libs/core/src/inventory/application/services/inventory-query.service.ts
@@ -10,13 +10,13 @@
  * @implements {IInventoryQueryService}
  * @see {@link IInventoryQueryService} for the service interface
  * @see {@link InventoryRepositoryPort} for inventory persistence
- * @see {@link ProductRepositoryPort} for product persistence
+ * @see {@link IProductsService} for cross-context product reads (#718)
  */
 import { Inject, Injectable } from '@nestjs/common';
 import {
   coverImageUrl,
-  PRODUCT_REPOSITORY_TOKEN,
-  ProductRepositoryPort,
+  IProductsService,
+  PRODUCTS_SERVICE_TOKEN,
 } from '@openlinker/core/products';
 import type { Product } from '@openlinker/core/products';
 import { INVENTORY_REPOSITORY_TOKEN } from '../../inventory.tokens';
@@ -35,8 +35,8 @@ export class InventoryQueryService implements IInventoryQueryService {
   constructor(
     @Inject(INVENTORY_REPOSITORY_TOKEN)
     private readonly inventoryRepository: InventoryRepositoryPort,
-    @Inject(PRODUCT_REPOSITORY_TOKEN)
-    private readonly productRepository: ProductRepositoryPort
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService
   ) {}
 
   async listInventoryItems(
@@ -56,23 +56,17 @@ export class InventoryQueryService implements IInventoryQueryService {
     if (!item) {
       return null;
     }
-    const product = await this.productRepository.findById(item.productId);
+    const product = await this.productsService.getProduct(item.productId);
     return this.compose(item, product);
   }
 
-  // TODO: Replace with a single findByIds(ids) call once ProductRepositoryPort supports batch lookup.
-  // Current implementation issues N individual findById calls (one per unique productId).
-  // For typical page sizes (≤20 items) this is acceptable, but a batch method would be more efficient.
   private async buildProductMap(productIds: string[]): Promise<Map<string, Product>> {
     const uniqueIds = [...new Set(productIds)];
-    const products = await Promise.all(uniqueIds.map((id) => this.productRepository.findById(id)));
+    const products = await this.productsService.getProductsByIds(uniqueIds);
     const map = new Map<string, Product>();
-    uniqueIds.forEach((id, idx) => {
-      const product = products[idx];
-      if (product) {
-        map.set(id, product);
-      }
-    });
+    for (const product of products) {
+      map.set(product.id, product);
+    }
     return map;
   }
 

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -11,8 +11,8 @@ import type { ConnectionPort, Connection } from '@openlinker/core/identifier-map
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { OfferManagerPort } from '@openlinker/core/listings';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
-import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
-import type { ProductVariant, ProductVariantRepositoryPort } from '@openlinker/core/products';
+import { PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
+import type { IProductsService, ProductVariant } from '@openlinker/core/products';
 
 import { OfferBuilderService } from '../offer-builder.service';
 import { CATEGORY_RESOLUTION_SERVICE_TOKEN } from '../../../listings.tokens';
@@ -22,7 +22,7 @@ import { MasterCatalogConnectionNotConfiguredException } from '../../../domain/e
 
 describe('OfferBuilderService', () => {
   let service: OfferBuilderService;
-  let variantRepo: jest.Mocked<Pick<ProductVariantRepositoryPort, 'findById'>>;
+  let productsService: jest.Mocked<Pick<IProductsService, 'getVariant'>>;
   let connectionPort: jest.Mocked<Pick<ConnectionPort, 'get'>>;
   let integrationsService: jest.Mocked<Pick<IIntegrationsService, 'getCapabilityAdapter'>>;
   let categoryResolution: jest.Mocked<Pick<ICategoryResolutionService, 'resolveCategory'>>;
@@ -49,7 +49,7 @@ describe('OfferBuilderService', () => {
   };
 
   beforeEach(async () => {
-    variantRepo = { findById: jest.fn().mockResolvedValue(defaultVariant) };
+    productsService = { getVariant: jest.fn().mockResolvedValue(defaultVariant) };
     connectionPort = {
       get: jest.fn().mockResolvedValue(defaultConnection as Connection),
     };
@@ -78,7 +78,7 @@ describe('OfferBuilderService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OfferBuilderService,
-        { provide: PRODUCT_VARIANT_REPOSITORY_TOKEN, useValue: variantRepo },
+        { provide: PRODUCTS_SERVICE_TOKEN, useValue: productsService },
         { provide: CONNECTION_PORT_TOKEN, useValue: connectionPort },
         { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrationsService },
         { provide: CATEGORY_RESOLUTION_SERVICE_TOKEN, useValue: categoryResolution },
@@ -97,7 +97,7 @@ describe('OfferBuilderService', () => {
         publishImmediately: true,
       });
 
-      expect(variantRepo.findById).toHaveBeenCalledWith(VARIANT_ID);
+      expect(productsService.getVariant).toHaveBeenCalledWith(VARIANT_ID);
       expect(connectionPort.get).toHaveBeenCalledWith(MARKETPLACE_CONN_ID);
       expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
         MASTER_CONN_ID,
@@ -141,7 +141,7 @@ describe('OfferBuilderService', () => {
     });
 
     it('throws OfferBuilderValidationException when no barcode and no override', async () => {
-      variantRepo.findById.mockResolvedValue({
+      productsService.getVariant.mockResolvedValue({
         ...(defaultVariant as unknown as Record<string, unknown>),
         ean: undefined,
         gtin: undefined,
@@ -175,7 +175,7 @@ describe('OfferBuilderService', () => {
 
   describe('variant and connection lookup', () => {
     it('throws OfferBuilderValidationException when variant is missing', async () => {
-      variantRepo.findById.mockResolvedValue(null);
+      productsService.getVariant.mockResolvedValue(null);
 
       await expect(
         service.buildCreateOfferCommand({

--- a/libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts
@@ -9,7 +9,7 @@ import type { OfferManagerPort, OfferLister, OfferEventReader } from '@openlinke
 import type { IIntegrationsService } from '@openlinker/core/integrations';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 import { IdentifierMappingConflictException } from '@openlinker/core/identifier-mapping';
-import type { ProductVariantRepositoryPort } from '@openlinker/core/products';
+import type { IProductsService } from '@openlinker/core/products';
 import type { ProductVariant } from '@openlinker/core/products';
 
 function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
@@ -29,7 +29,9 @@ describe('OfferMappingSyncService', () => {
   let service: OfferMappingSyncService;
   let integrationsService: jest.Mocked<IIntegrationsService>;
   let identifierMapping: jest.Mocked<IIdentifierMappingService>;
-  let variantRepository: jest.Mocked<ProductVariantRepositoryPort>;
+  // Only the two products-service methods the SUT actually calls — keeps the
+  // mock surface tight per #718 review.
+  let productsService: jest.Mocked<Pick<IProductsService, 'getVariantsBySkus' | 'getVariantsByBarcodes'>>;
   let marketplace: jest.Mocked<OfferManagerPort & OfferLister & OfferEventReader>;
 
   beforeEach(() => {
@@ -74,20 +76,15 @@ describe('OfferMappingSyncService', () => {
       deleteMapping: jest.fn(),
     } as unknown as jest.Mocked<IIdentifierMappingService>;
 
-    variantRepository = {
-      findById: jest.fn(),
-      findByProductId: jest.fn(),
-      findBySku: jest.fn(),
-      findBySkuIn: jest.fn(),
-      findByEanOrGtinIn: jest.fn(),
-      upsert: jest.fn(),
-      upsertMany: jest.fn(),
-    } as unknown as jest.Mocked<ProductVariantRepositoryPort>;
+    productsService = {
+      getVariantsBySkus: jest.fn(),
+      getVariantsByBarcodes: jest.fn(),
+    };
 
     service = new OfferMappingSyncService(
       integrationsService,
       identifierMapping,
-      variantRepository,
+      productsService as unknown as IProductsService,
       new OfferLinkingService()
     );
   });
@@ -101,12 +98,12 @@ describe('OfferMappingSyncService', () => {
       nextCursor: null,
     });
 
-    variantRepository.findBySkuIn.mockResolvedValue([
+    productsService.getVariantsBySkus.mockResolvedValue([
       makeVariant({ id: 'variant-1', productId: 'product-1', sku: 'SKU-1' }),
       makeVariant({ id: 'variant-2', productId: 'product-2', sku: 'SKU-2' }),
     ]);
 
-    variantRepository.findByEanOrGtinIn.mockResolvedValue([]);
+    productsService.getVariantsByBarcodes.mockResolvedValue([]);
 
     const result = await service.sync('connection-1', { limit: 50, cursor: null });
 
@@ -120,10 +117,10 @@ describe('OfferMappingSyncService', () => {
       nextCursor: null,
     });
 
-    variantRepository.findBySkuIn.mockResolvedValue([
+    productsService.getVariantsBySkus.mockResolvedValue([
       makeVariant({ id: 'variant-1', productId: 'product-1', sku: 'SKU-1' }),
     ]);
-    variantRepository.findByEanOrGtinIn.mockResolvedValue([]);
+    productsService.getVariantsByBarcodes.mockResolvedValue([]);
 
     identifierMapping.getOrCreateExactMapping.mockRejectedValue(
       new IdentifierMappingConflictException('Offer', 'offer-1', 'connection-1', 'old', 'new')
@@ -160,13 +157,13 @@ describe('OfferMappingSyncService', () => {
       nextCursor: null,
     });
 
-    variantRepository.findBySkuIn.mockResolvedValue([]);
-    variantRepository.findByEanOrGtinIn.mockResolvedValue([]);
+    productsService.getVariantsBySkus.mockResolvedValue([]);
+    productsService.getVariantsByBarcodes.mockResolvedValue([]);
 
     const result = await service.sync('connection-1', { limit: 50, cursor: null });
 
     expect(result).toEqual({ scanned: 1, linked: 0, skipped: 1, nextCursor: null });
-    expect(variantRepository.findByEanOrGtinIn).not.toHaveBeenCalled();
+    expect(productsService.getVariantsByBarcodes).not.toHaveBeenCalled();
   });
 
   it('uses masterCatalogConnectionId for barcode lookup', async () => {
@@ -175,8 +172,8 @@ describe('OfferMappingSyncService', () => {
       nextCursor: null,
     });
 
-    variantRepository.findBySkuIn.mockResolvedValue([]);
-    variantRepository.findByEanOrGtinIn.mockResolvedValue([
+    productsService.getVariantsBySkus.mockResolvedValue([]);
+    productsService.getVariantsByBarcodes.mockResolvedValue([
       makeVariant({
         id: 'variant-1',
         productId: 'product-1',
@@ -188,7 +185,7 @@ describe('OfferMappingSyncService', () => {
     const result = await service.sync('connection-1', { limit: 50, cursor: null });
 
     expect(result).toEqual({ scanned: 1, linked: 1, skipped: 0, nextCursor: null });
-    expect(variantRepository.findByEanOrGtinIn).toHaveBeenCalledWith(
+    expect(productsService.getVariantsByBarcodes).toHaveBeenCalledWith(
       'master-1',
       ['5901234123457'],
       'ean'

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -2,7 +2,7 @@
  * Offer Builder Service
  *
  * Assembles a platform-neutral `CreateOfferCommand` from an OL internal variant
- * id. Fetches variant metadata from the local repository, resolves the parent
+ * id. Fetches variant metadata via `IProductsService`, resolves the parent
  * master product via `ProductMasterPort` (for name/description/images/price),
  * resolves the marketplace category via `ICategoryResolutionService`, and
  * validates required fields. Throws `OfferBuilderValidationException` with a
@@ -21,8 +21,8 @@ import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/co
 import type { CreateOfferCommand } from '@openlinker/core/listings';
 import type { ProductMasterPort } from '@openlinker/core/products';
 import {
-  PRODUCT_VARIANT_REPOSITORY_TOKEN,
-  ProductVariantRepositoryPort,
+  IProductsService,
+  PRODUCTS_SERVICE_TOKEN,
 } from '@openlinker/core/products';
 
 import { MasterCatalogConnectionNotConfiguredException } from '../../domain/exceptions/master-catalog-connection-not-configured.exception';
@@ -38,8 +38,8 @@ export class OfferBuilderService implements IOfferBuilderService {
   private readonly logger = new Logger(OfferBuilderService.name);
 
   constructor(
-    @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
-    private readonly variantRepository: ProductVariantRepositoryPort,
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService,
     @Inject(CONNECTION_PORT_TOKEN)
     private readonly connectionPort: ConnectionPort,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
@@ -51,7 +51,7 @@ export class OfferBuilderService implements IOfferBuilderService {
   async buildCreateOfferCommand(input: BuildCreateOfferCommandInput): Promise<CreateOfferCommand> {
     const issues: OfferBuilderValidationIssue[] = [];
 
-    const variant = await this.variantRepository.findById(input.internalVariantId);
+    const variant = await this.productsService.getVariant(input.internalVariantId);
     if (!variant) {
       throw new OfferBuilderValidationException([
         {

--- a/libs/core/src/listings/application/services/offer-mapping-sync.service.ts
+++ b/libs/core/src/listings/application/services/offer-mapping-sync.service.ts
@@ -4,6 +4,7 @@
  * Orchestrates marketplace offer discovery and deterministic linking to internal variants.
  *
  * @module libs/core/src/listings/application/services
+ * @see {@link IProductsService} for cross-context variant reads (#718)
  */
 import { Injectable, Inject } from '@nestjs/common';
 import type { OfferManagerPort } from '@openlinker/core/listings';
@@ -12,8 +13,8 @@ import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/co
 import type { OfferFeedItem } from '@openlinker/core/listings';
 import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, IdentifierMappingConflictException, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import {
-  PRODUCT_VARIANT_REPOSITORY_TOKEN,
-  ProductVariantRepositoryPort,
+  IProductsService,
+  PRODUCTS_SERVICE_TOKEN,
   normalizeBarcode,
 } from '@openlinker/core/products';
 import { Logger } from '@openlinker/shared/logging';
@@ -34,8 +35,8 @@ export class OfferMappingSyncService implements IOfferMappingSyncService {
     private readonly integrationsService: IIntegrationsService,
     @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
     private readonly identifierMapping: IIdentifierMappingService,
-    @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
-    private readonly variantRepository: ProductVariantRepositoryPort,
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService,
     private readonly offerLinking: OfferLinkingService
   ) {}
 
@@ -141,21 +142,22 @@ export class OfferMappingSyncService implements IOfferMappingSyncService {
     );
 
     const skuCandidates = this.uniqueValues([...externalRefs, ...skus]);
-    const skuVariants =
-      skuCandidates.length > 0 ? await this.variantRepository.findBySkuIn(skuCandidates) : [];
+    // IProductsService.getVariantsBySkus short-circuits on []; consumer drops
+    // the length guard.
+    const skuVariants = await this.productsService.getVariantsBySkus(skuCandidates);
 
     const skuMap = this.buildUniqueMap(skuVariants, (variant) => variant.sku ?? null);
     const externalRefMap = this.selectLookup(externalRefs, skuMap);
     const directSkuMap = this.selectLookup(skus, skuMap);
 
-    const eanVariants =
-      masterConnectionId && eans.length > 0
-        ? await this.variantRepository.findByEanOrGtinIn(masterConnectionId, eans, 'ean')
-        : [];
-    const gtinVariants =
-      masterConnectionId && gtins.length > 0
-        ? await this.variantRepository.findByEanOrGtinIn(masterConnectionId, gtins, 'gtin')
-        : [];
+    // masterConnectionId guard remains because the service requires it; the
+    // values-length guard is internal to getVariantsByBarcodes.
+    const eanVariants = masterConnectionId
+      ? await this.productsService.getVariantsByBarcodes(masterConnectionId, eans, 'ean')
+      : [];
+    const gtinVariants = masterConnectionId
+      ? await this.productsService.getVariantsByBarcodes(masterConnectionId, gtins, 'gtin')
+      : [];
     this.logger.debug(
       `Barcode lookup results (eans: [${eans.join(',')}] → ${eanVariants.length} hit(s), gtins: [${gtins.join(',')}] → ${gtinVariants.length} hit(s))`
     );

--- a/libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts
@@ -1,8 +1,7 @@
 import { OrderItemRefResolverService } from '../order-item-ref-resolver.service';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
-import type { ProductVariant } from '@openlinker/core/products';
-import type { ProductVariantRepositoryPort } from '@openlinker/core/products';
+import type { IProductsService, ProductVariant } from '@openlinker/core/products';
 
 function makeVariant(id: string, productId: string): ProductVariant {
   return {
@@ -21,7 +20,9 @@ describe('OrderItemRefResolverService', () => {
   const connectionId = 'connection-123';
 
   let identifierMapping: jest.Mocked<IIdentifierMappingService>;
-  let variantRepository: jest.Mocked<ProductVariantRepositoryPort>;
+  // Only the products-service method the SUT actually calls — keeps the mock
+  // surface tight per #718 review.
+  let productsService: jest.Mocked<Pick<IProductsService, 'getVariant'>>;
   let service: OrderItemRefResolverService;
 
   beforeEach(() => {
@@ -35,22 +36,19 @@ describe('OrderItemRefResolverService', () => {
       deleteMapping: jest.fn(),
     } as unknown as jest.Mocked<IIdentifierMappingService>;
 
-    variantRepository = {
-      findById: jest.fn(),
-      findByProductId: jest.fn(),
-      findBySku: jest.fn(),
-      findBySkuIn: jest.fn(),
-      findByEanOrGtinIn: jest.fn(),
-      upsert: jest.fn(),
-      upsertMany: jest.fn(),
-    } as unknown as jest.Mocked<ProductVariantRepositoryPort>;
+    productsService = {
+      getVariant: jest.fn(),
+    };
 
-    service = new OrderItemRefResolverService(identifierMapping, variantRepository);
+    service = new OrderItemRefResolverService(
+      identifierMapping,
+      productsService as unknown as IProductsService,
+    );
   });
 
   it('resolves offer refs via IdentifierMappingService(Offer)', async () => {
     identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
-    variantRepository.findById.mockResolvedValueOnce(makeVariant('ol_variant_1', 'ol_product_1'));
+    productsService.getVariant.mockResolvedValueOnce(makeVariant('ol_variant_1', 'ol_product_1'));
 
     await expect(
       service.resolve(connectionId, { type: 'offer', externalId: 'offer-1' })
@@ -82,7 +80,7 @@ describe('OrderItemRefResolverService', () => {
 
   it('resolves variant refs via IdentifierMappingService(ProductVariant)', async () => {
     identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
-    variantRepository.findById.mockResolvedValueOnce(makeVariant('ol_variant_1', 'ol_product_1'));
+    productsService.getVariant.mockResolvedValueOnce(makeVariant('ol_variant_1', 'ol_product_1'));
 
     await expect(
       service.resolve(connectionId, { type: 'variant', externalId: 'v-1' })
@@ -97,7 +95,7 @@ describe('OrderItemRefResolverService', () => {
 
   it('resolves sku refs via IdentifierMappingService(Sku) and variant lookup', async () => {
     identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
-    variantRepository.findById.mockResolvedValueOnce(makeVariant('ol_variant_1', 'ol_product_1'));
+    productsService.getVariant.mockResolvedValueOnce(makeVariant('ol_variant_1', 'ol_product_1'));
 
     await expect(
       service.resolve(connectionId, { type: 'sku', externalId: 'SKU-1' })
@@ -108,7 +106,7 @@ describe('OrderItemRefResolverService', () => {
 
   it('falls back to product id when sku mapping is not a variant', async () => {
     identifierMapping.getInternalId.mockResolvedValueOnce('ol_product_1');
-    variantRepository.findById.mockResolvedValueOnce(null);
+    productsService.getVariant.mockResolvedValueOnce(null);
 
     await expect(
       service.resolve(connectionId, { type: 'sku', externalId: 'SKU-2' })
@@ -118,7 +116,7 @@ describe('OrderItemRefResolverService', () => {
   describe('tryResolve', () => {
     it('should return resolved=true with IDs when offer mapping exists', async () => {
       identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_1');
-      variantRepository.findById.mockResolvedValueOnce(makeVariant('ol_variant_1', 'ol_product_1'));
+      productsService.getVariant.mockResolvedValueOnce(makeVariant('ol_variant_1', 'ol_product_1'));
 
       const result = await service.tryResolve(connectionId, {
         type: 'offer',
@@ -147,7 +145,7 @@ describe('OrderItemRefResolverService', () => {
 
     it('should return resolved=false when variant lookup fails after offer mapping', async () => {
       identifierMapping.getInternalId.mockResolvedValueOnce('ol_variant_missing');
-      variantRepository.findById.mockResolvedValueOnce(null);
+      productsService.getVariant.mockResolvedValueOnce(null);
 
       const result = await service.tryResolve(connectionId, {
         type: 'offer',

--- a/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
+++ b/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
@@ -4,11 +4,11 @@
  * Resolves external-only IncomingOrder item references to internal OpenLinker IDs.
  *
  * @module libs/core/src/orders/application/services
+ * @see {@link IProductsService} for cross-context variant reads (#718)
  */
 import { Injectable, Inject } from '@nestjs/common';
 import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
-import { PRODUCT_VARIANT_REPOSITORY_TOKEN } from '@openlinker/core/products';
-import { ProductVariantRepositoryPort } from '@openlinker/core/products';
+import { IProductsService, PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
 import type { IncomingOrderItemRef } from '../../domain/types/incoming-order.types';
 import { MissingOrderItemMappingError } from '../../domain/exceptions/missing-order-item-mapping.error';
 import type {
@@ -23,8 +23,8 @@ export class OrderItemRefResolverService {
   constructor(
     @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
     private readonly identifierMapping: IIdentifierMappingService,
-    @Inject(PRODUCT_VARIANT_REPOSITORY_TOKEN)
-    private readonly variantRepository: ProductVariantRepositoryPort
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService
   ) {}
 
   async tryResolve(
@@ -60,7 +60,7 @@ export class OrderItemRefResolverService {
             'identifier_mappings:Offer'
           );
         }
-        const variant = await this.variantRepository.findById(internalVariantId);
+        const variant = await this.productsService.getVariant(internalVariantId);
         if (!variant) {
           throw new MissingOrderItemMappingError(
             connectionId,
@@ -98,7 +98,7 @@ export class OrderItemRefResolverService {
             'identifier_mappings:ProductVariant'
           );
         }
-        const variant = await this.variantRepository.findById(internalVariantId);
+        const variant = await this.productsService.getVariant(internalVariantId);
         if (!variant) {
           throw new MissingOrderItemMappingError(
             connectionId,
@@ -121,7 +121,7 @@ export class OrderItemRefResolverService {
             'identifier_mappings:Sku'
           );
         }
-        const variant = await this.variantRepository.findById(internalId);
+        const variant = await this.productsService.getVariant(internalId);
         if (variant) {
           return { internalProductId: variant.productId, internalVariantId: variant.id };
         }

--- a/libs/core/src/products/application/services/products.service.interface.ts
+++ b/libs/core/src/products/application/services/products.service.interface.ts
@@ -48,10 +48,37 @@ export interface IProductsService {
   getProduct(id: string): Promise<Product | null>;
 
   /**
+   * Batch product lookup by internal id. Missing ids are silently dropped
+   * (no null fillers) — caller maps results by `product.id` if presence
+   * matters. Empty input returns `[]` without a DB round-trip; consumers
+   * don't need a length guard before calling.
+   */
+  getProductsByIds(ids: string[]): Promise<Product[]>;
+
+  /**
    * Get a single product variant by internal ID. Returns null when no row
    * matches; the caller decides between 404 and a soft fallback.
    */
   getVariant(id: string): Promise<ProductVariant | null>;
+
+  /**
+   * Variant lookup by SKU list. Used by offer-mapping reconciliation flows
+   * to resolve marketplace external-refs / SKUs back to internal variants.
+   * Empty input returns `[]` without a DB round-trip.
+   */
+  getVariantsBySkus(skus: string[]): Promise<ProductVariant[]>;
+
+  /**
+   * Variant lookup by EAN or GTIN list, scoped to a master-catalog
+   * connection. The connection scope ensures variants on a different
+   * master tenant don't collide on the same barcode. Empty input returns
+   * `[]` without a DB round-trip.
+   */
+  getVariantsByBarcodes(
+    connectionId: string,
+    values: string[],
+    field: 'ean' | 'gtin'
+  ): Promise<ProductVariant[]>;
 
   /**
    * List products with optional filters and pagination

--- a/libs/core/src/products/application/services/products.service.spec.ts
+++ b/libs/core/src/products/application/services/products.service.spec.ts
@@ -49,6 +49,7 @@ describe('ProductsService', () => {
 
   const mockProductRepo: jest.Mocked<ProductRepositoryPort> = {
     findById: jest.fn(),
+    findByIds: jest.fn(),
     findMany: jest.fn(),
     upsert: jest.fn(),
   };
@@ -97,6 +98,67 @@ describe('ProductsService', () => {
       const result = await service.getProduct('nonexistent');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getProductsByIds', () => {
+    it('returns [] without hitting the repository for an empty input', async () => {
+      const result = await service.getProductsByIds([]);
+
+      expect(result).toEqual([]);
+      expect(productRepo.findByIds).not.toHaveBeenCalled();
+    });
+
+    it('forwards the id list to the repository and returns the result', async () => {
+      const products = [makeProduct(), makeProduct({ id: 'ol_product_2', name: 'Second' })];
+      productRepo.findByIds.mockResolvedValue(products);
+
+      const result = await service.getProductsByIds(['ol_product_1', 'ol_product_2']);
+
+      expect(result).toBe(products);
+      expect(productRepo.findByIds).toHaveBeenCalledWith(['ol_product_1', 'ol_product_2']);
+    });
+  });
+
+  describe('getVariantsBySkus', () => {
+    it('returns [] without hitting the repository for an empty input', async () => {
+      const result = await service.getVariantsBySkus([]);
+
+      expect(result).toEqual([]);
+      expect(variantRepo.findBySkuIn).not.toHaveBeenCalled();
+    });
+
+    it('forwards the sku list to the repository and returns the result', async () => {
+      const variants = [makeVariant()];
+      variantRepo.findBySkuIn.mockResolvedValue(variants);
+
+      const result = await service.getVariantsBySkus(['SKU-A', 'SKU-B']);
+
+      expect(result).toBe(variants);
+      expect(variantRepo.findBySkuIn).toHaveBeenCalledWith(['SKU-A', 'SKU-B']);
+    });
+  });
+
+  describe('getVariantsByBarcodes', () => {
+    it('returns [] without hitting the repository for an empty values input', async () => {
+      const result = await service.getVariantsByBarcodes('conn-1', [], 'ean');
+
+      expect(result).toEqual([]);
+      expect(variantRepo.findByEanOrGtinIn).not.toHaveBeenCalled();
+    });
+
+    it('forwards the (connectionId, values, field) triple to the repository', async () => {
+      const variants = [makeVariant()];
+      variantRepo.findByEanOrGtinIn.mockResolvedValue(variants);
+
+      const result = await service.getVariantsByBarcodes('conn-1', ['5901234567890'], 'ean');
+
+      expect(result).toBe(variants);
+      expect(variantRepo.findByEanOrGtinIn).toHaveBeenCalledWith(
+        'conn-1',
+        ['5901234567890'],
+        'ean'
+      );
     });
   });
 

--- a/libs/core/src/products/application/services/products.service.ts
+++ b/libs/core/src/products/application/services/products.service.ts
@@ -72,8 +72,27 @@ export class ProductsService implements IProductsService {
     return this.productRepository.findById(id);
   }
 
+  async getProductsByIds(ids: string[]): Promise<Product[]> {
+    if (ids.length === 0) return [];
+    return this.productRepository.findByIds(ids);
+  }
+
   async getVariant(id: string): Promise<ProductVariant | null> {
     return this.variantRepository.findById(id);
+  }
+
+  async getVariantsBySkus(skus: string[]): Promise<ProductVariant[]> {
+    if (skus.length === 0) return [];
+    return this.variantRepository.findBySkuIn(skus);
+  }
+
+  async getVariantsByBarcodes(
+    connectionId: string,
+    values: string[],
+    field: 'ean' | 'gtin'
+  ): Promise<ProductVariant[]> {
+    if (values.length === 0) return [];
+    return this.variantRepository.findByEanOrGtinIn(connectionId, values, field);
   }
 
   async listProducts(

--- a/libs/core/src/products/domain/ports/product-repository.port.ts
+++ b/libs/core/src/products/domain/ports/product-repository.port.ts
@@ -33,6 +33,19 @@ export interface ProductRepositoryPort {
   findById(id: string): Promise<Product | null>;
 
   /**
+   * Batch product lookup by internal-id list. Missing ids are silently
+   * dropped (no null fillers) — caller maps results by `product.id` if
+   * presence matters.
+   *
+   * Implementations MUST short-circuit on `ids.length === 0` and return
+   * `[]` without a storage round-trip. Consumers (incl. the in-memory
+   * fake adapter at `@openlinker/core/products/testing`, when added)
+   * rely on this contract; calling repositories with empty arrays is a
+   * legitimate code path through `IProductsService.getProductsByIds`.
+   */
+  findByIds(ids: string[]): Promise<Product[]>;
+
+  /**
    * Find products matching filters with offset pagination.
    * Results are ordered by createdAt DESC.
    */

--- a/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
@@ -15,7 +15,7 @@
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { ProductOrmEntity } from '../entities/product.orm-entity';
 import type { ProductRepositoryPort } from '../../../domain/ports/product-repository.port';
 import type { Product } from '../../../domain/entities/product.entity';
@@ -42,6 +42,14 @@ export class ProductRepository implements ProductRepositoryPort {
     }
 
     return this.toDomain(entity);
+  }
+
+  async findByIds(ids: string[]): Promise<Product[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+    const entities = await this.repository.find({ where: { id: In(ids) } });
+    return entities.map((entity) => this.toDomain(entity));
   }
 
   async findMany(

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -73,43 +73,8 @@ const VALID_EXTS = new Set(['.ts', '.tsx']);
  * together when #718 lands its corresponding PR.
  */
 const ALLOW_LIST = new Map([
-  // inventory → products.ProductRepositoryPort — rewire via IProductsService
-  [
-    'libs/core/src/inventory/application/services/inventory-query.service.ts',
-    new Set(['ProductRepositoryPort']),
-  ],
-  [
-    'libs/core/src/inventory/application/services/__tests__/inventory-query.service.spec.ts',
-    new Set(['ProductRepositoryPort']),
-  ],
-
-  // orders → products.ProductVariantRepositoryPort — rewire via IProductsService
-  [
-    'libs/core/src/orders/application/services/order-item-ref-resolver.service.ts',
-    new Set(['ProductVariantRepositoryPort']),
-  ],
-  [
-    'libs/core/src/orders/application/services/__tests__/order-item-ref-resolver.service.spec.ts',
-    new Set(['ProductVariantRepositoryPort']),
-  ],
-
-  // listings → products.ProductVariantRepositoryPort — rewire via IProductsService
-  [
-    'libs/core/src/listings/application/services/offer-mapping-sync.service.ts',
-    new Set(['ProductVariantRepositoryPort']),
-  ],
-  [
-    'libs/core/src/listings/application/services/__tests__/offer-mapping-sync.service.spec.ts',
-    new Set(['ProductVariantRepositoryPort']),
-  ],
-  [
-    'libs/core/src/listings/application/services/offer-builder.service.ts',
-    new Set(['ProductVariantRepositoryPort']),
-  ],
-  [
-    'libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts',
-    new Set(['ProductVariantRepositoryPort']),
-  ],
+  // (Slice 1 of #718 — products repository-port callers — rewired via
+  // IProductsService and dropped from this list. See PR for #718.)
 
   // listings → sync.SyncJobRepositoryPort — rewire via ISyncJobsService
   [


### PR DESCRIPTION
Slice 1 of 4 from #718. The other three slices (sync ports, listings.OfferMappingRepositoryPort, integrations.IntegrationCredentialRepositoryPort) follow in separate PRs.

This PR does **not** close #718. After merge, 8 of the 20 `(file, symbol)` allow-list entries in `scripts/check-cross-context-imports.mjs` are gone; 12 remain for the other slices.

## Summary

Drops the four cross-context value-imports of products-owned repository ports — `inventory-query`, `order-item-ref-resolver`, `offer-builder`, `offer-mapping-sync` — and routes them through `IProductsService` instead, per the cross-context coupling policy shipped by #713.

Pure DI-seam swap: no behaviour change, no migration, no security or contract impact.

## Changes inside the products context

- `ProductRepositoryPort.findByIds(ids)` — new batch method with a documented empty-input short-circuit contract for future port implementations (incl. the in-memory testing fake when it lands).
- `ProductRepository.findByIds` — one-line impl via TypeORM `In(ids)`.
- `IProductsService` extended with three pass-through methods:
  - `getProductsByIds(ids)` — wraps the new repo method.
  - `getVariantsBySkus(skus)` — wraps `findBySkuIn`.
  - `getVariantsByBarcodes(connectionId, values, field)` — wraps `findByEanOrGtinIn`.
  - The fourth call shape (single variant by id) already had `getVariant`; no rename needed.
- All three new service methods short-circuit at the service layer on empty input, so consumers drop their `length > 0 ?` guard ternaries.
- Naming follows the existing `get*` convention on `IProductsService`, not the repository-port `find*`.

## Consumer rewires

| File | Change |
|---|---|
| `inventory-query.service.ts` | `productRepository.findById` → `productsService.getProduct`; `buildProductMap`'s N-per-page loop replaced with a single `getProductsByIds(uniqueIds)` call — resolves the existing `// TODO` at line 63. |
| `order-item-ref-resolver.service.ts` | 3 `variantRepository.findById` call sites (offer / variant / sku branches) → `productsService.getVariant`. |
| `offer-builder.service.ts` | 1 `variantRepository.findById` → `productsService.getVariant`. |
| `offer-mapping-sync.service.ts` | `findBySkuIn` → `getVariantsBySkus`; both `findByEanOrGtinIn` → `getVariantsByBarcodes`. Consumer-side `length > 0` guards dropped (service short-circuits internally). |

## Per-spec mock surfaces

Each consumer spec uses `Pick<IProductsService, '...'>` to keep the mock scoped to the methods the SUT actually calls — protects against accidentally stubbing methods the consumer doesn't touch.

| Spec | Mock surface |
|---|---|
| `inventory-query.service.spec.ts` | `'getProduct' \| 'getProductsByIds'` |
| `order-item-ref-resolver.service.spec.ts` | `'getVariant'` |
| `offer-builder.service.spec.ts` | `'getVariant'` |
| `offer-mapping-sync.service.spec.ts` | `'getVariantsBySkus' \| 'getVariantsByBarcodes'` |

`products.service.spec.ts` gained 6 new test cases — empty-input + happy-path for each new method. `products.controller.spec.ts`'s full-surface `jest.Mocked<IProductsService>` mock added the three new method stubs.

## Allow-list cleanup

8 entries dropped from `scripts/check-cross-context-imports.mjs` (the three `products`-context rewire blocks at the top of the list). 12 entries remain for the three other #718 slices, grouped by target service interface in the script header for reference.

## Test plan

- [x] `pnpm lint` — 0 errors (only pre-existing warnings)
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 1,927 unit tests pass across 8 packages
- [x] `pnpm check:invariants` — green with 8 allow-list entries removed (188 cross-context imports / 475 files / 12 allow-listed entries remaining)
- [x] No migration; `pnpm --filter @openlinker/api migration:show` unchanged
- [ ] No manual smoke needed — DI-seam refactor, behaviour preserved verbatim

## Implementation plan

[`docs/plans/implementation-plan-718-products-repo-port-rewire.md`](./docs/plans/implementation-plan-718-products-repo-port-rewire.md) — full slice scope, design rationale, per-spec mock-surface table, and risks.

## Out of scope (separate PRs / issues)

- The other three #718 slices (sync ports, listings `OfferMappingRepositoryPort`, integrations credentials).
- `OrderItemRefResolverService` doesn't yet `implements I*Service` — pre-existing, tracked under #712 (broader service-interface coverage sweep). Out of scope here.
- Dropping the barrel exports of `ProductRepositoryPort` / `ProductVariantRepositoryPort` once all cross-context callers are gone. Intra-context callers (products' own services + repository) still need them; the lint script is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)