### PR TITLE
fix(web,listings): thread productCardId on auto-resolved bulk rows (#808)

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
@@ -5,7 +5,7 @@
  * productId; rows without a matching outcome keep their identity.
  */
 import { describe, expect, it } from 'vitest';
-import { mergeResolveOutcomes } from './bulk-wizard';
+import { mergeResolveOutcomes, selectBulkProductCardId } from './bulk-wizard';
 import type { BulkResolveOutcome } from './bulk-resolve-step';
 import type { BulkWizardRow } from './bulk-wizard.types';
 
@@ -87,5 +87,51 @@ describe('mergeResolveOutcomes', () => {
     const next = mergeResolveOutcomes(rows, [outcome('prod_2', { blockers: ['no-ean'] })]);
     expect(next[0]).toBe(rows[0]);
     expect(next[1]).toMatchObject({ productId: 'prod_2', blockers: ['no-ean'] });
+  });
+});
+
+describe('selectBulkProductCardId (#808)', () => {
+  function rowWith(partial: Partial<BulkWizardRow>): BulkWizardRow {
+    return { ...makeRow('prod_1'), ...partial };
+  }
+
+  it('threads the resolved card on a clean auto-resolved row', () => {
+    const row = rowWith({ resolvedCategoryId: '257933', resolvedProductCardId: 'card-1' });
+    expect(selectBulkProductCardId(row)).toBe('card-1');
+  });
+
+  it('threads the resolved card when the seeded/edited override repeats the resolved category', () => {
+    // Regression for the original bug: the review-step edit form seeds
+    // override.overrides.categoryId with the resolved category even for
+    // un-touched rows; the card must still be threaded.
+    const row = rowWith({
+      resolvedCategoryId: '257933',
+      resolvedProductCardId: 'card-1',
+      override: { overrides: { categoryId: '257933', title: 'Seeded title' } },
+    });
+    expect(selectBulkProductCardId(row)).toBe('card-1');
+  });
+
+  it('drops the card when the operator switched to a different category', () => {
+    const row = rowWith({
+      resolvedCategoryId: '257933',
+      resolvedProductCardId: 'card-1',
+      override: { overrides: { categoryId: '999000' } },
+    });
+    expect(selectBulkProductCardId(row)).toBeUndefined();
+  });
+
+  it('prefers an explicit operator-set card override', () => {
+    const row = rowWith({
+      resolvedCategoryId: '257933',
+      resolvedProductCardId: 'card-1',
+      override: { overrides: { productCardId: 'manual-card' } },
+    });
+    expect(selectBulkProductCardId(row)).toBe('manual-card');
+  });
+
+  it('returns undefined when there is no resolved card', () => {
+    const row = rowWith({ resolvedCategoryId: '257933', resolvedProductCardId: null });
+    expect(selectBulkProductCardId(row)).toBeUndefined();
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -162,15 +162,9 @@ export function BulkWizard({
             categoryId:
               row.override.overrides?.categoryId ?? row.resolvedCategoryId ?? undefined,
             // #808 — link the EAN-matched product card so Allegro inherits its
-            // required product parameters (Brand, Type, EAN, …). Dropped when
-            // the operator manually overrode the category, since the card was
-            // matched against the auto-detected one; the adapter then falls
-            // back to its (GTIN-tightened) re-resolution.
-            productCardId:
-              row.override.overrides?.productCardId ??
-              (row.override.overrides?.categoryId
-                ? undefined
-                : (row.resolvedProductCardId ?? undefined)),
+            // required product parameters (Brand, Type, EAN, …). See
+            // `selectBulkProductCardId` for the keep/drop rule.
+            productCardId: selectBulkProductCardId(row),
           },
         };
       }
@@ -340,6 +334,33 @@ export function mergeResolveOutcomes(
       categoryCandidates: o.categoryCandidates,
     };
   });
+}
+
+/**
+ * #808 — choose the catalogue card id to thread into a bulk submit override.
+ *
+ * The EAN-matched card was resolved against the auto-detected category, so it
+ * stays valid only while the category being submitted is still that resolved
+ * category — whether the category arrives via the seeded/edited override or
+ * the raw resolve. (The review-step edit form seeds `override.overrides` with
+ * the resolved category + title + description even for un-touched rows, so a
+ * plain "override has a categoryId" check is NOT a reliable "operator changed
+ * the category" signal — it must be compared to the resolved category.)
+ *
+ * An explicit operator-set card always wins; switching to a *different*
+ * category drops the card so the adapter re-resolves by barcode.
+ *
+ * Exported for unit testing; the wizard calls it from `handleSubmit`.
+ */
+export function selectBulkProductCardId(row: BulkWizardRow): string | undefined {
+  const explicit = row.override.overrides?.productCardId;
+  if (explicit) return explicit;
+  const submittedCategoryId =
+    row.override.overrides?.categoryId ?? row.resolvedCategoryId ?? null;
+  if (row.resolvedProductCardId && submittedCategoryId === row.resolvedCategoryId) {
+    return row.resolvedProductCardId;
+  }
+  return undefined;
 }
 
 function seedRows(products: Product[]): BulkWizardRow[] {


### PR DESCRIPTION
## What

Fixes the bulk Allegro offer-creation 422 (`ProductValidationException: … required parameters [Marka, Model, EAN (GTIN), …]`) that persisted after #809 and #811 merged.

## Root cause

#809 added the FE→command `productCardId` threading, but the bulk wizard's `handleSubmit` guard dropped the card whenever `row.override.overrides.categoryId` was truthy — on the assumption that field is only set when an operator *manually* overrides the category.

That assumption is false: the review-step edit form seeds `override.overrides` with the resolved category (plus title/description) even on **un-touched** rows. So the guard misfired on **every** auto-resolved row — the category still reached the submit (via the seeded override), but `productCardId` was nulled. With no card, Allegro fell back to inline product creation and 422'd on the required parameters.

Confirmed empirically, not guessed:
- The `allegro:ean-match` resolve cache was inspected and is **healthy** — both EANs carry a real `productCardId`, so the BE delivers it end-to-end.
- The #811 `OfferBuilder` debug line printed `productCardId=null` at the command even from a fresh incognito web bundle — proving the drop is in the FE submit, not deploy/cache/BE.

## Fix

Replace the truthiness guard with `selectBulkProductCardId(row)` — a pure, unit-tested helper that keeps the resolved card while the **submitted** category is still the auto-resolved one (the category the card was matched against), and drops it only when the operator switches to a genuinely different category. An explicit operator-set card still wins.

(The #811 `OfferBuilder` `productCardId=…` observability line is already on `main`; this PR is the FE behaviour fix on top of it.)

## Tests

`selectBulkProductCardId` unit tests cover: clean auto-resolved row, seeded/edited override repeating the resolved category (the regression), operator-switched-to-a-different-category (drop), explicit operator card (wins), and no-resolved-card. Full local gate green (lint 0 errors, invariants, type-check all packages, 1181 web tests).

Closes #808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)