### PR TITLE
feat(web,listings): surface per-record failure detail on bulk-batch progress (#806)

### DIFF
--- a/apps/api/src/listings/http/bulk-offer-creation.controller.spec.ts
+++ b/apps/api/src/listings/http/bulk-offer-creation.controller.spec.ts
@@ -183,6 +183,16 @@ describe('BulkOfferCreationController', () => {
           externalOfferId: 'ext-1',
           createdAt: new Date('2026-05-17T10:01:00Z'),
           updatedAt: new Date('2026-05-17T10:02:00Z'),
+          errors: null,
+        } as unknown as OfferCreationRecord,
+        {
+          id: 'r-2',
+          internalVariantId: 'v-b',
+          status: 'failed',
+          externalOfferId: null,
+          createdAt: new Date('2026-05-17T10:01:00Z'),
+          updatedAt: new Date('2026-05-17T10:03:00Z'),
+          errors: [{ field: 'price', code: 'INVALID', message: 'Price too low' }],
         } as unknown as OfferCreationRecord,
       ];
       bulkSubmit.getBatch.mockResolvedValue({ batch, records });
@@ -206,6 +216,16 @@ describe('BulkOfferCreationController', () => {
             externalOfferId: 'ext-1',
             createdAt: '2026-05-17T10:01:00.000Z',
             updatedAt: '2026-05-17T10:02:00.000Z',
+            errors: null,
+          },
+          {
+            id: 'r-2',
+            internalVariantId: 'v-b',
+            status: 'failed',
+            externalOfferId: null,
+            createdAt: '2026-05-17T10:01:00.000Z',
+            updatedAt: '2026-05-17T10:03:00.000Z',
+            errors: [{ field: 'price', code: 'INVALID', message: 'Price too low' }],
           },
         ],
       });

--- a/apps/api/src/listings/http/bulk-offer-creation.controller.ts
+++ b/apps/api/src/listings/http/bulk-offer-creation.controller.ts
@@ -202,6 +202,7 @@ export class BulkOfferCreationController {
       externalOfferId: record.externalOfferId,
       createdAt: record.createdAt.toISOString(),
       updatedAt: record.updatedAt.toISOString(),
+      errors: record.errors,
     }));
     return {
       id: summary.batch.id,

--- a/apps/api/src/listings/http/dto/bulk-offer-create-response.dto.ts
+++ b/apps/api/src/listings/http/dto/bulk-offer-create-response.dto.ts
@@ -10,7 +10,10 @@
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+import type { OfferCreationError } from '@openlinker/core/listings';
 import { BulkBatchStatusValues, OfferCreationStatusValues } from '@openlinker/core/listings';
+
+import { OfferCreationErrorDto } from './offer-creation-status-response.dto';
 
 export class BulkOfferCreateResponseDto {
   @ApiProperty({ description: 'Persisted batch id (UUID).', format: 'uuid' })
@@ -45,6 +48,13 @@ export class BulkBatchRecordSummaryDto {
 
   @ApiProperty({ type: String, format: 'date-time' })
   updatedAt!: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    type: [OfferCreationErrorDto],
+    description: 'Structured failure reasons populated when status=failed; null otherwise.',
+  })
+  errors!: OfferCreationError[] | null;
 }
 
 export class BulkBatchSummaryDto {

--- a/apps/api/test/integration/listings-bulk-offer-creation.int-spec.ts
+++ b/apps/api/test/integration/listings-bulk-offer-creation.int-spec.ts
@@ -75,6 +75,7 @@ async function seedRecord(
     internalVariantId: string;
     status: 'pending' | 'draft' | 'validating' | 'active' | 'failed';
     externalOfferId: string | null;
+    errors: Array<{ field?: string; code: string; message: string }>;
   }> = {}
 ): Promise<string> {
   const result = (await dataSource.query(
@@ -87,7 +88,7 @@ async function seedRecord(
       CONN_A,
       overrides.externalOfferId ?? null,
       overrides.status ?? 'pending',
-      null,
+      overrides.errors ? JSON.stringify(overrides.errors) : null,
       false,
       null,
       bulkBatchId,
@@ -227,6 +228,36 @@ describe('Listings Bulk Offer-Creation API Integration', () => {
       expect(response.body.records[1].id).toBe(recordB);
       expect(response.body.records[1].status).toBe('pending');
       expect(response.body.records[1].externalOfferId).toBeNull();
+    });
+
+    it('round-trips structured errors on a failed record (#806)', async () => {
+      const http = harness.getHttp();
+      const dataSource = harness.getDataSource();
+      const token = await loginAsAdmin(http, dataSource);
+
+      const batchId = await seedBatch(dataSource, {
+        status: 'failed',
+        totalCount: 1,
+        succeededCount: 0,
+        failedCount: 1,
+      });
+      const recordId = await seedRecord(dataSource, batchId, {
+        internalVariantId: 'ol_variant_fail',
+        status: 'failed',
+        errors: [{ field: 'price', code: 'INVALID_PRICE', message: 'Price too low' }],
+      });
+
+      const response = await http
+        .get(`/listings/bulk-create/${batchId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      const record = (response.body.records as Array<{ id: string; errors: unknown }>).find(
+        (r) => r.id === recordId
+      );
+      expect(record?.errors).toEqual([
+        { field: 'price', code: 'INVALID_PRICE', message: 'Price too low' },
+      ]);
     });
 
     it('returns an empty records array when the batch has no child rows yet', async () => {

--- a/apps/web/src/features/listings/api/bulk-listings.types.ts
+++ b/apps/web/src/features/listings/api/bulk-listings.types.ts
@@ -13,7 +13,7 @@
  * @module apps/web/src/features/listings/api
  */
 
-import type { OfferCreationStatus } from './listings.types';
+import type { OfferCreationError, OfferCreationStatus } from './listings.types';
 
 export const BulkBatchStatusValues = [
   'pending',
@@ -85,6 +85,8 @@ export interface BulkBatchRecordSummary {
   externalOfferId: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Structured failure reasons; populated when status=failed, null otherwise (#806). */
+  errors: OfferCreationError[] | null;
 }
 
 export interface BulkBatchSummary {

--- a/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.test.tsx
@@ -67,12 +67,33 @@ describe('BulkBatchProgressTable', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+    fireEvent.click(screen.getByRole('button', { name: /Failure details/ }));
 
     expect(screen.getByText('Record failure detail')).toBeInTheDocument();
     // Code + field are dialog-only (the inline cell shows just the message).
     expect(screen.getByText('INVALID_PRICE')).toBeInTheDocument();
     expect(screen.getByText('price')).toBeInTheDocument();
+  });
+
+  it('renders every structured error in the dialog list', () => {
+    renderWithProviders(
+      <BulkBatchProgressTable
+        records={[
+          rec({
+            errors: [
+              { field: 'price', code: 'INVALID_PRICE', message: 'Price too low for category' },
+              { code: 'MISSING_PARAM', message: 'Required parameter "Brand" is missing' },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Failure details/ }));
+
+    expect(screen.getByText('INVALID_PRICE')).toBeInTheDocument();
+    expect(screen.getByText('MISSING_PARAM')).toBeInTheDocument();
+    expect(screen.getByText('Required parameter "Brand" is missing')).toBeInTheDocument();
   });
 
   it('falls back to "Failed" inline when a failed row has no structured errors', () => {
@@ -90,6 +111,6 @@ describe('BulkBatchProgressTable', () => {
 
     const link = screen.getByRole('link', { name: /ALG-123/ });
     expect(link).toHaveAttribute('href', 'https://allegro.pl/oferta/ALG-123');
-    expect(screen.queryByRole('button', { name: 'Details' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Failure details/ })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * BulkBatchProgressTable tests (#806)
+ *
+ * Failed rows surface the first error message inline and open a per-record
+ * failure dialog with the full structured breakdown; succeeded rows link to
+ * the marketplace offer and carry no Details affordance.
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../../test/test-utils';
+import { BulkBatchProgressTable } from './bulk-batch-progress-table';
+import type { BulkBatchRecordSummary } from '../../api/bulk-listings.types';
+
+// jsdom has no matchMedia; force desktop (table, not card view) for the DataTable.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+});
+
+function rec(over: Partial<BulkBatchRecordSummary> = {}): BulkBatchRecordSummary {
+  return {
+    id: 'r-1',
+    internalVariantId: 'ol_variant_abc',
+    status: 'failed',
+    externalOfferId: null,
+    createdAt: '2026-05-21T10:00:00.000Z',
+    updatedAt: '2026-05-21T10:01:00.000Z',
+    errors: null,
+    ...over,
+  };
+}
+
+describe('BulkBatchProgressTable', () => {
+  it('shows the first error message inline for a failed row', () => {
+    renderWithProviders(
+      <BulkBatchProgressTable
+        records={[
+          rec({ errors: [{ code: 'INVALID_PRICE', message: 'Price too low for category' }] }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Price too low for category')).toBeInTheDocument();
+    // The old static placeholder is gone.
+    expect(screen.queryByText(/see record detail/)).not.toBeInTheDocument();
+  });
+
+  it('opens the failure dialog with the full structured breakdown on Details', () => {
+    renderWithProviders(
+      <BulkBatchProgressTable
+        records={[
+          rec({
+            errors: [
+              { field: 'price', code: 'INVALID_PRICE', message: 'Price too low for category' },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+
+    expect(screen.getByText('Record failure detail')).toBeInTheDocument();
+    // Code + field are dialog-only (the inline cell shows just the message).
+    expect(screen.getByText('INVALID_PRICE')).toBeInTheDocument();
+    expect(screen.getByText('price')).toBeInTheDocument();
+  });
+
+  it('falls back to "Failed" inline when a failed row has no structured errors', () => {
+    renderWithProviders(<BulkBatchProgressTable records={[rec({ errors: [] })]} />);
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('links to the marketplace offer and shows no Details button for a succeeded row', () => {
+    renderWithProviders(
+      <BulkBatchProgressTable
+        records={[rec({ status: 'active', externalOfferId: 'ALG-123', errors: null })]}
+        buildExternalOfferUrl={(id) => `https://allegro.pl/oferta/${id}`}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /ALG-123/ });
+    expect(link).toHaveAttribute('href', 'https://allegro.pl/oferta/ALG-123');
+    expect(screen.queryByRole('button', { name: 'Details' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.tsx
@@ -85,6 +85,7 @@ export function BulkBatchProgressTable({
                 <Button
                   tone="ghost"
                   className="button--xs"
+                  aria-label={`Failure details for ${record.internalVariantId}`}
                   onClick={() => {
                     setDetailRecord(record);
                   }}
@@ -141,7 +142,12 @@ export function BulkBatchProgressTable({
         }}
       >
         <DialogContent>
-          {detailRecord ? <RecordFailureDetail record={detailRecord} /> : null}
+          {detailRecord ? (
+            <RecordFailureDetail
+              record={detailRecord}
+              buildExternalOfferUrl={buildExternalOfferUrl}
+            />
+          ) : null}
           <DialogFooter>
             <DialogClose asChild>
               <Button tone="secondary">Close</Button>
@@ -153,7 +159,16 @@ export function BulkBatchProgressTable({
   );
 }
 
-function RecordFailureDetail({ record }: { record: BulkBatchRecordSummary }): ReactElement {
+function RecordFailureDetail({
+  record,
+  buildExternalOfferUrl,
+}: {
+  record: BulkBatchRecordSummary;
+  buildExternalOfferUrl?: (externalOfferId: string) => string;
+}): ReactElement {
+  const offerUrl = record.externalOfferId
+    ? buildExternalOfferUrl?.(record.externalOfferId)
+    : undefined;
   return (
     <>
       <DialogTitle>Record failure detail</DialogTitle>
@@ -170,7 +185,20 @@ function RecordFailureDetail({ record }: { record: BulkBatchRecordSummary }): Re
         {record.externalOfferId ? (
           <div className="bulk-batch__detail-row">
             <dt className="bulk-batch__detail-label">Offer</dt>
-            <dd className="mono-text">{record.externalOfferId}</dd>
+            <dd>
+              {offerUrl ? (
+                <a
+                  className="bulk-batch__ext-link"
+                  href={offerUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {record.externalOfferId} ↗
+                </a>
+              ) : (
+                <span className="mono-text">{record.externalOfferId}</span>
+              )}
+            </dd>
           </div>
         ) : null}
         <div className="bulk-batch__detail-row">

--- a/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.tsx
@@ -1,23 +1,33 @@
 /**
- * Bulk batch progress table (#741)
+ * Bulk batch progress table (#741 / #806)
  *
  * One row per `BulkBatchRecordSummary`. Variant ID as the identity column
  * (the BE summary doesn't carry product names today; mapping variant→product
  * for the row label is a follow-up tracked alongside the Smart-classification
  * surface — see plan §9 follow-up #6 candidate). Status pill + offer link /
- * failure excerpt + timestamp complete the row.
+ * failure reason + timestamp complete the row.
+ *
+ * Failed rows show the first error message inline (truncated) and a "Details"
+ * button that opens the per-record failure dialog (#806) — the structured
+ * errors ride along on the polled batch-summary payload, so no extra fetch.
  *
  * The Smart classification badge is intentionally not rendered here — see
  * implementation-plan §2 (parent AC-7 deferral).
  *
  * @module apps/web/src/features/listings/components/bulk
  */
-import { useMemo, type ReactElement } from 'react';
-import { DataTable, StatusBadge, TimeDisplay } from '../../../../shared/ui';
+import { useMemo, useState, type ReactElement } from 'react';
+import { Button, DataTable, StatusBadge, TimeDisplay } from '../../../../shared/ui';
 import type { DataTableColumn } from '../../../../shared/ui';
-import type {
-  BulkBatchRecordSummary,
-} from '../../api/bulk-listings.types';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../../shared/ui/dialog';
+import type { BulkBatchRecordSummary } from '../../api/bulk-listings.types';
 import type { OfferCreationStatus } from '../../api/listings.types';
 
 interface BulkBatchProgressTableProps {
@@ -30,6 +40,8 @@ export function BulkBatchProgressTable({
   records,
   buildExternalOfferUrl,
 }: BulkBatchProgressTableProps): ReactElement {
+  const [detailRecord, setDetailRecord] = useState<BulkBatchRecordSummary | null>(null);
+
   const columns: DataTableColumn<BulkBatchRecordSummary>[] = useMemo(
     () => [
       {
@@ -64,11 +76,21 @@ export function BulkBatchProgressTable({
             );
           }
           if (record.status === 'failed') {
-            // Truncated. Full error is on the offer-creation record detail (#465);
-            // a hover-expand follow-up is filed as part of the per-record retry.
+            const firstMessage = record.errors?.[0]?.message;
             return (
-              <span className="bulk-batch__err" title="Open the listing for full error details">
-                Failed — see record detail
+              <span className="bulk-batch__err-cell">
+                <span className="bulk-batch__err" title={firstMessage ?? 'Failed'}>
+                  {firstMessage ?? 'Failed'}
+                </span>
+                <Button
+                  tone="ghost"
+                  className="button--xs"
+                  onClick={() => {
+                    setDetailRecord(record);
+                  }}
+                >
+                  Details
+                </Button>
               </span>
             );
           }
@@ -104,20 +126,85 @@ export function BulkBatchProgressTable({
   );
 
   return (
-    <DataTable<BulkBatchRecordSummary>
-      caption="Bulk batch records"
-      columns={columns}
-      rows={records}
-      rowKey={(record) => record.id}
-    />
+    <>
+      <DataTable<BulkBatchRecordSummary>
+        caption="Bulk batch records"
+        columns={columns}
+        rows={records}
+        rowKey={(record) => record.id}
+      />
+
+      <Dialog
+        open={detailRecord !== null}
+        onOpenChange={(open) => {
+          if (!open) setDetailRecord(null);
+        }}
+      >
+        <DialogContent>
+          {detailRecord ? <RecordFailureDetail record={detailRecord} /> : null}
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button tone="secondary">Close</Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
-function RecordStatusBadge({
-  status,
-}: {
-  status: OfferCreationStatus;
-}): ReactElement {
+function RecordFailureDetail({ record }: { record: BulkBatchRecordSummary }): ReactElement {
+  return (
+    <>
+      <DialogTitle>Record failure detail</DialogTitle>
+      <DialogDescription>
+        Variant <span className="mono-text">{record.internalVariantId}</span>
+      </DialogDescription>
+      <dl className="bulk-batch__detail">
+        <div className="bulk-batch__detail-row">
+          <dt className="bulk-batch__detail-label">Status</dt>
+          <dd>
+            <RecordStatusBadge status={record.status} />
+          </dd>
+        </div>
+        {record.externalOfferId ? (
+          <div className="bulk-batch__detail-row">
+            <dt className="bulk-batch__detail-label">Offer</dt>
+            <dd className="mono-text">{record.externalOfferId}</dd>
+          </div>
+        ) : null}
+        <div className="bulk-batch__detail-row">
+          <dt className="bulk-batch__detail-label">Updated</dt>
+          <dd className="mono-text">
+            <TimeDisplay iso={record.updatedAt} format="datetime" />
+          </dd>
+        </div>
+        <div className="bulk-batch__detail-row bulk-batch__detail-row--errors">
+          <dt className="bulk-batch__detail-label">Errors</dt>
+          <dd>
+            {record.errors && record.errors.length > 0 ? (
+              <ul className="bulk-batch__err-list">
+                {record.errors.map((err, i) => (
+                  <li key={`${err.code}-${i}`} className="bulk-batch__err-item">
+                    <span className="bulk-batch__err-code">{err.code}</span>
+                    {err.field ? (
+                      <span className="bulk-batch__err-field mono-text">{err.field}</span>
+                    ) : null}
+                    <span className="bulk-batch__err-msg">{err.message}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <span className="dim">No structured error detail was recorded.</span>
+            )}
+          </dd>
+        </div>
+      </dl>
+    </>
+  );
+}
+
+function RecordStatusBadge({ status }: { status: OfferCreationStatus }): ReactElement {
   switch (status) {
     case 'pending':
       return <StatusBadge tone="neutral" withDot>pending</StatusBadge>;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8066,6 +8066,85 @@ html[data-density='compact'] .status-badge {
   text-decoration: underline;
 }
 
+/* ── Bulk batch record failure detail (#806) ──────────────────────── */
+.bulk-batch__err-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.bulk-batch__detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: var(--space-4) 0 0;
+}
+
+.bulk-batch__detail-row {
+  display: flex;
+  gap: var(--space-3);
+  align-items: baseline;
+}
+
+.bulk-batch__detail-row--errors {
+  align-items: flex-start;
+}
+
+.bulk-batch__detail-label {
+  flex: 0 0 84px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.bulk-batch__detail-row dd {
+  margin: 0;
+  min-width: 0;
+}
+
+.bulk-batch__err-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.bulk-batch__err-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.bulk-batch__err-code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--status-error-fg);
+  background: var(--status-error-soft);
+  border: 1px solid var(--status-error-border);
+  border-radius: var(--radius-sm);
+  padding: 1px 6px;
+}
+
+.bulk-batch__err-field {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.bulk-batch__err-msg {
+  font-size: 13px;
+  color: var(--text-primary);
+  min-width: 0;
+}
+
 @media (max-width: 639.98px) {
   .bulk-batch__summary {
     flex-direction: column;

--- a/apps/web/src/pages/listings/bulk-batch-progress-page.test.tsx
+++ b/apps/web/src/pages/listings/bulk-batch-progress-page.test.tsx
@@ -26,6 +26,7 @@ function makeBatch(overrides: Partial<BulkBatchSummary> = {}): BulkBatchSummary 
         externalOfferId: null,
         createdAt: '2026-05-18T15:00:00.000Z',
         updatedAt: '2026-05-18T15:00:00.000Z',
+        errors: null,
       },
       {
         id: 'rec_2',
@@ -34,6 +35,7 @@ function makeBatch(overrides: Partial<BulkBatchSummary> = {}): BulkBatchSummary 
         externalOfferId: '99988877',
         createdAt: '2026-05-18T15:00:01.000Z',
         updatedAt: '2026-05-18T15:00:30.000Z',
+        errors: null,
       },
     ],
     ...overrides,


### PR DESCRIPTION
## Problem

On the bulk-batch progress page (#741), a failed row rendered the static text **"Failed — see record detail"** with no link, button, or detail surface — so an operator couldn't actually see *why* a variant failed.

## Insight: the data was already there

`IBulkOfferCreationSubmitService.getBatch` returns `BulkBatchSummary { batch, records: OfferCreationRecord[] }`, and `OfferCreationRecord` already carries `errors: OfferCreationError[] | null`. The controller's `toSummaryDto` simply **dropped** them. So both deliverables share **one** BE change and need **no new endpoint, no extra fetch, and no migration** — the errors ride the batch-summary payload the page already polls every 5 s.

## Changes

**BE**
- `BulkBatchRecordSummaryDto` gains `errors` (reusing the existing `OfferCreationErrorDto` from `offer-creation-status-response.dto.ts`).
- `toSummaryDto` maps `errors: record.errors`.

**FE**
- `BulkBatchRecordSummary` gains `errors: OfferCreationError[] | null`.
- **Inline reason** — a failed row now shows the first error message (truncated, full on hover) instead of the placeholder.
- **Full detail** — a "Details" button opens a `Dialog` with the complete per-record breakdown: status, offer id, every error (`code` · `field` · `message`), and the updated timestamp. Reads straight from the row — no extra request.

## Testing

- `bulk-batch-progress-table.test.tsx` (new): inline reason rendering, dialog opens with the full structured breakdown, `"Failed"` fallback when a failed row has no structured errors, and succeeded rows link to the offer with no Details affordance.
- Extended `bulk-offer-creation.controller.spec.ts` to assert `errors` mapping (null pass-through on a succeeded record + a populated failed record).
- `pnpm lint && pnpm type-check && pnpm test` green across all packages. No migration.

## Out of scope

- A dedicated linkable per-record route (the Dialog keeps batch context; a route is a possible follow-up).
- Re-fetching the full offer-creation record via `getOfferCreationStatus` — unnecessary, the errors are already in the summary.

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)