### PR TITLE
fix(inventory): key master inventory to the product's canonical variant (#822)

### DIFF
--- a/apps/api/src/migrations/1799000000003-backfill-inventory-variant-id.ts
+++ b/apps/api/src/migrations/1799000000003-backfill-inventory-variant-id.ts
@@ -1,0 +1,72 @@
+/**
+ * Backfill inventory_items.productVariantId for single-variant products (#822)
+ *
+ * Master inventory historically landed product-level (`productVariantId = NULL`)
+ * while the canonical mapping/offer target — and the availability read used by
+ * the bulk offer wizard — is the variant. From #822 the sync writes
+ * variant-keyed rows; this migration converts the *existing* product-level rows
+ * in place so the variant-keyed read finds them.
+ *
+ * Scope: only products with **exactly one** variant (a simple product's
+ * deterministic synthetic variant). Multi-variant products can't have a single
+ * product-level aggregate split across variants here — they stay product-level
+ * pending per-combination support (#823 master / #824 Allegro destination).
+ *
+ * In place (no INSERT): converting the row rather than inserting a variant-keyed
+ * one avoids leaving an orphan product-level duplicate that a subsequent
+ * variant-keyed sync would otherwise create (the two partial unique indexes on
+ * inventory_items permit both a NULL-variant and a variant row for the same
+ * product). The `NOT EXISTS` guard keeps the UPDATE safe if any variant-keyed
+ * row already exists.
+ *
+ * Data-only migration — no schema change (the `productVariantId` column and both
+ * partial unique indexes already exist).
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BackfillInventoryVariantId1799000000003 implements MigrationInterface {
+  name = 'BackfillInventoryVariantId1799000000003';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "inventory_items" i
+      SET "productVariantId" = sub.variant_id
+      FROM (
+        SELECT v."productId" AS product_id, MIN(v."id") AS variant_id
+        FROM "product_variants" v
+        GROUP BY v."productId"
+        HAVING COUNT(*) = 1
+      ) sub
+      WHERE i."productId" = sub.product_id
+        AND i."productVariantId" IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM "inventory_items" i2
+          WHERE i2."productId" = i."productId"
+            AND i2."productVariantId" = sub.variant_id
+            AND i2."locationId" IS NOT DISTINCT FROM i."locationId"
+        )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert single-variant rows back to product-level. Inherently lossy: a
+    // data-migration down() cannot distinguish rows this migration converted
+    // from rows that were already variant-keyed beforehand (none existed at
+    // up() time, so this is exact for that case). Scoped with the same
+    // single-variant predicate as up() to minimise over-reach.
+    await queryRunner.query(`
+      UPDATE "inventory_items" i
+      SET "productVariantId" = NULL
+      FROM (
+        SELECT v."productId" AS product_id, MIN(v."id") AS variant_id
+        FROM "product_variants" v
+        GROUP BY v."productId"
+        HAVING COUNT(*) = 1
+      ) sub
+      WHERE i."productId" = sub.product_id
+        AND i."productVariantId" = sub.variant_id
+    `);
+  }
+}

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -50,6 +50,7 @@ function createMockProductsService(): jest.Mocked<IProductsService> {
     getProduct: jest.fn(),
     getProductsByIds: jest.fn(),
     getVariant: jest.fn(),
+    getVariantsByProductId: jest.fn(),
     getVariantsBySkus: jest.fn(),
     getVariantsByBarcodes: jest.fn(),
     listProducts: jest.fn(),

--- a/apps/api/test/integration/inventory-variant-backfill.int-spec.ts
+++ b/apps/api/test/integration/inventory-variant-backfill.int-spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Inventory Variant Backfill Migration Integration Test (#822)
+ *
+ * The shared harness runs migrations once against an empty DB at boot, so the
+ * data-only backfill UPDATE never executes on seeded data there. This spec
+ * seeds the pre-migration shape (product-level inventory rows) and runs the
+ * migration's `up()` directly to assert the conversion:
+ * - a single-variant product's product-level row becomes variant-keyed;
+ * - a multi-variant product's row stays product-level (NULL);
+ * - the `NOT EXISTS` guard skips a row that would collide with an existing
+ *   variant-keyed row (which would otherwise violate the variant-level partial
+ *   unique index).
+ *
+ * Uses real Postgres via Testcontainers.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  ProductOrmEntity,
+  ProductVariantOrmEntity,
+} from '@openlinker/core/products/orm-entities';
+import { InventoryItemOrmEntity } from '@openlinker/core/inventory/orm-entities';
+import { BackfillInventoryVariantId1799000000003 } from '../../src/migrations/1799000000003-backfill-inventory-variant-id';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+
+describe('BackfillInventoryVariantId migration (#822)', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function runBackfill(): Promise<void> {
+    const queryRunner = harness.getDataSource().createQueryRunner();
+    try {
+      await new BackfillInventoryVariantId1799000000003().up(queryRunner);
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  it('keys single-variant product-level rows to the variant; leaves multi-variant rows product-level', async () => {
+    const dataSource = harness.getDataSource();
+    const productRepo = dataSource.getRepository(ProductOrmEntity);
+    const variantRepo = dataSource.getRepository(ProductVariantOrmEntity);
+    const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+
+    // Simple product: one variant + one product-level inventory row.
+    const simpleProductId = `ol_product_simple_${suffix}`;
+    const simpleVariantId = `ol_variant_simple_${suffix}`;
+    const simpleInvId = `ol_inventory_simple_${suffix}`;
+    await productRepo.save(
+      productRepo.create({ id: simpleProductId, name: 'Simple', sku: null, price: null }),
+    );
+    await variantRepo.save(
+      variantRepo.create({
+        id: simpleVariantId,
+        productId: simpleProductId,
+        sku: null,
+        attributes: null,
+        ean: null,
+        gtin: null,
+      }),
+    );
+    await inventoryRepo.save(
+      inventoryRepo.create({
+        id: simpleInvId,
+        productId: simpleProductId,
+        productVariantId: null,
+        availableQuantity: 15,
+        reservedQuantity: 0,
+        locationId: null,
+      }),
+    );
+
+    // Multi-variant product: two variants + one product-level inventory row.
+    const multiProductId = `ol_product_multi_${suffix}`;
+    const multiInvId = `ol_inventory_multi_${suffix}`;
+    await productRepo.save(
+      productRepo.create({ id: multiProductId, name: 'Multi', sku: null, price: null }),
+    );
+    for (const n of ['m1', 'm2']) {
+      await variantRepo.save(
+        variantRepo.create({
+          id: `ol_variant_${n}_${suffix}`,
+          productId: multiProductId,
+          sku: null,
+          attributes: null,
+          ean: null,
+          gtin: null,
+        }),
+      );
+    }
+    await inventoryRepo.save(
+      inventoryRepo.create({
+        id: multiInvId,
+        productId: multiProductId,
+        productVariantId: null,
+        availableQuantity: 7,
+        reservedQuantity: 0,
+        locationId: null,
+      }),
+    );
+
+    await runBackfill();
+
+    const simpleAfter = await inventoryRepo.findOneByOrFail({ id: simpleInvId });
+    const multiAfter = await inventoryRepo.findOneByOrFail({ id: multiInvId });
+    expect(simpleAfter.productVariantId).toBe(simpleVariantId);
+    expect(multiAfter.productVariantId).toBeNull();
+  });
+
+  it('skips a product-level row that would collide with an existing variant-keyed row', async () => {
+    const dataSource = harness.getDataSource();
+    const productRepo = dataSource.getRepository(ProductOrmEntity);
+    const variantRepo = dataSource.getRepository(ProductVariantOrmEntity);
+    const inventoryRepo = dataSource.getRepository(InventoryItemOrmEntity);
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+
+    const productId = `ol_product_guard_${suffix}`;
+    const variantId = `ol_variant_guard_${suffix}`;
+    const variantRowId = `ol_inventory_variant_${suffix}`;
+    const productRowId = `ol_inventory_product_${suffix}`;
+
+    await productRepo.save(
+      productRepo.create({ id: productId, name: 'Guard', sku: null, price: null }),
+    );
+    await variantRepo.save(
+      variantRepo.create({
+        id: variantId,
+        productId,
+        sku: null,
+        attributes: null,
+        ean: null,
+        gtin: null,
+      }),
+    );
+    // A variant-keyed row already exists at (product, variant, null location)…
+    await inventoryRepo.save(
+      inventoryRepo.create({
+        id: variantRowId,
+        productId,
+        productVariantId: variantId,
+        availableQuantity: 20,
+        reservedQuantity: 0,
+        locationId: null,
+      }),
+    );
+    // …and a stray product-level row at the same location.
+    await inventoryRepo.save(
+      inventoryRepo.create({
+        id: productRowId,
+        productId,
+        productVariantId: null,
+        availableQuantity: 5,
+        reservedQuantity: 0,
+        locationId: null,
+      }),
+    );
+
+    // Must not throw (the guard avoids the would-be unique-index violation).
+    await runBackfill();
+
+    const productRowAfter = await inventoryRepo.findOneByOrFail({ id: productRowId });
+    expect(productRowAfter.productVariantId).toBeNull();
+  });
+});

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -144,6 +144,7 @@ The system is organized into the following core bounded contexts:
 - **Key Entities**: Inventory, InventoryAdjustment, InventoryMapping
 - **Location**: `libs/core/src/inventory/`
 - **Capability**: Uses `InventoryMasterPort` abstraction
+- **Variant-keyed master inventory (#822, [ADR-010](./architecture/adrs/010-variant-keyed-master-inventory.md))**: `MasterInventorySyncService` keys each `inventory_items` row to the product's canonical **variant** (a simple product's deterministic synthetic variant), not the bare product — so the variant-keyed availability read (`getAvailabilityByVariantIds`, used by the bulk offer wizard) finds stock. Resolution precedence: adapter-supplied `Inventory.variantId` → the product's lone variant when it has exactly one → else product-level (`productVariantId = NULL`). Multi-variant (combination) products stay product-level pending per-combination master stock (**#823**) and Allegro auto-grouped variant offers (**#824**); until then they read as 0 by variant.
 
 ### 4. Orders
 - **Responsibility**: Order ingestion, synchronization, and lifecycle management

--- a/docs/architecture/adrs/010-variant-keyed-master-inventory.md
+++ b/docs/architecture/adrs/010-variant-keyed-master-inventory.md
@@ -1,0 +1,49 @@
+# ADR-010: Variant-keyed master inventory
+
+- **Status**: Accepted
+- **Date**: 2026-05-24
+- **Authors**: @piotrswierzy
+
+## Context
+
+The bulk Allegro offer-creation wizard reported `NO MASTER STOCK` for every product even when stock existed (#822). Root cause: a read/write key mismatch in inventory. `MasterInventorySyncService` wrote `inventory_items` rows keyed to the **product** with `productVariantId = NULL` (the PrestaShop `InventoryMasterAdapter.getInventory(productId)` returns product-level `stock_availables` and never sets a `variantId`), while the availability read the wizard relies on — `getAvailabilityByVariantIds` → `findAvailabilityByVariantIds` — filters by `productVariantId`. The two keys never intersect, so every variant-keyed read missed and zero-filled.
+
+This contradicts the architecture's own rule that the **variant** is the canonical offer-link / mapping target (EAN/GTIN live on `ProductVariant`; simple products get a deterministic synthetic variant). Inventory being keyed to the bare product was the anomaly.
+
+## Decision
+
+Make master inventory **variant-keyed**: `MasterInventorySyncService` resolves the product's canonical variant and persists the `inventory_items` row against it. Resolution precedence:
+
+1. an adapter-supplied `Inventory.variantId` wins (future-proof; no adapter supplies one today);
+2. else, if the product has **exactly one** variant (a simple product's synthetic variant), key to it;
+3. else (multi-variant or zero-variant) keep product-level (`productVariantId = NULL`), logged.
+
+A data-only migration (`BackfillInventoryVariantId1799000000003`) converts existing single-variant product-level rows in place. No schema change — the `productVariantId` column and both partial unique indexes (NULL and NOT-NULL) already exist. No read-path change — once rows are variant-keyed the existing query finds them.
+
+## Alternatives considered
+
+- **Variant-keyed write + backfill** (chosen): removes the anomaly at the source; reads need no heuristic. Costs a data migration and leaves multi-variant products deferred.
+- **Read-side fallback** (the original Option 1): when no variant-keyed row exists, fall back to the product-level row for that variant's product. Rejected as the durable fix — it's a permanent heuristic on a shared endpoint that's only correct for single-variant products and would over-report stock for multi-variant siblings (an oversell vector in an offer-creation flow). It would have been the smaller tactical unblock, but the team chose the durable direction.
+- **Per-combination stock now**: rejected as out of scope for the bug fix — it requires the PrestaShop adapter to enumerate per-combination `stock_availables` and a port-shape change. Deferred to #823.
+
+## Consequences
+
+**Pros:**
+- The variant-keyed availability read finds stock; the bulk wizard reports correct master stock for simple products.
+- Inventory now agrees with the rest of the system (offers/mappings are variant-keyed) — the anomaly is gone.
+- No read-path complexity; no over-reporting heuristic.
+
+**Cons / trade-offs:**
+- **Multi-variant (combination) products stay product-level and read as 0 by variant** until per-combination stock lands. This is honest (not over-reported) but means they can't be bulk-listed yet. Tracked as two halves: **#823** (PrestaShop adapter enumerates per-combination stock → emits per-combination `Inventory.variantId`) and **#824** (Allegro lists one offer per variant, auto-grouped from the Product Catalog — note Allegro's explicit `/sale/offer-variants` API was removed 2026-04-14, so #824 must use auto-grouping, and Allegro stock is per-offer, which OL's 1-variant→1-offer model already matches).
+- The backfill migration is **load-bearing**: without it, a re-sync of a single-variant product would look up its row by the resolved variant key, miss the legacy NULL-variant row, and insert a second variant-keyed row — an orphan duplicate (both partial indexes permit it). Converting in place prevents this. CI runs migrations before app start.
+- The write-propagation dedupe key becomes variant-scoped for future stock changes (strictly more precise); the migration itself triggers no propagation (the no-change guard skips unchanged quantities).
+
+**Migration path:**
+- `BackfillInventoryVariantId1799000000003` (data-only) converts single-variant product-level rows to variant-keyed, in place, guarded against colliding with any pre-existing variant-keyed row. `down()` reverts the same rows to NULL (inherently lossy for a data migration — documented inline).
+
+## References
+
+- Related PRs: #822
+- Related issues: #822, #823 (per-combination master stock), #824 (Allegro auto-grouped variant offers)
+- Related ADRs: [ADR-004](./004-identifier-mapping-service.md) (variant identity)
+- Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md) § Inventory

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -99,5 +99,6 @@ One pointer per section, identical format every time.
 | [ADR-007](./007-syncjob-status-vs-outcome-split.md) | SyncJob status-vs-outcome split | Accepted | 2026-04-15 |
 | [ADR-008](./008-auth-failure-classifier-connection-reauth.md) | Marketplace-agnostic auth-failure classifier for connection re-auth flagging | Accepted | 2026-05-24 |
 | [ADR-009](./009-persisted-offer-status-snapshots.md) | Persisted offer-status snapshots | Accepted | 2026-05-23 |
+| [ADR-010](./010-variant-keyed-master-inventory.md) | Variant-keyed master inventory | Accepted | 2026-05-24 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/implementation-plan-822-master-stock-variant-keying.md
+++ b/docs/plans/implementation-plan-822-master-stock-variant-keying.md
@@ -1,0 +1,125 @@
+# Implementation Plan — #822 Bulk wizard "NO MASTER STOCK" (variant-keyed inventory — Option 2)
+
+## 1. Understand the task
+
+**Goal:** The bulk Allegro offer-creation wizard reports `NO MASTER STOCK` for every product even when stock exists, because `inventory_items` rows are keyed by **product** (`productVariantId = NULL`) while the wizard reads availability by **variant**. The architecture's canonical target for offers/mappings is the **variant** (simple products get a deterministic synthetic variant). Option 2 removes the anomaly: **make master-inventory sync write variant-keyed rows**, and backfill existing rows, so reads-by-variant find stock. No read-side heuristic.
+
+**Chosen approach (Option 2 — write-side normalization):**
+1. At sync time, resolve the product's canonical variant. For a **single-variant product** (the synthetic variant of a simple product), key the inventory row to that variant id.
+2. Backfill existing product-level rows (`productVariantId IS NULL`) to variant-keyed via a data migration, for single-variant products.
+3. No read-path change — the existing `findAvailabilityByVariantIds` query finds the now-variant-keyed rows.
+
+**Layer classification:** CORE — inventory application (sync service) + products application (one read method) + one **data migration** (`apps/api/src/migrations/`). **No schema change** (the `productVariantId` column and both partial unique indexes already exist — the ORM entity already "Supports both product-level and variant-level inventory"). No FE/API contract change.
+
+**Non-goals:**
+- **Multi-variant (combination) products.** The PrestaShop `InventoryMasterAdapter.getInventory(productId)` returns a single product-level aggregate (`id_product_attribute=0`) and never enumerates per-combination stock. Splitting one aggregate across multiple variants is not possible without an adapter change, so multi-variant products keep a product-level row and continue to read as 0 (honest, not over-reported). This deferred scope is split into two filed follow-ups, referenced from ADR-010 and from a code comment at the resolver fallback in `master-inventory-sync.service.ts` so the gap is discoverable, not silently permanent:
+  - **#823 (master half)** — PrestaShop adapter enumerates per-combination `stock_availables` → emits one `Inventory` per combination with `variantId`; sync writes one variant-keyed row per combination.
+  - **#824 (destination half)** — bulk flow lists one Allegro offer per variant, sharing the catalog product + emitting the variant parameter so Allegro **auto-groups** them. Note (verified against developer.allegro.pl): Allegro's explicit variant-set API (`/sale/offer-variants`) was removed on 2026-04-14 (returns 404); stock on Allegro is per-offer, so OL's existing 1-variant→1-offer model is already the right shape and #824 must use auto-grouping, not the dead API.
+- No read-side fallback (deliberately — variant-keyed storage is the durable fix).
+
+## 2. Research findings
+
+- **Schema already supports variant-keyed inventory** — `inventory-item.orm-entity.ts` declares two partial unique indexes: `(productId, locationId) WHERE productVariantId IS NULL` and `(productId, productVariantId, locationId) WHERE productVariantId IS NOT NULL`. Variant-keyed rows are first-class today; only the *data* and the *write path* default to NULL.
+- **Write path is the root cause** — `MasterInventorySyncService.toDomainInventoryItem` (`master-inventory-sync.service.ts:89`) sets `productVariantId = inventory.variantId ?? null`. The PrestaShop adapter calls `mapInventory(stockRecord, productId)` **without** a `variantId` arg (`prestashop-inventory-master.adapter.ts:113`), so `inventory.variantId` is always `undefined` → every row lands NULL. `Inventory.variantId?` is optional, so an adapter that later supplies it should win.
+- **DI already wired** — `ProductsModule` is imported by `inventory.module.ts:42` and (transitively) by the worker via `InventoryModule` (`sync-worker.module.ts:14`). Injecting `IProductsService` into `MasterInventorySyncService` needs **no module change**.
+- **Variant resolution available** — `ProductVariantRepository.findByProductId(productId)` already exists on the port; expose it through `IProductsService.getVariantsByProductId`.
+- **Read path unchanged** — `InventoryQueryService.getAvailabilityByVariantIds` → `findAvailabilityByVariantIds` (`inventory.repository.ts:103`) groups by `productVariantId`; once rows are variant-keyed it returns stock with zero new code.
+- **Next free migration prefix:** `1799000000003` (latest on `main` is `1799000000002-add-offer-status-snapshots-table.ts`).
+
+## 3. Design
+
+### Variant resolution (write path)
+
+In `MasterInventorySyncService.toDomainInventoryItem(inventory, productId)`:
+
+```
+resolvedVariantId =
+  inventory.variantId                                  // adapter-supplied wins (future-proof)
+  ?? (variants.length === 1 ? variants[0].id : null)   // single-variant ⇒ synthetic variant
+  // else null  ⇒ product-level (multi/zero-variant, logged)
+```
+
+where `variants = await productsService.getVariantsByProductId(productId)` (skip the call when `inventory.variantId` is already set). Use `resolvedVariantId` both for the existing-row lookup (`inventoryService.getInventory(productId, resolvedVariantId, locationId)`) and for the persisted `InventoryItem`. Emit a `logger.debug` when resolution falls back to product-level (`master_inventory_product_level_fallback product=… variants=N`).
+
+### Backfill migration (data only)
+
+Convert existing product-level rows to variant-keyed for single-variant products, in place (no new rows → no orphan duplicates):
+
+```sql
+UPDATE inventory_items i
+SET "productVariantId" = sub.variant_id
+FROM (
+  SELECT v."productId" AS product_id, MIN(v.id) AS variant_id
+  FROM product_variants v
+  GROUP BY v."productId"
+  HAVING COUNT(*) = 1
+) sub
+WHERE i."productId" = sub.product_id
+  AND i."productVariantId" IS NULL
+  AND NOT EXISTS (                       -- defensive: never collide with an existing variant row
+    SELECT 1 FROM inventory_items i2
+    WHERE i2."productId" = i."productId"
+      AND i2."productVariantId" = sub.variant_id
+      AND i2."locationId" IS NOT DISTINCT FROM i."locationId"
+  );
+```
+
+`down()` reverts the same single-variant rows back to `productVariantId = NULL`, scoped with the *same* predicate as `up()` (single-variant products, `productVariantId IS NOT NULL`). It carries an inline comment noting the inherent lossiness: a data-migration `down()` cannot distinguish rows this migration converted from rows that were already variant-keyed (none exist today, so it is exact now).
+
+**Why the migration is required (not just convenient):** without it, a re-sync of a single-variant product would look up its existing row by the *resolved variant key*, miss the legacy NULL-variant row, and **insert a second, variant-keyed row** — leaving an orphan product-level duplicate (the two partial indexes both permit it). Converting rows in place makes the next sync find-and-update them. CI runs migrations before app start ("migrate then start", `docs/migrations.md`).
+
+## 4. Step-by-step implementation
+
+### Products context — expose variant lookup by product
+
+1. `libs/core/src/products/application/services/products.service.interface.ts`
+   - Add `getVariantsByProductId(productId: string): Promise<ProductVariant[]>` with a doc comment.
+
+2. `libs/core/src/products/application/services/products.service.ts`
+   - Implement → `this.variantRepository.findByProductId(productId)`.
+   - **AC:** unit test in `products.service.spec.ts` — delegates and returns the repo result.
+
+### Inventory context — variant-keyed write
+
+3. `libs/core/src/inventory/application/services/master-inventory-sync.service.ts`
+   - Inject `@Inject(PRODUCTS_SERVICE_TOKEN) productsService: IProductsService` (import from `@openlinker/core/products`, top-level barrel — same seam `InventoryQueryService` already uses).
+   - In `toDomainInventoryItem`, compute `resolvedVariantId` per the design; use it for the existing-row lookup and the persisted entity; `logger.debug` on product-level fallback. The multi/zero-variant fallback branch carries a code comment referencing the multi-variant follow-up issue (see Non-goals).
+   - Skip the `getVariantsByProductId` call entirely when `inventory.variantId` is already set (adapter-supplied), so the common adapter path adds at most one indexed query per product sync.
+   - **AC:** `master-inventory-sync.service.spec.ts` (new) — (a) single-variant product ⇒ row keyed to that variant id; (b) multi-variant ⇒ `productVariantId = null` + fallback logged; (c) zero-variant ⇒ null; (d) adapter-supplied `inventory.variantId` ⇒ used verbatim (no products call); (e) `available` derivation unchanged.
+   - **Note (not a regression):** the migration triggers **no** propagation — `InventoryService.set` skips when quantity is unchanged (`previous.availableQuantity === upserted.availableQuantity`), and the first post-migration sync finds the converted row with the same quantity. The propagation dedupe key (`buildPropagationDedupeKey`, includes `variantId`) simply becomes variant-scoped for *future* stock changes — strictly more precise, not a re-fire. Call this out in the PR description.
+
+### Data migration
+
+4. `apps/api/src/migrations/1799000000003-backfill-inventory-variant-id.ts`
+   - Hand-authored data migration (no schema change) with the `up()` / `down()` SQL above. Class `BackfillInventoryVariantId1799000000003`.
+   - **AC:** `pnpm --filter @openlinker/api migration:show` lists it; `migration:run` then `migration:revert` succeed locally; `pnpm lint` timestamp-invariant passes.
+
+### Tests / regression
+
+5. `apps/api/test/integration/inventory-availability.int-spec.ts`
+   - Add a vertical-slice case: seed a product + single variant + a **variant-keyed** inventory row, assert `/inventory/availability` returns the stock for that variant (guards the end-to-end shape the bulk wizard depends on). Existing cases stay green.
+
+6. Backfill-migration integration test (the harness runs migrations against an empty DB at boot, so the `UPDATE` never executes on seeded data otherwise). After harness boot, seed a product-level row (`productVariantId NULL`) + a single variant for that product **and** a multi-variant product with a product-level row, run the backfill SQL via the `DataSource`, then assert: single-variant row becomes variant-keyed; multi-variant row stays NULL; the `NOT EXISTS` collision guard skips a pre-existing variant row.
+   - **AC:** both branches asserted against real Postgres; locks the load-bearing `HAVING COUNT(*) = 1` + collision-guard logic.
+
+7. Pre-flip verification (implementation step, recorded in PR description): grep for *external* readers that treat null-variant rows as "the product's stock" — FE `/inventory` list (handles `string | null`) and any order-reservation path. Expected clean (the inventory module is already variant-agnostic); confirm before flipping the write key.
+
+### Docs & follow-up
+
+8. `docs/architecture-overview.md` — Inventory context: note master-inventory sync keys rows to the product's canonical (synthetic) variant; product-level rows remain only for multi-variant products pending per-combination support.
+9. `docs/architecture/adrs/010-variant-keyed-master-inventory.md` — short ADR: decision (variant-keyed inventory), rejected alternative (read-side fallback, the original Option 1), trade-off (multi-variant deferred → #823 master / #824 destination, incl. the Allegro `/sale/offer-variants` deprecation finding), migration consequence. Add to `adrs/README.md` index.
+10. **Reference the filed multi-variant follow-ups** — #823 (PrestaShop per-combination stock) and #824 (Allegro auto-grouped variant offers) — in ADR-010 and in the `master-inventory-sync.service.ts` fallback comment, so the deferred scope is discoverable from the code. (Issues already filed; no new issue to create.)
+
+## 5. Validation
+
+- **Architecture:** sync service depends on `IProductsService` (allowed cross-context seam — `inventory → products` is in the documented dependency map); domain/ports stay framework-free; ORM mapping stays in the repo; no new SQL join across contexts.
+- **Naming:** `getVariantsByProductId` mirrors `getVariant` / `getProductsByIds`; migration class/file timestamp match (lint invariant).
+- **Testing:** unit (products service, sync service) + integration (availability slice); coverage targets — core app services 80%+.
+- **Security:** no new input surface; no secrets; endpoint unchanged.
+- **Migrations:** data-only, reversible `up`/`down`, defensive against index collisions, next-free unique timestamp.
+
+## Risks / open questions
+
+- **Multi-variant products stay at 0** in the bulk wizard (product-level rows, read-by-variant misses). Honest (no over-report) and unchanged from today; durable fix is the adapter per-combination follow-up. Documented + ADR.
+- **Migration is load-bearing** — skipping it risks orphan duplicate rows on re-sync (see §3). CI migrate-then-start covers prod; dev must `migration:run`.
+- **Worker DI** — `MasterInventorySyncService` gains a constructor dep; the worker resolves it via `InventoryModule` (already imports `ProductsModule`). Per the #786 lesson, confirm the worker boots (the sync service is exercised by `MasterInventorySyncHandler`).

--- a/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/master-inventory-sync.service.spec.ts
@@ -22,6 +22,7 @@ import type {
   Inventory as InventoryPortInterface,
 } from '@openlinker/core/inventory';
 import { InventoryItemEntity as InventoryItem } from '@openlinker/core/inventory';
+import type { IProductsService, ProductVariant } from '@openlinker/core/products';
 
 describe('MasterInventorySyncService', () => {
   let service: MasterInventorySyncService;
@@ -29,6 +30,7 @@ describe('MasterInventorySyncService', () => {
   let identifierMapping: jest.Mocked<IIdentifierMappingService>;
   let inventoryService: jest.Mocked<IInventoryService>;
   let inventoryAdapter: jest.Mocked<InventoryMasterPort>;
+  let productsService: jest.Mocked<Pick<IProductsService, 'getVariantsByProductId'>>;
 
   const connectionId = 'connection-123';
   const externalId = 'ext-product-9';
@@ -65,10 +67,17 @@ describe('MasterInventorySyncService', () => {
       getInventory: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<IInventoryService>;
 
+    productsService = {
+      // Default: no variants resolved ⇒ product-level (null) keying, which
+      // matches the pre-#822 behaviour the existing cases below assert.
+      getVariantsByProductId: jest.fn().mockResolvedValue([]),
+    };
+
     service = new MasterInventorySyncService(
       integrationsService,
       identifierMapping,
-      inventoryService
+      inventoryService,
+      productsService as unknown as IProductsService
     );
   });
 
@@ -245,6 +254,88 @@ describe('MasterInventorySyncService', () => {
       await expect(service.syncFromMasterByExternalId(connectionId, externalId)).rejects.toBe(boom);
 
       expect(inventoryService.setInventory).not.toHaveBeenCalled();
+    });
+  });
+
+  // #822 — master inventory is keyed to the product's canonical variant so the
+  // variant-keyed availability read (bulk offer wizard) finds stock. Log
+  // assertions are deliberately omitted per this file's logger-as-is precedent;
+  // the persisted `productVariantId` is the meaningful behavioural signal.
+  describe('variant resolution (#822)', () => {
+    const makeVariant = (id: string): ProductVariant => ({
+      id,
+      productId: internalProductId,
+      sku: null,
+      attributes: null,
+      ean: null,
+      gtin: null,
+    });
+
+    // PrestaShop returns product-level stock with no variantId (today's reality).
+    const productLevelAdapterInventory: InventoryPortInterface = {
+      id: 'adapter-inv',
+      productId: internalProductId,
+      quantity: 50,
+      reserved: 0,
+      available: 50,
+      updatedAt: new Date('2026-05-01T10:00:00Z'),
+    };
+
+    it('keys inventory to the synthetic variant when the product has exactly one variant', async () => {
+      inventoryAdapter.getInventory.mockResolvedValue(productLevelAdapterInventory);
+      productsService.getVariantsByProductId.mockResolvedValue([makeVariant('ol_variant_a')]);
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(productsService.getVariantsByProductId).toHaveBeenCalledWith(internalProductId);
+      // existing-row lookup uses the resolved variant key, not null
+      expect(inventoryService.getInventory).toHaveBeenCalledWith(
+        internalProductId,
+        'ol_variant_a',
+        null
+      );
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({ productVariantId: 'ol_variant_a' })
+      );
+    });
+
+    it('keeps inventory product-level (null) for a multi-variant product', async () => {
+      inventoryAdapter.getInventory.mockResolvedValue(productLevelAdapterInventory);
+      productsService.getVariantsByProductId.mockResolvedValue([
+        makeVariant('ol_variant_a'),
+        makeVariant('ol_variant_b'),
+      ]);
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({ productVariantId: null })
+      );
+    });
+
+    it('keeps inventory product-level (null) for a product with no variants', async () => {
+      inventoryAdapter.getInventory.mockResolvedValue(productLevelAdapterInventory);
+      productsService.getVariantsByProductId.mockResolvedValue([]);
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({ productVariantId: null })
+      );
+    });
+
+    it('uses an adapter-supplied variantId verbatim without resolving variants', async () => {
+      inventoryAdapter.getInventory.mockResolvedValue({
+        ...productLevelAdapterInventory,
+        variantId: 'ol_variant_adapter',
+      });
+
+      await service.syncFromMasterByExternalId(connectionId, externalId);
+
+      expect(productsService.getVariantsByProductId).not.toHaveBeenCalled();
+      expect(inventoryService.setInventory).toHaveBeenCalledWith(
+        expect.objectContaining({ productVariantId: 'ol_variant_adapter' })
+      );
     });
   });
 });

--- a/libs/core/src/inventory/application/services/master-inventory-sync.service.ts
+++ b/libs/core/src/inventory/application/services/master-inventory-sync.service.ts
@@ -11,6 +11,7 @@ import { Injectable, Inject } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
+import { IProductsService, PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
 import { INVENTORY_SERVICE_TOKEN } from '../../inventory.tokens';
 import { IInventoryService } from './inventory.service.interface';
 import type {
@@ -34,7 +35,9 @@ export class MasterInventorySyncService implements IMasterInventorySyncService {
     @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
     private readonly identifierMapping: IIdentifierMappingService,
     @Inject(INVENTORY_SERVICE_TOKEN)
-    private readonly inventoryService: IInventoryService
+    private readonly inventoryService: IInventoryService,
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService
   ) {}
 
   async syncFromMasterByExternalId(
@@ -72,9 +75,11 @@ export class MasterInventorySyncService implements IMasterInventorySyncService {
     inventory: InventoryPortInterface,
     productId: string
   ): Promise<InventoryItemDomainEntity> {
+    const variantId = await this.resolveVariantId(inventory, productId);
+
     const existing = await this.inventoryService.getInventory(
       productId,
-      inventory.variantId ?? null,
+      variantId,
       inventory.locationId ?? null
     );
 
@@ -86,11 +91,45 @@ export class MasterInventorySyncService implements IMasterInventorySyncService {
     return new InventoryItemDomainEntity(
       inventoryItemId,
       productId,
-      inventory.variantId ?? null,
+      variantId,
       availableQuantity,
       inventory.reserved ?? 0,
       inventory.locationId ?? null,
       inventory.updatedAt ?? new Date()
     );
+  }
+
+  /**
+   * Resolve the variant the inventory row is keyed to (#822). The canonical
+   * mapping/offer target is the variant, so master inventory is keyed to the
+   * product's variant rather than the bare product — this is what lets the
+   * variant-keyed availability read (the bulk offer wizard) find stock.
+   *
+   * - An adapter that already knows the variant wins (future-proof; the
+   *   PrestaShop adapter does not supply one today).
+   * - A simple product has exactly one deterministic synthetic variant ⇒ key to it.
+   * - A multi-variant (combination) product cannot have its single product-level
+   *   aggregate split across variants here, so it stays product-level (`null`)
+   *   and reads as 0 by variant until per-combination stock lands. Deferred:
+   *   #823 (PrestaShop per-combination master stock) / #824 (Allegro
+   *   auto-grouped variant offers).
+   */
+  private async resolveVariantId(
+    inventory: InventoryPortInterface,
+    productId: string
+  ): Promise<string | null> {
+    if (inventory.variantId) {
+      return inventory.variantId;
+    }
+
+    const variants = await this.productsService.getVariantsByProductId(productId);
+    if (variants.length === 1) {
+      return variants[0].id;
+    }
+
+    this.logger.debug(
+      `master_inventory_product_level_fallback product=${productId} variants=${variants.length} (multi/zero-variant — kept product-level pending #823/#824)`
+    );
+    return null;
   }
 }

--- a/libs/core/src/products/application/services/products.service.interface.ts
+++ b/libs/core/src/products/application/services/products.service.interface.ts
@@ -62,6 +62,15 @@ export interface IProductsService {
   getVariant(id: string): Promise<ProductVariant | null>;
 
   /**
+   * All variants belonging to a product, by internal product ID. A simple
+   * product resolves to its single deterministic synthetic variant; a
+   * combination product resolves to one variant per combination. An unknown
+   * product yields `[]`. Used by master-inventory sync to key inventory to the
+   * product's canonical variant (#822).
+   */
+  getVariantsByProductId(productId: string): Promise<ProductVariant[]>;
+
+  /**
    * Variant lookup by SKU list. Used by offer-mapping reconciliation flows
    * to resolve marketplace external-refs / SKUs back to internal variants.
    * Empty input returns `[]` without a DB round-trip.

--- a/libs/core/src/products/application/services/products.service.spec.ts
+++ b/libs/core/src/products/application/services/products.service.spec.ts
@@ -162,6 +162,26 @@ describe('ProductsService', () => {
     });
   });
 
+  describe('getVariantsByProductId', () => {
+    it('forwards the product id to the repository and returns the result', async () => {
+      const variants = [makeVariant()];
+      variantRepo.findByProductId.mockResolvedValue(variants);
+
+      const result = await service.getVariantsByProductId('ol_product_1');
+
+      expect(result).toBe(variants);
+      expect(variantRepo.findByProductId).toHaveBeenCalledWith('ol_product_1');
+    });
+
+    it('returns the repository result verbatim for an unknown product ([])', async () => {
+      variantRepo.findByProductId.mockResolvedValue([]);
+
+      const result = await service.getVariantsByProductId('ol_product_unknown');
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('listProducts', () => {
     it('should return paginated products', async () => {
       const products = [makeProduct(), makeProduct({ id: 'ol_product_2', name: 'Second' })];

--- a/libs/core/src/products/application/services/products.service.ts
+++ b/libs/core/src/products/application/services/products.service.ts
@@ -81,6 +81,10 @@ export class ProductsService implements IProductsService {
     return this.variantRepository.findById(id);
   }
 
+  async getVariantsByProductId(productId: string): Promise<ProductVariant[]> {
+    return this.variantRepository.findByProductId(productId);
+  }
+
   async getVariantsBySkus(skus: string[]): Promise<ProductVariant[]> {
     if (skus.length === 0) return [];
     return this.variantRepository.findBySkuIn(skus);


### PR DESCRIPTION
## What & why

The bulk Allegro offer-creation wizard reported **NO MASTER STOCK** for every product even when stock existed. Root cause: a read/write key mismatch — `MasterInventorySyncService` wrote `inventory_items` rows keyed to the **product** (`productVariantId = NULL`), while the wizard reads availability by **variant** (`getAvailabilityByVariantIds`). The two keys never intersect, so the read always missed and zero-filled. This also contradicted the architecture's rule that the **variant** is the canonical offer-link / mapping target.

**Fix (Option 2 — variant-keyed master inventory, durable):** resolve the product's canonical variant at sync time and key the row to it, so the variant-keyed read finds stock.

- `MasterInventorySyncService.resolveVariantId`: adapter-supplied `Inventory.variantId` wins (future-proof) → single-variant product ⇒ its synthetic variant → multi/zero-variant ⇒ product-level (`NULL`), logged.
- New `IProductsService.getVariantsByProductId` (delegates to the existing `ProductVariantRepository.findByProductId`).
- Data migration `1799000000003-backfill-inventory-variant-id` converts existing single-variant product-level rows **in place** (no schema change — the column + both partial unique indexes already exist; guarded against index collisions; reversible `down()`).
- **No read-path change, no FE/API contract change, no module wiring change** (`ProductsModule` was already imported by the inventory + worker modules).

See **[ADR-010](docs/architecture/adrs/010-variant-keyed-master-inventory.md)** for the decision, the rejected read-side-fallback alternative, and the deferred scope.

## Scope notes

- **Multi-variant (combination) products stay product-level and read as 0 by variant** until per-combination stock lands. Honest (not over-reported), and an accepted non-goal here. Tracked as two filed follow-ups, referenced from ADR-010 and a code comment at the fallback:
  - **#823** — PrestaShop adapter enumerates per-combination master stock.
  - **#824** — Allegro lists one offer per variant, auto-grouped from the Product Catalog (the explicit `/sale/offer-variants` API was removed by Allegro on 2026-04-14; stock on Allegro is per-offer, so OL's existing 1-variant→1-offer model already fits).
- The backfill migration is **load-bearing**: without it, a re-sync of a single-variant product would insert a second variant-keyed row, orphaning the product-level one. CI runs migrate-then-start; dev must `migration:run`.
- Not a regression: the migration triggers no propagation (the no-change guard skips unchanged quantities); the write-propagation dedupe key simply becomes variant-scoped for future changes.

## How to test

- `pnpm type-check && pnpm lint && pnpm test` — green across all packages (incl. the migration-timestamp + cross-context invariants).
- `pnpm --filter @openlinker/api test:integration` — full suite green; new `inventory-variant-backfill.int-spec.ts` asserts single-variant convert, multi-variant left NULL, and the collision-guard skip against real Postgres.
- Manual: a simple product (e.g. the Bosch/Canon repro) now shows its real master stock in the bulk wizard instead of NO MASTER STOCK.

## Related issues

Closes #822
Follow-ups: #823, #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)