### PR TITLE
fix(allegro): matchCategoryByBarcode uses /sale/products GTIN lookup

### DIFF
--- a/apps/web/src/features/listings/hooks/use-resolve-category-query.ts
+++ b/apps/web/src/features/listings/hooks/use-resolve-category-query.ts
@@ -6,7 +6,7 @@
  * id and the resolution method (`auto_detect` | `category_mapping` | `manual`).
  *
  * Enabled only when both `connectionId` and `barcode` are set. `retry: false`
- * because Allegro's `/sale/matching-categories` regularly returns "no match"
+ * because Allegro's `/sale/products` GTIN lookup regularly returns "no match"
  * and that's a normal 200 from our BE, not a transient error.
  *
  * @module apps/web/src/features/listings/hooks
@@ -20,7 +20,7 @@ import type { ResolveCategoryResponse } from '../api/listings.types';
 // barcode) pair — the only legitimate invalidator is an admin changing
 // category mappings, which is rare. 10 min covers a wizard session and the
 // usual Step 0 ↔ Step 2 navigation without re-hitting Allegro's rate-limited
-// /sale/matching-categories endpoint on every remount.
+// /sale/products GTIN lookup on every remount.
 export const RESOLVE_CATEGORY_STALE_TIME_MS = 10 * 60 * 1000;
 
 export function useResolveCategoryQuery(

--- a/apps/web/src/features/listings/lib/bulk-throttle.ts
+++ b/apps/web/src/features/listings/lib/bulk-throttle.ts
@@ -3,7 +3,7 @@
  *
  * Caps in-flight promises at `limit` while preserving result order. Used by
  * the bulk-wizard auto-match step to avoid saturating Allegro's
- * `/sale/matching-categories` endpoint at 50+ parallel requests (`useResolveCategoryQuery`
+ * `/sale/products` endpoint at 50+ parallel requests (`useResolveCategoryQuery`
  * has `retry: false`, so a 429 burst would silently flip rows to ❌).
  *
  * No external dependency — 20 lines, `Promise.allSettled` semantics.

--- a/docs/plans/implementation-plan-794-allegro-match-category-by-barcode-fix.md
+++ b/docs/plans/implementation-plan-794-allegro-match-category-by-barcode-fix.md
@@ -1,0 +1,158 @@
+# Implementation Plan — #794 Allegro `matchCategoryByBarcode` endpoint fix
+
+## Phase 1 — Understand the task
+
+**Goal.** Fix `AllegroOfferManagerAdapter.matchCategoryByBarcode` to use the correct Allegro endpoint for EAN → category resolution. The current implementation calls `/sale/matching-categories?ean=<barcode>`, which Allegro rejects with HTTP 400 — `name` is the required query parameter on that endpoint, not `ean`. The adapter's `try/catch` swallows the 400 and returns `null`, so the failure is silent at the application layer but the bulk-create wizard's Resolve step shows every EAN-bearing row as "manual category required".
+
+**Layer.** Integration (Allegro plugin). No domain or port changes.
+
+**Non-goals.**
+- Wiring the wizard's Resolve step through the batch capability (`EanCategoryMatcher.resolveCategoriesForBatchByEan`) — that's #795, which lands separately.
+- Re-architecting `CategoryResolutionService` — its contract is unchanged, only the underlying HTTP call.
+- Removing or renaming the `CategoryBarcodeMatcher` capability — still meaningful as the single-EAN entry point.
+- Surfacing 400s as exceptions to operators — current swallow-to-null behaviour is correct post-fix because the endpoint won't 400.
+- Adding `EanCategoryMatcher` to non-Allegro adapters.
+
+## Phase 2 — Research
+
+**Existing patterns.** The correct endpoint and matching logic already live in `libs/integrations/allegro/src/infrastructure/util/resolve-categories-for-batch-by-ean.ts` (#735). The batch util:
+- Calls `GET /sale/products?phrase={ean}&mode=GTIN&limit={N}` per item.
+- Filters results to those carrying an exact GTIN-marked parameter matching the input EAN.
+- Collapses to one of three `EanMatchResult` discriminants: `matched`, `no-match`, `multi-match` (plus `no-ean` for invalid input).
+- Caches successful matches and authoritative empty results for 24 h under `allegro:ean-match:{connectionId}:{ean}`.
+- HTTP failures collapse to `no-match` and are NOT cached.
+
+**Reuse strategy.** The single-EAN `matchCategoryByBarcode` method should delegate to the same util. The contract of `CategoryBarcodeMatcher.matchCategoryByBarcode(barcode): Promise<string | null>` is narrower than `EanMatchResult`:
+
+| `EanMatchResult.kind` | Single-call return |
+|---|---|
+| `matched` | `result.allegroCategoryId` |
+| `no-match` / `no-ean` / `multi-match` | `null` |
+
+Multi-match collapse to `null` preserves the previous single-call semantics (the broken implementation returned `null` for `matches.length > 1`).
+
+**Dead type to delete.** `AllegroMatchingCategoriesResponse` in `libs/integrations/allegro/src/domain/types/allegro-api.types.ts` is only referenced by the broken adapter call site. After the fix it's dead.
+
+**FE comment drift.** Two FE files reference `/sale/matching-categories` in comments:
+- `apps/web/src/features/listings/lib/bulk-throttle.ts:6`
+- `apps/web/src/features/listings/hooks/use-resolve-category-query.ts:9,23`
+
+These were written when the broken endpoint was thought to be canonical. The accompanying behaviours (concurrency cap, stale time) still apply — only the endpoint name in the comment is wrong.
+
+## Phase 3 — Design
+
+**Approach.** Delegate the single-call path to `resolveCategoriesForBatchByEan` with a one-item batch. Two-line implementation, single source of truth for the Allegro call + cache + matching logic.
+
+Rejected alternative: extracting `resolveOne` from the batch util into a sibling `resolve-category-by-ean.ts` helper. Pros: cleaner separation, no batch-Map overhead. Cons: ~80 lines moved, two files to maintain in lockstep, two test files updated. The "overhead" is microseconds — constructing a single-entry Map. Not worth the refactor surface area for a tightly-scoped bug fix.
+
+**Data flow (single-call path after fix):**
+
+```
+CategoryResolutionService.resolveCategory(connectionId, { barcode })
+  → marketplace.matchCategoryByBarcode(barcode)
+     → resolveCategoriesForBatchByEan(httpClient, cache, connectionId, { items: [{ variantId: 'single', ean: barcode }] })
+        → cache.get('allegro:ean-match:{conn}:{ean}')  (hit-return-on-cache)
+        → httpClient.get('/sale/products?phrase={ean}&mode=GTIN&limit=10')
+        → filter by hasExactGtin(card, ean)
+        → return EanMatchResult
+     → collapse to string | null
+```
+
+Cache key prefix and TTL are inherited from the batch util's defaults — same `allegro:ean-match:{connectionId}:{ean}` namespace, so a single-call match populates the cache for the next batch call and vice versa.
+
+**Backwards compatibility.** `CategoryBarcodeMatcher` interface is unchanged. Callers (`CategoryResolutionService.resolveCategory`) keep their existing contract. Existing tests of the service-level behaviour need no changes.
+
+## Phase 4 — Step-by-step plan
+
+### Step 1 — Rewrite `matchCategoryByBarcode`
+
+**File:** `libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts`
+
+- Remove the import of `AllegroMatchingCategoriesResponse` from `../../domain/types/allegro-api.types`.
+- Replace the body of `matchCategoryByBarcode(barcode: string): Promise<string | null>` with a delegation:
+
+```ts
+async matchCategoryByBarcode(barcode: string): Promise<string | null> {
+  const results = await resolveCategoriesForBatchByEan(
+    this.httpClient, this.cache, this.connectionId,
+    { items: [{ variantId: SINGLE_ITEM_KEY, ean: barcode }] },
+  );
+  const outcome = results.get(SINGLE_ITEM_KEY);
+  return outcome?.kind === 'matched' ? outcome.allegroCategoryId : null;
+}
+```
+
+`SINGLE_ITEM_KEY` is a private module constant — any stable string works because the result map is consumed by exactly one read in the same call.
+
+**Acceptance:** the method calls the batch util once and returns the matched categoryId or `null` for every other outcome kind. No HTTP call to `/sale/matching-categories` anywhere in the codebase.
+
+### Step 2 — Delete the dead response type
+
+**File:** `libs/integrations/allegro/src/domain/types/allegro-api.types.ts`
+
+- Delete `AllegroMatchingCategoriesResponse` interface and its surrounding doc comment at lines ~486-495.
+- `pnpm type-check` must remain green — the only consumer was the adapter import removed in Step 1.
+
+**Acceptance:** `grep -r "AllegroMatchingCategoriesResponse"` in the repo returns zero results.
+
+### Step 3 — Update adapter unit specs
+
+**File:** `libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts`
+
+Update the four cases under `describe('matchCategoryByBarcode')` (lines 714-765):
+
+1. **Single match** — mock `httpClient.get` with a `/sale/products` response whose `products[0].parameters` carries `options.isGTIN: true` and the matching `values: ['<ean>']`, plus `category.id: 'cat-100'`. Assert the returned value is `'cat-100'` and the call shape is:
+   ```ts
+   expect(httpClient.get).toHaveBeenCalledWith('/sale/products', {
+     queryParams: { phrase: '5901234123457', mode: 'GTIN', limit: 10 },
+   });
+   ```
+2. **No match** — empty products array → null.
+3. **Multi-match** — two products each with `isGTIN` parameters matching the EAN → null (preserves the previous single-call collapse).
+4. **HTTP failure** — `httpClient.get.mockRejectedValue(...)` → null.
+
+**Acceptance:** `pnpm test --filter @openlinker/integrations-allegro -- allegro-offer-manager` passes; the existing four cases keep their behavioural shape with the new endpoint contract.
+
+### Step 4 — FE comment cleanup
+
+**Files:**
+- `apps/web/src/features/listings/lib/bulk-throttle.ts:6`
+- `apps/web/src/features/listings/hooks/use-resolve-category-query.ts:9,23`
+
+Replace mentions of `/sale/matching-categories` with `/sale/products` in three doc-comment locations. No behaviour change — only the endpoint name in prose. The accompanying concurrency-cap and stale-time rationale remains correct.
+
+**Acceptance:** No misleading endpoint references remain in FE comments.
+
+### Step 5 — Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All three must pass with zero errors. No integration tests touched (no schema or persistence changes).
+
+## Phase 5 — Validate
+
+**Architecture compliance.**
+- Adapter remains in `libs/integrations/allegro/src/infrastructure/adapters/`.
+- Delegates to a sibling util in the same package — no cross-context import added.
+- Capability contract (`CategoryBarcodeMatcher.matchCategoryByBarcode`) unchanged.
+
+**Naming.** No new files; no new symbols at the public surface.
+
+**Testing strategy.**
+- Unit tests cover the four observable branches at the adapter boundary.
+- The batch util's existing specs cover cache + multi-match + HTTP-failure semantics — no duplication.
+
+**Security.** No new external inputs, no new HTTP shape. Same auth headers as the existing batch path. EAN is a numeric string at the persistence layer; the batch util normalises with `.trim()`. No injection vector.
+
+**Performance.** Single-call path now incurs the batch util's per-call overhead — one `Map<string, EanMatchResult>` construction, one iteration of a single-element array. Negligible. Cache hit rate improves because the single-call and batch-call paths share the same key namespace.
+
+**Risks.**
+- Allegro's `/sale/products` response shape under `mode=GTIN` is already exercised by the batch util in production. No new contract to validate against `developer.allegro.pl`.
+- The single-call path is currently only invoked from `CategoryResolutionService.resolveCategory`, which the bulk wizard hits per row. After fix, those calls will return real matches — the FE may need to handle the matched case differently than before (it already does, per `bulk-resolve-step.tsx:118-122`).
+- `multi-match` collapses to `null` in the single-call path. This is the same behaviour as before the fix (the broken implementation also collapsed multi-match → null). Preserves contract.
+
+**Open questions.** None.

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -483,20 +483,6 @@ export interface AllegroOfferFieldsPatchBody extends Record<string, unknown> {
 }
 
 /**
- * Response from Allegro GET /sale/matching-categories
- *
- * Returns categories that match a given product identified by barcode (EAN/GTIN).
- */
-export interface AllegroMatchingCategoriesResponse {
-  matchingCategories: Array<{
-    category: {
-      id: string;
-      name?: string;
-    };
-  }>;
-}
-
-/**
  * Allegro offer publication status — Allegro's string enum from the
  * `publication.status` field on the product-offer resource.
  *

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -13,6 +13,7 @@ import type { AllegroQuantityCommandRepositoryPort } from '../../../domain/ports
 import { Connection } from '@openlinker/core/identifier-mapping';
 import type {
   AllegroOfferQuantityChangeCommandResponse,
+  AllegroProductCardSummary,
   AllegroProductOfferCreateResponse,
 } from '../../../domain/types/allegro-api.types';
 import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
@@ -712,11 +713,29 @@ describe('AllegroOfferManagerAdapter', () => {
   });
 
   describe('matchCategoryByBarcode', () => {
-    it('should return category ID when exactly one match is found', async () => {
+    // Delegates to `resolveCategoriesForBatchByEan` (#735, #794) — these
+    // tests assert the public boundary contract (categoryId | null) plus the
+    // outgoing endpoint shape. Cache + multi-match nuances are covered by
+    // the batch util's own spec.
+    type ProductCardFixture = Pick<
+      AllegroProductCardSummary,
+      'id' | 'category' | 'parameters'
+    >;
+    function buildProductCard(
+      ean: string,
+      categoryId: string,
+      productId = 'prod-id',
+    ): ProductCardFixture {
+      return {
+        id: productId,
+        category: { id: categoryId },
+        parameters: [{ id: 'gtin', options: { isGTIN: true }, values: [ean] }],
+      };
+    }
+
+    it('should return category ID when exactly one exact-GTIN match is found', async () => {
       httpClient.get.mockResolvedValue({
-        data: {
-          matchingCategories: [{ category: { id: 'cat-100', name: 'Electronics' } }],
-        },
+        data: { products: [buildProductCard('5901234123457', 'cat-100')] },
         status: 200,
         headers: {},
       });
@@ -724,14 +743,14 @@ describe('AllegroOfferManagerAdapter', () => {
       const result = await adapter.matchCategoryByBarcode('5901234123457');
 
       expect(result).toBe('cat-100');
-      expect(httpClient.get).toHaveBeenCalledWith('/sale/matching-categories', {
-        queryParams: { ean: '5901234123457' },
+      expect(httpClient.get).toHaveBeenCalledWith('/sale/products', {
+        queryParams: { phrase: '5901234123457', mode: 'GTIN', limit: 10 },
       });
     });
 
-    it('should return null when no matches are found', async () => {
+    it('should return null when no exact-GTIN matches are found', async () => {
       httpClient.get.mockResolvedValue({
-        data: { matchingCategories: [] },
+        data: { products: [] },
         status: 200,
         headers: {},
       });
@@ -741,10 +760,13 @@ describe('AllegroOfferManagerAdapter', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null when multiple matches are found', async () => {
+    it('should return null when multiple exact-GTIN matches are found', async () => {
       httpClient.get.mockResolvedValue({
         data: {
-          matchingCategories: [{ category: { id: 'cat-1' } }, { category: { id: 'cat-2' } }],
+          products: [
+            buildProductCard('5901234123457', 'cat-1', 'prod-1'),
+            buildProductCard('5901234123457', 'cat-2', 'prod-2'),
+          ],
         },
         status: 200,
         headers: {},

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -79,7 +79,6 @@ import type {
   AllegroOffersResponse,
   AllegroOfferEventsResponse,
   AllegroOfferFieldsPatchBody,
-  AllegroMatchingCategoriesResponse,
   AllegroProductOfferCreateRequest,
   AllegroProductOfferCreateResponse,
   AllegroProductSetEntry,
@@ -110,6 +109,13 @@ const ALLEGRO_ADAPTER_KEY = 'allegro.publicapi.v1';
 const DEFAULT_CAT_PARAMS_TTL_SEC = 24 * 60 * 60;
 /** Cache key prefix — global namespace; Allegro category schemas are public taxonomy. */
 const CAT_PARAMS_CACHE_PREFIX = 'allegro:cat-params:';
+
+/**
+ * Variant key used when `matchCategoryByBarcode` delegates to the batch util
+ * with a single-item input. Any stable string works — the result map is
+ * consumed by one read in the same call.
+ */
+const SINGLE_ITEM_KEY = 'single';
 
 /**
  * Type guard used when filtering untyped `platformParams.parameters` into the
@@ -813,34 +819,24 @@ export class AllegroOfferManagerAdapter
   }
 
   async matchCategoryByBarcode(barcode: string): Promise<string | null> {
-    this.logger.debug(
-      `Matching Allegro category by barcode (connection: ${this.connectionId}, barcode: ${barcode})`
+    // Delegates to the shared #735 batch util so single-call and batch paths
+    // share the `/sale/products?phrase=…&mode=GTIN` endpoint, cache namespace,
+    // and exact-GTIN match logic. The util is no-throw — HTTP failures
+    // collapse to `no-match`, surfaced at the public boundary as `null`.
+    const results = await resolveCategoriesForBatchByEan(
+      this.httpClient,
+      this.cache,
+      this.connectionId,
+      { items: [{ variantId: SINGLE_ITEM_KEY, ean: barcode }] }
     );
-    try {
-      const response = await this.httpClient.get<AllegroMatchingCategoriesResponse>(
-        '/sale/matching-categories',
-        { queryParams: { ean: barcode } }
+    const outcome = results.get(SINGLE_ITEM_KEY);
+    if (outcome?.kind === 'matched') {
+      this.logger.debug(
+        `Barcode auto-detect matched category ${outcome.allegroCategoryId} (connection: ${this.connectionId})`
       );
-      const matches = response.data.matchingCategories ?? [];
-      if (matches.length === 1) {
-        const categoryId = matches[0].category.id;
-        this.logger.debug(
-          `Barcode auto-detect matched category ${categoryId} (connection: ${this.connectionId})`
-        );
-        return categoryId;
-      }
-      if (matches.length > 1) {
-        this.logger.debug(
-          `Barcode auto-detect returned ${matches.length} categories, skipping (connection: ${this.connectionId})`
-        );
-      }
-      return null;
-    } catch (error) {
-      this.logger.warn(
-        `Failed to match category by barcode (connection: ${this.connectionId}): ${(error as Error).message}`
-      );
-      return null;
+      return outcome.allegroCategoryId;
     }
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Summary

`AllegroOfferManagerAdapter.matchCategoryByBarcode` was calling `/sale/matching-categories?ean=…`, which Allegro rejects with HTTP 400 (`Required String parameter 'name' is not present`). The adapter's `try/catch` swallowed the 400 and returned `null` — so every EAN-bearing row in the bulk-create wizard's Resolve step silently degraded to "manual category required". Reproduced during dogfood on a 6-product batch where all 4 EAN-bearing rows 400'd.

The fix delegates the single-call path to the existing #735 batch util `resolveCategoriesForBatchByEan` with a one-item batch. Both paths now share `/sale/products?phrase=…&mode=GTIN&limit=N`, the same cache namespace, and the same exact-GTIN match logic. The util is no-throw — HTTP failures collapse to `no-match`, surfaced at the public boundary as `null` (matches the prior contract; multi-match also collapses to `null`, unchanged).

## Changes

- `allegro-offer-manager.adapter.ts` — rewrite `matchCategoryByBarcode` to delegate to the batch util; drop the dead `AllegroMatchingCategoriesResponse` import; add a `SINGLE_ITEM_KEY` module constant.
- `allegro-api.types.ts` — delete dead `AllegroMatchingCategoriesResponse` type (only consumer was the broken adapter call site).
- `allegro-offer-manager.adapter.spec.ts` — update 4 cases to assert the correct endpoint (`/sale/products` with `phrase` + `mode=GTIN` + `limit=10`) and the correct response shape (products with `parameters[].options.isGTIN: true`). Fixture helper typed against `Pick<AllegroProductCardSummary, 'id'|'category'|'parameters'>` for drift safety.
- `bulk-throttle.ts`, `use-resolve-category-query.ts` — update 3 misleading `/sale/matching-categories` references in FE doc-comments to `/sale/products` (prose-only, no behaviour change). Bundled here to avoid leaving misleading endpoint names in the tree.

## Observability note for reviewers

The pre-fix `try/catch` emitted `WARN [AllegroOfferManagerAdapter] Failed to match category by barcode (connection=…): <error>` on every per-EAN HTTP failure. The batch util silently catches and returns `null` for HTTP failures. `AllegroHttpClient` still logs the underlying error at `ERROR`, so HTTP-layer visibility is preserved — but the adapter-context `WARN` is gone. Acceptable noise reduction post-fix (failures should be rare); flagged here so reviewers don't expect the old log line.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 3,179 unit tests + 1,125 web tests pass
- [x] Manual repro from the bulk wizard with a valid Allegro EAN — no 400s in API logs, row matches a category instead of degrading to manual-pick
- [ ] Verify cache hit across single-call + batch paths in a follow-up bulk-wizard run (same `(connectionId, ean)` should hit the cache the second time regardless of which path warmed it)

## Related

- #735 — shipped the batch util this PR delegates to
- #795 — follow-up: wire the bulk wizard's per-row resolve loop through the `EanCategoryMatcher` batch capability (depends on this PR landing first)
- #796 — separate FE bug: timeout downgrades settled rows after 15 s (independent of this fix)
- Plan: `docs/plans/implementation-plan-794-allegro-match-category-by-barcode-fix.md`

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)