### PR TITLE
feat(web,i18n): export `getBcp47Locale` so consumers stop mirroring locale resolution

### DIFF
--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -33,7 +33,7 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { MetricCard } from '../../shared/ui/metric-card';
 import { EntityLabel } from '../../shared/ui/entity-label';
-import { useTranslation } from '../../shared/i18n';
+import { useTranslation, getBcp47Locale } from '../../shared/i18n';
 import type { LocaleCode } from '../../shared/i18n';
 import { useOrdersQuery } from '../../features/orders/hooks/use-orders-query';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
@@ -80,12 +80,13 @@ function isOrderSyncStatus(value: string | null): value is OrderSyncStatusValue 
 /**
  * Resolve the per-row total via the i18n seam (#612). Currency varies per row
  * so we instantiate per call — locale comes from the LocaleProvider rather
- * than being pinned to en-US. Mirrors `localeToBcp47` from `useNumberFormat`
- * to keep the seam single-source-of-truth on locale resolution.
+ * than being pinned to en-US. Locale resolution goes through the shared
+ * `getBcp47Locale` helper so the seam stays single-source-of-truth (#783).
  */
 function formatCurrency(amount: number, currency: string, locale: LocaleCode): string {
-  const bcp47 = locale === 'en' ? 'en-US' : locale;
-  return new Intl.NumberFormat(bcp47, { style: 'currency', currency }).format(amount);
+  return new Intl.NumberFormat(getBcp47Locale(locale), { style: 'currency', currency }).format(
+    amount,
+  );
 }
 
 /**
@@ -102,10 +103,10 @@ function formatFreshness(items: readonly OrderRecord[], locale: LocaleCode): str
     if (Number.isFinite(ms) && ms > mostRecentMs) mostRecentMs = ms;
   }
   if (mostRecentMs === 0) return null;
-  const bcp47 = locale === 'en' ? 'en-US' : locale;
-  const time = new Intl.DateTimeFormat(bcp47, { hour: '2-digit', minute: '2-digit' }).format(
-    new Date(mostRecentMs),
-  );
+  const time = new Intl.DateTimeFormat(getBcp47Locale(locale), {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(mostRecentMs));
   return `Synced ${time}`;
 }
 

--- a/apps/web/src/shared/i18n/index.ts
+++ b/apps/web/src/shared/i18n/index.ts
@@ -10,5 +10,6 @@
 export { LocaleProvider } from './locale-provider';
 export { useTranslation } from './use-translation';
 export { useNumberFormat } from './use-number-format';
+export { getBcp47Locale } from './locale';
 export { LocaleCodeValues } from './i18n.types';
 export type { LocaleCode, TranslationCatalog, LocaleContextValue } from './i18n.types';

--- a/apps/web/src/shared/i18n/locale.test.ts
+++ b/apps/web/src/shared/i18n/locale.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Tests for the exported BCP 47 locale resolver (#783).
+ *
+ * `getBcp47Locale` is the single source of truth consumers call when building
+ * per-row `Intl.*` formatters with dynamic options (currency, date), instead of
+ * mirroring the `'en' → 'en-US'` mapping inline.
+ *
+ * @module shared/i18n
+ */
+import { describe, expect, it } from 'vitest';
+import { getBcp47Locale } from './locale';
+import { LocaleCodeValues } from './i18n.types';
+
+describe('getBcp47Locale', () => {
+  it("should map 'en' to BCP 47 'en-US'", () => {
+    expect(getBcp47Locale('en')).toBe('en-US');
+  });
+
+  it('should resolve every supported locale to a well-formed BCP 47 tag', () => {
+    for (const locale of LocaleCodeValues) {
+      expect(getBcp47Locale(locale)).toMatch(/^[a-z]{2}(-[A-Z]{2})?$/);
+    }
+  });
+});

--- a/apps/web/src/shared/i18n/locale.ts
+++ b/apps/web/src/shared/i18n/locale.ts
@@ -1,0 +1,21 @@
+/**
+ * Locale resolution helpers
+ *
+ * Maps the app's `LocaleCode` to a BCP 47 language tag for `Intl.*`
+ * formatters. The single source of truth consumers use when building per-row
+ * formatters with dynamic options (currency, date) — instead of mirroring the
+ * `'en' → 'en-US'` mapping inline (#783).
+ *
+ * @module shared/i18n
+ */
+import type { LocaleCode } from './i18n.types';
+
+/**
+ * Resolve a `LocaleCode` to a BCP 47 language tag. Today `'en'` → `'en-US'`;
+ * extend here as locales land. Both `useNumberFormat` and inline `Intl.*`
+ * formatters route through this so locale resolution stays in one place.
+ */
+export function getBcp47Locale(locale: LocaleCode): string {
+  if (locale === 'en') return 'en-US';
+  return locale;
+}

--- a/apps/web/src/shared/i18n/use-number-format.ts
+++ b/apps/web/src/shared/i18n/use-number-format.ts
@@ -7,21 +7,16 @@
  * being pinned to en-US (#612).
  *
  * Today the only locale is `'en'`, which maps to BCP 47 `'en-US'`. When
- * additional locales land, extend `localeToBcp47` — or replace it with a
- * proper resolver — without changing the public hook surface.
+ * additional locales land, extend `getBcp47Locale` in `./locale` — or replace
+ * it with a proper resolver — without changing the public hook surface.
  *
  * @module shared/i18n
  */
 import { useMemo } from 'react';
 import { useTranslation } from './use-translation';
-import type { LocaleCode } from './i18n.types';
+import { getBcp47Locale } from './locale';
 
 export function useNumberFormat(options?: Intl.NumberFormatOptions): Intl.NumberFormat {
   const { locale } = useTranslation();
-  return useMemo(() => new Intl.NumberFormat(localeToBcp47(locale), options), [locale, options]);
-}
-
-function localeToBcp47(locale: LocaleCode): string {
-  if (locale === 'en') return 'en-US';
-  return locale;
+  return useMemo(() => new Intl.NumberFormat(getBcp47Locale(locale), options), [locale, options]);
 }

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -372,6 +372,7 @@ The frontend ships a **no-op i18n seam** at `apps/web/src/shared/i18n/` (#612). 
 - `LocaleProvider` — mounted at the app root between `ThemeProvider` and `PluginRegistryProvider`. Defaults to `locale='en'` with an empty catalog.
 - `useTranslation()` — returns `{ t, locale }`. `t(key, fallback)` returns the catalog hit or the fallback. With the host's empty catalog, every call returns its `fallback` argument today.
 - `useNumberFormat(options?)` — memoised `Intl.NumberFormat` for the current locale. Replaces module-scope `new Intl.NumberFormat('en-US')` instantiations so number formatting follows locale, not en-US-pinned.
+- `getBcp47Locale(locale)` — resolves a `LocaleCode` to a BCP 47 language tag for per-row `Intl.*` options (currency, date). Single source of truth so consumers don't mirror the `'en' → 'en-US'` mapping inline (#783). A locale resolver, not a formatter — so it doesn't reopen the deferred currency/date-formatting-helper scope below.
 - `LocaleCode`, `TranslationCatalog`, `LocaleContextValue` — types.
 
 **v1 scope** — explicitly **does NOT** migrate any existing English strings to `t()`. Every label, breadcrumb, button, and toast remains an inline string. The only host-side consumer is `useNumberFormat()` in `app-shell.tsx`. String migration is a per-feature follow-up issue per feature; each migration PR moves a single feature's strings to `t(key, fallback)` and ships an `en` catalog entry per key.

--- a/docs/plans/implementation-plan-i18n-bcp47-locale-export.md
+++ b/docs/plans/implementation-plan-i18n-bcp47-locale-export.md
@@ -1,0 +1,97 @@
+# Implementation Plan — export `getBcp47Locale` from `shared/i18n` (#783)
+
+## 1. Understand the task
+
+**Goal:** Make the locale → BCP 47 resolution a single source of truth. Export
+the helper currently private in `use-number-format.ts` so per-row formatters
+(e.g. orders list `formatCurrency` / `formatFreshness`) stop mirroring
+`locale === 'en' ? 'en-US' : locale` inline.
+
+**Layer:** Frontend, `shared/i18n` seam + one page consumer. No backend.
+
+**Chosen approach:** Option A from the issue (lighter touch) — export a pure
+`getBcp47Locale(locale)` helper; consumers call it inline with their own
+`Intl.NumberFormat` / `Intl.DateTimeFormat`. Defer Option B
+(`useCurrencyFormatter()` hook) until a second real consumer needs that shape.
+
+**Non-goals:** the `useCurrencyFormatter()` hook (Option B); migrating any other
+formatter; changing `useNumberFormat`'s public surface or behaviour.
+
+## 2. Research findings
+
+- `apps/web/src/shared/i18n/use-number-format.ts:24-27` — private
+  `localeToBcp47(locale)`; used by `useNumberFormat` at line 21. File header
+  (lines 9-11) references `localeToBcp47` by name.
+- `apps/web/src/shared/i18n/index.ts` — barrel; exports `useNumberFormat` but
+  not the helper.
+- `apps/web/src/pages/orders/orders-list-page.tsx` — **two** identical mirrors:
+  `formatCurrency` (L87) and `formatFreshness` (L105). The issue cites only the
+  first; the acceptance criterion ("the mirror is gone") covers both.
+- No `use-number-format.test.ts` exists today. The mapping is exercised only
+  indirectly through `locale-provider.test.tsx` (via `useNumberFormat`). The
+  issue's "no new coverage needed beyond use-number-format.test.ts" is premised
+  on a file that isn't there.
+
+## 3. Design
+
+Lift the private `localeToBcp47` into an exported `getBcp47Locale` (same 2-line
+body) and re-export from the barrel. Pure function, zero behaviour change.
+**Per the tech-review**, the helper lives in a dedicated `shared/i18n/locale.ts`
+sibling (a non-hook export doesn't belong in a `use-*.ts` file); `useNumberFormat`
+imports it from `./locale`.
+
+```ts
+// shared/i18n/locale.ts
+export function getBcp47Locale(locale: LocaleCode): string {
+  if (locale === 'en') return 'en-US';
+  return locale;
+}
+```
+
+## 4. Step-by-step implementation
+
+### Step 1 — extract helper to `shared/i18n/locale.ts`
+- Move the resolver into a new `locale.ts` as exported `getBcp47Locale`; have
+  `use-number-format.ts` import it from `./locale` (drops its now-unused
+  `LocaleCode` import) and update the file-header comment.
+- **Acceptance:** `getBcp47Locale` exported from `locale.ts`; `useNumberFormat`
+  unchanged in behaviour; no `localeToBcp47` identifier remains.
+
+### Step 2 — `shared/i18n/index.ts`
+- Add `getBcp47Locale` to the `./use-number-format` re-export.
+- **Acceptance:** `import { getBcp47Locale } from '../../shared/i18n'` resolves.
+
+### Step 3 — `orders-list-page.tsx`
+- Import `getBcp47Locale` from `../../shared/i18n`.
+- Replace the inline mirror in `formatCurrency` (L87) and `formatFreshness`
+  (L105) with `getBcp47Locale(locale)`. Update both comments that say
+  "Mirrors `localeToBcp47`" to reflect the shared helper.
+- **Acceptance:** no `locale === 'en' ? 'en-US' : locale` remains in the file.
+
+### Step 4 — `locale.test.ts` (new)
+- Colocated unit test for the now-public `getBcp47Locale`: `'en' → 'en-US'`,
+  plus a loop over `LocaleCodeValues` asserting a well-formed BCP 47 tag (guards
+  the contract as locales grow).
+- **Acceptance:** test passes; covers the public helper directly.
+
+### Step 5 — Quality gate
+- `pnpm --filter ./apps/web lint && … type-check && … test` green; `pnpm
+  check:invariants` unaffected.
+
+## 5. Validation
+
+- **Architecture:** stays within `shared/i18n`; `pages → shared` dependency
+  direction respected (orders page already imports from `shared/i18n`). No
+  `shared → features/pages` violation.
+- **Naming:** `getBcp47Locale` matches the issue's proposed name; colocated
+  `*.test.ts`.
+- **Risk:** essentially nil — pure-function extraction with no behaviour change.
+  Only watch item: ensure both mirror sites are updated (Step 3) so the
+  acceptance criterion is literally satisfied.
+
+## References
+- `apps/web/src/shared/i18n/use-number-format.ts:24-27`
+- `apps/web/src/shared/i18n/index.ts`
+- `apps/web/src/pages/orders/orders-list-page.tsx:86-89, 97-110`
+- `docs/frontend-architecture.md` § Internationalization (i18n)
+- #783; surfaced by tech-review on PR #782 (#778)


### PR DESCRIPTION
## What & why

The locale → BCP 47 mapping was private in `shared/i18n/use-number-format.ts`, so the orders list page mirrored `locale === 'en' ? 'en-US' : locale` inline for its per-row currency *and* freshness formatters (a smell flagged on PR #782). The i18n seam's intent is single-source-of-truth on locale resolution; the next page needing per-row currency would copy the same helper.

This ships the issue's lighter **Option A**: extract the resolver into a `shared/i18n/locale.ts` helper exported as `getBcp47Locale`, and route both orders-page formatters through it. Pure refactor — zero runtime behaviour change. (Option B, a `useCurrencyFormatter()` hook, stays deferred until a second consumer needs that shape.)

## Changes

- **`shared/i18n/locale.ts`** (new) — exports `getBcp47Locale(locale)`; re-exported from the i18n barrel. `useNumberFormat` imports it from `./locale` (behaviour unchanged).
- **`pages/orders/orders-list-page.tsx`** — `formatCurrency` + `formatFreshness` call `getBcp47Locale`; both inline `'en' → 'en-US'` mirrors removed.
- **`docs/frontend-architecture.md`** — add `getBcp47Locale` to the i18n § public-surface list (it's a documented seam export now).
- **`shared/i18n/locale.test.ts`** (new) — contract test for the now-public helper (`'en' → 'en-US'` + a loop over `LocaleCodeValues` asserting a well-formed BCP 47 tag).

## How to test

`pnpm --filter ./apps/web lint && … type-check && … test` — green (lint 0 errors, 1136 tests). `pnpm check:invariants` unaffected. No visual change: the orders list renders identically (the helper produces the same `en-US` tag the inline mirror did).

## Notes

- Both mirrors replaced — the issue cited only `formatCurrency`, but its acceptance criterion ("the mirror is gone") and the seam's single-source-of-truth intent cover the identical `formatFreshness` mirror too.
- Helper placed in a dedicated `locale.ts` rather than inside the `use-*.ts` hook file, since it's a pure non-hook export (tech-review refinement).

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)