### PR TITLE
feat(products): persist + expose ProductVariant.price (#792 PR 1)

### DIFF
--- a/apps/api/src/migrations/1799000000000-add-price-to-product-variants.ts
+++ b/apps/api/src/migrations/1799000000000-add-price-to-product-variants.ts
@@ -1,0 +1,37 @@
+/**
+ * Add Price To Product Variants
+ *
+ * Adds a `price` column to the `product_variants` table so the per-variant
+ * master price extracted by the master adapter (today: PrestaShop combination
+ * `price` and the synthetic-variant fallback to parent-product `price`)
+ * survives persistence and round-trips through the products read API.
+ *
+ * Unblocks #792 PR 1: the bulk-listing wizard needs `variant.price` on the
+ * wire to compute per-row resolved prices under the new master-pull + batch
+ * policy model. Today the master adapters extract the value but it is silently
+ * dropped at the persistence layer because no column exists.
+ *
+ * Decimal precision matches the existing `products.price` column
+ * (`decimal(10,2)`) for consistency. Nullable — existing variants stay null
+ * until their next sync populates the field; the FE surfaces `null` as a
+ * `no-master-price` blocker in the wizard's status model.
+ *
+ * No historical backfill — natural sync churn populates the field over time.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPriceToProductVariants1799000000000 implements MigrationInterface {
+  name = 'AddPriceToProductVariants1799000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" ADD COLUMN IF NOT EXISTS "price" numeric(10,2)`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "product_variants" DROP COLUMN "price"`);
+  }
+}

--- a/apps/api/src/products/http/dto/product-variant-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-variant-response.dto.ts
@@ -28,6 +28,13 @@ export class ProductVariantResponseDto {
   @ApiPropertyOptional({ nullable: true, description: 'GTIN barcode' })
   gtin!: string | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Master variant price. Nullable when not yet synced or unavailable from the master source.',
+  })
+  price!: number | null;
+
   @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
   createdAt!: string;
 

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -37,6 +37,7 @@ function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
     attributes: overrides.attributes ?? { size: 'S' },
     ean: overrides.ean ?? '1234567890123',
     gtin: overrides.gtin ?? null,
+    price: overrides.price,
     createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
     updatedAt: overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
   };
@@ -150,11 +151,27 @@ describe('ProductsController', () => {
       expect(result.currency).toBeNull();
       expect(result.variants).toHaveLength(1);
       expect(result.variants![0].id).toBe('ol_product_v1');
+      // Variant without a domain `price` serialises as `null` at the wire
+      // boundary (variantToDto normalises `undefined ↔ null`).
+      expect(result.variants![0].price).toBeNull();
       expect(result.externalIds).toHaveLength(1);
       expect(result.externalIds![0].externalId).toBe('42');
       // Verify correct entity type passed for product and variant
       expect(identifierMapping.getExternalIds).toHaveBeenCalledWith('Product', 'ol_product_1');
       expect(identifierMapping.getExternalIds).toHaveBeenCalledWith('Product', 'ol_product_v1');
+    });
+
+    it('should surface variant price when the domain entity carries one (#792)', async () => {
+      productsService.getProduct.mockResolvedValue(makeProduct());
+      productsService.listVariants.mockResolvedValue({
+        items: [makeVariant({ price: 19.99 })],
+        total: 1,
+      });
+      identifierMapping.getExternalIds.mockResolvedValue([]);
+
+      const result = await controller.getProduct('ol_product_1');
+
+      expect(result.variants![0].price).toBe(19.99);
     });
 
     it('should surface currency when the domain entity carries one', async () => {

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -55,6 +55,10 @@ function variantToDto(variant: ProductVariant): ProductVariantResponseDto {
     attributes: variant.attributes,
     ean: variant.ean ?? null,
     gtin: variant.gtin ?? null,
+    // Optional on the domain entity (adapters may omit on construction);
+    // normalised to `null` at the wire boundary so the FE sees a consistent
+    // nullable shape.
+    price: variant.price ?? null,
     createdAt: variant.createdAt!.toISOString(),
     updatedAt: variant.updatedAt!.toISOString(),
   };

--- a/apps/api/test/integration/products-read.int-spec.ts
+++ b/apps/api/test/integration/products-read.int-spec.ts
@@ -1,9 +1,14 @@
 /**
  * Products Read API Integration Test
  *
- * Vertical slice covering `currency` persistence round-trip for #358:
- * seed → `GET /products` → assert the field survives ORM ↔ domain ↔ DTO mapping
- * without loss (both a populated ISO 4217 code and the null case).
+ * Vertical slice covering:
+ *   - `currency` persistence round-trip for #358: seed → `GET /products` →
+ *     assert the field survives ORM ↔ domain ↔ DTO mapping without loss
+ *     (both a populated ISO 4217 code and the null case).
+ *   - `variant.price` persistence round-trip for #792 PR 1: seed a product
+ *     with a variant carrying a price → `GET /products/:id` → assert the
+ *     variant's `price` survives the chain end-to-end. Also covers the
+ *     null-price case (returns `null` on the wire).
  *
  * Uses real Postgres via Testcontainers.
  *
@@ -15,7 +20,10 @@ import {
   ProductRepositoryPort,
   PRODUCT_REPOSITORY_TOKEN,
 } from '@openlinker/core/products';
-import { ProductOrmEntity } from '@openlinker/core/products/orm-entities';
+import {
+  ProductOrmEntity,
+  ProductVariantOrmEntity,
+} from '@openlinker/core/products/orm-entities';
 import {
   getTestHarness,
   IntegrationTestHarness,
@@ -47,6 +55,31 @@ async function seedProduct(
     description: null,
     images: null,
     ...overrides,
+  });
+  return repo.save(entity);
+}
+
+interface SeedVariantOverrides {
+  id?: string;
+  productId: string;
+  sku?: string | null;
+  price?: number | null;
+}
+
+async function seedVariant(
+  dataSource: DataSource,
+  overrides: SeedVariantOverrides,
+): Promise<ProductVariantOrmEntity> {
+  const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+  const repo = dataSource.getRepository(ProductVariantOrmEntity);
+  const entity = repo.create({
+    id: overrides.id ?? `ol_variant_fixture_${suffix}`,
+    productId: overrides.productId,
+    sku: overrides.sku ?? 'SKU-FIX-V',
+    attributes: null,
+    ean: null,
+    gtin: null,
+    price: overrides.price ?? null,
   });
   return repo.save(entity);
 }
@@ -102,6 +135,40 @@ describe('Products Read API Integration — currency persistence', () => {
     );
     expect(item).toBeDefined();
     expect(item.currency).toBeNull();
+  });
+
+  it('should surface persisted variant price through GET /products/:id (#792)', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const product = await seedProduct(dataSource);
+    await seedVariant(dataSource, { productId: product.id, price: 19.99 });
+
+    const response = await http
+      .get(`/products/${product.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body.variants).toHaveLength(1);
+    expect(response.body.variants[0].price).toBe(19.99);
+  });
+
+  it('should return null variant price when the column is null (#792)', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource);
+
+    const product = await seedProduct(dataSource);
+    await seedVariant(dataSource, { productId: product.id, price: null });
+
+    const response = await http
+      .get(`/products/${product.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body.variants).toHaveLength(1);
+    expect(response.body.variants[0].price).toBeNull();
   });
 
   it('should persist currency via ProductRepository.upsert (domain → ORM)', async () => {

--- a/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
+++ b/apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx
@@ -50,6 +50,7 @@ const product: Product = {
       attributes: { size: 'M' },
       ean: '5901234567890',
       gtin: null,
+      price: null,
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
     },

--- a/apps/web/src/features/products/api/products.types.ts
+++ b/apps/web/src/features/products/api/products.types.ts
@@ -21,6 +21,11 @@ export interface ProductVariant {
   attributes: Record<string, string> | null;
   ean: string | null;
   gtin: string | null;
+  /**
+   * Master variant price. `null` until the master adapter populates the
+   * column on the next sync (no historical backfill — see #792 PR 1).
+   */
+  price: number | null;
   createdAt: string;
   updatedAt: string;
   externalIds?: ExternalIdMapping[];

--- a/apps/web/src/pages/products/product-detail-page.test.tsx
+++ b/apps/web/src/pages/products/product-detail-page.test.tsx
@@ -23,6 +23,7 @@ const sampleProduct: Product = {
       attributes: { size: 'M', color: 'blue' },
       ean: '1234567890123',
       gtin: null,
+      price: null,
       createdAt: '2026-01-15T10:00:00.000Z',
       updatedAt: '2026-01-15T10:00:00.000Z',
       externalIds: [

--- a/docs/plans/implementation-plan-792-persist-variant-price.md
+++ b/docs/plans/implementation-plan-792-persist-variant-price.md
@@ -1,0 +1,269 @@
+# Implementation Plan — Persist + expose `ProductVariant.price` (#792 PR 1)
+
+**Status:** ready for implementation
+**Branch:** `792-persist-variant-price`
+**Footer:** `Refs #792` (PR 1 of 3; does not close — see #792 sequencing)
+
+## 1. Goal
+
+Make per-variant master price readable end-to-end: from PrestaShop sync → ORM persistence → repository → application service → controller → HTTP DTO → FE wire type. Unblocks PR 2 (batch inventory) and PR 3 (wizard refactor) which both depend on `variant.price` being on the wire.
+
+**Layer:** Backend (CORE persistence + Integration adapter + Interface DTO) + Frontend transport types. No FE rendering.
+
+**Explicit non-goals:**
+- No wizard UI changes (PR 3).
+- No inventory endpoint changes (PR 2).
+- No `ProductVariantSummaryResponseDto` extension — keep summary projection unchanged.
+- No write-side API exposing variant price (read-only this PR).
+- No historical backfill — variants get `price` populated on natural sync churn; `null` until then.
+
+## 2. Codebase grounding
+
+| File | Current state | Change |
+|---|---|---|
+| `libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts` | No `price` column. | Add `@Column({ type: 'decimal', precision: 10, scale: 2, nullable: true }) price!: number \| null;` mirroring `ProductOrmEntity.price` precedent. |
+| `apps/api/src/migrations/` | Last timestamp `1798000000000`. | Add `1799000000000-add-price-to-product-variants.ts`. |
+| `libs/core/src/products/domain/entities/product-variant.entity.ts` | `price?: number` already declared, comment says "master-derived, not persisted". | Update comment — now persisted. Keep optional shape (adapters/drafts can still omit). |
+| `libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts` | `toDomain` and `toOrmEntity` skip price. | Round-trip price using `Number(entity.price) when !== null` pattern from `ProductRepository.toDomain` (line 86-98). |
+| `libs/integrations/prestashop/src/infrastructure/mappers/prestashop-product.mapper.ts:58` | `mapVariant` already returns `price: this.parseNumber(combination.price)`. | No change — works as-is once the ORM column exists. |
+| `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts:202-230` | Synthetic-variant branch (products without combinations) returns variant without `price`. | Add `price: this.parseNumber(prestashopProduct.price) ?? null` to the synthetic variant — without this, every simple product becomes `no-master-price` blocked in PR 3. |
+| `apps/api/src/products/http/dto/product-variant-response.dto.ts` | No price field. | Add `@ApiPropertyOptional({ nullable: true, description: 'Master variant price (nullable when not yet synced)' }) price!: number \| null;`. |
+| `apps/api/src/products/http/products.controller.ts:50-61` (shared `variantToDto`) | Doesn't pass through price. | Add `price: variant.price ?? null` to the returned DTO. Two call sites (`ProductsController.toVariantDto`, `VariantsController.toVariantDto`) both delegate to the shared helper — single edit. |
+| `apps/web/src/features/products/api/products.types.ts:17-27` | FE `ProductVariant` type has no price. | Add `price: number \| null;` mirroring the DTO. |
+
+**Precedents to follow exactly:**
+- Decimal column: `ProductOrmEntity.price` — `decimal(10,2) nullable`.
+- ORM → domain price coercion: `ProductRepository.toDomain` uses `entity.price !== null ? Number(entity.price) : null` to preserve `price=0` (TypeORM surfaces decimal as string).
+- DTO null-handling: `ProductResponseDto.price` is `number | null` with `@ApiPropertyOptional({ nullable: true })`.
+
+## 3. Changes — step by step
+
+### Step 1 — ORM column
+
+File: `libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts`
+
+Add after the `gtin` column:
+
+```ts
+@Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
+price!: number | null;
+```
+
+AC: TypeScript compiles, `pnpm --filter @openlinker/api migration:show` shows a pending migration after Step 2.
+
+### Step 2 — Migration
+
+```bash
+pnpm --filter @openlinker/api migration:generate -- src/migrations/AddPriceToProductVariants
+```
+
+Expected: generates `apps/api/src/migrations/{timestamp}-AddPriceToProductVariants.ts` with `ALTER TABLE "product_variants" ADD "price" numeric(10,2)`.
+
+**Always hand-rename to the next free 13-digit slot.** Existing migrations are hand-bumped (`1798000000000-…` is the latest), and `migration:generate` produces a current-clock `1779…`-range value that sorts *before* the existing migrations. Rename the file to `1799000000000-add-price-to-product-variants.ts` and update the class suffix (`AddPriceToProductVariants1799000000000`) to match. This is the repo convention — see `docs/migrations.md` § Timestamp uniqueness invariant.
+
+Then add a JSDoc header to the migration file (per `docs/engineering-standards.md` § File Headers) explaining what it does and the #792 context (one short paragraph).
+
+Run `pnpm lint` to verify `scripts/check-migration-timestamps.mjs` passes.
+
+AC:
+- [ ] Migration file at `apps/api/src/migrations/1799000000000-add-price-to-product-variants.ts`, class `AddPriceToProductVariants1799000000000`.
+- [ ] JSDoc header present on the migration file.
+- [ ] `pnpm lint` green (timestamp invariant + filename/class consistency).
+- [ ] `pnpm --filter @openlinker/api migration:run` applies cleanly on a fresh DB **and** on an existing dev DB.
+- [ ] `pnpm --filter @openlinker/api migration:revert` rolls back cleanly (drops the column).
+- [ ] Re-running `migration:run` after revert re-applies idempotently.
+- [ ] `pnpm --filter @openlinker/api migration:show` lists the new migration before run, marks it executed after.
+
+### Step 3 — Domain entity comment update
+
+File: `libs/core/src/products/domain/entities/product-variant.entity.ts:28-29`
+
+Update the comment on `price?: number`:
+
+```ts
+/**
+ * Master price for this variant. Persisted on the variants table.
+ * Optional at the domain level so adapter drafts and test factories may
+ * omit it; the repository / DTO layer normalises `undefined ↔ null` at
+ * the persistence and wire boundaries. Do not assign `null` directly to
+ * a domain instance — TypeScript will reject it, and the boundary
+ * normalisation is what callers should rely on.
+ */
+price?: number;
+```
+
+AC: comment reads correctly; no behavioural change.
+
+### Step 4 — Repository mapping
+
+File: `libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts:218-247`
+
+**`toDomain`** — add price after `gtin`:
+
+```ts
+price: entity.price !== null ? Number(entity.price) : undefined,
+```
+
+(Domain `price` is `number | undefined`, not `number | null` — preserve the optional-undefined shape.)
+
+**`toOrmEntity`** — add price after `gtin`:
+
+```ts
+entity.price = variant.price ?? null;
+```
+
+AC: existing repository unit tests still pass; new spec covers price round-trip.
+
+### Step 5 — PrestaShop synthetic-variant price fallback
+
+File: `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts:222-230`
+
+In the synthetic-variant branch (`combinations.length === 0`), add price from the parent product:
+
+```ts
+return [
+  {
+    id: internalId,
+    productId,
+    sku,
+    attributes: null,
+    ean: productEan ?? null,
+    gtin: productGtin ?? null,
+    price: this.parseProductPrice(prestashopProduct.price),
+  },
+];
+```
+
+Where `parseProductPrice` is either a small inline helper or — preferred — call `this.productMapper.mapProduct(prestashopProduct, 1).price` and pull `.price` (but that does extra work; an inline `Number(prestashopProduct.price)` with null-fallback is fine here, mirroring the mapper's `parseNumber`).
+
+**Decision**: inline a tiny private helper on the adapter:
+
+```ts
+private parseProductPrice(value: string | number | undefined): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+```
+
+(Lives on the adapter, not the mapper, because the adapter is the synthetic-variant branch's owner; reusing the mapper's private `parseNumber` would require widening the mapper interface.)
+
+AC: existing PrestaShop adapter unit tests still pass; new spec covers the synthetic-variant price-fallback case.
+
+### Step 6 — Response DTO
+
+File: `apps/api/src/products/http/dto/product-variant-response.dto.ts`
+
+Add after `gtin`:
+
+```ts
+@ApiPropertyOptional({
+  nullable: true,
+  description: 'Master variant price. Nullable when not yet synced or unavailable from the master source.',
+})
+price!: number | null;
+```
+
+File: `apps/api/src/products/http/products.controller.ts:50-61`
+
+Update the shared `variantToDto`:
+
+```ts
+function variantToDto(variant: ProductVariant): ProductVariantResponseDto {
+  return {
+    id: variant.id,
+    productId: variant.productId,
+    sku: variant.sku,
+    attributes: variant.attributes,
+    ean: variant.ean ?? null,
+    gtin: variant.gtin ?? null,
+    price: variant.price ?? null,
+    createdAt: variant.createdAt!.toISOString(),
+    updatedAt: variant.updatedAt!.toISOString(),
+  };
+}
+```
+
+AC: `ProductsController.spec.ts` updated to assert price passes through; both `GET /products/:id` (which includes variants) and `GET /products/:productId/variants` carry it.
+
+### Step 7 — FE wire type
+
+File: `apps/web/src/features/products/api/products.types.ts:17-27`
+
+Add `price: number | null;` after `gtin`:
+
+```ts
+export interface ProductVariant {
+  id: string;
+  productId: string;
+  sku: string | null;
+  attributes: Record<string, string> | null;
+  ean: string | null;
+  gtin: string | null;
+  price: number | null;
+  createdAt: string;
+  updatedAt: string;
+  externalIds?: ExternalIdMapping[];
+}
+```
+
+AC: FE `pnpm --filter @openlinker/web type-check` green. No FE consumers yet (PR 3 introduces them).
+
+### Step 8 — Tests
+
+| Test | Location | Coverage |
+|---|---|---|
+| `product-variant.repository.spec.ts` | `libs/core/src/products/infrastructure/persistence/repositories/__tests__/` (if existing) or colocated | Price round-trip via `upsert` → `findById`: null, zero, positive, decimal. |
+| `prestashop-product.mapper.spec.ts:580` (existing `mapVariant` block) | Already exists. | Add an assertion that returned variant carries `price` from `combination.price`. |
+| `prestashop-product-master.adapter.spec.ts` | Existing adapter spec. | New test: synthetic-variant branch (no combinations) carries `price` from `prestashopProduct.price`; handles missing/non-numeric gracefully (undefined preserved). |
+| `products.controller.spec.ts` | `apps/api/src/products/http/` | Assert the DTO carries `price: number \| null` for both null and non-null cases. |
+| **Integration spec — `products-read.int-spec.ts`** | `apps/api/test/integration/` (existing) | Extend with: seed a product + variant with non-null `price` via the repository, hit `GET /products/:id`, assert `variants[0].price` is the expected number. Also assert null-price variant serialises as `null`. End-to-end exercise of the ORM column → repository round-trip → DTO serialisation chain in one request. |
+
+AC: `pnpm test` green, `pnpm test:integration` green.
+
+## 4. Quality gate
+
+Run in order (each must be green):
+
+```bash
+pnpm lint                                                # invariants + ESLint
+pnpm type-check                                          # zero TS errors
+pnpm --filter @openlinker/api migration:show             # new migration listed pending
+pnpm --filter @openlinker/api migration:run              # applies cleanly
+pnpm --filter @openlinker/api migration:show             # marks executed
+pnpm --filter @openlinker/api migration:revert           # rolls back cleanly
+pnpm --filter @openlinker/api migration:run              # re-applies idempotently
+pnpm test                                                # unit tests green
+pnpm test:integration                                    # int-specs green (incl. products-read)
+```
+
+## 5. Risks & open questions
+
+| Risk | Mitigation |
+|---|---|
+| Migration timestamp collision (rare branch-merge window). | `pnpm lint` runs `scripts/check-migration-timestamps.mjs` and fails on collision. Manual recipe: bump to next free ms and update class suffix. |
+| Synthetic-variant branch silently swallows non-numeric prices. | Inline `parseProductPrice` returns `undefined` (not throw) on non-numeric input; matches `parseNumber` in the mapper. Surfaces as `no-master-price` blocker in PR 3 (correct downstream behaviour). |
+| Existing variants in dev/prod DBs get `null` price. | Documented in the issue body's Out of Scope (historical backfill — relies on natural sync churn). FE handles `null` as `no-master-price`. |
+| `ProductVariant.price` is optional in the domain entity but `number \| null` in DTO/FE — shape mismatch. | Repository normalises `undefined ↔ null` at the persistence boundary. Domain stays optional for pre-persistence draft compatibility (existing convention). |
+
+**Open questions:** none — all four BLOCKING items from the refinement were resolved when locking the issue body.
+
+## 6. Validation against standards
+
+- ✅ Hexagonal architecture: ORM entity is infrastructure; domain entity stays framework-free; adapter writes domain → repo persists.
+- ✅ Naming: `*.orm-entity.ts`, `*.repository.ts`, `*.adapter.ts`, `*-response.dto.ts` — all unchanged file shapes.
+- ✅ Repository port: no port change needed (price is just round-tripped through existing `upsert` / `findById` / `findByProductId` / `findBySku` / `findBySkuIn` / `findByEanOrGtinIn` / `findMany`).
+- ✅ Types: domain `ProductVariant` already declares price; DTO + FE types mirror.
+- ✅ `as const` pattern: not applicable (price is `number | null`, not enumerated).
+- ✅ Migration invariant: timestamp + class-name match enforced by `pnpm lint`.
+- ✅ Logging: no new log sites needed (sync path logs at the existing `getProductVariants` boundary).
+- ✅ Security: no auth-surface change, no credential handling.
+- ✅ Performance: one extra column read per variant — negligible.
+
+## 7. Out of scope (deferred to follow-ups)
+
+- Variant-price exposure in `ProductVariantSummaryResponseDto`.
+- Backfill job for historical variants.
+- Adapter implementations beyond PrestaShop (no other master adapters today).
+- Wizard FE consumption (PR 3 of #792).
+- Batch inventory endpoint (PR 2 of #792).

--- a/libs/core/src/products/domain/entities/product-variant.entity.ts
+++ b/libs/core/src/products/domain/entities/product-variant.entity.ts
@@ -25,7 +25,14 @@ export interface ProductVariant {
   createdAt?: Date;
   /** Populated by the repository on load; adapters/drafts may omit. */
   updatedAt?: Date;
-  /** Master-derived, not persisted on the variants table. */
+  /**
+   * Master price for this variant. Persisted on the variants table.
+   * Optional at the domain level so adapter drafts and test factories may
+   * omit it; the repository / DTO layer normalises `undefined ↔ null` at
+   * the persistence and wire boundaries. Do not assign `null` directly to
+   * a domain instance — TypeScript will reject it, and the boundary
+   * normalisation is what callers should rely on.
+   */
   price?: number;
   /** Master-derived, not persisted on the variants table. */
   weight?: number;

--- a/libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts
+++ b/libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts
@@ -42,6 +42,9 @@ export class ProductVariantOrmEntity {
   @Column({ type: 'varchar', nullable: true })
   gtin!: string | null;
 
+  @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
+  price!: number | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
@@ -213,7 +213,12 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
   }
 
   /**
-   * Map ORM entity to domain entity
+   * Map ORM entity to domain entity.
+   *
+   * TypeORM surfaces `decimal` columns as strings; `!== null` preserves
+   * `price=0` (a truthy shortcut would coerce it to `undefined`). Null on
+   * the ORM side becomes `undefined` on the domain side to match the
+   * optional `ProductVariant.price?: number` shape — see the entity comment.
    */
   private toDomain(entity: ProductVariantOrmEntity): ProductVariant {
     return {
@@ -223,6 +228,7 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
       attributes: entity.attributes,
       ean: entity.ean,
       gtin: entity.gtin,
+      price: entity.price !== null ? Number(entity.price) : undefined,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
     };
@@ -239,6 +245,7 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
     entity.attributes = variant.attributes;
     entity.ean = variant.ean;
     entity.gtin = variant.gtin;
+    entity.price = variant.price ?? null;
     // Adapters may omit timestamps on first insert; TypeORM's @CreateDateColumn
     // and @UpdateDateColumn populate them in that case.
     if (variant.createdAt) entity.createdAt = variant.createdAt;

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts
@@ -411,6 +411,9 @@ describe('PrestashopProductMasterAdapter', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].sku).toBe(samplePrestashopProduct.reference);
+      // Synthetic variant inherits master price from the parent product so
+      // simple products carry a usable price for the bulk wizard (#792).
+      expect(result[0].price).toBe(19.99);
       expect(mockIdentifierMapping.getOrCreateInternalId).toHaveBeenCalledWith(
         'ProductVariant',
         `product:${externalProductId}`,
@@ -429,6 +432,38 @@ describe('PrestashopProductMasterAdapter', () => {
         })
       );
     });
+
+    it.each([
+      ['undefined price', undefined],
+      ['null price', null],
+      ['non-numeric price', 'not-a-number'],
+    ])(
+      'should leave synthetic variant price undefined when parent product has %s',
+      async (_label, priceValue) => {
+        const productId = 'internal-product-456';
+        const externalProductId = '43';
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test mock: narrowing dynamic spy / fixture / response shape
+        mockIdentifierMapping.getExternalIds = jest.fn().mockResolvedValue([
+          {
+            connectionId: connection.id,
+            externalId: externalProductId,
+            entityType: 'Product',
+          },
+        ]);
+
+        mockHttpClient.getResource = jest
+          .fn()
+          .mockResolvedValue({ ...samplePrestashopProduct, price: priceValue });
+        mockHttpClient.listResources = jest.fn().mockResolvedValue([]);
+
+        const result = await adapter.getProductVariants(productId);
+
+        expect(result).toHaveLength(1);
+        // Surfaces as `no-master-price` blocker downstream in #792.
+        expect(result[0].price).toBeUndefined();
+      }
+    );
 
     it('should throw PrestashopResourceNotFoundException when product not found', async () => {
       const productId = 'internal-product-123';

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -226,6 +226,11 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
           attributes: null,
           ean: productEan ?? null,
           gtin: productGtin ?? null,
+          // Inherit master price from the parent product so the synthetic
+          // variant carries a usable price (simple products are the common
+          // case for SMB shops). Null/non-numeric → undefined → surfaces as
+          // a `no-master-price` blocker downstream (#792).
+          price: this.parseProductPrice(prestashopProduct.price),
         },
       ];
     }
@@ -291,6 +296,20 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
 
   private normalizeGtin(value?: string | null): string | null {
     return normalizeBarcode(value ?? null);
+  }
+
+  /**
+   * Parse the PrestaShop product `price` field into a domain number.
+   * Mirrors `PrestashopProductMapper.parseNumber` semantics — returns
+   * `undefined` for null / undefined / non-finite values so the
+   * downstream `no-master-price` blocker can surface accurately. Inlined
+   * here (rather than reusing the mapper's private `parseNumber`) to
+   * avoid widening the mapper's public interface for one call site.
+   */
+  private parseProductPrice(value: string | number | undefined | null): number | undefined {
+    if (value === undefined || value === null) return undefined;
+    const n = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(n) ? n : undefined;
   }
 
   // Write operations - not supported in MVP


### PR DESCRIPTION
## Summary

Adds a `price` column to `product_variants`, wires it through the repository round-trip, the PrestaShop master adapter sync path (including a parent-product fallback for synthetic single-product variants), the `ProductVariantResponseDto` Swagger contract, and the FE wire type.

**Unblocks #792 PR 2** (batch inventory endpoint) and **PR 3** (bulk-wizard master-pull refactor), which both depend on `variant.price` being readable on the wire.

`Refs #792` — first of three PRs sequenced under the issue. Does **not** close (PR 3 will).

## Why persist + migration (not derive)

The PrestaShop combination mapper at `prestashop-product.mapper.ts:58` already extracted `combination.price` into the domain entity. Today it is silently dropped at persistence because the ORM column doesn't exist. There is no derive-at-query-time path — the only viable shape is column + migration + adapter writes during sync.

The synthetic-variant branch (products without combinations — the common SMB shape) inherits the parent product's price so simple products carry a usable value too. Without this fallback, every simple product becomes a `no-master-price` blocker in PR 3.

## Files changed

```
apps/api/src/migrations/1799000000000-add-price-to-product-variants.ts    (new)
docs/plans/implementation-plan-792-persist-variant-price.md               (new)

apps/api/src/products/http/dto/product-variant-response.dto.ts             +7
apps/api/src/products/http/products.controller.ts                          +4
apps/api/src/products/http/products.controller.spec.ts                    +17
apps/api/test/integration/products-read.int-spec.ts                       +73/-2

apps/web/src/features/products/api/products.types.ts                       +5
apps/web/src/features/listings/components/AllegroCreateOfferWizard.test.tsx +1
apps/web/src/pages/products/product-detail-page.test.tsx                   +1

libs/core/src/products/domain/entities/product-variant.entity.ts           +8/-1
libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts +3
libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts +8/-1

libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts +19
libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-product-master.adapter.spec.ts +35
```

## Migration

- Timestamp `1799000000000` (next free slot per the repo's hand-bumped convention; verified by `scripts/check-migration-timestamps.mjs`).
- `up()` uses `ADD COLUMN IF NOT EXISTS` for re-application safety.
- `down()` is the symmetric `DROP COLUMN`.
- Precision `decimal(10, 2)` matches the `Product.price` precedent.

## Test plan

- [x] `pnpm lint` — invariant guards + ESLint green.
- [x] `pnpm type-check` — zero TS errors across all 11 packages.
- [x] `pnpm test` — 2058 unit tests green (mapper price extraction already existed; adapter spec gained synthetic-variant + 3 negative cases; controller spec gained null/non-null DTO assertions).
- [x] `pnpm test:integration` — 181 int-tests / 29 suites green. `products-read.int-spec.ts` covers ORM round-trip via `GET /products/:id` for both `price=19.99` and `price=null`. Testcontainers runs all migrations on a fresh DB on every boot, which is the effective end-to-end verification of the migration `up()` path.
- [ ] CI checks pass.

**Note on dev-DB migration ceremony**: `migration:run`/`migration:revert` against the local dev DB is currently non-runnable due to a pre-existing state issue (tables present but `migrations` tracking table empty — every migration shows pending and re-creates existing tables). This is independent of this PR. The Testcontainers integration sweep is the cleaner verification anyway since it runs the full 44-migration sequence on a fresh DB.

## Out of scope (deferred)

- Variant-price exposure in `ProductVariantSummaryResponseDto` (summary projection unchanged).
- Historical backfill — natural sync churn populates the column over time. Variants whose master sync has not run yet surface `price = null`, which the FE will treat as a `no-master-price` blocker in PR 3.
- Adapter implementations beyond PrestaShop (no other master adapters today).
- Wizard FE consumption (PR 3).
- Batch inventory endpoint (PR 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)