### PR TITLE
fix(api): align OL_CORS_ORIGIN default with web dev port (:4173)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -26,6 +26,14 @@ OL_BOOTSTRAP_ADMIN_EMAIL=admin@openlinker.local
 # apps/web/vite.config.ts.
 WEB_URL=http://localhost:4173
 
+# --- CORS ---------------------------------------------------------------------
+# Comma-separated list of allowed origins for browser API calls. Required to
+# include the web origin because the API uses `credentials: true` (refresh
+# cookie + Authorization round-trip), which forbids wildcard origins per the
+# CORS spec. Defaults to http://localhost:4173 (matches apps/web/vite.config.ts).
+# Set explicitly for any non-local environment.
+# OL_CORS_ORIGIN=http://localhost:4173
+
 # --- JWT auth -----------------------------------------------------------------
 # REQUIRED. Change for any non-local environment.
 JWT_SECRET=dev-secret-change-in-production

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -56,7 +56,7 @@ async function bootstrap(): Promise<void> {
   // setups, prod deploys must set it.
   const configService = app.get(ConfigService);
   const allowedOrigins = configService
-    .get<string>('OL_CORS_ORIGIN', 'http://localhost:5173')
+    .get<string>('OL_CORS_ORIGIN', 'http://localhost:4173')
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);

--- a/scripts/check-repo-urls.mjs
+++ b/scripts/check-repo-urls.mjs
@@ -62,6 +62,7 @@ const ALLOWLIST = new Set([
 // invariant working in both local and CI environments.
 const SKIP_DIRS = new Set([
   '.git',
+  '.claude',
   'node_modules',
   'dist',
   'build',


### PR DESCRIPTION
## Summary

- Change `OL_CORS_ORIGIN` default in `apps/api/src/main.ts` from `http://localhost:5173` to `http://localhost:4173` to match the web dev server port set in `apps/web/vite.config.ts:7`.
- Document `OL_CORS_ORIGIN` in `apps/api/.env.example` next to `WEB_URL` (same web origin, same neighborhood).
- Re-apply the `.claude` skip in `scripts/check-repo-urls.mjs` (same as PR #745) so the pre-commit hook stops false-positive-blocking on local scratch worktrees.

## Root cause

`apps/web/vite.config.ts:7` has had `port: 4173` since the initial web commit (`4bfa97b`) — deliberate, stable choice. The API's CORS default was set to the stock Vite `5173` without checking what the web app actually uses. With `credentials: true` on the CORS config, wildcard origins are forbidden per the CORS spec, so a fresh checkout without `apps/api/.env.local` got CORS-blocked on every browser API call.

## Test plan

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test` — pre-commit chain ran clean (383 tests across 34 suites)
- [ ] Local repro: open `http://localhost:4173/`, sign in, confirm API calls succeed without `.env.local` overriding `OL_CORS_ORIGIN`

## Notes for reviewer

The hook fix (`SKIP_DIRS` adding `.claude`) overlaps with PR #745. Whichever lands first leaves a no-op diff on the other — git auto-resolves at rebase time.

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
