### PR TITLE
fix: restore green main — makeVariant fixture + duplicate migration timestamp

### DIFF
--- a/apps/api/src/migrations/1799000000001-add-price-to-product-variants.ts
+++ b/apps/api/src/migrations/1799000000001-add-price-to-product-variants.ts
@@ -22,8 +22,8 @@
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddPriceToProductVariants1799000000000 implements MigrationInterface {
-  name = 'AddPriceToProductVariants1799000000000';
+export class AddPriceToProductVariants1799000000001 implements MigrationInterface {
+  name = 'AddPriceToProductVariants1799000000001';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
@@ -26,6 +26,7 @@ function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
     attributes: null,
     ean: '5901234123457',
     gtin: null,
+    price: null,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
     ...overrides,


### PR DESCRIPTION
## What & why

`main` is currently broken in **two independent ways**, both caused by PRs that were each green in isolation but combined into a broken tree (merged back-to-back without rebasing onto each other — classic semantic merge conflicts). This PR fixes both so `pnpm build` + `pnpm lint` are green again.

### 1. `tsc -b` / `pnpm build` failure (web)

`#799` added the `makeVariant` test factory in `bulk-resolve-step.test.tsx`; `#798` made `ProductVariant.price` a required `number | null`. They merged 14s apart. On the combined tree, `makeVariant` omits `price` and only picks it up via `...overrides` (`Partial<ProductVariant>`), so `price` infers as `number | null | undefined` — not assignable to the required field:

```
bulk-resolve-step.test.tsx(22,3): error TS2322
  Types of property 'price' are incompatible.
    Type 'undefined' is not assignable to type 'number | null'.
```

**Fix:** add `price: null` to the fixture (the documented default until the master adapter populates it).

### 2. Duplicate migration timestamp (api)

`#800` (`add-shipments-table`) and `#798` (`add-price-to-product-variants`) both picked timestamp `1799000000000`. TypeORM 0.3.17 sorts migrations by timestamp with no tie-breaker, so ordering between them is undefined — the [#374](https://github.com/openlinker-project/openlinker/issues/374)-class failure mode where one `up()` body can silently never run. `scripts/check-migration-timestamps.mjs` (via `pnpm lint`) flags it.

**Fix:** bump the later-merged file (price) to the next free millisecond `1799000000001` and match the class suffix, per `docs/migrations.md` branch-merge-window guidance. The price `up()` is `ADD COLUMN IF NOT EXISTS`, so re-running under the renamed class on a DB that already applied the old name is a safe no-op.

## How to test

```bash
pnpm type-check          # green
pnpm lint                # green (migration-timestamp invariant passes)
pnpm test                # all Jest + web Vitest suites pass
pnpm --filter @openlinker/api migration:show   # lists Shipments(…000) then Price(…001)
```

Verified locally: type-check ✅, lint ✅, full unit suites ✅ (Jest 2,086 + web Vitest 1,134), `migration:show` orders the two migrations correctly with no collision.

## Notes

- No issue to `Close` — this is a hotfix for already-merged `#798` / `#799` / `#800`.
- **Prevention (follow-up, not in this PR):** both breaks would have been caught by enabling GitHub's *"Require branches to be up to date before merging"* on `main`, which forces a rebase + CI re-run on the combined tree before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)