### PR TITLE
feat(allegro): propagate delivery.smart through order ingestion into OrderRecord

### DIFF
--- a/docs/plans/implementation-plan-738-allegro-delivery-smart.md
+++ b/docs/plans/implementation-plan-738-allegro-delivery-smart.md
@@ -26,17 +26,20 @@ Allegro's `GET /order/checkout-forms/{id}` returns `delivery.smart: boolean` ind
 | `AllegroCheckoutForm.delivery.smart?: boolean` | `libs/integrations/allegro/src/domain/types/allegro-api.types.ts:100` | Already typed; needs to be **consumed** |
 | `AllegroOrderSourceAdapter.getOrder` | `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts:146–220` | Maps response → `IncomingOrder`; new field added at the construction site |
 | `IncomingOrder` type | `libs/core/src/orders/domain/types/incoming-order.types.ts:15–77` | Add `deliverySmart?: boolean` as a new optional |
-| `OrderRecord` entity + ORM + repo | `libs/core/src/orders/...` | **No flat column** — order data persisted as `orderSnapshot: jsonb`; the new field rides the JSONB free |
-| Allegro adapter spec | `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts` | Extend with `delivery.smart=true / =false / missing` fixtures |
+| `OrderRecord` entity + ORM + repo | `libs/core/src/orders/...` | **No flat column** — order data persisted as `orderSnapshot: jsonb`. **Correction (post-tech-review)**: the snapshot is built field-by-field in `OrderRecordService.persistOrder` and `persistIncomingSnapshot` — adding a field to `IncomingOrder` is NOT sufficient; the new field must be threaded through `Order` → `buildUnifiedOrder` → both snapshot projections. |
+| Allegro adapter spec | `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts` | Extend with `delivery.smart=true / =false / missing-delivery / present-but-no-smart-key` fixtures |
+| `OrderRecordService` snapshot builders | `libs/core/src/orders/application/services/order-record.service.ts` | Add `deliverySmart` via conditional spread to both `persistOrder` and `persistIncomingSnapshot` (match the existing absent-vs-`undefined` precedent on `OrderItem.name` / `imageUrl`) |
+| `Order` domain type | `libs/core/src/orders/domain/types/order.types.ts` | Add `deliverySmart?: boolean` next to `shipping` / `pickupPoint` |
+| `OrderIngestionService.buildUnifiedOrder` | `libs/core/src/orders/application/services/order-ingestion.service.ts` | Forward `incoming.deliverySmart` into the constructed `Order` |
 
 ## 3. Spec deviations (call out)
 
 The issue body asks for two things the persistence model doesn't actually require:
 
-- **"Persist via a small migration (add `delivery_smart` column, nullable)"** — `OrderRecord` stores `orderSnapshot: jsonb` (not flat columns per field). The new field is automatically carried by the JSONB column once it appears on `IncomingOrder` (the type that backs `orderSnapshot`). Adding a dedicated column would mean either (a) duplicate storage (column shadowing the JSONB key) or (b) extracting the value at write time only — neither pays off for an "informational only" flag. **Skip the migration.**
+- **"Persist via a small migration (add `delivery_smart` column, nullable)"** — `OrderRecord` stores `orderSnapshot: jsonb` (not flat columns per field). The field rides inside the JSONB snapshot — no DDL migration needed. The snapshot itself is built field-by-field in two `OrderRecordService` methods, so the field still needs to be added to both projections (it does NOT "ride free" — that was an earlier mistake in this plan, caught by tech-review). **Skip the migration, expand the in-code propagation.**
 - **"Surface in OrderRecord domain entity"** — `OrderRecord`'s constructor takes `orderSnapshot` as an opaque blob. Callers already access nested fields via `record.orderSnapshot.x`. Adding a flat `deliverySmart` getter would be redundant with `record.orderSnapshot.deliverySmart`. **Skip the entity change.**
 
-Net effect: this issue ships as a **2-file change + 1 spec extension** (vs the issue body's 4-file change + migration). The acceptance criteria from the issue body re-map cleanly:
+Net effect: this issue ships as a **5-file change + 2 spec extensions** (vs the issue body's 4-file change + migration). The acceptance criteria from the issue body re-map cleanly:
 
 | Issue AC | How this plan satisfies it |
 |---|---|

--- a/docs/plans/implementation-plan-738-allegro-delivery-smart.md
+++ b/docs/plans/implementation-plan-738-allegro-delivery-smart.md
@@ -1,0 +1,84 @@
+# Implementation Plan — #738 (`feat(allegro): propagate delivery.smart boolean from order payload to OrderRecord`)
+
+**Status**: Draft
+**Issue**: [#738](https://github.com/SilkSoftwareHouse/openlinker/issues/738)
+**Parent epic**: #726 (Allegro Smart! + Bulk offer creation)
+**Branch**: `738-allegro-delivery-smart`
+
+---
+
+## 1. Goal
+
+Allegro's `GET /order/checkout-forms/{id}` returns `delivery.smart: boolean` indicating whether the order qualified for Allegro Smart!. Carry that signal through the order ingestion path into the persisted `OrderRecord` so future features (Smart-vs-non-Smart filtering, analytics, badges) can read it.
+
+**Layer classification**: Integration (Allegro adapter mapping) + CORE (one optional field on the neutral `IncomingOrder` DTO).
+
+**Non-goals**:
+- FE display (Smart badge on orders) — separate impl issue.
+- Smart-based order filtering — future feature.
+- Smart top-up fee tracking — settlement-level, separate concern.
+- Non-Allegro sources — PrestaShop / future shops will leave the field undefined.
+
+## 2. Verified surface (research findings)
+
+| Element | Path | Status |
+|---|---|---|
+| `AllegroCheckoutForm.delivery.smart?: boolean` | `libs/integrations/allegro/src/domain/types/allegro-api.types.ts:100` | Already typed; needs to be **consumed** |
+| `AllegroOrderSourceAdapter.getOrder` | `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts:146–220` | Maps response → `IncomingOrder`; new field added at the construction site |
+| `IncomingOrder` type | `libs/core/src/orders/domain/types/incoming-order.types.ts:15–77` | Add `deliverySmart?: boolean` as a new optional |
+| `OrderRecord` entity + ORM + repo | `libs/core/src/orders/...` | **No flat column** — order data persisted as `orderSnapshot: jsonb`; the new field rides the JSONB free |
+| Allegro adapter spec | `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts` | Extend with `delivery.smart=true / =false / missing` fixtures |
+
+## 3. Spec deviations (call out)
+
+The issue body asks for two things the persistence model doesn't actually require:
+
+- **"Persist via a small migration (add `delivery_smart` column, nullable)"** — `OrderRecord` stores `orderSnapshot: jsonb` (not flat columns per field). The new field is automatically carried by the JSONB column once it appears on `IncomingOrder` (the type that backs `orderSnapshot`). Adding a dedicated column would mean either (a) duplicate storage (column shadowing the JSONB key) or (b) extracting the value at write time only — neither pays off for an "informational only" flag. **Skip the migration.**
+- **"Surface in OrderRecord domain entity"** — `OrderRecord`'s constructor takes `orderSnapshot` as an opaque blob. Callers already access nested fields via `record.orderSnapshot.x`. Adding a flat `deliverySmart` getter would be redundant with `record.orderSnapshot.deliverySmart`. **Skip the entity change.**
+
+Net effect: this issue ships as a **2-file change + 1 spec extension** (vs the issue body's 4-file change + migration). The acceptance criteria from the issue body re-map cleanly:
+
+| Issue AC | How this plan satisfies it |
+|---|---|
+| Allegro orders carry `deliverySmart` value | New field on `IncomingOrder` populated by `AllegroOrderSourceAdapter.getOrder` from `checkoutForm.delivery?.smart` |
+| Pre-existing orders default to `null` | JSONB column tolerates missing keys; readers `record.orderSnapshot.deliverySmart` returns `undefined`. **Note**: the issue says "null" but the natural JS shape is `undefined` for an absent optional field. Documenting this — if downstream code needs strict `null`, the adapter coalesces with `?? null`. |
+| PrestaShop & other non-Allegro orders ingest with `null` | `PrestashopOrderSourceAdapter.getOrder` (`libs/integrations/prestashop/...`) is untouched; it never sets `deliverySmart`, so the field is `undefined` on its `IncomingOrder` outputs. Same JSONB tolerance. |
+| Migration up + down round-trips | **N/A** — no migration. |
+| Unit spec for `getOrder` with both `delivery.smart=true` and `=false` fixtures | Step 3 below. |
+
+## 4. Files to change
+
+| File | Change |
+|---|---|
+| `libs/core/src/orders/domain/types/incoming-order.types.ts` | Add `deliverySmart?: boolean` to the `IncomingOrder` interface (placed adjacent to `shipping` / `pickupPoint`) |
+| `libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts` | Map `checkoutForm.delivery?.smart` into the returned `IncomingOrder` |
+| `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts` | Three fixture variants: `delivery.smart=true`, `=false`, missing/undefined |
+
+If the orders barrel re-exports `IncomingOrder`, no edit needed — type already exported.
+
+## 5. Step-by-step
+
+1. **Add `deliverySmart?: boolean` to `IncomingOrder`**. Pure type-level change; placed near `shipping?` / `pickupPoint?` to keep the delivery-related fields visually grouped. JSDoc one-liner: "Allegro Smart! eligibility flag; informational only, undefined for non-Allegro sources."
+   ✅ acceptance: `pnpm --filter @openlinker/core type-check` green.
+2. **Map in `AllegroOrderSourceAdapter.getOrder`**. At the existing `IncomingOrder` construction site (~line 212), spread-in `deliverySmart: checkoutForm.delivery?.smart` so a missing value stays `undefined` (not coerced to `false`).
+   ✅ acceptance: type-check green for the Allegro plugin.
+3. **Extend the adapter spec** with three variants:
+   - `delivery.smart = true` → asserted `incomingOrder.deliverySmart === true`.
+   - `delivery.smart = false` → asserted `=== false`.
+   - `delivery` block missing the `smart` key (or `delivery` undefined entirely) → asserted `=== undefined`.
+   Re-use the spec's existing checkout-form fixture builder; add a tiny override pattern if not present.
+   ✅ acceptance: `pnpm --filter @openlinker/integrations-allegro test` green; 3 new cases.
+4. **Quality gate** — `pnpm lint && pnpm type-check && pnpm test`. All green.
+
+## 6. Risk / open questions
+
+- **`undefined` vs `null`** — issue text says "default to `null`". The JSONB shape natively encodes the field's absence as `undefined` on read. If a future caller does `JSON.stringify(record.orderSnapshot)` for outbound API responses, missing-key + present-and-null both render identically; the runtime difference is only TypeScript narrowing. **Decision**: leave as `undefined` (the natural shape); document in the type's JSDoc. If a future caller needs strict `null`, normalisation belongs at the read boundary, not at the write.
+- **No DB / schema impact** — confirmed against `OrderRecordOrmEntity` (only `orderSnapshot: jsonb` carries the order data); no migration needed.
+- **PrestaShop parity** — untouched. The acceptance criterion "non-Allegro orders ingest with null" is satisfied by leaving `deliverySmart` unset; no plumbing required in the PS adapter.
+
+## 7. Validation
+
+- `pnpm lint` — green
+- `pnpm type-check` — green
+- `pnpm test` — Allegro plugin spec green (3 new cases); core orders spec unaffected
+- `pnpm --filter @openlinker/api migration:show` — no pending migrations (confirms no schema impact)

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -209,6 +209,33 @@ describe('OrderRecordService', () => {
       expect(snapshotItems[0]).not.toHaveProperty('name');
       expect(snapshotItems[0]).not.toHaveProperty('imageUrl');
     });
+
+    it('should serialise Order.deliverySmart into the snapshot when present (#738)', async () => {
+      const order = createMockOrder();
+      order.deliverySmart = true;
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['deliverySmart']).toBe(true);
+    });
+
+    it('should omit deliverySmart from the snapshot when the Order does not carry it (#738)', async () => {
+      const order = createMockOrder();
+      // createMockOrder() leaves deliverySmart unset — assert conditional
+      // serialisation keeps the key absent rather than emitting `undefined`,
+      // so consumers can distinguish "Smart not reported" from "Smart false".
+      expect(order.deliverySmart).toBeUndefined();
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('deliverySmart');
+    });
   });
 
   describe('persistOrder - PII disabled', () => {
@@ -360,6 +387,30 @@ describe('OrderRecordService', () => {
         postalCode: '[REDACTED]',
         country: 'US',
       });
+    });
+
+    it('should serialise IncomingOrder.deliverySmart into the snapshot when present (#738)', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.deliverySmart = false;
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot['deliverySmart']).toBe(false);
+    });
+
+    it('should omit deliverySmart from the snapshot when IncomingOrder does not carry it (#738)', async () => {
+      const incoming = createMockIncomingOrder();
+      expect(incoming.deliverySmart).toBeUndefined();
+
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.orderSnapshot).not.toHaveProperty('deliverySmart');
     });
   });
 

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -348,6 +348,7 @@ export class OrderIngestionService implements IOrderIngestionService {
       billingAddress: incoming.billingAddress,
       shipping: incoming.shipping,
       pickupPoint: incoming.pickupPoint,
+      deliverySmart: incoming.deliverySmart,
       createdAt: new Date(incoming.createdAt),
       updatedAt: new Date(incoming.updatedAt),
     };

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -71,6 +71,11 @@ export class OrderRecordService implements IOrderRecordService {
       billingAddress: piiConfig.storePii
         ? order.billingAddress
         : this.sanitizeAddress(order.billingAddress),
+      // Conditional spread matches the items-level precedent above: keep the
+      // snapshot key absent (not `undefined` and not `false`) when the source
+      // did not supply the flag, so consumers can distinguish "Smart not
+      // reported" from "Smart explicitly false".
+      ...(order.deliverySmart !== undefined && { deliverySmart: order.deliverySmart }),
       createdAt: order.createdAt.toISOString(),
       updatedAt: order.updatedAt.toISOString(),
     };
@@ -124,6 +129,8 @@ export class OrderRecordService implements IOrderRecordService {
       createdAt: incoming.createdAt,
       updatedAt: incoming.updatedAt,
       metadata: incoming.metadata,
+      // See `persistOrder` above for the absent-vs-false rationale.
+      ...(incoming.deliverySmart !== undefined && { deliverySmart: incoming.deliverySmart }),
     };
 
     const orderRecord = new OrderRecord(

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -65,6 +65,15 @@ export interface IncomingOrder {
   pickupPoint?: OrderPickupPoint;
 
   /**
+   * Allegro Smart! free-delivery flag (`delivery.smart` on the checkout-form
+   * response). Informational only — no business logic depends on it in v1;
+   * future surfaces (filtering, analytics, badges) read this signal. Absent
+   * (`undefined`) for non-Allegro sources and for Allegro orders predating
+   * the Smart! program.
+   */
+  deliverySmart?: boolean;
+
+  /**
    * ISO timestamps (strings) to keep DTO stable across runtimes.
    */
   createdAt: string;

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -103,6 +103,14 @@ export interface Order {
    * and is greppable for downstream features.
    */
   pickupPoint?: OrderPickupPoint;
+  /**
+   * Allegro Smart! free-delivery eligibility flag, carried through from the
+   * source `IncomingOrder`. Informational only — no business logic depends on
+   * it in v1; future surfaces (filtering, analytics, badges) read this signal.
+   * Absent (`undefined`) for non-Allegro sources and for Allegro orders
+   * predating the Smart! program.
+   */
+  deliverySmart?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -617,6 +617,72 @@ describe('AllegroOrderSourceAdapter', () => {
         expect(incoming.shippingAddress?.city).toBe('BuyerCity');
       });
     });
+
+    describe('deliverySmart (#738)', () => {
+      const baseForm = (): AllegroCheckoutForm => ({
+        id: 'cf',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        buyer: {
+          id: 'b',
+          email: 'b@e.com',
+          login: 'b',
+          firstName: 'Buyer',
+          lastName: 'Profile',
+          phoneNumber: '+48000000000',
+          address: {
+            street: 'Profile Street 1',
+            city: 'BuyerCity',
+            zipCode: '00-001',
+            countryCode: 'PL',
+          },
+        },
+        lineItems: [
+          {
+            id: 'l1',
+            offer: { id: 'o1', name: 'O1' },
+            quantity: 1,
+            price: { amount: '10.00', currency: 'PLN' },
+          },
+        ],
+        summary: { totalToPay: { amount: '10.00', currency: 'PLN' } },
+        payment: { type: 'ONLINE' },
+      });
+
+      it('should populate deliverySmart=true when delivery.smart is true', async () => {
+        const form = baseForm();
+        form.delivery = { smart: true };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.deliverySmart).toBe(true);
+      });
+
+      it('should populate deliverySmart=false when delivery.smart is false', async () => {
+        const form = baseForm();
+        form.delivery = { smart: false };
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.deliverySmart).toBe(false);
+      });
+
+      // Single "missing" case covers both branches of the `?.smart` optional
+      // chain: (a) the `delivery` block is absent entirely, and (b) the
+      // `delivery` block is present but the `smart` key is not — both
+      // surface as `undefined` on the returned IncomingOrder.
+      it('should leave deliverySmart undefined when delivery block is absent', async () => {
+        const form = baseForm();
+        // No `delivery` block at all.
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.deliverySmart).toBeUndefined();
+      });
+    });
   });
 
   describe('SourceOptionsReader (#472 / #474)', () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -669,13 +669,21 @@ describe('AllegroOrderSourceAdapter', () => {
         expect(incoming.deliverySmart).toBe(false);
       });
 
-      // Single "missing" case covers both branches of the `?.smart` optional
-      // chain: (a) the `delivery` block is absent entirely, and (b) the
-      // `delivery` block is present but the `smart` key is not — both
-      // surface as `undefined` on the returned IncomingOrder.
       it('should leave deliverySmart undefined when delivery block is absent', async () => {
         const form = baseForm();
-        // No `delivery` block at all.
+        // No `delivery` block at all — covers `delivery === undefined`.
+        httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
+
+        const incoming = await adapter.getOrder({ externalOrderId: 'cf' });
+
+        expect(incoming.deliverySmart).toBeUndefined();
+      });
+
+      it('should leave deliverySmart undefined when delivery block is present but smart key is missing', async () => {
+        const form = baseForm();
+        // `delivery` present but no `smart` — guards the `?.smart` optional
+        // chain's "present-but-missing-key" branch explicitly.
+        form.delivery = {};
         httpClient.get.mockResolvedValueOnce({ data: form, status: 200, headers: {} });
 
         const incoming = await adapter.getOrder({ externalOrderId: 'cf' });

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -201,6 +201,7 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptions
         billingAddress: undefined,
         shipping: this.resolveShipping(checkoutForm),
         pickupPoint: this.resolvePickupPoint(checkoutForm),
+        deliverySmart: checkoutForm.delivery?.smart,
         createdAt,
         updatedAt,
         metadata: {


### PR DESCRIPTION
## Summary

Allegro's `GET /order/checkout-forms/{id}` exposes `delivery.smart: boolean` — Allegro Smart! free-delivery eligibility. The field was already typed on `AllegroCheckoutForm.delivery.smart` (with "Ignored today" JSDoc) but unconsumed. This PR wires it through the order-ingestion pipeline so the flag lands in the persisted `OrderRecord.orderSnapshot` JSONB column where future surfaces (filtering, analytics, badges) can read it.

The PR shipped in two commits intentionally — the first wired the adapter and DTO change, tech-review caught that the snapshot is built field-by-field (not object-spread) so the field was being silently dropped on the happy path, and the second commit threaded the field through the full cascade.

## Changes

**Adapter + DTO (commit 1, `1f8cfb8`)**
- `IncomingOrder.deliverySmart?: boolean` on the neutral order DTO (`libs/core/src/orders/domain/types/incoming-order.types.ts`)
- `AllegroOrderSourceAdapter.getOrder` maps `checkoutForm.delivery?.smart` into the returned `IncomingOrder`
- 3 adapter test cases (`true` / `false` / `delivery` absent)

**Persistence cascade (commit 2, `b19f2a4`)**
- `Order.deliverySmart?: boolean` on the canonical domain type (`libs/core/src/orders/domain/types/order.types.ts`), placed next to the sibling source-side fields (`shipping`, `pickupPoint`)
- `OrderIngestionService.buildUnifiedOrder` forwards `incoming.deliverySmart` into the constructed `Order`
- `OrderRecordService.persistOrder` + `persistIncomingSnapshot` both serialise the field via **conditional spread** — matches the existing `OrderItem.name` / `imageUrl` precedent so absent stays absent in the JSON (consumers can distinguish "Smart not reported" from "Smart explicitly false")
- 4 new service tests covering present + absent on each of the two write paths
- 1 new adapter test for the `delivery` block present but `smart` key missing

## Spec deviations (documented in the plan)

- **No migration**: `OrderRecord` persists order data as `orderSnapshot: jsonb`, not flat columns. The field rides inside the JSONB once it appears on both snapshot projections — no DDL needed.
- **No OrderRecord entity change**: callers already access nested snapshot fields via `record.orderSnapshot.x`. A flat getter would be redundant with `record.orderSnapshot.deliverySmart`.
- **Non-Allegro path**: field omitted from snapshot (not literal `null`) — JSON-equivalent at the boundary; the AC's "default to null" wording is satisfied by key-absence.

## Out of scope

- **Sibling field gap**: `shipping` and `pickupPoint` also live on `Order` / `IncomingOrder` but are similarly absent from the snapshot projections. Same shape as the bug this PR fixes, but a separate concern — I'll file a follow-up issue.
- FE display (Smart badge on orders) — separate impl issue.
- Smart-based order filtering — future feature.
- Smart top-up fee tracking — settlement-level, separate concern.

## Test plan

- [x] `pnpm lint` — green
- [x] `pnpm type-check` — green
- [x] `pnpm test` — Allegro 385 (+1), core 738 (+4), api 389, worker 118; all suites green
- [ ] Manual: ingest a real Allegro Smart order in a staging connection, verify `GET /orders/:id` returns `orderSnapshot.deliverySmart: true`
- [ ] Manual: ingest a real Allegro non-Smart order, verify `orderSnapshot.deliverySmart === false`
- [ ] Manual: ingest a PrestaShop order, verify `orderSnapshot.deliverySmart` is absent

Plan: `docs/plans/implementation-plan-738-allegro-delivery-smart.md`

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)