### PR TITLE
feat(shipping): add InPost ShipX shipping adapter + fake (#764, #765)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,6 +41,7 @@
     "@openlinker/core": "workspace:*",
     "@openlinker/integrations-ai": "workspace:*",
     "@openlinker/integrations-allegro": "workspace:*",
+    "@openlinker/integrations-inpost": "workspace:*",
     "@openlinker/integrations-prestashop": "workspace:*",
     "bcryptjs": "^3.0.3",
     "class-transformer": "0.5.1",

--- a/apps/api/src/plugins.ts
+++ b/apps/api/src/plugins.ts
@@ -30,9 +30,11 @@ import type { PluginEntry } from '@openlinker/core/integrations';
 import { PrestashopIntegrationModule } from '@openlinker/integrations-prestashop';
 import { AllegroIntegrationModule } from '@openlinker/integrations-allegro';
 import { AiIntegrationModule } from '@openlinker/integrations-ai';
+import { InpostIntegrationModule } from '@openlinker/integrations-inpost';
 
 export const apiPlugins: PluginEntry[] = [
   PrestashopIntegrationModule,
   AllegroIntegrationModule,
   AiIntegrationModule.register(),
+  InpostIntegrationModule,
 ];

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -17,6 +17,8 @@
       "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"],
       "@openlinker/integrations-ai": ["../../libs/integrations/ai/src/index.ts"],
       "@openlinker/integrations-ai/*": ["../../libs/integrations/ai/src/*"],
+      "@openlinker/integrations-inpost": ["../../libs/integrations/inpost/src/index.ts"],
+      "@openlinker/integrations-inpost/*": ["../../libs/integrations/inpost/src/*"],
       "@openlinker/test-kit": ["../../libs/test-kit/src/index.ts"],
       "@openlinker/test-kit/*": ["../../libs/test-kit/src/*"]
     }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -20,6 +20,8 @@
       "@openlinker/integrations-allegro/*": ["../../libs/integrations/allegro/src/*"],
       "@openlinker/integrations-ai": ["../../libs/integrations/ai/src/index.ts"],
       "@openlinker/integrations-ai/*": ["../../libs/integrations/ai/src/*"],
+      "@openlinker/integrations-inpost": ["../../libs/integrations/inpost/src/index.ts"],
+      "@openlinker/integrations-inpost/*": ["../../libs/integrations/inpost/src/*"],
       "@openlinker/test-kit": ["../../libs/test-kit/src/index.ts"],
       "@openlinker/test-kit/*": ["../../libs/test-kit/src/*"]
     }

--- a/docs/plans/implementation-plan-inpost-shipping-adapter.md
+++ b/docs/plans/implementation-plan-inpost-shipping-adapter.md
@@ -1,0 +1,114 @@
+# Implementation Plan — InPost ShipX shipping adapter + fake (#764, #765)
+
+> Design locked via `/grill-me` (2026‑05‑22) and grounded against the official
+> ShipX docs (dokumentacja-inpost.atlassian.net, EN space). One PR closes both.
+
+## 1. Task & layer
+
+Ship `@openlinker/integrations-inpost` whose `InpostShippingAdapter` implements
+`ShippingProviderManagerPort` (#763) + the `ShipmentCanceller` and
+`PickupPointFinder` sub-capabilities, against InPost's **ShipX REST API**, plus
+the `FakeInpostShippingAdapter` (#765).
+
+**Layer: CORE (shipping) + Integration.** ⚠️ Correction to the first draft —
+this is **not** "new package only." `GenerateLabelCommand` lacks the recipient
++ parcel data ShipX needs, and `#763`'s `generate-label.types.ts` header
+explicitly designates **this PR** as the one that adds them. So #764 also edits
+`libs/core/src/shipping/domain/types/`.
+
+**Contract correction:** #764's body lists `getCapabilities()`; the merged port
+(#763) is `generateLabel` / `getTracking` / `getSupportedMethods()` +
+optional `ShipmentCanceller` / `PickupPointFinder`. Implement the merged port.
+
+**Non-goals (sibling #727.x):** webhooks (#768), FE pages/settings (#769–#771),
+paczkomat cache (#766 — `findPickupPoints` is pass-through), polling
+orchestration (#772), `psModuleChoice` reader (#767), express/COD/international/
+multi-package/Allegro-method (v2), worker registration (→#772), connection
+tester (→#771), retry classifier (→#772).
+
+## 2. Locked decisions (from the grill)
+
+| # | Decision |
+|---|---|
+| Auth | Static **Bearer API token** (portal-generated; no OAuth refresh). creds = `{ apiToken }`; `organizationId` in **config** |
+| Module | SDK **`createNestAdapterModule`** — no plugin-specific Nest provider; config-validator registered via `plugin.register(host)` |
+| `labelPdfRef` | Opaque **re-fetchable ref** (`shipx:label:{id}`); no blob storage, no bytes (label is async-buffered anyway) |
+| Idempotency | **Thin adapter** + stamp ShipX `reference = cmd.shipmentId`; retry-safety at the **job layer**. Downstream guard required of #769/#772 (skip if `providerShipmentId` set; enqueue with idempotency key) |
+| Status mapping | Unknown ShipX code → non-terminal **`in-transit` + WARN**, never auto-terminal; full 42→7 table in `inpost-shipx.mapper.ts` (§4) |
+| Connection tester | Deferred to **#771** |
+| Registration | **API-only** this PR; worker reg deferred to **#772** |
+| HTTP client | Dedicated axios **`InpostHttpClient`** behind **`IInpostHttpClient`** (jittered 429/5xx retry, structured logging) |
+| Packaging | **One PR**, `Closes #764` + `Closes #765` |
+| Exceptions | `InpostUnauthorizedException` (401) · `InpostValidationException` (4xx + pre-submit) · `PaczkomatUnavailableException` · `InpostConfigException` · `InpostNetworkException` (5xx/timeout). 429 retried → `InpostNetworkException`; retry-classifier → #772 |
+| Config DTO | v1 = `{ environment, organizationId, senderAddress }`; `psModuleChoice` deferred to #767/#771 |
+| Command extension | Add **required** typed `recipient` + `parcel` (+ `ShipmentAddress`) to canonical `GenerateLabelCommand` (carrier-neutral; serves #732). **Breaking change** to the merged #763 input — update existing constructors + refresh the #763 header (Step 1). No `platformParams` escape hatch |
+
+## 3. ShipX API reference (verified against the docs)
+
+- **Base URLs:** sandbox `https://sandbox-api-shipx-pl.easypack24.net`, prod `https://api-shipx-pl.easypack24.net`. Header `Authorization: Bearer {apiToken}`.
+- **Create (simplified mode):** `POST /v1/organizations/{organizationId}/shipments`.
+  - Paczkomat: `receiver{company_name,first_name,last_name,email,phone}` (**no address**), `parcels` = object `{template}` (`small|medium|large`), `custom_attributes{sending_method:"dispatch_order", target_point}`, `service:"inpost_locker_standard"`, `reference`.
+  - Courier: `receiver{...,address{street,building_number,city,post_code,country_code}}` (**address required**), `parcels` = array `[{dimensions{length,width,height,unit:"mm"}, weight{amount,unit:"kg"}, is_non_standard}]`, `service:"inpost_courier_standard"`, `reference`.
+  - `sender` = connection `senderAddress` (same `Peer` shape, with address).
+  - Response `{ id: int, status, tracking_number: string|null }` → `providerShipmentId = String(id)`, `trackingNumber` nullable.
+- **Label:** `GET /v1/shipments/{id}/label?format=Pdf&type=normal` → binary PDF, **only ≥ `confirmed`**. Async-buffered after create ⇒ store the ref, fetch on demand later (#769).
+- **Cancel:** `DELETE /v1/shipments/{id}` → 204, **only `created`/`offers_prepared`**; else `invalid_action`. ⚠️ See §6 finding.
+- **Tracking:** the timeline (`tracking_details[]{status,origin_status,datetime}`) lives on `GET /v1/tracking/{tracking_number}` — keyed by *tracking number*, **unavailable in sandbox**. The port hands `providerShipmentId`, so `getTracking` reads current `status` from `GET /v1/shipments/{id}`; `dispatchedAt`/`deliveredAt` come from the timeline **only if the shipment-by-id response carries it — shape to confirm (Step 5)**. v1 fallback: return mapped `status` and leave the timestamps `null` (documented) rather than guess a two-call path.
+- **Points:** `GET /v1/points` (exact query/response fields — page `18153493` — to confirm during Step 5; pass-through, no cache).
+- **Status → OL bucket** (`inpost-shipx.mapper.ts`; unknown → `in-transit` + WARN):
+  - `generated`: created, offers_prepared, offer_selected, confirmed
+  - `dispatched`: dispatched_by_sender(_to_pok), collected_from_sender, taken_by_courier(_from_pok), adopted_at_source_branch, sent_from_source_branch, adopted_at_sorting_center, taken_by_courier_from_customer_service_point
+  - `in-transit`: out_for_delivery(_to_address), ready_to_pickup(_from_pok/_from_branch), pickup_reminder_sent(_address), avizo, readdressed, redirect_to_box, oversized, delay_in_delivery, stack_*/unstack_*, courier_avizo_in_customer_service_point, claimed
+  - `delivered` (terminal): delivered
+  - `cancelled` (terminal): canceled, canceled_redirect_to_box
+  - `failed` (terminal): returned_to_sender, rejected_by_receiver, undelivered, undelivered_wrong_address, undelivered_cod_cash_receiver, pickup_time_expired, stack_parcel_*_pickup_time_expired
+
+## 4. Design — core additions + package layout
+
+**CORE (`libs/core/src/shipping/domain/types/`):**
+- `shipment-recipient.types.ts` — `ShipmentRecipient { name?, firstName?, lastName?, email, phone, address?: ShipmentAddress }`, `ShipmentAddress { street, buildingNumber, city, postCode, countryCode }`.
+- `shipment-parcel.types.ts` — `ShipmentParcel { template?, dimensions?: {length,width,height}, weightGrams? }`.
+- Extend `GenerateLabelCommand` with **required** `recipient: ShipmentRecipient` + `parcel: ShipmentParcel`; export the new types from `@openlinker/core/shipping`. Required (not optional) — no carrier can label without them; this is a deliberate breaking change to the #763 input, mitigated in Step 1.
+
+**Plugin package `libs/integrations/inpost/`:** mirrors the Allegro layout —
+`package.json` (`.` + `./testing` exports), `index.ts`, `testing.ts`,
+`inpost.tokens.ts`, `inpost-plugin.ts` (`createInpostPlugin` + `inpostAdapterManifest`
+`{adapterKey:'inpost.shipx.v1', platformType:'inpost', supportedCapabilities:['ShippingProviderManager'], isDefault:true}`),
+`inpost-integration.module.ts` (`createNestAdapterModule`), `domain/types/inpost-shipx.types.ts`,
+`domain/types/inpost-credentials.types.ts`, `domain/exceptions/*`, `application/inpost-adapter.factory.ts`,
+`application/dto/inpost-connection-config.dto.ts`, `infrastructure/http/{inpost-http-client.ts, inpost-http-client.interface.ts}`,
+`infrastructure/adapters/{inpost-shipping.adapter.ts, inpost-connection-config-shape-validator.adapter.ts}`,
+`infrastructure/mappers/inpost-shipx.mapper.ts` (the single ShipX↔domain seam + status map),
+`testing/fake-inpost-shipping.adapter.ts`.
+
+Adapter class `InpostShippingAdapter` — deliberately shortened from the `{Platform}{Capability}Adapter` rule's `InpostShippingProviderManagerAdapter` (the capability name is unwieldy; the short form matches #764/#765 and the shipping-domain vocabulary). `getSupportedMethods()` → `['paczkomat','kurier']`; `generateLabel` validates method + paczkomatId, builds the per-service body, POSTs (simplified), returns `{providerShipmentId, trackingNumber, labelPdfRef:'shipx:label:'+id}`, stamps `reference=shipmentId`; `cancelShipment` → `DELETE`, maps `invalid_action`→`InpostValidationException`; `findPickupPoints` → `GET /v1/points`; `getTracking` → `GET /v1/shipments/{id}`.
+
+## 5. Steps
+
+1. **CORE types** — add `ShipmentRecipient`/`ShipmentAddress`/`ShipmentParcel`, extend `GenerateLabelCommand` with the two **required** fields, export from barrel. **Grep every existing `GenerateLabelCommand` constructor (specs/fixtures) and update them** — required fields are a breaking change. Replace `generate-label.types.ts`'s "#764 adds them / speculate later" header note with the landed `recipient`+`parcel` shape so #732 inherits the resolved contract (this header note is the contract record; no separate ADR). Run core build + existing shipping specs.
+2. **Scaffold package** (`package.json` `.`+`./testing`, tsconfigs, barrels, tokens); `pnpm install`.
+3. **Domain types + exceptions** (`inpost-shipx.types.ts`, `inpost-credentials.types.ts`, 5 exceptions).
+4. **HTTP client** (`IInpostHttpClient` + axios impl: Bearer, jittered 429/5xx retry, request-id logging).
+5. **Mapper** — request builders (paczkomat object / courier array), response→`GenerateLabelResult`, `GET /v1/points`→`PickupPoint`, tracking→`TrackingSnapshot` + the 42→7 status map. (Confirm points query/response shape from page `18153493` here.)
+6. **Adapter** — base port + `ShipmentCanceller` + `PickupPointFinder`; pre-submit validation; error mapping.
+7. **Config DTO + shape validator** (`environment`,`organizationId`,`senderAddress`) → `InvalidConnectionConfigException`.
+8. **Factory** — validate config → resolve `{apiToken}` via `credentialsResolver` → build client → adapter.
+9. **Plugin descriptor + `createNestAdapterModule`** (register config-validator in `register(host)`).
+10. **Fake (#765)** — `testing/fake-inpost-shipping.adapter.ts` + `./testing` sub-barrel; deterministic data + `seedFailure`/`seedPickupPoints`/`seedShipment`/`clear`.
+11. **Register** in `apps/api/src/plugins.ts` only.
+12. **Unit specs** — adapter (generate paczkomat/courier, method-unsupported throw, label-ref, cancel + `invalid_action`, tracking status map incl. unknown→in-transit+WARN, 401/validation/429 mapping), mapper, config-validator, fake. Mock `IInpostHttpClient`.
+13. **Gate** — `pnpm lint && pnpm type-check && pnpm test`. No migration (uses core `Shipment`).
+
+## 6. Validation, risks, downstream
+
+- **Architecture:** new package implements a CORE port; additive CORE-type change is sanctioned by #763's header; deps via barrels; domain-exception mapping; capability dispatch via SDK. ✓
+- **🔴 Cancel-window finding:** ShipX cancel is **pre-confirmation only** (`created`/`offers_prepared`). Simplified-mode shipments auto-advance to `confirmed`, so AC-7's "cancel while generated" is **not satisfiable via `DELETE`** for confirmed shipments. The adapter surfaces `invalid_action` as `InpostValidationException`; **#769 must treat cancel as best-effort** and use return/claim flows for already-confirmed parcels. Recorded for #769.
+- **Sandbox tracking unavailable** → `getTracking` can't be E2E-verified in sandbox; covered by unit tests + fake only.
+- **Can't E2E without creds** → offline deliverable = full adapter + fake + mocked-HTTP unit specs; sandbox verification is operator-side.
+- **Downstream requirements to carry forward:** #769/#772 idempotency guard; #772 worker registration + retry classifier; #771 connection tester + `psModuleChoice` config; #769 label-download proxy endpoint + best-effort cancel; #768 webhooks.
+- **To confirm in Step 5:** `GET /v1/shipments/{id}` response shape (does it carry the tracking timeline? — drives whether `getTracking` can populate `dispatchedAt`/`deliveredAt`); `GET /v1/points` query/response (`18153493`); ShipX error-body shapes; **`sending_method` per-method behaviour** — a wrong default yields unfulfillable shipments, so confirm before hardcoding `dispatch_order` and derive it from `shippingMethod` if it varies.
+
+## References
+- ShipX EN docs: Shipment `18153485`, simplified-create `18153501`, label `18153509`, cancel `18153504`, statuses `18153478`, tracking `18153479`, points `18153493`, webhooks `18153494`.
+- `libs/core/src/shipping/**` (#763), `libs/integrations/allegro/**` (template), `libs/plugin-sdk/src/{adapter-plugin,host-services,create-nest-adapter-module,dispatch-capability}.ts`, `apps/api/src/plugins.ts`.
+- `docs/specs/product-spec-727-inpost-integration.md`.

--- a/libs/core/src/shipping/domain/types/generate-label.types.ts
+++ b/libs/core/src/shipping/domain/types/generate-label.types.ts
@@ -7,21 +7,21 @@
  * `offer-create.types.ts` precedent — port files contain only the port
  * interface; their types live here).
  *
- * NOTE: no `platformParams` / `overrides` escape hatch in this foundation
- * slice. When #764 (InPost adapter) needs adapter-specific fields (parcel
- * dims, sender-address override, etc.), that PR adds them — either as
- * typed optional fields on the canonical command, or as a typed
- * `GenerateLabelOverrides` interface (mirroring listings'
- * `CreateOfferOverrides` shape) with `platformParams?: Record<string,
- * unknown>` as the bottom-of-stack escape hatch. Adding optional fields
- * is forward-compatible; speculating now would risk locking in the wrong
- * shape before two real adapters (#764 + future #732) reveal what's
- * shared vs adapter-specific.
+ * #764 (InPost) added the `recipient` + `parcel` fields below. They're
+ * carrier-neutral — every shipping provider needs a recipient and a parcel
+ * descriptor — so they live on the canonical command rather than behind a
+ * `platformParams` escape hatch. Provider-specific translation (ShipX
+ * `service` / `custom_attributes.target_point`, courier-vs-locker parcel
+ * shape, etc.) stays inside each adapter. A future provider needing a
+ * genuinely adapter-specific input should add a typed optional field here
+ * (or a `GenerateLabelOverrides` interface) — never an untyped bag.
  *
  * @module libs/core/src/shipping/domain/types
  */
 
 import type { ShippingMethod } from './shipping-method.types';
+import type { ShipmentRecipient } from './shipment-recipient.types';
+import type { ShipmentParcel } from './shipment-parcel.types';
 
 export interface GenerateLabelCommand {
   /** Internal Shipment id (`ol_shipment_*`). */
@@ -36,6 +36,14 @@ export interface GenerateLabelCommand {
   /** Required when `shippingMethod === 'paczkomat'`. Provider-issued
    * locker id (e.g. `'POZ08A'`). */
   paczkomatId?: string;
+  /** Recipient (buyer) — name, contact, optional postal address. The caller
+   * resolves it from the order. Adapters require `recipient.address` for
+   * courier methods. */
+  recipient: ShipmentRecipient;
+  /** Parcel descriptor — a carrier size `template` (locker) or
+   * `dimensions` + `weightGrams` (courier). The adapter validates the right
+   * combination per method. */
+  parcel: ShipmentParcel;
 }
 
 export interface GenerateLabelResult {

--- a/libs/core/src/shipping/domain/types/shipment-parcel.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-parcel.types.ts
@@ -1,0 +1,29 @@
+/**
+ * Shipment Parcel Types
+ *
+ * Carrier-neutral parcel descriptor for a label-generation command. A
+ * shipment is described EITHER by a carrier size `template` (locker
+ * shipments — the operator / connection picks a locker size, since an order
+ * carries no reliable per-item dimensions) OR by explicit `dimensions` +
+ * `weightGrams` (courier). Adapters validate the right combination per
+ * shipping method and translate to the provider's parcel shape (e.g. ShipX
+ * `parcels` object for lockers vs array for courier).
+ *
+ * @module libs/core/src/shipping/domain/types
+ */
+
+export interface ShipmentDimensions {
+  /** Millimetres. */
+  length: number;
+  width: number;
+  height: number;
+}
+
+export interface ShipmentParcel {
+  /** Carrier size code — locker shipments (e.g. InPost `'small' | 'medium' | 'large'`). */
+  template?: string;
+  /** Explicit dimensions (mm) — courier shipments. */
+  dimensions?: ShipmentDimensions;
+  /** Weight in grams — courier shipments. */
+  weightGrams?: number;
+}

--- a/libs/core/src/shipping/domain/types/shipment-recipient.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-recipient.types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shipment Recipient Types
+ *
+ * Carrier-neutral recipient + structured postal address for a label-
+ * generation command. Lives in core/shipping so every shipping adapter
+ * (InPost #764, Allegro Delivery #732, …) maps from one canonical shape; the
+ * adapter translates to its provider's wire format (e.g. ShipX `receiver` /
+ * `address` Peer).
+ *
+ * `address` is optional at the type level: locker/paczkomat shipments are
+ * addressed by the locker id (`GenerateLabelCommand.paczkomatId`), so ShipX
+ * omits the receiver address for them. Adapters that require an address for a
+ * given method (courier) validate its presence and throw a domain exception
+ * when it's missing — the type stays permissive, the adapter enforces.
+ *
+ * Distinct from `PickupPointAddress` (display-oriented `line1`/`line2`): a
+ * shipping address needs `street` + `buildingNumber` split out because that's
+ * what carrier create-shipment APIs require.
+ *
+ * @module libs/core/src/shipping/domain/types
+ */
+
+export interface ShipmentAddress {
+  street: string;
+  buildingNumber: string;
+  city: string;
+  postCode: string;
+  /** ISO 3166-1 alpha-2 (e.g. `'PL'`). */
+  countryCode: string;
+}
+
+export interface ShipmentRecipient {
+  /** Company or full name; used by the provider when first/last are absent. */
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+  /** Required — carriers use it for pickup / delivery notifications. */
+  email: string;
+  /** Required — carriers use it for the SMS pickup code / delivery contact. */
+  phone: string;
+  /**
+   * Optional for locker shipments (addressed by locker id); adapters require
+   * it for courier shipments.
+   */
+  address?: ShipmentAddress;
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -49,6 +49,15 @@ export type {
   GenerateLabelResult,
 } from './domain/types/generate-label.types';
 
+export type {
+  ShipmentRecipient,
+  ShipmentAddress,
+} from './domain/types/shipment-recipient.types';
+export type {
+  ShipmentParcel,
+  ShipmentDimensions,
+} from './domain/types/shipment-parcel.types';
+
 export type { TrackingSnapshot } from './domain/types/tracking-snapshot.types';
 
 export type {

--- a/libs/integrations/inpost/jest.config.mjs
+++ b/libs/integrations/inpost/jest.config.mjs
@@ -1,0 +1,35 @@
+export default {
+  testEnvironment: 'node',
+  rootDir: '.',
+
+  // IMPORTANT: avoid running fixtures/mocks as "tests"
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+
+  // ESM + TS support for Node16 module resolution
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+
+  // Helps when TS/Node16 emits/assumes .js in import paths
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@openlinker/integrations-inpost$': '<rootDir>/src/index.ts',
+    '^@openlinker/integrations-inpost/(.*)$': '<rootDir>/src/$1',
+    '^@openlinker/core/(.*)$': '<rootDir>/../../core/src/$1',
+    '^@openlinker/shared/(.*)$': '<rootDir>/../../shared/src/$1',
+    '^@openlinker/plugin-sdk$': '<rootDir>/../../plugin-sdk/src/index.ts',
+  },
+
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '<rootDir>/coverage',
+  clearMocks: true,
+  testTimeout: 30000,
+};

--- a/libs/integrations/inpost/package.json
+++ b/libs/integrations/inpost/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@openlinker/integrations-inpost",
+  "version": "0.1.0",
+  "description": "InPost ShipX shipping adapter for OpenLinker",
+  "license": "Apache-2.0",
+  "author": "OpenLinker",
+  "private": true,
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "require": "./dist/testing.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "jest --config ./jest.config.mjs",
+    "test:watch": "jest --watch --config ./jest.config.mjs",
+    "test:cov": "jest --coverage --config ./jest.config.mjs",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@openlinker/core": "workspace:*",
+    "@openlinker/plugin-sdk": "workspace:*",
+    "@openlinker/shared": "workspace:*",
+    "class-transformer": "0.5.1",
+    "class-validator": "0.14.1"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.12",
+    "@types/node": "20.11.30",
+    "@typescript-eslint/eslint-plugin": "7.3.1",
+    "@typescript-eslint/parser": "7.3.1",
+    "eslint": "8.57.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.2",
+    "typescript": "5.4.3"
+  }
+}

--- a/libs/integrations/inpost/src/application/dto/inpost-connection-config.dto.ts
+++ b/libs/integrations/inpost/src/application/dto/inpost-connection-config.dto.ts
@@ -1,0 +1,84 @@
+/**
+ * InPost Connection Config DTO
+ *
+ * Application-layer `class-validator` schema for the InPost `Connection.config`
+ * blob. Plugin-private — only `InpostConnectionConfigShapeValidatorAdapter`
+ * (registered with the host at boot) reaches into it; the API-layer
+ * `ConnectionService` invokes the validator via the registry and never touches
+ * this DTO directly. Sibling-context value (`InpostEnvironmentValues`) imported
+ * relatively to avoid a self-package `dist/` cycle (mirrors the Allegro DTO).
+ *
+ * @module libs/integrations/inpost/src/application/dto
+ */
+import {
+  IsEmail,
+  IsIn,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { InpostEnvironmentValues } from '../../domain/types/inpost-config.types';
+
+export class InpostAddressDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  street!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  buildingNumber!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  city!: string;
+
+  @IsString()
+  @Matches(/^\d{2}-\d{3}$/, { message: 'postCode must match the PL format NN-NNN' })
+  postCode!: string;
+
+  @IsString()
+  @Matches(/^[A-Z]{2}$/, { message: 'countryCode must be an ISO 3166-1 alpha-2 code' })
+  countryCode!: string;
+}
+
+export class InpostSenderContactDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  name?: string;
+
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(30)
+  phone!: string;
+
+  @ValidateNested()
+  @Type(() => InpostAddressDto)
+  @IsObject()
+  address!: InpostAddressDto;
+}
+
+export class InpostConnectionConfigDto {
+  @IsIn(InpostEnvironmentValues as readonly string[])
+  environment!: (typeof InpostEnvironmentValues)[number];
+
+  @IsString()
+  @IsNotEmpty()
+  organizationId!: string;
+
+  @ValidateNested()
+  @Type(() => InpostSenderContactDto)
+  @IsObject()
+  senderAddress!: InpostSenderContactDto;
+}

--- a/libs/integrations/inpost/src/application/inpost-adapter.factory.ts
+++ b/libs/integrations/inpost/src/application/inpost-adapter.factory.ts
@@ -1,0 +1,96 @@
+/**
+ * InPost Adapter Factory
+ *
+ * Builds a per-connection `InpostShippingAdapter`: reads + defensively
+ * validates the connection config, resolves the ShipX Bearer token via the
+ * host `CredentialsResolverPort`, selects the environment base URL, and wires
+ * the HTTP client. Invoked from the plugin's `createCapabilityAdapter`. Config
+ * *shape* is enforced earlier by the connection-config validator at
+ * create/update time; this factory's checks are a runtime safety net that
+ * raises `InpostConfigException` on a malformed/under-provisioned connection.
+ *
+ * @module libs/integrations/inpost/src/application
+ */
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { CredentialsResolverPort } from '@openlinker/core/integrations';
+import { InpostConfigException } from '../domain/exceptions/inpost-config.exception';
+import type {
+  InpostConnectionConfig,
+  InpostEnvironment,
+} from '../domain/types/inpost-config.types';
+import { InpostEnvironmentValues } from '../domain/types/inpost-config.types';
+import type { InpostCredentials } from '../domain/types/inpost-credentials.types';
+import { InpostShippingAdapter } from '../infrastructure/adapters/inpost-shipping.adapter';
+import { InpostHttpClient } from '../infrastructure/http/inpost-http-client';
+
+const BASE_URLS: Readonly<Record<InpostEnvironment, string>> = {
+  sandbox: 'https://sandbox-api-shipx-pl.easypack24.net',
+  production: 'https://api-shipx-pl.easypack24.net',
+};
+
+export async function createInpostShippingAdapter(
+  connection: Connection,
+  credentialsResolver: CredentialsResolverPort,
+): Promise<InpostShippingAdapter> {
+  const config = extractConfig(connection);
+  const apiToken = await resolveApiToken(connection, credentialsResolver);
+  const client = new InpostHttpClient(BASE_URLS[config.environment], apiToken);
+  return new InpostShippingAdapter(client, config);
+}
+
+function extractConfig(connection: Connection): InpostConnectionConfig {
+  const raw = (connection.config ?? {}) as Record<string, unknown>;
+
+  const environment = raw.environment;
+  if (
+    typeof environment !== 'string' ||
+    !InpostEnvironmentValues.includes(environment as InpostEnvironment)
+  ) {
+    throw new InpostConfigException(
+      `Connection ${connection.id} has invalid or missing InPost environment`,
+      connection.id,
+    );
+  }
+
+  const organizationId = raw.organizationId;
+  if (typeof organizationId !== 'string' || organizationId.length === 0) {
+    throw new InpostConfigException(
+      `Connection ${connection.id} is missing organizationId`,
+      connection.id,
+    );
+  }
+
+  const senderAddress = raw.senderAddress;
+  if (typeof senderAddress !== 'object' || senderAddress === null) {
+    throw new InpostConfigException(
+      `Connection ${connection.id} is missing senderAddress`,
+      connection.id,
+    );
+  }
+
+  return {
+    environment: environment as InpostEnvironment,
+    organizationId,
+    senderAddress: senderAddress as InpostConnectionConfig['senderAddress'],
+  };
+}
+
+async function resolveApiToken(
+  connection: Connection,
+  credentialsResolver: CredentialsResolverPort,
+): Promise<string> {
+  if (!connection.credentialsRef) {
+    throw new InpostConfigException(
+      `Connection ${connection.id} has no credentialsRef`,
+      connection.id,
+    );
+  }
+  const credentials = await credentialsResolver.get<InpostCredentials>(connection.credentialsRef);
+  if (!credentials?.apiToken) {
+    throw new InpostConfigException(
+      `Connection ${connection.id} credentials are missing apiToken`,
+      connection.id,
+    );
+  }
+  return credentials.apiToken;
+}

--- a/libs/integrations/inpost/src/domain/exceptions/inpost-config.exception.ts
+++ b/libs/integrations/inpost/src/domain/exceptions/inpost-config.exception.ts
@@ -1,0 +1,21 @@
+/**
+ * InPost Config Exception
+ *
+ * Thrown when a connection's config or credentials are invalid or missing
+ * required fields (no `apiToken`, no `organizationId`, …). Distinct from
+ * `InpostValidationException`, which covers per-shipment/command validation.
+ *
+ * @module libs/integrations/inpost/src/domain/exceptions
+ */
+export class InpostConfigException extends Error {
+  constructor(
+    message: string,
+    public readonly connectionId?: string,
+  ) {
+    super(message);
+    this.name = 'InpostConfigException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InpostConfigException);
+    }
+  }
+}

--- a/libs/integrations/inpost/src/domain/exceptions/inpost-network.exception.ts
+++ b/libs/integrations/inpost/src/domain/exceptions/inpost-network.exception.ts
@@ -1,0 +1,18 @@
+/**
+ * InPost Network Exception
+ *
+ * Thrown for transient ShipX failures — `5xx`, timeouts, connection errors,
+ * and rate-limit (`429`) exhaustion after the HTTP client's retry budget.
+ * Transient → the job layer may retry.
+ *
+ * @module libs/integrations/inpost/src/domain/exceptions
+ */
+export class InpostNetworkException extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, { cause });
+    this.name = 'InpostNetworkException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InpostNetworkException);
+    }
+  }
+}

--- a/libs/integrations/inpost/src/domain/exceptions/inpost-unauthorized.exception.ts
+++ b/libs/integrations/inpost/src/domain/exceptions/inpost-unauthorized.exception.ts
@@ -1,0 +1,21 @@
+/**
+ * InPost Unauthorized Exception
+ *
+ * Thrown when ShipX rejects the request with `401 unauthorized` or
+ * `403 access_forbidden` — a bad/expired API token or insufficient token
+ * permissions. Not retryable.
+ *
+ * @module libs/integrations/inpost/src/domain/exceptions
+ */
+export class InpostUnauthorizedException extends Error {
+  constructor(
+    message: string,
+    public readonly connectionId?: string,
+  ) {
+    super(message);
+    this.name = 'InpostUnauthorizedException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InpostUnauthorizedException);
+    }
+  }
+}

--- a/libs/integrations/inpost/src/domain/exceptions/inpost-validation.exception.ts
+++ b/libs/integrations/inpost/src/domain/exceptions/inpost-validation.exception.ts
@@ -1,0 +1,22 @@
+/**
+ * InPost Validation Exception
+ *
+ * Thrown for ShipX `400 validation_failed` / `invalid_action` responses and
+ * for adapter-side pre-submit checks (unsupported `shippingMethod`, missing
+ * `paczkomatId` for a locker shipment, missing courier address). `details`
+ * mirrors the ShipX per-field error map (`{ field: code[] }`) when present.
+ *
+ * @module libs/integrations/inpost/src/domain/exceptions
+ */
+export class InpostValidationException extends Error {
+  constructor(
+    message: string,
+    public readonly details?: Record<string, readonly string[]>,
+  ) {
+    super(message);
+    this.name = 'InpostValidationException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InpostValidationException);
+    }
+  }
+}

--- a/libs/integrations/inpost/src/domain/exceptions/paczkomat-unavailable.exception.ts
+++ b/libs/integrations/inpost/src/domain/exceptions/paczkomat-unavailable.exception.ts
@@ -1,0 +1,22 @@
+/**
+ * Paczkomat Unavailable Exception
+ *
+ * Thrown when a selected paczkomat/locker is unknown or not currently
+ * available for a shipment (ShipX rejects `target_point`, or a points lookup
+ * yields no usable locker). Lets callers surface a "pick another locker"
+ * affordance distinct from a generic validation error.
+ *
+ * @module libs/integrations/inpost/src/domain/exceptions
+ */
+export class PaczkomatUnavailableException extends Error {
+  constructor(
+    message: string,
+    public readonly paczkomatId?: string,
+  ) {
+    super(message);
+    this.name = 'PaczkomatUnavailableException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PaczkomatUnavailableException);
+    }
+  }
+}

--- a/libs/integrations/inpost/src/domain/types/inpost-config.types.ts
+++ b/libs/integrations/inpost/src/domain/types/inpost-config.types.ts
@@ -1,0 +1,32 @@
+/**
+ * InPost Connection Config Types
+ *
+ * Non-secret per-connection configuration: the ShipX environment, the
+ * organization id (a URL path parameter on every shipment endpoint), and the
+ * sender contact used as the ShipX shipment `sender`. Validated at the
+ * boundary by the connection-config shape validator (`class-validator` DTO);
+ * `psModuleChoice` is intentionally NOT here in v1 — it's a #767/#771 concern
+ * and this adapter never reads it.
+ *
+ * @module libs/integrations/inpost/src/domain/types
+ */
+import type { ShipmentAddress } from '@openlinker/core/shipping';
+
+export const InpostEnvironmentValues = ['sandbox', 'production'] as const;
+export type InpostEnvironment = (typeof InpostEnvironmentValues)[number];
+
+/** Sender contact — maps to a ShipX `sender` Peer (with address). */
+export interface InpostSenderContact {
+  name?: string;
+  email: string;
+  phone: string;
+  address: ShipmentAddress;
+}
+
+export interface InpostConnectionConfig {
+  environment: InpostEnvironment;
+  /** ShipX organization id — URL path param on shipment endpoints. */
+  organizationId: string;
+  /** Sender — populates the ShipX `sender` Peer on every shipment. */
+  senderAddress: InpostSenderContact;
+}

--- a/libs/integrations/inpost/src/domain/types/inpost-credentials.types.ts
+++ b/libs/integrations/inpost/src/domain/types/inpost-credentials.types.ts
@@ -1,0 +1,15 @@
+/**
+ * InPost Credentials Types
+ *
+ * The secret half of an InPost connection — the ShipX Bearer API token
+ * generated in the InPost Manager portal (Moje Konto → API). Resolved via the
+ * host `CredentialsResolverPort` from `connection.credentialsRef`; never
+ * logged or returned in responses.
+ *
+ * @module libs/integrations/inpost/src/domain/types
+ */
+
+export interface InpostCredentials {
+  /** ShipX Bearer API token (long-lived, portal-generated). */
+  apiToken: string;
+}

--- a/libs/integrations/inpost/src/domain/types/inpost-shipx.types.ts
+++ b/libs/integrations/inpost/src/domain/types/inpost-shipx.types.ts
@@ -1,0 +1,109 @@
+/**
+ * ShipX Wire Types
+ *
+ * Verbatim shapes for the InPost ShipX REST endpoints this adapter calls —
+ * create shipment (simplified mode), label, cancel, tracking, points, and the
+ * error body. Verified against the official ShipX EN docs
+ * (dokumentacja-inpost.atlassian.net). Translated to/from the carrier-neutral
+ * `@openlinker/core/shipping` types by `inpost-shipx.mapper.ts` — these wire
+ * types never leak past the mapper/adapter boundary.
+ *
+ * @module libs/integrations/inpost/src/domain/types
+ */
+
+export const ShipXServiceValues = [
+  'inpost_locker_standard',
+  'inpost_courier_standard',
+] as const;
+export type ShipXService = (typeof ShipXServiceValues)[number];
+
+export interface ShipXAddress {
+  street: string;
+  building_number: string;
+  city: string;
+  post_code: string;
+  country_code: string;
+}
+
+export interface ShipXPeer {
+  company_name?: string;
+  first_name?: string;
+  last_name?: string;
+  email: string;
+  phone: string;
+  /** Omitted for locker shipments (addressed by `target_point`). */
+  address?: ShipXAddress;
+}
+
+/** Locker parcel — a single size template (ShipX `parcels` is an object). */
+export interface ShipXLockerParcel {
+  template: string;
+}
+
+/** Courier parcel — explicit dims + weight (ShipX `parcels` is an array). */
+export interface ShipXCourierParcel {
+  dimensions: { length: string; width: string; height: string; unit: 'mm' };
+  weight: { amount: string; unit: 'kg' };
+  is_non_standard?: boolean;
+}
+
+export interface ShipXCreateShipmentRequest {
+  sender: ShipXPeer;
+  receiver: ShipXPeer;
+  parcels: ShipXLockerParcel | readonly ShipXCourierParcel[];
+  service: ShipXService;
+  /** Stamped with the internal `ol_shipment_*` id for traceability. */
+  reference?: string;
+  custom_attributes?: {
+    sending_method?: string;
+    /** Target paczkomat/locker id (e.g. `'BTO02M'`). */
+    target_point?: string;
+  };
+}
+
+/** Create-shipment response + the shipment-by-id resource (`GET /v1/shipments/:id`). */
+export interface ShipXShipment {
+  id: number;
+  status: string;
+  tracking_number: string | null;
+}
+
+export interface ShipXTrackingDetail {
+  status: string;
+  origin_status?: string;
+  datetime?: string;
+}
+
+export interface ShipXTrackingResponse {
+  tracking_number: string;
+  status: string;
+  tracking_details?: readonly ShipXTrackingDetail[];
+}
+
+export interface ShipXPoint {
+  /** Locker code (e.g. `'POZ08A'`). */
+  name: string;
+  type?: readonly string[] | string;
+  status?: string;
+  location?: { latitude: number; longitude: number };
+  address?: { line1?: string; line2?: string };
+  address_details?: {
+    city?: string;
+    post_code?: string;
+    street?: string;
+    building_number?: string;
+  };
+  opening_hours?: string;
+}
+
+export interface ShipXPointsResponse {
+  items: readonly ShipXPoint[];
+}
+
+/** ShipX error body — `error` is the machine key (`validation_failed`, `unauthorized`, …). */
+export interface ShipXErrorBody {
+  status?: number;
+  error?: string;
+  message?: string;
+  details?: Record<string, readonly string[]>;
+}

--- a/libs/integrations/inpost/src/index.ts
+++ b/libs/integrations/inpost/src/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @openlinker/integrations-inpost — Public Barrel
+ *
+ * InPost ShipX shipping adapter plugin. The runtime entry the host composes is
+ * `inpostIntegrationModule` (added with the plugin descriptor); this barrel
+ * also exports the static `inpostAdapterManifest` and the domain exceptions
+ * for host-side error handling.
+ *
+ * @module libs/integrations/inpost/src
+ */
+
+// Domain exceptions
+export { InpostConfigException } from './domain/exceptions/inpost-config.exception';
+export { InpostUnauthorizedException } from './domain/exceptions/inpost-unauthorized.exception';
+export { InpostValidationException } from './domain/exceptions/inpost-validation.exception';
+export { PaczkomatUnavailableException } from './domain/exceptions/paczkomat-unavailable.exception';
+export { InpostNetworkException } from './domain/exceptions/inpost-network.exception';
+
+// Config + credentials types
+export { InpostEnvironmentValues } from './domain/types/inpost-config.types';
+export type {
+  InpostEnvironment,
+  InpostConnectionConfig,
+  InpostSenderContact,
+} from './domain/types/inpost-config.types';
+export type { InpostCredentials } from './domain/types/inpost-credentials.types';
+
+// Plugin descriptor + host wiring
+export { inpostAdapterManifest, createInpostPlugin } from './inpost-plugin';
+export { InpostIntegrationModule } from './inpost-integration.module';

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-connection-config-shape-validator.adapter.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * InPost Connection Config Shape Validator — unit tests
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters
+ */
+import { InvalidConnectionConfigException } from '@openlinker/core/integrations';
+import { InpostConnectionConfigShapeValidatorAdapter } from '../inpost-connection-config-shape-validator.adapter';
+
+const validConfig: Record<string, unknown> = {
+  environment: 'sandbox',
+  organizationId: 'org-123',
+  senderAddress: {
+    name: 'Shop',
+    email: 'shop@example.com',
+    phone: '321321321',
+    address: {
+      street: 'Czerniakowska',
+      buildingNumber: '87A',
+      city: 'Warszawa',
+      postCode: '00-718',
+      countryCode: 'PL',
+    },
+  },
+};
+
+describe('InpostConnectionConfigShapeValidatorAdapter', () => {
+  const validator = new InpostConnectionConfigShapeValidatorAdapter('InPost');
+
+  it('should resolve for a well-formed config', async () => {
+    await expect(validator.validate(validConfig)).resolves.toBeUndefined();
+  });
+
+  it('should throw when organizationId is missing', async () => {
+    const config = { environment: validConfig.environment, senderAddress: validConfig.senderAddress };
+    await expect(validator.validate(config)).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+
+  it('should throw for an invalid environment', async () => {
+    await expect(validator.validate({ ...validConfig, environment: 'staging' })).rejects.toBeInstanceOf(
+      InvalidConnectionConfigException,
+    );
+  });
+
+  it('should throw for a malformed sender post code', async () => {
+    const config = {
+      ...validConfig,
+      senderAddress: {
+        ...(validConfig.senderAddress as Record<string, unknown>),
+        address: {
+          street: 'Czerniakowska',
+          buildingNumber: '87A',
+          city: 'Warszawa',
+          postCode: '0071',
+          countryCode: 'PL',
+        },
+      },
+    };
+    await expect(validator.validate(config)).rejects.toBeInstanceOf(InvalidConnectionConfigException);
+  });
+});

--- a/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-shipping.adapter.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/__tests__/inpost-shipping.adapter.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * InPost Shipping Adapter — unit tests
+ *
+ * Mocks `IInpostHttpClient` (per engineering-standards: mock the port, not a
+ * real transport). Verifies request shape, response mapping, the
+ * paczkomat-unavailable re-tag, and the unknown-status fallback.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters
+ */
+import type { GenerateLabelCommand } from '@openlinker/core/shipping';
+import type { InpostConnectionConfig } from '../../../domain/types/inpost-config.types';
+import type { IInpostHttpClient } from '../../http/inpost-http-client.interface';
+import { InpostUnauthorizedException } from '../../../domain/exceptions/inpost-unauthorized.exception';
+import { InpostValidationException } from '../../../domain/exceptions/inpost-validation.exception';
+import { PaczkomatUnavailableException } from '../../../domain/exceptions/paczkomat-unavailable.exception';
+import { InpostShippingAdapter } from '../inpost-shipping.adapter';
+
+const config: InpostConnectionConfig = {
+  environment: 'sandbox',
+  organizationId: 'org-123',
+  senderAddress: {
+    name: 'Shop',
+    email: 'shop@example.com',
+    phone: '321321321',
+    address: {
+      street: 'Czerniakowska',
+      buildingNumber: '87A',
+      city: 'Warszawa',
+      postCode: '00-718',
+      countryCode: 'PL',
+    },
+  },
+};
+
+const paczkomatCmd: GenerateLabelCommand = {
+  shipmentId: 'ol_shipment_abc',
+  orderId: 'ol_order_xyz',
+  connectionId: 'conn-1',
+  shippingMethod: 'paczkomat',
+  paczkomatId: 'POZ08A',
+  recipient: { email: 'buyer@example.com', phone: '111222333' },
+  parcel: { template: 'small' },
+};
+
+const courierCmd: GenerateLabelCommand = {
+  shipmentId: 'ol_shipment_def',
+  orderId: 'ol_order_uvw',
+  connectionId: 'conn-1',
+  shippingMethod: 'kurier',
+  recipient: {
+    firstName: 'Jan',
+    lastName: 'Kowalski',
+    email: 'buyer@example.com',
+    phone: '888000000',
+    address: {
+      street: 'Cybernetyki',
+      buildingNumber: '10',
+      city: 'Warszawa',
+      postCode: '02-677',
+      countryCode: 'PL',
+    },
+  },
+  parcel: { dimensions: { length: 80, width: 360, height: 640 }, weightGrams: 2500 },
+};
+
+function makeAdapter(): { adapter: InpostShippingAdapter; request: jest.Mock } {
+  const request = jest.fn();
+  const http = { request } as unknown as IInpostHttpClient;
+  return { adapter: new InpostShippingAdapter(http, config), request };
+}
+
+describe('InpostShippingAdapter', () => {
+  describe('getSupportedMethods', () => {
+    it('should return paczkomat and kurier', () => {
+      const { adapter } = makeAdapter();
+      expect(adapter.getSupportedMethods()).toEqual(['paczkomat', 'kurier']);
+    });
+  });
+
+  describe('generateLabel', () => {
+    it('should POST to the org shipments endpoint and map the response', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockResolvedValueOnce({ id: 1234, status: 'created', tracking_number: null });
+
+      const result = await adapter.generateLabel(paczkomatCmd);
+
+      expect(request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'POST',
+          path: '/v1/organizations/org-123/shipments',
+          body: expect.objectContaining({
+            service: 'inpost_locker_standard',
+            reference: 'ol_shipment_abc',
+          }),
+        }),
+      );
+      expect(result).toEqual({
+        providerShipmentId: '1234',
+        trackingNumber: null,
+        labelPdfRef: 'shipx:label:1234',
+      });
+    });
+
+    it('should POST a courier shipment with the courier service', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockResolvedValueOnce({ id: 5, status: 'created', tracking_number: null });
+
+      await adapter.generateLabel(courierCmd);
+
+      expect(request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.objectContaining({ service: 'inpost_courier_standard' }),
+        }),
+      );
+    });
+
+    it('should re-tag a target_point validation error as PaczkomatUnavailableException', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockRejectedValueOnce(
+        new InpostValidationException('invalid target_point', { target_point: ['invalid'] }),
+      );
+
+      await expect(adapter.generateLabel(paczkomatCmd)).rejects.toBeInstanceOf(
+        PaczkomatUnavailableException,
+      );
+    });
+
+    it('should rethrow non-paczkomat errors unchanged', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockRejectedValueOnce(new InpostUnauthorizedException('bad token'));
+
+      await expect(adapter.generateLabel(paczkomatCmd)).rejects.toBeInstanceOf(
+        InpostUnauthorizedException,
+      );
+    });
+  });
+
+  describe('getTracking', () => {
+    it('should map a known ShipX status to its OL bucket', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockResolvedValueOnce({ id: 1, status: 'delivered', tracking_number: 'X' });
+
+      const snapshot = await adapter.getTracking({ providerShipmentId: '1' });
+
+      expect(request).toHaveBeenCalledWith({ method: 'GET', path: '/v1/shipments/1' });
+      expect(snapshot).toEqual({ status: 'delivered', providerStatus: 'delivered' });
+    });
+
+    it('should fall back to in-transit for an unknown ShipX status', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockResolvedValueOnce({ id: 1, status: 'weird_code', tracking_number: null });
+
+      const snapshot = await adapter.getTracking({ providerShipmentId: '1' });
+
+      expect(snapshot).toEqual({ status: 'in-transit', providerStatus: 'weird_code' });
+    });
+  });
+
+  describe('cancelShipment', () => {
+    it('should DELETE the shipment by id', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockResolvedValueOnce(undefined);
+
+      await adapter.cancelShipment({ providerShipmentId: 'abc' });
+
+      expect(request).toHaveBeenCalledWith({ method: 'DELETE', path: '/v1/shipments/abc' });
+    });
+  });
+
+  describe('findPickupPoints', () => {
+    it('should query /v1/points and map the items', async () => {
+      const { adapter, request } = makeAdapter();
+      request.mockResolvedValueOnce({
+        items: [{ name: 'POZ08A', status: 'Operating', address_details: { city: 'Poznań' } }],
+      });
+
+      const points = await adapter.findPickupPoints({ city: 'Poznań' });
+
+      expect(request).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'GET', path: '/v1/points' }),
+      );
+      expect(points).toHaveLength(1);
+      expect(points[0].providerId).toBe('POZ08A');
+    });
+  });
+});

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-connection-config-shape-validator.adapter.ts
@@ -1,0 +1,40 @@
+/**
+ * InPost Connection Config Shape Validator Adapter
+ *
+ * Implements `ConnectionConfigShapeValidatorPort` for the InPost adapter.
+ * Runs `class-validator` against `InpostConnectionConfigDto` and throws
+ * `InvalidConnectionConfigException` carrying the flattened error list on
+ * failure. The host's `ConnectionService` maps that to `BadRequestException`
+ * at the API boundary — the plugin never depends on `@nestjs/common`.
+ *
+ * Registered with `host.connectionConfigShapeValidatorRegistry` at boot via
+ * `createInpostPlugin().register(host)`.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters
+ * @implements {ConnectionConfigShapeValidatorPort}
+ */
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import type { ConnectionConfigShapeValidatorPort } from '@openlinker/core/integrations';
+import {
+  InvalidConnectionConfigException,
+  flattenValidationErrors,
+} from '@openlinker/core/integrations';
+import { InpostConnectionConfigDto } from '../../application/dto/inpost-connection-config.dto';
+
+export class InpostConnectionConfigShapeValidatorAdapter
+  implements ConnectionConfigShapeValidatorPort
+{
+  constructor(private readonly pluginName: string = 'InPost') {}
+
+  async validate(config: Record<string, unknown>): Promise<void> {
+    const instance = plainToInstance(InpostConnectionConfigDto, config);
+    // `whitelist: false` — the persisted config may carry adjacent keys
+    // (e.g. future `psModuleChoice`) outside this DTO; validate shape on what
+    // the DTO describes, not exhaustive ownership of the blob.
+    const errors = await validate(instance, { whitelist: false, forbidNonWhitelisted: false });
+    if (errors.length > 0) {
+      throw new InvalidConnectionConfigException(this.pluginName, flattenValidationErrors(errors));
+    }
+  }
+}

--- a/libs/integrations/inpost/src/infrastructure/adapters/inpost-shipping.adapter.ts
+++ b/libs/integrations/inpost/src/infrastructure/adapters/inpost-shipping.adapter.ts
@@ -1,0 +1,122 @@
+/**
+ * InPost Shipping Adapter
+ *
+ * Implements the core `ShippingProviderManagerPort` plus the `ShipmentCanceller`
+ * and `PickupPointFinder` sub-capabilities against the InPost ShipX REST API.
+ * Thin orchestration only: it delegates wire translation to `inpost-shipx.mapper`
+ * and HTTP/retry/error-mapping to `IInpostHttpClient`. Persistence + idempotency
+ * are the caller's concern (the job layer) — this adapter just talks to ShipX.
+ *
+ * Class name is deliberately shortened from the `{Platform}{Capability}Adapter`
+ * rule's `InpostShippingProviderManagerAdapter` (the capability name is
+ * unwieldy; the short form matches #764/#765 and the shipping-domain vocabulary).
+ *
+ * @module libs/integrations/inpost/src/infrastructure/adapters
+ */
+import { Logger } from '@openlinker/shared/logging';
+import type {
+  ShippingProviderManagerPort,
+  ShipmentCanceller,
+  PickupPointFinder,
+  GenerateLabelCommand,
+  GenerateLabelResult,
+  TrackingSnapshot,
+  ShippingMethod,
+  PickupPoint,
+  FindPickupPointsQuery,
+} from '@openlinker/core/shipping';
+import type { InpostConnectionConfig } from '../../domain/types/inpost-config.types';
+import type { ShipXPointsResponse, ShipXShipment } from '../../domain/types/inpost-shipx.types';
+import { InpostValidationException } from '../../domain/exceptions/inpost-validation.exception';
+import { PaczkomatUnavailableException } from '../../domain/exceptions/paczkomat-unavailable.exception';
+import type { IInpostHttpClient } from '../http/inpost-http-client.interface';
+import {
+  buildCreateShipmentRequest,
+  buildPointsQuery,
+  mapShipXStatus,
+  toGenerateLabelResult,
+  toPickupPoint,
+  toTrackingSnapshot,
+} from '../mappers/inpost-shipx.mapper';
+
+const SUPPORTED_METHODS: readonly ShippingMethod[] = ['paczkomat', 'kurier'];
+
+export class InpostShippingAdapter
+  implements ShippingProviderManagerPort, ShipmentCanceller, PickupPointFinder
+{
+  private readonly logger = new Logger(InpostShippingAdapter.name);
+
+  constructor(
+    private readonly http: IInpostHttpClient,
+    private readonly config: InpostConnectionConfig,
+  ) {}
+
+  getSupportedMethods(): readonly ShippingMethod[] {
+    return SUPPORTED_METHODS;
+  }
+
+  async generateLabel(cmd: GenerateLabelCommand): Promise<GenerateLabelResult> {
+    const body = buildCreateShipmentRequest(cmd, this.config);
+    let shipment: ShipXShipment;
+    try {
+      shipment = await this.http.request<ShipXShipment>({
+        method: 'POST',
+        path: `/v1/organizations/${this.config.organizationId}/shipments`,
+        body,
+      });
+    } catch (error) {
+      // ShipX rejecting the chosen locker surfaces as a generic validation
+      // error; re-tag it so callers can offer "pick another locker".
+      if (
+        error instanceof InpostValidationException &&
+        cmd.paczkomatId &&
+        mentionsTargetPoint(error)
+      ) {
+        throw new PaczkomatUnavailableException(error.message, cmd.paczkomatId);
+      }
+      throw error;
+    }
+    return toGenerateLabelResult(shipment);
+  }
+
+  async getTracking(input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
+    const shipment = await this.http.request<ShipXShipment>({
+      method: 'GET',
+      path: `/v1/shipments/${input.providerShipmentId}`,
+    });
+    const mapped = mapShipXStatus(shipment.status);
+    if (mapped === null) {
+      this.logger.warn(
+        `Unknown ShipX status '${shipment.status}' for shipment ${input.providerShipmentId}; treating as in-transit`,
+      );
+      return toTrackingSnapshot('in-transit', shipment.status);
+    }
+    return toTrackingSnapshot(mapped, shipment.status);
+  }
+
+  async cancelShipment(input: { providerShipmentId: string }): Promise<void> {
+    // ShipX only permits cancellation pre-confirmation; once confirmed it
+    // returns `invalid_action`, which the HTTP client maps to
+    // InpostValidationException for the caller to handle (best-effort cancel).
+    await this.http.request<void>({
+      method: 'DELETE',
+      path: `/v1/shipments/${input.providerShipmentId}`,
+    });
+  }
+
+  async findPickupPoints(query: FindPickupPointsQuery): Promise<PickupPoint[]> {
+    const response = await this.http.request<ShipXPointsResponse>({
+      method: 'GET',
+      path: '/v1/points',
+      query: buildPointsQuery(query),
+    });
+    return (response.items ?? []).map(toPickupPoint);
+  }
+}
+
+function mentionsTargetPoint(error: InpostValidationException): boolean {
+  if (error.details && Object.keys(error.details).includes('target_point')) {
+    return true;
+  }
+  return /target_point|paczkomat/i.test(error.message);
+}

--- a/libs/integrations/inpost/src/infrastructure/http/__tests__/inpost-http-client.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/__tests__/inpost-http-client.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * InPost ShipX HTTP Client — unit tests
+ *
+ * Stubs `global.fetch` to verify the retry loop, the HTTP-status → domain
+ * exception classification, and the success/204 paths. Retry delays are tuned
+ * to ~1ms so the suite stays fast.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/http
+ */
+import { InpostUnauthorizedException } from '../../../domain/exceptions/inpost-unauthorized.exception';
+import { InpostValidationException } from '../../../domain/exceptions/inpost-validation.exception';
+import { InpostNetworkException } from '../../../domain/exceptions/inpost-network.exception';
+import { InpostHttpClient } from '../inpost-http-client';
+
+interface FakeResponseInit {
+  ok: boolean;
+  status: number;
+  body?: string;
+  retryAfter?: string;
+}
+
+function fakeResponse(init: FakeResponseInit): Response {
+  return {
+    ok: init.ok,
+    status: init.status,
+    headers: {
+      get: (name: string): string | null =>
+        name.toLowerCase() === 'retry-after' ? (init.retryAfter ?? null) : null,
+    },
+    text: (): Promise<string> => Promise.resolve(init.body ?? ''),
+  } as unknown as Response;
+}
+
+const originalFetch = global.fetch;
+
+describe('InpostHttpClient', () => {
+  let fetchMock: jest.Mock;
+  let client: InpostHttpClient;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    client = new InpostHttpClient('https://sandbox-api-shipx-pl.easypack24.net', 'test-token', {
+      maxRetries: 2,
+      initialDelayMs: 1,
+      backoffMultiplier: 1,
+      maxDelayMs: 1,
+    });
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('should parse a 2xx JSON body and attach the Bearer token', async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"id":1}' }));
+
+    const result = await client.request<{ id: number }>({ method: 'GET', path: '/v1/shipments/1' });
+
+    expect(result).toEqual({ id: 1 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://sandbox-api-shipx-pl.easypack24.net/v1/shipments/1',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+      }),
+    );
+  });
+
+  it('should resolve undefined for a 204 No Content response', async () => {
+    fetchMock.mockResolvedValueOnce(fakeResponse({ ok: true, status: 204 }));
+
+    await expect(
+      client.request<void>({ method: 'DELETE', path: '/v1/shipments/abc' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should map 401 to InpostUnauthorizedException without retrying', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ ok: false, status: 401, body: '{"error":"unauthorized","message":"bad token"}' }),
+    );
+
+    await expect(client.request({ method: 'GET', path: '/v1/x' })).rejects.toBeInstanceOf(
+      InpostUnauthorizedException,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should map other 4xx to InpostValidationException with details, no retry', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 400,
+        body: '{"error":"validation_failed","message":"x","details":{"name":["required"]}}',
+      }),
+    );
+
+    const error = await client
+      .request({ method: 'POST', path: '/v1/x' })
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(InpostValidationException);
+    expect((error as InpostValidationException).details).toEqual({ name: ['required'] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry a 429 and then succeed', async () => {
+    fetchMock
+      .mockResolvedValueOnce(fakeResponse({ ok: false, status: 429, retryAfter: '0', body: '{}' }))
+      .mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"ok":true}' }));
+
+    await expect(client.request({ method: 'GET', path: '/v1/x' })).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should retry a 5xx and then succeed', async () => {
+    fetchMock
+      .mockResolvedValueOnce(fakeResponse({ ok: false, status: 503, body: '{}' }))
+      .mockResolvedValueOnce(fakeResponse({ ok: true, status: 200, body: '{"ok":true}' }));
+
+    await expect(client.request({ method: 'GET', path: '/v1/x' })).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should surface InpostNetworkException after exhausting retries on persistent 429', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ ok: false, status: 429, retryAfter: '0', body: '{}' }),
+    );
+
+    await expect(client.request({ method: 'GET', path: '/v1/x' })).rejects.toBeInstanceOf(
+      InpostNetworkException,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it('should surface InpostNetworkException after exhausting retries on network errors', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+
+    await expect(client.request({ method: 'GET', path: '/v1/x' })).rejects.toBeInstanceOf(
+      InpostNetworkException,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.interface.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.interface.ts
@@ -1,0 +1,32 @@
+/**
+ * InPost HTTP Client Port
+ *
+ * Narrow transport contract the adapter codes against. Keeping it an interface
+ * (not the concrete client) lets adapter unit specs mock ShipX HTTP without a
+ * real `fetch`, per engineering-standards §"Interface and Implementation
+ * Separation".
+ *
+ * @module libs/integrations/inpost/src/infrastructure/http
+ */
+
+export type InpostHttpMethod = 'GET' | 'POST' | 'DELETE';
+
+export interface InpostRequestOptions {
+  method: InpostHttpMethod;
+  /** Absolute path on the ShipX host, e.g. `/v1/organizations/{org}/shipments`. */
+  path: string;
+  /** Query params; `undefined` values are dropped. */
+  query?: Record<string, string | number | boolean | undefined>;
+  /** JSON request body (serialised by the client). */
+  body?: unknown;
+}
+
+export interface IInpostHttpClient {
+  /**
+   * Issue a ShipX request. Resolves with the parsed JSON body (or `undefined`
+   * for `204`). Throws a mapped domain exception on failure
+   * (`InpostUnauthorizedException` / `InpostValidationException` /
+   * `InpostNetworkException`).
+   */
+  request<T>(options: InpostRequestOptions): Promise<T>;
+}

--- a/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.ts
+++ b/libs/integrations/inpost/src/infrastructure/http/inpost-http-client.ts
@@ -1,0 +1,192 @@
+/**
+ * InPost ShipX HTTP Client
+ *
+ * Native-`fetch` transport for the ShipX REST API (mirrors `AllegroHttpClient`
+ * — the established in-tree precedent; no axios). Attaches the static Bearer
+ * API token, applies a jittered retry loop for `429` / `5xx` / network errors
+ * (respecting `Retry-After`), enforces a request timeout, and maps ShipX error
+ * bodies to domain exceptions. Non-retryable `4xx` (401/403 → unauthorized,
+ * other → validation) throw immediately; retryable failures that exhaust the
+ * budget surface as `InpostNetworkException`.
+ *
+ * @module libs/integrations/inpost/src/infrastructure/http
+ */
+import { randomUUID } from 'node:crypto';
+import { Logger } from '@openlinker/shared/logging';
+import type { ShipXErrorBody } from '../../domain/types/inpost-shipx.types';
+import { InpostUnauthorizedException } from '../../domain/exceptions/inpost-unauthorized.exception';
+import { InpostValidationException } from '../../domain/exceptions/inpost-validation.exception';
+import { InpostNetworkException } from '../../domain/exceptions/inpost-network.exception';
+import type { IInpostHttpClient, InpostRequestOptions } from './inpost-http-client.interface';
+
+interface RetryConfig {
+  maxRetries: number;
+  initialDelayMs: number;
+  backoffMultiplier: number;
+  maxDelayMs: number;
+}
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  initialDelayMs: 500,
+  backoffMultiplier: 2,
+  maxDelayMs: 8000,
+};
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Internal marker for retryable transport failures (429 / 5xx / network).
+ * Never escapes the client — the retry loop converts it to
+ * `InpostNetworkException` once the budget is exhausted.
+ */
+class RetryableHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly retryAfterMs?: number,
+  ) {
+    super(message);
+    this.name = 'RetryableHttpError';
+  }
+}
+
+export class InpostHttpClient implements IInpostHttpClient {
+  private readonly logger = new Logger(InpostHttpClient.name);
+  private readonly retryConfig: RetryConfig;
+
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiToken: string,
+    retryConfig?: Partial<RetryConfig>,
+  ) {
+    this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+  }
+
+  async request<T>(options: InpostRequestOptions): Promise<T> {
+    const requestId = randomUUID();
+    let delay = this.retryConfig.initialDelayMs;
+
+    for (let attempt = 0; attempt <= this.retryConfig.maxRetries; attempt++) {
+      try {
+        return await this.executeOnce<T>(options);
+      } catch (error) {
+        if (!(error instanceof RetryableHttpError)) {
+          throw error;
+        }
+        if (attempt === this.retryConfig.maxRetries) {
+          throw new InpostNetworkException(error.message, error);
+        }
+        const waitMs = error.retryAfterMs ?? this.jitter(delay);
+        this.logger.warn(
+          `ShipX ${options.method} ${options.path} failed (attempt ${attempt + 1}/${this.retryConfig.maxRetries + 1}); retrying in ${waitMs}ms [requestId=${requestId}]`,
+        );
+        await this.sleep(waitMs);
+        delay = Math.min(delay * this.retryConfig.backoffMultiplier, this.retryConfig.maxDelayMs);
+      }
+    }
+
+    // Unreachable: the final attempt either returns or throws above.
+    throw new InpostNetworkException('ShipX request exhausted its retry budget');
+  }
+
+  private async executeOnce<T>(options: InpostRequestOptions): Promise<T> {
+    const url = this.buildUrl(options.path, options.query);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: options.method,
+        headers: {
+          Authorization: `Bearer ${this.apiToken}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      throw new RetryableHttpError(`ShipX network error: ${(error as Error).message}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (response.ok) {
+      if (response.status === 204) {
+        return undefined as T;
+      }
+      const text = await response.text();
+      if (!text) {
+        return undefined as T;
+      }
+      try {
+        const data: unknown = JSON.parse(text);
+        return data as T;
+      } catch (error) {
+        throw new InpostNetworkException('ShipX returned an unparseable response body', error);
+      }
+    }
+
+    const errorBody = await this.safeParseError(response);
+    const message =
+      errorBody?.message ?? `ShipX ${options.method} ${options.path} failed (${response.status})`;
+
+    if (response.status === 401 || response.status === 403) {
+      throw new InpostUnauthorizedException(message);
+    }
+    if (response.status === 429) {
+      throw new RetryableHttpError(
+        message,
+        response.status,
+        parseRetryAfterMs(response.headers.get('retry-after')),
+      );
+    }
+    if (response.status >= 500) {
+      throw new RetryableHttpError(message, response.status);
+    }
+    throw new InpostValidationException(message, errorBody?.details);
+  }
+
+  private buildUrl(path: string, query?: InpostRequestOptions['query']): string {
+    const url = new URL(path, this.baseUrl);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+    return url.toString();
+  }
+
+  private async safeParseError(response: Response): Promise<ShipXErrorBody | undefined> {
+    try {
+      const text = await response.text();
+      if (!text) {
+        return undefined;
+      }
+      const data: unknown = JSON.parse(text);
+      return data as ShipXErrorBody;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private jitter(delayMs: number): number {
+    return Math.round(delayMs * (0.5 + Math.random() * 0.5));
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) {
+    return undefined;
+  }
+  const seconds = Number(header);
+  return Number.isFinite(seconds) ? seconds * 1000 : undefined;
+}

--- a/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/__tests__/inpost-shipx.mapper.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * InPost ShipX Mapper — unit tests
+ *
+ * @module libs/integrations/inpost/src/infrastructure/mappers
+ */
+import type { GenerateLabelCommand } from '@openlinker/core/shipping';
+import type { InpostConnectionConfig } from '../../../domain/types/inpost-config.types';
+import type {
+  ShipXCourierParcel,
+  ShipXLockerParcel,
+  ShipXPoint,
+} from '../../../domain/types/inpost-shipx.types';
+import { InpostValidationException } from '../../../domain/exceptions/inpost-validation.exception';
+import {
+  buildCreateShipmentRequest,
+  buildPointsQuery,
+  mapShipXStatus,
+  toGenerateLabelResult,
+  toPickupPoint,
+} from '../inpost-shipx.mapper';
+
+const config: InpostConnectionConfig = {
+  environment: 'sandbox',
+  organizationId: 'org-123',
+  senderAddress: {
+    name: 'Shop',
+    email: 'shop@example.com',
+    phone: '321321321',
+    address: {
+      street: 'Czerniakowska',
+      buildingNumber: '87A',
+      city: 'Warszawa',
+      postCode: '00-718',
+      countryCode: 'PL',
+    },
+  },
+};
+
+const paczkomatCmd: GenerateLabelCommand = {
+  shipmentId: 'ol_shipment_abc',
+  orderId: 'ol_order_xyz',
+  connectionId: 'conn-1',
+  shippingMethod: 'paczkomat',
+  paczkomatId: 'POZ08A',
+  recipient: { email: 'buyer@example.com', phone: '111222333' },
+  parcel: { template: 'small' },
+};
+
+const courierCmd: GenerateLabelCommand = {
+  shipmentId: 'ol_shipment_def',
+  orderId: 'ol_order_uvw',
+  connectionId: 'conn-1',
+  shippingMethod: 'kurier',
+  recipient: {
+    firstName: 'Jan',
+    lastName: 'Kowalski',
+    email: 'buyer@example.com',
+    phone: '888000000',
+    address: {
+      street: 'Cybernetyki',
+      buildingNumber: '10',
+      city: 'Warszawa',
+      postCode: '02-677',
+      countryCode: 'PL',
+    },
+  },
+  parcel: { dimensions: { length: 80, width: 360, height: 640 }, weightGrams: 2500 },
+};
+
+describe('inpost-shipx.mapper', () => {
+  describe('buildCreateShipmentRequest', () => {
+    it('should build a locker request with object parcel and target_point when method is paczkomat', () => {
+      const request = buildCreateShipmentRequest(paczkomatCmd, config);
+
+      expect(request.service).toBe('inpost_locker_standard');
+      expect(request.reference).toBe('ol_shipment_abc');
+      expect(request.custom_attributes?.target_point).toBe('POZ08A');
+      expect(request.custom_attributes?.sending_method).toBe('dispatch_order');
+      expect((request.parcels as ShipXLockerParcel).template).toBe('small');
+      // Locker receiver carries no address (addressed by the locker).
+      expect(request.receiver.address).toBeUndefined();
+      expect(request.sender.address?.building_number).toBe('87A');
+    });
+
+    it('should build a courier request with array parcel and receiver address when method is kurier', () => {
+      const request = buildCreateShipmentRequest(courierCmd, config);
+
+      expect(request.service).toBe('inpost_courier_standard');
+      expect(Array.isArray(request.parcels)).toBe(true);
+      const parcel = (request.parcels as ShipXCourierParcel[])[0];
+      expect(parcel.dimensions).toEqual({ length: '80', width: '360', height: '640', unit: 'mm' });
+      expect(parcel.weight).toEqual({ amount: '2.50', unit: 'kg' });
+      expect(request.receiver.address?.post_code).toBe('02-677');
+    });
+
+    it('should throw InpostValidationException when paczkomat shipment lacks paczkomatId', () => {
+      expect(() => buildCreateShipmentRequest({ ...paczkomatCmd, paczkomatId: undefined }, config)).toThrow(
+        InpostValidationException,
+      );
+    });
+
+    it('should throw InpostValidationException when paczkomat shipment lacks a parcel template', () => {
+      expect(() =>
+        buildCreateShipmentRequest({ ...paczkomatCmd, parcel: {} }, config),
+      ).toThrow(InpostValidationException);
+    });
+
+    it('should throw InpostValidationException when courier shipment lacks a recipient address', () => {
+      expect(() =>
+        buildCreateShipmentRequest(
+          { ...courierCmd, recipient: { ...courierCmd.recipient, address: undefined } },
+          config,
+        ),
+      ).toThrow(InpostValidationException);
+    });
+
+    it('should throw InpostValidationException when courier shipment lacks dimensions or weight', () => {
+      expect(() =>
+        buildCreateShipmentRequest({ ...courierCmd, parcel: { template: 'small' } }, config),
+      ).toThrow(InpostValidationException);
+    });
+  });
+
+  describe('mapShipXStatus', () => {
+    it.each([
+      ['confirmed', 'generated'],
+      ['dispatched_by_sender', 'dispatched'],
+      ['out_for_delivery', 'in-transit'],
+      ['delivered', 'delivered'],
+      ['canceled', 'cancelled'],
+      ['returned_to_sender', 'failed'],
+    ])('should map ShipX status %s to OL bucket %s', (raw, expected) => {
+      expect(mapShipXStatus(raw)).toBe(expected);
+    });
+
+    it('should return null for an unknown ShipX status', () => {
+      expect(mapShipXStatus('totally_unknown_code')).toBeNull();
+    });
+  });
+
+  describe('toGenerateLabelResult', () => {
+    it('should stringify the id, pass through tracking_number, and build the label ref', () => {
+      const result = toGenerateLabelResult({ id: 1234, status: 'created', tracking_number: null });
+      expect(result).toEqual({
+        providerShipmentId: '1234',
+        trackingNumber: null,
+        labelPdfRef: 'shipx:label:1234',
+      });
+    });
+  });
+
+  describe('toPickupPoint', () => {
+    it('should map a ShipX point to the neutral PickupPoint', () => {
+      const point: ShipXPoint = {
+        name: 'POZ08A',
+        status: 'Operating',
+        location: { latitude: 52.4, longitude: 16.9 },
+        address: { line1: 'Główna 1', line2: 'paczkomat' },
+        address_details: { city: 'Poznań', post_code: '60-001', street: 'Główna', building_number: '1' },
+      };
+      const result = toPickupPoint(point);
+      expect(result.providerId).toBe('POZ08A');
+      expect(result.status).toBe('active');
+      expect(result.address.city).toBe('Poznań');
+      expect(result.lat).toBe(52.4);
+    });
+  });
+
+  describe('buildPointsQuery', () => {
+    it('should map the neutral finder query to ShipX query params', () => {
+      expect(
+        buildPointsQuery({ city: 'Warszawa', postalCode: '00-001', searchText: 'POZ', limit: 10 }),
+      ).toEqual({ city: 'Warszawa', post_code: '00-001', name: 'POZ', per_page: 10 });
+    });
+  });
+});

--- a/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
+++ b/libs/integrations/inpost/src/infrastructure/mappers/inpost-shipx.mapper.ts
@@ -1,0 +1,261 @@
+/**
+ * InPost ShipX Mapper
+ *
+ * Pure translation between the carrier-neutral `@openlinker/core/shipping`
+ * types and the ShipX wire shapes. The single seam where ShipX field names,
+ * the `service` discriminator, the parcel object-vs-array split, and the full
+ * status code table live — keeping the adapter free of wire-format detail.
+ *
+ * All functions are pure (no I/O, no logging). The unknown-status policy is
+ * expressed by `mapShipXStatus` returning `null`; the adapter logs the WARN
+ * and falls back to a non-terminal status (it owns the logger).
+ *
+ * @module libs/integrations/inpost/src/infrastructure/mappers
+ */
+import type {
+  GenerateLabelCommand,
+  GenerateLabelResult,
+  ShipmentStatus,
+  ShipmentAddress,
+  TrackingSnapshot,
+  PickupPoint,
+  PickupPointAddress,
+  PickupPointStatus,
+  FindPickupPointsQuery,
+} from '@openlinker/core/shipping';
+import { PICKUP_POINT_STATUS } from '@openlinker/core/shipping';
+import type { InpostConnectionConfig, InpostSenderContact } from '../../domain/types/inpost-config.types';
+import type {
+  ShipXAddress,
+  ShipXCreateShipmentRequest,
+  ShipXPeer,
+  ShipXPoint,
+  ShipXShipment,
+} from '../../domain/types/inpost-shipx.types';
+import { InpostValidationException } from '../../domain/exceptions/inpost-validation.exception';
+
+/**
+ * Full ShipX status → OpenLinker bucket table (verified against the ShipX
+ * "Statuses" doc). Codes absent here are unknown → `mapShipXStatus` returns
+ * `null` and the adapter maps them to a non-terminal `in-transit` + WARN.
+ */
+const SHIPX_STATUS_TO_OL: Readonly<Record<string, ShipmentStatus>> = {
+  // Pre-dispatch (created → ready-for-handoff) → label exists / generated.
+  created: 'generated',
+  offers_prepared: 'generated',
+  offer_selected: 'generated',
+  confirmed: 'generated',
+  // Handed off to InPost.
+  dispatched_by_sender: 'dispatched',
+  dispatched_by_sender_to_pok: 'dispatched',
+  collected_from_sender: 'dispatched',
+  taken_by_courier: 'dispatched',
+  taken_by_courier_from_pok: 'dispatched',
+  adopted_at_source_branch: 'dispatched',
+  sent_from_source_branch: 'dispatched',
+  adopted_at_sorting_center: 'dispatched',
+  taken_by_courier_from_customer_service_point: 'dispatched',
+  // In the network / out for delivery / awaiting pickup.
+  out_for_delivery: 'in-transit',
+  out_for_delivery_to_address: 'in-transit',
+  ready_to_pickup: 'in-transit',
+  ready_to_pickup_from_pok: 'in-transit',
+  ready_to_pickup_from_branch: 'in-transit',
+  pickup_reminder_sent: 'in-transit',
+  pickup_reminder_sent_address: 'in-transit',
+  avizo: 'in-transit',
+  readdressed: 'in-transit',
+  redirect_to_box: 'in-transit',
+  oversized: 'in-transit',
+  delay_in_delivery: 'in-transit',
+  stack_in_customer_service_point: 'in-transit',
+  unstack_from_customer_service_point: 'in-transit',
+  courier_avizo_in_customer_service_point: 'in-transit',
+  stack_in_box_machine: 'in-transit',
+  unstack_from_box_machine: 'in-transit',
+  claimed: 'in-transit',
+  // Terminal — delivered.
+  delivered: 'delivered',
+  // Terminal — cancelled.
+  canceled: 'cancelled',
+  canceled_redirect_to_box: 'cancelled',
+  // Terminal — non-delivery outcomes.
+  returned_to_sender: 'failed',
+  rejected_by_receiver: 'failed',
+  undelivered: 'failed',
+  undelivered_wrong_address: 'failed',
+  undelivered_cod_cash_receiver: 'failed',
+  pickup_time_expired: 'failed',
+  stack_parcel_pickup_time_expired: 'failed',
+  stack_parcel_in_box_machine_pickup_time_expired: 'failed',
+};
+
+/** Maps a raw ShipX status to an OL bucket; `null` for unknown codes. */
+export function mapShipXStatus(raw: string): ShipmentStatus | null {
+  return SHIPX_STATUS_TO_OL[raw] ?? null;
+}
+
+/** Build the simplified-mode create-shipment request for the command's method. */
+export function buildCreateShipmentRequest(
+  cmd: GenerateLabelCommand,
+  config: InpostConnectionConfig,
+): ShipXCreateShipmentRequest {
+  const sender = toSenderPeer(config.senderAddress);
+
+  if (cmd.shippingMethod === 'paczkomat') {
+    return buildLockerRequest(cmd, sender);
+  }
+  if (cmd.shippingMethod === 'kurier') {
+    return buildCourierRequest(cmd, sender);
+  }
+  throw new InpostValidationException(`Unsupported shipping method: ${String(cmd.shippingMethod)}`);
+}
+
+/** Map a ShipX shipment (create response / shipment-by-id) to the port result. */
+export function toGenerateLabelResult(shipment: ShipXShipment): GenerateLabelResult {
+  return {
+    providerShipmentId: String(shipment.id),
+    trackingNumber: shipment.tracking_number,
+    labelPdfRef: `shipx:label:${shipment.id}`,
+  };
+}
+
+/**
+ * Build a tracking snapshot from the already-mapped status + the raw ShipX
+ * code. v1 reads status from `GET /v1/shipments/:id`, which doesn't carry the
+ * `tracking_details` timeline, so `dispatchedAt` / `deliveredAt` are left
+ * unset (the tracking-number timeline endpoint is unavailable in sandbox).
+ */
+export function toTrackingSnapshot(status: ShipmentStatus, providerStatus: string): TrackingSnapshot {
+  return { status, providerStatus };
+}
+
+/** Map a ShipX point to the neutral `PickupPoint`. */
+export function toPickupPoint(point: ShipXPoint): PickupPoint {
+  return {
+    providerId: point.name,
+    name: point.name,
+    address: toPickupPointAddress(point),
+    status: mapPickupPointStatus(point.status),
+    lat: point.location?.latitude,
+    lon: point.location?.longitude,
+  };
+}
+
+/** Build the `GET /v1/points` query string from the neutral finder query. */
+export function buildPointsQuery(
+  query: FindPickupPointsQuery,
+): Record<string, string | number | undefined> {
+  return {
+    city: query.city,
+    post_code: query.postalCode,
+    name: query.searchText,
+    per_page: query.limit,
+  };
+}
+
+// --- internals ---------------------------------------------------------------
+
+function buildLockerRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): ShipXCreateShipmentRequest {
+  if (!cmd.paczkomatId) {
+    throw new InpostValidationException('paczkomatId is required for a paczkomat shipment');
+  }
+  if (!cmd.parcel.template) {
+    throw new InpostValidationException(
+      'parcel.template (locker size) is required for a paczkomat shipment',
+    );
+  }
+  return {
+    sender,
+    receiver: toReceiverPeer(cmd, false),
+    parcels: { template: cmd.parcel.template },
+    service: 'inpost_locker_standard',
+    reference: cmd.shipmentId,
+    custom_attributes: { sending_method: 'dispatch_order', target_point: cmd.paczkomatId },
+  };
+}
+
+function buildCourierRequest(cmd: GenerateLabelCommand, sender: ShipXPeer): ShipXCreateShipmentRequest {
+  if (!cmd.recipient.address) {
+    throw new InpostValidationException('recipient.address is required for a courier shipment');
+  }
+  const { dimensions, weightGrams } = cmd.parcel;
+  if (!dimensions || weightGrams === undefined) {
+    throw new InpostValidationException(
+      'parcel.dimensions and parcel.weightGrams are required for a courier shipment',
+    );
+  }
+  return {
+    sender,
+    receiver: toReceiverPeer(cmd, true),
+    parcels: [
+      {
+        dimensions: {
+          length: String(dimensions.length),
+          width: String(dimensions.width),
+          height: String(dimensions.height),
+          unit: 'mm',
+        },
+        weight: { amount: (weightGrams / 1000).toFixed(2), unit: 'kg' },
+        is_non_standard: false,
+      },
+    ],
+    service: 'inpost_courier_standard',
+    reference: cmd.shipmentId,
+    custom_attributes: { sending_method: 'dispatch_order' },
+  };
+}
+
+function toSenderPeer(sender: InpostSenderContact): ShipXPeer {
+  return {
+    company_name: sender.name,
+    email: sender.email,
+    phone: sender.phone,
+    address: toShipXAddress(sender.address),
+  };
+}
+
+function toReceiverPeer(cmd: GenerateLabelCommand, includeAddress: boolean): ShipXPeer {
+  const recipient = cmd.recipient;
+  const peer: ShipXPeer = {
+    company_name: recipient.name,
+    first_name: recipient.firstName,
+    last_name: recipient.lastName,
+    email: recipient.email,
+    phone: recipient.phone,
+  };
+  if (includeAddress && recipient.address) {
+    peer.address = toShipXAddress(recipient.address);
+  }
+  return peer;
+}
+
+function toShipXAddress(address: ShipmentAddress): ShipXAddress {
+  return {
+    street: address.street,
+    building_number: address.buildingNumber,
+    city: address.city,
+    post_code: address.postCode,
+    country_code: address.countryCode,
+  };
+}
+
+function toPickupPointAddress(point: ShipXPoint): PickupPointAddress {
+  return {
+    line1: point.address?.line1 ?? point.address_details?.street ?? '',
+    line2: point.address?.line2,
+    city: point.address_details?.city ?? '',
+    postalCode: point.address_details?.post_code ?? '',
+    country: 'PL',
+  };
+}
+
+function mapPickupPointStatus(raw?: string): PickupPointStatus {
+  if (!raw) {
+    return PICKUP_POINT_STATUS.Active;
+  }
+  const normalized = raw.toLowerCase();
+  return normalized.includes('operating') && !normalized.includes('non')
+    ? PICKUP_POINT_STATUS.Active
+    : PICKUP_POINT_STATUS.TemporarilyUnavailable;
+}

--- a/libs/integrations/inpost/src/inpost-integration.module.ts
+++ b/libs/integrations/inpost/src/inpost-integration.module.ts
@@ -1,0 +1,21 @@
+/**
+ * InPost Integration Module
+ *
+ * Host wiring for the InPost ShipX plugin. InPost has no plugin-specific
+ * NestJS providers, so it uses the SDK's `createNestAdapterModule` directly:
+ * the helper imports the integrations/sync/identifier-mapping modules, builds
+ * the `HostServices` bag from DI, registers the manifest + factory, and calls
+ * `plugin.register(host)` for the config-shape validator.
+ *
+ * Added to `apps/api/src/plugins.ts` as the single edit point that enables the
+ * plugin in the host. Not registered worker-side in this PR (#772 owns that).
+ *
+ * @module libs/integrations/inpost/src
+ */
+import type { DynamicModule } from '@nestjs/common';
+import { createNestAdapterModule } from '@openlinker/plugin-sdk';
+import { createInpostPlugin } from './inpost-plugin';
+
+export const InpostIntegrationModule: DynamicModule = createNestAdapterModule({
+  plugin: createInpostPlugin(),
+});

--- a/libs/integrations/inpost/src/inpost-plugin.ts
+++ b/libs/integrations/inpost/src/inpost-plugin.ts
@@ -1,0 +1,65 @@
+/**
+ * InPost Plugin Descriptor (#593)
+ *
+ * Framework-neutral `AdapterPlugin` for the InPost ShipX v1 integration. Holds
+ * the static manifest, the config-shape validator side-registration, and the
+ * per-connection `createCapabilityAdapter` factory (which resolves credentials
+ * + builds the shipping adapter, then dispatches by capability name).
+ *
+ * InPost needs no plugin-specific NestJS providers (no repository, no
+ * token-refresh service), so the host wires it via `createNestAdapterModule`
+ * — see `inpost-integration.module.ts`.
+ *
+ * @module libs/integrations/inpost/src
+ */
+import { dispatchCapability, type AdapterPlugin, type HostServices } from '@openlinker/plugin-sdk';
+import type { AdapterMetadata } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { createInpostShippingAdapter } from './application/inpost-adapter.factory';
+import { InpostConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/inpost-connection-config-shape-validator.adapter';
+
+/**
+ * Static plugin manifest (#575). Exported as a top-level `const` so host-side
+ * tooling can read `adapterKey` / `supportedCapabilities` / `version` without
+ * instantiating the plugin. `createInpostPlugin().manifest` returns the same
+ * reference, so static and runtime views can't drift.
+ */
+export const inpostAdapterManifest: AdapterMetadata = {
+  adapterKey: 'inpost.shipx.v1',
+  platformType: 'inpost',
+  supportedCapabilities: ['ShippingProviderManager'],
+  displayName: 'InPost ShipX v1',
+  version: '1.0.0',
+  isDefault: true,
+};
+
+/** Short brand label for domain-exception prefixes (manifest.displayName is too long). */
+const INPOST_BRAND = 'InPost';
+
+export function createInpostPlugin(): AdapterPlugin {
+  return {
+    manifest: inpostAdapterManifest,
+
+    register(host: HostServices): void {
+      host.connectionConfigShapeValidatorRegistry.register(
+        inpostAdapterManifest.adapterKey,
+        new InpostConnectionConfigShapeValidatorAdapter(INPOST_BRAND),
+      );
+      // No credentials-shape validator: the `{ apiToken }` shape is enforced
+      // at adapter construction time by the factory (deeper than this boundary).
+    },
+
+    async createCapabilityAdapter<T>(
+      connection: Connection,
+      capability: string,
+      host: HostServices,
+    ): Promise<T> {
+      const adapter = await createInpostShippingAdapter(connection, host.credentialsResolver);
+      return dispatchCapability<T>(
+        capability,
+        { ShippingProviderManager: () => adapter },
+        INPOST_BRAND,
+      );
+    },
+  };
+}

--- a/libs/integrations/inpost/src/testing.ts
+++ b/libs/integrations/inpost/src/testing.ts
@@ -1,0 +1,10 @@
+/**
+ * @openlinker/integrations-inpost/testing — test-only sub-barrel
+ *
+ * Exposes `FakeInpostShippingAdapter` (#765) for plugin-author / consumer unit
+ * tests that need an in-memory `ShippingProviderManagerPort` without hitting
+ * sandbox ShipX. Consumed only from `*.spec.ts`, never from runtime code.
+ *
+ * @module libs/integrations/inpost/src
+ */
+export { FakeInpostShippingAdapter } from './testing/fake-inpost-shipping.adapter';

--- a/libs/integrations/inpost/src/testing/__tests__/fake-inpost-shipping.adapter.spec.ts
+++ b/libs/integrations/inpost/src/testing/__tests__/fake-inpost-shipping.adapter.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Fake InPost Shipping Adapter — unit tests
+ *
+ * @module libs/integrations/inpost/src/testing
+ */
+import type { GenerateLabelCommand, PickupPoint } from '@openlinker/core/shipping';
+import { InpostValidationException } from '../../domain/exceptions/inpost-validation.exception';
+import { FakeInpostShippingAdapter } from '../fake-inpost-shipping.adapter';
+
+const paczkomatCmd: GenerateLabelCommand = {
+  shipmentId: 'ol_shipment_abc',
+  orderId: 'ol_order_xyz',
+  connectionId: 'conn-1',
+  shippingMethod: 'paczkomat',
+  paczkomatId: 'POZ08A',
+  recipient: { email: 'buyer@example.com', phone: '111222333' },
+  parcel: { template: 'small' },
+};
+
+describe('FakeInpostShippingAdapter', () => {
+  let fake: FakeInpostShippingAdapter;
+
+  beforeEach(() => {
+    fake = new FakeInpostShippingAdapter();
+  });
+
+  it('should return supported methods', () => {
+    expect(fake.getSupportedMethods()).toEqual(['paczkomat', 'kurier']);
+  });
+
+  it('should generate a deterministic label and ref', async () => {
+    const result = await fake.generateLabel(paczkomatCmd);
+    expect(result.providerShipmentId).toBe('fake-1');
+    expect(result.labelPdfRef).toBe('shipx:label:fake-1');
+    expect(result.trackingNumber).toBeNull();
+  });
+
+  it('should validate a missing paczkomatId like the real adapter', async () => {
+    await expect(fake.generateLabel({ ...paczkomatCmd, paczkomatId: undefined })).rejects.toBeInstanceOf(
+      InpostValidationException,
+    );
+  });
+
+  it('should report cancelled tracking after cancelShipment', async () => {
+    const { providerShipmentId } = await fake.generateLabel(paczkomatCmd);
+    await fake.cancelShipment({ providerShipmentId });
+    const snapshot = await fake.getTracking({ providerShipmentId });
+    expect(snapshot.status).toBe('cancelled');
+  });
+
+  it('should throw the seeded failure from generateLabel', async () => {
+    fake.seedFailure(new InpostValidationException('seeded'));
+    await expect(fake.generateLabel(paczkomatCmd)).rejects.toThrow('seeded');
+  });
+
+  it('should return seeded pickup points', async () => {
+    const point: PickupPoint = {
+      providerId: 'POZ08A',
+      name: 'POZ08A',
+      address: { line1: 'Główna 1', city: 'Poznań', postalCode: '60-001', country: 'PL' },
+      status: 'active',
+    };
+    fake.seedPickupPoints([point]);
+    await expect(fake.findPickupPoints({ city: 'Poznań' })).resolves.toEqual([point]);
+  });
+
+  it('should reset state on clear', async () => {
+    await fake.generateLabel(paczkomatCmd);
+    fake.clear();
+    const result = await fake.generateLabel(paczkomatCmd);
+    expect(result.providerShipmentId).toBe('fake-1');
+  });
+});

--- a/libs/integrations/inpost/src/testing/fake-inpost-shipping.adapter.ts
+++ b/libs/integrations/inpost/src/testing/fake-inpost-shipping.adapter.ts
@@ -1,0 +1,114 @@
+/**
+ * Fake InPost Shipping Adapter (#765)
+ *
+ * In-memory `ShippingProviderManagerPort` (+ `ShipmentCanceller`,
+ * `PickupPointFinder`) for plugin-author / consumer unit tests that need
+ * deterministic shipping behaviour without hitting sandbox ShipX. Mirrors the
+ * real adapter's observable contract — including the locker/courier pre-submit
+ * validation — and adds `seed*` / `clear` helpers for arranging test state.
+ *
+ * Consumed only from `*.spec.ts` via `@openlinker/integrations-inpost/testing`,
+ * never from runtime code.
+ *
+ * @module libs/integrations/inpost/src/testing
+ */
+import type {
+  ShippingProviderManagerPort,
+  ShipmentCanceller,
+  PickupPointFinder,
+  GenerateLabelCommand,
+  GenerateLabelResult,
+  TrackingSnapshot,
+  ShipmentStatus,
+  ShippingMethod,
+  PickupPoint,
+  FindPickupPointsQuery,
+} from '@openlinker/core/shipping';
+import { InpostValidationException } from '../domain/exceptions/inpost-validation.exception';
+
+const SUPPORTED_METHODS: readonly ShippingMethod[] = ['paczkomat', 'kurier'];
+
+export class FakeInpostShippingAdapter
+  implements ShippingProviderManagerPort, ShipmentCanceller, PickupPointFinder
+{
+  private counter = 0;
+  private seededFailure: Error | null = null;
+  private seededPoints: PickupPoint[] = [];
+  private readonly statusByShipmentId = new Map<string, ShipmentStatus>();
+  private readonly cancelled = new Set<string>();
+
+  getSupportedMethods(): readonly ShippingMethod[] {
+    return SUPPORTED_METHODS;
+  }
+
+  // Methods return resolved/rejected promises rather than `async` bodies: the
+  // fake does no real I/O, so there's nothing to await — and validation
+  // failures must surface as promise rejections (not sync throws) to match the
+  // real adapter's contract and `.rejects` assertions.
+  generateLabel(cmd: GenerateLabelCommand): Promise<GenerateLabelResult> {
+    if (this.seededFailure) {
+      return Promise.reject(this.seededFailure);
+    }
+    if (cmd.shippingMethod === 'paczkomat' && !cmd.paczkomatId) {
+      return Promise.reject(
+        new InpostValidationException('paczkomatId is required for a paczkomat shipment'),
+      );
+    }
+    if (cmd.shippingMethod === 'kurier' && !cmd.recipient.address) {
+      return Promise.reject(
+        new InpostValidationException('recipient.address is required for a courier shipment'),
+      );
+    }
+    const providerShipmentId = `fake-${(this.counter += 1)}`;
+    this.statusByShipmentId.set(providerShipmentId, 'generated');
+    return Promise.resolve({
+      providerShipmentId,
+      trackingNumber: null,
+      labelPdfRef: `shipx:label:${providerShipmentId}`,
+    });
+  }
+
+  getTracking(input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
+    if (this.cancelled.has(input.providerShipmentId)) {
+      return Promise.resolve({ status: 'cancelled', providerStatus: 'canceled' });
+    }
+    const status = this.statusByShipmentId.get(input.providerShipmentId) ?? 'generated';
+    return Promise.resolve({ status, providerStatus: status });
+  }
+
+  cancelShipment(input: { providerShipmentId: string }): Promise<void> {
+    this.cancelled.add(input.providerShipmentId);
+    this.statusByShipmentId.set(input.providerShipmentId, 'cancelled');
+    return Promise.resolve();
+  }
+
+  findPickupPoints(_query: FindPickupPointsQuery): Promise<PickupPoint[]> {
+    return Promise.resolve([...this.seededPoints]);
+  }
+
+  // --- test helpers ----------------------------------------------------------
+
+  /** Make the next `generateLabel` throw the given error. */
+  seedFailure(error: Error): void {
+    this.seededFailure = error;
+  }
+
+  /** Set the points returned by `findPickupPoints`. */
+  seedPickupPoints(points: readonly PickupPoint[]): void {
+    this.seededPoints = [...points];
+  }
+
+  /** Override the status `getTracking` reports for a shipment. */
+  seedTracking(providerShipmentId: string, status: ShipmentStatus): void {
+    this.statusByShipmentId.set(providerShipmentId, status);
+  }
+
+  /** Reset all in-memory state between tests. */
+  clear(): void {
+    this.counter = 0;
+    this.seededFailure = null;
+    this.seededPoints = [];
+    this.statusByShipmentId.clear();
+    this.cancelled.clear();
+  }
+}

--- a/libs/integrations/inpost/tsconfig.json
+++ b/libs/integrations/inpost/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "../../core" },
+    { "path": "../../shared" },
+    { "path": "../../plugin-sdk" }
+  ]
+}

--- a/libs/integrations/inpost/tsconfig.spec.json
+++ b/libs/integrations/inpost/tsconfig.spec.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/__tests__/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@openlinker/integrations-allegro':
         specifier: workspace:*
         version: link:../../libs/integrations/allegro
+      '@openlinker/integrations-inpost':
+        specifier: workspace:*
+        version: link:../../libs/integrations/inpost
       '@openlinker/integrations-prestashop':
         specifier: workspace:*
         version: link:../../libs/integrations/prestashop
@@ -515,6 +518,52 @@ importers:
       image-size:
         specifier: ^1.0.0
         version: 1.2.1
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.12
+        version: 29.5.12
+      '@types/node':
+        specifier: 20.11.30
+        version: 20.11.30
+      '@typescript-eslint/eslint-plugin':
+        specifier: 7.3.1
+        version: 7.3.1(@typescript-eslint/parser@7.3.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/parser':
+        specifier: 7.3.1
+        version: 7.3.1(eslint@8.57.0)(typescript@5.4.3)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@20.11.30)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3))
+      ts-jest:
+        specifier: 29.1.2
+        version: 29.1.2(@babel/core@7.28.5)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@20.11.30)(ts-node@10.9.2(@types/node@20.11.30)(typescript@5.4.3)))(typescript@5.4.3)
+      typescript:
+        specifier: 5.4.3
+        version: 5.4.3
+
+  libs/integrations/inpost:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.0.0
+        version: 10.3.0(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.1)(rxjs@7.8.1)
+      '@openlinker/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@openlinker/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../plugin-sdk
+      '@openlinker/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      class-transformer:
+        specifier: 0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: 0.14.1
+        version: 0.14.1
     devDependencies:
       '@types/jest':
         specifier: 29.5.12

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -39,6 +39,8 @@
       "@openlinker/integrations-ai/*": ["libs/integrations/ai/src/*"],
       "@openlinker/integrations-prestashop": ["libs/integrations/prestashop/src/index.ts"],
       "@openlinker/integrations-prestashop/*": ["libs/integrations/prestashop/src/*"],
+      "@openlinker/integrations-inpost": ["libs/integrations/inpost/src/index.ts"],
+      "@openlinker/integrations-inpost/*": ["libs/integrations/inpost/src/*"],
       "@openlinker/plugin-sdk": ["libs/plugin-sdk/src/index.ts"],
       "@openlinker/plugin-sdk/*": ["libs/plugin-sdk/src/*"],
       "@openlinker/test-kit": ["libs/test-kit/src/index.ts"],


### PR DESCRIPTION
## What & why

Implements `@openlinker/integrations-inpost` — `InpostShippingAdapter` against the InPost **ShipX** REST API — fulfilling the `ShippingProviderManagerPort` foundation (#763), plus `FakeInpostShippingAdapter` for consumer unit tests.

- **`InpostShippingAdapter`** implements `ShippingProviderManagerPort` + the `ShipmentCanceller` and `PickupPointFinder` sub-capabilities. Supports **paczkomat** (`inpost_locker_standard`) and **kurier** (`inpost_courier_standard`).
- **CORE change:** `GenerateLabelCommand` gains carrier-neutral **required** `recipient` + `parcel` fields (new `ShipmentRecipient` / `ShipmentAddress` / `ShipmentParcel` types). #763's `generate-label.types.ts` header explicitly scoped this addition to #764; the note is refreshed to the landed shape, and #732 (Allegro Delivery) reuses the same types. No existing `GenerateLabelCommand` constructors existed, so this is non-breaking in practice.
- **Transport:** native-`fetch` `InpostHttpClient` behind `IInpostHttpClient` (static Bearer token, jittered 429/`Retry-After` + 5xx retry, timeout). All ShipX ↔ domain translation is isolated in `inpost-shipx.mapper.ts`, including the full **42 → 7** status table.
- **Config/creds:** `apiToken` resolved via `CredentialsResolverPort` (never logged); `environment` + `organizationId` + sender address live in connection config, validated by a config-shape validator registered through `plugin.register(host)`.
- **Wiring:** registered API-side in `apps/api/src/plugins.ts` via the SDK `createNestAdapterModule`.

All ShipX wire shapes (create/label/cancel/tracking/points/errors/statuses) were verified against the official ShipX docs — not guessed.

## Scope / deferrals (recorded in the plan)

- **Worker registration → #772**; **connection tester → #771**; `psModuleChoice` config → #767/#771.
- **Cancel-window constraint:** ShipX `DELETE` only works pre-`confirmed`; simplified-mode shipments auto-confirm, so "cancel while generated" isn't always satisfiable — the adapter surfaces ShipX's `invalid_action` as a domain exception, and #769 must treat cancel as best-effort.
- **`getTracking`** reads status from `GET /v1/shipments/:id`; `dispatchedAt`/`deliveredAt` are left null in v1 (the timeline endpoint is keyed by tracking number and unavailable in sandbox).
- Minor follow-ups noted for confirmation: `GET /v1/points` `type` filter, `sending_method` per-method behaviour.

## How to test

`pnpm lint && pnpm type-check && pnpm test` — all green. New unit coverage: mapper (request builders + status table), adapter (paczkomat + courier generate, paczkomat-unavailable re-tag, tracking incl. unknown→in-transit, cancel, points), the `InpostHttpClient` retry/error-classification (mocked `fetch`), the config-shape validator, and the fake. No migration (additive command-input types only).

Closes #764
Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)