### PR TITLE
feat(workflow): introduce two-tier refinement + product spec for #726

### DIFF
--- a/.claude/agents/product-researcher.md
+++ b/.claude/agents/product-researcher.md
@@ -1,0 +1,109 @@
+---
+name: product-researcher
+description: |
+  Use this agent for product-research tasks during the `/refine-product` workflow, specifically Phase B (Evidence & user research) and Phase C (Solution exploration). The agent gathers external signal, summarizes competitor capabilities, aggregates community discussion patterns, and synthesizes findings into structured notes.
+
+  Use proactively when:
+  - Researching how a competitor (BaseLinker, Channel Engine, Pipe17, Linnworks) handles a specific workflow
+  - Aggregating public developer-forum / community-channel signal about a feature
+  - Comparing solution alternatives across the OSS ecosystem
+  - Investigating a marketplace's documented API surface for a given capability
+  - Synthesizing scattered user evidence (issues, comments, support transcripts) into a structured "what users actually want" report
+
+  Do NOT use for:
+  - Codebase exploration (use `Explore` agent)
+  - Architecture design (use `Plan` agent)
+  - User interviews (those require the actual user — the agent can prepare interview scripts but cannot conduct them)
+  - General-purpose research outside the product-refinement workflow
+
+tools: WebFetch, WebSearch, mcp__github__list_issues, mcp__github__search_issues, mcp__github__search_repositories, Read, Bash
+---
+
+You are the **OpenLinker Product Researcher**. You're invoked during product refinement to gather external signal that the maintainer cannot easily reach themselves.
+
+## Your role
+
+You answer **product questions**, not technical ones. The maintainer is deciding whether to build something, what shape it should take, and for whom. Your output feeds their decision — you do not make decisions yourself.
+
+## Your defaults
+
+1. **Cite every claim.** URLs, issue numbers, doc references. A claim without a source is a hypothesis.
+2. **Reject generic advice.** If a question can be answered without consulting external sources, you weren't the right tool — flag that and let the caller decide.
+3. **Surface conflicts.** If two sources disagree, present both and note the disagreement. Don't paper over it.
+4. **Distinguish signal from noise.** One angry forum post is noise. Five posts saying the same thing across two years is signal.
+5. **Stay product-focused.** Resist the urge to recommend architecture or technical solutions. Your job ends at "this is what users want / what competitors do / what the market expects".
+
+## Common research patterns
+
+### Competitor capability comparison
+
+Given a feature ("bulk Allegro listing"), produce a structured comparison:
+- BaseLinker: how does it work? (cite their docs/help pages)
+- Channel Engine, Linnworks, Pipe17 (international): how do they handle it?
+- Open-source alternatives (Spree, Saleor, n8n-based workflows): can they do it?
+- Output: feature matrix + observations about which dimensions matter most.
+
+### Community signal aggregation
+
+Given a feature, find evidence of user demand:
+- Search PL e-commerce Facebook groups, fora (forum.prestashop.pl, forum.allegro.pl)
+- Search Reddit (r/ecommerce, r/poland, r/programowanie)
+- Search BaseLinker's own community help / changelog for "most requested" themes
+- Output: ranked list of user-articulated pain points with quotes and source links.
+
+### Marketplace API capability check
+
+Given a feature that interacts with Allegro / PrestaShop / Amazon / Shopify:
+- Read their developer docs end-to-end for the relevant capability
+- Identify what's possible, what's documented, what's deprecated, what's coming
+- Flag gotchas (rate limits, deprecated endpoints, undocumented quirks mentioned in forums)
+- Output: capability summary with API endpoint references.
+
+### Existing user evidence synthesis
+
+Given a corpus of existing issues, comments, or support content:
+- Find all references to the feature/problem (use `mcp__github__search_issues`)
+- Group by theme
+- Identify the persona behind each (agency / merchant / contributor)
+- Output: thematic synthesis with representative quotes.
+
+## Output structure
+
+Default to:
+
+```markdown
+# Research: [Question]
+
+## Sources consulted
+- [URL or reference] — [what was found there]
+- ...
+
+## Findings
+
+### Theme 1: [...]
+- [Specific finding with citation]
+- ...
+
+### Theme 2: [...]
+- ...
+
+## Conflicts / open questions
+- [Source A says X; source B says Y. Cannot resolve without [further input].]
+
+## Confidence assessment
+- High confidence: [...]
+- Low confidence: [...]
+- Unverified hypotheses: [...]
+
+## What the caller might do with this
+- [Suggestion, framed as a product question, not a tech recommendation]
+- ...
+```
+
+## What not to do
+
+- Don't write code samples (you're not a coder in this role)
+- Don't propose architecture (you're not the architect)
+- Don't make build/no-build decisions (the maintainer does)
+- Don't pad with filler; if research returns thin signal, say "thin signal" and stop
+- Don't simulate user interviews ("a typical PL agency would say...") — that's hallucination, not research

--- a/.claude/commands/refine-product.md
+++ b/.claude/commands/refine-product.md
@@ -1,0 +1,180 @@
+@docs/contributors/refinement-workflow.md
+
+You are the **OpenLinker Product Lead** running a collaborative product refinement on a `product-design` GitHub issue. Your job is **not** to write code, **not** to design architecture, **not** to produce implementation plans. Your job is to lock down **what we're building, for whom, and why** before any engineering time is committed.
+
+Follow the four phases below in order. **Pause for user input at the ⏸ gates** — never skip a gate. If a phase reveals that the problem statement was wrong, go back to the previous phase rather than forcing forward.
+
+The full workflow doc is at `docs/contributors/refinement-workflow.md`. This skill executes Tier 1 (product refinement) only. Tier 2 (technical refinement) happens later via `/plan` on the spawned implementation issues.
+
+---
+
+## Inputs
+
+- `$ARGUMENTS` is the GitHub issue number to refine (a `product-design` issue).
+- If the issue has no `product-design` label, stop and tell the user — this skill is for product design issues only.
+
+---
+
+## Pre-flight
+
+1. Fetch the issue via `mcp__github__issue_read` for `SilkSoftwareHouse/openlinker`. Read body + comments.
+2. Check whether `docs/specs/product-spec-{N}-{slug}.md` already exists (resume support). If yes:
+   - Read the existing spec
+   - Identify which phase it's at (header `Status: phase A/B/C/D in progress | complete`)
+   - Resume from the appropriate phase
+3. Otherwise create a fresh skeleton at `docs/specs/product-spec-{N}-{slug}.md` with `Status: phase A in progress`.
+
+---
+
+## Phase A — Problem definition
+
+**Goal:** lock down whose pain we're solving, how painful, and why now.
+
+**Process:**
+
+1. From the issue body, draft an initial problem statement. Be concrete — not "shop owners struggle with X" but "PL Allegro+PrestaShop sellers running 50+ SKU catalogs spend ~8h per major SKU refresh; they currently use BaseLinker Cloud at PLN/order pricing that costs them ~Y EUR/month at their volume".
+2. Identify the **affected persona** with these axes:
+   - Company size (solo merchant / SMB / mid-market / enterprise)
+   - Sophistication (developer / agency / non-technical operator / accountant)
+   - Volume bucket (orders/day, SKUs in catalog)
+   - Geographic focus (PL only / PL+DACH / international)
+3. Surface what's unclear:
+   - Ambiguous terms in the issue body (e.g., "Smart" could mean Allegro Smart! buyer-subscription OR EAN-based product card linking)
+   - Hidden assumptions ("user wants bulk wizard" — but does user actually want a wizard, or do they want auto-listing on PS product publish?)
+4. Update the spec doc with `## 1. Problem` and `## 2. Affected persona` sections.
+
+⏸ **Gate A — present to user:**
+- Drafted problem statement
+- Proposed persona
+- List of ambiguities + your interpretation of each, asking for confirmation/correction
+- "Do you confirm this problem statement, or should we re-frame?"
+
+Wait for explicit confirmation before proceeding. If user corrects, update spec and re-present.
+
+---
+
+## Phase B — Evidence & user research
+
+**Goal:** validate (or invalidate) the problem statement against actual user signal.
+
+**Process:**
+
+1. Inventory existing evidence:
+   - Have we talked to users about this before? (ask user; if yes, summarize what was said)
+   - Are there support tickets, sales calls, or community discussions about this? (search `mcp__github__list_issues` for `OPEN` + related labels; check `mcp__github__search_issues` for keywords)
+   - Are there competitor patterns to learn from? (BaseLinker docs, Channel Engine, similar tools)
+2. Identify research gaps — what we still don't know.
+3. **Decision point:** is current evidence sufficient to proceed, or do we need new interviews?
+   - If sufficient: synthesize findings, proceed to Phase C
+   - If insufficient: produce a discovery interview plan (3-5 specific people + 5-10 specific questions); ⏸ pause for user to conduct interviews (this may take days/weeks); resume Phase B after findings shared
+4. **Delegate research-heavy work to a subagent.** Use the `Agent` tool with `subagent_type: general-purpose`, instructing it to play the role defined in `.claude/agents/product-researcher.md`. Hand it specific questions: competitor capability comparison, market signal aggregation, public Allegro/PrestaShop developer-forum signal, etc.
+5. Update the spec doc with `## 3. Evidence & user research` section. Cite sources (URLs, ticket numbers, interview dates).
+
+⏸ **Gate B — present to user:**
+- Summary of evidence gathered
+- "Does this support the problem statement, refute it, or change the persona?"
+- "Are we missing any critical input before scoping the solution?"
+
+Wait for confirmation. If evidence refutes the problem statement, return to Phase A.
+
+---
+
+## Phase C — Solution exploration
+
+**Goal:** explore the solution space WITHOUT committing to a specific shape. Identify the minimum viable cut.
+
+**Critical rule:** this phase is NOT about designing the solution. It's about exploring **what shape of solution best fits the validated problem**. You should produce 3-5 candidate approaches with trade-offs, not one chosen approach.
+
+**Process:**
+
+1. List candidate solution shapes. For each, sketch in 2-3 sentences:
+   - What it looks like for the user (outcome, not implementation)
+   - What "MVP cut" of it would deliver value
+   - Effort estimate (S/M/L/XL — gut feel, not commitment)
+   - What it excludes (out-of-scope)
+   - Example for "bulk Allegro listing":
+     - **A.** Multi-select wizard from shop catalog → N offer-create jobs (4-5 weeks, excludes CSV import, excludes auto-listing)
+     - **B.** "Auto-list every new PS product on Allegro" rule engine (2-3 weeks, excludes manual selection, excludes batch re-listing)
+     - **C.** CSV import → bulk create (1-2 weeks, excludes wizard, excludes per-product preview)
+     - **D.** "Do nothing — point users to BaseLinker for bulk operations" (0 weeks, accepts feature gap)
+2. Compare candidates against:
+   - Problem fit (does it solve the validated pain?)
+   - Persona fit (does the persona actually use it this way?)
+   - Strategic fit (does it move OpenLinker toward the "OSS alternative" positioning?)
+   - Risk (technical risk, scope creep risk, abandonment risk)
+3. Identify success metrics for the chosen direction (e.g., "operator can list 20 products in 5 minutes" / "30% reduction in time-to-first-offer for new shop deployments").
+4. Surface the "do nothing" alternative honestly — what's the real cost of not building this?
+5. Update the spec doc with `## 4. Solution exploration` section.
+
+⏸ **Gate C — present to user:**
+- Table of 3-5 candidate shapes with trade-offs
+- Your recommendation (with reasoning, but not a final decision)
+- Proposed success metrics
+- "Which shape do we commit to? Or do we hybridize?"
+
+Wait for explicit choice. If user picks a hybrid, write up the merged shape.
+
+---
+
+## Phase D — Product specification
+
+**Goal:** produce the **contract** that technical refinement must implement.
+
+**Critical calibration:** this is OpenLinker, Stage 1 (pre-paying-customer). The workflow doc's [project-stage calibration](../../docs/contributors/refinement-workflow.md#project-stage-calibration) applies. Default to *less* — the test for every section is "will this actually be used / measured / referenced?" If no, skip it. Filler sections are worse than missing sections.
+
+**Process:**
+
+1. Write user stories in the form: **"As [persona], I want [outcome], so that [benefit]."** Aim for 3-7 stories that fully cover the chosen solution shape. **Always required.**
+
+2. For each user story, write **acceptance criteria** in user-visible terms (not "API endpoint returns 201" but "operator sees confirmation that all 20 offers were submitted"). Engineering AC (rate-limit handling, retry semantics, internal data propagation) does **not** belong here — that's Tier 2 implementation plans. **Always required.**
+
+3. Write the **explicit out-of-scope list** — but cap at top 5-7 items. Pick the items someone might *actually ask about* ("why no CSV import?"), not the "obvious v2" items nobody would dispute. Long lists are noise.
+
+4. **Success metrics — Stage 1 default: skip.** OpenLinker doesn't have analytics infra, support-ticket counts, or telemetry instrumentation to measure "80% adoption in 7 days" claims. Replace with a qualitative **"Definition of done"** — 3-5 bullets answering "what does the maintainer subjectively need to see/feel before declaring v1 a success?" (e.g., "first 2-3 shops use this in production for ≥30 days without abandonment", "no Smart-related support questions surface from early users"). If you write percentages, you're writing theatre.
+
+5. Identify **risks** — cap at top 3-5 product-direction risks. Engineering risks (rate limits, API drift, schema migrations, runtime races) belong in implementation plans, not spec. The risks here should be ones that could invalidate the whole product direction, not implementation details.
+
+6. **Persona-fit verification subsection — skip.** It's circular self-congratulation. The user stories + decision log already capture this.
+
+7. **Effort estimate — rough order-of-magnitude only.** "~M effort", "~5-6 weeks". Day-by-day breakdown belongs in Tier 2 implementation plans.
+
+8. Update the spec doc with `## 5. Product specification`, `## 6. Out of scope`, `## 7. Definition of done` (replaces success metrics for Stage 1), and `## 8. Risks` sections. Skip empty sections — better to have 5 short sections than 10 sections half-filled with filler.
+
+9. Mark spec doc header `Status: phase D complete — pending Gate D`.
+
+⏸ **Gate D — the big gate:**
+- Present the full spec
+- Ask: **"Do we commit engineering time to this? YES / NO / DEFER"**
+- If YES: proceed to artifact creation
+- If NO: close the product-design issue with `state_reason: not_planned`, archive spec doc to `docs/specs/archive/`
+- If DEFER: leave issue open, mark spec `Status: phase D complete — deferred pending [reason]`, do not spawn implementation issues
+
+---
+
+## Phase E — Spawn implementation issues (only if Gate D = YES)
+
+1. From the product spec, identify implementation issues to create. Each implementation issue should:
+   - Be independently shippable
+   - Have effort S/M/L (avoid XL — split if necessary)
+   - Reference the parent product-design issue
+   - Reference the spec doc path
+2. Use `.github/ISSUE_TEMPLATE/implementation.md` as the body template.
+3. Create issues via `mcp__github__issue_write` with label `implementation` and a reference to the parent product-design issue (`Part of #N`).
+4. Update parent product-design issue body with links to children.
+5. Commit spec doc + any updates on the current branch.
+
+⏸ **Final pause — present to user:**
+- List of implementation issues created (with URLs)
+- Reminder: for each implementation issue, use `/plan <N>` (if architecture is non-trivial) or `/work <N>` (if trivial) to proceed.
+- Ask: "Anything else to add to the spec or issue list before closing this refinement?"
+
+---
+
+## Behavior rules
+
+- **Never skip a gate.** If user is impatient, remind them that skipping product refinement is exactly how features ship that nobody uses.
+- **Never make product decisions for the user.** Present options with trade-offs; the user decides.
+- **Never write technical design in this skill.** If you find yourself describing architecture, capability ports, or file paths — stop. That's `/plan` territory.
+- **Always cite evidence.** Every claim about user need should have a source (interview note, support ticket, competitor doc URL). If no source, flag as "assumption to validate".
+- **Persist progress.** After every phase, save the updated spec doc. The workflow must be resumable across sessions.
+- **Default to "don't build."** If product refinement reveals weak evidence, no clear persona, or no measurable success metric — the right answer is to close the issue, not force forward.

--- a/.github/ISSUE_TEMPLATE/implementation.md
+++ b/.github/ISSUE_TEMPLATE/implementation.md
@@ -1,0 +1,64 @@
+---
+name: Implementation (maintainer)
+about: A scoped implementation task derived from a Product Design issue (or a trivial fix that needs no product refinement).
+title: '[IMPL] '
+labels: ['implementation']
+assignees: ''
+---
+
+> **For maintainers.** This issue type is for engineering work derived from a Product Design issue, an established pattern, or a bug fix. See the [refinement workflow](../../docs/contributors/refinement-workflow.md) for context.
+
+## Design source
+
+Pick one (delete the others):
+
+- **Product Design parent:** Part of #N — see spec at `docs/specs/product-spec-{N}-{slug}.md`
+- **Established pattern:** Extends existing pattern at [file/module path]; no product refinement needed
+- **Bug fix:** Fixes bug #N; no product refinement needed
+- **Tech debt:** Refactor / cleanup; rationale: [why now]
+
+## Scope
+
+[What this specific implementation issue covers. Should be a subset of the parent Product Design's scope, or a single coherent change.]
+
+## Acceptance criteria
+
+User-visible criteria first; technical criteria second.
+
+- [ ] [User-visible behavior — e.g., "operator clicks X and sees Y"]
+- [ ] [User-visible behavior]
+- [ ] [Edge case handled]
+- [ ] Tests added (unit + integration where applicable)
+- [ ] Documentation updated if user-facing behavior changes
+- [ ] No new ESLint warnings or type errors introduced
+
+## Effort estimate
+
+- [ ] **S** — 1–3 days
+- [ ] **M** — 3–7 days
+- [ ] **L** — 1–2 weeks
+- [ ] **XL** — ⚠️ split into smaller issues before starting
+
+## Dependencies
+
+- **Blocked by:** #N, #N (must be merged first)
+- **Blocks:** #N, #N (these can't start until this is done)
+- **Independent** (this issue can be picked up immediately)
+
+## Out of scope for THIS issue
+
+- [Explicit cut from parent scope — what NOT to do here, even if tempting]
+- [Another cut]
+
+## Architecture notes (optional)
+
+- New ports/adapters? [name them]
+- New domain entities? [name them]
+- Touches FE / API / Worker / Core / Integration? [pick]
+- Migration needed? [yes/no — if yes, see `docs/migrations.md`]
+
+## Next step after merge
+
+- [ ] Closes Product Design parent #N (if last child)
+- [ ] No further action — feature complete
+- [ ] Triggers follow-up: #N

--- a/.github/ISSUE_TEMPLATE/product-design.md
+++ b/.github/ISSUE_TEMPLATE/product-design.md
@@ -1,0 +1,56 @@
+---
+name: Product Design (maintainer)
+about: Formal product refinement for a feature or initiative. Used by maintainers to lock down what/who/why before engineering time is committed.
+title: '[PRODUCT-DESIGN] '
+labels: ['product-design']
+assignees: ''
+---
+
+> **For maintainers.** This issue type kicks off the [two-tier refinement workflow](../../docs/contributors/refinement-workflow.md). If you're a contributor with a feature idea, please file a [Feature Request](?template=feature_request.md) instead — maintainers will convert it to a Product Design issue when it's prioritized.
+
+## Initial problem hypothesis
+
+[A concrete description of what's painful, for whom, and why now. Refined further during Phase A of `/refine-product`.]
+
+## Affected persona (hypothesis)
+
+- **Who:** [e.g. PL agency operator running 50+ SKU shops on PrestaShop+Allegro]
+- **Volume / scale:** [e.g. 50–500 SKUs per shop, 10–100 orders/day]
+- **Sophistication:** [e.g. technical but not developer, comfortable with operator UI]
+
+## Current workarounds
+
+[What do affected users do today? BaseLinker? Manual? Excel + macro?]
+
+## Strategic alignment
+
+- [ ] **Wedge-relevant** — supports the PL Allegro+PrestaShop+InPost wedge
+- [ ] **Differentiator** — gives us a feature BaseLinker doesn't have or charges too much for
+- [ ] **Foundational** — unblocks other features (specify which)
+- [ ] **Tech-debt-driven** — reduces friction across many features
+- [ ] **External requirement** — compliance, regulatory, marketplace API change
+
+## Out of scope (initial)
+
+- [What this Product Design issue is explicitly NOT trying to design — top 3-5 items, not exhaustive]
+
+## Open questions for refinement
+
+- [ ] [Question that the `/refine-product` workflow should resolve]
+- [ ] [Question that requires user research]
+- [ ] [Question that requires competitor analysis]
+
+> **Stage 1 calibration**: OpenLinker is pre-paying-customer. The refinement workflow produces a lightweight conviction spec — no success-metric theatre (no "80% adoption in 7 days" promises we can't measure), no anti-metrics, no exhaustive risk catalogs. See [`docs/contributors/refinement-workflow.md`](../../docs/contributors/refinement-workflow.md#project-stage-calibration) for what sections are required vs skipped at this stage.
+
+## Linked source
+
+- Originating feature request: #N (if any)
+- Related issues: #N, #N
+- Related plans: `docs/plans/...` (if any)
+
+## Definition of "refinement complete"
+
+- [ ] Product spec at `docs/specs/product-spec-{N}-{slug}.md` merged
+- [ ] Build/no-build decision recorded (Gate D output)
+- [ ] If "build": implementation issues spawned and linked here
+- [ ] If "no build": this issue closed with `state_reason: not_planned` and reasoning recorded

--- a/docs/contributors/refinement-workflow.md
+++ b/docs/contributors/refinement-workflow.md
@@ -1,0 +1,246 @@
+# Refinement Workflow
+
+This document defines how OpenLinker maintainers turn an idea into shipped code. It exists because the most expensive bugs are features that nobody needs — and the cheapest way to prevent them is to refine the product question before committing engineering time.
+
+## The two tiers
+
+Every non-trivial feature passes through two distinct tiers of refinement:
+
+```
+Idea
+  ↓
+┌────────────────────────────────────────────────────────────┐
+│ Tier 1 — Product refinement                                │
+│ Question: should we build it? what exactly? for whom? why? │
+│ Output: product spec in docs/specs/                        │
+│ Skill: /refine-product <issue>                             │
+│ ⏸ Gate: "commit engineering time?" YES / NO / DEFER       │
+└────────────────────────────────────────────────────────────┘
+  ↓ YES
+┌────────────────────────────────────────────────────────────┐
+│ Tier 2 — Technical refinement                              │
+│ Question: how exactly to build it?                         │
+│ Output: implementation plan in docs/plans/ + ADRs          │
+│ Skill: /plan <issue> (per implementation issue)            │
+│ ⏸ Gate: "ready for /work?" YES / NO                       │
+└────────────────────────────────────────────────────────────┘
+  ↓ YES
+┌────────────────────────────────────────────────────────────┐
+│ Implementation                                             │
+│ Skill: /work <issue>                                       │
+│ Output: merged PR                                          │
+└────────────────────────────────────────────────────────────┘
+```
+
+The tiers are **sequential and gated**. You cannot skip Tier 1 by being clever about Tier 2. The whole point of Tier 1 is to validate that the engineering time about to be spent in Tier 2 + implementation is well-spent.
+
+## When you can skip Tier 1
+
+Tier 1 is **not** required for:
+
+- **Bug fixes** — the problem is the bug; refinement happens by reading the bug report
+- **Established patterns** — adding a second adapter for an existing port (e.g. `ShopifyOrderSourceAdapter` after `AllegroOrderSourceAdapter` exists) doesn't need a new product spec
+- **Tech debt** — refactors, dependency upgrades, test improvements
+- **Maintenance** — fixing flaky tests, doc cleanups, dev-env improvements
+
+For these, file an `[IMPL]` issue directly with `Design source: established pattern / bug fix / tech debt`.
+
+## When Tier 1 is mandatory
+
+- **New user-facing capabilities** — anything that an operator, merchant, or agency would describe as "a feature"
+- **New bounded contexts or domain concepts** — adding "Shipments" as a first-class entity, introducing a new capability port type
+- **Cross-cutting changes** — touching multiple bounded contexts in service of a coherent user-facing goal
+- **Strategic bets** — initiatives that consume >2 weeks of engineering time
+
+If in doubt: file a Product Design issue. The cost of unnecessary refinement is a few hours of writing. The cost of unnecessary code is months of maintenance.
+
+## Issue types
+
+OpenLinker uses two **maintainer-only** issue types alongside the existing contributor templates:
+
+### Product Design issues (`product-design` label)
+
+- **Created by:** maintainers, often by converting a community feature request
+- **Template:** `.github/ISSUE_TEMPLATE/product-design.md`
+- **Lifecycle:** stays open as an epic until all child implementation issues are closed and post-launch validation confirms the spec
+- **Output:** product spec at `docs/specs/product-spec-{N}-{slug}.md` + N implementation children
+
+### Implementation issues (`implementation` label)
+
+- **Created by:** maintainers, typically spawned from a Product Design parent's Phase E
+- **Template:** `.github/ISSUE_TEMPLATE/implementation.md`
+- **Lifecycle:** closed by a single PR via `Closes #N`
+- **Output:** merged code + tests + docs
+
+Contributor issue types (`feature_request`, `bug_report`, `developer_task`, `new_integration`, `question`) are unchanged and remain the entry point for community contributions.
+
+## Tier 1: Product refinement — phase by phase
+
+The `/refine-product <issue>` skill executes four phases. Each ends in a ⏸ gate where the maintainer must explicitly confirm before the next phase starts.
+
+### Phase A — Problem definition
+
+**Goal:** lock down whose pain we're solving, how painful, and why now.
+
+**Activities:**
+- Restate the problem in concrete terms (who, how often, how painful)
+- Identify the affected persona (size, sophistication, volume, geography)
+- Surface ambiguities in the original issue body
+
+**Artifact:** `## 1. Problem` and `## 2. Affected persona` in the spec doc
+
+**Gate A:** maintainer confirms the problem statement or asks for re-framing
+
+### Phase B — Evidence & user research
+
+**Goal:** validate (or invalidate) the problem statement against actual user signal.
+
+**Activities:**
+- Inventory existing evidence (past interviews, support tickets, community discussions)
+- Identify gaps requiring new research
+- Optionally: conduct discovery interviews (3–5 users, 5–10 specific questions)
+- Use the `product-researcher` subagent for competitor analysis and community signal aggregation
+
+**Artifact:** `## 3. Evidence & user research` in the spec doc (with cited sources)
+
+**Gate B:** maintainer confirms evidence supports the problem statement, or returns to Phase A if not
+
+### Phase C — Solution exploration
+
+**Goal:** explore the solution space without committing to a specific shape.
+
+**Activities:**
+- Produce 3–5 candidate solution shapes with trade-offs
+- Compare against problem fit, persona fit, strategic fit, risk
+- Define success metrics (specific, measurable, time-bounded)
+- Honestly evaluate the "do nothing" alternative
+
+**Artifact:** `## 4. Solution exploration` in the spec doc
+
+**Gate C:** maintainer picks the chosen shape (or a hybrid)
+
+### Phase D — Product specification
+
+**Goal:** produce the contract that Tier 2 must implement.
+
+**Activities:**
+- Write user stories in "As [persona], I want [outcome], so that [benefit]" form
+- Write user-visible acceptance criteria
+- List explicit out-of-scope items with reasons
+- Define success metrics with numbers and timeline
+- Identify product-direction risks (not technical risks)
+
+**Artifact:** complete spec doc with `Status: phase D complete — ready for implementation breakdown`
+
+**Gate D — the big gate:** maintainer commits engineering time, defers, or closes
+
+### Phase E — Spawn implementation issues (only on Gate D = YES)
+
+**Goal:** create the GitHub issues that engineering will pick up.
+
+**Activities:**
+- Identify independently shippable implementation slices
+- Create `[IMPL]` issues with `Part of #N` reference to the parent
+- Link from parent Product Design issue body
+
+**Artifact:** GitHub implementation issues, all linked to parent
+
+## Tier 2: Technical refinement — via `/plan`
+
+After Phase E, each implementation issue lives independently. Maintainers (or contributors who pick them up) use the existing `/plan <issue>` skill if the technical work is non-trivial, then `/work <issue>` for execution.
+
+**Use `/plan` when:**
+- The issue introduces a new architectural concept (new port type, new bounded context, new persistence pattern)
+- Multiple ADRs are needed
+- The work spans multiple layers and requires coordination
+
+**Skip `/plan` and go straight to `/work` when:**
+- The issue extends an established pattern
+- The architecture is fully determined by existing conventions
+- The change is small enough that a plan adds noise rather than clarity
+
+`/plan` produces `docs/plans/implementation-plan-{N}-{slug}.md` and may produce ADR drafts at `docs/architecture/adrs/` if non-trivial architectural decisions are made.
+
+## Artifacts and where they live
+
+| Artifact | Location | Created by |
+|---|---|---|
+| Product spec | `docs/specs/product-spec-{N}-{slug}.md` | `/refine-product` (Phase A-D) |
+| Implementation plan | `docs/plans/implementation-plan-{N}-{slug}.md` | `/plan` |
+| ADRs | `docs/architecture/adrs/ADR-{NNN}-{slug}.md` | `/plan` or ad-hoc per ADR practice (#725) |
+| Product Design issues | GitHub | maintainers |
+| Implementation issues | GitHub | maintainers (Phase E) |
+| Merged code + tests | repository | `/work` |
+
+## Resume and recovery
+
+Refinements span hours to weeks. The workflow must survive interruption:
+
+- **Resume `/refine-product`:** re-running the skill on the same issue number reads the existing spec doc and picks up from the recorded `Status:` header
+- **Multi-session continuity:** spec doc header always reflects current phase; previous-phase artifacts are immutable (don't rewrite Phase A findings after they were confirmed)
+- **Mid-refinement scope change:** if Phase C or D reveals that Phase A's problem statement was wrong, the workflow loops back rather than forcing forward. Note the regression in the spec doc.
+
+## When refinement fails
+
+It's a valid outcome — and a healthy one. Two failure modes:
+
+### "Don't build" outcome (Gate D = NO)
+
+- Close the Product Design issue with `state_reason: not_planned`
+- Archive the spec doc to `docs/specs/archive/`
+- Record the reasoning in the closing comment — future maintainers asking the same question deserve to find your answer
+
+### Indefinite defer (Gate D = DEFER)
+
+- Leave issue open with `Status: phase D complete — deferred pending [reason]`
+- Do not spawn implementation issues
+- Revisit when the deferring condition changes (e.g., "deferred until we have a DACH design partner")
+
+## Principles
+
+1. **Default to "don't build."** Most features that survive Tier 1 do because their problem statement held up to scrutiny. Most features that don't survive shouldn't have been built.
+2. **Cite evidence.** Every product claim should have a source — an interview note, a support ticket, a competitor doc URL. Hypotheses are fine, but they must be labelled as such.
+3. **Surface alternatives.** Refinement is exploration, not advocacy for a predetermined solution.
+4. **Persist progress.** Every phase update writes to the spec doc, so the workflow survives interruption and audit.
+5. **Time-box gates.** A Tier 1 gate that's been open for 2+ weeks is a signal that something else is wrong (lack of conviction, missing evidence, wrong issue scope) — not a signal to lower the standard.
+6. **Calibrate to project stage** (see below).
+
+## Project-stage calibration
+
+The same workflow runs on a pre-revenue OSS prototype and on a mature platform with 10k customers. Output depth must scale to stage.
+
+OpenLinker is in **Stage 1: pre-paying-customer**. Until we have ≥3 paying customers (Cloud subscribers) or ≥10 design-partner deployments, spec docs follow these caps:
+
+| Section | Stage 1 cap | Stage 2+ guidance |
+|---|---|---|
+| Out-of-scope list | **Top 5–7 items** that someone might actually ask about | Comprehensive list once support tickets surface the questions |
+| Risks | **Top 3–5 product-direction risks** | Add engineering risks once you have operational scars |
+| Success metrics | **Skip OR replace with qualitative "definition of done"** | Quantitative metrics only when telemetry/analytics infra exists |
+| Anti-metrics | **Skip entirely** | Add when you can actually instrument them |
+| Effort estimate | **Rough order-of-magnitude only** ("~M effort", "~5–6 weeks") | Day-by-day breakdown belongs in Tier 2 implementation plans, not spec |
+| User stories / acceptance criteria | **Always required** | Always required |
+| Decision log | **Always required** | Always required |
+
+**The test:** for every section before writing, ask *"will anyone actually use this — measure it, reference it, audit against it?"* If the answer is "no — it's just here because product specs are supposed to have it", **skip the section**. Filler sections are worse than missing sections: they make the doc look comprehensive while contributing zero signal.
+
+**Common slop to avoid in Stage 1:**
+
+- Success-metric percentages we have no infrastructure to measure ("80% adoption within 7 days")
+- Anti-metrics we'll never instrument ("abandon rate > 20% triggers re-review")
+- Persona-fit verification sub-sections (circular self-congratulation)
+- "Cross-cutting acceptance criteria" that are really engineering concerns
+- Long out-of-scope lists where every item is "obvious v2"
+- Risk catalogs with engineering risks (R5: rate limits, R8: validation drift, etc.) — those belong in implementation plans
+- Comprehensive "stakeholder alignment" sections when there are 1–2 maintainers
+
+A 1-page conviction spec that captures the real reasoning beats a 10-page spec that buries it in compliance theatre.
+
+## Related documents
+
+- `docs/architecture-overview.md` — the technical context that constrains Tier 2 design
+- `docs/engineering-standards.md` — code-level conventions that Tier 2 must follow
+- `docs/architecture/adrs/` — Architecture Decision Records produced during Tier 2 (see #725)
+- `docs/specs/README.md` — what lives in the spec directory and how to navigate it
+- `.claude/commands/refine-product.md` — the Tier 1 skill itself
+- `.claude/commands/plan.md` — the Tier 2 skill
+- `.claude/commands/work.md` — implementation skill

--- a/docs/plans/implementation-plan-726-allegro-smart-bulk.md
+++ b/docs/plans/implementation-plan-726-allegro-smart-bulk.md
@@ -1,0 +1,603 @@
+> ⚠️ **PRE-REFINEMENT DRAFT — NOT AN AUTHORITATIVE PLAN**
+>
+> This document was produced **before** OpenLinker's [two-tier refinement workflow](../contributors/refinement-workflow.md) was introduced. It mixes product reasoning (what/who/why) and technical design (how) without proper Tier 1 (product) refinement.
+>
+> **Current role:** input for Phase B (Evidence) of `/refine-product 726`. The codebase audit and Allegro Smart! research below remain useful reference material. The product scope decisions (8-step wizard, 100-product batch size, AI description toggle, etc.) are **hypotheses to be validated, not commitments**.
+>
+> **Authoritative artifacts will be:**
+> - Product spec at `docs/specs/product-spec-726-{slug}.md` (output of Tier 1, in progress)
+> - Implementation plans at `docs/plans/implementation-plan-{child-issue-N}-*.md` (output of Tier 2 per implementation issue, after Tier 1 completes)
+>
+> Once those artifacts exist and the spec is locked, this file should be either archived to `docs/plans/archive/` with a pointer to the authoritative replacement, or deleted if it adds no remaining reference value.
+
+---
+
+# Implementation Plan — #726 Allegro Smart! support + Bulk listing creation (PRE-REFINEMENT DRAFT)
+
+**Issue:** [#726](https://github.com/SilkSoftwareHouse/openlinker/issues/726) — Discovery & refinement (converting to Product Design)
+**Layer:** Integration (`libs/integrations/allegro`) + Application (`libs/core/src/listings`) + Frontend (`apps/web`)
+**Branch (this discovery doc):** `726-allegro-smart-bulk-refinement`
+**Status:** ⚠️ Pre-refinement draft — supersedes by `docs/specs/product-spec-726-{slug}.md` once Tier 1 refinement completes.
+
+---
+
+## 1. Goal
+
+Two related but distinct capabilities that this plan treats as **separate features sharing a single bulk wizard**:
+
+### Feature A — Bulk offer creation
+
+Allow operators to select N products from the connected shop catalog (PrestaShop today) and create Allegro offers for all of them in one workflow, with shared category/parameters/policies and per-product overrides.
+
+### Feature B — Allegro Smart! eligibility
+
+Make offers created by OpenLinker eligible for the **Allegro Smart!** program (free shipping for buyers subscribed to Smart!). Smart! eligibility is **not a separate API call** — it follows from the offer's delivery method configuration. The feature is therefore "make Smart-eligible delivery methods first-class in the wizard, validate eligibility before submit".
+
+### In scope (v1)
+
+**Bulk:**
+- Multi-select from PrestaShop catalog (10–100 products per batch)
+- Shared category + shared parameters per batch, with per-product preview/override
+- Shared price strategy (copy from shop / fixed markup % / fixed value)
+- Per-product AI-generated description (reuse `ContentSuggestionService` infrastructure, channel `allegro`)
+- Job-based async submission via existing `marketplace.offer.create` handler
+- Bulk progress view: per-product status (pending / running / success / failed) with retry per-failure
+- Idempotency: same product+connection in same batch is deduped
+
+**Smart!:**
+- Wizard surface for selecting a Smart-eligible **delivery profile** (existing Allegro seller policy)
+- Pre-submit validation that the selected delivery profile is Smart-eligible
+- Display Smart eligibility status per offer in the bulk progress view (post-create)
+
+### Non-goals (v1)
+
+- CSV import — use shop catalog only
+- Promoted offers ("wyróżnione")
+- Bulk price/stock updates of **existing** offers (separate feature — see [`OfferQuantityBatchUpdater`](../engineering-standards.md#sub-capabilities) for related primitive)
+- Bulk de-listing / archiving
+- Variation explosion — v1 collapses one shop product into one Allegro offer (using Allegro's variant matrix); separate-offer-per-variant is v2
+- Seller-account-level Smart! enrollment management (Allegro handles this; OL doesn't manage seller subscriptions)
+- Cross-marketplace bulk listing (only Allegro in v1; future: Amazon, eBay)
+- Custom invoice numbering / fiscal handling in bulk flow — covered by #728 (Subiekt integration), orthogonal
+
+---
+
+## 2. What is Allegro Smart!? (research findings)
+
+This section is the **discovery output** — it codifies what we now believe about the Smart! program so future work doesn't re-research it.
+
+### Buyer-side
+
+- Allegro Smart! is a paid subscription for buyers (~59 zł/year as of 2026; pricing per Allegro's product page).
+- Subscribers get free shipping on eligible orders above a threshold (typically 45 zł).
+- Smart! works across pick-up methods: paczkomat (InPost), Allegro ONE Box, courier, ORLEN Paczka, partner pickup points.
+
+### Seller-side eligibility
+
+- Sellers do **not** pay extra to be in Smart!.
+- Eligibility per offer is determined automatically by Allegro based on the offer's **delivery method configuration**:
+  - The offer must offer at least one Smart!-eligible delivery method
+  - The buyer-facing shipping cost on that method (for Smart subscribers) must be 0 zł
+  - The offer must be on allegro.pl (not allegro.cz / allegro.sk / etc.)
+- Smart!-eligible delivery methods are configured by the seller in their **delivery configurations** ("Cenniki dostawy") in Allegro seller panel. Each delivery configuration is a named bundle (e.g. "Standard PL", "Premium PL Smart") that maps methods to prices.
+- A delivery configuration is Smart!-eligible if it satisfies Allegro's rules — typically by including InPost paczkomaty at 0 zł above 45 zł (or similar).
+- Offers reference a delivery configuration by ID; that ID's Smart! eligibility flows through automatically.
+
+### Allegro API surface
+
+- `GET /sale/delivery-methods` — list of delivery methods supported by the seller's account
+- `GET /sale/shipping-rates` — seller's named shipping-rate tables (delivery configurations)
+- `POST /sale/product-offers` — the offer body's `delivery.shippingRates.id` references one
+- Smart! eligibility is **not directly settable** on the offer; it's a derived property of the delivery configuration.
+
+### What this means for OpenLinker
+
+- We don't need a "make this offer Smart!" toggle. We need a **delivery configuration picker** in the wizard.
+- For Smart! support we need:
+  1. List the seller's shipping rates via the existing `SellerPoliciesReader` capability (`fetchSellerPolicies()` already exists on the Allegro adapter).
+  2. Surface the picker in the bulk wizard with a "Smart!-eligible" badge per option.
+  3. (Future) Compute Smart! eligibility client-side from the rate's contents — but for v1, trust Allegro's classification at create time and read it back post-create.
+
+### Open question to validate in discovery interview
+
+- How do sellers identify which of their delivery configurations is "Smart!-eligible" today? Does Allegro return a flag, or do sellers know by naming convention? **Action: probe Allegro API response shape from `fetchSellerPolicies()` first; if no flag, defer Smart! badging to v2 and rely on seller knowing their own config names.**
+
+---
+
+## 3. Current state (what already exists)
+
+This section codifies the audit done as part of this refinement so implementation work doesn't need to re-discover.
+
+### Single-offer creation pipeline — fully exists
+
+- **`OfferBuilderService`** (`libs/core/src/listings/application/services/offer-builder.service.ts:51`) — composes `CreateOfferCommand` from variant → product → category → price → images
+- **`OfferCreationExecutionService`** (`libs/core/src/listings/application/services/offer-creation-execution.service.ts:79`) — orchestrates: load-or-create `OfferCreationRecord`, build command, call `OfferCreator.createOffer`, persist mapping, schedule status poll, map outcome to `'ok' | 'business_failure'`
+- **`OfferCreator` capability** (`libs/core/src/listings/domain/ports/capabilities/offer-creator.capability.ts:17`): `createOffer(cmd: CreateOfferCommand): Promise<CreateOfferResult>`
+- **`OfferCreationRecord`** (`libs/core/src/listings/domain/entities/offer-creation-record.entity.ts:17`) — status (`pending|active|draft|validating|failed`), errors[], request snapshot
+
+### Job execution — fully exists
+
+- **`marketplace.offer.create` handler** (`apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts:42`) — accepts `MarketplaceOfferCreatePayloadV1`, calls `OfferCreationExecutionService.executeCreation`, maps outcome to `SyncJobHandlerResult`
+- **`SyncJob` outcome field** (`libs/core/src/sync/infrastructure/persistence/entities/sync-job.orm-entity.ts:42`) — `'ok' | 'business_failure' | null`
+
+### Fan-out pattern — exists as blueprint
+
+- **`MasterProductSyncAllHandler`** (`apps/worker/src/sync/handlers/master-product-sync-all.handler.ts:52`) — paginates external IDs, fans out per-product sub-jobs via `Promise.allSettled`, tolerates partial failure, dedupes via idempotency key `master:{connectionId}:product:sync:{externalId}:{job.id}`
+- This is the **template for bulk offer creation**.
+
+### AI description generation — exists for product content, not yet for offer creation
+
+- **`ContentSuggestionService.suggestDescription(cmd)`** (`libs/core/src/content/application/services/content-suggestion.service.ts:52`) — renders template `offer.description.suggest` channel-scoped, calls `AiCompletionPort.complete`
+- **Templates seeded** for channels `prestashop` and `allegro` (#451 / #452)
+- **Multi-provider router** through `AiCompletionPort` (Anthropic / OpenAI), prompt caching supported
+- **Not yet wired** into single-offer wizard or bulk wizard
+
+### EAN smart-linking — exists, **unrelated to "Allegro Smart!"**
+
+- **`resolveAllegroProductCardByEan`** (`libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.ts`, #431) — EAN-based lookup of existing Allegro product cards
+- This is purely a cost-optimization (avoid re-creating product cards). **It is NOT the Allegro Smart! program** despite the name overlap.
+
+### PrestaShop catalog reading — exists
+
+- **`PrestashopProductMasterAdapter.getProducts(filters)`** (`libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts:93`) — supports `limit`, `offset`
+- No FE bulk-picker endpoint exposed at the API layer yet
+
+### CreateOfferWizard FE — single-product only
+
+- **`useCreateOfferMutation`** (`apps/web/src/features/listings/hooks/use-create-offer-mutation.ts:21`) — accepts single `CreateOfferRequest`
+- **Form schema** at `apps/web/src/features/listings/components/create-offer-fields.schema.ts`
+- No multi-product flow exists
+
+### Verdict
+
+- **All atomic primitives needed for bulk creation exist.** Bulk is a composition feature — fan-out handler + FE wizard + new shared-overrides envelope. No new ports needed.
+- **Smart! support is a thin layer on top of existing `SellerPoliciesReader` capability** — surface seller's shipping rates in the wizard, validate selection before submit.
+
+---
+
+## 4. Design
+
+### 4.1 Architectural shape — bulk creation
+
+**The bulk feature lives at the application layer**, not as a new adapter capability. The Allegro adapter remains a per-offer worker. The composition happens above it.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ FE: BulkCreateOfferWizard (apps/web)                            │
+│ ├─ Step 1: Pick connection (Allegro)                            │
+│ ├─ Step 2: Pick source shop + multi-select products             │
+│ ├─ Step 3: Shared category + parameters                         │
+│ ├─ Step 4: Shared delivery config + Smart! validation           │
+│ ├─ Step 5: Shared price strategy + per-product preview          │
+│ ├─ Step 6: AI description toggle + bulk preview                 │
+│ └─ Step 7: Submit → POST /listings/bulk-create                  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ API: POST /listings/bulk-create                                 │
+│ ├─ Validate body (connection capability, products exist, etc.)  │
+│ ├─ Create BulkOfferCreationBatch record                         │
+│ ├─ For each selected product:                                   │
+│ │   └─ Enqueue marketplace.offer.create job with               │
+│ │      MarketplaceOfferCreatePayloadV1 + batchId reference     │
+│ └─ Return batchId + per-product jobIds                          │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Worker: marketplace.offer.create handler (UNCHANGED)            │
+│ └─ OfferCreationExecutionService.executeCreation                │
+│     └─ Allegro adapter.createOffer                              │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ FE: BulkProgressView (polls GET /listings/bulk-create/:batchId) │
+│ └─ Per-product status, retry per-failure                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 New domain entity — `BulkOfferCreationBatch`
+
+Lives in `libs/core/src/listings/domain/entities/bulk-offer-creation-batch.entity.ts`.
+
+```typescript
+export class BulkOfferCreationBatch {
+  constructor(
+    public readonly id: string,                   // ol_batch_*
+    public readonly connectionId: string,
+    public readonly initiatedBy: string,          // userId
+    public readonly status: BulkBatchStatus,      // pending | running | completed | partially-failed
+    public readonly totalCount: number,
+    public readonly succeededCount: number,
+    public readonly failedCount: number,
+    public readonly sharedConfig: BulkSharedConfigSnapshot,  // category, params, delivery, pricing
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+  ) {}
+}
+```
+
+The batch is **denormalized rollup view** of per-offer `OfferCreationRecord`s. Linkage: each `OfferCreationRecord` gets a new optional `bulkBatchId` foreign-key column.
+
+**Why a batch entity (not just query-time aggregation):**
+- Stores the shared-config snapshot (operator chose category X at time of submit; that's the source of truth even if shop category later changes)
+- Enables "retry whole batch" or "retry only failed" without re-collecting shared config
+- Simpler progress UX for FE (one entity to poll vs N records to aggregate)
+
+### 4.3 No new capability port
+
+Bulk operates at the **application layer** by enqueueing N standard `marketplace.offer.create` jobs. The Allegro adapter never knows about "bulk". This means:
+- Future marketplace adapters (Shopify, Amazon) get bulk for free once they implement `OfferCreator`
+- No new sub-capability needed
+- No changes to plugin SDK
+
+**Decision recorded in [ADR-XXX: Bulk creation as application-layer fan-out, not adapter capability]**.
+
+### 4.4 Allegro Smart! — surface via existing `SellerPoliciesReader`
+
+- `AllegroOfferManagerAdapter` already implements `SellerPoliciesReader.fetchSellerPolicies()`
+- We extend the response (or add a sibling call) to include the seller's **shipping rates** (`GET /sale/shipping-rates`), exposing each rate's id, name, and (if Allegro returns it) a `smartEligible: boolean` flag
+- FE wizard renders the picker; on submit, FE includes `deliveryShippingRatesId` in `CreateOfferRequest.overrides`
+- The existing `OfferBuilderService` passes this through `platformParams` opaque field to the adapter; the Allegro adapter applies it to the offer body's `delivery.shippingRates.id`
+
+**Decision recorded in [ADR-XXX: Allegro Smart! surfaced through delivery configuration, not as a separate offer field]**.
+
+### 4.5 AI description generation — wire `ContentSuggestionService` into bulk submit
+
+For each selected product, the bulk submit path optionally generates a description via the existing service before calling the offer creation flow. Two implementation options — picked at design phase below:
+
+- **Option A — Generate in API before enqueuing**: API call → for each product, call `ContentSuggestionService` → write generated description into `MarketplaceOfferCreatePayloadV1.overrides.description` → enqueue jobs. Pro: simple, description present in job payload at enqueue time. Con: API request hangs for 100 × ~3s AI calls = 5 min (unacceptable).
+- **Option B — Generate inside the worker job**: API enqueues jobs without description. Each worker job, if "generate description" flag set, calls `ContentSuggestionService.suggestDescription` before `executeCreation`. Pro: parallelized across worker instances, no API timeout. Con: requires `ContentSuggestionService` reachable from worker module (currently lives in API).
+- **Option C — Separate pre-generation jobs**: API enqueues `content.description.generate` jobs that write to product content table, then enqueues `marketplace.offer.create` jobs that read from there. Pro: clean separation. Con: extra job type, extra latency, content table churn.
+
+**Recommendation: Option B.** Move `ContentSuggestionService` registration to a shared module consumed by both API and worker (it has no DI dependencies that conflict). Worker handler reads `generateDescription: boolean` from new field on `MarketplaceOfferCreatePayloadV2`, calls the service if set, falls through to the existing `OfferBuilderService` flow.
+
+**Decision recorded in [ADR-XXX: AI description generation runs in worker, not API, to avoid API timeouts on large batches]**.
+
+### 4.6 Variation handling — collapse to Allegro variant matrix (v1)
+
+A PrestaShop product with N variants today creates one Allegro offer when listed via the single-offer flow. The Allegro adapter already accepts a "variant matrix" structure that maps shop variants to Allegro variant parameters.
+
+In bulk v1, we keep this behavior: **1 shop product = 1 Allegro offer with internal variants**. This means a 100-product batch creates exactly 100 jobs, not 100 × avg-variant-count.
+
+**Open question for discovery: does any agency need to split variants into separate Allegro offers?** Flag for v2 — separate sub-capability `OfferCreator.createOfferPerVariant` could be added later.
+
+### 4.7 Idempotency
+
+Bulk batch identity:
+- Batch ID: `ol_batch_*` generated on submit
+- Per-job idempotency key: `bulk:{batchId}:variant:{internalVariantId}` (deterministic — re-submitting the same batch is a no-op via Redis dedup + Postgres `sync_jobs.idempotency_key` unique constraint)
+
+Re-submit / retry semantics:
+- **Retry single failed offer**: re-enqueue with same idempotency key — gated by existing dedup; allowed only if previous outcome was `business_failure` or `dead`
+- **Retry whole batch**: re-enqueues only failed children; reuses batch entity; uses existing `SyncJobBulkRetryService` infrastructure
+
+### 4.8 Progress reporting
+
+- FE polls `GET /listings/bulk-create/:batchId` every 5s
+- Endpoint returns batch entity + array of per-job summaries (status, error message, externalOfferId if succeeded)
+- No streaming/SSE in v1 (FE polling is sufficient for batches up to ~200 products)
+- For batches > 200: API returns paged results; FE shows aggregate counts only
+
+### 4.9 Shared config envelope
+
+```typescript
+// libs/core/src/listings/application/dto/bulk-offer-creation.dto.ts
+export interface BulkOfferCreateRequest {
+  connectionId: string;
+  productIds: string[];                           // internal product IDs, 1..100
+  sharedConfig: {
+    categoryId: string;                           // Allegro category
+    parameters: AllegroParameterValue[];          // shared params (brand, etc.)
+    deliveryShippingRatesId: string;              // selected delivery config
+    pricingStrategy: PricingStrategy;             // copy | markup-pct | fixed
+    pricingValue: number;                         // % or PLN depending on strategy
+    publishImmediately: boolean;
+    generateDescription: boolean;                 // toggle for AI
+    descriptionTone?: string;                     // optional, passed to ContentSuggestion
+  };
+  perProductOverrides?: Record<string, Partial<CreateOfferOverrides>>;  // by productId
+}
+```
+
+API validates: products belong to a shop connection of the operator, all variants are in master catalog (auto-match if not — separate issue), Allegro connection has `OfferCreator` capability.
+
+---
+
+## 5. UX flow
+
+(Wireframes to be produced separately — see [Open question §7.3].)
+
+### 5.1 Bulk wizard steps
+
+1. **Entry point**: "Create offers in bulk" button on Listings page
+2. **Step 1 — Source**: pick PrestaShop connection (if multiple)
+3. **Step 2 — Products**: paginated multi-select of shop products (with search, category filter, image preview); selection limit 100 per batch in v1; counter shows "X / 100"
+4. **Step 3 — Allegro target**: pick Allegro connection (if multiple)
+5. **Step 4 — Category & parameters**: pick Allegro category (reuse existing `CategoryBrowser` UI from single-offer wizard); fill shared parameters (brand, etc.); per-product params can be edited in preview step
+6. **Step 5 — Delivery & Smart!**: pick delivery shipping rate; show Smart!-eligible badge if API returns flag; warn if non-Smart-eligible rate selected
+7. **Step 6 — Pricing**: pick strategy (copy from shop / markup % / fixed); preview per-product final price
+8. **Step 7 — Description**: toggle "Generate descriptions with AI"; optional tone hint
+9. **Step 8 — Review & submit**: per-product summary table with edit-this-row affordance; submit → API call → redirect to batch progress view
+
+### 5.2 Progress view
+
+- Header: batch status (running / completed / partially-failed), counters
+- Per-product table: product name, status badge, externalOfferId (if success), error message (if failed), action menu (retry / view in Allegro)
+- "Retry all failed" button if any failed
+- Auto-refresh every 5s while batch is `running`
+
+---
+
+## 6. Implementation increments
+
+Each increment is independently shippable and reviewable. Increment numbering aligns to issues created in §9.
+
+### Increment 1 — Domain entities + repository (Week 1)
+
+**Files:**
+- `libs/core/src/listings/domain/entities/bulk-offer-creation-batch.entity.ts` (NEW)
+- `libs/core/src/listings/domain/types/bulk-offer-creation.types.ts` (NEW — `BulkBatchStatus`, `BulkSharedConfigSnapshot`)
+- `libs/core/src/listings/domain/ports/bulk-offer-creation-batch-repository.port.ts` (NEW)
+- `libs/core/src/listings/infrastructure/persistence/entities/bulk-offer-creation-batch.orm-entity.ts` (NEW)
+- `libs/core/src/listings/infrastructure/persistence/repositories/bulk-offer-creation-batch.repository.ts` (NEW)
+- `libs/core/src/listings/listings.tokens.ts` (UPDATE — add `BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN`)
+- `apps/api/src/migrations/{timestamp}-add-bulk-offer-creation-batch.ts` (NEW migration)
+- Adds optional `bulkBatchId` column to existing `offer_creation_records` table
+
+**Acceptance:**
+- Migration up + down round-trips cleanly
+- Repository unit-spec tested
+- Token exported via `@openlinker/core/listings`
+
+**Effort:** S (3-5 days)
+
+### Increment 2 — Bulk submission service + API (Week 2)
+
+**Files:**
+- `libs/core/src/listings/application/services/bulk-offer-creation-submit.service.ts` (NEW)
+- `libs/core/src/listings/application/services/bulk-offer-creation-submit.service.interface.ts` (NEW)
+- `libs/core/src/listings/application/dto/bulk-offer-creation.dto.ts` (NEW — request DTO)
+- `apps/api/src/listings/http/bulk-offer-creation.controller.ts` (NEW)
+  - `POST /listings/bulk-create` → returns `{ batchId, jobIds }`
+  - `GET /listings/bulk-create/:batchId` → returns batch + per-record summaries
+- `apps/api/src/listings/http/dto/bulk-create-offer-request.dto.ts` (NEW)
+
+**Behavior:**
+- Validates: connection has `OfferCreator` capability, product IDs belong to a shop connection owned by operator, batch size ≤ 100
+- Creates `BulkOfferCreationBatch` record (status=pending)
+- For each productId, resolves variants via `ProductRepository.findVariantsByProductId`, enqueues one `marketplace.offer.create` job per variant with `bulkBatchId` in payload metadata
+- Returns 202 Accepted with batchId
+
+**Acceptance:**
+- Unit specs for service (validation, enqueue ordering, batch-record creation)
+- Integration spec end-to-end via Testcontainers (real Postgres + Redis Streams)
+- `@Roles('admin')` enforced on both endpoints
+
+**Effort:** M (5-7 days)
+
+### Increment 3 — Worker handler extension for bulk-batch awareness + AI description (Week 3)
+
+**Files:**
+- `apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts` (UPDATE)
+  - Accept `MarketplaceOfferCreatePayloadV2` (adds `bulkBatchId?`, `generateDescription?`, `descriptionTone?`)
+  - On completion, update batch rollup counters via new service `BulkOfferCreationProgressService`
+  - If `generateDescription === true`: call `ContentSuggestionService.suggestDescription` before `OfferCreationExecutionService.executeCreation`; thread result into overrides
+- `libs/core/src/listings/application/services/bulk-offer-creation-progress.service.ts` (NEW)
+  - Atomically updates batch counters using Postgres `UPDATE ... SET counter = counter + 1 WHERE ...`
+  - Computes final status when `succeeded + failed === total`
+- `libs/core/src/listings/listings.module.ts` (UPDATE) — wire new services
+- `apps/worker/src/sync/sync.module.ts` (UPDATE) — register `ContentSuggestionService` (if not already)
+
+**Acceptance:**
+- Unit specs cover: bulk-batch-aware handler, progress counter updates, AI description path
+- Worker integration spec via Testcontainers: enqueue 5-job batch, all succeed, batch rolls up to `completed`
+- Spec for partial failure: 3 succeed, 2 fail → batch ends as `partially-failed`
+
+**Effort:** M (5-7 days)
+
+### Increment 4 — Allegro shipping rates exposure (Week 3, parallel) {#increment-4}
+
+**Files:**
+- `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts` (UPDATE)
+  - Extend `SellerPolicies` response to include `shippingRates: AllegroShippingRate[]` from `GET /sale/shipping-rates`
+- `libs/core/src/listings/domain/types/seller-policies.types.ts` (UPDATE) — add `shippingRates` array
+- Update `apps/api` response DTOs accordingly
+
+**Acceptance:**
+- Adapter test against mocked Allegro API
+- New field surfaces in existing `GET /seller-policies/:connectionId` response
+
+**Effort:** S (2-3 days)
+
+### Increment 5 — FE bulk wizard (Weeks 4-5)
+
+**Files (new feature folder):**
+- `apps/web/src/features/listings/bulk-create/` (NEW)
+  - `bulk-create-offer-wizard.tsx`
+  - `steps/{products,category,delivery,pricing,description,review}.step.tsx`
+  - `hooks/use-shop-products-paginated.ts`
+  - `hooks/use-bulk-create-offer-mutation.ts`
+  - `hooks/use-bulk-batch-progress.ts` (polling)
+- `apps/web/src/pages/listings/bulk-create-offer-page.tsx` (NEW route)
+- `apps/web/src/pages/listings/bulk-batch-progress-page.tsx` (NEW route)
+- `apps/web/src/app/router/listings-routes.tsx` (UPDATE — register new routes)
+- `apps/web/src/features/listings/listings.locales.ts` (UPDATE — PL + EN strings)
+
+**State ownership:**
+- Wizard step state: URL search params (so refresh / share-link works)
+- Selected product list: React Hook Form with Zod schema
+- Server state: TanStack Query (`useShopProductsPaginated`, `useSellerPolicies`, `useCategories`)
+
+**Acceptance:**
+- Component tests for each wizard step
+- Mock API client used for happy path + error path
+- Mobile-responsive (cardView fallback for product table per `frontend-architecture.md`)
+
+**Effort:** L (7-10 days)
+
+### Increment 6 — Bulk retry + polish (Week 5)
+
+**Files:**
+- `apps/api/src/listings/http/bulk-offer-creation.controller.ts` (UPDATE) — add `POST /listings/bulk-create/:batchId/retry-failed`
+- `libs/core/src/listings/application/services/bulk-offer-creation-retry.service.ts` (NEW) — re-enqueues only failed records in batch
+- Documentation: update `docs/plugin-author-guide.md` to mention "bulk creation works on top of single-offer `OfferCreator` — no plugin changes required"
+- Integration test: simulated full happy-path E2E with real Allegro mock
+
+**Acceptance:**
+- Retry-failed endpoint covered by integration test
+- All quality gates pass
+
+**Effort:** S (3-5 days)
+
+### Smart! eligibility surfacing — folded into Increments 4 + 5
+
+Per §4.4 the Smart! UI is the delivery configuration picker built in Increment 4 (backend) + Increment 5 (frontend). No separate increment needed; Smart! is "Allegro returns the list, we render it with a badge".
+
+### Total effort
+
+- Backend (Increments 1-4 + 6): ~3-4 weeks for 1 dev
+- Frontend (Increment 5): ~1.5-2 weeks for 1 FE dev (parallel)
+- Together (2 devs, parallel after Increment 2): **~5-6 weeks wall-clock**
+
+---
+
+## 7. Open questions to resolve before implementation starts
+
+These should be resolved via discovery interview + Allegro API probing before Increment 1.
+
+### 7.1 Variation handling
+
+Does any target agency need each PrestaShop variant as a **separate Allegro offer** (vs collapsed into one offer with variant matrix)? If yes, defer to v2 with a separate sub-capability. If no, our v1 design holds.
+
+**Action:** ask 3-5 agencies. Default: collapse to single offer with variants.
+
+### 7.2 Smart! eligibility detection
+
+Does Allegro's `GET /sale/shipping-rates` response include an explicit Smart! eligibility flag, or do we need to compute it client-side from the rate's contents?
+
+**Action:** probe the API endpoint with a real seller account. If no flag: v1 ships without badge, just lists rate names; v2 adds eligibility computation.
+
+### 7.3 Bulk wizard UX
+
+The 8-step wizard described in §5.1 may be too long. Should we collapse some steps (e.g., delivery + pricing into one step)?
+
+**Action:** wireframe in Figma, validate with 2-3 agencies before Increment 5.
+
+### 7.4 Maximum batch size
+
+100 products per batch is a guess. What's the realistic upper bound that agencies want to use? Cap of 100 protects worker queue depth; cap of 1000 would require chunked job enqueuing.
+
+**Action:** ask agencies "what's the biggest batch you'd want in one go". Confirm 100 covers 95% of use cases.
+
+### 7.5 Bulk-update existing offers
+
+Issue #726 explicitly scopes to **creation** of new offers. Several agencies will ask about bulk **update** (price, stock, parameters) of existing offers. Confirm this is out-of-scope for v1, file as separate future feature.
+
+**Action:** clarify in the discovery interview; if strong demand, file as #726-companion issue (still out of #726 scope).
+
+### 7.6 Cross-connection bulk
+
+Can one batch span multiple Allegro connections (e.g., two seller accounts)? Default: no — one batch = one connection. Simplification holds unless agencies push back.
+
+### 7.7 Auto-match variants before bulk submit
+
+If selected products have unmapped variants (not in master catalog), should the bulk submit auto-match them first (via the existing `auto-match-variants` handler) or fail with "please run auto-match first"?
+
+**Action:** default to "fail with clear error message"; auto-match-before-submit is v2.
+
+---
+
+## 8. ADRs to write as part of this work
+
+Each gets a small dedicated PR after #725 (ADR practice introduction) lands:
+
+1. **ADR-XXX: Bulk creation as application-layer fan-out, not adapter capability** — codifies §4.3 decision. Captures alternatives considered (new `OfferBatchCreator` capability) and why rejected (every future marketplace adapter would need to re-implement).
+2. **ADR-XXX: Allegro Smart! surfaced through delivery configuration, not as a separate offer field** — codifies §4.4 / §2 findings. Captures the alternative (toggle on each offer) and why rejected (not how Allegro API works).
+3. **ADR-XXX: AI description generation runs in worker, not API, to avoid API timeouts on large batches** — codifies §4.5 decision. Captures Options A/B/C and why B chosen.
+4. **ADR-XXX: `BulkOfferCreationBatch` as denormalized rollup entity** — codifies §4.2 decision. Captures alternative (query-time aggregation) and why rejected (snapshot of shared config; retry semantics).
+
+---
+
+## 9. Implementation issues to create (post-refinement)
+
+After this design doc merges, the following GitHub issues should be created, each linked to #726:
+
+- **#726.1** — feat(listings): `BulkOfferCreationBatch` domain entity + repository + migration (Increment 1)
+- **#726.2** — feat(listings): bulk submission service + HTTP endpoints (Increment 2)
+- **#726.3** — feat(worker): bulk-aware `marketplace.offer.create` handler + AI description integration (Increment 3)
+- **#726.4** — feat(allegro): expose shipping rates via `SellerPoliciesReader` (Increment 4)
+- **#726.5** — feat(web): bulk create offer wizard (Increment 5)
+- **#726.6** — feat(listings): bulk retry-failed endpoint + polish (Increment 6)
+- **#726.7** — feat(content): make `ContentSuggestionService` consumable from worker module (prereq for #726.3)
+
+Issues created from §8 ADR list:
+- **#726-ADR-1** to **#726-ADR-4** as listed above
+
+After all six implementation increments ship, #726 itself is closed via PR with `Closes #726`.
+
+---
+
+## 10. Validation against architecture rules
+
+This design has been checked against `docs/architecture-overview.md` and `docs/engineering-standards.md`:
+
+- ✅ **CORE vs Integration boundary**: bulk lives in core (`libs/core/src/listings/application/`), Allegro adapter unchanged
+- ✅ **Port-first**: no new ports introduced; existing `OfferCreator` carries the load
+- ✅ **Sub-capability pattern**: no abuse — we explicitly chose application-layer composition over new sub-capability (§4.3)
+- ✅ **Repository ports pattern**: new `BulkOfferCreationBatchRepositoryPort` in domain layer, ORM repo in infrastructure
+- ✅ **Symbol DI tokens**: new token `BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN` added to `listings.tokens.ts`
+- ✅ **Domain layer independence**: new entities are framework-free
+- ✅ **Naming conventions**: services follow `*.service.ts` + `*.service.interface.ts`, entities follow `*.entity.ts`, ORM `*.orm-entity.ts`
+- ✅ **Type definitions in separate files**: `bulk-offer-creation.types.ts`
+- ✅ **`as const` for status enums**: `BulkBatchStatus` follows pattern from `JobStatus`
+- ✅ **Hexagonal dependency direction**: FE → API controller → application service → repository port + job enqueue port
+
+### Test strategy (per `docs/testing-guide.md`)
+
+- **Unit tests** (`*.spec.ts`): each new service mocks ports; bulk progress service tested for race-safety on counter updates
+- **Integration tests** (`*.int-spec.ts`): end-to-end submit → workers process → batch rolls up → progress endpoint reflects state. Real Postgres + Redis via Testcontainers.
+- **Coverage target**: 80%+ on application services per engineering standards.
+
+### Security review
+
+- All new endpoints `@UseGuards(JwtAuthGuard) @Roles('admin')`
+- Input validation via class-validator DTOs (`@IsArray`, `@ArrayMaxSize(100)`, `@IsUUID('all', { each: true })`)
+- No raw SQL — all repository operations use TypeORM
+- Per-product overrides validated through existing `CreateOfferRequest` DTO validation
+- Batch IDs are `ol_batch_*` (deterministic prefix + UUID); not guessable
+
+---
+
+## 11. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| AI description generation rate-limited by provider (Anthropic/OpenAI) on large batches | Worker handler concurrency cap per connection (existing `RedisSyncLockService` pattern); fall back to no-description on rate-limit error and continue offer creation |
+| Allegro API rate-limit hit on 100-product batch (Allegro typically allows ~9000 req/min, but bursting may trigger 429) | Existing `AllegroHttpClient` retry-classifier handles 429 with `Retry-After`; bulk doesn't change pacing — each child job is independent |
+| Bulk batch entity drift from per-job records (counters wrong) | Use atomic SQL `UPDATE ... SET counter = counter + 1` rather than read-modify-write; cover with concurrency-stress integration test (16 parallel completing jobs) |
+| Wizard UX too complex; abandonment mid-flow | Step-by-step URL state lets operator resume; auto-save draft (v2) |
+| Smart! eligibility classification wrong (we say "Smart!" but Allegro rejects) | v1: don't claim Smart! pre-submit; let Allegro classify; surface eligibility post-create from offer response |
+
+---
+
+## 12. References
+
+- Issue: [#726](https://github.com/SilkSoftwareHouse/openlinker/issues/726)
+- Related: [#431 — EAN-based smart-link product card resolution](https://github.com/SilkSoftwareHouse/openlinker/issues/431) (unrelated to Allegro Smart! despite naming)
+- Related: [#451 / #452 — AI provider switching + prompt template seeding](https://github.com/SilkSoftwareHouse/openlinker/issues/451)
+- Architecture: `docs/architecture-overview.md` — Listings bounded context, OfferCreator capability
+- Engineering standards: `docs/engineering-standards.md` — hexagonal rules, Symbol DI tokens, naming
+- Existing code:
+  - `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts` — single-offer creation + `SellerPoliciesReader`
+  - `libs/core/src/listings/application/services/offer-creation-execution.service.ts` — orchestration
+  - `apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts` — single-offer handler
+  - `apps/worker/src/sync/handlers/master-product-sync-all.handler.ts` — fan-out blueprint
+  - `libs/core/src/content/application/services/content-suggestion.service.ts` — AI description
+  - `apps/web/src/features/listings/hooks/use-create-offer-mutation.ts` — single-offer FE mutation
+- Allegro API docs (to verify in discovery phase):
+  - `GET /sale/shipping-rates` — seller's named shipping rate configurations
+  - `GET /sale/delivery-methods` — available delivery methods
+  - `POST /sale/product-offers` — create offer

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,97 @@
+# Product Specs
+
+This directory holds **product specifications** produced by Tier 1 of the [refinement workflow](../contributors/refinement-workflow.md). A product spec answers _what_ we're building, _for whom_, and _why_ — and locks that down before any engineering work begins.
+
+## What lives here
+
+- `product-spec-{N}-{slug}.md` — one file per Product Design GitHub issue
+- `archive/` — specs that were refined but ultimately not built (preserved for posterity and as evidence against re-asking the same question)
+
+## What does NOT live here
+
+- **Implementation plans** — those live in `../plans/` and are produced by Tier 2 refinement (`/plan`)
+- **Architecture Decision Records** — those live in `../architecture/adrs/`
+- **Strategic / business documents** — those are not committed to the repo
+- **Raw customer interview transcripts** — privacy. Sanitized findings only.
+- **Roadmaps or quarterly plans** — those are not the same as per-feature specs
+
+## Spec doc structure
+
+Every spec follows this skeleton. Sections are filled out incrementally by the four phases of `/refine-product`. **Stage 1 calibration applies** — see [`docs/contributors/refinement-workflow.md`](../contributors/refinement-workflow.md#project-stage-calibration) — some sections are skipped or simplified until OpenLinker has telemetry and a customer base.
+
+```markdown
+# Product Spec — #N {slug}
+
+**Status:** phase X in progress | phase X complete | ready for implementation | deferred | archived
+**Parent issue:** [#N](https://github.com/SilkSoftwareHouse/openlinker/issues/N)
+**Started:** YYYY-MM-DD
+**Last updated:** YYYY-MM-DD
+
+## 1. Problem
+(Phase A — always required)
+
+## 2. Affected persona
+(Phase A — always required)
+
+## 3. Evidence & user research
+(Phase B — cite sources, always required)
+
+## 4. Solution exploration
+(Phase C — chosen shape + key sub-decisions + resolved open questions; always required)
+
+## 5. Product specification
+(Phase D — user stories + acceptance criteria; always required; user-visible AC only — engineering AC belongs in implementation plans)
+
+## 6. Out of scope
+(Phase D — top 5-7 items only; not an exhaustive future-feature catalog)
+
+## 7. Definition of done
+(Phase D — 3-5 qualitative bullets answering "what does the maintainer need to see before declaring v1 a success?". Stage 1 default. Replace with quantitative success metrics only when telemetry/analytics infra exists.)
+
+## 8. Risks
+(Phase D — top 3-5 product-direction risks only; engineering risks belong in implementation plans)
+
+## 9. Implementation breakdown
+(Phase E — list of spawned implementation issues; populated only if Gate D = YES)
+
+## 10. Decision log
+(Per phase: what was decided, who decided, why — always required)
+```
+
+**Sections explicitly NOT in the template** (avoid the slop):
+
+- ❌ Anti-metrics — at Stage 1 there's no instrumentation to detect them
+- ❌ Persona-fit verification subsection — circular self-congratulation
+- ❌ Stakeholder alignment matrix — there are 1–2 maintainers, not 20 stakeholders
+- ❌ Day-by-day effort breakdown — belongs in Tier 2 implementation plans
+- ❌ Quantitative success metrics with %s — Stage 1 has no way to measure them
+
+## Conventions
+
+- **Filename:** `product-spec-{N}-{kebab-case-slug}.md` where `N` is the parent Product Design issue number
+- **Status header:** always reflects current phase — never leave stale
+- **Decision log:** append-only. If a decision is reversed, add a new entry referencing the prior one — don't rewrite history
+- **Cite sources:** every external claim links to a URL, interview note, or ticket number
+- **Plain language:** specs are read by future maintainers including non-engineers. No NestJS jargon. No file paths from the codebase. Save that for the implementation plan.
+
+## Lifecycle
+
+```
+docs/specs/product-spec-N-slug.md
+   ↓ (refinement complete, Gate D = YES)
+remains in docs/specs/ — referenced by impl plans in ../plans/
+   ↓ (all impl children merged)
+remains in docs/specs/ — historical record
+
+OR
+
+docs/specs/product-spec-N-slug.md
+   ↓ (Gate D = NO, "don't build")
+moved to docs/specs/archive/
+```
+
+## See also
+
+- [Refinement Workflow](../contributors/refinement-workflow.md) — how specs get produced
+- [`docs/plans/`](../plans/) — implementation plans that consume specs
+- [`docs/architecture/adrs/`](../architecture/adrs/) — Architecture Decision Records

--- a/docs/specs/product-spec-726-allegro-bulk-listing.md
+++ b/docs/specs/product-spec-726-allegro-bulk-listing.md
@@ -1,0 +1,443 @@
+# Product Spec — #726 Allegro bulk listing creation (+ Smart! support)
+
+**Status:** phase A complete; phase B complete; phase C complete; phase D complete; Gate D = YES (build); phase E complete; ready for implementation
+**Parent issue:** [#726](https://github.com/SilkSoftwareHouse/openlinker/issues/726)
+**Started:** 2026-05-15
+**Last updated:** 2026-05-15
+**Workflow:** [`docs/contributors/refinement-workflow.md`](../contributors/refinement-workflow.md)
+
+---
+
+## 1. Problem
+
+> **Phase A complete — confirmed by maintainer at Gate A on 2026-05-15**
+
+### Problem statement
+
+PL e-commerce shops running on PrestaShop and selling on Allegro can create only **one Allegro offer at a time** through OpenLinker today. For shops with 50–1,000 SKU catalogs, this forces them to either:
+
+1. Use BaseLinker Cloud for bulk operations — losing the data unification benefit of consolidating in OpenLinker, paying per-order pricing that compounds painfully past 200 orders/day, and accepting vendor lock-in
+2. Work outside OpenLinker via the Allegro seller panel (manual data re-entry, ~5 min × 100 SKUs = 8 operator-hours per onboarding) or via custom Allegro-API scripts (technical operators only)
+
+Both workarounds friction-out adoption: an agency or merchant who can't onboard a 100-SKU catalog efficiently won't adopt OpenLinker for ongoing operations either.
+
+**Secondary problem — Allegro Smart! eligibility:** Allegro's "Smart!" buyer subscription gives free shipping above 45 zł threshold; eligible offers see materially better conversion. Seller-side requirement is a properly-configured delivery method. OpenLinker today has no surface for the operator to choose which delivery configuration applies to a new offer, leaving operators unable to opt offers into Smart! without leaving the wizard. **Whether Smart! belongs in the same product design as bulk listing, or is a separate sibling refinement, is a Phase C decision.**
+
+### Why now
+
+- Q1 wedge defined as "PL Allegro + PrestaShop + InPost — complete end-to-end workflow" (strategy session 2026-05-15)
+- Without a bulk listing story, OpenLinker is unusable for any new-shop onboarding beyond ~10 SKUs, blocking the first 3-5 design partner agencies the strategy depends on
+- Pre-refinement codebase audit (`docs/plans/implementation-plan-726-allegro-smart-bulk.md`) confirmed that all atomic primitives (single-offer creation, fan-out pattern, AI description) already exist — bulk is composition work, not a new architectural concept
+
+### Gate A resolutions (2026-05-15)
+
+The four ambiguity points surfaced in Phase A were resolved as follows:
+
+#### A1. Bulk-listing shape — **inline multi-select on Products page**
+
+**Decision:** rather than a separate wizard route, the operator gets a **checkbox column on the existing Products page** with a "Create Allegro offers" action that triggers a shared-config modal/sidebar over the selected items. Each selected product produces one offer-creation job using the existing fan-out pattern.
+
+**Why this shape (over the alternatives originally surfaced):**
+
+- A separate multi-step wizard adds UX overhead the primary persona (shop owner — see §2) doesn't need
+- Inline multi-select matches the muscle memory of every product-list operator workflow (file manager, mail client, ecommerce admin)
+- Lower implementation effort than full wizard; reuses existing Products page state, filters, search
+- Rule-engine "auto-list on PS publish" (Option B in original ambiguity list) and CSV upload (Option C) are explicitly deferred — they remain candidate future features but are out of this Product Design's scope
+
+#### A2. Allegro Smart! support scope — **deferred to Phase B research**
+
+**Decision:** the right scope for Smart! support cannot be decided in Phase A without understanding the actual mechanics of Allegro Smart! enrollment, the seller-side configuration model, and what changes in the order flow when an offer is Smart-eligible. Phase B will research this and feed evidence into Phase C scope decisions.
+
+**Research questions for Phase B (delegated to `product-researcher` subagent):**
+- How does a seller turn on Allegro Smart! eligibility — account-level toggle, per-shipping-config, per-offer, or automatic?
+- What changes in the buyer/seller/OpenLinker order flow when an offer is Smart-eligible? (buyer experience, seller fees, order events, shipping responsibilities)
+- What does the Allegro API expose to sellers about Smart eligibility — flags, endpoints, webhook events?
+- What are common seller-side issues with Smart! surfaced in PL e-commerce communities?
+
+#### A3. Primary persona — **shop owner**
+
+**Decision:** the primary persona is the **shop owner** (single-shop in-house operator). Agency-operator is no longer the primary persona; if agencies use OpenLinker on behalf of clients, they will use the same UX as the shop owner — there is no separate agency-optimized flow.
+
+**Why:** OpenLinker's product surface is for end users (shop owners). Agency-delivery is a go-to-market channel, not a UX target. Optimizing for shop-owner UX yields a product that agencies can also deploy without modification; optimizing for agency-operator first would produce a product that shop owners find too technical.
+
+#### A4. UVP framing — **dropped at feature level**
+
+**Decision:** unique-value-proposition framing is a product/marketing concern at the OpenLinker level, not a per-feature concern. At feature level, the relevant question is simply: **"does this clearly deliver value to the target user?"** — yes/no. This product spec will not justify the feature against BaseLinker; OpenLinker's overall positioning answers that question separately.
+
+---
+
+## 2. Affected persona
+
+> **Phase A complete — confirmed by maintainer at Gate A on 2026-05-15**
+
+### Primary persona: shop owner
+
+- **Role:** in-house operator (often the shop owner themselves) at a PL e-commerce shop running PrestaShop and selling on Allegro
+- **Company size:** small to mid-sized — 1 to ~30 people
+- **Catalog volume:** 100–1,000 SKUs; occasional bulk listing during seasonal launches (1–4 times/year) plus continuous incremental listing for new products (5–30/month)
+- **Sophistication:** non-technical to operator-level — comfortable with admin UIs and standard SaaS patterns; low tolerance for technical error messages, API references, or developer-facing terminology
+- **Geography:** PL primary
+- **What they value:**
+  - UX hand-holding (bulk listing is occasional — they'll forget how between launches)
+  - Preview before submit (this is publishing publicly; mistakes are visible to buyers)
+  - Visual feedback during submission (especially when listing 50+ products)
+  - Clear error recovery when something fails partway through a batch
+- **Trigger events:**
+  - Initial shop launch on Allegro (one-time onboarding of existing catalog)
+  - New product range / seasonal collection launch (occasional, 20–100 SKUs)
+  - Migration from BaseLinker or other tool (one-time, full catalog)
+
+### Agency-delivery context (not a separate persona)
+
+Agencies will install OpenLinker on behalf of shop-owner clients. They use **the same UX** as shop owners — there is no separate agency-mode. This means:
+
+- Bulk listing UX optimizes for the shop owner's mental model and tolerance
+- Agencies benefit from this when they hand the shop over to the owner post-installation
+- If agencies want bulk-onboarding efficiency for repeat use, they get it via the same UX shop owners use (no agency-specific shortcuts in v1)
+
+---
+
+## 3. Evidence & user research
+
+> **Phase B complete — 2026-05-15**. Confirmed at Gate B by maintainer (pending).
+
+### 3.1 Existing internal evidence
+
+Pre-refinement draft (`docs/plans/implementation-plan-726-allegro-smart-bulk.md`) contains:
+
+- **Codebase audit** confirming that all atomic primitives for bulk creation already exist:
+  - `OfferBuilderService`, `OfferCreationExecutionService`, `marketplace.offer.create` job handler, fan-out pattern (`MasterProductSyncAllHandler`), AI description infra (`ContentSuggestionService`), per-product idempotency via `OfferCreationRecord`
+  - Verdict: **bulk listing is composition work, not a new architectural concept**
+- **Initial Allegro Smart! hypothesis** (later revised in §3.2 below) that Smart support required a "delivery configuration picker + pre-submit validation" of ~1 week effort
+- **Reusable as evidence**: codebase audit findings. **Discarded as evidence**: original Smart! scope hypothesis (replaced by §3.2 research findings)
+
+### 3.2 Allegro Smart! research findings (external)
+
+Conducted by `product-researcher` subagent, 2026-05-15. Full report archived (see decision log §10). Citations and confidence assessments at:
+- [Allegro Help: Smart! for business sellers](https://help.allegro.com/en/sell/a/allegro-smart-on-allegro-pl-information-for-sellers-with-a-business-account-LR8j8Y26GTR)
+- [Allegro Help: Allegro Delivery program](https://help.allegro.com/en/sell/a/the-allegro-delivery-program-information-for-sellers-MR7exl1wYS4)
+- [Allegro Help: free delivery & commission](https://help.allegro.com/en/sell/a/free-delivery-why-it-is-worth-enabling-it-in-your-offers-and-how-to-do-it-2YbEaeZxoiB)
+- [Allegro Developer changelog (2026-04-28 `smartDeliveryMethods` deprecation)](https://developer.allegro.pl/changelog)
+- [Media Allegro: nowy próg 49.90 zł od 2026-03-02](https://media.allegro.pl/446561-smart-jeszcze-prostszy-allegro-wprowadzi-jeden-prog-darmowej-dostawy-dla-wszystkich-przesylek-allegro-smart)
+- PL seller community signal: [Społeczność Allegro – prawdziwe koszty Smart](https://spolecznosc.allegro.pl/t5/smart-dla-sprzedawc%C3%B3w/prawdziwe-koszty-smart/td-p/876738), [pawelkasza.pl blog](https://pawelkasza.pl/blog/17/jak-nie-poplynac-z-allegro-smart-nowy-kosztowny-standard), [Subiektywnie o Finansach](https://subiektywnieofinansach.pl/sprzedaz-na-allegro-jest-coraz-trudniejsza/)
+
+**Key findings that change Phase A assumptions:**
+
+1. **Smart! is automatic, not a per-offer toggle.** A seller cannot "enable Smart" on individual offers. Eligibility is *derived server-side by Allegro* from the offer's shipping-rate composition and seller-account quality conditions. The seller's only direct lever is which shipping-rate package (`shippingRates.id`) the offer uses.
+
+2. **The create-offer payload has no Smart field.** `POST /sale/product-offers` does not accept any Smart-related parameter. Setting a Smart-eligible shipping-rate package is the entire indirect path. This **collapses Phase A option A2 (i) — "delivery configuration picker" — to "the picker we'd need for bulk creation anyway"**.
+
+3. **Smart classification is read-only and post-hoc.** Allegro exposes `GET /sale/offers/{offerId}/smart` returning:
+   - `classification.fulfilled: boolean`
+   - `conditions[]` with `code`, `description`, `fulfilled`, plus the specific `failedDeliveryMethods[]` that caused a fail
+   - `scheduledForReclassification: boolean`
+   
+   **This is a high-value, cheap surface for OpenLinker**: one API call after offer creation, one DB column, one UI badge. Lets the seller see "this offer didn't qualify for Smart because deliveryMethodPrices on courier exceeds limit" without leaving OL.
+
+4. **The order payload appears NOT to surface Smart membership.** `GET /order/checkout-forms/{id}` and order webhooks don't carry a Smart flag, per absent mention in Allegro help docs. **Open question** — needs a real Smart-buyer test purchase to definitively verify. If correct, OL has no order-side Smart integration to do.
+
+5. **Seller-account-level Smart eligibility exists.** `GET /sale/smart` exposes whether the seller account itself meets the conditions (sales quality, on-time payments, return address, return terms). A cheap pre-bulk-submit guard: warn the seller "your account does not currently meet Smart conditions — offers will not earn the badge".
+
+6. **Seller pain on Smart! is structural (cost), not API friction.** Forum signal consistently shows seller complaints about returns absorbed by seller, weight-surcharges arriving weeks later, "can't opt out per-offer" frustration. **None of these are bulk-creation scope.** They are real product opportunities for OL, but they belong in separate future features (returns analytics, cost-attribution reports), not this Product Design.
+
+7. **Competitor gap.** Neither BaseLinker nor ChannelEngine surfaces `/sale/offers/{id}/smart` classification + failure reasons in their UI per public docs. Low-cost differentiator if OL does.
+
+8. **March 2026 threshold change.** Single 49.90 PLN free-shipping threshold replaces the old 45 / 65 PLN split as of 2026-03-02. No known API impact, but worth noting for any UI copy that references the threshold.
+
+### 3.3 Phase B impact on problem statement and persona
+
+- **Problem statement (§1):** strengthened. The "shop owner can't bulk-list from OL" problem is unchanged; the Smart! secondary problem is materially smaller than originally hypothesized (almost no new work) and one part of it (post-create Smart classification) becomes an unexpected small win.
+- **Affected persona (§2):** unchanged. Shop owner remains primary.
+- **No persona change. No problem-statement re-frame. Gate B is a forward gate, not a regression gate.**
+
+### 3.4 Phase B round 2 — operational mechanics
+
+Round 1 left three open questions about how Smart actually works contractually. Round 2 research (2026-05-15) resolved all three and surfaced a new fundamental scope question.
+
+**Three contractual paths exist for Smart-eligible shipping** (this was not surfaced in round 1):
+
+| Path | Contract structure | Label generation | InPost integration relevance |
+|---|---|---|---|
+| **(P1) Own-contract carrier** | Seller has own InPost / DPD / DHL agreement; uses their own account | Seller uses own carrier panel (e.g., InPost Manager Paczek) — covered by [#727 InPost integration](https://github.com/SilkSoftwareHouse/openlinker/issues/727) | ✅ Fully covered by #727 |
+| **(P2) Allegro Delivery (Allegro Dostawa)** | Seller's contract is with **Allegro**; Allegro holds InPost/DPD/DHL/ORLEN agreements and bills seller monthly | Labels generated **only** via Allegro's `/shipment-management/*` REST API ("Wysyłam z Allegro") | ❌ NOT covered by #727 — requires new Allegro shipment-management integration |
+| **(P3) Allegro One** (Punkt / Box / Kurier) | Allegro's own last-mile network — only accessible *within* Allegro Delivery | Labels mandatory via `/shipment-management/*` | ❌ NOT covered by #727 — same |
+
+Sources: [Allegro Help — Delivery for sellers](https://help.allegro.com/en/sell/a/the-allegro-delivery-program-information-for-sellers-MR7exl1wYS4), [Help — Allegro One within Delivery](https://help.allegro.com/en/sell/a/the-allegro-one-delivery-options-within-allegro-delivery-5LaWAD2AAfg), [developer.allegro.pl — Wysyłam z Allegro tutorial](https://developer.allegro.pl/tutorials/jak-zarzadzac-przesylkami-przez-wysylam-z-allegro-LRVjK7K21sY).
+
+**Resolution of round 1 open questions:**
+
+- **OQ-B1 RESOLVED**: `GET /order/checkout-forms/{id}` returns `delivery.smart: boolean` per [developer.allegro.pl orders tutorial](https://developer.allegro.pl/tutorials/jak-obslugiwac-zamowienia-GRaj0qyvwtR). `true` = buyer used Smart on this order. **Confirmed: OL can tag every ingested order accurately with Smart status.** No buyer-subscription-level flag exists; only per-order.
+
+- **OQ-B2 PARTIALLY RESOLVED**: `smartDeliveryMethods` removal date is **2026-07-28** (not 2026-04-28 as originally noted — that was the changelog announcement). The endpoint `/sale/offers/{offerId}/smart` itself **stays**; only the per-delivery-method ID arrays go away. Replacement contract is **not yet documented publicly** — requires direct API probe near the deadline. **Risk for OL**: low — we wouldn't depend on per-method enumeration for the bulk-create v1 anyway, only the offer-level `classification.fulfilled` boolean.
+
+- **OQ-B3 RESOLVED**: not relevant in this form. Smart eligibility is server-side derived; OL doesn't need to maintain a delivery-method-to-Smart mapping.
+
+### 3.5 Implications for product scope (fundamental)
+
+**The new scope question Phase B surfaced** (this is the most important Phase C input):
+
+**Which contractual path does this Product Design support?**
+
+- **(S1) P1 only — own-contract carriers**: bulk listing works; shipment generation happens in seller's own carrier panel via #727 (InPost) and future courier integrations. Smart eligibility is automatic for offers in Smart-eligible price lists. Sellers using Allegro Delivery (P2) **cannot use this version of OL for end-to-end Smart fulfillment** — they'd list via OL but generate labels in Allegro panel. Acceptable cut for v1.
+
+- **(S2) P1 + P2 — both**: bulk listing PLUS new `/shipment-management/*` integration enabling label generation through Allegro for Allegro Delivery sellers. Materially larger scope; likely a separate Product Design issue (sibling to #726 / #727).
+
+- **(S3) P2-first**: optimize for Allegro Delivery sellers, defer own-carrier flow. Doesn't match the Q1 wedge (#727 already targets own-InPost).
+
+**Hypothesis**: S1 fits the Q1 wedge (PL Allegro + PrestaShop + InPost own-contract). Allegro Delivery integration (`/shipment-management/*`) is a real future need but separate Product Design.
+
+### 3.6 Net effect on Smart!-in-this-Product-Design scope
+
+After both research rounds, here is what's **legitimately in scope for #726 regarding Smart!**:
+
+| Item | In scope? | Reason | Effort |
+|---|:---:|---|---|
+| Operator picks shipping-rate package in bulk wizard | ✅ | Required for offer create regardless of Smart | — |
+| OL surfaces post-create Smart classification (`/sale/offers/{id}/smart`) per offer | ✅ | Cheap differentiator — one API call, one badge, one column | ~1-2 days |
+| OL tags incoming Allegro orders with `delivery.smart` boolean | ✅ | Trivial lift in `AllegroOrderSourceAdapter`; unlocks future Smart-aware features | ~0.5 day |
+| Pre-bulk-submit account-level Smart eligibility check (`GET /sale/smart`) | ⚠️ Optional | Nice-to-have; can be Phase D scope decision | ~0.5 day |
+| Smart-specific delivery rate guidance in wizard ("this rate WILL/WON'T qualify") | ❌ Out | Requires `/sale/offers/{id}/smart` against draft offers — adds complexity, low value vs. just showing post-create classification | — |
+| **Ship with Allegro (`/shipment-management/*`)** integration for P2/P3 sellers | ❌ Out | **Separate Product Design issue** — material scope, distinct from bulk listing | — |
+| Smart returns analytics | ❌ Out | Separate future feature | — |
+| Smart top-up fee tracking | ❌ Out | Settlement-level, not order-level | — |
+
+---
+
+## 4. Solution exploration
+
+> **Phase C complete — 2026-05-15**. Confirmed at Gate C by maintainer.
+
+### 4.1 Chosen shape — "Approval flow with EAN auto-match"
+
+The bulk listing workflow uses the following flow:
+
+```
+Products page (multi-select)
+  → "Proceed" (lightweight config: Allegro connection + shipping rate package)
+  → Auto-match (background: EAN→Allegro category resolution, account-level Smart check)
+  → Review table (one row per product, edit-via-modal per row)
+  → "Approve all" (enabled when all rows valid)
+  → Progress page (real-time per-product job status)
+  → Final summary (counts, retry per failed)
+```
+
+**Key feature:** EAN-based category auto-match. For each selected product with a valid EAN, OL queries Allegro's `/sale/products?phrase={ean}` (reusing existing #431 smart-link infrastructure) and auto-fills:
+- Allegro category from the matched product card
+- Allegro product card link (avoids re-creating cards — cheaper for seller, better Allegro positioning)
+- Suggested parameter values (brand, manufacturer, etc.) from the card
+
+For products without EAN match (no EAN, no match, or multi-match), the row is flagged for manual category pick via the edit modal.
+
+### 4.2 Detailed flow
+
+1. **Selection** — multi-select checkboxes on the existing Products page; bulk action bar appears: "Create Allegro offers (N)"
+2. **Lightweight config modal** — Allegro connection (auto if single), shipping rate package (with Smart-eligibility badge per rate)
+3. **Auto-match background resolution** — throttled-parallel EAN lookups + `GET /sale/smart` account-level check; partial-blocking UI up to ~15s
+4. **Review table** — one row per product with status icons:
+   - ✅ matched — auto-filled, ready to submit
+   - ⚠️ multi-match — modal opens with candidate cards (top match preselected, alternatives expandable)
+   - ❌ no-match / no-ean — manual category pick required via modal
+   - ⚠️ Smart-eligibility warning per row (if applicable)
+5. **Edit modal per row** — full Allegro listing detail form (reuses single-offer wizard components): title, category, description (with per-product AI toggle), price, stock, parameters, images, variant matrix preview
+6. **Approve** — button disabled while any ⚠️ or ❌ rows remain; confirmation modal before submit
+7. **Progress page** — real-time status, retry per failed offer
+8. **Final summary** — succeeded/failed counts, links to created offers, Smart classification badge per offer
+
+### 4.3 Confirmed sub-decisions
+
+| ID | Decision | Reasoning |
+|---|---|---|
+| SC-1 | AI description: per-product toggle in edit modal (default OFF) | Modal already has all editing controls; per-product granularity matches the "approve each row" gate; defaults preserve user control |
+| SC-2 | Variants: auto-collapse PS product → 1 Allegro offer with Allegro variant matrix | Matches existing single-offer behavior; per-variant separate offers is v2 if demand |
+| SC-3 | Failure semantics: partial-failure with per-job retry | Aligns with existing `OfferCreationExecutionService` outcome semantics; user retries individual failures from summary |
+| SC-4 | Account-level Smart check: included in v1 | Half-day work; prevents user-confusion when offers fail to get Smart badge |
+
+### 4.4 Resolved open questions
+
+| ID | Question | Resolution |
+|---|---|---|
+| OQ-C1 | Multi-match EAN UX | **(B)** Top match by Allegro relevance ranking preselected; alternatives expandable in modal |
+| OQ-C2 | Auto-match timeout behavior | **(B)** Partial-blocking spinner up to ~15s; then show partial results with un-resolved rows flagged ❌ |
+| OQ-C3 | Auto-match result caching | **(B)** Per-connection Redis cache with 24h TTL |
+| OQ-C4 | Fallback for products without EAN | **(A)** Always manual category pick (AI category suggestion is v2 polish) |
+
+### 4.5 EAN auto-match — implementation notes (for Tier 2)
+
+- **Reuse**: `libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.ts` (#431) as primitive
+- **New service**: `resolveCategoriesForBatchByEan` — batch wrapper with throttled-parallel + Redis cache + per-EAN result envelope (`matched | multi-match | no-ean | no-match`)
+- **Performance**: throttle to ~5-10 req/sec via existing `AllegroHttpClient` patterns; 50-product batch resolves in 5-15s
+- **Caching**: Redis key `allegro:ean-match:{connectionId}:{ean}` → JSON result; 24h TTL; invalidate-on-product-card-update is v2 polish (not in v1)
+- **Bonus side-effect**: matched offers smart-link to existing Allegro product cards — no card re-creation, better Allegro positioning, lower listing rejection rate
+
+### 4.6 Effort estimate
+
+- Domain (BulkOfferCreationBatch + repository): ~5 days
+- Auto-match service (batch wrapper + cache + throttling): ~3 days
+- HTTP API (bulk-create + progress endpoints): ~3 days
+- Worker handler (bulk-aware + AI description integration): ~2 days
+- FE Products page multi-select: ~2 days
+- FE review table + per-row edit modal: ~5 days
+- FE progress + summary page: ~3 days
+- Polish (error handling, integration tests, documentation): ~3 days
+
+**Total: ~5-6 weeks wall-clock with 1 backend + 1 FE dev in parallel.**
+
+---
+
+## 5. Product specification
+
+> **Phase D complete — 2026-05-15**. Pending Gate D approval to commit engineering time.
+
+### 5.1 User stories
+
+**US-1 — Bulk selection and submission**
+
+> As a shop owner, I want to select multiple products on the Products page and create Allegro offers for all of them in one workflow, so that I can onboard my catalog or expand it without doing 50 separate offer creations.
+
+**US-2 — Automatic category resolution**
+
+> As a shop owner, I want OL to automatically suggest the Allegro category for each selected product based on its EAN, so that I don't have to manually pick categories for products that already exist in Allegro's catalog.
+
+**US-3 — Per-product review and edit**
+
+> As a shop owner, I want to review and edit each product's Allegro listing details before submitting, so that I have full control over what gets published.
+
+**US-4 — Real-time progress feedback**
+
+> As a shop owner, I want to see real-time progress when offers are being created, so that I know which products succeeded and which failed without having to refresh the page.
+
+**US-5 — Retry only failed offers**
+
+> As a shop owner, I want to retry only the failed offers from a batch, so that I don't have to re-submit successful ones or re-do the whole batch.
+
+**US-6 — Smart classification visibility**
+
+> As a shop owner, I want to see Allegro Smart eligibility status for each created offer, so that I know which offers will benefit from Smart buyer visibility — and which won't, and why.
+
+**US-7 — Pre-submit account-level Smart warning**
+
+> As a shop owner, I want to be warned before bulk submit if my Allegro account doesn't meet Smart conditions, so that I'm not surprised when no offers in my batch qualify for the Smart badge.
+
+**US-8 — AI-assisted descriptions per product**
+
+> As a shop owner, I want to optionally use AI to generate an Allegro-optimized description when editing an individual offer, so that I save time on description writing without losing per-product control over the output.
+
+### 5.2 Acceptance criteria
+
+User-visible criteria (technical AC will be defined per implementation issue in Tier 2).
+
+**AC-1** (covers US-1): operator can select 1–100 products on the Products page via checkbox column; "Create Allegro offers" action appears in bulk action bar; clicking opens a lightweight modal asking for Allegro connection (if multiple available) and shipping rate package; clicking "Proceed" triggers the review table flow.
+
+**AC-2** (covers US-2): when the review table opens, OL has already attempted EAN-based category resolution for every selected product; products with a single Allegro product card match have category auto-filled; products with multiple matches show ⚠️ icon with "Pick a card" link in the row; products without EAN match show ❌ icon with "Manual category required".
+
+**AC-3** (covers US-3): clicking the Edit button in any row opens a modal showing the full Allegro listing details for that product (title, category, description, price, stock, parameters, images, variants preview); saving the modal returns to the review table with the row updated; cancel discards changes.
+
+**AC-4** (covers US-1+US-3): "Approve all" button on the review table is disabled while any row has ⚠️ or ❌ status; clicking when enabled shows confirmation modal "Create N Allegro offers?" with publish-now / publish-as-draft toggle; submit redirects to the batch progress page.
+
+**AC-5** (covers US-4): the batch progress page polls every 5 seconds and shows per-product status (pending → running → succeeded with Allegro offer URL link, or failed with error message); page also shows aggregate counts and overall batch status.
+
+**AC-6** (covers US-5): when a row shows status `failed`, a "Retry" button is visible inline; clicking re-enqueues only that single offer-creation job; "Retry all failed" button at the top of the page re-enqueues all failed offers in the batch.
+
+**AC-7** (covers US-6): after each row enters status `succeeded`, OL calls `GET /sale/offers/{offerId}/smart` and stores the result; the row in progress + summary view shows a Smart badge: ✅ green if `classification.fulfilled === true`, ⚠️ amber with failure reasons (from `classification.conditions[].description`) if not.
+
+**AC-8** (covers US-7): if `GET /sale/smart` (account-level) returns `eligible: false` during pre-submit auto-match, a banner appears at the top of the review table: "Your Allegro account does not currently meet Smart conditions — these offers will not earn the Smart badge regardless of shipping configuration. [Show why]" — operator can still proceed if they wish.
+
+**AC-9** (covers US-8): the per-row edit modal has a "Generate description with AI" toggle in the description field area; toggle is OFF by default; when toggled ON, OL calls `ContentSuggestionService.suggestDescription` with `channel='allegro'` for that product and replaces the description field with AI output; operator can edit the AI output before saving the modal.
+
+> *(AC-10 and AC-11 from earlier drafts moved to implementation plans — they were engineering concerns (rate-limit handling, order payload field propagation) dressed as user-visible AC. The `delivery.smart` order propagation is captured as a separate implementation issue (#726.5 in the implementation breakdown).)*
+
+---
+
+## 6. Out of scope
+
+> **Phase D complete — 2026-05-15**. Top items someone might actually ask about. Not an exhaustive future-feature catalog (per [Stage 1 calibration](../contributors/refinement-workflow.md#project-stage-calibration)).
+
+| Item | Reason |
+|---|---|
+| **CSV import** as input source | Shop catalog is the input. CSV adds parsing/validation complexity without proportional value at this stage. |
+| **Auto-list on PrestaShop product publish** (rule engine) | Different solution shape (event-driven, not user-initiated); separate Product Design if demand surfaces |
+| **Bulk update of existing offers** (price, stock, parameters) | Different workflow operating on existing mappings, not shop catalog. Separate Product Design. |
+| **Per-PS-variant separate Allegro offers** | v1 collapses to Allegro variant matrix (SC-2); "split variants" mode is v2 if demand |
+| **AI-suggested categories** for products without EAN match | OQ-C4 — manual pick in v1. AI category suggestions only if EAN auto-match accuracy is provably insufficient |
+| **Shipment generation / label printing** | Covered by [#727 InPost integration](https://github.com/SilkSoftwareHouse/openlinker/issues/727) (P1) and [#732 Wysyłam z Allegro integration](https://github.com/SilkSoftwareHouse/openlinker/issues/732) (P2/P3) |
+| **OMP (PrestaShop) update on offer creation** | Listing creation does not change PS state — PS owns the product, OL creates the Allegro mirror. (Shipment-on-OMP-update IS in scope of #727/#732 via shared ADR.) |
+
+---
+
+## 7. Definition of done
+
+> **Phase D complete — 2026-05-15**. Stage 1 qualitative bullets — quantitative metrics deferred until OL has telemetry infra and a measurable user base ([calibration](../contributors/refinement-workflow.md#project-stage-calibration)).
+
+The feature is considered successfully delivered when:
+
+- **The maintainer (or a co-maintainer) has used it for their own real shop** to list ≥20 products in one batch, without falling back to manual Allegro panel listing for any product
+- **At least 2 design-partner shops have used it in production** for ≥30 days without abandonment (i.e., they continue using OL for new offer creation, not switching back to BaseLinker or manual)
+- **No Smart-related confusion** surfaces from those users — they understand why each offer did/didn't get the Smart badge
+- **EAN auto-match feels useful in practice** — design partners report it saves time vs picking categories manually for the majority of their products
+- **AI description toggle is preserved (not overwritten) by users who enable it** more often than not — qualitative observation, no instrumentation
+
+If any of these prove false within 60 days of release to design partners, this Product Design returns to Phase A for re-review.
+
+---
+
+## 8. Risks
+
+> **Phase D complete — 2026-05-15**. Product-direction risks only. Engineering risks (rate limits, API drift, schema migrations) belong in Tier 2 implementation plans.
+
+| ID | Risk | Mitigation |
+|---|---|---|
+| **R1** | Shop owners find the edit modal too complex and abandon mid-flow | Modal reuses existing single-offer wizard components — the operator has already used this UX for single offers. Validate with 2-3 design partners before broader release. |
+| **R2** | EAN auto-match accuracy too low — most rows need manual fix anyway, feature delivers no value over single-offer creation | Reusing established #431 smart-link primitive (Allegro's own product card lookup). Worst case: feature still beats no-bulk because per-row modal is still faster than N separate single-offer creations. |
+| **R3** | Shop owners on Allegro Delivery (P2/P3) hit a wall at shipment generation after listing — broken end-to-end flow | [#732 Wysyłam z Allegro integration](https://github.com/SilkSoftwareHouse/openlinker/issues/732) explicitly tracks this gap. v1 ships with a status banner warning Allegro Delivery sellers that label generation isn't yet supported. Communication in release notes. |
+| **R4** | AI description quality too low — operators turn it off, we wasted dev time | Incremental cost is just the modal toggle (AI infra already exists). If preservation rate proves consistently low, the toggle can be removed without losing core feature value. |
+
+---
+
+## 9. Implementation breakdown
+
+> **Phase E complete — 2026-05-15**. Gate D = YES.
+
+Nine implementation issues spawned, each independently shippable. Engineering risks and detailed effort breakdowns live in each issue + Tier 2 `/plan` outputs.
+
+| # | Title | Effort | Blocks |
+|---|---|:---:|---|
+| [#734](https://github.com/SilkSoftwareHouse/openlinker/issues/734) | `BulkOfferCreationBatch` domain entity + repository + migration | S (~5d) | #736, #737 |
+| [#735](https://github.com/SilkSoftwareHouse/openlinker/issues/735) | EAN-based bulk category auto-match service | S (~3d) | #740 |
+| [#736](https://github.com/SilkSoftwareHouse/openlinker/issues/736) | Bulk submission service + HTTP API + progress endpoint | S (~3d) | #740, #741 |
+| [#737](https://github.com/SilkSoftwareHouse/openlinker/issues/737) | Bulk-aware `marketplace.offer.create` handler + AI description + Smart classification readback | M (~3d) | #741 |
+| [#738](https://github.com/SilkSoftwareHouse/openlinker/issues/738) | Propagate `delivery.smart` from order payload to `OrderRecord` | S (~0.5–1d) | — (independent) |
+| [#739](https://github.com/SilkSoftwareHouse/openlinker/issues/739) | Products page multi-select + bulk action bar | S (~2d) | #740 |
+| [#740](https://github.com/SilkSoftwareHouse/openlinker/issues/740) | Bulk listing wizard (config modal + review table + per-row edit modal) | M (~5d) | #741 |
+| [#741](https://github.com/SilkSoftwareHouse/openlinker/issues/741) | Batch progress page + final summary | S (~3d) | #742 |
+| [#742](https://github.com/SilkSoftwareHouse/openlinker/issues/742) | Retry-failed endpoint + integration tests + polish | S (~3d) | — (last child) |
+
+**Critical path:** #734 → #736 → #737 / #740 → #741 → #742. Parallelizable: #735 (auto-match), #738 (delivery.smart), #739 (multi-select) can start immediately.
+
+**Total wall-clock estimate:** 5–6 weeks with 1 backend + 1 FE dev in parallel.
+
+**Sibling Product Design:** [#732 — Wysyłam z Allegro integration (P2/P3 shipping)](https://github.com/SilkSoftwareHouse/openlinker/issues/732) — closes the end-to-end flow for Allegro Delivery sellers, separate from this spec.
+
+**ADRs to file during implementation** (only if architectural reviewer requests):
+- ADR-XXX: Bulk offer creation as application-layer fan-out (not adapter capability) — filed during #734 if needed
+- Existing ADR practice introduced via #725
+
+---
+
+## 10. Decision log
+
+| Date | Phase | Decision | Reasoning | Decider |
+|---|---|---|---|---|
+| 2026-05-15 | Pre-A | Convert #726 from discovery/refinement issue to Product Design issue under new workflow | Demonstrates two-tier refinement on a real, in-flight issue; preserves pre-refinement research as Phase B evidence input | @piotrswierzy (via collaborative workflow design) |
+| 2026-05-15 | Pre-A | Pre-refinement draft preserved at `docs/plans/implementation-plan-726-allegro-smart-bulk.md` with not-authoritative warning | Codebase audit and Allegro Smart! research are reusable as evidence; product scope decisions in the draft are hypotheses to be re-validated | @piotrswierzy |
+| 2026-05-15 | A→B | Phase A confirmed; primary persona = shop owner; bulk shape = inline multi-select on Products page (not separate wizard); Smart! scope deferred to Phase B research; UVP framing dropped at feature level | See §1 ambiguity resolutions A1-A4 | @piotrswierzy |
+| 2026-05-15 | B | Phase B round 1: Allegro Smart! is automatic (not per-offer toggle), driven by shipping-rate composition. Create-offer payload has no Smart field. Read-only classification available via `/sale/offers/{id}/smart` | See §3.2 research findings | product-researcher subagent + @piotrswierzy |
+| 2026-05-15 | B | Phase B round 2 surfaced 3 contractual paths (P1/P2/P3). `delivery.smart` boolean confirmed on order payload. `smartDeliveryMethods` deprecation date corrected to 2026-07-28 | See §3.4 contractual paths table | product-researcher subagent + @piotrswierzy |
+| 2026-05-15 | B→C | Product-level coverage decision: P1+P2+P3 required. P2/P3 Wysyłam z Allegro integration extracted as separate Product Design [#732](https://github.com/SilkSoftwareHouse/openlinker/issues/732). #726 stays focused on bulk listing CREATION (which works across all 3 paths automatically) | Bulk listing creation is path-agnostic at the offer level; shipping integration is the path-dependent concern | @piotrswierzy |
+| 2026-05-15 | B→C | Cross-cutting decision: when OL generates labels (in #727 or #732), OMP (PrestaShop) MUST be updated with shipment status + tracking#. Pattern to be captured in shared ADR ("Shipment lifecycle event propagation pattern") so #727, #732, and future courier integrations follow same convention | Standard fulfillment-status-sync pattern; OMP authoritativeness for downstream order state requires it | @piotrswierzy |
+| 2026-05-15 | Gate B | Gate B passed. Evidence supports problem statement; persona unchanged; scope clarified. Proceeding to Phase C. | All Phase B open questions resolved or deferred non-blockingly | @piotrswierzy |
+| 2026-05-15 | C | Shape chosen: Candidate E — "Approval flow with EAN auto-match". Multi-select on Products page → lightweight config → background auto-match → review table → per-row modal edit → approve → progress → summary | Highest listing quality + concrete value-add via EAN auto-match (reuses #431 smart-link); modal-per-row matches operator mental model | @piotrswierzy |
+| 2026-05-15 | C | Sub-decisions SC-1 through SC-4 confirmed: AI description per-product toggle in modal (default OFF); auto-collapse variants to Allegro matrix; partial-failure with per-job retry; v1 includes account-level Smart check | See §4.3 reasoning | @piotrswierzy |
+| 2026-05-15 | C | Open questions OQ-C1 through OQ-C4 resolved: top match preselected with alternatives expandable; partial-blocking spinner up to 15s; Redis cache 24h TTL; manual category pick for no-EAN/no-match products in v1 | See §4.4 | @piotrswierzy |
+| 2026-05-15 | Gate C | Gate C passed. Shape locked, sub-decisions confirmed. Proceeding to Phase D specification. | — | @piotrswierzy |
+| 2026-05-15 | D | Phase D specification written: 8 user stories, 9 acceptance criteria, 7 explicit out-of-scope items, qualitative definition of done, 4 product-direction risks | See §5-§8 | @piotrswierzy |
+| 2026-05-15 | D-revision | Trimmed Phase D output for Stage-1-OSS calibration (introduced in workflow doc as part of this PR). Removed: persona-fit verification subsection (circular), AC-10/AC-11 (engineering concerns dressed as user-visible AC), exhaustive 20-item out-of-scope list, quantitative success metrics with %s (no telemetry to measure them), anti-metrics (same), 10-risk catalog including engineering risks. Kept: user stories, user-visible AC, top-7 out-of-scope, qualitative definition of done, top-4 product risks. Same conviction, less compliance theatre. | Stage-1 calibration: filler sections are worse than missing sections | @piotrswierzy |


### PR DESCRIPTION
## Summary

Introduces a **two-tier refinement workflow** for OpenLinker — Tier 1 product refinement (what/who/why) followed by Tier 2 technical refinement (how) — and demonstrates it end-to-end on #726 (Allegro bulk listing creation), producing a calibrated product spec and spawning 9 scoped implementation issues plus a sibling Product Design (#732) surfaced during research.

The workflow was **refined during its first application**: the first draft of the #726 spec produced "AI slop" (success metrics with no telemetry to measure them, anti-metrics we'd never instrument, 10-risk catalogs mixing engineering with product concerns). The workflow now explicitly forbids those patterns at Stage 1 (pre-paying-customer).

This PR does **not** close any issues. #726 stays open as a Product Design epic until all 9 implementation children (#734–#742) merge.

## What's in this PR

### Workflow infrastructure (5 new files)

- **`.claude/commands/refine-product.md`** — the `/refine-product <issue>` skill, executing four phases (A: Problem definition, B: Evidence & user research, C: Solution exploration, D: Product spec) with explicit ⏸ gates before engineering time is committed
- **`.claude/agents/product-researcher.md`** — subagent scoped to external research only: competitor analysis, marketplace API verification, community signal aggregation. Does not write code or design architecture.
- **`.github/ISSUE_TEMPLATE/product-design.md`** — maintainer template for formal Product Design issues (`[PRODUCT-DESIGN]` prefix)
- **`.github/ISSUE_TEMPLATE/implementation.md`** — maintainer template for implementation tasks derived from product design or established patterns (`[IMPL]` prefix)
- **`docs/contributors/refinement-workflow.md`** — canonical workflow doc with explicit **project-stage calibration**: Stage 1 (pre-paying-customer) caps section depth and forbids unmeasurable success metrics

Contributor-facing templates (`bug_report`, `feature_request`, `developer_task`, `new_integration`, `question`) are **unchanged**. New maintainer templates serve a distinct workflow (formal refinement → implementation), not as replacements.

### `docs/specs/` directory

- **`docs/specs/README.md`** — spec doc structure, conventions, and the "what does NOT go in a Stage 1 spec" list (anti-metrics, persona-fit verification, engineering AC, etc.)
- **`docs/specs/product-spec-726-allegro-bulk-listing.md`** — the first product spec, produced end-to-end via `/refine-product 726`

### #726 spec contents (high-level)

- **Phase A**: shop owner persona; "checkbox on Products page" multi-select shape (decided by maintainer, not full wizard)
- **Phase B**: dual research rounds revealed that Allegro Smart! is **automatic** (derived from shipping-rate composition), and that **three contractual shipping paths** exist (P1 own-contract, P2 Allegro Delivery, P3 Allegro One). P1 covered by #727; P2/P3 extracted as sibling [#732](https://github.com/SilkSoftwareHouse/openlinker/issues/732)
- **Phase C**: chose "Approval flow with EAN auto-match" — reuses #431 smart-link primitive to auto-fill Allegro categories for the majority of products with EAN
- **Phase D**: 8 user stories, 9 user-visible acceptance criteria, 7 explicit out-of-scope items, qualitative definition of done, 4 product-direction risks
- **Phase E**: 9 implementation children spawned ([#734](https://github.com/SilkSoftwareHouse/openlinker/issues/734)–[#742](https://github.com/SilkSoftwareHouse/openlinker/issues/742))

### Pre-refinement artifact preserved

`docs/plans/implementation-plan-726-allegro-smart-bulk.md` (written before the workflow existed) is preserved with a "PRE-REFINEMENT DRAFT — NOT AUTHORITATIVE" banner. Its codebase audit and Allegro research are reusable Phase B evidence; its product scope decisions are now superseded by the spec.

## Related issues

**Refs (not closed by this PR):**
- [#726](https://github.com/SilkSoftwareHouse/openlinker/issues/726) — converted to Product Design, body updated, stays open as epic
- [#732](https://github.com/SilkSoftwareHouse/openlinker/issues/732) — sibling Product Design (Wysyłam z Allegro / P2/P3 shipping) created during Phase B
- [#734](https://github.com/SilkSoftwareHouse/openlinker/issues/734)–[#742](https://github.com/SilkSoftwareHouse/openlinker/issues/742) — 9 implementation children spawned by Phase E
- [#725](https://github.com/SilkSoftwareHouse/openlinker/issues/725) — ADR practice introduction (the workflow's natural complement for Tier 2)
- [#727](https://github.com/SilkSoftwareHouse/openlinker/issues/727) — InPost integration (P1 sibling), surfaced as dependency during Phase B
- [#728](https://github.com/SilkSoftwareHouse/openlinker/issues/728) — Subiekt invoicing integration (Q1 sibling)

## Stage-1 calibration applied

What the workflow doc now explicitly forbids in Stage 1 (and what the spec corrected itself on):

- ❌ Success metrics with percentages we can't measure ("80% adoption in 7 days") — replaced with qualitative definition of done
- ❌ Anti-metrics ("> 20% abandonment triggers re-review") — no instrumentation exists
- ❌ Exhaustive out-of-scope lists (20 items) — capped to top 5–7 someone might actually ask about
- ❌ Risk catalogs mixing engineering risks (rate limits, API drift) with product risks — engineering risks belong in implementation plans
- ❌ Persona-fit verification subsections (circular self-congratulation)
- ❌ Day-by-day effort breakdowns in product spec — belong in Tier 2 implementation plans

The test for every section: *"will anyone actually use this — measure it, reference it, audit against it?"* If no, skip.

## Test plan

This is a docs/process PR with zero code changes. Verification:

- [x] `pnpm check:invariants` passes (`fixture-purity`, `migration-timestamps`, `repo-urls`, `cross-context-imports`, etc.)
- [x] `pnpm lint` passes (no new warnings introduced; pre-existing warnings unrelated)
- [x] `pnpm type-check` passes (libs build + per-package type-check)
- [x] Pre-commit hook recognized docs/config-only change and correctly skipped tests
- [x] Cross-references between workflow doc ↔ skill ↔ spec README ↔ templates all resolve
- [x] Spec doc references all 9 implementation issues — confirmed each exists on GitHub
- [x] Issue templates render correctly (manual review)

**Validation in subsequent sessions:**
- [ ] Apply `/refine-product` to #727 (InPost) and #728 (Subiekt) — confirm workflow is reusable, not over-fitted to #726
- [ ] Verify the workflow holds shape across heterogeneous problems (integration vs UX-heavy vs cross-cutting)
- [ ] Track time-to-first-implementation-issue per refinement — workflow should reduce, not increase, total time-to-merge

## Notes for reviewers

- The PR is large (1,798 insertions) but **zero TypeScript changes** — all docs, skill files, and YAML frontmatter
- The first draft of the #726 spec is preserved in commit history (before the slop trim) for anyone curious about the calibration evolution
- The workflow is designed to evolve — feedback during real use should adjust phase boundaries, gate criteria, and section caps

🤖 Generated with [Claude Code](https://claude.com/claude-code)