### PR TITLE
fix(web,listings): stop bulk-resolve timeout from downgrading settled rows

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * BulkResolveStep tests
+ *
+ * Covers the #796 regression where the 15-s fallback timeout fired with a
+ * stale `resolved` closure and overwrote already-settled rows with
+ * `pending-after-timeout`. Two cases:
+ *
+ *   1. Resolves settle fast → advance past the 15-s deadline → outcomes
+ *      remain `matched`, no second `onComplete` fires.
+ *   2. Slow resolves → only the unsettled rows become `pending-after-
+ *      timeout`; pre-timeout settled rows keep their status.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from '@testing-library/react';
+import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
+import { BulkResolveStep, BULK_RESOLVE_TIMEOUT_MS } from './bulk-resolve-step';
+import type { BulkResolveOutcome } from './bulk-resolve-step';
+import type { BulkWizardRow } from './bulk-wizard.types';
+import type { Product, ProductVariant } from '../../../products';
+
+function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
+  return {
+    id: 'var_1',
+    productId: 'prod_1',
+    sku: 'SKU-1',
+    attributes: null,
+    ean: '5901234123457',
+    gtin: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 'prod_1',
+    name: 'Test product',
+    sku: 'SKU-1',
+    price: 99.99,
+    currency: 'PLN',
+    description: null,
+    images: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeRow(
+  productId: string,
+  ean: string,
+  status: BulkWizardRow['status'] = 'resolving',
+): BulkWizardRow {
+  return {
+    productId,
+    product: makeProduct({ id: productId, name: `Product ${productId}` }),
+    primaryVariant: makeVariant({
+      id: `var_${productId}`,
+      productId,
+      ean,
+    }),
+    status,
+    resolvedCategoryId: null,
+    resolutionMethod: null,
+    override: {},
+  };
+}
+
+describe('BulkResolveStep', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not re-fire onComplete after the 15s timeout when resolves already settled (#796 regression)', async () => {
+    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
+    const apiClient = createMockApiClient({
+      listings: {
+        resolveCategory: vi.fn().mockResolvedValue({
+          allegroCategoryId: 'cat-A',
+          method: 'auto_detect',
+        }),
+      },
+    });
+
+    const rows = [makeRow('prod_1', '5901234123457')];
+
+    renderWithProviders(
+      <BulkResolveStep rows={rows} connectionId="conn_1" onComplete={onComplete} />,
+      { apiClient },
+    );
+
+    // Let the resolve loop's promise chain drain; the fake clock isn't
+    // involved here — the mocked `resolveCategory` resolves synchronously.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    const firstCallOutcomes = onComplete.mock.calls[0][0];
+    expect(firstCallOutcomes).toEqual([
+      expect.objectContaining({ productId: 'prod_1', status: 'matched', categoryId: 'cat-A' }),
+    ]);
+
+    // Advance past the fallback deadline. The completedRef guard must
+    // short-circuit the timeout, leaving onComplete at exactly one call.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(BULK_RESOLVE_TIMEOUT_MS + 1_000);
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep synthetic no-ean rows intact while flagging in-flight EAN rows as pending-after-timeout when the deadline hits', async () => {
+    // The resolve-step seeds `no-ean` rows synchronously into the resolved
+    // map (they need no BE call). When the fallback timeout fires while
+    // an EAN-bearing row is still in flight, the seeded entries must be
+    // preserved (proves the timeout reads the *current* ref, not the
+    // closure-captured map) and the in-flight row must flip to
+    // `pending-after-timeout`.
+    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
+
+    // Hold the EAN-row resolve indefinitely so the timeout fires first.
+    let releaseSlow: (value: { allegroCategoryId: string | null; method: string }) => void;
+    const slowPromise = new Promise<{ allegroCategoryId: string | null; method: string }>(
+      (resolve) => {
+        releaseSlow = resolve;
+      },
+    );
+
+    const apiClient = createMockApiClient({
+      listings: { resolveCategory: vi.fn().mockReturnValue(slowPromise) },
+    });
+
+    const rows: BulkWizardRow[] = [
+      // No-ean: seeded into the resolved map at mount (no primary variant
+      // EAN/GTIN). Verifies the timeout outcomes carry forward seed state.
+      {
+        ...makeRow('prod_noean', ''),
+        primaryVariant: makeVariant({
+          id: 'var_noean',
+          productId: 'prod_noean',
+          ean: null,
+          gtin: null,
+        }),
+        status: 'no-ean',
+      },
+      // EAN row: in-flight at timeout time.
+      makeRow('prod_slow', '2222222222222'),
+    ];
+
+    renderWithProviders(
+      <BulkResolveStep rows={rows} connectionId="conn_1" onComplete={onComplete} />,
+      { apiClient },
+    );
+
+    // No settlement yet — pAllLimit is blocked on the slow promise.
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // Advance past the 15-s deadline.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(BULK_RESOLVE_TIMEOUT_MS + 1);
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    const outcomes = onComplete.mock.calls[0][0];
+    const noEan = outcomes.find((o) => o.productId === 'prod_noean');
+    const slow = outcomes.find((o) => o.productId === 'prod_slow');
+    expect(noEan).toMatchObject({ status: 'no-ean' });
+    expect(slow).toMatchObject({ status: 'pending-after-timeout', categoryId: null });
+
+    // Release the slow promise so the resolve loop unwinds cleanly under
+    // fake timers (avoids a dangling pending microtask between tests).
+    releaseSlow!({ allegroCategoryId: 'cat-SLOW', method: 'auto_detect' });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
@@ -186,9 +186,8 @@ export function BulkResolveStep({
     };
     // Mount-only effect — the 15 s budget is anchored to mount, not to
     // every render. Closure-captured `rows` is acceptable because the
-    // wizard never mutates the row list mid-resolve; live state flows
-    // through `resolvedRef`. Live state flowing through `resolvedRef`
-    // means partial-settle progress survives the closure.
+    // wizard never mutates the row list mid-resolve; live `resolved` state
+    // flows through `resolvedRef` so partial-settle progress survives.
   }, []);
 
   // Prefetch the resolved-categories queries so they're hot for the Review

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
@@ -56,6 +56,22 @@ export function BulkResolveStep({
   );
   const [progress, setProgress] = useState({ done: 0, total: rows.length });
   const startedRef = useRef(false);
+  // The timeout effect has `[]` deps so it can't read `resolved` directly —
+  // mirroring through a ref keeps the legitimate slow-resolves case correct
+  // (some rows settled, some not; the timeout outcomes must reflect the
+  // current resolved map, not the seed-time closure).
+  const resolvedRef = useRef(resolved);
+  // Flipped to true when the resolve loop fires `onComplete` itself, so the
+  // 15-s fallback timeout knows to short-circuit and not overwrite settled
+  // statuses with a stale `pending-after-timeout` outcome (#796).
+  const completedRef = useRef(false);
+  // Holds the timeout id so the success path can `clearTimeout` it eagerly.
+  // Defence in depth — `completedRef` would short-circuit the callback anyway.
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    resolvedRef.current = resolved;
+  }, [resolved]);
 
   // Tasks that need a BE call (have a barcode, no synthetic outcome yet).
   const tasks: ResolveTask[] = useMemo(
@@ -135,6 +151,11 @@ export function BulkResolveStep({
         done += 1;
         setProgress({ done, total });
       });
+      completedRef.current = true;
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
       setResolved(next);
       onComplete(buildOutcomes(rows, next));
     })();
@@ -148,19 +169,26 @@ export function BulkResolveStep({
   }, [tasks]);
 
   // 15-second budget: if not all tasks settled by now, advance anyway.
-  // The Review step still subscribes to the same cached queries via the
-  // wizard's outcomes, so late-arriving resolves flip rows from
-  // `pending-after-timeout` to `matched` automatically.
+  // Reads through `resolvedRef.current` so partial-settle state is preserved
+  // when the timeout legitimately fires; `completedRef` short-circuits the
+  // callback when the resolve loop already finished, preventing the stale
+  // overwrite that flipped settled rows to `pending-after-timeout` (#796).
   useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      onComplete(buildOutcomes(rows, resolved, true));
+    timerRef.current = window.setTimeout(() => {
+      if (completedRef.current) return;
+      onComplete(buildOutcomes(rows, resolvedRef.current, true));
     }, BULK_RESOLVE_TIMEOUT_MS);
     return () => {
-      window.clearTimeout(timeoutId);
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
     };
     // Mount-only effect — the 15 s budget is anchored to mount, not to
-    // every render. Resolving fresh state happens through the resolves
-    // loop above; this one only fires once.
+    // every render. Closure-captured `rows` is acceptable because the
+    // wizard never mutates the row list mid-resolve; live state flows
+    // through `resolvedRef`. Live state flowing through `resolvedRef`
+    // means partial-settle progress survives the closure.
   }, []);
 
   // Prefetch the resolved-categories queries so they're hot for the Review

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * BulkWizard pure-reducer tests
+ *
+ * Pins the #796 widened guard: a `pending-after-timeout` outcome must not
+ * overwrite a row already in a terminal state. The resolve-step fix
+ * prevents the stale-closure `onComplete` from firing, so this is defence
+ * in depth — but the reducer is the actual safety net, and a future
+ * regression in the resolve step shouldn't be able to flip settled rows.
+ */
+import { describe, expect, it } from 'vitest';
+import { applyResolveOutcomes } from './bulk-wizard';
+import type { BulkResolveOutcome } from './bulk-resolve-step';
+import type { BulkRowStatus, BulkWizardRow } from './bulk-wizard.types';
+
+function makeRow(productId: string, status: BulkRowStatus): BulkWizardRow {
+  return {
+    productId,
+    product: null,
+    primaryVariant: null,
+    status,
+    resolvedCategoryId: null,
+    resolutionMethod: null,
+    override: {},
+  };
+}
+
+function timedOut(productId: string): BulkResolveOutcome {
+  return {
+    productId,
+    status: 'pending-after-timeout',
+    categoryId: null,
+    method: null,
+  };
+}
+
+describe('applyResolveOutcomes', () => {
+  it.each<BulkRowStatus>(['matched', 'no-match', 'no-ean', 'no-variant'])(
+    'should ignore a pending-after-timeout outcome for a row already in terminal state "%s"',
+    (terminalStatus) => {
+      const rows = [{ ...makeRow('prod_1', terminalStatus), resolvedCategoryId: 'cat-A' }];
+      const next = applyResolveOutcomes(rows, [timedOut('prod_1')]);
+      expect(next[0]).toEqual(rows[0]);
+    },
+  );
+
+  it('should apply a pending-after-timeout outcome when the row is still resolving', () => {
+    const rows = [makeRow('prod_1', 'resolving')];
+    const next = applyResolveOutcomes(rows, [timedOut('prod_1')]);
+    expect(next[0]).toMatchObject({
+      productId: 'prod_1',
+      status: 'pending-after-timeout',
+    });
+  });
+
+  it('should apply a settled outcome regardless of prior status (status flows forward in the happy path)', () => {
+    const rows = [makeRow('prod_1', 'resolving')];
+    const next = applyResolveOutcomes(rows, [
+      {
+        productId: 'prod_1',
+        status: 'matched',
+        categoryId: 'cat-A',
+        method: 'auto_detect',
+      },
+    ]);
+    expect(next[0]).toMatchObject({
+      productId: 'prod_1',
+      status: 'matched',
+      resolvedCategoryId: 'cat-A',
+      resolutionMethod: 'auto_detect',
+    });
+  });
+
+  it('should leave rows without a matching outcome untouched', () => {
+    const rows = [makeRow('prod_1', 'matched'), makeRow('prod_2', 'resolving')];
+    const next = applyResolveOutcomes(rows, [timedOut('prod_2')]);
+    expect(next[0]).toBe(rows[0]);
+    expect(next[1]).toMatchObject({ status: 'pending-after-timeout' });
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -83,25 +83,7 @@ export function BulkWizard({
 
   const handleResolveComplete = useCallback(
     (outcomes: BulkResolveOutcome[]) => {
-      setRows((prev) =>
-        prev.map((row) => {
-          const o = outcomes.find((x) => x.productId === row.productId);
-          if (!o) return row;
-          // If a resolved-from-cache outcome already exists, don't downgrade it.
-          if (
-            row.status === 'matched' &&
-            o.status === 'pending-after-timeout'
-          ) {
-            return row;
-          }
-          return {
-            ...row,
-            status: o.status,
-            resolvedCategoryId: o.categoryId,
-            resolutionMethod: o.method,
-          };
-        }),
-      );
+      setRows((prev) => applyResolveOutcomes(prev, outcomes));
       setStep('review');
     },
     [],
@@ -298,6 +280,40 @@ export function BulkWizard({
 
 function stepOrder(step: BulkWizardStep): number {
   return WIZARD_STEPS.findIndex((s) => s.id === step);
+}
+
+/**
+ * Pure reducer that applies a batch of resolve-step outcomes to the wizard's
+ * row state. Exported for unit testing; the wizard calls it from
+ * `handleResolveComplete` via `setRows((prev) => applyResolveOutcomes(...))`.
+ *
+ * Guard semantics (#796): a `pending-after-timeout` outcome must NEVER
+ * overwrite a row already in a terminal state (`matched` / `no-match` /
+ * `no-ean` / `no-variant`). The resolve-step fix prevents the stale-closure
+ * `onComplete` from firing in the first place; this guard catches any
+ * future regression that tries to downgrade settled rows.
+ */
+export function applyResolveOutcomes(
+  rows: BulkWizardRow[],
+  outcomes: BulkResolveOutcome[],
+): BulkWizardRow[] {
+  return rows.map((row) => {
+    const o = outcomes.find((x) => x.productId === row.productId);
+    if (!o) return row;
+    if (
+      o.status === 'pending-after-timeout' &&
+      row.status !== 'resolving' &&
+      row.status !== 'pending-after-timeout'
+    ) {
+      return row;
+    }
+    return {
+      ...row,
+      status: o.status,
+      resolvedCategoryId: o.categoryId,
+      resolutionMethod: o.method,
+    };
+  });
 }
 
 function seedRows(products: Product[]): BulkWizardRow[] {

--- a/docs/plans/implementation-plan-796-bulk-resolve-timeout-fix.md
+++ b/docs/plans/implementation-plan-796-bulk-resolve-timeout-fix.md
@@ -1,0 +1,186 @@
+# Implementation Plan — #796 Bulk wizard Resolve-step timeout downgrade fix
+
+## Phase 1 — Understand the task
+
+**Goal.** Stop the bulk-create wizard's Resolve step (`apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx`) from silently downgrading already-settled rows to `pending-after-timeout` 15 seconds after mount, even when the resolve loop completed long before.
+
+**Layer.** Frontend (`features/listings/components/bulk/`).
+
+**Non-goals.**
+- Rearchitecting the Resolve step around the batch capability (`EanCategoryMatcher.resolveCategoriesForBatchByEan`) — that's #795.
+- Fixing the upstream Allegro endpoint correctness — already landed (#794, PR #797).
+- Touching `useResolveCategoryQuery` stale-time or `pAllLimit` concurrency.
+
+## Phase 2 — Research
+
+**Root cause** (from issue #796 + code at `bulk-resolve-step.tsx:154-164`):
+
+```ts
+useEffect(() => {
+  const timeoutId = window.setTimeout(() => {
+    onComplete(buildOutcomes(rows, resolved, true));   // ← stale `resolved` from closure
+  }, BULK_RESOLVE_TIMEOUT_MS);
+  return () => { window.clearTimeout(timeoutId); };
+}, []);  // ← `[]` deps: closes over seed-time `resolved`
+```
+
+Two compounding problems:
+1. **Stale closure.** `[]` deps captures `rows` + `resolved` from the first render. `resolved` is the seed map (only `no-ean` / `no-variant` rows). EAN-bearing rows are absent.
+2. **Unconditional fire.** Resolve loop success path at `bulk-resolve-step.tsx:138-139` calls `setResolved` + `onComplete` but leaves the timer running. At T+15s it fires again with the stale map → `buildOutcomes` returns `pending-after-timeout` for every EAN-bearing row → parent wizard overwrites their settled statuses.
+
+**Parent guard is partial** (`bulk-wizard.tsx:91-96`):
+
+```ts
+if (row.status === 'matched' && o.status === 'pending-after-timeout') {
+  return row;
+}
+```
+
+Only `matched` rows are protected. `no-match` / `no-ean` / `no-variant` rows get downgraded.
+
+**No existing tests** for `bulk-resolve-step.tsx` or `bulk-wizard.tsx` (verified with `find apps/web/src/features/listings -name "*.test.*"`). Test infrastructure available: `renderWithProviders()` + `createMockApiClient()` from `apps/web/src/test/test-utils.tsx`; pattern reference in `AllegroCreateOfferWizard.test.tsx`. Vitest is the runner; `vi.useFakeTimers()` is the standard for time-dependent specs.
+
+## Phase 3 — Design
+
+Three localised changes, no behaviour change in the happy path.
+
+### 3a. `bulk-resolve-step.tsx` — refs
+
+Three refs in module body:
+- `resolvedRef` — mirrors `resolved` state. Synced in a small `useEffect` keyed on `[resolved]`.
+- `completedRef` — boolean. Set to `true` in the resolve-loop success path before calling `onComplete`.
+- `timerRef` — `number | null`. Holds the timeout id so the success path can `clearTimeout` it.
+
+Timeout effect changes:
+- Stores the timer in `timerRef.current`.
+- Callback short-circuits with `if (completedRef.current) return;`.
+- Reads `resolvedRef.current` instead of the closure-captured `resolved`.
+- Cleanup uses the ref.
+
+Resolve-loop success path changes:
+- Sets `completedRef.current = true`.
+- Clears `timerRef.current` via `window.clearTimeout` before `onComplete`.
+
+The `cancelled` flag stays — it guards against React unmount mid-await of the resolve loop.
+
+### 3b. `bulk-wizard.tsx` — guard widening
+
+Replace the narrow `matched`-only guard with:
+
+```ts
+if (
+  o.status === 'pending-after-timeout' &&
+  row.status !== 'resolving' &&
+  row.status !== 'pending-after-timeout'
+) {
+  return row;
+}
+```
+
+Reads: "Any `pending-after-timeout` outcome arriving for a row that's already in a terminal state is ignored." Defence in depth — the resolve-step fix should prevent the stale `onComplete` from firing in the first place; this guard protects against any future regression.
+
+### 3c. New component test: `bulk-resolve-step.test.tsx`
+
+Two test cases under `describe('BulkResolveStep')`:
+
+1. **`should not overwrite settled outcomes when the 15s timeout fires after resolves complete`**
+   - Mock `resolveCategory` to resolve immediately with `{ allegroCategoryId: 'cat-A', method: 'auto_detect' }` for one row.
+   - Mount with `vi.useFakeTimers()`.
+   - `await vi.runOnlyPendingTimersAsync()` (or `act` + `vi.advanceTimersByTime(0)` to drain microtasks) to let the resolve loop settle.
+   - Assert `onComplete` called with row status = `matched`.
+   - Advance timers by 16 s.
+   - Assert `onComplete` was NOT called a second time, OR the second call (if any) carries the same `matched` status.
+   - Implementation note: with `completedRef`, the second call is suppressed entirely — assert `mockOnComplete.mock.calls.length === 1`.
+
+2. **`should flag only unsettled rows as pending-after-timeout when the 15s deadline hits before resolves complete`**
+   - Two rows: one resolves immediately, one resolves after a controllable delay (use `new Promise<never>(() => {})` for the slow one OR `vi.advanceTimersByTime` to control).
+   - Mount with `vi.useFakeTimers()`.
+   - Advance timers past the resolve of the fast row but before the slow one settles.
+   - Advance timers by full `BULK_RESOLVE_TIMEOUT_MS`.
+   - Assert `onComplete` was called with: fast row = `matched`, slow row = `pending-after-timeout`.
+
+Tests use `renderWithProviders` + `createMockApiClient`. Standard vitest pattern: `vi.useFakeTimers({ shouldAdvanceTime: true })` to allow `act`/Testing Library async helpers to coexist with the fake clock; `vi.useRealTimers()` in `afterEach`.
+
+### Why not also test `bulk-wizard.tsx`?
+
+The wizard guard widening is a small in-place change; the resolve-step tests already exercise the *spirit* of the regression (no overwrite on settled rows). Adding a `bulk-wizard.test.tsx` would test internals of `handleResolveComplete` — the natural test of the wizard's downgrade resistance is the resolve-step test, since the wizard is purely a downstream consumer. Skip the dedicated wizard test for now; revisit if the guard widens further in a future PR.
+
+## Phase 4 — Step-by-step plan
+
+### Step 1 — Add the three refs to `bulk-resolve-step.tsx`
+
+Add `import { useRef }` (already imported), declare `resolvedRef` / `completedRef` / `timerRef` after the existing `startedRef`. Add a small `useEffect([resolved])` to mirror state to the ref.
+
+**Acceptance:** Refs declared with correct initial values (`resolvedRef.current = resolved` initial, `completedRef.current = false`, `timerRef.current = null`).
+
+### Step 2 — Wire the resolve-loop success path
+
+Before `setResolved(next)` + `onComplete(...)`:
+
+```ts
+completedRef.current = true;
+if (timerRef.current !== null) {
+  window.clearTimeout(timerRef.current);
+  timerRef.current = null;
+}
+```
+
+**Acceptance:** Success path explicitly cancels the timer and flips the completion flag before notifying the parent.
+
+### Step 3 — Rewrite the timeout effect
+
+```ts
+useEffect(() => {
+  timerRef.current = window.setTimeout(() => {
+    if (completedRef.current) return;
+    onComplete(buildOutcomes(rows, resolvedRef.current, true));
+  }, BULK_RESOLVE_TIMEOUT_MS);
+  return () => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+}, []);
+```
+
+**Acceptance:** Timer fires only if resolves haven't completed; reads through `resolvedRef` so partial-settle state survives.
+
+### Step 4 — Widen the wizard guard in `bulk-wizard.tsx`
+
+Replace the narrow `matched`-only guard with the broader check from § 3b.
+
+**Acceptance:** Any `pending-after-timeout` outcome for a row already in a terminal state is rejected.
+
+### Step 5 — Add `bulk-resolve-step.test.tsx`
+
+Two cases per § 3c. Use `renderWithProviders` + `createMockApiClient` + `vi.useFakeTimers`. Mock `apiClient.listings.resolveCategory`.
+
+**Acceptance:** Both tests pass; regression test fails against the pre-fix code (verify by temporarily reverting Step 1-3 and re-running).
+
+### Step 6 — Quality gate
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+All green. No integration tests touched.
+
+## Phase 5 — Validate
+
+**Architecture compliance.**
+- All changes inside `features/listings/components/bulk/` — same feature module.
+- No new cross-boundary imports.
+- State ownership unchanged: resolve outcomes stay local to the wizard subtree.
+
+**Naming.** No new files outside the canonical feature structure. Test file: `bulk-resolve-step.test.tsx` colocated with source per project convention.
+
+**Testing strategy.** Two tests cover both branches of the bug (success-path-then-timeout, and slow-resolves-legitimately-timing-out). Mocking strategy uses the documented `createMockApiClient` boundary — no internal-state inspection.
+
+**Risks.**
+- Fake-timer interactions with TanStack Query's `fetchQuery` need care. Using `vi.useFakeTimers({ shouldAdvanceTime: true })` keeps real timers running underneath where the test runner needs them. If this turns out fragile, fall back to `vi.useFakeTimers()` with explicit `vi.advanceTimersByTimeAsync(...)` calls.
+- The wizard guard widening is broader than the original. The only legitimate path that produces a `pending-after-timeout` outcome is the timeout effect — which post-fix only fires when resolves haven't completed. So broadening can't suppress a real signal.
+
+**Open questions.** None.


### PR DESCRIPTION
## Summary

The bulk-create wizard's Resolve step ran a 15-s fallback timer alongside the resolve loop. The timeout effect's `[]` deps captured the seed-time `resolved` map and `rows` prop. When the resolve loop completed first — the common case at ~100 ms per row — the timer kept ticking; at T+15 s it fired with the stale closure, called `onComplete` with `pending-after-timeout` for every EAN-bearing row, and the parent wizard's narrow `matched`-only downgrade guard let the stale outcomes overwrite settled `no-match` / `no-ean` / `no-variant` rows.

User-visible symptom: badges flipped from "MANUAL CATEGORY REQUIRED" back to a pulsing "STILL RESOLVING" 15 s after the wizard arrived at the Review step.

## Changes

**`bulk-resolve-step.tsx` — three refs + cancel-on-success:**

1. `resolvedRef` mirrors `resolved` state via a small `useEffect([resolved])`. The timeout callback reads through the ref so the legitimate slow case (some rows settled, some not) keeps settled data alongside `pending-after-timeout` for in-flight rows.
2. `completedRef` is flipped to `true` in the resolve-loop success path before `onComplete` fires. The timeout callback short-circuits when set — the common fast case never produces a second `onComplete`.
3. `timerRef` holds the timeout id so the success path can `clearTimeout` eagerly. Defence in depth alongside `completedRef`.

**`bulk-wizard.tsx` — guard widened, reducer extracted:**

The narrow `matched`-only downgrade guard is replaced with: reject any `pending-after-timeout` outcome arriving for a row already in a terminal state (`matched` / `no-match` / `no-ean` / `no-variant`). The reducer is extracted as an exported `applyResolveOutcomes` pure helper so the guard can be locked in by a focused unit test without rendering the full wizard.

## Tests (9 new)

**`bulk-resolve-step.test.tsx`** — 2 cases using `vi.useFakeTimers()` + explicit `vi.advanceTimersByTimeAsync` for deterministic timing:
- **Regression:** resolves settle fast → advance timers 16 s past the deadline → assert `onComplete` was called exactly once with `matched` outcomes; no second call.
- **Legitimate slow case:** synthetic `no-ean` row + held EAN-row Promise → timeout fires while EAN row is in flight → `no-ean` row stays as `no-ean` (proving the timeout reads `resolvedRef.current`, not the closure) and EAN row becomes `pending-after-timeout`.

**`bulk-wizard.test.tsx`** — 6 cases via `it.each<BulkRowStatus>` exercising `applyResolveOutcomes` directly: every terminal status rejects `pending-after-timeout`; happy-path outcomes still flow forward; rows without a matching outcome stay untouched.

## Alternative considered (not taken)

The current shape uses three refs. A `Promise.race(pAllLimit(...), timeoutPromise)` rewrite would collapse the second `useEffect` entirely and avoid closure capture altogether — but it changes the file's documented design more than the bug requires, so the three-ref fix is the right size for this PR.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — full suite green (146 web test files, 1134 web tests; 3,179 unit tests across other packages)
- [ ] Manual repro from the bulk wizard: dogfood a 6-product batch, observe Review step at T+15 s — badges should not flip

## Related

- #794 / PR #797 — fixes the upstream Allegro 400 that surfaced this bug during dogfood
- #795 — replaces the per-row resolve loop with a batch call (independent follow-up)
- Plan: `docs/plans/implementation-plan-796-bulk-resolve-timeout-fix.md`

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)