### PR TITLE
feat(shipping): converge InPost dispatch onto the fulfillment-routing model (#835)

### DIFF
--- a/apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts
+++ b/apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts
@@ -1,0 +1,79 @@
+/**
+ * InPost Test ShippingProviderManagerPort Stub Helper (#835)
+ *
+ * Registers a synthetic `inpost.test.v1` adapter declaring
+ * `ShippingProviderManager` with the running Nest app's
+ * `AdapterRegistryService` + `AdapterFactoryResolverService` — the same public
+ * plugin seam real integrations use (#570 / #574). Mirrors
+ * `allegro-test-source-stub.helper.ts`.
+ *
+ * The shipment-dispatch seam (#835) resolves the processor connection's
+ * `ShippingProviderManagerPort` via `getCapabilityAdapter` and calls
+ * `generateLabel`. The real InPost adapter would hit ShipX over HTTP, so the
+ * int-spec routes to this in-memory stub instead — exercising the full seam
+ * (real routing + compatibility + repository) against a fake provider.
+ *
+ * Lifetime: suite-scoped. Call once in `beforeAll`.
+ *
+ * @module apps/api/test/integration/helpers
+ */
+import {
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterFactoryResolverService,
+  AdapterRegistryPort,
+} from '@openlinker/core/integrations';
+import type {
+  GenerateLabelCommand,
+  GenerateLabelResult,
+  ShippingMethod,
+  ShippingProviderManagerPort,
+  TrackingSnapshot,
+} from '@openlinker/core/shipping';
+import type { IntegrationTestHarness } from '../setup';
+
+export const INPOST_TEST_ADAPTER_KEY = 'inpost.test.v1';
+export const INPOST_TEST_PLATFORM_TYPE = 'inpost';
+
+export function installInpostTestShippingStub(harness: IntegrationTestHarness): {
+  readonly adapterKey: string;
+  readonly platformType: string;
+} {
+  const adapterRegistry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+  const factoryResolver = harness
+    .getApp()
+    .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
+
+  let counter = 0;
+  const shippingStub: ShippingProviderManagerPort = {
+    getSupportedMethods(): readonly ShippingMethod[] {
+      return ['paczkomat', 'kurier'];
+    },
+    generateLabel(cmd: GenerateLabelCommand): Promise<GenerateLabelResult> {
+      counter += 1;
+      return Promise.resolve({
+        providerShipmentId: `stub-${counter}`,
+        trackingNumber: null,
+        labelPdfRef: `stub:label:${cmd.shipmentId}`,
+      });
+    },
+    getTracking(_input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
+      return Promise.resolve({ status: 'generated', providerStatus: 'generated' });
+    },
+  };
+
+  adapterRegistry.register({
+    adapterKey: INPOST_TEST_ADAPTER_KEY,
+    platformType: INPOST_TEST_PLATFORM_TYPE,
+    supportedCapabilities: ['ShippingProviderManager'],
+    displayName: 'InPost (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+
+  factoryResolver.registerFactory(INPOST_TEST_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(shippingStub as unknown as T),
+  });
+
+  return { adapterKey: INPOST_TEST_ADAPTER_KEY, platformType: INPOST_TEST_PLATFORM_TYPE };
+}

--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -66,6 +66,9 @@ const harness = createIntegrationTestHarness({
     'refresh_tokens',
     'product_variants',
     'products',
+    // shipments (#763 / #835) — order- + connection-scoped; truncate before
+    // connections so the dispatch int-spec starts each case with no rows.
+    'shipments',
     // fulfillment_routing_rules is connection-scoped config (#832). Listed
     // explicitly because — like connection_carrier_mappings — its FKs live in
     // the migration, not the ORM decorators, so the synchronize-built test

--- a/apps/api/test/integration/shipment-dispatch.int-spec.ts
+++ b/apps/api/test/integration/shipment-dispatch.int-spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Shipment Dispatch Integration Test (#835)
+ *
+ * Exercises the convergence seam end-to-end against real Postgres: a routing
+ * rule is configured via the real #832 `FulfillmentRoutingService` (so the
+ * compatibility gate runs), then `ShipmentDispatchService.dispatch` resolves
+ * the processor, creates a `Shipment`, and generates a label via the resolved
+ * connection's `ShippingProviderManagerPort` — routed to an in-memory stub
+ * adapter (the real InPost adapter would hit ShipX over HTTP).
+ *
+ * Covers: ol_managed_carrier dispatch → persisted `generated` shipment;
+ * omp_fulfilled default → null + no row; idempotency.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import {
+  IShipmentDispatchService,
+  ShipmentDispatchInput,
+  SHIPMENT_DISPATCH_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import {
+  INPOST_TEST_ADAPTER_KEY,
+  installInpostTestShippingStub,
+} from './helpers/inpost-test-shipping-stub.helper';
+
+const RECIPIENT = {
+  email: 'buyer@example.com',
+  phone: '+48500600700',
+  address: {
+    street: 'Krakowska',
+    buildingNumber: '12',
+    city: 'Poznań',
+    postCode: '60-001',
+    countryCode: 'PL',
+  },
+};
+const PARCEL = { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1200 };
+
+describe('Shipment Dispatch Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    installInpostTestShippingStub(harness);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const dispatchService = (): IShipmentDispatchService =>
+    harness.getApp().get<IShipmentDispatchService>(SHIPMENT_DISPATCH_SERVICE_TOKEN);
+  const routingService = (): IFulfillmentRoutingService =>
+    harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+
+  async function seedConnections(): Promise<{ sourceId: string; carrierId: string }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    const carrier = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: INPOST_TEST_ADAPTER_KEY,
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    return { sourceId: source.id, carrierId: carrier.id };
+  }
+
+  it('should dispatch an ol_managed_carrier order to a persisted generated shipment', async () => {
+    const { sourceId, carrierId } = await seedConnections();
+    await routingService().replaceRules(sourceId, [
+      {
+        sourceDeliveryMethodId: 'allegro-courier',
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: carrierId,
+      },
+    ]);
+
+    const result = await dispatchService().dispatch({
+      sourceConnectionId: sourceId,
+      sourceDeliveryMethodId: 'allegro-courier',
+      orderId: 'ol_order_dispatch_1',
+      shippingMethod: 'kurier',
+      recipient: RECIPIENT,
+      parcel: PARCEL,
+    });
+
+    expect(result.kind).toBe('dispatched');
+    if (result.kind !== 'dispatched') throw new Error('expected a dispatched shipment');
+    const { shipment } = result;
+    expect(shipment).toMatchObject({
+      orderId: 'ol_order_dispatch_1',
+      connectionId: carrierId,
+      shippingMethod: 'kurier',
+      status: 'generated',
+    });
+    expect(shipment.providerShipmentId).toMatch(/^stub-/);
+    expect(shipment.labelPdfRef).toContain('stub:label:');
+    // Persistence is proven by the round-trip: the repo's `update` re-reads the
+    // row from Postgres (or throws ShipmentNotFoundException if `create` hadn't
+    // persisted it), and the idempotency test below confirms the row is queryable.
+  });
+
+  it('should return omp_fulfilled and create no shipment for an unconfigured method (default)', async () => {
+    const { sourceId } = await seedConnections();
+
+    const result = await dispatchService().dispatch({
+      sourceConnectionId: sourceId,
+      sourceDeliveryMethodId: 'unmapped-method',
+      orderId: 'ol_order_omp_1',
+      shippingMethod: 'kurier',
+      recipient: RECIPIENT,
+      parcel: PARCEL,
+    });
+
+    expect(result).toEqual({ kind: 'omp_fulfilled' });
+  });
+
+  it('should be idempotent — a second dispatch returns the same shipment with no new row', async () => {
+    const { sourceId, carrierId } = await seedConnections();
+    await routingService().replaceRules(sourceId, [
+      {
+        sourceDeliveryMethodId: 'allegro-courier',
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: carrierId,
+      },
+    ]);
+    const input: ShipmentDispatchInput = {
+      sourceConnectionId: sourceId,
+      sourceDeliveryMethodId: 'allegro-courier',
+      orderId: 'ol_order_idem_1',
+      shippingMethod: 'kurier',
+      recipient: RECIPIENT,
+      parcel: PARCEL,
+    };
+
+    const first = await dispatchService().dispatch(input);
+    const second = await dispatchService().dispatch(input);
+
+    expect(first.kind).toBe('dispatched');
+    expect(second.kind).toBe('dispatched');
+    if (first.kind !== 'dispatched' || second.kind !== 'dispatched') {
+      throw new Error('expected dispatched results');
+    }
+    // Same id proves both persistence and idempotency: if the first row hadn't
+    // persisted, the service's findActiveByOrderId would miss it and the second
+    // dispatch would create a new shipment with a different id.
+    expect(second.shipment.id).toBe(first.shipment.id);
+  });
+});

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1174,6 +1174,8 @@ graph LR
   sync --> orders
   ai --> integrations
   integrations --> identifier-mapping
+  shipping --> integrations
+  shipping --> mappings
 ```
 
 `identifier-mapping`, `integrations`, and `events` form the most-depended-upon "infrastructure spine" (each used by 5+ siblings). `users`, `webhooks`, and `mappings` have minimal outbound coupling.

--- a/docs/plans/implementation-plan-shipment-dispatch-convergence.md
+++ b/docs/plans/implementation-plan-shipment-dispatch-convergence.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Shipment dispatch seam — converge InPost onto the routing model (#835)
+
+**Date**: 2026-05-25
+**Status**: Ready for implementation (design resolved via `/grill-me` Q1–Q11)
+**Estimated Effort**: S–M (1–3 days; core seam + tests, no migration, no new port)
+
+---
+
+## 0. Premise reconciliation (read first)
+
+The #835 issue is written as a **retrofit** — "converge the in-flight InPost path … eliminating any parallel/separate routing mechanism." Verified against `main` (post-#812 + #832), **no such path exists**:
+
+- ✅ InPost adapter (#812) and routing model (#832) are merged.
+- ❌ **Zero** shipment-dispatch code: no `generateLabel` caller, no `SHIPMENT_REPOSITORY_TOKEN` consumer, **no `application/` layer in the shipping context**, no worker handler, InPost not in `apps/worker/src/plugins.ts`. The #727 live path (#766–#772) is still open; **0 open PRs**.
+
+So there is **no parallel mechanism to eliminate**. #835 therefore *builds the single convergence point* so InPost dispatch routes through #832 **from day one** — the same discipline #832 used (ship `resolve()`, leave it unwired). "No parallel mechanism" is achieved **by construction**: there's exactly one dispatch entry point and it owns the `resolve()` call.
+
+---
+
+## 1. Scope
+
+**In scope** — a core `ShipmentDispatchService` (the "seam"), **unwired** (no trigger):
+
+`dispatch(input)` → `resolve()` the processor → branch on `processorKind` → for a label-generating kind, create `Shipment(draft)` → `generateLabel()` via the resolved connection's `ShippingProviderManagerPort` → persist `generated` → return. Idempotent; persists `failed` on adapter error.
+
+**Out of scope** (other issues): the *trigger* / call-site (manual button / auto-on-paid — #769/#771); order→recipient/parcel assembly (operator input + #767 paczkomat-from-PS-module + PII email sourcing); Allegro Delivery adapter (#833); status read-back (#834/#838); FE (#769/#770/#836/#839); worker registration of InPost (the trigger issue does it).
+
+---
+
+## 2. Resolved design decisions (Q1–Q11)
+
+1. **Q1 — Deliverable**: the unwired core seam (like #832's `resolve()`). *Confirmed.*
+2. **Q2 — Command boundary (Design A)**: the seam **consumes** a caller-supplied label payload (`recipient`, `parcel`, `shippingMethod`, `paczkomatId?`); it does **not** parse orders. Rationale: a complete `GenerateLabelCommand` is **not derivable** from a persisted `Order` — `parcel` is never on the order; `recipient.email` (required) is absent under `OL_STORE_PII=false`; `Address` needs `street`/`buildingNumber` splitting; `phone` is optional. Those are operator/PII/#767 concerns owned by #769/#767/#771. The seam owns the *routing + Shipment aggregate + dispatch*. *Confirmed.*
+3. **Q3 — Branch semantics (unified path)**: branch on `processorKind === omp_fulfilled` → `null` (covers the default's `null` connection **and** a *configured* omp_fulfilled rule's non-null connection — OMP ships externally, no OL label; read-back is #834). `ol_managed_carrier` **and** `source_brokered` share **one** path (both implement `ShippingProviderManagerPort`; topology is enforced at rule-creation by #832's `assertCompatible`, not at dispatch). **No `source_brokered` guard** — it's unreachable today (Allegro lacks the capability so no such rule persists) and `getCapabilityAdapter` is defensively safe; #833 then "just works" with zero seam rework. Exhaustive `default` guard mirrors #832. *Confirmed.*
+4. **Q4 — Lifecycle**: `repo.create({orderId, connectionId: resolution.processorConnectionId, shippingMethod, paczkomatId})` (always `draft`) → on `generateLabel` success `repo.update(id, {status:'generated', providerShipmentId, trackingNumber, labelPdfRef})`.
+5. **Q5 — Placement**: `libs/core/src/shipping/application/{services,interfaces,types}/`. `ShipmentDispatchService implements IShipmentDispatchService`. `SHIPMENT_DISPATCH_SERVICE_TOKEN` in `shipping.tokens.ts`. `ShippingModule` imports `MappingsModule` + `IntegrationsModule`. No cross-context cycle (nothing imports shipping at the module layer except `app.module`).
+6. **Q6 — Input type**: `ShipmentDispatchInput = { sourceConnectionId; sourceDeliveryMethodId: string|null } & Omit<GenerateLabelCommand,'shipmentId'|'connectionId'>` in `application/types/shipment-dispatch.types.ts`. Thin reshape of the shipped command → near-zero contract drift with #769. Exported from the barrel (the future caller needs it).
+7. **Q7 — Repository**: no changes — `create` / `update` / `findActiveByOrderId` already exist with the right shapes. **No migration.**
+8. **Q8 — Errors**: `generateLabel` rejection → `repo.update(id, {status:'failed', failedAt: now, errorMessage})` then **rethrow** the domain error (visible `failed` row for #770 + retry; error propagates for UX). `log.warn`.
+9. **Q9 — Idempotency**: after determining a label-generating kind, `findActiveByOrderId(orderId)`; if a non-terminal shipment exists, **return it** (no second label/fee). Cancel+re-issue flips to `cancelled` first, so a re-dispatch is allowed.
+10. **Q10 — Worker**: untouched (unwired seam).
+11. **Q11 — Tests**: unit (mock `ShipmentRepositoryPort` + `IFulfillmentRoutingService` + `IIntegrationsService`) covering omp_fulfilled default + configured-omp_fulfilled (the Q3 catch) + ol_managed_carrier happy path + source_brokered identical-path + idempotency + failure + exhaustiveness. Integration (`shipment-dispatch.int-spec.ts`) with an **inlined `ShippingProviderManager` stub** registered via `AdapterRegistryService` + `AdapterFactoryResolverService` under `inpost.test.v1` (mirrors `allegro-test-source-stub`) — real Postgres + real `replaceRules` compatibility + real `resolve` + real seam + fake provider.
+
+---
+
+## 3. Step-by-step
+
+1. `shipping.tokens.ts` — add `SHIPMENT_DISPATCH_SERVICE_TOKEN = Symbol('IShipmentDispatchService')`.
+2. `application/types/shipment-dispatch.types.ts` — `ShipmentDispatchInput`.
+3. `application/interfaces/shipment-dispatch.service.interface.ts` — `IShipmentDispatchService` (`dispatch(input): Promise<Shipment | null>`).
+4. `application/services/shipment-dispatch.service.ts` — `ShipmentDispatchService` (resolve → branch → idempotency → create → generateLabel → persist; failed+rethrow on error).
+5. `shipping.module.ts` — import `MappingsModule` + `IntegrationsModule`; provide `ShipmentDispatchService` + bind `SHIPMENT_DISPATCH_SERVICE_TOKEN` (`useExisting`); export the token.
+6. `index.ts` — export `IShipmentDispatchService` (type) + `ShipmentDispatchInput` (type); token auto-exported via `export * from './shipping.tokens'`.
+7. `application/services/shipment-dispatch.service.spec.ts` — unit tests.
+8. `apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts` — inlined ShippingProviderManager stub + registry registration.
+9. `apps/api/test/integration/shipment-dispatch.int-spec.ts` — integration test.
+10. `apps/api/test/integration/setup.ts` — add `'shipments'` to `tablesToTruncate`.
+
+---
+
+## 4. Architecture / validation
+
+- CORE-only; no integration code touched. New `shipping/application/` layer. Anemic `Shipment` (ADR-011) unchanged. Symbol token + barrel conventions (#595). Cross-context surface used: `IFulfillmentRoutingService` + token + `FULFILLMENT_PROCESSOR_KIND` (mappings), `IIntegrationsService` + token (integrations), `ShippingProviderManagerPort` (own context). No new ESLint/type errors. No migration.
+- **AC mapping**: AC "InPost routed via the same #832 config (no separate mechanism)" → the single seam owns `resolve()`; **AC "existing #727 behavior preserved"** → vacuously true (no prior path) + omp_fulfilled default unchanged; AC "tests added" → unit + integration. PR body records that the seam is **unwired** (trigger = #769/#771), matching the #832 precedent.
+
+## 5. Risks
+
+- **R1 — input-contract drift** vs #769's real needs. *Mitigation*: `ShipmentDispatchInput` is a thin `Omit<GenerateLabelCommand,…>` reshape — #769 builds exactly that.
+- **R2 — premise mismatch** (issue assumes a path that doesn't exist). *Mitigation*: §0 documents it; PR body states #835 builds the convergence point rather than retrofitting one.
+
+## 6. Post-review refinements (tech-review)
+
+- **Return type** — `dispatch` returns a discriminated union `ShipmentDispatchResult` (`{ kind: 'dispatched'; shipment } | { kind: 'omp_fulfilled' }`) rather than `Shipment | null`, so the future caller (#769) handles both outcomes explicitly. A `generateLabel` failure is still surfaced as a thrown error.
+- **Invariant guards** — the exhaustiveness `default` and the null-connection guard throw a typed domain error `UndispatchableResolutionException` (in `shipping/domain/exceptions/`), mirroring #832's exhaustiveness discipline rather than a bare `Error`.
+- **Idempotency is best-effort (carried to #769/#771)** — the `findActiveByOrderId` → `create` check is **not atomic**; concurrent dispatches for one order can double-create (the schema allows N shipments/order by design — no DB guard). The live call-site must serialise dispatch per order (debounce / job-level dedup). Documented in the service + interface.
+- **Provider partial-failure (carried to #812/#833)** — if `generateLabel` commits provider-side but its response fails, the shipment is marked `failed` and a re-dispatch starts a fresh attempt, which could double-create at the provider. `GenerateLabelCommand.shipmentId` is available for adapters to use as a provider-side idempotency key.

--- a/libs/core/src/shipping/application/interfaces/shipment-dispatch.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/shipment-dispatch.service.interface.ts
@@ -1,0 +1,35 @@
+/**
+ * Shipment Dispatch Service Interface
+ *
+ * The convergence seam (#835): the single entry point that routes an order's
+ * fulfillment through the #832 routing model and dispatches a label-generating
+ * shipment to the resolved processor connection. Built unwired — no trigger
+ * calls it yet (the manual/auto trigger is #769/#771), mirroring how #832
+ * shipped `resolve()` without a live call-site. Having one entry point that
+ * owns `resolve()` guarantees "no parallel routing mechanism" by construction.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+
+import type { ShipmentDispatchInput, ShipmentDispatchResult } from '../types/shipment-dispatch.types';
+
+export interface IShipmentDispatchService {
+  /**
+   * Resolve the fulfillment processor for the order and, when it's a
+   * label-generating kind (`ol_managed_carrier` / `source_brokered`), create a
+   * `Shipment` and generate the label via the resolved connection's
+   * `ShippingProviderManagerPort`.
+   *
+   * Returns a {@link ShipmentDispatchResult}: `{ kind: 'dispatched', shipment }`
+   * for a label-generating kind, or `{ kind: 'omp_fulfilled' }` when the OMP
+   * ships externally (no OL label — read-back is #834; covers both the fan-out
+   * default and a configured omp_fulfilled rule).
+   *
+   * Idempotent (best-effort): if a non-terminal shipment already exists for the
+   * order it is returned unchanged (no second label). The check is NOT
+   * concurrency-safe — see the implementation note; a concurrent call site
+   * (#769/#771) must serialise dispatch per order. On `generateLabel` failure
+   * the shipment is persisted `failed` and the error is rethrown.
+   */
+  dispatch(input: ShipmentDispatchInput): Promise<ShipmentDispatchResult>;
+}

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * Shipment Dispatch Service unit tests (#835).
+ *
+ * Mocks the three ports (ShipmentRepositoryPort + IFulfillmentRoutingService +
+ * IIntegrationsService → a fake ShippingProviderManager adapter). Covers every
+ * branch of the convergence seam: omp_fulfilled (default + configured),
+ * ol_managed_carrier happy path, source_brokered identical path, idempotency,
+ * generateLabel failure, and the exhaustiveness guard.
+ */
+
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  type FulfillmentProcessorKind,
+  type FulfillmentRoutingResolution,
+  type IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import { ShipmentDispatchService } from './shipment-dispatch.service';
+import type { ShipmentDispatchInput } from '../types/shipment-dispatch.types';
+import { Shipment } from '../../domain/entities/shipment.entity';
+import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import { UndispatchableResolutionException } from '../../domain/exceptions/undispatchable-resolution.exception';
+
+const SOURCE = 'conn-allegro';
+const INPOST = 'conn-inpost';
+const PS = 'conn-prestashop';
+
+function makeInput(overrides: Partial<ShipmentDispatchInput> = {}): ShipmentDispatchInput {
+  return {
+    sourceConnectionId: SOURCE,
+    sourceDeliveryMethodId: 'allegro-courier',
+    orderId: 'ol_order_1',
+    shippingMethod: 'kurier',
+    recipient: {
+      email: 'buyer@example.com',
+      phone: '+48500600700',
+      address: {
+        street: 'Krakowska',
+        buildingNumber: '12',
+        city: 'Poznań',
+        postCode: '60-001',
+        countryCode: 'PL',
+      },
+    },
+    parcel: { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1200 },
+    ...overrides,
+  };
+}
+
+function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? INPOST,
+    overrides.shippingMethod ?? 'kurier',
+    overrides.status ?? 'draft',
+    overrides.providerShipmentId ?? null,
+    overrides.paczkomatId ?? null,
+    overrides.trackingNumber ?? null,
+    overrides.labelPdfRef ?? null,
+    null,
+    null,
+    null,
+    overrides.failedAt ?? null,
+    overrides.errorMessage ?? null,
+    new Date(),
+    new Date(),
+  );
+}
+
+function resolution(
+  overrides: Partial<FulfillmentRoutingResolution> = {},
+): FulfillmentRoutingResolution {
+  return {
+    processorKind: overrides.processorKind ?? FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+    processorConnectionId:
+      overrides.processorConnectionId === undefined ? INPOST : overrides.processorConnectionId,
+    source: overrides.source ?? 'rule',
+  };
+}
+
+describe('ShipmentDispatchService', () => {
+  let repository: jest.Mocked<ShipmentRepositoryPort>;
+  let routing: jest.Mocked<IFulfillmentRoutingService>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let adapter: jest.Mocked<ShippingProviderManagerPort>;
+  let service: ShipmentDispatchService;
+
+  beforeEach(() => {
+    repository = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findByProviderShipmentId: jest.fn(),
+      update: jest.fn(),
+    };
+    routing = { getRules: jest.fn(), replaceRules: jest.fn(), resolve: jest.fn() };
+    adapter = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: jest.fn(),
+    };
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn().mockResolvedValue(adapter),
+      resolveAdapterMetadata: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+    };
+    service = new ShipmentDispatchService(repository, routing, integrations);
+  });
+
+  describe('omp_fulfilled (branch-1, no OL label)', () => {
+    it('should return omp_fulfilled for the default (null connection)', async () => {
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled, processorConnectionId: null, source: 'default' }),
+      );
+
+      const result = await service.dispatch(makeInput());
+
+      expect(result).toEqual({ kind: 'omp_fulfilled' });
+      expect(repository.findActiveByOrderId).not.toHaveBeenCalled();
+      expect(repository.create).not.toHaveBeenCalled();
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    });
+
+    it('should return omp_fulfilled for a CONFIGURED omp_fulfilled rule (non-null connection)', async () => {
+      // The Q3 catch: a configured omp_fulfilled rule pins a method to a
+      // specific OMP and resolves with a non-null connection — but the OMP
+      // still ships externally, so no OL label.
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled, processorConnectionId: PS, source: 'rule' }),
+      );
+
+      const result = await service.dispatch(makeInput());
+
+      expect(result).toEqual({ kind: 'omp_fulfilled' });
+      expect(repository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('label-generating dispatch', () => {
+    it('should create a draft shipment, generate the label, and persist generated for ol_managed_carrier', async () => {
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier, processorConnectionId: INPOST }),
+      );
+      repository.findActiveByOrderId.mockResolvedValue(null);
+      const draft = makeShipment({ status: 'draft' });
+      repository.create.mockResolvedValue(draft);
+      adapter.generateLabel.mockResolvedValue({
+        providerShipmentId: 'shipx-1',
+        trackingNumber: null,
+        labelPdfRef: 'shipx:label:shipx-1',
+      });
+      const generated = makeShipment({ status: 'generated', providerShipmentId: 'shipx-1' });
+      repository.update.mockResolvedValue(generated);
+
+      const input = makeInput({ shippingMethod: 'paczkomat', paczkomatId: 'POZ08A' });
+      const result = await service.dispatch(input);
+
+      expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(INPOST, 'ShippingProviderManager');
+      expect(repository.create).toHaveBeenCalledWith({
+        orderId: 'ol_order_1',
+        connectionId: INPOST,
+        shippingMethod: 'paczkomat',
+        paczkomatId: 'POZ08A',
+      });
+      expect(adapter.generateLabel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          shipmentId: draft.id,
+          connectionId: INPOST,
+          orderId: 'ol_order_1',
+          shippingMethod: 'paczkomat',
+          paczkomatId: 'POZ08A',
+          recipient: input.recipient,
+          parcel: input.parcel,
+        }),
+      );
+      expect(repository.update).toHaveBeenCalledWith(
+        draft.id,
+        expect.objectContaining({
+          status: 'generated',
+          providerShipmentId: 'shipx-1',
+          trackingNumber: undefined,
+          labelPdfRef: 'shipx:label:shipx-1',
+        }),
+      );
+      expect(result).toEqual({ kind: 'dispatched', shipment: generated });
+    });
+
+    it('should dispatch source_brokered through the identical path (no rework for #833)', async () => {
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: FULFILLMENT_PROCESSOR_KIND.SourceBrokered, processorConnectionId: SOURCE }),
+      );
+      repository.findActiveByOrderId.mockResolvedValue(null);
+      repository.create.mockResolvedValue(makeShipment({ connectionId: SOURCE }));
+      adapter.generateLabel.mockResolvedValue({
+        providerShipmentId: 'allegro-1',
+        trackingNumber: 'TRACK-1',
+        labelPdfRef: 'allegro:label:1',
+      });
+      repository.update.mockResolvedValue(makeShipment({ status: 'generated' }));
+
+      const result = await service.dispatch(makeInput());
+
+      expect(result.kind).toBe('dispatched');
+      expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(SOURCE, 'ShippingProviderManager');
+      expect(adapter.generateLabel).toHaveBeenCalled();
+      expect(repository.update).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ status: 'generated', trackingNumber: 'TRACK-1' }),
+      );
+    });
+
+    it('should be idempotent — return the existing non-terminal shipment without re-dispatching', async () => {
+      routing.resolve.mockResolvedValue(resolution());
+      const existing = makeShipment({ status: 'generated', providerShipmentId: 'shipx-existing' });
+      repository.findActiveByOrderId.mockResolvedValue(existing);
+
+      const result = await service.dispatch(makeInput());
+
+      expect(result).toEqual({ kind: 'dispatched', shipment: existing });
+      expect(repository.create).not.toHaveBeenCalled();
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+      expect(adapter.generateLabel).not.toHaveBeenCalled();
+    });
+
+    it('should persist failed and rethrow when generateLabel rejects', async () => {
+      routing.resolve.mockResolvedValue(resolution());
+      repository.findActiveByOrderId.mockResolvedValue(null);
+      const draft = makeShipment({ status: 'draft' });
+      repository.create.mockResolvedValue(draft);
+      const boom = new Error('paczkomat unavailable');
+      adapter.generateLabel.mockRejectedValue(boom);
+      repository.update.mockResolvedValue(makeShipment({ status: 'failed' }));
+
+      await expect(service.dispatch(makeInput())).rejects.toBe(boom);
+
+      expect(repository.update).toHaveBeenCalledWith(
+        draft.id,
+        expect.objectContaining({ status: 'failed', errorMessage: 'paczkomat unavailable' }),
+      );
+    });
+  });
+
+  describe('exhaustiveness guard', () => {
+    it('should throw for an unknown processor kind', async () => {
+      routing.resolve.mockResolvedValue(
+        resolution({ processorKind: 'teleporter' as FulfillmentProcessorKind, processorConnectionId: INPOST }),
+      );
+
+      await expect(service.dispatch(makeInput())).rejects.toBeInstanceOf(
+        UndispatchableResolutionException,
+      );
+      expect(repository.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.ts
@@ -1,0 +1,169 @@
+/**
+ * Shipment Dispatch Service
+ *
+ * Converges fulfillment dispatch onto the #832 routing model (#835): resolves
+ * the processor for an order, and for a label-generating processor kind
+ * (`ol_managed_carrier` / `source_brokered`) creates a `Shipment` and calls
+ * `generateLabel` on the resolved connection's `ShippingProviderManagerPort`.
+ *
+ * This is the single dispatch entry point — it owns the `resolve()` call, so
+ * there is no parallel routing mechanism by construction. It is unwired in
+ * #835 (no trigger); the manual/auto call-site is #769/#771, exactly as #832
+ * shipped `resolve()` without a live caller.
+ *
+ * `ol_managed_carrier` and `source_brokered` share one path: both implement
+ * `ShippingProviderManagerPort` and the source-vs-distinct-connection topology
+ * is enforced at rule-creation (#832 `assertCompatible`), not here. So #833's
+ * Allegro Delivery adapter dispatches through this same code with zero changes
+ * the day it declares the capability.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IShipmentDispatchService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import {
+  type IFulfillmentRoutingService,
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+} from '@openlinker/core/mappings';
+
+import type { IShipmentDispatchService } from '../interfaces/shipment-dispatch.service.interface';
+import type {
+  ShipmentDispatchInput,
+  ShipmentDispatchResult,
+} from '../types/shipment-dispatch.types';
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import { UndispatchableResolutionException } from '../../domain/exceptions/undispatchable-resolution.exception';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import { SHIPMENT_STATUS } from '../../domain/types/shipment-status.types';
+import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+/** Capability the resolved processor connection must declare to issue a label. */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+@Injectable()
+export class ShipmentDispatchService implements IShipmentDispatchService {
+  private readonly logger = new Logger(ShipmentDispatchService.name);
+
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+    @Inject(FULFILLMENT_ROUTING_SERVICE_TOKEN)
+    private readonly routing: IFulfillmentRoutingService,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+  ) {}
+
+  async dispatch(input: ShipmentDispatchInput): Promise<ShipmentDispatchResult> {
+    const resolution = await this.routing.resolve({
+      sourceConnectionId: input.sourceConnectionId,
+      sourceDeliveryMethodId: input.sourceDeliveryMethodId,
+    });
+
+    switch (resolution.processorKind) {
+      case FULFILLMENT_PROCESSOR_KIND.OmpFulfilled:
+        // Branch-1: the OMP ships via its own carrier setup — OL generates no
+        // label. Read-back is #834. Covers both the fan-out default (null
+        // connection) and a configured omp_fulfilled rule (non-null connection).
+        return { kind: 'omp_fulfilled' };
+
+      case FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier:
+      case FULFILLMENT_PROCESSOR_KIND.SourceBrokered: {
+        const shipment = await this.dispatchViaShippingProvider(
+          input,
+          resolution.processorConnectionId,
+        );
+        return { kind: 'dispatched', shipment };
+      }
+
+      default: {
+        // Exhaustiveness guard — a new processor kind must fail loud, not
+        // silently skip dispatch (mirrors #832's assertCompatible).
+        const exhaustive: never = resolution.processorKind;
+        throw new UndispatchableResolutionException(
+          `unknown processor kind: ${String(exhaustive)}`,
+        );
+      }
+    }
+  }
+
+  private async dispatchViaShippingProvider(
+    input: ShipmentDispatchInput,
+    processorConnectionId: string | null,
+  ): Promise<Shipment> {
+    if (!processorConnectionId) {
+      // A label-generating rule always carries a processor connection (it can't
+      // pass #832's compatibility gate otherwise). Defensive — unreachable.
+      throw new UndispatchableResolutionException(
+        'a label-generating processor resolved without a connection id',
+      );
+    }
+
+    // Idempotency (best-effort): don't issue a second label/fee while a
+    // non-terminal shipment for this order is in flight. The cancel + re-issue
+    // flow flips the prior row to `cancelled` first, so a genuine re-dispatch is
+    // still allowed. NOTE: this find→create is NOT atomic — two concurrent
+    // dispatches for the same order can both pass it and double-create (the
+    // schema allows N shipments/order by design, so there is no DB guard). The
+    // live call-site (#769/#771) must serialise dispatch per order
+    // (debounce / job-level dedup).
+    const active = await this.shipments.findActiveByOrderId(input.orderId);
+    if (active) {
+      return active;
+    }
+
+    const adapter = await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
+      processorConnectionId,
+      SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+    );
+
+    const shipment = await this.shipments.create({
+      orderId: input.orderId,
+      connectionId: processorConnectionId,
+      shippingMethod: input.shippingMethod,
+      paczkomatId: input.paczkomatId,
+    });
+
+    // NOTE: if generateLabel commits provider-side but its response fails, the
+    // shipment is marked `failed` (catch below) and a later re-dispatch starts a
+    // fresh attempt — which could double-create at the provider. The command
+    // carries `shipmentId`; adapters (#812/#833) should use it as a
+    // provider-side idempotency key to close that at-least-once hazard.
+    try {
+      const result = await adapter.generateLabel({
+        shipmentId: shipment.id,
+        connectionId: processorConnectionId,
+        orderId: input.orderId,
+        shippingMethod: input.shippingMethod,
+        paczkomatId: input.paczkomatId,
+        recipient: input.recipient,
+        parcel: input.parcel,
+      });
+
+      return await this.shipments.update(shipment.id, {
+        status: SHIPMENT_STATUS.Generated,
+        providerShipmentId: result.providerShipmentId,
+        // Some providers issue tracking asynchronously; leave null when absent.
+        trackingNumber: result.trackingNumber ?? undefined,
+        labelPdfRef: result.labelPdfRef,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `generateLabel failed for shipment ${shipment.id} (order ${input.orderId}): ${message}`,
+      );
+      // Persist the visible failure (surfaces in /shipments + enables retry),
+      // then propagate the domain error so the caller can render it.
+      await this.shipments.update(shipment.id, {
+        status: SHIPMENT_STATUS.Failed,
+        failedAt: new Date(),
+        errorMessage: message,
+      });
+      throw error;
+    }
+  }
+}

--- a/libs/core/src/shipping/application/types/shipment-dispatch.types.ts
+++ b/libs/core/src/shipping/application/types/shipment-dispatch.types.ts
@@ -1,0 +1,44 @@
+/**
+ * Shipment Dispatch Types
+ *
+ * Input contract for `IShipmentDispatchService.dispatch` (#835). The dispatch
+ * seam owns routing + the `Shipment` aggregate + the adapter call; the caller
+ * owns the label payload — `recipient` / `parcel` are NOT derivable from a
+ * persisted `Order` (parcel is never on the order; `recipient.email` is absent
+ * under `OL_STORE_PII=false`; the address needs street/building-number
+ * splitting), so they're supplied by the caller (operator input / #767 / #769).
+ *
+ * Deliberately a thin reshape of `GenerateLabelCommand` (drop the two fields
+ * the seam fills itself — `shipmentId` after creating the row, `connectionId`
+ * from the resolved processor) plus the routing keys. Keeping it a reshape of
+ * the shipped command type minimises contract drift with the future call-site
+ * (#769).
+ *
+ * @module libs/core/src/shipping/application/types
+ */
+
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import type { GenerateLabelCommand } from '../../domain/types/generate-label.types';
+
+export type ShipmentDispatchInput = {
+  /** Order source connection (the routing rule's scope). */
+  sourceConnectionId: string;
+  /** Source-side delivery method id; `null` resolves to the omp_fulfilled default. */
+  sourceDeliveryMethodId: string | null;
+} & Omit<GenerateLabelCommand, 'shipmentId' | 'connectionId'>;
+
+/**
+ * Outcome of a dispatch. A discriminated union (rather than `Shipment | null`)
+ * so the caller must handle both outcomes explicitly:
+ * - `dispatched` — a label-generating processor (`ol_managed_carrier` /
+ *   `source_brokered`) produced, or returned an in-flight, `Shipment`.
+ * - `omp_fulfilled` — the OMP ships externally; OL produced no shipment
+ *   (covers the fan-out default and a configured omp_fulfilled rule; read-back
+ *   is #834).
+ *
+ * A `generateLabel` failure is surfaced as a thrown error (the shipment is
+ * persisted `failed` first), never as a result variant.
+ */
+export type ShipmentDispatchResult =
+  | { readonly kind: 'dispatched'; readonly shipment: Shipment }
+  | { readonly kind: 'omp_fulfilled' };

--- a/libs/core/src/shipping/domain/exceptions/undispatchable-resolution.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/undispatchable-resolution.exception.ts
@@ -1,0 +1,20 @@
+/**
+ * Undispatchable Resolution Exception
+ *
+ * Thrown by `ShipmentDispatchService` when a fulfillment-routing resolution
+ * cannot be dispatched — an invariant violation that #832's compatibility gate
+ * should already prevent (a label-generating kind with no processor connection,
+ * or an unknown processor kind). Surfaces loud rather than silently skipping
+ * dispatch. Mirrors #832's exhaustiveness-guard discipline with a typed domain
+ * error instead of a bare `Error`.
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+
+export class UndispatchableResolutionException extends Error {
+  constructor(public readonly reason: string) {
+    super(`Fulfillment routing resolution cannot be dispatched: ${reason}`);
+    this.name = 'UndispatchableResolutionException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -82,3 +82,13 @@ export { isPickupPointFinder } from './domain/ports/capabilities/pickup-point-fi
 
 // Domain exceptions
 export { ShipmentNotFoundException } from './domain/exceptions/shipment-not-found.exception';
+export { UndispatchableResolutionException } from './domain/exceptions/undispatchable-resolution.exception';
+
+// Application — dispatch seam (#835). Interface + types only; the service
+// class is injected via SHIPMENT_DISPATCH_SERVICE_TOKEN (exported above via
+// `export * from './shipping.tokens'`), never value-imported.
+export type { IShipmentDispatchService } from './application/interfaces/shipment-dispatch.service.interface';
+export type {
+  ShipmentDispatchInput,
+  ShipmentDispatchResult,
+} from './application/types/shipment-dispatch.types';

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -5,10 +5,10 @@
  * `ShipmentOrmEntity` privately (via `TypeOrmModule.forFeature`) and binds
  * the concrete `ShipmentRepository` to `SHIPMENT_REPOSITORY_TOKEN`.
  *
- * Exports ONLY the port binding — does NOT re-export
- * `TypeOrmModule.forFeature(...)` because consumers inject via the
- * Symbol token (`@Inject(SHIPMENT_REPOSITORY_TOKEN)`) and never see
- * `Repository<ShipmentOrmEntity>` directly. Keeping the ORM type private
+ * Exports only the Symbol-token bindings (`SHIPMENT_REPOSITORY_TOKEN`,
+ * `SHIPMENT_DISPATCH_SERVICE_TOKEN`) — never `TypeOrmModule.forFeature(...)`
+ * or the concrete classes, because consumers inject via the tokens and never
+ * see `Repository<ShipmentOrmEntity>` directly. Keeping the ORM type private
  * to the module preserves the hexagonal boundary documented in
  * engineering-standards §"ORM ↔ Domain Mapping".
  *
@@ -19,20 +19,36 @@
  */
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { IntegrationsModule } from '@openlinker/core/integrations';
+import { MappingsModule } from '@openlinker/core/mappings';
 
 import { ShipmentOrmEntity } from './infrastructure/persistence/entities/shipment.orm-entity';
 import { ShipmentRepository } from './infrastructure/persistence/repositories/shipment.repository';
-import { SHIPMENT_REPOSITORY_TOKEN } from './shipping.tokens';
+import { ShipmentDispatchService } from './application/services/shipment-dispatch.service';
+import { SHIPMENT_DISPATCH_SERVICE_TOKEN, SHIPMENT_REPOSITORY_TOKEN } from './shipping.tokens';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ShipmentOrmEntity])],
+  imports: [
+    TypeOrmModule.forFeature([ShipmentOrmEntity]),
+    // #835 dispatch seam: resolve the processor via the routing model
+    // (MappingsModule) and dispatch to the resolved connection's
+    // ShippingProviderManager adapter (IntegrationsModule). No cycle — nothing
+    // imports ShippingModule except the host app graph.
+    IntegrationsModule,
+    MappingsModule,
+  ],
   providers: [
     ShipmentRepository,
     {
       provide: SHIPMENT_REPOSITORY_TOKEN,
       useExisting: ShipmentRepository,
     },
+    ShipmentDispatchService,
+    {
+      provide: SHIPMENT_DISPATCH_SERVICE_TOKEN,
+      useExisting: ShipmentDispatchService,
+    },
   ],
-  exports: [SHIPMENT_REPOSITORY_TOKEN],
+  exports: [SHIPMENT_REPOSITORY_TOKEN, SHIPMENT_DISPATCH_SERVICE_TOKEN],
 })
 export class ShippingModule {}

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -12,3 +12,4 @@
 
 export const SHIPMENT_REPOSITORY_TOKEN = Symbol('ShipmentRepositoryPort');
 export const PICKUP_POINT_CACHE_TOKEN = Symbol('PickupPointCachePort');
+export const SHIPMENT_DISPATCH_SERVICE_TOKEN = Symbol('IShipmentDispatchService');


### PR DESCRIPTION
## What & why

Adds the single **shipment-dispatch seam** (`ShipmentDispatchService`) that routes fulfillment through the #832 routing model. It owns the `resolve()` call, so InPost (#812) — and any future `ShippingProviderManager` processor — dispatches through **one entry point with no parallel routing mechanism**, achieved *by construction*.

Designed via a full `/grill-me` pass (Q1–Q11) and refined through `/tech-review`.

## ⚠️ Scope note (please read — the issue's premise doesn't match `main`)

#835 is written as a *retrofit* ("eliminate any parallel/separate routing mechanism"). On `main` (post-#812 + #832) **there is no in-flight InPost dispatch path to retrofit** — only the adapter (#812) and the routing model (#832) exist; #727's live path (#766–#772) is still open, and there were 0 open PRs. So this PR **builds the convergence point** so InPost routes through #832 *from day one*, rather than removing a parallel one — mirroring how #832 shipped `resolve()` unwired. Full reasoning in the plan doc §0.

## What's included

- **`ShipmentDispatchService`** (core `shipping/application/`): `resolve()` → branch on `processorKind` → for a label-generating kind create `Shipment(draft)` → `generateLabel` via the resolved connection's `ShippingProviderManagerPort` → persist `generated`.
  - Returns a discriminated union `ShipmentDispatchResult` (`{ kind: 'dispatched', shipment } | { kind: 'omp_fulfilled' }`) so the future caller handles both outcomes explicitly.
  - `omp_fulfilled` (the fan-out default **and** a configured rule) ships nothing — the OMP fulfils externally; read-back is #834.
  - `ol_managed_carrier` and `source_brokered` share **one** path (topology is enforced at rule-creation by #832, not at dispatch), so **#833 needs zero seam rework**.
  - Idempotent (`findActiveByOrderId` guard); persists `failed` + rethrows on `generateLabel` error; invariant guards throw the typed `UndispatchableResolutionException`.
- `ShipmentDispatchInput` (a thin `Omit<GenerateLabelCommand, …>` reshape) + `IShipmentDispatchService` + `SHIPMENT_DISPATCH_SERVICE_TOKEN`; `ShippingModule` imports Mappings/Integrations (allowed cross-context surface; dependency map updated).
- **No new port, no migration.**

## ⚠️ Unwired (by design)

There is **no trigger / call-site** yet — that's #769/#771, exactly as #832 left `resolve()` unwired. Nothing in production calls `dispatch()` from this PR.

## Carried-forward hazards (documented in code + plan §6)

- **Idempotency is best-effort** — the `findActiveByOrderId` → `create` check is **not concurrency-safe**; the live call-site (#769/#771) must serialise dispatch per order (the schema allows N shipments/order by design, so there's no DB guard).
- **Provider partial-failure** — a `generateLabel` that commits provider-side then fails its response can double-create on re-dispatch; adapters (#812/#833) should use `GenerateLabelCommand.shipmentId` as a provider-side idempotency key.

## Tests / verification

- **Unit** (`shipment-dispatch.service.spec.ts`): every branch — omp_fulfilled default + configured, ol_managed_carrier happy path, source_brokered identical path, idempotency, `failed`+rethrow, exhaustiveness guard.
- **Integration** (`shipment-dispatch.int-spec.ts`): full real stack — `replaceRules` compatibility → `resolve` → dispatch → persist, against real Postgres with a `ShippingProviderManager` stub registered through the adapter-registry seam (real ShipX/Allegro HTTP would be unviable in CI).
- Gate: `pnpm type-check` ✓ · `pnpm lint` 0 errors + `check:invariants` conform ✓ · unit **core 858 / api 402 / worker 141** ✓ · integration **3/3** ✓.

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)