### PR TITLE
feat(web,listings): pre-submit blocker for bulk rows missing required product params (#810)

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.schema.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.schema.ts
@@ -20,6 +20,11 @@ const ALLOWED_CURRENCIES = ['PLN', 'EUR', 'USD', 'GBP', 'CZK'] as const;
 export const bulkEditModalSchema = z.object({
   title: z.string().trim().min(1, 'Title is required').max(TITLE_MAX),
   categoryId: z.string().trim().min(1, 'Category is required'),
+  // Hidden field — not user-editable. Set when the operator picks a multi-match
+  // candidate chip so the offer links that card (#810, mirrors #808). Cleared
+  // on a manual category change since the card belongs to the candidate's
+  // category. Threaded into `overrides.productCardId` at submit.
+  productCardId: z.string().optional(),
   description: z.string().trim().min(1, 'Description is required').max(DESCRIPTION_MAX),
   stock: z.coerce.number().int().min(0, 'Stock cannot be negative'),
   priceAmount: z

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -10,7 +10,7 @@
  * data dependencies.
  */
 import { describe, expect, it, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../../../test/test-utils';
 import { BulkEditModal } from './bulk-edit-modal';
 import type { BulkWizardRow } from './bulk-wizard.types';
@@ -137,5 +137,36 @@ describe('BulkEditModal', () => {
 
     expect(screen.getByDisplayValue('Widget')).toBeInTheDocument();
     expect(screen.queryByDisplayValue('Changed name')).not.toBeInTheDocument();
+  });
+
+  it('threads the picked candidate product card into the saved override (#810)', async () => {
+    const onSave = vi.fn();
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeRow({
+          candidates: [{ allegroCategoryId: 'cat-B', productCardId: 'card-B', name: 'Books' }],
+        })}
+        connectionId="conn_1"
+        defaults={DEFAULTS}
+        onSave={onSave}
+      />,
+    );
+
+    // Pick the candidate → category + card move together; fill the required
+    // description so the form passes validation.
+    fireEvent.click(screen.getByRole('button', { name: 'Books' }));
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'A fine description' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save row' }));
+
+    await waitFor(() => { expect(onSave).toHaveBeenCalledTimes(1); });
+    const override = onSave.mock.calls[0][1] as {
+      overrides?: { categoryId?: string; productCardId?: string };
+    };
+    expect(override.overrides?.categoryId).toBe('cat-B');
+    expect(override.overrides?.productCardId).toBe('card-B');
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -138,6 +138,7 @@ function BulkEditModalForm({
     initialValuesRef.current = {
       title: o.title ?? row.product?.name ?? '',
       categoryId: o.categoryId ?? row.resolvedCategoryId ?? '',
+      productCardId: o.productCardId ?? '',
       description:
         typeof o.description === 'string' ? o.description : row.product?.description ?? '',
       stock: row.override.stock ?? defaults.stock,
@@ -205,6 +206,7 @@ function BulkEditModalForm({
         title: values.title,
         description: values.description,
         categoryId: values.categoryId,
+        ...(values.productCardId ? { productCardId: values.productCardId } : {}),
         ...(Object.keys(platformParams).length > 0 ? { platformParams } : {}),
       },
     };
@@ -265,7 +267,13 @@ function BulkEditModalForm({
                     type="button"
                     className="bulk-edit__candidate-chip"
                     onClick={() => {
+                      // Link the candidate's card so Allegro inherits its
+                      // required product params (#810, mirrors #808's unique-
+                      // match path). Both move together.
                       form.setValue('categoryId', candidate.allegroCategoryId, {
+                        shouldDirty: true,
+                      });
+                      form.setValue('productCardId', candidate.productCardId, {
                         shouldDirty: true,
                       });
                     }}
@@ -291,6 +299,11 @@ function BulkEditModalForm({
                   value={field.value || null}
                   onChange={(id) => {
                     field.onChange(id);
+                    // A manual category pick is not tied to a candidate card —
+                    // drop any card so the offer doesn't link a card from a
+                    // different category (#810). Re-clicking a candidate chip
+                    // re-sets both.
+                    form.setValue('productCardId', '', { shouldDirty: true });
                   }}
                   invalid={Boolean(form.formState.errors.categoryId)}
                 />

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.test.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.test.ts
@@ -222,4 +222,71 @@ describe('computeBlockers', () => {
     );
     expect(result).toEqual([]);
   });
+
+  // #810 — needs-product-parameters (no card to inherit from + required product params)
+  const withPickedCategory = (extra: Partial<ComputeBlockersInput> = {}) =>
+    base({
+      categoryResult: { kind: 'no-match' },
+      override: { overrides: { categoryId: 'cat-1' } },
+      willLinkProductCard: false,
+      ...extra,
+    });
+
+  it('fires needs-product-parameters when no card links and a required product param is missing', () => {
+    const result = computeBlockers(
+      withPickedCategory({ requiredProductParamIds: ['brand', 'model'] }),
+    );
+    expect(result).toContain('needs-product-parameters');
+  });
+
+  it('does NOT fire when all required product params are supplied (clearable)', () => {
+    const result = computeBlockers(
+      withPickedCategory({
+        requiredProductParamIds: ['brand', 'model'],
+        override: {
+          overrides: {
+            categoryId: 'cat-1',
+            platformParams: {
+              productParameters: [
+                { id: 'brand', valuesIds: ['x'] },
+                { id: 'model', values: ['Z9'] },
+              ],
+            },
+          },
+        },
+      }),
+    );
+    expect(result).not.toContain('needs-product-parameters');
+  });
+
+  it('does NOT fire when the row links a product card (params inherited, #808)', () => {
+    const result = computeBlockers(
+      withPickedCategory({
+        willLinkProductCard: true,
+        requiredProductParamIds: ['brand'],
+      }),
+    );
+    expect(result).not.toContain('needs-product-parameters');
+  });
+
+  it('does NOT fire while the category schema is still unknown (undefined ids)', () => {
+    const result = computeBlockers(withPickedCategory({ requiredProductParamIds: undefined }));
+    expect(result).not.toContain('needs-product-parameters');
+  });
+
+  it('does NOT fire for a category with no required product params (empty ids)', () => {
+    const result = computeBlockers(withPickedCategory({ requiredProductParamIds: [] }));
+    expect(result).not.toContain('needs-product-parameters');
+  });
+
+  it('orders the param blocker after the category resolves and before price/stock', () => {
+    const result = computeBlockers(
+      withPickedCategory({
+        requiredProductParamIds: ['brand'],
+        masterPrice: null,
+        masterStock: null,
+      }),
+    );
+    expect(result).toEqual(['needs-product-parameters', 'no-master-price', 'no-master-stock']);
+  });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.ts
@@ -14,6 +14,8 @@ import type { EanMatchResult } from '../../api/listings.types';
 import type {
   BulkRowBlocker,
   BulkValueSource,
+  BulkWizardConfig,
+  BulkWizardRow,
   PricingPolicy,
   StockPolicy,
 } from './bulk-wizard.types';
@@ -212,4 +214,86 @@ function suppliedProductParamIds(override: BulkPerProductOverride): Set<string> 
     }
   }
   return ids;
+}
+
+/**
+ * Reconstruct an `EanMatchResult` from a row's current category state so
+ * `computeBlockers` can re-derive the category blocker after a per-row edit
+ * without re-fetching. An operator-picked / previously-matched category id
+ * yields `matched`; otherwise the surviving category blocker decides.
+ */
+export function categoryResultFor(
+  row: BulkWizardRow,
+  resolvedCategoryId: string | null,
+): EanMatchResult {
+  if (resolvedCategoryId) {
+    return {
+      kind: 'matched',
+      allegroCategoryId: resolvedCategoryId,
+      productCardId: row.resolvedProductCardId ?? '',
+    };
+  }
+  if (row.blockers.includes('no-ean')) return { kind: 'no-ean' };
+  if (row.blockers.includes('multi-match')) {
+    return { kind: 'multi-match', candidates: [...row.categoryCandidates] };
+  }
+  return { kind: 'no-match' };
+}
+
+/**
+ * #808 — choose the catalogue card id to thread into a bulk submit override.
+ *
+ * The EAN-matched card was resolved against the auto-detected category, so it
+ * stays valid only while the category being submitted is still that resolved
+ * category — whether the category arrives via the seeded/edited override or
+ * the raw resolve. (The review-step edit form seeds `override.overrides` with
+ * the resolved category + title + description even for un-touched rows, so a
+ * plain "override has a categoryId" check is NOT a reliable "operator changed
+ * the category" signal — it must be compared to the resolved category.)
+ *
+ * An explicit operator-set card always wins; switching to a *different*
+ * category drops the card so the adapter re-resolves by barcode.
+ *
+ * Exported for unit testing; the wizard calls it from `handleSubmit`.
+ */
+export function selectBulkProductCardId(row: BulkWizardRow): string | undefined {
+  const explicit = row.override.overrides?.productCardId;
+  if (explicit) return explicit;
+  const submittedCategoryId =
+    row.override.overrides?.categoryId ?? row.resolvedCategoryId ?? null;
+  if (row.resolvedProductCardId && submittedCategoryId === row.resolvedCategoryId) {
+    return row.resolvedProductCardId;
+  }
+  return undefined;
+}
+
+/**
+ * Recompute a row's full blocker set from its current state — the shared path
+ * for the post-resolve sites (the Edit-save handler and the schema-reconcile
+ * effect). Threads the #808 card-link signal and the #810 required-product-
+ * param ids for the row's submit category into `computeBlockers`. Pure (no
+ * closure) so the wizard's reconcile effect needs no `rows` dependency.
+ */
+export function recomputeRowBlockers(
+  row: BulkWizardRow,
+  config: BulkWizardConfig,
+  requiredByCategory: Map<string, readonly string[]>,
+): BulkRowBlocker[] {
+  if (!row.primaryVariant) return ['no-variant'];
+  const submitCategoryId = row.override.overrides?.categoryId ?? row.resolvedCategoryId;
+  return computeBlockers({
+    hasVariant: true,
+    categoryResult: categoryResultFor(row, submitCategoryId),
+    pricingPolicy: config.pricingPolicy,
+    stockPolicy: config.stockPolicy,
+    masterPrice: row.masterPrice,
+    masterStock: row.masterStock,
+    masterCurrency: row.masterCurrency,
+    batchCurrency: config.currency,
+    override: row.override,
+    willLinkProductCard: selectBulkProductCardId(row) !== undefined,
+    requiredProductParamIds: submitCategoryId
+      ? requiredByCategory.get(submitCategoryId)
+      : undefined,
+  });
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.ts
@@ -1,9 +1,13 @@
 /**
  * Bulk wizard pricing/stock policy + blocker computation (#792 PR 3)
  *
- * Pure, side-effect-free helpers shared by the Resolve step (blocker compute)
- * and the Review step (computed value + provenance rendering). Kept isolated
- * from React so the policy maths are unit-testable without rendering.
+ * Pure, side-effect-free helpers for the bulk wizard: pricing/stock resolution
+ * + blocker computation, plus the #808 card-link selector and #810
+ * product-parameter derivation. Consumed by the Resolve step (initial blocker
+ * compute), the Review step (computed value + provenance rendering), the
+ * Edit-save handler + schema-reconcile effect (`recomputeRowBlockers`), and the
+ * submit path (`selectBulkProductCardId`). Kept isolated from React so the
+ * policy maths are unit-testable without rendering.
  *
  * Resolution precedence: master → policy → per-row override (override wins).
  *
@@ -221,8 +225,10 @@ function suppliedProductParamIds(override: BulkPerProductOverride): Set<string> 
  * `computeBlockers` can re-derive the category blocker after a per-row edit
  * without re-fetching. An operator-picked / previously-matched category id
  * yields `matched`; otherwise the surviving category blocker decides.
+ *
+ * Module-private — only `recomputeRowBlockers` consumes it.
  */
-export function categoryResultFor(
+function categoryResultFor(
   row: BulkWizardRow,
   resolvedCategoryId: string | null,
 ): EanMatchResult {

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.ts
@@ -121,6 +121,19 @@ export interface ComputeBlockersInput {
   masterCurrency: string | null;
   batchCurrency: string;
   override: BulkPerProductOverride;
+  /**
+   * True when the submit will link an Allegro catalogue card (#808), which
+   * inherits the category's required product parameters. Card-linked rows are
+   * never blocked for missing product params. Omitted (undefined) at resolve
+   * time, where no-card rows have no category yet — treated as not-blocking.
+   */
+  willLinkProductCard?: boolean;
+  /**
+   * Required `section: 'product'` parameter ids for the row's submit category
+   * (unconditional only — `dependsOn`-gated params are excluded). undefined =
+   * schema not loaded yet → do not block (avoids flicker). (#810)
+   */
+  requiredProductParamIds?: readonly string[];
 }
 
 /**
@@ -147,6 +160,18 @@ export function computeBlockers(input: ComputeBlockersInput): BulkRowBlocker[] {
     // 'matched' → no category blocker
   }
 
+  // Product parameters (#810) — a row that creates a product inline (no card to
+  // inherit from) under a category with required product-section params it
+  // hasn't supplied would 422 at submit. Card-linked rows (#808) inherit the
+  // params, so they're exempt. Coverage-based so the blocker clears once the
+  // operator fills the params in the edit modal.
+  if (!input.willLinkProductCard && input.requiredProductParamIds?.length) {
+    const supplied = suppliedProductParamIds(input.override);
+    if (input.requiredProductParamIds.some((id) => !supplied.has(id))) {
+      blockers.push('needs-product-parameters');
+    }
+  }
+
   // Price / stock — override-aware via the resolvers above.
   const price = computeResolvedPrice(input.pricingPolicy, input.masterPrice, input.override);
   if (price.blocker) blockers.push(price.blocker);
@@ -168,4 +193,23 @@ export function computeBlockers(input: ComputeBlockersInput): BulkRowBlocker[] {
   }
 
   return blockers;
+}
+
+/**
+ * Extract the set of product-section parameter ids the operator has supplied
+ * for a row, read from the serialized `platformParams.productParameters` wire
+ * array (`{ id, … }[]`, see `serializeAllegroParameters`). Used to coverage-
+ * check the required product params so the `needs-product-parameters` blocker
+ * clears once they're filled (#810).
+ */
+function suppliedProductParamIds(override: BulkPerProductOverride): Set<string> {
+  const params: unknown = override.overrides?.platformParams?.productParameters;
+  const ids = new Set<string>();
+  if (!Array.isArray(params)) return ids;
+  for (const p of params) {
+    if (p && typeof p === 'object' && typeof (p as { id?: unknown }).id === 'string') {
+      ids.add((p as { id: string }).id);
+    }
+  }
+  return ids;
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
@@ -166,15 +166,15 @@ describe('BulkReviewStep', () => {
   it('renders the add-product-params chip and a remediation hint', () => {
     renderReview([makeRow('a', ['needs-product-parameters'], { masterPrice: 12, masterStock: 5 })]);
     expect(screen.getByText('add product params')).toBeInTheDocument();
-    expect(screen.getByRole('note')).toHaveTextContent(/Edit/);
-    expect(screen.getByRole('note')).toHaveTextContent(/product parameters/);
+    expect(screen.getByRole('status')).toHaveTextContent(/Edit/);
+    expect(screen.getByRole('status')).toHaveTextContent(/product parameters/);
   });
 
   it('singularises the hint for one affected row and pluralises for many', () => {
     const { rerender } = renderReview([
       makeRow('a', ['needs-product-parameters'], { masterPrice: 12, masterStock: 5 }),
     ]);
-    expect(screen.getByRole('note')).toHaveTextContent(/1\s+row needs/);
+    expect(screen.getByRole('status')).toHaveTextContent(/1\s+row needs/);
 
     rerender(
       <BulkReviewStep
@@ -193,7 +193,7 @@ describe('BulkReviewStep', () => {
         onBack={() => undefined}
       />,
     );
-    expect(screen.getByRole('note')).toHaveTextContent(/2\s+rows need/);
+    expect(screen.getByRole('status')).toHaveTextContent(/2\s+rows need/);
   });
 
   it('disables Approve all while category-parameter schemas are still resolving', () => {

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
@@ -79,6 +79,7 @@ function renderReview(
   rows: BulkWizardRow[],
   pricingPolicy: PricingPolicy = { mode: 'use-master' },
   stockPolicy: StockPolicy = { mode: 'use-master' },
+  paramsResolving = false,
 ) {
   return renderWithProviders(
     <BulkReviewStep
@@ -88,6 +89,7 @@ function renderReview(
       stockPolicy={stockPolicy}
       currency="PLN"
       publishImmediately
+      paramsResolving={paramsResolving}
       onUpdateRow={() => undefined}
       onApproveAll={() => undefined}
       onBack={() => undefined}
@@ -142,6 +144,7 @@ describe('BulkReviewStep', () => {
         stockPolicy={{ mode: 'use-master' }}
         currency="PLN"
         publishImmediately
+        paramsResolving={false}
         onUpdateRow={() => undefined}
         onApproveAll={() => undefined}
         onBack={() => undefined}
@@ -157,5 +160,49 @@ describe('BulkReviewStep', () => {
     };
     renderReview([makeRow('a', [], { masterPrice: 12, masterStock: 5 }), noVariantRow]);
     expect(screen.getByRole('button', { name: /Approve all/ })).toBeEnabled();
+  });
+
+  // #810 — needs-product-parameters blocker surfacing
+  it('renders the add-product-params chip and a remediation hint', () => {
+    renderReview([makeRow('a', ['needs-product-parameters'], { masterPrice: 12, masterStock: 5 })]);
+    expect(screen.getByText('add product params')).toBeInTheDocument();
+    expect(screen.getByRole('note')).toHaveTextContent(/Edit/);
+    expect(screen.getByRole('note')).toHaveTextContent(/product parameters/);
+  });
+
+  it('singularises the hint for one affected row and pluralises for many', () => {
+    const { rerender } = renderReview([
+      makeRow('a', ['needs-product-parameters'], { masterPrice: 12, masterStock: 5 }),
+    ]);
+    expect(screen.getByRole('note')).toHaveTextContent(/1\s+row needs/);
+
+    rerender(
+      <BulkReviewStep
+        rows={[
+          makeRow('a', ['needs-product-parameters'], { masterPrice: 12, masterStock: 5 }),
+          makeRow('b', ['needs-product-parameters'], { masterPrice: 12, masterStock: 5 }),
+        ]}
+        connectionId="conn_1"
+        pricingPolicy={{ mode: 'use-master' }}
+        stockPolicy={{ mode: 'use-master' }}
+        currency="PLN"
+        publishImmediately
+        paramsResolving={false}
+        onUpdateRow={() => undefined}
+        onApproveAll={() => undefined}
+        onBack={() => undefined}
+      />,
+    );
+    expect(screen.getByRole('note')).toHaveTextContent(/2\s+rows need/);
+  });
+
+  it('disables Approve all while category-parameter schemas are still resolving', () => {
+    renderReview(
+      [makeRow('a', [], { masterPrice: 12, masterStock: 5 })],
+      { mode: 'use-master' },
+      { mode: 'use-master' },
+      true,
+    );
+    expect(screen.getByRole('button', { name: /Approve all/ })).toBeDisabled();
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
@@ -235,7 +235,7 @@ export function BulkReviewStep({
         </div>
       </header>
 
-      <div className="bulk-wizard__review-summary">
+      <div className="bulk-wizard__review-summary" aria-live="polite">
         <span><strong>{counts.ready}</strong> ready</span>
         {counts.needsAttention > 0 ? (
           <>
@@ -252,7 +252,7 @@ export function BulkReviewStep({
       </div>
 
       {needsProductParamsCount > 0 ? (
-        <p className="bulk-wizard__review-hint" role="note">
+        <p className="bulk-wizard__review-hint" role="status">
           <strong>{needsProductParamsCount}</strong>{' '}
           {needsProductParamsCount === 1 ? 'row needs' : 'rows need'} required product
           parameters. There's no matched product card to inherit them, so{' '}

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
@@ -134,17 +134,22 @@ export function BulkReviewStep({
       {
         id: 'category',
         header: 'Matched category',
-        cell: (row) => (
-          <span
-            className={
-              row.resolvedCategoryId
-                ? 'bulk-wizard__row-category'
-                : 'bulk-wizard__row-category bulk-wizard__row-category--dim'
-            }
-          >
-            {row.resolvedCategoryId ?? '—'}
-          </span>
-        ),
+        // Effective submit category — an operator pick (override) wins over the
+        // EAN-resolved value, which stays put for the card-link guard (#810).
+        cell: (row) => {
+          const categoryId = row.override.overrides?.categoryId ?? row.resolvedCategoryId;
+          return (
+            <span
+              className={
+                categoryId
+                  ? 'bulk-wizard__row-category'
+                  : 'bulk-wizard__row-category bulk-wizard__row-category--dim'
+              }
+            >
+              {categoryId ?? '—'}
+            </span>
+          );
+        },
       },
       {
         id: 'stock',

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
@@ -235,7 +235,7 @@ export function BulkReviewStep({
         </div>
       </header>
 
-      <div className="bulk-wizard__review-summary" aria-live="polite">
+      <div className="bulk-wizard__review-summary">
         <span><strong>{counts.ready}</strong> ready</span>
         {counts.needsAttention > 0 ? (
           <>

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
@@ -42,6 +42,12 @@ interface BulkReviewStepProps {
   /** Batch-wide currency (D7). */
   currency: string;
   publishImmediately: boolean;
+  /**
+   * True while category parameter schemas are still loading (#810). Gates
+   * "Approve all" so the operator can't submit before the
+   * `needs-product-parameters` blocker has had a chance to appear.
+   */
+  paramsResolving: boolean;
   onUpdateRow: (
     variantId: string,
     override: BulkPerProductOverride,
@@ -56,6 +62,7 @@ const BLOCKER_CHIPS: Record<BulkRowBlocker, { tone: StatusBadgeTone; label: stri
   'no-ean': { tone: 'error', label: 'no EAN' },
   'no-match': { tone: 'error', label: 'manual category' },
   'multi-match': { tone: 'warning', label: 'choose category' },
+  'needs-product-parameters': { tone: 'warning', label: 'add product params' },
   'no-master-price': { tone: 'error', label: 'no master price' },
   'no-master-stock': { tone: 'error', label: 'no master stock' },
   'currency-mismatch': { tone: 'warning', label: 'currency mismatch' },
@@ -68,6 +75,7 @@ export function BulkReviewStep({
   stockPolicy,
   currency,
   publishImmediately,
+  paramsResolving,
   onUpdateRow,
   onApproveAll,
   onBack,
@@ -87,8 +95,15 @@ export function BulkReviewStep({
 
   const counts = useMemo(() => countByReadiness(rows), [rows]);
   // No-variant rows are skipped on submit, not blocking. Approval is gated on
-  // every *listable* row being clear, with at least one ready row to submit.
-  const canApprove = counts.ready > 0 && counts.needsAttention === 0;
+  // every *listable* row being clear, with at least one ready row to submit —
+  // and on category-parameter schemas having settled, so a row that's about to
+  // gain the `needs-product-parameters` blocker can't sneak through (#810).
+  const canApprove = counts.ready > 0 && counts.needsAttention === 0 && !paramsResolving;
+
+  const needsProductParamsCount = useMemo(
+    () => rows.filter((r) => r.blockers.includes('needs-product-parameters')).length,
+    [rows],
+  );
 
   const editingRow = useMemo(
     () => (editingId ? rows.find((r) => r.productId === editingId) ?? null : null),
@@ -230,6 +245,15 @@ export function BulkReviewStep({
           </>
         ) : null}
       </div>
+
+      {needsProductParamsCount > 0 ? (
+        <p className="bulk-wizard__review-hint" role="note">
+          <strong>{needsProductParamsCount}</strong>{' '}
+          {needsProductParamsCount === 1 ? 'row needs' : 'rows need'} required product
+          parameters. There's no matched product card to inherit them, so{' '}
+          <strong>Edit</strong> each row to add them before submitting.
+        </p>
+      ) : null}
 
       <DataTable<BulkWizardRow>
         caption="Bulk listing review"

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
@@ -214,4 +214,17 @@ describe('recomputeRowBlockers (#810)', () => {
     const blockers = recomputeRowBlockers(row, config, new Map());
     expect(blockers).not.toContain('needs-product-parameters');
   });
+
+  it('drops the stale card and blocks when a matched row is recategorised to a card-less category', () => {
+    // Regression: editing an auto-matched row to a *different* category must
+    // drop the card (it belonged to the resolved category), so the row is no
+    // longer card-linked and the new category's required params apply.
+    const row = variantRow({
+      resolvedCategoryId: 'cat-A',
+      resolvedProductCardId: 'card-1',
+      override: { overrides: { categoryId: 'cat-B' } },
+    });
+    const blockers = recomputeRowBlockers(row, config, new Map([['cat-B', ['brand']]]));
+    expect(blockers).toContain('needs-product-parameters');
+  });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
@@ -5,11 +5,8 @@
  * productId; rows without a matching outcome keep their identity.
  */
 import { describe, expect, it } from 'vitest';
-import {
-  mergeResolveOutcomes,
-  recomputeRowBlockers,
-  selectBulkProductCardId,
-} from './bulk-wizard';
+import { mergeResolveOutcomes } from './bulk-wizard';
+import { recomputeRowBlockers, selectBulkProductCardId } from './bulk-policy';
 import type { BulkResolveOutcome } from './bulk-resolve-step';
 import type { BulkWizardConfig, BulkWizardRow } from './bulk-wizard.types';
 import type { ProductVariant } from '../../../products';

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
@@ -5,9 +5,14 @@
  * productId; rows without a matching outcome keep their identity.
  */
 import { describe, expect, it } from 'vitest';
-import { mergeResolveOutcomes, selectBulkProductCardId } from './bulk-wizard';
+import {
+  mergeResolveOutcomes,
+  recomputeRowBlockers,
+  selectBulkProductCardId,
+} from './bulk-wizard';
 import type { BulkResolveOutcome } from './bulk-resolve-step';
-import type { BulkWizardRow } from './bulk-wizard.types';
+import type { BulkWizardConfig, BulkWizardRow } from './bulk-wizard.types';
+import type { ProductVariant } from '../../../products';
 
 function makeRow(productId: string): BulkWizardRow {
   return {
@@ -133,5 +138,80 @@ describe('selectBulkProductCardId (#808)', () => {
   it('returns undefined when there is no resolved card', () => {
     const row = rowWith({ resolvedCategoryId: '257933', resolvedProductCardId: null });
     expect(selectBulkProductCardId(row)).toBeUndefined();
+  });
+});
+
+describe('recomputeRowBlockers (#810)', () => {
+  const config: BulkWizardConfig = {
+    connectionId: 'conn_1',
+    deliveryPolicyId: 'dp_1',
+    currency: 'PLN',
+    pricingPolicy: { mode: 'flat', amount: 50 },
+    stockPolicy: { mode: 'flat', value: 3 },
+    publishImmediately: true,
+    generateDescription: false,
+  };
+
+  const variant: ProductVariant = {
+    id: 'var_1',
+    productId: 'prod_1',
+    sku: 'SKU',
+    attributes: null,
+    ean: '590',
+    gtin: null,
+    price: 50,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  function variantRow(partial: Partial<BulkWizardRow>): BulkWizardRow {
+    return { ...makeRow('prod_1'), primaryVariant: variant, ...partial };
+  }
+
+  it('raises needs-product-parameters for a manually-categorised no-card row', () => {
+    const row = variantRow({
+      resolvedProductCardId: null,
+      override: { overrides: { categoryId: 'cat-X' } },
+    });
+    const blockers = recomputeRowBlockers(row, config, new Map([['cat-X', ['brand', 'model']]]));
+    expect(blockers).toContain('needs-product-parameters');
+  });
+
+  it('does not raise it once the required params are supplied', () => {
+    const row = variantRow({
+      resolvedProductCardId: null,
+      override: {
+        overrides: {
+          categoryId: 'cat-X',
+          platformParams: {
+            productParameters: [
+              { id: 'brand', valuesIds: ['1'] },
+              { id: 'model', values: ['Z'] },
+            ],
+          },
+        },
+      },
+    });
+    const blockers = recomputeRowBlockers(row, config, new Map([['cat-X', ['brand', 'model']]]));
+    expect(blockers).not.toContain('needs-product-parameters');
+  });
+
+  it('exempts a card-linked row (params inherited, #808)', () => {
+    const row = variantRow({
+      resolvedCategoryId: 'cat-X',
+      resolvedProductCardId: 'card-1',
+      override: { overrides: { categoryId: 'cat-X' } },
+    });
+    const blockers = recomputeRowBlockers(row, config, new Map([['cat-X', ['brand']]]));
+    expect(blockers).not.toContain('needs-product-parameters');
+  });
+
+  it('stays inert until the category schema is known (no map entry)', () => {
+    const row = variantRow({
+      resolvedProductCardId: null,
+      override: { overrides: { categoryId: 'cat-X' } },
+    });
+    const blockers = recomputeRowBlockers(row, config, new Map());
+    expect(blockers).not.toContain('needs-product-parameters');
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -19,13 +19,17 @@ import type {
   BulkOfferCreateRequest,
   BulkPerProductOverride,
 } from '../../api/bulk-listings.types';
-import type { EanMatchResult } from '../../api/listings.types';
 import type { Product, ProductVariant } from '../../../products';
 import { BulkConfigStep } from './bulk-config-step';
 import { BulkResolveStep, type BulkResolveOutcome } from './bulk-resolve-step';
 import { BulkReviewStep } from './bulk-review-step';
 import { BulkConfirmModal } from './bulk-confirm-modal';
-import { computeBlockers, computeResolvedPrice, computeResolvedStock } from './bulk-policy';
+import {
+  computeResolvedPrice,
+  computeResolvedStock,
+  recomputeRowBlockers,
+  selectBulkProductCardId,
+} from './bulk-policy';
 import type {
   BulkRowBlocker,
   BulkWizardConfig,
@@ -327,64 +331,6 @@ function stepOrder(step: BulkWizardStep): number {
   return WIZARD_STEPS.findIndex((s) => s.id === step);
 }
 
-/**
- * Reconstruct an `EanMatchResult` from a row's current category state so
- * `computeBlockers` can re-derive the category blocker after a per-row edit
- * without re-fetching. An operator-picked / previously-matched category id
- * yields `matched`; otherwise the surviving category blocker decides.
- */
-function categoryResultFor(
-  row: BulkWizardRow,
-  resolvedCategoryId: string | null,
-): EanMatchResult {
-  if (resolvedCategoryId) {
-    return {
-      kind: 'matched',
-      allegroCategoryId: resolvedCategoryId,
-      productCardId: row.resolvedProductCardId ?? '',
-    };
-  }
-  if (row.blockers.includes('no-ean')) return { kind: 'no-ean' };
-  if (row.blockers.includes('multi-match')) {
-    return { kind: 'multi-match', candidates: [...row.categoryCandidates] };
-  }
-  return { kind: 'no-match' };
-}
-
-/**
- * Recompute a row's full blocker set from its current state — the shared path
- * for the post-resolve sites (the Edit-save handler and the schema-reconcile
- * effect). Threads the #808 card-link signal and the #810 required-product-
- * param ids for the row's submit category into `computeBlockers`. Module-scope
- * (not a closure) so the reconcile effect needs no `rows` dependency.
- *
- * Exported for unit testing; the wizard calls it from `handleUpdateRow` and the
- * schema-reconcile effect.
- */
-export function recomputeRowBlockers(
-  row: BulkWizardRow,
-  config: BulkWizardConfig,
-  requiredByCategory: Map<string, readonly string[]>,
-): BulkRowBlocker[] {
-  if (!row.primaryVariant) return ['no-variant'];
-  const submitCategoryId = row.override.overrides?.categoryId ?? row.resolvedCategoryId;
-  return computeBlockers({
-    hasVariant: true,
-    categoryResult: categoryResultFor(row, submitCategoryId),
-    pricingPolicy: config.pricingPolicy,
-    stockPolicy: config.stockPolicy,
-    masterPrice: row.masterPrice,
-    masterStock: row.masterStock,
-    masterCurrency: row.masterCurrency,
-    batchCurrency: config.currency,
-    override: row.override,
-    willLinkProductCard: selectBulkProductCardId(row) !== undefined,
-    requiredProductParamIds: submitCategoryId
-      ? requiredByCategory.get(submitCategoryId)
-      : undefined,
-  });
-}
-
 /** Order-sensitive blocker-list equality (`computeBlockers` emits a stable order). */
 function sameBlockers(a: readonly BulkRowBlocker[], b: readonly BulkRowBlocker[]): boolean {
   return a.length === b.length && a.every((blocker, i) => blocker === b[i]);
@@ -414,33 +360,6 @@ export function mergeResolveOutcomes(
       categoryCandidates: o.categoryCandidates,
     };
   });
-}
-
-/**
- * #808 — choose the catalogue card id to thread into a bulk submit override.
- *
- * The EAN-matched card was resolved against the auto-detected category, so it
- * stays valid only while the category being submitted is still that resolved
- * category — whether the category arrives via the seeded/edited override or
- * the raw resolve. (The review-step edit form seeds `override.overrides` with
- * the resolved category + title + description even for un-touched rows, so a
- * plain "override has a categoryId" check is NOT a reliable "operator changed
- * the category" signal — it must be compared to the resolved category.)
- *
- * An explicit operator-set card always wins; switching to a *different*
- * category drops the card so the adapter re-resolves by barcode.
- *
- * Exported for unit testing; the wizard calls it from `handleSubmit`.
- */
-export function selectBulkProductCardId(row: BulkWizardRow): string | undefined {
-  const explicit = row.override.overrides?.productCardId;
-  if (explicit) return explicit;
-  const submittedCategoryId =
-    row.override.overrides?.categoryId ?? row.resolvedCategoryId ?? null;
-  if (row.resolvedProductCardId && submittedCategoryId === row.resolvedCategoryId) {
-    return row.resolvedProductCardId;
-  }
-  return undefined;
 }
 
 function seedRows(products: Product[]): BulkWizardRow[] {

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -137,9 +137,13 @@ export function BulkWizard({
       setRows((prev) =>
         prev.map((row) => {
           if (row.primaryVariant?.id !== variantId) return row;
-          const resolvedCategoryId =
-            override.overrides?.categoryId ?? row.resolvedCategoryId;
-          const updated: BulkWizardRow = { ...row, override, editFormValues, resolvedCategoryId };
+          // `resolvedCategoryId` is the EAN-matched category and stays put — it's
+          // the reference `selectBulkProductCardId` compares the submit category
+          // against to decide whether the matched card still applies (#810). The
+          // operator's pick lives in `override.categoryId`; overwriting the
+          // resolved value here would defeat that guard and thread a stale card
+          // under a switched category.
+          const updated: BulkWizardRow = { ...row, override, editFormValues };
           return {
             ...updated,
             blockers: recomputeRowBlockers(updated, config, requiredByCategory),

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -9,11 +9,12 @@
  *
  * @module apps/web/src/features/listings/components/bulk
  */
-import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Alert, PageLayout, SetupStepper } from '../../../../shared/ui';
 import { useToast } from '../../../../shared/ui/toast-provider';
 import { useBulkSubmitMutation } from '../../hooks/use-bulk-submit-mutation';
+import { useBulkRequiredProductParams } from '../../hooks/use-bulk-required-product-params';
 import type {
   BulkOfferCreateRequest,
   BulkPerProductOverride,
@@ -26,6 +27,7 @@ import { BulkReviewStep } from './bulk-review-step';
 import { BulkConfirmModal } from './bulk-confirm-modal';
 import { computeBlockers, computeResolvedPrice, computeResolvedStock } from './bulk-policy';
 import type {
+  BulkRowBlocker,
   BulkWizardConfig,
   BulkWizardRow,
   BulkWizardStep,
@@ -74,6 +76,47 @@ export function BulkWizard({
     });
   }, [productsSignature, products]);
 
+  // Distinct categories of rows that will submit WITHOUT a card link (#810).
+  // Only these can hit the missing-product-parameters 422 — card-linked rows
+  // inherit the params. Feeds the schema fan-out below.
+  const noCardCategoryIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const row of rows) {
+      if (!row.primaryVariant) continue;
+      if (selectBulkProductCardId(row) !== undefined) continue;
+      const categoryId = row.override.overrides?.categoryId ?? row.resolvedCategoryId;
+      if (categoryId) set.add(categoryId);
+    }
+    return Array.from(set);
+  }, [rows]);
+
+  const { requiredByCategory, isResolving: paramsResolving } = useBulkRequiredProductParams(
+    config?.connectionId,
+    noCardCategoryIds,
+  );
+
+  // Reconcile the `needs-product-parameters` blocker whenever a category's
+  // schema resolves (it loads after the operator picks the category, so it
+  // can't be decided at resolve time). Gated to the Review step: only there do
+  // rows carry resolved master data, so recomputing earlier would clobber the
+  // seed blockers with values derived from un-resolved (null) master data.
+  // `recomputeRowBlockers` is idempotent and the identity guard prevents a
+  // re-render loop. (#810)
+  useEffect(() => {
+    if (!config || step !== 'review') return;
+    setRows((prev) => {
+      let changed = false;
+      const next = prev.map((row) => {
+        if (!row.primaryVariant) return row;
+        const blockers = recomputeRowBlockers(row, config, requiredByCategory);
+        if (sameBlockers(blockers, row.blockers)) return row;
+        changed = true;
+        return { ...row, blockers };
+      });
+      return changed ? next : prev;
+    });
+  }, [config, step, requiredByCategory]);
+
   const handleConfigProceed = useCallback((next: BulkWizardConfig) => {
     setConfig(next);
     setStep('resolve');
@@ -96,22 +139,15 @@ export function BulkWizard({
           if (row.primaryVariant?.id !== variantId) return row;
           const resolvedCategoryId =
             override.overrides?.categoryId ?? row.resolvedCategoryId;
-          const blockers = computeBlockers({
-            hasVariant: true,
-            categoryResult: categoryResultFor(row, resolvedCategoryId),
-            pricingPolicy: config.pricingPolicy,
-            stockPolicy: config.stockPolicy,
-            masterPrice: row.masterPrice,
-            masterStock: row.masterStock,
-            masterCurrency: row.masterCurrency,
-            batchCurrency: config.currency,
-            override,
-          });
-          return { ...row, override, editFormValues, blockers, resolvedCategoryId };
+          const updated: BulkWizardRow = { ...row, override, editFormValues, resolvedCategoryId };
+          return {
+            ...updated,
+            blockers: recomputeRowBlockers(updated, config, requiredByCategory),
+          };
         }),
       );
     },
-    [config],
+    [config, requiredByCategory],
   );
 
   const handleSubmit = useCallback(
@@ -256,6 +292,7 @@ export function BulkWizard({
               stockPolicy={config.stockPolicy}
               currency={config.currency}
               publishImmediately={config.publishImmediately}
+              paramsResolving={paramsResolving}
               onUpdateRow={handleUpdateRow}
               onApproveAll={() => { setConfirmOpen(true); }}
               onBack={() => { setStep('config'); }}
@@ -308,6 +345,45 @@ function categoryResultFor(
     return { kind: 'multi-match', candidates: [...row.categoryCandidates] };
   }
   return { kind: 'no-match' };
+}
+
+/**
+ * Recompute a row's full blocker set from its current state — the shared path
+ * for the post-resolve sites (the Edit-save handler and the schema-reconcile
+ * effect). Threads the #808 card-link signal and the #810 required-product-
+ * param ids for the row's submit category into `computeBlockers`. Module-scope
+ * (not a closure) so the reconcile effect needs no `rows` dependency.
+ *
+ * Exported for unit testing; the wizard calls it from `handleUpdateRow` and the
+ * schema-reconcile effect.
+ */
+export function recomputeRowBlockers(
+  row: BulkWizardRow,
+  config: BulkWizardConfig,
+  requiredByCategory: Map<string, readonly string[]>,
+): BulkRowBlocker[] {
+  if (!row.primaryVariant) return ['no-variant'];
+  const submitCategoryId = row.override.overrides?.categoryId ?? row.resolvedCategoryId;
+  return computeBlockers({
+    hasVariant: true,
+    categoryResult: categoryResultFor(row, submitCategoryId),
+    pricingPolicy: config.pricingPolicy,
+    stockPolicy: config.stockPolicy,
+    masterPrice: row.masterPrice,
+    masterStock: row.masterStock,
+    masterCurrency: row.masterCurrency,
+    batchCurrency: config.currency,
+    override: row.override,
+    willLinkProductCard: selectBulkProductCardId(row) !== undefined,
+    requiredProductParamIds: submitCategoryId
+      ? requiredByCategory.get(submitCategoryId)
+      : undefined,
+  });
+}
+
+/** Order-sensitive blocker-list equality (`computeBlockers` emits a stable order). */
+function sameBlockers(a: readonly BulkRowBlocker[], b: readonly BulkRowBlocker[]): boolean {
+  return a.length === b.length && a.every((blocker, i) => blocker === b[i]);
 }
 
 /**

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.types.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.types.ts
@@ -37,6 +37,10 @@ export const BulkRowBlockerValues = [
   'no-match',
   // EAN matched several Allegro cards — operator picks one from the candidates.
   'multi-match',
+  // Row will create a product inline (no card to inherit from) under a category
+  // whose required product-section params (Marka, Model, EAN, …) aren't supplied.
+  // Clears once the operator fills them in the edit modal (#810).
+  'needs-product-parameters',
   // Active pricing policy needs a master price and the variant has none.
   'no-master-price',
   // Active stock policy needs a master stock value and it's 0 or null.

--- a/apps/web/src/features/listings/hooks/use-bulk-required-product-params.test.tsx
+++ b/apps/web/src/features/listings/hooks/use-bulk-required-product-params.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * use-bulk-required-product-params tests (#810)
+ *
+ * Verifies the per-category fan-out returns the required, unconditional,
+ * product-section parameter ids — and only those — and stays inert with no
+ * categories to resolve.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { renderHook, waitFor, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useBulkRequiredProductParams } from './use-bulk-required-product-params';
+import type { CategoryParameter } from '../api/listings.types';
+
+function param(overrides: Partial<CategoryParameter>): CategoryParameter {
+  return {
+    id: 'p',
+    name: 'P',
+    type: 'string',
+    required: false,
+    restrictions: {},
+    section: 'offer',
+    ...overrides,
+  };
+}
+
+describe('useBulkRequiredProductParams', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+  afterEach(() => { cleanup(); });
+
+  function wrap(apiClient: ReturnType<typeof createMockApiClient>): React.FC<{ children: React.ReactNode }> {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    return ({ children }) => (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  }
+
+  it('keeps only required, unconditional, product-section params', async () => {
+    const getCategoryParameters = vi.fn().mockResolvedValue({
+      parameters: [
+        param({ id: 'brand', required: true, section: 'product' }), // keep
+        param({ id: 'model', required: true, section: 'product' }), // keep
+        param({ id: 'color', required: false, section: 'product' }), // drop — optional
+        param({ id: 'warranty', required: true, section: 'offer' }), // drop — offer section
+        param({
+          id: 'sub-type',
+          required: true,
+          section: 'product',
+          dependsOn: { parameterId: 'brand', valueIds: ['x'] },
+        }), // drop — conditional
+      ],
+    });
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    const { result } = renderHook(() => useBulkRequiredProductParams('conn-1', ['cat-A']), {
+      wrapper: wrap(apiClient),
+    });
+
+    await waitFor(() => expect(result.current.requiredByCategory.has('cat-A')).toBe(true));
+    expect(result.current.requiredByCategory.get('cat-A')).toEqual(['brand', 'model']);
+    expect(result.current.isResolving).toBe(false);
+  });
+
+  it('resolves an empty category with an empty id list (no required product params)', async () => {
+    const getCategoryParameters = vi.fn().mockResolvedValue({
+      parameters: [param({ id: 'warranty', required: true, section: 'offer' })],
+    });
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    const { result } = renderHook(() => useBulkRequiredProductParams('conn-1', ['cat-A']), {
+      wrapper: wrap(apiClient),
+    });
+
+    await waitFor(() => expect(result.current.requiredByCategory.has('cat-A')).toBe(true));
+    expect(result.current.requiredByCategory.get('cat-A')).toEqual([]);
+  });
+
+  it('maps multiple categories and dedupes repeats', async () => {
+    const getCategoryParameters = vi.fn().mockImplementation((_conn: string, categoryId: string) =>
+      Promise.resolve({
+        parameters:
+          categoryId === 'cat-A'
+            ? [param({ id: 'brand', required: true, section: 'product' })]
+            : [param({ id: 'gtin', required: true, section: 'product' })],
+      }),
+    );
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    const { result } = renderHook(
+      () => useBulkRequiredProductParams('conn-1', ['cat-A', 'cat-B', 'cat-A']),
+      { wrapper: wrap(apiClient) },
+    );
+
+    await waitFor(() => expect(result.current.requiredByCategory.size).toBe(2));
+    expect(result.current.requiredByCategory.get('cat-A')).toEqual(['brand']);
+    expect(result.current.requiredByCategory.get('cat-B')).toEqual(['gtin']);
+    // Deduped: 'cat-A' fetched once despite appearing twice.
+    expect(getCategoryParameters).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing when there are no categories to resolve', () => {
+    const getCategoryParameters = vi.fn();
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    const { result } = renderHook(() => useBulkRequiredProductParams('conn-1', []), {
+      wrapper: wrap(apiClient),
+    });
+
+    expect(result.current.requiredByCategory.size).toBe(0);
+    expect(result.current.isResolving).toBe(false);
+    expect(getCategoryParameters).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch without a connection id', () => {
+    const getCategoryParameters = vi.fn();
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    renderHook(() => useBulkRequiredProductParams(undefined, ['cat-A']), {
+      wrapper: wrap(apiClient),
+    });
+
+    expect(getCategoryParameters).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/listings/hooks/use-bulk-required-product-params.ts
+++ b/apps/web/src/features/listings/hooks/use-bulk-required-product-params.ts
@@ -1,0 +1,88 @@
+/**
+ * use-bulk-required-product-params (#810)
+ *
+ * Fans the per-category parameter schema query out over the distinct set of
+ * categories that the bulk wizard's no-card rows will submit under, and returns
+ * the *required, unconditional, product-section* parameter ids per category.
+ * The wizard feeds these into `computeBlockers` to raise the
+ * `needs-product-parameters` blocker on rows that would 422 (no card to inherit
+ * from + missing required product params).
+ *
+ * Reuses the same query key + queryFn + 24h staleTime as
+ * `useCategoryParametersQuery`, so categories already opened in the edit modal
+ * are cache hits and a batch sharing one category fetches it once.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { CategoryParameter } from '../api/listings.types';
+import { CATEGORY_PARAMETERS_STALE_TIME_MS } from './use-category-parameters-query';
+
+export interface BulkRequiredProductParams {
+  /**
+   * category id → required, unconditional (`!dependsOn`) product-section param
+   * ids. Absent key = schema not loaded yet (caller treats as "don't block").
+   */
+  requiredByCategory: Map<string, readonly string[]>;
+  /** True while any category's schema is still loading its first response. */
+  isResolving: boolean;
+}
+
+export function useBulkRequiredProductParams(
+  connectionId: string | undefined,
+  categoryIds: readonly string[],
+): BulkRequiredProductParams {
+  const apiClient = useApiClient();
+
+  // Distinct + stable order so the useQueries array stays index-aligned across
+  // renders that don't change the set.
+  const distinctIds = useMemo(
+    () => Array.from(new Set(categoryIds)).sort(),
+    [categoryIds],
+  );
+
+  const results = useQueries({
+    queries: distinctIds.map((categoryId) => ({
+      queryKey: listingsQueryKeys.categoryParameters(connectionId ?? '', categoryId),
+      queryFn: async (): Promise<CategoryParameter[]> => {
+        const response = await apiClient.listings.getCategoryParameters(
+          connectionId as string,
+          categoryId,
+        );
+        return response.parameters;
+      },
+      enabled: Boolean(connectionId) && categoryId.length > 0,
+      staleTime: CATEGORY_PARAMETERS_STALE_TIME_MS,
+    })),
+  });
+
+  const isResolving = results.some((q) => q.isLoading);
+
+  // A category's schema is immutable, so this signature flips at most once per
+  // category (unloaded → loaded). Memoising the return value on it keeps the
+  // object identity stable when nothing changed — the consumer effect depends
+  // on `requiredByCategory`, so a fresh Map every render would re-run it.
+  const signature = distinctIds
+    .map((id, i) => `${id}:${results[i]?.data ? '1' : '0'}`)
+    .join('|');
+
+  return useMemo<BulkRequiredProductParams>(() => {
+    const requiredByCategory = new Map<string, readonly string[]>();
+    distinctIds.forEach((categoryId, i) => {
+      const data = results[i]?.data;
+      if (!data) return;
+      requiredByCategory.set(
+        categoryId,
+        data
+          .filter((p) => p.required && p.section === 'product' && !p.dependsOn)
+          .map((p) => p.id),
+      );
+    });
+    return { requiredByCategory, isResolving };
+    // `signature` captures distinctIds + each query's loaded state; `results`
+    // identity changes every render so it intentionally isn't a dep.
+  }, [signature, isResolving]);
+}

--- a/apps/web/src/features/listings/hooks/use-bulk-required-product-params.ts
+++ b/apps/web/src/features/listings/hooks/use-bulk-required-product-params.ts
@@ -61,28 +61,18 @@ export function useBulkRequiredProductParams(
 
   const isResolving = results.some((q) => q.isLoading);
 
-  // A category's schema is immutable, so this signature flips at most once per
-  // category (unloaded → loaded). Memoising the return value on it keeps the
-  // object identity stable when nothing changed — the consumer effect depends
-  // on `requiredByCategory`, so a fresh Map every render would re-run it.
-  const signature = distinctIds
-    .map((id, i) => `${id}:${results[i]?.data ? '1' : '0'}`)
-    .join('|');
+  // Built fresh each render — no memoisation. The only consumer (the wizard's
+  // schema-reconcile effect) short-circuits when the recomputed blocker set is
+  // unchanged, so a new `Map` identity per render can't cause a re-render loop.
+  const requiredByCategory = new Map<string, readonly string[]>();
+  distinctIds.forEach((categoryId, i) => {
+    const data = results[i]?.data;
+    if (!data) return;
+    requiredByCategory.set(
+      categoryId,
+      data.filter((p) => p.required && p.section === 'product' && !p.dependsOn).map((p) => p.id),
+    );
+  });
 
-  return useMemo<BulkRequiredProductParams>(() => {
-    const requiredByCategory = new Map<string, readonly string[]>();
-    distinctIds.forEach((categoryId, i) => {
-      const data = results[i]?.data;
-      if (!data) return;
-      requiredByCategory.set(
-        categoryId,
-        data
-          .filter((p) => p.required && p.section === 'product' && !p.dependsOn)
-          .map((p) => p.id),
-      );
-    });
-    return { requiredByCategory, isResolving };
-    // `signature` captures distinctIds + each query's loaded state; `results`
-    // identity changes every render so it intentionally isn't a dep.
-  }, [signature, isResolving]);
+  return { requiredByCategory, isResolving };
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7869,6 +7869,18 @@ html[data-density='compact'] .status-badge {
   color: var(--border-strong);
 }
 
+/* Missing-product-params nudge (#810) */
+.bulk-wizard__review-hint {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  background: var(--status-warning-soft);
+  border: 1px solid var(--status-warning-border);
+  border-radius: var(--radius-md);
+  color: var(--status-warning-fg);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
 .bulk-wizard__row-name {
   display: flex;
   align-items: center;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7877,7 +7877,7 @@ html[data-density='compact'] .status-badge {
   border: 1px solid var(--status-warning-border);
   border-radius: var(--radius-md);
   color: var(--status-warning-fg);
-  font-size: 12.5px;
+  font-size: 0.8125rem;
   line-height: 1.5;
 }
 

--- a/docs/plans/implementation-plan-bulk-needs-product-parameters-blocker.md
+++ b/docs/plans/implementation-plan-bulk-needs-product-parameters-blocker.md
@@ -111,6 +111,10 @@ Picking a multi-match candidate chip (`bulk-edit-modal.tsx:267`) currently sets 
 
 Recommendation: **(B)** — it's a few lines, removes a whole class of avoidable blocks, and is the same pattern #808 established. Confirm before implementing.
 
+### 3.6 Stale-card fix (grill-surfaced)
+
+`handleUpdateRow` overwrote `row.resolvedCategoryId` with the operator's pick, which defeated `selectBulkProductCardId`'s guard (`submitCategory === resolvedCategoryId`): a *matched* row recategorised via the picker kept threading its **stale** card under the new category → Allegro 422 (wrong-category card) **and** `willLinkProductCard` was wrongly `true`, so the new blocker never fired — a silent "looks ready" 422, the exact failure class #810 targets. Fix: stop overwriting `resolvedCategoryId` (it stays the EAN-resolved reference); the review category column renders the *effective* category (`override.categoryId ?? resolvedCategoryId`). Now a recategorised matched row drops the card, re-resolves/creates inline, and the param blocker fires if the new category needs params. The existing `selectBulkProductCardId` "drops the card on category switch" test already encodes the target behaviour — the fix makes the live flow reach it.
+
 ## 4. Step-by-step implementation
 
 1. **`bulk-wizard.types.ts`** — add `'needs-product-parameters'` to `BulkRowBlockerValues` + doc comment. *AC: type compiles; value exported.*

--- a/docs/plans/implementation-plan-bulk-needs-product-parameters-blocker.md
+++ b/docs/plans/implementation-plan-bulk-needs-product-parameters-blocker.md
@@ -1,0 +1,138 @@
+# Implementation Plan — Bulk `needs-product-parameters` review blocker (#810)
+
+## 1. Understand the task
+
+**Goal.** Stop bulk-offer rows from silently 422-ing on Allegro when they will create a product **inline** (no catalogue card to inherit from) under a category that has **required product-section parameters** (Marka, Model, EAN, …) that the operator has not supplied. Surface the condition as a **pre-submit review blocker** instead of a post-submit per-record failure.
+
+**Layer.** Frontend only (`apps/web`, `features/listings`). No CORE / Integration / API change — the `GET /listings/connections/:connectionId/categories/:categoryId/parameters` endpoint already returns each parameter's `required` and `section` (`'offer' | 'product'`).
+
+**Explicit non-goals.**
+- No new BE endpoint or resolve-batch contract change.
+- No change to the worker / adapter create path (#806 keeps surfacing the post-submit detail as a backstop).
+- Not building a *new* product-parameter form — the bulk **edit modal already collects product-section params** (`bulk-edit-modal.tsx`, #740: `CategoryParametersStep` + `serializeAllegroParameters` → `platformParams.productParameters`). The blocker simply routes the operator back into that existing modal.
+
+### Corrected premise (vs the issue text)
+
+The issue assumed "the bulk wizard has no per-row product-parameter form." It does (#740). The real gap is two-fold:
+1. The edit modal does **not** hard-block save when required params are missing (it explicitly allows save: *"the worker may reject"* — `bulk-edit-modal.tsx:430`).
+2. `computeBlockers` **clears** the category blocker the instant `override.categoryId` is set (`bulk-policy.ts:137`), so a row where the operator picked a category but skipped the required product params shows **"ready"** and enters the submit gate → 422.
+
+So the blocker's remedy is **"edit the row to add the required product parameters"**, not "create individually."
+
+### Why detection must be FE-side (rejecting Option 2)
+
+The BE batch-resolve (`resolveCategoriesForBatchByEan`) only ever yields a category **together with** a card (`matched`, or `multi-match` candidates each carrying `productCardId`). The "category without a card" state is created **exclusively by FE operator overrides** the BE never sees. Therefore a BE `requiresProductParameters` flag (issue Option 2) cannot detect the primary case. Option 3 (accept-and-route on the worker 422) is the explicit non-goal of the issue ("operator only finds out *after* submit"). **Option 1 (FE detection, reusing the existing category-parameters query) is the only option that meets the pre-submit AC.**
+
+## 2. Research findings (anchors)
+
+| Concern | Location |
+|---|---|
+| Blocker union | `bulk-wizard.types.ts:31` `BulkRowBlockerValues` |
+| Blocker computation (pure) | `bulk-policy.ts:131` `computeBlockers` / `:109` `ComputeBlockersInput` |
+| Card-link selector (#808) | `bulk-wizard.tsx` `selectBulkProductCardId(row)` (exported) |
+| Blockers recomputed | `bulk-resolve-step.tsx:121` `buildOutcomes`; `bulk-wizard.tsx:99` `handleUpdateRow` |
+| Submit gate | `bulk-wizard.tsx:128` `submittable`, `:206` `readyCount` |
+| Review readiness gate | `bulk-review-step.tsx:88` `canApprove`, `:306` `countByReadiness` |
+| Blocker chip labels | `bulk-review-step.tsx:54` `BLOCKER_CHIPS` |
+| Category params query | `hooks/use-category-parameters-query.ts:22` (24 h cache) |
+| Param type (`required`, `section`) | `api/listings.types.ts:307` `CategoryParameter` |
+| Serialized product-param shape | `serialize-allegro-parameters.ts:45` `AllegroParameterInput { id, values?, valuesIds?, rangeValue? }` |
+
+## 3. Design
+
+### 3.1 Blocker value
+
+Add `'needs-product-parameters'` to `BulkRowBlockerValues` (`bulk-wizard.types.ts`). Co-occurring with the existing model.
+
+### 3.2 Detection (pure, in `computeBlockers`)
+
+Extend `ComputeBlockersInput` with two plain-data fields (keeps the function pure + unit-testable):
+
+```ts
+/** Card will be linked on submit (selectBulkProductCardId(row) !== undefined). */
+willLinkProductCard: boolean;
+/**
+ * Required product-section param ids for the row's SUBMIT category, with no
+ * `dependsOn` gating. undefined = schema not loaded yet (do not block — avoids
+ * flicker / false block while the query is in flight).
+ */
+requiredProductParamIds: string[] | undefined;
+```
+
+Rule appended in `computeBlockers`:
+
+```ts
+if (!input.willLinkProductCard && input.requiredProductParamIds?.length) {
+  const supplied = new Set(
+    (input.override.overrides?.platformParams?.productParameters as
+      | { id: string }[]
+      | undefined ?? []
+    ).map((p) => p.id),
+  );
+  if (input.requiredProductParamIds.some((id) => !supplied.has(id))) {
+    blockers.push('needs-product-parameters');
+  }
+}
+```
+
+- **Clearable**: filling the params in the edit modal writes `platformParams.productParameters`, coverage satisfies, blocker lifts.
+- **No false positive on card-linked rows**: `willLinkProductCard` short-circuits (AC).
+- **No false positive when the category has no required product params**: `requiredProductParamIds` empty → skip (AC).
+- **Conservative on `dependsOn`**: conditional params are excluded from the required set so an inapplicable gated param can never permanently block.
+
+### 3.3 Feeding the schema (async → plain map)
+
+New hook `use-bulk-required-product-params.ts` in `features/listings/hooks/`:
+
+```ts
+export function useBulkRequiredProductParams(
+  connectionId: string,
+  submitCategoryIds: readonly string[], // distinct categories of no-card rows
+): { requiredByCategory: Map<string, string[]>; isResolving: boolean }
+```
+
+- Uses TanStack `useQueries` over the **existing** `getCategoryParameters` query (same 24 h-cached key — repeats across a batch are cache hits).
+- For each category returns the ids of params where `required && section === 'product' && !dependsOn`.
+- `isResolving` true while any query is pending → used to gate "Approve all" so the operator can't beat the check.
+
+The wizard derives, per row, `willLinkProductCard = selectBulkProductCardId(row) !== undefined` and the submit category `override.overrides?.categoryId ?? resolvedCategoryId`. Distinct submit-categories of no-card rows feed the hook. The resulting `requiredByCategory.get(submitCategoryId)` is passed into `computeBlockers` at all three recompute sites (resolve `buildOutcomes`, `handleUpdateRow`, and a new recompute when `requiredByCategory` changes).
+
+### 3.4 Review-step surfacing
+
+- `BLOCKER_CHIPS['needs-product-parameters'] = { tone: 'warning', label: 'add product params' }` (`bulk-review-step.tsx:54`).
+- The existing per-row "Edit" affordance is the remedy; add a one-line hint in the review summary when `needs-product-parameters` rows exist: *"N row(s) need required product parameters — edit each to add them."* No new routing.
+- `countByReadiness` already counts any blocker as `needsAttention`; `canApprove` already gates on it. Add: `canApprove` also requires `!isResolving` (3.3).
+
+### 3.5 Open scope question — multi-match candidate card-threading
+
+Picking a multi-match candidate chip (`bulk-edit-modal.tsx:267`) currently sets **only** `categoryId`, dropping the candidate's `productCardId` — so a resolved multi-match row creates inline and hits this blocker. Two scopes:
+- **(A) Blocker-only** — out of scope to thread the card; multi-match rows get blocked → operator fills params. Smallest change.
+- **(B) Blocker + thread candidate card** — clicking a candidate also writes `override.overrides.productCardId = candidate.productCardId` (mirrors #808). The row then links the card, inherits params, and never hits the blocker. Small, reuses #808 plumbing, fixes a latent multi-match 422 too.
+
+Recommendation: **(B)** — it's a few lines, removes a whole class of avoidable blocks, and is the same pattern #808 established. Confirm before implementing.
+
+## 4. Step-by-step implementation
+
+1. **`bulk-wizard.types.ts`** — add `'needs-product-parameters'` to `BulkRowBlockerValues` + doc comment. *AC: type compiles; value exported.*
+2. **`bulk-policy.ts`** — extend `ComputeBlockersInput` (`willLinkProductCard`, `requiredProductParamIds`); append the rule in §3.2. *AC: pure, no new imports beyond types.*
+3. **`hooks/use-bulk-required-product-params.ts`** (new) — `useQueries` fan-out per §3.3. *AC: returns `{ requiredByCategory, isResolving }`; only `required && section==='product' && !dependsOn` ids.*
+4. **`bulk-wizard.tsx`** — compute distinct no-card submit-categories; call the hook; thread `willLinkProductCard` + `requiredProductParamIds` into `computeBlockers` at `buildOutcomes`, `handleUpdateRow`, and a new recompute effect on `requiredByCategory` change. *AC: blockers update when schema loads / operator edits.*
+5. **`bulk-review-step.tsx`** — `BLOCKER_CHIPS` entry; summary hint; `canApprove &&= !isResolving`. *AC: chip renders; approve disabled while resolving.*
+6. **(If scope B)** **`bulk-edit-modal.tsx:267`** — candidate-chip click also sets `productCardId`. *AC: picking a candidate threads its card; row links card, no blocker.*
+
+## 5. Tests
+
+- `bulk-policy.test.ts` — new `computeBlockers` cases: (a) no-card + uncovered required product param → blocker; (b) covered → no blocker; (c) card-linked → no blocker even if params missing; (d) `requiredProductParamIds` undefined → no blocker; (e) category with no required product params → no blocker; (f) `dependsOn` param excluded.
+- `use-bulk-required-product-params.test.ts` (new) — filters to `required && product && !dependsOn`; dedupes categories; `isResolving` lifecycle.
+- `bulk-review-step.test.tsx` — chip label renders; approve disabled while `isResolving`; summary hint shows.
+- `bulk-edit-modal.test.tsx` (scope B) — candidate-chip click writes `productCardId`.
+- `bulk-wizard.test.tsx` — integration: a no-card row under a product-param category is blocked pre-submit and excluded from `submittable`; filling params clears it.
+
+## 6. Validate
+
+- **Architecture**: FE-only, dependency direction intact (`features` only); reuses existing query/endpoint; no `shared`→`features` import.
+- **State ownership**: server state (schemas) via TanStack Query; blocker is derived, not stored as separate global state.
+- **Naming**: `use-*.ts` hook, `*.test.tsx` colocated, kebab files.
+- **No false positives**: guarded by `willLinkProductCard` + empty-set + `dependsOn` exclusion (§3.2) — meets the issue's AC.
+- **Security**: none touched (read-only schema fetch already authorized).
+- **Risk**: brief window where a row reads "ready" before the param query resolves → mitigated by `isResolving` gating "Approve all" and `submittable` recompute.


### PR DESCRIPTION
## What & why

Follow-up to #808. Bulk rows whose EAN matches **no** Allegro card (or that the operator manually categorises) create a product **inline** — there's no catalogue card to inherit from. If the chosen category has required **product-section** params (Marka, Model, EAN, …) the operator hasn't supplied, the offer 422s, and today the operator only finds out **after** submit, per-record.

This surfaces it **pre-submit** as a `needs-product-parameters` review blocker, so the row is kept out of the submit gate until the params are filled (the bulk edit modal already collects them, #740) — turning a post-submit `ProductValidationException` into a clear "add product params, then Edit the row" nudge.

## Premise correction vs the issue

The issue assumed the bulk wizard can't collect product params. It can (#740: the edit modal nests `CategoryParametersStep` → `platformParams.productParameters`). The real gap is that the modal lets you save **without** them, and `computeBlockers` clears the category blocker the moment `override.categoryId` is set — so the row shows "ready" and 422s. The remedy is therefore "edit the row to add params," not "create individually."

## Why FE-only detection (rejecting issue Option 2)

The "category without a card" state is created **exclusively by FE operator overrides** the BE batch-resolve never sees — the resolver always pairs a category *with* a card (`matched` / `multi-match` candidates). So a BE `requiresProductParameters` resolve flag can't reach the primary case. Detection reuses the existing `GET …/categories/:id/parameters` endpoint (already returns `required` + `section`). **No BE / API / worker change.**

## How

- **`bulk-policy.ts`** — `computeBlockers` gains `willLinkProductCard` + `requiredProductParamIds`; a **coverage-based** rule fires the blocker only when a required product-section id isn't present in `platformParams.productParameters`, so it **clears** once the operator fills them.
- **`use-bulk-required-product-params.ts`** (new) — `useQueries` fan-out over the distinct no-card submit-categories, reusing the 24h-cached category-params query; returns required, unconditional (`!dependsOn`) product-section ids + `isResolving`.
- **`bulk-wizard.tsx`** — shared `recomputeRowBlockers`; a **Review-step-gated**, identity-guarded reconcile effect adds/removes the blocker as schemas resolve.
- **`bulk-review-step.tsx`** — `add product params` chip, a remediation hint, and `Approve all` gated on `!paramsResolving` (so a row can't slip through before the check loads).
- **Scope B** — picking a multi-match candidate chip now threads its `productCardId` (mirrors #808), so those rows link the card and inherit params instead of hitting the blocker; a manual category change drops the card.

## Acceptance criteria

- [x] Rows that would 422 for missing required product params (no card link + category requires them) are flagged pre-submit.
- [x] Blocked rows are excluded from the submit gate; operator is pointed at the fix (Edit the row).
- [x] No false positives for card-linked rows (#808) or categories with no required product params.
- [x] Tests at the chosen layer (detection + review-step rendering + hook).

## Testing

`pnpm lint` ✓ (0 errors, cross-context invariants pass) · `pnpm type-check` ✓ · `pnpm test` ✓ (web 153 files / 1200 tests; +27 new for this work; full repo green).

New/updated tests: `computeBlockers` coverage cases, `useBulkRequiredProductParams` filtering, review-step chip/hint/approve-gate, edit-modal candidate card-threading, `recomputeRowBlockers` wiring.

Plan: `docs/plans/implementation-plan-bulk-needs-product-parameters-blocker.md`.

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)