### PR TITLE
feat(mappings): general fulfillment-routing model + compatibility (#832)

### DIFF
--- a/apps/api/src/migrations/1799000000005-add-fulfillment-routing-rules.ts
+++ b/apps/api/src/migrations/1799000000005-add-fulfillment-routing-rules.ts
@@ -1,0 +1,41 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add the `fulfillment_routing_rules` table (#832) — the general
+ * fulfillment-routing model generalizing `connection_carrier_mappings`.
+ *
+ * Additive: `connection_carrier_mappings` is left untouched (it remains the
+ * co-keyed branch-1 carrier source). One rule per
+ * `(source_connection_id, source_delivery_method_id)`. Both connection
+ * references FK to `connections` ON DELETE CASCADE — a deleted source removes
+ * its rules; a deleted processor removes rules that route to it (reverting
+ * that `(source, method)` to the omp_fulfilled default). See ADR-012.
+ */
+export class AddFulfillmentRoutingRules1799000000005 implements MigrationInterface {
+  name = 'AddFulfillmentRoutingRules1799000000005';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "fulfillment_routing_rules" (
+        "id"                         uuid                   NOT NULL DEFAULT gen_random_uuid(),
+        "source_connection_id"       uuid                   NOT NULL,
+        "source_delivery_method_id"  character varying(100) NOT NULL,
+        "processor_kind"             character varying(32)  NOT NULL,
+        "processor_connection_id"    uuid                   NOT NULL,
+        "created_at"                 timestamptz            NOT NULL DEFAULT now(),
+        "updated_at"                 timestamptz            NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_fulfillment_routing_rules_id" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_fulfillment_routing_rules_source_method"
+          UNIQUE ("source_connection_id", "source_delivery_method_id"),
+        CONSTRAINT "FK_fulfillment_routing_rules_source_connection"
+          FOREIGN KEY ("source_connection_id") REFERENCES "connections" ("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_fulfillment_routing_rules_processor_connection"
+          FOREIGN KEY ("processor_connection_id") REFERENCES "connections" ("id") ON DELETE CASCADE
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "fulfillment_routing_rules"`);
+  }
+}

--- a/apps/api/test/integration/fulfillment-routing.int-spec.ts
+++ b/apps/api/test/integration/fulfillment-routing.int-spec.ts
@@ -1,0 +1,248 @@
+/**
+ * Fulfillment Routing Integration Test (#832)
+ *
+ * Vertical slice for the general fulfillment-routing model: persistence
+ * round-trip through `FulfillmentRoutingService`, capability + topology
+ * compatibility validation against the **real** booted adapter registry
+ * (PrestaShop / Allegro / InPost manifests), rule resolution with the
+ * omp_fulfilled no-regression default, and the migration's
+ * `ON DELETE CASCADE` foreign keys.
+ *
+ * Uses real Postgres via Testcontainers — the migration under test
+ * (`AddFulfillmentRoutingRules1799000000005`) is applied by the harness.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+  IncompatibleProcessorException,
+} from '@openlinker/core/mappings';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+
+interface SeededConnections {
+  /** Allegro order source (`allegro.publicapi.v1` — OrderSource, OfferManager). */
+  sourceId: string;
+  /** PrestaShop OMP (`prestashop.webservice.v1` — declares OrderProcessorManager). */
+  prestashopId: string;
+  /** InPost OL-managed carrier (`inpost.shipx.v1` — declares ShippingProviderManager). */
+  inpostId: string;
+}
+
+describe('Fulfillment Routing Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  function getService(): IFulfillmentRoutingService {
+    return harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+  }
+
+  /**
+   * Seed the three connection shapes the routing model distinguishes. Their
+   * adapterKeys resolve to the real registered manifests, so compatibility
+   * checks run against production capability metadata — not a stub.
+   */
+  async function seedConnections(): Promise<SeededConnections> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    const prestashop = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      name: 'PrestaShop OMP',
+      adapterKey: 'prestashop.webservice.v1',
+      enabledCapabilities: ['OrderProcessorManager'],
+    });
+    const inpost = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: 'inpost.shipx.v1',
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    return { sourceId: source.id, prestashopId: prestashop.id, inpostId: inpost.id };
+  }
+
+  describe('replaceRules + getRules', () => {
+    it('should persist compatible omp_fulfilled and ol_managed_carrier rules and read them back', async () => {
+      const { sourceId, prestashopId, inpostId } = await seedConnections();
+      const service = getService();
+
+      await service.replaceRules(sourceId, [
+        {
+          sourceDeliveryMethodId: 'allegro-courier',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+          processorConnectionId: prestashopId,
+        },
+        {
+          sourceDeliveryMethodId: 'allegro-one-box',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+          processorConnectionId: inpostId,
+        },
+      ]);
+
+      const rules = await service.getRules(sourceId);
+      expect(rules).toHaveLength(2);
+
+      const byMethod = new Map(rules.map((r) => [r.sourceDeliveryMethodId, r]));
+      expect(byMethod.get('allegro-courier')).toMatchObject({
+        sourceConnectionId: sourceId,
+        processorKind: 'omp_fulfilled',
+        processorConnectionId: prestashopId,
+      });
+      expect(byMethod.get('allegro-one-box')).toMatchObject({
+        sourceConnectionId: sourceId,
+        processorKind: 'ol_managed_carrier',
+        processorConnectionId: inpostId,
+      });
+    });
+
+    it('should reject an omp_fulfilled rule whose processor does not declare OrderProcessorManager', async () => {
+      const { sourceId } = await seedConnections();
+      const service = getService();
+
+      // Routing an OMP rule at the Allegro source itself — Allegro declares
+      // OrderSource/OfferManager but not OrderProcessorManager.
+      await expect(
+        service.replaceRules(sourceId, [
+          {
+            sourceDeliveryMethodId: 'allegro-courier',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+            processorConnectionId: sourceId,
+          },
+        ]),
+      ).rejects.toBeInstanceOf(IncompatibleProcessorException);
+
+      // Nothing persisted — the whole replace is rejected before any write.
+      expect(await service.getRules(sourceId)).toHaveLength(0);
+    });
+
+    it('should reject an ol_managed_carrier rule whose processor is the source connection', async () => {
+      const { sourceId } = await seedConnections();
+      const service = getService();
+
+      await expect(
+        service.replaceRules(sourceId, [
+          {
+            sourceDeliveryMethodId: 'allegro-one-box',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+            processorConnectionId: sourceId,
+          },
+        ]),
+      ).rejects.toBeInstanceOf(IncompatibleProcessorException);
+    });
+
+    it('should reject a source_brokered rule because the source does not yet declare ShippingProviderManager (#833)', async () => {
+      const { sourceId } = await seedConnections();
+      const service = getService();
+
+      // source_brokered requires the source connection itself to declare
+      // ShippingProviderManager. Allegro Delivery (#833) is not yet
+      // implemented, so the Allegro adapter declares no shipping capability —
+      // the rule is correctly uncreatable until that lands behind this seam.
+      await expect(
+        service.replaceRules(sourceId, [
+          {
+            sourceDeliveryMethodId: 'allegro-one-box',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.SourceBrokered,
+            processorConnectionId: sourceId,
+          },
+        ]),
+      ).rejects.toBeInstanceOf(IncompatibleProcessorException);
+    });
+
+    it('should fully replace the previous rule set on a second call', async () => {
+      const { sourceId, prestashopId, inpostId } = await seedConnections();
+      const service = getService();
+
+      await service.replaceRules(sourceId, [
+        {
+          sourceDeliveryMethodId: 'allegro-courier',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+          processorConnectionId: prestashopId,
+        },
+      ]);
+
+      await service.replaceRules(sourceId, [
+        {
+          sourceDeliveryMethodId: 'allegro-one-box',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+          processorConnectionId: inpostId,
+        },
+      ]);
+
+      const rules = await service.getRules(sourceId);
+      expect(rules).toHaveLength(1);
+      expect(rules[0]).toMatchObject({
+        sourceDeliveryMethodId: 'allegro-one-box',
+        processorKind: 'ol_managed_carrier',
+        processorConnectionId: inpostId,
+      });
+    });
+  });
+
+  describe('resolve', () => {
+    it('should resolve the configured processor when a rule matches', async () => {
+      const { sourceId, inpostId } = await seedConnections();
+      const service = getService();
+
+      await service.replaceRules(sourceId, [
+        {
+          sourceDeliveryMethodId: 'allegro-one-box',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+          processorConnectionId: inpostId,
+        },
+      ]);
+
+      const resolution = await service.resolve({
+        sourceConnectionId: sourceId,
+        sourceDeliveryMethodId: 'allegro-one-box',
+      });
+
+      expect(resolution).toEqual({
+        processorKind: 'ol_managed_carrier',
+        processorConnectionId: inpostId,
+        source: 'rule',
+      });
+    });
+
+    it('should fall back to the omp_fulfilled default for an unconfigured method (no regression)', async () => {
+      const { sourceId } = await seedConnections();
+      const service = getService();
+
+      const resolution = await service.resolve({
+        sourceConnectionId: sourceId,
+        sourceDeliveryMethodId: 'unmapped-method',
+      });
+
+      expect(resolution).toEqual({
+        processorKind: 'omp_fulfilled',
+        processorConnectionId: null,
+        source: 'default',
+      });
+    });
+  });
+
+  // NOTE: the migration's `ON DELETE CASCADE` foreign keys are NOT asserted
+  // here. The integration harness builds its schema via TypeORM `synchronize`
+  // (DatabaseModule: `synchronize: NODE_ENV !== 'production'`, `migrationsRun:
+  // false`), and — mirroring `CarrierMapping` — the FKs live only in the
+  // migration, not the ORM-entity decorators. So the synchronize-built schema
+  // has no FK to cascade. The migration's FK behaviour is validated by the
+  // up/down round-trip (`migration:run` / `migration:revert`) and review.
+});

--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -66,6 +66,11 @@ const harness = createIntegrationTestHarness({
     'refresh_tokens',
     'product_variants',
     'products',
+    // fulfillment_routing_rules is connection-scoped config (#832). Listed
+    // explicitly because — like connection_carrier_mappings — its FKs live in
+    // the migration, not the ORM decorators, so the synchronize-built test
+    // schema has no FK to cascade from `connections`.
+    'fulfillment_routing_rules',
     'connections',
     'users',
   ],

--- a/docs/architecture/adrs/012-branch-1-fulfillment-modeling.md
+++ b/docs/architecture/adrs/012-branch-1-fulfillment-modeling.md
@@ -1,0 +1,42 @@
+# ADR-012: Branch-1 (OMP-fulfilled) fulfillment modeling — delegate-to-OMP, not a degenerate shipping adapter
+
+- **Status**: Accepted
+- **Date**: 2026-05-25
+- **Authors**: @piotrswierzy
+
+## Context
+
+The #832 fulfillment-routing model (#732) routes each `(orderSource, sourceDeliveryMethod)` to one of three **processor kinds**: *OMP-fulfilled* (the destination shop ships via its own carrier setup), *OL-managed carrier* (OL drives an own-contract carrier — InPost ShipX, #812), *source-brokered* (OL drives the marketplace's own shipping — Allegro Delivery, #833). Branches 2 and 3 map cleanly onto `ShippingProviderManagerPort` (#763) — one capability, different adapters. **Branch 1 is the genuine fork:** the OMP (PrestaShop) ships externally, OL generates no label and holds no provider shipment id. How should branch 1 be modeled?
+
+## Decision
+
+Branch 1 is **not** a `ShippingProviderManagerPort` adapter. It stays on the existing `OrderProcessorManagerPort` + `CarrierMapping` path it uses today — OL sets the destination carrier on the mirrored OMP order; the shop's own workflow ships. Only branches 2/3 implement `ShippingProviderManagerPort`. Branch-1 status read-back becomes a separate, small `FulfillmentStatusReader` capability — **named here, implemented in #834**.
+
+The routing rule carries an explicit, **stored** `processorKind` discriminator (an operator choice — *not* derived from declared capabilities, since one connection may declare several). A single core dispatch orchestrator owns the `switch (processorKind)`; downstream consumers call the orchestrator rather than re-branching. The orchestrator lands with the first executor (#835/#833), not in #832.
+
+**Rule shape & compatibility.** The rule stores only `{ processorKind, processorConnectionId }`. The OMP destination is *derived* (= the processor connection for `omp_fulfilled`; the order's fan-out destination set otherwise) and the branch-1 destination carrier is sourced from the **co-keyed `CarrierMapping`** (same `(source, method)` key) — neither is a stored column. Routing is **operator-configured per `(source, method)`** and validated at save against each processor's **declared capability + topology** (`omp_fulfilled` → declares `OrderProcessorManager`; `ol_managed_carrier` / `source_brokered` → declares `ShippingProviderManager`, with `source_brokered` requiring `processorConnectionId === sourceConnectionId`). **Method-granular auto-detection** — whether an order's `delivery.method.id` is Allegro-Delivery-eligible (the order-method ↔ `/shipment-management/delivery-services` namespace question, OQ-B1) — is a **#833 refinement layered behind the routing-compatibility seam, not a dependency**: the model functions on operator config + capability validation regardless of how OQ-B1 resolves, and a method-incompatible choice surfaces as a readable error at label generation. Compatibility lives behind the service seam so the routing model never reshapes if the compatibility signal's source changes.
+
+## Alternatives considered
+
+- **(i) Degenerate PrestaShop `ShippingProviderManagerPort` adapter** (`generateLabel` = assign-carrier/no-op, `getTracking` = read PS), unifying all targets to "ship-capable connections." **Rejected.** It can't honor the contract: `GenerateLabelResult.providerShipmentId`/`labelPdfRef` are non-nullable and provider-issued (branch 1 has neither), and `getTracking({providerShipmentId})` is keyed on an id branch 1 never gets. Making it fit means widening both — degrading the contract for the adapters that *do* generate labels (#812, #833) — and writing fabricated ids into the partial-unique `providerShipmentId` index. The "uniformity" is illusory: dispatch and status consumers must still branch on "is this the fake adapter?", so (i) hides the fork instead of removing it.
+- **(iii) Overload the `Shipment` lifecycle** for branch 1 (`generated` = "carrier assigned"). **Rejected.** Overloads `ShipmentStatus` and conflates shipment status with order/workflow status — against #827's separable-axes requirement.
+
+## Consequences
+
+**Pros:**
+- Keeps `ShippingProviderManagerPort` honest for the only adapters that generate labels; models branch 1 as what it is.
+- Scales by *adding adapters*: same-mechanic processors are new adapters (zero switch growth); a new arm appears only for a genuinely new mechanic (e.g. a future 3PL/fulfilment-house).
+- Branch-1-as-delegate survives even if OL later becomes the system-of-record — dropship/3PL fulfillment OL observes-but-doesn't-perform is permanent.
+
+**Cons / trade-offs:**
+- A `switch (processorKind)` exists (dispatch + status acquisition) — contained in one orchestrator.
+- `processorKind` is stored config that can drift from a connection's real capabilities; compatibility validation guards rule creation.
+
+**Migration path:**
+- Additive — new `fulfillment_routing_rules` table; `connection_carrier_mappings` preserved as the branch-1 carrier detail and the resolution fallback.
+
+## References
+
+- Related issues: #832, #732, #834 (`FulfillmentStatusReader`), #835 (InPost convergence), #833 (Allegro Delivery), #763
+- Related ADRs: [ADR-011](./011-domain-entity-behavior.md)
+- Primary doc: [docs/architecture-overview.md](../../architecture-overview.md) § Capability Abstractions (Business Roles); spec `docs/specs/product-spec-732-allegro-delivery-shipment.md` § "Is this three capabilities, or one?"

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -101,5 +101,6 @@ One pointer per section, identical format every time.
 | [ADR-009](./009-persisted-offer-status-snapshots.md) | Persisted offer-status snapshots | Accepted | 2026-05-23 |
 | [ADR-010](./010-variant-keyed-master-inventory.md) | Variant-keyed master inventory | Accepted | 2026-05-24 |
 | [ADR-011](./011-domain-entity-behavior.md) | Domain entity behavior — anemic-by-default with pure read-only derivations | Accepted | 2026-05-25 |
+| [ADR-012](./012-branch-1-fulfillment-modeling.md) | Branch-1 (OMP-fulfilled) fulfillment modeling — delegate-to-OMP, not a degenerate shipping adapter | Accepted | 2026-05-25 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*

--- a/docs/plans/implementation-plan-fulfillment-routing-model.md
+++ b/docs/plans/implementation-plan-fulfillment-routing-model.md
@@ -1,0 +1,214 @@
+# Implementation Plan: Fulfillment-routing model + compatibility (#832)
+
+**Date**: 2026-05-25
+**Status**: Implemented — reconciled to the final shape after a `/grill-me` design review (Q1–Q8). See §0.
+**Estimated Effort**: ~2–4 days for the scoped foundation below (issue is labelled **L**; the L estimate includes the downstream adapters/FE/read-back which are *separate* issues #833–#839)
+
+---
+
+## 0. Design Reconciliation (Q1–Q8 — supersedes shape details below)
+
+The original draft (§1–§9) was sharpened through an interview that walked every
+branch of the design tree. The **final, implemented shape** differs from the
+draft in four ways — where the prose below still describes the draft shape, this
+section wins.
+
+**Final rule shape** — `(sourceConnectionId, sourceDeliveryMethodId) → { processorKind, processorConnectionId }`. The draft's `ompDestinationConnectionId` and `destinationCarrierId` columns were **dropped** (Q3/Q8): the OMP destination is *derived* (orders fan out to **all** `OrderProcessorManager` connections — `OrderSyncService.resolveDestinations` — so there is no single stored destination), and the branch-1 carrier stays **co-keyed** in `connection_carrier_mappings`.
+
+**Final service surface** — `IFulfillmentRoutingService` exposes `getRules` / `replaceRules` / `resolve(query)`. There is **no** `resolveForOrder` and **no** live wiring into the PrestaShop order-processor adapter (Q2 = option **C**): #832 ships the **model + resolution + compatibility validation only**. The dispatch orchestrator that calls `resolve()` on the live order path is **#835**; branch-2/3 execution is **#833**. Consequently there is no `UnsupportedProcessorKindException` — nothing executes a non-default kind yet.
+
+**Final compatibility** — capability **+ topology** (Q5): `omp_fulfilled` → processor declares `OrderProcessorManager`; `ol_managed_carrier` → declares `ShippingProviderManager` **and** processor ≠ source; `source_brokered` → declares `ShippingProviderManager` **and** processor == source. Method-granular eligibility (the OQ-B1 `/delivery-services` namespace probe) is a **#833** refinement layered behind the same `assertCompatible` seam — not a #832 dependency. See ADR-012 § "Rule shape & compatibility".
+
+**AC amendments to record at close** (so #832 can be checked off honestly):
+- **AC-1** ("selecting a processor + OMP destination + destination carrier") — satisfied *in intent*: processor is stored; OMP destination is **derived** (fan-out) and destination carrier is **co-keyed** in `CarrierMapping`, neither stored on the rule. US-1's "and a destination" is met because the destination is the fan-out target set, not a per-rule column.
+- **AC-2** ("compatible for a given method") — satisfied at **capability + topology** granularity; method-granular eligibility deferred to #833 behind the seam. Honest to check given the spec marks method↔modality a Phase-C / #833 question.
+- **AC-3** ("the system resolves the configured processor") — `resolve()` is implemented and unit/integration-tested; it is **not yet wired** into the live order path (Q2 = C). The resolver-call-site is #835. Record this explicitly in the PR body. **#835 must handle the resolution asymmetry**: a *configured* `omp_fulfilled` rule resolves with a non-null `processorConnectionId`, but the *default* `omp_fulfilled` (no rule) resolves with `processorConnectionId: null` (no single fulfilling OMP under fan-out) — the dispatcher must treat null as "fan-out default," not "no processor."
+- **AC-4** ("preserved/upgraded") — **preserved, additive** (not destructively upgraded): `connection_carrier_mappings` is untouched and remains the co-keyed branch-1 carrier source.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Introduce a general, source-/carrier-/OMP-agnostic **fulfillment-routing model** — a connection-scoped mapping of `(orderSource, sourceDeliveryMethod) → fulfillment processor` (final shape, §0) — generalizing today's `CarrierMapping` (which hardcodes the *OMP-fulfilled* `allegroDeliveryMethodId → prestashopCarrierId` branch for the Allegro→PS pair). Plus a resolution service (`resolve(query)` → processor, with today's PS-fulfilled `omp_fulfilled` fallback), capability + topology compatibility validation, a migration, and the **branch-1 modeling ADR**.
+
+**Context**: Foundation (E1) for the #732 Allegro Delivery epic — see `docs/specs/product-spec-732-allegro-delivery-shipment.md` §1, §"Is this three capabilities, or one?", §5 AC-1, §9. Blocks #833 (Allegro Delivery adapter), #834 (branch-1 read-back), #835 (#727 InPost convergence), #836/#839 (FE).
+
+**Classification**: **CORE** (`mappings` context, generalizing `CarrierMapping`) + a thin, behaviour-preserving wiring touch in the PrestaShop integration. **+ ADR.**
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- `FulfillmentRoutingRule` domain entity + types + repository port/impl + ORM entity in the `mappings` context.
+- `fulfillment_routing_rules` table + migration (up/down round-trip).
+- `FulfillmentRoutingService` (application service) — `resolve(query)` → routing decision with **today's PS-fulfilled `omp_fulfilled` default** when unconfigured; `getRules` / `replaceRules` + **capability + topology compatibility validation** on persist.
+- **ADR-012**: branch-1 (OMP-fulfilled) modeling decision.
+- Unit + integration tests.
+
+### Out of Scope (separate issues)
+- **Live order-path wiring of the resolver** — the dispatch orchestrator that calls `resolve()` is **#835** (Q2 = C). #832 is model + resolution + compatibility only.
+- Allegro Delivery adapter / `/shipment-management/*` (#833).
+- Branch-1 (PS-fulfilled) status read-back + the `FulfillmentStatusReader` capability *implementation* (#834) — ADR-012 *names* it; #834 builds it.
+- **Method-granular compatibility** (mapping a `sourceDeliveryMethodId` → adapter `ShippingMethod`/modality via the seller's `/delivery-services` set; the OQ-B1 namespace probe). #832 ships **capability-level** compatibility behind a seam; #833 sharpens it.
+- #727 InPost convergence (#835); all FE (#836, #839).
+- Destructive fold/removal of `connection_carrier_mappings` (see §7 Alt-2).
+
+### Constraints
+- **No regression** to today's Allegro→PS carrier resolution (`resolveExternalCarrierId`).
+- Migration must round-trip; existing `CarrierMapping` data preserved.
+- Anemic-by-default entities per **ADR-011**.
+- No new ESLint warnings / type errors.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: CORE — `libs/core/src/mappings/**` (the context that owns `CarrierMapping`); behaviour-preserving wiring in `libs/integrations/prestashop/**`.
+
+**Capabilities Involved**:
+- `ShippingProviderManagerPort` (#763) — consulted by compatibility validation for branches 2/3; **not implemented here**.
+- `OrderProcessorManagerPort` — the branch-1 (omp_fulfilled) executor that already ships.
+- `IIntegrationsService` — to resolve a processor connection's declared capabilities for compatibility checks.
+
+**Existing Services Reused**:
+- `MappingConfigService.resolveCarrierMapping` (the branch-1 carrier detail) + `resolveExternalCarrierId` chain (`prestashop-order-processor-manager.adapter.ts:650`).
+- `IIntegrationsService` capability resolution; `IdentifierMappingService` formatting (`formatInternalId`) if a prefixed id is wanted (rules can use `uuid` PK like `CarrierMapping` — simplest, mirrors the existing mapping table).
+
+**New Components**:
+- Domain: `FulfillmentRoutingRule` entity, `fulfillment-routing.types.ts`, `FulfillmentRoutingRepositoryPort`, routing exceptions.
+- Application: `FulfillmentRoutingService` + `IFulfillmentRoutingService`.
+- Infrastructure: `FulfillmentRoutingRepository` + `FulfillmentRoutingRuleOrmEntity`.
+- Tokens: `FULFILLMENT_ROUTING_REPOSITORY_TOKEN`, `FULFILLMENT_ROUTING_SERVICE_TOKEN` (in `mappings.tokens.ts`).
+- Migration: `apps/api/src/migrations/{ts}-add-fulfillment-routing-rules.ts`.
+- ADR-012 + index row.
+
+**Core vs Integration Justification**: routing is domain policy (which processor fulfils an order) — must be CORE so every order source/OMP/carrier reasons against one model. It generalizes `CarrierMapping`, already in `mappings`. The PrestaShop touch is only the *consumption* seam (an integration consuming a CORE port), preserving the boundary.
+
+---
+
+## 4. External / Domain Research
+
+### Internal patterns (verified — see codebase audit)
+- **`CarrierMapping`** (`libs/core/src/mappings/...`): 4-field anemic entity; ORM table `connection_carrier_mappings` (unique `connection_id` + `allegro_delivery_method_id`, FK → `connections` ON DELETE CASCADE); repo `findByConnectionId` / `replaceForConnection` (delete+insert in a transaction); facade `MappingConfigService.resolveCarrierMapping(sourceConnectionId, methodId)`.
+- **Branch-1 resolution today** (`prestashop-order-processor-manager.adapter.ts:650-705`): `resolveExternalCarrierId` chains CarrierMapping → `config.defaultCarrierId` → OL Dynamic carrier. This *is* the omp_fulfilled default the new model must reproduce.
+- **`ShippingProviderManagerPort`** (`libs/core/src/shipping/...`): `generateLabel` + `getTracking({providerShipmentId})` + `getSupportedMethods(): readonly ShippingMethod[]`; `ShipmentCanceller` / `PickupPointFinder` sub-capabilities with `is*` guards. No adapter implements it on `main` yet.
+- **Migration/module/tokens conventions**: mirror `AddConnectionMappingTables1778000000000`; `mappings.tokens.ts` Symbol tokens; ORM discovered via the `libs/core/src/**/*.orm-entity{.ts,.js}` glob in `apps/api/src/database/data-source.ts` (no `orm-entities.ts` sub-barrel needed unless an external consumer needs the entity — none does).
+
+### Key spec facts shaping the model
+- Three **processor kinds** are a *taxonomy of where the fulfilling connection sits*, not three mechanisms (spec §"Is this three capabilities, or one?"). Branches 2 & 3 = same `ShippingProviderManagerPort`, different adapters. **Branch 1 is the genuine fork** (no `generateLabel`, no `providerShipmentId`).
+- Routing key = **source delivery method** (`OrderShipping.methodId`); modality is adapter-internal; destination carrier matters only for branch 1.
+- Compatibility is **adapter-declared**, never hardcoded (R1: keep it behind an abstraction so its source can change).
+
+---
+
+## 5. Questions & Assumptions
+
+### Decisions to confirm (see §7 for rationale)
+1. **Branch-1 modeling (ADR-012)** — recommend **Option (ii): delegate-to-OMP** (branch 1 stays on `OrderProcessorManagerPort` + `CarrierMapping`; only branches 2/3 are `ShippingProviderManagerPort`; read-back is a separate `FulfillmentStatusReader` capability, *implemented in #834*). Rejected: Option (i) degenerate PS adapter (no-op `generateLabel`, providerShipmentId-less `getTracking`) — a degenerate abstraction that pollutes the port for every consumer, against the ADR-011 instinct and the spec's own observation that branch 1 "doesn't fit `getTracking({providerShipmentId})` cleanly."
+2. **Migration strategy** — recommend **additive**: new `fulfillment_routing_rules` table; `connection_carrier_mappings` kept intact as the branch-1 carrier detail + resolution fallback. Satisfies "preserved/upgraded" via preservation + logical generalization, with a trivial down-migration and zero regression. Rejected: destructive fold (migrate rows + drop `connection_carrier_mappings`) — OMP-destination is ambiguous at migration time (a CarrierMapping row doesn't record which PS connection is the OMP), and it couples to #835/#836.
+3. **Compatibility granularity** — recommend **capability-level** for #832 (a processor connection is compatible iff it declares the capability its `processorKind` requires: branches 2/3 → `ShippingProviderManager`; branch 1 → `OrderProcessorManager` and processor == OMP). **Method-granular** compatibility (method→modality via `/delivery-services`, OQ-B1) deferred to #833, behind the same `FulfillmentRoutingService` seam.
+4. **Live wiring** — recommend threading `resolveForOrder` into the PS order processor so the **default path reproduces today's behaviour** (proves AC + no-regression in an int-test); branches 2/3 resolve but throw an explicit `UnsupportedProcessorKindException` until #833 (operators can't create such rules until the FE/adapter exists; the migration creates none).
+
+### Assumptions
+- Rule PK is `uuid` (mirrors `CarrierMapping`), not an `ol_*` prefixed id — rules are config rows, not cross-context entities.
+- `sourceConnectionId` is the order **source** connection (Allegro), matching today's CarrierMapping scoping convention.
+- One rule per `(sourceConnectionId, sourceDeliveryMethodId)` (unique constraint).
+
+### Documentation gaps
+- The method↔modality compatibility key is explicitly a Phase C / #833 question (spec §3.3) — recorded here as deferred, not invented.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 0 — ADR (decision first)
+1. **ADR-012 — branch-1 fulfillment modeling**
+   - **File**: `docs/architecture/adrs/012-branch-1-fulfillment-modeling.md` (+ index row in `README.md`; pointer in `architecture-overview.md` § appropriate shipping/mappings section).
+   - **Action**: Record Option (ii) (delegate-to-OMP + future `FulfillmentStatusReader`), alternatives (i)/(ii), consequences. Reference spec §"Is this three capabilities, or one?" and ADR-011.
+   - **Acceptance**: `check:invariants` (repo-url + ADR conventions) green; ≤500-word body; index updated.
+
+### Phase 1 — Domain + persistence (the model)
+2. **Types** — `libs/core/src/mappings/domain/types/fulfillment-routing.types.ts`
+   - `FulfillmentProcessorKindValues` as-const union (`omp_fulfilled | ol_managed_carrier | source_brokered`); `FulfillmentRoutingRuleInput`; `FulfillmentRoutingResolution` (+ `source: 'rule' | 'default'`).
+   - **Acceptance**: types-only file; no runtime artifact beyond the values array.
+3. **Entity** — `domain/entities/fulfillment-routing-rule.entity.ts` (anemic; readonly fields per ADR-011).
+4. **Repository port** — `domain/ports/fulfillment-routing-repository.port.ts`: `findBySourceConnectionId`, `findRule(sourceConnectionId, methodId)`, `replaceForConnection(sourceConnectionId, items)`.
+5. **Exceptions** — `domain/exceptions/`: `IncompatibleProcessorException` + `DuplicateRoutingRuleException` (both extend `Error`, per standards). *(No `UnsupportedProcessorKindException` — §0: nothing executes a non-default kind in #832, so there is no execution-guard to throw.)*
+6. **ORM entity** — `infrastructure/persistence/entities/fulfillment-routing-rule.orm-entity.ts`: table `fulfillment_routing_rules`; unique `(source_connection_id, source_delivery_method_id)`; FKs `source_connection_id` **and** `processor_connection_id` → `connections` ON DELETE CASCADE; columns `processor_kind`, `processor_connection_id`, timestamps. *(Final shape, §0: no `omp_destination_connection_id` / `destination_carrier_id` columns — derived/co-keyed.)*
+7. **Repository impl** — `infrastructure/persistence/repositories/fulfillment-routing.repository.ts` (mirror `CarrierMappingRepository`: `replaceForConnection` = delete+insert in a `dataSource.transaction`; private `toDomain`).
+8. **Tokens** — append to `mappings.tokens.ts`; **barrel** `index.ts` exports entity, types, port type, exceptions (per cross-context contract rules — repo *port* is intra-context, but the resolution *service interface* is the cross-context seam).
+   - **Acceptance**: `mappings` barrel-purity holds; tokens auto-exported via `export * from './mappings.tokens'`.
+
+### Phase 2 — Migration
+9. **Migration** — `apps/api/src/migrations/{ts}-add-fulfillment-routing-rules.ts` (unique 13-digit ts; class suffix matches). `up`: `CREATE TABLE fulfillment_routing_rules`. `down`: `DROP TABLE`. Leaves `connection_carrier_mappings` untouched.
+   - **Acceptance**: `pnpm --filter @openlinker/api migration:show` lists it; `migration:run` then `migration:revert` round-trips; `check-migration-timestamps` green.
+
+### Phase 3 — Resolution + compatibility service *(final surface — §0)*
+10. **Service interface** — `application/interfaces/fulfillment-routing.service.interface.ts` (`IFulfillmentRoutingService`): `getRules(sourceConnectionId)`, `replaceRules(sourceConnectionId, items)`, `resolve(query)`. *(No `resolveForOrder` — the live order-path call site is #835.)*
+11. **Service impl** — `application/services/fulfillment-routing.service.ts`:
+    - `resolve(query)`: `findRule(sourceConnectionId, sourceDeliveryMethodId)` → `{ processorKind, processorConnectionId, source: 'rule' }`; null method or no rule → **default** `{ processorKind: omp_fulfilled, processorConnectionId: null, source: 'default' }` (no single fulfilling OMP under fan-out).
+    - `replaceRules`: validate the whole batch before persisting — reject duplicate `(method)` rows (`DuplicateRoutingRuleException`), assert the source connection resolves (`getAdapter`), then validate every rule's **capability + topology** compatibility (§0) via `IIntegrationsService.getAdapter`, rejecting with `IncompatibleProcessorException`. Validation isolated in private `assertNoDuplicateMethods` + `assertCompatible(sourceConnectionId, item)` (the latter carries an exhaustiveness `default` so a new processor kind can't bypass the gate) — the #833 method-granular extension point. Validating at the service keeps the unique constraint + connection FKs from surfacing as raw `QueryFailedError`.
+    - Bind in `mappings.module.ts` (providers + token + export); inject `INTEGRATIONS_SERVICE_TOKEN` + the repository token.
+    - **Acceptance**: unit tests cover rule-hit, default fallback (null + unmapped method), and each kind's compatibility accept/reject.
+12. **Live wiring — DEFERRED to #835** (Q2 = C). #832 stops at the resolver; nothing calls `resolve()` on the order path yet, so today's behaviour is preserved by *omission* (the existing `resolveExternalCarrierId` chain is untouched). The integration test exercises `resolve()` and compatibility directly through the service rather than through the order path.
+
+### Phase 4 — Tests
+13. **Unit**: `fulfillment-routing.service.spec.ts` — mocks the repository port + `IIntegrationsService`; covers resolution (rule-hit / default / null-method) and capability + topology compatibility accept/reject for all three kinds. *(No separate repository unit spec — the repo is a thin delete+insert mirror of `CarrierMappingRepository`, exercised by the int-spec against real Postgres.)*
+14. **Integration**: `test/integration/fulfillment-routing.int-spec.ts` (Testcontainers) — persist + read-back round-trip, full-replace semantics, `resolve` rule-hit + `omp_fulfilled` default, compatibility validated against the **real** booted adapter manifests (PrestaShop / Allegro / InPost), and the migration's `ON DELETE CASCADE` FK (deleting a processor connection drops its rules).
+
+---
+
+## 7. Alternatives Considered
+
+- **Branch-1 = degenerate `ShippingProviderManagerPort` adapter (Option i)** — rejected: forces a no-op `generateLabel` + a `providerShipmentId`-less `getTracking`, polluting the port contract for every consumer; contradicts ADR-011's "no degenerate abstractions" and the spec's own note. Option (ii) keeps the port honest.
+- **Destructive CarrierMapping fold** — rejected for #832: OMP-destination is ambiguous per existing row, down-migration is lossy, and it couples to #835/#836. Additive layering gives zero-regression now; a later consolidation can happen once the FE (#836) writes routing rules directly.
+- **Put the model in `shipping` not `mappings`** — rejected: it *generalizes `CarrierMapping`* (in `mappings`), and orders already imports `MappingsModule`; placing it in `shipping` would add a new cross-context edge for no benefit.
+- **A standalone `MethodCompatibilityPort` now** — deferred: capability-level compatibility is a small service-internal check for #832; extracting a port earns its place in #833 when the `/delivery-services` granularity lands.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ CORE owns the model; integration only consumes it via the service interface. Anemic entity (ADR-011). Symbol tokens + barrel conventions (#595). Migration conventions (#599/#374).
+
+### Risks
+- **R1 — compatibility-key namespace (OQ-B1)**: method-granular compat is unproven (sandbox probe pending). *Mitigation*: #832 ships only capability-level compat behind `assertCompatible`; the granular logic + probe are #833.
+- **R2 — accidental regression in order processing**: *Mitigation*: default resolution reproduces today's path verbatim; existing PS int-spec must stay green + a new no-regression int-spec.
+- **R3 — scope creep into adapters/read-back**: *Mitigation*: explicit Out-of-Scope; branches 2/3 guarded with `UnsupportedProcessorKindException`.
+
+### Backward Compatibility
+- ✅ Additive table; `connection_carrier_mappings` untouched; live path behaviour-identical when no rule exists. Down-migration drops only the new table.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit
+- `fulfillment-routing.service.spec.ts`, `fulfillment-routing.repository.spec.ts` (mock ports / ORM repo).
+
+### Integration
+- `fulfillment-routing.int-spec.ts` (Testcontainers): persist/replace round-trip, `resolve` rule-hit + `omp_fulfilled` default, compatibility against real adapter manifests, FK `ON DELETE CASCADE`.
+
+### Acceptance Criteria (mirrors #832 — amendments per §0)
+- [x] A routing rule persists per `(source, delivery method)` selecting a **processor**. OMP destination is *derived* (fan-out) and destination carrier is *co-keyed* in `CarrierMapping` — see §0 / AC-1 amendment.
+- [x] Only **capability + topology-compatible** processors are valid (incompatible rejected). Method-granular eligibility deferred to #833 behind `assertCompatible` — see §0 / AC-2 amendment.
+- [x] `resolve()` returns the configured processor; unconfigured → today's `omp_fulfilled` default. **Resolver not yet wired to the live order path** (#835) — see §0 / AC-3 amendment.
+- [x] Migration up/down round-trips; `CarrierMapping` data **preserved** (additive, not destructively upgraded) — see §0 / AC-4 amendment.
+- [x] ADR-012 filed for branch-1 modeling (incl. rule-shape + compatibility note).
+- [x] Tests added (unit + integration); no new ESLint/type errors.
+
+---
+
+## 10. Alignment Checklist
+- [x] Hexagonal architecture; CORE/Integration boundary respected
+- [x] Existing patterns reused (CarrierMapping shape, mappings module, migration conventions); no unnecessary abstractions
+- [x] Idempotency: `replaceForConnection` transactional delete+insert
+- [x] Error handling: domain exceptions in `domain/exceptions/`
+- [x] Testing strategy complete (unit + integration)
+- [x] Naming + file structure per standards; ADR-011 anemic entities
+- [x] Plan saved as markdown
+
+## Related Documentation
+- `docs/specs/product-spec-732-allegro-delivery-shipment.md` · `docs/architecture/adrs/011-domain-entity-behavior.md` · `docs/migrations.md` · `docs/engineering-standards.md`

--- a/libs/core/src/mappings/application/interfaces/fulfillment-routing.service.interface.ts
+++ b/libs/core/src/mappings/application/interfaces/fulfillment-routing.service.interface.ts
@@ -1,0 +1,40 @@
+/**
+ * Fulfillment Routing Service Interface
+ *
+ * Application contract for the general fulfillment-routing model (#832): read
+ * + replace connection-scoped routing rules (with capability/topology
+ * compatibility validation on write), and resolve a routing decision for an
+ * order. See ADR-012 for the model and branch-1 decision.
+ *
+ * @module libs/core/src/mappings/application/interfaces
+ */
+
+import type { FulfillmentRoutingRule } from '../../domain/entities/fulfillment-routing-rule.entity';
+import type {
+  FulfillmentRoutingQuery,
+  FulfillmentRoutingResolution,
+  FulfillmentRoutingRuleInput,
+} from '../../domain/types/fulfillment-routing.types';
+
+export interface IFulfillmentRoutingService {
+  /** All routing rules scoped to a source connection. */
+  getRules(sourceConnectionId: string): Promise<FulfillmentRoutingRule[]>;
+
+  /**
+   * Replace all routing rules for a source connection. Each rule's processor
+   * is validated for capability + topology compatibility before persisting;
+   * an incompatible rule throws `IncompatibleProcessorException` and no rules
+   * are written.
+   */
+  replaceRules(
+    sourceConnectionId: string,
+    items: FulfillmentRoutingRuleInput[],
+  ): Promise<FulfillmentRoutingRule[]>;
+
+  /**
+   * Resolve the routing decision for an order's `(source, method)`. Falls back
+   * to the `omp_fulfilled` default (today's PrestaShop-fulfilled behaviour)
+   * when no rule matches or the order carries no delivery method.
+   */
+  resolve(query: FulfillmentRoutingQuery): Promise<FulfillmentRoutingResolution>;
+}

--- a/libs/core/src/mappings/application/services/fulfillment-routing.service.spec.ts
+++ b/libs/core/src/mappings/application/services/fulfillment-routing.service.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Fulfillment Routing Service unit tests (#832).
+ *
+ * Mocks the repository port + IIntegrationsService. Covers resolution
+ * (rule-hit / default / null-method) and capability+topology compatibility
+ * validation on replace (per ADR-012). Method-granular compatibility is #833
+ * and not exercised here.
+ */
+
+import type { AdapterMetadata, IIntegrationsService } from '@openlinker/core/integrations';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import { FulfillmentRoutingService } from './fulfillment-routing.service';
+import type { FulfillmentRoutingRepositoryPort } from '../../domain/ports/fulfillment-routing-repository.port';
+import { FulfillmentRoutingRule } from '../../domain/entities/fulfillment-routing-rule.entity';
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  type FulfillmentProcessorKind,
+} from '../../domain/types/fulfillment-routing.types';
+import { IncompatibleProcessorException } from '../../domain/exceptions/incompatible-processor.exception';
+import { DuplicateRoutingRuleException } from '../../domain/exceptions/duplicate-routing-rule.exception';
+
+const SOURCE = 'conn-allegro';
+const PS = 'conn-prestashop';
+const INPOST = 'conn-inpost';
+
+function makeRule(overrides: Partial<FulfillmentRoutingRule> = {}): FulfillmentRoutingRule {
+  return new FulfillmentRoutingRule(
+    overrides.id ?? 'rule-1',
+    overrides.sourceConnectionId ?? SOURCE,
+    overrides.sourceDeliveryMethodId ?? 'method-x',
+    overrides.processorKind ?? FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+    overrides.processorConnectionId ?? PS,
+    overrides.createdAt ?? new Date(),
+    overrides.updatedAt ?? new Date(),
+  );
+}
+
+describe('FulfillmentRoutingService', () => {
+  let repository: jest.Mocked<FulfillmentRoutingRepositoryPort>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let service: FulfillmentRoutingService;
+
+  /** Stub `getAdapter` to return a connection declaring the given capabilities. */
+  function declareCapabilities(connectionId: string, capabilities: string[]): void {
+    integrations.getAdapter.mockResolvedValue({
+      connection: { id: connectionId } as Connection,
+      metadata: { supportedCapabilities: capabilities } as AdapterMetadata,
+    });
+  }
+
+  beforeEach(() => {
+    repository = {
+      findBySourceConnectionId: jest.fn(),
+      findRule: jest.fn(),
+      replaceForConnection: jest.fn(),
+    };
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn(),
+      resolveAdapterMetadata: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+    };
+    service = new FulfillmentRoutingService(repository, integrations);
+  });
+
+  describe('resolve', () => {
+    it('should return the configured rule decision when a rule matches', async () => {
+      repository.findRule.mockResolvedValue(
+        makeRule({ processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier, processorConnectionId: INPOST }),
+      );
+
+      const result = await service.resolve({
+        sourceConnectionId: SOURCE,
+        sourceDeliveryMethodId: 'method-x',
+      });
+
+      expect(result).toEqual({
+        processorKind: 'ol_managed_carrier',
+        processorConnectionId: INPOST,
+        source: 'rule',
+      });
+    });
+
+    it('should fall back to the omp_fulfilled default when no rule matches', async () => {
+      repository.findRule.mockResolvedValue(null);
+
+      const result = await service.resolve({
+        sourceConnectionId: SOURCE,
+        sourceDeliveryMethodId: 'method-x',
+      });
+
+      expect(result).toEqual({
+        processorKind: 'omp_fulfilled',
+        processorConnectionId: null,
+        source: 'default',
+      });
+    });
+
+    it('should return the default without a rule lookup when the order has no delivery method', async () => {
+      const result = await service.resolve({
+        sourceConnectionId: SOURCE,
+        sourceDeliveryMethodId: null,
+      });
+
+      expect(result.source).toBe('default');
+      expect(result.processorKind).toBe('omp_fulfilled');
+      expect(repository.findRule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('replaceRules', () => {
+    it('should persist an omp_fulfilled rule when the processor declares OrderProcessorManager', async () => {
+      declareCapabilities(PS, ['OrderProcessorManager']);
+      repository.replaceForConnection.mockResolvedValue([]);
+
+      await service.replaceRules(SOURCE, [
+        {
+          sourceDeliveryMethodId: 'method-x',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+          processorConnectionId: PS,
+        },
+      ]);
+
+      expect(repository.replaceForConnection).toHaveBeenCalledWith(SOURCE, expect.any(Array));
+    });
+
+    it('should reject an omp_fulfilled rule when the processor does not declare OrderProcessorManager', async () => {
+      declareCapabilities(PS, ['OfferManager']);
+
+      await expect(
+        service.replaceRules(SOURCE, [
+          {
+            sourceDeliveryMethodId: 'method-x',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+            processorConnectionId: PS,
+          },
+        ]),
+      ).rejects.toBeInstanceOf(IncompatibleProcessorException);
+      expect(repository.replaceForConnection).not.toHaveBeenCalled();
+    });
+
+    it('should persist an ol_managed_carrier rule for a ShippingProviderManager connection distinct from the source', async () => {
+      declareCapabilities(INPOST, ['ShippingProviderManager']);
+      repository.replaceForConnection.mockResolvedValue([]);
+
+      await service.replaceRules(SOURCE, [
+        {
+          sourceDeliveryMethodId: 'method-inpost',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+          processorConnectionId: INPOST,
+        },
+      ]);
+
+      expect(repository.replaceForConnection).toHaveBeenCalled();
+    });
+
+    it('should reject an ol_managed_carrier rule whose processor is the source connection', async () => {
+      declareCapabilities(SOURCE, ['ShippingProviderManager']);
+
+      await expect(
+        service.replaceRules(SOURCE, [
+          {
+            sourceDeliveryMethodId: 'method-inpost',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+            processorConnectionId: SOURCE,
+          },
+        ]),
+      ).rejects.toBeInstanceOf(IncompatibleProcessorException);
+    });
+
+    it('should persist a source_brokered rule when the processor is the source and declares ShippingProviderManager', async () => {
+      declareCapabilities(SOURCE, ['OrderSource', 'ShippingProviderManager']);
+      repository.replaceForConnection.mockResolvedValue([]);
+
+      await service.replaceRules(SOURCE, [
+        {
+          sourceDeliveryMethodId: 'allegro-one-box',
+          processorKind: FULFILLMENT_PROCESSOR_KIND.SourceBrokered,
+          processorConnectionId: SOURCE,
+        },
+      ]);
+
+      expect(repository.replaceForConnection).toHaveBeenCalled();
+    });
+
+    it('should reject a source_brokered rule whose processor is not the source connection', async () => {
+      declareCapabilities(INPOST, ['ShippingProviderManager']);
+
+      await expect(
+        service.replaceRules(SOURCE, [
+          {
+            sourceDeliveryMethodId: 'allegro-one-box',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.SourceBrokered,
+            processorConnectionId: INPOST,
+          },
+        ]),
+      ).rejects.toBeInstanceOf(IncompatibleProcessorException);
+    });
+
+    it('should reject a batch that maps the same delivery method to more than one processor', async () => {
+      await expect(
+        service.replaceRules(SOURCE, [
+          {
+            sourceDeliveryMethodId: 'method-x',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+            processorConnectionId: PS,
+          },
+          {
+            sourceDeliveryMethodId: 'method-x',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+            processorConnectionId: INPOST,
+          },
+        ]),
+      ).rejects.toBeInstanceOf(DuplicateRoutingRuleException);
+
+      // Dedup runs before any I/O — no adapter lookup, no write.
+      expect(integrations.getAdapter).not.toHaveBeenCalled();
+      expect(repository.replaceForConnection).not.toHaveBeenCalled();
+    });
+
+    it('should reject an unknown processor kind (exhaustiveness guard)', async () => {
+      declareCapabilities(PS, ['OrderProcessorManager']);
+
+      await expect(
+        service.replaceRules(SOURCE, [
+          {
+            sourceDeliveryMethodId: 'method-x',
+            processorKind: 'teleporter' as FulfillmentProcessorKind,
+            processorConnectionId: PS,
+          },
+        ]),
+      ).rejects.toBeInstanceOf(IncompatibleProcessorException);
+      expect(repository.replaceForConnection).not.toHaveBeenCalled();
+    });
+
+    it('should reject when the source connection cannot be resolved', async () => {
+      integrations.getAdapter.mockRejectedValue(new Error('connection not found'));
+
+      await expect(
+        service.replaceRules(SOURCE, [
+          {
+            sourceDeliveryMethodId: 'method-x',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+            processorConnectionId: PS,
+          },
+        ]),
+      ).rejects.toThrow('connection not found');
+      expect(repository.replaceForConnection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRules', () => {
+    it('should delegate to the repository', async () => {
+      const rules = [makeRule()];
+      repository.findBySourceConnectionId.mockResolvedValue(rules);
+
+      await expect(service.getRules(SOURCE)).resolves.toBe(rules);
+      expect(repository.findBySourceConnectionId).toHaveBeenCalledWith(SOURCE);
+    });
+  });
+});

--- a/libs/core/src/mappings/application/services/fulfillment-routing.service.ts
+++ b/libs/core/src/mappings/application/services/fulfillment-routing.service.ts
@@ -1,0 +1,190 @@
+/**
+ * Fulfillment Routing Service
+ *
+ * Owns the general fulfillment-routing model (#832, epic #732): read/replace
+ * connection-scoped routing rules and resolve a routing decision for an order.
+ *
+ * `replaceRules` validates each rule's processor for **capability + topology**
+ * compatibility (ADR-012) — it does NOT check method-granular eligibility
+ * (the OQ-B1 `/shipment-management/delivery-services` question), which is a
+ * #833 refinement layered behind this same seam. `resolve` falls back to the
+ * `omp_fulfilled` default (today's PrestaShop-fulfilled behaviour) when no
+ * rule matches, preserving no-regression.
+ *
+ * @module application/services
+ * @implements {IFulfillmentRoutingService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  type CoreCapability,
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+} from '@openlinker/core/integrations';
+import type { IFulfillmentRoutingService } from '../interfaces/fulfillment-routing.service.interface';
+import { FULFILLMENT_ROUTING_REPOSITORY_TOKEN } from '../../mappings.tokens';
+import { FulfillmentRoutingRepositoryPort } from '../../domain/ports/fulfillment-routing-repository.port';
+import type { FulfillmentRoutingRule } from '../../domain/entities/fulfillment-routing-rule.entity';
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  type FulfillmentRoutingQuery,
+  type FulfillmentRoutingResolution,
+  type FulfillmentRoutingRuleInput,
+} from '../../domain/types/fulfillment-routing.types';
+import { IncompatibleProcessorException } from '../../domain/exceptions/incompatible-processor.exception';
+import { DuplicateRoutingRuleException } from '../../domain/exceptions/duplicate-routing-rule.exception';
+
+/**
+ * Capability a connection must declare to be an `omp_fulfilled` processor.
+ * Typed as `CoreCapability` so a rename in the closed capability set fails at
+ * compile time here.
+ */
+const ORDER_PROCESSOR_MANAGER_CAPABILITY: CoreCapability = 'OrderProcessorManager';
+/**
+ * Capability a connection must declare to be a label-generating processor.
+ * `ShippingProviderManager` is an open/plugin capability (#763) — not a member
+ * of the closed `CoreCapability` set — so it stays a bare literal here, matching
+ * the InPost adapter manifest that registers it.
+ */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+@Injectable()
+export class FulfillmentRoutingService implements IFulfillmentRoutingService {
+  constructor(
+    @Inject(FULFILLMENT_ROUTING_REPOSITORY_TOKEN)
+    private readonly repository: FulfillmentRoutingRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+  ) {}
+
+  async getRules(sourceConnectionId: string): Promise<FulfillmentRoutingRule[]> {
+    return this.repository.findBySourceConnectionId(sourceConnectionId);
+  }
+
+  async replaceRules(
+    sourceConnectionId: string,
+    items: FulfillmentRoutingRuleInput[],
+  ): Promise<FulfillmentRoutingRule[]> {
+    // Validate the whole batch before writing any — a single bad rule rejects
+    // the entire replace (the repository's delete+insert is atomic). Validating
+    // here keeps the `(source, method)` unique constraint and the connection FKs
+    // from surfacing as raw QueryFailedErrors.
+    this.assertNoDuplicateMethods(items);
+    // The source must resolve to a known connection; getAdapter throws
+    // ConnectionNotFoundException / ConnectionDisabledException otherwise.
+    await this.integrations.getAdapter(sourceConnectionId);
+    for (const item of items) {
+      await this.assertCompatible(sourceConnectionId, item);
+    }
+    return this.repository.replaceForConnection(sourceConnectionId, items);
+  }
+
+  async resolve(query: FulfillmentRoutingQuery): Promise<FulfillmentRoutingResolution> {
+    const { sourceConnectionId, sourceDeliveryMethodId } = query;
+
+    if (sourceDeliveryMethodId) {
+      const rule = await this.repository.findRule(sourceConnectionId, sourceDeliveryMethodId);
+      if (rule) {
+        return {
+          processorKind: rule.processorKind,
+          processorConnectionId: rule.processorConnectionId,
+          source: 'rule',
+        };
+      }
+    }
+
+    // No rule (or no method): today's PrestaShop-fulfilled default. Under
+    // fan-out there is no single fulfilling OMP, so processorConnectionId is null.
+    return {
+      processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+      processorConnectionId: null,
+      source: 'default',
+    };
+  }
+
+  /**
+   * Capability + topology compatibility for a single rule. `getAdapter`
+   * resolves the connection's adapter metadata and throws
+   * `ConnectionNotFoundException` / `ConnectionDisabledException` for an
+   * invalid processor connection — those propagate unchanged.
+   */
+  private async assertCompatible(
+    sourceConnectionId: string,
+    item: FulfillmentRoutingRuleInput,
+  ): Promise<void> {
+    const { processorKind, processorConnectionId } = item;
+    const { metadata } = await this.integrations.getAdapter(processorConnectionId);
+    const capabilities = metadata.supportedCapabilities;
+
+    switch (processorKind) {
+      case FULFILLMENT_PROCESSOR_KIND.OmpFulfilled:
+        if (!capabilities.includes(ORDER_PROCESSOR_MANAGER_CAPABILITY)) {
+          throw new IncompatibleProcessorException(
+            processorConnectionId,
+            processorKind,
+            `does not declare the ${ORDER_PROCESSOR_MANAGER_CAPABILITY} capability`,
+          );
+        }
+        return;
+
+      case FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier:
+        if (!capabilities.includes(SHIPPING_PROVIDER_MANAGER_CAPABILITY)) {
+          throw new IncompatibleProcessorException(
+            processorConnectionId,
+            processorKind,
+            `does not declare the ${SHIPPING_PROVIDER_MANAGER_CAPABILITY} capability`,
+          );
+        }
+        if (processorConnectionId === sourceConnectionId) {
+          throw new IncompatibleProcessorException(
+            processorConnectionId,
+            processorKind,
+            'an OL-managed carrier must be a connection distinct from the order source',
+          );
+        }
+        return;
+
+      case FULFILLMENT_PROCESSOR_KIND.SourceBrokered:
+        if (!capabilities.includes(SHIPPING_PROVIDER_MANAGER_CAPABILITY)) {
+          throw new IncompatibleProcessorException(
+            processorConnectionId,
+            processorKind,
+            `does not declare the ${SHIPPING_PROVIDER_MANAGER_CAPABILITY} capability`,
+          );
+        }
+        if (processorConnectionId !== sourceConnectionId) {
+          throw new IncompatibleProcessorException(
+            processorConnectionId,
+            processorKind,
+            'a source-brokered processor must be the order source connection itself',
+          );
+        }
+        return;
+
+      default: {
+        // Exhaustiveness guard: a new FulfillmentProcessorKind added without a
+        // matching compatibility rule must fail loud, never pass unvalidated.
+        const exhaustive: never = processorKind;
+        throw new IncompatibleProcessorException(
+          processorConnectionId,
+          String(exhaustive),
+          'unknown processor kind has no compatibility rule',
+        );
+      }
+    }
+  }
+
+  /**
+   * Reject a replace batch that maps the same `sourceDeliveryMethodId` to more
+   * than one processor — the persisted shape is one rule per `(source, method)`.
+   */
+  private assertNoDuplicateMethods(items: FulfillmentRoutingRuleInput[]): void {
+    const seen = new Set<string>();
+    for (const { sourceDeliveryMethodId } of items) {
+      if (seen.has(sourceDeliveryMethodId)) {
+        throw new DuplicateRoutingRuleException(sourceDeliveryMethodId);
+      }
+      seen.add(sourceDeliveryMethodId);
+    }
+  }
+}

--- a/libs/core/src/mappings/domain/entities/fulfillment-routing-rule.entity.ts
+++ b/libs/core/src/mappings/domain/entities/fulfillment-routing-rule.entity.ts
@@ -1,0 +1,30 @@
+/**
+ * Fulfillment Routing Rule Domain Entity
+ *
+ * A connection-scoped routing rule: for a given order source + source delivery
+ * method, which fulfillment processor handles the shipment. Generalizes
+ * `CarrierMapping` (#832, epic #732).
+ *
+ * Stores only the routing decision — `processorKind` + `processorConnectionId`.
+ * The OMP destination is derived and the branch-1 destination carrier is
+ * sourced from the co-keyed `CarrierMapping`; neither is a column here (ADR-012).
+ *
+ * Anemic per ADR-011 — readonly fields, no behaviour. `processorKind` is a
+ * stored operator choice (ADR-012), not derived.
+ *
+ * @module libs/core/src/mappings/domain/entities
+ */
+
+import type { FulfillmentProcessorKind } from '../types/fulfillment-routing.types';
+
+export class FulfillmentRoutingRule {
+  constructor(
+    public readonly id: string,
+    public readonly sourceConnectionId: string,
+    public readonly sourceDeliveryMethodId: string,
+    public readonly processorKind: FulfillmentProcessorKind,
+    public readonly processorConnectionId: string,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date,
+  ) {}
+}

--- a/libs/core/src/mappings/domain/exceptions/duplicate-routing-rule.exception.ts
+++ b/libs/core/src/mappings/domain/exceptions/duplicate-routing-rule.exception.ts
@@ -1,0 +1,21 @@
+/**
+ * Duplicate Routing Rule Exception
+ *
+ * Thrown by `FulfillmentRoutingService.replaceRules` when a replace batch
+ * contains more than one rule for the same `sourceDeliveryMethodId`. Caught at
+ * the service layer before any write so the `(source_connection_id,
+ * source_delivery_method_id)` unique constraint never surfaces as a raw
+ * `QueryFailedError`.
+ *
+ * @module libs/core/src/mappings/domain/exceptions
+ */
+
+export class DuplicateRoutingRuleException extends Error {
+  constructor(public readonly sourceDeliveryMethodId: string) {
+    super(
+      `Duplicate fulfillment routing rule for delivery method '${sourceDeliveryMethodId}': a source delivery method may map to at most one processor`,
+    );
+    this.name = 'DuplicateRoutingRuleException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/mappings/domain/exceptions/incompatible-processor.exception.ts
+++ b/libs/core/src/mappings/domain/exceptions/incompatible-processor.exception.ts
@@ -1,0 +1,24 @@
+/**
+ * Incompatible Processor Exception
+ *
+ * Thrown by `FulfillmentRoutingService` when a routing rule names a processor
+ * connection that isn't compatible with its declared `processorKind` —
+ * capability + topology validated at save time (see ADR-012). Method-granular
+ * compatibility is a #833 concern and not checked here.
+ *
+ * @module libs/core/src/mappings/domain/exceptions
+ */
+
+export class IncompatibleProcessorException extends Error {
+  constructor(
+    public readonly processorConnectionId: string,
+    public readonly processorKind: string,
+    public readonly reason: string,
+  ) {
+    super(
+      `Connection ${processorConnectionId} is not a compatible '${processorKind}' processor: ${reason}`,
+    );
+    this.name = 'IncompatibleProcessorException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/mappings/domain/ports/fulfillment-routing-repository.port.ts
+++ b/libs/core/src/mappings/domain/ports/fulfillment-routing-repository.port.ts
@@ -1,0 +1,37 @@
+/**
+ * Fulfillment Routing Repository Port
+ *
+ * Persistence contract for `FulfillmentRoutingRule`. Mirrors
+ * `CarrierMappingRepositoryPort`'s connection-scoped replace semantics, plus
+ * a single-rule lookup used by resolution.
+ *
+ * Implemented by the infrastructure layer.
+ *
+ * @module libs/core/src/mappings/domain/ports
+ */
+
+import type { FulfillmentRoutingRule } from '../entities/fulfillment-routing-rule.entity';
+import type { FulfillmentRoutingRuleInput } from '../types/fulfillment-routing.types';
+
+export interface FulfillmentRoutingRepositoryPort {
+  /** All rules scoped to a source connection. */
+  findBySourceConnectionId(sourceConnectionId: string): Promise<FulfillmentRoutingRule[]>;
+
+  /**
+   * The rule for a `(sourceConnectionId, sourceDeliveryMethodId)` pair, or
+   * null if none is configured.
+   */
+  findRule(
+    sourceConnectionId: string,
+    sourceDeliveryMethodId: string
+  ): Promise<FulfillmentRoutingRule | null>;
+
+  /**
+   * Replace all rules for a source connection atomically (delete + insert in
+   * a transaction). Mirrors `CarrierMappingRepositoryPort.replaceForConnection`.
+   */
+  replaceForConnection(
+    sourceConnectionId: string,
+    items: FulfillmentRoutingRuleInput[]
+  ): Promise<FulfillmentRoutingRule[]>;
+}

--- a/libs/core/src/mappings/domain/types/fulfillment-routing.types.ts
+++ b/libs/core/src/mappings/domain/types/fulfillment-routing.types.ts
@@ -1,0 +1,102 @@
+/**
+ * Fulfillment Routing Types
+ *
+ * Types for the general fulfillment-routing model (#832, epic #732): a
+ * connection-scoped mapping of `(orderSource, sourceDeliveryMethod) →
+ * fulfillment processor`, generalizing `CarrierMapping` (which hardcodes the
+ * OMP-fulfilled Allegro→PrestaShop branch).
+ *
+ * The rule stores only `{ processorKind, processorConnectionId }`. Two axes
+ * are deliberately NOT stored on the rule (see ADR-012):
+ * - **OMP destination** is *derived* — for `omp_fulfilled` it is the
+ *   processor connection itself; for the other kinds it is the order's
+ *   destination set (today: fan-out to all OMP connections).
+ * - **Branch-1 destination carrier** is sourced from the co-keyed
+ *   `CarrierMapping` (same `(source, method)` key), not duplicated here.
+ *
+ * `processorKind` is a *stored* operator choice (ADR-012), not derived from a
+ * connection's declared capabilities.
+ *
+ * @module libs/core/src/mappings/domain/types
+ */
+
+/**
+ * Where the fulfilling connection sits, per ADR-012 / spec §"Is this three
+ * capabilities, or one?":
+ * - `omp_fulfilled`: the destination OMP ships via its own carrier setup;
+ *   OL maps the source method → an OMP carrier (via `CarrierMapping`) and
+ *   reads status back. Stays on `OrderProcessorManagerPort` + `CarrierMapping`
+ *   — NOT a `ShippingProviderManagerPort` adapter.
+ * - `ol_managed_carrier`: OL drives an own-contract carrier integration
+ *   (`ShippingProviderManagerPort`, e.g. InPost ShipX, #812).
+ * - `source_brokered`: OL drives the order source's own shipping brokerage
+ *   (`ShippingProviderManagerPort` hosted on the source connection, e.g.
+ *   Allegro Delivery, #833).
+ */
+export const FulfillmentProcessorKindValues = [
+  'omp_fulfilled',
+  'ol_managed_carrier',
+  'source_brokered',
+] as const;
+
+export type FulfillmentProcessorKind = (typeof FulfillmentProcessorKindValues)[number];
+
+/**
+ * Named-constant map for `FulfillmentProcessorKind`, so call sites reference
+ * kinds by name rather than bare string literals (mirrors `SHIPMENT_STATUS`).
+ */
+export const FULFILLMENT_PROCESSOR_KIND = {
+  OmpFulfilled: 'omp_fulfilled',
+  OlManagedCarrier: 'ol_managed_carrier',
+  SourceBrokered: 'source_brokered',
+} as const satisfies Record<
+  'OmpFulfilled' | 'OlManagedCarrier' | 'SourceBrokered',
+  FulfillmentProcessorKind
+>;
+
+/**
+ * Whether a resolution matched a persisted rule or fell back to the
+ * OMP-fulfilled default (today's PrestaShop-fulfilled behaviour).
+ */
+export const FulfillmentRoutingSourceValues = ['rule', 'default'] as const;
+export type FulfillmentRoutingSource = (typeof FulfillmentRoutingSourceValues)[number];
+
+/**
+ * Upsert input for a routing rule. `sourceConnectionId` is supplied by the
+ * caller of `replaceForConnection` (the connection the rules are scoped to),
+ * so it is not repeated here. A stored rule always names a processor, so
+ * `processorConnectionId` is required.
+ */
+export interface FulfillmentRoutingRuleInput {
+  sourceDeliveryMethodId: string;
+  processorKind: FulfillmentProcessorKind;
+  /** The connection that fulfils. For `omp_fulfilled` this is the OMP
+   * connection; for the other kinds the carrier / source-broker connection. */
+  processorConnectionId: string;
+}
+
+/**
+ * Inputs to resolve a routing decision for an order. Kept as primitives (not
+ * the `Order` entity) so the `mappings` context does not couple to `orders`.
+ */
+export interface FulfillmentRoutingQuery {
+  sourceConnectionId: string;
+  /** `OrderShipping.methodId`; null when the order carries no method →
+   * resolves to the `omp_fulfilled` default. */
+  sourceDeliveryMethodId: string | null;
+}
+
+/**
+ * The resolved routing decision. `source` distinguishes a configured-rule hit
+ * from the OMP-fulfilled fallback (no regression to today's behaviour).
+ *
+ * `processorConnectionId` is null for the `omp_fulfilled` **default** (no rule
+ * matched): under today's fan-out there is no single fulfilling OMP, so each
+ * destination resolves its own carrier via the existing chain. It is non-null
+ * for an explicit rule.
+ */
+export interface FulfillmentRoutingResolution {
+  processorKind: FulfillmentProcessorKind;
+  processorConnectionId: string | null;
+  source: FulfillmentRoutingSource;
+}

--- a/libs/core/src/mappings/index.ts
+++ b/libs/core/src/mappings/index.ts
@@ -21,3 +21,21 @@ export type {
   PaymentMappingInput,
   CategoryMappingInput,
 } from './domain/types/mapping.types';
+
+// Fulfillment routing (#832)
+export type { IFulfillmentRoutingService } from './application/interfaces/fulfillment-routing.service.interface';
+export { FulfillmentRoutingRule } from './domain/entities/fulfillment-routing-rule.entity';
+export { IncompatibleProcessorException } from './domain/exceptions/incompatible-processor.exception';
+export { DuplicateRoutingRuleException } from './domain/exceptions/duplicate-routing-rule.exception';
+export {
+  FulfillmentProcessorKindValues,
+  FULFILLMENT_PROCESSOR_KIND,
+  FulfillmentRoutingSourceValues,
+} from './domain/types/fulfillment-routing.types';
+export type {
+  FulfillmentProcessorKind,
+  FulfillmentRoutingSource,
+  FulfillmentRoutingRuleInput,
+  FulfillmentRoutingQuery,
+  FulfillmentRoutingResolution,
+} from './domain/types/fulfillment-routing.types';

--- a/libs/core/src/mappings/infrastructure/persistence/entities/fulfillment-routing-rule.orm-entity.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/entities/fulfillment-routing-rule.orm-entity.ts
@@ -1,0 +1,50 @@
+/**
+ * Fulfillment Routing Rule ORM Entity
+ *
+ * TypeORM entity for the `fulfillment_routing_rules` table — the general
+ * fulfillment-routing model (#832) generalizing `connection_carrier_mappings`.
+ * One rule per `(source_connection_id, source_delivery_method_id)`.
+ *
+ * FK constraints (`source_connection_id` + `processor_connection_id` →
+ * `connections` ON DELETE CASCADE) are emitted by the migration, mirroring the
+ * `connection_carrier_mappings` convention; the entity declares only the
+ * unique index.
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/entities
+ */
+
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+import { FulfillmentProcessorKind } from '../../../domain/types/fulfillment-routing.types';
+
+@Entity('fulfillment_routing_rules')
+@Index(['sourceConnectionId', 'sourceDeliveryMethodId'], { unique: true })
+export class FulfillmentRoutingRuleOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', name: 'source_connection_id' })
+  sourceConnectionId!: string;
+
+  @Column({ type: 'varchar', length: 100, name: 'source_delivery_method_id' })
+  sourceDeliveryMethodId!: string;
+
+  @Column({ type: 'varchar', length: 32, name: 'processor_kind' })
+  processorKind!: FulfillmentProcessorKind;
+
+  @Column({ type: 'uuid', name: 'processor_connection_id' })
+  processorConnectionId!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/libs/core/src/mappings/infrastructure/persistence/repositories/fulfillment-routing.repository.ts
+++ b/libs/core/src/mappings/infrastructure/persistence/repositories/fulfillment-routing.repository.ts
@@ -1,0 +1,80 @@
+/**
+ * Fulfillment Routing Repository
+ *
+ * Implements `FulfillmentRoutingRepositoryPort` using TypeORM. `replaceForConnection`
+ * uses a transaction to atomically delete + re-insert all rules for a source
+ * connection (mirrors `CarrierMappingRepository`).
+ *
+ * @module libs/core/src/mappings/infrastructure/persistence/repositories
+ * @implements {FulfillmentRoutingRepositoryPort}
+ */
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { FulfillmentRoutingRuleOrmEntity } from '../entities/fulfillment-routing-rule.orm-entity';
+import type { FulfillmentRoutingRepositoryPort } from '../../../domain/ports/fulfillment-routing-repository.port';
+import { FulfillmentRoutingRule } from '../../../domain/entities/fulfillment-routing-rule.entity';
+import type { FulfillmentRoutingRuleInput } from '../../../domain/types/fulfillment-routing.types';
+
+@Injectable()
+export class FulfillmentRoutingRepository implements FulfillmentRoutingRepositoryPort {
+  constructor(
+    @InjectRepository(FulfillmentRoutingRuleOrmEntity)
+    private readonly repo: Repository<FulfillmentRoutingRuleOrmEntity>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async findBySourceConnectionId(sourceConnectionId: string): Promise<FulfillmentRoutingRule[]> {
+    const entities = await this.repo.find({ where: { sourceConnectionId } });
+    return entities.map((e) => this.toDomain(e));
+  }
+
+  async findRule(
+    sourceConnectionId: string,
+    sourceDeliveryMethodId: string,
+  ): Promise<FulfillmentRoutingRule | null> {
+    const entity = await this.repo.findOne({
+      where: { sourceConnectionId, sourceDeliveryMethodId },
+    });
+    return entity ? this.toDomain(entity) : null;
+  }
+
+  async replaceForConnection(
+    sourceConnectionId: string,
+    items: FulfillmentRoutingRuleInput[],
+  ): Promise<FulfillmentRoutingRule[]> {
+    return this.dataSource.transaction(async (manager) => {
+      await manager.delete(FulfillmentRoutingRuleOrmEntity, { sourceConnectionId });
+
+      if (items.length === 0) {
+        return [];
+      }
+
+      const entities = items.map((item) => {
+        const entity = new FulfillmentRoutingRuleOrmEntity();
+        entity.sourceConnectionId = sourceConnectionId;
+        entity.sourceDeliveryMethodId = item.sourceDeliveryMethodId;
+        entity.processorKind = item.processorKind;
+        entity.processorConnectionId = item.processorConnectionId;
+        return entity;
+      });
+
+      const saved = await manager.save(FulfillmentRoutingRuleOrmEntity, entities);
+      return saved.map((e) => this.toDomain(e));
+    });
+  }
+
+  private toDomain(entity: FulfillmentRoutingRuleOrmEntity): FulfillmentRoutingRule {
+    return new FulfillmentRoutingRule(
+      entity.id,
+      entity.sourceConnectionId,
+      entity.sourceDeliveryMethodId,
+      entity.processorKind,
+      entity.processorConnectionId,
+      entity.createdAt,
+      entity.updatedAt,
+    );
+  }
+}

--- a/libs/core/src/mappings/mappings.module.ts
+++ b/libs/core/src/mappings/mappings.module.ts
@@ -2,29 +2,37 @@
  * Mappings Module
  *
  * NestJS module for the connection-scoped mapping configuration bounded context.
- * Registers ORM entities, repositories, and the MappingConfigService.
- * Exports MAPPING_CONFIG_SERVICE_TOKEN for use in other modules (e.g., OrdersModule).
+ * Registers ORM entities, repositories, the MappingConfigService, and the
+ * fulfillment-routing model (#832).
+ * Exports MAPPING_CONFIG_SERVICE_TOKEN + FULFILLMENT_ROUTING_SERVICE_TOKEN for
+ * use in other modules (e.g., OrdersModule).
  *
  * @module libs/core/src/mappings
  */
 
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { IntegrationsModule } from '@openlinker/core/integrations';
 import { StatusMappingOrmEntity } from './infrastructure/persistence/entities/status-mapping.orm-entity';
 import { CarrierMappingOrmEntity } from './infrastructure/persistence/entities/carrier-mapping.orm-entity';
 import { PaymentMappingOrmEntity } from './infrastructure/persistence/entities/payment-mapping.orm-entity';
 import { CategoryMappingOrmEntity } from './infrastructure/persistence/entities/category-mapping.orm-entity';
+import { FulfillmentRoutingRuleOrmEntity } from './infrastructure/persistence/entities/fulfillment-routing-rule.orm-entity';
 import { StatusMappingRepository } from './infrastructure/persistence/repositories/status-mapping.repository';
 import { CarrierMappingRepository } from './infrastructure/persistence/repositories/carrier-mapping.repository';
 import { PaymentMappingRepository } from './infrastructure/persistence/repositories/payment-mapping.repository';
 import { CategoryMappingRepository } from './infrastructure/persistence/repositories/category-mapping.repository';
+import { FulfillmentRoutingRepository } from './infrastructure/persistence/repositories/fulfillment-routing.repository';
 import { MappingConfigService } from './application/services/mapping-config.service';
+import { FulfillmentRoutingService } from './application/services/fulfillment-routing.service';
 import {
   MAPPING_CONFIG_SERVICE_TOKEN,
   STATUS_MAPPING_REPOSITORY_TOKEN,
   CARRIER_MAPPING_REPOSITORY_TOKEN,
   PAYMENT_MAPPING_REPOSITORY_TOKEN,
   CATEGORY_MAPPING_REPOSITORY_TOKEN,
+  FULFILLMENT_ROUTING_REPOSITORY_TOKEN,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
 } from './mappings.tokens';
 
 @Module({
@@ -34,14 +42,18 @@ import {
       CarrierMappingOrmEntity,
       PaymentMappingOrmEntity,
       CategoryMappingOrmEntity,
+      FulfillmentRoutingRuleOrmEntity,
     ]),
+    IntegrationsModule,
   ],
   providers: [
     StatusMappingRepository,
     CarrierMappingRepository,
     PaymentMappingRepository,
     CategoryMappingRepository,
+    FulfillmentRoutingRepository,
     MappingConfigService,
+    FulfillmentRoutingService,
     {
       provide: STATUS_MAPPING_REPOSITORY_TOKEN,
       useExisting: StatusMappingRepository,
@@ -59,13 +71,22 @@ import {
       useExisting: CategoryMappingRepository,
     },
     {
+      provide: FULFILLMENT_ROUTING_REPOSITORY_TOKEN,
+      useExisting: FulfillmentRoutingRepository,
+    },
+    {
       provide: MAPPING_CONFIG_SERVICE_TOKEN,
       useExisting: MappingConfigService,
+    },
+    {
+      provide: FULFILLMENT_ROUTING_SERVICE_TOKEN,
+      useExisting: FulfillmentRoutingService,
     },
   ],
   exports: [
     MAPPING_CONFIG_SERVICE_TOKEN,
     MappingConfigService,
+    FULFILLMENT_ROUTING_SERVICE_TOKEN,
   ],
 })
 export class MappingsModule {}

--- a/libs/core/src/mappings/mappings.tokens.ts
+++ b/libs/core/src/mappings/mappings.tokens.ts
@@ -11,3 +11,5 @@ export const STATUS_MAPPING_REPOSITORY_TOKEN = Symbol('StatusMappingRepositoryPo
 export const CARRIER_MAPPING_REPOSITORY_TOKEN = Symbol('CarrierMappingRepositoryPort');
 export const PAYMENT_MAPPING_REPOSITORY_TOKEN = Symbol('PaymentMappingRepositoryPort');
 export const CATEGORY_MAPPING_REPOSITORY_TOKEN = Symbol('CategoryMappingRepositoryPort');
+export const FULFILLMENT_ROUTING_REPOSITORY_TOKEN = Symbol('FulfillmentRoutingRepositoryPort');
+export const FULFILLMENT_ROUTING_SERVICE_TOKEN = Symbol('IFulfillmentRoutingService');


### PR DESCRIPTION
## What & why

The CORE foundation (E1) for the #732 Allegro Delivery shipment epic. Generalizes today's `CarrierMapping` (which hardcodes the OMP-fulfilled Allegro→PrestaShop carrier branch) into a connection-scoped **fulfillment-routing model**:

```
(sourceConnectionId, sourceDeliveryMethodId) → { processorKind, processorConnectionId }
```

across three processor kinds — `omp_fulfilled` (shop ships, delegate-to-OMP), `ol_managed_carrier` (OL drives an own-contract carrier, e.g. InPost ShipX #812), `source_brokered` (OL drives the marketplace's own shipping, e.g. Allegro Delivery #833).

This was designed via a full `/grill-me` pass (Q1–Q8); the locked decisions and the rule shape are captured in **ADR-012**.

## What's included

- **Domain** — `FulfillmentRoutingRule` (anemic, ADR-011), `fulfillment-routing.types.ts` (`as const` unions), repository port, `IncompatibleProcessorException` + `DuplicateRoutingRuleException`.
- **Infra** — ORM entity + repository (transactional delete+insert, mirrors `CarrierMappingRepository`).
- **App** — `FulfillmentRoutingService` (`getRules` / `replaceRules` / `resolve`). `replaceRules` validates the whole batch before any write: duplicate-method rejection, source-connection existence, and per-rule **capability + topology** compatibility against adapter-declared metadata, with an exhaustiveness guard so a new processor kind can't bypass the gate. `resolve` falls back to the `omp_fulfilled` default (today's PS-fulfilled behaviour) when unconfigured.
- **Migration** — `fulfillment_routing_rules` table; both connection FKs `ON DELETE CASCADE`; unique `(source, method)`.
- **Docs** — ADR-012 (filed + indexed) and a reconciled implementation plan with explicit AC-amendment notes.

## Tests / verification

- Unit: `fulfillment-routing.service.spec.ts` — resolution + all compatibility/topology branches + dedup + unknown-kind guard + source-existence.
- Integration: `fulfillment-routing.int-spec.ts` — persistence round-trip, full-replace, resolve rule-hit + default, with compatibility asserted against the **real booted PrestaShop / Allegro / InPost adapter manifests**.
- Migration DDL `up()`/`down()` round-trip (incl. both `ON DELETE CASCADE` FKs) validated against real Postgres 16 — the synchronize-built test harness can't verify migration-only FKs, so the FK-cascade case is validated there rather than in the int-spec.
- Gate green: `pnpm type-check`, `pnpm lint` (0 errors) + `check:invariants`, core unit **851** + worker **141**, int-spec **7/7**.

## Scope notes (honest AC accounting — see plan §0)

- **Q2 = C:** model + resolution + compatibility **only**. The resolver is **not yet wired** to the live order path — the dispatch orchestrator is **#835**; branch-2/3 execution is **#833**. No regression: today's path is untouched.
- **#835 must handle the resolution asymmetry:** a configured `omp_fulfilled` rule resolves with a non-null `processorConnectionId`, but the default resolves `null` (no single fulfilling OMP under fan-out) — treat null as "fan-out default," not "no processor."
- OMP destination is *derived* (order fan-out) and the branch-1 carrier stays *co-keyed* in `CarrierMapping`; `connection_carrier_mappings` is preserved (additive).
- Method-granular eligibility (OQ-B1 `/delivery-services`) is deferred to **#833** behind the `assertCompatible` seam.

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)