### PR TITLE
feat(sync,allegro,web): flag connection + surface re-auth on terminal OAuth refresh rejection (#819)

### DIFF
--- a/apps/api/src/integrations/application/interfaces/allegro-oauth.service.interface.ts
+++ b/apps/api/src/integrations/application/interfaces/allegro-oauth.service.interface.ts
@@ -36,7 +36,8 @@ export interface IAllegroOAuthService {
     environment?: string,
     state?: string,
     connectionName?: string,
-    masterCatalogConnectionId?: string
+    masterCatalogConnectionId?: string,
+    connectionId?: string
   ): Promise<AllegroOAuthAuthorizationResponse>;
 
   /**

--- a/apps/api/src/integrations/application/interfaces/allegro-oauth.service.types.ts
+++ b/apps/api/src/integrations/application/interfaces/allegro-oauth.service.types.ts
@@ -40,6 +40,13 @@ export interface OAuthStateData {
   environment: string;
   connectionName?: string;
   masterCatalogConnectionId?: string;
+  /**
+   * When set, the callback re-authenticates this existing connection in place
+   * (rotating its stored credentials and clearing a `needs_reauth` flag) rather
+   * than minting a new connection (#819). Re-using the connection preserves all
+   * connection-scoped identifier mappings (products / offers / orders).
+   */
+  connectionId?: string;
 }
 
 /**

--- a/apps/api/src/integrations/application/services/allegro-oauth.service.spec.ts
+++ b/apps/api/src/integrations/application/services/allegro-oauth.service.spec.ts
@@ -22,7 +22,9 @@ describe('AllegroOAuthService', () => {
     del: jest.Mock;
   };
   let credentials: jest.Mocked<ICredentialsService>;
-  let connectionService: jest.Mocked<Pick<ConnectionService, 'get' | 'create'>>;
+  let connectionService: jest.Mocked<
+    Pick<ConnectionService, 'get' | 'create' | 'update' | 'updateCredentials'>
+  >;
 
   beforeEach(async () => {
     redisClient = {
@@ -38,7 +40,11 @@ describe('AllegroOAuthService', () => {
     connectionService = {
       get: jest.fn(),
       create: jest.fn(),
-    } as unknown as jest.Mocked<Pick<ConnectionService, 'get' | 'create'>>;
+      update: jest.fn(),
+      updateCredentials: jest.fn(),
+    } as unknown as jest.Mocked<
+      Pick<ConnectionService, 'get' | 'create' | 'update' | 'updateCredentials'>
+    >;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -236,6 +242,67 @@ describe('AllegroOAuthService', () => {
       const createCall = (connectionService.create as jest.Mock).mock.calls[0] as unknown[];
       const createdConfig = (createCall[0] as { config: Record<string, unknown> }).config;
       expect(createdConfig.masterCatalogConnectionId).toBeUndefined();
+    });
+
+    it('re-authenticates an existing connection in place when stateData.connectionId is set (#819)', async () => {
+      connectionService.get.mockResolvedValue({
+        id: 'conn-existing',
+        name: 'My Allegro',
+        platformType: 'allegro',
+        status: 'needs_reauth',
+      } as never);
+      connectionService.updateCredentials.mockResolvedValue(undefined as never);
+      connectionService.update.mockResolvedValue({
+        id: 'conn-existing',
+        name: 'My Allegro',
+        status: 'active',
+      } as never);
+
+      const result = await service.storeCredentialsAndCreateConnection(
+        { access_token: 'fresh-tok', refresh_token: 'fresh-rt', token_type: 'bearer' },
+        {
+          clientId: 'cid',
+          clientSecret: 'csec',
+          redirectUri: 'https://example.com/cb',
+          environment: 'sandbox',
+          connectionId: 'conn-existing',
+        }
+      );
+
+      // Credentials rotated in place; status cleared to active; NO new connection minted.
+      expect(connectionService.updateCredentials).toHaveBeenCalledWith(
+        'conn-existing',
+        expect.objectContaining({ accessToken: 'fresh-tok', refreshToken: 'fresh-rt' })
+      );
+      expect(connectionService.update).toHaveBeenCalledWith('conn-existing', { status: 'active' });
+      expect(connectionService.create).not.toHaveBeenCalled();
+      expect(credentials.create).not.toHaveBeenCalled();
+      expect(result).toEqual(expect.objectContaining({ id: 'conn-existing', status: 'active' }));
+    });
+
+    it('rejects re-auth when the target connection is not an Allegro connection', async () => {
+      connectionService.get.mockResolvedValue({
+        id: 'conn-ps',
+        name: 'Shop',
+        platformType: 'prestashop',
+        status: 'active',
+      } as never);
+
+      await expect(
+        service.storeCredentialsAndCreateConnection(
+          { access_token: 'tok', token_type: 'bearer' },
+          {
+            clientId: 'cid',
+            clientSecret: 'csec',
+            redirectUri: 'https://example.com/cb',
+            environment: 'sandbox',
+            connectionId: 'conn-ps',
+          }
+        )
+      ).rejects.toThrow(BadRequestException);
+
+      expect(connectionService.updateCredentials).not.toHaveBeenCalled();
+      expect(connectionService.update).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/integrations/application/services/allegro-oauth.service.ts
+++ b/apps/api/src/integrations/application/services/allegro-oauth.service.ts
@@ -395,6 +395,16 @@ export class AllegroOAuthService implements IAllegroOAuthService {
     this.logger.log(`Re-authenticating existing Allegro connection in place: ${connectionId}`);
 
     // Resolve + guard: must be an existing Allegro connection.
+    //
+    // ASSUMPTION (#819 / ADR-008): the operator re-authenticates the SAME
+    // Allegro seller account. We validate platformType but NOT that the new
+    // token authorizes the same seller — OpenLinker doesn't yet persist the
+    // Allegro account id on the connection. Re-authing with a different
+    // developer app / seller would silently rebind this connection while
+    // retaining mappings keyed to the previous seller's external-id space.
+    // It's admin-gated and the operator supplies their own credentials, so
+    // it's a foot-gun, not a security hole. Validating seller identity here
+    // is a tracked follow-up.
     const existing = await this.connectionService.get(connectionId);
     if (existing.platformType !== 'allegro') {
       throw new BadRequestException(

--- a/apps/api/src/integrations/application/services/allegro-oauth.service.ts
+++ b/apps/api/src/integrations/application/services/allegro-oauth.service.ts
@@ -64,7 +64,8 @@ export class AllegroOAuthService implements IAllegroOAuthService {
     environment: string = 'sandbox',
     state?: string,
     connectionName?: string,
-    masterCatalogConnectionId?: string
+    masterCatalogConnectionId?: string,
+    connectionId?: string
   ): Promise<AllegroOAuthAuthorizationResponse> {
     // Generate state if not provided
     const oauthState = state || randomBytes(32).toString('hex');
@@ -78,6 +79,7 @@ export class AllegroOAuthService implements IAllegroOAuthService {
       environment,
       connectionName,
       masterCatalogConnectionId,
+      connectionId,
     };
     const stateKey = `allegro:oauth:state:${oauthState}`;
     await this.redisClient.setEx(stateKey, this.STATE_TTL_SECONDS, JSON.stringify(stateData));
@@ -303,6 +305,14 @@ export class AllegroOAuthService implements IAllegroOAuthService {
     tokenResponse: AllegroOAuthTokenResponse,
     stateData: OAuthStateData
   ): Promise<Connection> {
+    // Re-authentication path (#819): when state carries an existing
+    // connectionId, rotate that connection's credentials in place and clear
+    // its needs_reauth flag instead of minting a new connection — re-using the
+    // connection preserves all connection-scoped identifier mappings.
+    if (stateData.connectionId) {
+      return this.reauthenticateExistingConnection(tokenResponse, stateData, stateData.connectionId);
+    }
+
     this.logger.log(
       `Storing credentials and creating connection for Allegro (environment: ${stateData.environment}, connectionName: ${stateData.connectionName || 'N/A'})`
     );
@@ -363,6 +373,56 @@ export class AllegroOAuthService implements IAllegroOAuthService {
 
     this.logger.log(
       `Connection created successfully: ${connection.id} (name: ${connection.name}, credentialsRef: ${connection.credentialsRef})`
+    );
+
+    return connection;
+  }
+
+  /**
+   * Re-authenticate an existing connection in place (#819).
+   *
+   * Rotates the connection's stored OAuth credentials with the freshly-issued
+   * token and flips its status back to `active`, clearing a `needs_reauth`
+   * flag. Unlike the create path, this preserves the connection's id — and
+   * therefore every connection-scoped identifier mapping (products, offers,
+   * orders) that would be orphaned by minting a new connection.
+   */
+  private async reauthenticateExistingConnection(
+    tokenResponse: AllegroOAuthTokenResponse,
+    stateData: OAuthStateData,
+    connectionId: string
+  ): Promise<Connection> {
+    this.logger.log(`Re-authenticating existing Allegro connection in place: ${connectionId}`);
+
+    // Resolve + guard: must be an existing Allegro connection.
+    const existing = await this.connectionService.get(connectionId);
+    if (existing.platformType !== 'allegro') {
+      throw new BadRequestException(
+        `Connection ${connectionId} is not an Allegro connection (platformType: ${existing.platformType})`
+      );
+    }
+
+    // Same credential blob shape the create path persists, with the rotated token.
+    const credentials = {
+      accessToken: tokenResponse.access_token,
+      refreshToken: tokenResponse.refresh_token,
+      expiresAt: tokenResponse.expires_in
+        ? new Date(Date.now() + tokenResponse.expires_in * 1000).toISOString()
+        : undefined,
+      clientId: stateData.clientId,
+      clientSecret: stateData.clientSecret,
+    };
+
+    await this.connectionService.updateCredentials(
+      connectionId,
+      credentials as unknown as Record<string, unknown>
+    );
+
+    // Clear the re-auth flag — return the connection to active service.
+    const connection = await this.connectionService.update(connectionId, { status: 'active' });
+
+    this.logger.log(
+      `Connection re-authenticated successfully: ${connection.id} (name: ${connection.name}, status: ${connection.status})`
     );
 
     return connection;

--- a/apps/api/src/integrations/http/allegro.controller.spec.ts
+++ b/apps/api/src/integrations/http/allegro.controller.spec.ts
@@ -136,6 +136,7 @@ describe('AllegroController', () => {
         'sandbox',
         undefined,
         'Test Connection',
+        undefined,
         undefined
       );
     });
@@ -161,6 +162,7 @@ describe('AllegroController', () => {
         'test-client-secret',
         'https://example.com/callback',
         'sandbox',
+        undefined,
         undefined,
         undefined,
         undefined

--- a/apps/api/src/integrations/http/allegro.controller.ts
+++ b/apps/api/src/integrations/http/allegro.controller.ts
@@ -127,7 +127,8 @@ export class AllegroController {
       dto.environment || 'sandbox',
       dto.state,
       dto.connectionName,
-      dto.masterCatalogConnectionId
+      dto.masterCatalogConnectionId,
+      dto.connectionId // present when re-authenticating an existing connection in place (#819)
     );
 
     return result;

--- a/apps/api/src/integrations/http/dto/allegro-oauth-connect.dto.ts
+++ b/apps/api/src/integrations/http/dto/allegro-oauth-connect.dto.ts
@@ -72,5 +72,16 @@ export class AllegroOAuthConnectDto {
   @IsUUID()
   @IsOptional()
   masterCatalogConnectionId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'UUID of an existing Allegro connection to re-authenticate in place. When set, the ' +
+      'callback rotates this connection’s credentials and clears its needs_reauth flag ' +
+      'instead of creating a new connection (#819).',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsUUID()
+  @IsOptional()
+  connectionId?: string;
 }
 

--- a/apps/web/src/features/allegro/api/allegro.api.ts
+++ b/apps/web/src/features/allegro/api/allegro.api.ts
@@ -5,6 +5,12 @@ export interface StartAllegroOAuthInput {
   environment?: 'sandbox' | 'production';
   connectionName?: string;
   masterCatalogConnectionId?: string;
+  /**
+   * UUID of an existing Allegro connection to re-authenticate in place. When
+   * set, the callback rotates that connection's credentials and clears its
+   * needs_reauth flag instead of creating a new connection (#819).
+   */
+  connectionId?: string;
 }
 
 export interface StartAllegroOAuthResponse {

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
@@ -12,6 +12,7 @@
  *      screen so the access token can come back through the callback page
  */
 import { useEffect, useState, type ReactElement } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, type Path } from 'react-hook-form';
 import { useStartAllegroOAuthMutation } from '../hooks/use-start-allegro-oauth-mutation';
@@ -49,6 +50,11 @@ function maskSecret(secret: string): string {
 }
 
 export function AllegroSetupForm(): ReactElement {
+  const [searchParams] = useSearchParams();
+  // When present, this OAuth run re-authenticates an existing connection in
+  // place (rotating its credentials, clearing needs_reauth) instead of minting
+  // a new one (#819).
+  const reauthConnectionId = searchParams.get('reauth') ?? undefined;
   const startOAuth = useStartAllegroOAuthMutation();
   const { connectionsQuery, productMasterConnections, autoSelectedConnectionId } =
     useProductMasterConnections();
@@ -99,7 +105,7 @@ export function AllegroSetupForm(): ReactElement {
     try {
       const redirectUri = `${window.location.origin}/integrations/allegro/connect/callback`;
       const { authorizationUrl } = await startOAuth.mutateAsync(
-        toStartOAuthInput(values, redirectUri)
+        toStartOAuthInput(values, redirectUri, reauthConnectionId)
       );
       // Clear the dirty flag so abandon-prevention doesn't pop a native
       // "leave page?" confirm when we navigate to Allegro's consent screen.
@@ -132,6 +138,13 @@ export function AllegroSetupForm(): ReactElement {
       <form className="wizard-card" onSubmit={(event) => void onSubmit(event)} noValidate>
         <BackLink to="/connections/new" label="Connections" className="wizard-card__back" />
 
+        {reauthConnectionId ? (
+          <Alert tone="warning" title="Re-authenticating an existing connection">
+            Completing this flow replaces the stored credentials for the flagged connection and
+            resumes syncing. Re-enter the Client ID and Client Secret from your Allegro developer
+            app — the connection and its mappings are preserved.
+          </Alert>
+        ) : null}
         {form.formState.submitCount > 0 && validationMessages.length > 0 ? (
           <FormErrorSummary errors={validationMessages} />
         ) : null}

--- a/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
+++ b/apps/web/src/features/allegro/components/AllegroSetupForm.tsx
@@ -141,8 +141,10 @@ export function AllegroSetupForm(): ReactElement {
         {reauthConnectionId ? (
           <Alert tone="warning" title="Re-authenticating an existing connection">
             Completing this flow replaces the stored credentials for the flagged connection and
-            resumes syncing. Re-enter the Client ID and Client Secret from your Allegro developer
-            app — the connection and its mappings are preserved.
+            resumes syncing. Re-enter the Client ID and Client Secret for the{' '}
+            <strong>same Allegro seller account</strong> from your developer app — the connection and
+            its mappings are preserved. The Environment and Product-catalog selections below do not
+            change the existing connection&rsquo;s configuration; only the credentials are rotated.
           </Alert>
         ) : null}
         {form.formState.submitCount > 0 && validationMessages.length > 0 ? (

--- a/apps/web/src/features/allegro/components/allegro-setup.schema.test.ts
+++ b/apps/web/src/features/allegro/components/allegro-setup.schema.test.ts
@@ -1,0 +1,52 @@
+/**
+ * allegro-setup.schema — toStartOAuthInput tests (#819)
+ *
+ * Pins the re-auth wiring: an existing connectionId threads through to the
+ * OAuth start payload so the callback re-authenticates that connection in
+ * place instead of minting a new one.
+ */
+import { describe, expect, it } from 'vitest';
+import { toStartOAuthInput, type AllegroSetupFormSubmission } from './allegro-setup.schema';
+
+const baseValues: AllegroSetupFormSubmission = {
+  name: 'Allegro sandbox',
+  environment: 'sandbox',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  masterCatalogConnectionId: undefined,
+};
+
+const REDIRECT_URI = 'https://app.example.com/integrations/allegro/connect/callback';
+
+describe('toStartOAuthInput', () => {
+  it('includes connectionId when a re-auth connection id is provided', () => {
+    const input = toStartOAuthInput(baseValues, REDIRECT_URI, 'conn-existing');
+
+    expect(input.connectionId).toBe('conn-existing');
+    expect(input).toMatchObject({
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      redirectUri: REDIRECT_URI,
+      environment: 'sandbox',
+      connectionName: 'Allegro sandbox',
+    });
+  });
+
+  it('omits connectionId when no re-auth connection id is provided', () => {
+    const input = toStartOAuthInput(baseValues, REDIRECT_URI);
+
+    expect(input.connectionId).toBeUndefined();
+    expect('connectionId' in input).toBe(false);
+  });
+
+  it('still threads masterCatalogConnectionId independently of the re-auth id', () => {
+    const input = toStartOAuthInput(
+      { ...baseValues, masterCatalogConnectionId: 'cat-1' },
+      REDIRECT_URI,
+      'conn-existing',
+    );
+
+    expect(input.masterCatalogConnectionId).toBe('cat-1');
+    expect(input.connectionId).toBe('conn-existing');
+  });
+});

--- a/apps/web/src/features/allegro/components/allegro-setup.schema.ts
+++ b/apps/web/src/features/allegro/components/allegro-setup.schema.ts
@@ -37,6 +37,7 @@ export const ALLEGRO_SETUP_DEFAULT_VALUES: AllegroSetupFormValues = {
 export function toStartOAuthInput(
   values: AllegroSetupFormSubmission,
   redirectUri: string,
+  reauthConnectionId?: string,
 ): StartAllegroOAuthInput {
   return {
     clientId: values.clientId,
@@ -47,5 +48,6 @@ export function toStartOAuthInput(
     ...(values.masterCatalogConnectionId
       ? { masterCatalogConnectionId: values.masterCatalogConnectionId }
       : {}),
+    ...(reauthConnectionId ? { connectionId: reauthConnectionId } : {}),
   };
 }

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -15,7 +15,7 @@ export const CORE_PLATFORM_TYPES = ['prestashop', 'allegro'] as const;
  */
 export type PlatformType = string;
 
-export type ConnectionStatus = 'active' | 'disabled' | 'error';
+export type ConnectionStatus = 'active' | 'disabled' | 'error' | 'needs_reauth';
 
 /**
  * Well-known core capabilities — mirrors `CoreCapabilityValues` on the backend.

--- a/apps/web/src/pages/connections/connection-detail-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.test.tsx
@@ -271,4 +271,24 @@ describe('ConnectionDetailPage', () => {
       expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
     });
   });
+
+  describe('ReauthRequiredBanner (#819)', () => {
+    it('shows the re-auth banner with an OAuth re-auth link when status is needs_reauth', async () => {
+      const connection = makeAllegro({ status: 'needs_reauth' });
+      const apiClient = apiClientForBanner(connection, []);
+      await renderDetailPage(connection, apiClient);
+
+      expect(await screen.findByText('Re-authentication required')).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /re-authenticate/i });
+      expect(link).toHaveAttribute('href', `/connections/new/allegro?reauth=${ALLEGRO_UUID}`);
+    });
+
+    it('does NOT show the re-auth banner when the connection is active', async () => {
+      const connection = makeAllegro({ status: 'active' });
+      const apiClient = apiClientForBanner(connection, []);
+      await renderDetailPage(connection, apiClient);
+
+      expect(screen.queryByText('Re-authentication required')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { Alert } from '../../shared/ui/alert';
+import { usePlatform } from '../../shared/plugins';
 
 function toStatusTone(status: ConnectionStatus): StatusBadgeTone {
   switch (status) {
@@ -24,7 +25,52 @@ function toStatusTone(status: ConnectionStatus): StatusBadgeTone {
       return 'neutral';
     case 'error':
       return 'error';
+    case 'needs_reauth':
+      return 'warning';
   }
+}
+
+/**
+ * Re-authentication banner (#819).
+ *
+ * Shown when a connection has been auto-flagged `needs_reauth` after a terminal
+ * credential rejection (the scheduler has paused syncing against it). For OAuth
+ * platforms it links to the setup wizard in re-auth mode (`?reauth={id}`),
+ * which rotates credentials in place and clears the flag. Non-OAuth platforms
+ * fall back to editing the connection's credentials.
+ */
+function ReauthRequiredBanner({ connection }: { connection: Connection }): ReactElement | null {
+  const platform = usePlatform(connection.platformType);
+
+  if (connection.status !== 'needs_reauth') return null;
+
+  const platformLabel = platform?.displayName ?? connection.platformType;
+  const oauthReauthTo =
+    platform?.requiresExternalAuthRedirect && platform.setupCard?.to
+      ? `${platform.setupCard.to}?reauth=${connection.id}`
+      : null;
+
+  return (
+    <Alert
+      tone="warning"
+      title="Re-authentication required"
+      action={
+        oauthReauthTo ? (
+          <Link className="button button--primary" to={oauthReauthTo}>
+            Re-authenticate
+          </Link>
+        ) : (
+          <Link className="button button--primary" to={`/connections/${connection.id}/edit`}>
+            Update credentials
+          </Link>
+        )
+      }
+    >
+      OpenLinker can no longer authenticate with {platformLabel} — the stored credentials were
+      rejected, so syncing is paused for this connection. Re-authenticate to restore access; the
+      connection and its mappings are preserved.
+    </Alert>
+  );
 }
 
 const TAB_VALUES = ['overview', 'health', 'actions', 'config'] as const;
@@ -195,6 +241,7 @@ export function ConnectionDetailPage(): ReactElement {
           message="No connection data was returned for this route. Retry from the integrations list or verify the selected identifier."
         />
       ) : null}
+      {connection ? <ReauthRequiredBanner connection={connection} /> : null}
       {connection ? (
         <ProductCatalogLinkBanner
           connection={connection}

--- a/apps/web/src/pages/connections/connections-list-page.tsx
+++ b/apps/web/src/pages/connections/connections-list-page.tsx
@@ -11,7 +11,7 @@ import { Button } from '../../shared/ui/button';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Select } from '../../shared/ui/select';
 
-const CONNECTION_STATUSES = ['active', 'disabled', 'error'] as const;
+const CONNECTION_STATUSES = ['active', 'disabled', 'error', 'needs_reauth'] as const;
 
 function isValidStatus(value: string): value is ConnectionStatus {
   return CONNECTION_STATUSES.includes(value as ConnectionStatus);
@@ -25,6 +25,8 @@ function toStatusTone(status: ConnectionStatus): StatusBadgeTone {
       return 'neutral';
     case 'error':
       return 'error';
+    case 'needs_reauth':
+      return 'warning';
   }
 }
 

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -41,6 +41,7 @@ function groupKey(group: Pick<SyncJobGroup, 'connectionId' | 'jobType'>): string
 function toRowStatusTone(status: ConnectionStatus | JobStatus): DashboardTone {
   if (status === 'active' || status === 'succeeded') return 'success';
   if (status === 'error' || status === 'dead') return 'error';
+  if (status === 'needs_reauth') return 'warning';
   return 'neutral';
 }
 

--- a/apps/worker/src/sync/__tests__/sync-job.runner.spec.ts
+++ b/apps/worker/src/sync/__tests__/sync-job.runner.spec.ts
@@ -16,20 +16,26 @@ import {
   SYNC_JOB_REPOSITORY_TOKEN,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
   RetryClassifierRegistryService,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+  AuthFailureClassifierRegistryService,
 } from '@openlinker/core/sync';
 import { SyncJobHandlerRegistry } from '../handlers/sync-job-handler.registry';
 import type { SyncJobHandler } from '@openlinker/core/sync';
 import { SyncJobEntity as SyncJob } from '@openlinker/core/sync';
 import { SyncJobExecutionError } from '@openlinker/core/sync';
-// The runner's *production* code is now platform-neutral (#581) — it
-// asks the retry-classifier registry instead of `instanceof`-ing Allegro
+import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import { CONNECTION_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
+// The runner's *production* code is now platform-neutral (#581 / #819) — it
+// asks the classifier registries instead of `instanceof`-ing Allegro
 // classes directly. The runner *spec* still uses the real Allegro
-// classifier wired into a real registry to verify end-to-end behaviour;
+// classifiers wired into real registries to verify end-to-end behaviour;
 // these imports don't follow the runner's deletions.
 import {
   AllegroApiException,
   AllegroNetworkException,
+  AllegroAuthenticationException,
   AllegroRetryClassifierAdapter,
+  AllegroAuthFailureClassifierAdapter,
 } from '@openlinker/integrations-allegro';
 import { OfferCreationInvariantException } from '@openlinker/core/listings';
 import { randomUUID } from 'crypto';
@@ -39,6 +45,7 @@ describe('SyncJobRunner', () => {
   let jobRepository: jest.Mocked<SyncJobRepositoryPort>;
   let handlerRegistry: jest.Mocked<SyncJobHandlerRegistry>;
   let mockHandler: jest.Mocked<SyncJobHandler>;
+  let connectionPort: jest.Mocked<ConnectionPort>;
   let moduleRef: TestingModule;
 
   beforeEach(async () => {
@@ -77,6 +84,30 @@ describe('SyncJobRunner', () => {
     const retryClassifierRegistry = new RetryClassifierRegistryService();
     retryClassifierRegistry.register('allegro.publicapi.v1', new AllegroRetryClassifierAdapter());
 
+    // Real auth-failure registry + real Allegro classifier — same rationale as
+    // the retry registry above: exercise the production registration path so
+    // the runner's "flag on terminal credential rejection" behaviour (#819) is
+    // verified end-to-end rather than via a mocked `isCredentialRejected`.
+    const authFailureClassifierRegistry = new AuthFailureClassifierRegistryService();
+    authFailureClassifierRegistry.register(
+      'allegro.publicapi.v1',
+      new AllegroAuthFailureClassifierAdapter()
+    );
+
+    // Connection port mock — the runner flips a flagged connection's status.
+    // Default: an active Allegro connection that updates cleanly.
+    const mockConnectionPort = {
+      get: jest.fn().mockResolvedValue({
+        id: 'conn-1',
+        platformType: 'allegro',
+        status: 'active',
+      }),
+      update: jest.fn().mockResolvedValue(undefined),
+      list: jest.fn(),
+      create: jest.fn(),
+      disable: jest.fn(),
+    } as unknown as jest.Mocked<ConnectionPort>;
+
     moduleRef = await Test.createTestingModule({
       providers: [
         SyncJobRunner,
@@ -101,12 +132,21 @@ describe('SyncJobRunner', () => {
           provide: RETRY_CLASSIFIER_REGISTRY_TOKEN,
           useValue: retryClassifierRegistry,
         },
+        {
+          provide: AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+          useValue: authFailureClassifierRegistry,
+        },
+        {
+          provide: CONNECTION_PORT_TOKEN,
+          useValue: mockConnectionPort,
+        },
       ],
     }).compile();
 
     runner = moduleRef.get<SyncJobRunner>(SyncJobRunner);
     jobRepository = moduleRef.get(SYNC_JOB_REPOSITORY_TOKEN);
     handlerRegistry = moduleRef.get(SyncJobHandlerRegistry);
+    connectionPort = moduleRef.get(CONNECTION_PORT_TOKEN);
   });
 
   afterEach(async () => {
@@ -424,6 +464,141 @@ describe('SyncJobRunner', () => {
         expect.any(Date)
       );
       expect(jobRepository.markDead).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('connection flagging on terminal credential rejection (#819)', () => {
+    const createMockJob = (): SyncJob =>
+      new SyncJob(
+        randomUUID(),
+        'marketplace.orders.poll',
+        'conn-1',
+        { externalId: '1' },
+        'running',
+        `test-key-${randomUUID()}`,
+        1,
+        10,
+        new Date(),
+        new Date(),
+        'worker-123',
+        null,
+        new Date(),
+        new Date()
+      );
+
+    it('flags the connection needs_reauth when the cause is a terminal credential rejection', async () => {
+      const job = createMockJob();
+      const cause = new AllegroAuthenticationException(
+        'Authentication failed: Invalid or expired access token',
+        401,
+        'https://api.allegro.pl/order/checkout-forms'
+      );
+      const error = new SyncJobExecutionError(
+        'Marketplace orders poll failed: ' + cause.message,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        cause
+      );
+      connectionPort.get.mockResolvedValueOnce({
+        id: job.connectionId,
+        platformType: 'allegro',
+        status: 'active',
+      } as never);
+      jobRepository.markDead.mockResolvedValueOnce(undefined);
+
+      await (runner as any).handleJobFailure(job, error);
+
+      expect(connectionPort.update).toHaveBeenCalledWith(job.connectionId, {
+        status: 'needs_reauth',
+      });
+      // The job is still marked dead — flagging is in addition to, not instead of.
+      expect(jobRepository.markDead).toHaveBeenCalledWith(job.id, error.message);
+      expect(jobRepository.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('does NOT flag the connection on a transient network failure (still retryable)', async () => {
+      const job = createMockJob();
+      const cause = new AllegroNetworkException(
+        'Token refresh network failure: fetch failed',
+        'https://allegro.pl/auth/oauth/token'
+      );
+      const error = new SyncJobExecutionError(
+        'Marketplace orders poll failed: ' + cause.message,
+        job.id,
+        job.jobType,
+        job.connectionId,
+        cause
+      );
+      jobRepository.markFailed.mockResolvedValueOnce(undefined);
+
+      await (runner as any).handleJobFailure(job, error);
+
+      expect(connectionPort.update).not.toHaveBeenCalled();
+      expect(jobRepository.markFailed).toHaveBeenCalled();
+      expect(jobRepository.markDead).not.toHaveBeenCalled();
+    });
+
+    it('does NOT flag the connection on a non-auth non-retryable error (deterministic 422)', async () => {
+      const job = createMockJob();
+      const cause = new AllegroApiException('Validation failed', 422, 'body', 'https://api.allegro.pl/x');
+      const error = new SyncJobExecutionError(
+        'Marketplace offer create failed: Validation failed',
+        job.id,
+        job.jobType,
+        job.connectionId,
+        cause
+      );
+      jobRepository.markDead.mockResolvedValueOnce(undefined);
+
+      await (runner as any).handleJobFailure(job, error);
+
+      // Marked dead (non-retryable) but NOT flagged — a 422 is a data problem,
+      // not a credential rejection.
+      expect(jobRepository.markDead).toHaveBeenCalledWith(job.id, error.message);
+      expect(connectionPort.update).not.toHaveBeenCalled();
+    });
+
+    it('does NOT re-flag a connection that is not currently active', async () => {
+      const job = createMockJob();
+      const cause = new AllegroAuthenticationException('Invalid refresh token', 401);
+      const error = new SyncJobExecutionError(
+        'Marketplace orders poll failed',
+        job.id,
+        job.jobType,
+        job.connectionId,
+        cause
+      );
+      connectionPort.get.mockResolvedValueOnce({
+        id: job.connectionId,
+        platformType: 'allegro',
+        status: 'disabled',
+      } as never);
+      jobRepository.markDead.mockResolvedValueOnce(undefined);
+
+      await (runner as any).handleJobFailure(job, error);
+
+      expect(connectionPort.update).not.toHaveBeenCalled();
+      expect(jobRepository.markDead).toHaveBeenCalled();
+    });
+
+    it('swallows connection-flagging errors without masking the job failure', async () => {
+      const job = createMockJob();
+      const cause = new AllegroAuthenticationException('Invalid refresh token', 401);
+      const error = new SyncJobExecutionError(
+        'Marketplace orders poll failed',
+        job.id,
+        job.jobType,
+        job.connectionId,
+        cause
+      );
+      connectionPort.get.mockRejectedValueOnce(new Error('DB down'));
+      jobRepository.markDead.mockResolvedValueOnce(undefined);
+
+      await expect((runner as any).handleJobFailure(job, error)).resolves.toBeUndefined();
+
+      // Job is still marked dead despite the flagging failure.
+      expect(jobRepository.markDead).toHaveBeenCalledWith(job.id, error.message);
     });
   });
 

--- a/apps/worker/src/sync/sync-job.runner.ts
+++ b/apps/worker/src/sync/sync-job.runner.ts
@@ -17,8 +17,11 @@ import {
   SyncJobExecutionError,
   RetryClassifierRegistryService,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  AuthFailureClassifierRegistryService,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
 } from '@openlinker/core/sync';
 import { OfferCreationInvariantException } from '@openlinker/core/listings';
+import { ConnectionPort, CONNECTION_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
 import { SyncJobHandlerRegistry } from './handlers/sync-job-handler.registry';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -48,7 +51,11 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
     private readonly handlerRegistry: SyncJobHandlerRegistry,
     private readonly configService: ConfigService,
     @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
-    private readonly retryClassifierRegistry: RetryClassifierRegistryService
+    private readonly retryClassifierRegistry: RetryClassifierRegistryService,
+    @Inject(AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort
   ) {}
 
   onModuleInit(): void {
@@ -297,6 +304,17 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
 
     // Check for non-retryable errors (authentication failures)
     if (this.isNonRetryableError(error)) {
+      // A terminal *credential rejection* (e.g. Allegro `invalid_grant` on
+      // token refresh) flags the originating connection for re-authentication
+      // (#819). This is the narrow `credential-rejected` subset of
+      // non-retryable errors — a deterministic 422 validation failure is also
+      // non-retryable but must NOT flag the connection. Transient
+      // `network-failure` during refresh is surfaced as a retryable exception
+      // and never reaches this branch.
+      const cause = error instanceof SyncJobExecutionError && error.cause ? error.cause : error;
+      if (this.authFailureClassifierRegistry.isCredentialRejected(cause)) {
+        await this.flagConnectionNeedsReauth(job.connectionId);
+      }
       await this.jobRepository.markDead(job.id, errorMessage);
       this.logger.warn(`Job ${job.id} (${job.jobType}) marked as dead due to non-retryable error`);
       return;
@@ -360,6 +378,39 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
     }
 
     return this.retryClassifierRegistry.isNonRetryable(cause);
+  }
+
+  /**
+   * Flag a connection as needing re-authentication after a terminal credential
+   * rejection (#819).
+   *
+   * Only flips a connection that is currently `active`: we never clobber an
+   * admin-set `disabled`, never re-write an already-flagged connection, and
+   * never thrash on the repeated failures that a dead-credentials connection
+   * produces. Once flagged, the scheduler's `status: 'active'` filter stops
+   * enqueuing new jobs against it until a successful re-auth flips it back.
+   *
+   * Best-effort by design: a failure here must never mask the original job
+   * failure or break the runner loop, so errors are logged and swallowed.
+   */
+  private async flagConnectionNeedsReauth(connectionId: string): Promise<void> {
+    try {
+      const connection = await this.connectionPort.get(connectionId);
+      if (connection.status !== 'active') {
+        return;
+      }
+      await this.connectionPort.update(connectionId, { status: 'needs_reauth' });
+      this.logger.warn(
+        `Connection ${connectionId} (${connection.platformType}) flagged needs_reauth ` +
+          `after a terminal credential rejection — scheduler will stop enqueuing jobs ` +
+          `against it until re-authentication`
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to flag connection ${connectionId} as needs_reauth`,
+        error instanceof Error ? error.stack : String(error)
+      );
+    }
   }
 
   /**

--- a/apps/worker/test/integration/connection-reauth-flagging.int-spec.ts
+++ b/apps/worker/test/integration/connection-reauth-flagging.int-spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Connection Re-auth Flagging Integration Test (#819)
+ *
+ * Drives the production `SyncJobRunner.handleJobFailure` path against a real
+ * Postgres + the full worker module graph (so the Allegro auth-failure
+ * classifier is registered exactly as it is at boot). Verifies that a terminal
+ * credential rejection flips the originating connection to `needs_reauth` while
+ * a transient / non-auth failure leaves it `active`.
+ *
+ * @module apps/worker/test/integration
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any -- driving the runner's private handleJobFailure with the production seam */
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { WorkerIntegrationTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import { createTestSyncJob, getSyncJobById } from './helpers/test-sync-job.helper';
+import { SyncJobRunner } from '../../src/sync/sync-job.runner';
+import { SyncJobEntity as SyncJob, SyncJobExecutionError } from '@openlinker/core/sync';
+import type { ConnectionPort } from '@openlinker/core/identifier-mapping';
+import { CONNECTION_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
+import {
+  AllegroAuthenticationException,
+  AllegroApiException,
+} from '@openlinker/integrations-allegro';
+
+describe('Connection Re-auth Flagging Integration (#819)', () => {
+  let harness: WorkerIntegrationTestHarness;
+  let runner: SyncJobRunner;
+  let connectionPort: ConnectionPort;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    runner = harness.get(SyncJobRunner);
+    connectionPort = harness.get(CONNECTION_PORT_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function runFailure(connectionId: string, cause: unknown): Promise<string> {
+    const ormJob = await createTestSyncJob(harness.getDataSource(), {
+      jobType: 'marketplace.orders.poll',
+      connectionId,
+      status: 'running',
+      attempts: 1,
+      maxAttempts: 10,
+    });
+    const job = new SyncJob(
+      ormJob.id,
+      ormJob.jobType,
+      connectionId,
+      ormJob.payloadJson,
+      'running',
+      ormJob.idempotencyKey,
+      1,
+      10,
+      new Date(),
+      new Date(),
+      'worker-test',
+      null,
+      new Date(),
+      new Date()
+    );
+    const error = new SyncJobExecutionError(
+      'Marketplace orders poll failed',
+      job.id,
+      job.jobType,
+      connectionId,
+      cause
+    );
+    await (runner as any).handleJobFailure(job, error);
+    return ormJob.id;
+  }
+
+  it('flips an active Allegro connection to needs_reauth on a terminal credential rejection', async () => {
+    const connection = await createTestConnection(harness.getDataSource(), {
+      platformType: 'allegro',
+      status: 'active',
+      adapterKey: 'allegro.publicapi.v1',
+      config: { environment: 'sandbox' },
+    });
+
+    const jobId = await runFailure(
+      connection.id,
+      new AllegroAuthenticationException('Invalid refresh token', 401)
+    );
+
+    const updated = await connectionPort.get(connection.id);
+    expect(updated.status).toBe('needs_reauth');
+
+    // The job is still marked dead — flagging is additive.
+    const job = await getSyncJobById(harness.getDataSource(), jobId);
+    expect(job?.status).toBe('dead');
+  });
+
+  it('leaves the connection active on a non-auth non-retryable failure (422)', async () => {
+    const connection = await createTestConnection(harness.getDataSource(), {
+      platformType: 'allegro',
+      status: 'active',
+      adapterKey: 'allegro.publicapi.v1',
+      config: { environment: 'sandbox' },
+    });
+
+    await runFailure(
+      connection.id,
+      new AllegroApiException('Validation failed', 422, 'body', 'https://api.allegro.pl/x')
+    );
+
+    const updated = await connectionPort.get(connection.id);
+    expect(updated.status).toBe('active');
+  });
+});

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -525,7 +525,7 @@ interface Connection {
   id: string;                    // Unique connection ID
   platformType: string;          // 'prestashop', 'allegro', etc.
   name: string;                  // Human-readable name
-  status: 'active' | 'disabled' | 'error';
+  status: 'active' | 'disabled' | 'error' | 'needs_reauth';
   config: Record<string, any>;   // Connection-specific configuration
   credentialsRef: string;        // Reference to credentials storage
   createdAt: Date;
@@ -1266,7 +1266,7 @@ OpenLinker uses **implicit capabilities**: capabilities are declared in code via
   id: string;                    // UUID
   platformType: string;          // 'prestashop', 'allegro', etc.
   name: string;                  // Human-readable name
-  status: 'active' | 'disabled' | 'error';
+  status: 'active' | 'disabled' | 'error' | 'needs_reauth';
   config: Record<string, any>;   // Platform-specific config
   credentialsRef: string;        // Reference to stored credentials
   adapterKey?: string;           // Optional explicit adapter key
@@ -1294,8 +1294,10 @@ registrations (connection tester, retry classifier, scheduler tasks, email
 normalizer, webhook provisioner), and a `createCapabilityAdapter(connection,
 capability, host)` factory. The `HostServices` bag carries the curated set
 of services every plugin can rely on: `logger`, `identifierMapping`,
-`credentialsResolver`, optional `cache`, plus typed handles to the 7
-well-known registries. Plugin-specific cross-package ports (e.g.
+`credentialsResolver`, optional `cache`, plus typed handles to the 8
+well-known registries (the 7 originals plus the auth-failure classifier
+registry, #819 — see [ADR-008](./architecture/adrs/008-auth-failure-classifier-connection-reauth.md)).
+Plugin-specific cross-package ports (e.g.
 `CustomerIdentityResolverPort`, `IMappingConfigService`) are passed into
 the descriptor's constructor closure — they're intentionally not in the
 host bag, to keep the contract surface lean.

--- a/docs/architecture/adrs/008-auth-failure-classifier-connection-reauth.md
+++ b/docs/architecture/adrs/008-auth-failure-classifier-connection-reauth.md
@@ -60,6 +60,14 @@ from the overloaded `error`) carries the precise signal to the FE re-auth banner
   by type-check). This is the deliberate cost of keeping the seam marketplace-agnostic.
 - A second classifier registry sits alongside the retry one; the two are correlated but intentionally
   separate.
+- **In-place re-auth assumes the operator re-authenticates the *same* seller account.** Re-using the
+  connection id is what preserves connection-scoped mappings, but the recovery path validates only
+  `platformType`, not that the freshly-issued token authorizes the same Allegro seller as the original
+  connection. Re-authing with a different developer app / seller would silently rebind the connection
+  while retaining mappings keyed to the previous seller's external-id space. It is admin-gated and the
+  operator supplies their own credentials, so it is a foot-gun rather than a security hole. Validating
+  seller identity on re-auth (e.g. persisting the Allegro account id on the connection and comparing)
+  is tracked as a follow-up.
 
 **Migration path (if applicable):**
 - PrestaShop (API-key, non-OAuth) does not register a classifier yet — it never reaches `needs_reauth`

--- a/docs/architecture/adrs/008-auth-failure-classifier-connection-reauth.md
+++ b/docs/architecture/adrs/008-auth-failure-classifier-connection-reauth.md
@@ -1,0 +1,73 @@
+# ADR-008: Marketplace-agnostic auth-failure classifier for connection re-auth flagging
+
+- **Status**: Accepted
+- **Date**: 2026-05-24
+- **Authors**: @piotrswierzy
+
+## Context
+
+When an OAuth connection's credentials are rejected server-side (e.g. Allegro returns
+`400 invalid_grant` on token refresh), every job on that connection fails authentication and is
+marked dead. Nothing flagged the connection, so it stayed `status='active'` and the scheduler kept
+enqueuing jobs that died immediately — indefinitely, with no operator-facing signal (#819). The
+offer-status sync (#818) made this hourly-visible.
+
+The fix needs the `SyncJobRunner` — which is marketplace-agnostic and must not import
+`AllegroAuthenticationException` — to recognise, at the dead-job boundary, that a *specific*
+terminal failure is a **credential rejection** (re-auth required) as opposed to any other
+non-retryable failure (a deterministic `422`, an `OfferCreationInvariantException`). The
+terminal-vs-transient distinction is already encoded upstream: the Allegro HTTP client throws a
+retryable `AllegroNetworkException` for transient refresh blips and `AllegroAuthenticationException`
+only for genuine credential rejection (#499). So the runner just needs a way to classify the
+exception type without coupling to the plugin.
+
+## Decision
+
+Add a dedicated `AuthFailureClassifierPort` (`isCredentialRejected(cause)`) plus an
+`AuthFailureClassifierRegistryService` in `libs/core/src/sync`, exposed on the plugin contract's
+`HostServices` bag — a direct parallel of the existing `RetryClassifierPort` /
+`RetryClassifierRegistryService` seam (#581). Plugins register their classifier in `register(host)`;
+the runner OR-aggregates across registered classifiers. On a terminal credential rejection the runner
+flags the originating connection (`active → needs_reauth`, guarded + best-effort), which the
+scheduler's `status:'active'` filter then excludes. A new `needs_reauth` connection status (distinct
+from the overloaded `error`) carries the precise signal to the FE re-auth banner.
+
+## Alternatives considered
+
+- **Extend `RetryClassifierPort` with a second method.** Rejected: conflates retry policy with
+  auth/credential semantics on one port, and both are answered at different decision points. A focused
+  single-responsibility port reads better and lets platforms opt in independently.
+- **Neutral `CredentialsRejectedError` thrown by plugins, caught structurally in core.** Rejected:
+  forces every plugin to translate its own exception into a core error type deep in its HTTP stack;
+  the classifier-registry precedent keeps plugin exceptions plugin-owned and core classification-only.
+- **Duck-typed marker property on the exception (`err.credentialsRejected === true`).** Rejected:
+  less explicit than a port and inconsistent with the established registry pattern, for marginal
+  wiring savings.
+- **Reuse `status='error'` instead of `needs_reauth`.** Rejected: `error` is used for other failure
+  modes, so the FE couldn't distinguish "re-authenticate" from a generic error without a second field.
+
+## Consequences
+
+**Pros:**
+- Core/runner stay free of any Allegro import; the seam works for any future OAuth integration.
+- Mirrors a contract the codebase already proves out (#581) — low conceptual cost for reviewers and
+  plugin authors.
+- Scheduler halts dead-job churn automatically via the existing active-only filter; no scheduler change.
+- `needs_reauth` is a string-column value — **no DB migration**.
+
+**Cons / trade-offs:**
+- Adds one field to the `HostServices` contract — every host-bag assembly site must wire it (enforced
+  by type-check). This is the deliberate cost of keeping the seam marketplace-agnostic.
+- A second classifier registry sits alongside the retry one; the two are correlated but intentionally
+  separate.
+
+**Migration path (if applicable):**
+- PrestaShop (API-key, non-OAuth) does not register a classifier yet — it never reaches `needs_reauth`
+  today. It can adopt the port later with no core change.
+
+## References
+
+- Related PRs: #819
+- Related issues: #819, #818, #499, #447
+- Related ADRs: [ADR-002](./002-capability-ports-with-sub-capabilities.md), [ADR-003](./003-plugin-sdk-trust-model.md), [ADR-007](./007-syncjob-status-vs-outcome-split.md)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md)

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -97,5 +97,6 @@ One pointer per section, identical format every time.
 | [ADR-005](./005-postgres-authoritative-job-dedup.md) | Postgres-authoritative job dedup with Redis Streams as transport | Accepted | 2026-05-13 |
 | [ADR-006](./006-credentials-encryption-at-rest.md) | AES-256-GCM credentials encryption with prod-gate | Accepted | 2026-05-15 |
 | [ADR-007](./007-syncjob-status-vs-outcome-split.md) | SyncJob status-vs-outcome split | Accepted | 2026-04-15 |
+| [ADR-008](./008-auth-failure-classifier-connection-reauth.md) | Marketplace-agnostic auth-failure classifier for connection re-auth flagging | Accepted | 2026-05-24 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/implementation-plan-flag-connection-reauth.md
+++ b/docs/plans/implementation-plan-flag-connection-reauth.md
@@ -1,0 +1,201 @@
+# Implementation Plan — Flag connection + surface re-auth on terminal OAuth refresh rejection (#819)
+
+## 1. Goal & Classification
+
+When an Allegro connection's **refresh token is rejected server-side** (`400 invalid_grant` →
+`credential-rejected`), every job on that connection dies, but nothing flags the connection or
+tells the operator. The connection stays `status='active'`, so the scheduler keeps enqueuing
+jobs that immediately die — now hourly because of the offer-status sync (#818).
+
+**Fix:** on a **terminal `credential-rejected`** OAuth failure (never on transient
+`network-failure`), flag the connection so (a) the scheduler stops enqueuing against it, (b) the
+operator sees a "re-authentication required" affordance, and (c) a successful re-auth clears the
+flag.
+
+**Layer classification:**
+- **CORE** — new marketplace-agnostic auth-failure classification seam in the `sync` context;
+  `SyncJobRunner` flags the connection at the dead-job boundary.
+- **Integration (Allegro)** — register an auth-failure classifier for `AllegroAuthenticationException`;
+  thread an existing `connectionId` through the OAuth re-auth flow.
+- **Interface (FE)** — "Re-authentication required" banner on connection detail + list marker.
+
+**Non-goals:**
+- Token-rotation correctness (the sandbox token was invalidated server-side — not an OL bug; see
+  issue Assumptions). This issue is detection + surfacing + halting dead-job noise.
+- PrestaShop auth flagging (API-key based, not OAuth-refresh). The seam is generic; PrestaShop can
+  register a classifier in a follow-up.
+- A general "re-authenticate any OAuth connection" admin UX beyond what recovery needs.
+
+## 2. Key findings from codebase research
+
+- **Classification already happens in the Allegro http client.** `refreshOnUnauthorized`
+  (`allegro-connection-token-state.ts`) returns a tagged outcome; the http client throws
+  `AllegroNetworkException` for `network-failure` (retryable) and `AllegroAuthenticationException`
+  for `credential-rejected` / `no-callback` (terminal). **So by the time the error reaches the
+  worker, the terminal-vs-transient distinction is already encoded in the exception type** — a
+  network blip never surfaces as an auth exception. We do not need to thread `connectionId` through
+  the exception: the runner already has `job.connectionId`.
+- **The runner is the right seam.** `SyncJobRunner.handleJobFailure()`
+  (`apps/worker/src/sync/sync-job.runner.ts:289`) already classifies non-retryable errors via
+  `RetryClassifierRegistryService` (a marketplace-agnostic registry plugins register into — #581).
+  At the non-retryable dead-job branch (line 299) `job.connectionId` and the unwrapped `cause` are
+  in hand. This is the exact precedent to mirror for auth-failure classification.
+- **`isNonRetryableError` is broader than auth.** It also returns `true` for deterministic 4xx
+  (422 business errors, `OfferCreationInvariantException`). We must **only** flag the connection
+  when the cause is specifically a *credential rejection*, not any non-retryable failure — hence a
+  dedicated classifier, not "flag on every dead job".
+- **`connections.status` is a free-form string column** (`@Column() status!: string`) — adding a
+  new status value needs **no DB migration**.
+- **Scheduler filters `status: 'active'`** (`scheduler.service.ts:152`) — any non-`active` status
+  automatically stops enqueuing. ✔
+- **Re-auth currently mints a NEW connection.** `AllegroOauthService.storeCredentialsAndCreateConnection`
+  always calls `connectionService.create(...)`; OAuth `state` carries no existing `connectionId`.
+  Minting a new connection on re-auth would **orphan all connection-scoped identifier mappings**
+  (products/offers/orders are keyed to `connectionId`). Proper recovery must update the existing
+  connection in place.
+- **`ConnectionService.updateCredentials` exists** (in-place credential rotation, db-backed refs)
+  but is never called from the OAuth path and does not touch status.
+- **Worker DI** already imports `IdentifierMappingModule` (→ `CONNECTION_PORT_TOKEN`) and `SyncModule`
+  (→ classifier registries) into `SyncWorkerModule`, so the runner can inject both.
+
+## 3. Design
+
+### 3.1 Marketplace-agnostic auth-failure classification (CORE, `sync` context)
+
+Mirror the `RetryClassifierPort` / `RetryClassifierRegistryService` pattern exactly.
+
+- `libs/core/src/sync/domain/ports/auth-failure-classifier.port.ts`
+  ```ts
+  export interface AuthFailureClassifierPort {
+    /** True iff the cause is a terminal credential rejection for this
+     *  platform's exception hierarchy (re-authentication required).
+     *  False for everything else (transient, deterministic-4xx, unknown). */
+    isCredentialRejected(cause: unknown): boolean;
+  }
+  ```
+- `libs/core/src/sync/infrastructure/adapters/auth-failure-classifier-registry.service.ts` —
+  `register(adapterKey, classifier)` + OR-across-all `isCredentialRejected(cause)` (copy of the
+  retry registry; iterate-all because the runner holds a raw error, not an `adapterKey`).
+- `libs/core/src/sync/sync.tokens.ts` — `AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN = Symbol('AuthFailureClassifierRegistryService')`.
+- `sync.module.ts` — provide (`useExisting`) + export both token and service; barrel re-exports the
+  port + registry (mirroring the retry-classifier exports).
+
+### 3.2 Connection status flag (`needs_reauth`)
+
+- `libs/core/src/identifier-mapping/domain/types/connection.types.ts` — extend
+  `ConnectionStatusValues` to `['active', 'disabled', 'error', 'needs_reauth'] as const`.
+  Propagates to `UpdateConnectionDto` enum, `connection-response.dto.ts`, FE type. No migration.
+- New port/service surface for writing the flag: the runner calls the existing
+  `ConnectionPort.update(connectionId, { status: 'needs_reauth' })` (from
+  `@openlinker/core/identifier-mapping`), **guarded** so it only flips a connection that is
+  currently `active` (never clobber `disabled`, never re-write if already flagged).
+
+### 3.3 Runner wiring (worker)
+
+`SyncJobRunner` (`apps/worker/src/sync/sync-job.runner.ts`):
+- Inject `AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN` and `CONNECTION_PORT_TOKEN`.
+- In `handleJobFailure`, at the non-retryable branch (before/with `markDead`):
+  ```ts
+  if (this.isNonRetryableError(error)) {
+    const cause = unwrap(error);
+    if (this.authFailureClassifierRegistry.isCredentialRejected(cause)) {
+      await this.flagConnectionNeedsReauth(job.connectionId);
+    }
+    await this.jobRepository.markDead(job.id, errorMessage);
+    return;
+  }
+  ```
+- `flagConnectionNeedsReauth(connectionId)`: fetch connection; if `status === 'active'`, update to
+  `needs_reauth`; log a structured warn (`{ connectionId, platformType, from, to }`). Swallow errors
+  from the flagging step (must never mask the original job failure / crash the runner loop).
+- **Telemetry:** structured log on transition. (Domain event optional — deferred; logging satisfies
+  the criterion and avoids new event plumbing.)
+
+### 3.4 Allegro classifier (Integration)
+
+- `libs/integrations/allegro/src/infrastructure/adapters/allegro-auth-failure-classifier.adapter.ts`
+  — `AllegroAuthFailureClassifierAdapter implements AuthFailureClassifierPort`:
+  `isCredentialRejected(cause) => cause instanceof AllegroAuthenticationException`.
+- Register in `allegro-plugin.ts` `register(host)`:
+  `host.authFailureClassifierRegistry.register('allegro.publicapi.v1', new AllegroAuthFailureClassifierAdapter())`.
+
+### 3.5 Plugin contract (`HostServices`)
+
+Add `readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService;` to
+`libs/plugin-sdk/src/host-services.ts`, and add the field to every place a `HostServices` literal is
+assembled (Allegro + PrestaShop Nest modules' `onModuleInit`, and `createNestAdapterModule`).
+Type-check will enumerate them. **Plugin-contract change → write a short ADR.**
+
+### 3.6 Auto-recovery — re-authenticate the *existing* connection (Integration + API)
+
+> Scope decision pending user confirmation — see §6. Plan below is the recommended full slice.
+
+- `AllegroOAuthConnectDto` + `OAuthStateData` — add optional `connectionId`.
+- `allegro.controller.ts` `oauth/connect` — pass through `connectionId`.
+- `allegro-oauth.service.ts`:
+  - `generateAuthorizationUrl` — persist `connectionId` in the Redis state blob.
+  - `storeCredentialsAndCreateConnection` (or a new branch `reauthExistingConnection`) — when
+    `state.connectionId` is present: resolve the connection, `updateCredentials(connectionId, creds)`
+    (in-place, db-backed), then `connectionPort.update(connectionId, { status: 'active' })`.
+    Otherwise keep the existing create-new path.
+- This preserves all connection-scoped identifier mappings and satisfies the "successful re-auth
+  clears the flag" criterion.
+
+### 3.7 Frontend
+
+- `connection.types.ts` (FE) — add `'needs_reauth'` to `ConnectionStatus`.
+- `connections-list-page.tsx` `toStatusTone()` — map `'needs_reauth'` → `'warning'` and label.
+- `connection-detail-page.tsx` — when `status === 'needs_reauth'`, render a `<Alert tone="warning"
+  title="Re-authentication required">` with a "Re-authenticate" action that starts OAuth for **this
+  connection** (Allegro: `useStartAllegroOAuthMutation` with the current `connectionId`), reusing the
+  `requiresExternalAuthRedirect` / PlatformContribution pattern.
+
+## 4. Step-by-step implementation
+
+| # | File | Change | Acceptance |
+|---|------|--------|-----------|
+| 1 | `libs/core/src/sync/domain/ports/auth-failure-classifier.port.ts` | New port | Interface compiles; header comment |
+| 2 | `libs/core/src/sync/infrastructure/adapters/auth-failure-classifier-registry.service.ts` | New registry (mirror retry) | `register` + `isCredentialRejected` OR-across-all |
+| 3 | `libs/core/src/sync/sync.tokens.ts` | New token | `AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN` |
+| 4 | `libs/core/src/sync/sync.module.ts` + barrel | provide/export port+registry+token | Worker + plugins resolve it |
+| 5 | `libs/core/src/identifier-mapping/.../connection.types.ts` | add `'needs_reauth'` | union + DTO enum updated |
+| 6 | `libs/plugin-sdk/src/host-services.ts` | add `authFailureClassifierRegistry` | type-check finds all literal sites |
+| 7 | host-bag assembly sites (Allegro/PrestaShop modules, `createNestAdapterModule`) | wire new field | boot wiring compiles |
+| 8 | `libs/integrations/allegro/.../allegro-auth-failure-classifier.adapter.ts` | New classifier | true only for `AllegroAuthenticationException` |
+| 9 | `allegro-plugin.ts` | register classifier | registered at boot |
+| 10 | `apps/worker/src/sync/sync-job.runner.ts` | inject + flag on credential-rejected | flips `active→needs_reauth`, guarded, error-swallowed |
+| 11 | Auto-recovery: DTO/state/controller/oauth service | re-auth existing connection in place | `updateCredentials` + status→active; mappings preserved |
+| 12 | FE: types + list tone + detail banner + re-auth action | surface + CTA | banner shows on `needs_reauth`, links to OAuth |
+| 13 | `docs/architecture/adrs/NNN-*.md` | ADR for the classifier seam + HostServices addition | rationale captured |
+
+## 5. Tests
+
+- **Unit (`sync-job.runner.spec.ts`)**: flags connection on credential-rejected non-retryable cause;
+  does **not** flag on (a) transient/retryable error, (b) non-retryable non-auth (422 /
+  `OfferCreationInvariantException`); flagging guarded to `active`; flagging error swallowed.
+- **Unit**: `AuthFailureClassifierRegistryService` (OR-across-all, unknown → false);
+  `AllegroAuthFailureClassifierAdapter` (true for `AllegroAuthenticationException`, false otherwise).
+- **Integration (`*.int-spec.ts`)**: real Postgres — a dead-on-credential-rejection job flips the
+  connection to `needs_reauth`; scheduler `list({status:'active'})` then excludes it; re-auth
+  in-place resets to `active` and preserves the credentials ref / mappings.
+- **FE**: detail page renders the re-auth banner when `status === 'needs_reauth'`; list shows the
+  marker; banner CTA invokes the OAuth start for the connection.
+
+## 6. Open questions for the user (scope)
+
+1. **Status value:** dedicated `'needs_reauth'` (recommended — precise FE signal, no migration,
+   scheduler auto-excludes) vs reuse `'error'`.
+2. **Auto-recovery scope:** build the in-place re-auth-existing-connection flow now (recommended —
+   required to preserve connection-scoped mappings and to satisfy "re-auth clears the flag") vs
+   defer it to a follow-up (ship detection + flagging + FE banner now; clear the flag via
+   `updateCredentials` so a later re-auth flow recovers automatically).
+
+## 7. Validation / architecture compliance
+
+- Marketplace-agnostic seam (classifier registry) — no Allegro imports in core/runner. ✔
+- Ports + Symbol tokens; domain layer framework-free. ✔
+- Only `credential-rejected` flags (transient `network-failure` surfaces as retryable
+  `AllegroNetworkException`, never reaches the auth branch). ✔
+- No `any`; structured `Logger`; flag write guarded + error-swallowed so it never destabilises the
+  runner loop. ✔
+- No DB migration (string status column). ✔

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -440,7 +440,7 @@ authoring your plugin). Its four fields:
 
 The `HostServices` bag passed into `register` and `createCapabilityAdapter`
 is defined at
-[`libs/plugin-sdk/src/host-services.ts:50-121`](../libs/plugin-sdk/src/host-services.ts#L50-L121).
+[`libs/plugin-sdk/src/host-services.ts:51-131`](../libs/plugin-sdk/src/host-services.ts#L51-L131).
 It splits into two blocks:
 
 - **Read inputs** (use): `logger`, `identifierMapping`,
@@ -1022,7 +1022,7 @@ If you're proposing a new "bulk" capability on a port, that's almost certainly a
   vertical-slice patterns, the PrestaShop opt-in helper.
 - [`libs/plugin-sdk/src/adapter-plugin.ts:42-110`](../libs/plugin-sdk/src/adapter-plugin.ts#L42-L110)
   — the `AdapterPlugin` contract spec, header-comment form.
-- [`libs/plugin-sdk/src/host-services.ts:50-121`](../libs/plugin-sdk/src/host-services.ts#L50-L121)
+- [`libs/plugin-sdk/src/host-services.ts:51-131`](../libs/plugin-sdk/src/host-services.ts#L51-L131)
   — the `HostServices` bag, fields split into read-inputs vs side
   registries.
 

--- a/libs/core/src/identifier-mapping/domain/types/connection.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/connection.types.ts
@@ -18,8 +18,15 @@ export type PlatformType = string;
  * Runtime array of all valid connection status values. Used for validation,
  * Swagger documentation, and UI dropdowns. Follows OpenLinker engineering
  * standards: `as const` + derived union type pattern.
+ *
+ * `needs_reauth` is set automatically when a job dies from a terminal
+ * credential rejection (e.g. Allegro `invalid_grant` on token refresh, #819).
+ * It is distinct from `error` (which covers other failure modes) so the UI can
+ * surface a precise "re-authentication required" affordance, and — like every
+ * non-`active` status — the scheduler's `status: 'active'` filter stops
+ * enqueuing jobs against it. A successful re-auth flips it back to `active`.
  */
-export const ConnectionStatusValues = ['active', 'disabled', 'error'] as const;
+export const ConnectionStatusValues = ['active', 'disabled', 'error', 'needs_reauth'] as const;
 
 /**
  * Connection status type

--- a/libs/core/src/sync/domain/ports/auth-failure-classifier.port.ts
+++ b/libs/core/src/sync/domain/ports/auth-failure-classifier.port.ts
@@ -1,0 +1,42 @@
+/**
+ * Auth Failure Classifier Port
+ *
+ * Per-platform contract for deciding whether an error caught by the
+ * `SyncJobRunner` is a **terminal credential rejection** — i.e. the
+ * connection's stored credentials have been definitively rejected by the
+ * external platform (e.g. Allegro `400 invalid_grant` on token refresh) and
+ * re-authentication is required. When true, the runner flags the originating
+ * connection so the scheduler stops enqueuing dead-on-arrival jobs and the
+ * operator is prompted to re-authenticate (#819).
+ *
+ * This is a deliberately narrower question than `RetryClassifierPort`: a 422
+ * validation error or an `OfferCreationInvariantException` is non-retryable but
+ * is NOT a credential rejection — those must never flag the connection. A
+ * transient `network-failure` during refresh is surfaced by the adapter as a
+ * retryable network exception and never reaches this classifier at all.
+ *
+ * Resolved by the runner via `AuthFailureClassifierRegistryService`, which
+ * aggregates answers across registered classifiers — the runner has the raw
+ * error in hand, not an `adapterKey`, so dispatch is OR-across-all rather than
+ * indexed by key (mirrors the retry-classifier seam, #581).
+ *
+ * Implementations should return `false` for unknown errors. A classifier never
+ * sees errors from other platforms because each owns disjoint exception
+ * hierarchies, so the unknown-error branch is purely a safety net.
+ *
+ * @module libs/core/src/sync/domain/ports
+ * @see {@link AuthFailureClassifierRegistryService} for the registry that
+ *   aggregates implementations.
+ */
+export interface AuthFailureClassifierPort {
+  /**
+   * Returns `true` iff the cause is a terminal credential rejection for this
+   * platform's exception hierarchy (re-authentication required). Returns
+   * `false` otherwise (transient failures, deterministic non-auth 4xx,
+   * unknown errors).
+   *
+   * The runner unwraps `SyncJobExecutionError.cause` before calling, so
+   * implementations see the original platform exception directly.
+   */
+  isCredentialRejected(cause: unknown): boolean;
+}

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -13,6 +13,7 @@ export { SyncJobRepositoryPort } from './domain/ports/sync-job-repository.port';
 export { SyncJobHandler } from './domain/ports/sync-job-handler.port';
 export { ConnectionCursorRepositoryPort } from './domain/ports/connection-cursor-repository.port';
 export { RetryClassifierPort } from './domain/ports/retry-classifier.port';
+export { AuthFailureClassifierPort } from './domain/ports/auth-failure-classifier.port';
 export { SyncJobQueuePort, EnqueueJobRequest, EnqueueJobOptions } from './application/ports/sync-job-queue.port';
 export { SyncLockPort, SyncLockToken } from './application/ports/sync-lock.port';
 
@@ -84,6 +85,7 @@ export { SyncJobNotFoundError } from './domain/exceptions/sync-job-not-found.err
 // Infrastructure exports (for testing/mocking)
 export { RedisStreamsJobEnqueueService } from './infrastructure/adapters/redis-streams-job-enqueue.service';
 export { RetryClassifierRegistryService } from './infrastructure/adapters/retry-classifier-registry.service';
+export { AuthFailureClassifierRegistryService } from './infrastructure/adapters/auth-failure-classifier-registry.service';
 export { SchedulerTaskRegistryService } from './infrastructure/adapters/scheduler-task-registry.service';
 
 // Scheduler task contract (consumed by integration modules to contribute cron tasks)

--- a/libs/core/src/sync/infrastructure/adapters/__tests__/auth-failure-classifier-registry.service.spec.ts
+++ b/libs/core/src/sync/infrastructure/adapters/__tests__/auth-failure-classifier-registry.service.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Auth Failure Classifier Registry Service — Unit Tests
+ *
+ * Pins the registry's contract: register / get / has + the OR-aggregating
+ * `isCredentialRejected`. Mirrors `retry-classifier-registry.service.spec.ts`.
+ * Regressions here would silently change which terminal failures flag a
+ * connection for re-authentication (#819).
+ *
+ * @module libs/core/src/sync/infrastructure/adapters/__tests__
+ */
+import { AuthFailureClassifierRegistryService } from '../auth-failure-classifier-registry.service';
+import type { AuthFailureClassifierPort } from '../../../domain/ports/auth-failure-classifier.port';
+
+describe('AuthFailureClassifierRegistryService', () => {
+  let registry: AuthFailureClassifierRegistryService;
+
+  const makeClassifier = (matches: (cause: unknown) => boolean): AuthFailureClassifierPort => ({
+    isCredentialRejected: jest.fn(matches),
+  });
+
+  beforeEach(() => {
+    registry = new AuthFailureClassifierRegistryService();
+  });
+
+  describe('register / get / has', () => {
+    it('returns the registered classifier by adapterKey', () => {
+      const classifier = makeClassifier(() => false);
+      registry.register('foo.v1', classifier);
+
+      expect(registry.get('foo.v1')).toBe(classifier);
+      expect(registry.has('foo.v1')).toBe(true);
+    });
+
+    it('returns undefined / false for unknown adapterKey', () => {
+      expect(registry.get('not-registered')).toBeUndefined();
+      expect(registry.has('not-registered')).toBe(false);
+    });
+
+    it('overwrites silently when the same adapterKey is registered twice', () => {
+      const first = makeClassifier(() => false);
+      const second = makeClassifier(() => true);
+      registry.register('foo.v1', first);
+      registry.register('foo.v1', second);
+
+      expect(registry.get('foo.v1')).toBe(second);
+    });
+  });
+
+  describe('isCredentialRejected aggregation', () => {
+    class FooAuthError extends Error {}
+    class BarError extends Error {}
+
+    it('returns false when no classifiers are registered', () => {
+      expect(registry.isCredentialRejected(new Error('boom'))).toBe(false);
+    });
+
+    it('returns false when no classifier matches', () => {
+      registry.register(
+        'foo.v1',
+        makeClassifier((cause) => cause instanceof FooAuthError)
+      );
+      expect(registry.isCredentialRejected(new BarError())).toBe(false);
+    });
+
+    it('returns true when any classifier matches', () => {
+      registry.register(
+        'foo.v1',
+        makeClassifier((cause) => cause instanceof FooAuthError)
+      );
+      registry.register(
+        'bar.v1',
+        makeClassifier((cause) => cause instanceof BarError)
+      );
+
+      expect(registry.isCredentialRejected(new FooAuthError())).toBe(true);
+      expect(registry.isCredentialRejected(new BarError())).toBe(true);
+    });
+
+    it('passes the raw cause through to each classifier', () => {
+      const matcher = jest.fn((cause: unknown) => cause instanceof FooAuthError);
+      registry.register('foo.v1', { isCredentialRejected: matcher });
+
+      const cause = new FooAuthError('specific message');
+      registry.isCredentialRejected(cause);
+
+      expect(matcher).toHaveBeenCalledWith(cause);
+    });
+  });
+});

--- a/libs/core/src/sync/infrastructure/adapters/auth-failure-classifier-registry.service.ts
+++ b/libs/core/src/sync/infrastructure/adapters/auth-failure-classifier-registry.service.ts
@@ -1,0 +1,58 @@
+/**
+ * Auth Failure Classifier Registry Service
+ *
+ * Holds `AuthFailureClassifierPort` implementations keyed by `adapterKey`.
+ * Integration modules register their classifiers at bootstrap alongside their
+ * adapter factory + retry classifier, mirroring the shape of
+ * `RetryClassifierRegistryService`.
+ *
+ * Consumed by `SyncJobRunner` to answer "does this terminal error mean the
+ * connection's credentials were rejected (re-auth required)?" without importing
+ * platform-specific exception classes. The runner has the raw error in hand
+ * (not an `adapterKey`), so dispatch differs from key-indexed registries:
+ * `isCredentialRejected(cause)` walks every registered classifier and OR's the
+ * answers — each classifier owns disjoint exception hierarchies, so at most one
+ * matches in practice. Iteration is O(handful) and each check is O(1)
+ * `instanceof`.
+ *
+ * Silent overwrite on duplicate `adapterKey` mirrors the sister registries;
+ * integration modules register exactly once at boot so collisions are
+ * near-impossible by construction (#819).
+ *
+ * @module libs/core/src/sync/infrastructure/adapters
+ * @see {@link AuthFailureClassifierPort} for the port interface.
+ */
+import { Injectable } from '@nestjs/common';
+import type { AuthFailureClassifierPort } from '../../domain/ports/auth-failure-classifier.port';
+
+@Injectable()
+export class AuthFailureClassifierRegistryService {
+  private readonly classifiers: Map<string, AuthFailureClassifierPort> = new Map();
+
+  register(adapterKey: string, classifier: AuthFailureClassifierPort): void {
+    this.classifiers.set(adapterKey, classifier);
+  }
+
+  get(adapterKey: string): AuthFailureClassifierPort | undefined {
+    return this.classifiers.get(adapterKey);
+  }
+
+  has(adapterKey: string): boolean {
+    return this.classifiers.has(adapterKey);
+  }
+
+  /**
+   * Aggregate credential-rejection classification across registered
+   * classifiers. Returns `true` as soon as any classifier reports the cause as
+   * a terminal credential rejection; `false` if no classifier matches (the
+   * default — unknown errors are not treated as credential rejections).
+   */
+  isCredentialRejected(cause: unknown): boolean {
+    for (const classifier of this.classifiers.values()) {
+      if (classifier.isCredentialRejected(cause)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/libs/core/src/sync/sync.module.ts
+++ b/libs/core/src/sync/sync.module.ts
@@ -12,6 +12,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventsModule } from '@openlinker/core/events';
 import { RedisStreamsJobEnqueueService } from './infrastructure/adapters/redis-streams-job-enqueue.service';
 import { RetryClassifierRegistryService } from './infrastructure/adapters/retry-classifier-registry.service';
+import { AuthFailureClassifierRegistryService } from './infrastructure/adapters/auth-failure-classifier-registry.service';
 import { SchedulerTaskRegistryService } from './infrastructure/adapters/scheduler-task-registry.service';
 import { SyncJobOrmEntity } from './infrastructure/persistence/entities/sync-job.orm-entity';
 import { SyncJobRepository } from './infrastructure/persistence/repositories/sync-job.repository';
@@ -32,6 +33,7 @@ import {
   SYNC_JOB_RETRY_SERVICE_TOKEN,
   SYNC_JOB_BULK_RETRY_SERVICE_TOKEN,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
   SCHEDULER_TASK_REGISTRY_TOKEN,
   SYNC_JOBS_SERVICE_TOKEN,
   SYNC_CURSORS_SERVICE_TOKEN,
@@ -47,6 +49,7 @@ export {
   SYNC_JOB_RETRY_SERVICE_TOKEN,
   SYNC_JOB_BULK_RETRY_SERVICE_TOKEN,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
   SCHEDULER_TASK_REGISTRY_TOKEN,
   SYNC_JOBS_SERVICE_TOKEN,
   SYNC_CURSORS_SERVICE_TOKEN,
@@ -111,6 +114,17 @@ export {
       useExisting: RetryClassifierRegistryService,
     },
 
+    // Auth-failure classifier registry — integration modules self-register
+    // their platform-specific classifiers in `onModuleInit`; the runner queries
+    // the registry to decide whether a terminal job failure means the
+    // connection's credentials were rejected (re-auth required) without
+    // importing platform exception classes by name (#819).
+    AuthFailureClassifierRegistryService,
+    {
+      provide: AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+      useExisting: AuthFailureClassifierRegistryService,
+    },
+
     // Scheduler task registry — integration modules contribute their cron
     // tasks (Allegro orders-poll, offers-sync, …) at bootstrap; the API-side
     // `SchedulerService` drains the registry at `onApplicationBootstrap`
@@ -152,6 +166,8 @@ export {
     SyncJobBulkRetryService,
     RETRY_CLASSIFIER_REGISTRY_TOKEN,
     RetryClassifierRegistryService,
+    AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+    AuthFailureClassifierRegistryService,
     SCHEDULER_TASK_REGISTRY_TOKEN,
     SchedulerTaskRegistryService,
     SYNC_JOBS_SERVICE_TOKEN,

--- a/libs/core/src/sync/sync.tokens.ts
+++ b/libs/core/src/sync/sync.tokens.ts
@@ -17,6 +17,7 @@ export const SYNC_LOCK_TOKEN = Symbol('SyncLockPort');
 export const SYNC_JOB_RETRY_SERVICE_TOKEN = Symbol('SyncJobRetryServicePort');
 export const SYNC_JOB_BULK_RETRY_SERVICE_TOKEN = Symbol('SyncJobBulkRetryServicePort');
 export const RETRY_CLASSIFIER_REGISTRY_TOKEN = Symbol('RetryClassifierRegistryService');
+export const AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN = Symbol('AuthFailureClassifierRegistryService');
 export const SCHEDULER_TASK_REGISTRY_TOKEN = Symbol('SchedulerTaskRegistryService');
 export const SYNC_JOBS_SERVICE_TOKEN = Symbol('ISyncJobsService');
 export const SYNC_CURSORS_SERVICE_TOKEN = Symbol('ISyncCursorsService');

--- a/libs/integrations/allegro/src/__tests__/allegro-plugin.spec.ts
+++ b/libs/integrations/allegro/src/__tests__/allegro-plugin.spec.ts
@@ -29,6 +29,7 @@ describe('createAllegroPlugin → register(host)', () => {
       connectionTesterRegistry: { register: jest.fn() },
       emailNormalizerRegistry: { register: jest.fn() },
       retryClassifierRegistry: { register: jest.fn() },
+      authFailureClassifierRegistry: { register: jest.fn() },
       schedulerTaskRegistry: { register: jest.fn() },
       connectionConfigShapeValidatorRegistry: configRegistry,
       connectionCredentialsShapeValidatorRegistry: credentialsRegistry,

--- a/libs/integrations/allegro/src/allegro-integration.module.ts
+++ b/libs/integrations/allegro/src/allegro-integration.module.ts
@@ -43,6 +43,8 @@ import {
   SyncModule,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
   RetryClassifierRegistryService,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+  AuthFailureClassifierRegistryService,
   SCHEDULER_TASK_REGISTRY_TOKEN,
   SchedulerTaskRegistryService,
 } from '@openlinker/core/sync';
@@ -119,6 +121,8 @@ export class AllegroIntegrationModule implements OnModuleInit {
     private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
     @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
     private readonly retryClassifierRegistry: RetryClassifierRegistryService,
+    @Inject(AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService,
     @Inject(SCHEDULER_TASK_REGISTRY_TOKEN)
     private readonly schedulerTaskRegistry: SchedulerTaskRegistryService,
     @Inject(CUSTOMER_IDENTITY_RESOLVER_PORT_TOKEN)
@@ -169,6 +173,7 @@ export class AllegroIntegrationModule implements OnModuleInit {
       connectionTesterRegistry: this.connectionTesterRegistry,
       emailNormalizerRegistry: this.emailNormalizerRegistry,
       retryClassifierRegistry: this.retryClassifierRegistry,
+      authFailureClassifierRegistry: this.authFailureClassifierRegistry,
       schedulerTaskRegistry: this.schedulerTaskRegistry,
       webhookProvisioningRegistry: this.webhookProvisioningRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,

--- a/libs/integrations/allegro/src/allegro-plugin.ts
+++ b/libs/integrations/allegro/src/allegro-plugin.ts
@@ -31,6 +31,7 @@ import type { QuantityPollConfig } from './infrastructure/adapters/allegro-offer
 import { AllegroConnectionTesterAdapter } from './infrastructure/adapters/allegro-connection-tester.adapter';
 import { AllegroEmailNormalizerAdapter } from './infrastructure/adapters/allegro-email-normalizer.adapter';
 import { AllegroRetryClassifierAdapter } from './infrastructure/adapters/allegro-retry-classifier.adapter';
+import { AllegroAuthFailureClassifierAdapter } from './infrastructure/adapters/allegro-auth-failure-classifier.adapter';
 import { AllegroConnectionConfigShapeValidatorAdapter } from './infrastructure/adapters/allegro-connection-config-shape-validator.adapter';
 import { buildAllegroSchedulerTasks } from './infrastructure/scheduler/allegro-scheduler-tasks';
 import type { AllegroTokenRefreshService } from './infrastructure/token-refresh/allegro-token-refresh.service';
@@ -113,6 +114,10 @@ export function createAllegroPlugin(deps: CreateAllegroPluginDeps): AdapterPlugi
       host.retryClassifierRegistry.register(
         'allegro.publicapi.v1',
         new AllegroRetryClassifierAdapter()
+      );
+      host.authFailureClassifierRegistry.register(
+        'allegro.publicapi.v1',
+        new AllegroAuthFailureClassifierAdapter()
       );
       host.connectionConfigShapeValidatorRegistry.register(
         'allegro.publicapi.v1',

--- a/libs/integrations/allegro/src/index.ts
+++ b/libs/integrations/allegro/src/index.ts
@@ -91,6 +91,11 @@ export {
 // asymmetry should be reconsidered (export both, or move both behind
 // deep paths).
 export { AllegroRetryClassifierAdapter } from './infrastructure/adapters/allegro-retry-classifier.adapter';
+// Auth-failure classifier (#819) — exported so the worker runner spec can
+// register the real classifier in its auth-failure registry (mirrors the
+// retry classifier above). Plugin host modules register via
+// `host.authFailureClassifierRegistry`.
+export { AllegroAuthFailureClassifierAdapter } from './infrastructure/adapters/allegro-auth-failure-classifier.adapter';
 // Config shape validator (#587) — exported so the host-side
 // `connection.service.spec.ts` can register the real validator in its
 // shape-validator registry instead of duplicating the DTO logic in a

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-auth-failure-classifier.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-auth-failure-classifier.adapter.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Allegro Auth Failure Classifier Adapter — Unit Tests
+ *
+ * Pins that only `AllegroAuthenticationException` is treated as a terminal
+ * credential rejection (#819) — transient network failures, deterministic
+ * API errors, and unknown errors must not flag the connection for re-auth.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/adapters/__tests__
+ */
+import { AllegroAuthFailureClassifierAdapter } from '../allegro-auth-failure-classifier.adapter';
+import { AllegroAuthenticationException } from '../../../domain/exceptions/allegro-authentication.exception';
+import { AllegroNetworkException } from '../../../domain/exceptions/allegro-network.exception';
+import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
+
+describe('AllegroAuthFailureClassifierAdapter', () => {
+  const classifier = new AllegroAuthFailureClassifierAdapter();
+
+  it('classifies AllegroAuthenticationException as a credential rejection', () => {
+    const cause = new AllegroAuthenticationException('Invalid refresh token', 401);
+    expect(classifier.isCredentialRejected(cause)).toBe(true);
+  });
+
+  it('does not classify a transient network failure as a credential rejection', () => {
+    const cause = new AllegroNetworkException('fetch failed', 'https://allegro.pl/auth/oauth/token');
+    expect(classifier.isCredentialRejected(cause)).toBe(false);
+  });
+
+  it('does not classify a deterministic API error (422) as a credential rejection', () => {
+    const cause = new AllegroApiException('Validation failed', 422, 'body', 'https://api.allegro.pl/x');
+    expect(classifier.isCredentialRejected(cause)).toBe(false);
+  });
+
+  it('does not classify unknown errors as credential rejections', () => {
+    expect(classifier.isCredentialRejected(new Error('boom'))).toBe(false);
+    expect(classifier.isCredentialRejected('string error')).toBe(false);
+    expect(classifier.isCredentialRejected(undefined)).toBe(false);
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-auth-failure-classifier.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-auth-failure-classifier.adapter.ts
@@ -1,0 +1,35 @@
+/**
+ * Allegro Auth Failure Classifier Adapter
+ *
+ * Implements `AuthFailureClassifierPort` (#819) for the Allegro platform —
+ * answers the runner's "does this terminal failure mean the connection's
+ * credentials were rejected (re-authentication required)?" question for
+ * Allegro's own exception hierarchy. Self-registered by
+ * `AllegroIntegrationModule.onModuleInit` against
+ * `AuthFailureClassifierRegistryService` alongside the retry classifier.
+ *
+ * Credential-rejection (return `true`):
+ *   - `AllegroAuthenticationException` — the HTTP client throws this only after
+ *     a token refresh definitively fails with a credential rejection
+ *     (`invalid_grant`, missing/expired refresh token, missing client creds) or
+ *     a non-recoverable 401. Transient `network-failure` during refresh is
+ *     surfaced as `AllegroNetworkException` (retryable) and never reaches here,
+ *     so a one-second blip on `auth.allegro.pl` will not flag the connection
+ *     for re-auth (#499 classification preserved).
+ *
+ * Everything else (return `false`):
+ *   - `AllegroApiException` deterministic 4xx (422 validation, …) — non-retryable
+ *     but a business/data problem, not a credential rejection.
+ *   - Network / rate-limit / unknown errors — not credential rejections.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/adapters
+ * @implements {AuthFailureClassifierPort}
+ */
+import type { AuthFailureClassifierPort } from '@openlinker/core/sync';
+import { AllegroAuthenticationException } from '../../domain/exceptions/allegro-authentication.exception';
+
+export class AllegroAuthFailureClassifierAdapter implements AuthFailureClassifierPort {
+  isCredentialRejected(cause: unknown): boolean {
+    return cause instanceof AllegroAuthenticationException;
+  }
+}

--- a/libs/integrations/prestashop/src/prestashop-integration.module.ts
+++ b/libs/integrations/prestashop/src/prestashop-integration.module.ts
@@ -47,6 +47,8 @@ import {
   SyncModule,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
   RetryClassifierRegistryService,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+  AuthFailureClassifierRegistryService,
   SCHEDULER_TASK_REGISTRY_TOKEN,
   SchedulerTaskRegistryService,
 } from '@openlinker/core/sync';
@@ -106,6 +108,8 @@ export class PrestashopIntegrationModule implements OnModuleInit {
     private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
     @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
     private readonly retryClassifierRegistry: RetryClassifierRegistryService,
+    @Inject(AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN)
+    private readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService,
     @Inject(SCHEDULER_TASK_REGISTRY_TOKEN)
     private readonly schedulerTaskRegistry: SchedulerTaskRegistryService,
     @Inject(IDENTIFIER_MAPPING_PORT_TOKEN)
@@ -149,6 +153,7 @@ export class PrestashopIntegrationModule implements OnModuleInit {
       connectionTesterRegistry: this.connectionTesterRegistry,
       emailNormalizerRegistry: this.emailNormalizerRegistry,
       retryClassifierRegistry: this.retryClassifierRegistry,
+      authFailureClassifierRegistry: this.authFailureClassifierRegistry,
       schedulerTaskRegistry: this.schedulerTaskRegistry,
       webhookProvisioningRegistry: this.webhookProvisioningRegistry,
       connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,

--- a/libs/plugin-sdk/src/create-nest-adapter-module.spec.ts
+++ b/libs/plugin-sdk/src/create-nest-adapter-module.spec.ts
@@ -28,6 +28,7 @@ import {
 } from '@openlinker/core/integrations';
 import {
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
   SCHEDULER_TASK_REGISTRY_TOKEN,
 } from '@openlinker/core/sync';
 import { IDENTIFIER_MAPPING_PORT_TOKEN } from '@openlinker/core/identifier-mapping';
@@ -58,6 +59,7 @@ describe('createNestAdapterModule', () => {
     connectionConfigShapeValidatorRegistry: object;
     connectionCredentialsShapeValidatorRegistry: object;
     retryClassifierRegistry: object;
+    authFailureClassifierRegistry: object;
     schedulerTaskRegistry: object;
   } {
     return {
@@ -71,6 +73,7 @@ describe('createNestAdapterModule', () => {
       connectionConfigShapeValidatorRegistry: {},
       connectionCredentialsShapeValidatorRegistry: {},
       retryClassifierRegistry: {},
+      authFailureClassifierRegistry: {},
       schedulerTaskRegistry: {},
     };
   }
@@ -103,6 +106,10 @@ describe('createNestAdapterModule', () => {
           useValue: registries.connectionCredentialsShapeValidatorRegistry,
         },
         { provide: RETRY_CLASSIFIER_REGISTRY_TOKEN, useValue: registries.retryClassifierRegistry },
+        {
+          provide: AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+          useValue: registries.authFailureClassifierRegistry,
+        },
         { provide: SCHEDULER_TASK_REGISTRY_TOKEN, useValue: registries.schedulerTaskRegistry },
         { provide: IDENTIFIER_MAPPING_PORT_TOKEN, useValue: stubIdentifierMapping },
         { provide: CREDENTIALS_RESOLVER_TOKEN, useValue: stubCredentialsResolver },
@@ -162,6 +169,7 @@ describe('createNestAdapterModule', () => {
         emailNormalizerRegistry: expect.any(Object),
         webhookProvisioningRegistry: expect.any(Object),
         retryClassifierRegistry: expect.any(Object),
+        authFailureClassifierRegistry: expect.any(Object),
         schedulerTaskRegistry: expect.any(Object),
       }),
     );

--- a/libs/plugin-sdk/src/create-nest-adapter-module.ts
+++ b/libs/plugin-sdk/src/create-nest-adapter-module.ts
@@ -54,6 +54,8 @@ import {
   SyncModule,
   RETRY_CLASSIFIER_REGISTRY_TOKEN,
   RetryClassifierRegistryService,
+  AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN,
+  AuthFailureClassifierRegistryService,
   SCHEDULER_TASK_REGISTRY_TOKEN,
   SchedulerTaskRegistryService,
 } from '@openlinker/core/sync';
@@ -108,6 +110,8 @@ export function createNestAdapterModule(options: CreateNestAdapterModuleOptions)
       private readonly connectionCredentialsShapeValidatorRegistry: ConnectionCredentialsShapeValidatorRegistryService,
       @Inject(RETRY_CLASSIFIER_REGISTRY_TOKEN)
       private readonly retryClassifierRegistry: RetryClassifierRegistryService,
+      @Inject(AUTH_FAILURE_CLASSIFIER_REGISTRY_TOKEN)
+      private readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService,
       @Inject(SCHEDULER_TASK_REGISTRY_TOKEN)
       private readonly schedulerTaskRegistry: SchedulerTaskRegistryService,
       @Inject(IDENTIFIER_MAPPING_PORT_TOKEN)
@@ -134,6 +138,7 @@ export function createNestAdapterModule(options: CreateNestAdapterModuleOptions)
         connectionTesterRegistry: this.connectionTesterRegistry,
         emailNormalizerRegistry: this.emailNormalizerRegistry,
         retryClassifierRegistry: this.retryClassifierRegistry,
+        authFailureClassifierRegistry: this.authFailureClassifierRegistry,
         schedulerTaskRegistry: this.schedulerTaskRegistry,
         webhookProvisioningRegistry: this.webhookProvisioningRegistry,
         connectionConfigShapeValidatorRegistry: this.connectionConfigShapeValidatorRegistry,

--- a/libs/plugin-sdk/src/host-services.ts
+++ b/libs/plugin-sdk/src/host-services.ts
@@ -44,6 +44,7 @@ import type {
 } from '@openlinker/core/integrations';
 import type {
   RetryClassifierRegistryService,
+  AuthFailureClassifierRegistryService,
   SchedulerTaskRegistryService,
 } from '@openlinker/core/sync';
 
@@ -94,6 +95,15 @@ export interface HostServices {
 
   /** Retry-classifier registry — adapter-owned exception-to-retry-policy mapping (#581). */
   readonly retryClassifierRegistry: RetryClassifierRegistryService;
+
+  /**
+   * Auth-failure classifier registry — adapter-owned mapping from an exception
+   * to "this is a terminal credential rejection, the connection needs
+   * re-authentication" (#819). The runner consults it at the dead-job boundary
+   * to flag the originating connection. Narrower than the retry classifier: a
+   * non-retryable validation error must NOT be classified here.
+   */
+  readonly authFailureClassifierRegistry: AuthFailureClassifierRegistryService;
 
   /** Scheduler-task registry — adapter-contributed cron tasks (#584). */
   readonly schedulerTaskRegistry: SchedulerTaskRegistryService;

--- a/scripts/check-plugin-guide-quotes.mjs
+++ b/scripts/check-plugin-guide-quotes.mjs
@@ -18,7 +18,7 @@
  *      110; the link still resolves but lands on the wrong content.
  *
  *   3. **Boundary check** for the `HostServices` interface at
- *      `libs/plugin-sdk/src/host-services.ts:50-121`. Same shape.
+ *      `libs/plugin-sdk/src/host-services.ts:51-131`. Same shape.
  *
  * Both checks are deliberately strict: when they fire on a benign
  * refactor (e.g., new import above the interface), the human updates
@@ -68,9 +68,9 @@ const BOUNDARY_REFS = [
   {
     label: 'HostServices',
     sourceFile: 'libs/plugin-sdk/src/host-services.ts',
-    sourceStart: 50,
-    sourceEnd: 121,
-    guideLinkSubstring: 'host-services.ts:50-121',
+    sourceStart: 51,
+    sourceEnd: 131,
+    guideLinkSubstring: 'host-services.ts:51-131',
     expectedStart: /^export interface HostServices \{$/,
     expectedEnd: /^\}\s*$/,
   },


### PR DESCRIPTION
## What & why

When an Allegro connection's refresh token is rejected server-side (`400 invalid_grant` → terminal `credential-rejected`), every job on that connection died but nothing flagged it — the connection stayed `status='active'`, so the scheduler kept enqueuing jobs that died immediately, indefinitely (now hourly because of the offer-status sync #818).

This wires a **marketplace-agnostic seam** so the sync runner flags such a connection `needs_reauth`, halting the dead-job churn and surfacing a re-authentication affordance to the operator. A successful **in-place** re-auth clears the flag.

The terminal-vs-transient distinction is already encoded upstream (the Allegro HTTP client throws retryable `AllegroNetworkException` for transient refresh blips and `AllegroAuthenticationException` only for genuine credential rejection, #499), so the runner just needs to classify the exception type without coupling to the plugin — exactly the precedent set by `RetryClassifier` (#581).

## Changes

**CORE (`libs/core/src/sync`)**
- New `AuthFailureClassifierPort` (`isCredentialRejected(cause)`) + `AuthFailureClassifierRegistryService` (OR-across-registered, mirrors the retry-classifier registry) + token; wired into `SyncModule` and exposed on the plugin contract's `HostServices` bag.
- New connection status `needs_reauth` added to `ConnectionStatusValues` (no DB migration — `status` is a plain string column).

**Worker (`apps/worker`)**
- `SyncJobRunner.handleJobFailure` flips a connection `active → needs_reauth` when a dead-job cause is classified credential-rejected — guarded (only `active`), best-effort (errors logged + swallowed so it never destabilises the loop). The scheduler's existing `status:'active'` filter then stops enqueuing automatically.

**Allegro (`libs/integrations/allegro`)**
- `AllegroAuthFailureClassifierAdapter` (true only for `AllegroAuthenticationException`), registered in the plugin.
- In-place OAuth re-auth of an **existing** connection: an optional `connectionId` threads through the connect DTO → OAuth `state` → callback, which rotates the connection's credentials and resets status to `active` rather than minting a new connection — preserving all connection-scoped identifier mappings.

**Web (`apps/web`)**
- `needs_reauth` status + tone mapping (list, detail, dashboard); a "Re-authentication required" banner on the connection-detail page with a CTA that starts OAuth for the existing connection (`?reauth=<id>`).

**Docs** — ADR-008 (the classifier seam + plugin-contract addition, incl. a cons note on the re-auth seller-rebind hazard); architecture-overview refreshed.

## Testing

- `pnpm lint`, `pnpm type-check`, `pnpm test` all green (1720 unit tests).
- Unit: classifier, registry, runner flag/no-flag (credential-rejected vs transient vs non-auth 422 vs already-non-active vs flagging-error-swallowed), OAuth in-place re-auth, `toStartOAuthInput` connectionId passthrough, FE re-auth banner render + CTA href.
- Integration (`apps/worker/test/integration/connection-reauth-flagging.int-spec.ts`, Testcontainers): a credential-rejected dead job flips the connection to `needs_reauth` against a real Postgres + full worker module graph; a 422 does not.

## Follow-up

- #820 — validate same-seller identity on in-place re-auth (documented assumption today: the operator re-authenticates the same Allegro seller; ADR-008 cons note + inline comment).

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)