### PR TITLE
fix(listings,allegro): thread EAN-matched productCardId so bulk offers link the card (#808)

### DIFF
--- a/apps/api/src/listings/http/dto/create-offer.dto.ts
+++ b/apps/api/src/listings/http/dto/create-offer.dto.ts
@@ -96,6 +96,14 @@ export class CreateOfferOverridesDto {
   categoryId?: string;
 
   @ApiPropertyOptional({
+    description:
+      'Platform-specific catalogue product-card id resolved from the variant barcode (#808). When present, smart-linking adapters link the existing card and inherit its required product parameters instead of creating a product inline.',
+  })
+  @IsOptional()
+  @IsString()
+  productCardId?: string;
+
+  @ApiPropertyOptional({
     nullable: true,
     isArray: true,
     type: String,

--- a/apps/web/src/features/listings/api/bulk-listings.types.ts
+++ b/apps/web/src/features/listings/api/bulk-listings.types.ts
@@ -40,6 +40,8 @@ export interface BulkOfferOverrides {
   title?: string;
   description?: string | null;
   categoryId?: string;
+  /** Catalogue product-card id from a unique EAN match (#808). */
+  productCardId?: string;
   imageUrls?: string[] | null;
   platformParams?: Record<string, unknown>;
 }

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -157,6 +157,12 @@ export interface CreateOfferOverrides {
   title?: string;
   description?: string | null;
   categoryId?: string;
+  /**
+   * Catalogue product-card id resolved from the variant barcode (#808).
+   * Threaded through so smart-linking adapters link the existing card and
+   * inherit its required product parameters instead of creating one inline.
+   */
+  productCardId?: string;
   imageUrls?: string[] | null;
   platformParams?: Record<string, unknown>;
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -62,6 +62,7 @@ function makeRow(opts: {
     primaryVariant: variant,
     blockers: [],
     resolvedCategoryId: null,
+    resolvedProductCardId: null,
     resolutionMethod: null,
     masterPrice: 12,
     masterStock: 5,

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.test.tsx
@@ -50,6 +50,7 @@ function makeRow(productId: string, variant: Partial<ProductVariant>, product: P
     primaryVariant: makeVariant({ id: `var_${productId}`, productId, ...variant }),
     blockers: [],
     resolvedCategoryId: null,
+    resolvedProductCardId: null,
     resolutionMethod: null,
     masterPrice: null,
     masterStock: null,
@@ -119,7 +120,12 @@ describe('BulkResolveStep', () => {
     });
     const outcomes = onComplete.mock.calls[0][0];
     expect(outcomes.every((o) => o.blockers.length === 0)).toBe(true);
-    expect(outcomes[0]).toMatchObject({ resolvedCategoryId: 'cat-A', masterPrice: 12, masterStock: 5 });
+    expect(outcomes[0]).toMatchObject({
+      resolvedCategoryId: 'cat-A',
+      resolvedProductCardId: 'card-A',
+      masterPrice: 12,
+      masterStock: 5,
+    });
   });
 
   it('flags no-master-price when the variant has no master price', async () => {

--- a/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-resolve-step.tsx
@@ -32,6 +32,7 @@ export interface BulkResolveOutcome {
   productId: string;
   blockers: readonly BulkRowBlocker[];
   resolvedCategoryId: string | null;
+  resolvedProductCardId: string | null;
   resolutionMethod: 'auto_detect' | 'category_mapping' | 'manual' | null;
   masterPrice: number | null;
   masterStock: number | null;
@@ -98,6 +99,7 @@ export function BulkResolveStep({
           productId: row.productId,
           blockers: ['no-variant'] as const,
           resolvedCategoryId: null,
+          resolvedProductCardId: null,
           resolutionMethod: null,
           masterPrice: null,
           masterStock: null,
@@ -133,6 +135,8 @@ export function BulkResolveStep({
         blockers,
         resolvedCategoryId:
           categoryResult.kind === 'matched' ? categoryResult.allegroCategoryId : null,
+        resolvedProductCardId:
+          categoryResult.kind === 'matched' ? categoryResult.productCardId : null,
         resolutionMethod: categoryResult.kind === 'matched' ? 'auto_detect' : null,
         masterPrice,
         masterStock,

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
@@ -65,6 +65,7 @@ function makeRow(
     primaryVariant: variant,
     blockers,
     resolvedCategoryId: opts.resolvedCategoryId ?? (blockers.length === 0 ? 'cat-A' : null),
+    resolvedProductCardId: null,
     resolutionMethod: null,
     masterPrice: opts.masterPrice ?? null,
     masterStock: opts.masterStock ?? null,

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
@@ -16,6 +16,7 @@ function makeRow(productId: string): BulkWizardRow {
     primaryVariant: null,
     blockers: [],
     resolvedCategoryId: null,
+    resolvedProductCardId: null,
     resolutionMethod: null,
     masterPrice: null,
     masterStock: null,
@@ -33,6 +34,7 @@ function outcome(
     productId,
     blockers: [],
     resolvedCategoryId: null,
+    resolvedProductCardId: null,
     resolutionMethod: null,
     masterPrice: null,
     masterStock: null,
@@ -47,22 +49,24 @@ describe('mergeResolveOutcomes', () => {
     const rows = [makeRow('prod_1')];
     const next = mergeResolveOutcomes(rows, [
       outcome('prod_1', {
-        blockers: ['multi-match'],
-        resolvedCategoryId: null,
+        blockers: [],
+        resolvedCategoryId: 'cat-A',
+        resolvedProductCardId: 'card-A',
         masterPrice: 12,
         masterStock: 3,
         masterCurrency: 'PLN',
-        categoryCandidates: [{ allegroCategoryId: 'cat-B', productCardId: 'card-B' }],
+        categoryCandidates: [],
       }),
     ]);
 
     expect(next[0]).toMatchObject({
       productId: 'prod_1',
-      blockers: ['multi-match'],
+      blockers: [],
+      resolvedCategoryId: 'cat-A',
+      resolvedProductCardId: 'card-A',
       masterPrice: 12,
       masterStock: 3,
       masterCurrency: 'PLN',
-      categoryCandidates: [{ allegroCategoryId: 'cat-B', productCardId: 'card-B' }],
     });
   });
 

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -161,6 +161,16 @@ export function BulkWizard({
             ...(row.override.overrides ?? {}),
             categoryId:
               row.override.overrides?.categoryId ?? row.resolvedCategoryId ?? undefined,
+            // #808 — link the EAN-matched product card so Allegro inherits its
+            // required product parameters (Brand, Type, EAN, …). Dropped when
+            // the operator manually overrode the category, since the card was
+            // matched against the auto-detected one; the adapter then falls
+            // back to its (GTIN-tightened) re-resolution.
+            productCardId:
+              row.override.overrides?.productCardId ??
+              (row.override.overrides?.categoryId
+                ? undefined
+                : (row.resolvedProductCardId ?? undefined)),
           },
         };
       }
@@ -293,7 +303,11 @@ function categoryResultFor(
   resolvedCategoryId: string | null,
 ): EanMatchResult {
   if (resolvedCategoryId) {
-    return { kind: 'matched', allegroCategoryId: resolvedCategoryId, productCardId: '' };
+    return {
+      kind: 'matched',
+      allegroCategoryId: resolvedCategoryId,
+      productCardId: row.resolvedProductCardId ?? '',
+    };
   }
   if (row.blockers.includes('no-ean')) return { kind: 'no-ean' };
   if (row.blockers.includes('multi-match')) {
@@ -318,6 +332,7 @@ export function mergeResolveOutcomes(
       ...row,
       blockers: o.blockers,
       resolvedCategoryId: o.resolvedCategoryId,
+      resolvedProductCardId: o.resolvedProductCardId,
       resolutionMethod: o.resolutionMethod,
       masterPrice: o.masterPrice,
       masterStock: o.masterStock,
@@ -339,6 +354,7 @@ function seedRow(product: Product): BulkWizardRow {
     primaryVariant,
     blockers: primaryVariant ? [] : ['no-variant'],
     resolvedCategoryId: null,
+    resolvedProductCardId: null,
     resolutionMethod: null,
     masterPrice: null,
     masterStock: null,

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.types.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.types.ts
@@ -81,6 +81,12 @@ export interface BulkWizardRow {
   blockers: readonly BulkRowBlocker[];
   /** Resolved Allegro category id (after Resolve, or operator pick). */
   resolvedCategoryId: string | null;
+  /**
+   * Catalogue product-card id from a unique EAN match (#808). Threaded to
+   * `overrides.productCardId` on submit so the adapter links the card and
+   * inherits its required product parameters. Null when no unique match.
+   */
+  resolvedProductCardId: string | null;
   /** How the category was resolved (telemetry / UI hint). */
   resolutionMethod: 'auto_detect' | 'category_mapping' | 'manual' | null;
   /** Master variant price captured at resolve (`variant.price`). Null if unset. */

--- a/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx
+++ b/apps/web/src/pages/webhook-deliveries/webhook-deliveries-page.test.tsx
@@ -126,8 +126,12 @@ describe('WebhookDeliveriesPage', () => {
 
     renderWithProviders(<WebhookDeliveriesPage />, { apiClient: mockApi });
 
-    expect(await screen.findByText('PrestaShop Main')).toBeInTheDocument();
-  });
+    // ConnectionEntityLabel resolves the name via a second async query
+    // (deliveries load → render → connections query settles). Give it a
+    // generous ceiling so a starved event loop under full-suite parallel CI
+    // can't lapse the default 1000ms mid-chain (#808 drive-by de-flake).
+    expect(await screen.findByText('PrestaShop Main', {}, { timeout: 5000 })).toBeInTheDocument();
+  }, 15000);
 
   it('filters deliveries by the selected connection when changing the dropdown', async () => {
     const user = userEvent.setup();

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -123,7 +123,33 @@ describe('OfferBuilderService', () => {
         idempotencyKey: undefined,
         // #431 — barcode threaded through for adapter-side smart-link.
         variantBarcode: '5901234123457',
+        // #808 — no pre-resolved card on this input.
+        productCardId: null,
       });
+    });
+
+    it('lifts overrides.productCardId to the top-level command (#808)', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        overrides: { categoryId: 'explicit-cat', productCardId: 'allegro-card-42' },
+      });
+
+      expect(result.productCardId).toBe('allegro-card-42');
+      // Stays a top-level hint (like variantBarcode), not duplicated in overrides.
+      expect(result.overrides).not.toHaveProperty('productCardId');
+    });
+
+    it('sets productCardId null when no overrides.productCardId is provided (#808)', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        overrides: { categoryId: 'explicit-cat' },
+      });
+
+      expect(result.productCardId).toBeNull();
     });
   });
 

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -126,6 +126,12 @@ export class OfferBuilderService implements IOfferBuilderService {
       // #431 — smart-link by barcode. Pre-resolved here so adapters that
       // need it (Allegro) don't have to re-fetch the variant.
       variantBarcode: variant.ean ?? variant.gtin ?? null,
+      // #808 — smart-link by pre-resolved catalogue card. When the wizard
+      // already matched a unique product card by EAN, thread its id straight
+      // through so the adapter links it (and inherits its required product
+      // parameters) instead of re-resolving — kept off `overrides` so the
+      // adapter sees it as a top-level hint alongside `variantBarcode`.
+      productCardId: input.overrides?.productCardId ?? null,
     };
 
     this.logger.debug(

--- a/libs/core/src/listings/domain/types/offer-create.types.ts
+++ b/libs/core/src/listings/domain/types/offer-create.types.ts
@@ -30,6 +30,15 @@ export interface CreateOfferOverrides {
   /** Platform-specific category id (e.g. Allegro category id). */
   categoryId?: string;
   /**
+   * Platform-specific catalogue product-card id resolved from the variant's
+   * barcode (e.g. an Allegro product-card UUID). When present, adapters that
+   * support catalogue smart-linking (#431) link the offer to the existing
+   * card — so required product parameters (Brand, Type, EAN, …) are inherited
+   * from the card rather than supplied inline. Carried FE→BE so a resolution
+   * the wizard already performed isn't redone (and weakened) at create time.
+   */
+  productCardId?: string;
+  /**
    * Image URLs in display order. Falls back to variant images. `null` or
    * `undefined` both mean "no override".
    */
@@ -77,6 +86,14 @@ export interface CreateOfferCommand {
    * `null` means "no usable barcode" (variant has neither EAN nor GTIN).
    */
   variantBarcode?: string | null;
+  /**
+   * Pre-resolved catalogue product-card id (e.g. Allegro product-card UUID),
+   * lifted by `OfferBuilderService` from `overrides.productCardId`. When set,
+   * smart-linking adapters link this card directly via the platform's product
+   * set and skip re-resolving by barcode — Allegro then inherits the card's
+   * required product parameters. `null`/absent means "resolve from barcode".
+   */
+  productCardId?: string | null;
 }
 
 /**

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -2091,6 +2091,35 @@ describe('AllegroOfferManagerAdapter', () => {
         );
       });
 
+      it('on pre-resolved productCardId (#808): links the card directly and skips the catalogue search', async () => {
+        httpClient.post.mockResolvedValue(
+          mockHttpResponse({
+            id: 'allegro-offer-prelinked',
+            publication: { status: 'INACTIVE' },
+          })
+        );
+
+        await adapter.createOffer({
+          ...baseCmd,
+          // Pre-resolved by the bulk wizard's EAN match. A barcode is present
+          // too, but the pre-resolved id must win without any /sale/products
+          // re-search (the path that previously downgraded to inline → 422).
+          productCardId: 'allegro-card-pre',
+          variantBarcode: '5901234123457',
+          stock: 4,
+          overrides: {
+            ...baseCmd.overrides,
+            platformParams: {
+              productParameters: [{ id: '248811', valuesIds: ['248811_canon'] }],
+            },
+          },
+        });
+
+        expect(httpClient.get).not.toHaveBeenCalledWith('/sale/products', expect.anything());
+        const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
+        expect(body.productSet).toEqual([{ product: { id: 'allegro-card-pre' }, quantity: 4 }]);
+      });
+
       it('falls through to inline path when variantBarcode is missing (smart-link short-circuits)', async () => {
         httpClient.post.mockResolvedValue(
           mockHttpResponse({

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -1391,6 +1391,18 @@ export class AllegroOfferManagerAdapter
   private async maybeResolveProductCard(
     cmd: CreateOfferCommand
   ): Promise<ResolveProductCardResult> {
+    // #808 — when the caller already resolved a unique catalogue card (the
+    // bulk wizard's EAN match), link it directly. Skipping the re-search
+    // avoids the weaker fuzzy `phrase` lookup that can downgrade a known
+    // unique match to `ambiguous`/`no_match` and force inline product
+    // creation (→ 422 on categories with required product parameters).
+    if (cmd.productCardId) {
+      this.logger.debug(
+        `Allegro smart-link: using pre-resolved productCardId=${cmd.productCardId} ` +
+          `connection=${this.connectionId}`
+      );
+      return { kind: 'unique', productId: cmd.productCardId };
+    }
     const ean = cmd.variantBarcode;
     const categoryId = cmd.overrides?.categoryId;
     if (!ean || !categoryId) {

--- a/libs/integrations/allegro/src/infrastructure/util/__tests__/resolve-allegro-product-card-by-ean.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/__tests__/resolve-allegro-product-card-by-ean.spec.ts
@@ -76,7 +76,7 @@ describe('resolveAllegroProductCardByEan', () => {
 
     expect(result).toEqual({ kind: 'unique', productId: 'allegro-prod-1' });
     expect(httpClient.get).toHaveBeenCalledWith('/sale/products', {
-      queryParams: { phrase: '5901234123457', 'category.id': 'cat-1', limit: 10 },
+      queryParams: { phrase: '5901234123457', mode: 'GTIN', 'category.id': 'cat-1', limit: 10 },
     });
     expect(cache.set).toHaveBeenCalledWith(
       'allegro:product-card:cat-1:5901234123457',

--- a/libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.ts
+++ b/libs/integrations/allegro/src/infrastructure/util/resolve-allegro-product-card-by-ean.ts
@@ -84,6 +84,10 @@ export async function resolveAllegroProductCardByEan(
     const response = await httpClient.get<AllegroProductsSearchResponse>('/sale/products', {
       queryParams: {
         phrase: input.ean,
+        // #808 — `mode=GTIN` tells Allegro to interpret `phrase` as a GTIN,
+        // matching the tighter lookup the category matcher uses (#735/#797)
+        // rather than the looser phrase-only search this path used before.
+        mode: 'GTIN',
         'category.id': input.categoryId,
         limit,
       },


### PR DESCRIPTION
## Problem

Bulk Allegro offer creation 422'd for products in categories with required **product** parameters:

```
ProductValidationException: Unable to create product without proper values in all
required parameters: [Marka, Typ, Rodzaj, EAN (GTIN), Typ uchwytu, Waga wiertarki]
in category: 252043   (path: productSet[0].product)
```

The EAN matched a unique Allegro **product card** (that's how the category was derived) — but the offer tried to *create a new product* inline instead of linking the card, so Allegro demanded every required parameter.

## Root cause

Per #431, a unique EAN→card match should link `productSet[0].product.id = <cardId>` and inherit Brand/Type/EAN/… from the card. Two compounding gaps broke the **bulk** path:

1. **The matched `productCardId` was dropped** — the bulk resolve step kept only `allegroCategoryId`; no field carried the card id to the worker/adapter.
2. **The adapter re-resolved less precisely** — `resolveAllegroProductCardByEan` queried `/sale/products?phrase=<EAN>&category.id=…` *without* `mode=GTIN`, so it downgraded a known-unique match to `ambiguous`/`no_match` → inline product creation → 422.

## Fix — thread the matched `productCardId` end-to-end

| Layer | Change |
|---|---|
| **core** | `CreateOfferOverrides.productCardId` (FE→BE carrier) + top-level `CreateOfferCommand.productCardId` hint (sibling to `variantBarcode`); `OfferBuilderService` lifts the former into the latter. |
| **allegro** | `maybeResolveProductCard` short-circuits to `{ kind: 'unique' }` when `cmd.productCardId` is set — **no catalogue re-search**. The fallback resolver now sends `mode=GTIN` (matching the category matcher #735/#797). |
| **api** | `CreateOfferOverridesDto` gains `productCardId` (else `forbidNonWhitelisted` would 400 it). |
| **web** | Bulk resolve captures `resolvedProductCardId` on a unique match and threads it through submit `overrides.productCardId`. Dropped when the operator manually overrides the category (the card was matched for the auto-detected one) → adapter falls back to the GTIN-tightened re-resolution. |

## Tests
- **offer-builder**: lifts `overrides.productCardId` → `command.productCardId` (and null when absent).
- **allegro adapter**: with `cmd.productCardId`, `productSet[0].product.id` is the card and **no `/sale/products` GET** fires.
- **resolver**: query now includes `mode=GTIN`.
- **web**: resolve outcome captures `resolvedProductCardId`; `mergeResolveOutcomes` folds it.
- **Drive-by de-flake**: the webhook-deliveries connection-name test had the same full-suite-parallelism timing fragility as #792's bulk-config-step (passes in isolation, flakes under load) — bumped its async-name-resolution wait. Surfaced because the new tests shifted scheduling; unrelated to the offer logic.

`pnpm build && pnpm lint && pnpm type-check && pnpm test` all green. No migration.

## Out of scope (follow-up)
Rows whose EAN matches **no** Allegro card still can't be created in bulk — bulk has no per-row product-parameter form like the single-offer wizard (#415). Those should surface as a review blocker ("requires product details — create individually") rather than 422 at the worker.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)