### PR TITLE
feat(web,listings): bulk wizard master-pull policies + batch category resolve (#792, #795)

### DIFF
--- a/apps/api/src/listings/http/dto/resolve-category-batch.dto.ts
+++ b/apps/api/src/listings/http/dto/resolve-category-batch.dto.ts
@@ -1,0 +1,70 @@
+/**
+ * Resolve Category Batch DTOs (#795)
+ *
+ * Request and response DTOs for the batch category-resolution endpoint.
+ * Wraps the `EanCategoryMatcher` sub-capability (#735): one call resolves
+ * N variant EANs to marketplace categories, replacing the bulk wizard's
+ * previous one-call-per-row loop. Mirrors `BatchCategoryByEanInput` /
+ * `Map<string, EanMatchResult>` from `@openlinker/core/listings`.
+ *
+ * @module apps/api/src/listings/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+import type { EanMatchResult } from '@openlinker/core/listings';
+
+export class ResolveCategoryBatchItemDto {
+  @ApiProperty({ description: 'Internal product-variant ID; echoed back as the result key.' })
+  @IsString()
+  @IsNotEmpty()
+  variantId!: string;
+
+  @ApiPropertyOptional({
+    description: 'EAN/GTIN for the variant. Null/empty resolves to a no-ean outcome.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  ean?: string | null;
+}
+
+export class ResolveCategoryBatchRequestDto {
+  @ApiProperty({
+    description: 'Per-variant EAN items to resolve (max 200). One result entry per item.',
+    type: [ResolveCategoryBatchItemDto],
+  })
+  @IsArray()
+  @ArrayMinSize(1, { message: 'items must contain at least one entry' })
+  @ArrayMaxSize(200, { message: 'items may contain at most 200 entries per request' })
+  @ValidateNested({ each: true })
+  @Type(() => ResolveCategoryBatchItemDto)
+  items!: ResolveCategoryBatchItemDto[];
+}
+
+export class ResolveCategoryBatchResponseDto {
+  /**
+   * Per-variant `EanMatchResult`, keyed by `variantId`. The value is the
+   * `EanMatchResult` discriminated union (`matched` / `multi-match` /
+   * `no-ean` / `no-match`). A record-of-discriminated-union can't be
+   * expressed precisely in OpenAPI, so the field is documented loosely while
+   * staying strongly typed in TypeScript — the wire JSON is the contract.
+   */
+  @ApiProperty({
+    description: 'Per-variant EanMatchResult, keyed by variantId.',
+    type: 'object',
+    additionalProperties: true,
+  })
+  results!: Record<string, EanMatchResult>;
+}

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -11,10 +11,12 @@ import type {
   CatalogProduct,
   CatalogProductMatchResult,
   CategoryParameter,
+  EanMatchResult,
   OfferManagerPort,
   SellerPolicies,
 } from '@openlinker/core/listings';
 import {
+  AdapterCapabilityNotSupportedException,
   CatalogProductNotFoundException,
   CategoryNotFoundException,
 } from '@openlinker/core/listings';
@@ -121,6 +123,7 @@ describe('ListingsController', () => {
     };
     categoryResolution = {
       resolveCategory: jest.fn(),
+      resolveCategoriesBatch: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -754,6 +757,58 @@ describe('ListingsController', () => {
       ).rejects.toBeInstanceOf(ConnectionNotFoundException);
 
       expect(categoryResolution.resolveCategory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveCategoriesBatch (#795)', () => {
+    it('maps null EANs through and converts the service Map to a results record', async () => {
+      const serviceResult = new Map<string, EanMatchResult>([
+        ['v1', { kind: 'matched', allegroCategoryId: '257933', productCardId: 'card-1' }],
+        ['v2', { kind: 'no-ean' }],
+      ]);
+      categoryResolution.resolveCategoriesBatch.mockResolvedValue(serviceResult);
+
+      const result = await controller.resolveCategoriesBatch('conn-1', {
+        items: [
+          { variantId: 'v1', ean: '5901234567890' },
+          { variantId: 'v2' },
+        ],
+      });
+
+      expect(categoryResolution.resolveCategoriesBatch).toHaveBeenCalledWith('conn-1', {
+        items: [
+          { variantId: 'v1', ean: '5901234567890' },
+          { variantId: 'v2', ean: null },
+        ],
+      });
+      expect(result).toEqual({
+        results: {
+          v1: { kind: 'matched', allegroCategoryId: '257933', productCardId: 'card-1' },
+          v2: { kind: 'no-ean' },
+        },
+      });
+    });
+
+    it('maps AdapterCapabilityNotSupportedException to 422', async () => {
+      categoryResolution.resolveCategoriesBatch.mockRejectedValue(
+        new AdapterCapabilityNotSupportedException('conn-1', 'EanCategoryMatcher')
+      );
+
+      await expect(
+        controller.resolveCategoriesBatch('conn-1', { items: [{ variantId: 'v1', ean: '590' }] })
+      ).rejects.toBeInstanceOf(UnprocessableEntityException);
+    });
+
+    it('propagates non-capability errors (e.g. connection not found) untouched', async () => {
+      categoryResolution.resolveCategoriesBatch.mockRejectedValue(
+        new ConnectionNotFoundException('conn-missing')
+      );
+
+      await expect(
+        controller.resolveCategoriesBatch('conn-missing', {
+          items: [{ variantId: 'v1', ean: '590' }],
+        })
+      ).rejects.toBeInstanceOf(ConnectionNotFoundException);
     });
   });
 

--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -29,6 +29,7 @@ import { randomUUID } from 'crypto';
 
 import { Roles } from '../../auth/decorators/roles.decorator';
 import {
+  AdapterCapabilityNotSupportedException,
   CatalogProductNotFoundException,
   CategoryNotFoundException,
   CATEGORY_RESOLUTION_SERVICE_TOKEN,
@@ -74,6 +75,10 @@ import { SellerPoliciesResponseDto } from './dto/seller-policies-response.dto';
 import type { CategoryParameterResponseDto } from './dto/category-parameter-response.dto';
 import { CategoryParametersListResponseDto } from './dto/category-parameter-response.dto';
 import { ResolveCategoryRequestDto, ResolveCategoryResponseDto } from './dto/resolve-category.dto';
+import {
+  ResolveCategoryBatchRequestDto,
+  ResolveCategoryBatchResponseDto,
+} from './dto/resolve-category-batch.dto';
 import type { FindProductsByBarcodeResponseDto } from './dto/catalog-product.dto';
 import {
   CatalogProductResponseDto,
@@ -491,6 +496,49 @@ export class ListingsController {
       allegroCategoryId: result.allegroCategoryId,
       method: result.method,
     };
+  }
+
+  @Post('connections/:connectionId/categories/resolve-batch')
+  @HttpCode(HttpStatus.OK)
+  @ApiParam({ name: 'connectionId', description: 'Marketplace connection ID' })
+  @ApiOperation({
+    summary: 'Batch-resolve marketplace categories by variant EAN (#795)',
+    description:
+      'Resolves up to 200 variant EANs to marketplace categories in one call via the ' +
+      'connection adapter’s EanCategoryMatcher sub-capability (#735). EAN-only — no ' +
+      'mapping fallback. Drives the bulk-listing wizard Resolve step, replacing the ' +
+      'previous one-HTTP-call-per-row loop. Results are keyed by variantId; every input ' +
+      'item gets exactly one entry.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Per-variant resolution results.',
+    type: ResolveCategoryBatchResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Connection not found.' })
+  @ApiResponse({ status: 409, description: 'Connection disabled.' })
+  @ApiResponse({
+    status: 422,
+    description: 'Connection adapter does not support OfferManager / EanCategoryMatcher.',
+  })
+  async resolveCategoriesBatch(
+    @Param('connectionId') connectionId: string,
+    @Body() dto: ResolveCategoryBatchRequestDto
+  ): Promise<ResolveCategoryBatchResponseDto> {
+    try {
+      const results = await this.categoryResolution.resolveCategoriesBatch(connectionId, {
+        items: dto.items.map((item) => ({ variantId: item.variantId, ean: item.ean ?? null })),
+      });
+      return { results: Object.fromEntries(results) };
+    } catch (error) {
+      if (error instanceof AdapterCapabilityNotSupportedException) {
+        // Connection is a marketplace but its adapter can't batch-resolve EANs
+        // (e.g. a future Shopify/WooCommerce adapter). Single-product flows can
+        // still use the per-row /categories/resolve route.
+        throw new UnprocessableEntityException(error.message);
+      }
+      throw error;
+    }
   }
 
   // -----------------------------------------------------------------

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -19,6 +19,8 @@ import type {
   OfferCreationStatusResponse,
   OfferMapping,
   PaginatedOfferMappings,
+  ResolveCategoriesBatchRequest,
+  ResolveCategoriesBatchResponse,
   ResolveCategoryRequest,
   ResolveCategoryResponse,
   SellerPoliciesResponse,
@@ -80,6 +82,16 @@ export interface ListingsApi {
     connectionId: string,
     body: ResolveCategoryRequest,
   ) => Promise<ResolveCategoryResponse>;
+  /**
+   * Batch-resolve N variant EANs to marketplace categories in one call (#795).
+   * Wraps the adapter's `EanCategoryMatcher` sub-capability; drives the bulk
+   * wizard's Resolve step, replacing the per-row `resolveCategory` loop. Max
+   * 200 items per request; results keyed by `variantId`.
+   */
+  resolveCategoriesBatch: (
+    connectionId: string,
+    body: ResolveCategoriesBatchRequest,
+  ) => Promise<ResolveCategoriesBatchResponse>;
   /**
    * Submit a bulk offer-creation batch (#736). Returns the persisted
    * `batchId` and per-job message IDs. 1..100 variants per batch.
@@ -173,6 +185,16 @@ export function createListingsApi(request: ApiRequest): ListingsApi {
     resolveCategory(connectionId, body): Promise<ResolveCategoryResponse> {
       return request<ResolveCategoryResponse>(
         `/listings/connections/${connectionId}/categories/resolve`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+      );
+    },
+    resolveCategoriesBatch(connectionId, body): Promise<ResolveCategoriesBatchResponse> {
+      return request<ResolveCategoriesBatchResponse>(
+        `/listings/connections/${connectionId}/categories/resolve-batch`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/features/listings/api/listings.query-keys.ts
+++ b/apps/web/src/features/listings/api/listings.query-keys.ts
@@ -45,6 +45,11 @@ export const listingsQueryKeys = {
       barcode ?? '',
       sourceCategoryIds ?? [],
     ] as const,
+  // #795 — batch EAN → Allegro category resolution for the bulk wizard.
+  // Keyed on the variant-id set so a different selection doesn't share a
+  // cache entry; distinct prefix from the single-row `resolveCategory` key.
+  resolveCategoryBatch: (connectionId: string, variantIds: string[]) =>
+    ['listings', 'resolveCategoryBatch', connectionId, variantIds] as const,
   /** #741 — bulk batch progress polling. */
   bulkBatch: (batchId: string) => ['listings', 'bulkBatch', batchId] as const,
 };

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -397,3 +397,44 @@ export interface ResolveCategoryResponse {
   /** Which step of the 3-step fallback produced the result. */
   method: CategoryResolutionMethod;
 }
+
+/**
+ * Per-variant outcome of the batch EAN→category resolve (#795). Mirrors the BE
+ * `EanMatchResult` discriminated union from `@openlinker/core/listings`
+ * (duplicated FE-side per #591 — same convention as `CategoryResolutionMethod`
+ * above). The richer envelope (vs single-resolve's flat shape) carries the
+ * `multi-match` candidate list the bulk-wizard edit modal surfaces (#740 / #792).
+ */
+export const EanMatchResultKindValues = [
+  'matched',
+  'multi-match',
+  'no-ean',
+  'no-match',
+] as const;
+export type EanMatchResultKind = (typeof EanMatchResultKindValues)[number];
+
+export interface EanMatchCandidate {
+  allegroCategoryId: string;
+  productCardId: string;
+  /** Allegro display name for the candidate-picker chip. */
+  name?: string;
+}
+
+export type EanMatchResult =
+  | { kind: 'matched'; allegroCategoryId: string; productCardId: string }
+  | { kind: 'multi-match'; candidates: EanMatchCandidate[] }
+  | { kind: 'no-ean' }
+  | { kind: 'no-match' };
+
+/**
+ * Request body for `POST /listings/connections/:connectionId/categories/resolve-batch`
+ * (#795). One result entry per item, keyed by `variantId`.
+ */
+export interface ResolveCategoriesBatchRequest {
+  items: Array<{ variantId: string; ean: string | null }>;
+}
+
+/** Response from the batch resolve route (#795). Keyed by `variantId`. */
+export interface ResolveCategoriesBatchResponse {
+  results: Record<string, EanMatchResult>;
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * BulkConfigStep tests (#792 PR 3)
+ *
+ * The Config step builds the batch-wide `BulkWizardConfig` — connection,
+ * delivery policy, currency, and the pricing/stock policy objects — and gates
+ * "Proceed" on per-mode validation.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
+import { BulkConfigStep } from './bulk-config-step';
+import type { BulkWizardConfig } from './bulk-wizard.types';
+import type { Connection } from '../../../connections';
+
+function makeClient() {
+  const connection = {
+    id: 'conn-1',
+    name: 'My Allegro',
+    status: 'active',
+    platformType: 'allegro',
+    supportedCapabilities: ['OfferManager'],
+  } as unknown as Connection;
+  return createMockApiClient({
+    connections: { list: vi.fn().mockResolvedValue([connection]) },
+    listings: {
+      getSellerPolicies: vi.fn().mockResolvedValue({
+        deliveryPolicies: [{ id: 'dp1', name: 'Courier 24h' }],
+      }),
+    },
+  });
+}
+
+async function renderAndSelectPolicy() {
+  const onProceed = vi.fn<(c: BulkWizardConfig) => void>();
+  renderWithProviders(
+    <BulkConfigStep initial={{}} onProceed={onProceed} onCancel={() => undefined} />,
+    { apiClient: makeClient() },
+  );
+  // Wait for the delivery option to render — that only happens after the lone
+  // connection auto-selects and its seller policies load (the select is shown
+  // empty before then, since a disabled query isn't "loading").
+  await screen.findByRole('option', { name: 'Courier 24h' });
+  fireEvent.change(screen.getByRole('combobox', { name: 'Shipping rate package' }), {
+    target: { value: 'dp1' },
+  });
+  return { onProceed };
+}
+
+async function clickProceed(): Promise<void> {
+  const proceed = screen.getByRole('button', { name: /Proceed/ });
+  await waitFor(() => { expect(proceed).toBeEnabled(); });
+  fireEvent.click(proceed);
+}
+
+describe('BulkConfigStep', () => {
+  it('proceeds with use-master pricing/stock by default', async () => {
+    const { onProceed } = await renderAndSelectPolicy();
+
+    await clickProceed();
+
+    expect(onProceed).toHaveBeenCalledTimes(1);
+    expect(onProceed.mock.calls[0][0]).toEqual({
+      connectionId: 'conn-1',
+      deliveryPolicyId: 'dp1',
+      currency: 'PLN',
+      pricingPolicy: { mode: 'use-master' },
+      stockPolicy: { mode: 'use-master' },
+      publishImmediately: true,
+      generateDescription: false,
+    });
+  });
+
+  it('builds markup + cap policy objects from the selected modes and values', async () => {
+    const { onProceed } = await renderAndSelectPolicy();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Markup on master price/ }));
+    fireEvent.change(screen.getByLabelText('Markup %'), { target: { value: '15' } });
+    fireEvent.click(screen.getByRole('radio', { name: /Cap master stock/ }));
+    fireEvent.change(screen.getByLabelText('Cap at'), { target: { value: '8' } });
+
+    await clickProceed();
+
+    expect(onProceed).toHaveBeenCalledTimes(1);
+    expect(onProceed.mock.calls[0][0]).toMatchObject({
+      pricingPolicy: { mode: 'markup', percent: 15 },
+      stockPolicy: { mode: 'cap', value: 8 },
+    });
+  });
+
+  it('disables Proceed when the markup percent is out of range', async () => {
+    await renderAndSelectPolicy();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Markup on master price/ }));
+    fireEvent.change(screen.getByLabelText('Markup %'), { target: { value: '999' } });
+
+    expect(screen.getByRole('button', { name: /Proceed/ })).toBeDisabled();
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
@@ -36,10 +36,12 @@ async function renderAndSelectPolicy() {
     <BulkConfigStep initial={{}} onProceed={onProceed} onCancel={() => undefined} />,
     { apiClient: makeClient() },
   );
-  // Wait for the delivery option to render — that only happens after the lone
-  // connection auto-selects and its seller policies load (the select is shown
-  // empty before then, since a disabled query isn't "loading").
-  await screen.findByRole('option', { name: 'Courier 24h' });
+  // Wait for the delivery option to render — that only happens after a 3-hop
+  // async chain: connections query → auto-select effect → seller-policies query
+  // resolves (the select renders empty before then, since a disabled query
+  // isn't "loading"). The generous timeout rides out a starved event loop under
+  // heavy parallel CI load, where the default 1000ms can lapse mid-chain.
+  await screen.findByRole('option', { name: 'Courier 24h' }, { timeout: 5000 });
   fireEvent.change(screen.getByRole('combobox', { name: 'Shipping rate package' }), {
     target: { value: 'dp1' },
   });
@@ -48,7 +50,7 @@ async function renderAndSelectPolicy() {
 
 async function clickProceed(): Promise<void> {
   const proceed = screen.getByRole('button', { name: /Proceed/ });
-  await waitFor(() => { expect(proceed).toBeEnabled(); });
+  await waitFor(() => { expect(proceed).toBeEnabled(); }, { timeout: 5000 });
   fireEvent.click(proceed);
 }
 
@@ -68,7 +70,7 @@ describe('BulkConfigStep', () => {
       publishImmediately: true,
       generateDescription: false,
     });
-  });
+  }, 15000);
 
   it('builds markup + cap policy objects from the selected modes and values', async () => {
     const { onProceed } = await renderAndSelectPolicy();
@@ -85,7 +87,7 @@ describe('BulkConfigStep', () => {
       pricingPolicy: { mode: 'markup', percent: 15 },
       stockPolicy: { mode: 'cap', value: 8 },
     });
-  });
+  }, 15000);
 
   it('disables Proceed when the markup percent is out of range', async () => {
     await renderAndSelectPolicy();
@@ -94,5 +96,5 @@ describe('BulkConfigStep', () => {
     fireEvent.change(screen.getByLabelText('Markup %'), { target: { value: '999' } });
 
     expect(screen.getByRole('button', { name: /Proceed/ })).toBeDisabled();
-  });
+  }, 15000);
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
@@ -377,13 +377,17 @@ function PolicyRadio({
   children,
 }: PolicyRadioProps): ReactElement {
   return (
-    <label className="bulk-config__policy-option">
-      <input type="radio" name={name} checked={checked} onChange={onChange} />
-      <span className="bulk-config__policy-text">
-        <strong>{label}</strong>
-        <small style={{ display: 'block', color: 'var(--text-muted)' }}>{hint}</small>
-        {children}
-      </span>
-    </label>
+    <div className="bulk-config__policy-option">
+      <label className="bulk-config__policy-label">
+        <input type="radio" name={name} checked={checked} onChange={onChange} />
+        <span className="bulk-config__policy-text">
+          <strong>{label}</strong>
+          <small style={{ display: 'block', color: 'var(--text-muted)' }}>{hint}</small>
+        </span>
+      </label>
+      {/* Conditional input lives OUTSIDE the <label> — nesting a FormField (which
+          renders its own <label>) inside would produce invalid label-in-label markup. */}
+      {children ? <div className="bulk-config__policy-detail">{children}</div> : null}
+    </div>
   );
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
@@ -211,32 +211,6 @@ export function BulkConfigStep({
               ))}
             </Select>
           )}
-            ))}
-          </Select>
-        )}
-      </FormField>
-
-      <div className="form-field-row form-field-row--cols-3">
-        <FormField name="bulk-config-stock" label="Default stock">
-          <Input
-            type="number"
-            min={0}
-            value={defaultStock}
-            onChange={(e) => { setDefaultStock(e.target.value); }}
-            aria-invalid={!stockValid}
-          />
-        </FormField>
-        <FormField
-          name="bulk-config-price-amount"
-          label="Default price (optional)"
-          description="Used when a product has no price set."
-        >
-          <Input
-            placeholder="79.00"
-            value={defaultPriceAmount}
-            onChange={(e) => { setDefaultPriceAmount(e.target.value); }}
-            aria-invalid={!priceValid}
-          />
         </FormField>
         <FormField name="bulk-config-currency" label="Currency">
           <Select value={currency} onChange={(e) => { setCurrency(e.target.value); }}>

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
@@ -1,9 +1,11 @@
 /**
  * Bulk wizard Step 1 — Config
  *
- * Shared defaults applied to every row before review/edit. Operator picks
- * the Allegro connection (auto-hidden when there's exactly one) and the
- * shipping rate / delivery policy from the seller's catalogue.
+ * Batch-wide settings applied to every row before review/edit: connection,
+ * shipping/delivery policy, listing currency, and the master-pull pricing +
+ * stock policies (#792 PR 3). Per-row values are computed from each product's
+ * master price/stock via the policy; the operator overrides individual rows in
+ * the next step.
  *
  * @module apps/web/src/features/listings/components/bulk
  */
@@ -18,7 +20,13 @@ import {
 import { useConnectionsQuery } from '../../../connections';
 import type { Connection } from '../../../connections';
 import { useSellerPoliciesQuery } from '../../hooks/use-seller-policies-query';
-import type { BulkWizardConfig } from './bulk-wizard.types';
+import type {
+  BulkWizardConfig,
+  PricingPolicy,
+  PricingPolicyMode,
+  StockPolicy,
+  StockPolicyMode,
+} from './bulk-wizard.types';
 
 interface BulkConfigStepProps {
   initial: Partial<BulkWizardConfig>;
@@ -27,6 +35,7 @@ interface BulkConfigStepProps {
 }
 
 const DEFAULT_CURRENCY = 'PLN';
+const CURRENCY_OPTIONS = ['PLN', 'EUR', 'USD'] as const;
 
 export function BulkConfigStep({
   initial,
@@ -35,14 +44,10 @@ export function BulkConfigStep({
 }: BulkConfigStepProps): ReactElement {
   const connectionsQuery = useConnectionsQuery({ platformType: 'allegro' });
   const allegroConnections: Connection[] = (connectionsQuery.data ?? []).filter(
-    (c) =>
-      c.status === 'active' &&
-      c.supportedCapabilities?.includes('OfferManager'),
+    (c) => c.status === 'active' && c.supportedCapabilities?.includes('OfferManager'),
   );
 
-  const [connectionId, setConnectionId] = useState<string>(
-    initial.connectionId ?? '',
-  );
+  const [connectionId, setConnectionId] = useState<string>(initial.connectionId ?? '');
 
   // Auto-select the only available active connection.
   useEffect(() => {
@@ -57,15 +62,28 @@ export function BulkConfigStep({
   const [deliveryPolicyId, setDeliveryPolicyId] = useState<string>(
     initial.deliveryPolicyId ?? '',
   );
-  const [defaultStock, setDefaultStock] = useState<string>(
-    String(initial.defaultStock ?? 1),
+  const [currency, setCurrency] = useState<string>(initial.currency ?? DEFAULT_CURRENCY);
+
+  const [pricingMode, setPricingMode] = useState<PricingPolicyMode>(
+    initial.pricingPolicy?.mode ?? 'use-master',
   );
-  const [defaultPriceAmount, setDefaultPriceAmount] = useState<string>(
-    initial.defaultPrice ? String(initial.defaultPrice.amount) : '',
+  const [markupPercent, setMarkupPercent] = useState<string>(
+    initial.pricingPolicy?.mode === 'markup' ? String(initial.pricingPolicy.percent) : '10',
   );
-  const [defaultPriceCurrency, setDefaultPriceCurrency] = useState<string>(
-    initial.defaultPrice?.currency ?? DEFAULT_CURRENCY,
+  const [flatPriceAmount, setFlatPriceAmount] = useState<string>(
+    initial.pricingPolicy?.mode === 'flat' ? String(initial.pricingPolicy.amount) : '',
   );
+
+  const [stockMode, setStockMode] = useState<StockPolicyMode>(
+    initial.stockPolicy?.mode ?? 'use-master',
+  );
+  const [capValue, setCapValue] = useState<string>(
+    initial.stockPolicy?.mode === 'cap' ? String(initial.stockPolicy.value) : '5',
+  );
+  const [flatStockValue, setFlatStockValue] = useState<string>(
+    initial.stockPolicy?.mode === 'flat' ? String(initial.stockPolicy.value) : '',
+  );
+
   const [publishImmediately, setPublishImmediately] = useState<boolean>(
     initial.publishImmediately ?? true,
   );
@@ -75,42 +93,55 @@ export function BulkConfigStep({
 
   // Reset deliveryPolicyId if the connection changes (different seller, different list).
   useEffect(() => {
-    if (
-      deliveryPolicyId &&
-      !deliveryPolicies.some((p) => p.id === deliveryPolicyId)
-    ) {
+    if (deliveryPolicyId && !deliveryPolicies.some((p) => p.id === deliveryPolicyId)) {
       setDeliveryPolicyId('');
     }
   }, [deliveryPolicyId, deliveryPolicies]);
 
-  const stockValid = /^\d+$/.test(defaultStock.trim()) && Number(defaultStock) >= 0;
-  const priceProvided = defaultPriceAmount.trim() !== '';
-  const priceValid =
-    !priceProvided ||
-    /^\d+([.,]\d{1,2})?$/.test(defaultPriceAmount.trim());
+  const markupValid =
+    pricingMode !== 'markup' ||
+    (/^-?\d+(\.\d+)?$/.test(markupPercent.trim()) &&
+      Number(markupPercent) >= -100 &&
+      Number(markupPercent) <= 500);
+  const flatPriceValid =
+    pricingMode !== 'flat' || /^\d+([.,]\d{1,2})?$/.test(flatPriceAmount.trim());
+  const capValid =
+    stockMode !== 'cap' || (/^\d+$/.test(capValue.trim()) && Number(capValue) >= 1);
+  const flatStockValid =
+    stockMode !== 'flat' || (/^\d+$/.test(flatStockValue.trim()) && Number(flatStockValue) >= 1);
 
   const canProceed =
     connectionId !== '' &&
     deliveryPolicyId !== '' &&
-    stockValid &&
-    priceValid;
+    markupValid &&
+    flatPriceValid &&
+    capValid &&
+    flatStockValid;
+
+  function buildPricingPolicy(): PricingPolicy {
+    if (pricingMode === 'markup') return { mode: 'markup', percent: Number(markupPercent) };
+    if (pricingMode === 'flat') {
+      return { mode: 'flat', amount: Number(flatPriceAmount.replace(',', '.')) };
+    }
+    return { mode: 'use-master' };
+  }
+
+  function buildStockPolicy(): StockPolicy {
+    if (stockMode === 'cap') return { mode: 'cap', value: Number(capValue) };
+    if (stockMode === 'flat') return { mode: 'flat', value: Number(flatStockValue) };
+    return { mode: 'use-master' };
+  }
 
   function handleProceed(): void {
     if (!canProceed) return;
     onProceed({
       connectionId,
       deliveryPolicyId,
-      defaultStock: Number(defaultStock),
+      currency,
+      pricingPolicy: buildPricingPolicy(),
+      stockPolicy: buildStockPolicy(),
       publishImmediately,
       generateDescription,
-      ...(priceProvided
-        ? {
-            defaultPrice: {
-              amount: Number(defaultPriceAmount.replace(',', '.')),
-              currency: defaultPriceCurrency,
-            },
-          }
-        : {}),
     });
   }
 
@@ -120,8 +151,8 @@ export function BulkConfigStep({
   if (allegroConnections.length === 0) {
     return (
       <Alert tone="error">
-        No active Allegro connections with offer-creation capability found. Add one
-        from <a href="/connections">Connections</a>.
+        No active Allegro connections with offer-creation capability found. Add one from{' '}
+        <a href="/connections">Connections</a>.
       </Alert>
     );
   }
@@ -133,17 +164,15 @@ export function BulkConfigStep({
           Configure batch
         </h2>
         <p style={{ margin: '4px 0 0', color: 'var(--text-secondary)', fontSize: 13 }}>
-          Shared defaults applied to all selected products. You can override per row in
-          the next step.
+          Batch-wide settings applied to all selected products. Per-row price and stock are
+          pulled from each product's master data via the policies below; override individual
+          rows in the next step.
         </p>
       </header>
 
       {allegroConnections.length > 1 ? (
         <FormField name="bulk-config-connection" label="Allegro connection">
-          <Select
-            value={connectionId}
-            onChange={(e) => { setConnectionId(e.target.value); }}
-          >
+          <Select value={connectionId} onChange={(e) => { setConnectionId(e.target.value); }}>
             <option value="" disabled>
               Select a connection…
             </option>
@@ -160,62 +189,135 @@ export function BulkConfigStep({
         </Alert>
       )}
 
-      <FormField name="bulk-config-shipping" label="Shipping rate package">
-        {policiesQuery.isLoading ? (
-          <Input disabled value="Loading policies…" />
-        ) : policiesQuery.error ? (
-          <Alert tone="error">Could not load shipping policies for this connection.</Alert>
-        ) : (
-          <Select
-            value={deliveryPolicyId}
-            onChange={(e) => { setDeliveryPolicyId(e.target.value); }}
-            disabled={deliveryPolicies.length === 0}
-          >
-            <option value="" disabled>
-              Select a delivery package…
-            </option>
-            {deliveryPolicies.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
+      <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 'var(--space-3)' }}>
+        <FormField name="bulk-config-shipping" label="Shipping rate package">
+          {policiesQuery.isLoading ? (
+            <Input disabled value="Loading policies…" />
+          ) : policiesQuery.error ? (
+            <Alert tone="error">Could not load shipping policies for this connection.</Alert>
+          ) : (
+            <Select
+              value={deliveryPolicyId}
+              onChange={(e) => { setDeliveryPolicyId(e.target.value); }}
+              disabled={deliveryPolicies.length === 0}
+            >
+              <option value="" disabled>
+                Select a delivery package…
+              </option>
+              {deliveryPolicies.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </Select>
+          )}
+        </FormField>
+        <FormField name="bulk-config-currency" label="Currency">
+          <Select value={currency} onChange={(e) => { setCurrency(e.target.value); }}>
+            {CURRENCY_OPTIONS.map((c) => (
+              <option key={c} value={c}>
+                {c}
               </option>
             ))}
           </Select>
-        )}
-      </FormField>
-
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 'var(--space-3)' }}>
-        <FormField name="bulk-config-stock" label="Default stock">
-          <Input
-            type="number"
-            min={0}
-            value={defaultStock}
-            onChange={(e) => { setDefaultStock(e.target.value); }}
-            aria-invalid={!stockValid}
-          />
-        </FormField>
-        <FormField
-          name="bulk-config-price-amount"
-          label="Default price (optional)"
-          description="Used when a product has no price set."
-        >
-          <Input
-            placeholder="79.00"
-            value={defaultPriceAmount}
-            onChange={(e) => { setDefaultPriceAmount(e.target.value); }}
-            aria-invalid={!priceValid}
-          />
-        </FormField>
-        <FormField name="bulk-config-price-currency" label="Currency">
-          <Select
-            value={defaultPriceCurrency}
-            onChange={(e) => { setDefaultPriceCurrency(e.target.value); }}
-          >
-            <option value="PLN">PLN</option>
-            <option value="EUR">EUR</option>
-            <option value="USD">USD</option>
-          </Select>
         </FormField>
       </div>
+
+      <fieldset className="bulk-config__policy">
+        <legend>Pricing policy</legend>
+        <PolicyRadio
+          name="bulk-pricing-mode"
+          checked={pricingMode === 'use-master'}
+          onChange={() => { setPricingMode('use-master'); }}
+          label="Use master price"
+          hint="Each offer uses the product's own price. Rows without a master price are flagged."
+        />
+        <PolicyRadio
+          name="bulk-pricing-mode"
+          checked={pricingMode === 'markup'}
+          onChange={() => { setPricingMode('markup'); }}
+          label="Markup on master price"
+          hint="Apply a percentage to each master price (negative = discount)."
+        >
+          {pricingMode === 'markup' ? (
+            <FormField name="bulk-config-markup" label="Markup %">
+              <Input
+                placeholder="10"
+                value={markupPercent}
+                onChange={(e) => { setMarkupPercent(e.target.value); }}
+                aria-invalid={!markupValid}
+              />
+            </FormField>
+          ) : null}
+        </PolicyRadio>
+        <PolicyRadio
+          name="bulk-pricing-mode"
+          checked={pricingMode === 'flat'}
+          onChange={() => { setPricingMode('flat'); }}
+          label="Flat price for all rows"
+          hint={`Same price (in ${currency}) for every offer, ignoring master prices.`}
+        >
+          {pricingMode === 'flat' ? (
+            <FormField name="bulk-config-flat-price" label={`Flat price (${currency})`}>
+              <Input
+                placeholder="79.00"
+                value={flatPriceAmount}
+                onChange={(e) => { setFlatPriceAmount(e.target.value); }}
+                aria-invalid={!flatPriceValid}
+              />
+            </FormField>
+          ) : null}
+        </PolicyRadio>
+      </fieldset>
+
+      <fieldset className="bulk-config__policy">
+        <legend>Stock policy</legend>
+        <PolicyRadio
+          name="bulk-stock-mode"
+          checked={stockMode === 'use-master'}
+          onChange={() => { setStockMode('use-master'); }}
+          label="Use master stock"
+          hint="Each offer uses the product's available quantity. Zero-stock rows are flagged."
+        />
+        <PolicyRadio
+          name="bulk-stock-mode"
+          checked={stockMode === 'cap'}
+          onChange={() => { setStockMode('cap'); }}
+          label="Cap master stock"
+          hint="Use the master quantity, capped at N."
+        >
+          {stockMode === 'cap' ? (
+            <FormField name="bulk-config-cap" label="Cap at">
+              <Input
+                type="number"
+                min={1}
+                value={capValue}
+                onChange={(e) => { setCapValue(e.target.value); }}
+                aria-invalid={!capValid}
+              />
+            </FormField>
+          ) : null}
+        </PolicyRadio>
+        <PolicyRadio
+          name="bulk-stock-mode"
+          checked={stockMode === 'flat'}
+          onChange={() => { setStockMode('flat'); }}
+          label="Flat stock for all rows"
+          hint="Same quantity for every offer, ignoring master stock."
+        >
+          {stockMode === 'flat' ? (
+            <FormField name="bulk-config-flat-stock" label="Stock">
+              <Input
+                type="number"
+                min={1}
+                value={flatStockValue}
+                onChange={(e) => { setFlatStockValue(e.target.value); }}
+                aria-invalid={!flatStockValid}
+              />
+            </FormField>
+          ) : null}
+        </PolicyRadio>
+      </fieldset>
 
       <label style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-2)' }}>
         <input
@@ -240,8 +342,8 @@ export function BulkConfigStep({
         <span>
           <strong>Generate AI descriptions by default</strong>
           <small style={{ display: 'block', color: 'var(--text-muted)' }}>
-            Worker uses ContentSuggestionService per row. Per-row toggle in the edit
-            modal overrides this.
+            Worker uses ContentSuggestionService per row. Per-row toggle in the edit modal
+            overrides this.
           </small>
         </span>
       </label>
@@ -254,5 +356,34 @@ export function BulkConfigStep({
         </Button>
       </footer>
     </div>
+  );
+}
+
+interface PolicyRadioProps {
+  name: string;
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  hint: string;
+  children?: ReactElement | null;
+}
+
+function PolicyRadio({
+  name,
+  checked,
+  onChange,
+  label,
+  hint,
+  children,
+}: PolicyRadioProps): ReactElement {
+  return (
+    <label className="bulk-config__policy-option">
+      <input type="radio" name={name} checked={checked} onChange={onChange} />
+      <span className="bulk-config__policy-text">
+        <strong>{label}</strong>
+        <small style={{ display: 'block', color: 'var(--text-muted)' }}>{hint}</small>
+        {children}
+      </span>
+    </label>
   );
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * BulkEditModal tests (#792 PR 3)
+ *
+ * Multi-match candidate chips + snapshot pre-fill (the form binds to a
+ * one-time snapshot of the row at open and does not re-bind when a background
+ * row update changes the `row` prop mid-edit).
+ *
+ * The category picker, parameters query, parameters step, and AI suggestion
+ * dialog are stubbed so the test isolates the modal's own logic from their
+ * data dependencies.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../../test/test-utils';
+import { BulkEditModal } from './bulk-edit-modal';
+import type { BulkWizardRow } from './bulk-wizard.types';
+import type { EanMatchCandidate } from '../../api/listings.types';
+import type { Product, ProductVariant } from '../../../products';
+
+vi.mock('../CategoryPicker', () => ({
+  CategoryPicker: ({ value }: { value: string | null }) => (
+    <div data-testid="category-picker">{value ?? 'none'}</div>
+  ),
+}));
+vi.mock('../../hooks/use-category-parameters-query', () => ({
+  useCategoryParametersQuery: () => ({ data: [], isLoading: false, error: null }),
+}));
+vi.mock('../../../content', () => ({ SuggestionDialog: () => null }));
+vi.mock('../category-parameters-step', () => ({ CategoryParametersStep: () => null }));
+
+const DEFAULTS = { stock: 5, publishImmediately: true, priceAmount: '12.00', priceCurrency: 'PLN' };
+
+function makeRow(opts: {
+  name?: string;
+  candidates?: EanMatchCandidate[];
+} = {}): BulkWizardRow {
+  const variant: ProductVariant = {
+    id: 'var_1',
+    productId: 'prod_1',
+    sku: 'SKU',
+    attributes: null,
+    ean: '590',
+    gtin: null,
+    price: 12,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+  const product: Product = {
+    id: 'prod_1',
+    name: opts.name ?? 'Widget',
+    sku: 'SKU',
+    price: 12,
+    currency: 'PLN',
+    description: null,
+    images: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+  return {
+    productId: 'prod_1',
+    product,
+    primaryVariant: variant,
+    blockers: [],
+    resolvedCategoryId: null,
+    resolutionMethod: null,
+    masterPrice: 12,
+    masterStock: 5,
+    masterCurrency: 'PLN',
+    categoryCandidates: opts.candidates ?? [],
+    override: {},
+  };
+}
+
+describe('BulkEditModal', () => {
+  it('renders a suggested-category chip per multi-match candidate, falling back to the id', () => {
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeRow({
+          candidates: [
+            { allegroCategoryId: 'cat-B', productCardId: 'card-B', name: 'Books' },
+            { allegroCategoryId: 'cat-C', productCardId: 'card-C' },
+          ],
+        })}
+        connectionId="conn_1"
+        defaults={DEFAULTS}
+        onSave={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Books' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'cat-C' })).toBeInTheDocument();
+  });
+
+  it('does not render the suggestion chip row when there are no candidates', () => {
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeRow()}
+        connectionId="conn_1"
+        defaults={DEFAULTS}
+        onSave={() => undefined}
+      />,
+    );
+    expect(screen.queryByText(/Suggested categories/)).not.toBeInTheDocument();
+  });
+
+  it('pre-fills the title from a snapshot and does not re-bind when the row prop changes mid-edit', () => {
+    const { rerender } = renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeRow({ name: 'Widget' })}
+        connectionId="conn_1"
+        defaults={DEFAULTS}
+        onSave={() => undefined}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('Widget')).toBeInTheDocument();
+
+    // A background availability refetch upstream produces a structurally-new
+    // row object with a changed product name. The modal must keep the snapshot.
+    rerender(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeRow({ name: 'Changed name' })}
+        connectionId="conn_1"
+        defaults={DEFAULTS}
+        onSave={() => undefined}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('Widget')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Changed name')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -11,7 +11,7 @@
  *
  * @module apps/web/src/features/listings/components/bulk
  */
-import { useEffect, useMemo, type ReactElement } from 'react';
+import { useRef, type ReactElement } from 'react';
 import {
   Controller,
   FormProvider,
@@ -122,13 +122,20 @@ function BulkEditModalForm({
 }: BulkEditModalFormProps): ReactElement {
   const variantId = row.primaryVariant?.id ?? '';
 
-  const initialValues = useMemo<BulkEditModalValues>(() => {
+  // Snapshot the row's resolved values at modal-open time. `BulkEditModalForm`
+  // mounts fresh on open (Radix Dialog portals its content), so a one-time ref
+  // capture is the snapshot. A background availability refetch can mutate the
+  // `row` prop while the modal is open; binding to this snapshot (and NOT
+  // resetting the form on `row` changes) prevents it from clobbering the
+  // operator's in-progress edits (#792).
+  const initialValuesRef = useRef<BulkEditModalValues | null>(null);
+  if (initialValuesRef.current === null) {
     const o = row.override.overrides ?? {};
     // Restore the operator's previously-entered parameter form values from
     // the row's FE-only stash, NOT from `platformParams` (the wire payload).
     const storedFormParameters =
       (row.editFormValues?.parameters as Record<string, unknown> | undefined) ?? {};
-    return {
+    initialValuesRef.current = {
       title: o.title ?? row.product?.name ?? '',
       categoryId: o.categoryId ?? row.resolvedCategoryId ?? '',
       description:
@@ -139,21 +146,17 @@ function BulkEditModalForm({
           ? String(row.override.price.amount)
           : defaults.priceAmount,
       priceCurrency: (row.override.price?.currency ?? defaults.priceCurrency) as BulkEditModalValues['priceCurrency'],
-      publishImmediately:
-        row.override.publishImmediately ?? defaults.publishImmediately,
+      publishImmediately: row.override.publishImmediately ?? defaults.publishImmediately,
       parameters: storedFormParameters,
     };
-  }, [row, defaults]);
+  }
+  const initialValues = initialValuesRef.current;
 
   const form = useForm<BulkEditModalValues, undefined, BulkEditModalSubmission>({
     defaultValues: initialValues,
     resolver: zodResolver(bulkEditModalSchema),
     mode: 'onSubmit',
   });
-
-  useEffect(() => {
-    form.reset(initialValues);
-  }, [form, initialValues]);
 
   // Watch categoryId so the parameters query refetches on category change.
   const watchedCategoryId = form.watch('categoryId');
@@ -250,6 +253,29 @@ function BulkEditModalForm({
             />
           </FormField>
 
+          {row.categoryCandidates.length > 0 ? (
+            <div className="bulk-edit__candidates">
+              <span className="bulk-edit__candidates-label">
+                Suggested categories (EAN matched several)
+              </span>
+              <div className="bulk-edit__candidate-chips">
+                {row.categoryCandidates.map((candidate) => (
+                  <button
+                    key={candidate.allegroCategoryId}
+                    type="button"
+                    className="bulk-edit__candidate-chip"
+                    onClick={() => {
+                      form.setValue('categoryId', candidate.allegroCategoryId, {
+                        shouldDirty: true,
+                      });
+                    }}
+                  >
+                    {candidate.name ?? candidate.allegroCategoryId}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
           <FormField
             name="bulk-edit-category"
             label="Allegro category"

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.test.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.test.ts
@@ -63,6 +63,18 @@ describe('computeResolvedPrice', () => {
     ).toBe('no-master-price');
   });
 
+  it('blocks no-master-price when a markup zeroes the price (e.g. -100%)', () => {
+    const result = computeResolvedPrice({ mode: 'markup', percent: -100 }, 12, NO_OVERRIDE);
+    expect(result.value).toBeNull();
+    expect(result.blocker).toBe('no-master-price');
+  });
+
+  it('blocks no-master-price under use-master when master price is 0', () => {
+    expect(computeResolvedPrice({ mode: 'use-master' }, 0, NO_OVERRIDE).blocker).toBe(
+      'no-master-price',
+    );
+  });
+
   it('uses the flat amount verbatim and never blocks', () => {
     expect(computeResolvedPrice({ mode: 'flat', amount: 79 }, null, NO_OVERRIDE)).toEqual({
       value: 79,

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.test.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Bulk policy helper — unit tests (#792 PR 3)
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { describe, expect, it } from 'vitest';
+import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
+import {
+  clampMarkupPercent,
+  computeBlockers,
+  computeResolvedPrice,
+  computeResolvedStock,
+  roundHalfUp,
+  type ComputeBlockersInput,
+} from './bulk-policy';
+
+const NO_OVERRIDE: BulkPerProductOverride = {};
+
+describe('roundHalfUp', () => {
+  it('rounds half up to 2 decimals', () => {
+    expect(roundHalfUp(13.205)).toBe(13.21);
+    expect(roundHalfUp(13.2)).toBe(13.2);
+    expect(roundHalfUp(12 * 1.1)).toBe(13.2);
+  });
+});
+
+describe('clampMarkupPercent', () => {
+  it('clamps to [-100, 500]', () => {
+    expect(clampMarkupPercent(-250)).toBe(-100);
+    expect(clampMarkupPercent(900)).toBe(500);
+    expect(clampMarkupPercent(10)).toBe(10);
+  });
+});
+
+describe('computeResolvedPrice', () => {
+  it('uses master verbatim under use-master', () => {
+    expect(computeResolvedPrice({ mode: 'use-master' }, 12, NO_OVERRIDE)).toEqual({
+      value: 12,
+      source: 'master',
+      blocker: null,
+    });
+  });
+
+  it('blocks no-master-price under use-master when master is null', () => {
+    expect(computeResolvedPrice({ mode: 'use-master' }, null, NO_OVERRIDE)).toEqual({
+      value: null,
+      source: 'master',
+      blocker: 'no-master-price',
+    });
+  });
+
+  it('applies markup half-up under markup', () => {
+    expect(computeResolvedPrice({ mode: 'markup', percent: 10 }, 12, NO_OVERRIDE)).toEqual({
+      value: 13.2,
+      source: 'policy',
+      blocker: null,
+    });
+  });
+
+  it('blocks no-master-price under markup when master is null', () => {
+    expect(
+      computeResolvedPrice({ mode: 'markup', percent: 10 }, null, NO_OVERRIDE).blocker,
+    ).toBe('no-master-price');
+  });
+
+  it('uses the flat amount verbatim and never blocks', () => {
+    expect(computeResolvedPrice({ mode: 'flat', amount: 79 }, null, NO_OVERRIDE)).toEqual({
+      value: 79,
+      source: 'policy',
+      blocker: null,
+    });
+  });
+
+  it('lets a per-row price override win over the policy', () => {
+    const override: BulkPerProductOverride = { price: { amount: 99, currency: 'PLN' } };
+    expect(computeResolvedPrice({ mode: 'use-master' }, null, override)).toEqual({
+      value: 99,
+      source: 'override',
+      blocker: null,
+    });
+  });
+});
+
+describe('computeResolvedStock', () => {
+  it('uses master under use-master', () => {
+    expect(computeResolvedStock({ mode: 'use-master' }, 3, NO_OVERRIDE)).toEqual({
+      value: 3,
+      source: 'master',
+      blocker: null,
+    });
+  });
+
+  it('blocks no-master-stock under use-master when master is 0 or null', () => {
+    expect(computeResolvedStock({ mode: 'use-master' }, 0, NO_OVERRIDE).blocker).toBe(
+      'no-master-stock',
+    );
+    expect(computeResolvedStock({ mode: 'use-master' }, null, NO_OVERRIDE).blocker).toBe(
+      'no-master-stock',
+    );
+  });
+
+  it('caps to min(master, N) under cap', () => {
+    expect(computeResolvedStock({ mode: 'cap', value: 5 }, 12, NO_OVERRIDE)).toEqual({
+      value: 5,
+      source: 'policy',
+      blocker: null,
+    });
+    expect(computeResolvedStock({ mode: 'cap', value: 5 }, 3, NO_OVERRIDE).value).toBe(3);
+  });
+
+  it('blocks cap when master is null or the capped value is 0', () => {
+    expect(computeResolvedStock({ mode: 'cap', value: 5 }, null, NO_OVERRIDE).blocker).toBe(
+      'no-master-stock',
+    );
+    expect(computeResolvedStock({ mode: 'cap', value: 5 }, 0, NO_OVERRIDE).blocker).toBe(
+      'no-master-stock',
+    );
+  });
+
+  it('uses the flat value verbatim and never blocks', () => {
+    expect(computeResolvedStock({ mode: 'flat', value: 7 }, null, NO_OVERRIDE)).toEqual({
+      value: 7,
+      source: 'policy',
+      blocker: null,
+    });
+  });
+
+  it('lets a per-row stock override win over the policy', () => {
+    expect(computeResolvedStock({ mode: 'use-master' }, null, { stock: 4 })).toEqual({
+      value: 4,
+      source: 'override',
+      blocker: null,
+    });
+  });
+});
+
+describe('computeBlockers', () => {
+  function base(overrides: Partial<ComputeBlockersInput> = {}): ComputeBlockersInput {
+    return {
+      hasVariant: true,
+      categoryResult: { kind: 'matched', allegroCategoryId: 'cat-1', productCardId: 'card-1' },
+      pricingPolicy: { mode: 'use-master' },
+      stockPolicy: { mode: 'use-master' },
+      masterPrice: 12,
+      masterStock: 3,
+      masterCurrency: 'PLN',
+      batchCurrency: 'PLN',
+      override: {},
+      ...overrides,
+    };
+  }
+
+  it('returns no blockers for a fully-resolved matched row', () => {
+    expect(computeBlockers(base())).toEqual([]);
+  });
+
+  it('returns exactly [no-variant] when the product has no variant', () => {
+    expect(computeBlockers(base({ hasVariant: false }))).toEqual(['no-variant']);
+  });
+
+  it('maps category outcomes to blockers', () => {
+    expect(computeBlockers(base({ categoryResult: { kind: 'no-ean' } }))).toEqual(['no-ean']);
+    expect(computeBlockers(base({ categoryResult: { kind: 'no-match' } }))).toEqual(['no-match']);
+    expect(
+      computeBlockers(
+        base({ categoryResult: { kind: 'multi-match', candidates: [] } }),
+      ),
+    ).toEqual(['multi-match']);
+  });
+
+  it('co-occurs no-ean + no-master-price', () => {
+    const result = computeBlockers(
+      base({ categoryResult: { kind: 'no-ean' }, masterPrice: null }),
+    );
+    expect(result).toEqual(['no-ean', 'no-master-price']);
+  });
+
+  it('fires currency-mismatch under markup when master currency differs', () => {
+    const result = computeBlockers(
+      base({ pricingPolicy: { mode: 'markup', percent: 10 }, masterCurrency: 'EUR' }),
+    );
+    expect(result).toContain('currency-mismatch');
+  });
+
+  it('does NOT fire currency-mismatch under flat pricing', () => {
+    const result = computeBlockers(
+      base({ pricingPolicy: { mode: 'flat', amount: 50 }, masterCurrency: 'EUR' }),
+    );
+    expect(result).not.toContain('currency-mismatch');
+  });
+
+  it('does NOT fire currency-mismatch when product currency is null', () => {
+    const result = computeBlockers(base({ masterCurrency: null, masterPrice: 12 }));
+    expect(result).not.toContain('currency-mismatch');
+  });
+
+  it('clears category + price + stock blockers once the operator overrides them', () => {
+    const override: BulkPerProductOverride = {
+      stock: 4,
+      price: { amount: 50, currency: 'PLN' },
+      overrides: { categoryId: 'cat-picked' },
+    };
+    const result = computeBlockers(
+      base({
+        categoryResult: { kind: 'multi-match', candidates: [] },
+        masterPrice: null,
+        masterStock: null,
+        override,
+      }),
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.ts
@@ -1,0 +1,164 @@
+/**
+ * Bulk wizard pricing/stock policy + blocker computation (#792 PR 3)
+ *
+ * Pure, side-effect-free helpers shared by the Resolve step (blocker compute)
+ * and the Review step (computed value + provenance rendering). Kept isolated
+ * from React so the policy maths are unit-testable without rendering.
+ *
+ * Resolution precedence: master → policy → per-row override (override wins).
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
+import type { EanMatchResult } from '../../api/listings.types';
+import type {
+  BulkRowBlocker,
+  BulkValueSource,
+  PricingPolicy,
+  StockPolicy,
+} from './bulk-wizard.types';
+
+const PRICE_DECIMALS = 2;
+const MARKUP_MIN_PERCENT = -100;
+const MARKUP_MAX_PERCENT = 500;
+
+export interface ResolvedPrice {
+  value: number | null;
+  source: BulkValueSource;
+  blocker: 'no-master-price' | null;
+}
+
+export interface ResolvedStock {
+  value: number | null;
+  source: BulkValueSource;
+  blocker: 'no-master-stock' | null;
+}
+
+/** Half-up rounding to `dp` decimals. Inputs here are non-negative (factor ≥ 0). */
+export function roundHalfUp(value: number, dp = PRICE_DECIMALS): number {
+  const factor = 10 ** dp;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function clampMarkupPercent(percent: number): number {
+  return Math.min(MARKUP_MAX_PERCENT, Math.max(MARKUP_MIN_PERCENT, percent));
+}
+
+export function computeResolvedPrice(
+  policy: PricingPolicy,
+  masterPrice: number | null,
+  override: BulkPerProductOverride,
+): ResolvedPrice {
+  if (override.price !== undefined) {
+    return { value: override.price.amount, source: 'override', blocker: null };
+  }
+  switch (policy.mode) {
+    case 'flat':
+      return { value: policy.amount, source: 'policy', blocker: null };
+    case 'markup': {
+      if (masterPrice === null) {
+        return { value: null, source: 'policy', blocker: 'no-master-price' };
+      }
+      const factor = 1 + clampMarkupPercent(policy.percent) / 100;
+      return { value: roundHalfUp(masterPrice * factor), source: 'policy', blocker: null };
+    }
+    case 'use-master':
+    default:
+      if (masterPrice === null) {
+        return { value: null, source: 'master', blocker: 'no-master-price' };
+      }
+      return { value: masterPrice, source: 'master', blocker: null };
+  }
+}
+
+export function computeResolvedStock(
+  policy: StockPolicy,
+  masterStock: number | null,
+  override: BulkPerProductOverride,
+): ResolvedStock {
+  if (override.stock !== undefined) {
+    return { value: override.stock, source: 'override', blocker: null };
+  }
+  switch (policy.mode) {
+    case 'flat':
+      return { value: policy.value, source: 'policy', blocker: null };
+    case 'cap': {
+      if (masterStock === null) {
+        return { value: null, source: 'policy', blocker: 'no-master-stock' };
+      }
+      // min(master, N); 0-stock can't publish on Allegro, so it blocks too.
+      const value = Math.min(masterStock, policy.value);
+      return { value, source: 'policy', blocker: value <= 0 ? 'no-master-stock' : null };
+    }
+    case 'use-master':
+    default:
+      if (masterStock === null || masterStock <= 0) {
+        return { value: masterStock, source: 'master', blocker: 'no-master-stock' };
+      }
+      return { value: masterStock, source: 'master', blocker: null };
+  }
+}
+
+export interface ComputeBlockersInput {
+  hasVariant: boolean;
+  /**
+   * Per-variant category outcome. The Resolve step synthesizes `{ kind: 'no-ean' }`
+   * for variant rows without a barcode (no BE call); `undefined` is treated
+   * defensively as `no-match`.
+   */
+  categoryResult: EanMatchResult | undefined;
+  pricingPolicy: PricingPolicy;
+  stockPolicy: StockPolicy;
+  masterPrice: number | null;
+  masterStock: number | null;
+  masterCurrency: string | null;
+  batchCurrency: string;
+  override: BulkPerProductOverride;
+}
+
+/**
+ * Compute the co-occurring blocker set for a row. A row with an empty result
+ * is ready. `no-variant` is exclusive (nothing else is meaningful without a
+ * variant); all other blockers can co-occur.
+ */
+export function computeBlockers(input: ComputeBlockersInput): BulkRowBlocker[] {
+  if (!input.hasVariant) return ['no-variant'];
+
+  const blockers: BulkRowBlocker[] = [];
+
+  // Category — an operator-picked category override clears the category blocker.
+  const hasCategoryOverride = Boolean(input.override.overrides?.categoryId);
+  if (!hasCategoryOverride) {
+    const cat = input.categoryResult;
+    if (!cat || cat.kind === 'no-match') {
+      blockers.push('no-match');
+    } else if (cat.kind === 'no-ean') {
+      blockers.push('no-ean');
+    } else if (cat.kind === 'multi-match') {
+      blockers.push('multi-match');
+    }
+    // 'matched' → no category blocker
+  }
+
+  // Price / stock — override-aware via the resolvers above.
+  const price = computeResolvedPrice(input.pricingPolicy, input.masterPrice, input.override);
+  if (price.blocker) blockers.push(price.blocker);
+  const stock = computeResolvedStock(input.stockPolicy, input.masterStock, input.override);
+  if (stock.blocker) blockers.push(stock.blocker);
+
+  // Currency mismatch only matters when the master price is actually consumed
+  // (use-master / markup, no explicit price override). Under flat pricing or an
+  // override the published price is already in the batch currency.
+  const pricingUsesMaster =
+    (input.pricingPolicy.mode === 'use-master' || input.pricingPolicy.mode === 'markup') &&
+    input.override.price === undefined;
+  if (
+    pricingUsesMaster &&
+    input.masterCurrency !== null &&
+    input.masterCurrency !== input.batchCurrency
+  ) {
+    blockers.push('currency-mismatch');
+  }
+
+  return blockers;
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.ts
@@ -54,17 +54,24 @@ export function computeResolvedPrice(
   }
   switch (policy.mode) {
     case 'flat':
+      // Operator's explicit batch-wide amount — used verbatim, never blocks.
       return { value: policy.amount, source: 'policy', blocker: null };
     case 'markup': {
       if (masterPrice === null) {
         return { value: null, source: 'policy', blocker: 'no-master-price' };
       }
       const factor = 1 + clampMarkupPercent(policy.percent) / 100;
-      return { value: roundHalfUp(masterPrice * factor), source: 'policy', blocker: null };
+      const value = roundHalfUp(masterPrice * factor);
+      // A markup that zeroes the price (e.g. -100%) can't publish on Allegro;
+      // flag it client-side so the operator sets a per-row price instead.
+      return value > 0
+        ? { value, source: 'policy', blocker: null }
+        : { value: null, source: 'policy', blocker: 'no-master-price' };
     }
     case 'use-master':
     default:
-      if (masterPrice === null) {
+      // Null or non-positive master price has no usable value to publish.
+      if (masterPrice === null || masterPrice <= 0) {
         return { value: null, source: 'master', blocker: 'no-master-price' };
       }
       return { value: masterPrice, source: 'master', blocker: null };

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
@@ -1,22 +1,17 @@
 /**
- * BulkResolveStep tests
+ * BulkResolveStep tests (#792 PR 3 / #795)
  *
- * Covers the #796 regression where the 15-s fallback timeout fired with a
- * stale `resolved` closure and overwrote already-settled rows with
- * `pending-after-timeout`. Two cases:
- *
- *   1. Resolves settle fast → advance past the 15-s deadline → outcomes
- *      remain `matched`, no second `onComplete` fires.
- *   2. Slow resolves → only the unsettled rows become `pending-after-
- *      timeout`; pre-timeout settled rows keep their status.
+ * The Resolve step issues exactly one batch category call + one availability
+ * call, then computes each row's blocker set and hands outcomes back via
+ * `onComplete` once both settle. On batch error it surfaces a Retry affordance.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
 import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
-import { BulkResolveStep, BULK_RESOLVE_TIMEOUT_MS } from './bulk-resolve-step';
-import type { BulkResolveOutcome } from './bulk-resolve-step';
+import { BulkResolveStep, type BulkResolveOutcome } from './bulk-resolve-step';
 import type { BulkWizardRow } from './bulk-wizard.types';
 import type { Product, ProductVariant } from '../../../products';
+import type { EanMatchResult } from '../../api/listings.types';
 
 function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
   return {
@@ -26,7 +21,7 @@ function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
     attributes: null,
     ean: '5901234123457',
     gtin: null,
-    price: null,
+    price: 12,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
     ...overrides,
@@ -38,7 +33,7 @@ function makeProduct(overrides: Partial<Product> = {}): Product {
     id: 'prod_1',
     name: 'Test product',
     sku: 'SKU-1',
-    price: 99.99,
+    price: 12,
     currency: 'PLN',
     description: null,
     images: null,
@@ -48,140 +43,178 @@ function makeProduct(overrides: Partial<Product> = {}): Product {
   };
 }
 
-function makeRow(
-  productId: string,
-  ean: string,
-  status: BulkWizardRow['status'] = 'resolving',
-): BulkWizardRow {
+function makeRow(productId: string, variant: Partial<ProductVariant>, product: Partial<Product> = {}): BulkWizardRow {
   return {
     productId,
-    product: makeProduct({ id: productId, name: `Product ${productId}` }),
-    primaryVariant: makeVariant({
-      id: `var_${productId}`,
-      productId,
-      ean,
-    }),
-    status,
+    product: makeProduct({ id: productId, ...product }),
+    primaryVariant: makeVariant({ id: `var_${productId}`, productId, ...variant }),
+    blockers: [],
     resolvedCategoryId: null,
     resolutionMethod: null,
+    masterPrice: null,
+    masterStock: null,
+    masterCurrency: null,
+    categoryCandidates: [],
     override: {},
   };
 }
 
+function mockClient(opts: {
+  results?: Record<string, EanMatchResult>;
+  availability?: Array<{ productVariantId: string; totalAvailable: number; locationCount: number }>;
+  categoryRejects?: boolean;
+}) {
+  return createMockApiClient({
+    listings: {
+      resolveCategoriesBatch: opts.categoryRejects
+        ? vi.fn().mockRejectedValue(new Error('Allegro 503'))
+        : vi.fn().mockResolvedValue({ results: opts.results ?? {} }),
+    },
+    inventory: {
+      availability: vi.fn().mockResolvedValue({ items: opts.availability ?? [] }),
+    },
+  });
+}
+
 describe('BulkResolveStep', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('should not re-fire onComplete after the 15s timeout when resolves already settled (#796 regression)', async () => {
+  it('issues one batch category call for an N-row batch and advances with empty blockers on a clean match', async () => {
     const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
-    const apiClient = createMockApiClient({
-      listings: {
-        resolveCategory: vi.fn().mockResolvedValue({
-          allegroCategoryId: 'cat-A',
-          method: 'auto_detect',
-        }),
+    const apiClient = mockClient({
+      results: {
+        var_prod_a: { kind: 'matched', allegroCategoryId: 'cat-A', productCardId: 'card-A' },
+        var_prod_b: { kind: 'matched', allegroCategoryId: 'cat-B', productCardId: 'card-B' },
       },
+      availability: [
+        { productVariantId: 'var_prod_a', totalAvailable: 5, locationCount: 1 },
+        { productVariantId: 'var_prod_b', totalAvailable: 9, locationCount: 2 },
+      ],
     });
 
-    const rows = [makeRow('prod_1', '5901234123457')];
-
-    renderWithProviders(
-      <BulkResolveStep rows={rows} connectionId="conn_1" onComplete={onComplete} />,
-      { apiClient },
-    );
-
-    // Let the resolve loop's promise chain drain; the fake clock isn't
-    // involved here — the mocked `resolveCategory` resolves synchronously.
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(onComplete).toHaveBeenCalledTimes(1);
-    const firstCallOutcomes = onComplete.mock.calls[0][0];
-    expect(firstCallOutcomes).toEqual([
-      expect.objectContaining({ productId: 'prod_1', status: 'matched', categoryId: 'cat-A' }),
-    ]);
-
-    // Advance past the fallback deadline. The completedRef guard must
-    // short-circuit the timeout, leaving onComplete at exactly one call.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(BULK_RESOLVE_TIMEOUT_MS + 1_000);
-    });
-
-    expect(onComplete).toHaveBeenCalledTimes(1);
-  });
-
-  it('should keep synthetic no-ean rows intact while flagging in-flight EAN rows as pending-after-timeout when the deadline hits', async () => {
-    // The resolve-step seeds `no-ean` rows synchronously into the resolved
-    // map (they need no BE call). When the fallback timeout fires while
-    // an EAN-bearing row is still in flight, the seeded entries must be
-    // preserved (proves the timeout reads the *current* ref, not the
-    // closure-captured map) and the in-flight row must flip to
-    // `pending-after-timeout`.
-    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
-
-    // Hold the EAN-row resolve indefinitely so the timeout fires first.
-    let releaseSlow: (value: { allegroCategoryId: string | null; method: string }) => void;
-    const slowPromise = new Promise<{ allegroCategoryId: string | null; method: string }>(
-      (resolve) => {
-        releaseSlow = resolve;
-      },
-    );
-
-    const apiClient = createMockApiClient({
-      listings: { resolveCategory: vi.fn().mockReturnValue(slowPromise) },
-    });
-
-    const rows: BulkWizardRow[] = [
-      // No-ean: seeded into the resolved map at mount (no primary variant
-      // EAN/GTIN). Verifies the timeout outcomes carry forward seed state.
-      {
-        ...makeRow('prod_noean', ''),
-        primaryVariant: makeVariant({
-          id: 'var_noean',
-          productId: 'prod_noean',
-          ean: null,
-          gtin: null,
-        }),
-        status: 'no-ean',
-      },
-      // EAN row: in-flight at timeout time.
-      makeRow('prod_slow', '2222222222222'),
+    const rows = [
+      makeRow('prod_a', { ean: '5901111111111' }),
+      makeRow('prod_b', { ean: '5902222222222' }),
     ];
 
     renderWithProviders(
-      <BulkResolveStep rows={rows} connectionId="conn_1" onComplete={onComplete} />,
+      <BulkResolveStep
+        rows={rows}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'use-master' }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        onComplete={onComplete}
+      />,
       { apiClient },
     );
 
-    // No settlement yet — pAllLimit is blocked on the slow promise.
-    expect(onComplete).not.toHaveBeenCalled();
+    await waitFor(() => { expect(onComplete).toHaveBeenCalledTimes(1); });
 
-    // Advance past the 15-s deadline.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(BULK_RESOLVE_TIMEOUT_MS + 1);
+    // One batch call, not one-per-row.
+    expect(apiClient.listings.resolveCategoriesBatch).toHaveBeenCalledTimes(1);
+    expect(apiClient.listings.resolveCategoriesBatch).toHaveBeenCalledWith('conn_1', {
+      items: [
+        { variantId: 'var_prod_a', ean: '5901111111111' },
+        { variantId: 'var_prod_b', ean: '5902222222222' },
+      ],
     });
-
-    expect(onComplete).toHaveBeenCalledTimes(1);
     const outcomes = onComplete.mock.calls[0][0];
-    const noEan = outcomes.find((o) => o.productId === 'prod_noean');
-    const slow = outcomes.find((o) => o.productId === 'prod_slow');
-    expect(noEan).toMatchObject({ status: 'no-ean' });
-    expect(slow).toMatchObject({ status: 'pending-after-timeout', categoryId: null });
+    expect(outcomes.every((o) => o.blockers.length === 0)).toBe(true);
+    expect(outcomes[0]).toMatchObject({ resolvedCategoryId: 'cat-A', masterPrice: 12, masterStock: 5 });
+  });
 
-    // Release the slow promise so the resolve loop unwinds cleanly under
-    // fake timers (avoids a dangling pending microtask between tests).
-    releaseSlow!({ allegroCategoryId: 'cat-SLOW', method: 'auto_detect' });
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
+  it('flags no-master-price when the variant has no master price', async () => {
+    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
+    const apiClient = mockClient({
+      results: { var_prod_a: { kind: 'matched', allegroCategoryId: 'cat-A', productCardId: 'card-A' } },
+      availability: [{ productVariantId: 'var_prod_a', totalAvailable: 5, locationCount: 1 }],
     });
+
+    renderWithProviders(
+      <BulkResolveStep
+        rows={[makeRow('prod_a', { ean: '590', price: null })]}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'use-master' }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        onComplete={onComplete}
+      />,
+      { apiClient },
+    );
+
+    await waitFor(() => { expect(onComplete).toHaveBeenCalledTimes(1); });
+    expect(onComplete.mock.calls[0][0][0].blockers).toContain('no-master-price');
+  });
+
+  it('flags currency-mismatch under markup when master currency differs from the batch', async () => {
+    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
+    const apiClient = mockClient({
+      results: { var_prod_a: { kind: 'matched', allegroCategoryId: 'cat-A', productCardId: 'card-A' } },
+      availability: [{ productVariantId: 'var_prod_a', totalAvailable: 5, locationCount: 1 }],
+    });
+
+    renderWithProviders(
+      <BulkResolveStep
+        rows={[makeRow('prod_a', { ean: '590', price: 200 }, { currency: 'EUR' })]}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'markup', percent: 10 }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        onComplete={onComplete}
+      />,
+      { apiClient },
+    );
+
+    await waitFor(() => { expect(onComplete).toHaveBeenCalledTimes(1); });
+    expect(onComplete.mock.calls[0][0][0].blockers).toContain('currency-mismatch');
+  });
+
+  it('carries multi-match candidates onto the outcome', async () => {
+    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
+    const apiClient = mockClient({
+      results: {
+        var_prod_a: {
+          kind: 'multi-match',
+          candidates: [{ allegroCategoryId: 'cat-X', productCardId: 'card-X', name: 'Books' }],
+        },
+      },
+      availability: [{ productVariantId: 'var_prod_a', totalAvailable: 5, locationCount: 1 }],
+    });
+
+    renderWithProviders(
+      <BulkResolveStep
+        rows={[makeRow('prod_a', { ean: '590' })]}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'use-master' }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        onComplete={onComplete}
+      />,
+      { apiClient },
+    );
+
+    await waitFor(() => { expect(onComplete).toHaveBeenCalledTimes(1); });
+    const out = onComplete.mock.calls[0][0][0];
+    expect(out.blockers).toContain('multi-match');
+    expect(out.categoryCandidates).toHaveLength(1);
+  });
+
+  it('shows a Retry affordance and does not advance when the batch call fails', async () => {
+    const onComplete = vi.fn<(outcomes: BulkResolveOutcome[]) => void>();
+    const apiClient = mockClient({ categoryRejects: true });
+
+    renderWithProviders(
+      <BulkResolveStep
+        rows={[makeRow('prod_a', { ean: '590' })]}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'use-master' }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        onComplete={onComplete}
+      />,
+      { apiClient },
+    );
+
+    expect(await screen.findByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(onComplete).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
@@ -1,215 +1,188 @@
 /**
- * Bulk wizard Step 2 — EAN-to-category auto-match
+ * Bulk wizard Step 2 — master-pull resolve (#792 PR 3 / #795)
  *
- * Runs `useResolveCategoryQuery` per row in throttled-parallel (cap = 8, see
- * `bulk-throttle.ts`). Shows a progress strip "Resolving N of M…". Auto-
- * advances when every query settles. A 15-second timeout transitions to the
- * Review step regardless; rows whose query hasn't settled are flagged
- * `pending-after-timeout` and continue settling in the background.
+ * Two batch calls, then compute each row's blocker set:
+ * 1. `resolveCategoriesBatch` — one call resolves every variant EAN to a
+ *    marketplace category (#795), replacing the previous one-call-per-row loop.
+ * 2. `useInventoryAvailabilityBatchQuery` — one call for summed master stock.
+ *
+ * Master price/currency are read off the already-loaded products. Per-row
+ * blockers are derived from (category result × pricing/stock policy × master
+ * values). Auto-advances to Review when both batch queries settle; surfaces an
+ * error + Retry if either fails.
  *
  * @module apps/web/src/features/listings/components/bulk
  */
-import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
-import { useQueries, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, type ReactElement } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Alert, Button } from '../../../../shared/ui';
 import { useApiClient } from '../../../../app/api/api-client-provider';
+import { useInventoryAvailabilityBatchQuery } from '../../../inventory';
 import { listingsQueryKeys } from '../../api/listings.query-keys';
-import { BULK_RESOLVE_CONCURRENCY, pAllLimit } from '../../lib/bulk-throttle';
-import {
-  RESOLVE_CATEGORY_STALE_TIME_MS,
-} from '../../hooks/use-resolve-category-query';
+import type { EanMatchCandidate, EanMatchResult } from '../../api/listings.types';
+import { computeBlockers } from './bulk-policy';
 import type {
-  ResolveCategoryRequest,
-  ResolveCategoryResponse,
-} from '../../api/listings.types';
-import type { BulkWizardRow, BulkRowStatus } from './bulk-wizard.types';
-
-export const BULK_RESOLVE_TIMEOUT_MS = 15_000;
+  BulkRowBlocker,
+  BulkWizardRow,
+  PricingPolicy,
+  StockPolicy,
+} from './bulk-wizard.types';
 
 export interface BulkResolveOutcome {
   productId: string;
-  status: BulkRowStatus;
-  categoryId: string | null;
-  method: ResolveCategoryResponse['method'] | null;
+  blockers: readonly BulkRowBlocker[];
+  resolvedCategoryId: string | null;
+  resolutionMethod: 'auto_detect' | 'category_mapping' | 'manual' | null;
+  masterPrice: number | null;
+  masterStock: number | null;
+  masterCurrency: string | null;
+  categoryCandidates: readonly EanMatchCandidate[];
 }
 
 interface BulkResolveStepProps {
   rows: BulkWizardRow[];
   connectionId: string;
-  /** Called once with the resolved outcomes for every row. */
+  pricingPolicy: PricingPolicy;
+  stockPolicy: StockPolicy;
+  /** Batch-wide currency (D7) — drives the currency-mismatch blocker. */
+  currency: string;
+  /** Called once with the resolved outcomes for every row, on settle. */
   onComplete: (outcomes: BulkResolveOutcome[]) => void;
 }
 
-interface ResolveTask {
-  productId: string;
-  barcode: string | null;
+function barcodeOf(row: BulkWizardRow): string | null {
+  const raw = row.primaryVariant?.ean ?? row.primaryVariant?.gtin ?? null;
+  return raw && raw.trim() !== '' ? raw : null;
 }
 
 export function BulkResolveStep({
   rows,
   connectionId,
+  pricingPolicy,
+  stockPolicy,
+  currency,
   onComplete,
 }: BulkResolveStepProps): ReactElement {
   const apiClient = useApiClient();
-  const queryClient = useQueryClient();
-  const [resolved, setResolved] = useState<Map<string, BulkResolveOutcome>>(
-    () => seedFromRows(rows),
-  );
-  const [progress, setProgress] = useState({ done: 0, total: rows.length });
-  const startedRef = useRef(false);
-  // The timeout effect has `[]` deps so it can't read `resolved` directly —
-  // mirroring through a ref keeps the legitimate slow-resolves case correct
-  // (some rows settled, some not; the timeout outcomes must reflect the
-  // current resolved map, not the seed-time closure).
-  const resolvedRef = useRef(resolved);
-  // Flipped to true when the resolve loop fires `onComplete` itself, so the
-  // 15-s fallback timeout knows to short-circuit and not overwrite settled
-  // statuses with a stale `pending-after-timeout` outcome (#796).
-  const completedRef = useRef(false);
-  // Holds the timeout id so the success path can `clearTimeout` it eagerly.
-  // Defence in depth — `completedRef` would short-circuit the callback anyway.
-  const timerRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    resolvedRef.current = resolved;
-  }, [resolved]);
+  const variantRows = rows.filter((r) => r.primaryVariant !== null);
+  const variantIds = variantRows.map((r) => r.primaryVariant!.id);
+  const barcodeItems = variantRows
+    .map((r) => ({ variantId: r.primaryVariant!.id, ean: barcodeOf(r) }))
+    .filter((i): i is { variantId: string; ean: string } => i.ean !== null);
+  const barcodeVariantIds = barcodeItems.map((i) => i.variantId);
 
-  // Tasks that need a BE call (have a barcode, no synthetic outcome yet).
-  const tasks: ResolveTask[] = useMemo(
-    () =>
-      rows
-        .filter((r) => {
-          if (r.status === 'no-variant') return false;
-          const barcode = r.primaryVariant?.ean ?? r.primaryVariant?.gtin ?? null;
-          return Boolean(barcode);
-        })
-        .map((r) => ({
-          productId: r.productId,
-          barcode: r.primaryVariant!.ean ?? r.primaryVariant!.gtin ?? null,
-        })),
-    [rows],
-  );
-
-  // Kick off the resolves once on mount. The async path is intentionally not
-  // a useQuery — we want explicit throttling and a single onComplete fire.
-  useEffect(() => {
-    if (startedRef.current) return;
-    startedRef.current = true;
-
-    let cancelled = false;
-    const total = tasks.length;
-    let done = 0;
-
-    void (async () => {
-      const settled = await pAllLimit(tasks, BULK_RESOLVE_CONCURRENCY, async (task) => {
-        // Cache through TanStack so a re-run during edit-back-then-forward
-        // gets a hit instead of re-firing Allegro requests.
-        const queryKey = listingsQueryKeys.resolveCategory(
-          connectionId,
-          task.barcode,
-        );
-        const body: ResolveCategoryRequest = { barcode: task.barcode };
-        const result = await queryClient.fetchQuery<ResolveCategoryResponse>({
-          queryKey,
-          queryFn: () => apiClient.listings.resolveCategory(connectionId, body),
-          staleTime: RESOLVE_CATEGORY_STALE_TIME_MS,
-        });
-        return { productId: task.productId, result };
-      });
-
-      if (cancelled) return;
-
-      const next = new Map(resolved);
-      settled.forEach((entry, i) => {
-        // `pAllLimit` preserves input order, so tasks[i] is the task whose
-        // mapper produced this entry — that's the productId we record the
-        // result against (success or failure).
-        const task = tasks[i];
-        if (!task) return;
-        if (entry.status === 'fulfilled') {
-          const { result } = entry.value;
-          next.set(task.productId, {
-            productId: task.productId,
-            categoryId: result.allegroCategoryId,
-            method: result.method,
-            status:
-              result.allegroCategoryId !== null && result.method !== 'manual'
-                ? 'matched'
-                : 'no-match',
-          });
-        } else {
-          // Failed lookup → flag as no-match so the operator can fix
-          // manually via the edit modal. Without this branch the row stayed
-          // in `resolving` forever and "Approve all" stayed blocked with no
-          // affordance for the operator to escape it.
-          next.set(task.productId, {
-            productId: task.productId,
-            categoryId: null,
-            method: null,
-            status: 'no-match',
-          });
-        }
-        done += 1;
-        setProgress({ done, total });
-      });
-      completedRef.current = true;
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-      setResolved(next);
-      onComplete(buildOutcomes(rows, next));
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-    // Intentionally only depends on `tasks` — re-mounts of this step
-    // re-resolve from scratch. `rows` and `resolved` deliberately omitted
-    // so they don't restart the loop on every status flip.
-  }, [tasks]);
-
-  // 15-second budget: if not all tasks settled by now, advance anyway.
-  // Reads through `resolvedRef.current` so partial-settle state is preserved
-  // when the timeout legitimately fires; `completedRef` short-circuits the
-  // callback when the resolve loop already finished, preventing the stale
-  // overwrite that flipped settled rows to `pending-after-timeout` (#796).
-  useEffect(() => {
-    timerRef.current = window.setTimeout(() => {
-      if (completedRef.current) return;
-      onComplete(buildOutcomes(rows, resolvedRef.current, true));
-    }, BULK_RESOLVE_TIMEOUT_MS);
-    return () => {
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-    };
-    // Mount-only effect — the 15 s budget is anchored to mount, not to
-    // every render. Closure-captured `rows` is acceptable because the
-    // wizard never mutates the row list mid-resolve; live `resolved` state
-    // flows through `resolvedRef` so partial-settle progress survives.
-  }, []);
-
-  // Prefetch the resolved-categories queries so they're hot for the Review
-  // step's optional refresh.
-  useQueries({
-    queries: tasks.map((t) => ({
-      queryKey: listingsQueryKeys.resolveCategory(connectionId, t.barcode),
-      queryFn: () =>
-        apiClient.listings.resolveCategory(connectionId, { barcode: t.barcode }),
-      enabled: false, // we drive the resolves manually above; this is a co-cache.
-    })),
+  const categoryQuery = useQuery({
+    queryKey: listingsQueryKeys.resolveCategoryBatch(connectionId, barcodeVariantIds),
+    queryFn: () => apiClient.listings.resolveCategoriesBatch(connectionId, { items: barcodeItems }),
+    enabled: barcodeItems.length > 0,
   });
 
-  const percent =
-    progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 100;
+  const availabilityQuery = useInventoryAvailabilityBatchQuery(variantIds);
+
+  const categoryReady = barcodeItems.length === 0 || categoryQuery.isSuccess;
+  const availabilityReady = variantIds.length === 0 || availabilityQuery.isSuccess;
+  const hasError = categoryQuery.isError || availabilityQuery.isError;
+  const settled = categoryReady && availabilityReady && !hasError;
+
+  const buildOutcomes = useCallback((): BulkResolveOutcome[] => {
+    const categoryResults: Record<string, EanMatchResult> = categoryQuery.data?.results ?? {};
+    const availabilityMap = new Map(
+      (availabilityQuery.data?.items ?? []).map((i) => [i.productVariantId, i.totalAvailable]),
+    );
+
+    return rows.map((row) => {
+      const variant = row.primaryVariant;
+      if (!variant) {
+        return {
+          productId: row.productId,
+          blockers: ['no-variant'] as const,
+          resolvedCategoryId: null,
+          resolutionMethod: null,
+          masterPrice: null,
+          masterStock: null,
+          masterCurrency: null,
+          categoryCandidates: [],
+        };
+      }
+
+      const categoryResult: EanMatchResult =
+        barcodeOf(row) !== null
+          ? categoryResults[variant.id] ?? { kind: 'no-match' }
+          : { kind: 'no-ean' };
+      const masterPrice = variant.price;
+      const masterCurrency = row.product?.currency ?? null;
+      const masterStock = availabilityMap.has(variant.id)
+        ? availabilityMap.get(variant.id)!
+        : null;
+
+      const blockers = computeBlockers({
+        hasVariant: true,
+        categoryResult,
+        pricingPolicy,
+        stockPolicy,
+        masterPrice,
+        masterStock,
+        masterCurrency,
+        batchCurrency: currency,
+        override: row.override,
+      });
+
+      return {
+        productId: row.productId,
+        blockers,
+        resolvedCategoryId:
+          categoryResult.kind === 'matched' ? categoryResult.allegroCategoryId : null,
+        resolutionMethod: categoryResult.kind === 'matched' ? 'auto_detect' : null,
+        masterPrice,
+        masterStock,
+        masterCurrency,
+        categoryCandidates:
+          categoryResult.kind === 'multi-match' ? categoryResult.candidates : [],
+      };
+    });
+  }, [
+    rows,
+    categoryQuery.data,
+    availabilityQuery.data,
+    pricingPolicy,
+    stockPolicy,
+    currency,
+  ]);
+
+  // Fire onComplete exactly once, when both batch queries have settled.
+  const completedRef = useRef(false);
+  useEffect(() => {
+    if (completedRef.current || !settled) return;
+    completedRef.current = true;
+    onComplete(buildOutcomes());
+  }, [settled, buildOutcomes, onComplete]);
+
+  if (hasError) {
+    const message =
+      categoryQuery.error?.message ??
+      availabilityQuery.error?.message ??
+      'Resolution failed.';
+    return (
+      <div className="bulk-wizard__body--center" role="alert">
+        <Alert tone="error">
+          Could not resolve categories and stock for this batch. {message}
+        </Alert>
+        <Button
+          tone="secondary"
+          onClick={() => {
+            if (categoryQuery.isError) void categoryQuery.refetch();
+            if (availabilityQuery.isError) void availabilityQuery.refetch();
+          }}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
 
   return (
-    <div
-      className="bulk-wizard__body--center"
-      role="status"
-      aria-live="polite"
-    >
+    <div className="bulk-wizard__body--center" role="status" aria-live="polite">
       <div className="loading-state__spinner" aria-hidden="true" />
       <h2
         style={{
@@ -221,64 +194,13 @@ export function BulkResolveStep({
           margin: 0,
         }}
       >
-        Resolving categories from EANs
+        Resolving categories &amp; stock
       </h2>
-      <div className="bulk-wizard__progress-count">
-        {progress.done} of {progress.total}
-      </div>
-      <div className="bulk-wizard__progress-bar">
-        <div
-          className="bulk-wizard__progress-fill"
-          style={{ width: `${percent.toString()}%` }}
-        />
-      </div>
       <p className="bulk-wizard__resolve-sub">
-        We're matching each product's EAN against Allegro's catalog. This typically
-        takes 5–15 seconds. Rows without a clean match are flagged so you can pick a
-        category manually before submit.
+        Matching every product's EAN against Allegro's catalog and pulling master price and
+        stock in one pass. Rows without a clean match or master value are flagged so you can
+        fix them before submit.
       </p>
     </div>
   );
-}
-
-function seedFromRows(rows: BulkWizardRow[]): Map<string, BulkResolveOutcome> {
-  const map = new Map<string, BulkResolveOutcome>();
-  for (const row of rows) {
-    if (row.status === 'no-variant') {
-      map.set(row.productId, {
-        productId: row.productId,
-        categoryId: null,
-        method: null,
-        status: 'no-variant',
-      });
-    } else {
-      const barcode = row.primaryVariant?.ean ?? row.primaryVariant?.gtin ?? null;
-      if (!barcode) {
-        map.set(row.productId, {
-          productId: row.productId,
-          categoryId: null,
-          method: null,
-          status: 'no-ean',
-        });
-      }
-    }
-  }
-  return map;
-}
-
-function buildOutcomes(
-  rows: BulkWizardRow[],
-  resolved: Map<string, BulkResolveOutcome>,
-  timedOut = false,
-): BulkResolveOutcome[] {
-  return rows.map((row) => {
-    const fromResolved = resolved.get(row.productId);
-    if (fromResolved) return fromResolved;
-    return {
-      productId: row.productId,
-      categoryId: null,
-      method: null,
-      status: timedOut ? 'pending-after-timeout' : 'resolving',
-    };
-  });
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * BulkReviewStep tests (#792 PR 3)
+ *
+ * Multi-chip status cell, computed-value provenance badges, currency-mismatch
+ * price rendering, and the blockers-driven "Approve all" gate.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import { renderWithProviders } from '../../../../test/test-utils';
+import { BulkReviewStep } from './bulk-review-step';
+import type { BulkRowBlocker, BulkWizardRow, PricingPolicy, StockPolicy } from './bulk-wizard.types';
+import type { Product, ProductVariant } from '../../../products';
+
+// jsdom has no matchMedia; force desktop (table, not card view) for the DataTable.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+});
+
+function makeRow(
+  productId: string,
+  blockers: BulkRowBlocker[],
+  opts: {
+    masterPrice?: number | null;
+    masterStock?: number | null;
+    masterCurrency?: string | null;
+    resolvedCategoryId?: string | null;
+  } = {},
+): BulkWizardRow {
+  const variant: ProductVariant = {
+    id: `var_${productId}`,
+    productId,
+    sku: 'SKU',
+    attributes: null,
+    ean: '590',
+    gtin: null,
+    price: opts.masterPrice ?? null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+  const product: Product = {
+    id: productId,
+    name: `Product ${productId}`,
+    sku: 'SKU',
+    price: opts.masterPrice ?? null,
+    currency: opts.masterCurrency ?? 'PLN',
+    description: null,
+    images: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+  return {
+    productId,
+    product,
+    primaryVariant: variant,
+    blockers,
+    resolvedCategoryId: opts.resolvedCategoryId ?? (blockers.length === 0 ? 'cat-A' : null),
+    resolutionMethod: null,
+    masterPrice: opts.masterPrice ?? null,
+    masterStock: opts.masterStock ?? null,
+    masterCurrency: opts.masterCurrency ?? 'PLN',
+    categoryCandidates: [],
+    override: {},
+  };
+}
+
+function renderReview(
+  rows: BulkWizardRow[],
+  pricingPolicy: PricingPolicy = { mode: 'use-master' },
+  stockPolicy: StockPolicy = { mode: 'use-master' },
+) {
+  return renderWithProviders(
+    <BulkReviewStep
+      rows={rows}
+      connectionId="conn_1"
+      pricingPolicy={pricingPolicy}
+      stockPolicy={stockPolicy}
+      currency="PLN"
+      publishImmediately
+      onUpdateRow={() => undefined}
+      onApproveAll={() => undefined}
+      onBack={() => undefined}
+    />,
+  );
+}
+
+describe('BulkReviewStep', () => {
+  it('renders one chip per active blocker', () => {
+    renderReview([makeRow('a', ['no-ean', 'no-master-price'])]);
+    expect(screen.getByText('no EAN')).toBeInTheDocument();
+    expect(screen.getByText('no master price')).toBeInTheDocument();
+  });
+
+  it('renders a ready chip when a row has no blockers', () => {
+    renderReview([makeRow('a', [], { masterPrice: 12, masterStock: 5 })]);
+    // Scope to the table — the summary line also contains the word "ready".
+    expect(within(screen.getByRole('table')).getByText('ready')).toBeInTheDocument();
+  });
+
+  it('shows a POLICY provenance badge for a markup-computed price', () => {
+    renderReview(
+      [makeRow('a', [], { masterPrice: 12, masterStock: 5 })],
+      { mode: 'markup', percent: 10 },
+    );
+    expect(screen.getByText('13.20 PLN')).toBeInTheDocument();
+    expect(screen.getByText('POLICY')).toBeInTheDocument();
+  });
+
+  it('renders a currency-mismatch chip and dashes the price column', () => {
+    renderReview(
+      [makeRow('a', ['currency-mismatch'], { masterPrice: 200, masterStock: 5, masterCurrency: 'EUR' })],
+      { mode: 'markup', percent: 10 },
+    );
+    expect(screen.getByText('currency mismatch')).toBeInTheDocument();
+    // No converted figure rendered — the price column shows an em dash, never "EUR" / "PLN".
+    expect(screen.queryByText(/PLN/)).not.toBeInTheDocument();
+  });
+
+  it('disables Approve all while a listable row has blockers and enables it when all are ready', () => {
+    const { rerender } = renderReview([
+      makeRow('a', [], { masterPrice: 12, masterStock: 5 }),
+      makeRow('b', ['no-ean']),
+    ]);
+    expect(screen.getByRole('button', { name: /Approve all/ })).toBeDisabled();
+
+    rerender(
+      <BulkReviewStep
+        rows={[makeRow('a', [], { masterPrice: 12, masterStock: 5 })]}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'use-master' }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        publishImmediately
+        onUpdateRow={() => undefined}
+        onApproveAll={() => undefined}
+        onBack={() => undefined}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /Approve all/ })).toBeEnabled();
+  });
+
+  it('does not count no-variant rows as blocking the gate', () => {
+    const noVariantRow: BulkWizardRow = {
+      ...makeRow('skip', ['no-variant']),
+      primaryVariant: null,
+    };
+    renderReview([makeRow('a', [], { masterPrice: 12, masterStock: 5 }), noVariantRow]);
+    expect(screen.getByRole('button', { name: /Approve all/ })).toBeEnabled();
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
@@ -1,11 +1,11 @@
 /**
- * Bulk wizard Step 3 — Review table
+ * Bulk wizard Step 3 — Review table (#792 PR 3)
  *
- * One row per selected product. Renders the per-row status pill, the
- * resolved category, and an Edit button that opens the per-row modal.
- * The "Approve all" CTA stays disabled while any row is not in a ready
- * state (matched or pending-after-timeout — both flip to matched once
- * late-arriving resolves settle).
+ * One row per selected product. Renders the per-row blocker chips, the
+ * computed price/stock (master → policy → override) with a provenance badge
+ * when the value isn't the raw master, the resolved category, and an Edit
+ * button. "Approve all" stays disabled while any listable row still carries a
+ * blocker; no-variant products are skipped, not blocking.
  *
  * @module apps/web/src/features/listings/components/bulk
  */
@@ -17,20 +17,31 @@ import {
   ProductThumbnail,
   StatusBadge,
 } from '../../../../shared/ui';
-import type { DataTableColumn } from '../../../../shared/ui';
+import type { DataTableColumn, StatusBadgeTone } from '../../../../shared/ui';
 import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
-import type { BulkRowStatus, BulkWizardRow } from './bulk-wizard.types';
+import {
+  computeResolvedPrice,
+  computeResolvedStock,
+  type ResolvedPrice,
+  type ResolvedStock,
+} from './bulk-policy';
+import type {
+  BulkRowBlocker,
+  BulkValueSource,
+  BulkWizardRow,
+  PricingPolicy,
+  StockPolicy,
+} from './bulk-wizard.types';
 import { BulkEditModal } from './bulk-edit-modal';
 
 interface BulkReviewStepProps {
   rows: BulkWizardRow[];
   connectionId: string;
-  defaults: {
-    stock: number;
-    publishImmediately: boolean;
-    priceAmount: string;
-    priceCurrency: string;
-  };
+  pricingPolicy: PricingPolicy;
+  stockPolicy: StockPolicy;
+  /** Batch-wide currency (D7). */
+  currency: string;
+  publishImmediately: boolean;
   onUpdateRow: (
     variantId: string,
     override: BulkPerProductOverride,
@@ -40,10 +51,23 @@ interface BulkReviewStepProps {
   onBack: () => void;
 }
 
+const BLOCKER_CHIPS: Record<BulkRowBlocker, { tone: StatusBadgeTone; label: string }> = {
+  'no-variant': { tone: 'neutral', label: 'no variant' },
+  'no-ean': { tone: 'error', label: 'no EAN' },
+  'no-match': { tone: 'error', label: 'manual category' },
+  'multi-match': { tone: 'warning', label: 'choose category' },
+  'no-master-price': { tone: 'error', label: 'no master price' },
+  'no-master-stock': { tone: 'error', label: 'no master stock' },
+  'currency-mismatch': { tone: 'warning', label: 'currency mismatch' },
+};
+
 export function BulkReviewStep({
   rows,
   connectionId,
-  defaults,
+  pricingPolicy,
+  stockPolicy,
+  currency,
+  publishImmediately,
   onUpdateRow,
   onApproveAll,
   onBack,
@@ -54,14 +78,17 @@ export function BulkReviewStep({
   const filteredRows = useMemo(() => {
     if (filter.trim() === '') return rows;
     const needle = filter.toLowerCase();
-    return rows.filter((r) =>
-      (r.product?.name ?? '').toLowerCase().includes(needle) ||
-      (r.primaryVariant?.sku ?? '').toLowerCase().includes(needle),
+    return rows.filter(
+      (r) =>
+        (r.product?.name ?? '').toLowerCase().includes(needle) ||
+        (r.primaryVariant?.sku ?? '').toLowerCase().includes(needle),
     );
   }, [rows, filter]);
 
   const counts = useMemo(() => countByReadiness(rows), [rows]);
-  const canApprove = counts.notReady === 0 && rows.length > 0;
+  // No-variant rows are skipped on submit, not blocking. Approval is gated on
+  // every *listable* row being clear, with at least one ready row to submit.
+  const canApprove = counts.ready > 0 && counts.needsAttention === 0;
 
   const editingRow = useMemo(
     () => (editingId ? rows.find((r) => r.productId === editingId) ?? null : null),
@@ -87,7 +114,7 @@ export function BulkReviewStep({
       {
         id: 'status',
         header: 'Status',
-        cell: (row) => <RowStatusBadge status={row.status} />,
+        cell: (row) => <RowStatusCell blockers={row.blockers} />,
       },
       {
         id: 'category',
@@ -108,22 +135,29 @@ export function BulkReviewStep({
         id: 'stock',
         header: 'Stock',
         align: 'right',
-        cell: (row) => (
-          <span className="tabular">{row.override.stock ?? defaults.stock}</span>
-        ),
+        cell: (row) => {
+          const stock = computeResolvedStock(stockPolicy, row.masterStock, row.override);
+          return <ValueCell value={stock.value} source={stock.source} />;
+        },
         hideBelow: 768,
       },
       {
         id: 'price',
         header: 'Price',
         align: 'right',
-        cell: (row) => (
-          <span className="tabular">
-            {row.override.price !== undefined
-              ? `${row.override.price.amount.toFixed(2)} ${row.override.price.currency}`
-              : `${defaults.priceAmount} ${defaults.priceCurrency}`}
-          </span>
-        ),
+        cell: (row) => {
+          if (row.blockers.includes('currency-mismatch')) {
+            return <span className="bulk-wizard__row-category--dim">—</span>;
+          }
+          const price = computeResolvedPrice(pricingPolicy, row.masterPrice, row.override);
+          return (
+            <ValueCell
+              value={price.value}
+              source={price.source}
+              format={(v) => `${v.toFixed(2)} ${currency}`}
+            />
+          );
+        },
         hideBelow: 768,
       },
       {
@@ -131,10 +165,8 @@ export function BulkReviewStep({
         header: '',
         align: 'right',
         cell: (row) =>
-          row.status === 'no-variant' ? (
-            <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>
-              No variant
-            </span>
+          row.primaryVariant === null ? (
+            <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>No variant</span>
           ) : (
             <Button
               tone="ghost"
@@ -146,8 +178,15 @@ export function BulkReviewStep({
           ),
       },
     ],
-    [defaults],
+    [pricingPolicy, stockPolicy, currency],
   );
+
+  const editingPrice: ResolvedPrice | null = editingRow
+    ? computeResolvedPrice(pricingPolicy, editingRow.masterPrice, editingRow.override)
+    : null;
+  const editingStock: ResolvedStock | null = editingRow
+    ? computeResolvedStock(stockPolicy, editingRow.masterStock, editingRow.override)
+    : null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
@@ -157,8 +196,8 @@ export function BulkReviewStep({
             Review {rows.length} {rows.length === 1 ? 'product' : 'products'}
           </h2>
           <p style={{ margin: '4px 0 0', color: 'var(--text-secondary)', fontSize: 13 }}>
-            Click <strong>Edit</strong> to override any row before submit. Approve all
-            stays disabled while rows need attention.
+            Click <strong>Edit</strong> to override any row before submit. Approve all stays
+            disabled while rows need attention.
           </p>
         </div>
         <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
@@ -170,33 +209,24 @@ export function BulkReviewStep({
             style={{ minWidth: 220 }}
             aria-label="Filter rows by product name or SKU"
           />
-          <Button
-            tone="primary"
-            disabled={!canApprove}
-            onClick={onApproveAll}
-          >
-            Approve all ({rows.length})
+          <Button tone="primary" disabled={!canApprove} onClick={onApproveAll}>
+            Approve all ({counts.ready})
           </Button>
         </div>
       </header>
 
       <div className="bulk-wizard__review-summary">
         <span><strong>{counts.ready}</strong> ready</span>
-        {counts.pending > 0 ? (
+        {counts.needsAttention > 0 ? (
           <>
             <span className="sep">·</span>
-            <span>
-              <strong>{counts.pending}</strong>{' '}
-              {counts.pending === 1 ? 'still resolving' : 'still resolving'}
-            </span>
+            <span><strong>{counts.needsAttention}</strong> need attention</span>
           </>
         ) : null}
-        {counts.notReady > 0 ? (
+        {counts.skipped > 0 ? (
           <>
             <span className="sep">·</span>
-            <span>
-              <strong>{counts.notReady}</strong> need manual category
-            </span>
+            <span><strong>{counts.skipped}</strong> skipped (no variant)</span>
           </>
         ) : null}
       </div>
@@ -213,7 +243,7 @@ export function BulkReviewStep({
         <div className="bulk-wizard__footer-spacer" />
       </footer>
 
-      {editingRow && editingRow.primaryVariant ? (
+      {editingRow && editingRow.primaryVariant && editingPrice && editingStock ? (
         <BulkEditModal
           open={editingId !== null}
           onOpenChange={(open) => {
@@ -221,7 +251,12 @@ export function BulkReviewStep({
           }}
           row={editingRow}
           connectionId={connectionId}
-          defaults={defaults}
+          defaults={{
+            stock: editingStock.value ?? 0,
+            publishImmediately,
+            priceAmount: editingPrice.value !== null ? editingPrice.value.toFixed(2) : '',
+            priceCurrency: currency,
+          }}
           onSave={onUpdateRow}
         />
       ) : null}
@@ -229,47 +264,61 @@ export function BulkReviewStep({
   );
 }
 
-function RowStatusBadge({ status }: { status: BulkRowStatus }): ReactElement {
-  switch (status) {
-    case 'matched':
-      return <StatusBadge tone="success" withDot>matched</StatusBadge>;
-    case 'resolving':
-    case 'pending-after-timeout':
-      return (
-        <StatusBadge tone="info" withDot pulse>
-          {status === 'resolving' ? 'resolving' : 'still resolving'}
-        </StatusBadge>
-      );
-    case 'no-ean':
-      return <StatusBadge tone="error" withDot>no EAN</StatusBadge>;
-    case 'no-variant':
-      return <StatusBadge tone="error" withDot>no variant</StatusBadge>;
-    case 'no-match':
-      return <StatusBadge tone="error" withDot>manual category required</StatusBadge>;
+function RowStatusCell({ blockers }: { blockers: readonly BulkRowBlocker[] }): ReactElement {
+  if (blockers.length === 0) {
+    return <StatusBadge tone="success" withDot>ready</StatusBadge>;
   }
+  return (
+    <span style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 'var(--space-1)' }}>
+      {blockers.map((b) => (
+        <StatusBadge key={b} tone={BLOCKER_CHIPS[b].tone} withDot compact>
+          {BLOCKER_CHIPS[b].label}
+        </StatusBadge>
+      ))}
+    </span>
+  );
+}
+
+function ValueCell({
+  value,
+  source,
+  format,
+}: {
+  value: number | null;
+  source: BulkValueSource;
+  format?: (v: number) => string;
+}): ReactElement {
+  if (value === null) {
+    return <span className="bulk-wizard__row-category--dim">—</span>;
+  }
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-1)', justifyContent: 'flex-end' }}>
+      <span className="tabular">{format ? format(value) : value}</span>
+      {source === 'policy' ? (
+        <StatusBadge tone="warning" compact>POLICY</StatusBadge>
+      ) : source === 'override' ? (
+        <StatusBadge tone="review" compact>OVERRIDE</StatusBadge>
+      ) : null}
+    </span>
+  );
 }
 
 function countByReadiness(rows: BulkWizardRow[]): {
   ready: number;
-  pending: number;
-  notReady: number;
+  needsAttention: number;
+  skipped: number;
 } {
   let ready = 0;
-  let pending = 0;
-  let notReady = 0;
+  let needsAttention = 0;
+  let skipped = 0;
   for (const r of rows) {
-    if (r.status === 'matched') {
-      // A matched-from-resolve row can become "not ready" if the operator
-      // explicitly cleared the override's categoryId; but ready by default.
-      // If a row needed manual but the operator filled it via the edit modal,
-      // we'd surface that here too. For v1 we trust the wizard's
-      // applyOverrides mutation to update row.status on save (see wizard).
+    if (r.primaryVariant === null) {
+      skipped += 1;
+    } else if (r.blockers.length === 0) {
       ready += 1;
-    } else if (r.status === 'pending-after-timeout' || r.status === 'resolving') {
-      pending += 1;
     } else {
-      notReady += 1;
+      needsAttention += 1;
     }
   }
-  return { ready, pending, notReady };
+  return { ready, needsAttention, skipped };
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
@@ -1,79 +1,87 @@
 /**
- * BulkWizard pure-reducer tests
+ * BulkWizard pure-reducer tests (#792 PR 3)
  *
- * Pins the #796 widened guard: a `pending-after-timeout` outcome must not
- * overwrite a row already in a terminal state. The resolve-step fix
- * prevents the stale-closure `onComplete` from firing, so this is defence
- * in depth — but the reducer is the actual safety net, and a future
- * regression in the resolve step shouldn't be able to flip settled rows.
+ * Pins `mergeResolveOutcomes`: resolve outcomes are folded into rows by
+ * productId; rows without a matching outcome keep their identity.
  */
 import { describe, expect, it } from 'vitest';
-import { applyResolveOutcomes } from './bulk-wizard';
+import { mergeResolveOutcomes } from './bulk-wizard';
 import type { BulkResolveOutcome } from './bulk-resolve-step';
-import type { BulkRowStatus, BulkWizardRow } from './bulk-wizard.types';
+import type { BulkWizardRow } from './bulk-wizard.types';
 
-function makeRow(productId: string, status: BulkRowStatus): BulkWizardRow {
+function makeRow(productId: string): BulkWizardRow {
   return {
     productId,
     product: null,
     primaryVariant: null,
-    status,
+    blockers: [],
     resolvedCategoryId: null,
     resolutionMethod: null,
+    masterPrice: null,
+    masterStock: null,
+    masterCurrency: null,
+    categoryCandidates: [],
     override: {},
   };
 }
 
-function timedOut(productId: string): BulkResolveOutcome {
+function outcome(
+  productId: string,
+  partial: Partial<BulkResolveOutcome> = {},
+): BulkResolveOutcome {
   return {
     productId,
-    status: 'pending-after-timeout',
-    categoryId: null,
-    method: null,
+    blockers: [],
+    resolvedCategoryId: null,
+    resolutionMethod: null,
+    masterPrice: null,
+    masterStock: null,
+    masterCurrency: null,
+    categoryCandidates: [],
+    ...partial,
   };
 }
 
-describe('applyResolveOutcomes', () => {
-  it.each<BulkRowStatus>(['matched', 'no-match', 'no-ean', 'no-variant'])(
-    'should ignore a pending-after-timeout outcome for a row already in terminal state "%s"',
-    (terminalStatus) => {
-      const rows = [{ ...makeRow('prod_1', terminalStatus), resolvedCategoryId: 'cat-A' }];
-      const next = applyResolveOutcomes(rows, [timedOut('prod_1')]);
-      expect(next[0]).toEqual(rows[0]);
-    },
-  );
+describe('mergeResolveOutcomes', () => {
+  it('folds resolve outcome fields into the matching row', () => {
+    const rows = [makeRow('prod_1')];
+    const next = mergeResolveOutcomes(rows, [
+      outcome('prod_1', {
+        blockers: ['multi-match'],
+        resolvedCategoryId: null,
+        masterPrice: 12,
+        masterStock: 3,
+        masterCurrency: 'PLN',
+        categoryCandidates: [{ allegroCategoryId: 'cat-B', productCardId: 'card-B' }],
+      }),
+    ]);
 
-  it('should apply a pending-after-timeout outcome when the row is still resolving', () => {
-    const rows = [makeRow('prod_1', 'resolving')];
-    const next = applyResolveOutcomes(rows, [timedOut('prod_1')]);
     expect(next[0]).toMatchObject({
       productId: 'prod_1',
-      status: 'pending-after-timeout',
+      blockers: ['multi-match'],
+      masterPrice: 12,
+      masterStock: 3,
+      masterCurrency: 'PLN',
+      categoryCandidates: [{ allegroCategoryId: 'cat-B', productCardId: 'card-B' }],
     });
   });
 
-  it('should apply a settled outcome regardless of prior status (status flows forward in the happy path)', () => {
-    const rows = [makeRow('prod_1', 'resolving')];
-    const next = applyResolveOutcomes(rows, [
-      {
-        productId: 'prod_1',
-        status: 'matched',
-        categoryId: 'cat-A',
-        method: 'auto_detect',
-      },
-    ]);
+  it('records a matched category + method', () => {
+    const next = mergeResolveOutcomes(
+      [makeRow('prod_1')],
+      [outcome('prod_1', { resolvedCategoryId: 'cat-A', resolutionMethod: 'auto_detect' })],
+    );
     expect(next[0]).toMatchObject({
-      productId: 'prod_1',
-      status: 'matched',
+      blockers: [],
       resolvedCategoryId: 'cat-A',
       resolutionMethod: 'auto_detect',
     });
   });
 
-  it('should leave rows without a matching outcome untouched', () => {
-    const rows = [makeRow('prod_1', 'matched'), makeRow('prod_2', 'resolving')];
-    const next = applyResolveOutcomes(rows, [timedOut('prod_2')]);
+  it('leaves rows without a matching outcome untouched (identity preserved)', () => {
+    const rows = [makeRow('prod_1'), makeRow('prod_2')];
+    const next = mergeResolveOutcomes(rows, [outcome('prod_2', { blockers: ['no-ean'] })]);
     expect(next[0]).toBe(rows[0]);
-    expect(next[1]).toMatchObject({ status: 'pending-after-timeout' });
+    expect(next[1]).toMatchObject({ productId: 'prod_2', blockers: ['no-ean'] });
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -1,11 +1,11 @@
 /**
- * Bulk listing wizard (#740)
+ * Bulk listing wizard (#740 / #792 PR 3)
  *
- * Multi-step controller: Config → Resolving → Review (with Edit modal) →
- * Confirm → submit. Owns the rows[] state + sharedConfig + perRow overrides.
- *
- * `step` is driven via URL search param so the wizard is linkable; on submit
- * the page redirects to /listings/bulk-batches/:batchId.
+ * Multi-step controller: Config → Resolve → Review (with Edit modal) →
+ * Confirm → submit. Owns the rows[] state + batch config + per-row overrides.
+ * The Resolve step pulls each product's master price/stock and computes the
+ * per-row blocker set from the batch-wide pricing/stock policies (#792); the
+ * Review step renders the computed values and gates submit on `blockers`.
  *
  * @module apps/web/src/features/listings/components/bulk
  */
@@ -18,13 +18,14 @@ import type {
   BulkOfferCreateRequest,
   BulkPerProductOverride,
 } from '../../api/bulk-listings.types';
+import type { EanMatchResult } from '../../api/listings.types';
 import type { Product, ProductVariant } from '../../../products';
 import { BulkConfigStep } from './bulk-config-step';
 import { BulkResolveStep, type BulkResolveOutcome } from './bulk-resolve-step';
 import { BulkReviewStep } from './bulk-review-step';
 import { BulkConfirmModal } from './bulk-confirm-modal';
+import { computeBlockers, computeResolvedPrice, computeResolvedStock } from './bulk-policy';
 import type {
-  BulkRowStatus,
   BulkWizardConfig,
   BulkWizardRow,
   BulkWizardStep,
@@ -61,13 +62,10 @@ export function BulkWizard({
   const [rows, setRows] = useState<BulkWizardRow[]>(() => seedRows(products));
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  // Sync row state when products list changes (rare — would only happen if
-  // the page upstream refetches). We compare against the product-id set,
-  // not the product object identities, so a passive cache refresh that
-  // produces structurally-equal products doesn't clobber row state.
-  // `productsSignature` (not `products` directly) is the dependency —
-  // `products` flips identity on every TanStack cache rehydrate, which
-  // would re-run this for structurally-equal data and clobber row state.
+  // Sync row state when products list changes (rare — would only happen if the
+  // page upstream refetches). Compare against the product-id signature, not
+  // object identity, so a passive cache refresh producing structurally-equal
+  // products doesn't clobber row state.
   const productsSignature = products.map((p) => p.id).join(',');
   useEffect(() => {
     setRows((prev) => {
@@ -81,13 +79,10 @@ export function BulkWizard({
     setStep('resolve');
   }, []);
 
-  const handleResolveComplete = useCallback(
-    (outcomes: BulkResolveOutcome[]) => {
-      setRows((prev) => applyResolveOutcomes(prev, outcomes));
-      setStep('review');
-    },
-    [],
-  );
+  const handleResolveComplete = useCallback((outcomes: BulkResolveOutcome[]) => {
+    setRows((prev) => mergeResolveOutcomes(prev, outcomes));
+    setStep('review');
+  }, []);
 
   const handleUpdateRow = useCallback(
     (
@@ -95,46 +90,45 @@ export function BulkWizard({
       override: BulkPerProductOverride,
       editFormValues: Record<string, unknown>,
     ) => {
+      if (!config) return;
       setRows((prev) =>
         prev.map((row) => {
           if (row.primaryVariant?.id !== variantId) return row;
-          // Filling in a category override marks a previously-error row as ready.
-          const newStatus: BulkRowStatus =
-            override.overrides?.categoryId &&
-            (row.status === 'no-ean' ||
-              row.status === 'no-match' ||
-              row.status === 'pending-after-timeout')
-              ? 'matched'
-              : row.status;
-          return {
-            ...row,
+          const resolvedCategoryId =
+            override.overrides?.categoryId ?? row.resolvedCategoryId;
+          const blockers = computeBlockers({
+            hasVariant: true,
+            categoryResult: categoryResultFor(row, resolvedCategoryId),
+            pricingPolicy: config.pricingPolicy,
+            stockPolicy: config.stockPolicy,
+            masterPrice: row.masterPrice,
+            masterStock: row.masterStock,
+            masterCurrency: row.masterCurrency,
+            batchCurrency: config.currency,
             override,
-            editFormValues,
-            status: newStatus,
-            resolvedCategoryId:
-              override.overrides?.categoryId ?? row.resolvedCategoryId,
-          };
+          });
+          return { ...row, override, editFormValues, blockers, resolvedCategoryId };
         }),
       );
     },
-    [],
+    [config],
   );
 
   const handleSubmit = useCallback(
     async (publishImmediately: boolean) => {
       if (!config) return;
 
-      // Build the bulk submit payload. Variant IDs (NOT product IDs) go in
-      // `productIds` — the BE field name is misleading; see
-      // `bulk-listings.types.ts` file header.
+      // Submittable = has a variant and no outstanding blockers. Variant IDs
+      // (NOT product IDs) go in `productIds` — the BE field name is misleading;
+      // see `bulk-listings.types.ts` file header.
       const submittableRows = rows.filter(
-        (r) => r.primaryVariant !== null && r.status === 'matched',
+        (r) => r.primaryVariant !== null && r.blockers.length === 0,
       );
 
       if (submittableRows.length === 0) {
         showToast({
           tone: 'error',
-          description: 'No rows are ready to submit. Approve some matched rows first.',
+          description: 'No rows are ready to submit. Resolve the flagged rows first.',
         });
         return;
       }
@@ -142,41 +136,41 @@ export function BulkWizard({
       const variantIds = submittableRows.map((r) => r.primaryVariant!.id);
       const perProductOverrides: Record<string, BulkPerProductOverride> = {};
       for (const row of submittableRows) {
-        if (Object.keys(row.override).length > 0 || row.resolvedCategoryId) {
-          // Always send the resolved category — even if the operator didn't
-          // touch the row — so the worker doesn't fall back to auto-detect.
-          perProductOverrides[row.primaryVariant!.id] = {
-            ...row.override,
-            overrides: {
-              ...(row.override.overrides ?? {}),
-              categoryId:
-                row.override.overrides?.categoryId ??
-                row.resolvedCategoryId ??
-                undefined,
-            },
-          };
-        }
+        // Every submittable row carries its own computed price + stock (the
+        // policy resolves a distinct value per product); send them per-row so
+        // the worker never falls back to the shared nominal default.
+        const price = computeResolvedPrice(config.pricingPolicy, row.masterPrice, row.override);
+        const stock = computeResolvedStock(config.stockPolicy, row.masterStock, row.override);
+        perProductOverrides[row.primaryVariant!.id] = {
+          ...row.override,
+          stock: row.override.stock ?? stock.value ?? undefined,
+          price:
+            row.override.price ??
+            (price.value !== null
+              ? { amount: price.value, currency: config.currency }
+              : undefined),
+          overrides: {
+            ...(row.override.overrides ?? {}),
+            categoryId:
+              row.override.overrides?.categoryId ?? row.resolvedCategoryId ?? undefined,
+          },
+        };
       }
-
-      const sharedOverridesPlatformParams: Record<string, unknown> = {
-        deliveryPolicyId: config.deliveryPolicyId,
-      };
 
       const request: BulkOfferCreateRequest = {
         connectionId: config.connectionId,
         productIds: variantIds,
         sharedConfig: {
-          stock: config.defaultStock,
+          // Per-row stock is always supplied via perProductOverrides above; this
+          // is a required nominal fallback the worker should never reach.
+          stock: 1,
           publishImmediately,
           generateDescription: config.generateDescription,
-          ...(config.defaultPrice ? { price: config.defaultPrice } : {}),
           overrides: {
-            platformParams: sharedOverridesPlatformParams,
+            platformParams: { deliveryPolicyId: config.deliveryPolicyId },
           },
         },
-        ...(Object.keys(perProductOverrides).length > 0
-          ? { perProductOverrides }
-          : {}),
+        perProductOverrides,
       };
 
       try {
@@ -197,7 +191,10 @@ export function BulkWizard({
     [config, rows, mutation, navigate, showToast],
   );
 
-  const noVariants = rows.filter((r) => r.status === 'no-variant').length;
+  const noVariants = rows.filter((r) => r.primaryVariant === null).length;
+  const readyCount = rows.filter(
+    (r) => r.primaryVariant !== null && r.blockers.length === 0,
+  ).length;
 
   return (
     <PageLayout
@@ -210,18 +207,14 @@ export function BulkWizard({
           <SetupStepper
             steps={WIZARD_STEPS.map((s) => s.label)}
             currentStep={stepOrder(step)}
-            completedSteps={
-              new Set(
-                Array.from({ length: stepOrder(step) }, (_, i) => i),
-              )
-            }
+            completedSteps={new Set(Array.from({ length: stepOrder(step) }, (_, i) => i))}
           />
         </div>
 
         {noVariants > 0 ? (
           <Alert tone="warning">
-            {noVariants} of {rows.length} products have no variants and cannot be
-            listed. They'll be skipped on submit.
+            {noVariants} of {rows.length} products have no variants and cannot be listed.
+            They'll be skipped on submit.
           </Alert>
         ) : null}
 
@@ -237,6 +230,9 @@ export function BulkWizard({
             <BulkResolveStep
               rows={rows}
               connectionId={config.connectionId}
+              pricingPolicy={config.pricingPolicy}
+              stockPolicy={config.stockPolicy}
+              currency={config.currency}
               onComplete={handleResolveComplete}
             />
           )}
@@ -244,14 +240,10 @@ export function BulkWizard({
             <BulkReviewStep
               rows={rows}
               connectionId={config.connectionId}
-              defaults={{
-                stock: config.defaultStock,
-                publishImmediately: config.publishImmediately,
-                priceAmount: config.defaultPrice
-                  ? config.defaultPrice.amount.toFixed(2)
-                  : '0.00',
-                priceCurrency: config.defaultPrice?.currency ?? 'PLN',
-              }}
+              pricingPolicy={config.pricingPolicy}
+              stockPolicy={config.stockPolicy}
+              currency={config.currency}
+              publishImmediately={config.publishImmediately}
               onUpdateRow={handleUpdateRow}
               onApproveAll={() => { setConfirmOpen(true); }}
               onBack={() => { setStep('config'); }}
@@ -263,7 +255,7 @@ export function BulkWizard({
           <BulkConfirmModal
             open={confirmOpen}
             onOpenChange={setConfirmOpen}
-            rowCount={rows.filter((r) => r.status === 'matched').length}
+            rowCount={readyCount}
             connectionName={resolveConnectionName(config.connectionId)}
             initialPublishImmediately={config.publishImmediately}
             isSubmitting={mutation.isPending}
@@ -283,35 +275,46 @@ function stepOrder(step: BulkWizardStep): number {
 }
 
 /**
- * Pure reducer that applies a batch of resolve-step outcomes to the wizard's
- * row state. Exported for unit testing; the wizard calls it from
- * `handleResolveComplete` via `setRows((prev) => applyResolveOutcomes(...))`.
- *
- * Guard semantics (#796): a `pending-after-timeout` outcome must NEVER
- * overwrite a row already in a terminal state (`matched` / `no-match` /
- * `no-ean` / `no-variant`). The resolve-step fix prevents the stale-closure
- * `onComplete` from firing in the first place; this guard catches any
- * future regression that tries to downgrade settled rows.
+ * Reconstruct an `EanMatchResult` from a row's current category state so
+ * `computeBlockers` can re-derive the category blocker after a per-row edit
+ * without re-fetching. An operator-picked / previously-matched category id
+ * yields `matched`; otherwise the surviving category blocker decides.
  */
-export function applyResolveOutcomes(
+function categoryResultFor(
+  row: BulkWizardRow,
+  resolvedCategoryId: string | null,
+): EanMatchResult {
+  if (resolvedCategoryId) {
+    return { kind: 'matched', allegroCategoryId: resolvedCategoryId, productCardId: '' };
+  }
+  if (row.blockers.includes('no-ean')) return { kind: 'no-ean' };
+  if (row.blockers.includes('multi-match')) {
+    return { kind: 'multi-match', candidates: [...row.categoryCandidates] };
+  }
+  return { kind: 'no-match' };
+}
+
+/**
+ * Merge resolve-step outcomes into the wizard's rows by `productId`. Exported
+ * for unit testing; the wizard calls it from `handleResolveComplete`.
+ */
+export function mergeResolveOutcomes(
   rows: BulkWizardRow[],
   outcomes: BulkResolveOutcome[],
 ): BulkWizardRow[] {
+  const byId = new Map(outcomes.map((o) => [o.productId, o]));
   return rows.map((row) => {
-    const o = outcomes.find((x) => x.productId === row.productId);
+    const o = byId.get(row.productId);
     if (!o) return row;
-    if (
-      o.status === 'pending-after-timeout' &&
-      row.status !== 'resolving' &&
-      row.status !== 'pending-after-timeout'
-    ) {
-      return row;
-    }
     return {
       ...row,
-      status: o.status,
-      resolvedCategoryId: o.categoryId,
-      resolutionMethod: o.method,
+      blockers: o.blockers,
+      resolvedCategoryId: o.resolvedCategoryId,
+      resolutionMethod: o.resolutionMethod,
+      masterPrice: o.masterPrice,
+      masterStock: o.masterStock,
+      masterCurrency: o.masterCurrency,
+      categoryCandidates: o.categoryCandidates,
     };
   });
 }
@@ -322,21 +325,17 @@ function seedRows(products: Product[]): BulkWizardRow[] {
 
 function seedRow(product: Product): BulkWizardRow {
   const primaryVariant: ProductVariant | null = product.variants?.[0] ?? null;
-  let status: BulkRowStatus;
-  if (!primaryVariant) {
-    status = 'no-variant';
-  } else if (!primaryVariant.ean && !primaryVariant.gtin) {
-    status = 'no-ean';
-  } else {
-    status = 'resolving';
-  }
   return {
     productId: product.id,
     product,
     primaryVariant,
-    status,
+    blockers: primaryVariant ? [] : ['no-variant'],
     resolvedCategoryId: null,
     resolutionMethod: null,
+    masterPrice: null,
+    masterStock: null,
+    masterCurrency: null,
+    categoryCandidates: [],
     override: {},
   };
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -118,14 +118,24 @@ export function BulkWizard({
     async (publishImmediately: boolean) => {
       if (!config) return;
 
-      // Submittable = has a variant and no outstanding blockers. Variant IDs
-      // (NOT product IDs) go in `productIds` — the BE field name is misleading;
+      // Submittable = has a variant, no blockers, AND a concrete computed
+      // price + stock. The price/stock guard is belt-and-suspenders: a
+      // blocker-free row always resolves both, but filtering on them here
+      // means a future logic gap excludes the row rather than silently
+      // publishing the nominal `sharedConfig` fallback. Variant IDs (NOT
+      // product IDs) go in `productIds` — the BE field name is misleading;
       // see `bulk-listings.types.ts` file header.
-      const submittableRows = rows.filter(
-        (r) => r.primaryVariant !== null && r.blockers.length === 0,
-      );
+      const submittable = rows
+        .filter((r) => r.primaryVariant !== null && r.blockers.length === 0)
+        .map((row) => ({
+          row,
+          variantId: row.primaryVariant!.id,
+          price: computeResolvedPrice(config.pricingPolicy, row.masterPrice, row.override),
+          stock: computeResolvedStock(config.stockPolicy, row.masterStock, row.override),
+        }))
+        .filter(({ price, stock }) => price.value !== null && stock.value !== null);
 
-      if (submittableRows.length === 0) {
+      if (submittable.length === 0) {
         showToast({
           tone: 'error',
           description: 'No rows are ready to submit. Resolve the flagged rows first.',
@@ -133,17 +143,15 @@ export function BulkWizard({
         return;
       }
 
-      const variantIds = submittableRows.map((r) => r.primaryVariant!.id);
+      const variantIds = submittable.map((s) => s.variantId);
       const perProductOverrides: Record<string, BulkPerProductOverride> = {};
-      for (const row of submittableRows) {
-        // Every submittable row carries its own computed price + stock (the
-        // policy resolves a distinct value per product); send them per-row so
-        // the worker never falls back to the shared nominal default.
-        const price = computeResolvedPrice(config.pricingPolicy, row.masterPrice, row.override);
-        const stock = computeResolvedStock(config.stockPolicy, row.masterStock, row.override);
-        perProductOverrides[row.primaryVariant!.id] = {
+      for (const { row, variantId, price, stock } of submittable) {
+        // Each row carries its own computed price + stock (the policy resolves
+        // a distinct value per product). A per-row override price keeps its own
+        // currency; policy-derived prices use the batch-wide currency (D7).
+        perProductOverrides[variantId] = {
           ...row.override,
-          stock: row.override.stock ?? stock.value ?? undefined,
+          stock: stock.value ?? undefined,
           price:
             row.override.price ??
             (price.value !== null

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.types.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.types.ts
@@ -1,13 +1,18 @@
 /**
  * Bulk wizard internal types
  *
- * Co-located row + step types used only inside the wizard subtree.
+ * Co-located row + step + policy types used only inside the wizard subtree.
  * Public BE transport types live in `../api/bulk-listings.types.ts`.
+ *
+ * #792 PR 3 replaced the single-string row status with a multi-blocker model
+ * (`blockers`) plus master-pull pricing/stock policies; #795 collapsed the
+ * per-row category resolve into one batch call.
  *
  * @module apps/web/src/features/listings/components/bulk
  */
 import type { Product, ProductVariant } from '../../../products';
 import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
+import type { EanMatchCandidate } from '../../api/listings.types';
 
 export const BulkWizardStepValues = [
   'config',
@@ -17,22 +22,54 @@ export const BulkWizardStepValues = [
 ] as const;
 export type BulkWizardStep = (typeof BulkWizardStepValues)[number];
 
-export const BulkRowStatusValues = [
-  // Background resolves are still running for this row.
-  'resolving',
-  // EAN→category lookup succeeded; row is ready for submit.
-  'matched',
-  // 15s budget exhausted, query still in flight; will auto-flip to matched
-  // when it settles.
-  'pending-after-timeout',
-  // No EAN on the variant → operator must pick a category manually.
-  'no-ean',
-  // No primary variant on the product → cannot bulk-list this product.
+/**
+ * Per-row blockers (#792). Co-occurring — a row can carry several at once
+ * (e.g. `['no-ean', 'no-master-price']`). A row is **ready** iff its
+ * `blockers` list is empty; the Review-step "Approve all" gate counts any
+ * row with `blockers.length > 0` as not-ready.
+ */
+export const BulkRowBlockerValues = [
+  // Product has no primary variant — cannot bulk-list.
   'no-variant',
-  // EAN present but Allegro returned no match.
+  // Primary variant has no EAN/GTIN — operator must pick a category manually.
+  'no-ean',
+  // EAN present but Allegro returned zero matches.
   'no-match',
+  // EAN matched several Allegro cards — operator picks one from the candidates.
+  'multi-match',
+  // Active pricing policy needs a master price and the variant has none.
+  'no-master-price',
+  // Active stock policy needs a master stock value and it's 0 or null.
+  'no-master-stock',
+  // Master price currency differs from the batch currency (use-master/markup only).
+  'currency-mismatch',
 ] as const;
-export type BulkRowStatus = (typeof BulkRowStatusValues)[number];
+export type BulkRowBlocker = (typeof BulkRowBlockerValues)[number];
+
+/**
+ * Provenance of a computed price/stock value — drives the Review-step badge.
+ * `master` shows no badge; `policy` / `override` get a tonal badge (#792).
+ */
+export const BulkValueSourceValues = ['master', 'policy', 'override'] as const;
+export type BulkValueSource = (typeof BulkValueSourceValues)[number];
+
+/** Pricing policy applied batch-wide; per-row override still wins (#792). */
+export const PricingPolicyModeValues = ['use-master', 'markup', 'flat'] as const;
+export type PricingPolicyMode = (typeof PricingPolicyModeValues)[number];
+export type PricingPolicy =
+  | { mode: 'use-master' }
+  // percent ∈ [-100, +500]; computed = roundHalfUp(master × (1 + percent/100), 2)
+  | { mode: 'markup'; percent: number }
+  // amount in the batch-wide currency (D7 — flat carries no own currency)
+  | { mode: 'flat'; amount: number };
+
+/** Stock policy applied batch-wide; per-row override still wins (#792). */
+export const StockPolicyModeValues = ['use-master', 'cap', 'flat'] as const;
+export type StockPolicyMode = (typeof StockPolicyModeValues)[number];
+export type StockPolicy =
+  | { mode: 'use-master' }
+  | { mode: 'cap'; value: number } // computed = min(masterStock, value)
+  | { mode: 'flat'; value: number };
 
 export interface BulkWizardRow {
   productId: string;
@@ -40,11 +77,20 @@ export interface BulkWizardRow {
   product: Product | null;
   /** Primary variant (variants[0]). Null when product has no variants. */
   primaryVariant: ProductVariant | null;
-  status: BulkRowStatus;
-  /** Resolved Allegro category id (after Step 2). */
+  /** Active blockers; empty means ready. Populated by the Resolve step (#792). */
+  blockers: readonly BulkRowBlocker[];
+  /** Resolved Allegro category id (after Resolve, or operator pick). */
   resolvedCategoryId: string | null;
   /** How the category was resolved (telemetry / UI hint). */
   resolutionMethod: 'auto_detect' | 'category_mapping' | 'manual' | null;
+  /** Master variant price captured at resolve (`variant.price`). Null if unset. */
+  masterPrice: number | null;
+  /** Master stock summed across locations (availability endpoint). Null if absent. */
+  masterStock: number | null;
+  /** Master price currency (`product.currency`). Null if the product has none. */
+  masterCurrency: string | null;
+  /** Multi-match category candidates; empty unless the row's blocker is `multi-match`. */
+  categoryCandidates: readonly EanMatchCandidate[];
   /** Per-row overrides written by the edit modal. Sent on bulk submit. */
   override: BulkPerProductOverride;
   /**
@@ -59,12 +105,12 @@ export interface BulkWizardConfig {
   connectionId: string;
   /** Allegro delivery policy ID. */
   deliveryPolicyId: string;
-  defaultStock: number;
+  /** Batch-wide listing currency (D7) — flat-price + mismatch reason key off this. */
+  currency: string;
+  /** How each row's price is computed from master data. */
+  pricingPolicy: PricingPolicy;
+  /** How each row's stock is computed from master data. */
+  stockPolicy: StockPolicy;
   publishImmediately: boolean;
   generateDescription: boolean;
-  /** Optional default price applied to every row that doesn't have a product-side price. */
-  defaultPrice?: { amount: number; currency: string };
 }
-
-/** Status filter set after Step 2 — used by the review-step gate logic. */
-export const READY_ROW_STATUSES: readonly BulkRowStatus[] = ['matched'];

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7941,6 +7941,73 @@ html[data-density='compact'] .status-badge {
   text-decoration: underline;
 }
 
+/* ── Bulk wizard master-pull policies + candidate chips (#792) ──────── */
+.bulk-config__policy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: 0;
+  padding: var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.bulk-config__policy legend {
+  padding: 0 var(--space-2);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.bulk-config__policy-option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.bulk-config__policy-text {
+  display: block;
+  min-width: 0;
+  flex: 1;
+}
+
+.bulk-edit__candidates {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.bulk-edit__candidates-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.bulk-edit__candidate-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.bulk-edit__candidate-chip {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--status-review-fg);
+  background: var(--status-review-soft);
+  border: 1px solid var(--status-review-border);
+  border-radius: var(--radius-pill);
+  padding: 4px 10px;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.bulk-edit__candidate-chip:hover {
+  background: color-mix(in oklab, var(--status-review-soft) 70%, var(--status-review-border));
+}
+
 /* ── Bulk batch progress (#741) ─────────────────────────────────────
  * Cockpit layout: KPI strip (4 cards) + status banner + records table.
  */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7963,6 +7963,12 @@ html[data-density='compact'] .status-badge {
 
 .bulk-config__policy-option {
   display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.bulk-config__policy-label {
+  display: flex;
   align-items: flex-start;
   gap: var(--space-2);
 }
@@ -7971,6 +7977,11 @@ html[data-density='compact'] .status-badge {
   display: block;
   min-width: 0;
   flex: 1;
+}
+
+/* Conditional policy input, indented under the radio caption. */
+.bulk-config__policy-detail {
+  padding-left: calc(14px + var(--space-2));
 }
 
 .bulk-edit__candidates {

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -22,6 +22,7 @@
 export { Alert } from './alert';
 export type { AlertTone } from './alert';
 export { StatusBadge } from './status-badge';
+export type { StatusBadgeTone } from './status-badge';
 export { EmptyState, ErrorState, LoadingState } from './feedback-state';
 export { StructuredErrorList } from './structured-error-list';
 

--- a/docs/plans/implementation-plan-792-795-bulk-wizard-master-pull-batch-resolve.md
+++ b/docs/plans/implementation-plan-792-795-bulk-wizard-master-pull-batch-resolve.md
@@ -1,0 +1,218 @@
+# Implementation Plan — #792 PR 3 + #795: Bulk wizard master-pull policies + batch category resolve
+
+**Issues:** [#792](https://github.com/openlinker-project/openlinker/issues/792) (PR 3 — FE wizard refactor) + [#795](https://github.com/openlinker-project/openlinker/issues/795) (wire `EanCategoryMatcher` batch capability end-to-end)
+**Branch:** `792-795-bulk-wizard-master-pull-batch-resolve`
+**Base:** `6c1631f` (origin/main — includes #792 PR 1 `ProductVariant.price` + PR 2 batch-availability endpoint)
+
+---
+
+## Phase 1 — Understand the task
+
+### Goal
+
+The bulk Allegro offer-creation wizard's **Resolve step** is being rewritten twice over by two issues that touch the same file (`bulk-resolve-step.tsx`) and the same row-status model. We bundle them into **one** coherent rewrite:
+
+- **#795** — the wizard fires one HTTP `POST /categories/resolve` per row (throttled at concurrency 8). The Allegro adapter already ships a batch capability (`EanCategoryMatcher.resolveCategoriesForBatchByEan`, #735) that does all lookups in one call with shared cache, but **nothing consumes it** — no core service, no HTTP route, no FE caller. Wire it end-to-end: N round-trips → 1.
+- **#792 PR 3** — the Config step exposes a single flat *default stock* + *default price* applied to every row, which is wrong for a batch of N different products. Replace with **pricing/stock policies** (`use-master` / `markup`|`cap` / `flat`) that pull each product's master price (`variant.price`, PR 1) and master stock (batch inventory-availability endpoint, PR 2). Widen the single-string row status into a multi-blocker, two-axis state model.
+
+### Layer classification
+
+- **#795:** CORE application service (`CategoryResolutionService` extension) + Interface (HTTP route + DTOs) + Frontend (api client/types/hook).
+- **#792 PR 3:** Frontend only (`apps/web/src/features/listings`), consuming PR 1/PR 2 wire shapes already on `main`.
+
+### Non-goals (explicit)
+
+- **No migration** — PR 1 (variant price column) and PR 2 (availability endpoint) already merged with their migrations; this bundle adds no schema change.
+- Removing/deprecating the per-row `/categories/resolve` route — single-product offer-create still uses it (#795 out-of-scope).
+- Adding `EanCategoryMatcher` to non-Allegro adapters — they degrade to the per-row route until they implement the capability.
+- Per-variant pricing for multi-variant products — V1 reads `variants[0]` only.
+- Currency conversion — `currency-mismatch` is surfaced as a blocker, no FX.
+- `ProductVariantSummaryResponseDto` price — left unchanged.
+
+---
+
+## Phase 2 — Research (key contracts found)
+
+### #795 backend contracts
+
+| Symbol | Location |
+|---|---|
+| `EanCategoryMatcher` + `isEanCategoryMatcher(adapter)` | `libs/core/src/listings/domain/ports/capabilities/ean-category-matcher.capability.ts` |
+| `BatchCategoryByEanInput` = `{ items: Array<{ variantId: string; ean: string \| null }> }` | `libs/core/src/listings/domain/types/ean-category-match.types.ts:70` |
+| `EanMatchResult` (union: `matched` / `multi-match` / `no-ean` / `no-match`) | `…/ean-category-match.types.ts:49` |
+| `AllegroOfferManagerAdapter.resolveCategoriesForBatchByEan` → `Promise<Map<string, EanMatchResult>>` | `libs/integrations/allegro/.../allegro-offer-manager.adapter.ts:851` |
+| `CategoryResolutionService` (single resolve, injects `INTEGRATIONS_SERVICE_TOKEN`) | `libs/core/src/listings/application/services/category-resolution.service.ts` |
+| `ICategoryResolutionService` | `libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts` |
+| `CATEGORY_RESOLUTION_SERVICE_TOKEN` | `libs/core/src/listings/listings.tokens.ts:21` |
+| Single-resolve route `POST connections/:connectionId/categories/resolve` (`@Roles('admin')`) | `apps/api/src/listings/http/listings.controller.ts:448` |
+| `AdapterCapabilityNotSupportedException(connectionId, capability)` → mapped to **422** at boundary | `libs/core/src/listings/domain/exceptions/…` ; mapping precedent `bulk-offer-creation.controller.ts:177` |
+| Comma/array DTO validation precedent (`@Transform` + `@ArrayMinSize`/`@ArrayMaxSize`) | `apps/api/src/inventory/http/dto/get-inventory-availability-query.dto.ts` |
+
+### #792 PR 3 frontend contracts (PR 1 + PR 2 already on `main`)
+
+| Symbol | Location |
+|---|---|
+| `ProductVariant.price: number \| null` | `apps/web/src/features/products/api/products.types.ts:28` |
+| `Product.currency: string \| null` | `apps/web/src/features/products/api/products.types.ts:40` |
+| `useInventoryAvailabilityBatchQuery(ids, opts?)` (dedupes, auto-disables on empty) | `apps/web/src/features/inventory/hooks/use-inventory-availability-batch-query.ts`, exported from `features/inventory/index.ts` |
+| `InventoryAvailability = { productVariantId; totalAvailable; locationCount }` | `apps/web/src/features/inventory/api/inventory.types.ts:49` |
+| `BulkWizardConfig` (`defaultStock`, `defaultPrice?`) | `bulk-wizard.types.ts:58` |
+| `BulkRowStatus` (6-value string union), `BulkWizardRow`, `READY_ROW_STATUSES` | `bulk-wizard.types.ts:35,37,70` |
+| `pAllLimit`, `BULK_RESOLVE_CONCURRENCY=8`, 15 s timeout three-ref guard (#796) | `bulk-resolve-step.tsx`, `bulk-throttle.ts` |
+| `apiClient.listings.resolveCategory` | `apps/web/src/features/listings/api/listings.api.ts:173` |
+| `applyResolveOutcomes` reducer (#796 guard) | `bulk-wizard.tsx:296` |
+| Existing tests: `bulk-resolve-step.test.tsx`, `bulk-wizard.test.tsx` | assert old status model — **must be rewritten** |
+
+---
+
+## Phase 3 — Design
+
+### 3.1 Unified Resolve-step data flow (replaces the per-row loop)
+
+```
+Resolve step mount
+  ├─ 1 call:  apiClient.listings.resolveCategoriesBatch(connectionId, { items: [{variantId, ean}] })   ← #795
+  │             → { results: Record<variantId, EanMatchResult> }
+  ├─ 1 call:  useInventoryAvailabilityBatchQuery(variantIds)                                            ← #792 PR2
+  │             → { items: [{ productVariantId, totalAvailable, locationCount }] }
+  ├─ read off already-loaded rows: masterPrice = primaryVariant.price, masterCurrency = product.currency ← #792 PR1
+  └─ per row: compute BulkRowState.blockers from (categoryResult × pricingPolicy × stockPolicy × master values)
+```
+
+**Advancement (D5):** the step waits for both batch queries to settle, then auto-advances to Review. No 15 s timer, no #796 three-ref guard, no `resolveTimedOut` axis — the single batch call makes that per-row-budget machinery obsolete. On batch error it shows an error + **Retry** (query refetch). `isResolving` is **Resolve-step-local UI state** (derived from the two queries' loading flags), not a per-row field.
+
+**Resolve → wizard handoff:** on settle the step calls `onComplete(outcomes: BulkResolveOutcome[])` where each outcome carries everything the orchestrator folds into its row by `productId`:
+
+```ts
+interface BulkResolveOutcome {
+  productId: string;
+  blockers: readonly BulkRowBlocker[];
+  resolvedCategoryId: string | null;
+  resolutionMethod: ResolutionMethod | null;     // matched→'auto_detect', else null
+  masterPrice: number | null;
+  masterStock: number | null;
+  masterCurrency: string | null;
+  categoryCandidates: readonly EanMatchCandidate[]; // [] unless multi-match
+}
+```
+
+`bulk-wizard.tsx`'s `handleResolveComplete(outcomes)` merges by `productId` and advances to Review. This replaces the old `applyResolveOutcomes` reducer + its #796 guard wholesale.
+
+### 3.2 #795 — CORE service extension
+
+`ICategoryResolutionService` gains:
+
+```ts
+resolveCategoriesBatch(
+  connectionId: string,
+  input: BatchCategoryByEanInput,
+): Promise<Map<string, EanMatchResult>>;
+```
+
+Implementation (`CategoryResolutionService`): resolve `getCapabilityAdapter<OfferManagerPort>(connectionId, 'OfferManager')`, narrow with `isEanCategoryMatcher(adapter)`, throw `AdapterCapabilityNotSupportedException(connectionId, 'EanCategoryMatcher')` if unsupported, else delegate to `adapter.resolveCategoriesForBatchByEan(input)`. No mapping-config dependency needed for the batch path.
+
+### 3.3 #795 — HTTP route
+
+`POST /listings/connections/:connectionId/categories/resolve-batch` on `listings.controller.ts` — inherits the **class-level** `@Roles('admin')` (line 84), no per-route decorator needed.
+
+- **DTO file**: all three classes in `apps/api/src/listings/http/dto/resolve-category-batch.dto.ts`, mirroring the single-resolve `resolve-category.dto.ts` (request + response co-located; the `resolve` verb doesn't fit the `create-*`/`update-*` filename convention — the sibling file already established this local exception).
+- **Request** `ResolveCategoryBatchRequestDto`: `items: ResolveCategoryBatchItemDto[]` — `@ValidateNested({ each: true })` + `@Type(() => ResolveCategoryBatchItemDto)`, `@ArrayMinSize(1)`, `@ArrayMaxSize(200)` (matches the inventory-availability cap). Item: `variantId` `@IsString @IsNotEmpty`, `ean` `@IsOptional @IsString`.
+- **Response** `ResolveCategoryBatchResponseDto`: `{ results: Record<string, EanMatchResult> }` (controller converts the service `Map` → plain object). Swagger: `@ApiProperty({ type: 'object', additionalProperties: true })` on `results` (a record-of-discriminated-union can't be expressed precisely; the wire JSON is the contract — keep the field strongly typed as `Record<string, EanMatchResult>` in TS, loosely documented in OpenAPI). No typed-`any`.
+- Resolve adapter first (validates connection exists/active — same as single route), call service, map `Map`→`Record`.
+- Catch `AdapterCapabilityNotSupportedException` → `UnprocessableEntityException` (422) at the boundary (mirrors `bulk-offer-creation.controller.ts:177`).
+
+### 3.4 #795 — FE wire
+
+- `listings.types.ts`: mirror `EanMatchResult` union (incl. `EanMatchCandidate` for the multi-match arm — needed by the edit-modal chips, D2/D3) + `ResolveCategoriesBatchRequest`/`Response`.
+- `listings.api.ts`: `resolveCategoriesBatch(connectionId, body)` → `POST .../categories/resolve-batch`.
+- `listings.query-keys.ts`: `resolveCategoryBatch(connectionId, variantIds)` key.
+
+### 3.5 #792 PR 3 — types (`bulk-wizard.types.ts`)
+
+`as const` arrays + derived unions (per engineering-standards § Union Types):
+
+```ts
+PricingPolicyModeValues = ['use-master','markup','flat'];
+PricingPolicy = {mode:'use-master'} | {mode:'markup'; percent} | {mode:'flat'; amount};   // D7: flat has NO own currency
+StockPolicyModeValues = ['use-master','cap','flat'];
+StockPolicy   = {mode:'use-master'} | {mode:'cap'; value} | {mode:'flat'; value};
+BulkRowBlockerValues = ['no-variant','no-ean','no-match','multi-match','no-master-price','no-master-stock','currency-mismatch'];  // D2: +multi-match
+```
+
+- `BulkWizardConfig`: drop `defaultStock` + `defaultPrice`; add `pricingPolicy`, `stockPolicy`, `currency: string` (single batch-wide currency — D7).
+- `BulkWizardRow`: replace `status: BulkRowStatus` with `blockers: readonly BulkRowBlocker[]` **directly on the row** (no `BulkRowState` wrapper — D5 dropped `resolveTimedOut`, and `isResolving` is Resolve-step-local UI state per frontend-architecture state-ownership rules, so a row-level state object would be a single-field wrapper). Add `masterPrice: number | null`, `masterStock: number | null`, `masterCurrency: string | null` (captured at resolve) and `categoryCandidates: readonly EanMatchCandidate[]` (populated only for `multi-match` rows — D2/D3). Keep `resolvedCategoryId`, `resolutionMethod`, `override`, `editFormValues`.
+- A row is **ready** ⟺ `row.blockers.length === 0`. The Resolve step owns its own `isResolving` (derived from the two queries' loading flags); the operator only lands on Review after the batch settles (D5), so resolving-ness never reaches the Review gate.
+
+### 3.6 #792 PR 3 — pure policy helper (`bulk-policy.ts`, new)
+
+Isolated, unit-tested pure functions:
+
+- `computeResolvedPrice(policy, masterPrice, override) → { value: number | null; source: 'master'|'policy'|'override'; blocker?: 'no-master-price' }`
+  - `markup`: `roundHalfUp(masterPrice × (1 + clamp(percent, -100, 500)/100), 2)`; null master → `no-master-price`.
+  - `flat`: verbatim, never blocks.
+  - `use-master`: null master → `no-master-price`.
+- `computeResolvedStock(policy, masterStock, override) → { value, source, blocker?: 'no-master-stock' }`
+  - `cap`: `min(masterStock, N)`; null master → `no-master-stock`.
+  - `flat`: verbatim, never blocks.
+  - `use-master`: `0` or null → `no-master-stock` (Allegro rejects 0-stock publishes).
+- `computeBlockers({ categoryResult, pricingPolicy, stockPolicy, masterPrice, masterStock, masterCurrency, batchCurrency, hasVariant, hasEan, override })` → `BulkRowBlocker[]` (co-occurring). `currency-mismatch` fires when `masterCurrency != null && masterCurrency !== batchCurrency` (`batchCurrency` = `config.currency` — D7); independent of price/stock; null currency does **not** fire it.
+- Category-result → blocker mapping (D2): `matched` → none (sets `resolvedCategoryId`); `no-ean` → `no-ean`; `no-match` → `no-match`; `multi-match` → **`multi-match`** blocker + stash `categoryCandidates` on the row (operator picks via candidate chips in the edit modal — D3). Selecting any category (candidate chip or manual pick) clears `no-match`/`multi-match` and promotes the row toward ready.
+
+### 3.7 #792 PR 3 — component changes
+
+- **`bulk-config-step.tsx`** — remove flat stock/price inputs; render two policy radio groups with conditional inputs (markup percent, cap value, flat amount). Currency select stays batch-wide. AI-description toggle + publish-immediately unchanged.
+- **`bulk-resolve-step.tsx`** — rewrite per 3.1: one batch category call + one availability call; build `BulkResolveOutcome[]` (per row: `blockers` + `masterPrice`/`masterStock`/`masterCurrency`/`categoryCandidates` + `resolvedCategoryId`/`resolutionMethod`) and hand back via `onComplete`. Inventory hook imported via `features/inventory` barrel. **Wait-for-settle advancement (D5)**: auto-advance to Review when both batch queries settle; local `isResolving` spinner while in flight; on batch error show error + **Retry**. **No 15 s timer, no #796 three-ref guard** — both were per-row-budget machinery the single batch call makes obsolete.
+- **`bulk-review-step.tsx`** — render computed price/stock via `bulk-policy`; status cell renders **one chip per active blocker** (none when ready), incl. a distinct `multi-match` chip (copy e.g. "choose category"); provenance badge only when source ≠ `master` (`POLICY` → `warning` tone, `OVERRIDE` → `review` tone per UI style guide); `currency-mismatch` row → `—` in price column. "Approve all" gate: any row with `blockers.length > 0` is not-ready.
+- **`bulk-edit-modal.tsx`** — capture `initialValues` from a `useRef` snapshot taken on `open === true`; don't re-bind on later row updates (prevents a background availability refetch clobbering in-progress edits). **Candidate chips (D3)**: when `row.categoryCandidates.length > 0`, render a "Suggested categories" chip row above the existing `CategoryPicker` (one chip per candidate, label `name ?? allegroCategoryId`); clicking a chip `setValue('categoryId', candidate.allegroCategoryId)`. Picker stays as manual fallback; chips don't render when there are no candidates.
+- **`bulk-wizard.tsx`** — new config shape; drive the multi-blocker state model; submit filters `blockers.length === 0` rows; promote a row to ready when an operator override clears its blockers.
+
+### 3.8 Tests
+
+- **BE (D6 — no int-spec):** `category-resolution.service.spec.ts` — extend with batch cases (delegates when `isEanCategoryMatcher`; throws `AdapterCapabilityNotSupportedException` otherwise). Controller unit test for the new route (mocked service; 200 happy path + 422 unsupported). **No int-spec** — the listings int-harness deliberately avoids adapter-backed routes (live creds) and there's no fake-`OfferManager` registration path; deviation justified in the PR body (matches how `POST /offers` is tested).
+- **FE:** `bulk-policy.test.ts` (new, pure — markup clamp/round, cap min, all blocker permutations incl. `multi-match`). Rewrite `bulk-resolve-step.test.tsx` (single batch call assertion; hydration paths: price+stock, null price, null stock, currency-mismatch, multi-blocker, multi-match; wait-for-settle advancement + error→Retry — **no fake-timer tests**), `bulk-wizard.test.tsx` (policy combinations + worked example, gate logic; old `applyResolveOutcomes`/#796 timer tests removed). Add/extend `bulk-review-step.test.tsx` (multi-chip incl. `multi-match`, provenance, currency-mismatch column), `bulk-edit-modal.test.tsx` (snapshot pre-fill + no re-bind; candidate-chip click fills `categoryId`).
+
+---
+
+## Phase 4 — Step-by-step implementation order
+
+1. **BE #795 service** — interface method + `CategoryResolutionService.resolveCategoriesBatch` + unit spec.
+2. **BE #795 route** — request/response DTOs + controller handler + 422 mapping + controller test.
+3. **BE #795 barrel** — export any new public types from `@openlinker/core/listings` if needed.
+4. **FE #795 wire** — `listings.types.ts` + `listings.api.ts` + `listings.query-keys.ts`.
+5. **FE types #792** — `bulk-wizard.types.ts` (policies, blockers, row state, config).
+6. **FE helper #792** — `bulk-policy.ts` + `bulk-policy.test.ts`.
+7. **FE config step** — policy radios.
+8. **FE resolve step** — unified batch + availability + blocker compute.
+9. **FE review step** — computed values, multi-chip, provenance, gate.
+10. **FE edit modal** — snapshot pre-fill.
+11. **FE wizard orchestrator** — wire config + state model + submit filter.
+12. **Tests** — rewrite/extend all affected specs.
+13. **Quality gate** — `pnpm lint && pnpm type-check && pnpm test` (+ `pnpm test:integration` if the route int-spec lands).
+
+Each step keeps `pnpm type-check` green before moving on where practical (BE first so the FE wire types compile against committed shapes).
+
+---
+
+## Phase 5 — Validation
+
+- **Architecture:** #795 stays inside the existing `CategoryResolutionService` (no new core service); adapter resolved via `IntegrationsService`, narrowed via the existing capability guard — CORE↔Integration boundary intact. FE consumes inventory via the feature barrel (no deep cross-feature import).
+- **Naming/standards:** `as const` + union arrays for all new enumerations; DTO validation via class-validator at the boundary; domain exception mapped to HTTP at the controller; Symbol token reuse.
+- **Security:** new route `@Roles('admin')` + `@ApiBearerAuth()` like its siblings; input capped at 200 items; no secrets in responses.
+- **Testing:** pure policy logic isolated for high-value unit coverage; component tests cover hydration + gate + provenance; service/controller specs cover both capability branches.
+
+### Resolved decisions (grill session)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Batch path is EAN-only** — thin pass-through to `resolveCategoriesForBatchByEan`, no mapping fallback. | Behavior-preserving: the wizard already sends barcode-only (never `sourceCategoryIds`). |
+| D2 | **`multi-match` surfaces candidates** — new `multi-match` blocker; candidates stashed on the row. | Operator reviews real candidates instead of blind manual search; never auto-publishes a guessed category. |
+| D3 | **Candidate UI = suggestion chips above `CategoryPicker`** — click fills `categoryId`; picker stays as manual fallback. | Additive; degrades to nothing when no candidates. |
+| D4 | **One batch call, no chunking** — wizard caps selection at 100 (`bulk-create-wizard-page.tsx`) ≤ route/hook cap of 200. Route DTO cap = 200. | 100 ≤ 200, so chunking is dead code. |
+| D5 | **Wait-for-settle advancement** — auto-advance on settle; error → Retry; **drop the 15 s timer + #796 three-ref guard + `resolveTimedOut`**. | The single batch call makes per-row budget machinery obsolete; a 15 s timer would false-fire on ~100-item batches (util runs concurrency 3). |
+| D6 | **No int-spec for the new route** — service spec + controller spec (200/422) + FE single-call test. | No fake-`OfferManager` int-harness; mirrors how `POST /offers` is tested; documented in PR. |
+| D7 | **Single batch-wide currency** — `PricingPolicy` flat = `{ mode, amount }`; mismatch + published price both keyed to `config.currency`. | Resolves the issue's own redundancy; one source of truth, no contradictory flat currency. |
+
+### Residual risks
+
+1. **Scope size** — ~4 BE files + ~7 FE files + ~6 test files. Bundled deliberately because #795 and #792 PR 3 both rewrite `bulk-resolve-step.tsx` and the status model (splitting would guarantee a merge conflict). The BE-only slice of #795 (steps 1–4) is independently shippable first if the reviewer prefers.
+2. **`Closes` magic words** — the combined PR body carries both `Closes #792` **and** `Closes #795`.

--- a/libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts
+++ b/libs/core/src/listings/application/interfaces/category-resolution.service.interface.ts
@@ -8,6 +8,10 @@
  */
 
 import type {
+  BatchCategoryByEanInput,
+  EanMatchResult,
+} from '@openlinker/core/listings';
+import type {
   CategoryResolutionInput,
   CategoryResolutionResult,
 } from '../types/category-resolution.types';
@@ -22,4 +26,21 @@ export interface ICategoryResolutionService {
    * 3. Manual — return null for merchant to pick
    */
   resolveCategory(input: CategoryResolutionInput): Promise<CategoryResolutionResult>;
+
+  /**
+   * Resolve marketplace categories for N variant EANs in one batch (#795).
+   *
+   * Thin pass-through to the connection's `EanCategoryMatcher` sub-capability
+   * (#735) — EAN-only, no mapping fallback. Drives the bulk-listing wizard's
+   * Resolve step (#792 PR 3), collapsing the previous one-call-per-row loop
+   * into a single call.
+   *
+   * Throws `AdapterCapabilityNotSupportedException` when the resolved
+   * `OfferManager` adapter does not implement `EanCategoryMatcher`.
+   * Returned map is keyed by `variantId`; every input item has one entry.
+   */
+  resolveCategoriesBatch(
+    connectionId: string,
+    input: BatchCategoryByEanInput,
+  ): Promise<Map<string, EanMatchResult>>;
 }

--- a/libs/core/src/listings/application/services/category-resolution.service.spec.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Category Resolution Service — unit tests
+ *
+ * Covers the 3-step single-resolve chain and the #795 batch path
+ * (`resolveCategoriesBatch`): delegation to the `EanCategoryMatcher`
+ * sub-capability when supported, and the `AdapterCapabilityNotSupportedException`
+ * branch when the resolved adapter cannot batch-resolve EANs.
+ *
+ * @module libs/core/src/listings/application/services
+ */
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import type { IMappingConfigService } from '@openlinker/core/mappings';
+import {
+  AdapterCapabilityNotSupportedException,
+  type BatchCategoryByEanInput,
+  type EanMatchResult,
+} from '@openlinker/core/listings';
+
+import { CategoryResolutionService } from './category-resolution.service';
+
+const CONNECTION_ID = 'conn-123';
+
+describe('CategoryResolutionService', () => {
+  let integrationsService: { getCapabilityAdapter: jest.Mock };
+  let mappingConfig: { resolveAllegroCategory: jest.Mock };
+  let service: CategoryResolutionService;
+
+  beforeEach(() => {
+    integrationsService = { getCapabilityAdapter: jest.fn() };
+    mappingConfig = { resolveAllegroCategory: jest.fn() };
+    service = new CategoryResolutionService(
+      integrationsService as unknown as IIntegrationsService,
+      mappingConfig as unknown as IMappingConfigService
+    );
+  });
+
+  describe('resolveCategory', () => {
+    it('should resolve via auto_detect when the adapter matches the barcode', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        matchCategoryByBarcode: jest.fn().mockResolvedValue('allegro-cat-1'),
+      });
+
+      const result = await service.resolveCategory({ connectionId: CONNECTION_ID, barcode: '590' });
+
+      expect(result).toEqual({ allegroCategoryId: 'allegro-cat-1', method: 'auto_detect' });
+    });
+
+    it('should fall back to category_mapping when auto_detect misses', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        matchCategoryByBarcode: jest.fn().mockResolvedValue(null),
+      });
+      mappingConfig.resolveAllegroCategory.mockResolvedValue('allegro-cat-mapped');
+
+      const result = await service.resolveCategory({
+        connectionId: CONNECTION_ID,
+        barcode: '590',
+        sourceCategoryIds: ['src-1'],
+      });
+
+      expect(result).toEqual({ allegroCategoryId: 'allegro-cat-mapped', method: 'category_mapping' });
+    });
+
+    it('should return manual with null id when nothing resolves', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        matchCategoryByBarcode: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await service.resolveCategory({ connectionId: CONNECTION_ID, barcode: '590' });
+
+      expect(result).toEqual({ allegroCategoryId: null, method: 'manual' });
+    });
+  });
+
+  describe('resolveCategoriesBatch', () => {
+    const input: BatchCategoryByEanInput = {
+      items: [
+        { variantId: 'v1', ean: '590111' },
+        { variantId: 'v2', ean: null },
+      ],
+    };
+
+    it('should delegate to the adapter when it implements EanCategoryMatcher', async () => {
+      const adapterResult = new Map<string, EanMatchResult>([
+        ['v1', { kind: 'matched', allegroCategoryId: 'cat-1', productCardId: 'card-1' }],
+        ['v2', { kind: 'no-ean' }],
+      ]);
+      const resolveCategoriesForBatchByEan = jest.fn().mockResolvedValue(adapterResult);
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        resolveCategoriesForBatchByEan,
+      });
+
+      const result = await service.resolveCategoriesBatch(CONNECTION_ID, input);
+
+      expect(integrationsService.getCapabilityAdapter).toHaveBeenCalledWith(
+        CONNECTION_ID,
+        'OfferManager'
+      );
+      expect(resolveCategoriesForBatchByEan).toHaveBeenCalledWith(input);
+      expect(result).toBe(adapterResult);
+    });
+
+    it('should throw AdapterCapabilityNotSupportedException when the adapter cannot batch-resolve', async () => {
+      integrationsService.getCapabilityAdapter.mockResolvedValue({
+        updateOfferQuantity: jest.fn(),
+        // no resolveCategoriesForBatchByEan → not an EanCategoryMatcher
+      });
+
+      await expect(service.resolveCategoriesBatch(CONNECTION_ID, input)).rejects.toBeInstanceOf(
+        AdapterCapabilityNotSupportedException
+      );
+    });
+
+    it('should propagate connection-resolution errors from getCapabilityAdapter', async () => {
+      const boom = new Error('connection not found');
+      integrationsService.getCapabilityAdapter.mockRejectedValue(boom);
+
+      await expect(service.resolveCategoriesBatch(CONNECTION_ID, input)).rejects.toBe(boom);
+    });
+  });
+});

--- a/libs/core/src/listings/application/services/category-resolution.service.ts
+++ b/libs/core/src/listings/application/services/category-resolution.service.ts
@@ -12,8 +12,16 @@
 
 import { Injectable, Inject } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
-import type { OfferManagerPort } from '@openlinker/core/listings';
-import { isCategoryBarcodeMatcher } from '@openlinker/core/listings';
+import type {
+  OfferManagerPort,
+  BatchCategoryByEanInput,
+  EanMatchResult,
+} from '@openlinker/core/listings';
+import {
+  isCategoryBarcodeMatcher,
+  isEanCategoryMatcher,
+  AdapterCapabilityNotSupportedException,
+} from '@openlinker/core/listings';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
 import type { ICategoryResolutionService } from '../interfaces/category-resolution.service.interface';
@@ -61,6 +69,26 @@ export class CategoryResolutionService implements ICategoryResolutionService {
     // Step 3: Manual pick
     this.logger.debug(`Category unresolved, manual pick required (connection=${connectionId})`);
     return { allegroCategoryId: null, method: 'manual' };
+  }
+
+  async resolveCategoriesBatch(
+    connectionId: string,
+    input: BatchCategoryByEanInput
+  ): Promise<Map<string, EanMatchResult>> {
+    // Resolving the OfferManager adapter validates the connection up front:
+    // unknown/disabled connections surface as 404/409, and a non-marketplace
+    // connection as 422 — same gate the single-resolve route relies on.
+    const adapter = await this.integrationsService.getCapabilityAdapter<OfferManagerPort>(
+      connectionId,
+      'OfferManager'
+    );
+    if (!isEanCategoryMatcher(adapter)) {
+      throw new AdapterCapabilityNotSupportedException(connectionId, 'EanCategoryMatcher');
+    }
+    this.logger.debug(
+      `Batch-resolving ${input.items.length} variant EAN(s) (connection=${connectionId})`
+    );
+    return adapter.resolveCategoriesForBatchByEan(input);
   }
 
   private async tryAutoDetect(connectionId: string, barcode: string): Promise<string | null> {


### PR DESCRIPTION
## What & why

Bundles two issues that both rewrite the bulk Allegro offer-creation wizard's **Resolve step** (shipping them together avoids a guaranteed self-conflict on `bulk-resolve-step.tsx` + the row-status model):

- **#795** — wires the dangling `EanCategoryMatcher` batch capability (#735) end-to-end. The wizard fired one `POST /categories/resolve` per row; now one batch call resolves every variant EAN.
- **#792 PR 3** — replaces the Config step's single flat *default stock/price* (wrong for N different products) with **master-pull pricing/stock policies**, consuming the BE work already merged: `ProductVariant.price` (#798) and the batch inventory-availability endpoint (#801).

## #795 — backend + FE wire

- `CategoryResolutionService.resolveCategoriesBatch(connectionId, input)` resolves the connection's `OfferManager` adapter, narrows via `isEanCategoryMatcher`, delegates to the batch util (EAN-only — no mapping fallback, behaviour-preserving since the wizard never sent `sourceCategoryIds`), and throws `AdapterCapabilityNotSupportedException` otherwise.
- `POST /listings/connections/:connectionId/categories/resolve-batch` — inherits class-level `@Roles('admin')`, validates `items` (`@ArrayMinSize(1)` / `@ArrayMaxSize(200)`), maps the domain exception to **422** at the boundary, returns `{ results: Record<variantId, EanMatchResult> }`.
- FE: `apiClient.listings.resolveCategoriesBatch` + mirrored `EanMatchResult` types + query key.

## #792 PR 3 — FE wizard refactor

- **Config step**: two policy radio groups — pricing (`use-master` / `markup` / `flat`) and stock (`use-master` / `cap` / `flat`) — plus one batch-wide currency.
- **Row model**: single-string status → multi-blocker (`no-variant`, `no-ean`, `no-match`, `multi-match`, `no-master-price`, `no-master-stock`, `currency-mismatch`); co-occurring. A row is ready iff `blockers` is empty.
- **Resolve step**: one batch category call + one availability call, reads `variant.price` / `product.currency` off loaded products, computes blockers per row via a pure `bulk-policy.ts` helper. **Wait-for-settle** advancement with an error → Retry path — drops the per-row 15 s timer and the #796 three-ref guard (obsolete with a single batch call).
- **Review step**: computed price/stock with `POLICY` / `OVERRIDE` provenance badges, one chip per active blocker, `—` for currency-mismatch; "Approve all" gates on `blockers` (no-variant rows are skipped, not blocking).
- **Multi-match**: candidates surface as suggestion chips above the `CategoryPicker` in the edit modal (click fills the category).
- **Edit modal**: pre-fills from an open-time snapshot so a background availability refetch can't clobber in-progress edits.

## Decisions (recorded in the plan doc)

EAN-only batch path · multi-match → candidate chips · one batch call (wizard caps at 100 ≤ 200) · wait-for-settle (drop timer) · single batch-wide currency · no int-spec for the new route (no fake-`OfferManager` harness; mirrors how `POST /offers` is tested).

> **Note — `currency-mismatch` is policy-aware (deliberate refinement).** #792's literal definition is policy-independent (`product.currency != null && != batchCurrency`). The implementation fires it **only** under `use-master`/`markup` with no per-row price override — under `flat` pricing or an explicit override the published price is already in the batch currency, so the mismatch is moot. This avoids falsely blocking flat-priced rows whose master happens to be in another currency. Documented inline in `bulk-policy.ts`.

## Testing

- **BE**: `category-resolution.service.spec.ts` (delegates / throws branches), controller spec (200 / 422 / propagate).
- **FE**: `bulk-policy.test.ts` (pure markup/cap/blocker logic incl. the zero-price guard), `bulk-resolve-step` (single-call assertion, hydration paths, multi-match, error→Retry), `bulk-review-step` (multi-chip, provenance, currency-mismatch, gate), `bulk-wizard` (`mergeResolveOutcomes`), `bulk-edit-modal` (candidate chips + snapshot pre-fill), `bulk-config-step` (policy-object building + Proceed gating).
- `pnpm lint && pnpm type-check && pnpm test` green across all packages. No migration (BE deps already on `main`).

## Tech-review follow-up (commit 2)

Addressed a self-review pass on the shipped code:
- **Invalid `<label>`-in-`<label>` fixed** — the Config step's conditional policy input (a `FormField`, which renders its own `<label>`) was nested inside the radio's `<label>`. The label now wraps only the radio + caption; the detail input is a sibling.
- **Zero-price guard** — a markup that zeroes the price (e.g. -100%) or a use-master price of 0 now surfaces the `no-master-price` blocker client-side instead of submitting an Allegro-rejected 0-price offer.
- **Submit hardening** — submittable rows are filtered on a concrete computed price + stock, so a null can never silently fall back to the nominal `sharedConfig.stock`; per-row override prices keep their own currency.
- Added the `bulk-config-step` test + extended `bulk-policy` coverage for the above.

Closes #792
Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)