### PR TITLE
docs(readme): add Integrations table with live/in-progress/planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ If you sell on your own shop *and* on marketplaces like Allegro, you've already 
 
 ---
 
+## Integrations
+
+| Integration | Role | Status |
+|---|---|---|
+| **[PrestaShop](./libs/integrations/prestashop/)** | Shop *(source + destination)* | ✅ Live |
+| **[Allegro](./libs/integrations/allegro/)** | Marketplace *(source + offers)* | ✅ Live |
+| **[AI router](./libs/integrations/ai/)** *(Anthropic, OpenAI)* | Content suggestion | ✅ Live |
+| **Subiekt nexo** *([#728](https://github.com/SilkSoftwareHouse/openlinker/issues/728))* | Invoicing *(via Sfera bridge — first `InvoicingPort` adapter)* | 🚧 In progress |
+| **InPost** *([#727](https://github.com/SilkSoftwareHouse/openlinker/issues/727))* | Shipping *(ShipX — paczkomat + kurier, labels, webhooks)* | 🚧 In progress |
+| Shopify · WooCommerce · BigCommerce · Magento | Shop | 📋 Planned |
+| eBay · Amazon · OLX · Empik · Bol | Marketplace | 📋 Planned |
+| DPD · DHL · FedEx · ORLEN Paczka · GLS | Shipping *(pending `ShippingProviderPort` from #727)* | 📋 Planned |
+| Fakturownia · iFirma · wFirma · inFakt | Invoicing *(siblings of Subiekt under `InvoicingPort`)* | 📋 Planned |
+
+Planned items are open for community contributions — see [Adding your own integration](#adding-your-own-integration) below.
+
+---
+
 ## Capabilities
 
 OpenLinker is built around a small set of capability ports. Each integration implements one or more of them — adding a new platform means adding implementations, not changing core code.
@@ -187,14 +205,7 @@ Full walkthrough in the [Plugin Author Guide](./docs/plugin-author-guide.md). Th
 
 ### Wanted
 
-Community plugins explicitly welcome for:
-
-- **Shops** — Shopify, WooCommerce, BigCommerce, Magento
-- **Marketplaces** — eBay, Amazon, OLX, Empik, Bol
-- **Shipping providers** — InPost, DPD, DHL, FedEx (the `ShippingProviderPort` is on the roadmap)
-- **Payment processors** — Stripe, Adyen, Przelewy24 (`PaymentProcessorPort` is on the roadmap)
-
-Propose one — or anything not listed — via the [`new_integration` issue template](./.github/ISSUE_TEMPLATE/new_integration.md). The [Plugin Author Guide](./docs/plugin-author-guide.md) walks through port selection, package layout, registry wiring, OAuth, and tests.
+Any **📋 Planned** row in the [Integrations table](#integrations) is open for community contribution — or propose something not listed via the [`new_integration` issue template](./.github/ISSUE_TEMPLATE/new_integration.md). The [Plugin Author Guide](./docs/plugin-author-guide.md) walks through port selection, package layout, registry wiring, OAuth, and tests.
 
 ### Where we're at
 


### PR DESCRIPTION
## Summary

- Adds a new **Integrations** section between *What you can do today* and *Capabilities* — surfaces what OpenLinker integrates with above the fold instead of leaving it buried in the deep-dive *Implementations* section ~50 lines further down.
- Single table grouped by status: **3 Live** (PrestaShop, Allegro, AI router) · **2 In progress** (Subiekt nexo #728, InPost #727) · **4 Planned** buckets (Shops, Marketplaces, Shipping, Invoicing).
- Per-row blocking notes where a port isn't stable yet — e.g. Shipping row notes *"pending `ShippingProviderPort` from #727"*, Invoicing row notes *"siblings of Subiekt under `InvoicingPort`"*.
- Slims the **Wanted** subsection under *For developers* to a one-liner pointing back at the new table (the previous list was redundant with the new Planned rows and still listed InPost as community-wanted even though we're shipping it ourselves).
- Removes the speculative Payment row — no concrete plan exists for `PaymentProcessorPort` and the table reads more honestly without it.

## Test plan

- [ ] README renders correctly on GitHub (table formatting, emoji status markers, internal anchor link to `#adding-your-own-integration`)
- [ ] Issue links `#727` and `#728` resolve to the correct InPost / Subiekt specs
- [ ] Implementation deep-link paths (`./libs/integrations/prestashop/`, `./libs/integrations/allegro/`, `./libs/integrations/ai/`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)