### PR TITLE
fix(worker): wire AI_COMPLETION_PORT_TOKEN into WorkerContentModule

### DIFF
--- a/apps/worker/src/app.module.ts
+++ b/apps/worker/src/app.module.ts
@@ -12,14 +12,11 @@ import { CacheModule } from '@openlinker/shared/cache';
 import { DatabaseModule } from '@openlinker/shared/database';
 import { RedisConfigModule } from '@openlinker/shared/redis';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
-import {
-  IntegrationsModule as CoreIntegrationsModule,
-  PluginRegistryModule,
-} from '@openlinker/core/integrations';
+import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
 import { ProductsModule } from '@openlinker/core/products';
 import { InventoryModule } from '@openlinker/core/inventory';
 import { SyncModule } from '@openlinker/core/sync';
-import { workerPlugins } from './plugins';
+import { IntegrationsModule } from './integrations/integrations.module';
 import { SyncWorkerModule } from './sync/sync-worker.module';
 import { WorkerHeartbeatService } from './health/worker-heartbeat.service';
 
@@ -34,7 +31,7 @@ import { WorkerHeartbeatService } from './health/worker-heartbeat.service';
     CacheModule,
     IdentifierMappingModule,
     CoreIntegrationsModule,
-    PluginRegistryModule.forRoot({ plugins: workerPlugins }),
+    IntegrationsModule,
     ProductsModule,
     InventoryModule,
     SyncModule,

--- a/apps/worker/src/content/__tests__/worker-content.module.spec.ts
+++ b/apps/worker/src/content/__tests__/worker-content.module.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Worker Content Module Wiring Test
+ *
+ * Asserts the DI wiring that resolves `AI_COMPLETION_PORT_TOKEN` for
+ * `ContentSuggestionService` in the worker process (#737). The original
+ * defect: `WorkerContentModule` imported only `CoreIntegrationsModule`,
+ * which does not expose the per-plugin tokens contributed by
+ * `workerPlugins` (notably `AI_COMPLETION_PORT_TOKEN` from
+ * `AiIntegrationModule.register()`). Nest blew up at worker boot with
+ * "Nest can't resolve dependencies of the ContentSuggestionService ...
+ * Symbol(AiCompletionPort)".
+ *
+ * The fix wires `WorkerContentModule` to the worker-side `IntegrationsModule`
+ * wrapper (`apps/worker/src/integrations/integrations.module.ts`), which
+ * composes the plugin list via `PluginRegistryModule.forRoot(...)` and
+ * re-exports `PluginRegistryModule`. This test pins that contract with two
+ * structural assertions so removing either side fails at unit-test time
+ * rather than at worker boot.
+ *
+ * Structural (Reflect-metadata) rather than behavioural because compiling
+ * `WorkerContentModule` end-to-end would require booting `DatabaseModule`,
+ * `RedisConfigModule`, and the full plugin graph — that's covered by the
+ * worker integration suite (which DID catch the defect locally), but is not
+ * yet wired into CI (`.github/workflows/ci.yml` runs only
+ * `pnpm --filter @openlinker/api test:integration`). A unit-level structural
+ * gate runs under `pnpm test:ci` for every PR.
+ *
+ * @module apps/worker/src/content
+ */
+import 'reflect-metadata';
+import { PluginRegistryModule } from '@openlinker/core/integrations';
+import { IntegrationsModule as WorkerIntegrationsModule } from '../../integrations/integrations.module';
+import { WorkerContentModule } from '../worker-content.module';
+
+describe('WorkerContentModule wiring (#737)', () => {
+  it('imports the worker IntegrationsModule wrapper so AI_COMPLETION_PORT_TOKEN resolves', () => {
+    const imports = (Reflect.getMetadata('imports', WorkerContentModule) ?? []) as unknown[];
+
+    expect(imports).toContain(WorkerIntegrationsModule);
+  });
+
+  it('IntegrationsModule wrapper re-exports PluginRegistryModule so per-plugin tokens propagate', () => {
+    const exports = (Reflect.getMetadata('exports', WorkerIntegrationsModule) ?? []) as unknown[];
+
+    expect(exports).toContain(PluginRegistryModule);
+  });
+});

--- a/apps/worker/src/content/worker-content.module.ts
+++ b/apps/worker/src/content/worker-content.module.ts
@@ -4,10 +4,10 @@
  * Binds `CONTENT_SUGGESTION_SERVICE_TOKEN` to `ContentSuggestionService` for
  * the worker process. Mirrors the `apps/api/src/content/content.module.ts`
  * suggestion-binding pattern — the suggestion service depends on
- * `AI_COMPLETION_PORT_TOKEN`, which the worker resolves via
- * `PluginRegistryModule.forRoot({ plugins: workerPlugins })` in
- * `AppModule` (where `workerPlugins` includes `AiIntegrationModule.register()`
- * as of #737).
+ * `AI_COMPLETION_PORT_TOKEN`, which the worker resolves via the worker-side
+ * `IntegrationsModule` wrapper (`apps/worker/src/integrations/integrations.module.ts`),
+ * which composes `workerPlugins` (including `AiIntegrationModule.register()`
+ * as of #737) through `PluginRegistryModule.forRoot` and re-exports it.
  *
  * Cannot live in `libs/core/src/content/content.module.ts` because that
  * would force core to value-import `@openlinker/integrations-ai`,
@@ -31,9 +31,16 @@ import {
 import { ContentSuggestionService } from '@openlinker/core/content';
 import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
 import { ListingsModule as CoreListingsModule } from '@openlinker/core/listings/services';
+import { IntegrationsModule } from '../integrations/integrations.module';
 
 @Module({
-  imports: [CoreContentModule, CoreIntegrationsModule, CoreListingsModule, CoreAiModule],
+  imports: [
+    CoreContentModule,
+    CoreIntegrationsModule,
+    CoreListingsModule,
+    CoreAiModule,
+    IntegrationsModule, // `AI_COMPLETION_PORT_TOKEN` resolves via `PluginRegistryModule` re-export.
+  ],
   providers: [
     ContentSuggestionService,
     {

--- a/apps/worker/src/integrations/integrations.module.ts
+++ b/apps/worker/src/integrations/integrations.module.ts
@@ -1,0 +1,29 @@
+/**
+ * Worker Integrations Module
+ *
+ * Composes the worker's plugin list (`workerPlugins`) via
+ * `PluginRegistryModule.forRoot({ plugins })` and re-exports
+ * `PluginRegistryModule` so downstream modules (e.g. `WorkerContentModule`)
+ * resolve per-plugin tokens (`AI_COMPLETION_PORT_TOKEN`, etc.) through a
+ * single import of this module. Mirrors the API-side wrapper at
+ * `apps/api/src/integrations/integrations.module.ts`.
+ *
+ * Naming convention: this class is intentionally also called
+ * `IntegrationsModule`, matching the API-side wrapper and shadowing the
+ * core `IntegrationsModule` from `@openlinker/core/integrations`. Consumers
+ * resolve the collision by aliasing the core module on import
+ * (`import { IntegrationsModule as CoreIntegrationsModule }`); the host-side
+ * wrapper keeps the unqualified name in every app to make "this is the
+ * per-app plugin-composition seam" instantly recognizable.
+ *
+ * @module apps/worker/src/integrations
+ */
+import { Module } from '@nestjs/common';
+import { PluginRegistryModule } from '@openlinker/core/integrations';
+import { workerPlugins } from '../plugins';
+
+@Module({
+  imports: [PluginRegistryModule.forRoot({ plugins: workerPlugins })],
+  exports: [PluginRegistryModule],
+})
+export class IntegrationsModule {}


### PR DESCRIPTION
## Summary

- `pnpm start:dev:worker` was crashing at Nest bootstrap with `Symbol(AiCompletionPort)` unresolved in `WorkerContentModule` — see #787 for the full root-cause analysis. The token-providing module (`AiIntegrationModule.register()`, added to `workerPlugins` in #737) was composed at the `AppModule` level via `PluginRegistryModule.forRoot`, but providers from a root `forRoot` don't propagate into nested modules that don't import it.
- Add a worker-side `IntegrationsModule` wrapper at `apps/worker/src/integrations/integrations.module.ts` that mirrors `apps/api/src/integrations/integrations.module.ts` exactly: composes `PluginRegistryModule.forRoot({ plugins: workerPlugins })` once and re-exports `PluginRegistryModule`. Both `AppModule` and `WorkerContentModule` import the wrapper; Nest dedupes by reference, so the plugin list evaluates once.
- Lock the wiring with a unit-level structural test on the imports + exports module metadata. Full behavioural coverage via the worker Testcontainers harness (which already boots `AppModule` and would have caught this) is tracked separately in **#786** — CI doesn't run `pnpm --filter @openlinker/worker test:integration` yet, which is the underlying gap that let this and #744 both ship.

Closes #787

## Test plan

- [x] `pnpm lint` — green (passes the pre-commit hook)
- [x] `pnpm type-check` — green
- [x] `pnpm --filter @openlinker/worker test` — 129 tests pass, including 2 new structural assertions
- [x] `pnpm start:dev:worker` — boots cleanly; `MultiProviderAiCompletionAdapter` logs `Registered AI completion adapter for provider: {anthropic,openai,fake}` before the consumption loop starts
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
