### PR TITLE
fix(allegro): drop bare-number productSet[].quantity on card-link create (#431)

### DIFF
--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -275,12 +275,6 @@ export interface AllegroProductSetEntry {
     images?: string[];
   };
   /**
-   * Per-entry quantity, used on the smart-link path (#431) where stock is
-   * declared on the productSet entry rather than on `body.stock`. The
-   * inline-product path leaves this undefined and uses `body.stock`.
-   */
-  quantity?: number;
-  /**
    * EU GPSR (Reg. 2023/988) responsible-producer reference. Required by
    * Allegro on every `productSet[]` entry when the entry creates an inline
    * product (no `product.id`). Smart-linked entries inherit this from the

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -2045,7 +2045,7 @@ describe('AllegroOfferManagerAdapter', () => {
     });
 
     describe('smart-link by EAN (#431)', () => {
-      it('on unique match: links via productSet[0].product.id, omits inline name/parameters/images/GPSR, uses per-entry quantity', async () => {
+      it('on unique match: links via productSet[0].product.id, omits inline name/parameters/images/GPSR, and carries sellable stock on body.stock (not productSet)', async () => {
         httpClient.post.mockResolvedValue(
           mockHttpResponse({
             id: 'allegro-offer-linked',
@@ -2078,12 +2078,12 @@ describe('AllegroOfferManagerAdapter', () => {
         });
 
         const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
-        expect(body.productSet).toEqual([
-          {
-            product: { id: 'allegro-card-1' },
-            quantity: 7,
-          },
-        ]);
+        // Card reference is id-only; Allegro rejects a bare-number
+        // `productSet[].quantity` with JsonMappingException (#808).
+        expect(body.productSet).toEqual([{ product: { id: 'allegro-card-1' } }]);
+        // Sellable stock lives on body.stock.available, never on the
+        // productSet entry (whose `quantity` is multipack size).
+        expect(body.stock).toEqual({ available: 7, unit: 'UNIT' });
         // Card-linked offers inherit GPSR from the card — adapter must NOT
         // write `responsibleProducer` / `safetyInformation` on the entry.
         expect(body.productSet).not.toContainEqual(
@@ -2117,7 +2117,10 @@ describe('AllegroOfferManagerAdapter', () => {
 
         expect(httpClient.get).not.toHaveBeenCalledWith('/sale/products', expect.anything());
         const body = httpClient.post.mock.calls[0][1] as Record<string, unknown>;
-        expect(body.productSet).toEqual([{ product: { id: 'allegro-card-pre' }, quantity: 4 }]);
+        expect(body.productSet).toEqual([{ product: { id: 'allegro-card-pre' } }]);
+        // Stock on body.stock.available, not as a (wrong-typed) productSet
+        // quantity that Allegro rejects with JsonMappingException (#808).
+        expect(body.stock).toEqual({ available: 4, unit: 'UNIT' });
       });
 
       it('falls through to inline path when variantBarcode is missing (smart-link short-circuits)', async () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -1492,7 +1492,7 @@ export class AllegroOfferManagerAdapter
     // ensures `this.sellerDefaults` is defined by the time we get here).
     body.location = { ...this.sellerDefaults!.location };
 
-    this.applyPlatformParams(body, platformParams, cardLinkResult, cmd.stock);
+    this.applyPlatformParams(body, platformParams, cardLinkResult);
 
     return body;
   }
@@ -1500,8 +1500,7 @@ export class AllegroOfferManagerAdapter
   private applyPlatformParams(
     body: AllegroProductOfferCreateRequest,
     platformParams: Record<string, unknown>,
-    cardLinkResult: ResolveProductCardResult,
-    stock: number
+    cardLinkResult: ResolveProductCardResult
   ): void {
     const deliveryPolicyId = platformParams['deliveryPolicyId'];
     const handlingTime = platformParams['handlingTime'];
@@ -1552,12 +1551,14 @@ export class AllegroOfferManagerAdapter
     // so we **skip** writing all of those on the entry. Offer-section
     // `body.parameters[]` (set above) still flows through normally.
     if (cardLinkResult.kind === 'unique') {
-      body.productSet = [
-        {
-          product: { id: cardLinkResult.productId },
-          quantity: stock,
-        },
-      ];
+      // Reference the catalogue card by id only. The offer's sellable quantity
+      // lives on `body.stock.available` (set in buildCreateOfferRequest on
+      // every path). `productSet[].quantity` is the *multipack size* — units of
+      // the card per sale item — which defaults to 1 when omitted. Writing the
+      // sellable stock here was both wrong-typed (Allegro wants an object, not
+      // a bare int → `JsonMappingException` at `productSet[0].quantity`) and
+      // wrong semantics. OL lists 1 variant = 1 sale unit, so we omit it (#808).
+      body.productSet = [{ product: { id: cardLinkResult.productId } }];
       this.logger.log(
         `Allegro smart-link applied: connection=${this.connectionId} ` +
           `productId=${cardLinkResult.productId} outcome=unique`


### PR DESCRIPTION
## What

When an offer create links an existing Allegro catalogue card (the #431 smart-link / #808 pre-resolved-card path), Allegro rejected it with:

```
JsonMappingException … path: productSet[0].quantity — "Message is not readable"
```

## Root cause

The card-link branch wrote `productSet[0].quantity` as a **bare number** (the sellable stock). Allegro's `/sale/product-offers`:
- Doesn't accept a bare int there (→ `JsonMappingException`), and
- Treats `productSet[].quantity` as the **multipack size** (units of the card per sale item), **not** the sellable stock.

The sellable quantity is already declared on `body.stock.available` (`{ available, unit: 'UNIT' }`) on **every** path. OpenLinker lists one variant as one sale unit, so the multipack quantity is always 1 and can be omitted (Allegro defaults it). The inline-product path already omits it and is accepted — the card-link path now matches that shape: `productSet: [{ product: { id } }]`.

This was **latent until #813** fixed `productCardId` threading — before that the flow never reached a successful card-link, so the malformed entry was never sent. It also affects the **single-offer #431 path**, not just bulk.

## Confirmed against live logs

After #813, the worker logs showed `smart-link applied … outcome=unique` (card now links ✓) immediately followed by the `JsonMappingException` at `productSet[0].quantity` — pinpointing this exact field.

## Change

- Drop `quantity` from the unique-card `productSet` entry; remove the now-unused `stock` param of `applyPlatformParams`.
- Remove the dead `AllegroProductSetEntry.quantity` field (nothing reads it; its comment was the source of the bug).
- Update the two smart-link adapter specs to assert id-only `productSet` + sellable stock on `body.stock.available`.

## Tests

116/116 Allegro adapter specs pass; full local gate green (lint 0 errors, invariants, type-check all packages, web tests).

> **Note:** this and **#813** are both required for bulk EAN-matched card-linking to succeed end-to-end — #813 makes the FE thread the card; this makes Allegro accept the resulting payload. Recommend merging both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)