### PR TITLE
feat(listings): bulk-aware marketplace.offer.create handler + Smart classification readback (#737)

### DIFF
--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -97,6 +97,7 @@ describe('ListingsController', () => {
       updateExternalOfferId: jest.fn(),
       updateExternalIdAndStatus: jest.fn(),
       findByBulkBatchId: jest.fn(),
+      updateClassificationReport: jest.fn(),
     };
     offerCreationEnqueue = {
       enqueueCreation: jest.fn(),

--- a/apps/api/src/migrations/1798000000000-add-smart-classification-and-batch-advancements.ts
+++ b/apps/api/src/migrations/1798000000000-add-smart-classification-and-batch-advancements.ts
@@ -1,0 +1,51 @@
+/**
+ * Add classification-report column + bulk_batch_advancements table (#737)
+ *
+ * Two related changes for the bulk-flow worker handler:
+ *
+ * 1. `offer_creation_records.classificationReport` (jsonb, nullable) —
+ *    persists the post-create marketplace classification report
+ *    (Allegro Smart today). Single jsonb keeps the column shape
+ *    forward-compat against Allegro response changes; the FE distinguishes
+ *    `null` (unread / not applicable) from `{ fulfilled: false, ... }`
+ *    (classified non-Smart) explicitly.
+ *
+ * 2. `bulk_batch_advancements` table — at-most-once guard for the
+ *    counter-advancement path. Composite PK `(bulkBatchId,
+ *    offerCreationRecordId)` + the repository's `INSERT ON CONFLICT DO
+ *    NOTHING` query makes the bulk-batch counter increment race-free
+ *    across N concurrent worker invocations + worker retries, without a
+ *    transaction. Kept as a separate table (vs. a column on
+ *    `offer_creation_records`) so the single-offer entity stays clean —
+ *    bulk-flow concerns don't leak into the per-attempt record.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSmartClassificationAndBatchAdvancements1798000000000
+  implements MigrationInterface
+{
+  name = 'AddSmartClassificationAndBatchAdvancements1798000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "offer_creation_records" ADD COLUMN "classificationReport" jsonb`,
+    );
+    await queryRunner.query(`
+      CREATE TABLE "bulk_batch_advancements" (
+        "bulkBatchId"            uuid      NOT NULL,
+        "offerCreationRecordId"  uuid      NOT NULL,
+        "advancedAt"             TIMESTAMP NOT NULL DEFAULT now(),
+        PRIMARY KEY ("bulkBatchId", "offerCreationRecordId")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "bulk_batch_advancements"`);
+    await queryRunner.query(
+      `ALTER TABLE "offer_creation_records" DROP COLUMN "classificationReport"`,
+    );
+  }
+}

--- a/apps/worker/src/content/worker-content.module.ts
+++ b/apps/worker/src/content/worker-content.module.ts
@@ -1,0 +1,46 @@
+/**
+ * Worker Content Module (#737)
+ *
+ * Binds `CONTENT_SUGGESTION_SERVICE_TOKEN` to `ContentSuggestionService` for
+ * the worker process. Mirrors the `apps/api/src/content/content.module.ts`
+ * suggestion-binding pattern — the suggestion service depends on
+ * `AI_COMPLETION_PORT_TOKEN`, which the worker resolves via
+ * `PluginRegistryModule.forRoot({ plugins: workerPlugins })` in
+ * `AppModule` (where `workerPlugins` includes `AiIntegrationModule.register()`
+ * as of #737).
+ *
+ * Cannot live in `libs/core/src/content/content.module.ts` because that
+ * would force core to value-import `@openlinker/integrations-ai`,
+ * reversing the core → integration dependency direction (see the core
+ * `content.module.ts` file header for the full rationale). Per-host
+ * mirror is the OpenLinker convention for services whose concrete
+ * collaborators sit in integration packages.
+ *
+ * Slimmer than the API mirror: no controllers (worker has no HTTP
+ * surface), no `ContentController` — just the suggestion-service
+ * binding.
+ *
+ * @module apps/worker/src/content
+ */
+import { Module } from '@nestjs/common';
+import { AiModule as CoreAiModule } from '@openlinker/core/ai';
+import {
+  CONTENT_SUGGESTION_SERVICE_TOKEN,
+  ContentModule as CoreContentModule,
+} from '@openlinker/core/content';
+import { ContentSuggestionService } from '@openlinker/core/content';
+import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
+import { ListingsModule as CoreListingsModule } from '@openlinker/core/listings/services';
+
+@Module({
+  imports: [CoreContentModule, CoreIntegrationsModule, CoreListingsModule, CoreAiModule],
+  providers: [
+    ContentSuggestionService,
+    {
+      provide: CONTENT_SUGGESTION_SERVICE_TOKEN,
+      useExisting: ContentSuggestionService,
+    },
+  ],
+  exports: [CONTENT_SUGGESTION_SERVICE_TOKEN],
+})
+export class WorkerContentModule {}

--- a/apps/worker/src/plugins.ts
+++ b/apps/worker/src/plugins.ts
@@ -11,8 +11,10 @@
  *   2. Import its module here.
  *   3. Add it to the `workerPlugins` array below.
  *
- * The worker does not need `AiIntegrationModule` because the AI suggestion
- * flow is handled synchronously in-process by the API.
+ * `AiIntegrationModule` is registered here (#737) because the bulk-flow
+ * `marketplace.offer.create` handler calls `ContentSuggestionService` for
+ * per-job AI description generation. Without this, `AI_COMPLETION_PORT_TOKEN`
+ * is unresolved in the worker's DI scope.
  *
  * See `docs/architecture-overview.md` § *Adapter Registry (Code-Level)* for
  * the conceptual model.
@@ -22,8 +24,10 @@
 import type { PluginEntry } from '@openlinker/core/integrations';
 import { PrestashopIntegrationModule } from '@openlinker/integrations-prestashop';
 import { AllegroIntegrationModule } from '@openlinker/integrations-allegro';
+import { AiIntegrationModule } from '@openlinker/integrations-ai';
 
 export const workerPlugins: PluginEntry[] = [
   PrestashopIntegrationModule,
   AllegroIntegrationModule,
+  AiIntegrationModule.register(),
 ];

--- a/apps/worker/src/sync/handlers/__tests__/marketplace-offer-create.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/marketplace-offer-create.handler.spec.ts
@@ -1,22 +1,41 @@
 /**
  * Marketplace Offer Create Handler Tests
  *
+ * Covers both V1 (single-offer) and V2 (bulk-aware) payload paths and the
+ * two V2 side-effects the handler owns: AI description prep and
+ * BulkOfferCreationProgressService counter advancement.
+ *
+ * Smart classification readback was moved into OfferCreationExecutionService
+ * (so the handler stays cross-context-clean — no repository-port imports).
+ * Smart-readback test coverage lives in
+ * `libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts`
+ * and `offer-status-poll.service.spec.ts`.
+ *
  * @module apps/worker/src/sync/handlers/__tests__
  */
 import { MarketplaceOfferCreateHandler } from '../marketplace-offer-create.handler';
 import { SyncJobExecutionError } from '@openlinker/core/sync';
 import type { SyncJobEntity as SyncJob } from '@openlinker/core/sync';
-import { OfferCreationRecord } from '@openlinker/core/listings';
-import type { IOfferCreationExecutionService } from '@openlinker/core/listings';
+import {
+  OfferCreationRecord,
+  type IBulkOfferCreationProgressService,
+  type IOfferCreationExecutionService,
+} from '@openlinker/core/listings';
+import type { IContentSuggestionService } from '@openlinker/core/content';
+import type { IProductsService } from '@openlinker/core/products';
 
 const VARIANT_ID = 'ol_variant_123';
+const PRODUCT_ID = 'ol_product_456';
 const CONNECTION_ID = 'conn-allegro';
 const JOB_ID = 'job-1';
+const RECORD_ID = 'rec-1';
+const EXTERNAL_OFFER_ID = 'allegro-offer-1';
+const BATCH_ID = 'batch-uuid-1';
 
 const buildRecord = (overrides: Partial<OfferCreationRecord> = {}): OfferCreationRecord => {
   const now = new Date('2026-01-01T00:00:00Z');
   return new OfferCreationRecord(
-    overrides.id ?? 'rec-1',
+    overrides.id ?? RECORD_ID,
     overrides.internalVariantId ?? VARIANT_ID,
     overrides.connectionId ?? CONNECTION_ID,
     overrides.externalOfferId ?? null,
@@ -24,26 +43,50 @@ const buildRecord = (overrides: Partial<OfferCreationRecord> = {}): OfferCreatio
     overrides.errors ?? null,
     overrides.publishImmediately ?? false,
     overrides.createdAt ?? now,
-    overrides.updatedAt ?? now
+    overrides.updatedAt ?? now,
+    overrides.request ?? null,
+    overrides.bulkBatchId ?? null,
+    overrides.classificationReport ?? null
   );
 };
 
 describe('MarketplaceOfferCreateHandler', () => {
   let handler: MarketplaceOfferCreateHandler;
   let offerCreation: jest.Mocked<IOfferCreationExecutionService>;
+  let contentSuggestion: jest.Mocked<IContentSuggestionService>;
+  let products: jest.Mocked<IProductsService>;
+  let bulkProgress: jest.Mocked<IBulkOfferCreationProgressService>;
 
   beforeEach(() => {
     offerCreation = {
       executeCreation: jest.fn(),
-    };
-    handler = new MarketplaceOfferCreateHandler(offerCreation);
+    } as unknown as jest.Mocked<IOfferCreationExecutionService>;
+
+    contentSuggestion = {
+      suggestDescription: jest.fn(),
+    } as unknown as jest.Mocked<IContentSuggestionService>;
+
+    products = {
+      getVariant: jest.fn(),
+    } as unknown as jest.Mocked<IProductsService>;
+
+    bulkProgress = {
+      advanceBatchStatus: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<IBulkOfferCreationProgressService>;
+
+    handler = new MarketplaceOfferCreateHandler(
+      offerCreation,
+      contentSuggestion,
+      products,
+      bulkProgress
+    );
   });
 
-  const createJob = (payload: Record<string, unknown>): SyncJob => ({
+  const createJob = (payload: Record<string, unknown> | undefined): SyncJob => ({
     id: JOB_ID,
     jobType: 'marketplace.offer.create' as unknown as SyncJob['jobType'],
     connectionId: CONNECTION_ID,
-    payload,
+    payload: payload as never,
     idempotencyKey: 'idem-key',
     status: 'queued',
     attempts: 0,
@@ -56,99 +99,276 @@ describe('MarketplaceOfferCreateHandler', () => {
     updatedAt: new Date(),
   });
 
-  it('delegates to the execution service with parsed payload + job connection id', async () => {
-    offerCreation.executeCreation.mockResolvedValue({
-      offerCreationRecord: buildRecord({ status: 'draft', externalOfferId: 'allegro-1' }),
-      outcome: 'ok',
+  // ---------- V1 payload path ----------
+
+  describe('V1 payload (single-offer)', () => {
+    it('delegates to the execution service with parsed payload + job connection id', async () => {
+      offerCreation.executeCreation.mockResolvedValue({
+        offerCreationRecord: buildRecord({ status: 'draft', externalOfferId: 'allegro-1' }),
+        outcome: 'ok',
+      });
+
+      const job = createJob({
+        schemaVersion: 1,
+        internalVariantId: VARIANT_ID,
+        stock: 3,
+        publishImmediately: true,
+        price: { amount: 49.99, currency: 'PLN' },
+        overrides: { title: 'Hello' },
+        idempotencyKey: 'idem-1',
+      });
+
+      const result = await handler.execute(job);
+
+      expect(result).toEqual({ outcome: 'ok' });
+      expect(offerCreation.executeCreation).toHaveBeenCalledWith({
+        internalVariantId: VARIANT_ID,
+        connectionId: CONNECTION_ID,
+        stock: 3,
+        publishImmediately: true,
+        price: { amount: 49.99, currency: 'PLN' },
+        overrides: { title: 'Hello' },
+        idempotencyKey: 'idem-1',
+        offerCreationRecordId: undefined,
+      });
+      // V1 must not call any V2-only side-effects.
+      expect(contentSuggestion.suggestDescription).not.toHaveBeenCalled();
+      expect(bulkProgress.advanceBatchStatus).not.toHaveBeenCalled();
     });
 
-    const job = createJob({
-      schemaVersion: 1,
-      internalVariantId: VARIANT_ID,
-      stock: 3,
-      publishImmediately: true,
-      price: { amount: 49.99, currency: 'PLN' },
-      overrides: { title: 'Hello' },
-      idempotencyKey: 'idem-1',
+    it('returns outcome=business_failure when the service records a terminal failure', async () => {
+      offerCreation.executeCreation.mockResolvedValue({
+        offerCreationRecord: buildRecord({
+          status: 'failed',
+          errors: [{ field: 'price.amount', code: 'REQUIRED', message: 'Required' }],
+        }),
+        outcome: 'business_failure',
+      });
+
+      const job = createJob({
+        schemaVersion: 1,
+        internalVariantId: VARIANT_ID,
+        stock: 3,
+        publishImmediately: false,
+      });
+
+      await expect(handler.execute(job)).resolves.toEqual({ outcome: 'business_failure' });
     });
 
-    const result = await handler.execute(job);
+    it('wraps unknown service errors in SyncJobExecutionError for retry', async () => {
+      offerCreation.executeCreation.mockRejectedValue(new Error('redis down'));
 
-    expect(result).toEqual({ outcome: 'ok' });
-    expect(offerCreation.executeCreation).toHaveBeenCalledWith({
-      internalVariantId: VARIANT_ID,
-      connectionId: CONNECTION_ID,
-      stock: 3,
-      publishImmediately: true,
-      price: { amount: 49.99, currency: 'PLN' },
-      overrides: { title: 'Hello' },
-      idempotencyKey: 'idem-1',
-      offerCreationRecordId: undefined,
+      const job = createJob({
+        schemaVersion: 1,
+        internalVariantId: VARIANT_ID,
+        stock: 1,
+        publishImmediately: false,
+      });
+
+      await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+    });
+
+    it('throws SyncJobExecutionError when payload is missing', async () => {
+      const job = createJob(undefined);
+      await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+      expect(offerCreation.executeCreation).not.toHaveBeenCalled();
+    });
+
+    it('throws SyncJobExecutionError when internalVariantId is missing', async () => {
+      const job = createJob({ schemaVersion: 1, stock: 1, publishImmediately: false });
+      await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+      expect(offerCreation.executeCreation).not.toHaveBeenCalled();
+    });
+
+    it('throws SyncJobExecutionError when stock is missing or negative', async () => {
+      const job = createJob({
+        schemaVersion: 1,
+        internalVariantId: VARIANT_ID,
+        stock: -1,
+        publishImmediately: false,
+      });
+      await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+    });
+
+    it('throws SyncJobExecutionError when schemaVersion is unsupported', async () => {
+      const job = createJob({
+        schemaVersion: 99,
+        internalVariantId: VARIANT_ID,
+        stock: 1,
+        publishImmediately: false,
+      });
+      await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+      expect(offerCreation.executeCreation).not.toHaveBeenCalled();
     });
   });
 
-  it('returns outcome=business_failure when the service records a terminal failure', async () => {
-    offerCreation.executeCreation.mockResolvedValue({
-      offerCreationRecord: buildRecord({
-        status: 'failed',
-        errors: [{ field: 'price.amount', code: 'REQUIRED', message: 'Required' }],
-      }),
-      outcome: 'business_failure',
-    });
+  // ---------- V2 payload path ----------
 
-    const job = createJob({
-      schemaVersion: 1,
-      internalVariantId: VARIANT_ID,
-      stock: 3,
-      publishImmediately: false,
-    });
-
-    await expect(handler.execute(job)).resolves.toEqual({ outcome: 'business_failure' });
-  });
-
-  it('wraps unknown service errors in SyncJobExecutionError for retry', async () => {
-    offerCreation.executeCreation.mockRejectedValue(new Error('redis down'));
-
-    const job = createJob({
-      schemaVersion: 1,
-      internalVariantId: VARIANT_ID,
-      stock: 1,
-      publishImmediately: false,
-    });
-
-    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
-  });
-
-  it('throws SyncJobExecutionError when payload is missing', async () => {
-    const job = createJob(undefined as unknown as Record<string, unknown>);
-    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
-    expect(offerCreation.executeCreation).not.toHaveBeenCalled();
-  });
-
-  it('throws SyncJobExecutionError when internalVariantId is missing', async () => {
-    const job = createJob({ schemaVersion: 1, stock: 1, publishImmediately: false });
-    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
-    expect(offerCreation.executeCreation).not.toHaveBeenCalled();
-  });
-
-  it('throws SyncJobExecutionError when stock is missing or negative', async () => {
-    const job = createJob({
-      schemaVersion: 1,
-      internalVariantId: VARIANT_ID,
-      stock: -1,
-      publishImmediately: false,
-    });
-    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
-  });
-
-  it('throws SyncJobExecutionError when schemaVersion is unsupported', async () => {
-    const job = createJob({
+  describe('V2 payload (bulk-aware)', () => {
+    const baseV2 = (overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> => ({
       schemaVersion: 2,
       internalVariantId: VARIANT_ID,
       stock: 1,
       publishImmediately: false,
+      offerCreationRecordId: RECORD_ID,
+      bulkBatchId: BATCH_ID,
+      generateDescription: false,
+      ...overrides,
     });
-    await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
-    expect(offerCreation.executeCreation).not.toHaveBeenCalled();
+
+    it('threads AI-generated description into overrides when generateDescription=true', async () => {
+      products.getVariant.mockResolvedValue({
+        id: VARIANT_ID,
+        productId: PRODUCT_ID,
+      } as never);
+      contentSuggestion.suggestDescription.mockResolvedValue({
+        suggestion: '<p>AI-built description</p>',
+      } as never);
+      offerCreation.executeCreation.mockResolvedValue({
+        offerCreationRecord: buildRecord({
+          status: 'active',
+          externalOfferId: EXTERNAL_OFFER_ID,
+          bulkBatchId: BATCH_ID,
+        }),
+        outcome: 'ok',
+      });
+
+      const job = createJob(
+        baseV2({
+          generateDescription: true,
+          overrides: { title: 'Operator Title' },
+          descriptionTone: 'professional',
+        })
+      );
+
+      await handler.execute(job);
+
+      expect(products.getVariant).toHaveBeenCalledWith(VARIANT_ID);
+      expect(contentSuggestion.suggestDescription).toHaveBeenCalledWith({
+        productId: PRODUCT_ID,
+        channel: 'allegro',
+        tone: 'professional',
+      });
+      expect(offerCreation.executeCreation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overrides: { title: 'Operator Title', description: '<p>AI-built description</p>' },
+        })
+      );
+    });
+
+    it('falls through with operator overrides when AI suggestion fails', async () => {
+      products.getVariant.mockResolvedValue({
+        id: VARIANT_ID,
+        productId: PRODUCT_ID,
+      } as never);
+      contentSuggestion.suggestDescription.mockRejectedValue(new Error('LLM 503'));
+      offerCreation.executeCreation.mockResolvedValue({
+        offerCreationRecord: buildRecord({ status: 'failed' }),
+        outcome: 'business_failure',
+      });
+
+      const job = createJob(
+        baseV2({
+          generateDescription: true,
+          overrides: { title: 'Operator Title' },
+        })
+      );
+
+      await handler.execute(job);
+
+      // The fallback is operator overrides — description not added by AI.
+      expect(offerCreation.executeCreation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overrides: { title: 'Operator Title' },
+        })
+      );
+    });
+
+    it('falls through when variant lookup fails (AI skipped, no throw)', async () => {
+      products.getVariant.mockRejectedValue(new Error('DB blip'));
+      offerCreation.executeCreation.mockResolvedValue({
+        offerCreationRecord: buildRecord({ status: 'failed' }),
+        outcome: 'business_failure',
+      });
+
+      const job = createJob(baseV2({ generateDescription: true, overrides: { title: 'X' } }));
+
+      await handler.execute(job);
+
+      expect(contentSuggestion.suggestDescription).not.toHaveBeenCalled();
+      expect(offerCreation.executeCreation).toHaveBeenCalledWith(
+        expect.objectContaining({ overrides: { title: 'X' } })
+      );
+    });
+
+    it('does not invoke AI when generateDescription=false', async () => {
+      offerCreation.executeCreation.mockResolvedValue({
+        offerCreationRecord: buildRecord({
+          status: 'active',
+          externalOfferId: EXTERNAL_OFFER_ID,
+        }),
+        outcome: 'ok',
+      });
+
+      const job = createJob(baseV2({ generateDescription: false }));
+
+      await handler.execute(job);
+
+      expect(products.getVariant).not.toHaveBeenCalled();
+      expect(contentSuggestion.suggestDescription).not.toHaveBeenCalled();
+    });
+
+    it('advances batch with succeeded on outcome=ok', async () => {
+      offerCreation.executeCreation.mockResolvedValue({
+        offerCreationRecord: buildRecord({
+          status: 'active',
+          externalOfferId: EXTERNAL_OFFER_ID,
+        }),
+        outcome: 'ok',
+      });
+
+      const job = createJob(baseV2());
+
+      await handler.execute(job);
+
+      expect(bulkProgress.advanceBatchStatus).toHaveBeenCalledWith(
+        BATCH_ID,
+        RECORD_ID,
+        'succeeded'
+      );
+    });
+
+    it('advances batch with failed on outcome=business_failure', async () => {
+      offerCreation.executeCreation.mockResolvedValue({
+        offerCreationRecord: buildRecord({
+          status: 'failed',
+          externalOfferId: null,
+          errors: [{ code: 'X', message: 'y' }],
+        }),
+        outcome: 'business_failure',
+      });
+
+      const job = createJob(baseV2());
+
+      await handler.execute(job);
+
+      expect(bulkProgress.advanceBatchStatus).toHaveBeenCalledWith(BATCH_ID, RECORD_ID, 'failed');
+    });
+
+    it('throws SyncJobExecutionError when bulkBatchId is missing', async () => {
+      const job = createJob(baseV2({ bulkBatchId: undefined }));
+      await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+      expect(offerCreation.executeCreation).not.toHaveBeenCalled();
+    });
+
+    it('throws SyncJobExecutionError when offerCreationRecordId is missing', async () => {
+      const job = createJob(baseV2({ offerCreationRecordId: undefined }));
+      await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+    });
+
+    it('throws SyncJobExecutionError when generateDescription is missing', async () => {
+      const job = createJob(baseV2({ generateDescription: undefined }));
+      await expect(handler.execute(job)).rejects.toBeInstanceOf(SyncJobExecutionError);
+    });
   });
 });

--- a/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
@@ -1,26 +1,52 @@
 /**
  * Marketplace Offer Create Handler
  *
- * Handles sync jobs of type `marketplace.offer.create`. Acts as a thin shell
- * around the core `OfferCreationExecutionService` — it validates the payload,
- * delegates the orchestration policy to core, and translates unexpected
- * failures into retryable `SyncJobExecutionError`s.
+ * Handles sync jobs of type `marketplace.offer.create`. V1 payloads run the
+ * original single-offer path: validate payload → `OfferCreationExecutionService.executeCreation`
+ * → return outcome.
  *
- * Per `architecture-overview.md` §6, orchestration lives in a core application
- * service rather than the handler so that the future REST endpoint (#259) and
- * this worker path share identical semantics.
+ * V2 payloads (#737, bulk-flow) layer two orthogonal side-effects:
+ *
+ *   1. **Before** `executeCreation`: if `generateDescription === true`,
+ *      call `ContentSuggestionService.suggestDescription({ channel:'allegro' })`
+ *      and thread the result into `overrides.description`. AI failure falls
+ *      through — operator override or builder default takes over (AC-9).
+ *   2. **After** `executeCreation`, terminal outcome: advance the parent
+ *      batch's counters via `BulkOfferCreationProgressService` — which
+ *      gates on the `bulk_batch_advancements` table to give at-most-once
+ *      counter semantics across retries + concurrent workers.
+ *
+ * Smart classification readback lives inside `OfferCreationExecutionService`
+ * (active-on-create branch) and `OfferStatusPollService` (validating→active
+ * branch) so the handler stays cross-context-clean — no repository-port
+ * imports.
+ *
+ * Per `architecture-overview.md` §7, orchestration policies live in core
+ * application services; the handler is a thin shell coordinating them.
  *
  * @module apps/worker/src/sync/handlers
  */
 import { Inject, Injectable } from '@nestjs/common';
 
 import {
-  IOfferCreationExecutionService,
+  CONTENT_SUGGESTION_SERVICE_TOKEN,
+  type IContentSuggestionService,
+} from '@openlinker/core/content';
+import {
+  BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
+  type CreateOfferOverrides,
+  type IBulkOfferCreationProgressService,
+  type IOfferCreationExecutionService,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
   OfferCreationInvariantException,
 } from '@openlinker/core/listings';
+import {
+  PRODUCTS_SERVICE_TOKEN,
+  type IProductsService,
+} from '@openlinker/core/products';
 import type {
   MarketplaceOfferCreatePayloadV1,
+  MarketplaceOfferCreatePayloadV2,
   SyncJob as SyncJobEntity,
   SyncJobHandler,
   SyncJobHandlerResult,
@@ -29,6 +55,7 @@ import { SyncJobExecutionError } from '@openlinker/core/sync';
 import { Logger } from '@openlinker/shared/logging';
 
 type SyncJob = SyncJobEntity;
+type Payload = MarketplaceOfferCreatePayloadV1 | MarketplaceOfferCreatePayloadV2;
 
 @Injectable()
 export class MarketplaceOfferCreateHandler implements SyncJobHandler {
@@ -36,24 +63,32 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
 
   constructor(
     @Inject(OFFER_CREATION_EXECUTION_SERVICE_TOKEN)
-    private readonly offerCreation: IOfferCreationExecutionService
+    private readonly offerCreation: IOfferCreationExecutionService,
+    @Inject(CONTENT_SUGGESTION_SERVICE_TOKEN)
+    private readonly contentSuggestion: IContentSuggestionService,
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly products: IProductsService,
+    @Inject(BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN)
+    private readonly bulkProgress: IBulkOfferCreationProgressService
   ) {}
 
   async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
     const payload = this.getPayload(job);
 
     this.logger.log(
-      `Executing marketplace.offer.create job ${job.id} variant=${payload.internalVariantId} connection=${job.connectionId}`
+      `Executing marketplace.offer.create job ${job.id} variant=${payload.internalVariantId} connection=${job.connectionId} schemaVersion=${payload.schemaVersion}`
     );
 
     try {
+      const overrides = await this.maybeRunAiDescription(payload);
+
       const { offerCreationRecord, outcome } = await this.offerCreation.executeCreation({
         internalVariantId: payload.internalVariantId,
         connectionId: job.connectionId,
         stock: payload.stock,
         publishImmediately: payload.publishImmediately,
         price: payload.price,
-        overrides: payload.overrides,
+        overrides,
         idempotencyKey: payload.idempotencyKey,
         offerCreationRecordId: payload.offerCreationRecordId,
       });
@@ -61,6 +96,17 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
       this.logger.log(
         `Offer creation finished: job=${job.id} recordId=${offerCreationRecord.id} status=${offerCreationRecord.status} outcome=${outcome} externalOfferId=${offerCreationRecord.externalOfferId ?? 'n/a'}`
       );
+
+      if (this.isV2(payload)) {
+        // Counter advancement — gated at-most-once by
+        // `bulk_batch_advancements` inside the progress service.
+        const batchOutcome = outcome === 'ok' ? 'succeeded' : 'failed';
+        await this.bulkProgress.advanceBatchStatus(
+          payload.bulkBatchId,
+          offerCreationRecord.id,
+          batchOutcome
+        );
+      }
 
       return { outcome };
     } catch (error) {
@@ -82,8 +128,60 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
     }
   }
 
-  private getPayload(job: SyncJob): MarketplaceOfferCreatePayloadV1 {
-    const payload = job.payload as unknown as Partial<MarketplaceOfferCreatePayloadV1>;
+  private isV2(p: Payload): p is MarketplaceOfferCreatePayloadV2 {
+    return p.schemaVersion === 2;
+  }
+
+  /**
+   * V2-only: when `generateDescription === true`, run the AI suggestion and
+   * thread the result into `overrides.description`. AI failure logs a warning
+   * and falls through (operator override or builder default takes over).
+   *
+   * V1 (or V2 with `generateDescription: false`) returns payload.overrides
+   * unchanged.
+   */
+  private async maybeRunAiDescription(payload: Payload): Promise<CreateOfferOverrides | undefined> {
+    if (!this.isV2(payload) || payload.generateDescription !== true) {
+      return payload.overrides;
+    }
+
+    let productId: string;
+    try {
+      const variant = await this.products.getVariant(payload.internalVariantId);
+      if (!variant) {
+        this.logger.warn(
+          `AI description skipped — variant not found: ${payload.internalVariantId}`
+        );
+        return payload.overrides;
+      }
+      productId = variant.productId;
+    } catch (err) {
+      this.logger.warn(
+        `AI description skipped — variant lookup failed: ${(err as Error).message}`
+      );
+      return payload.overrides;
+    }
+
+    try {
+      const result = await this.contentSuggestion.suggestDescription({
+        productId,
+        channel: 'allegro',
+        tone: payload.descriptionTone,
+      });
+      return {
+        ...payload.overrides,
+        description: result.suggestion,
+      };
+    } catch (err) {
+      this.logger.warn(
+        `AI description failed (falling back to operator override / default): ${(err as Error).message}`
+      );
+      return payload.overrides;
+    }
+  }
+
+  private getPayload(job: SyncJob): Payload {
+    const payload = job.payload as unknown as Partial<MarketplaceOfferCreatePayloadV1 | MarketplaceOfferCreatePayloadV2>;
 
     if (!payload || typeof payload !== 'object') {
       throw new SyncJobExecutionError(
@@ -94,15 +192,24 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
       );
     }
 
-    if (payload.schemaVersion !== 1) {
-      throw new SyncJobExecutionError(
-        `Unsupported schemaVersion (${String(payload.schemaVersion)}) in payload: ${JSON.stringify(job.payload)}`,
-        job.id,
-        job.jobType,
-        job.connectionId
-      );
+    if (payload.schemaVersion === 1) {
+      return this.validateV1(job, payload);
     }
+    if (payload.schemaVersion === 2) {
+      return this.validateV2(job, payload);
+    }
+    throw new SyncJobExecutionError(
+      `Unsupported schemaVersion (${String(payload.schemaVersion)}) in payload: ${JSON.stringify(job.payload)}`,
+      job.id,
+      job.jobType,
+      job.connectionId
+    );
+  }
 
+  private validateV1(
+    job: SyncJob,
+    payload: Partial<MarketplaceOfferCreatePayloadV1>
+  ): MarketplaceOfferCreatePayloadV1 {
     if (typeof payload.internalVariantId !== 'string' || payload.internalVariantId.length === 0) {
       throw new SyncJobExecutionError(
         `Missing or invalid internalVariantId in payload: ${JSON.stringify(job.payload)}`,
@@ -111,7 +218,6 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
         job.connectionId
       );
     }
-
     if (
       typeof payload.stock !== 'number' ||
       !Number.isInteger(payload.stock) ||
@@ -124,7 +230,6 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
         job.connectionId
       );
     }
-
     if (typeof payload.publishImmediately !== 'boolean') {
       throw new SyncJobExecutionError(
         `Missing or invalid publishImmediately in payload: ${JSON.stringify(job.payload)}`,
@@ -133,7 +238,6 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
         job.connectionId
       );
     }
-
     return {
       schemaVersion: 1,
       internalVariantId: payload.internalVariantId,
@@ -143,6 +247,77 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
       overrides: payload.overrides,
       idempotencyKey: payload.idempotencyKey,
       offerCreationRecordId: payload.offerCreationRecordId,
+    };
+  }
+
+  private validateV2(
+    job: SyncJob,
+    payload: Partial<MarketplaceOfferCreatePayloadV2>
+  ): MarketplaceOfferCreatePayloadV2 {
+    if (typeof payload.internalVariantId !== 'string' || payload.internalVariantId.length === 0) {
+      throw new SyncJobExecutionError(
+        `Missing or invalid internalVariantId in V2 payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (
+      typeof payload.stock !== 'number' ||
+      !Number.isInteger(payload.stock) ||
+      payload.stock < 0
+    ) {
+      throw new SyncJobExecutionError(
+        `Missing or invalid stock in V2 payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (typeof payload.publishImmediately !== 'boolean') {
+      throw new SyncJobExecutionError(
+        `Missing or invalid publishImmediately in V2 payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (typeof payload.offerCreationRecordId !== 'string' || payload.offerCreationRecordId.length === 0) {
+      throw new SyncJobExecutionError(
+        `Missing offerCreationRecordId in V2 payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (typeof payload.bulkBatchId !== 'string' || payload.bulkBatchId.length === 0) {
+      throw new SyncJobExecutionError(
+        `Missing bulkBatchId in V2 payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    if (typeof payload.generateDescription !== 'boolean') {
+      throw new SyncJobExecutionError(
+        `Missing or invalid generateDescription in V2 payload: ${JSON.stringify(job.payload)}`,
+        job.id,
+        job.jobType,
+        job.connectionId
+      );
+    }
+    return {
+      schemaVersion: 2,
+      internalVariantId: payload.internalVariantId,
+      stock: payload.stock,
+      publishImmediately: payload.publishImmediately,
+      price: payload.price,
+      overrides: payload.overrides,
+      idempotencyKey: payload.idempotencyKey,
+      offerCreationRecordId: payload.offerCreationRecordId,
+      bulkBatchId: payload.bulkBatchId,
+      generateDescription: payload.generateDescription,
+      descriptionTone: payload.descriptionTone,
     };
   }
 }

--- a/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts
@@ -34,6 +34,7 @@ import {
 } from '@openlinker/core/content';
 import {
   BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
+  type BulkChildOutcome,
   type CreateOfferOverrides,
   type IBulkOfferCreationProgressService,
   type IOfferCreationExecutionService,
@@ -100,7 +101,7 @@ export class MarketplaceOfferCreateHandler implements SyncJobHandler {
       if (this.isV2(payload)) {
         // Counter advancement — gated at-most-once by
         // `bulk_batch_advancements` inside the progress service.
-        const batchOutcome = outcome === 'ok' ? 'succeeded' : 'failed';
+        const batchOutcome: BulkChildOutcome = outcome === 'ok' ? 'succeeded' : 'failed';
         await this.bulkProgress.advanceBatchStatus(
           payload.bulkBatchId,
           offerCreationRecord.id,

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -14,6 +14,7 @@ import { ProductsModule } from '@openlinker/core/products';
 import { InventoryModule } from '@openlinker/core/inventory';
 import { OrdersModule } from '@openlinker/core/orders';
 import { ListingsModule } from '@openlinker/core/listings/services';
+import { WorkerContentModule } from '../content/worker-content.module';
 import { JobIntakeConsumer } from './job-intake.consumer';
 import { SyncJobRunner } from './sync-job.runner';
 import { SyncJobHandlerRegistry } from './handlers/sync-job-handler.registry';
@@ -41,6 +42,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     InventoryModule, // Import InventoryModule to access INVENTORY_SERVICE_TOKEN
     OrdersModule, // Import OrdersModule to access ORDER_SYNC_SERVICE_TOKEN
     ListingsModule, // Import ListingsModule to access OFFER_MAPPING_SYNC_SERVICE_TOKEN
+    WorkerContentModule, // Worker-side ContentModule for #737 — exposes CONTENT_SUGGESTION_SERVICE_TOKEN
   ],
   providers: [
     JobIntakeConsumer,

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -250,7 +250,7 @@ The system is organized into the following core bounded contexts:
 - **Admin surface**: `PromptTemplatesController` at `apps/api/src/ai/http/prompt-templates.controller.ts`; `AiProviderSettingsController` at `apps/api/src/ai/http/ai-provider-settings.controller.ts` exposes `GET /ai-provider-settings`, `PUT /keys/:provider`, `DELETE /keys/:provider`, `PUT /active` (all `@Roles('admin')`). FE admin UI at `/ai/prompt-templates` and `/ai/provider-settings`.
 - **Storage**: `prompt_templates` table with four partial unique indexes honouring `NULL`-distinct semantics on the nullable `channel` column (version uniqueness + "at most one published per `(key, channel)`").
 - **Telemetry**: per-completion structured log `{ requestId, model, latencyMs, inputTokens, outputTokens, cachedInputTokens }`; publish / revert actions log `{ templateId, key, channel, version, actor }`.
-- **Worker registration**: not required for #342. The suggestion flow is handled synchronously in-process by the API (`ContentSuggestionService`), so `AiCompletionPort` has no `apps/worker/` consumer yet — wiring will be added if / when a long-running AI job type is introduced.
+- **Worker registration (#737)**: `AiIntegrationModule.register()` is registered in `apps/worker/src/plugins.ts` so the bulk-flow `marketplace.offer.create` handler can call `ContentSuggestionService.suggestDescription()` per-job for AI-generated offer descriptions. `AI_COMPLETION_PORT_TOKEN` resolves through `PluginRegistryModule.forRoot({ plugins: workerPlugins })` in the worker's `AppModule`. The suggestion binding lives at `apps/worker/src/content/worker-content.module.ts` (mirrors `apps/api/src/content/content.module.ts`) — it cannot live in `libs/core/src/content/content.module.ts` because that would force core to value-import `@openlinker/integrations-ai`, reversing the core → integration dependency direction.
 
 ---
 
@@ -484,6 +484,7 @@ Each is an independent interface + co-located `is{Capability}(adapter)` type gua
 | `CategoryBarcodeMatcher` | `matchCategoryByBarcode(barcode)` |
 | `OfferCreator` | `createOffer(cmd)` |
 | `OfferStatusReader` | `getOfferStatus(externalOfferId)` |
+| `OfferSmartClassificationReader` | `getOfferSmartClassification(externalOfferId)` |
 | `SellerPoliciesReader` | `fetchSellerPolicies()` |
 | `CatalogProductReader` | `findProductsByBarcode(input)`, `getProduct(input)` |
 

--- a/docs/plans/implementation-plan-737-bulk-aware-offer-create-worker.md
+++ b/docs/plans/implementation-plan-737-bulk-aware-offer-create-worker.md
@@ -1,0 +1,608 @@
+# Implementation Plan — Bulk-aware `marketplace.offer.create` worker handler (#737)
+
+**Issue**: [#737 — feat(worker): bulk-aware marketplace.offer.create handler + AI description + Smart classification readback](https://github.com/SilkSoftwareHouse/openlinker/issues/737)
+**Parent epic**: [#726 — Allegro Smart! + bulk listing](https://github.com/SilkSoftwareHouse/openlinker/issues/726)
+**Spec**: `docs/specs/product-spec-726-allegro-bulk-listing.md` AC-7 + AC-9
+**Branch**: `737-bulk-aware-offer-create-worker`
+
+---
+
+## 0. Goal
+
+Bring the bulk offer-creation flow to a working end-to-end BE state. After this PR, a `marketplace.offer.create` job from a bulk submission (#736) advances its parent `BulkOfferCreationBatch` correctly, optionally generates an AI description via `ContentSuggestionService`, and reads the post-create Allegro Smart classification (with a follow-up read on the `validating → active` transition for offers that need async validation).
+
+**Non-goals** (explicitly out of scope):
+- Order ingestion `delivery.smart` propagation (separate slice → #738).
+- FE for any of this (→ #739–#741).
+- AI per-batch generation (we do per-job, not per-batch).
+- Allegro Smart reclassification handling (`scheduledForReclassification: true`) beyond the initial read at `active`-transition — future polling-based re-reads are a separate concern.
+
+---
+
+## 1. Layer mapping
+
+This PR touches all four layers, one migration, and a sub-barrel promotion:
+
+| File | Layer | Role |
+|---|---|---|
+| `libs/core/src/listings/domain/types/smart-classification.types.ts` | CORE — Domain | Neutral `SmartClassificationReport` + `SmartClassificationCondition` types (Allegro-shaped today, named generically) |
+| `libs/core/src/listings/domain/ports/capabilities/offer-smart-classification-reader.capability.ts` | CORE — Domain | New `OfferSmartClassificationReader` sub-capability of `OfferManagerPort` + `isOfferSmartClassificationReader` guard. Bare-string method: `getOfferSmartClassification(externalOfferId)` |
+| `libs/core/src/listings/domain/entities/offer-creation-record.entity.ts` | CORE — Domain | One new readonly field `classificationReport: SmartClassificationReport \| null` |
+| `libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts` | CORE — Domain | New method `updateClassificationReport(id, report)` |
+| `libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts` | CORE — Infra | `classificationReport jsonb \| null` column (single field, not per-axis) |
+| `libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts` | CORE — Infra | Implement `updateClassificationReport` |
+| `libs/core/src/listings/domain/entities/bulk-batch-advancement.entity.ts` | CORE — Domain | New domain entity for the at-most-once advancement guard (replaces the original guard-column plan) |
+| `libs/core/src/listings/domain/ports/bulk-batch-advancement-repository.port.ts` | CORE — Domain | Repo port with one method: `markAdvancedIfNotExists(bulkBatchId, offerCreationRecordId) → Promise<{ created: boolean }>` |
+| `libs/core/src/listings/infrastructure/persistence/entities/bulk-batch-advancement.orm-entity.ts` | CORE — Infra | TypeORM entity for new `bulk_batch_advancements` table (PK: composite `bulkBatchId + offerCreationRecordId`) |
+| `libs/core/src/listings/infrastructure/persistence/repositories/bulk-batch-advancement.repository.ts` | CORE — Infra | Implements `markAdvancedIfNotExists` via INSERT ... ON CONFLICT DO NOTHING; returns `{created}` discriminating whether the row landed |
+| `libs/core/src/listings/application/services/bulk-offer-creation-progress.service.ts` | CORE — App | **New service** (per Q1 grilling decision). Owns the worker-side state machine: counter increment + terminal-status derivation. Method: `advanceBatchStatus(batchId, offerCreationRecordId, outcome) → Promise<BulkOfferCreationBatch \| null>`. Internally consults `bulkBatchAdvancementRepository.markAdvancedIfNotExists` for at-most-once before delegating to `bulkBatchRepository.incrementCounters` + status derivation |
+| `libs/core/src/listings/application/services/bulk-offer-creation-progress.service.interface.ts` | CORE — App | `IBulkOfferCreationProgressService` |
+| `libs/core/src/listings/listings.tokens.ts` | CORE — DI | New token `BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN` + `BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN` |
+| `libs/core/src/listings/application/services/offer-status-poll.service.ts` | CORE — App | Extend `validating → active` transition with Smart-readback hook (Q4 grilling outcome) |
+| `libs/core/src/listings/services/listings.module.ts` | CORE — wiring | Register the new progress service + new advancement repository |
+| `libs/core/src/listings/index.ts` | CORE — barrel | Re-export new types + capability + guard + progress-service interface + new tokens |
+| `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts` | Integration | Add `OfferSmartClassificationReader` to `implements`, plus `getOfferSmartClassification` method calling `GET /sale/offers/{offerId}/smart` |
+| `libs/integrations/allegro/src/domain/types/allegro-api.types.ts` | Integration | `AllegroSmartOfferClassificationReport` raw response type |
+| `apps/api/src/migrations/{timestamp}-add-smart-classification-and-batch-advancements.ts` | DX — migration | Single migration: (1) `classificationReport jsonb` column on `offer_creation_records`; (2) `bulk_batch_advancements` table |
+| **`libs/core/src/content/services/content.module.ts`** | CORE — wiring | **Move target** for `apps/api/src/content/content.module.ts` (Q5 sub-barrel promotion) |
+| **`libs/core/src/content/services/index.ts`** | CORE — wiring | New sub-barrel index that exports `ContentModule` |
+| **`libs/core/package.json`** | CORE — wiring | Add `"./content/services"` export entry mirroring `"./listings/services"` |
+| `apps/api/src/app.module.ts` (or wherever `ContentModule` is currently imported) | API — wiring | Update import path from local to `@openlinker/core/content/services` |
+| `apps/worker/src/sync/sync-worker.module.ts` | Worker — wiring | Import `ContentModule` from `@openlinker/core/content/services` so handler can `@Inject(CONTENT_SUGGESTION_SERVICE_TOKEN)` |
+| `apps/worker/src/plugins.ts` | Worker — wiring | Append `AiIntegrationModule.register()` to `workerPlugins` so `AI_COMPLETION_PORT_TOKEN` resolves |
+| `apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts` | Worker — handler | V2 payload branch: AI before, Smart readback + progress after; V1 backwards-compat preserved |
+| `apps/worker/src/sync/handlers/marketplace-offer-create.handler.spec.ts` | Worker — test | Unit spec for handler |
+| `libs/core/src/listings/application/services/__tests__/bulk-offer-creation-progress.service.spec.ts` | Test | Progress service unit spec — counter math + terminal derivation + advancement guard |
+| `libs/core/src/listings/application/services/__tests__/offer-status-poll.service.spec.ts` | Test (additive) | Poll-service Smart-readback hook spec |
+| `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts` | Test (additive) | Adapter spec for `getOfferSmartClassification` |
+| `apps/api/test/integration/listings/bulk-offer-creation.int-spec.ts` | Test — integration | 5-job batch end-to-end (per issue AC) |
+| `docs/architecture-overview.md § 13 AI` | Doc | Replace the "worker registration not required" note with the new wiring topology |
+| `docs/engineering-standards.md § Import Aliases` | Doc | Add `@openlinker/core/content/services` to the sub-barrel list |
+
+---
+
+## 2. Domain shape additions
+
+### 2.1 `SmartClassificationReport` (neutral)
+
+```ts
+// libs/core/src/listings/domain/types/smart-classification.types.ts
+
+/**
+ * Neutral, marketplace-agnostic classification report. Today only Allegro
+ * produces one; the shape is named generically so future marketplaces
+ * can reuse it without a rename.
+ *
+ * Stored on `OfferCreationRecord.classificationReport`. Null when never
+ * read (pre-bulk-flow records, marketplaces with no classification, or
+ * readback failures).
+ */
+export interface SmartClassificationReport {
+  fulfilled: boolean | null;
+  conditions: SmartClassificationCondition[];
+  scheduledForReclassification?: boolean;
+}
+
+export interface SmartClassificationCondition {
+  code: string;
+  name: string;
+  description: string;
+  fulfilled: boolean;
+}
+```
+
+### 2.2 `OfferSmartClassificationReader` capability
+
+```ts
+// libs/core/src/listings/domain/ports/capabilities/offer-smart-classification-reader.capability.ts
+
+import type { OfferManagerPort } from '../offer-manager.port';
+import type { SmartClassificationReport } from '../../types/smart-classification.types';
+
+export interface OfferSmartClassificationReader {
+  /**
+   * Fetch the marketplace's Smart-classification report for an offer.
+   *
+   * - Returns `null` only for **404** — the offer isn't yet classified
+   *   (Allegro takes a few seconds-to-minutes post-create to compute).
+   *   Persistable; callers do NOT retry on null.
+   * - Throws on any other error (5xx, 4xx other than 404, network).
+   *   Caller is expected to wrap in try/catch and degrade gracefully
+   *   (Smart readback failure MUST NOT fail the offer-creation job —
+   *   AC-7).
+   */
+  getOfferSmartClassification(externalOfferId: string): Promise<SmartClassificationReport | null>;
+}
+
+export function isOfferSmartClassificationReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferSmartClassificationReader {
+  return (
+    typeof (adapter as Partial<OfferSmartClassificationReader>).getOfferSmartClassification ===
+    'function'
+  );
+}
+```
+
+### 2.3 `OfferCreationRecord` widening
+
+Add one readonly field:
+
+```ts
+// Constructor positional, after `request`, before `bulkBatchId`:
+public readonly classificationReport: SmartClassificationReport | null = null,
+```
+
+Defaults to `null` so existing instantiation sites compile unchanged.
+
+### 2.4 Repository port — one new method
+
+```ts
+updateClassificationReport(
+  id: string,
+  report: SmartClassificationReport | null,
+): Promise<OfferCreationRecord>;
+```
+
+Throws `OfferCreationRecordNotFoundException` if missing (matches sibling-method precedent).
+
+### 2.5 `BulkBatchAdvancement` entity + types
+
+```ts
+// libs/core/src/listings/domain/entities/bulk-batch-advancement.entity.ts
+
+export class BulkBatchAdvancement {
+  constructor(
+    public readonly bulkBatchId: string,
+    public readonly offerCreationRecordId: string,
+    public readonly advancedAt: Date,
+  ) {}
+}
+```
+
+```ts
+// libs/core/src/listings/domain/ports/bulk-batch-advancement-repository.port.ts
+
+export interface BulkBatchAdvancementRepositoryPort {
+  /**
+   * INSERT ... ON CONFLICT DO NOTHING. Returns `{ created: true }` when the
+   * row landed (first-time advancement, caller should run the increment);
+   * `{ created: false }` when it already existed (retry path, caller should
+   * skip the increment to keep at-most-once semantics).
+   *
+   * Composite PK `(bulkBatchId, offerCreationRecordId)` makes the race-free
+   * guarantee atomic at the DB level — no transaction needed.
+   */
+  markAdvancedIfNotExists(
+    bulkBatchId: string,
+    offerCreationRecordId: string,
+  ): Promise<{ created: boolean }>;
+}
+```
+
+### 2.6 `BulkOfferCreationProgressService`
+
+New service per Q1 grilling decision. Lives at
+`libs/core/src/listings/application/services/`.
+
+```ts
+// .service.interface.ts
+export interface IBulkOfferCreationProgressService {
+  advanceBatchStatus(
+    batchId: string,
+    offerCreationRecordId: string,
+    outcome: 'succeeded' | 'failed',
+  ): Promise<BulkOfferCreationBatch | null>;
+}
+
+// .service.ts
+@Injectable()
+export class BulkOfferCreationProgressService implements IBulkOfferCreationProgressService {
+  private readonly logger = new Logger(BulkOfferCreationProgressService.name);
+
+  constructor(
+    @Inject(BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN)
+    private readonly bulkBatchRepository: BulkOfferCreationBatchRepositoryPort,
+    @Inject(BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN)
+    private readonly advancementRepository: BulkBatchAdvancementRepositoryPort,
+  ) {}
+
+  async advanceBatchStatus(
+    batchId: string,
+    offerCreationRecordId: string,
+    outcome: 'succeeded' | 'failed',
+  ): Promise<BulkOfferCreationBatch | null> {
+    // At-most-once guard: insert-if-not-exists into the advancement join table.
+    const { created } = await this.advancementRepository.markAdvancedIfNotExists(
+      batchId,
+      offerCreationRecordId,
+    );
+    if (!created) {
+      // Retry path — advancement already happened. Skip the counter
+      // increment to preserve idempotency.
+      this.logger.debug(
+        `Skipping advance — already advanced. batchId=${batchId} recordId=${offerCreationRecordId}`,
+      );
+      return null;
+    }
+
+    const delta = outcome === 'succeeded' ? { succeeded: 1 } : { failed: 1 };
+    const batch = await this.bulkBatchRepository.incrementCounters(batchId, delta);
+
+    const finished = batch.succeededCount + batch.failedCount === batch.totalCount;
+    if (!finished) return null;
+
+    const terminal: BulkBatchStatus =
+      batch.failedCount === 0
+        ? BULK_BATCH_STATUS.Completed
+        : batch.succeededCount === 0
+          ? BULK_BATCH_STATUS.Failed
+          : BULK_BATCH_STATUS.PartiallyFailed;
+
+    return this.bulkBatchRepository.updateStatus(batchId, terminal);
+  }
+}
+```
+
+The advancement guard sits inside the service, NOT inside `incrementCounters` (which stays single-purpose). The service is the single owner of "has this record's outcome been counted yet?" — that's an orchestration concern, not a repository concern.
+
+---
+
+## 3. Migration
+
+`apps/api/src/migrations/{timestamp}-add-smart-classification-and-batch-advancements.ts`:
+
+```sql
+-- 1. Smart classification report on offer_creation_records (per Q6: single jsonb).
+ALTER TABLE "offer_creation_records" ADD COLUMN "classificationReport" jsonb;
+
+-- 2. At-most-once advancement guard table (per Q2 + tech-review IMPORTANT #2).
+CREATE TABLE "bulk_batch_advancements" (
+  "bulkBatchId"            uuid NOT NULL,
+  "offerCreationRecordId"  uuid NOT NULL,
+  "advancedAt"             TIMESTAMP NOT NULL DEFAULT now(),
+  PRIMARY KEY ("bulkBatchId", "offerCreationRecordId")
+);
+
+-- Index for the bulk-batch-progress-page query path (#741): "give me all
+-- advancement rows for this batch", typically used to render the per-row
+-- ✅/❌ counter at FE-render time. The PK already covers (batchId, recordId)
+-- so prefix-queries by batchId are free; no extra index needed.
+```
+
+`down()`: reverse — drop table, drop column.
+
+Timestamp: next free slot. Most recent migration in repo is `1798000000000` (the BulkOfferCreationBatch foundation from #734). I shipped #735 without a migration; #736 (bulk submit + HTTP API) also shipped without migration. Next free: `1799000000000`.
+
+No backfill needed:
+- `classificationReport` is null for any pre-existing record. The FE treats null as "unread / not applicable".
+- `bulk_batch_advancements` is empty at migration time. New advancements from #737's handler flow populate it forward.
+
+---
+
+## 4. Allegro Smart capability implementation
+
+### 4.1 Adapter method
+
+```ts
+// In AllegroOfferManagerAdapter
+async getOfferSmartClassification(
+  externalOfferId: string,
+): Promise<SmartClassificationReport | null> {
+  try {
+    const response = await this.httpClient.get<AllegroSmartOfferClassificationReport>(
+      `/sale/offers/${externalOfferId}/smart`,
+    );
+    return mapToNeutralReport(response.data);
+  } catch (err) {
+    if (err instanceof AllegroApiException && err.statusCode === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+```
+
+**Error contract** (concrete per tech-review SUGGESTION #8):
+- **404** → `null`. Only Allegro's "offer not yet classified" signal collapses. Sets up the caller for "we'll try again on the poll-service `validating → active` hook".
+- **Anything else** propagates: 400 / 422 (malformed offer-id — impossible in our flow but still propagate so a bug surfaces), 403 (permission lost — operator-actionable), 5xx (Allegro infra), network errors. Caller (handler / poll service) catches + logs + degrades — Smart-readback failure must NOT fail the offer-creation job (AC-7).
+
+### 4.2 Mapper
+
+```ts
+function mapToNeutralReport(
+  raw: AllegroSmartOfferClassificationReport,
+): SmartClassificationReport {
+  return {
+    fulfilled: raw.classification?.fulfilled ?? null,
+    conditions: (raw.conditions ?? []).map(c => ({
+      code: c.code,
+      name: c.name,
+      description: c.description,
+      fulfilled: c.fulfilled,
+    })),
+    scheduledForReclassification: raw.scheduledForReclassification,
+  };
+}
+```
+
+Drops `smartDeliveryMethods` + `passed/failedDeliveryMethods` (deprecated 2026-07-28 per swagger).
+
+### 4.3 Adapter `implements` list
+
+`AllegroOfferManagerAdapter` adds `OfferSmartClassificationReader` (now 14 sub-capabilities — same growth pattern as #735's `EanCategoryMatcher`).
+
+---
+
+## 5. Worker handler V2
+
+### 5.1 Detection
+
+The V2 payload is already defined and emitted by #736's `OfferCreationEnqueueService` when `input.bulkBatchId !== undefined`. The handler discriminates by presence:
+
+```ts
+function isV2Payload(
+  p: MarketplaceOfferCreatePayloadV1 | MarketplaceOfferCreatePayloadV2,
+): p is MarketplaceOfferCreatePayloadV2 {
+  return 'bulkBatchId' in p && typeof p.bulkBatchId === 'string';
+}
+```
+
+Per SUGGESTION #6: keep the presence-based predicate; if a V3 ever lands, refactor to a discriminant field at that time.
+
+### 5.2 Flow
+
+```
+1. Parse payload (zod-validated). Extend existing schema to cover V2 fields.
+2. If isV2 + generateDescription === true:
+     a. Try contentSuggestionService.suggestDescription({
+          channel: 'allegro', variantId, tone: payload.descriptionTone,
+        })
+     b. On success: overrides.description = aiResult.description
+     c. On failure: log warn, fall through — operator override or
+        builder default takes over. AI failure does NOT fail the job
+        (Q3 outcome).
+3. Call offerCreationExecutionService.executeCreation(payload).
+   This still owns OfferCreationRecord status updates (success + failure).
+4. If isV2: derive outcome from result.outcome ('ok' → 'succeeded',
+   'business_failure' → 'failed').
+5. If isV2 + result.outcome === 'ok' + externalOfferId present:
+     a. Resolve adapter via integrationsService.getCapabilityAdapter<OfferManagerPort>(connectionId, 'OfferManager').
+     b. Narrow via isOfferSmartClassificationReader(adapter).
+     c. If supported: try { report = await adapter.getOfferSmartClassification(externalOfferId) }
+        catch { log warn; report = null }
+     d. Persist via offerCreationRecordRepository.updateClassificationReport(recordId, report).
+6. If isV2: await bulkOfferCreationProgressService.advanceBatchStatus(
+     payload.bulkBatchId,
+     result.offerCreationRecord.id,
+     outcome
+   ).
+   The service does at-most-once via the advancement table — on retry,
+   skips the increment cleanly. Handler doesn't need its own guard.
+7. Return SyncJobHandlerResult per existing #391/#400 outcome contract.
+```
+
+### 5.3 Backwards-compat
+
+V1 payloads skip steps 2 / 4 / 5 / 6 entirely. Reduces to today's behaviour.
+
+---
+
+## 6. Poll-service Smart hook (per Q4)
+
+`OfferStatusPollService` already handles the `validating → active` transition for offers that need async Allegro validation (per its existing implementation). When that transition happens, it currently calls `updateExternalIdAndStatus` on the record. New hook:
+
+```ts
+// In OfferStatusPollService, in the branch where status transitions to 'active'
+// (or for the first time a non-validating-status is observed):
+if (newStatus === OFFER_CREATION_STATUS.Active) {
+  // Best-effort Smart readback. Mirrors the handler's try/catch shape.
+  const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+    connectionId, 'OfferManager',
+  );
+  if (isOfferSmartClassificationReader(adapter)) {
+    let report: SmartClassificationReport | null = null;
+    try {
+      report = await adapter.getOfferSmartClassification(externalOfferId);
+    } catch (err) {
+      this.logger.warn(`Smart readback failed during poll: ${(err as Error).message}`);
+    }
+    await this.offerCreationRecordRepository.updateClassificationReport(recordId, report);
+  }
+}
+```
+
+The poll service already has the right injections (`integrationsService`, `offerCreationRecordRepository`) — no constructor changes. Adding the Smart-readback call is ~10 lines.
+
+**Why we read at create-success AND on `validating → active`**: offers that come back `active` immediately get Smart-classified at create time (one call, one read). Offers that go through `validating` get a placeholder `null` at create time + a definitive read once they're `active`. AC-7 is satisfied for both paths.
+
+---
+
+## 7. Worker AI wiring (with Q5 sub-barrel promotion)
+
+### 7.1 The promotion
+
+Move `apps/api/src/content/content.module.ts` → `libs/core/src/content/services/content.module.ts`. Update `libs/core/package.json` to export the new sub-barrel:
+
+```json
+{
+  "exports": {
+    "./content/services": "./dist/content/services/index.js",
+    // ... existing entries
+  }
+}
+```
+
+Add `libs/core/src/content/services/index.ts` that exports `ContentModule`.
+
+### 7.2 Verification step (per IMPORTANT #3)
+
+Before committing the move:
+- `pnpm --filter @openlinker/api start:dev` (or boot via test) — confirm API still serves the existing `/content/*` and `/ai/prompt-templates/*` endpoints.
+- `pnpm test` — full suite passes, no API-side imports left dangling.
+- `pnpm lint` — `check-cross-context-imports.mjs` invariant doesn't fire (the existing API → content imports are not cross-context; they become consumer-of-core, which is the standard shape).
+
+Captured as **Step 11.5** in the implementation order.
+
+### 7.3 Worker plugin registration
+
+`apps/worker/src/plugins.ts`:
+
+```ts
+import { AiIntegrationModule } from '@openlinker/integrations-ai';
+
+export const workerPlugins: PluginEntry[] = [
+  // ... existing plugins ...
+  AiIntegrationModule.register(),
+];
+```
+
+This makes `AI_COMPLETION_PORT_TOKEN` resolvable in the worker's DI graph.
+
+### 7.4 Worker content module import
+
+`apps/worker/src/sync/sync-worker.module.ts`:
+
+```ts
+import { ContentModule } from '@openlinker/core/content/services';
+
+@Module({
+  imports: [
+    // ... existing imports ...
+    ContentModule,
+  ],
+  // ...
+})
+```
+
+Handler can now `@Inject(CONTENT_SUGGESTION_SERVICE_TOKEN)`.
+
+---
+
+## 8. Implementation steps (ordered)
+
+| # | Step | File(s) | AC |
+|---|---|---|---|
+| 1 | Add `SmartClassificationReport` + `SmartClassificationCondition` types | `libs/core/src/listings/domain/types/smart-classification.types.ts` (new) | Type-only, no framework deps |
+| 2 | Add `OfferSmartClassificationReader` capability + `isOfferSmartClassificationReader` guard | `libs/core/src/listings/domain/ports/capabilities/offer-smart-classification-reader.capability.ts` (new) | Mirrors #735's `EanCategoryMatcher` shape |
+| 3 | Widen `OfferCreationRecord` entity with `classificationReport: SmartClassificationReport \| null = null` | `libs/core/src/listings/domain/entities/offer-creation-record.entity.ts` | Default null; existing instantiation sites compile unchanged |
+| 4 | Extend `OfferCreationRecordRepositoryPort` with `updateClassificationReport` | `libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts` | Throws `OfferCreationRecordNotFoundException` on missing |
+| 5 | Add ORM column + repo impl | `libs/core/src/listings/infrastructure/persistence/{entities,repositories}/offer-creation-record.*` | `classificationReport jsonb`, nullable, no default |
+| 6 | Add `BulkBatchAdvancement` entity + port + ORM entity + repository | `libs/core/src/listings/domain/{entities,ports}/bulk-batch-advancement*` + `infrastructure/persistence/{entities,repositories}/bulk-batch-advancement.*` (new — 4 files) | Composite-PK ORM entity; `markAdvancedIfNotExists` via INSERT ON CONFLICT DO NOTHING |
+| 7 | Add `BulkOfferCreationProgressService` interface + impl | `libs/core/src/listings/application/services/bulk-offer-creation-progress.service.{interface,ts}` (new) | At-most-once guard + counter increment + terminal-status derivation |
+| 8 | Add new tokens + register the new service & repository in `ListingsModule` | `libs/core/src/listings/listings.tokens.ts` + `libs/core/src/listings/services/listings.module.ts` | `BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN`, `BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN` |
+| 9 | Migration: column + table | `apps/api/src/migrations/1799000000000-add-smart-classification-and-batch-advancements.ts` (new) | Single migration; `up()` and `down()` both implemented |
+| 10 | Allegro raw type + adapter method + `implements` update | `libs/integrations/allegro/src/{domain/types,infrastructure/adapters}/...` | 404 → null; everything else propagates |
+| 11 | Update listings barrel | `libs/core/src/listings/index.ts` | Re-export new types, capability, guard, progress-service interface, both new tokens |
+| **11.5** | **Move `ContentModule` to `@openlinker/core/content/services`** + verification | `libs/core/src/content/services/{content.module.ts,index.ts}` + `libs/core/package.json` exports + update `apps/api`'s import | API boots locally; existing `/content/*` endpoints respond; `pnpm test` green; `check-cross-context-imports.mjs` doesn't fire |
+| 12 | Wire worker AI: plugin registration + ContentModule import | `apps/worker/src/plugins.ts` + `apps/worker/src/sync/sync-worker.module.ts` | `CONTENT_SUGGESTION_SERVICE_TOKEN` resolvable in worker |
+| 13 | Extend handler V2 branch | `apps/worker/src/sync/handlers/marketplace-offer-create.handler.ts` | V1 backwards-compat preserved; V2 path runs AI before + Smart + progress after |
+| 14 | Extend `OfferStatusPollService` with Smart-readback hook | `libs/core/src/listings/application/services/offer-status-poll.service.ts` | On `validating → active` transition, best-effort Smart readback |
+| 15 | Handler unit spec (8 cases) | `apps/worker/src/sync/handlers/marketplace-offer-create.handler.spec.ts` | Per § 9.1 |
+| 16 | `BulkOfferCreationProgressService` spec (6 cases) | `libs/core/src/listings/application/services/__tests__/bulk-offer-creation-progress.service.spec.ts` (new) | Per § 9.2 |
+| 17 | `OfferStatusPollService` Smart-hook spec (additive 3 cases) | existing `offer-status-poll.service.spec.ts` | Per § 9.3 |
+| 18 | Adapter `getOfferSmartClassification` spec (5 cases) | `allegro-offer-manager.adapter.spec.ts` (additive) | Per § 9.4 |
+| 19 | Integration spec — 5-job batch end-to-end | `apps/api/test/integration/listings/bulk-offer-creation.int-spec.ts` | Per § 9.5; existing test harness |
+| 20 | Update `docs/architecture-overview.md § 13 AI` | `docs/architecture-overview.md` | Replace "not required for #342" note per SUGGESTION #5 wording |
+| 21 | Update `docs/engineering-standards.md § Import Aliases` | `docs/engineering-standards.md` | Add `@openlinker/core/content/services` to sub-barrel list |
+| 22 | Quality gate | — | `pnpm lint && pnpm type-check && pnpm test && pnpm test:integration` all green |
+
+---
+
+## 9. Tests
+
+### 9.1 Handler unit spec — 8 cases
+
+| # | Case | Coverage |
+|---|---|---|
+| 1 | V1 payload (no `bulkBatchId`) | Today's path: `executeCreation` called; no AI, no Smart, no progress |
+| 2 | V2 + no `generateDescription`, success | AI NOT called; Smart called; progress.advanceBatchStatus called |
+| 3 | V2 + `generateDescription: true`, AI succeeds | AI called with `{channel:'allegro', variantId, tone}`; result threaded into `overrides.description` |
+| 4 | V2 + `generateDescription: true`, AI throws | Warning logged; falls back to `overrides.description` or builder default; `executeCreation` still called; job succeeds |
+| 5 | V2 + success, Smart readback throws (5xx) | Warning logged; `updateClassificationReport(recordId, null)` called; counter still advanced; job succeeds |
+| 6 | V2 + success, Smart readback returns null (404) | `updateClassificationReport(recordId, null)` called; counter advanced |
+| 7 | V2 + `executeCreation` returns `outcome: 'business_failure'` | No Smart readback; counter advanced via `advanceBatchStatus(..., 'failed')` |
+| 8 | V2 retry path (advancement already marked) | `executeCreation` runs; `advanceBatchStatus` returns null (`created: false`); no double-increment |
+
+### 9.2 `BulkOfferCreationProgressService` spec — 6 cases
+
+| # | Case | Coverage |
+|---|---|---|
+| 1 | First-time advancement, not yet terminal (1 of 5 succeeded) | `markAdvancedIfNotExists` returns `created: true`; `incrementCounters({succeeded:1})` called; `updateStatus` NOT called; returns null |
+| 2 | All succeeded (5 of 5) | Status → `completed` |
+| 3 | All failed (5 of 5) | Status → `failed` |
+| 4 | Mixed (3 succeeded + 2 failed) | Status → `partially-failed` |
+| 5 | `outcome: 'failed'` input | `incrementCounters({failed:1})` (verifies branch) |
+| 6 | Retry path: `markAdvancedIfNotExists` returns `created: false` | `incrementCounters` NOT called; returns null; logs debug |
+
+### 9.3 `OfferStatusPollService` Smart-hook spec — 3 additive cases
+
+| # | Case | Coverage |
+|---|---|---|
+| 1 | Transition `validating → active` + adapter supports Smart | `getOfferSmartClassification` called; `updateClassificationReport` called with the report |
+| 2 | Transition `validating → active` + Smart readback throws | Warning logged; `updateClassificationReport(recordId, null)` called; poll iteration succeeds |
+| 3 | Transition `validating → failed` (no Smart applicable) | Smart NOT called; existing failure path unchanged |
+
+### 9.4 Adapter spec — 5 cases
+
+Per swagger schema verification:
+
+| # | Case | Coverage |
+|---|---|---|
+| 1 | 200 + classification.fulfilled=true | Neutral report; conditions mapped; deprecated fields dropped |
+| 2 | 200 + classification.fulfilled=false + conditions[] | Failed conditions surfaced |
+| 3 | 404 | Returns `null` (no throw) |
+| 4 | 5xx | Throws `AllegroApiException` |
+| 5 | `isOfferSmartClassificationReader(adapter) === true` (guard assertion) | Capability registered |
+
+### 9.5 Integration spec — 5-job batch end-to-end
+
+Per issue AC. Location: `apps/api/test/integration/listings/bulk-offer-creation.int-spec.ts`.
+
+1. Seed connection + 5 variants with EANs + a bulk batch.
+2. POST `/bulk-offer-creations` → service enqueues 5 jobs.
+3. Drain jobs via the test harness's worker (in-process).
+4. Stub `AllegroOfferManagerAdapter`: 3 succeed, 2 fail.
+5. Stub Smart endpoint: success → fulfilled=true; failure → 404.
+6. Assert:
+   - 5 `OfferCreationRecord` rows with expected statuses
+   - 5 `bulk_batch_advancements` rows
+   - Successful rows have `classificationReport` populated; failed have null
+   - `BulkOfferCreationBatch.succeededCount = 3`, `failedCount = 2`, `status = 'partially-failed'`
+
+---
+
+## 10. Decisions locked
+
+| # | Decision | Source | Why |
+|---|---|---|---|
+| 1 | **New `BulkOfferCreationProgressService`** (separate from submit service) | grill-me Q1 | Per-phase orchestration pattern (matches `OfferCreationEnqueueService` / `OfferCreationExecutionService` / `OfferStatusPollService`); submit-side and progress-side have different concurrency profiles + different consumers |
+| 2 | **At-most-once guard via `bulk_batch_advancements` join table** (not a column on `offer_creation_records`) | tech-review IMPORTANT #2 | Keeps `OfferCreationRecord` pure (single-offer concept); INSERT ON CONFLICT DO NOTHING is race-free; one table grows with bulk-flow activity but stays cleanly orthogonal to the single-offer concept |
+| 3 | **AI failure → log + fall through** (no status column) | grill-me Q3 | Operator override or builder default takes over; matches the AC-7 Smart-readback shape for symmetry; offer still ships to Allegro |
+| 4 | **Smart readback at handler create-success AND poll-service `validating → active` hook** | grill-me Q4 | At create time: covers offers that come back `active` immediately. At poll time: covers offers that go through `validating`. AC-7 is satisfied for both paths |
+| 5 | **Promote `ContentModule` to `@openlinker/core/content/services`** sub-barrel | grill-me Q5 | Mirrors `@openlinker/core/listings/services` precedent; single source of truth across `apps/api` and `apps/worker`; eliminates mirror-module maintenance drift |
+| 6 | **Single `classificationReport jsonb` column** (neutral name, not `smartReport`) | grill-me Q6 + tech-review IMPORTANT #1 | jsonb is forward-compat against Allegro response shape changes; "classification" is the neutral domain term (Smart is Allegro's brand for the same concept); future marketplaces with classification can reuse |
+| 7 | **Bare-string `getOfferSmartClassification(externalOfferId)`** | grill-me Q7 | Matches sibling capability shape (`getOfferStatus`, `getOffer`, `matchCategoryByBarcode`); shape-based rule in this codebase (single-arg = bare, multi-arg = object) |
+| 8 | **404 → null; everything else throws** in the Allegro adapter | tech-review SUGGESTION #8 | Crisp error contract; 404 is "not yet classified" (Allegro's documented signal); everything else surfaces (operator-actionable or infra failure) |
+| 9 | **Capability port lives on `OfferManagerPort` as a sub-capability** | #337 precedent | Uniform with the existing 13 sub-capabilities on the Allegro adapter |
+| 10 | **Migration timestamp `1799000000000`** | repo state | Most recent migration is `1798000000000` (#734's bulk-offer-creation-batches); next free slot |
+| 11 | **No `as const` runtime values** for `SmartClassificationReport` | Allegro's free-form `code`/`name`/`description` strings | The enum-shaped runtime array isn't applicable; structural type only |
+
+---
+
+## 11. Residual risks
+
+- **Migration timestamp collision**: `1799000000000`. Lint catches collisions via `check-migration-timestamps.mjs`.
+- **`ContentModule` move risk**: § 7.2 verification gate (Step 11.5) catches regression to the API's existing endpoints before commit. The diff touches paths in `apps/api/src/` so reviewers will see the impact clearly.
+- **AI flake amplification**: if the LLM provider has a bad hour, every job in a 50-row batch logs a warning and falls through. Operationally noisy but doesn't fail jobs. FE (#741) may want to surface "AI didn't run for these N rows" — out of scope here but flagged for #741.
+- **Smart readback timing on first attempt**: offers that come back `active` immediately are read for Smart status at create-time. Allegro's docs note Smart classification can take a few seconds-to-minutes post-create. If we read too eagerly and Allegro returns 404, we persist null; the poll-service hook covers the `validating → active` path, but offers that come back `active` immediately and aren't yet classified end up with null forever in #737's scope. The plan accepts this — the `scheduledForReclassification` field on the report shape gives the FE a signal to poll-or-refresh manually if needed. A future follow-up could add periodic re-reads for null-classification offers.
+- **Counter-advancement at-most-once across concurrent workers**: the `bulk_batch_advancements` table uses a composite-PK INSERT-ON-CONFLICT-DO-NOTHING. Two workers attempting the same `(batchId, recordId)` see exactly one `created: true` and one `created: false`. Counter increments accordingly. Verified safe.
+- **Sub-barrel precedent now 4 deep**: `listings/services`, `<ctx>/orm-entities`, `<ctx>/testing`, and now `content/services`. The engineering-standards doc § Import Aliases needs updating (Step 21).
+
+---
+
+## 12. After this PR
+
+- #742 (bulk retry-failed endpoint) — depends on this; retry re-enqueues failed records, and the `bulk_batch_advancements` row from the failed attempt is removed (or the advancement row is checked against `OfferCreationRecord.status` for "retry-eligible") so the new attempt re-counts correctly.
+- #739–#741 (FE) — start landing once this is merged.
+- Architecture-overview § 13 AI flips from "not required for #342" to "Wired in #737".

--- a/libs/core/src/listings/application/services/__tests__/bulk-offer-creation-progress.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-offer-creation-progress.service.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Bulk Offer Creation Progress Service — Unit Tests
+ *
+ * Covers the terminal-status derivation rule and the at-most-once gate via
+ * `BulkBatchAdvancementRepositoryPort.markAdvancedIfNotExists`. Mocks both
+ * repository ports; the service has no other collaborators.
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+import { BulkOfferCreationProgressService } from '../bulk-offer-creation-progress.service';
+import { BulkOfferCreationBatch } from '../../../domain/entities/bulk-offer-creation-batch.entity';
+import { BULK_BATCH_STATUS } from '../../../domain/types/bulk-offer-creation-batch.types';
+import type { BulkBatchAdvancementRepositoryPort } from '../../../domain/ports/bulk-batch-advancement-repository.port';
+import type { BulkOfferCreationBatchRepositoryPort } from '../../../domain/ports/bulk-offer-creation-batch-repository.port';
+
+const BATCH_ID = 'batch-uuid-1';
+const RECORD_ID = 'rec-uuid-1';
+
+const buildBatch = (overrides: Partial<BulkOfferCreationBatch> = {}): BulkOfferCreationBatch => {
+  const now = new Date('2026-05-17T10:00:00Z');
+  return new BulkOfferCreationBatch(
+    overrides.id ?? BATCH_ID,
+    overrides.connectionId ?? 'conn-1',
+    overrides.initiatedBy ?? 'user-1',
+    overrides.status ?? BULK_BATCH_STATUS.Running,
+    overrides.totalCount ?? 3,
+    overrides.succeededCount ?? 0,
+    overrides.failedCount ?? 0,
+    overrides.sharedConfig ?? {},
+    overrides.createdAt ?? now,
+    overrides.updatedAt ?? now
+  );
+};
+
+describe('BulkOfferCreationProgressService', () => {
+  let service: BulkOfferCreationProgressService;
+  let batches: jest.Mocked<BulkOfferCreationBatchRepositoryPort>;
+  let advancements: jest.Mocked<BulkBatchAdvancementRepositoryPort>;
+
+  beforeEach(() => {
+    batches = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      incrementCounters: jest.fn(),
+      updateStatus: jest.fn(),
+    };
+    advancements = {
+      markAdvancedIfNotExists: jest.fn(),
+    };
+    service = new BulkOfferCreationProgressService(batches, advancements);
+  });
+
+  it('skips counter increment when advancement already exists (idempotent retry)', async () => {
+    advancements.markAdvancedIfNotExists.mockResolvedValue({ created: false });
+
+    const result = await service.advanceBatchStatus(BATCH_ID, RECORD_ID, 'succeeded');
+
+    expect(result).toBeNull();
+    expect(batches.incrementCounters).not.toHaveBeenCalled();
+    expect(batches.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('increments succeeded counter when outcome=succeeded and not yet finished', async () => {
+    advancements.markAdvancedIfNotExists.mockResolvedValue({ created: true });
+    batches.incrementCounters.mockResolvedValue(
+      buildBatch({ totalCount: 3, succeededCount: 1, failedCount: 0 })
+    );
+
+    const result = await service.advanceBatchStatus(BATCH_ID, RECORD_ID, 'succeeded');
+
+    expect(advancements.markAdvancedIfNotExists).toHaveBeenCalledWith(BATCH_ID, RECORD_ID);
+    expect(batches.incrementCounters).toHaveBeenCalledWith(BATCH_ID, { succeeded: 1 });
+    expect(batches.updateStatus).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('increments failed counter when outcome=failed and not yet finished', async () => {
+    advancements.markAdvancedIfNotExists.mockResolvedValue({ created: true });
+    batches.incrementCounters.mockResolvedValue(
+      buildBatch({ totalCount: 3, succeededCount: 0, failedCount: 1 })
+    );
+
+    const result = await service.advanceBatchStatus(BATCH_ID, RECORD_ID, 'failed');
+
+    expect(batches.incrementCounters).toHaveBeenCalledWith(BATCH_ID, { failed: 1 });
+    expect(batches.updateStatus).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('transitions to completed when all children succeed', async () => {
+    advancements.markAdvancedIfNotExists.mockResolvedValue({ created: true });
+    batches.incrementCounters.mockResolvedValue(
+      buildBatch({ totalCount: 3, succeededCount: 3, failedCount: 0 })
+    );
+    const completedBatch = buildBatch({
+      totalCount: 3,
+      succeededCount: 3,
+      failedCount: 0,
+      status: BULK_BATCH_STATUS.Completed,
+    });
+    batches.updateStatus.mockResolvedValue(completedBatch);
+
+    const result = await service.advanceBatchStatus(BATCH_ID, RECORD_ID, 'succeeded');
+
+    expect(batches.updateStatus).toHaveBeenCalledWith(BATCH_ID, BULK_BATCH_STATUS.Completed);
+    expect(result).toEqual(completedBatch);
+  });
+
+  it('transitions to failed when all children fail', async () => {
+    advancements.markAdvancedIfNotExists.mockResolvedValue({ created: true });
+    batches.incrementCounters.mockResolvedValue(
+      buildBatch({ totalCount: 3, succeededCount: 0, failedCount: 3 })
+    );
+    const failedBatch = buildBatch({
+      totalCount: 3,
+      succeededCount: 0,
+      failedCount: 3,
+      status: BULK_BATCH_STATUS.Failed,
+    });
+    batches.updateStatus.mockResolvedValue(failedBatch);
+
+    const result = await service.advanceBatchStatus(BATCH_ID, RECORD_ID, 'failed');
+
+    expect(batches.updateStatus).toHaveBeenCalledWith(BATCH_ID, BULK_BATCH_STATUS.Failed);
+    expect(result).toEqual(failedBatch);
+  });
+
+  it('transitions to partially-failed when mixed outcomes', async () => {
+    advancements.markAdvancedIfNotExists.mockResolvedValue({ created: true });
+    batches.incrementCounters.mockResolvedValue(
+      buildBatch({ totalCount: 3, succeededCount: 2, failedCount: 1 })
+    );
+    const partialBatch = buildBatch({
+      totalCount: 3,
+      succeededCount: 2,
+      failedCount: 1,
+      status: BULK_BATCH_STATUS.PartiallyFailed,
+    });
+    batches.updateStatus.mockResolvedValue(partialBatch);
+
+    const result = await service.advanceBatchStatus(BATCH_ID, RECORD_ID, 'failed');
+
+    expect(batches.updateStatus).toHaveBeenCalledWith(BATCH_ID, BULK_BATCH_STATUS.PartiallyFailed);
+    expect(result).toEqual(partialBatch);
+  });
+
+  it('does not transition status when totalCount has not been reached', async () => {
+    advancements.markAdvancedIfNotExists.mockResolvedValue({ created: true });
+    batches.incrementCounters.mockResolvedValue(
+      buildBatch({ totalCount: 10, succeededCount: 5, failedCount: 2 })
+    );
+
+    const result = await service.advanceBatchStatus(BATCH_ID, RECORD_ID, 'succeeded');
+
+    expect(batches.updateStatus).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/libs/core/src/listings/application/services/__tests__/bulk-offer-creation-submit.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-offer-creation-submit.service.spec.ts
@@ -68,6 +68,7 @@ describe('BulkOfferCreationSubmitService', () => {
       updateExternalOfferId: jest.fn(),
       updateExternalIdAndStatus: jest.fn(),
       findByBulkBatchId: jest.fn().mockResolvedValue([]),
+      updateClassificationReport: jest.fn(),
     };
     enqueueService = {
       enqueueCreation: jest

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-enqueue.service.spec.ts
@@ -61,6 +61,7 @@ describe('OfferCreationEnqueueService', () => {
       updateExternalOfferId: jest.fn(),
       updateExternalIdAndStatus: jest.fn(),
       findByBulkBatchId: jest.fn(),
+      updateClassificationReport: jest.fn(),
     };
 
     jobEnqueue = {

--- a/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-creation-execution.service.spec.ts
@@ -97,6 +97,7 @@ describe('OfferCreationExecutionService', () => {
           Promise.resolve(buildRecord({ id, externalOfferId, status, errors: errors ?? null }))
         ),
       findByBulkBatchId: jest.fn(),
+      updateClassificationReport: jest.fn(),
     };
     identifierMapping = {
       createMapping: jest.fn().mockResolvedValue(undefined),
@@ -498,6 +499,106 @@ describe('OfferCreationExecutionService', () => {
       expect(result.outcome).toBe('ok');
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failed to schedule poll'));
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('Smart classification readback (#737)', () => {
+    it('reads and persists Smart report when adapter implements the capability and status=active', async () => {
+      const report = { fulfilled: true, conditions: [] };
+      const smartAdapter = {
+        createOffer: jest.fn().mockResolvedValue({
+          externalOfferId: EXTERNAL_OFFER_ID,
+          status: 'active',
+        } satisfies CreateOfferResult),
+        getOfferSmartClassification: jest.fn().mockResolvedValue(report),
+      };
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(
+        smartAdapter as unknown as OfferManagerPort
+      );
+      records.updateExternalIdAndStatus.mockResolvedValueOnce(
+        buildRecord({ status: 'active', externalOfferId: EXTERNAL_OFFER_ID })
+      );
+
+      await service.executeCreation(baseInput);
+
+      expect(smartAdapter.getOfferSmartClassification).toHaveBeenCalledWith(EXTERNAL_OFFER_ID);
+      expect(records.updateClassificationReport).toHaveBeenCalledWith('rec-1', report);
+    });
+
+    it('persists null when Smart readback throws (best-effort, AC-7)', async () => {
+      const smartAdapter = {
+        createOffer: jest.fn().mockResolvedValue({
+          externalOfferId: EXTERNAL_OFFER_ID,
+          status: 'active',
+        } satisfies CreateOfferResult),
+        getOfferSmartClassification: jest.fn().mockRejectedValue(new Error('Allegro 500')),
+      };
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(
+        smartAdapter as unknown as OfferManagerPort
+      );
+      records.updateExternalIdAndStatus.mockResolvedValueOnce(
+        buildRecord({ status: 'active', externalOfferId: EXTERNAL_OFFER_ID })
+      );
+
+      const result = await service.executeCreation(baseInput);
+
+      expect(result.outcome).toBe('ok');
+      expect(records.updateClassificationReport).toHaveBeenCalledWith('rec-1', null);
+    });
+
+    it('skips Smart readback when status=validating (poll-service handles it)', async () => {
+      const smartAdapter = {
+        createOffer: jest.fn().mockResolvedValue({
+          externalOfferId: EXTERNAL_OFFER_ID,
+          status: 'validating',
+        } satisfies CreateOfferResult),
+        getOfferSmartClassification: jest.fn(),
+      };
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(
+        smartAdapter as unknown as OfferManagerPort
+      );
+      records.updateExternalIdAndStatus.mockResolvedValueOnce(
+        buildRecord({ status: 'validating', externalOfferId: EXTERNAL_OFFER_ID })
+      );
+
+      await service.executeCreation(baseInput);
+
+      expect(smartAdapter.getOfferSmartClassification).not.toHaveBeenCalled();
+      expect(records.updateClassificationReport).not.toHaveBeenCalled();
+    });
+
+    it('skips Smart readback when status=draft', async () => {
+      const smartAdapter = {
+        createOffer: jest.fn().mockResolvedValue({
+          externalOfferId: EXTERNAL_OFFER_ID,
+          status: 'draft',
+        } satisfies CreateOfferResult),
+        getOfferSmartClassification: jest.fn(),
+      };
+      integrationsService.getCapabilityAdapter.mockResolvedValueOnce(
+        smartAdapter as unknown as OfferManagerPort
+      );
+
+      await service.executeCreation(baseInput);
+
+      expect(smartAdapter.getOfferSmartClassification).not.toHaveBeenCalled();
+      expect(records.updateClassificationReport).not.toHaveBeenCalled();
+    });
+
+    it('skips Smart readback when adapter does not implement the capability', async () => {
+      // The default `adapter` fixture has only `createOffer` — no
+      // getOfferSmartClassification — so isOfferSmartClassificationReader is false.
+      adapter.createOffer.mockResolvedValueOnce({
+        externalOfferId: EXTERNAL_OFFER_ID,
+        status: 'active',
+      });
+      records.updateExternalIdAndStatus.mockResolvedValueOnce(
+        buildRecord({ status: 'active', externalOfferId: EXTERNAL_OFFER_ID })
+      );
+
+      await service.executeCreation(baseInput);
+
+      expect(records.updateClassificationReport).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/core/src/listings/application/services/__tests__/offer-status-poll.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-status-poll.service.spec.ts
@@ -48,6 +48,24 @@ function statusReader(result: OfferStatusReadResult | (() => never)): OfferManag
   } as unknown as OfferManagerPort;
 }
 
+/**
+ * Variant of `statusReader` whose adapter also implements
+ * `OfferSmartClassificationReader`. Used by the Smart-readback hook tests.
+ */
+function statusAndSmartReader(
+  status: OfferStatusReadResult,
+  smart: { result: unknown } | { error: Error }
+): OfferManagerPort {
+  return {
+    updateOfferQuantity: jest.fn(),
+    getOfferStatus: jest.fn().mockResolvedValue(status),
+    getOfferSmartClassification:
+      'error' in smart
+        ? jest.fn().mockRejectedValue(smart.error)
+        : jest.fn().mockResolvedValue(smart.result),
+  } as unknown as OfferManagerPort;
+}
+
 describe('OfferStatusPollService', () => {
   let service: OfferStatusPollService;
   let integrations: jest.Mocked<IIntegrationsService>;
@@ -74,6 +92,7 @@ describe('OfferStatusPollService', () => {
       updateExternalOfferId: jest.fn(),
       updateExternalIdAndStatus: jest.fn(),
       findByBulkBatchId: jest.fn(),
+      updateClassificationReport: jest.fn(),
     };
 
     syncJobs = {
@@ -351,6 +370,88 @@ describe('OfferStatusPollService', () => {
         [{ code: 'POLL_TIMEOUT', message: expect.stringContaining('POLL_TIMEOUT') }],
       );
     });
+
+  });
+
+  describe('pollOnce — Smart classification readback hook (#737)', () => {
+    function pollInput(pollAttempt = 1): PollOnceInput {
+      return {
+        offerCreationRecordId: RECORD_ID,
+        externalOfferId: EXTERNAL_OFFER_ID,
+        connectionId: CONNECTION_ID,
+        pollAttempt,
+      };
+    }
+
+    it('reads and persists Smart report on validating→active transition', async () => {
+      const report = { fulfilled: true, conditions: [] };
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        statusAndSmartReader(
+          { publicationStatus: 'active', validationErrors: [] },
+          { result: report }
+        )
+      );
+
+      await service.pollOnce(pollInput());
+
+      expect(records.updateClassificationReport).toHaveBeenCalledWith(RECORD_ID, report);
+    });
+
+    it('persists null when Smart readback fails (best-effort, AC-7)', async () => {
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        statusAndSmartReader(
+          { publicationStatus: 'active', validationErrors: [] },
+          { error: new Error('Allegro 500') }
+        )
+      );
+
+      const result = await service.pollOnce(pollInput());
+
+      // Poll iteration MUST still succeed
+      expect(result.outcome).toBe('ok');
+      expect(records.updateClassificationReport).toHaveBeenCalledWith(RECORD_ID, null);
+    });
+
+    it('does NOT call Smart readback on non-active terminal transitions', async () => {
+      // INACTIVE+errors → failed; Smart is meaningless here
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        statusAndSmartReader(
+          {
+            publicationStatus: 'inactive',
+            validationErrors: [{ code: 'X', message: 'y', field: 'z' }],
+          },
+          { result: { fulfilled: true, conditions: [] } }
+        )
+      );
+
+      await service.pollOnce(pollInput());
+
+      expect(records.updateClassificationReport).not.toHaveBeenCalled();
+    });
+
+    it('skips Smart readback when adapter lacks the capability', async () => {
+      // status-only adapter — no getOfferSmartClassification method
+      integrations.getCapabilityAdapter.mockResolvedValue(
+        statusReader({ publicationStatus: 'active', validationErrors: [] })
+      );
+
+      const result = await service.pollOnce(pollInput());
+
+      expect(result.outcome).toBe('ok');
+      expect(records.updateStatus).toHaveBeenCalledWith(RECORD_ID, 'active', null);
+      expect(records.updateClassificationReport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pollOnce — cadence cap (final)', () => {
+    function pollInput(pollAttempt = 1): PollOnceInput {
+      return {
+        offerCreationRecordId: RECORD_ID,
+        externalOfferId: EXTERNAL_OFFER_ID,
+        connectionId: CONNECTION_ID,
+        pollAttempt,
+      };
+    }
 
     it('cadence caps at maxDelaySeconds for high pollAttempts', async () => {
       // Iteration 5: 5 * 2^4 = 80s, capped to 60s.

--- a/libs/core/src/listings/application/services/bulk-offer-creation-progress.service.interface.ts
+++ b/libs/core/src/listings/application/services/bulk-offer-creation-progress.service.interface.ts
@@ -1,10 +1,10 @@
 /**
  * Bulk Offer Creation Progress Service Interface (#737)
  *
- * The worker-side state-machine owner for `BulkOfferCreationBatch`. Called
- * by the `marketplace.offer.create` handler after each child job completes,
- * to increment the batch's counters and (when total reached) derive the
- * terminal status — `completed | partially-failed | failed`.
+ * Core state-machine owner for `BulkOfferCreationBatch`. Called by the
+ * worker's `marketplace.offer.create` handler after each child job
+ * terminates, to increment the batch's counters and (when total reached)
+ * derive the terminal status — `completed | partially-failed | failed`.
  *
  * Split from `BulkOfferCreationSubmitService` (which owns the HTTP-side
  * intake half — submit + transition to `running`) to keep the per-phase
@@ -15,6 +15,7 @@
  * @module libs/core/src/listings/application/services
  */
 import type { BulkOfferCreationBatch } from '../../domain/entities/bulk-offer-creation-batch.entity';
+import type { BulkChildOutcome } from '../../domain/types/bulk-child-outcome.types';
 
 export interface IBulkOfferCreationProgressService {
   /**
@@ -36,6 +37,6 @@ export interface IBulkOfferCreationProgressService {
   advanceBatchStatus(
     batchId: string,
     offerCreationRecordId: string,
-    outcome: 'succeeded' | 'failed',
+    outcome: BulkChildOutcome,
   ): Promise<BulkOfferCreationBatch | null>;
 }

--- a/libs/core/src/listings/application/services/bulk-offer-creation-progress.service.interface.ts
+++ b/libs/core/src/listings/application/services/bulk-offer-creation-progress.service.interface.ts
@@ -1,0 +1,41 @@
+/**
+ * Bulk Offer Creation Progress Service Interface (#737)
+ *
+ * The worker-side state-machine owner for `BulkOfferCreationBatch`. Called
+ * by the `marketplace.offer.create` handler after each child job completes,
+ * to increment the batch's counters and (when total reached) derive the
+ * terminal status — `completed | partially-failed | failed`.
+ *
+ * Split from `BulkOfferCreationSubmitService` (which owns the HTTP-side
+ * intake half — submit + transition to `running`) to keep the per-phase
+ * orchestration pattern uniform with sibling services
+ * (`OfferCreationEnqueueService` / `OfferCreationExecutionService` /
+ * `OfferStatusPollService`).
+ *
+ * @module libs/core/src/listings/application/services
+ */
+import type { BulkOfferCreationBatch } from '../../domain/entities/bulk-offer-creation-batch.entity';
+
+export interface IBulkOfferCreationProgressService {
+  /**
+   * Record that a single child offer-creation completed, advance the batch
+   * counters accordingly, and derive the terminal status if the batch is
+   * now finished.
+   *
+   * At-most-once across concurrent workers + worker retries: gates on
+   * `BulkBatchAdvancementRepositoryPort.markAdvancedIfNotExists`. A retry
+   * (or a second concurrent caller for the same record) returns `null`
+   * without touching counters.
+   *
+   * Returns:
+   * - The post-update `BulkOfferCreationBatch` when the batch reached its
+   *   terminal state on this call.
+   * - `null` when the batch is still in progress, OR when the advancement
+   *   was already recorded (idempotent retry path).
+   */
+  advanceBatchStatus(
+    batchId: string,
+    offerCreationRecordId: string,
+    outcome: 'succeeded' | 'failed',
+  ): Promise<BulkOfferCreationBatch | null>;
+}

--- a/libs/core/src/listings/application/services/bulk-offer-creation-progress.service.ts
+++ b/libs/core/src/listings/application/services/bulk-offer-creation-progress.service.ts
@@ -1,0 +1,77 @@
+/**
+ * Bulk Offer Creation Progress Service (#737)
+ *
+ * Worker-side state-machine for `BulkOfferCreationBatch`. Per
+ * `architecture-overview.md § 7`, orchestration policies live in core
+ * application services, not in worker handlers — so the terminal-status
+ * derivation rule lives here, with the handler reduced to a thin shell
+ * that calls `advanceBatchStatus` after each child terminates.
+ *
+ * Implements at-most-once advancement via
+ * `BulkBatchAdvancementRepositoryPort.markAdvancedIfNotExists` (composite-PK
+ * INSERT-ON-CONFLICT-DO-NOTHING) so retries + concurrent workers can't
+ * double-increment the counters.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IBulkOfferCreationProgressService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+
+import { Logger } from '@openlinker/shared/logging';
+
+import type { BulkOfferCreationBatch } from '../../domain/entities/bulk-offer-creation-batch.entity';
+import { BulkBatchAdvancementRepositoryPort } from '../../domain/ports/bulk-batch-advancement-repository.port';
+import { BulkOfferCreationBatchRepositoryPort } from '../../domain/ports/bulk-offer-creation-batch-repository.port';
+import {
+  BULK_BATCH_STATUS,
+  type BulkBatchStatus,
+} from '../../domain/types/bulk-offer-creation-batch.types';
+import {
+  BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
+  BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+} from '../../listings.tokens';
+import type { IBulkOfferCreationProgressService } from './bulk-offer-creation-progress.service.interface';
+
+@Injectable()
+export class BulkOfferCreationProgressService implements IBulkOfferCreationProgressService {
+  private readonly logger = new Logger(BulkOfferCreationProgressService.name);
+
+  constructor(
+    @Inject(BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN)
+    private readonly bulkBatchRepository: BulkOfferCreationBatchRepositoryPort,
+    @Inject(BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN)
+    private readonly advancementRepository: BulkBatchAdvancementRepositoryPort
+  ) {}
+
+  async advanceBatchStatus(
+    batchId: string,
+    offerCreationRecordId: string,
+    outcome: 'succeeded' | 'failed'
+  ): Promise<BulkOfferCreationBatch | null> {
+    const { created } = await this.advancementRepository.markAdvancedIfNotExists(
+      batchId,
+      offerCreationRecordId
+    );
+    if (!created) {
+      this.logger.debug(
+        `Skipping advance — already recorded. batchId=${batchId} recordId=${offerCreationRecordId}`
+      );
+      return null;
+    }
+
+    const delta = outcome === 'succeeded' ? { succeeded: 1 } : { failed: 1 };
+    const batch = await this.bulkBatchRepository.incrementCounters(batchId, delta);
+
+    const finished = batch.succeededCount + batch.failedCount === batch.totalCount;
+    if (!finished) return null;
+
+    const terminal: BulkBatchStatus =
+      batch.failedCount === 0
+        ? BULK_BATCH_STATUS.Completed
+        : batch.succeededCount === 0
+          ? BULK_BATCH_STATUS.Failed
+          : BULK_BATCH_STATUS.PartiallyFailed;
+
+    return this.bulkBatchRepository.updateStatus(batchId, terminal);
+  }
+}

--- a/libs/core/src/listings/application/services/bulk-offer-creation-progress.service.ts
+++ b/libs/core/src/listings/application/services/bulk-offer-creation-progress.service.ts
@@ -22,6 +22,7 @@ import { Logger } from '@openlinker/shared/logging';
 import type { BulkOfferCreationBatch } from '../../domain/entities/bulk-offer-creation-batch.entity';
 import { BulkBatchAdvancementRepositoryPort } from '../../domain/ports/bulk-batch-advancement-repository.port';
 import { BulkOfferCreationBatchRepositoryPort } from '../../domain/ports/bulk-offer-creation-batch-repository.port';
+import type { BulkChildOutcome } from '../../domain/types/bulk-child-outcome.types';
 import {
   BULK_BATCH_STATUS,
   type BulkBatchStatus,
@@ -46,7 +47,7 @@ export class BulkOfferCreationProgressService implements IBulkOfferCreationProgr
   async advanceBatchStatus(
     batchId: string,
     offerCreationRecordId: string,
-    outcome: 'succeeded' | 'failed'
+    outcome: BulkChildOutcome
   ): Promise<BulkOfferCreationBatch | null> {
     const { created } = await this.advancementRepository.markAdvancedIfNotExists(
       batchId,

--- a/libs/core/src/listings/application/services/bulk-offer-creation-submit.service.ts
+++ b/libs/core/src/listings/application/services/bulk-offer-creation-submit.service.ts
@@ -195,37 +195,7 @@ export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitS
 }
 
 /*
- * Worker-handler seam for #737:
- *
- * Once #737 lands, the `marketplace.offer.create` handler will call this
- * service after each terminal child status to derive the batch's
- * terminal status. The future public method shape is:
- *
- *   advanceBatchStatus(batchId, outcome: 'succeeded' | 'failed')
- *     → Promise<BulkOfferCreationBatch | null>
- *
- * Algorithm (verified against `BulkBatchStatus` semantics):
- *
- *   1. `bulkBatchRepository.incrementCounters(batchId, { succeeded?, failed? })`
- *      with `succeeded: 1` xor `failed: 1` depending on `outcome`.
- *      The returned entity is the post-update read so terminal-status
- *      derivation runs against the freshest counters.
- *   2. `finished = succeededCount + failedCount === totalCount`.
- *      Return `null` when not finished — the batch stays `'running'`.
- *   3. When finished, derive terminal:
- *      - `failedCount === 0`                       → `'completed'`
- *      - `succeededCount === 0 && failedCount > 0` → `'failed'`
- *      - otherwise                                 → `'partially-failed'`
- *      Then `bulkBatchRepository.updateStatus(batchId, terminal)` and
- *      return the post-update entity.
- *
- * Both repository methods already throw
- * `BulkOfferCreationBatchNotFoundException` (→ HTTP 404) on missing
- * rows, so handler error mapping mirrors the existing single-offer
- * execution path.
- *
- * Kept as a comment in #736 (not a private method) so TypeScript's
- * `noUnusedLocals` invariant doesn't have to be silenced for an
- * intentionally-unused method. Promote to a class method + the
- * `IBulkOfferCreationSubmitService` interface in #737.
+ * Worker-handler seam: shipped as `BulkOfferCreationProgressService.advanceBatchStatus`
+ * in #737. The terminal-state derivation rule lives there. See
+ * `bulk-offer-creation-progress.service.ts`.
  */

--- a/libs/core/src/listings/application/services/offer-creation-execution.service.ts
+++ b/libs/core/src/listings/application/services/offer-creation-execution.service.ts
@@ -26,8 +26,12 @@
 import { Inject, Injectable } from '@nestjs/common';
 
 import { DuplicateIdentifierMappingError, IDENTIFIER_MAPPING_SERVICE_TOKEN, IIdentifierMappingService, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
-import type { OfferManagerPort } from '@openlinker/core/listings';
-import { isOfferCreator, OFFER_CREATION_STATUS } from '@openlinker/core/listings';
+import type { OfferManagerPort, SmartClassificationReport } from '@openlinker/core/listings';
+import {
+  isOfferCreator,
+  isOfferSmartClassificationReader,
+  OFFER_CREATION_STATUS,
+} from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import type {
   CreateOfferCommand,
@@ -164,7 +168,41 @@ export class OfferCreationExecutionService implements IOfferCreationExecutionSer
       }
     }
 
+    // Smart classification readback (#737). Only meaningful when the offer
+    // landed at `active` directly (no validation hop). For `validating`,
+    // the poll service does the readback on the `validating → active`
+    // transition. Best-effort: failures persist null (AC-7).
+    if (finalRecord.status === OFFER_CREATION_STATUS.Active) {
+      await this.readAndPersistSmartClassification(adapter, result.externalOfferId, finalRecord.id);
+    }
+
     return this.buildResult(finalRecord, input.connectionId);
+  }
+
+  /**
+   * Best-effort Smart classification readback after a successful offer
+   * creation (#737). Mirrors the poll-service's readback shape — capability
+   * gate, swallow errors, persist `null` on failure so the next read can
+   * recover. Never throws — Smart readback failure must not fail the
+   * offer-creation operation (AC-7).
+   */
+  private async readAndPersistSmartClassification(
+    adapter: OfferManagerPort,
+    externalOfferId: string,
+    offerCreationRecordId: string
+  ): Promise<void> {
+    if (!isOfferSmartClassificationReader(adapter)) {
+      return;
+    }
+    let report: SmartClassificationReport | null = null;
+    try {
+      report = await adapter.getOfferSmartClassification(externalOfferId);
+    } catch (err) {
+      this.logger.warn(
+        `Smart classification readback failed for offer ${externalOfferId}: ${(err as Error).message}`
+      );
+    }
+    await this.offerCreationRecords.updateClassificationReport(offerCreationRecordId, report);
   }
 
   /**

--- a/libs/core/src/listings/application/services/offer-status-poll.service.ts
+++ b/libs/core/src/listings/application/services/offer-status-poll.service.ts
@@ -23,8 +23,9 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
-import type { OfferManagerPort } from '@openlinker/core/listings';
+import type { OfferManagerPort, SmartClassificationReport } from '@openlinker/core/listings';
 import {
+  isOfferSmartClassificationReader,
   isOfferStatusReader,
   OFFER_CREATION_STATUS,
   OfferNotFoundOnMarketplaceException,
@@ -162,6 +163,22 @@ export class OfferStatusPollService implements IOfferStatusPollService {
         decision.recordStatus,
         decision.errors
       );
+
+      // Smart classification readback (#737): when an offer transitions to
+      // `active`, this is the canonical moment to read its classification
+      // (offers can take seconds-to-minutes after create to be classified;
+      // the create-time read in the worker handler often returns 404 for
+      // offers that go through `validating`). Best-effort: failures log
+      // and persist null. Smart-readback failure MUST NOT fail the poll
+      // iteration (AC-7).
+      if (decision.recordStatus === OFFER_CREATION_STATUS.Active) {
+        await this.readAndPersistSmartClassification(
+          adapter,
+          input.externalOfferId,
+          input.offerCreationRecordId
+        );
+      }
+
       return { outcome: decision.outcome };
     }
 
@@ -268,6 +285,32 @@ export class OfferStatusPollService implements IOfferStatusPollService {
     const exp = pollAttempt - 1;
     const raw = this.cadence.initialDelaySeconds * Math.pow(this.cadence.backoffMultiplier, exp);
     return Math.min(raw, this.cadence.maxDelaySeconds);
+  }
+
+  /**
+   * Smart classification readback on `validating → active` transition (#737).
+   *
+   * Best-effort: capability check, swallow errors, persist `null` on failure.
+   * Never throws — Smart-readback failure must not fail the poll iteration
+   * (AC-7).
+   */
+  private async readAndPersistSmartClassification(
+    adapter: OfferManagerPort,
+    externalOfferId: string,
+    offerCreationRecordId: string
+  ): Promise<void> {
+    if (!isOfferSmartClassificationReader(adapter)) {
+      return;
+    }
+    let report: SmartClassificationReport | null = null;
+    try {
+      report = await adapter.getOfferSmartClassification(externalOfferId);
+    } catch (err) {
+      this.logger.warn(
+        `Smart classification readback failed for offer ${externalOfferId} during poll: ${(err as Error).message}`
+      );
+    }
+    await this.offerCreationRecords.updateClassificationReport(offerCreationRecordId, report);
   }
 
   /**

--- a/libs/core/src/listings/domain/entities/bulk-batch-advancement.entity.ts
+++ b/libs/core/src/listings/domain/entities/bulk-batch-advancement.entity.ts
@@ -1,0 +1,23 @@
+/**
+ * Bulk Batch Advancement Domain Entity (#737)
+ *
+ * Records that a single `OfferCreationRecord`'s outcome has been counted
+ * toward its parent `BulkOfferCreationBatch`. Acts as the at-most-once
+ * guard for the worker handler's counter-advancement path: composite-PK
+ * `(bulkBatchId, offerCreationRecordId)` + INSERT-ON-CONFLICT-DO-NOTHING
+ * makes the guarantee race-free across N concurrent worker invocations
+ * without a transaction.
+ *
+ * Stays cleanly orthogonal to the single-offer `OfferCreationRecord` —
+ * the bulk-flow concern doesn't leak into the per-attempt entity.
+ *
+ * @module libs/core/src/listings/domain/entities
+ */
+
+export class BulkBatchAdvancement {
+  constructor(
+    public readonly bulkBatchId: string,
+    public readonly offerCreationRecordId: string,
+    public readonly advancedAt: Date,
+  ) {}
+}

--- a/libs/core/src/listings/domain/entities/offer-creation-record.entity.ts
+++ b/libs/core/src/listings/domain/entities/offer-creation-record.entity.ts
@@ -13,6 +13,7 @@
 
 import type { OfferCreationError, OfferCreationStatus } from '../types/offer-creation-record.types';
 import type { OfferCreationRequestSnapshot } from '../types/offer-creation-request-snapshot.types';
+import type { SmartClassificationReport } from '../types/smart-classification.types';
 
 export class OfferCreationRecord {
   constructor(
@@ -36,6 +37,13 @@ export class OfferCreationRecord {
      * Parent BulkOfferCreationBatch id. Null for single-offer attempts; set
      * when the record was created as part of a bulk submission (#736).
      */
-    public readonly bulkBatchId: string | null = null
+    public readonly bulkBatchId: string | null = null,
+    /**
+     * Marketplace classification report (#737). Today only Allegro populates
+     * this — via `GET /sale/offers/{id}/smart` after create-success and on
+     * the `validating → active` transition. Null when never read, not yet
+     * classified, or readback failed.
+     */
+    public readonly classificationReport: SmartClassificationReport | null = null
   ) {}
 }

--- a/libs/core/src/listings/domain/ports/bulk-batch-advancement-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/bulk-batch-advancement-repository.port.ts
@@ -1,0 +1,29 @@
+/**
+ * Bulk Batch Advancement Repository Port (#737)
+ *
+ * Persistence contract for `BulkBatchAdvancement`. Sole consumer is
+ * `BulkOfferCreationProgressService`, which uses this port to ensure the
+ * counter-advancement path is at-most-once per (batch, record) pair across
+ * concurrent worker invocations and worker retries.
+ *
+ * @module libs/core/src/listings/domain/ports
+ */
+
+export interface BulkBatchAdvancementRepositoryPort {
+  /**
+   * INSERT … ON CONFLICT DO NOTHING on the `bulk_batch_advancements` table.
+   *
+   * - `{ created: true }` — the row landed (first-time advancement). Caller
+   *   should run the counter increment.
+   * - `{ created: false }` — the row already existed (retry path, or
+   *   concurrent winner). Caller should SKIP the counter increment to
+   *   preserve at-most-once semantics.
+   *
+   * Composite PK `(bulkBatchId, offerCreationRecordId)` guarantees the
+   * race-free semantics at the DB level — no transaction needed.
+   */
+  markAdvancedIfNotExists(
+    bulkBatchId: string,
+    offerCreationRecordId: string,
+  ): Promise<{ created: boolean }>;
+}

--- a/libs/core/src/listings/domain/ports/capabilities/offer-smart-classification-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/offer-smart-classification-reader.capability.ts
@@ -6,8 +6,8 @@
  * `implements OfferManagerPort, OfferSmartClassificationReader`.
  *
  * Today only the Allegro adapter implements this (reading `/sale/offers/{id}/smart`).
- * The bulk-offer-creation flow (#737) uses it twice per offer:
- *   1. At create-success in the worker handler.
+ * The offer-creation flow (#737) uses it twice per offer:
+ *   1. At create-success in `OfferCreationExecutionService` (active-on-create branch).
  *   2. On the `validating → active` transition in `OfferStatusPollService`.
  *
  * See `offer-lister.capability.ts` for the shared naming convention.

--- a/libs/core/src/listings/domain/ports/capabilities/offer-smart-classification-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/offer-smart-classification-reader.capability.ts
@@ -1,0 +1,43 @@
+/**
+ * Offer Smart Classification Reader Capability
+ *
+ * Optional sub-capability of `OfferManagerPort` — adapters that can fetch
+ * a post-create classification report for an offer declare
+ * `implements OfferManagerPort, OfferSmartClassificationReader`.
+ *
+ * Today only the Allegro adapter implements this (reading `/sale/offers/{id}/smart`).
+ * The bulk-offer-creation flow (#737) uses it twice per offer:
+ *   1. At create-success in the worker handler.
+ *   2. On the `validating → active` transition in `OfferStatusPollService`.
+ *
+ * See `offer-lister.capability.ts` for the shared naming convention.
+ *
+ * @module libs/core/src/listings/domain/ports/capabilities
+ */
+import type { OfferManagerPort } from '../offer-manager.port';
+import type { SmartClassificationReport } from '../../types/smart-classification.types';
+
+export interface OfferSmartClassificationReader {
+  /**
+   * Fetch the marketplace's classification report for an offer.
+   *
+   * - Returns `null` only for **404** — the offer isn't yet classified
+   *   (Allegro takes a few seconds-to-minutes post-create to compute).
+   *   Persistable; callers do NOT retry on null in this PR's scope.
+   * - Throws on any other error: 4xx (non-404), 5xx, network. Callers
+   *   are expected to wrap in try/catch and degrade gracefully — Smart
+   *   readback failure MUST NOT fail the offer-creation job (AC-7).
+   *
+   * Call sites narrow via `isOfferSmartClassificationReader(adapter)`.
+   */
+  getOfferSmartClassification(externalOfferId: string): Promise<SmartClassificationReport | null>;
+}
+
+export function isOfferSmartClassificationReader(
+  adapter: OfferManagerPort,
+): adapter is OfferManagerPort & OfferSmartClassificationReader {
+  return (
+    typeof (adapter as Partial<OfferSmartClassificationReader>).getOfferSmartClassification ===
+    'function'
+  );
+}

--- a/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/offer-creation-record-repository.port.ts
@@ -14,6 +14,7 @@ import type {
   OfferCreationError,
   OfferCreationStatus,
 } from '../types/offer-creation-record.types';
+import type { SmartClassificationReport } from '../types/smart-classification.types';
 
 export interface OfferCreationRecordRepositoryPort {
   /**
@@ -112,4 +113,16 @@ export interface OfferCreationRecordRepositoryPort {
    * Backed by `IDX_offer_creation_records_bulkBatchId` (#734).
    */
   findByBulkBatchId(bulkBatchId: string): Promise<OfferCreationRecord[]>;
+
+  /**
+   * Persist the marketplace classification report for an existing record (#737).
+   * `null` is a valid value meaning "readback yielded no report" (e.g. 404 from
+   * Allegro for not-yet-classified offers) — distinguishes from "never read".
+   *
+   * Throws `OfferCreationRecordNotFoundException` if the record does not exist.
+   */
+  updateClassificationReport(
+    id: string,
+    report: SmartClassificationReport | null
+  ): Promise<OfferCreationRecord>;
 }

--- a/libs/core/src/listings/domain/types/bulk-child-outcome.types.ts
+++ b/libs/core/src/listings/domain/types/bulk-child-outcome.types.ts
@@ -1,0 +1,17 @@
+/**
+ * Bulk Child Outcome Types (#737)
+ *
+ * The terminal outcome a single child of a `BulkOfferCreationBatch` reports
+ * back to the parent batch via `IBulkOfferCreationProgressService.advanceBatchStatus`.
+ * Maps the V2 sync-job's `JobOutcome` (`'ok' | 'business_failure'`) onto the
+ * batch-counter axis (`succeeded` / `failed`) — the handler does that mapping
+ * once at the call site.
+ *
+ * `as const` + union pattern per `engineering-standards.md § Union Types`.
+ * Runtime array enables exhaustiveness checks and future Swagger surfacing.
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+export const BulkChildOutcomeValues = ['succeeded', 'failed'] as const;
+export type BulkChildOutcome = (typeof BulkChildOutcomeValues)[number];

--- a/libs/core/src/listings/domain/types/smart-classification.types.ts
+++ b/libs/core/src/listings/domain/types/smart-classification.types.ts
@@ -1,0 +1,38 @@
+/**
+ * Smart Classification Report Types
+ *
+ * Neutral, marketplace-agnostic classification report. Today only Allegro
+ * produces one (via `GET /sale/offers/{offerId}/smart`); the shape is named
+ * generically so future marketplaces with classification programs can reuse
+ * it without a rename. Stored on `OfferCreationRecord.classificationReport`.
+ *
+ * Null when never read — pre-bulk-flow records, marketplaces without a
+ * classification surface, or readback failures.
+ *
+ * @module libs/core/src/listings/domain/types
+ */
+
+export interface SmartClassificationReport {
+  /**
+   * Whether the offer currently meets the marketplace's classification.
+   * `null` when the marketplace can't yet determine (Allegro returns 404
+   * for offers not yet classified post-create).
+   */
+  fulfilled: boolean | null;
+  conditions: SmartClassificationCondition[];
+  /**
+   * Marketplace will re-evaluate within its policy window (Allegro: 24h).
+   * When true, the FE may want to refresh on its next visit.
+   */
+  scheduledForReclassification?: boolean;
+}
+
+export interface SmartClassificationCondition {
+  /** Technical condition name (`deliveryMethodPrices`, `returnPaidBy`, etc.). */
+  code: string;
+  /** Marketplace-localized condition name for display. */
+  name: string;
+  /** Marketplace-localized description suitable for showing an operator. */
+  description: string;
+  fulfilled: boolean;
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -88,6 +88,9 @@ export type {
 export type { BulkOfferCreationBatchRepositoryPort } from './domain/ports/bulk-offer-creation-batch-repository.port';
 export { BulkOfferCreationBatchNotFoundException } from './domain/exceptions/bulk-offer-creation-batch-not-found.exception';
 export { EmptyBulkSubmissionException } from './domain/exceptions/empty-bulk-submission.exception';
+export { BulkBatchAdvancement } from './domain/entities/bulk-batch-advancement.entity';
+export type { BulkBatchAdvancementRepositoryPort } from './domain/ports/bulk-batch-advancement-repository.port';
+export type { IBulkOfferCreationProgressService } from './application/services/bulk-offer-creation-progress.service.interface';
 export type { IBulkOfferCreationSubmitService } from './application/interfaces/bulk-offer-creation-submit.service.interface';
 export type {
   BulkSharedConfig,
@@ -166,6 +169,12 @@ export type { CategoryBarcodeMatcher } from './domain/ports/capabilities/categor
 export { isCategoryBarcodeMatcher } from './domain/ports/capabilities/category-barcode-matcher.capability';
 export type { EanCategoryMatcher } from './domain/ports/capabilities/ean-category-matcher.capability';
 export { isEanCategoryMatcher } from './domain/ports/capabilities/ean-category-matcher.capability';
+export type { OfferSmartClassificationReader } from './domain/ports/capabilities/offer-smart-classification-reader.capability';
+export { isOfferSmartClassificationReader } from './domain/ports/capabilities/offer-smart-classification-reader.capability';
+export type {
+  SmartClassificationReport,
+  SmartClassificationCondition,
+} from './domain/types/smart-classification.types';
 export { EanMatchResultKindValues } from './domain/types/ean-category-match.types';
 export type {
   EanMatchResultKind,

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -90,6 +90,8 @@ export { BulkOfferCreationBatchNotFoundException } from './domain/exceptions/bul
 export { EmptyBulkSubmissionException } from './domain/exceptions/empty-bulk-submission.exception';
 export { BulkBatchAdvancement } from './domain/entities/bulk-batch-advancement.entity';
 export type { BulkBatchAdvancementRepositoryPort } from './domain/ports/bulk-batch-advancement-repository.port';
+export { BulkChildOutcomeValues } from './domain/types/bulk-child-outcome.types';
+export type { BulkChildOutcome } from './domain/types/bulk-child-outcome.types';
 export type { IBulkOfferCreationProgressService } from './application/services/bulk-offer-creation-progress.service.interface';
 export type { IBulkOfferCreationSubmitService } from './application/interfaces/bulk-offer-creation-submit.service.interface';
 export type {

--- a/libs/core/src/listings/infrastructure/persistence/entities/bulk-batch-advancement.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/bulk-batch-advancement.orm-entity.ts
@@ -1,0 +1,26 @@
+/**
+ * Bulk Batch Advancement ORM Entity (#737)
+ *
+ * TypeORM entity for the `bulk_batch_advancements` table — the at-most-once
+ * guard for bulk-offer-creation counter advancement.
+ *
+ * Composite PK on `(bulkBatchId, offerCreationRecordId)` makes the
+ * INSERT-ON-CONFLICT-DO-NOTHING path in `BulkBatchAdvancementRepository`
+ * atomic without a transaction.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/entities
+ * @see {@link BulkBatchAdvancement} for the corresponding domain entity
+ */
+import { Entity, PrimaryColumn, CreateDateColumn } from 'typeorm';
+
+@Entity('bulk_batch_advancements')
+export class BulkBatchAdvancementOrmEntity {
+  @PrimaryColumn({ type: 'uuid' })
+  bulkBatchId!: string;
+
+  @PrimaryColumn({ type: 'uuid' })
+  offerCreationRecordId!: string;
+
+  @CreateDateColumn()
+  advancedAt!: Date;
+}

--- a/libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts
+++ b/libs/core/src/listings/infrastructure/persistence/entities/offer-creation-record.orm-entity.ts
@@ -19,6 +19,7 @@ import {
 import { OfferCreationStatus } from '../../../domain/types/offer-creation-record.types';
 import type { OfferCreationError } from '../../../domain/types/offer-creation-record.types';
 import type { OfferCreationRequestSnapshot } from '../../../domain/types/offer-creation-request-snapshot.types';
+import type { SmartClassificationReport } from '../../../domain/types/smart-classification.types';
 
 @Entity('offer_creation_records')
 @Index(['internalVariantId', 'connectionId'])
@@ -74,6 +75,15 @@ export class OfferCreationRecordOrmEntity {
   @Column({ type: 'uuid', nullable: true })
   @Index('IDX_offer_creation_records_bulkBatchId')
   bulkBatchId!: string | null;
+
+  /**
+   * Marketplace classification report (#737). Populated by the bulk-flow
+   * worker handler at create-success and again on the `validating → active`
+   * transition (via `OfferStatusPollService`). Null when never read, not
+   * yet classified by the marketplace, or readback failed.
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  classificationReport!: SmartClassificationReport | null;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/libs/core/src/listings/infrastructure/persistence/repositories/bulk-batch-advancement.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/bulk-batch-advancement.repository.ts
@@ -1,0 +1,43 @@
+/**
+ * Bulk Batch Advancement Repository (#737)
+ *
+ * TypeORM implementation of `BulkBatchAdvancementRepositoryPort`. Uses an
+ * `INSERT ... ON CONFLICT DO NOTHING` query to atomically discover whether
+ * a `(bulkBatchId, offerCreationRecordId)` row already exists, in one
+ * round-trip, without a transaction.
+ *
+ * `result.identifiers.length` is the boundary signal: if the insert landed,
+ * TypeORM returns the inserted PK; if it was a no-op (row existed),
+ * `identifiers` is empty. Both paths return successfully — no exception
+ * leaks for the contention case.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/repositories
+ * @implements {BulkBatchAdvancementRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import type { BulkBatchAdvancementRepositoryPort } from '../../../domain/ports/bulk-batch-advancement-repository.port';
+import { BulkBatchAdvancementOrmEntity } from '../entities/bulk-batch-advancement.orm-entity';
+
+@Injectable()
+export class BulkBatchAdvancementRepository implements BulkBatchAdvancementRepositoryPort {
+  constructor(
+    @InjectRepository(BulkBatchAdvancementOrmEntity)
+    private readonly repository: Repository<BulkBatchAdvancementOrmEntity>,
+  ) {}
+
+  async markAdvancedIfNotExists(
+    bulkBatchId: string,
+    offerCreationRecordId: string,
+  ): Promise<{ created: boolean }> {
+    const result = await this.repository
+      .createQueryBuilder()
+      .insert()
+      .values({ bulkBatchId, offerCreationRecordId })
+      .orIgnore()
+      .execute();
+    return { created: result.identifiers.length > 0 };
+  }
+}

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.spec.ts
@@ -38,6 +38,7 @@ describe('OfferCreationRecordRepository', () => {
     publishImmediately: false,
     request: null,
     bulkBatchId: null,
+    classificationReport: null,
     createdAt: now,
     updatedAt: now,
     ...overrides,

--- a/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/offer-creation-record.repository.ts
@@ -21,6 +21,7 @@ import type {
   OfferCreationError,
   OfferCreationStatus,
 } from '../../../domain/types/offer-creation-record.types';
+import type { SmartClassificationReport } from '../../../domain/types/smart-classification.types';
 import { OfferCreationRecordOrmEntity } from '../entities/offer-creation-record.orm-entity';
 
 @Injectable()
@@ -116,6 +117,19 @@ export class OfferCreationRecordRepository implements OfferCreationRecordReposit
     return entities.map((entity) => this.toDomain(entity));
   }
 
+  async updateClassificationReport(
+    id: string,
+    report: SmartClassificationReport | null
+  ): Promise<OfferCreationRecord> {
+    const entity = await this.repository.findOne({ where: { id } });
+    if (!entity) {
+      throw new OfferCreationRecordNotFoundException(id);
+    }
+    entity.classificationReport = report;
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
   private buildOrmEntity(input: CreateOfferCreationRecordInput): OfferCreationRecordOrmEntity {
     const entity = new OfferCreationRecordOrmEntity();
     entity.internalVariantId = input.internalVariantId;
@@ -141,7 +155,8 @@ export class OfferCreationRecordRepository implements OfferCreationRecordReposit
       entity.createdAt,
       entity.updatedAt,
       entity.request,
-      entity.bulkBatchId
+      entity.bulkBatchId,
+      entity.classificationReport
     );
   }
 }

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -22,6 +22,9 @@ import { OfferCreationRecordOrmEntity } from './infrastructure/persistence/entit
 import { OfferCreationRecordRepository } from './infrastructure/persistence/repositories/offer-creation-record.repository';
 import { BulkOfferCreationBatchOrmEntity } from './infrastructure/persistence/entities/bulk-offer-creation-batch.orm-entity';
 import { BulkOfferCreationBatchRepository } from './infrastructure/persistence/repositories/bulk-offer-creation-batch.repository';
+import { BulkBatchAdvancementOrmEntity } from './infrastructure/persistence/entities/bulk-batch-advancement.orm-entity';
+import { BulkBatchAdvancementRepository } from './infrastructure/persistence/repositories/bulk-batch-advancement.repository';
+import { BulkOfferCreationProgressService } from './application/services/bulk-offer-creation-progress.service';
 import { OfferBuilderService } from './application/services/offer-builder.service';
 import { OfferCreationExecutionService } from './application/services/offer-creation-execution.service';
 import { SellerPoliciesCacheOrmEntity } from './infrastructure/persistence/entities/seller-policies-cache.orm-entity';
@@ -37,6 +40,8 @@ import {
   OFFER_MAPPING_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+  BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
+  BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
@@ -55,6 +60,8 @@ export {
   OFFER_MAPPING_REPOSITORY_TOKEN,
   OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
   BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+  BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
+  BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
   OFFER_BUILDER_SERVICE_TOKEN,
   OFFER_CREATION_EXECUTION_SERVICE_TOKEN,
@@ -71,6 +78,7 @@ export {
       IdentifierMappingOrmEntity,
       OfferCreationRecordOrmEntity,
       BulkOfferCreationBatchOrmEntity,
+      BulkBatchAdvancementOrmEntity,
       SellerPoliciesCacheOrmEntity,
     ]),
     IntegrationsModule,
@@ -87,6 +95,8 @@ export {
     OfferMappingRepository,
     OfferCreationRecordRepository,
     BulkOfferCreationBatchRepository,
+    BulkBatchAdvancementRepository,
+    BulkOfferCreationProgressService,
     OfferBuilderService,
     OfferCreationExecutionService,
     OfferCreationEnqueueService,
@@ -117,6 +127,14 @@ export {
     {
       provide: BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
       useExisting: BulkOfferCreationBatchRepository,
+    },
+    {
+      provide: BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
+      useExisting: BulkBatchAdvancementRepository,
+    },
+    {
+      provide: BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
+      useExisting: BulkOfferCreationProgressService,
     },
     {
       provide: CATEGORY_RESOLUTION_SERVICE_TOKEN,
@@ -158,6 +176,8 @@ export {
     OFFER_MAPPING_REPOSITORY_TOKEN,
     OFFER_CREATION_RECORD_REPOSITORY_TOKEN,
     BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN,
+    BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN,
+    BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN,
     CATEGORY_RESOLUTION_SERVICE_TOKEN,
     OFFER_BUILDER_SERVICE_TOKEN,
     OFFER_CREATION_EXECUTION_SERVICE_TOKEN,

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -12,6 +12,12 @@ export const OFFER_CREATION_RECORD_REPOSITORY_TOKEN = Symbol('OfferCreationRecor
 export const BULK_OFFER_CREATION_BATCH_REPOSITORY_TOKEN = Symbol(
   'BulkOfferCreationBatchRepositoryPort',
 );
+export const BULK_BATCH_ADVANCEMENT_REPOSITORY_TOKEN = Symbol(
+  'BulkBatchAdvancementRepositoryPort',
+);
+export const BULK_OFFER_CREATION_PROGRESS_SERVICE_TOKEN = Symbol(
+  'IBulkOfferCreationProgressService',
+);
 export const CATEGORY_RESOLUTION_SERVICE_TOKEN = Symbol('ICategoryResolutionService');
 export const OFFER_BUILDER_SERVICE_TOKEN = Symbol('IOfferBuilderService');
 export const OFFER_CREATION_EXECUTION_SERVICE_TOKEN = Symbol('IOfferCreationExecutionService');

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -779,3 +779,30 @@ export interface AllegroImpliedWarrantiesResponse {
   impliedWarranties: AllegroSellerPolicyEntry[];
 }
 
+
+/**
+ * Response from `GET /sale/offers/{offerId}/smart` (#737) — Allegro Smart!
+ * classification report. The neutral `SmartClassificationReport` type in
+ * core (`libs/core/src/listings/domain/types/smart-classification.types.ts`)
+ * is the consumer surface; this raw shape is mapped onto it by
+ * `AllegroOfferManagerAdapter.getOfferSmartClassification`.
+ *
+ * Deprecated fields documented in the swagger (`smartDeliveryMethods`,
+ * `passedDeliveryMethods`, `failedDeliveryMethods`) are intentionally
+ * omitted — slated for removal 2026-07-28 per Allegro changelog.
+ *
+ * Reference: developer.allegro.pl/swagger.yaml SmartOfferClassificationReport.
+ */
+export interface AllegroSmartOfferClassificationReport {
+  classification?: {
+    fulfilled: boolean;
+    lastChanged?: string;
+  };
+  scheduledForReclassification?: boolean;
+  conditions?: Array<{
+    code: string;
+    name: string;
+    description: string;
+    fulfilled: boolean;
+  }>;
+}

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -23,6 +23,7 @@ import {
   OfferNotFoundOnMarketplaceException,
   isCatalogProductReader,
   isEanCategoryMatcher,
+  isOfferSmartClassificationReader,
   isOfferStatusReader,
   isSafetyAttachmentUploader,
   type CreateOfferCommand,
@@ -2459,6 +2460,92 @@ describe('AllegroOfferManagerAdapter', () => {
       // private-helper coverage is implicit: if the helper signature drifts,
       // both call sites fail TypeScript before the test runs.
       expect(httpClient.get).toHaveBeenCalledWith('/sale/product-offers/7781562863');
+    });
+  });
+
+  describe('getOfferSmartClassification (#737)', () => {
+    it('declares the OfferSmartClassificationReader sub-capability', () => {
+      expect(isOfferSmartClassificationReader(adapter)).toBe(true);
+    });
+
+    it('maps a fulfilled Allegro response to the neutral SmartClassificationReport', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          classification: { fulfilled: true },
+          conditions: [
+            {
+              code: 'FAST_SHIPPING',
+              name: 'Fast shipping',
+              description: 'Ships within 24h',
+              fulfilled: true,
+            },
+            {
+              code: 'GOOD_PRICE',
+              name: 'Good price',
+              description: 'Competitive price',
+              fulfilled: false,
+            },
+          ],
+          scheduledForReclassification: false,
+        },
+        status: 200,
+      } as never);
+
+      const result = await adapter.getOfferSmartClassification('7781562863');
+
+      expect(httpClient.get).toHaveBeenCalledWith('/sale/offers/7781562863/smart');
+      expect(result).toEqual({
+        fulfilled: true,
+        conditions: [
+          {
+            code: 'FAST_SHIPPING',
+            name: 'Fast shipping',
+            description: 'Ships within 24h',
+            fulfilled: true,
+          },
+          {
+            code: 'GOOD_PRICE',
+            name: 'Good price',
+            description: 'Competitive price',
+            fulfilled: false,
+          },
+        ],
+        scheduledForReclassification: false,
+      });
+    });
+
+    it('returns null on Allegro 404 (offer not yet classified)', async () => {
+      httpClient.get.mockRejectedValueOnce(new AllegroApiException('not classified', 404));
+
+      const result = await adapter.getOfferSmartClassification('fresh-offer-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('propagates non-404 AllegroApiException unchanged', async () => {
+      httpClient.get.mockRejectedValueOnce(new AllegroApiException('upstream', 503));
+
+      await expect(adapter.getOfferSmartClassification('7781562863')).rejects.toMatchObject({
+        name: 'AllegroApiException',
+        statusCode: 503,
+      });
+    });
+
+    it('handles missing classification block (fulfilled defaults to null)', async () => {
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          conditions: [],
+        },
+        status: 200,
+      } as never);
+
+      const result = await adapter.getOfferSmartClassification('7781562863');
+
+      expect(result).toEqual({
+        fulfilled: null,
+        conditions: [],
+        scheduledForReclassification: undefined,
+      });
     });
   });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -30,6 +30,8 @@ import type {
   OfferStatusReadResult,
   OfferPublicationStatus,
   OfferReader,
+  OfferSmartClassificationReader,
+  SmartClassificationReport,
   SellerPoliciesReader,
   ResponsibleProducerReader,
   ResponsibleProducerEntry,
@@ -89,6 +91,7 @@ import type {
   AllegroSellerPolicyEntry,
   AllegroResponsibleProducerEntry,
   AllegroResponsibleProducersResponse,
+  AllegroSmartOfferClassificationReport,
 } from '../../domain/types/allegro-api.types';
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
 import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
@@ -210,6 +213,7 @@ export class AllegroOfferManagerAdapter
     CatalogProductReader,
     OfferCreator,
     OfferStatusReader,
+    OfferSmartClassificationReader,
     OfferReader,
     SellerPoliciesReader,
     ResponsibleProducerReader,
@@ -581,6 +585,47 @@ export class AllegroOfferManagerAdapter
     const validationErrors = this.mapValidationErrors(offer.validation?.errors ?? []);
 
     return { publicationStatus, validationErrors };
+  }
+
+  /**
+   * `OfferSmartClassificationReader.getOfferSmartClassification` (#737) —
+   * fetch the Allegro Smart! classification for a single offer.
+   *
+   * 404 collapses to `null` (Allegro hasn't yet classified the offer — most
+   * commonly because the offer is fresh from create-offer and pre-validation).
+   * Every other error propagates so the caller can decide how to degrade —
+   * the bulk-flow handler + poll-service hook catch + log + persist null
+   * per AC-7 (Smart readback must not fail the offer-creation job).
+   */
+  async getOfferSmartClassification(
+    externalOfferId: string
+  ): Promise<SmartClassificationReport | null> {
+    try {
+      const response = await this.httpClient.get<AllegroSmartOfferClassificationReport>(
+        `/sale/offers/${externalOfferId}/smart`
+      );
+      return this.mapSmartClassificationReport(response.data);
+    } catch (err) {
+      if (err instanceof AllegroApiException && err.statusCode === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  private mapSmartClassificationReport(
+    raw: AllegroSmartOfferClassificationReport
+  ): SmartClassificationReport {
+    return {
+      fulfilled: raw.classification?.fulfilled ?? null,
+      conditions: (raw.conditions ?? []).map((c) => ({
+        code: c.code,
+        name: c.name,
+        description: c.description,
+        fulfilled: c.fulfilled,
+      })),
+      scheduledForReclassification: raw.scheduledForReclassification,
+    };
   }
 
   private mapAllegroPublicationStatus(


### PR DESCRIPTION
## Summary

- Bulk-aware V2 payload path for `marketplace.offer.create`. Handler is a thin shell: AI-description prep (channel `allegro`, `generateDescription === true`), delegate to `OfferCreationExecutionService`, advance bulk-batch counters through the new `BulkOfferCreationProgressService`.
- At-most-once counter advancement via the new `bulk_batch_advancements` join table (composite-PK + `INSERT ON CONFLICT DO NOTHING`) — race-safe across N concurrent workers and worker retries, no transaction needed.
- New `OfferSmartClassificationReader` sub-capability on `OfferManagerPort`, implemented by Allegro against `/sale/offers/{id}/smart`. Smart readback fires inside core — `OfferCreationExecutionService` on the active-on-create branch, `OfferStatusPollService` on the `validating → active` transition. Both paths swallow errors and persist `null` per AC-7 (Smart-readback failure must not fail offer creation).
- Migration `1798000000000` adds `offer_creation_records.classificationReport` (jsonb, nullable) + the `bulk_batch_advancements` table.
- Worker now registers `AiIntegrationModule.register()` in `apps/worker/src/plugins.ts`; suggestion binding lives at `apps/worker/src/content/worker-content.module.ts` (mirrors the api-side pattern; cannot live in core/content without reversing the core → integration dependency direction).

Closes #737

## Test plan

- [x] `pnpm lint` — passes (cross-context check clean, no new allow-list entries)
- [x] `pnpm type-check` — passes
- [x] `pnpm test` — 1,977 unit tests passing (V1 + V2 handler paths, AI fallback, Smart readback on create-time + poll-time, at-most-once advancement, terminal-status derivation, Allegro adapter 404 → null)
- [x] `pnpm test:integration` — 170 / 174 passing locally; 1 suite (`order-destination-retry.int-spec.ts`) flaked on Redis blocking-client startup in the bulk run but passes in isolation
- [ ] Smoke V2 end-to-end via the bulk submit endpoint once merged (handler dispatch, AI prep, progress advancement) on a staging Allegro connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)