### PR TITLE
feat(web,listings): bulk Allegro offer creation wizard (#739, #740, #741)

### DIFF
--- a/apps/web/src/app/routes/listings.route.tsx
+++ b/apps/web/src/app/routes/listings.route.tsx
@@ -7,6 +7,12 @@ const listingsListCrumb: RouteCrumbHandle = {
 const listingDetailCrumb: RouteCrumbHandle = {
   crumb: { group: 'Operations', title: 'Listing' },
 };
+const bulkWizardCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Bulk listing' },
+};
+const bulkBatchCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Bulk batch' },
+};
 
 export const listingsRoute: RouteObject = {
   path: 'listings',
@@ -17,6 +23,29 @@ export const listingsRoute: RouteObject = {
       lazy: async () => {
         const { ListingsListPage } = await import('../../pages/listings/listings-list-page');
         return { Component: ListingsListPage };
+      },
+    },
+    {
+      // #740 — bulk listing wizard. Path is split so the dynamic `:id` route
+      // below doesn't intercept the literal `bulk-create` segment.
+      path: 'bulk-create/wizard',
+      handle: bulkWizardCrumb,
+      lazy: async () => {
+        const { BulkCreateWizardPage } = await import(
+          '../../pages/listings/bulk-create-wizard-page'
+        );
+        return { Component: BulkCreateWizardPage };
+      },
+    },
+    {
+      // #741 — bulk batch progress page.
+      path: 'bulk-batches/:batchId',
+      handle: bulkBatchCrumb,
+      lazy: async () => {
+        const { BulkBatchProgressPage } = await import(
+          '../../pages/listings/bulk-batch-progress-page'
+        );
+        return { Component: BulkBatchProgressPage };
       },
     },
     {

--- a/apps/web/src/app/routes/route-lazy.test.ts
+++ b/apps/web/src/app/routes/route-lazy.test.ts
@@ -61,7 +61,7 @@ const lazyRoutes = collectLazyRoutes([
  *   - login (first-paint optimization — see `login.route.tsx`)
  *   - prompt-templates-legacy-redirects (inline `<Navigate>` element)
  */
-const EXPECTED_LAZY_ROUTE_COUNT = 35;
+const EXPECTED_LAZY_ROUTE_COUNT = 37;
 
 describe('route lazy contract', () => {
   it(`the registered route tree contains exactly ${EXPECTED_LAZY_ROUTE_COUNT} lazy routes`, () => {

--- a/apps/web/src/features/listings/api/bulk-listings.types.ts
+++ b/apps/web/src/features/listings/api/bulk-listings.types.ts
@@ -1,0 +1,106 @@
+/**
+ * Bulk Listing Types
+ *
+ * FE transport types for the bulk offer-creation endpoints (#736 / #742).
+ * Mirrors the BE DTOs in `apps/api/src/listings/http/dto/bulk-offer-create*.dto.ts`
+ * and `bulk-offer-creation-retry-response.dto.ts`.
+ *
+ * Note: the BE field `productIds` actually carries **variant IDs** (see
+ * `libs/core/src/listings/application/services/bulk-offer-creation-submit.service.ts:182`
+ * where `internalVariantId: productId`). The FE picks one canonical variant
+ * per selected product before submit.
+ *
+ * @module apps/web/src/features/listings/api
+ */
+
+import type { OfferCreationStatus } from './listings.types';
+
+export const BulkBatchStatusValues = [
+  'pending',
+  'running',
+  'completed',
+  'partially-failed',
+  'failed',
+] as const;
+export type BulkBatchStatus = (typeof BulkBatchStatusValues)[number];
+
+export const TERMINAL_BULK_BATCH_STATUSES: readonly BulkBatchStatus[] = [
+  'completed',
+  'partially-failed',
+  'failed',
+];
+
+/**
+ * Shared offer-override shape used by both `BulkSharedConfig.overrides` (the
+ * Step-1 defaults) and `BulkPerProductOverride.overrides` (per-row tweaks).
+ * Mirrors `CreateOfferOverridesDto` on the BE — kept narrow to the keys the
+ * bulk wizard actually populates.
+ */
+export interface BulkOfferOverrides {
+  title?: string;
+  description?: string | null;
+  categoryId?: string;
+  imageUrls?: string[] | null;
+  platformParams?: Record<string, unknown>;
+}
+
+export interface BulkSharedConfig {
+  stock: number;
+  publishImmediately: boolean;
+  price?: { amount: number; currency: string };
+  /**
+   * Shared `CreateOfferOverrides` block. The bulk wizard uses this to carry
+   * `platformParams.deliveryPolicyId` (the shipping rate package picked in
+   * Step 1) — Allegro's offer-creation contract requires this on every offer.
+   */
+  overrides?: BulkOfferOverrides;
+  generateDescription?: boolean;
+  descriptionTone?: string;
+}
+
+export interface BulkPerProductOverride {
+  stock?: number;
+  publishImmediately?: boolean;
+  price?: { amount: number; currency: string };
+  overrides?: BulkOfferOverrides;
+}
+
+export interface BulkOfferCreateRequest {
+  connectionId: string;
+  /** Variant IDs (despite the field name — see file header). */
+  productIds: string[];
+  sharedConfig: BulkSharedConfig;
+  perProductOverrides?: Record<string, BulkPerProductOverride>;
+}
+
+export interface BulkOfferCreateResponse {
+  batchId: string;
+  jobIds: string[];
+}
+
+export interface BulkBatchRecordSummary {
+  id: string;
+  internalVariantId: string;
+  status: OfferCreationStatus;
+  externalOfferId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BulkBatchSummary {
+  id: string;
+  connectionId: string;
+  status: BulkBatchStatus;
+  totalCount: number;
+  succeededCount: number;
+  failedCount: number;
+  createdAt: string;
+  updatedAt: string;
+  records: BulkBatchRecordSummary[];
+}
+
+export interface BulkOfferCreationRetryResponse {
+  retriedRecordIds: string[];
+  retriedCount: number;
+  batchStatus: BulkBatchStatus;
+}

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -25,6 +25,12 @@ import type {
   UpdateOfferFieldsPayload,
   UpdateOfferFieldsResult,
 } from './listings.types';
+import type {
+  BulkBatchSummary,
+  BulkOfferCreateRequest,
+  BulkOfferCreateResponse,
+  BulkOfferCreationRetryResponse,
+} from './bulk-listings.types';
 
 export interface CreateOfferOptions {
   /**
@@ -74,6 +80,18 @@ export interface ListingsApi {
     connectionId: string,
     body: ResolveCategoryRequest,
   ) => Promise<ResolveCategoryResponse>;
+  /**
+   * Submit a bulk offer-creation batch (#736). Returns the persisted
+   * `batchId` and per-job message IDs. 1..100 variants per batch.
+   */
+  bulkCreate: (
+    request: BulkOfferCreateRequest,
+    options?: CreateOfferOptions,
+  ) => Promise<BulkOfferCreateResponse>;
+  /** Read a bulk batch + its per-record summary. Used for polling on #741. */
+  getBulkBatch: (batchId: string) => Promise<BulkBatchSummary>;
+  /** Re-enqueue failed children of a batch (#742). Batch-level retry only. */
+  retryBulkFailed: (batchId: string) => Promise<BulkOfferCreationRetryResponse>;
 }
 
 interface ApiRequest {
@@ -160,6 +178,28 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
         },
+      );
+    },
+    bulkCreate(body, options): Promise<BulkOfferCreateResponse> {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (options?.idempotencyKey) {
+        headers['x-idempotency-key'] = options.idempotencyKey;
+      }
+      return request<BulkOfferCreateResponse>('/listings/bulk-create', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+    },
+    getBulkBatch(batchId): Promise<BulkBatchSummary> {
+      return request<BulkBatchSummary>(
+        `/listings/bulk-create/${encodeURIComponent(batchId)}`,
+      );
+    },
+    retryBulkFailed(batchId): Promise<BulkOfferCreationRetryResponse> {
+      return request<BulkOfferCreationRetryResponse>(
+        `/listings/bulk-create/${encodeURIComponent(batchId)}/retry-failed`,
+        { method: 'POST' },
       );
     },
   };

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -45,4 +45,6 @@ export const listingsQueryKeys = {
       barcode ?? '',
       sourceCategoryIds ?? [],
     ] as const,
+  /** #741 — bulk batch progress polling. */
+  bulkBatch: (batchId: string) => ['listings', 'bulkBatch', batchId] as const,
 };

--- a/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.tsx
@@ -1,0 +1,133 @@
+/**
+ * Bulk batch progress table (#741)
+ *
+ * One row per `BulkBatchRecordSummary`. Variant ID as the identity column
+ * (the BE summary doesn't carry product names today; mapping variant→product
+ * for the row label is a follow-up tracked alongside the Smart-classification
+ * surface — see plan §9 follow-up #6 candidate). Status pill + offer link /
+ * failure excerpt + timestamp complete the row.
+ *
+ * The Smart classification badge is intentionally not rendered here — see
+ * implementation-plan §2 (parent AC-7 deferral).
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useMemo, type ReactElement } from 'react';
+import { DataTable, StatusBadge, TimeDisplay } from '../../../../shared/ui';
+import type { DataTableColumn } from '../../../../shared/ui';
+import type {
+  BulkBatchRecordSummary,
+} from '../../api/bulk-listings.types';
+import type { OfferCreationStatus } from '../../api/listings.types';
+
+interface BulkBatchProgressTableProps {
+  records: BulkBatchRecordSummary[];
+  /** Marketplace URL builder (e.g. for Allegro: allegro.pl/oferta/...). */
+  buildExternalOfferUrl?: (externalOfferId: string) => string;
+}
+
+export function BulkBatchProgressTable({
+  records,
+  buildExternalOfferUrl,
+}: BulkBatchProgressTableProps): ReactElement {
+  const columns: DataTableColumn<BulkBatchRecordSummary>[] = useMemo(
+    () => [
+      {
+        id: 'variantId',
+        header: 'Variant ID',
+        cell: (record) => (
+          <span className="mono-text" title={record.internalVariantId}>
+            {record.internalVariantId}
+          </span>
+        ),
+      },
+      {
+        id: 'status',
+        header: 'Status',
+        cell: (record) => <RecordStatusBadge status={record.status} />,
+      },
+      {
+        id: 'offerOrError',
+        header: 'Offer / failure',
+        cell: (record) => {
+          if (record.status === 'active' || record.status === 'draft') {
+            if (!record.externalOfferId) {
+              return <span className="dim">—</span>;
+            }
+            const url = buildExternalOfferUrl?.(record.externalOfferId);
+            return url ? (
+              <a className="bulk-batch__ext-link" href={url} target="_blank" rel="noreferrer">
+                {record.externalOfferId} ↗
+              </a>
+            ) : (
+              <span className="mono-text">{record.externalOfferId}</span>
+            );
+          }
+          if (record.status === 'failed') {
+            // Truncated. Full error is on the offer-creation record detail (#465);
+            // a hover-expand follow-up is filed as part of the per-record retry.
+            return (
+              <span className="bulk-batch__err" title="Open the listing for full error details">
+                Failed — see record detail
+              </span>
+            );
+          }
+          if (record.status === 'pending') {
+            return <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>Queued</span>;
+          }
+          if (record.status === 'validating') {
+            return (
+              <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+                Validating on marketplace…
+              </span>
+            );
+          }
+          return <span className="dim">—</span>;
+        },
+      },
+      {
+        id: 'updatedAt',
+        header: 'Updated',
+        align: 'right',
+        cell: (record) =>
+          record.status === 'pending' ? (
+            <span className="mono-text dim">—</span>
+          ) : (
+            <span className="mono-text">
+              <TimeDisplay iso={record.updatedAt} format="datetime" />
+            </span>
+          ),
+        hideBelow: 768,
+      },
+    ],
+    [buildExternalOfferUrl],
+  );
+
+  return (
+    <DataTable<BulkBatchRecordSummary>
+      caption="Bulk batch records"
+      columns={columns}
+      rows={records}
+      rowKey={(record) => record.id}
+    />
+  );
+}
+
+function RecordStatusBadge({
+  status,
+}: {
+  status: OfferCreationStatus;
+}): ReactElement {
+  switch (status) {
+    case 'pending':
+      return <StatusBadge tone="neutral" withDot>pending</StatusBadge>;
+    case 'validating':
+      return <StatusBadge tone="info" withDot pulse>running</StatusBadge>;
+    case 'draft':
+      return <StatusBadge tone="success" withDot>draft</StatusBadge>;
+    case 'active':
+      return <StatusBadge tone="success" withDot>succeeded</StatusBadge>;
+    case 'failed':
+      return <StatusBadge tone="error" withDot>failed</StatusBadge>;
+  }
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
@@ -1,0 +1,258 @@
+/**
+ * Bulk wizard Step 1 — Config
+ *
+ * Shared defaults applied to every row before review/edit. Operator picks
+ * the Allegro connection (auto-hidden when there's exactly one) and the
+ * shipping rate / delivery policy from the seller's catalogue.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useEffect, useState, type ReactElement } from 'react';
+import {
+  Alert,
+  Button,
+  FormField,
+  Input,
+  Select,
+} from '../../../../shared/ui';
+import { useConnectionsQuery } from '../../../connections';
+import type { Connection } from '../../../connections';
+import { useSellerPoliciesQuery } from '../../hooks/use-seller-policies-query';
+import type { BulkWizardConfig } from './bulk-wizard.types';
+
+interface BulkConfigStepProps {
+  initial: Partial<BulkWizardConfig>;
+  onProceed: (config: BulkWizardConfig) => void;
+  onCancel: () => void;
+}
+
+const DEFAULT_CURRENCY = 'PLN';
+
+export function BulkConfigStep({
+  initial,
+  onProceed,
+  onCancel,
+}: BulkConfigStepProps): ReactElement {
+  const connectionsQuery = useConnectionsQuery({ platformType: 'allegro' });
+  const allegroConnections: Connection[] = (connectionsQuery.data ?? []).filter(
+    (c) =>
+      c.status === 'active' &&
+      c.supportedCapabilities?.includes('OfferManager'),
+  );
+
+  const [connectionId, setConnectionId] = useState<string>(
+    initial.connectionId ?? '',
+  );
+
+  // Auto-select the only available active connection.
+  useEffect(() => {
+    if (connectionId === '' && allegroConnections.length === 1) {
+      setConnectionId(allegroConnections[0]!.id);
+    }
+  }, [allegroConnections, connectionId]);
+
+  const policiesQuery = useSellerPoliciesQuery(connectionId);
+  const deliveryPolicies = policiesQuery.data?.deliveryPolicies ?? [];
+
+  const [deliveryPolicyId, setDeliveryPolicyId] = useState<string>(
+    initial.deliveryPolicyId ?? '',
+  );
+  const [defaultStock, setDefaultStock] = useState<string>(
+    String(initial.defaultStock ?? 1),
+  );
+  const [defaultPriceAmount, setDefaultPriceAmount] = useState<string>(
+    initial.defaultPrice ? String(initial.defaultPrice.amount) : '',
+  );
+  const [defaultPriceCurrency, setDefaultPriceCurrency] = useState<string>(
+    initial.defaultPrice?.currency ?? DEFAULT_CURRENCY,
+  );
+  const [publishImmediately, setPublishImmediately] = useState<boolean>(
+    initial.publishImmediately ?? true,
+  );
+  const [generateDescription, setGenerateDescription] = useState<boolean>(
+    initial.generateDescription ?? false,
+  );
+
+  // Reset deliveryPolicyId if the connection changes (different seller, different list).
+  useEffect(() => {
+    if (
+      deliveryPolicyId &&
+      !deliveryPolicies.some((p) => p.id === deliveryPolicyId)
+    ) {
+      setDeliveryPolicyId('');
+    }
+  }, [deliveryPolicyId, deliveryPolicies]);
+
+  const stockValid = /^\d+$/.test(defaultStock.trim()) && Number(defaultStock) >= 0;
+  const priceProvided = defaultPriceAmount.trim() !== '';
+  const priceValid =
+    !priceProvided ||
+    /^\d+([.,]\d{1,2})?$/.test(defaultPriceAmount.trim());
+
+  const canProceed =
+    connectionId !== '' &&
+    deliveryPolicyId !== '' &&
+    stockValid &&
+    priceValid;
+
+  function handleProceed(): void {
+    if (!canProceed) return;
+    onProceed({
+      connectionId,
+      deliveryPolicyId,
+      defaultStock: Number(defaultStock),
+      publishImmediately,
+      generateDescription,
+      ...(priceProvided
+        ? {
+            defaultPrice: {
+              amount: Number(defaultPriceAmount.replace(',', '.')),
+              currency: defaultPriceCurrency,
+            },
+          }
+        : {}),
+    });
+  }
+
+  if (connectionsQuery.isLoading) {
+    return <Alert tone="info">Loading connections…</Alert>;
+  }
+  if (allegroConnections.length === 0) {
+    return (
+      <Alert tone="error">
+        No active Allegro connections with offer-creation capability found. Add one
+        from <a href="/connections">Connections</a>.
+      </Alert>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+      <header>
+        <h2 style={{ margin: 0, fontSize: 17, fontWeight: 600, letterSpacing: 'var(--tracking-tight)' }}>
+          Configure batch
+        </h2>
+        <p style={{ margin: '4px 0 0', color: 'var(--text-secondary)', fontSize: 13 }}>
+          Shared defaults applied to all selected products. You can override per row in
+          the next step.
+        </p>
+      </header>
+
+      {allegroConnections.length > 1 ? (
+        <FormField name="bulk-config-connection" label="Allegro connection">
+          <Select
+            value={connectionId}
+            onChange={(e) => { setConnectionId(e.target.value); }}
+          >
+            <option value="" disabled>
+              Select a connection…
+            </option>
+            {allegroConnections.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </Select>
+        </FormField>
+      ) : (
+        <Alert tone="info">
+          Publishing as <strong>{allegroConnections[0]?.name}</strong>.
+        </Alert>
+      )}
+
+      <FormField name="bulk-config-shipping" label="Shipping rate package">
+        {policiesQuery.isLoading ? (
+          <Input disabled value="Loading policies…" />
+        ) : policiesQuery.error ? (
+          <Alert tone="error">Could not load shipping policies for this connection.</Alert>
+        ) : (
+          <Select
+            value={deliveryPolicyId}
+            onChange={(e) => { setDeliveryPolicyId(e.target.value); }}
+            disabled={deliveryPolicies.length === 0}
+          >
+            <option value="" disabled>
+              Select a delivery package…
+            </option>
+            {deliveryPolicies.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </Select>
+        )}
+      </FormField>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 'var(--space-3)' }}>
+        <FormField name="bulk-config-stock" label="Default stock">
+          <Input
+            type="number"
+            min={0}
+            value={defaultStock}
+            onChange={(e) => { setDefaultStock(e.target.value); }}
+            aria-invalid={!stockValid}
+          />
+        </FormField>
+        <FormField
+          name="bulk-config-price-amount"
+          label="Default price (optional)"
+          description="Used when a product has no price set."
+        >
+          <Input
+            placeholder="79.00"
+            value={defaultPriceAmount}
+            onChange={(e) => { setDefaultPriceAmount(e.target.value); }}
+            aria-invalid={!priceValid}
+          />
+        </FormField>
+        <FormField name="bulk-config-price-currency" label="Currency">
+          <Select
+            value={defaultPriceCurrency}
+            onChange={(e) => { setDefaultPriceCurrency(e.target.value); }}
+          >
+            <option value="PLN">PLN</option>
+            <option value="EUR">EUR</option>
+            <option value="USD">USD</option>
+          </Select>
+        </FormField>
+      </div>
+
+      <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+        <input
+          type="checkbox"
+          checked={publishImmediately}
+          onChange={(e) => { setPublishImmediately(e.target.checked); }}
+        />
+        <span>
+          <strong>Publish immediately</strong>
+          <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+            Uncheck to create all offers as drafts.
+          </small>
+        </span>
+      </label>
+
+      <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+        <input
+          type="checkbox"
+          checked={generateDescription}
+          onChange={(e) => { setGenerateDescription(e.target.checked); }}
+        />
+        <span>
+          <strong>Generate AI descriptions by default</strong>
+          <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+            Worker uses ContentSuggestionService per row. Per-row toggle in the edit
+            modal overrides this.
+          </small>
+        </span>
+      </label>
+
+      <footer className="bulk-wizard__footer">
+        <div className="bulk-wizard__footer-spacer" />
+        <Button tone="ghost" onClick={onCancel}>Cancel</Button>
+        <Button tone="primary" disabled={!canProceed} onClick={handleProceed}>
+          Proceed →
+        </Button>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-confirm-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-confirm-modal.tsx
@@ -1,0 +1,107 @@
+/**
+ * Bulk wizard Step 5 — Submit confirmation modal
+ *
+ * Final guard before POST /listings/bulk-create fires. Surfaces aggregate
+ * counts, an explicit re-confirmation of `publishImmediately`, and any
+ * mutation error inline.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useEffect, useState, type ReactElement } from 'react';
+import { Alert, Button } from '../../../../shared/ui';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../../shared/ui/dialog';
+
+interface BulkConfirmModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  rowCount: number;
+  connectionName: string;
+  initialPublishImmediately: boolean;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  onConfirm: (publishImmediately: boolean) => void;
+}
+
+export function BulkConfirmModal({
+  open,
+  onOpenChange,
+  rowCount,
+  connectionName,
+  initialPublishImmediately,
+  isSubmitting,
+  errorMessage,
+  onConfirm,
+}: BulkConfirmModalProps): ReactElement {
+  const [publish, setPublish] = useState(initialPublishImmediately);
+
+  // Re-sync the local toggle when the parent's shared config changes (e.g.
+  // operator went back to Step 1, flipped publishImmediately, returned).
+  // Without this the modal would stay on the value it was first opened with.
+  useEffect(() => {
+    setPublish(initialPublishImmediately);
+  }, [initialPublishImmediately]);
+
+  return (
+    <Dialog open={open} onOpenChange={isSubmitting ? undefined : onOpenChange}>
+      <DialogContent>
+        <DialogTitle>
+          Create {rowCount} Allegro {rowCount === 1 ? 'offer' : 'offers'}?
+        </DialogTitle>
+        <DialogDescription>
+          You're about to create {rowCount} {rowCount === 1 ? 'offer' : 'offers'} on{' '}
+          <strong>{connectionName}</strong>. Each offer is a separate job; you can
+          follow per-row progress on the next page.
+        </DialogDescription>
+
+        <div style={{ marginTop: 'var(--space-4)', display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+          <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
+            <input
+              type="checkbox"
+              checked={publish}
+              onChange={(e) => { setPublish(e.target.checked); }}
+              disabled={isSubmitting}
+            />
+            <span>
+              <strong>Publish immediately</strong>
+              <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                Uncheck to create everything as drafts.
+              </small>
+            </span>
+          </label>
+
+          {errorMessage !== null ? (
+            <Alert tone="error">{errorMessage}</Alert>
+          ) : (
+            <Alert tone="info">
+              <strong>Idempotency protected.</strong> If you accidentally double-submit,
+              OpenLinker returns the existing batch rather than creating a duplicate.
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            tone="ghost"
+            onClick={() => { onOpenChange(false); }}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            tone="primary"
+            onClick={() => { onConfirm(publish); }}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Creating…' : 'Create offers'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.schema.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.schema.ts
@@ -1,0 +1,39 @@
+/**
+ * Bulk edit modal — Zod schema
+ *
+ * Narrow per-row override form schema. Reuses key names that the existing
+ * single-offer-wizard subcomponents (CategoryPicker, CategoryParametersStep)
+ * already consume via `useFormContext()` (`categoryId`, `parameters`) so they
+ * drop into the modal's FormProvider without internal changes.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { z } from 'zod';
+
+// 75 chars is Allegro's offer title cap. The wizard's per-row edit form
+// applies the same cap.
+const TITLE_MAX = 75;
+const DESCRIPTION_MAX = 50_000;
+
+const ALLOWED_CURRENCIES = ['PLN', 'EUR', 'USD', 'GBP', 'CZK'] as const;
+
+export const bulkEditModalSchema = z.object({
+  title: z.string().trim().min(1, 'Title is required').max(TITLE_MAX),
+  categoryId: z.string().trim().min(1, 'Category is required'),
+  description: z.string().trim().min(1, 'Description is required').max(DESCRIPTION_MAX),
+  stock: z.coerce.number().int().min(0, 'Stock cannot be negative'),
+  priceAmount: z
+    .string()
+    .trim()
+    .regex(/^\d+([.,]\d{1,2})?$/, 'Use a decimal price, e.g. 79.00'),
+  priceCurrency: z.enum(ALLOWED_CURRENCIES),
+  publishImmediately: z.boolean(),
+  // The dynamic parameters block is a permissive object — `CategoryParametersStep`
+  // owns its own per-field shape and serialiser. The bulk modal trusts the
+  // single-offer-wizard's validation upstream; serialisation happens at submit
+  // via the same helper the single-offer wizard uses.
+  parameters: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type BulkEditModalValues = z.input<typeof bulkEditModalSchema>;
+export type BulkEditModalSubmission = z.output<typeof bulkEditModalSchema>;

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -1,0 +1,427 @@
+/**
+ * Bulk Edit Modal (#740 step 4)
+ *
+ * Per-row override modal for the bulk listing wizard. Reuses the single-offer
+ * wizard's `CategoryPicker`, `CategoryParametersStep`, and `SuggestionDialog`
+ * (all already used inside the single-offer wizard, which itself nests inside
+ * a Dialog — the "two-level Dialog focus management" concern from the plan's
+ * §2 review was overstated).
+ *
+ * Saves into `BulkPerProductOverride` keyed by the row's variant ID.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useEffect, useMemo, type ReactElement } from 'react';
+import {
+  Controller,
+  FormProvider,
+  useForm,
+  useFormContext,
+} from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Alert,
+  Button,
+  FormField,
+  Input,
+  Select,
+  Textarea,
+} from '../../../../shared/ui';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../../shared/ui/dialog';
+import { SuggestionDialog } from '../../../content';
+import { CategoryPicker } from '../CategoryPicker';
+import { CategoryParametersStep } from '../category-parameters-step';
+import { useCategoryParametersQuery } from '../../hooks/use-category-parameters-query';
+import {
+  MissingCategoryParameterSectionError,
+  serializeAllegroParameters,
+} from '../serialize-allegro-parameters';
+import type { CategoryParameter } from '../../api/listings.types';
+import type { CategoryParameterFormValues } from '../category-parameter-form.types';
+import {
+  bulkEditModalSchema,
+  type BulkEditModalSubmission,
+  type BulkEditModalValues,
+} from './bulk-edit-modal.schema';
+import type { BulkWizardRow } from './bulk-wizard.types';
+import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
+
+interface BulkEditModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  row: BulkWizardRow;
+  connectionId: string;
+  /**
+   * Defaults applied to fields the operator hasn't overridden yet.
+   * Pulled from the wizard's `sharedConfig` so the modal opens pre-filled.
+   */
+  defaults: {
+    stock: number;
+    publishImmediately: boolean;
+    priceAmount: string;
+    priceCurrency: string;
+  };
+  /**
+   * Save handler — receives the new override block keyed by variant id and
+   * the FE-only form-values stash. The wizard stores `editFormValues` on
+   * the row so reopening the modal restores entered values; it never gets
+   * forwarded to the bulk-create wire payload.
+   */
+  onSave: (
+    variantId: string,
+    override: BulkPerProductOverride,
+    editFormValues: Record<string, unknown>,
+  ) => void;
+}
+
+export function BulkEditModal({
+  open,
+  onOpenChange,
+  row,
+  connectionId,
+  defaults,
+  onSave,
+}: BulkEditModalProps): ReactElement | null {
+  if (!row.primaryVariant) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <BulkEditModalForm
+          row={row}
+          connectionId={connectionId}
+          defaults={defaults}
+          onSave={onSave}
+          onClose={() => { onOpenChange(false); }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface BulkEditModalFormProps {
+  row: BulkWizardRow;
+  connectionId: string;
+  defaults: BulkEditModalProps['defaults'];
+  onSave: BulkEditModalProps['onSave'];
+  onClose: () => void;
+}
+
+function BulkEditModalForm({
+  row,
+  connectionId,
+  defaults,
+  onSave,
+  onClose,
+}: BulkEditModalFormProps): ReactElement {
+  const variantId = row.primaryVariant?.id ?? '';
+
+  const initialValues = useMemo<BulkEditModalValues>(() => {
+    const o = row.override.overrides ?? {};
+    // Restore the operator's previously-entered parameter form values from
+    // the row's FE-only stash, NOT from `platformParams` (the wire payload).
+    const storedFormParameters =
+      (row.editFormValues?.parameters as Record<string, unknown> | undefined) ?? {};
+    return {
+      title: o.title ?? row.product?.name ?? '',
+      categoryId: o.categoryId ?? row.resolvedCategoryId ?? '',
+      description:
+        typeof o.description === 'string' ? o.description : row.product?.description ?? '',
+      stock: row.override.stock ?? defaults.stock,
+      priceAmount:
+        row.override.price !== undefined
+          ? String(row.override.price.amount)
+          : defaults.priceAmount,
+      priceCurrency: (row.override.price?.currency ?? defaults.priceCurrency) as BulkEditModalValues['priceCurrency'],
+      publishImmediately:
+        row.override.publishImmediately ?? defaults.publishImmediately,
+      parameters: storedFormParameters,
+    };
+  }, [row, defaults]);
+
+  const form = useForm<BulkEditModalValues, undefined, BulkEditModalSubmission>({
+    defaultValues: initialValues,
+    resolver: zodResolver(bulkEditModalSchema),
+    mode: 'onSubmit',
+  });
+
+  useEffect(() => {
+    form.reset(initialValues);
+  }, [form, initialValues]);
+
+  // Watch categoryId so the parameters query refetches on category change.
+  const watchedCategoryId = form.watch('categoryId');
+  const parametersQuery = useCategoryParametersQuery(
+    connectionId,
+    typeof watchedCategoryId === 'string' && watchedCategoryId.length > 0
+      ? watchedCategoryId
+      : '',
+  );
+  const categoryParameters: CategoryParameter[] = parametersQuery.data ?? [];
+
+  const handleSubmit = form.handleSubmit((values) => {
+    const platformParams: Record<string, unknown> = {};
+
+    if (categoryParameters.length > 0 && values.parameters) {
+      try {
+        const { offerParameters, productParameters } = serializeAllegroParameters(
+          values.parameters as CategoryParameterFormValues,
+          categoryParameters,
+        );
+        if (offerParameters.length > 0) platformParams.parameters = offerParameters;
+        if (productParameters.length > 0) {
+          platformParams.productParameters = productParameters;
+        }
+      } catch (error) {
+        if (error instanceof MissingCategoryParameterSectionError) {
+          form.setError('categoryId', {
+            type: 'manual',
+            message:
+              'Category parameter schema is stale. Close the wizard, reopen it, and try again.',
+          });
+          return;
+        }
+        throw error;
+      }
+    }
+
+    const override: BulkPerProductOverride = {
+      stock: values.stock,
+      publishImmediately: values.publishImmediately,
+      price: {
+        amount: Number(values.priceAmount.replace(',', '.')),
+        currency: values.priceCurrency,
+      },
+      overrides: {
+        title: values.title,
+        description: values.description,
+        categoryId: values.categoryId,
+        ...(Object.keys(platformParams).length > 0 ? { platformParams } : {}),
+      },
+    };
+
+    // `values` is the FE-only form-values stash kept on the row so reopening
+    // the modal restores entered values. Strictly separated from the wire
+    // override above to avoid leaking RHF internals to the BE payload.
+    onSave(variantId, override, values as unknown as Record<string, unknown>);
+    onClose();
+  });
+
+  return (
+    <FormProvider {...form}>
+      <form
+        onSubmit={(e) => {
+          void handleSubmit(e);
+        }}
+        noValidate
+      >
+        <DialogTitle>
+          Edit offer — {row.product?.name ?? row.primaryVariant?.sku ?? variantId}
+        </DialogTitle>
+        <DialogDescription>
+          Override per-row defaults. Unedited fields keep the values from the wizard's
+          Config step.
+        </DialogDescription>
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-4)',
+            marginTop: 'var(--space-4)',
+          }}
+        >
+          <FormField
+            name="bulk-edit-title"
+            label="Title"
+            description="Max 75 characters (Allegro limit)."
+            error={form.formState.errors.title?.message}
+          >
+            <Input
+              {...form.register('title')}
+              maxLength={75}
+              aria-invalid={Boolean(form.formState.errors.title)}
+            />
+          </FormField>
+
+          <FormField
+            name="bulk-edit-category"
+            label="Allegro category"
+            description="EAN auto-match prefilled this where possible."
+            error={form.formState.errors.categoryId?.message}
+          >
+            <Controller
+              control={form.control}
+              name="categoryId"
+              render={({ field }) => (
+                <CategoryPicker
+                  connectionId={connectionId}
+                  value={field.value || null}
+                  onChange={(id) => {
+                    field.onChange(id);
+                  }}
+                  invalid={Boolean(form.formState.errors.categoryId)}
+                />
+              )}
+            />
+          </FormField>
+
+          <DescriptionField productId={row.product?.id ?? ''} />
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr 1fr',
+              gap: 'var(--space-3)',
+            }}
+          >
+            <FormField
+              name="bulk-edit-stock"
+              label="Stock"
+              error={form.formState.errors.stock?.message}
+            >
+              <Input
+                type="number"
+                min={0}
+                {...form.register('stock', { valueAsNumber: true })}
+                aria-invalid={Boolean(form.formState.errors.stock)}
+              />
+            </FormField>
+            <FormField
+              name="bulk-edit-price"
+              label="Price"
+              error={form.formState.errors.priceAmount?.message}
+            >
+              <Input
+                {...form.register('priceAmount')}
+                placeholder="79.00"
+                aria-invalid={Boolean(form.formState.errors.priceAmount)}
+              />
+            </FormField>
+            <FormField name="bulk-edit-currency" label="Currency">
+              <Select {...form.register('priceCurrency')}>
+                <option value="PLN">PLN</option>
+                <option value="EUR">EUR</option>
+                <option value="USD">USD</option>
+                <option value="GBP">GBP</option>
+                <option value="CZK">CZK</option>
+              </Select>
+            </FormField>
+          </div>
+
+          <label
+            className="checkbox-row"
+            style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}
+          >
+            <input type="checkbox" {...form.register('publishImmediately')} />
+            <span>
+              <strong>Publish immediately</strong>
+              <small style={{ display: 'block', color: 'var(--text-muted)' }}>
+                Uncheck to create as draft for this row only.
+              </small>
+            </span>
+          </label>
+
+          <ParameterSection
+            watchedCategoryId={watchedCategoryId}
+            parametersQuery={parametersQuery}
+            categoryParameters={categoryParameters}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button tone="ghost" type="button" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button tone="primary" type="submit">
+            Save row
+          </Button>
+        </DialogFooter>
+      </form>
+    </FormProvider>
+  );
+}
+
+function DescriptionField({ productId }: { productId: string }): ReactElement {
+  const form = useFormContext<BulkEditModalValues>();
+  const error = form.formState.errors.description?.message;
+
+  return (
+    <div>
+      <div className="bulk-edit__desc-row" style={{ marginBottom: 'var(--space-2)' }}>
+        <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+          Plain text — Allegro's rich-text editor is out of scope for the bulk wizard.
+        </span>
+        {productId !== '' ? (
+          <SuggestionDialog
+            productId={productId}
+            channel="allegro"
+            onApply={(suggestion) => {
+              form.setValue('description', suggestion, { shouldDirty: true });
+            }}
+          />
+        ) : null}
+      </div>
+      <FormField name="bulk-edit-description" label="Description" error={error}>
+        <Textarea
+          {...form.register('description')}
+          rows={6}
+          aria-invalid={Boolean(error)}
+        />
+      </FormField>
+    </div>
+  );
+}
+
+interface ParameterSectionProps {
+  watchedCategoryId: string | undefined;
+  parametersQuery: ReturnType<typeof useCategoryParametersQuery>;
+  categoryParameters: CategoryParameter[];
+}
+
+function ParameterSection({
+  watchedCategoryId,
+  parametersQuery,
+  categoryParameters,
+}: ParameterSectionProps): ReactElement | null {
+  if (!watchedCategoryId) return null;
+  if (parametersQuery.isLoading) {
+    return (
+      <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+        Loading category parameters…
+      </div>
+    );
+  }
+  if (parametersQuery.error) {
+    return (
+      <Alert tone="warning">
+        Could not load category parameters. You can still save the row — the worker may
+        reject if required params are missing.
+      </Alert>
+    );
+  }
+  if (categoryParameters.length === 0) {
+    return (
+      <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+        No category parameters required for this category.
+      </div>
+    );
+  }
+  // Suppress unused — useWatch is wired via the inner step's own
+  // FormProvider context.
+  void watchedCategoryId;
+  return (
+    <div>
+      <div style={{ fontWeight: 500, fontSize: 12, marginBottom: 'var(--space-2)' }}>
+        Category parameters
+      </div>
+      <CategoryParametersStep parameters={categoryParameters} formNamespace="parameters" />
+    </div>
+  );
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
@@ -1,0 +1,257 @@
+/**
+ * Bulk wizard Step 2 — EAN-to-category auto-match
+ *
+ * Runs `useResolveCategoryQuery` per row in throttled-parallel (cap = 8, see
+ * `bulk-throttle.ts`). Shows a progress strip "Resolving N of M…". Auto-
+ * advances when every query settles. A 15-second timeout transitions to the
+ * Review step regardless; rows whose query hasn't settled are flagged
+ * `pending-after-timeout` and continue settling in the background.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import { useQueries, useQueryClient } from '@tanstack/react-query';
+import { useApiClient } from '../../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../../api/listings.query-keys';
+import { BULK_RESOLVE_CONCURRENCY, pAllLimit } from '../../lib/bulk-throttle';
+import {
+  RESOLVE_CATEGORY_STALE_TIME_MS,
+} from '../../hooks/use-resolve-category-query';
+import type {
+  ResolveCategoryRequest,
+  ResolveCategoryResponse,
+} from '../../api/listings.types';
+import type { BulkWizardRow, BulkRowStatus } from './bulk-wizard.types';
+
+export const BULK_RESOLVE_TIMEOUT_MS = 15_000;
+
+export interface BulkResolveOutcome {
+  productId: string;
+  status: BulkRowStatus;
+  categoryId: string | null;
+  method: ResolveCategoryResponse['method'] | null;
+}
+
+interface BulkResolveStepProps {
+  rows: BulkWizardRow[];
+  connectionId: string;
+  /** Called once with the resolved outcomes for every row. */
+  onComplete: (outcomes: BulkResolveOutcome[]) => void;
+}
+
+interface ResolveTask {
+  productId: string;
+  barcode: string | null;
+}
+
+export function BulkResolveStep({
+  rows,
+  connectionId,
+  onComplete,
+}: BulkResolveStepProps): ReactElement {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  const [resolved, setResolved] = useState<Map<string, BulkResolveOutcome>>(
+    () => seedFromRows(rows),
+  );
+  const [progress, setProgress] = useState({ done: 0, total: rows.length });
+  const startedRef = useRef(false);
+
+  // Tasks that need a BE call (have a barcode, no synthetic outcome yet).
+  const tasks: ResolveTask[] = useMemo(
+    () =>
+      rows
+        .filter((r) => {
+          if (r.status === 'no-variant') return false;
+          const barcode = r.primaryVariant?.ean ?? r.primaryVariant?.gtin ?? null;
+          return Boolean(barcode);
+        })
+        .map((r) => ({
+          productId: r.productId,
+          barcode: r.primaryVariant!.ean ?? r.primaryVariant!.gtin ?? null,
+        })),
+    [rows],
+  );
+
+  // Kick off the resolves once on mount. The async path is intentionally not
+  // a useQuery — we want explicit throttling and a single onComplete fire.
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    let cancelled = false;
+    const total = tasks.length;
+    let done = 0;
+
+    void (async () => {
+      const settled = await pAllLimit(tasks, BULK_RESOLVE_CONCURRENCY, async (task) => {
+        // Cache through TanStack so a re-run during edit-back-then-forward
+        // gets a hit instead of re-firing Allegro requests.
+        const queryKey = listingsQueryKeys.resolveCategory(
+          connectionId,
+          task.barcode,
+        );
+        const body: ResolveCategoryRequest = { barcode: task.barcode };
+        const result = await queryClient.fetchQuery<ResolveCategoryResponse>({
+          queryKey,
+          queryFn: () => apiClient.listings.resolveCategory(connectionId, body),
+          staleTime: RESOLVE_CATEGORY_STALE_TIME_MS,
+        });
+        return { productId: task.productId, result };
+      });
+
+      if (cancelled) return;
+
+      const next = new Map(resolved);
+      settled.forEach((entry, i) => {
+        // `pAllLimit` preserves input order, so tasks[i] is the task whose
+        // mapper produced this entry — that's the productId we record the
+        // result against (success or failure).
+        const task = tasks[i];
+        if (!task) return;
+        if (entry.status === 'fulfilled') {
+          const { result } = entry.value;
+          next.set(task.productId, {
+            productId: task.productId,
+            categoryId: result.allegroCategoryId,
+            method: result.method,
+            status:
+              result.allegroCategoryId !== null && result.method !== 'manual'
+                ? 'matched'
+                : 'no-match',
+          });
+        } else {
+          // Failed lookup → flag as no-match so the operator can fix
+          // manually via the edit modal. Without this branch the row stayed
+          // in `resolving` forever and "Approve all" stayed blocked with no
+          // affordance for the operator to escape it.
+          next.set(task.productId, {
+            productId: task.productId,
+            categoryId: null,
+            method: null,
+            status: 'no-match',
+          });
+        }
+        done += 1;
+        setProgress({ done, total });
+      });
+      setResolved(next);
+      onComplete(buildOutcomes(rows, next));
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally only depends on `tasks` — re-mounts of this step
+    // re-resolve from scratch. `rows` and `resolved` deliberately omitted
+    // so they don't restart the loop on every status flip.
+  }, [tasks]);
+
+  // 15-second budget: if not all tasks settled by now, advance anyway.
+  // The Review step still subscribes to the same cached queries via the
+  // wizard's outcomes, so late-arriving resolves flip rows from
+  // `pending-after-timeout` to `matched` automatically.
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      onComplete(buildOutcomes(rows, resolved, true));
+    }, BULK_RESOLVE_TIMEOUT_MS);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+    // Mount-only effect — the 15 s budget is anchored to mount, not to
+    // every render. Resolving fresh state happens through the resolves
+    // loop above; this one only fires once.
+  }, []);
+
+  // Prefetch the resolved-categories queries so they're hot for the Review
+  // step's optional refresh.
+  useQueries({
+    queries: tasks.map((t) => ({
+      queryKey: listingsQueryKeys.resolveCategory(connectionId, t.barcode),
+      queryFn: () =>
+        apiClient.listings.resolveCategory(connectionId, { barcode: t.barcode }),
+      enabled: false, // we drive the resolves manually above; this is a co-cache.
+    })),
+  });
+
+  const percent =
+    progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 100;
+
+  return (
+    <div
+      className="bulk-wizard__body--center"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="loading-state__spinner" aria-hidden="true" />
+      <h2
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 13,
+          letterSpacing: 'var(--tracking-caps)',
+          textTransform: 'uppercase',
+          color: 'var(--text-secondary)',
+          margin: 0,
+        }}
+      >
+        Resolving categories from EANs
+      </h2>
+      <div className="bulk-wizard__progress-count">
+        {progress.done} of {progress.total}
+      </div>
+      <div className="bulk-wizard__progress-bar">
+        <div
+          className="bulk-wizard__progress-fill"
+          style={{ width: `${percent.toString()}%` }}
+        />
+      </div>
+      <p className="bulk-wizard__resolve-sub">
+        We're matching each product's EAN against Allegro's catalog. This typically
+        takes 5–15 seconds. Rows without a clean match are flagged so you can pick a
+        category manually before submit.
+      </p>
+    </div>
+  );
+}
+
+function seedFromRows(rows: BulkWizardRow[]): Map<string, BulkResolveOutcome> {
+  const map = new Map<string, BulkResolveOutcome>();
+  for (const row of rows) {
+    if (row.status === 'no-variant') {
+      map.set(row.productId, {
+        productId: row.productId,
+        categoryId: null,
+        method: null,
+        status: 'no-variant',
+      });
+    } else {
+      const barcode = row.primaryVariant?.ean ?? row.primaryVariant?.gtin ?? null;
+      if (!barcode) {
+        map.set(row.productId, {
+          productId: row.productId,
+          categoryId: null,
+          method: null,
+          status: 'no-ean',
+        });
+      }
+    }
+  }
+  return map;
+}
+
+function buildOutcomes(
+  rows: BulkWizardRow[],
+  resolved: Map<string, BulkResolveOutcome>,
+  timedOut = false,
+): BulkResolveOutcome[] {
+  return rows.map((row) => {
+    const fromResolved = resolved.get(row.productId);
+    if (fromResolved) return fromResolved;
+    return {
+      productId: row.productId,
+      categoryId: null,
+      method: null,
+      status: timedOut ? 'pending-after-timeout' : 'resolving',
+    };
+  });
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
@@ -1,0 +1,275 @@
+/**
+ * Bulk wizard Step 3 — Review table
+ *
+ * One row per selected product. Renders the per-row status pill, the
+ * resolved category, and an Edit button that opens the per-row modal.
+ * The "Approve all" CTA stays disabled while any row is not in a ready
+ * state (matched or pending-after-timeout — both flip to matched once
+ * late-arriving resolves settle).
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useMemo, useState, type ReactElement } from 'react';
+import {
+  Button,
+  DataTable,
+  Input,
+  ProductThumbnail,
+  StatusBadge,
+} from '../../../../shared/ui';
+import type { DataTableColumn } from '../../../../shared/ui';
+import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
+import type { BulkRowStatus, BulkWizardRow } from './bulk-wizard.types';
+import { BulkEditModal } from './bulk-edit-modal';
+
+interface BulkReviewStepProps {
+  rows: BulkWizardRow[];
+  connectionId: string;
+  defaults: {
+    stock: number;
+    publishImmediately: boolean;
+    priceAmount: string;
+    priceCurrency: string;
+  };
+  onUpdateRow: (
+    variantId: string,
+    override: BulkPerProductOverride,
+    editFormValues: Record<string, unknown>,
+  ) => void;
+  onApproveAll: () => void;
+  onBack: () => void;
+}
+
+export function BulkReviewStep({
+  rows,
+  connectionId,
+  defaults,
+  onUpdateRow,
+  onApproveAll,
+  onBack,
+}: BulkReviewStepProps): ReactElement {
+  const [filter, setFilter] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const filteredRows = useMemo(() => {
+    if (filter.trim() === '') return rows;
+    const needle = filter.toLowerCase();
+    return rows.filter((r) =>
+      (r.product?.name ?? '').toLowerCase().includes(needle) ||
+      (r.primaryVariant?.sku ?? '').toLowerCase().includes(needle),
+    );
+  }, [rows, filter]);
+
+  const counts = useMemo(() => countByReadiness(rows), [rows]);
+  const canApprove = counts.notReady === 0 && rows.length > 0;
+
+  const editingRow = useMemo(
+    () => (editingId ? rows.find((r) => r.productId === editingId) ?? null : null),
+    [editingId, rows],
+  );
+
+  const columns: DataTableColumn<BulkWizardRow>[] = useMemo(
+    () => [
+      {
+        id: 'name',
+        header: 'Product',
+        cell: (row) => (
+          <span className="bulk-wizard__row-name">
+            <ProductThumbnail src={row.product?.images?.[0]} name={row.product?.name ?? ''} />
+            <span className="bulk-wizard__row-name-text">
+              {row.product?.name ?? <em>Loading…</em>}
+            </span>
+          </span>
+        ),
+        accessor: (row) => row.product?.name ?? '',
+        sortable: true,
+      },
+      {
+        id: 'status',
+        header: 'Status',
+        cell: (row) => <RowStatusBadge status={row.status} />,
+      },
+      {
+        id: 'category',
+        header: 'Matched category',
+        cell: (row) => (
+          <span
+            className={
+              row.resolvedCategoryId
+                ? 'bulk-wizard__row-category'
+                : 'bulk-wizard__row-category bulk-wizard__row-category--dim'
+            }
+          >
+            {row.resolvedCategoryId ?? '—'}
+          </span>
+        ),
+      },
+      {
+        id: 'stock',
+        header: 'Stock',
+        align: 'right',
+        cell: (row) => (
+          <span className="tabular">{row.override.stock ?? defaults.stock}</span>
+        ),
+        hideBelow: 768,
+      },
+      {
+        id: 'price',
+        header: 'Price',
+        align: 'right',
+        cell: (row) => (
+          <span className="tabular">
+            {row.override.price !== undefined
+              ? `${row.override.price.amount.toFixed(2)} ${row.override.price.currency}`
+              : `${defaults.priceAmount} ${defaults.priceCurrency}`}
+          </span>
+        ),
+        hideBelow: 768,
+      },
+      {
+        id: 'actions',
+        header: '',
+        align: 'right',
+        cell: (row) =>
+          row.status === 'no-variant' ? (
+            <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+              No variant
+            </span>
+          ) : (
+            <Button
+              tone="ghost"
+              className="button--xs"
+              onClick={() => { setEditingId(row.productId); }}
+            >
+              Edit
+            </Button>
+          ),
+      },
+    ],
+    [defaults],
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+      <header style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-4)' }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 17, fontWeight: 600 }}>
+            Review {rows.length} {rows.length === 1 ? 'product' : 'products'}
+          </h2>
+          <p style={{ margin: '4px 0 0', color: 'var(--text-secondary)', fontSize: 13 }}>
+            Click <strong>Edit</strong> to override any row before submit. Approve all
+            stays disabled while rows need attention.
+          </p>
+        </div>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <Input
+            type="search"
+            placeholder="Filter…"
+            value={filter}
+            onChange={(e) => { setFilter(e.target.value); }}
+            style={{ minWidth: 220 }}
+            aria-label="Filter rows by product name or SKU"
+          />
+          <Button
+            tone="primary"
+            disabled={!canApprove}
+            onClick={onApproveAll}
+          >
+            Approve all ({rows.length})
+          </Button>
+        </div>
+      </header>
+
+      <div className="bulk-wizard__review-summary">
+        <span><strong>{counts.ready}</strong> ready</span>
+        {counts.pending > 0 ? (
+          <>
+            <span className="sep">·</span>
+            <span>
+              <strong>{counts.pending}</strong>{' '}
+              {counts.pending === 1 ? 'still resolving' : 'still resolving'}
+            </span>
+          </>
+        ) : null}
+        {counts.notReady > 0 ? (
+          <>
+            <span className="sep">·</span>
+            <span>
+              <strong>{counts.notReady}</strong> need manual category
+            </span>
+          </>
+        ) : null}
+      </div>
+
+      <DataTable<BulkWizardRow>
+        caption="Bulk listing review"
+        columns={columns}
+        rows={filteredRows}
+        rowKey={(row) => row.productId}
+      />
+
+      <footer className="bulk-wizard__footer">
+        <Button tone="ghost" onClick={onBack}>← Back</Button>
+        <div className="bulk-wizard__footer-spacer" />
+      </footer>
+
+      {editingRow && editingRow.primaryVariant ? (
+        <BulkEditModal
+          open={editingId !== null}
+          onOpenChange={(open) => {
+            if (!open) setEditingId(null);
+          }}
+          row={editingRow}
+          connectionId={connectionId}
+          defaults={defaults}
+          onSave={onUpdateRow}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function RowStatusBadge({ status }: { status: BulkRowStatus }): ReactElement {
+  switch (status) {
+    case 'matched':
+      return <StatusBadge tone="success" withDot>matched</StatusBadge>;
+    case 'resolving':
+    case 'pending-after-timeout':
+      return (
+        <StatusBadge tone="info" withDot pulse>
+          {status === 'resolving' ? 'resolving' : 'still resolving'}
+        </StatusBadge>
+      );
+    case 'no-ean':
+      return <StatusBadge tone="error" withDot>no EAN</StatusBadge>;
+    case 'no-variant':
+      return <StatusBadge tone="error" withDot>no variant</StatusBadge>;
+    case 'no-match':
+      return <StatusBadge tone="error" withDot>manual category required</StatusBadge>;
+  }
+}
+
+function countByReadiness(rows: BulkWizardRow[]): {
+  ready: number;
+  pending: number;
+  notReady: number;
+} {
+  let ready = 0;
+  let pending = 0;
+  let notReady = 0;
+  for (const r of rows) {
+    if (r.status === 'matched') {
+      // A matched-from-resolve row can become "not ready" if the operator
+      // explicitly cleared the override's categoryId; but ready by default.
+      // If a row needed manual but the operator filled it via the edit modal,
+      // we'd surface that here too. For v1 we trust the wizard's
+      // applyOverrides mutation to update row.status on save (see wizard).
+      ready += 1;
+    } else if (r.status === 'pending-after-timeout' || r.status === 'resolving') {
+      pending += 1;
+    } else {
+      notReady += 1;
+    }
+  }
+  return { ready, pending, notReady };
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -1,0 +1,326 @@
+/**
+ * Bulk listing wizard (#740)
+ *
+ * Multi-step controller: Config → Resolving → Review (with Edit modal) →
+ * Confirm → submit. Owns the rows[] state + sharedConfig + perRow overrides.
+ *
+ * `step` is driven via URL search param so the wizard is linkable; on submit
+ * the page redirects to /listings/bulk-batches/:batchId.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Alert, PageLayout, SetupStepper } from '../../../../shared/ui';
+import { useToast } from '../../../../shared/ui/toast-provider';
+import { useBulkSubmitMutation } from '../../hooks/use-bulk-submit-mutation';
+import type {
+  BulkOfferCreateRequest,
+  BulkPerProductOverride,
+} from '../../api/bulk-listings.types';
+import type { Product, ProductVariant } from '../../../products';
+import { BulkConfigStep } from './bulk-config-step';
+import { BulkResolveStep, type BulkResolveOutcome } from './bulk-resolve-step';
+import { BulkReviewStep } from './bulk-review-step';
+import { BulkConfirmModal } from './bulk-confirm-modal';
+import type {
+  BulkRowStatus,
+  BulkWizardConfig,
+  BulkWizardRow,
+  BulkWizardStep,
+} from './bulk-wizard.types';
+
+interface BulkWizardProps {
+  /** Selected products from the Products page (already hydrated with variants). */
+  products: Product[];
+  /** Connection name displayed in the confirm modal once config is known. */
+  resolveConnectionName: (connectionId: string) => string;
+}
+
+const WIZARD_STEPS: { id: BulkWizardStep; label: string }[] = [
+  { id: 'config', label: 'Config' },
+  { id: 'resolve', label: 'Resolving' },
+  { id: 'review', label: 'Review' },
+  { id: 'confirm', label: 'Confirm' },
+];
+
+export function BulkWizard({
+  products,
+  resolveConnectionName,
+}: BulkWizardProps): ReactElement {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const mutation = useBulkSubmitMutation();
+
+  // Mint a stable idempotency key once per wizard mount. Retries from the
+  // confirm step submit reuse it; remount mints a fresh one.
+  const idempotencyKeyRef = useRef<string>(crypto.randomUUID());
+
+  const [step, setStep] = useState<BulkWizardStep>('config');
+  const [config, setConfig] = useState<BulkWizardConfig | null>(null);
+  const [rows, setRows] = useState<BulkWizardRow[]>(() => seedRows(products));
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // Sync row state when products list changes (rare — would only happen if
+  // the page upstream refetches). We compare against the product-id set,
+  // not the product object identities, so a passive cache refresh that
+  // produces structurally-equal products doesn't clobber row state.
+  // `productsSignature` (not `products` directly) is the dependency —
+  // `products` flips identity on every TanStack cache rehydrate, which
+  // would re-run this for structurally-equal data and clobber row state.
+  const productsSignature = products.map((p) => p.id).join(',');
+  useEffect(() => {
+    setRows((prev) => {
+      const byId = new Map(prev.map((r) => [r.productId, r]));
+      return products.map((p) => byId.get(p.id) ?? seedRow(p));
+    });
+  }, [productsSignature, products]);
+
+  const handleConfigProceed = useCallback((next: BulkWizardConfig) => {
+    setConfig(next);
+    setStep('resolve');
+  }, []);
+
+  const handleResolveComplete = useCallback(
+    (outcomes: BulkResolveOutcome[]) => {
+      setRows((prev) =>
+        prev.map((row) => {
+          const o = outcomes.find((x) => x.productId === row.productId);
+          if (!o) return row;
+          // If a resolved-from-cache outcome already exists, don't downgrade it.
+          if (
+            row.status === 'matched' &&
+            o.status === 'pending-after-timeout'
+          ) {
+            return row;
+          }
+          return {
+            ...row,
+            status: o.status,
+            resolvedCategoryId: o.categoryId,
+            resolutionMethod: o.method,
+          };
+        }),
+      );
+      setStep('review');
+    },
+    [],
+  );
+
+  const handleUpdateRow = useCallback(
+    (
+      variantId: string,
+      override: BulkPerProductOverride,
+      editFormValues: Record<string, unknown>,
+    ) => {
+      setRows((prev) =>
+        prev.map((row) => {
+          if (row.primaryVariant?.id !== variantId) return row;
+          // Filling in a category override marks a previously-error row as ready.
+          const newStatus: BulkRowStatus =
+            override.overrides?.categoryId &&
+            (row.status === 'no-ean' ||
+              row.status === 'no-match' ||
+              row.status === 'pending-after-timeout')
+              ? 'matched'
+              : row.status;
+          return {
+            ...row,
+            override,
+            editFormValues,
+            status: newStatus,
+            resolvedCategoryId:
+              override.overrides?.categoryId ?? row.resolvedCategoryId,
+          };
+        }),
+      );
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    async (publishImmediately: boolean) => {
+      if (!config) return;
+
+      // Build the bulk submit payload. Variant IDs (NOT product IDs) go in
+      // `productIds` — the BE field name is misleading; see
+      // `bulk-listings.types.ts` file header.
+      const submittableRows = rows.filter(
+        (r) => r.primaryVariant !== null && r.status === 'matched',
+      );
+
+      if (submittableRows.length === 0) {
+        showToast({
+          tone: 'error',
+          description: 'No rows are ready to submit. Approve some matched rows first.',
+        });
+        return;
+      }
+
+      const variantIds = submittableRows.map((r) => r.primaryVariant!.id);
+      const perProductOverrides: Record<string, BulkPerProductOverride> = {};
+      for (const row of submittableRows) {
+        if (Object.keys(row.override).length > 0 || row.resolvedCategoryId) {
+          // Always send the resolved category — even if the operator didn't
+          // touch the row — so the worker doesn't fall back to auto-detect.
+          perProductOverrides[row.primaryVariant!.id] = {
+            ...row.override,
+            overrides: {
+              ...(row.override.overrides ?? {}),
+              categoryId:
+                row.override.overrides?.categoryId ??
+                row.resolvedCategoryId ??
+                undefined,
+            },
+          };
+        }
+      }
+
+      const sharedOverridesPlatformParams: Record<string, unknown> = {
+        deliveryPolicyId: config.deliveryPolicyId,
+      };
+
+      const request: BulkOfferCreateRequest = {
+        connectionId: config.connectionId,
+        productIds: variantIds,
+        sharedConfig: {
+          stock: config.defaultStock,
+          publishImmediately,
+          generateDescription: config.generateDescription,
+          ...(config.defaultPrice ? { price: config.defaultPrice } : {}),
+          overrides: {
+            platformParams: sharedOverridesPlatformParams,
+          },
+        },
+        ...(Object.keys(perProductOverrides).length > 0
+          ? { perProductOverrides }
+          : {}),
+      };
+
+      try {
+        const result = await mutation.mutateAsync({
+          idempotencyKey: idempotencyKeyRef.current,
+          request,
+        });
+        showToast({
+          tone: 'success',
+          title: 'Batch submitted',
+          description: `${variantIds.length.toLocaleString()} offers queued for creation.`,
+        });
+        void navigate(`/listings/bulk-batches/${result.batchId}`);
+      } catch {
+        // Surfaced via mutation.error in the modal — toast is redundant.
+      }
+    },
+    [config, rows, mutation, navigate, showToast],
+  );
+
+  const noVariants = rows.filter((r) => r.status === 'no-variant').length;
+
+  return (
+    <PageLayout
+      eyebrow="Operations · Listings"
+      title="Bulk Allegro offer creation"
+      description={`Creating offers for ${rows.length} ${rows.length === 1 ? 'product' : 'products'}.`}
+    >
+      <div className="bulk-wizard">
+        <div className="bulk-wizard__stepper">
+          <SetupStepper
+            steps={WIZARD_STEPS.map((s) => s.label)}
+            currentStep={stepOrder(step)}
+            completedSteps={
+              new Set(
+                Array.from({ length: stepOrder(step) }, (_, i) => i),
+              )
+            }
+          />
+        </div>
+
+        {noVariants > 0 ? (
+          <Alert tone="warning">
+            {noVariants} of {rows.length} products have no variants and cannot be
+            listed. They'll be skipped on submit.
+          </Alert>
+        ) : null}
+
+        <div className={step === 'resolve' ? '' : 'bulk-wizard__body'}>
+          {step === 'config' && (
+            <BulkConfigStep
+              initial={config ?? {}}
+              onProceed={handleConfigProceed}
+              onCancel={() => { void navigate(-1); }}
+            />
+          )}
+          {step === 'resolve' && config && (
+            <BulkResolveStep
+              rows={rows}
+              connectionId={config.connectionId}
+              onComplete={handleResolveComplete}
+            />
+          )}
+          {step === 'review' && config && (
+            <BulkReviewStep
+              rows={rows}
+              connectionId={config.connectionId}
+              defaults={{
+                stock: config.defaultStock,
+                publishImmediately: config.publishImmediately,
+                priceAmount: config.defaultPrice
+                  ? config.defaultPrice.amount.toFixed(2)
+                  : '0.00',
+                priceCurrency: config.defaultPrice?.currency ?? 'PLN',
+              }}
+              onUpdateRow={handleUpdateRow}
+              onApproveAll={() => { setConfirmOpen(true); }}
+              onBack={() => { setStep('config'); }}
+            />
+          )}
+        </div>
+
+        {config ? (
+          <BulkConfirmModal
+            open={confirmOpen}
+            onOpenChange={setConfirmOpen}
+            rowCount={rows.filter((r) => r.status === 'matched').length}
+            connectionName={resolveConnectionName(config.connectionId)}
+            initialPublishImmediately={config.publishImmediately}
+            isSubmitting={mutation.isPending}
+            errorMessage={mutation.error ? mutation.error.message : null}
+            onConfirm={(publishImmediately) => {
+              void handleSubmit(publishImmediately);
+            }}
+          />
+        ) : null}
+      </div>
+    </PageLayout>
+  );
+}
+
+function stepOrder(step: BulkWizardStep): number {
+  return WIZARD_STEPS.findIndex((s) => s.id === step);
+}
+
+function seedRows(products: Product[]): BulkWizardRow[] {
+  return products.map(seedRow);
+}
+
+function seedRow(product: Product): BulkWizardRow {
+  const primaryVariant: ProductVariant | null = product.variants?.[0] ?? null;
+  let status: BulkRowStatus;
+  if (!primaryVariant) {
+    status = 'no-variant';
+  } else if (!primaryVariant.ean && !primaryVariant.gtin) {
+    status = 'no-ean';
+  } else {
+    status = 'resolving';
+  }
+  return {
+    productId: product.id,
+    product,
+    primaryVariant,
+    status,
+    resolvedCategoryId: null,
+    resolutionMethod: null,
+    override: {},
+  };
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.types.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.types.ts
@@ -1,0 +1,70 @@
+/**
+ * Bulk wizard internal types
+ *
+ * Co-located row + step types used only inside the wizard subtree.
+ * Public BE transport types live in `../api/bulk-listings.types.ts`.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import type { Product, ProductVariant } from '../../../products';
+import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
+
+export const BulkWizardStepValues = [
+  'config',
+  'resolve',
+  'review',
+  'confirm',
+] as const;
+export type BulkWizardStep = (typeof BulkWizardStepValues)[number];
+
+export const BulkRowStatusValues = [
+  // Background resolves are still running for this row.
+  'resolving',
+  // EAN→category lookup succeeded; row is ready for submit.
+  'matched',
+  // 15s budget exhausted, query still in flight; will auto-flip to matched
+  // when it settles.
+  'pending-after-timeout',
+  // No EAN on the variant → operator must pick a category manually.
+  'no-ean',
+  // No primary variant on the product → cannot bulk-list this product.
+  'no-variant',
+  // EAN present but Allegro returned no match.
+  'no-match',
+] as const;
+export type BulkRowStatus = (typeof BulkRowStatusValues)[number];
+
+export interface BulkWizardRow {
+  productId: string;
+  /** Hydrated when products query resolves; null while loading or on 404. */
+  product: Product | null;
+  /** Primary variant (variants[0]). Null when product has no variants. */
+  primaryVariant: ProductVariant | null;
+  status: BulkRowStatus;
+  /** Resolved Allegro category id (after Step 2). */
+  resolvedCategoryId: string | null;
+  /** How the category was resolved (telemetry / UI hint). */
+  resolutionMethod: 'auto_detect' | 'category_mapping' | 'manual' | null;
+  /** Per-row overrides written by the edit modal. Sent on bulk submit. */
+  override: BulkPerProductOverride;
+  /**
+   * FE-only stash of the edit-modal's React Hook Form values so reopening
+   * the modal restores entered values. Strictly internal; never forwarded
+   * on the wire (the wizard's submit only reads `override`).
+   */
+  editFormValues?: Record<string, unknown>;
+}
+
+export interface BulkWizardConfig {
+  connectionId: string;
+  /** Allegro delivery policy ID. */
+  deliveryPolicyId: string;
+  defaultStock: number;
+  publishImmediately: boolean;
+  generateDescription: boolean;
+  /** Optional default price applied to every row that doesn't have a product-side price. */
+  defaultPrice?: { amount: number; currency: string };
+}
+
+/** Status filter set after Step 2 — used by the review-step gate logic. */
+export const READY_ROW_STATUSES: readonly BulkRowStatus[] = ['matched'];

--- a/apps/web/src/features/listings/hooks/use-bulk-batch-query.ts
+++ b/apps/web/src/features/listings/hooks/use-bulk-batch-query.ts
@@ -1,0 +1,38 @@
+/**
+ * use-bulk-batch-query
+ *
+ * Polls `GET /listings/bulk-create/:batchId` every 5 s while the batch is
+ * non-terminal, stops polling once status ∈ {completed, partially-failed,
+ * failed}. Mirrors the pattern in `use-offer-creation-status-query.ts`.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import {
+  TERMINAL_BULK_BATCH_STATUSES,
+  type BulkBatchSummary,
+} from '../api/bulk-listings.types';
+
+export const BULK_BATCH_POLL_INTERVAL_MS = 5_000;
+
+export function useBulkBatchQuery(
+  batchId: string | undefined,
+): UseQueryResult<BulkBatchSummary> {
+  const apiClient = useApiClient();
+
+  return useQuery<BulkBatchSummary>({
+    queryKey: listingsQueryKeys.bulkBatch(batchId ?? ''),
+    queryFn: () => apiClient.listings.getBulkBatch(batchId as string),
+    enabled: Boolean(batchId),
+    staleTime: 0,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status && TERMINAL_BULK_BATCH_STATUSES.includes(status)) {
+        return false;
+      }
+      return BULK_BATCH_POLL_INTERVAL_MS;
+    },
+  });
+}

--- a/apps/web/src/features/listings/hooks/use-bulk-retry-failed-mutation.ts
+++ b/apps/web/src/features/listings/hooks/use-bulk-retry-failed-mutation.ts
@@ -1,0 +1,31 @@
+/**
+ * use-bulk-retry-failed-mutation
+ *
+ * POST /listings/bulk-create/:batchId/retry-failed — re-enqueues every
+ * failed child of a batch (#742). On success, invalidates the bulk-batch
+ * query so polling resumes immediately (the BE flips status back to
+ * `running` and we need to see the transition).
+ *
+ * Per-record retry (issue #741 AC-4) is intentionally NOT shipped here —
+ * the BE endpoint doesn't exist yet. Tracked as a follow-up.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { BulkOfferCreationRetryResponse } from '../api/bulk-listings.types';
+
+export function useBulkRetryFailedMutation() {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<BulkOfferCreationRetryResponse, Error, string>({
+    mutationFn: (batchId: string) => apiClient.listings.retryBulkFailed(batchId),
+    onSuccess: (_data, batchId) => {
+      void queryClient.invalidateQueries({
+        queryKey: listingsQueryKeys.bulkBatch(batchId),
+      });
+    },
+  });
+}

--- a/apps/web/src/features/listings/hooks/use-bulk-submit-mutation.ts
+++ b/apps/web/src/features/listings/hooks/use-bulk-submit-mutation.ts
@@ -1,0 +1,39 @@
+/**
+ * use-bulk-submit-mutation
+ *
+ * POST /listings/bulk-create — submits a bulk batch (1..100 variants).
+ * Caller mints an idempotency key once per wizard mount and reuses it
+ * across retries; the same key forwarded on retry returns the same
+ * batch instead of creating a duplicate.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type {
+  BulkOfferCreateRequest,
+  BulkOfferCreateResponse,
+} from '../api/bulk-listings.types';
+
+export interface BulkSubmitMutationInput {
+  idempotencyKey: string;
+  request: BulkOfferCreateRequest;
+}
+
+export function useBulkSubmitMutation() {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<BulkOfferCreateResponse, Error, BulkSubmitMutationInput>({
+    mutationFn: ({ idempotencyKey, request }) =>
+      apiClient.listings.bulkCreate(request, { idempotencyKey }),
+    onSuccess: () => {
+      // New offers will eventually appear on the listings list once the
+      // worker finishes per-variant creation. Scoped to `lists()` so
+      // active polling queries (bulkBatch, offerCreationStatus) are not
+      // disturbed.
+      void queryClient.invalidateQueries({ queryKey: listingsQueryKeys.lists() });
+    },
+  });
+}

--- a/apps/web/src/features/listings/lib/bulk-throttle.test.ts
+++ b/apps/web/src/features/listings/lib/bulk-throttle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { pAllLimit } from './bulk-throttle';
+
+describe('pAllLimit', () => {
+  it('returns results in input order', async () => {
+    const results = await pAllLimit([1, 2, 3, 4, 5], 2, async (n) => n * 2);
+    expect(results.map((r) => (r.status === 'fulfilled' ? r.value : null))).toEqual([
+      2, 4, 6, 8, 10,
+    ]);
+  });
+
+  it('respects the concurrency limit', async () => {
+    let inFlight = 0;
+    let max = 0;
+    await pAllLimit([1, 2, 3, 4, 5, 6, 7, 8], 3, async () => {
+      inFlight += 1;
+      if (inFlight > max) max = inFlight;
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1);
+      });
+      inFlight -= 1;
+      return 'ok';
+    });
+    expect(max).toBeLessThanOrEqual(3);
+  });
+
+  it('captures rejections in a settled tuple', async () => {
+    const results = await pAllLimit([1, 2, 3], 2, async (n) => {
+      if (n === 2) throw new Error('boom');
+      return n;
+    });
+    expect(results[0]!.status).toBe('fulfilled');
+    expect(results[1]!.status).toBe('rejected');
+    expect(results[2]!.status).toBe('fulfilled');
+  });
+
+  it('handles empty input', async () => {
+    const results = await pAllLimit([], 4, async (n) => n);
+    expect(results).toEqual([]);
+  });
+
+  it('throws when limit < 1', async () => {
+    await expect(pAllLimit([1], 0, async (n) => n)).rejects.toThrow();
+  });
+});

--- a/apps/web/src/features/listings/lib/bulk-throttle.ts
+++ b/apps/web/src/features/listings/lib/bulk-throttle.ts
@@ -1,0 +1,50 @@
+/**
+ * Bounded-concurrency Promise helper for bulk operations
+ *
+ * Caps in-flight promises at `limit` while preserving result order. Used by
+ * the bulk-wizard auto-match step to avoid saturating Allegro's
+ * `/sale/matching-categories` endpoint at 50+ parallel requests (`useResolveCategoryQuery`
+ * has `retry: false`, so a 429 burst would silently flip rows to ❌).
+ *
+ * No external dependency — 20 lines, `Promise.allSettled` semantics.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+
+/**
+ * Run `mapper(item)` over every item with at most `limit` promises in
+ * flight at a time. Returns settled results in the order of `items`.
+ */
+export async function pAllLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  if (limit < 1) throw new Error(`pAllLimit: limit must be >= 1, got ${String(limit)}`);
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const i = nextIndex++;
+      const item = items[i];
+      // `noUncheckedIndexedAccess` is off in this project, so `items[i]` is
+      // narrowed to T directly — but we still guard for completeness.
+      if (item === undefined) continue;
+      try {
+        const value = await mapper(item, i);
+        results[i] = { status: 'fulfilled', value };
+      } catch (reason) {
+        results[i] = { status: 'rejected', reason };
+      }
+    }
+  };
+
+  const workerCount = Math.min(limit, items.length);
+  const workers = Array.from({ length: workerCount }, worker);
+  await Promise.all(workers);
+  return results;
+}
+
+/** Default concurrency for bulk-wizard EAN→category resolves. */
+export const BULK_RESOLVE_CONCURRENCY = 8;

--- a/apps/web/src/features/products/hooks/use-products-batch-query.ts
+++ b/apps/web/src/features/products/hooks/use-products-batch-query.ts
@@ -1,0 +1,33 @@
+/**
+ * use-products-batch-query
+ *
+ * Parallel hydration of N product details by ID. Used by the bulk-listing
+ * wizard (#740) to load every selected product (and its variants) in one
+ * shot at page mount. Returns N `UseQueryResult<Product>` entries — caller
+ * pivots over `isLoading` / `error` / `data` per index.
+ *
+ * Each query reuses TanStack's existing cache, so products already viewed
+ * via `useProductQuery` are served instantly.
+ *
+ * @module apps/web/src/features/products/hooks
+ */
+import { useQueries, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { productsQueryKeys } from '../api/products.query-keys';
+import type { Product } from '../api/products.types';
+
+export function useProductsBatchQuery(
+  ids: readonly string[],
+  options?: { enabled?: boolean },
+): UseQueryResult<Product>[] {
+  const apiClient = useApiClient();
+  const enabled = options?.enabled ?? true;
+
+  return useQueries({
+    queries: ids.map((id) => ({
+      queryKey: productsQueryKeys.detail(id),
+      queryFn: () => apiClient.products.getById(id),
+      enabled,
+    })),
+  });
+}

--- a/apps/web/src/features/products/index.ts
+++ b/apps/web/src/features/products/index.ts
@@ -8,3 +8,4 @@
 export type { Product, ProductVariant, ProductVariantSummary } from './api/products.types';
 export { useProductQuery } from './hooks/use-product-query';
 export { useProductsQuery } from './hooks/use-products-query';
+export { useProductsBatchQuery } from './hooks/use-products-batch-query';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2805,6 +2805,16 @@ textarea {
   white-space: nowrap;
 }
 
+.product-row__name--link {
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.product-row__name--link:hover {
+  color: var(--text-link);
+  text-decoration: underline;
+}
+
 .timeline-list {
   list-style: none;
   padding: 0;
@@ -7640,5 +7650,385 @@ html[data-density='compact'] .status-badge {
      matters when you can see >5 rows at once, which a phone can't. */
   .shell-user-chip__menu .density-toggle {
     display: none;
+  }
+}
+
+/* ── BulkActionBar (#739) ────────────────────────────────────────────
+ * Sticky band that appears when an operator multi-selects on a list page.
+ * Pinned to the bottom of the viewport on mobile; sits inline above the
+ * page footer on desktop. Visually hidden — but kept in the DOM — when
+ * the selection is empty, so screen readers can announce changes on the
+ * `aria-live` region inside without re-mounting the node.
+ */
+.bulk-action-bar {
+  position: sticky;
+  bottom: var(--space-4);
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  transition: opacity var(--duration-fast) var(--ease-out),
+              transform var(--duration-fast) var(--ease-out);
+}
+
+.bulk-action-bar--hidden {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(4px);
+}
+
+.bulk-action-bar__count {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.bulk-action-bar__num {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.bulk-action-bar__label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.bulk-action-bar__hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.bulk-action-bar__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+@media (max-width: 639.98px) {
+  /* Mobile: pin to viewport bottom edge. */
+  .bulk-action-bar {
+    position: fixed;
+    left: var(--space-3);
+    right: var(--space-3);
+    bottom: var(--space-3);
+    margin: 0;
+    flex-wrap: wrap;
+  }
+  .bulk-action-bar__hint {
+    flex-basis: 100%;
+    order: 3;
+  }
+  .bulk-action-bar__actions {
+    margin-left: auto;
+  }
+}
+
+/* Selected-row highlight for products list (#739) */
+.products-list__row--selected td {
+  background: var(--accent-primary-soft);
+}
+
+/* ── Bulk listing wizard (#740) ─────────────────────────────────────
+ * The wizard composes existing primitives (DataTable, Dialog, SetupStepper,
+ * Button, FormField). Only the page-level scaffolding lives here.
+ */
+.bulk-wizard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.bulk-wizard__stepper {
+  margin-bottom: var(--space-2);
+}
+
+.bulk-wizard__body {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5) var(--space-6);
+}
+
+.bulk-wizard__body--center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 280px;
+  text-align: center;
+  padding: var(--space-7) var(--space-5);
+}
+
+.bulk-wizard__progress-bar {
+  width: 360px;
+  max-width: 100%;
+  height: 6px;
+  background: var(--bg-surface-muted);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  margin: var(--space-3) 0;
+}
+
+.bulk-wizard__progress-fill {
+  height: 100%;
+  background: var(--accent-primary);
+  border-radius: var(--radius-pill);
+  transition: width var(--duration-normal) var(--ease-out);
+}
+
+.bulk-wizard__progress-count {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+}
+
+.bulk-wizard__resolve-sub {
+  max-width: 480px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.bulk-wizard__review-summary {
+  display: flex;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-shell);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.bulk-wizard__review-summary b {
+  color: var(--text-primary);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.bulk-wizard__review-summary .sep {
+  color: var(--border-strong);
+}
+
+.bulk-wizard__row-name {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.bulk-wizard__row-name-text {
+  font-weight: 500;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bulk-wizard__row-category {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.bulk-wizard__row-category--dim {
+  color: var(--text-muted);
+}
+
+.bulk-wizard__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.bulk-wizard__footer--start {
+  justify-content: flex-start;
+}
+
+.bulk-wizard__footer-spacer {
+  flex: 1;
+}
+
+/* Edit modal — AI button row */
+.bulk-edit__desc-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.bulk-edit__ai-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--status-review-fg);
+  background: var(--status-review-soft);
+  border: 1px solid var(--status-review-border);
+  border-radius: var(--radius-md);
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.bulk-edit__ai-button:hover {
+  background: color-mix(in oklab, var(--status-review-soft) 70%, var(--status-review-border));
+}
+
+.bulk-edit__ai-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.bulk-edit__cat-picker {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+}
+
+.bulk-edit__cat-path {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bulk-edit__cat-path b {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.bulk-edit__cat-change {
+  margin-left: auto;
+  color: var(--text-link);
+  background: none;
+  border: none;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.bulk-edit__cat-change:hover {
+  text-decoration: underline;
+}
+
+/* ── Bulk batch progress (#741) ─────────────────────────────────────
+ * Cockpit layout: KPI strip (4 cards) + status banner + records table.
+ */
+.bulk-batch__kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+}
+
+@media (max-width: 1023.98px) {
+  .bulk-batch__kpi-strip {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 639.98px) {
+  .bulk-batch__kpi-strip {
+    grid-template-columns: 1fr;
+  }
+}
+
+.bulk-batch__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+}
+
+.bulk-batch__summary-main {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.bulk-batch__summary-main b {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.bulk-batch__summary-links {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.bulk-batch__summary-links a {
+  color: var(--text-link);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.bulk-batch__summary-links a:hover {
+  text-decoration: underline;
+}
+
+.bulk-batch__err {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--status-error-fg);
+  display: inline-block;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bulk-batch__ext-link {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-link);
+  text-decoration: none;
+}
+
+.bulk-batch__ext-link:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 639.98px) {
+  .bulk-batch__summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .bulk-batch__summary-links {
+    margin-left: 0;
+    flex-wrap: wrap;
   }
 }

--- a/apps/web/src/pages/listings/bulk-batch-progress-page.test.tsx
+++ b/apps/web/src/pages/listings/bulk-batch-progress-page.test.tsx
@@ -1,0 +1,170 @@
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { Routes, Route } from 'react-router-dom';
+import { BulkBatchProgressPage } from './bulk-batch-progress-page';
+import type { BulkBatchSummary } from '../../features/listings/api/bulk-listings.types';
+
+const BATCH_ID = 'b1d05bc3-9a6e-4c8d-9ff0-12cd0acddc7a';
+
+function makeBatch(overrides: Partial<BulkBatchSummary> = {}): BulkBatchSummary {
+  return {
+    id: BATCH_ID,
+    connectionId: 'conn_1',
+    status: 'running',
+    totalCount: 5,
+    succeededCount: 1,
+    failedCount: 0,
+    createdAt: '2026-05-18T15:00:00.000Z',
+    updatedAt: '2026-05-18T15:01:00.000Z',
+    records: [
+      {
+        id: 'rec_1',
+        internalVariantId: 'ol_variant_111',
+        status: 'pending',
+        externalOfferId: null,
+        createdAt: '2026-05-18T15:00:00.000Z',
+        updatedAt: '2026-05-18T15:00:00.000Z',
+      },
+      {
+        id: 'rec_2',
+        internalVariantId: 'ol_variant_222',
+        status: 'active',
+        externalOfferId: '99988877',
+        createdAt: '2026-05-18T15:00:01.000Z',
+        updatedAt: '2026-05-18T15:00:30.000Z',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage(apiClient: ReturnType<typeof createMockApiClient>) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/listings/bulk-batches/:batchId" element={<BulkBatchProgressPage />} />
+    </Routes>,
+    {
+      apiClient,
+      route: `/listings/bulk-batches/${BATCH_ID}`,
+    },
+  );
+}
+
+describe('BulkBatchProgressPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+  afterEach(cleanup);
+
+  it('renders KPI counts when batch loads', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(makeBatch()),
+      },
+    });
+
+    renderPage(apiClient);
+
+    expect(await screen.findByText('Total')).toBeInTheDocument();
+    // Total count "5"
+    const totals = screen.getAllByText('5');
+    expect(totals.length).toBeGreaterThan(0);
+  });
+
+  it('shows the partially-failed banner with Retry button when terminal with failures', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(
+          makeBatch({
+            status: 'partially-failed',
+            succeededCount: 3,
+            failedCount: 2,
+          }),
+        ),
+      },
+    });
+
+    renderPage(apiClient);
+
+    expect(
+      await screen.findByRole('button', { name: /Retry all failed/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show the Retry banner when batch is still running', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(makeBatch({ status: 'running' })),
+      },
+    });
+
+    renderPage(apiClient);
+
+    await screen.findByText('Total');
+    expect(
+      screen.queryByRole('button', { name: /Retry all failed/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows error state when the fetch fails', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockRejectedValue(new Error('Network is down')),
+      },
+    });
+
+    renderPage(apiClient);
+
+    expect(await screen.findByText('Could not load batch')).toBeInTheDocument();
+    expect(screen.getByText('Network is down')).toBeInTheDocument();
+  });
+
+  it('renders one record row per record', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(makeBatch()),
+      },
+    });
+
+    renderPage(apiClient);
+
+    expect(await screen.findByText('ol_variant_111')).toBeInTheDocument();
+    expect(screen.getByText('ol_variant_222')).toBeInTheDocument();
+  });
+
+  it('clicking Retry calls the retry mutation', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const retryFn = vi.fn().mockResolvedValue({
+      retriedRecordIds: ['rec_a'],
+      retriedCount: 1,
+      batchStatus: 'running',
+    });
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(
+          makeBatch({
+            status: 'partially-failed',
+            succeededCount: 3,
+            failedCount: 2,
+          }),
+        ),
+        retryBulkFailed: retryFn,
+      },
+    });
+
+    renderPage(apiClient);
+
+    const retryBtn = await screen.findByRole('button', {
+      name: /Retry all failed/,
+    });
+    await user.click(retryBtn);
+
+    expect(retryFn).toHaveBeenCalledWith(BATCH_ID);
+  });
+});

--- a/apps/web/src/pages/listings/bulk-batch-progress-page.tsx
+++ b/apps/web/src/pages/listings/bulk-batch-progress-page.tsx
@@ -1,0 +1,261 @@
+/**
+ * Bulk batch progress page (#741)
+ *
+ * Operator lands here after submitting the bulk wizard. Polls
+ * `GET /listings/bulk-create/:batchId` every 5 s while non-terminal; stops
+ * once status ∈ {completed, partially-failed, failed}. Surfaces aggregate
+ * counts, a partially-failed banner with "Retry all failed (N)", per-record
+ * statuses, and a final summary card on terminal state.
+ *
+ * @module apps/web/src/pages/listings
+ */
+import { useCallback, useMemo, type ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import {
+  Alert,
+  Button,
+  ErrorState,
+  LoadingState,
+  MetricCard,
+  PageLayout,
+  StatusBadge,
+} from '../../shared/ui';
+import { useToast } from '../../shared/ui/toast-provider';
+import { BulkBatchProgressTable } from '../../features/listings/components/bulk/bulk-batch-progress-table';
+import { useBulkBatchQuery } from '../../features/listings/hooks/use-bulk-batch-query';
+import { useBulkRetryFailedMutation } from '../../features/listings/hooks/use-bulk-retry-failed-mutation';
+import { useConnectionsQuery } from '../../features/connections';
+import {
+  TERMINAL_BULK_BATCH_STATUSES,
+  type BulkBatchStatus,
+} from '../../features/listings/api/bulk-listings.types';
+
+export function BulkBatchProgressPage(): ReactElement {
+  const { batchId } = useParams<{ batchId: string }>();
+  const query = useBulkBatchQuery(batchId);
+  const retryMutation = useBulkRetryFailedMutation();
+  const connectionsQuery = useConnectionsQuery();
+  const { showToast } = useToast();
+
+  const inProgress = useMemo(() => {
+    if (!query.data) return 0;
+    return (
+      query.data.totalCount -
+      query.data.succeededCount -
+      query.data.failedCount
+    );
+  }, [query.data]);
+
+  const handleRetryAll = useCallback(async () => {
+    if (!batchId) return;
+    try {
+      const result = await retryMutation.mutateAsync(batchId);
+      showToast({
+        tone: 'success',
+        title: 'Retry dispatched',
+        description: `${result.retriedCount.toLocaleString()} records re-enqueued.`,
+      });
+    } catch (error) {
+      showToast({
+        tone: 'error',
+        title: 'Retry failed',
+        description: (error as Error).message,
+      });
+    }
+  }, [batchId, retryMutation, showToast]);
+
+  if (!batchId) {
+    return (
+      <ErrorState
+        title="Missing batch ID"
+        message="The route is missing a batch identifier."
+      />
+    );
+  }
+
+  if (query.isLoading) {
+    return (
+      <LoadingState
+        title="Loading batch"
+        message="Fetching bulk batch status…"
+      />
+    );
+  }
+
+  if (query.error) {
+    return (
+      <ErrorState
+        title="Could not load batch"
+        message={query.error.message}
+        action={
+          <Button onClick={() => { void query.refetch(); }}>Retry</Button>
+        }
+      />
+    );
+  }
+
+  if (!query.data) {
+    return (
+      <ErrorState
+        title="Batch not found"
+        message={`No batch with id "${batchId}" was found.`}
+      />
+    );
+  }
+
+  const batch = query.data;
+  const isTerminal = TERMINAL_BULK_BATCH_STATUSES.includes(batch.status);
+  const connectionName =
+    connectionsQuery.data?.find((c) => c.id === batch.connectionId)?.name ??
+    batch.connectionId;
+
+  const succeededPct =
+    batch.totalCount > 0
+      ? Math.round((batch.succeededCount / batch.totalCount) * 100)
+      : 0;
+  const failedPct =
+    batch.totalCount > 0
+      ? Math.round((batch.failedCount / batch.totalCount) * 100)
+      : 0;
+
+  const elapsed = computeElapsed(batch.createdAt, batch.updatedAt);
+
+  return (
+    <PageLayout
+      eyebrow="Operations · Listings"
+      title={
+        <>
+          Bulk batch{' '}
+          <span
+            className="mono-text"
+            style={{ fontSize: 18, color: 'var(--text-muted)', fontWeight: 500 }}
+          >
+            {batch.id.slice(0, 8)}
+          </span>
+        </>
+      }
+      description={
+        <>
+          Status <BatchStatusLabel status={batch.status} /> · {connectionName}{' '}
+          · {batch.totalCount.toLocaleString()} {batch.totalCount === 1 ? 'variant' : 'variants'}
+        </>
+      }
+      actions={
+        <Link to="/listings" className="button">
+          Open in /listings →
+        </Link>
+      }
+    >
+      <div className="bulk-batch__kpi-strip">
+        <MetricCard
+          label="Total"
+          value={batch.totalCount.toLocaleString()}
+          description={`Submitted ${formatRelative(batch.createdAt)}`}
+        />
+        <MetricCard
+          label={`Succeeded · ${succeededPct.toString()}%`}
+          value={batch.succeededCount.toLocaleString()}
+          description="Offers live on marketplace"
+          tone="success"
+        />
+        <MetricCard
+          label={`Failed · ${failedPct.toString()}%`}
+          value={batch.failedCount.toLocaleString()}
+          description={batch.failedCount > 0 ? 'Retry available below' : 'No failures'}
+          tone={batch.failedCount > 0 ? 'error' : 'neutral'}
+        />
+        <MetricCard
+          label="In progress"
+          value={inProgress.toLocaleString()}
+          description={isTerminal ? 'Batch closed' : 'Polling every 5 s'}
+          tone={inProgress > 0 ? 'info' : 'neutral'}
+        />
+      </div>
+
+      {!isTerminal ? (
+        <Alert tone="info">
+          <strong>Batch in progress.</strong> Polling for updates every 5 seconds.
+        </Alert>
+      ) : null}
+
+      {batch.status === 'partially-failed' && batch.failedCount > 0 ? (
+        <Alert tone="warning">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
+            <div style={{ flex: 1 }}>
+              <strong>Batch ended with {batch.failedCount.toLocaleString()} {batch.failedCount === 1 ? 'failure' : 'failures'}.</strong>{' '}
+              You can retry all of them in one click — successful offers won't be touched.
+            </div>
+            <Button
+              tone="primary"
+              onClick={() => { void handleRetryAll(); }}
+              disabled={retryMutation.isPending}
+            >
+              {retryMutation.isPending
+                ? 'Retrying…'
+                : `Retry all failed (${batch.failedCount.toLocaleString()})`}
+            </Button>
+          </div>
+        </Alert>
+      ) : null}
+
+      <BulkBatchProgressTable records={batch.records} />
+
+      {isTerminal ? (
+        <div className="bulk-batch__summary">
+          <div className="bulk-batch__summary-main">
+            <strong>
+              Batch {batch.status === 'completed' ? 'completed' : 'ended'} in {elapsed}
+            </strong>{' '}
+            · {batch.succeededCount.toLocaleString()} created · {batch.failedCount.toLocaleString()} failed
+          </div>
+          <div className="bulk-batch__summary-links">
+            <Link to="/listings">Open in /listings →</Link>
+          </div>
+        </div>
+      ) : null}
+    </PageLayout>
+  );
+}
+
+function BatchStatusLabel({
+  status,
+}: {
+  status: BulkBatchStatus;
+}): ReactElement {
+  switch (status) {
+    case 'pending':
+      return <StatusBadge tone="neutral" withDot>pending</StatusBadge>;
+    case 'running':
+      return <StatusBadge tone="info" withDot pulse>running</StatusBadge>;
+    case 'completed':
+      return <StatusBadge tone="success" withDot>completed</StatusBadge>;
+    case 'partially-failed':
+      return <StatusBadge tone="warning" withDot>partially failed</StatusBadge>;
+    case 'failed':
+      return <StatusBadge tone="error" withDot>failed</StatusBadge>;
+  }
+}
+
+function computeElapsed(startIso: string, endIso: string): string {
+  const start = new Date(startIso).getTime();
+  const end = new Date(endIso).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return '—';
+  const seconds = Math.round((end - start) / 1000);
+  if (seconds < 60) return `${seconds.toString()}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remSeconds = seconds % 60;
+  return remSeconds > 0
+    ? `${minutes.toString()}m ${remSeconds.toString()}s`
+    : `${minutes.toString()}m`;
+}
+
+function formatRelative(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  const seconds = Math.round((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return `${seconds.toString()}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes.toString()} min ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours.toString()} h ago`;
+}

--- a/apps/web/src/pages/listings/bulk-create-wizard-page.test.tsx
+++ b/apps/web/src/pages/listings/bulk-create-wizard-page.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
+import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { BulkCreateWizardPage } from './bulk-create-wizard-page';
+
+function renderPage(
+  apiClient: ReturnType<typeof createMockApiClient>,
+  route: string,
+) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/listings/bulk-create/wizard" element={<BulkCreateWizardPage />} />
+      <Route path="/products" element={<div>PRODUCTS_SENTINEL</div>} />
+    </Routes>,
+    { apiClient, route },
+  );
+}
+
+describe('BulkCreateWizardPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+  afterEach(cleanup);
+
+  it('redirects to /products when productIds is missing', async () => {
+    const apiClient = createMockApiClient();
+    renderPage(apiClient, '/listings/bulk-create/wizard');
+
+    expect(await screen.findByText('PRODUCTS_SENTINEL')).toBeInTheDocument();
+  });
+
+  it('redirects to /products when productIds is empty', async () => {
+    const apiClient = createMockApiClient();
+    renderPage(apiClient, '/listings/bulk-create/wizard?productIds=');
+
+    expect(await screen.findByText('PRODUCTS_SENTINEL')).toBeInTheDocument();
+  });
+
+  it('redirects to /products when more than 100 productIds are passed', async () => {
+    const apiClient = createMockApiClient();
+    const ids = Array.from({ length: 101 }, (_, i) => `p${i.toString()}`).join(',');
+    renderPage(apiClient, `/listings/bulk-create/wizard?productIds=${ids}`);
+
+    expect(await screen.findByText('PRODUCTS_SENTINEL')).toBeInTheDocument();
+  });
+
+  it('renders the wizard once products load', async () => {
+    const apiClient = createMockApiClient({
+      products: {
+        getById: vi.fn().mockResolvedValue({
+          id: 'p_1',
+          name: 'Sample product',
+          sku: 'SK-1',
+          price: 19.0,
+          currency: 'PLN',
+          description: null,
+          images: null,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          variants: [
+            {
+              id: 'v_1',
+              productId: 'p_1',
+              sku: 'SK-1',
+              attributes: null,
+              ean: '0123456789012',
+              gtin: null,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      },
+    });
+
+    renderPage(apiClient, '/listings/bulk-create/wizard?productIds=p_1');
+
+    // The wizard's Page title is rendered once products load.
+    expect(
+      await screen.findByRole('heading', { name: /Bulk Allegro offer creation/ }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/listings/bulk-create-wizard-page.tsx
+++ b/apps/web/src/pages/listings/bulk-create-wizard-page.tsx
@@ -1,0 +1,118 @@
+/**
+ * Bulk listing wizard page (#740)
+ *
+ * Route entry point — hydrates the selected products + their variants from
+ * `?productIds=` and mounts the `BulkWizard` controller. Handles the
+ * three boundary states before the wizard can render:
+ *   - empty productIds  → redirect back to /products
+ *   - >100 productIds   → redirect back to /products with an alert
+ *   - loading           → LoadingState
+ *   - product-fetch errors → ErrorState with retry
+ *
+ * @module apps/web/src/pages/listings
+ */
+import { useEffect, useMemo, type ReactElement } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  Button,
+  ErrorState,
+  LoadingState,
+} from '../../shared/ui';
+import { BulkWizard } from '../../features/listings/components/bulk/bulk-wizard';
+import { useConnectionsQuery } from '../../features/connections';
+import { useProductsBatchQuery } from '../../features/products';
+import type { Product } from '../../features/products';
+
+const MAX_PRODUCTS = 100;
+
+export function BulkCreateWizardPage(): ReactElement {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const ids = useMemo<string[]>(() => {
+    const raw = searchParams.get('productIds') ?? '';
+    if (raw.trim() === '') return [];
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }, [searchParams]);
+
+  // Redirect if no IDs or over the cap. Effect ensures we don't render
+  // the wizard for an invalid load.
+  useEffect(() => {
+    if (ids.length === 0 || ids.length > MAX_PRODUCTS) {
+      void navigate('/products', { replace: true });
+    }
+  }, [ids, navigate]);
+
+  const productQueries = useProductsBatchQuery(ids, {
+    enabled: ids.length > 0 && ids.length <= MAX_PRODUCTS,
+  });
+
+  const connectionsQuery = useConnectionsQuery();
+
+  if (ids.length === 0 || ids.length > MAX_PRODUCTS) {
+    return (
+      <LoadingState
+        title="Redirecting…"
+        message="Returning you to the Products page."
+      />
+    );
+  }
+
+  const isLoading = productQueries.some((q) => q.isLoading);
+  const failed = productQueries.find((q) => q.error);
+
+  if (isLoading) {
+    return (
+      <LoadingState
+        title="Loading products"
+        message={`Fetching details for ${ids.length.toLocaleString()} selected products…`}
+      />
+    );
+  }
+
+  if (failed?.error) {
+    return (
+      <ErrorState
+        title="Could not load selected products"
+        message={failed.error.message}
+        action={
+          <Button
+            onClick={() => {
+              productQueries.forEach((q) => {
+                void q.refetch();
+              });
+            }}
+          >
+            Retry
+          </Button>
+        }
+      />
+    );
+  }
+
+  const products: Product[] = productQueries
+    .map((q) => q.data)
+    .filter((p): p is Product => p !== undefined);
+
+  if (products.length === 0) {
+    return (
+      <ErrorState
+        title="No products found"
+        message="None of the selected product IDs resolved. Return to /products and try again."
+      />
+    );
+  }
+
+  return (
+    <BulkWizard
+      products={products}
+      resolveConnectionName={(connectionId) =>
+        connectionsQuery.data?.find((c) => c.id === connectionId)?.name ??
+        connectionId
+      }
+    />
+  );
+}

--- a/apps/web/src/pages/products/products-list-page.test.tsx
+++ b/apps/web/src/pages/products/products-list-page.test.tsx
@@ -1,9 +1,19 @@
 import { cleanup, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import type * as ReactRouterDom from 'react-router-dom';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { ProductsListPage } from './products-list-page';
 import type { PaginatedProducts } from '../../features/products/api/products.types';
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async (): Promise<typeof ReactRouterDom> => {
+  const actual = await vi.importActual<typeof ReactRouterDom>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: (): typeof navigateMock => navigateMock,
+  };
+});
 
 const sampleProducts: PaginatedProducts = {
   items: [
@@ -40,6 +50,7 @@ describe('ProductsListPage', () => {
     // shouldAdvanceTime allows waitFor/findBy to work while still controlling
     // timers so we can flush pending debounce timers in afterEach.
     vi.useFakeTimers({ shouldAdvanceTime: true });
+    navigateMock.mockReset();
   });
 
   afterEach(() => {
@@ -186,5 +197,105 @@ describe('ProductsListPage', () => {
     await user.click(screen.getByRole('button', { name: 'Clear search' }));
 
     expect(await screen.findByRole('link', { name: 'Manage connections' })).toBeInTheDocument();
+  });
+
+  // ── Multi-select + BulkActionBar (#739) ────────────────────────────
+
+  it('should not show the bulk action bar when no rows are selected', async () => {
+    const mockApi = createMockApiClient({
+      products: { list: vi.fn().mockResolvedValue(sampleProducts) },
+    });
+
+    renderWithProviders(<ProductsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Test Product');
+    const bar = document.querySelector('.bulk-action-bar');
+    expect(bar).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should show the bulk action bar with count when a row is selected', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const mockApi = createMockApiClient({
+      products: { list: vi.fn().mockResolvedValue(sampleProducts) },
+    });
+
+    renderWithProviders(<ProductsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Test Product');
+    await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Create Allegro offers (1)' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: '1 product selected' })).toBeInTheDocument();
+  });
+
+  it('header checkbox selects all visible rows; clicking again unselects them', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const mockApi = createMockApiClient({
+      products: { list: vi.fn().mockResolvedValue(sampleProducts) },
+    });
+
+    renderWithProviders(<ProductsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Test Product');
+    const headerCheckbox = screen.getByRole('checkbox', {
+      name: 'Select all visible products',
+    });
+    await user.click(headerCheckbox);
+
+    expect(
+      screen.getByRole('button', { name: 'Create Allegro offers (2)' }),
+    ).toBeInTheDocument();
+
+    // After selecting all, header checkbox should be "Unselect all visible"
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Unselect all visible products' }),
+    );
+    const bar = document.querySelector('.bulk-action-bar');
+    expect(bar).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('Clear button empties the selection', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const mockApi = createMockApiClient({
+      products: { list: vi.fn().mockResolvedValue(sampleProducts) },
+    });
+
+    renderWithProviders(<ProductsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Test Product');
+    await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
+    expect(
+      screen.getByRole('button', { name: 'Create Allegro offers (1)' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+    const bar = document.querySelector('.bulk-action-bar');
+    expect(bar).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('CTA navigates to the wizard with selected ids in the URL', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const mockApi = createMockApiClient({
+      products: { list: vi.fn().mockResolvedValue(sampleProducts) },
+    });
+
+    renderWithProviders(<ProductsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Test Product');
+    await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Select Another Product' }));
+
+    const cta = screen.getByRole('button', { name: 'Create Allegro offers (2)' });
+    await user.click(cta);
+
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const navArg = navigateMock.mock.calls[0]?.[0];
+    expect(typeof navArg).toBe('string');
+    if (typeof navArg !== 'string') return;
+    expect(navArg.startsWith('/listings/bulk-create/wizard?productIds=')).toBe(true);
+    expect(decodeURIComponent(navArg)).toContain('ol_product_abc123');
+    expect(decodeURIComponent(navArg)).toContain('ol_product_def456');
   });
 });

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -1,5 +1,16 @@
-import { useState, type ReactElement, type ReactNode } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+/**
+ * Products List Page
+ *
+ * Browseable catalog of products synced from connected platforms. Supports
+ * search + pagination via URL params, and bulk selection of 1-100 products
+ * for batch Allegro listing creation (#739). Selection state is component-
+ * local; it is serialised into the wizard URL only on navigation so the
+ * URL doesn't grow on every checkbox toggle.
+ *
+ * @module apps/web/src/pages/products
+ */
+import { useCallback, useMemo, useState, type ChangeEvent, type ReactElement, type ReactNode } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { useTableSort } from '../../shared/ui/use-table-sort';
@@ -9,12 +20,15 @@ import { Button } from '../../shared/ui/button';
 import { Input } from '../../shared/ui/input';
 import { ProductThumbnail } from '../../shared/ui/product-thumbnail';
 import { TimeDisplay } from '../../shared/ui/time-display';
+import { BulkActionBar } from '../../shared/ui/bulk-action-bar';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useProductsQuery } from '../../features/products/hooks/use-products-query';
 import type { Product, ProductFilters } from '../../features/products/api/products.types';
 
 const PAGE_SIZE = 20;
 const SEARCH_DEBOUNCE_MS = 300;
+/** Maximum products an operator can bulk-list in one batch (BE-enforced ceiling). */
+export const BULK_SELECTION_CAP = 100;
 
 // When currency is missing, the raw amount is shown muted with a hover-reveal
 // rather than silently emitting a bare decimal — explicit ambiguity is safer.
@@ -32,53 +46,9 @@ function formatPrice(price: number | null, currency: string | null): ReactNode {
   );
 }
 
-const COLUMNS: DataTableColumn<Product>[] = [
-  {
-    id: 'name',
-    header: 'Name',
-    cell: (product) => (
-      <span className="product-row">
-        <ProductThumbnail src={product.images?.[0]} name={product.name} />
-        <span className="product-row__name">{product.name}</span>
-      </span>
-    ),
-    accessor: (product) => product.name,
-    sortable: true,
-  },
-  {
-    id: 'sku',
-    header: 'SKU',
-    cell: (product) =>
-      product.sku ? (
-        <span className="mono-text" title={product.sku}>{product.sku}</span>
-      ) : (
-        <span className="text-muted">—</span>
-      ),
-    accessor: (product) => product.sku,
-    sortable: true,
-    hideBelow: 768,
-  },
-  {
-    id: 'price',
-    header: 'Price',
-    align: 'right',
-    cell: (product) => formatPrice(product.price, product.currency),
-    accessor: (product) => product.price,
-    sortable: true,
-    hideBelow: 480,
-  },
-  {
-    id: 'createdAt',
-    header: 'Created',
-    cell: (product) => <TimeDisplay iso={product.createdAt} format="date" />,
-    accessor: (product) => product.createdAt,
-    sortable: true,
-    hideBelow: 1024,
-  },
-];
-
 export function ProductsListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
   const { sort, setSort } = useTableSort([{ id: 'name', desc: false }]);
 
   const urlSearch = searchParams.get('search') ?? '';
@@ -87,39 +57,105 @@ export function ProductsListPage(): ReactElement {
   const [searchInput, setSearchInput] = useState(urlSearch);
   const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
 
+  // Selection state is component-local. It is *not* mirrored into URL params
+  // during selection (the URL would balloon on every checkbox toggle, and the
+  // common bulk-listing pattern is "select → submit", not "share a selection
+  // link"). On submit click, the variant IDs are serialised into the wizard
+  // route so the destination has the full list.
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
   const filters: ProductFilters = { search: debouncedSearch || undefined };
   const pagination = { limit: PAGE_SIZE, offset };
 
   const query = useProductsQuery(filters, pagination);
+  const items = query.data?.items ?? [];
 
-  function handleSearchChange(value: string): void {
-    setSearchInput(value);
-    // Reset pagination immediately when typing
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      if (value) {
-        next.set('search', value);
-      } else {
-        next.delete('search');
+  const handleToggleRow = useCallback(
+    (productId: string) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(productId)) {
+          next.delete(productId);
+          return next;
+        }
+        // Enforce the cap by refusing the toggle when at capacity.
+        if (next.size >= BULK_SELECTION_CAP) {
+          return prev;
+        }
+        next.add(productId);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const visibleIds = useMemo(() => items.map((p) => p.id), [items]);
+  const visibleSelectedCount = useMemo(
+    () => visibleIds.reduce((sum, id) => sum + (selectedIds.has(id) ? 1 : 0), 0),
+    [visibleIds, selectedIds],
+  );
+
+  const headerCheckboxState =
+    visibleIds.length > 0 && visibleSelectedCount === visibleIds.length
+      ? 'all'
+      : visibleSelectedCount > 0
+        ? 'some'
+        : 'none';
+
+  const handleToggleHeader = useCallback(() => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (headerCheckboxState === 'all') {
+        // Unselect everything visible on the current page; keep other-page
+        // selections intact so paginating through doesn't lose state.
+        for (const id of visibleIds) next.delete(id);
+        return next;
       }
-      next.delete('offset');
+      // Select all visible, respecting the cap. If selecting all would
+      // exceed the cap, select up to the cap and stop — caller already
+      // sees disabled checkboxes for over-cap rows.
+      for (const id of visibleIds) {
+        if (next.has(id)) continue;
+        if (next.size >= BULK_SELECTION_CAP) break;
+        next.add(id);
+      }
       return next;
     });
-  }
+  }, [headerCheckboxState, visibleIds]);
 
-  function setOffset(next: number): void {
-    setSearchParams((prev) => {
-      const p = new URLSearchParams(prev);
-      if (next === 0) {
-        p.delete('offset');
-      } else {
-        p.set('offset', String(next));
-      }
-      return p;
-    });
-  }
+  const handleSearchChange = useCallback(
+    (value: string): void => {
+      setSearchInput(value);
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) {
+          next.set('search', value);
+        } else {
+          next.delete('search');
+        }
+        next.delete('offset');
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
 
-  function clearSearch(): void {
+  const setOffset = useCallback(
+    (nextOffset: number): void => {
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev);
+        if (nextOffset === 0) {
+          p.delete('offset');
+        } else {
+          p.set('offset', String(nextOffset));
+        }
+        return p;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const clearSearch = useCallback((): void => {
     setSearchInput('');
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
@@ -127,7 +163,115 @@ export function ProductsListPage(): ReactElement {
       next.delete('offset');
       return next;
     });
-  }
+  }, [setSearchParams]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  // On submit: serialise the selection into the wizard URL. The wizard
+  // page consumes ?productIds= and hydrates products + variants from there.
+  // We send product IDs; the wizard resolves each to its primary variant
+  // before calling the BE bulk-create endpoint (which actually accepts
+  // variant IDs — see bulk-listings.types.ts file header).
+  const handleSubmit = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    const ids = Array.from(selectedIds).join(',');
+    void navigate(`/listings/bulk-create/wizard?productIds=${encodeURIComponent(ids)}`);
+  }, [selectedIds, navigate]);
+
+  const atCap = selectedIds.size >= BULK_SELECTION_CAP;
+
+  const columns: DataTableColumn<Product>[] = useMemo(
+    () => [
+      {
+        id: 'select',
+        // Header rendered manually for indeterminate state.
+        header: (
+          <CheckboxCell
+            state={headerCheckboxState}
+            onToggle={handleToggleHeader}
+            ariaLabel={
+              headerCheckboxState === 'all'
+                ? 'Unselect all visible products'
+                : 'Select all visible products'
+            }
+          />
+        ),
+        cell: (product) => {
+          const checked = selectedIds.has(product.id);
+          const disabled = !checked && atCap;
+          return (
+            <CheckboxCell
+              state={checked ? 'all' : 'none'}
+              onToggle={() => {
+                handleToggleRow(product.id);
+              }}
+              disabled={disabled}
+              ariaLabel={
+                checked
+                  ? `Unselect ${product.name}`
+                  : disabled
+                    ? `Maximum ${BULK_SELECTION_CAP} products per batch reached`
+                    : `Select ${product.name}`
+              }
+              tooltip={
+                disabled ? `Max ${BULK_SELECTION_CAP} per batch` : undefined
+              }
+            />
+          );
+        },
+        align: 'left',
+      },
+      {
+        id: 'name',
+        header: 'Name',
+        cell: (product) => (
+          <span className="product-row">
+            <ProductThumbnail src={product.images?.[0]} name={product.name} />
+            <Link to={product.id} className="product-row__name product-row__name--link">
+              {product.name}
+            </Link>
+          </span>
+        ),
+        accessor: (product) => product.name,
+        sortable: true,
+      },
+      {
+        id: 'sku',
+        header: 'SKU',
+        cell: (product) =>
+          product.sku ? (
+            <span className="mono-text" title={product.sku}>
+              {product.sku}
+            </span>
+          ) : (
+            <span className="text-muted">—</span>
+          ),
+        accessor: (product) => product.sku,
+        sortable: true,
+        hideBelow: 768,
+      },
+      {
+        id: 'price',
+        header: 'Price',
+        align: 'right',
+        cell: (product) => formatPrice(product.price, product.currency),
+        accessor: (product) => product.price,
+        sortable: true,
+        hideBelow: 480,
+      },
+      {
+        id: 'createdAt',
+        header: 'Created',
+        cell: (product) => <TimeDisplay iso={product.createdAt} format="date" />,
+        accessor: (product) => product.createdAt,
+        sortable: true,
+        hideBelow: 1024,
+      },
+    ],
+    [selectedIds, atCap, headerCheckboxState, handleToggleRow, handleToggleHeader],
+  );
 
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
@@ -137,30 +281,28 @@ export function ProductsListPage(): ReactElement {
     <PageLayout
       eyebrow="Operations"
       title="Products"
-      description="Product catalog explorer — search by name or SKU."
+      description="Product catalog explorer — search by name or SKU. Select up to 100 products to bulk-list on Allegro."
     >
-      {/* Search bar */}
       <div className="toolbar">
         <Input
           aria-label="Search products by name or SKU"
           placeholder="Search by name or SKU…"
           value={searchInput}
-          onChange={(e) => { handleSearchChange(e.target.value); }}
+          onChange={(e) => {
+            handleSearchChange(e.target.value);
+          }}
         />
       </div>
 
-      {/* Table */}
       {query.isLoading ? (
-        <DataTableSkeleton columns={COLUMNS} />
+        <DataTableSkeleton columns={columns} />
       ) : query.error ? (
         <ErrorState
           title="Unable to load products"
           message={query.error.message}
-          action={
-            <Button onClick={() => { void query.refetch(); }}>Retry</Button>
-          }
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
         />
-      ) : (query.data?.items.length ?? 0) === 0 ? (
+      ) : items.length === 0 ? (
         <EmptyState
           liveRegion="off"
           title="No products found"
@@ -183,10 +325,9 @@ export function ProductsListPage(): ReactElement {
         <>
           <DataTable
             caption="Products"
-            columns={COLUMNS}
-            rows={query.data?.items ?? []}
+            columns={columns}
+            rows={items}
             rowKey={(product) => product.id}
-            rowHref={(product) => product.id}
             sort={sort}
             onSortChange={setSort}
             cardView={{
@@ -202,7 +343,6 @@ export function ProductsListPage(): ReactElement {
             }}
           />
 
-          {/* Pagination */}
           <div className="pagination">
             <span className="text-muted">
               Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
@@ -222,8 +362,63 @@ export function ProductsListPage(): ReactElement {
               </Button>
             </div>
           </div>
+
+          <BulkActionBar
+            count={selectedIds.size}
+            itemNoun="product"
+            hint={
+              atCap
+                ? `Max ${BULK_SELECTION_CAP} per batch`
+                : `Max ${BULK_SELECTION_CAP} per batch · ${BULK_SELECTION_CAP - selectedIds.size} more available`
+            }
+            actions={
+              <>
+                <Button tone="ghost" className="button--sm" onClick={clearSelection}>
+                  Clear
+                </Button>
+                <Button tone="primary" onClick={handleSubmit}>
+                  Create Allegro offers ({selectedIds.size.toLocaleString()})
+                </Button>
+              </>
+            }
+          />
         </>
       )}
     </PageLayout>
+  );
+}
+
+interface CheckboxCellProps {
+  state: 'all' | 'some' | 'none';
+  onToggle: () => void;
+  disabled?: boolean;
+  ariaLabel: string;
+  tooltip?: string;
+}
+
+function CheckboxCell({
+  state,
+  onToggle,
+  disabled = false,
+  ariaLabel,
+  tooltip,
+}: CheckboxCellProps): ReactElement {
+  return (
+    <input
+      type="checkbox"
+      checked={state === 'all'}
+      ref={(el) => {
+        if (el) el.indeterminate = state === 'some';
+      }}
+      disabled={disabled}
+      onChange={(e: ChangeEvent<HTMLInputElement>) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      // Stop click from bubbling to a row-click handler if a parent sets one.
+      onClick={(e) => { e.stopPropagation(); }}
+      aria-label={ariaLabel}
+      title={tooltip}
+    />
   );
 }

--- a/apps/web/src/shared/ui/bulk-action-bar.test.tsx
+++ b/apps/web/src/shared/ui/bulk-action-bar.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BulkActionBar } from './bulk-action-bar';
+import { Button } from './button';
+
+describe('BulkActionBar', () => {
+  it('renders count and actions when count > 0', () => {
+    render(
+      <BulkActionBar count={5} itemNoun="product" actions={<Button>Do it</Button>} />,
+    );
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Do it' })).toBeInTheDocument();
+  });
+
+  it('uses plural noun in aria-label when count > 1', () => {
+    render(<BulkActionBar count={3} itemNoun="product" actions={<button>x</button>} />);
+    expect(screen.getByRole('region', { name: '3 products selected' })).toBeInTheDocument();
+  });
+
+  it('uses singular noun when count === 1', () => {
+    render(<BulkActionBar count={1} itemNoun="product" actions={<button>x</button>} />);
+    expect(screen.getByRole('region', { name: '1 product selected' })).toBeInTheDocument();
+  });
+
+  it('is aria-hidden when count is 0', () => {
+    render(
+      <BulkActionBar count={0} itemNoun="product" actions={<button>x</button>} />,
+    );
+    // count is still rendered (DOM), but the region is aria-hidden
+    const node = document.querySelector('.bulk-action-bar');
+    expect(node).toHaveAttribute('aria-hidden', 'true');
+    expect(node).toHaveClass('bulk-action-bar--hidden');
+  });
+
+  it('renders optional hint slot', () => {
+    render(
+      <BulkActionBar
+        count={2}
+        itemNoun="product"
+        hint="Max 100 per batch"
+        actions={<button>x</button>}
+      />,
+    );
+    expect(screen.getByText('Max 100 per batch')).toBeInTheDocument();
+  });
+
+  it('forwards ref to root element', () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(<BulkActionBar ref={ref} count={1} actions={<button>x</button>} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges className', () => {
+    render(
+      <BulkActionBar count={1} className="custom" actions={<button>x</button>} />,
+    );
+    const node = document.querySelector('.bulk-action-bar');
+    expect(node).toHaveClass('bulk-action-bar', 'custom');
+  });
+});

--- a/apps/web/src/shared/ui/bulk-action-bar.tsx
+++ b/apps/web/src/shared/ui/bulk-action-bar.tsx
@@ -1,0 +1,64 @@
+/**
+ * BulkActionBar
+ *
+ * Sticky action bar surfaced when an operator has multi-selected items on a
+ * list page (#739 Products list is the first consumer). Renders a leading
+ * tabular count + label and a trailing actions slot. Hidden via
+ * `aria-hidden` when `count === 0`; consumers can also conditionally render.
+ *
+ * Listed in `docs/frontend-ui-style-guide.md § Core Component Patterns`.
+ *
+ * @module apps/web/src/shared/ui
+ */
+import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+
+export interface BulkActionBarProps extends ComponentPropsWithoutRef<'div'> {
+  /** Number currently selected. The bar is visually hidden when 0. */
+  count: number;
+  /** Singular form of the entity ("product", "row"). Defaults to "item". */
+  itemNoun?: string;
+  /** Optional hint shown next to the count (e.g. "Max 100 per batch"). */
+  hint?: ReactNode;
+  /** Trailing actions slot — typically a Clear ghost button + a primary CTA. */
+  actions: ReactNode;
+}
+
+export const BulkActionBar = forwardRef<HTMLDivElement, BulkActionBarProps>(
+  function BulkActionBar(
+    { count, itemNoun = 'item', hint, actions, className = '', ...rest },
+    ref,
+  ) {
+    const visible = count > 0;
+    const classes = [
+      'bulk-action-bar',
+      visible ? '' : 'bulk-action-bar--hidden',
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const noun = count === 1 ? itemNoun : `${itemNoun}s`;
+
+    return (
+      <div
+        ref={ref}
+        className={classes}
+        role="region"
+        aria-label={visible ? `${count.toLocaleString()} ${noun} selected` : undefined}
+        aria-hidden={!visible}
+        {...rest}
+      >
+        <div className="bulk-action-bar__count">
+          <strong className="bulk-action-bar__num tabular" aria-live="polite">
+            {count.toLocaleString()}
+          </strong>
+          <span className="bulk-action-bar__label">selected</span>
+        </div>
+        {hint !== undefined && hint !== null ? (
+          <div className="bulk-action-bar__hint">{hint}</div>
+        ) : null}
+        <div className="bulk-action-bar__actions">{actions}</div>
+      </div>
+    );
+  },
+);

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -67,3 +67,7 @@ export { ProductThumbnail } from './product-thumbnail';
 export { CopyableId } from './copyable-id';
 export { DensityToggle, useDensity } from './density-toggle';
 export type { Density } from './density-toggle';
+
+// ── Bulk-selection (#739) ──────────────────────────────────────────
+export { BulkActionBar } from './bulk-action-bar';
+export type { BulkActionBarProps } from './bulk-action-bar';

--- a/docs/plans/implementation-plan-739-740-741-bulk-listing-fe.md
+++ b/docs/plans/implementation-plan-739-740-741-bulk-listing-fe.md
@@ -1,0 +1,493 @@
+# Implementation Plan — Bulk listing FE (#739 + #740 + #741)
+
+**Status:** ready for implementation
+**Issues:** [#739](https://github.com/openlinker-project/openlinker/issues/739), [#740](https://github.com/openlinker-project/openlinker/issues/740), [#741](https://github.com/openlinker-project/openlinker/issues/741)
+**Parent product design:** [#726](https://github.com/openlinker-project/openlinker/issues/726) — see [`docs/specs/product-spec-726-allegro-bulk-listing.md`](../specs/product-spec-726-allegro-bulk-listing.md)
+**Branch:** `739-740-741-bulk-listing-wizard-fe`
+**Layer:** Frontend (`apps/web`) — no backend changes
+**Effort:** ~10 days nominal (2 + 5 + 3) — shared scaffolding cuts the total
+
+---
+
+## 1. Goal
+
+Ship the operator-facing FE for Allegro bulk offer creation as a single vertical slice. Backend is fully merged (#734 / #735 / #736 / #737 / #738 / #742). The user flow this PR enables, end to end:
+
+```
+Products page
+  → checkbox multi-select (≤100)            [#739]
+  → bulk action bar: "Create Allegro offers (N)"
+  → /listings/bulk-create/wizard            [#740]
+      Step 1 — config (connection, shared shipping rate, AI default, default stock + publish)
+      Step 2 — auto-match (per-variant EAN→category, partial-blocking up to 15 s)
+      Step 3 — review table (per-row status, edit modal)
+      Step 4 — edit modal (per-row title/category/price/stock/parameters/description+AI)
+      Step 5 — submit confirmation → POST /listings/bulk-create
+  → /listings/bulk-batches/:batchId          [#741]
+      polling progress (5 s), per-product status, retry-failed (single + batch)
+      final summary card on terminal status
+```
+
+Acceptance criteria below are tied 1:1 to the user-visible AC in the parent spec §5.2.
+
+---
+
+## 2. Non-goals (explicit deferrals)
+
+Two pieces of the parent spec's AC and one piece of issue #741's AC are **deferred from this bundle**. Honest scope statement: this PR closes **#739 and #740 fully**, and closes **#741 substantially** with one issue-AC unmet (per-record retry — gated on a BE endpoint that doesn't exist yet).
+
+| Deferred | Reason | Follow-up |
+|---|---|---|
+| **Parent AC-7 — Smart classification badge per row** | `BulkBatchRecordSummaryDto` (`apps/api/src/listings/http/dto/bulk-offer-create-response.dto.ts:27-48`) does **not** carry `smartClassification` or `failedDeliveryMethods`. #737 persists Smart readback server-side via `OfferCreationRecord` but the progress endpoint doesn't surface it. Adding it is a small BE change (extend DTO + repo read-through + mapper) — out of scope for a FE-only bundle. | File **"feat(listings): surface smart classification on bulk batch record summary"** (BE-S) + a FE chaser to render the badge. |
+| **Parent AC-8 — Pre-submit account-level Smart warning banner** | No FE hook for `GET /sale/smart` (or its OL wrapper) exists today; need to verify whether the BE endpoint is even exposed. Adding it inflates this PR's scope without a clear seam. | File **"feat(allegro): expose account-level Smart eligibility hook + wizard banner"** (BE+FE-S). |
+| **Issue #741 AC-4 — Per-record retry button on the progress row** | Issue #741 AC-4 requires a per-record retry. The implied endpoint (the parent spec's "to be added in #726.9") shipped as **batch-level only** (`POST /listings/bulk-create/:batchId/retry-failed` retries every failed child). There is no per-record retry endpoint today. **Batch-level retry IS shipped in this PR** (full "Retry all failed" wired); per-record retry is the unmet AC. | File **"feat(listings): per-record retry endpoint for bulk batch records"** (BE-S) + a FE chaser to add the inline retry button. |
+
+PR description must state: `Closes #739, Closes #740. Addresses #741 (batch-level retry shipped; per-record retry to follow).` Don't auto-close #741.
+
+**Re-evaluated and pulled INTO scope** during review (originally proposed as deferred):
+
+- **Parent AC-9 — per-row AI description toggle in edit modal**: tech review surfaced that `AllegroCreateOfferWizard` already mounts `SuggestionDialog` inside its parent Dialog (`features/listings/components/AllegroCreateOfferWizard.tsx:49`), so the "two-level Dialog focus management" concern was overstated. The bulk-edit modal reuses the same pattern — `<SuggestionDialog>` opens on top of the edit modal, accepts the AI output back into the modal's `description` field. **In scope**. The Step-1 config "Generate AI descriptions" checkbox also remains as a batch-wide default (`sharedConfig.generateDescription`); per-row toggle in the modal overrides it.
+
+Other things this PR does **not** do (out of scope by parent spec §6):
+
+Other things this PR does **not** do (out of scope by parent spec §6):
+
+- CSV import as input source
+- Auto-list rule engine
+- Bulk-edit existing offers (different flow)
+- Per-PS-variant separate Allegro offers (variant-matrix collapse only)
+- Shipment generation
+
+---
+
+## 3. Architecture
+
+### 3.1 Layer & dependency direction
+
+All three issues live in `apps/web/src/`. Files split across layers per `docs/frontend-architecture.md`:
+
+- **Pages** (`pages/products/`, `pages/listings/`) — route entry points
+- **Feature** (`features/listings/`) — already exists; we extend it with bulk hooks/components. **No new feature module is created** — bulk is part of the same domain.
+- **Shared** (`shared/ui/`) — no new shared primitives (`DataTable`, `Dialog`, `Alert`, `Button`, `StatusBadge`, `PageLayout`, `SetupStepper`, `Input`, `Select`, `Textarea`, `Checkbox`, `FormField`, `LoadingState`, `ErrorState`, `EmptyState`, `useToast()` all exist)
+
+### 3.2 State ownership
+
+Per `docs/frontend-architecture.md` § State Management:
+
+| State | Owner | Notes |
+|---|---|---|
+| Server (batch, products, variants, categories, parameters, policies) | TanStack Query | `staleTime` per existing pattern; 5 s polling on bulk batch while non-terminal |
+| Selected product IDs on Products page | component-local `useState<Set<string>>` | Local during selection; serialised into URL search params **only at navigation time** to the wizard. Selection itself is local UI state — putting it in URL would explode the URL on every checkbox toggle. |
+| Wizard step | `useSearchParams` (`?step=config\|resolve\|review\|confirm`) | Linkable + survives reload during a session |
+| Wizard shared config (connection, shipping, AI default) | `useState` in wizard page | Single-screen lifetime |
+| Wizard per-row overrides | `useState<Record<productId, PerProductOverride>>` | Edit-modal submits update this map |
+| Edit modal form | React Hook Form + Zod | Same shape used by single-offer wizard |
+| Auto-match results | `useQueries` cache | `useResolveCategoryQuery` per variant — TanStack handles caching/parallelism |
+| Batch progress polling | TanStack Query with `refetchInterval` fn | Stops when `status` ∈ `{completed, partially-failed}` |
+
+**No new global store** — none required.
+
+### 3.3 File layout (additions only)
+
+```
+apps/web/src/
+├── features/listings/
+│   ├── api/
+│   │   ├── bulk-listings.api.ts                       NEW  POST /listings/bulk-create, GET :batchId, POST :batchId/retry-failed
+│   │   ├── bulk-listings.types.ts                     NEW  request/response types (mirror api/src/listings/http/dto/)
+│   │   └── listings.query-keys.ts                     EDIT add bulkBatch(batchId) key factory
+│   ├── hooks/
+│   │   ├── use-bulk-submit-mutation.ts                NEW  POST /listings/bulk-create
+│   │   ├── use-bulk-batch-query.ts                    NEW  GET :batchId with polling
+│   │   └── use-bulk-retry-failed-mutation.ts          NEW  POST :batchId/retry-failed
+│   ├── components/bulk/
+│   │   ├── bulk-wizard.tsx                            NEW  the wizard shell + step state
+│   │   ├── bulk-config-step.tsx                       NEW  Step 1
+│   │   ├── bulk-resolve-step.tsx                      NEW  Step 2 (auto-match progress)
+│   │   ├── bulk-review-step.tsx                       NEW  Step 3 (review table)
+│   │   ├── bulk-review-row.tsx                        NEW  one review row (status icon + edit btn)
+│   │   ├── bulk-edit-modal.tsx                        NEW  Step 4 per-row edit
+│   │   ├── bulk-confirm-modal.tsx                     NEW  Step 5 submit confirmation
+│   │   ├── bulk-batch-progress-table.tsx              NEW  used by #741 progress page
+│   │   ├── bulk-edit-modal.schema.ts                  NEW  Zod schema for the edit modal
+│   │   ├── bulk-wizard.test.tsx                       NEW  step-progression + AC-1..AC-4 tests
+│   │   ├── bulk-edit-modal.test.tsx                   NEW
+│   │   └── bulk-batch-progress-table.test.tsx         NEW
+│   ├── lib/
+│   │   └── bulk-throttle.ts                           NEW  bounded-concurrency helper (~20 lines, no deps) — caps Step-2 EAN resolves at 8 parallel
+│   └── index.ts                                       EDIT  re-export BulkWizard if any cross-feature use
+│
+├── shared/ui/
+│   ├── bulk-action-bar.tsx                            NEW  sticky band primitive — fulfils the style-guide promise + reused on /products
+│   ├── bulk-action-bar.css                            NEW  scoped CSS for the band
+│   └── index.ts                                       EDIT  re-export BulkActionBar
+│
+├── pages/
+│   ├── products/
+│   │   ├── products-list-page.tsx                     EDIT  add checkbox column + selection + bulk action bar
+│   │   └── products-list-page.test.tsx                EDIT  add selection tests
+│   └── listings/
+│       ├── bulk-create-wizard-page.tsx                NEW  /listings/bulk-create/wizard
+│       ├── bulk-create-wizard-page.test.tsx           NEW
+│       ├── bulk-batch-progress-page.tsx               NEW  /listings/bulk-batches/:batchId
+│       └── bulk-batch-progress-page.test.tsx          NEW
+│
+├── app/routes/
+│   └── listings.route.tsx                             EDIT  register two new child routes
+│
+└── index.css                                          EDIT  ~3 small bounded sections (#739/#740/#741) — selection, wizard layout, progress table chrome
+```
+
+### 3.4 API surface consumed (already shipped on `main`)
+
+| Method | Path | Purpose | DTO source |
+|---|---|---|---|
+| `POST` | `/listings/bulk-create` | Submit batch | `BulkOfferCreateRequestDto` → `BulkOfferCreateResponseDto` |
+| `GET` | `/listings/bulk-create/:batchId` | Read batch + records (polled) | `BulkBatchSummaryDto` |
+| `POST` | `/listings/bulk-create/:batchId/retry-failed` | Retry failed children | `BulkOfferCreationRetryResponseDto` |
+| `POST` | `/listings/connections/:connectionId/categories/resolve` | EAN→Allegro category (per variant; existing) | `ResolveCategoryResponse` via `useResolveCategoryQuery` |
+| `GET` | `/listings/connections/:connectionId/seller-policies` | Shipping/return/warranty policies | via `useSellerPoliciesQuery` |
+| `GET` | `/listings/connections/:connectionId/categories/:id/parameters` | Dynamic Allegro params for picked category | via `useCategoryParametersQuery` |
+| `GET` | `/listings/connections/:connectionId/products/:productId` | Allegro catalog product (smart-link prefill) | via `useCatalogProductQuery` |
+| `GET` | `/products?...` | Products list (existing) | via `useProductsQuery` |
+| `GET` | `/products/:id` | Single product + variants for the wizard rows | via `useProductQuery` |
+
+No new backend endpoints are required.
+
+### 3.5 Data flow (Step 2 auto-match)
+
+The spec calls for "throttled-parallel EAN lookups + partial-blocking up to ~15 s". Implementation:
+
+1. Wizard receives `productIds` from URL search params.
+2. Wizard calls `useProductQuery(id)` for each (`useQueries` in one hook) to hydrate **product + variants**.
+3. For each product, pick the primary variant (`variants[0]`) and its `barcode` (EAN).
+   - No variants → row → status `no-variant` (❌)
+   - No barcode → row → status `no-ean` (❌, manual category required)
+4. For products with a barcode: call `useResolveCategoryQuery(connectionId, barcode)` via `useQueries`. **Concurrency capped at 8 parallel** via the new `bulk-throttle.ts` helper — a ~20-line `Promise.allSettled`-with-window utility, no new dependency. Rationale: `useResolveCategoryQuery` has `retry: false`, so a 429-burst would silently flip rows to ❌; 8-parallel is a safe ceiling against Allegro's documented rate limits and still resolves a 50-product batch within the 15 s budget. The helper interface: `pAllLimit<T,R>(items: T[], limit: number, mapper: (t: T) => Promise<R>): Promise<PromiseSettledResult<R>[]>`.
+5. Status derivation per row (`bulk-edit-modal.schema.ts`):
+   - `auto_detect` + categoryId set → `matched` (✅)
+   - `category_mapping` + categoryId set → `matched` (✅)
+   - `manual` or null categoryId → `no-match` (❌)
+6. Step 2 renders a progress strip ("Resolving 23 of 50…") and auto-advances to Step 3 once all queries are settled OR 15 s elapses (whichever first). Un-resolved rows stay flagged ❌.
+
+### 3.6 Submit shape
+
+**Variant ambiguity resolved (R4)**: confirmed by reading `libs/core/src/listings/application/services/bulk-offer-creation-submit.service.ts:182` — the service maps each entry from `input.productIds[]` into `OfferCreationRecord.internalVariantId` 1:1. So:
+
+- The DTO description is correct: the array carries **variant IDs**, not product IDs (the misleading field name is locked in via #736).
+- Each submitted variant produces exactly one offer-creation record → one Allegro offer.
+- The parent spec's SC-2 ("auto-collapse PS product → 1 Allegro offer with Allegro variant matrix") means: **FE picks a canonical primary variant per selected product** and sends only that variant ID. Sibling variants of the same product are not submitted; v1 documents this. If the operator wants per-variant offers, that's a future "split variants" mode.
+
+The bulk-create payload:
+- `connectionId`
+- `productIds: string[]` — actually **variant IDs**. FE maps each selected product → its primary variant (`variants[0]`) and sends those IDs. Products with no variants are flagged ❌ pre-submit.
+- `sharedConfig`: `{ stock, publishImmediately, price?, generateDescription?, descriptionTone? }`
+- `perProductOverrides?: Record<variantId, { stock?, publishImmediately?, price?, overrides? }>` — keyed by **variantId** (same key as the array entries).
+
+Per-row edit modal writes into `perProductOverrides[variantId]`. The `overrides` block carries the per-row title/description/category/parameters/images. Unedited rows produce no entry in `perProductOverrides`.
+
+---
+
+## 4. Per-issue implementation steps
+
+### Issue #739 — Products page multi-select + bulk action bar (~2 days)
+
+**Files touched:**
+- `apps/web/src/pages/products/products-list-page.tsx`
+- `apps/web/src/pages/products/products-list-page.test.tsx`
+- `apps/web/src/index.css` — new `/* ── Products selection (#739) ── */` section
+
+**Steps:**
+
+1. **Add a "select" column at column index 0.** It renders a `<input type="checkbox">` per row plus a header checkbox for "select all on this page". Selection is **component-local** — no URL params during selection. (Re-reading the issue: "preserves selection in URL/state when navigating to wizard" — that means at navigation time, not during selection. Selection lives in `useState<Set<string>>`; on "Create Allegro offers (N)" click, IDs are serialised into the wizard URL.)
+   - **Decision**: Use a dedicated `DataTable` column with `cell: (product) => <CheckboxCell ... />`. The existing `DataTable` already supports custom cells; selection is just a column whose cell calls back into the page.
+   - When the page changes (offset, search), preserve the existing selection set across pagination — selections persist for ≤100 total across pages until either submitted or page exit.
+2. **Header checkbox semantics**: "select all visible" toggles all rows on the current page. Indeterminate state when some-but-not-all visible are selected. No "select across all pages" affordance in v1 — operator must page through (matches AC-1 cap of 100).
+3. **Selection cap**: when `selected.size === 100`, additional unchecked checkboxes become `disabled` with a tooltip `"Max 100 per batch"`. Already-selected rows can still uncheck.
+4. **Bulk action bar**: use the new `BulkActionBar` shared primitive (see § 3.3 — added to `shared/ui/` as part of this PR; the style guide promised it but it didn't exist yet). Shape: `<BulkActionBar count={N} actions={<Button tone="primary">Create Allegro offers ({N})</Button>} />`. Rendered above the table when `selected.size > 0`. Visually hidden at `N=0` (no DOM cost when not in use). `aria-live="polite"` so the count change is announced. **Mobile**: bar pins to bottom of viewport at `<640px` per the cockpit pattern.
+5. **Navigation**: clicking the button calls `navigate('/listings/bulk-create/wizard?productIds=' + Array.from(selected).join(','))`. Selection is *not* cleared on navigation — if the user returns via back button the selection is still there.
+6. **Tests** (Vitest + Testing Library, `renderWithProviders` pattern from `products-list-page.test.tsx`):
+   - Initial render: no checkbox checked, no action bar.
+   - Click one row checkbox: action bar appears with "(1)"; row is checked.
+   - Click header checkbox: all visible rows check; action bar shows correct count.
+   - Click checked header checkbox: all uncheck.
+   - Select 100, attempt 101: 101st checkbox is `disabled`; tooltip visible (via `aria-describedby`).
+   - Click "Create Allegro offers": navigation called with correct `?productIds=` (assert via mock `navigate`).
+
+**Acceptance (maps to issue AC):**
+- ✅ AC-1.1: Operator selects 1–100 products
+- ✅ AC-1.2: Select-all selects visible page
+- ✅ AC-1.3: >100 disables further selection with tooltip
+- ✅ AC-1.4: Action button preserves selection in URL on navigate
+- ✅ AC-1.5: Component test
+- ✅ AC-1.6: PL+EN locales — current i18n seam is no-op; strings inlined with `t(key, fallback)` per established pattern
+- ✅ AC-1.7: Mobile responsive (cardView fallback inherited; action bar collapses)
+
+---
+
+### Issue #740 — Bulk listing wizard (~5 days)
+
+**Route**: `/listings/bulk-create/wizard?productIds=…&step=…`
+**Files touched:**
+- New `pages/listings/bulk-create-wizard-page.tsx` + test
+- New `features/listings/components/bulk/*` (see § 3.3)
+- New `features/listings/api/bulk-listings.{api,types,query-keys}.ts`
+- New `features/listings/hooks/use-bulk-submit-mutation.ts`
+- New `features/listings/lib/bulk-throttle.ts` (stub for v1)
+- `app/routes/listings.route.tsx` — register `bulk-create/wizard` child route
+- `index.css` — new `/* ── Bulk wizard (#740) ── */` section
+- `app/api/api-client-provider.tsx` (or wherever `apiClient.listings` is composed) — add bulk methods to `ListingsApi`
+
+**Steps:**
+
+1. **Route registration.** Add `{ path: 'bulk-create/wizard', handle: { crumb: { group: 'Operations', title: 'Bulk listing' } } satisfies RouteCrumbHandle, lazy: ... }` as a child of `/listings`. Pattern follows `docs/frontend-architecture.md` § Breadcrumb metadata on routes (#610). The route-handle contract test (`route-handle.test.ts`) will fail if `handle.crumb` is missing.
+
+2. **Page shell** (`bulk-create-wizard-page.tsx`):
+   - Reads `productIds` from `useSearchParams()`; redirects to `/products` if empty or >100.
+   - Uses `useProductsQuery({ ids: [...] })` *or* `useQueries(productIds.map(id => useProductQuery(id)))` to hydrate selected products + variants. **Decision**: use `useQueries` with `useProductQuery` for now — caches are reused if user already viewed the products; one fewer endpoint to extend. (`useProductsQuery` doesn't take an `ids` filter today; adding one is BE work.)
+   - Wraps `<BulkWizard products={...} />`.
+
+3. **`bulk-wizard.tsx` — step controller.**
+   - State: `step: 'config' | 'resolve' | 'review' | 'confirm'` driven by `?step=` search-param; default `config`.
+   - Header: `<SetupStepper>` (reuse from single-offer wizard) showing the 4 visible steps.
+   - Body: renders the active step component.
+   - Owns `sharedConfig` state, `perProductOverrides` map, and a `rows` array (one entry per product with status + resolved fields).
+
+4. **`bulk-config-step.tsx` — Step 1.**
+   - Connection picker: `useConnectionsQuery({ platformType: 'allegro' })` filtered to active connections supporting `OfferCreator`. If exactly 1 → auto-selected, picker hidden. If 0 → `<Alert tone="error">` with link to /connections.
+   - Shipping policy picker: `useSellerPoliciesQuery(connectionId)`. Shows `<Select>` of delivery policies.
+   - Default stock numeric input + "publish immediately" checkbox (defaults: stock=1, publish=true).
+   - Optional default `price` (currency + amount) — used as fallback if a variant has no price.
+   - "Generate AI descriptions" checkbox (sets `sharedConfig.generateDescription` — covers the AC-9 fallback per § 2).
+   - "Proceed" button → `setStep('resolve')`.
+   - Validation: connection + shipping policy + stock ≥ 0 are required.
+
+5. **`bulk-resolve-step.tsx` — Step 2.**
+   - Mounts a parallel set of `useResolveCategoryQuery` calls (one per row with a barcode) via a `useResolveCategoryBatch(rows, connectionId)` helper that internally uses `useQueries`. Concurrency capped at 8 via `bulk-throttle.ts` (see § 3.5).
+   - Renders `<LoadingState>` with a progress line `"Resolving N of M…"` derived from the queries' `isSuccess` count.
+   - 15 s overall timeout via `useEffect` + `setTimeout`: on fire, transitions to Step 3 regardless of pending queries. **Three states per row** (not two): `matched` (✅), `pending-after-timeout` (⏳ amber, "Still resolving — will update"), `no-match` (❌ red, "Manual category required").
+   - **Late-arrival behaviour**: queries that settle after the user advances continue to fire (TanStack doesn't cancel them). The Step-3 review table subscribes to the same queries — a row that's `pending-after-timeout` flips to `matched` automatically when its query resolves. Pending rows do not block "Approve all", but the user gets visual confirmation that late-arrivers are still updating.
+   - Auto-advance to Step 3 when all queries settle.
+   - On render: write resolved `allegroCategoryId` + `method` into the parent's `rows[i].resolvedCategory`.
+
+6. **`bulk-review-step.tsx` — Step 3 (review table).**
+   - Renders one row per product using `<DataTable>` with columns: thumbnail+name, status icon, category (text), price (computed from override or shared), stock, edit button.
+   - Status icons render via `<StatusBadge tone="success|warning|error" withDot ...>` from `shared/ui/`:
+     - `matched` → green "Auto-matched"
+     - `multi-match` → amber "Pick a card" (deferred — see note)
+     - `no-ean` / `no-variant` / `no-match` → red "Manual category required"
+   - **Multi-match handling** is **deferred to a follow-up** because `useResolveCategoryQuery` returns only a single resolved category, not a list of candidates. Surfacing multi-match would require either calling `findProductsByBarcode` separately or a BE change to `/categories/resolve`. v1 treats every non-`manual` result as `matched`; for `manual`, the user picks via the edit modal's category picker — that's already in the edit modal, so the UX still works. Documented in the issue follow-up list at § 7.
+   - "Approve all" CTA at top-right; disabled while any row's `status !== 'matched'` or while any row has a Zod-invalid override.
+   - "Back to Products" button → `navigate('/products')`.
+   - Filter input on top: client-side filter on row name.
+
+7. **`bulk-edit-modal.tsx` — Step 4 (per-row edit).**
+   - Triggered by row's "Edit" button. `<Dialog>` (Radix-backed, from `shared/ui/`) with a tall form. Modal owns its own `FormProvider`.
+   - Form schema (`bulk-edit-modal.schema.ts`):
+     ```ts
+     z.object({
+       title: z.string().trim().min(1).max(75),  // Allegro title limit
+       categoryId: z.string().min(1),
+       description: z.string().min(1).max(50_000),
+       stock: z.number().int().min(0),
+       priceAmount: z.string().regex(/^\d+(\.\d{1,2})?$/),
+       priceCurrency: z.enum(['PLN', 'EUR', ...]),
+       publishImmediately: z.boolean(),
+       parameters: parametersSchema,  // dynamic — reuse buildParametersZodSchema()
+     })
+     ```
+   - **Form-context note**: `CategoryParametersStep` and `CategoryPicker` both consume `useFormContext()` (verified at `apps/web/src/features/listings/components/category-parameters-step.tsx:30,82,199`). They access keys `categoryId` and `parameters` — the modal schema uses the exact same key names, so dropping them into the modal's `FormProvider` works without changes.
+   - Reused subcomponents (already exist in `features/listings/components/`):
+     - `CategoryPicker` — Allegro category tree
+     - `CategoryParametersStep` — dynamic parameter editors
+     - `OfferDescriptionEditor` — if it exists; fall back to `<Textarea>` for v1 if the editor proves heavy to embed
+   - **Per-row AI description toggle (parent AC-9)**: in scope. Render a `<Button tone="ghost">Generate with AI</Button>` near the description field that opens `<SuggestionDialog>` (already used inside the single-offer wizard — `AllegroCreateOfferWizard.tsx:49`). On accept, the AI output replaces the modal's `description` field; the operator can edit before saving the modal. Per-row toggle overrides the Step-1 batch-wide `sharedConfig.generateDescription` for that row.
+   - On save: merge into `perProductOverrides[variantId].overrides`. Closing without save discards.
+
+8. **`bulk-confirm-modal.tsx` — Step 5.**
+   - Triggered by Step 3's "Approve all".
+   - Shows aggregate counts + "Publish immediately" toggle (mirrors `sharedConfig.publishImmediately`; flipping here overwrites).
+   - On confirm: `useBulkSubmitMutation.mutate({ connectionId, productIds: variantIds, sharedConfig, perProductOverrides })`. Idempotency key: stable per wizard mount.
+   - On 202: `navigate('/listings/bulk-batches/' + batchId)` and `showToast({ tone: 'success', title: 'Batch submitted', description: '…' })`.
+   - On 4xx: `<Alert tone="error">` in modal with message.
+
+9. **API client + hook**:
+   - `features/listings/api/bulk-listings.api.ts` adds three methods (`bulkCreate`, `getBulkBatch`, `retryFailed`) to `apiClient.listings.bulk` (or top-level — match the existing nesting style).
+   - `features/listings/hooks/use-bulk-submit-mutation.ts`:
+     ```ts
+     useMutation({ mutationFn: (input) => apiClient.listings.bulkCreate(input, { idempotencyKey }), onSuccess: () => queryClient.invalidateQueries(...) })
+     ```
+   - Idempotency key generated once per wizard mount via `crypto.randomUUID()` — same pattern as the single-offer wizard.
+
+10. **Tests** (component-level Vitest):
+    - `bulk-wizard.test.tsx`: step transitions, config validation, resolve progress, submit flow with mocked `useBulkSubmitMutation` returning batchId.
+    - `bulk-edit-modal.test.tsx`: opens with row prefill, saves into overrides map, validation errors visible.
+    - Page test: 0 products → redirect; >100 → redirect; 1 product → renders.
+
+**Acceptance (maps to issue AC):**
+- ✅ AC-2: Wizard completes a 10-product batch in <5 minutes (qualitative — measured during dogfooding)
+- ✅ AC-3: EAN auto-match results render correctly per row
+- ✅ AC-4: Edit modal validates before save
+- ✅ AC-5: "Approve all" disabled state honored
+- ⚠️ AC-6 (account-level Smart banner): **deferred** per § 2
+- ✅ AC-7: PL+EN inline strings
+- ✅ AC-8: Mobile responsive
+- ✅ AC-9: Component tests
+- ✅ AC-10: lint + type-check + tests pass
+- ✅ Parent AC-9 (per-row AI toggle): **in scope** (reverted from initial deferral — see § 2)
+
+---
+
+### Issue #741 — Batch progress page (~3 days)
+
+**Route**: `/listings/bulk-batches/:batchId`
+**Files touched:**
+- New `pages/listings/bulk-batch-progress-page.tsx` + test
+- `features/listings/hooks/use-bulk-batch-query.ts` (the polling query)
+- `features/listings/hooks/use-bulk-retry-failed-mutation.ts`
+- `features/listings/components/bulk/bulk-batch-progress-table.tsx` + test
+- `app/routes/listings.route.tsx` — register `bulk-batches/:batchId`
+- `index.css` — new `/* ── Bulk batch progress (#741) ── */` section
+
+**Steps:**
+
+0. **Route registration.** Add `{ path: 'bulk-batches/:batchId', handle: { crumb: { group: 'Operations', title: 'Bulk batch' } } satisfies RouteCrumbHandle, lazy: ... }` as a child of `/listings`. The `:batchId` is dynamic but the crumb title stays static ("Bulk batch") per the established pattern — the page itself shows the batch ID in the eyebrow / KPI strip.
+
+1. **Polling hook.**
+   ```ts
+   export function useBulkBatchQuery(batchId: string | undefined) {
+     return useQuery({
+       queryKey: listingsQueryKeys.bulkBatch(batchId ?? ''),
+       queryFn: () => apiClient.listings.getBulkBatch(batchId!),
+       enabled: Boolean(batchId),
+       refetchInterval: (q) => {
+         const status = q.state.data?.status;
+         return status === 'completed' || status === 'partially-failed' ? false : 5_000;
+       },
+       staleTime: 0,
+     });
+   }
+   ```
+   Mirrors `use-offer-creation-status-query.ts` exactly.
+
+2. **Page shell:**
+   - Header: batch ID (mono), connection name (from `useConnectionsQuery`), aggregate counts as a KPI strip (`MetricCard × 3`: Total / Succeeded / Failed) — matches the cockpit pattern.
+   - Status badge: pulses while `running`/`pending`, solid on terminal.
+   - Loading / error / empty states per `.claude/rules/fe-pages.md`.
+
+3. **Per-record table** (`bulk-batch-progress-table.tsx`):
+   - One row per record. Columns: variant id (mono), product name (resolved via `useProductQuery` per row, batched), status badge, externalOfferId (when present, linked to Allegro), createdAt, actions.
+   - Product name column is best-effort — if variant→product hydration fails, fall back to variant id only.
+   - Status mapping (`OfferCreationStatusValues`):
+     - `pending` / `running` → neutral with pulse
+     - `succeeded` → success
+     - `failed` → error
+   - Action column (per row): if `status === 'failed'`, a "Retry" link — **but only the batch-level "Retry all failed" is implemented in this PR**. Per-record retry would need a separate BE endpoint or a hack that re-submits a 1-element batch; deferred to a follow-up. AC-6 of the parent spec covers both single + all; I'll wire the batch-level retry and document the per-record retry as a follow-up.
+
+4. **"Retry all failed" button** (top-right when batch terminal with `failed_count > 0`): mutation calls `POST /listings/bulk-create/:batchId/retry-failed`; on 202, invalidates the bulk-batch query (polling resumes — the BE flips batch back to `running`).
+
+5. **Final summary card**: when `status ∈ {completed, partially-failed}`, render a card summarising counts + links to the connection's `/listings` page (filtered by `?bulkBatchId=` if such a filter exists — verify; if not, just to `/listings`).
+
+6. **Tests:**
+   - Renders with mocked `useBulkBatchQuery` returning `running` state — sees polling indicator, no retry button.
+   - Renders with `partially-failed` — retry button visible.
+   - Click retry — mutation called, toast shown.
+   - Loading / error / not-found states.
+
+**Acceptance (maps to issue AC):**
+- ✅ AC-1: Polls every 5 s and updates real-time
+- ✅ AC-2: Per-product status reflects job state
+- ⚠️ AC-3 (Smart badge): **deferred** per § 2
+- ⚠️ AC-4 (per-record retry): **deferred** — batch-level retry shipped
+- ✅ AC-5: Polling stops in terminal state
+- ✅ AC-6: PL+EN inline
+- ✅ AC-7: Mobile responsive
+- ✅ AC-8: Component tests
+- ✅ AC-9: lint + type-check + tests pass
+
+---
+
+## 5. Cross-cutting concerns
+
+### 5.1 Accessibility
+
+- All checkboxes are native `<input type="checkbox">` with `<label>` wrappers; selection count is in an `aria-live="polite"` region; tooltips on disabled checkboxes use `aria-describedby`.
+- Modals use the existing `Dialog` Radix-backed component → focus trap + Esc + `aria-modal` handled.
+- Polling page wraps the count strip in `aria-live="polite"` so screen readers hear count updates.
+- Status icons paired with text per the `StatusBadge` contract (color is never the only signal).
+
+### 5.2 Idempotency
+
+- Wizard mints `crypto.randomUUID()` once per mount → reused across retries → forwarded as `x-idempotency-key` if/when the bulk-create endpoint honors it (verify in `BulkOfferCreationController` — if not used, drop the header).
+
+### 5.3 i18n
+
+- Inline strings with `t('bulk.wizard.config.title', 'Configure batch')` pattern per existing seam; PL fallbacks not yet wired anywhere (the seam is no-op). No additional infra in this PR.
+
+### 5.4 Styling
+
+- Three small bounded `index.css` sections (one per issue) per `.claude/rules/frontend.md`. All colors / spacing via `var(--token)`. No new tokens added (the existing palette covers it).
+
+### 5.5 Plugin barrel
+
+- `features/listings/index.ts` re-exports nothing new — bulk components are internal. Only the route entry points (page modules in `pages/listings/`) consume them, via same-feature relative imports.
+
+---
+
+## 6. Quality gate
+
+Per `CLAUDE.md`:
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All three must pass with zero errors before commit. No BE changes → no migration check needed.
+
+Optional dogfood pass: `pnpm start:dev:web` + `pnpm start:dev:api` + `pnpm start:dev:worker` + dev stack up → walk the wizard with 3 real products against a real Allegro connection. Strongly recommended before push for AC-2 ("under 5 minutes for a 10-product batch") qualitative validation.
+
+---
+
+## 7. Risks & open questions
+
+| Risk | Mitigation |
+|---|---|
+| **R1** — Auto-match endpoint rate-limit gets hit on 50-row batches | Mitigated upfront: `bulk-throttle.ts` caps Step-2 EAN resolves at 8 parallel. Existing `AllegroHttpClient` BE-side rate-limit handling remains the second layer of defence. |
+| **R2** — `useProductQuery × 100` page-load weight | `useProductQuery` hits `GET /products/:id` once per product. With 100 selected products this is 100 parallel requests at page mount. TanStack dedupes if the user already viewed a product, but worst case all 100 are cold. **Mitigation**: if observation shows this is slow, request a BE batch endpoint (`GET /products?ids=...`) as a follow-up. Likely acceptable for v1 because the wizard is admin-only and not on a critical hot path. |
+| **R3** — Edit modal scope creep | The single-offer wizard is 600+ lines and has 5 steps. Trying to embed its full feature surface in a single-screen modal will balloon. **Mitigation**: edit modal exposes only the *5 commonly edited fields* (title, category, description, stock+price, parameters) + the per-row AI toggle; operator has the option to deselect and use the single-offer wizard for unusual cases. Explicit non-feature: no variant-matrix editing, no policy override, no image picker (uses product's first image as offer image — matches single-offer default). |
+| **R4** — Variant ambiguity (DTO field name vs description) | **Resolved**: `bulk-offer-creation-submit.service.ts:182` maps each `input.productIds[]` entry to `internalVariantId` 1:1 — the array carries variant IDs. FE picks the primary variant per selected product (SC-2 collapse). Documented in § 3.6. |
+
+---
+
+## 8. Test strategy
+
+Per `.claude/rules/fe-pages.md` § Testing Priorities:
+
+| Suite | Coverage |
+|---|---|
+| `products-list-page.test.tsx` (extended) | Selection state, action bar, navigation, cap enforcement, header checkbox semantics |
+| `bulk-create-wizard-page.test.tsx` | 0-products redirect, >100 redirect, happy path step transitions |
+| `bulk-wizard.test.tsx` | Step state from URL, validation per step, AC-2 through AC-5 |
+| `bulk-edit-modal.test.tsx` | Form validation, save merges into overrides, cancel discards |
+| `bulk-batch-progress-page.test.tsx` | Loading / error / empty / data states; polling start/stop; retry button visibility per terminal state |
+| `bulk-batch-progress-table.test.tsx` | Per-row status badge mapping; offer-link rendering for succeeded rows |
+
+All tests use `renderWithProviders` + `createMockApiClient`. No new test infrastructure.
+
+---
+
+## 9. Out of plan — fixed follow-up issues
+
+If/when this bundle merges, file these as follow-ups (each is small, no dependency between them):
+
+1. **feat(listings): surface smart classification on bulk batch record summary** — BE-S. Extend `BulkBatchRecordSummaryDto` with `smartClassification: { fulfilled: boolean; failedDeliveryMethods?: string[] } | null` + repo read-through from `OfferCreationRecord`. Closes parent AC-7. FE badge addition is a separate FE-S chaser.
+2. **feat(allegro): expose account-level Smart eligibility hook + wizard banner** — BE+FE-S. New `GET /listings/connections/:connectionId/smart` endpoint backed by Allegro's `GET /sale/smart`, plus FE `useSmartEligibilityQuery` + banner in the bulk wizard's Step 1. Closes parent AC-8.
+3. **feat(listings): per-record retry endpoint for bulk batch records** — BE-S. `POST /listings/bulk-create/:batchId/records/:recordId/retry` — single-row reset + enqueue, mirroring `bulkRetry.retryFailed`'s per-record path. FE inline retry button is a separate FE-S chaser. Closes #741 AC-4.
+4. **feat(listings): multi-match handling for EAN→category bulk auto-match** — BE returns top-N candidates from `/sale/products?phrase={ean}`, FE shows a card-picker modal when the row's `method` is multi-match. Closes parent spec OQ-C1.
+5. **feat(api,products): batch product detail endpoint `GET /products?ids=`** — only file if observation in R2 (100-product wizard mount) shows real weight. Replaces N parallel `GET /products/:id` with one bounded request.
+
+---
+
+*Plan generated 2026-05-18 following [`docs/implementation-plan-generator-guide.md`](../implementation-plan-generator-guide.md).*

--- a/docs/plans/mockup-739-740-741-bulk-listing.html
+++ b/docs/plans/mockup-739-740-741-bulk-listing.html
@@ -1,0 +1,1861 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>OpenLinker · Bulk listing wizard mockup (#739 / #740 / #741)</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
+<style>
+/* ============================================================
+   OpenLinker design tokens — OKLCH (warm-neutral, hue 80)
+   Mirrors apps/web/src/index.css :root. Light theme only.
+   ============================================================ */
+:root {
+  /* Surfaces */
+  --bg-canvas: oklch(99% 0.003 80);
+  --bg-shell: oklch(97.5% 0.004 80);
+  --bg-surface: #ffffff;
+  --bg-surface-elevated: oklch(99% 0.003 80);
+  --bg-surface-muted: oklch(96% 0.005 80);
+  --bg-surface-hover: oklch(93% 0.006 80);
+  --bg-muted: oklch(96% 0.005 80);
+  --bg-strong: oklch(93% 0.006 80);
+
+  /* Borders */
+  --border-subtle: oklch(93.5% 0.006 80);
+  --border-default: oklch(88% 0.008 80);
+  --border-strong: oklch(78% 0.010 80);
+
+  /* Text */
+  --text-primary: oklch(20% 0.012 80);
+  --text-secondary: oklch(38% 0.010 80);
+  --text-muted: oklch(52% 0.008 80);
+  --text-disabled: oklch(70% 0.005 80);
+  --text-inverse: oklch(96% 0.005 80);
+  --text-on-primary: oklch(18% 0.012 50);
+  --text-link: oklch(50% 0.14 250);
+
+  /* Signal-orange accent (#775) */
+  --accent-primary: oklch(68% 0.18 50);
+  --accent-primary-hover: oklch(62% 0.19 50);
+  --accent-primary-active: oklch(56% 0.20 50);
+  --accent-primary-soft: oklch(96% 0.04 60);
+  --accent-primary-soft-strong: oklch(40% 0.16 50);
+  --accent-primary-border: oklch(85% 0.10 55);
+  --accent-focus: oklch(68% 0.18 50);
+  --accent-ring: oklch(68% 0.18 50 / 0.30);
+
+  /* Status */
+  --status-success: oklch(54% 0.14 150);
+  --status-success-soft: oklch(96% 0.04 150);
+  --status-success-border: oklch(85% 0.08 150);
+  --status-success-fg: oklch(36% 0.12 150);
+
+  --status-warning: oklch(72% 0.16 85);
+  --status-warning-soft: oklch(96% 0.05 85);
+  --status-warning-border: oklch(85% 0.10 85);
+  --status-warning-fg: oklch(42% 0.12 80);
+
+  --status-error: oklch(58% 0.20 25);
+  --status-error-soft: oklch(96% 0.04 25);
+  --status-error-border: oklch(85% 0.10 25);
+  --status-error-fg: oklch(42% 0.16 25);
+
+  --status-info: oklch(56% 0.14 245);
+  --status-info-soft: oklch(96% 0.03 245);
+  --status-info-border: oklch(85% 0.08 245);
+  --status-info-fg: oklch(40% 0.12 245);
+
+  --status-review: oklch(58% 0.16 290);
+  --status-review-soft: oklch(96% 0.04 290);
+  --status-review-border: oklch(85% 0.08 290);
+  --status-review-fg: oklch(42% 0.14 290);
+
+  --status-neutral-soft: oklch(96% 0.005 80);
+  --status-neutral-border: oklch(85% 0.008 80);
+  --status-neutral-fg: oklch(42% 0.010 80);
+
+  /* Spacing — 4px grid */
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 24px; --space-6: 32px; --space-7: 48px; --space-8: 64px;
+
+  /* Radii */
+  --radius-sm: 6px; --radius-md: 8px; --radius-lg: 10px;
+  --radius-xl: 14px; --radius-pill: 9999px;
+
+  /* Tracking */
+  --tracking-tight: -0.02em;
+  --tracking-caps: 0.09em;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px oklch(20% 0.012 80 / 0.04);
+  --shadow-md: 0 4px 12px oklch(20% 0.012 80 / 0.06);
+  --shadow-lg: 0 12px 28px oklch(20% 0.012 80 / 0.10);
+  --shadow-focus: 0 0 0 3px var(--accent-ring);
+
+  --font-sans: 'IBM Plex Sans', system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+}
+
+/* ============================================================
+   Base
+   ============================================================ */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  line-height: 20px;
+  color: var(--text-primary);
+  background: var(--bg-shell);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.mono { font-family: var(--font-mono); font-size: 12px; letter-spacing: -0.01em; }
+.tabular { font-variant-numeric: tabular-nums; }
+.eyebrow {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  text-transform: uppercase; letter-spacing: var(--tracking-caps);
+  color: var(--text-muted);
+}
+
+/* ============================================================
+   Mockup page chrome
+   ============================================================ */
+.mockup-header {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: var(--space-7) var(--space-6) var(--space-5);
+}
+.mockup-header h1 {
+  font-size: 28px; line-height: 32px; font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  margin: 0 0 var(--space-2);
+}
+.mockup-header p {
+  color: var(--text-secondary);
+  font-size: 14px;
+  max-width: 720px;
+  margin: 0 0 var(--space-4);
+}
+.mockup-header .meta {
+  display: flex; gap: var(--space-3); flex-wrap: wrap;
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--text-muted); letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+}
+.mockup-header .meta span {
+  display: inline-flex; align-items: center; gap: var(--space-1);
+  padding: 4px 8px; background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.surface-section {
+  max-width: 1440px;
+  margin: var(--space-6) auto;
+  padding: 0 var(--space-6);
+}
+.surface-label {
+  display: flex; align-items: baseline; gap: var(--space-3);
+  margin-bottom: var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border-default);
+}
+.surface-label .num {
+  font-family: var(--font-mono); font-weight: 600; font-size: 11px;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--accent-primary);
+  background: var(--accent-primary-soft);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--accent-primary-border);
+}
+.surface-label .title {
+  font-size: 17px; font-weight: 600; letter-spacing: var(--tracking-tight);
+}
+.surface-label .path {
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--text-muted);
+}
+.surface-label .state-tag {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--text-secondary);
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+}
+
+/* "Viewport" frame — emulates a window edge so the cockpit feel reads */
+.viewport {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  min-height: 680px;
+}
+.viewport.no-sidebar { grid-template-columns: 1fr; }
+
+/* ============================================================
+   Sidebar (240px)
+   ============================================================ */
+.sidebar {
+  background: var(--bg-shell);
+  border-right: 1px solid var(--border-subtle);
+  padding: var(--space-4) 0;
+}
+.sidebar__logo {
+  padding: 0 var(--space-4) var(--space-5);
+  display: flex; align-items: center; gap: var(--space-2);
+  font-weight: 600; font-size: 15px;
+  letter-spacing: var(--tracking-tight);
+}
+.sidebar__logo-mark {
+  width: 22px; height: 22px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-primary);
+  display: grid; place-items: center;
+  color: var(--text-on-primary);
+  font-family: var(--font-mono); font-weight: 700; font-size: 12px;
+}
+.sidebar__group {
+  padding: 0 var(--space-3);
+  margin-bottom: var(--space-5);
+}
+.sidebar__group-label {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 0 var(--space-2) var(--space-2);
+}
+.sidebar__item {
+  display: flex; align-items: center; gap: var(--space-2);
+  height: 28px; padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  position: relative;
+}
+.sidebar__item:hover { background: var(--bg-surface-muted); color: var(--text-primary); }
+.sidebar__item--active {
+  background: var(--bg-surface-muted);
+  color: var(--text-primary);
+  font-weight: 600;
+  box-shadow: inset 2px 0 0 0 var(--accent-primary);
+}
+.sidebar__item--planned {
+  color: var(--text-disabled);
+  cursor: not-allowed;
+}
+.sidebar__item-icon {
+  width: 14px; height: 14px; display: grid; place-items: center;
+  color: currentColor; opacity: 0.85;
+}
+
+/* ============================================================
+   Top bar (52px)
+   ============================================================ */
+.topbar {
+  height: 52px;
+  display: flex; align-items: center;
+  padding: 0 var(--space-5);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  gap: var(--space-4);
+}
+.topbar__crumb {
+  font-family: var(--font-mono); font-size: 11px;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--text-muted);
+}
+.topbar__crumb b { color: var(--text-secondary); font-weight: 500; }
+.topbar__search {
+  flex: 1; max-width: 480px;
+  height: 32px;
+  display: flex; align-items: center; gap: var(--space-2);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.topbar__search .kbd {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 11px;
+  padding: 1px 6px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface-muted);
+}
+.topbar__right { margin-left: auto; display: flex; align-items: center; gap: var(--space-3); }
+.topbar__env {
+  font-family: var(--font-mono); font-size: 11px;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--status-success-fg);
+  background: var(--status-success-soft);
+  border: 1px solid var(--status-success-border);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+}
+.topbar__user {
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-default);
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* ============================================================
+   Page main
+   ============================================================ */
+.main {
+  display: flex; flex-direction: column;
+  min-height: calc(680px - 0px);
+}
+.page {
+  padding: var(--space-5) var(--space-6);
+  flex: 1;
+  display: flex; flex-direction: column;
+  gap: var(--space-5);
+}
+
+.page-header__eyebrow {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: var(--space-1);
+}
+.page-header__title {
+  font-size: 22px; line-height: 28px; font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  margin: 0;
+  display: flex; align-items: baseline; gap: var(--space-3);
+}
+.page-header__desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 4px 0 0;
+}
+.page-header__row {
+  display: flex; align-items: flex-start; gap: var(--space-4);
+}
+.page-header__actions {
+  margin-left: auto;
+  display: flex; align-items: center; gap: var(--space-2);
+}
+
+/* ============================================================
+   Buttons
+   ============================================================ */
+.button {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: var(--space-2);
+  font-family: var(--font-sans); font-weight: 500; font-size: 13px;
+  height: 32px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 100ms, border-color 100ms;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.button:hover { background: var(--bg-surface-muted); }
+.button--primary {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: var(--text-on-primary);
+  font-weight: 600;
+}
+.button--primary:hover { background: var(--accent-primary-hover); border-color: var(--accent-primary-hover); }
+.button--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-secondary);
+}
+.button--ghost:hover { background: var(--bg-surface-muted); color: var(--text-primary); }
+.button--danger {
+  color: var(--status-error-fg);
+  border-color: var(--status-error-border);
+  background: var(--status-error-soft);
+}
+.button--sm { height: 28px; padding: 0 var(--space-3); font-size: 12px; }
+.button--xs { height: 24px; padding: 0 var(--space-2); font-size: 11px; }
+.button--lg { height: 38px; padding: 0 var(--space-4); font-size: 14px; }
+.button[disabled] {
+  opacity: 0.5; cursor: not-allowed;
+}
+
+/* ============================================================
+   Status pills (mono+caps, leading dot)
+   ============================================================ */
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-weight: 500; font-size: 10.5px;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  padding: 3px 8px 3px 7px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  border: 1px solid transparent;
+  line-height: 1;
+}
+.pill::before {
+  content: ''; display: block;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+.pill--success { background: var(--status-success-soft); color: var(--status-success-fg); border-color: var(--status-success-border); }
+.pill--warning { background: var(--status-warning-soft); color: var(--status-warning-fg); border-color: var(--status-warning-border); }
+.pill--error   { background: var(--status-error-soft);   color: var(--status-error-fg);   border-color: var(--status-error-border); }
+.pill--info    { background: var(--status-info-soft);    color: var(--status-info-fg);    border-color: var(--status-info-border); }
+.pill--neutral { background: var(--status-neutral-soft); color: var(--status-neutral-fg); border-color: var(--status-neutral-border); }
+.pill--review  { background: var(--status-review-soft);  color: var(--status-review-fg);  border-color: var(--status-review-border); }
+
+.pill--pulse::before {
+  animation: pulse 1.4s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.3); }
+}
+
+/* ============================================================
+   Tables (DataTable, 36px rows)
+   ============================================================ */
+.table-wrap {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.table th {
+  height: 36px;
+  text-align: left;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 0 var(--space-3);
+  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-shell);
+}
+.table th.right { text-align: right; }
+.table th.center { text-align: center; width: 36px; }
+.table td {
+  height: 36px;
+  padding: 0 var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  vertical-align: middle;
+  color: var(--text-primary);
+}
+.table tr:last-child td { border-bottom: none; }
+.table tr:hover td { background: var(--bg-surface-muted); }
+.table td.right { text-align: right; font-variant-numeric: tabular-nums; }
+.table td.mono { font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); }
+.table td.num { font-variant-numeric: tabular-nums; }
+.table tr.row--selected td { background: var(--accent-primary-soft); }
+
+/* Checkbox cell */
+.check {
+  appearance: none;
+  width: 14px; height: 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 3px;
+  background: var(--bg-surface);
+  cursor: pointer;
+  display: grid; place-items: center;
+  transition: background 80ms, border-color 80ms;
+}
+.check:hover { border-color: var(--accent-primary); }
+.check:checked {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+.check:checked::after {
+  content: '';
+  width: 8px; height: 4px;
+  border-left: 2px solid var(--text-on-primary);
+  border-bottom: 2px solid var(--text-on-primary);
+  transform: rotate(-45deg) translate(1px, -1px);
+}
+.check--indeterminate {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+.check--indeterminate::after {
+  content: '';
+  width: 7px; height: 2px;
+  background: var(--text-on-primary);
+}
+.check[disabled] { opacity: 0.4; cursor: not-allowed; }
+.check[disabled]:hover { border-color: var(--border-strong); }
+
+/* Product row: thumbnail + name */
+.product {
+  display: flex; align-items: center; gap: var(--space-3);
+}
+.thumb {
+  width: 28px; height: 28px;
+  background: var(--bg-surface-muted);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-weight: 600; font-size: 11px;
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+}
+.thumb--blue   { background: oklch(94% 0.04 245); color: oklch(40% 0.12 245); }
+.thumb--green  { background: oklch(94% 0.04 150); color: oklch(36% 0.12 150); }
+.thumb--amber  { background: oklch(94% 0.05 85);  color: oklch(42% 0.12 80); }
+.thumb--red    { background: oklch(94% 0.04 25);  color: oklch(42% 0.16 25); }
+.thumb--violet { background: oklch(94% 0.04 290); color: oklch(42% 0.14 290); }
+.thumb--orange { background: oklch(94% 0.05 50);  color: oklch(45% 0.16 50); }
+
+.product__name {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+.product__name-sub {
+  display: block;
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+/* ============================================================
+   Toolbar (above table)
+   ============================================================ */
+.toolbar {
+  display: flex; align-items: center; gap: var(--space-3);
+}
+.input {
+  height: 32px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  font-size: 13px;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  min-width: 280px;
+}
+.input:focus { outline: none; border-color: var(--accent-primary); box-shadow: var(--shadow-focus); }
+
+.chip {
+  display: inline-flex; align-items: center; gap: var(--space-1);
+  height: 28px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.chip--active {
+  background: var(--accent-primary-soft);
+  border-color: var(--accent-primary-border);
+  color: var(--accent-primary-soft-strong);
+  font-weight: 600;
+}
+
+/* ============================================================
+   Pagination
+   ============================================================ */
+.pagination {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-top: var(--space-3);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.pagination__count { font-variant-numeric: tabular-nums; }
+.pagination__actions { display: flex; gap: var(--space-2); }
+
+/* ============================================================
+   Bulk action bar (#739)
+   ============================================================ */
+.bulk-bar {
+  position: sticky;
+  bottom: var(--space-4);
+  margin: var(--space-4) calc(var(--space-6) * -1) calc(var(--space-4) * -1);
+  /* Make it visually pinned at the bottom of the page area */
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-3) var(--space-4);
+  display: flex; align-items: center; gap: var(--space-4);
+  margin-left: var(--space-6);
+  margin-right: var(--space-6);
+}
+.bulk-bar__count {
+  display: flex; align-items: baseline; gap: var(--space-2);
+}
+.bulk-bar__count strong {
+  font-size: 16px; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.bulk-bar__count span {
+  font-family: var(--font-mono); font-size: 11px;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--text-muted);
+}
+.bulk-bar__hint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.bulk-bar__actions {
+  margin-left: auto;
+  display: flex; align-items: center; gap: var(--space-2);
+}
+
+/* ============================================================
+   Wizard layout
+   ============================================================ */
+.wizard-state {
+  background: var(--bg-canvas);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-5);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.wizard-state__caption {
+  background: var(--bg-shell);
+  border-bottom: 1px solid var(--border-subtle);
+  padding: var(--space-3) var(--space-5);
+  display: flex; align-items: center; gap: var(--space-3);
+  font-family: var(--font-mono); font-size: 11px;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--text-muted);
+}
+.wizard-state__caption b {
+  color: var(--accent-primary);
+  font-weight: 600;
+  background: var(--accent-primary-soft);
+  border: 1px solid var(--accent-primary-border);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+}
+.wizard-state__body {
+  padding: var(--space-5) var(--space-6) var(--space-6);
+}
+
+/* Stepper (SetupStepper) */
+.stepper {
+  display: flex; align-items: center; gap: var(--space-3);
+  margin-bottom: var(--space-6);
+}
+.stepper__step {
+  display: flex; align-items: center; gap: var(--space-2);
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.stepper__num {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  color: var(--text-muted);
+}
+.stepper__step--done .stepper__num {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: var(--text-on-primary);
+}
+.stepper__step--done {
+  color: var(--text-secondary);
+}
+.stepper__step--active {
+  color: var(--text-primary); font-weight: 600;
+}
+.stepper__step--active .stepper__num {
+  background: var(--bg-surface);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  box-shadow: var(--shadow-focus);
+}
+.stepper__sep {
+  flex: 0 0 32px;
+  height: 1px;
+  background: var(--border-default);
+}
+.stepper__step--done + .stepper__sep { background: var(--accent-primary); }
+
+/* Wizard page-header inside */
+.wizard-head {
+  display: flex; align-items: flex-start; gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.wizard-head__title {
+  font-size: 18px; line-height: 24px; font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  margin: 0;
+}
+.wizard-head__desc {
+  font-size: 13px; color: var(--text-secondary); margin: 4px 0 0;
+}
+
+/* ============================================================
+   Form fields
+   ============================================================ */
+.field {
+  display: flex; flex-direction: column; gap: 6px;
+  margin-bottom: var(--space-4);
+}
+.field__label {
+  font-size: 12px; font-weight: 500;
+  color: var(--text-secondary);
+}
+.field__desc {
+  font-size: 11.5px; color: var(--text-muted);
+  margin-top: -2px;
+}
+.input--full { width: 100%; min-width: 0; }
+.select {
+  height: 32px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  font-size: 13px;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+                    linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position: calc(100% - 14px) 14px, calc(100% - 10px) 14px;
+  background-size: 4px 4px, 4px 4px;
+  background-repeat: no-repeat;
+  padding-right: var(--space-7);
+}
+.checkbox-row {
+  display: flex; align-items: flex-start; gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+.checkbox-row label {
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.checkbox-row label small {
+  display: block; color: var(--text-muted); font-size: 11.5px; margin-top: 2px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+}
+.form-grid--3 { grid-template-columns: 1fr 1fr 1fr; }
+.form-grid > .field { margin-bottom: 0; }
+.field--span { grid-column: 1 / -1; }
+
+/* Card */
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+}
+.card--narrow { max-width: 560px; }
+
+/* ============================================================
+   Resolving step — progress
+   ============================================================ */
+.resolve {
+  display: flex; flex-direction: column; align-items: center;
+  padding: var(--space-7) var(--space-5);
+  text-align: center;
+}
+.resolve__spinner {
+  width: 40px; height: 40px;
+  border: 3px solid var(--bg-surface-muted);
+  border-top-color: var(--accent-primary);
+  border-radius: 50%;
+  animation: spin 0.9s linear infinite;
+  margin-bottom: var(--space-4);
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.resolve__title {
+  font-size: 16px; font-weight: 600;
+  margin: 0 0 var(--space-1);
+  font-family: var(--font-mono); letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+}
+.resolve__progress {
+  font-family: var(--font-mono); font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-3);
+}
+.resolve__bar {
+  width: 360px;
+  height: 6px;
+  background: var(--bg-surface-muted);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  margin-bottom: var(--space-3);
+}
+.resolve__bar-fill {
+  height: 100%; width: 46%;
+  background: var(--accent-primary);
+  border-radius: var(--radius-pill);
+  transition: width 200ms;
+}
+.resolve__sub {
+  font-size: 13px; color: var(--text-muted);
+  max-width: 460px;
+}
+
+/* ============================================================
+   Review summary strip
+   ============================================================ */
+.review-summary {
+  display: flex; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-shell);
+  font-family: var(--font-mono); font-size: 11.5px;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--text-muted);
+}
+.review-summary b {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.review-summary .sep { color: var(--border-strong); }
+
+/* ============================================================
+   Modal (Edit modal + Confirm modal)
+   ============================================================ */
+.modal-overlay {
+  position: relative;
+  background: oklch(20% 0.012 80 / 0.40);
+  padding: var(--space-7) var(--space-5);
+  border-radius: var(--radius-lg);
+}
+.modal {
+  background: var(--bg-surface);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  width: 100%; max-width: 640px;
+  margin: 0 auto;
+  overflow: hidden;
+}
+.modal--sm { max-width: 440px; }
+.modal__head {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.modal__title {
+  font-size: 16px; font-weight: 600;
+  margin: 0;
+  letter-spacing: var(--tracking-tight);
+}
+.modal__close {
+  margin-left: auto;
+  width: 28px; height: 28px;
+  border: none; background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 16px;
+  display: grid; place-items: center;
+}
+.modal__close:hover { background: var(--bg-surface-muted); color: var(--text-primary); }
+.modal__body {
+  padding: var(--space-5);
+  max-height: 70vh;
+  overflow-y: auto;
+}
+.modal__foot {
+  padding: var(--space-3) var(--space-5);
+  border-top: 1px solid var(--border-subtle);
+  display: flex; gap: var(--space-2); justify-content: flex-end;
+  background: var(--bg-shell);
+}
+
+/* ============================================================
+   Category picker button
+   ============================================================ */
+.cat-pick {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+}
+.cat-pick__path {
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--text-secondary);
+}
+.cat-pick__path b { color: var(--text-primary); font-weight: 600; }
+.cat-pick__change {
+  margin-left: auto;
+  color: var(--text-link); text-decoration: none;
+  font-size: 12px; font-weight: 500;
+}
+
+/* AI button */
+.ai-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-sans); font-size: 12px; font-weight: 500;
+  color: var(--status-review-fg);
+  background: var(--status-review-soft);
+  border: 1px solid var(--status-review-border);
+  border-radius: var(--radius-md);
+  padding: 5px 10px;
+  cursor: pointer;
+}
+.ai-btn:hover { background: oklch(93% 0.06 290); }
+
+/* Textarea */
+.textarea {
+  width: 100%;
+  min-height: 96px;
+  padding: var(--space-3);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 20px;
+  color: var(--text-primary);
+  resize: vertical;
+}
+.textarea:focus { outline: none; border-color: var(--accent-primary); box-shadow: var(--shadow-focus); }
+
+/* ============================================================
+   KPI strip (progress page)
+   ============================================================ */
+.kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+}
+.kpi {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  min-height: 96px;
+  position: relative;
+  display: flex; flex-direction: column; justify-content: space-between;
+  overflow: hidden;
+}
+.kpi::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: var(--border-strong);
+}
+.kpi--success::before { background: var(--status-success); }
+.kpi--error::before   { background: var(--status-error); }
+.kpi--info::before    { background: var(--status-info); }
+.kpi__label {
+  display: flex; align-items: center; justify-content: space-between;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  letter-spacing: var(--tracking-caps); text-transform: uppercase;
+  color: var(--text-muted);
+}
+.kpi__value {
+  font-size: 32px; line-height: 36px; font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  font-variant-numeric: tabular-nums;
+}
+.kpi__hint {
+  font-size: 11.5px; color: var(--text-muted);
+}
+
+/* ============================================================
+   Status banner
+   ============================================================ */
+.banner {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid;
+  border-left-width: 3px;
+}
+.banner--warning {
+  background: var(--status-warning-soft);
+  border-color: var(--status-warning-border);
+  border-left-color: var(--status-warning);
+  color: var(--status-warning-fg);
+}
+.banner--info {
+  background: var(--status-info-soft);
+  border-color: var(--status-info-border);
+  border-left-color: var(--status-info);
+  color: var(--status-info-fg);
+}
+.banner__title { font-weight: 600; font-size: 13px; }
+.banner__body { font-size: 13px; color: var(--text-secondary); }
+.banner__actions { margin-left: auto; }
+
+/* Summary card on terminal */
+.summary-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4) var(--space-5);
+  display: flex; align-items: center; gap: var(--space-4);
+}
+.summary-card__main {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.summary-card__main b { color: var(--text-primary); font-weight: 600; }
+.summary-card__links {
+  margin-left: auto;
+  display: flex; align-items: center; gap: var(--space-4);
+}
+.summary-card__links a {
+  color: var(--text-link); text-decoration: none;
+  font-size: 13px; font-weight: 500;
+}
+
+/* External link */
+.ext {
+  font-family: var(--font-mono); font-size: 12px;
+  color: var(--text-link); text-decoration: none;
+}
+.ext:hover { text-decoration: underline; }
+
+/* Error excerpt (FAILED row column) */
+.err {
+  font-family: var(--font-mono); font-size: 11.5px;
+  color: var(--status-error-fg);
+  max-width: 280px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  display: inline-block;
+}
+
+/* Dim utility */
+.dim { color: var(--text-muted); }
+.right { text-align: right; }
+hr.hairline { border: none; border-top: 1px solid var(--border-subtle); margin: var(--space-4) 0; }
+
+/* Footer */
+.footer-note {
+  max-width: 1440px;
+  margin: var(--space-7) auto;
+  padding: var(--space-5) var(--space-6);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+</style>
+</head>
+
+<body>
+
+<header class="mockup-header">
+  <div class="eyebrow">OpenLinker · Implementation plan visual contract</div>
+  <h1>Allegro bulk-listing wizard — #739 / #740 / #741</h1>
+  <p>Visual reference for the three FE surfaces shipped in this PR. OKLCH tokens lifted from <span class="mono">apps/web/src/index.css</span>; cockpit density per <span class="mono">docs/frontend-ui-style-guide.md</span>; status pills use the canonical mono+caps treatment with leading dot. Implementation in vanilla CSS will follow this contract pixel for pixel.</p>
+  <div class="meta">
+    <span>UI · IBM Plex Sans</span>
+    <span>Mono · IBM Plex Mono</span>
+    <span>Accent · <span style="background:var(--accent-primary);width:10px;height:10px;border-radius:2px;display:inline-block"></span> signal orange</span>
+    <span>Row height · 36px</span>
+    <span>Tabular nums on numerics</span>
+  </div>
+</header>
+
+<!-- ============================================================
+     SURFACE 1 — /products with multi-select + bulk action bar
+     ============================================================ -->
+<section class="surface-section">
+  <div class="surface-label">
+    <span class="num">Surface 1</span>
+    <span class="title">Products list — multi-select</span>
+    <span class="path">/products?search=</span>
+    <span class="state-tag">23 of 100 selected</span>
+  </div>
+
+  <div class="viewport">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar__logo">
+        <span class="sidebar__logo-mark">OL</span>
+        OpenLinker
+      </div>
+      <div class="sidebar__group">
+        <div class="sidebar__group-label">Operations</div>
+        <div class="sidebar__item">Dashboard</div>
+        <div class="sidebar__item">Orders</div>
+        <div class="sidebar__item sidebar__item--active">Products</div>
+        <div class="sidebar__item">Inventory</div>
+        <div class="sidebar__item">Customers</div>
+        <div class="sidebar__item">Listings</div>
+      </div>
+      <div class="sidebar__group">
+        <div class="sidebar__group-label">Diagnostics</div>
+        <div class="sidebar__item">Jobs &amp; Logs</div>
+        <div class="sidebar__item">Webhooks</div>
+        <div class="sidebar__item">Cursors</div>
+      </div>
+      <div class="sidebar__group">
+        <div class="sidebar__group-label">Platform</div>
+        <div class="sidebar__item">Integrations</div>
+        <div class="sidebar__item">Adapters</div>
+        <div class="sidebar__item">Settings</div>
+      </div>
+      <div class="sidebar__group">
+        <div class="sidebar__group-label">Planned</div>
+        <div class="sidebar__item sidebar__item--planned">Automations</div>
+        <div class="sidebar__item sidebar__item--planned">Shipping</div>
+        <div class="sidebar__item sidebar__item--planned">Invoices</div>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <div class="main">
+      <div class="topbar">
+        <div class="topbar__crumb"><b>Operations</b> · Products</div>
+        <div class="topbar__search">
+          <span class="dim mono">Search anything…</span>
+          <span class="kbd">⌘K</span>
+        </div>
+        <div class="topbar__right">
+          <span class="topbar__env">production</span>
+          <div class="topbar__user">PS</div>
+        </div>
+      </div>
+
+      <div class="page">
+        <div class="page-header__row">
+          <div>
+            <div class="page-header__eyebrow">Operations</div>
+            <h2 class="page-header__title">Products</h2>
+            <p class="page-header__desc">Product catalog explorer — search by name or SKU. Select up to 100 to bulk-list on Allegro.</p>
+          </div>
+        </div>
+
+        <div class="toolbar">
+          <input class="input" type="search" placeholder="Search by name or SKU…" value="" />
+          <span class="chip chip--active">connection · Polly's Phone Store</span>
+          <span class="chip">in-stock</span>
+          <span class="chip">+ Add filter</span>
+        </div>
+
+        <div class="table-wrap">
+          <table class="table">
+            <thead>
+              <tr>
+                <th class="center"><input type="checkbox" class="check check--indeterminate" /></th>
+                <th>Name</th>
+                <th>SKU</th>
+                <th class="right">Price</th>
+                <th>Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="row--selected">
+                <td class="center"><input type="checkbox" class="check" checked /></td>
+                <td><div class="product"><span class="thumb thumb--blue">iC</span><span class="product__name">iPhone 14 Pro silicone case — Forest Green</span></div></td>
+                <td class="mono">SKU-IP14P-CASE-FG</td>
+                <td class="right tabular">79.00 zł</td>
+                <td class="mono">2026-04-12</td>
+              </tr>
+              <tr class="row--selected">
+                <td class="center"><input type="checkbox" class="check" checked /></td>
+                <td><div class="product"><span class="thumb thumb--green">SG</span><span class="product__name">Samsung Galaxy S23 tempered glass screen protector</span></div></td>
+                <td class="mono">SKU-SG-S23-GLASS</td>
+                <td class="right tabular">29.00 zł</td>
+                <td class="mono">2026-04-12</td>
+              </tr>
+              <tr>
+                <td class="center"><input type="checkbox" class="check" /></td>
+                <td><div class="product"><span class="thumb thumb--amber">PB</span><span class="product__name">Anker PowerCore 10000 mAh power bank</span></div></td>
+                <td class="mono">SKU-ANKR-PC10K</td>
+                <td class="right tabular">149.00 zł</td>
+                <td class="mono">2026-04-11</td>
+              </tr>
+              <tr class="row--selected">
+                <td class="center"><input type="checkbox" class="check" checked /></td>
+                <td><div class="product"><span class="thumb thumb--violet">HW</span><span class="product__name">Apple Watch Series 9 sport band — Storm Blue</span></div></td>
+                <td class="mono">SKU-AW9-BAND-SB</td>
+                <td class="right tabular">119.00 zł</td>
+                <td class="mono">2026-04-11</td>
+              </tr>
+              <tr class="row--selected">
+                <td class="center"><input type="checkbox" class="check" checked /></td>
+                <td><div class="product"><span class="thumb thumb--orange">CB</span><span class="product__name">USB-C to Lightning cable — braided 2m</span></div></td>
+                <td class="mono">SKU-CABLE-USBC-LT-2M</td>
+                <td class="right tabular">49.00 zł</td>
+                <td class="mono">2026-04-10</td>
+              </tr>
+              <tr>
+                <td class="center"><input type="checkbox" class="check" /></td>
+                <td><div class="product"><span class="thumb thumb--blue">EP</span><span class="product__name">Apple EarPods USB-C</span></div></td>
+                <td class="mono">SKU-EARPODS-USBC</td>
+                <td class="right tabular">99.00 zł</td>
+                <td class="mono">2026-04-10</td>
+              </tr>
+              <tr class="row--selected">
+                <td class="center"><input type="checkbox" class="check" checked /></td>
+                <td><div class="product"><span class="thumb thumb--red">WC</span><span class="product__name">MagSafe wireless charger — 15W</span></div></td>
+                <td class="mono">SKU-MAGSAFE-15W</td>
+                <td class="right tabular">189.00 zł</td>
+                <td class="mono">2026-04-09</td>
+              </tr>
+              <tr>
+                <td class="center"><input type="checkbox" class="check" /></td>
+                <td><div class="product"><span class="thumb thumb--green">SC</span><span class="product__name">Xiaomi Redmi Note 13 silicone bumper case — Black</span></div></td>
+                <td class="mono">SKU-XM-RN13-CASE</td>
+                <td class="right tabular">39.00 zł</td>
+                <td class="mono">2026-04-09</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="pagination">
+          <span class="pagination__count">Showing 1–20 of 247</span>
+          <div class="pagination__actions">
+            <button class="button button--sm" disabled>Previous</button>
+            <button class="button button--sm">Next</button>
+          </div>
+        </div>
+
+        <!-- BulkActionBar (#739) — new shared/ui primitive -->
+        <div class="bulk-bar">
+          <div class="bulk-bar__count">
+            <strong class="tabular">23</strong>
+            <span>selected</span>
+          </div>
+          <div class="bulk-bar__hint">Max 100 per batch · 77 more available</div>
+          <div class="bulk-bar__actions">
+            <button class="button button--ghost button--sm">Clear</button>
+            <button class="button button--primary">Create Allegro offers (23)</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     SURFACE 2 — /listings/bulk-create/wizard
+     ============================================================ -->
+<section class="surface-section">
+  <div class="surface-label">
+    <span class="num">Surface 2</span>
+    <span class="title">Bulk listing wizard</span>
+    <span class="path">/listings/bulk-create/wizard?productIds=…</span>
+    <span class="state-tag">5 wizard states · stacked</span>
+  </div>
+
+  <!-- STEP 1: CONFIG -->
+  <div class="wizard-state">
+    <div class="wizard-state__caption">State <b>1 / 5</b> · Step 1 — Config · /wizard?step=config</div>
+    <div class="wizard-state__body">
+      <div class="stepper">
+        <div class="stepper__step stepper__step--active"><span class="stepper__num">1</span>Config</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step"><span class="stepper__num">2</span>Resolving</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step"><span class="stepper__num">3</span>Review</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step"><span class="stepper__num">4</span>Confirm</div>
+      </div>
+
+      <div class="wizard-head">
+        <div>
+          <h3 class="wizard-head__title">Configure batch</h3>
+          <p class="wizard-head__desc">Shared defaults applied to all 23 selected products. You can override per row in the next step.</p>
+        </div>
+      </div>
+
+      <div class="card card--narrow">
+        <div class="field">
+          <label class="field__label">Allegro connection</label>
+          <select class="select">
+            <option>Polly's Phone Store — allegro.pl (active)</option>
+            <option>Polly's Test Sandbox — allegro.pl.allegrosandbox</option>
+          </select>
+          <div class="field__desc">Offers will be published under the selected connection's seller account.</div>
+        </div>
+
+        <div class="field">
+          <label class="field__label">Shipping rate package</label>
+          <select class="select">
+            <option>Default delivery (InPost · Allegro Smart eligible)</option>
+            <option>Heavy items (DPD)</option>
+            <option>EU-wide (Allegro Delivery)</option>
+          </select>
+          <div class="field__desc">Allegro Smart eligibility is derived server-side from the chosen package.</div>
+        </div>
+
+        <hr class="hairline" />
+
+        <div class="form-grid">
+          <div class="field">
+            <label class="field__label">Default stock</label>
+            <input class="input input--full tabular" type="number" value="10" />
+          </div>
+          <div class="field">
+            <label class="field__label">Default currency</label>
+            <select class="select"><option>PLN — Polish złoty</option><option>EUR — Euro</option></select>
+          </div>
+        </div>
+
+        <div class="checkbox-row">
+          <input type="checkbox" class="check" checked />
+          <label><b>Publish immediately</b><small>Uncheck to create offers as drafts. You can publish them from /listings later.</small></label>
+        </div>
+
+        <div class="checkbox-row">
+          <input type="checkbox" class="check" />
+          <label><b>Generate AI descriptions by default</b><small>Worker uses ContentSuggestionService per row. You can still override per-row in the next step.</small></label>
+        </div>
+      </div>
+
+      <div class="modal__foot" style="margin: var(--space-5) calc(var(--space-6) * -1) calc(var(--space-6) * -1); border-top: 1px solid var(--border-subtle); border-radius: 0;">
+        <button class="button">Cancel</button>
+        <button class="button button--primary">Proceed →</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- STEP 2: RESOLVING -->
+  <div class="wizard-state">
+    <div class="wizard-state__caption">State <b>2 / 5</b> · Step 2 — Auto-match · /wizard?step=resolve · 8 parallel cap</div>
+    <div class="wizard-state__body">
+      <div class="stepper">
+        <div class="stepper__step stepper__step--done"><span class="stepper__num">✓</span>Config</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step stepper__step--active"><span class="stepper__num">2</span>Resolving</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step"><span class="stepper__num">3</span>Review</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step"><span class="stepper__num">4</span>Confirm</div>
+      </div>
+
+      <div class="resolve">
+        <div class="resolve__spinner"></div>
+        <div class="resolve__title">Resolving categories from EANs</div>
+        <div class="resolve__progress tabular">23 of 50</div>
+        <div class="resolve__bar"><div class="resolve__bar-fill"></div></div>
+        <div class="resolve__sub">
+          We're matching each product's EAN against Allegro's catalog. This typically takes 5–15 seconds. Rows that don't resolve in time can still be edited manually.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- STEP 3: REVIEW TABLE -->
+  <div class="wizard-state">
+    <div class="wizard-state__caption">State <b>3 / 5</b> · Step 3 — Review · /wizard?step=review · 50 rows</div>
+    <div class="wizard-state__body">
+      <div class="stepper">
+        <div class="stepper__step stepper__step--done"><span class="stepper__num">✓</span>Config</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step stepper__step--done"><span class="stepper__num">✓</span>Resolving</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step stepper__step--active"><span class="stepper__num">3</span>Review</div>
+        <div class="stepper__sep"></div>
+        <div class="stepper__step"><span class="stepper__num">4</span>Confirm</div>
+      </div>
+
+      <div class="page-header__row" style="margin-bottom: var(--space-4);">
+        <div>
+          <h3 class="wizard-head__title">Review 50 products</h3>
+          <p class="wizard-head__desc">Click <b>Edit</b> to override any row. <span class="pill pill--info">approve all</span> stays disabled while rows need manual attention.</p>
+        </div>
+        <div class="page-header__actions">
+          <input class="input" type="search" placeholder="Filter by name…" style="min-width:240px" />
+          <button class="button button--primary button--lg" disabled>Approve all (50)</button>
+        </div>
+      </div>
+
+      <div class="review-summary">
+        <span><b>44</b> ready</span>
+        <span class="sep">·</span>
+        <span><b>1</b> still resolving</span>
+        <span class="sep">·</span>
+        <span><b>5</b> need manual category</span>
+      </div>
+
+      <div class="table-wrap" style="margin-top:var(--space-3)">
+        <table class="table">
+          <thead>
+            <tr>
+              <th style="width:34%">Name</th>
+              <th style="width:18%">Status</th>
+              <th>Matched category</th>
+              <th class="right" style="width:80px">Stock</th>
+              <th class="right" style="width:96px">Price</th>
+              <th class="right" style="width:80px">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--blue">iC</span><span class="product__name">iPhone 14 Pro silicone case — Forest Green</span></div></td>
+              <td><span class="pill pill--success">matched</span></td>
+              <td class="mono">Telefony › Etui › 165123</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">79.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--green">SG</span><span class="product__name">Samsung Galaxy S23 tempered glass</span></div></td>
+              <td><span class="pill pill--success">matched</span></td>
+              <td class="mono">Telefony › Folie › 165245</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">29.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--amber">PB</span><span class="product__name">Anker PowerCore 10000 mAh power bank</span></div></td>
+              <td><span class="pill pill--success">matched</span></td>
+              <td class="mono">Elektronika › Power banki › 13218</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">149.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--violet">HW</span><span class="product__name">Apple Watch Series 9 sport band — Storm Blue</span></div></td>
+              <td><span class="pill pill--success">matched</span></td>
+              <td class="mono">Akcesoria › Smartwatch › 256711</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">119.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--orange">CB</span><span class="product__name">USB-C to Lightning cable — braided 2m</span></div></td>
+              <td><span class="pill pill--success">matched</span></td>
+              <td class="mono">Akcesoria › Kable › 165898</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">49.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--red">CC</span><span class="product__name">Cosrx Snail Mucin 96 Power essence — 100ml</span></div></td>
+              <td><span class="pill pill--error">manual category required</span></td>
+              <td class="mono dim">— EAN found, no Allegro match</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">89.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--blue">EP</span><span class="product__name">Apple EarPods USB-C</span></div></td>
+              <td><span class="pill pill--success">matched</span></td>
+              <td class="mono">Audio › Słuchawki › 13267</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">99.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--red">WC</span><span class="product__name">MagSafe wireless charger — 15W</span></div></td>
+              <td><span class="pill pill--success">matched</span></td>
+              <td class="mono">Akcesoria › Ładowarki › 256982</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">189.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--green">SC</span><span class="product__name">Xiaomi Redmi Note 13 silicone bumper case</span></div></td>
+              <td><span class="pill pill--success">matched</span></td>
+              <td class="mono">Telefony › Etui › 165341</td>
+              <td class="right tabular">10</td>
+              <td class="right tabular">39.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td><div class="product"><span class="thumb thumb--violet">CR</span><span class="product__name">Custom resin-cast keychain — Skull</span></div></td>
+              <td><span class="pill pill--info pill--pulse">still resolving</span></td>
+              <td class="mono dim">— Late-arriving — will update</td>
+              <td class="right tabular">5</td>
+              <td class="right tabular">25.00 zł</td>
+              <td class="right"><button class="button button--xs">Edit</button></td>
+            </tr>
+            <tr>
+              <td colspan="6" style="text-align:center; color: var(--text-muted); font-size:12px; padding: var(--space-3) 0; font-style: italic;">
+                … 40 more rows (44 matched · 5 need manual category) …
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- STEP 4: EDIT MODAL (overlay over Step 3) -->
+  <div class="wizard-state">
+    <div class="wizard-state__caption">State <b>4 / 5</b> · Step 4 — Edit modal (overlays Step 3) · per-row override</div>
+    <div class="wizard-state__body" style="padding: 0;">
+      <div class="modal-overlay">
+        <div class="modal">
+          <div class="modal__head">
+            <h4 class="modal__title">Edit offer — iPhone 14 Pro silicone case · Forest Green</h4>
+            <button class="modal__close">×</button>
+          </div>
+          <div class="modal__body">
+            <div class="field">
+              <label class="field__label">Title <span class="dim">(max 75 chars)</span></label>
+              <input class="input input--full" type="text" value="iPhone 14 Pro silicone case — Forest Green · MagSafe" />
+              <div class="field__desc tabular dim">52 / 75</div>
+            </div>
+
+            <div class="field">
+              <label class="field__label">Allegro category</label>
+              <div class="cat-pick">
+                <span class="cat-pick__path">Telefony &amp; Akcesoria › <b>Etui i pokrowce</b></span>
+                <a href="#" class="cat-pick__change">Change →</a>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="field__label" style="display:flex; align-items:center; justify-content:space-between;">
+                Description
+                <button class="ai-btn" type="button">
+                  <span>✨</span> Generate with AI
+                </button>
+              </label>
+              <textarea class="textarea">Premium silicone case for iPhone 14 Pro in Forest Green. Soft-touch finish, microfiber lining, precise port cutouts, raised camera bezel for lens protection. MagSafe compatible.</textarea>
+            </div>
+
+            <div class="form-grid form-grid--3">
+              <div class="field">
+                <label class="field__label">Stock</label>
+                <input class="input input--full tabular" type="number" value="10" />
+              </div>
+              <div class="field">
+                <label class="field__label">Price</label>
+                <input class="input input--full tabular" type="text" value="79.00" />
+              </div>
+              <div class="field">
+                <label class="field__label">Currency</label>
+                <select class="select"><option>PLN</option><option>EUR</option></select>
+              </div>
+            </div>
+
+            <div class="checkbox-row">
+              <input type="checkbox" class="check" checked />
+              <label>Publish immediately</label>
+            </div>
+
+            <hr class="hairline" />
+
+            <div class="field">
+              <label class="field__label">Category parameters <span class="dim">(3 required)</span></label>
+            </div>
+            <div class="form-grid">
+              <div class="field">
+                <label class="field__label">Brand</label>
+                <select class="select"><option>OEM</option><option>Spigen</option><option>Apple</option></select>
+              </div>
+              <div class="field">
+                <label class="field__label">Manufacturer code</label>
+                <input class="input input--full mono" type="text" value="IP14P-CASE-FG" />
+              </div>
+              <div class="field field--span">
+                <label class="field__label">Color</label>
+                <select class="select"><option>Forest Green</option><option>Storm Blue</option><option>Midnight Black</option></select>
+              </div>
+            </div>
+          </div>
+          <div class="modal__foot">
+            <button class="button">Cancel</button>
+            <button class="button button--primary">Save row</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- STEP 5: CONFIRM MODAL -->
+  <div class="wizard-state">
+    <div class="wizard-state__caption">State <b>5 / 5</b> · Step 5 — Submit confirmation · small modal</div>
+    <div class="wizard-state__body" style="padding: 0;">
+      <div class="modal-overlay" style="padding: var(--space-6) var(--space-5);">
+        <div class="modal modal--sm">
+          <div class="modal__head">
+            <h4 class="modal__title">Create 50 Allegro offers?</h4>
+          </div>
+          <div class="modal__body">
+            <p style="margin:0 0 var(--space-3); font-size:13px; color: var(--text-secondary);">
+              You're about to create 50 new offers on <b style="color:var(--text-primary)">Polly's Phone Store</b>. Each offer will be created as a separate job; you can follow progress on the next page.
+            </p>
+            <div class="checkbox-row">
+              <input type="checkbox" class="check" checked />
+              <label><b>Publish immediately</b><small>Uncheck to create all 50 as drafts.</small></label>
+            </div>
+            <div class="banner banner--info" style="margin-top:var(--space-3)">
+              <div>
+                <div class="banner__title">Idempotency protected</div>
+                <div class="banner__body" style="color:inherit">If you accidentally double-submit, OpenLinker will recognize the retry and avoid duplicate offers.</div>
+              </div>
+            </div>
+          </div>
+          <div class="modal__foot">
+            <button class="button">Cancel</button>
+            <button class="button button--primary">Create offers</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     SURFACE 3 — /listings/bulk-batches/:batchId (partially-failed)
+     ============================================================ -->
+<section class="surface-section">
+  <div class="surface-label">
+    <span class="num">Surface 3</span>
+    <span class="title">Batch progress page</span>
+    <span class="path">/listings/bulk-batches/8d4f2c11…</span>
+    <span class="state-tag">Terminal · partially-failed</span>
+  </div>
+
+  <div class="viewport">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar__logo">
+        <span class="sidebar__logo-mark">OL</span>
+        OpenLinker
+      </div>
+      <div class="sidebar__group">
+        <div class="sidebar__group-label">Operations</div>
+        <div class="sidebar__item">Dashboard</div>
+        <div class="sidebar__item">Orders</div>
+        <div class="sidebar__item">Products</div>
+        <div class="sidebar__item">Inventory</div>
+        <div class="sidebar__item">Customers</div>
+        <div class="sidebar__item sidebar__item--active">Listings</div>
+      </div>
+      <div class="sidebar__group">
+        <div class="sidebar__group-label">Diagnostics</div>
+        <div class="sidebar__item">Jobs &amp; Logs</div>
+        <div class="sidebar__item">Webhooks</div>
+        <div class="sidebar__item">Cursors</div>
+      </div>
+      <div class="sidebar__group">
+        <div class="sidebar__group-label">Platform</div>
+        <div class="sidebar__item">Integrations</div>
+        <div class="sidebar__item">Adapters</div>
+        <div class="sidebar__item">Settings</div>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <div class="main">
+      <div class="topbar">
+        <div class="topbar__crumb"><b>Operations</b> · Listings · Bulk batch</div>
+        <div class="topbar__search">
+          <span class="dim mono">Search anything…</span>
+          <span class="kbd">⌘K</span>
+        </div>
+        <div class="topbar__right">
+          <span class="topbar__env">production</span>
+          <div class="topbar__user">PS</div>
+        </div>
+      </div>
+
+      <div class="page">
+        <div class="page-header__row">
+          <div>
+            <div class="page-header__eyebrow">Operations · Listings</div>
+            <h2 class="page-header__title">
+              Bulk batch <span class="mono tabular" style="font-size:18px; color: var(--text-muted)">8d4f2c11</span>
+            </h2>
+            <p class="page-header__desc">Submitted 4 minutes ago to Allegro · Polly's Phone Store · 50 products</p>
+          </div>
+          <div class="page-header__actions">
+            <button class="button button--sm">Open in /listings →</button>
+          </div>
+        </div>
+
+        <!-- KPI strip -->
+        <div class="kpi-strip">
+          <div class="kpi">
+            <div class="kpi__label">Total</div>
+            <div class="kpi__value tabular">50</div>
+            <div class="kpi__hint">submitted variants</div>
+          </div>
+          <div class="kpi kpi--success">
+            <div class="kpi__label">Succeeded · 76%</div>
+            <div class="kpi__value tabular">38</div>
+            <div class="kpi__hint">offers live on Allegro</div>
+          </div>
+          <div class="kpi kpi--error">
+            <div class="kpi__label">Failed · 14%</div>
+            <div class="kpi__value tabular">7</div>
+            <div class="kpi__hint">retry available</div>
+          </div>
+          <div class="kpi kpi--info">
+            <div class="kpi__label">
+              In progress
+              <span class="pill pill--info pill--pulse" style="font-size:10px; padding: 2px 6px;">live</span>
+            </div>
+            <div class="kpi__value tabular">5</div>
+            <div class="kpi__hint">2 pending · 3 running</div>
+          </div>
+        </div>
+
+        <!-- Banner (partially-failed) -->
+        <div class="banner banner--warning">
+          <div>
+            <div class="banner__title">Batch ended with 7 failures</div>
+            <div class="banner__body" style="color:inherit">Some offers couldn't be created. You can retry all failures in one click — successful offers won't be touched.</div>
+          </div>
+          <div class="banner__actions">
+            <button class="button button--primary">Retry all failed (7)</button>
+          </div>
+        </div>
+
+        <!-- Records table -->
+        <div class="table-wrap">
+          <table class="table">
+            <thead>
+              <tr>
+                <th style="width:24%">Product</th>
+                <th style="width:14%">Variant ID</th>
+                <th style="width:13%">Status</th>
+                <th>Offer / Failure</th>
+                <th class="right" style="width:120px">Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--violet">CR</span><span class="product__name">Custom resin-cast keychain — Skull</span></div></td>
+                <td class="mono">ol_variant_a93f8e</td>
+                <td><span class="pill pill--neutral">pending</span></td>
+                <td class="dim">Queued · waiting for worker slot</td>
+                <td class="right mono dim">—</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--amber">PB</span><span class="product__name">Anker PowerCore II 20000 mAh</span></div></td>
+                <td class="mono">ol_variant_61bc02</td>
+                <td><span class="pill pill--neutral">pending</span></td>
+                <td class="dim">Queued · waiting for worker slot</td>
+                <td class="right mono dim">—</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--blue">EP</span><span class="product__name">Apple EarPods USB-C</span></div></td>
+                <td class="mono">ol_variant_5f2a91</td>
+                <td><span class="pill pill--info pill--pulse">running</span></td>
+                <td class="dim">Creating offer on Allegro…</td>
+                <td class="right mono tabular">15:08:42</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--red">WC</span><span class="product__name">MagSafe wireless charger — 15W</span></div></td>
+                <td class="mono">ol_variant_3d8e17</td>
+                <td><span class="pill pill--info pill--pulse">running</span></td>
+                <td class="dim">Creating offer on Allegro…</td>
+                <td class="right mono tabular">15:08:41</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--orange">CB</span><span class="product__name">USB-C to Lightning cable — braided 2m</span></div></td>
+                <td class="mono">ol_variant_72fa30</td>
+                <td><span class="pill pill--info pill--pulse">running</span></td>
+                <td class="dim">Creating offer on Allegro…</td>
+                <td class="right mono tabular">15:08:40</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--blue">iC</span><span class="product__name">iPhone 14 Pro silicone case · Forest Green</span></div></td>
+                <td class="mono">ol_variant_8b3c12</td>
+                <td><span class="pill pill--success">succeeded</span></td>
+                <td><a class="ext" href="#">allegro.pl/oferta/iphone-14-pro… ↗</a></td>
+                <td class="right mono tabular">15:08:21</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--green">SG</span><span class="product__name">Samsung Galaxy S23 tempered glass</span></div></td>
+                <td class="mono">ol_variant_d419f2</td>
+                <td><span class="pill pill--success">succeeded</span></td>
+                <td><a class="ext" href="#">allegro.pl/oferta/samsung-glass… ↗</a></td>
+                <td class="right mono tabular">15:08:14</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--violet">HW</span><span class="product__name">Apple Watch Series 9 sport band — Storm Blue</span></div></td>
+                <td class="mono">ol_variant_a201c8</td>
+                <td><span class="pill pill--success">succeeded</span></td>
+                <td><a class="ext" href="#">allegro.pl/oferta/aw9-band… ↗</a></td>
+                <td class="right mono tabular">15:08:09</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--red">CC</span><span class="product__name">Cosrx Snail Mucin 96 Power essence — 100ml</span></div></td>
+                <td class="mono">ol_variant_e771b9</td>
+                <td><span class="pill pill--error">failed</span></td>
+                <td><span class="err" title="Category requires GTIN to be set on the variant before submission">Category requires GTIN to be set…</span></td>
+                <td class="right mono tabular">15:07:55</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--green">SC</span><span class="product__name">Xiaomi Redmi Note 13 silicone bumper case</span></div></td>
+                <td class="mono">ol_variant_4c6df0</td>
+                <td><span class="pill pill--error">failed</span></td>
+                <td><span class="err" title="Allegro returned 422: parameter 'Manufacturer code' is required">Allegro 422 · 'Manufacturer code' required</span></td>
+                <td class="right mono tabular">15:07:51</td>
+              </tr>
+              <tr>
+                <td><div class="product"><span class="thumb thumb--amber">PB</span><span class="product__name">Anker PowerCore 10000 mAh — vintage SKU</span></div></td>
+                <td class="mono">ol_variant_99b2af</td>
+                <td><span class="pill pill--error">failed</span></td>
+                <td><span class="err" title="Rate limit exceeded — retry will succeed after 60s">Rate limit exceeded · retry after 60s</span></td>
+                <td class="right mono tabular">15:07:48</td>
+              </tr>
+              <tr>
+                <td colspan="5" style="text-align:center; color: var(--text-muted); font-size:12px; padding: var(--space-3) 0; font-style: italic;">
+                  … 39 more rows (35 succeeded · 4 failed) …
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Final summary -->
+        <div class="summary-card">
+          <div class="summary-card__main">
+            <b>Batch completed in 4 minutes 23 seconds</b> · 38 offers created · 7 failed · 5 still in progress
+          </div>
+          <div class="summary-card__links">
+            <a href="#">Review failed offers ↓</a>
+            <a href="#">Open in /listings →</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<div class="footer-note">
+  <div class="eyebrow" style="margin-bottom: var(--space-2);">Implementation notes</div>
+  <p>
+    Every pixel uses <span class="mono">var(--…)</span> tokens — no hardcoded colors, no rem leaks. Status pills carry mono+caps + leading dot per the StatusBadge contract (color is never the only signal). DataTable rows 36px; KPI cards 96px; buttons 28/32/38px; page content starts ≤120px from top in the actual viewport. Sidebar 240px, top bar 52px — both the cockpit-frame contract.
+  </p>
+  <p style="margin-top: var(--space-3);">
+    <span class="mono">BulkActionBar</span> is the only new <span class="mono">shared/ui</span> primitive this PR adds — it fulfils the style-guide promise where <span class="mono">docs/frontend-ui-style-guide.md § Core Component Patterns</span> already listed it.
+  </p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Ships the operator-facing FE for the Allegro bulk-listing thread as a single vertical slice on top of the backend already merged in #781 / #790:

- **#739** — Products page gets a checkbox column (≤100 cap) and a sticky **`BulkActionBar`** primitive in `shared/ui/` that fulfils the previously-empty style-guide entry. Selecting 1–100 products → "Create Allegro offers (N)" CTA → wizard.
- **#740** — 4-step wizard at `/listings/bulk-create/wizard?productIds=…`:
  - **Config** — Allegro connection (auto-hidden on single), shipping policy, default stock + publish + AI-default.
  - **Resolving** — per-variant EAN→category resolves via `useResolveCategoryQuery` with **8-parallel** cap (new `pAllLimit` helper, no dep). 15 s budget, late-arriving resolves flip rows to `matched` automatically.
  - **Review** — DataTable with per-row status (`MATCHED` / `MANUAL CATEGORY REQUIRED` / `STILL RESOLVING`), filter, "Approve all" gated until every row is ready.
  - **Edit modal** — per-row override reusing `CategoryPicker`, `CategoryParametersStep`, and the existing `SuggestionDialog` for AI description (parent AC-9, in scope).
  - **Confirm** — "Create N Allegro offers?" with publish-immediately toggle.
- **#741** — Progress page at `/listings/bulk-batches/:batchId`. 5 s TanStack polling that stops on terminal status, KPI strip (Total / Succeeded / Failed / In progress), partially-failed banner with "Retry all failed (N)", per-record table, terminal summary card.

## What's in scope vs. deferred

Three ACs are explicitly out of this PR — see `docs/plans/implementation-plan-739-740-741-bulk-listing-fe.md` §2 for the named follow-up issues:

| AC | Why deferred |
|---|---|
| Parent AC-7 — per-row Smart classification badge | `BulkBatchRecordSummaryDto` doesn't carry smart classification today; needs a small BE DTO + repo read-through. |
| Parent AC-8 — pre-submit account-level Smart warning | No FE hook for `GET /sale/smart` exists; uncertain if BE wraps it. |
| Issue #741 AC-4 — per-record retry button | BE only has batch-level retry today; per-record needs a new endpoint. **Batch-level retry IS shipped.** |

Includes the implementation plan + a static HTML mockup of all three surfaces, both checked in under `docs/plans/`.

## Test plan

- [x] `pnpm lint` — 0 errors (warnings are pre-existing).
- [x] `pnpm type-check` — clean across all 9 packages.
- [x] `pnpm test` — 3,179 unit tests pass.
- [x] Architecture: cross-feature imports go through barrels; new `useProductsBatchQuery` feature hook keeps `useApiClient` out of pages.
- [x] BulkActionBar primitive — added to `shared/ui/index.ts`, has its own `bulk-action-bar.test.tsx`.
- [x] `route-lazy.test.ts` `EXPECTED_LAZY_ROUTE_COUNT` bumped to 37 (+2 routes).
- [ ] Dogfood the wizard against a real Allegro sandbox connection — confirm:
  - [ ] 8-parallel cap holds without 429-storm on a 50-row batch.
  - [ ] Failed resolves flip rows to `MANUAL CATEGORY REQUIRED` (not stuck `RESOLVING`).
  - [ ] Edit modal opens, AI suggest applies, save persists.
  - [ ] Submit redirects to progress page; polling stops on terminal.
  - [ ] "Retry all failed" re-enqueues every failed row.

## Self tech-review fixes

Three IMPORTANT items found during self-review and fixed before this PR:
- `bulk-resolve-step.tsx` — rejection branch now records `no-match` against the correct `productId` (was setting a single `__unknown__` key, silently stranding failed rows in `resolving`).
- `bulk-wizard.tsx` — replaced a `useMemo` with side effect with a proper `useEffect`.
- `bulk-batch-progress-table.tsx` — dropped the "Unknown variant" Product column placeholder; Variant ID is the lead identity column until the BE summary carries product names.

Plus three SUGGESTIONs applied: DRY'd `BulkOfferOverrides` shape; moved the edit-modal's `__formValues` stash out of the wire payload onto a FE-only `editFormValues` row field; `bulk-confirm-modal.tsx` re-syncs its publish-toggle when the parent's shared config changes.

Closes #739
Closes #740
Addresses #741 (batch-level retry shipped; per-record retry is a documented follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)