### PR TITLE
fix(listings): merge shared + per-product overrides in bulk submit (#808)

### DIFF
--- a/libs/core/src/listings/application/services/__tests__/bulk-offer-creation-submit.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-offer-creation-submit.service.spec.ts
@@ -162,6 +162,45 @@ describe('BulkOfferCreationSubmitService', () => {
       });
     });
 
+    it('preserves shared platformParams when a per-product override has none, and deep-merges when it does (#808)', async () => {
+      await service.submit({
+        connectionId,
+        initiatedBy,
+        productIds: ['v-a', 'v-b'],
+        sharedConfig: {
+          stock: 5,
+          publishImmediately: false,
+          overrides: {
+            platformParams: { deliveryPolicyId: 'dp-shared', handlingTime: 'PT24H' },
+          },
+        },
+        perProductOverrides: {
+          // Row override carries category/card but NO platformParams — the
+          // shared deliveryPolicyId must still flow through (the bug: a
+          // wholesale replace dropped it → DefaultShippingRatesNotFound).
+          'v-a': { overrides: { categoryId: '257933', productCardId: 'card-a' } },
+          // Row override with its own platformParams — deep-merged: per-product
+          // key wins, shared sibling key survives.
+          'v-b': { overrides: { platformParams: { deliveryPolicyId: 'dp-b' } } },
+        },
+      });
+
+      expect(enqueueService.enqueueCreation.mock.calls[0][0]).toMatchObject({
+        internalVariantId: 'v-a',
+        overrides: {
+          categoryId: '257933',
+          productCardId: 'card-a',
+          platformParams: { deliveryPolicyId: 'dp-shared', handlingTime: 'PT24H' },
+        },
+      });
+      expect(enqueueService.enqueueCreation.mock.calls[1][0]).toMatchObject({
+        internalVariantId: 'v-b',
+        overrides: {
+          platformParams: { deliveryPolicyId: 'dp-b', handlingTime: 'PT24H' },
+        },
+      });
+    });
+
     it('forwards AI flags from shared config into every enqueue call', async () => {
       await service.submit({
         connectionId,

--- a/libs/core/src/listings/application/services/bulk-offer-creation-submit.service.ts
+++ b/libs/core/src/listings/application/services/bulk-offer-creation-submit.service.ts
@@ -34,6 +34,7 @@ import {
   IOfferCreationEnqueueService,
   OfferCreationRecordRepositoryPort} from '@openlinker/core/listings';
 import type {
+  CreateOfferOverrides,
   OfferManagerPort,
 } from '@openlinker/core/listings';
 import {
@@ -176,7 +177,12 @@ export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitS
     const publishImmediately =
       override?.publishImmediately ?? input.sharedConfig.publishImmediately;
     const price = override?.price ?? input.sharedConfig.price;
-    const overrides = override?.overrides ?? input.sharedConfig.overrides;
+    // Layer per-product overrides on top of the batch-wide shared overrides.
+    // A wholesale `??` replacement silently dropped shared settings the wizard
+    // never repeats per row — notably `platformParams.deliveryPolicyId`, whose
+    // absence makes Allegro reject the offer with
+    // `DefaultShippingRatesNotFoundException`. (#808)
+    const overrides = this.mergeOverrides(input.sharedConfig.overrides, override?.overrides);
 
     return {
       internalVariantId: productId,
@@ -191,6 +197,29 @@ export class BulkOfferCreationSubmitService implements IBulkOfferCreationSubmitS
         descriptionTone: input.sharedConfig.descriptionTone,
       }),
     };
+  }
+
+  /**
+   * Layer a per-product override on top of the batch-wide shared overrides.
+   * Scalar fields (title, categoryId, productCardId, imageUrls, …) take the
+   * per-product value when present; `platformParams` is **deep-merged** so
+   * shared keys (e.g. `deliveryPolicyId`) survive even when a row supplies its
+   * own platform tweaks. Returns `undefined` only when neither side has any
+   * overrides, so the enqueue input keeps omitting the field in that case.
+   */
+  private mergeOverrides(
+    shared: CreateOfferOverrides | undefined,
+    perProduct: CreateOfferOverrides | undefined
+  ): CreateOfferOverrides | undefined {
+    if (!shared && !perProduct) return undefined;
+    const merged: CreateOfferOverrides = { ...shared, ...perProduct };
+    if (shared?.platformParams || perProduct?.platformParams) {
+      merged.platformParams = {
+        ...shared?.platformParams,
+        ...perProduct?.platformParams,
+      };
+    }
+    return merged;
   }
 }
 


### PR DESCRIPTION
## What

Bulk offer create reached Allegro and was rejected with:

```
DefaultShippingRatesNotFoundException — path: delivery.shippingRates
"…default delivery price list 'default'… you don't have it"
```

## Root cause

`BulkOfferCreationSubmitService.buildEnqueueInput` selected overrides **wholesale**:

```ts
const overrides = override?.overrides ?? input.sharedConfig.overrides;
```

The wizard always emits a per-product override (title/description/categoryId/productCardId) and keeps **batch-wide** settings — notably `platformParams.deliveryPolicyId` — only in `sharedConfig.overrides`. So for every product the shared overrides were dropped, `platformParams` never reached the worker, the adapter never set `delivery.shippingRates`, and Allegro fell back to a non-existent `default` price list.

Confirmed from the persisted `request.overrides`: `{title, description, categoryId, productCardId}` — **no `platformParams`**, despite `sharedConfig.overrides.platformParams.deliveryPolicyId` being set.

This was **masked until #813/#814** — Allegro validates the product before delivery, so the earlier missing-params / `productSet[0].quantity` 422s fired first.

## Fix

Replace the wholesale select with `mergeOverrides(shared, perProduct)`:
- Scalar fields (title, categoryId, productCardId, imageUrls, …) take the per-product value when present.
- **`platformParams` is deep-merged** so shared keys (`deliveryPolicyId`, `handlingTime`, …) survive even when a row supplies its own platform tweaks (per-product key wins, shared siblings preserved).
- Returns `undefined` only when neither side has overrides (enqueue input keeps omitting the field).

The adapter already maps `platformParams.deliveryPolicyId → delivery.shippingRates` correctly (verified, lines 1509-1510, before the smart-link return) — it was simply never receiving the param.

## Tests

New spec case locks both behaviours: shared `platformParams` preserved when a per-product override has none (the bug), and deep-merge when it has its own. 11/11 bulk-submit specs pass; full local gate green (lint 0 errors, invariants, type-check all packages).

## Sequence note

This is the **third and final** layer of the bulk EAN-card-link flow, each a distinct latent bug surfaced in order:
1. **#813** — FE threads `productCardId` (web)
2. **#814** — Allegro accepts the card-link payload shape (`productSet[].quantity`)
3. **#815** (this) — bulk submit carries the shared delivery price-list through

All three are required for a bulk card-linked offer to create successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #808.