### PR TITLE
refactor(sync): rewire offer-status-poll + order-ingestion through ISyncJobsService / ISyncCursorsService (#718, slice 2 of 4)

### DIFF
--- a/docs/plans/implementation-plan-718-sync-repo-port-rewire.md
+++ b/docs/plans/implementation-plan-718-sync-repo-port-rewire.md
@@ -1,0 +1,358 @@
+# Implementation Plan — Rewire sync repository-port callers through ISyncJobsService / ISyncCursorsService (#718, slice 2 of 4)
+
+**Issue**: [#718 — Rewire cross-context repository-port couplings through service interfaces](https://github.com/SilkSoftwareHouse/openlinker/issues/718)
+**Slice**: 2 of 4 — sync-context callers.
+**Branch**: `718-sync-repo-port-rewire`
+**Drops**: 4 of the 12 remaining `(file, symbol)` entries from `scripts/check-cross-context-imports.mjs`.
+
+---
+
+## 0. Goal
+
+Eliminate two cross-context value-imports of sync-owned repository ports. After this PR:
+
+- `libs/core/src/listings/application/services/offer-status-poll.service.ts` no longer imports `SyncJobRepositoryPort` — it calls a new `ISyncJobsService` instead.
+- `libs/core/src/orders/application/services/order-ingestion.service.ts` no longer imports `ConnectionCursorRepositoryPort` — it calls a new `ISyncCursorsService` instead.
+- 4 entries (2 production + 2 spec) drop from the cross-context-imports allow-list.
+- `pnpm check:invariants` stays green with those 4 entries removed.
+
+**Non-goals** (deferred to a follow-up):
+
+- The apps/worker callers of the same two ports — `cursors.controller`, `allegro.controller`, `sync.controller`, `connection.controller`, `marketplace-offers-sync.handler`, `job-intake.consumer`, `sync-job.runner`, plus int-specs. Roughly 17 allow-list entries. These surfaced under #719's extended scope and are not part of #718's original 10-file audit. The new service interfaces this PR introduces are the right seam for them; that rewire is mechanical once the seam exists and belongs in a separate follow-up issue.
+- Slice 3 (`listings.OfferMappingRepositoryPort` callers, content → IListingsService).
+- Slice 4 (`integrations.IntegrationCredentialRepositoryPort` callers, ai → ICredentialsService).
+
+---
+
+## 1. Architecture mapping
+
+| Layer | What lands here |
+|---|---|
+| **CORE — Sync application** | Two new service interfaces (`ISyncJobsService`, `ISyncCursorsService`) + their concrete implementations (`SyncJobsService`, `SyncCursorsService`). Both proxy through to the existing repository ports. |
+| **CORE — Sync tokens** | Two new Symbol tokens (`SYNC_JOBS_SERVICE_TOKEN`, `SYNC_CURSORS_SERVICE_TOKEN`) in `libs/core/src/sync/sync.tokens.ts`. |
+| **CORE — Sync barrel** | `libs/core/src/sync/index.ts` re-exports the two interfaces. |
+| **CORE — Sync module** | `SyncModule` registers both services as `useExisting` bindings and exports their tokens. |
+| **CORE — Listings application** | `offer-status-poll.service.ts` injects `ISyncJobsService` instead of `SyncJobRepositoryPort`; the single call site swaps from `createIfNotExistsByIdempotencyKey` to a single service method. |
+| **CORE — Orders application** | `order-ingestion.service.ts` injects `ISyncCursorsService` instead of `ConnectionCursorRepositoryPort`; two call sites (`get` / `set`) swap to service methods. |
+| **Lint** | Drop 4 entries from the `ALLOW_LIST` in `scripts/check-cross-context-imports.mjs`. |
+
+**Why two services and not one umbrella `ISyncService`?**
+
+The two responsibilities are operationally distinct: scheduling jobs vs. tracking cursors. They share a context (sync) but no methods, no return types, no error vocabulary. A single umbrella would mix the two domains. Two narrow services keep the seam intentional and let consumers depend on only what they use. The issue body explicitly names both — `ISyncJobsService` and `ISyncCursorsService`.
+
+**Why not extend the existing `SyncJobQueuePort`?**
+
+The existing `SyncJobQueueService` (`sync-job-queue.service.ts:32`) explicitly throws on `delayMs > 0` — Redis Streams doesn't support delayed delivery. The `offer-status-poll` path uses `SyncJobRepositoryPort.createIfNotExistsByIdempotencyKey({...}, { runAfter })` precisely *because* the queue-port can't schedule into the future. That's a different mechanism (DB-backed `nextRunAt` + worker poll) from queue-port's stream-fanout model. Building a "scheduleDelayed" hook into `SyncJobQueuePort` would muddy that port's contract. A separate `ISyncJobsService` is the cleaner home.
+
+---
+
+## 2. New service: ISyncJobsService
+
+### 2.1 Types (separate file per Engineering Standards § "Type Definitions in Separate Files")
+
+`libs/core/src/sync/application/services/sync-jobs.types.ts`
+
+```ts
+import type { JobType } from '../../domain/types/sync-job.types';
+
+export interface ScheduleJobInput {
+  jobType: JobType;
+  connectionId: string;
+  payload: Record<string, unknown>;
+  /**
+   * Deterministic idempotency key. Two scheduling attempts with the same
+   * key produce one row; later attempts return the existing row.
+   */
+  idempotencyKey: string;
+  /** Max attempts the runner will give this job. */
+  maxAttempts?: number;
+  /** Earliest time the runner is allowed to pick up the job. */
+  runAfter: Date;
+}
+```
+
+### 2.2 Interface
+
+`libs/core/src/sync/application/services/sync-jobs.service.interface.ts`
+
+```ts
+import type { SyncJob } from '../../domain/entities/sync-job.entity';
+import type { ScheduleJobInput } from './sync-jobs.types';
+
+export interface ISyncJobsService {
+  /**
+   * Schedule a sync job with a required `runAfter`, idempotently.
+   *
+   * This path inserts the job directly via the sync-job repository
+   * rather than the Redis-stream queue, because the stream-based
+   * enqueue (`SyncJobQueuePort.enqueue`) does not deliver messages on
+   * a future timestamp. The worker's polling loop picks the job up
+   * when `nextRunAt <= now()`.
+   *
+   * Returns the persisted job — the freshly-created row, or the
+   * pre-existing row when the idempotency key has already been seen.
+   */
+  schedule(input: ScheduleJobInput): Promise<SyncJob>;
+}
+```
+
+Method name is `schedule`, not `scheduleDelayed`: every call through this method is delayed (`runAfter` is required), so the "Delayed" suffix would be redundant labelling. If a non-delayed variant is ever added it can be a new method on the same interface — the contract doesn't have to evolve to accommodate it.
+
+### 2.3 Implementation
+
+`libs/core/src/sync/application/services/sync-jobs.service.ts`
+
+```ts
+/**
+ * Sync Jobs Service
+ *
+ * Application-layer entry point for scheduling sync jobs from
+ * cross-context callers. The single method (`schedule`) bypasses the
+ * Redis-stream enqueue path on purpose — the stream backend does not
+ * support delayed delivery — and writes the job row directly through
+ * `SyncJobRepositoryPort`. The worker poller (`nextRunAt <= now()`)
+ * picks the row up at the requested time.
+ *
+ * @module libs/core/src/sync/application/services
+ * @implements {ISyncJobsService}
+ */
+@Injectable()
+export class SyncJobsService implements ISyncJobsService {
+  constructor(
+    @Inject(SYNC_JOB_REPOSITORY_TOKEN)
+    private readonly syncJobRepository: SyncJobRepositoryPort,
+  ) {}
+
+  async schedule(input: ScheduleJobInput): Promise<SyncJob> {
+    return this.syncJobRepository.createIfNotExistsByIdempotencyKey(
+      {
+        jobType: input.jobType,
+        connectionId: input.connectionId,
+        payload: input.payload,
+        idempotencyKey: input.idempotencyKey,
+        maxAttempts: input.maxAttempts,
+      },
+      { runAfter: input.runAfter },
+    );
+  }
+}
+```
+
+Pass-through with no extra logic — the service is the seam, not a place for new policy.
+
+---
+
+## 3. New service: ISyncCursorsService
+
+### 3.1 Interface
+
+`libs/core/src/sync/application/services/sync-cursors.service.interface.ts`
+
+```ts
+export interface ISyncCursorsService {
+  /**
+   * Read the current cursor value for a connection + cursor-key pair.
+   * Returns null when no row exists (treat as "from beginning").
+   */
+  getCursor(connectionId: string, cursorKey: string): Promise<string | null>;
+
+  /**
+   * Set the cursor for a connection + cursor-key pair to `value`.
+   * Creates the row if missing, updates otherwise. Idempotent and
+   * safe for concurrent advances (atomic upsert in the persistence
+   * layer).
+   *
+   * **Monotonicity is the caller's responsibility.** The underlying
+   * repository upserts unconditionally — it does NOT reject a value
+   * lower than the current one. Callers that need monotonic-only
+   * advancement must read with `getCursor` and apply the comparison
+   * themselves before calling this method.
+   */
+  advanceCursor(connectionId: string, cursorKey: string, value: string): Promise<void>;
+}
+```
+
+Method names use operational verbs (`getCursor` / `advanceCursor`) rather than mirroring the repository-port `get` / `set`. Per slice 1's convention: the service is the seam, names should describe intent at the seam level. The monotonicity note exists because `advanceCursor` reads as a guaranteed-monotonic operation, but the underlying `set` is a plain upsert; without the note a future caller might assume server-side enforcement that isn't there.
+
+### 3.2 Implementation
+
+`libs/core/src/sync/application/services/sync-cursors.service.ts`
+
+```ts
+@Injectable()
+export class SyncCursorsService implements ISyncCursorsService {
+  constructor(
+    @Inject(CONNECTION_CURSOR_REPOSITORY_TOKEN)
+    private readonly cursorRepository: ConnectionCursorRepositoryPort,
+  ) {}
+
+  async getCursor(connectionId: string, cursorKey: string): Promise<string | null> {
+    return this.cursorRepository.get(connectionId, cursorKey);
+  }
+
+  async advanceCursor(connectionId: string, cursorKey: string, value: string): Promise<void> {
+    await this.cursorRepository.set(connectionId, cursorKey, value);
+  }
+}
+```
+
+---
+
+## 4. Tokens, barrel, module
+
+### 4.1 `sync.tokens.ts`
+
+Add two Symbol tokens:
+
+```ts
+export const SYNC_JOBS_SERVICE_TOKEN = Symbol('ISyncJobsService');
+export const SYNC_CURSORS_SERVICE_TOKEN = Symbol('ISyncCursorsService');
+```
+
+### 4.2 `libs/core/src/sync/index.ts`
+
+Add re-exports for the two interfaces + the input type (tokens already re-exported via `export * from './sync.tokens'`):
+
+```ts
+export type { ISyncJobsService } from './application/services/sync-jobs.service.interface';
+export type { ScheduleJobInput } from './application/services/sync-jobs.types';
+export type { ISyncCursorsService } from './application/services/sync-cursors.service.interface';
+```
+
+### 4.3 `sync.module.ts`
+
+Register both concrete services + their token bindings, export the tokens:
+
+```ts
+providers: [
+  // ... existing
+  SyncJobsService,
+  { provide: SYNC_JOBS_SERVICE_TOKEN, useExisting: SyncJobsService },
+  SyncCursorsService,
+  { provide: SYNC_CURSORS_SERVICE_TOKEN, useExisting: SyncCursorsService },
+],
+exports: [
+  // ... existing
+  SYNC_JOBS_SERVICE_TOKEN,
+  SYNC_CURSORS_SERVICE_TOKEN,
+],
+```
+
+---
+
+## 5. Consumer rewires
+
+### 5.1 `offer-status-poll.service.ts`
+
+- Drop `SYNC_JOB_REPOSITORY_TOKEN` + `SyncJobRepositoryPort` imports.
+- Add `SYNC_JOBS_SERVICE_TOKEN` + `ISyncJobsService` imports.
+- Constructor: replace the `@Inject(SYNC_JOB_REPOSITORY_TOKEN) private readonly syncJobRepository: SyncJobRepositoryPort` binding with `@Inject(SYNC_JOBS_SERVICE_TOKEN) private readonly syncJobs: ISyncJobsService`.
+- Call-site: replace
+  ```ts
+  await this.syncJobRepository.createIfNotExistsByIdempotencyKey(
+    { jobType: POLL_JOB_TYPE, connectionId, payload, idempotencyKey, maxAttempts: RUNNER_RETRY_BUDGET },
+    { runAfter },
+  );
+  ```
+  with
+  ```ts
+  await this.syncJobs.schedule({
+    jobType: POLL_JOB_TYPE,
+    connectionId,
+    payload,
+    idempotencyKey,
+    maxAttempts: RUNNER_RETRY_BUDGET,
+    runAfter,
+  });
+  ```
+- File-header comment at line 13 (`Bypasses Redis Streams: enqueues directly via SyncJobRepositoryPort so we can set a future nextRunAt`) is now stale after the rewire — the consumer no longer touches the repository or the stream. Replace with a one-liner noting `ISyncJobsService` is the seam, with the bypass rationale moved to the service's own docblock (§2.3).
+- Update file-header `@see` (currently mentions `SyncJobRepositoryPort`) to reference `ISyncJobsService` for #718 consistency with slice 1.
+
+### 5.2 `order-ingestion.service.ts`
+
+- Drop `CONNECTION_CURSOR_REPOSITORY_TOKEN` + `ConnectionCursorRepositoryPort` imports.
+- Add `SYNC_CURSORS_SERVICE_TOKEN` + `ISyncCursorsService` imports.
+- Constructor: same swap.
+- Two call sites:
+  - `this.cursorRepository.get(connectionId, cursorKey)` → `this.syncCursors.getCursor(connectionId, cursorKey)`.
+  - `this.cursorRepository.set(connectionId, cursorKey, nextCursor)` → `this.syncCursors.advanceCursor(connectionId, cursorKey, nextCursor)`.
+- Update file-header `@see` if it references the repository port.
+
+---
+
+## 6. Spec rewires
+
+| Spec | `Pick<I*, …>` |
+|---|---|
+| `offer-status-poll.service.spec.ts` | `Pick<ISyncJobsService, 'schedule'>` |
+| `order-ingestion.service.spec.ts` | `Pick<ISyncCursorsService, 'getCursor' \| 'advanceCursor'>` |
+
+Each spec drops the repository-port mock + its `provide: *_REPOSITORY_TOKEN` binding and replaces with a service-token binding. Assertion verbs change: `expect(syncJobRepository.createIfNotExistsByIdempotencyKey)` → `expect(syncJobs.scheduleDelayed)`; `expect(cursorRepository.get/set)` → `expect(syncCursors.getCursor/advanceCursor)`.
+
+---
+
+## 7. New service unit tests
+
+`libs/core/src/sync/application/services/sync-jobs.service.spec.ts` — covers `scheduleDelayed` pass-through.
+
+`libs/core/src/sync/application/services/sync-cursors.service.spec.ts` — covers `getCursor` + `advanceCursor` pass-through.
+
+Both specs follow the slice-1 pattern: mock the underlying repository port, assert the service forwards exact args.
+
+---
+
+## 8. Allow-list cleanup
+
+Remove these four entries from `scripts/check-cross-context-imports.mjs`:
+
+```
+'libs/core/src/listings/application/services/offer-status-poll.service.ts'        → 'SyncJobRepositoryPort'
+'libs/core/src/listings/application/services/__tests__/offer-status-poll.service.spec.ts' → 'SyncJobRepositoryPort'
+'libs/core/src/orders/application/services/order-ingestion.service.ts'            → 'ConnectionCursorRepositoryPort'
+'libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts'     → 'ConnectionCursorRepositoryPort'
+```
+
+The apps/worker entries (17+ across sync.controller, allegro.controller, cursors.controller, connection.controller, marketplace-offers-sync.handler, job-intake.consumer, sync-job.runner, and int-specs) stay until a separate follow-up rewires them through `ISyncJobsService` / `ISyncCursorsService`.
+
+---
+
+## 9. Testing strategy
+
+| Layer | Test | What it asserts |
+|---|---|---|
+| Sync service | `sync-jobs.service.spec.ts` | `scheduleDelayed` forwards `(jobType, connectionId, payload, idempotencyKey, maxAttempts)` + `{ runAfter }` to the repository unchanged. |
+| Sync service | `sync-cursors.service.spec.ts` | `getCursor`/`advanceCursor` forward `(connectionId, cursorKey[, value])` to the repository unchanged. |
+| Listings consumer | `offer-status-poll.service.spec.ts` | `enqueuePoll` calls `syncJobs.scheduleDelayed` exactly once with the correct (payload, idempotencyKey, runAfter) triple. |
+| Orders consumer | `order-ingestion.service.spec.ts` | Existing assertions on cursor get/set move verbatim to `getCursor`/`advanceCursor`. |
+| Lint invariant | `pnpm check:invariants` | 4 allow-list entries removed; remaining entries still pass. |
+
+No behaviour change → no integration test needed.
+
+---
+
+## 10. Acceptance criteria (slice 2 of #718)
+
+- [ ] `offer-status-poll.service.ts` no longer imports `SyncJobRepositoryPort` or `SYNC_JOB_REPOSITORY_TOKEN`.
+- [ ] `order-ingestion.service.ts` no longer imports `ConnectionCursorRepositoryPort` or `CONNECTION_CURSOR_REPOSITORY_TOKEN`.
+- [ ] Both consumer specs mock the new service interfaces.
+- [ ] `ISyncJobsService` + `ISyncCursorsService` exist and are exported from `@openlinker/core/sync`.
+- [ ] Allow-list drops the 4 core entries listed in §8.
+- [ ] `pnpm check:invariants`, `pnpm lint`, `pnpm type-check`, `pnpm test` all green.
+
+---
+
+## 11. Risks & open questions
+
+- **Apps/worker scope**: chosen to defer (see §0). New service interfaces are the right seam for them; rewire is mechanical once this PR lands. **List the 17 deferred allow-list entries explicitly in the PR body's "Follow-ups" section**, so the work doesn't get lost to "we'll file it after merge" drift — the next reader of the allow-list (slice-3 or slice-4 author) sees the queued cleanup at the entry point rather than having to dig through git history. Filing a separate GitHub issue is optional; the PR-body checklist is the load-bearing seam.
+- **`SyncJob` return type leak**: `scheduleDelayed` returns `SyncJob` (the domain entity). `offer-status-poll`'s single caller ignores the return value (`await this.syncJobRepository.createIfNotExistsByIdempotencyKey(...)` — return is unused). Keeping the return for parity with the underlying repository method, but worth noting that the consumer doesn't read it. If this becomes the only caller, the service could narrow to `Promise<void>`. Defer the narrowing decision until a second caller emerges.
+- **`maxAttempts` optionality**: `ScheduleDelayedJobInput.maxAttempts` is optional in the input type to mirror the repository's existing optional field. The current `offer-status-poll` caller always passes `RUNNER_RETRY_BUDGET`. Optional in the contract for future-flexibility, not a current need.
+- **Module circulars**: `SyncModule` already exports its token surface; no new imports between `SyncModule` and consumer modules (`ListingsModule`, `OrdersModule`). Consumer modules already import `SyncModule` (they currently use `SYNC_JOB_REPOSITORY_TOKEN` / `CONNECTION_CURSOR_REPOSITORY_TOKEN`). Verify per-module during implementation.
+
+---
+
+## 12. Out-of-scope follow-ups
+
+- **Apps/worker sync-port rewire** (~17 allow-list entries) — file a new issue once this PR merges. Title: "Rewire apps + worker sync repository-port callers through ISyncJobsService / ISyncCursorsService (#718 follow-up)".
+- **Slice 3** — listings.OfferMappingRepositoryPort callers (content → IListingsService).
+- **Slice 4** — integrations.IntegrationCredentialRepositoryPort callers (ai → ICredentialsService).
+- **Barrel cleanup**: dropping `SyncJobRepositoryPort` and `ConnectionCursorRepositoryPort` from `@openlinker/core/sync`'s barrel once all cross-context callers (incl. apps/worker) are rewired. Intra-context users (the sync context itself) still need them; the lint script is the active gate.

--- a/libs/core/src/listings/application/services/__tests__/offer-status-poll.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-status-poll.service.spec.ts
@@ -14,7 +14,7 @@ import type { IIntegrationsService } from '@openlinker/core/integrations';
 import type { OfferManagerPort, OfferStatusReadResult } from '@openlinker/core/listings';
 import { OfferNotFoundOnMarketplaceException } from '@openlinker/core/listings';
 import type { PollOnceInput } from '../../types/offer-status-poll.types';
-import type { SyncJobRepositoryPort } from '@openlinker/core/sync';
+import type { ISyncJobsService } from '@openlinker/core/sync';
 
 import { OfferCreationRecord } from '../../../domain/entities/offer-creation-record.entity';
 import type { OfferCreationRecordRepositoryPort } from '../../../domain/ports/offer-creation-record-repository.port';
@@ -52,7 +52,9 @@ describe('OfferStatusPollService', () => {
   let service: OfferStatusPollService;
   let integrations: jest.Mocked<IIntegrationsService>;
   let records: jest.Mocked<OfferCreationRecordRepositoryPort>;
-  let syncJobs: jest.Mocked<SyncJobRepositoryPort>;
+  // Only the products-of-sync method the SUT actually calls — tight Pick<>
+  // mock surface per #718 review.
+  let syncJobs: jest.Mocked<Pick<ISyncJobsService, 'schedule'>>;
   let configService: jest.Mocked<ConfigService>;
 
   beforeEach(() => {
@@ -74,8 +76,8 @@ describe('OfferStatusPollService', () => {
     };
 
     syncJobs = {
-      createIfNotExistsByIdempotencyKey: jest.fn().mockResolvedValue({}),
-    } as unknown as jest.Mocked<SyncJobRepositoryPort>;
+      schedule: jest.fn().mockResolvedValue({}),
+    };
 
     configService = {
       get: jest.fn().mockImplementation((key: string) => {
@@ -94,7 +96,12 @@ describe('OfferStatusPollService', () => {
       }),
     } as unknown as jest.Mocked<ConfigService>;
 
-    service = new OfferStatusPollService(integrations, records, syncJobs, configService);
+    service = new OfferStatusPollService(
+      integrations,
+      records,
+      syncJobs as unknown as ISyncJobsService,
+      configService
+    );
   });
 
   describe('scheduleFirstPoll', () => {
@@ -107,22 +114,21 @@ describe('OfferStatusPollService', () => {
         connectionId: CONNECTION_ID,
       });
 
-      const call = syncJobs.createIfNotExistsByIdempotencyKey.mock.calls[0];
-      const [job, options] = call;
-      expect(job).toMatchObject({
+      const [input] = syncJobs.schedule.mock.calls[0];
+      expect(input).toMatchObject({
         jobType: 'marketplace.offer.pollCreationStatus',
         connectionId: CONNECTION_ID,
         idempotencyKey: `pollCreationStatus:${RECORD_ID}:1`,
         maxAttempts: 3,
       });
-      expect(job.payload).toEqual({
+      expect(input.payload).toEqual({
         schemaVersion: 1,
         offerCreationRecordId: RECORD_ID,
         externalOfferId: EXTERNAL_OFFER_ID,
         pollAttempt: 1,
       });
-      expect(options?.runAfter).toBeInstanceOf(Date);
-      const delayMs = (options!.runAfter as Date).getTime() - before;
+      expect(input.runAfter).toBeInstanceOf(Date);
+      const delayMs = input.runAfter.getTime() - before;
       // Initial delay = 5s; allow some slack for test scheduling.
       expect(delayMs).toBeGreaterThanOrEqual(4_900);
       expect(delayMs).toBeLessThanOrEqual(5_500);
@@ -148,7 +154,7 @@ describe('OfferStatusPollService', () => {
 
       expect(result.outcome).toBe('ok');
       expect(records.updateStatus).toHaveBeenCalledWith(RECORD_ID, 'active', null);
-      expect(syncJobs.createIfNotExistsByIdempotencyKey).not.toHaveBeenCalled();
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
     });
 
     it('ACTIVATING → no record write, re-enqueues iteration 2 with backoff', async () => {
@@ -161,11 +167,11 @@ describe('OfferStatusPollService', () => {
 
       expect(result.outcome).toBe('ok');
       expect(records.updateStatus).not.toHaveBeenCalled();
-      const [job, options] = syncJobs.createIfNotExistsByIdempotencyKey.mock.calls[0];
-      expect(job.idempotencyKey).toBe(`pollCreationStatus:${RECORD_ID}:2`);
-      expect((job.payload as { pollAttempt: number }).pollAttempt).toBe(2);
+      const [input] = syncJobs.schedule.mock.calls[0];
+      expect(input.idempotencyKey).toBe(`pollCreationStatus:${RECORD_ID}:2`);
+      expect((input.payload as { pollAttempt: number }).pollAttempt).toBe(2);
       // Iteration 2 delay = 5 * 2 = 10s
-      const delayMs = (options!.runAfter as Date).getTime() - before;
+      const delayMs = input.runAfter.getTime() - before;
       expect(delayMs).toBeGreaterThanOrEqual(9_500);
       expect(delayMs).toBeLessThanOrEqual(10_500);
     });
@@ -179,7 +185,7 @@ describe('OfferStatusPollService', () => {
 
       expect(result.outcome).toBe('ok');
       expect(records.updateStatus).not.toHaveBeenCalled();
-      expect(syncJobs.createIfNotExistsByIdempotencyKey).toHaveBeenCalledTimes(1);
+      expect(syncJobs.schedule).toHaveBeenCalledTimes(1);
     });
 
     it('INACTIVE without errors → record.status=draft, outcome=ok', async () => {
@@ -191,7 +197,7 @@ describe('OfferStatusPollService', () => {
 
       expect(result.outcome).toBe('ok');
       expect(records.updateStatus).toHaveBeenCalledWith(RECORD_ID, 'draft', null);
-      expect(syncJobs.createIfNotExistsByIdempotencyKey).not.toHaveBeenCalled();
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
     });
 
     it('INACTIVE with errors → record.status=failed (with errors), outcome=business_failure', async () => {
@@ -215,7 +221,7 @@ describe('OfferStatusPollService', () => {
         { code: 'TOO_LONG', message: 'name is too long', field: 'name' },
         { code: 'MISSING', message: 'EAN required', field: undefined },
       ]);
-      expect(syncJobs.createIfNotExistsByIdempotencyKey).not.toHaveBeenCalled();
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
     });
 
     it('ENDED → record.status=draft, outcome=ok', async () => {
@@ -302,7 +308,7 @@ describe('OfferStatusPollService', () => {
       expect(result.outcome).toBe('ok');
       expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
       expect(records.updateStatus).not.toHaveBeenCalled();
-      expect(syncJobs.createIfNotExistsByIdempotencyKey).not.toHaveBeenCalled();
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
     });
 
     it('record vanished → drops gracefully + outcome=ok', async () => {
@@ -328,7 +334,7 @@ describe('OfferStatusPollService', () => {
       expect(recordId).toBe(RECORD_ID);
       expect(status).toBe('failed');
       expect(errors?.[0]).toMatchObject({ code: 'POLL_TIMEOUT' });
-      expect(syncJobs.createIfNotExistsByIdempotencyKey).not.toHaveBeenCalled();
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
     });
 
     it('pollAttempt > maxAttempts on entry (forward guard) → POLL_TIMEOUT, no marketplace call', async () => {
@@ -354,8 +360,8 @@ describe('OfferStatusPollService', () => {
 
       await service.pollOnce(pollInput(5));
 
-      const [, options] = syncJobs.createIfNotExistsByIdempotencyKey.mock.calls[0];
-      const delayMs = (options!.runAfter as Date).getTime() - before;
+      const [input] = syncJobs.schedule.mock.calls[0];
+      const delayMs = input.runAfter.getTime() - before;
       // Iteration 6 delay = min(5 * 2^5, 60) = min(160, 60) = 60s
       expect(delayMs).toBeGreaterThanOrEqual(59_500);
       expect(delayMs).toBeLessThanOrEqual(60_500);

--- a/libs/core/src/listings/application/services/offer-status-poll.service.ts
+++ b/libs/core/src/listings/application/services/offer-status-poll.service.ts
@@ -10,12 +10,13 @@
  *   - `sync_jobs.attempts` (runner-owned): transient HTTP retry per iteration,
  *     capped at `RUNNER_RETRY_BUDGET` per row (=3 — absorbs 1–2 blips).
  *
- * Bypasses Redis Streams: enqueues directly via `SyncJobRepositoryPort` so we
- * can set a future `nextRunAt`. The poll job is internal-orchestration only;
- * fan-out semantics aren't needed.
+ * Schedules via `ISyncJobsService` (#718) — see its docblock for the
+ * Redis-stream bypass rationale (queue path doesn't support delayed
+ * delivery, so the poll job goes through the DB-backed `nextRunAt`).
  *
  * @module libs/core/src/listings/application/services
  * @implements {IOfferStatusPollService}
+ * @see {@link ISyncJobsService} for the cross-context scheduling seam (#718)
  */
 
 import { Inject, Injectable } from '@nestjs/common';
@@ -31,9 +32,9 @@ import {
   type OfferStatusReadResult,
 } from '@openlinker/core/listings';
 import {
+  ISyncJobsService,
   type MarketplaceOfferPollCreationStatusPayloadV1,
-  SYNC_JOB_REPOSITORY_TOKEN,
-  type SyncJobRepositoryPort,
+  SYNC_JOBS_SERVICE_TOKEN,
 } from '@openlinker/core/sync';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -70,8 +71,8 @@ export class OfferStatusPollService implements IOfferStatusPollService {
     private readonly integrationsService: IIntegrationsService,
     @Inject(OFFER_CREATION_RECORD_REPOSITORY_TOKEN)
     private readonly offerCreationRecords: OfferCreationRecordRepositoryPort,
-    @Inject(SYNC_JOB_REPOSITORY_TOKEN)
-    private readonly syncJobRepository: SyncJobRepositoryPort,
+    @Inject(SYNC_JOBS_SERVICE_TOKEN)
+    private readonly syncJobs: ISyncJobsService,
     configService: ConfigService
   ) {
     this.cadence = {
@@ -244,16 +245,14 @@ export class OfferStatusPollService implements IOfferStatusPollService {
     };
     const idempotencyKey = `pollCreationStatus:${input.offerCreationRecordId}:${input.pollAttempt}`;
 
-    await this.syncJobRepository.createIfNotExistsByIdempotencyKey(
-      {
-        jobType: POLL_JOB_TYPE,
-        connectionId: input.connectionId,
-        payload: payload as unknown as Record<string, unknown>,
-        idempotencyKey,
-        maxAttempts: RUNNER_RETRY_BUDGET,
-      },
-      { runAfter }
-    );
+    await this.syncJobs.schedule({
+      jobType: POLL_JOB_TYPE,
+      connectionId: input.connectionId,
+      payload: payload as unknown as Record<string, unknown>,
+      idempotencyKey,
+      maxAttempts: RUNNER_RETRY_BUDGET,
+      runAfter,
+    });
 
     this.logger.debug(
       `Scheduled poll iteration ${input.pollAttempt} for record ${input.offerCreationRecordId} ` +

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -10,7 +10,7 @@ import { OrderIngestionService } from '../order-ingestion.service';
 import type { IIntegrationsService } from '@openlinker/core/integrations';
 import type { OrderSourcePort } from '@openlinker/core/orders';
 import type {
-  ConnectionCursorRepositoryPort,
+  ISyncCursorsService,
   SyncJobQueuePort,
   SyncLockPort,
 } from '@openlinker/core/sync';
@@ -28,7 +28,9 @@ describe('OrderIngestionService', () => {
   let service: OrderIngestionService;
 
   let integrationsService: jest.Mocked<IIntegrationsService>;
-  let cursorRepository: jest.Mocked<ConnectionCursorRepositoryPort>;
+  // Only the two methods the SUT actually calls — tight Pick<> mock surface
+  // per #718 review.
+  let syncCursors: jest.Mocked<Pick<ISyncCursorsService, 'getCursor' | 'advanceCursor'>>;
   let jobQueue: jest.Mocked<SyncJobQueuePort>;
   let lock: jest.Mocked<SyncLockPort>;
   let identifierMapping: jest.Mocked<IIdentifierMappingService>;
@@ -55,11 +57,10 @@ describe('OrderIngestionService', () => {
       listCapabilityAdapters: jest.fn(),
     } as unknown as jest.Mocked<IIntegrationsService>;
 
-    cursorRepository = {
-      get: jest.fn(),
-      set: jest.fn(),
-      delete: jest.fn(),
-    } as unknown as jest.Mocked<ConnectionCursorRepositoryPort>;
+    syncCursors = {
+      getCursor: jest.fn(),
+      advanceCursor: jest.fn(),
+    };
 
     jobQueue = {
       enqueue: jest.fn(),
@@ -110,7 +111,7 @@ describe('OrderIngestionService', () => {
 
     service = new OrderIngestionService(
       integrationsService,
-      cursorRepository,
+      syncCursors as unknown as ISyncCursorsService,
       jobQueue,
       lock,
       identifierMapping,
@@ -129,16 +130,16 @@ describe('OrderIngestionService', () => {
       const result = await service.ingestOrders(connectionId, { cursorKey, limit: 10 });
 
       expect(result.skippedDueToLock).toBe(true);
-      expect(cursorRepository.get).not.toHaveBeenCalled();
+      expect(syncCursors.getCursor).not.toHaveBeenCalled();
       expect(jobQueue.enqueueBulk).not.toHaveBeenCalled();
-      expect(cursorRepository.set).not.toHaveBeenCalled();
+      expect(syncCursors.advanceCursor).not.toHaveBeenCalled();
     });
 
     it('commits cursor only after enqueueBulk succeeds', async () => {
       lock.acquire.mockResolvedValueOnce('token-1');
       lock.release.mockResolvedValueOnce(true);
 
-      cursorRepository.get.mockResolvedValueOnce('event-100');
+      syncCursors.getCursor.mockResolvedValueOnce('event-100');
       orderSource.listOrderFeed.mockResolvedValueOnce({
         items: [
           {
@@ -156,7 +157,7 @@ describe('OrderIngestionService', () => {
       const result = await service.ingestOrders(connectionId, { cursorKey, limit: 10 });
 
       expect(result.committed).toBe(true);
-      expect(cursorRepository.set).toHaveBeenCalledWith(connectionId, cursorKey, 'event-101');
+      expect(syncCursors.advanceCursor).toHaveBeenCalledWith(connectionId, cursorKey, 'event-101');
       expect(jobQueue.enqueueBulk).toHaveBeenCalledWith([
         expect.objectContaining({
           type: 'marketplace.order.sync',
@@ -174,7 +175,7 @@ describe('OrderIngestionService', () => {
       lock.acquire.mockResolvedValueOnce('token-1');
       lock.release.mockResolvedValueOnce(true);
 
-      cursorRepository.get.mockResolvedValueOnce('event-100');
+      syncCursors.getCursor.mockResolvedValueOnce('event-100');
       orderSource.listOrderFeed.mockResolvedValueOnce({
         items: [
           {
@@ -193,14 +194,14 @@ describe('OrderIngestionService', () => {
         'enqueue failed'
       );
 
-      expect(cursorRepository.set).not.toHaveBeenCalled();
+      expect(syncCursors.advanceCursor).not.toHaveBeenCalled();
     });
 
     it('does not commit cursor when adapter returns a regressing cursor', async () => {
       lock.acquire.mockResolvedValueOnce('token-1');
       lock.release.mockResolvedValueOnce(true);
 
-      cursorRepository.get.mockResolvedValueOnce('200');
+      syncCursors.getCursor.mockResolvedValueOnce('200');
       orderSource.listOrderFeed.mockResolvedValueOnce({
         items: [
           {
@@ -218,7 +219,7 @@ describe('OrderIngestionService', () => {
       const result = await service.ingestOrders(connectionId, { cursorKey, limit: 10 });
 
       expect(result.committed).toBe(false);
-      expect(cursorRepository.set).not.toHaveBeenCalled();
+      expect(syncCursors.advanceCursor).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -10,14 +10,15 @@
  * - Hydration of full order via OrderSourcePort and routing via OrderSyncService
  *
  * @module libs/core/src/orders/application/services
+ * @see {@link ISyncCursorsService} for the cross-context cursor seam (#718)
  */
 
 import { Injectable, Inject } from '@nestjs/common';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type { OrderSourcePort } from '@openlinker/core/orders';
 import {
-  ConnectionCursorRepositoryPort,
-  CONNECTION_CURSOR_REPOSITORY_TOKEN,
+  ISyncCursorsService,
+  SYNC_CURSORS_SERVICE_TOKEN,
   SyncJobQueuePort,
   SYNC_JOB_QUEUE_TOKEN,
   SyncLockPort,
@@ -54,8 +55,8 @@ export class OrderIngestionService implements IOrderIngestionService {
   constructor(
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrationsService: IIntegrationsService,
-    @Inject(CONNECTION_CURSOR_REPOSITORY_TOKEN)
-    private readonly cursorRepository: ConnectionCursorRepositoryPort,
+    @Inject(SYNC_CURSORS_SERVICE_TOKEN)
+    private readonly syncCursors: ISyncCursorsService,
     @Inject(SYNC_JOB_QUEUE_TOKEN)
     private readonly jobQueue: SyncJobQueuePort,
     @Inject(SYNC_LOCK_TOKEN)
@@ -92,7 +93,7 @@ export class OrderIngestionService implements IOrderIngestionService {
 
     try {
       const { cursorKey, limit, eventTypes } = options;
-      const fromCursor = await this.cursorRepository.get(connectionId, cursorKey);
+      const fromCursor = await this.syncCursors.getCursor(connectionId, cursorKey);
 
       const orderSource = await this.integrationsService.getCapabilityAdapter<OrderSourcePort>(
         connectionId,
@@ -142,7 +143,7 @@ export class OrderIngestionService implements IOrderIngestionService {
             skippedDueToLock: false,
           };
         }
-        await this.cursorRepository.set(connectionId, cursorKey, nextCursor);
+        await this.syncCursors.advanceCursor(connectionId, cursorKey, nextCursor);
         committed = true;
       }
 

--- a/libs/core/src/sync/application/services/sync-cursors.service.interface.ts
+++ b/libs/core/src/sync/application/services/sync-cursors.service.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Sync Cursors Service Interface
+ *
+ * Cross-context application surface for reading and advancing
+ * connection-scoped sync cursors (#718). Wraps the persistence-layer
+ * `ConnectionCursorRepositoryPort` so consumers don't reach across
+ * context boundaries to a repository port.
+ *
+ * @module libs/core/src/sync/application/services
+ * @see {@link SyncCursorsService} for the implementation
+ */
+
+export interface ISyncCursorsService {
+  /**
+   * Read the current cursor value for a connection + cursor-key pair.
+   * Returns null when no row exists (treat as "from beginning").
+   */
+  getCursor(connectionId: string, cursorKey: string): Promise<string | null>;
+
+  /**
+   * Set the cursor for a connection + cursor-key pair to `value`.
+   * Creates the row if missing, updates otherwise. Idempotent and
+   * safe for concurrent advances (atomic upsert in the persistence
+   * layer).
+   *
+   * **Monotonicity is the caller's responsibility.** The underlying
+   * repository upserts unconditionally — it does NOT reject a value
+   * lower than the current one. Callers that need monotonic-only
+   * advancement must read with `getCursor` and apply the comparison
+   * themselves before calling this method.
+   */
+  advanceCursor(connectionId: string, cursorKey: string, value: string): Promise<void>;
+}

--- a/libs/core/src/sync/application/services/sync-cursors.service.spec.ts
+++ b/libs/core/src/sync/application/services/sync-cursors.service.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Sync Cursors Service Unit Tests
+ *
+ * Pass-through assertions for `getCursor` / `advanceCursor` — verifies
+ * the service forwards `(connectionId, cursorKey[, value])` to the
+ * underlying repository unchanged.
+ *
+ * @module libs/core/src/sync/application/services
+ */
+import { SyncCursorsService } from './sync-cursors.service';
+import type { ConnectionCursorRepositoryPort } from '../../domain/ports/connection-cursor-repository.port';
+
+describe('SyncCursorsService', () => {
+  let repository: jest.Mocked<Pick<ConnectionCursorRepositoryPort, 'get' | 'set'>>;
+  let service: SyncCursorsService;
+
+  beforeEach(() => {
+    repository = {
+      get: jest.fn(),
+      set: jest.fn(),
+    };
+    service = new SyncCursorsService(repository as unknown as ConnectionCursorRepositoryPort);
+  });
+
+  describe('getCursor', () => {
+    it('forwards (connectionId, cursorKey) to the repository and returns the value', async () => {
+      repository.get.mockResolvedValue('cursor-42');
+
+      const result = await service.getCursor('conn-1', 'allegro.orders.lastEventId');
+
+      expect(result).toBe('cursor-42');
+      expect(repository.get).toHaveBeenCalledWith('conn-1', 'allegro.orders.lastEventId');
+    });
+
+    it('returns null when the repository has no row for the pair', async () => {
+      repository.get.mockResolvedValue(null);
+
+      const result = await service.getCursor('conn-1', 'missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('advanceCursor', () => {
+    it('forwards (connectionId, cursorKey, value) to repository.set', async () => {
+      repository.set.mockResolvedValue(undefined);
+
+      await service.advanceCursor('conn-1', 'allegro.orders.lastEventId', 'cursor-99');
+
+      expect(repository.set).toHaveBeenCalledWith(
+        'conn-1',
+        'allegro.orders.lastEventId',
+        'cursor-99'
+      );
+    });
+  });
+});

--- a/libs/core/src/sync/application/services/sync-cursors.service.ts
+++ b/libs/core/src/sync/application/services/sync-cursors.service.ts
@@ -1,0 +1,37 @@
+/**
+ * Sync Cursors Service
+ *
+ * Application-layer entry point for cursor reads/writes from
+ * cross-context callers (#718). Thin pass-through over
+ * `ConnectionCursorRepositoryPort` — the service is the seam, not a
+ * place for new policy. Monotonicity is the caller's responsibility
+ * (see interface docstring).
+ *
+ * @module libs/core/src/sync/application/services
+ * @implements {ISyncCursorsService}
+ * @see {@link ISyncCursorsService} for the contract
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { CONNECTION_CURSOR_REPOSITORY_TOKEN } from '../../sync.tokens';
+import { ConnectionCursorRepositoryPort } from '../../domain/ports/connection-cursor-repository.port';
+import type { ISyncCursorsService } from './sync-cursors.service.interface';
+
+@Injectable()
+export class SyncCursorsService implements ISyncCursorsService {
+  constructor(
+    @Inject(CONNECTION_CURSOR_REPOSITORY_TOKEN)
+    private readonly cursorRepository: ConnectionCursorRepositoryPort
+  ) {}
+
+  async getCursor(connectionId: string, cursorKey: string): Promise<string | null> {
+    return this.cursorRepository.get(connectionId, cursorKey);
+  }
+
+  async advanceCursor(
+    connectionId: string,
+    cursorKey: string,
+    value: string
+  ): Promise<void> {
+    await this.cursorRepository.set(connectionId, cursorKey, value);
+  }
+}

--- a/libs/core/src/sync/application/services/sync-jobs.service.interface.ts
+++ b/libs/core/src/sync/application/services/sync-jobs.service.interface.ts
@@ -1,0 +1,31 @@
+/**
+ * Sync Jobs Service Interface
+ *
+ * Cross-context application surface for scheduling sync jobs. The
+ * single method (`schedule`) bypasses the Redis-stream queue path
+ * on purpose — the stream backend does not support delayed delivery —
+ * and writes the job row directly through `SyncJobRepositoryPort`.
+ * The worker's polling loop (`nextRunAt <= now()`) picks the row up
+ * at the requested time.
+ *
+ * @module libs/core/src/sync/application/services
+ * @see {@link SyncJobsService} for the implementation
+ */
+import type { SyncJob } from '../../domain/entities/sync-job.entity';
+import type { ScheduleJobInput } from './sync-jobs.types';
+
+export interface ISyncJobsService {
+  /**
+   * Schedule a sync job with a required `runAfter`, idempotently.
+   *
+   * This path inserts the job directly via the sync-job repository
+   * rather than the Redis-stream queue, because the stream-based
+   * enqueue (`SyncJobQueuePort.enqueue`) does not deliver messages
+   * on a future timestamp. The worker's polling loop picks the job
+   * up when `nextRunAt <= now()`.
+   *
+   * Returns the persisted job — the freshly-created row, or the
+   * pre-existing row when the idempotency key has already been seen.
+   */
+  schedule(input: ScheduleJobInput): Promise<SyncJob>;
+}

--- a/libs/core/src/sync/application/services/sync-jobs.service.spec.ts
+++ b/libs/core/src/sync/application/services/sync-jobs.service.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Sync Jobs Service Unit Tests
+ *
+ * Pass-through assertions for `schedule` — verifies the service forwards
+ * `(jobType, connectionId, payload, idempotencyKey, maxAttempts)` and
+ * `{ runAfter }` to `SyncJobRepositoryPort.createIfNotExistsByIdempotencyKey`
+ * unchanged.
+ *
+ * @module libs/core/src/sync/application/services
+ */
+import { SyncJobsService } from './sync-jobs.service';
+import type { SyncJobRepositoryPort } from '../../domain/ports/sync-job-repository.port';
+import type { SyncJob } from '../../domain/entities/sync-job.entity';
+import type { ScheduleJobInput } from './sync-jobs.types';
+
+describe('SyncJobsService', () => {
+  let repository: jest.Mocked<Pick<SyncJobRepositoryPort, 'createIfNotExistsByIdempotencyKey'>>;
+  let service: SyncJobsService;
+
+  beforeEach(() => {
+    repository = {
+      createIfNotExistsByIdempotencyKey: jest.fn(),
+    };
+    service = new SyncJobsService(repository as unknown as SyncJobRepositoryPort);
+  });
+
+  describe('schedule', () => {
+    it('forwards (input fields, runAfter) to createIfNotExistsByIdempotencyKey', async () => {
+      const runAfter = new Date('2026-06-01T00:00:00.000Z');
+      const input: ScheduleJobInput = {
+        jobType: 'marketplace.offer.pollCreationStatus',
+        connectionId: 'conn-1',
+        payload: { foo: 'bar' },
+        idempotencyKey: 'pollCreationStatus:rec-1:1',
+        maxAttempts: 3,
+        runAfter,
+      };
+      const persisted = { id: 'job-1' } as SyncJob;
+      repository.createIfNotExistsByIdempotencyKey.mockResolvedValue(persisted);
+
+      const result = await service.schedule(input);
+
+      expect(result).toBe(persisted);
+      expect(repository.createIfNotExistsByIdempotencyKey).toHaveBeenCalledTimes(1);
+      expect(repository.createIfNotExistsByIdempotencyKey).toHaveBeenCalledWith(
+        {
+          jobType: input.jobType,
+          connectionId: input.connectionId,
+          payload: input.payload,
+          idempotencyKey: input.idempotencyKey,
+          maxAttempts: input.maxAttempts,
+        },
+        { runAfter }
+      );
+    });
+
+    it('forwards a different maxAttempts value verbatim', async () => {
+      const runAfter = new Date('2026-06-01T00:00:00.000Z');
+      repository.createIfNotExistsByIdempotencyKey.mockResolvedValue({ id: 'job-x' } as SyncJob);
+
+      await service.schedule({
+        jobType: 'marketplace.offer.pollCreationStatus',
+        connectionId: 'conn-1',
+        payload: {},
+        idempotencyKey: 'key',
+        maxAttempts: 7,
+        runAfter,
+      });
+
+      const [arg0] = repository.createIfNotExistsByIdempotencyKey.mock.calls[0];
+      expect(arg0.maxAttempts).toBe(7);
+    });
+  });
+});

--- a/libs/core/src/sync/application/services/sync-jobs.service.ts
+++ b/libs/core/src/sync/application/services/sync-jobs.service.ts
@@ -1,0 +1,43 @@
+/**
+ * Sync Jobs Service
+ *
+ * Application-layer entry point for scheduling sync jobs from
+ * cross-context callers (#718). The single method (`schedule`)
+ * bypasses the Redis-stream enqueue path on purpose — the stream
+ * backend does not support delayed delivery — and writes the job row
+ * directly through `SyncJobRepositoryPort`. The worker poller
+ * (`nextRunAt <= now()`) picks the row up at the requested time.
+ *
+ * @module libs/core/src/sync/application/services
+ * @implements {ISyncJobsService}
+ * @see {@link ISyncJobsService} for the contract
+ * @see {@link SyncJobRepositoryPort} for the persistence port this
+ *   service wraps
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { SYNC_JOB_REPOSITORY_TOKEN } from '../../sync.tokens';
+import { SyncJobRepositoryPort } from '../../domain/ports/sync-job-repository.port';
+import type { SyncJob } from '../../domain/entities/sync-job.entity';
+import type { ISyncJobsService } from './sync-jobs.service.interface';
+import type { ScheduleJobInput } from './sync-jobs.types';
+
+@Injectable()
+export class SyncJobsService implements ISyncJobsService {
+  constructor(
+    @Inject(SYNC_JOB_REPOSITORY_TOKEN)
+    private readonly syncJobRepository: SyncJobRepositoryPort
+  ) {}
+
+  async schedule(input: ScheduleJobInput): Promise<SyncJob> {
+    return this.syncJobRepository.createIfNotExistsByIdempotencyKey(
+      {
+        jobType: input.jobType,
+        connectionId: input.connectionId,
+        payload: input.payload,
+        idempotencyKey: input.idempotencyKey,
+        maxAttempts: input.maxAttempts,
+      },
+      { runAfter: input.runAfter }
+    );
+  }
+}

--- a/libs/core/src/sync/application/services/sync-jobs.types.ts
+++ b/libs/core/src/sync/application/services/sync-jobs.types.ts
@@ -1,0 +1,25 @@
+/**
+ * Sync Jobs Service Types
+ *
+ * Input shapes for the cross-context sync-jobs service surface (#718).
+ * Kept in a separate file from the interface per Engineering Standards
+ * § "Type Definitions in Separate Files".
+ *
+ * @module libs/core/src/sync/application/services
+ */
+import type { JobType } from '../../domain/types/sync-job.types';
+
+export interface ScheduleJobInput {
+  jobType: JobType;
+  connectionId: string;
+  payload: Record<string, unknown>;
+  /**
+   * Deterministic idempotency key. Two scheduling attempts with the
+   * same key produce one row; later attempts return the existing row.
+   */
+  idempotencyKey: string;
+  /** Max attempts the runner will give this job. */
+  maxAttempts: number;
+  /** Earliest time the runner is allowed to pick up the job. */
+  runAfter: Date;
+}

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -89,6 +89,9 @@ export type { SchedulerTaskConfig } from './domain/types/scheduler-task.types';
 // Application Services (interfaces)
 export type { ISyncJobRetryService } from './application/services/sync-job-retry.service.interface';
 export type { ISyncJobBulkRetryService } from './application/services/sync-job-bulk-retry.service.interface';
+export type { ISyncJobsService } from './application/services/sync-jobs.service.interface';
+export type { ScheduleJobInput } from './application/services/sync-jobs.types';
+export type { ISyncCursorsService } from './application/services/sync-cursors.service.interface';
 
 // Module and tokens
 export { SyncModule } from './sync.module';

--- a/libs/core/src/sync/sync.module.ts
+++ b/libs/core/src/sync/sync.module.ts
@@ -21,6 +21,8 @@ import { SyncJobQueueService } from './application/services/sync-job-queue.servi
 import { RedisSyncLockService } from './application/services/redis-sync-lock.service';
 import { SyncJobRetryService } from './application/services/sync-job-retry.service';
 import { SyncJobBulkRetryService } from './application/services/sync-job-bulk-retry.service';
+import { SyncJobsService } from './application/services/sync-jobs.service';
+import { SyncCursorsService } from './application/services/sync-cursors.service';
 import {
   JOB_ENQUEUE_TOKEN,
   SYNC_JOB_REPOSITORY_TOKEN,
@@ -31,6 +33,8 @@ import {
   SYNC_JOB_BULK_RETRY_SERVICE_TOKEN,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
   SCHEDULER_TASK_REGISTRY_TOKEN,
+  SYNC_JOBS_SERVICE_TOKEN,
+  SYNC_CURSORS_SERVICE_TOKEN,
 } from './sync.tokens';
 
 // Re-export tokens for convenience
@@ -44,6 +48,8 @@ export {
   SYNC_JOB_BULK_RETRY_SERVICE_TOKEN,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
   SCHEDULER_TASK_REGISTRY_TOKEN,
+  SYNC_JOBS_SERVICE_TOKEN,
+  SYNC_CURSORS_SERVICE_TOKEN,
 } from './sync.tokens';
 
 @Module({
@@ -114,6 +120,20 @@ export {
       provide: SCHEDULER_TASK_REGISTRY_TOKEN,
       useExisting: SchedulerTaskRegistryService,
     },
+
+    // Cross-context service seams (#718 slice 2): jobs scheduling +
+    // cursors. Wrap the repository ports so consumers in other contexts
+    // don't reach across the boundary to a `*RepositoryPort`.
+    SyncJobsService,
+    {
+      provide: SYNC_JOBS_SERVICE_TOKEN,
+      useExisting: SyncJobsService,
+    },
+    SyncCursorsService,
+    {
+      provide: SYNC_CURSORS_SERVICE_TOKEN,
+      useExisting: SyncCursorsService,
+    },
   ],
   exports: [
     JOB_ENQUEUE_TOKEN,
@@ -134,6 +154,8 @@ export {
     RetryClassifierRegistryService,
     SCHEDULER_TASK_REGISTRY_TOKEN,
     SchedulerTaskRegistryService,
+    SYNC_JOBS_SERVICE_TOKEN,
+    SYNC_CURSORS_SERVICE_TOKEN,
   ],
 })
 export class SyncModule {}

--- a/libs/core/src/sync/sync.tokens.ts
+++ b/libs/core/src/sync/sync.tokens.ts
@@ -18,6 +18,8 @@ export const SYNC_JOB_RETRY_SERVICE_TOKEN = Symbol('SyncJobRetryServicePort');
 export const SYNC_JOB_BULK_RETRY_SERVICE_TOKEN = Symbol('SyncJobBulkRetryServicePort');
 export const RETRY_CLASSIFIER_REGISTRY_TOKEN = Symbol('RetryClassifierRegistryService');
 export const SCHEDULER_TASK_REGISTRY_TOKEN = Symbol('SchedulerTaskRegistryService');
+export const SYNC_JOBS_SERVICE_TOKEN = Symbol('ISyncJobsService');
+export const SYNC_CURSORS_SERVICE_TOKEN = Symbol('ISyncCursorsService');
 
 
 

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -139,15 +139,9 @@ const ALLOW_LIST = new Map([
     new Set(['ProductVariantRepositoryPort']),
   ],
 
-  // listings → sync.SyncJobRepositoryPort — rewire via ISyncJobsService
-  [
-    'libs/core/src/listings/application/services/offer-status-poll.service.ts',
-    new Set(['SyncJobRepositoryPort']),
-  ],
-  [
-    'libs/core/src/listings/application/services/__tests__/offer-status-poll.service.spec.ts',
-    new Set(['SyncJobRepositoryPort']),
-  ],
+  // (Slice 2 of #718 — sync repository-port callers — rewired via
+  // ISyncJobsService + ISyncCursorsService and dropped from this list.
+  // See PR for #718 slice 2.)
 
   // content → listings.OfferMappingRepositoryPort — rewire via IListingsService
   [
@@ -183,16 +177,6 @@ const ALLOW_LIST = new Map([
   [
     'libs/core/src/ai/infrastructure/adapters/credentials-ai-provider.adapter.spec.ts',
     new Set(['IntegrationCredentialRepositoryPort']),
-  ],
-
-  // orders → sync.ConnectionCursorRepositoryPort — rewire via ISyncCursorsService
-  [
-    'libs/core/src/orders/application/services/order-ingestion.service.ts',
-    new Set(['ConnectionCursorRepositoryPort']),
-  ],
-  [
-    'libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts',
-    new Set(['ConnectionCursorRepositoryPort']),
   ],
 
   // ─── Plugins + apps (#719) — tracked in #722 ────────────────────────


### PR DESCRIPTION
Slice 2 of 4 from #718. The other two slices (listings `OfferMappingRepositoryPort`, integrations credentials) follow in separate PRs.

This PR does **not** close #718. After merge, 4 of the 12 remaining `(file, symbol)` allow-list entries are gone; 8 stay for slices 3 & 4.

## Summary

Eliminates the two cross-context value-imports of sync-owned repository ports — `offer-status-poll` (`SyncJobRepositoryPort`) and `order-ingestion` (`ConnectionCursorRepositoryPort`) — by introducing two new narrow service interfaces in `libs/core/src/sync/application/services/`:

- **`ISyncJobsService.schedule(input)`** — wraps `SyncJobRepositoryPort.createIfNotExistsByIdempotencyKey({...}, { runAfter })`. Inserts directly via the repository because `SyncJobQueuePort.enqueue` throws on `delayMs > 0` — Redis Streams can't deliver delayed messages. The bypass-intent docblock lives on the service + its contract; the previously-stale comment in `offer-status-poll.service.ts:13` is gone.
- **`ISyncCursorsService.getCursor` / `.advanceCursor`** — wraps `ConnectionCursorRepositoryPort.get` / `.set`. Monotonicity is explicitly documented as the caller's responsibility: the underlying upsert accepts any value, including rewinds.

Pure DI-seam swap. No behaviour change, no migration, no security or contract impact.

## Design decisions

- **Method name `schedule`, not `scheduleDelayed`** — every call through this method is delayed (`runAfter` is required), so the suffix would be redundant labelling.
- **`maxAttempts` is required on `ScheduleJobInput`** — matches the underlying entity shape, which the repository port re-exports as `Omit<SyncJob, ...>` without omitting `maxAttempts`. Optional in the original audit guess, but the contract is required.
- **Two narrow services, not one umbrella** — jobs scheduling and cursor tracking have no shared methods, no shared return types. The issue body names both. Slice 1's precedent (`IProductsService` umbrella) only fit because all 4 methods read the same aggregate family.
- **Types live in `sync-jobs.types.ts`** — Engineering Standards §"Type Definitions in Separate Files" + slice 1 review precedent.

## Consumer rewires (libs/core only)

| File | Change |
|---|---|
| `offer-status-poll.service.ts` | Constructor: `@Inject(SYNC_JOB_REPOSITORY_TOKEN) syncJobRepository: SyncJobRepositoryPort` → `@Inject(SYNC_JOBS_SERVICE_TOKEN) syncJobs: ISyncJobsService`. Call site: `createIfNotExistsByIdempotencyKey(req, opts)` → `schedule(input)` with `runAfter` inlined. Stale "Bypasses Redis Streams" header comment replaced by an `@see ISyncJobsService` reference. |
| `order-ingestion.service.ts` | Constructor: `@Inject(CONNECTION_CURSOR_REPOSITORY_TOKEN) cursorRepository: ConnectionCursorRepositoryPort` → `@Inject(SYNC_CURSORS_SERVICE_TOKEN) syncCursors: ISyncCursorsService`. Two call sites: `cursorRepository.get/set` → `syncCursors.getCursor/advanceCursor`. |

## Per-spec mock surfaces (slice 1 precedent)

| Spec | Mock surface |
|---|---|
| `offer-status-poll.service.spec.ts` | `Pick<ISyncJobsService, 'schedule'>` |
| `order-ingestion.service.spec.ts` | `Pick<ISyncCursorsService, 'getCursor' \| 'advanceCursor'>` |

Two new service unit tests cover pass-through behavior (`sync-jobs.service.spec.ts`, `sync-cursors.service.spec.ts`).

## Allow-list cleanup

4 entries dropped from `scripts/check-cross-context-imports.mjs` (the two `sync`-context rewire blocks). 8 entries remain for slices 3 & 4.

## Follow-ups (out of scope, NOT this PR)

The apps/worker callers of the same two ports were added to the allow-list under #719's extended scope and are tracked separately in #722. The service interfaces this PR introduces are the right seam for them — rewire is mechanical once this lands. **Specifically out-of-scope for this PR**:

- [ ] `apps/api/src/sync/http/sync.controller.{ts,spec.ts}` → `ISyncJobsService`
- [ ] `apps/api/src/integrations/http/connection.controller.{ts,spec.ts}` → `ISyncJobsService`
- [ ] `apps/api/src/integrations/http/allegro.controller.{ts,spec.ts}` → `ISyncCursorsService`
- [ ] `apps/api/src/cursors/http/cursors.controller.{ts,spec.ts}` → `ISyncCursorsService`
- [ ] `apps/worker/src/sync/job-intake.consumer.{ts,spec.ts}` → `ISyncJobsService`
- [ ] `apps/worker/src/sync/sync-job.runner.{ts,spec.ts}` → `ISyncJobsService`
- [ ] `apps/worker/src/sync/handlers/marketplace-offers-sync.handler.{ts,spec.ts}` → `ISyncCursorsService`
- [ ] Worker int-specs (5 files) → drop their direct-port imports

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 1,932 unit tests across 8 packages pass
- [x] `pnpm check:invariants` — green; cross-context invariant down to 8 allow-list entries for the remaining #718 slices
- [x] No migration; `pnpm --filter @openlinker/api migration:show` unchanged
- [ ] No manual smoke needed — DI-seam refactor, behaviour preserved verbatim

## Implementation plan

[`docs/plans/implementation-plan-718-sync-repo-port-rewire.md`](./docs/plans/implementation-plan-718-sync-repo-port-rewire.md) — full slice scope, design rationale, per-spec mock-surface table, and risks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)