### PR TITLE
feat(mappings): shipment-routing config API + FE (#836)

### DIFF
--- a/apps/api/src/mappings/http/dto/candidate-processor-response.dto.ts
+++ b/apps/api/src/mappings/http/dto/candidate-processor-response.dto.ts
@@ -1,0 +1,31 @@
+/**
+ * Candidate Processor Response DTO
+ *
+ * A processor option the operator may route a delivery method to (#836).
+ * IDs + kind only — the FE resolves the connection's display name
+ * (ConnectionEntityLabel) and maps the kind to a label client-side.
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  FulfillmentProcessorKindValues,
+  type CandidateProcessor,
+  type FulfillmentProcessorKind,
+} from '@openlinker/core/mappings';
+
+export class CandidateProcessorResponseDto {
+  @ApiProperty({ enum: FulfillmentProcessorKindValues })
+  processorKind!: FulfillmentProcessorKind;
+
+  @ApiProperty()
+  processorConnectionId!: string;
+
+  static fromDomain(candidate: CandidateProcessor): CandidateProcessorResponseDto {
+    const dto = new CandidateProcessorResponseDto();
+    dto.processorKind = candidate.processorKind;
+    dto.processorConnectionId = candidate.processorConnectionId;
+    return dto;
+  }
+}

--- a/apps/api/src/mappings/http/dto/routing-rule-input.dto.ts
+++ b/apps/api/src/mappings/http/dto/routing-rule-input.dto.ts
@@ -1,0 +1,36 @@
+/**
+ * Routing Rule Input DTO
+ *
+ * Single fulfillment-routing rule item used in replace (PUT) requests (#836).
+ * "Default / PrestaShop-fulfilled" methods are represented by rule ABSENCE —
+ * the FE submits only diverted methods, so every item here names an explicit
+ * processor. Mirrors the carrier-mapping input-DTO shape.
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsIn, IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  FulfillmentProcessorKindValues,
+  type FulfillmentProcessorKind,
+} from '@openlinker/core/mappings';
+
+export class RoutingRuleInputDto {
+  @ApiProperty({
+    description: 'Source delivery method id (e.g. an Allegro delivery.method.id)',
+    example: '2488f7b7-5d1c-4d65-b85c-4cbcf253fd93',
+  })
+  @IsString()
+  @IsNotEmpty()
+  sourceDeliveryMethodId!: string;
+
+  @ApiProperty({ enum: FulfillmentProcessorKindValues })
+  @IsIn([...FulfillmentProcessorKindValues])
+  processorKind!: FulfillmentProcessorKind;
+
+  @ApiProperty({ description: 'The connection that fulfils this method' })
+  @IsString()
+  @IsNotEmpty()
+  processorConnectionId!: string;
+}

--- a/apps/api/src/mappings/http/dto/routing-rule-response.dto.ts
+++ b/apps/api/src/mappings/http/dto/routing-rule-response.dto.ts
@@ -1,0 +1,41 @@
+/**
+ * Routing Rule Response DTO
+ *
+ * Wire shape for a persisted fulfillment-routing rule (#836).
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  FulfillmentProcessorKindValues,
+  type FulfillmentProcessorKind,
+  type FulfillmentRoutingRule,
+} from '@openlinker/core/mappings';
+
+export class RoutingRuleResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  sourceConnectionId!: string;
+
+  @ApiProperty()
+  sourceDeliveryMethodId!: string;
+
+  @ApiProperty({ enum: FulfillmentProcessorKindValues })
+  processorKind!: FulfillmentProcessorKind;
+
+  @ApiProperty()
+  processorConnectionId!: string;
+
+  static fromDomain(rule: FulfillmentRoutingRule): RoutingRuleResponseDto {
+    const dto = new RoutingRuleResponseDto();
+    dto.id = rule.id;
+    dto.sourceConnectionId = rule.sourceConnectionId;
+    dto.sourceDeliveryMethodId = rule.sourceDeliveryMethodId;
+    dto.processorKind = rule.processorKind;
+    dto.processorConnectionId = rule.processorConnectionId;
+    return dto;
+  }
+}

--- a/apps/api/src/mappings/http/dto/upsert-routing-rules.dto.ts
+++ b/apps/api/src/mappings/http/dto/upsert-routing-rules.dto.ts
@@ -1,0 +1,22 @@
+/**
+ * Upsert Routing Rules DTO
+ *
+ * Replace-all body for a source connection's fulfillment-routing rules (#836).
+ * Only diverted methods are included; omitted methods fall back to the
+ * `omp_fulfilled` default (rule absence).
+ *
+ * @module apps/api/src/mappings/http/dto
+ */
+
+import { IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { RoutingRuleInputDto } from './routing-rule-input.dto';
+
+export class UpsertRoutingRulesDto {
+  @ApiProperty({ type: [RoutingRuleInputDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => RoutingRuleInputDto)
+  items!: RoutingRuleInputDto[];
+}

--- a/apps/api/src/mappings/http/fulfillment-routing.controller.spec.ts
+++ b/apps/api/src/mappings/http/fulfillment-routing.controller.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Fulfillment Routing Controller unit tests (#836).
+ *
+ * Mocks IFulfillmentRoutingService. Covers delegation + DTO mapping and the
+ * full domain-exception → HTTP mapping (404 / 400) at the boundary.
+ */
+
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  type IFulfillmentRoutingService,
+  FulfillmentRoutingRule,
+  IncompatibleProcessorException,
+  DuplicateRoutingRuleException,
+} from '@openlinker/core/mappings';
+import {
+  ConnectionNotFoundException,
+  ConnectionDisabledException,
+} from '@openlinker/core/identifier-mapping';
+import { FulfillmentRoutingController } from './fulfillment-routing.controller';
+import { UpsertRoutingRulesDto } from './dto/upsert-routing-rules.dto';
+
+const SOURCE = 'conn-allegro';
+
+function makeRule(): FulfillmentRoutingRule {
+  return new FulfillmentRoutingRule(
+    'rule-1',
+    SOURCE,
+    'method-x',
+    'ol_managed_carrier',
+    'conn-inpost',
+    new Date(),
+    new Date(),
+  );
+}
+
+function dto(): UpsertRoutingRulesDto {
+  const d = new UpsertRoutingRulesDto();
+  d.items = [
+    { sourceDeliveryMethodId: 'method-x', processorKind: 'ol_managed_carrier', processorConnectionId: 'conn-inpost' },
+  ];
+  return d;
+}
+
+describe('FulfillmentRoutingController', () => {
+  let routing: jest.Mocked<IFulfillmentRoutingService>;
+  let controller: FulfillmentRoutingController;
+
+  beforeEach(() => {
+    routing = {
+      getRules: jest.fn(),
+      getCandidateProcessors: jest.fn(),
+      replaceRules: jest.fn(),
+      resolve: jest.fn(),
+    };
+    controller = new FulfillmentRoutingController(routing);
+  });
+
+  describe('getRules', () => {
+    it('should map persisted rules to response DTOs', async () => {
+      routing.getRules.mockResolvedValue([makeRule()]);
+
+      const result = await controller.getRules(SOURCE);
+
+      expect(routing.getRules).toHaveBeenCalledWith(SOURCE);
+      expect(result).toEqual([
+        {
+          id: 'rule-1',
+          sourceConnectionId: SOURCE,
+          sourceDeliveryMethodId: 'method-x',
+          processorKind: 'ol_managed_carrier',
+          processorConnectionId: 'conn-inpost',
+        },
+      ]);
+    });
+  });
+
+  describe('getCandidates', () => {
+    it('should map candidates to response DTOs', async () => {
+      routing.getCandidateProcessors.mockResolvedValue([
+        { processorKind: 'omp_fulfilled', processorConnectionId: 'conn-ps' },
+      ]);
+
+      const result = await controller.getCandidates(SOURCE);
+
+      expect(result).toEqual([{ processorKind: 'omp_fulfilled', processorConnectionId: 'conn-ps' }]);
+    });
+
+    it('should map ConnectionNotFoundException to 404', async () => {
+      routing.getCandidateProcessors.mockRejectedValue(new ConnectionNotFoundException(SOURCE));
+
+      await expect(controller.getCandidates(SOURCE)).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('replaceRules', () => {
+    it('should delegate and map the result', async () => {
+      routing.replaceRules.mockResolvedValue([makeRule()]);
+
+      const result = await controller.replaceRules(SOURCE, dto());
+
+      expect(routing.replaceRules).toHaveBeenCalledWith(SOURCE, dto().items);
+      expect(result).toHaveLength(1);
+    });
+
+    it('should map IncompatibleProcessorException to 400', async () => {
+      routing.replaceRules.mockRejectedValue(
+        new IncompatibleProcessorException('conn-inpost', 'ol_managed_carrier', 'nope'),
+      );
+
+      await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should map DuplicateRoutingRuleException to 400', async () => {
+      routing.replaceRules.mockRejectedValue(new DuplicateRoutingRuleException('method-x'));
+
+      await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should map ConnectionDisabledException to 400', async () => {
+      routing.replaceRules.mockRejectedValue(new ConnectionDisabledException('conn-inpost'));
+
+      await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should map ConnectionNotFoundException to 404', async () => {
+      routing.replaceRules.mockRejectedValue(new ConnectionNotFoundException(SOURCE));
+
+      await expect(controller.replaceRules(SOURCE, dto())).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/mappings/http/fulfillment-routing.controller.spec.ts
+++ b/apps/api/src/mappings/http/fulfillment-routing.controller.spec.ts
@@ -72,6 +72,12 @@ describe('FulfillmentRoutingController', () => {
         },
       ]);
     });
+
+    it('should map ConnectionNotFoundException to 404', async () => {
+      routing.getRules.mockRejectedValue(new ConnectionNotFoundException(SOURCE));
+
+      await expect(controller.getRules(SOURCE)).rejects.toBeInstanceOf(NotFoundException);
+    });
   });
 
   describe('getCandidates', () => {

--- a/apps/api/src/mappings/http/fulfillment-routing.controller.ts
+++ b/apps/api/src/mappings/http/fulfillment-routing.controller.ts
@@ -1,0 +1,119 @@
+/**
+ * Fulfillment Routing Controller
+ *
+ * HTTP REST endpoints for connection-scoped fulfillment-routing rules (#836).
+ * `:connectionId` is the **source** (order-source) connection. Operators read
+ * and replace the rules that *divert* a source delivery method away from the
+ * default PrestaShop-fulfilled path to an OL-managed carrier or a source-brokered
+ * processor, and list the compatible processor candidates for the config UI.
+ * Routing domain exceptions are mapped to HTTP at this boundary. Admin + JWT.
+ *
+ * @module apps/api/src/mappings/http
+ */
+
+import {
+  Controller,
+  Get,
+  Put,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import {
+  type IFulfillmentRoutingService,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IncompatibleProcessorException,
+  DuplicateRoutingRuleException,
+} from '@openlinker/core/mappings';
+import {
+  ConnectionNotFoundException,
+  ConnectionDisabledException,
+} from '@openlinker/core/identifier-mapping';
+import { UpsertRoutingRulesDto } from './dto/upsert-routing-rules.dto';
+import { RoutingRuleResponseDto } from './dto/routing-rule-response.dto';
+import { CandidateProcessorResponseDto } from './dto/candidate-processor-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('mappings')
+@Controller('connections/:connectionId/routing-rules')
+export class FulfillmentRoutingController {
+  constructor(
+    @Inject(FULFILLMENT_ROUTING_SERVICE_TOKEN)
+    private readonly routing: IFulfillmentRoutingService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get fulfillment-routing rules for a source connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [RoutingRuleResponseDto] })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async getRules(@Param('connectionId') connectionId: string): Promise<RoutingRuleResponseDto[]> {
+    const rules = await this.routing.getRules(connectionId);
+    return rules.map((rule) => RoutingRuleResponseDto.fromDomain(rule));
+  }
+
+  @Get('candidates')
+  @ApiOperation({
+    summary: 'List processors a source connection may route its delivery methods to',
+  })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [CandidateProcessorResponseDto] })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
+  async getCandidates(
+    @Param('connectionId') connectionId: string,
+  ): Promise<CandidateProcessorResponseDto[]> {
+    try {
+      const candidates = await this.routing.getCandidateProcessors(connectionId);
+      return candidates.map((candidate) => CandidateProcessorResponseDto.fromDomain(candidate));
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+  }
+
+  @Put()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Replace all fulfillment-routing rules for a source connection' })
+  @ApiParam({ name: 'connectionId', type: String })
+  @ApiResponse({ status: 200, type: [RoutingRuleResponseDto] })
+  @ApiResponse({ status: 400, description: 'Incompatible processor, duplicate method, or disabled connection' })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async replaceRules(
+    @Param('connectionId') connectionId: string,
+    @Body() dto: UpsertRoutingRulesDto,
+  ): Promise<RoutingRuleResponseDto[]> {
+    try {
+      const rules = await this.routing.replaceRules(connectionId, dto.items);
+      return rules.map((rule) => RoutingRuleResponseDto.fromDomain(rule));
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+  }
+
+  /**
+   * Map the full set of routing domain exceptions to HTTP. `replaceRules` /
+   * `getCandidateProcessors` resolve adapter metadata, so connection errors
+   * surface here alongside the compatibility/duplicate errors — none may fall
+   * through to a 500 on ordinary bad input.
+   */
+  private toHttpException(error: unknown): Error {
+    if (error instanceof ConnectionNotFoundException) {
+      return new NotFoundException(error.message);
+    }
+    if (
+      error instanceof ConnectionDisabledException ||
+      error instanceof IncompatibleProcessorException ||
+      error instanceof DuplicateRoutingRuleException
+    ) {
+      return new BadRequestException(error.message);
+    }
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}

--- a/apps/api/src/mappings/http/fulfillment-routing.controller.ts
+++ b/apps/api/src/mappings/http/fulfillment-routing.controller.ts
@@ -53,10 +53,15 @@ export class FulfillmentRoutingController {
   @ApiOperation({ summary: 'Get fulfillment-routing rules for a source connection' })
   @ApiParam({ name: 'connectionId', type: String })
   @ApiResponse({ status: 200, type: [RoutingRuleResponseDto] })
+  @ApiResponse({ status: 404, description: 'Connection not found' })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async getRules(@Param('connectionId') connectionId: string): Promise<RoutingRuleResponseDto[]> {
-    const rules = await this.routing.getRules(connectionId);
-    return rules.map((rule) => RoutingRuleResponseDto.fromDomain(rule));
+    try {
+      const rules = await this.routing.getRules(connectionId);
+      return rules.map((rule) => RoutingRuleResponseDto.fromDomain(rule));
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
   }
 
   @Get('candidates')

--- a/apps/api/src/mappings/mappings.module.ts
+++ b/apps/api/src/mappings/mappings.module.ts
@@ -14,6 +14,7 @@ import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { CategoriesModule } from '../categories/categories.module';
 import { MappingsController } from './http/mappings.controller';
 import { MappingOptionsController } from './http/mapping-options.controller';
+import { FulfillmentRoutingController } from './http/fulfillment-routing.controller';
 
 @Module({
   // - CoreIntegrationsModule provides INTEGRATIONS_SERVICE_TOKEN — the
@@ -26,6 +27,6 @@ import { MappingOptionsController } from './http/mapping-options.controller';
   //   IdentifierMappingModule but does not re-export the token, so the
   //   import here is direct.
   imports: [CoreMappingsModule, CoreIntegrationsModule, IdentifierMappingModule, CategoriesModule],
-  controllers: [MappingsController, MappingOptionsController],
+  controllers: [MappingsController, MappingOptionsController, FulfillmentRoutingController],
 })
 export class MappingsApiModule {}

--- a/apps/api/test/integration/routing-rules.int-spec.ts
+++ b/apps/api/test/integration/routing-rules.int-spec.ts
@@ -1,0 +1,200 @@
+/**
+ * Fulfillment Routing HTTP Integration Test (#836)
+ *
+ * Vertical slice for the connection-scoped routing-rules API: the
+ * `FulfillmentRoutingController` routes (GET / PUT / GET candidates) end-to-end
+ * through the booted Nest app, real Postgres (Testcontainers), JWT auth and the
+ * `@Roles('admin')` guard. Asserts the read-candidates / write-validation
+ * symmetry (both driven by the shared compatibility predicate) and the domain
+ * → HTTP exception mapping (incompatible → 400, unknown connection → 404).
+ *
+ * The service-level persistence / resolution semantics are covered separately
+ * in `fulfillment-routing.int-spec.ts` — this spec owns the HTTP boundary.
+ *
+ * @module apps/api/test/integration
+ */
+import * as bcrypt from 'bcryptjs';
+import { FULFILLMENT_PROCESSOR_KIND } from '@openlinker/core/mappings';
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import type { IntegrationTestHarness } from './setup';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+import { createTestConnection } from './helpers/test-connection.helper';
+
+interface SeededConnections {
+  /** Allegro order source (`allegro.publicapi.v1` — OrderSource / OfferManager). */
+  sourceId: string;
+  /** PrestaShop OMP (`prestashop.webservice.v1` — OrderProcessorManager). */
+  prestashopId: string;
+  /** InPost OL-managed carrier (`inpost.shipx.v1` — ShippingProviderManager). */
+  inpostId: string;
+}
+
+describe('Fulfillment Routing HTTP Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function seedConnections(): Promise<SeededConnections> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    const prestashop = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      name: 'PrestaShop OMP',
+      adapterKey: 'prestashop.webservice.v1',
+      enabledCapabilities: ['OrderProcessorManager'],
+    });
+    const inpost = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: 'inpost.shipx.v1',
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    return { sourceId: source.id, prestashopId: prestashop.id, inpostId: inpost.id };
+  }
+
+  async function loginAsViewer(username = 'viewer'): Promise<string> {
+    const passwordHash = await bcrypt.hash('viewer-pass', 4);
+    await harness.getDataSource().query(
+      `INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, $3, 'viewer')`,
+      [username, `${username}@example.com`, passwordHash],
+    );
+    const response = await harness
+      .getHttp()
+      .post('/auth/login')
+      .send({ username, password: 'viewer-pass' })
+      .expect(200);
+    return response.body.access_token as string;
+  }
+
+  it('round-trips rules through PUT then GET', async () => {
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+    const { sourceId, prestashopId, inpostId } = await seedConnections();
+
+    // Empty before any write.
+    const initial = await http
+      .get(`/connections/${sourceId}/routing-rules`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(initial.body).toEqual([]);
+
+    const putRes = await http
+      .put(`/connections/${sourceId}/routing-rules`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        items: [
+          {
+            sourceDeliveryMethodId: 'allegro-courier',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+            processorConnectionId: prestashopId,
+          },
+          {
+            sourceDeliveryMethodId: 'allegro-one-box',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+            processorConnectionId: inpostId,
+          },
+        ],
+      })
+      .expect(200);
+    expect(putRes.body).toHaveLength(2);
+
+    const getRes = await http
+      .get(`/connections/${sourceId}/routing-rules`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const byMethod = new Map<string, { processorKind: string; processorConnectionId: string }>(
+      (getRes.body as { sourceDeliveryMethodId: string; processorKind: string; processorConnectionId: string }[]).map(
+        (r) => [r.sourceDeliveryMethodId, r],
+      ),
+    );
+    expect(byMethod.get('allegro-courier')).toMatchObject({
+      processorKind: 'omp_fulfilled',
+      processorConnectionId: prestashopId,
+    });
+    expect(byMethod.get('allegro-one-box')).toMatchObject({
+      processorKind: 'ol_managed_carrier',
+      processorConnectionId: inpostId,
+    });
+  });
+
+  it('lists the capability-compatible candidates for the source connection', async () => {
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+    const { sourceId, prestashopId, inpostId } = await seedConnections();
+
+    const res = await http
+      .get(`/connections/${sourceId}/routing-rules/candidates`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const candidates = res.body as { processorKind: string; processorConnectionId: string }[];
+    // PrestaShop is the only OMP-capable processor; InPost the only shipping
+    // carrier. Allegro (source) declares neither, so it is not a candidate.
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        { processorKind: 'omp_fulfilled', processorConnectionId: prestashopId },
+        { processorKind: 'ol_managed_carrier', processorConnectionId: inpostId },
+      ]),
+    );
+    expect(candidates).toHaveLength(2);
+  });
+
+  it('rejects an incompatible processor with 400', async () => {
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+    const { sourceId } = await seedConnections();
+
+    // Routing an OMP rule at the Allegro source itself — Allegro does not
+    // declare OrderProcessorManager.
+    await http
+      .put(`/connections/${sourceId}/routing-rules`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        items: [
+          {
+            sourceDeliveryMethodId: 'allegro-courier',
+            processorKind: FULFILLMENT_PROCESSOR_KIND.OmpFulfilled,
+            processorConnectionId: sourceId,
+          },
+        ],
+      })
+      .expect(400);
+  });
+
+  it('returns 404 when listing candidates for an unknown connection', async () => {
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    await http
+      .get('/connections/ol_connection_does_not_exist/routing-rules/candidates')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404);
+  });
+
+  it('rejects a non-admin caller with 403', async () => {
+    const http = harness.getHttp();
+    const { sourceId } = await seedConnections();
+    const viewerToken = await loginAsViewer();
+
+    await http
+      .get(`/connections/${sourceId}/routing-rules`)
+      .set('Authorization', `Bearer ${viewerToken}`)
+      .expect(403);
+  });
+});

--- a/apps/web/src/features/mappings/api/mappings.api.ts
+++ b/apps/web/src/features/mappings/api/mappings.api.ts
@@ -29,6 +29,9 @@ import type {
   UpsertCarrierMappingsPayload,
   UpsertPaymentMappingsPayload,
   UpsertCategoryMappingPayload,
+  RoutingRule,
+  CandidateProcessor,
+  UpsertRoutingRulesPayload,
 } from './mappings.types';
 
 export interface MappingsApi {
@@ -58,6 +61,14 @@ export interface MappingsApi {
   deleteCategoryMapping: (connectionId: string, prestashopCategoryId: string) => Promise<void>;
   getAllegroCategories: (connectionId: string, parentId?: string) => Promise<AllegroCategory[]>;
   getPrestashopCategories: (connectionId: string) => Promise<PrestashopCategory[]>;
+
+  // Fulfillment routing (#836) — sibling of /mappings, keyed on the source connection.
+  getRoutingRules: (connectionId: string) => Promise<RoutingRule[]>;
+  replaceRoutingRules: (
+    connectionId: string,
+    payload: UpsertRoutingRulesPayload,
+  ) => Promise<RoutingRule[]>;
+  getRoutingCandidates: (connectionId: string) => Promise<CandidateProcessor[]>;
 }
 
 interface ApiRequest {
@@ -92,6 +103,18 @@ export function createMappingsApi(request: ApiRequest): MappingsApi {
         method: 'PUT',
         body: JSON.stringify(payload),
       }),
+
+    getRoutingRules: (connectionId) =>
+      request<RoutingRule[]>(`/connections/${connectionId}/routing-rules`),
+
+    replaceRoutingRules: (connectionId, payload) =>
+      request<RoutingRule[]>(`/connections/${connectionId}/routing-rules`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      }),
+
+    getRoutingCandidates: (connectionId) =>
+      request<CandidateProcessor[]>(`/connections/${connectionId}/routing-rules/candidates`),
 
     getMappingOptions: (connectionId, side, kind) =>
       request<MappingOption[]>(

--- a/apps/web/src/features/mappings/api/mappings.query-keys.ts
+++ b/apps/web/src/features/mappings/api/mappings.query-keys.ts
@@ -16,4 +16,8 @@ export const mappingsQueryKeys = {
   categories: (connectionId: string) => ['mappings', connectionId, 'categories'] as const,
   allegroCategories: (connectionId: string, parentId?: string) =>
     ['mappings', connectionId, 'allegro-categories', parentId ?? 'root'] as const,
+  /** Fulfillment-routing rules + candidate processors for a source connection (#836). */
+  routingRules: (connectionId: string) => ['mappings', connectionId, 'routing-rules'] as const,
+  routingCandidates: (connectionId: string) =>
+    ['mappings', connectionId, 'routing-candidates'] as const,
 };

--- a/apps/web/src/features/mappings/api/mappings.types.ts
+++ b/apps/web/src/features/mappings/api/mappings.types.ts
@@ -123,6 +123,41 @@ export interface UpsertCategoryMappingPayload {
   allegroCategoryPath?: string;
 }
 
+// ── Fulfillment routing (#836) ─────────────────────────────────────────────
+
+/** Mirrors the backend `FulfillmentProcessorKind` (`@openlinker/core/mappings`). */
+export const FulfillmentProcessorKindValues = [
+  'omp_fulfilled',
+  'ol_managed_carrier',
+  'source_brokered',
+] as const;
+export type FulfillmentProcessorKind = (typeof FulfillmentProcessorKindValues)[number];
+
+/** A persisted routing rule — a source delivery method diverted away from the PS default. */
+export interface RoutingRule {
+  id: string;
+  sourceConnectionId: string;
+  sourceDeliveryMethodId: string;
+  processorKind: FulfillmentProcessorKind;
+  processorConnectionId: string;
+}
+
+export interface RoutingRuleInput {
+  sourceDeliveryMethodId: string;
+  processorKind: FulfillmentProcessorKind;
+  processorConnectionId: string;
+}
+
+export interface UpsertRoutingRulesPayload {
+  items: RoutingRuleInput[];
+}
+
+/** A processor a delivery method may be routed to (from the candidates endpoint). */
+export interface CandidateProcessor {
+  processorKind: FulfillmentProcessorKind;
+  processorConnectionId: string;
+}
+
 // ── Mapping options bundle ────────────────────────────────────────────────
 
 export interface MappingOptions {

--- a/apps/web/src/features/mappings/components/routing-rules-panel.test.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * RoutingRulesPanel tests (#836)
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import type { ComponentProps } from 'react';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import { RoutingRulesPanel } from './routing-rules-panel';
+import type { MappingsApi } from '../api/mappings.api';
+import type {
+  CandidateProcessor,
+  MappingOption,
+  RoutingRule,
+} from '../api/mappings.types';
+import type { Connection } from '../../connections';
+
+const DELIVERY_METHODS: MappingOption[] = [
+  { value: 'm1', label: 'InPost Paczkomat' },
+  { value: 'm2', label: 'Kurier24' },
+];
+
+const CANDIDATES: CandidateProcessor[] = [
+  { processorKind: 'omp_fulfilled', processorConnectionId: 'conn_ps' },
+  { processorKind: 'source_brokered', processorConnectionId: 'conn_allegro' },
+  { processorKind: 'ol_managed_carrier', processorConnectionId: 'conn_inpost' },
+];
+
+const CONNECTIONS: Connection[] = [
+  { ...sampleConnection, id: 'conn_ps', name: 'My Shop' },
+  { ...sampleConnection, id: 'conn_allegro', name: 'Allegro Main' },
+  { ...sampleConnection, id: 'conn_inpost', name: 'InPost' },
+];
+
+interface RoutingMocks {
+  rules?: RoutingRule[];
+  candidates?: CandidateProcessor[];
+  replace?: ReturnType<typeof vi.fn>;
+}
+
+function buildApiClient(mocks: RoutingMocks = {}): ReturnType<typeof createMockApiClient> {
+  return createMockApiClient({
+    mappings: {
+      getRoutingRules: vi.fn().mockResolvedValue(mocks.rules ?? []),
+      getRoutingCandidates: vi.fn().mockResolvedValue(mocks.candidates ?? CANDIDATES),
+      replaceRoutingRules: (mocks.replace ??
+        vi.fn().mockResolvedValue([])) as MappingsApi['replaceRoutingRules'],
+    },
+    connections: {
+      list: vi.fn().mockResolvedValue(CONNECTIONS),
+    },
+  });
+}
+
+function renderPanel(
+  apiClient: ReturnType<typeof createMockApiClient>,
+  props: Partial<ComponentProps<typeof RoutingRulesPanel>> = {},
+): void {
+  renderWithProviders(
+    <RoutingRulesPanel
+      connectionId="conn_1"
+      deliveryMethods={DELIVERY_METHODS}
+      deliveryMethodsLoading={false}
+      deliveryMethodsError={null}
+      {...props}
+    />,
+    { apiClient },
+  );
+}
+
+describe('RoutingRulesPanel', () => {
+  afterEach(cleanup);
+
+  it('shows the loading state while delivery methods load', () => {
+    renderPanel(buildApiClient(), { deliveryMethodsLoading: true });
+    expect(screen.getByText('Loading fulfillment routing')).toBeInTheDocument();
+  });
+
+  it('shows the error state when delivery methods fail to load', async () => {
+    renderPanel(buildApiClient(), { deliveryMethodsError: new Error('boom') });
+    // The panel's own queries settle first; once they do, the injected
+    // delivery-methods error wins over the (loaded) empty data.
+    expect(
+      await screen.findByText('Unable to load routing configuration'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when the source reports no delivery methods', async () => {
+    renderPanel(buildApiClient(), { deliveryMethods: [] });
+    expect(
+      await screen.findByText(/reported no delivery methods to route/i),
+    ).toBeInTheDocument();
+  });
+
+  it('defaults every method to the OMP and offers only non-OMP divert options', async () => {
+    renderPanel(buildApiClient());
+
+    const select = await screen.findByRole('combobox', {
+      name: /Fulfillment processor for InPost Paczkomat/i,
+    });
+    // Default selection is rule-absence.
+    expect(select).toHaveValue('__default__');
+
+    const optionLabels = within(select)
+      .getAllByRole('option')
+      .map((o) => o.textContent ?? '');
+    // Default option is data-driven from the omp_fulfilled candidate's connection.
+    expect(optionLabels.some((l) => /My Shop.*default/.test(l))).toBe(true);
+    // omp_fulfilled is the default — never offered as an explicit divert option.
+    expect(optionLabels.some((l) => l.includes('Order-management platform'))).toBe(false);
+    // The two non-OMP candidates ARE offered.
+    expect(optionLabels.some((l) => l.includes('Marketplace-brokered'))).toBe(true);
+    expect(optionLabels.some((l) => l.includes('OpenLinker-managed carrier'))).toBe(true);
+  });
+
+  it('persists only diverted methods via the replace-all mutation', async () => {
+    const replace = vi.fn().mockResolvedValue([]);
+    renderPanel(buildApiClient({ replace }));
+
+    const select = await screen.findByRole('combobox', {
+      name: /Fulfillment processor for InPost Paczkomat/i,
+    });
+    fireEvent.change(select, { target: { value: 'source_brokered::conn_allegro' } });
+
+    expect(await screen.findByText('Unsaved changes')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save routing' }));
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('conn_1', {
+        items: [
+          {
+            sourceDeliveryMethodId: 'm1',
+            processorKind: 'source_brokered',
+            processorConnectionId: 'conn_allegro',
+          },
+        ],
+      });
+    });
+  });
+
+  it('pre-populates a saved rule and stays clean until edited', async () => {
+    const rules: RoutingRule[] = [
+      {
+        id: 'r1',
+        sourceConnectionId: 'conn_1',
+        sourceDeliveryMethodId: 'm1',
+        processorKind: 'ol_managed_carrier',
+        processorConnectionId: 'conn_inpost',
+      },
+    ];
+    renderPanel(buildApiClient({ rules }));
+
+    const select = await screen.findByRole('combobox', {
+      name: /Fulfillment processor for InPost Paczkomat/i,
+    });
+    await waitFor(() => {
+      expect(select).toHaveValue('ol_managed_carrier::conn_inpost');
+    });
+    expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/mappings/components/routing-rules-panel.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.tsx
@@ -1,0 +1,311 @@
+/**
+ * RoutingRulesPanel (#836)
+ *
+ * Default-vs-divert editor for fulfillment routing. Lists every source
+ * delivery method; each stays with the default order-management platform
+ * (rule absence) unless the operator diverts it to a compatible processor.
+ * The divert dropdown is filtered to the candidates the backend reports as
+ * capability-compatible for this source connection. Mirrors the structure
+ * and density of the sibling `MappingPanel`.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
+import { ConnectionEntityLabel, useConnectionsQuery } from '../../connections';
+import {
+  useRoutingRulesQuery,
+  useRoutingCandidatesQuery,
+  useReplaceRoutingRules,
+} from '../hooks/use-routing-rules';
+import {
+  FulfillmentProcessorKindValues,
+  type FulfillmentProcessorKind,
+  type MappingOption,
+  type RoutingRuleInput,
+} from '../api/mappings.types';
+
+interface RoutingRulesPanelProps {
+  connectionId: string;
+  /** Source delivery methods to route — owned by the page's `useMappingOptions`. */
+  deliveryMethods: MappingOption[];
+  deliveryMethodsLoading: boolean;
+  deliveryMethodsError: Error | null;
+}
+
+/** Sentinel selection key meaning "no rule" → the default OMP fulfils the method. */
+const DEFAULT_KEY = '__default__';
+
+/** Human qualifier shown before the connection name in dropdowns + row display. */
+const PROCESSOR_KIND_LABEL: Record<FulfillmentProcessorKind, string> = {
+  omp_fulfilled: 'Order-management platform',
+  ol_managed_carrier: 'OpenLinker-managed carrier',
+  source_brokered: 'Marketplace-brokered',
+};
+
+/** Truncates long ids (Allegro UUIDs) for inline hints; short ids render verbatim (#474). */
+function shortValue(value: string): string {
+  return value.length <= 9 ? value : `${value.slice(0, 8)}…`;
+}
+
+/** `${kind}::${connectionId}` → its parts, or null for the default sentinel / malformed keys. */
+function parseSelectionKey(
+  key: string,
+): { kind: FulfillmentProcessorKind; connectionId: string } | null {
+  if (key === DEFAULT_KEY) return null;
+  const idx = key.indexOf('::');
+  if (idx < 0) return null;
+  const kind = key.slice(0, idx) as FulfillmentProcessorKind;
+  const connectionId = key.slice(idx + 2);
+  if (!FulfillmentProcessorKindValues.includes(kind) || connectionId.length === 0) return null;
+  return { kind, connectionId };
+}
+
+interface DivertOption {
+  key: string;
+  label: string;
+}
+
+export function RoutingRulesPanel({
+  connectionId,
+  deliveryMethods,
+  deliveryMethodsLoading,
+  deliveryMethodsError,
+}: RoutingRulesPanelProps): ReactElement {
+  const rulesQuery = useRoutingRulesQuery(connectionId);
+  const candidatesQuery = useRoutingCandidatesQuery(connectionId);
+  const connectionsQuery = useConnectionsQuery();
+  const replaceMutation = useReplaceRoutingRules(connectionId);
+
+  const savedRules = useMemo(() => rulesQuery.data ?? [], [rulesQuery.data]);
+
+  // Persisted selection per method (`${kind}::${connId}`); methods absent here default.
+  const savedKeyByMethod = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const rule of savedRules) {
+      map.set(rule.sourceDeliveryMethodId, `${rule.processorKind}::${rule.processorConnectionId}`);
+    }
+    return map;
+  }, [savedRules]);
+
+  const [selections, setSelections] = useState<Record<string, string>>(() =>
+    Object.fromEntries(savedKeyByMethod),
+  );
+
+  // Resync local edits to server state after a successful save / refetch.
+  useEffect(() => {
+    setSelections(Object.fromEntries(savedKeyByMethod));
+  }, [savedKeyByMethod]);
+
+  const connectionNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const conn of connectionsQuery.data ?? []) map.set(conn.id, conn.name);
+    return map;
+  }, [connectionsQuery.data]);
+
+  function connName(id: string): string {
+    return connectionNameById.get(id) ?? shortValue(id);
+  }
+
+  const candidates = useMemo(() => candidatesQuery.data ?? [], [candidatesQuery.data]);
+
+  // Default label is data-driven from the omp_fulfilled candidate (no hardcoded
+  // platform name) — falls back to a generic phrase when none is reported.
+  const ompCandidate = candidates.find((c) => c.processorKind === 'omp_fulfilled') ?? null;
+  const defaultLabel = ompCandidate
+    ? `${connName(ompCandidate.processorConnectionId)} — default`
+    : 'Default (order-management platform)';
+
+  // Divert options exclude omp_fulfilled — that IS the default in v1; explicit
+  // OMP pinning is the multi-OMP follow-up.
+  const divertOptions: DivertOption[] = candidates
+    .filter((c) => c.processorKind !== 'omp_fulfilled')
+    .map((c) => ({
+      key: `${c.processorKind}::${c.processorConnectionId}`,
+      label: `${PROCESSOR_KIND_LABEL[c.processorKind]} · ${connName(c.processorConnectionId)}`,
+    }));
+
+  // Render a row per delivery method, plus any saved rule whose method the
+  // source no longer reports — so a replace-all save never silently drops it.
+  const rowMethods = useMemo<MappingOption[]>(() => {
+    const known = new Set(deliveryMethods.map((m) => m.value));
+    const orphans: MappingOption[] = [];
+    for (const methodId of savedKeyByMethod.keys()) {
+      if (!known.has(methodId)) orphans.push({ value: methodId, label: methodId });
+    }
+    return [...deliveryMethods, ...orphans];
+  }, [deliveryMethods, savedKeyByMethod]);
+
+  const isDirty = rowMethods.some(
+    (m) => (selections[m.value] ?? DEFAULT_KEY) !== (savedKeyByMethod.get(m.value) ?? DEFAULT_KEY),
+  );
+
+  function optionsForRow(currentKey: string): DivertOption[] {
+    const base: DivertOption[] = [{ key: DEFAULT_KEY, label: defaultLabel }, ...divertOptions];
+    // Keep a saved selection visible even when it is no longer a live candidate
+    // (connection disabled, capability lost), so the operator can see + decide.
+    if (currentKey !== DEFAULT_KEY && !base.some((o) => o.key === currentKey)) {
+      const parsed = parseSelectionKey(currentKey);
+      base.push({
+        key: currentKey,
+        label: parsed
+          ? `${PROCESSOR_KIND_LABEL[parsed.kind]} · ${connName(parsed.connectionId)} (unavailable)`
+          : currentKey,
+      });
+    }
+    return base;
+  }
+
+  function handleSelect(methodId: string, key: string): void {
+    setSelections((prev) => ({ ...prev, [methodId]: key }));
+  }
+
+  function handleSave(): void {
+    const items: RoutingRuleInput[] = [];
+    for (const method of rowMethods) {
+      const key = selections[method.value] ?? DEFAULT_KEY;
+      const parsed = parseSelectionKey(key);
+      if (!parsed) continue;
+      items.push({
+        sourceDeliveryMethodId: method.value,
+        processorKind: parsed.kind,
+        processorConnectionId: parsed.connectionId,
+      });
+    }
+    replaceMutation.mutate({ items });
+  }
+
+  if (deliveryMethodsLoading || rulesQuery.isLoading || candidatesQuery.isLoading) {
+    return (
+      <LoadingState
+        liveRegion="off"
+        title="Loading fulfillment routing"
+        message="Fetching delivery methods and compatible processors…"
+      />
+    );
+  }
+
+  const dataError = deliveryMethodsError ?? rulesQuery.error ?? candidatesQuery.error ?? null;
+  if (dataError) {
+    return <ErrorState title="Unable to load routing configuration" message={dataError.message} />;
+  }
+
+  function renderMethodLabel(method: MappingOption): ReactNode {
+    if (method.label === method.value) {
+      return <span className="mono-text">{method.value}</span>;
+    }
+    return (
+      <>
+        {method.label}{' '}
+        <span className="mapping-id-hint mono-text">{shortValue(method.value)}</span>
+      </>
+    );
+  }
+
+  function renderRoutedTo(currentKey: string): ReactNode {
+    if (currentKey === DEFAULT_KEY) {
+      return <span className="muted-text">{defaultLabel}</span>;
+    }
+    const parsed = parseSelectionKey(currentKey);
+    if (!parsed) return <span className="mono-text">{currentKey}</span>;
+    return (
+      <>
+        <span>{PROCESSOR_KIND_LABEL[parsed.kind]}</span>{' '}
+        <ConnectionEntityLabel
+          connectionId={parsed.connectionId}
+          linkToDetail={false}
+          showId={false}
+        />
+      </>
+    );
+  }
+
+  return (
+    <div className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Configuration</p>
+          <h3 className="section-title">Fulfillment Routing</h3>
+        </div>
+        {isDirty && (
+          <span className="status-badge status-badge--warning" aria-live="polite">
+            Unsaved changes
+          </span>
+        )}
+      </div>
+
+      <p className="muted-text" style={{ marginBottom: '1rem' }}>
+        Choose how each marketplace delivery method is fulfilled. Methods stay with the default
+        order-management platform unless you divert them to a connected carrier or
+        marketplace-delivery processor.
+      </p>
+
+      {divertOptions.length === 0 && (
+        <p className="muted-text" role="status" aria-live="polite" style={{ marginBottom: '0.75rem' }}>
+          No compatible fulfillment processors are connected yet. Every method stays with the
+          default until you add a carrier-managed or marketplace-delivery connection.
+        </p>
+      )}
+
+      {rowMethods.length === 0 ? (
+        <p className="muted-text" role="status" aria-live="polite">
+          This connection reported no delivery methods to route. Routing becomes configurable once
+          the source exposes delivery methods.
+        </p>
+      ) : (
+        <table className="data-table" aria-label="Fulfillment routing rules">
+          <thead>
+            <tr>
+              <th>Delivery method</th>
+              <th>Routed to</th>
+              <th>Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rowMethods.map((method) => {
+              const currentKey = selections[method.value] ?? DEFAULT_KEY;
+              return (
+                <tr key={method.value}>
+                  <td>{renderMethodLabel(method)}</td>
+                  <td>{renderRoutedTo(currentKey)}</td>
+                  <td>
+                    <select
+                      aria-label={`Fulfillment processor for ${method.label}`}
+                      value={currentKey}
+                      onChange={(e) => { handleSelect(method.value, e.target.value); }}
+                    >
+                      {optionsForRow(currentKey).map((o) => (
+                        <option key={o.key} value={o.key}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {replaceMutation.error && (
+        <p className="error-message" role="alert" style={{ marginTop: '0.5rem' }}>
+          {replaceMutation.error.message}
+        </p>
+      )}
+
+      <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <Button tone="primary" disabled={!isDirty || replaceMutation.isPending} onClick={handleSave}>
+          {replaceMutation.isPending ? 'Saving…' : 'Save routing'}
+        </Button>
+        {replaceMutation.error && (
+          <Button tone="secondary" disabled={replaceMutation.isPending} onClick={handleSave}>
+            Try again
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/mappings/components/routing-rules-panel.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.tsx
@@ -236,14 +236,19 @@ export function RoutingRulesPanel({
         )}
       </div>
 
-      <p className="muted-text" style={{ marginBottom: '1rem' }}>
+      <p className="muted-text" style={{ marginBottom: 'var(--space-4)' }}>
         Choose how each marketplace delivery method is fulfilled. Methods stay with the default
         order-management platform unless you divert them to a connected carrier or
         marketplace-delivery processor.
       </p>
 
       {divertOptions.length === 0 && (
-        <p className="muted-text" role="status" aria-live="polite" style={{ marginBottom: '0.75rem' }}>
+        <p
+          className="muted-text"
+          role="status"
+          aria-live="polite"
+          style={{ marginBottom: 'var(--space-3)' }}
+        >
           No compatible fulfillment processors are connected yet. Every method stays with the
           default until you add a carrier-managed or marketplace-delivery connection.
         </p>
@@ -291,12 +296,19 @@ export function RoutingRulesPanel({
       )}
 
       {replaceMutation.error && (
-        <p className="error-message" role="alert" style={{ marginTop: '0.5rem' }}>
+        <p className="error-message" role="alert" style={{ marginTop: 'var(--space-2)' }}>
           {replaceMutation.error.message}
         </p>
       )}
 
-      <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+      <div
+        style={{
+          marginTop: 'var(--space-4)',
+          display: 'flex',
+          gap: 'var(--space-2)',
+          alignItems: 'center',
+        }}
+      >
         <Button tone="primary" disabled={!isDirty || replaceMutation.isPending} onClick={handleSave}>
           {replaceMutation.isPending ? 'Saving…' : 'Save routing'}
         </Button>

--- a/apps/web/src/features/mappings/hooks/use-routing-rules.ts
+++ b/apps/web/src/features/mappings/hooks/use-routing-rules.ts
@@ -23,10 +23,15 @@ import type {
   UpsertRoutingRulesPayload,
 } from '../api/mappings.types';
 
-export function useRoutingRulesQuery(connectionId: string): UseQueryResult<RoutingRule[]> {
+export function useRoutingRulesQuery(
+  connectionId: string,
+  options?: { enabled?: boolean },
+): UseQueryResult<RoutingRule[]> {
   const apiClient = useApiClient();
   return useQuery({
-    enabled: connectionId.length > 0,
+    // Caller may gate further (e.g. only for OrderSource connections); the
+    // connectionId guard always applies.
+    enabled: connectionId.length > 0 && (options?.enabled ?? true),
     queryKey: mappingsQueryKeys.routingRules(connectionId),
     queryFn: () => apiClient.mappings.getRoutingRules(connectionId),
   });

--- a/apps/web/src/features/mappings/hooks/use-routing-rules.ts
+++ b/apps/web/src/features/mappings/hooks/use-routing-rules.ts
@@ -1,0 +1,60 @@
+/**
+ * Fulfillment Routing Hooks (#836)
+ *
+ * Server-state hooks for the routing-config panel: the persisted rules, the
+ * compatible processor candidates, and the replace-all mutation. Mirrors
+ * `use-carrier-mappings`.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type UseQueryResult,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { mappingsQueryKeys } from '../api/mappings.query-keys';
+import type {
+  RoutingRule,
+  CandidateProcessor,
+  UpsertRoutingRulesPayload,
+} from '../api/mappings.types';
+
+export function useRoutingRulesQuery(connectionId: string): UseQueryResult<RoutingRule[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    enabled: connectionId.length > 0,
+    queryKey: mappingsQueryKeys.routingRules(connectionId),
+    queryFn: () => apiClient.mappings.getRoutingRules(connectionId),
+  });
+}
+
+export function useRoutingCandidatesQuery(
+  connectionId: string,
+): UseQueryResult<CandidateProcessor[]> {
+  const apiClient = useApiClient();
+  return useQuery({
+    enabled: connectionId.length > 0,
+    queryKey: mappingsQueryKeys.routingCandidates(connectionId),
+    queryFn: () => apiClient.mappings.getRoutingCandidates(connectionId),
+  });
+}
+
+export function useReplaceRoutingRules(
+  connectionId: string,
+): UseMutationResult<RoutingRule[], Error, UpsertRoutingRulesPayload> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: UpsertRoutingRulesPayload) =>
+      apiClient.mappings.replaceRoutingRules(connectionId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: mappingsQueryKeys.routingRules(connectionId),
+      });
+    },
+  });
+}

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -116,9 +116,17 @@ export function ConnectionMappingsPage(): ReactElement {
   // can't load the connection we just suppress the banner; the BE still
   // does the right thing at sync time per #516.
   const connectionQuery = useConnectionQuery(connectionId);
+
+  // The Fulfillment tab + routing rules apply only to connections that ingest
+  // orders (the routing key is a *source* delivery method). Capability-gated,
+  // not platformType-gated, so any future OrderSource adapter inherits it.
+  const supportsOrderSource =
+    connectionQuery.data?.supportedCapabilities.includes('OrderSource') ?? false;
+
   // Routing rules feed two things: the Fulfillment tab and the routing-aware
-  // carrier-banner count (#836). Deduped with the panel's own subscription.
-  const routingRulesQuery = useRoutingRulesQuery(connectionId);
+  // carrier-banner count (#836). Gated to OrderSource connections (no rules
+  // exist otherwise); deduped with the panel's own subscription.
+  const routingRulesQuery = useRoutingRulesQuery(connectionId, { enabled: supportsOrderSource });
 
   // Per-panel error isolation (#484): a failure in one bundle key must not
   // block the other tabs. Each panel only watches the two keys it actually
@@ -143,12 +151,6 @@ export function ConnectionMappingsPage(): ReactElement {
     paymentQuery.isLoading ||
     connectionQuery.isLoading;
   const loadError = statusQuery.error ?? carrierQuery.error ?? paymentQuery.error ?? null;
-
-  // The Fulfillment tab applies only to connections that ingest orders (the
-  // routing key is a *source* delivery method). Capability-gated, not
-  // platformType-gated, so any future OrderSource adapter inherits it.
-  const supportsOrderSource =
-    connectionQuery.data?.supportedCapabilities.includes('OrderSource') ?? false;
 
   const tabs: { id: TabId; label: string }[] = [
     ...(supportsOrderSource ? [{ id: 'fulfillment' as const, label: 'Fulfillment' }] : []),

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -13,22 +13,18 @@ import { PageLayout } from '../../shared/ui/page-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
 import { Alert } from '../../shared/ui/alert';
 import { MappingPanel, type MappingRow } from '../../features/mappings/components/MappingPanel';
+import { RoutingRulesPanel } from '../../features/mappings/components/routing-rules-panel';
 import { useStatusMappingsQuery, useUpsertStatusMappings } from '../../features/mappings/hooks/use-status-mappings';
 import { useCarrierMappingsQuery, useUpsertCarrierMappings } from '../../features/mappings/hooks/use-carrier-mappings';
 import { usePaymentMappingsQuery, useUpsertPaymentMappings } from '../../features/mappings/hooks/use-payment-mappings';
+import { useRoutingRulesQuery } from '../../features/mappings/hooks/use-routing-rules';
 import { useMappingOptions } from '../../features/mappings/hooks/use-mapping-options';
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
 import type { MappingOption } from '../../features/mappings/api/mappings.types';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { DesktopOnlyBanner } from '../../shared/ui/desktop-only-banner';
 
-type TabId = 'status' | 'carriers' | 'payments';
-
-const TABS: { id: TabId; label: string }[] = [
-  { id: 'status', label: 'Order Statuses' },
-  { id: 'carriers', label: 'Carriers' },
-  { id: 'payments', label: 'Payments' },
-];
+type TabId = 'fulfillment' | 'status' | 'carriers' | 'payments';
 
 interface FallbackBannerSpec {
   tone: 'info' | 'warning';
@@ -40,6 +36,11 @@ interface FallbackBannerSpec {
  * Returns null when the banner should not render (loading, errored,
  * nothing unmapped, or when we genuinely don't have enough info to
  * decide). Banner only fires on the carriers tab.
+ *
+ * `unmappedCount` is routing-aware (#836): methods diverted to a non-OMP
+ * processor (Allegro Delivery, OL-managed carrier) never flow through PS
+ * carrier mapping, so the caller excludes them before counting — the
+ * banner only warns about methods that genuinely still need a PS carrier.
  *
  * Decision tree mirrors the BE adapter's resolution chain (#516):
  *   (1) `defaultCarrierId` set        → "using fallback: {name}"   info
@@ -115,6 +116,9 @@ export function ConnectionMappingsPage(): ReactElement {
   // can't load the connection we just suppress the banner; the BE still
   // does the right thing at sync time per #516.
   const connectionQuery = useConnectionQuery(connectionId);
+  // Routing rules feed two things: the Fulfillment tab and the routing-aware
+  // carrier-banner count (#836). Deduped with the panel's own subscription.
+  const routingRulesQuery = useRoutingRulesQuery(connectionId);
 
   // Per-panel error isolation (#484): a failure in one bundle key must not
   // block the other tabs. Each panel only watches the two keys it actually
@@ -130,8 +134,29 @@ export function ConnectionMappingsPage(): ReactElement {
   const upsertCarrier = useUpsertCarrierMappings(connectionId);
   const upsertPayment = useUpsertPaymentMappings(connectionId);
 
-  const isLoading = statusQuery.isLoading || carrierQuery.isLoading || paymentQuery.isLoading;
+  // Wait for the connection too so the capability-gated Fulfillment tab doesn't
+  // pop in after load. A connection *error* is still tolerated below (the tab
+  // simply stays hidden), matching the carrier-banner's error tolerance.
+  const isLoading =
+    statusQuery.isLoading ||
+    carrierQuery.isLoading ||
+    paymentQuery.isLoading ||
+    connectionQuery.isLoading;
   const loadError = statusQuery.error ?? carrierQuery.error ?? paymentQuery.error ?? null;
+
+  // The Fulfillment tab applies only to connections that ingest orders (the
+  // routing key is a *source* delivery method). Capability-gated, not
+  // platformType-gated, so any future OrderSource adapter inherits it.
+  const supportsOrderSource =
+    connectionQuery.data?.supportedCapabilities.includes('OrderSource') ?? false;
+
+  const tabs: { id: TabId; label: string }[] = [
+    ...(supportsOrderSource ? [{ id: 'fulfillment' as const, label: 'Fulfillment' }] : []),
+    { id: 'status' as const, label: 'Order Statuses' },
+    { id: 'carriers' as const, label: 'Carriers' },
+    { id: 'payments' as const, label: 'Payments' },
+  ];
+  const defaultTab = tabs[0].id;
 
   if (isLoading) {
     return (
@@ -164,14 +189,30 @@ export function ConnectionMappingsPage(): ReactElement {
   // rather than inline in the JSX so the conditions (loading/errored/no
   // unmapped methods) read top-to-bottom. Suppressed when any required
   // input isn't ready; the BE still does the right thing at sync time.
+  // Routing-aware unmapped count (#836): a method is "unmapped" for the carrier
+  // banner only if it has neither a PS carrier mapping NOR a routing rule
+  // diverting it to a non-PS processor. Subtraction by id (not length) is exact
+  // even when saved rows reference methods no longer in the live options.
+  const divertedMethodIds = new Set(
+    (routingRulesQuery.data ?? []).map((r) => r.sourceDeliveryMethodId),
+  );
+  const carrierMappedIds = new Set(carrierRows.map((r) => r.sourceValue));
+  const unmappedDeliveryCount = options.allegroDeliveryMethods.filter(
+    (m) => !carrierMappedIds.has(m.value) && !divertedMethodIds.has(m.value),
+  ).length;
+
   const carriersReady =
-    !optionsLoading && carrierOptionsError === null && connectionQuery.data !== undefined;
+    !optionsLoading &&
+    carrierOptionsError === null &&
+    connectionQuery.data !== undefined &&
+    !routingRulesQuery.isLoading &&
+    routingRulesQuery.error === null;
   const connectionConfig = connectionQuery.data?.config as
     | { defaultCarrierId?: unknown }
     | undefined;
   const carrierFallbackBanner = carriersReady
     ? deriveCarrierFallbackBanner({
-        unmappedCount: options.allegroDeliveryMethods.length - carrierRows.length,
+        unmappedCount: unmappedDeliveryCount,
         defaultCarrierId:
           connectionConfig?.defaultCarrierId !== undefined &&
           connectionConfig.defaultCarrierId !== null
@@ -216,14 +257,25 @@ export function ConnectionMappingsPage(): ReactElement {
         visible but large tables may overflow horizontally.
       </DesktopOnlyBanner>
 
-      <Tabs defaultValue="status" aria-label="Mapping types">
+      <Tabs defaultValue={defaultTab} aria-label="Mapping types">
         <TabsList>
-          {TABS.map((tab) => (
+          {tabs.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id}>
               {tab.label}
             </TabsTrigger>
           ))}
         </TabsList>
+
+        {supportsOrderSource && (
+          <TabsContent value="fulfillment">
+            <RoutingRulesPanel
+              connectionId={connectionId}
+              deliveryMethods={options.allegroDeliveryMethods}
+              deliveryMethodsLoading={optionsLoading}
+              deliveryMethodsError={optionsErrors.allegroDeliveryMethods ?? null}
+            />
+          </TabsContent>
+        )}
 
         <TabsContent value="status">
           <MappingPanel

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -316,6 +316,9 @@ export function createMockApiClient(
       getPaymentMappings: vi.fn().mockResolvedValue([]),
       upsertPaymentMappings: vi.fn().mockResolvedValue([]),
       getMappingOptions: vi.fn().mockResolvedValue([]),
+      getRoutingRules: vi.fn().mockResolvedValue([]),
+      replaceRoutingRules: vi.fn().mockResolvedValue([]),
+      getRoutingCandidates: vi.fn().mockResolvedValue([]),
       ...overrides.mappings,
     } as ApiClient['mappings'],
     syncJobs: {

--- a/docs/plans/implementation-plan-836-shipment-routing-config.md
+++ b/docs/plans/implementation-plan-836-shipment-routing-config.md
@@ -1,0 +1,87 @@
+# Implementation Plan — #836 Shipment-routing config (API + FE)
+
+**Issue:** [#836](https://github.com/openlinker-project/openlinker/issues/836) (Part of #732)
+**Branch:** `836-shipment-routing-config`
+**Spec:** `docs/specs/product-spec-732-allegro-delivery-shipment.md` §5 US-1 / AC-1
+**Builds on:** #832/#842 (core `FulfillmentRoutingService` + `fulfillment_routing_rules` table, ADR-012) — **merged**
+
+---
+
+## 1. Understand the task
+
+Expose the #832 fulfillment-routing model to operators as a **"default vs divert"** config: each Allegro **source delivery method** defaults to **PrestaShop (OMP-fulfilled)** — today's behaviour, the no-rule state — and the operator can **divert** specific methods to an `ol_managed_carrier` (InPost) or `source_brokered` (Allegro Delivery) processor. #832 shipped core-only (service + table + ADR-012), so this slice adds the **HTTP API** (none exists yet) + the **FE config UI**.
+
+**Layer:** Interface (API) + Frontend, plus one additive core method (`getCandidateProcessors`, see §3). The service contract `IFulfillmentRoutingService` already exists.
+
+**Ship independently (grill-me decision):** the routing model is **inert until a consumer wires `resolve()`** (#835 for InPost, #837/#838 for Allegro Delivery). #836 is the *config plane*; consumers are the *execution plane*; `IFulfillmentRoutingService` is the seam. Per the hexagonal contract-as-seam principle — and mirroring #832 itself (model shipped with no consumer, validated by an int-spec) — **#836 ships against the contract independently, NOT coupled to #835's merge.** The UI degrades honestly: divert options are capability-derived, so when no divert-capable connection exists the only option rendered is "PrestaShop (default)" (a no-op by definition).
+
+**Non-goals:** method-granular eligibility (OQ-B1, deferred to #833); the resolve-path wiring (#835/#837/#838); branch-1 read-back (#834); the Allegro Delivery / InPost shipment surfaces (#839); explicit `omp_fulfilled`-pinned-to-a-specific-OMP rules (a **multi-OMP future** need — v1 leaves PS as the rule-absence default). This is *only* the routing-rule config screen + its API.
+
+## 2. Research — established patterns to mirror
+
+- **API:** `apps/api/src/mappings/http/mappings.controller.ts` — `@Controller('connections/:connectionId/mappings')`, `@Roles('admin')`, GET/PUT per mapping type delegating to `IMappingConfigService`, DTO `*.fromDomain()` mappers. Mirror for routing rules.
+- **Core service (reuse as-is):** `IFulfillmentRoutingService` (`@openlinker/core/mappings`, token `FULFILLMENT_ROUTING_SERVICE_TOKEN`) — `getRules(connId)` / `replaceRules(connId, items)` / `resolve(query)`. `replaceRules` already validates compatibility, throwing `IncompatibleProcessorException` / `DuplicateRoutingRuleException`.
+- **Compatibility rules** (from `assertCompatible`): `omp_fulfilled` → processor connection declares `OrderProcessorManager`; `ol_managed_carrier` → declares `ShippingProviderManager` AND ≠ source; `source_brokered` → declares `ShippingProviderManager` AND == source.
+- **Source delivery methods:** reuse the same source the carrier-mapping UI keys against (`mapping-options` / `useMappingOptions` → Allegro `/sale/delivery-methods`).
+- **FE:** `features/mappings/` — `MappingPanel.tsx`, `hooks/use-carrier-mappings.ts`, `api/mappings.{api,types,query-keys}.ts`, rendered by `pages/connections/connection-mappings-page.tsx`. Mirror for a routing-rules panel.
+
+## 3. Design
+
+**API** — new `FulfillmentRoutingController` at `connections/:connectionId/routing-rules` (kept separate from `MappingsController` to avoid mixing service tokens):
+- `GET /routing-rules` → `getRules` → `RoutingRuleResponseDto[]`
+- `PUT /routing-rules` → `replaceRules` → `RoutingRuleResponseDto[]` (body `UpsertRoutingRulesDto { items: RoutingRuleInputDto[] }`)
+- **Exception mapping — must cover the FULL set `replaceRules` raises**, not just the two validation ones. `replaceRules` calls `integrations.getAdapter(...)` for the source *and* every processor connection, which can throw `ConnectionNotFoundException` / `ConnectionDisabledException` in addition to `IncompatibleProcessorException` / `DuplicateRoutingRuleException`. Map: `IncompatibleProcessor` / `DuplicateRoutingRule` / `ConnectionDisabled` → **400**; `ConnectionNotFound` → **404**. Anything unmapped must not fall through to a 500 on ordinary bad input.
+
+**Compatibility-filtered dropdown (AC-1) — DECIDED: option B (backend candidates endpoint).** The FE must offer *only compatible* processors per method. Option A (derive client-side from connections + `supportedCapabilities`) was **rejected**: it would duplicate the backend's `assertCompatible` capability/topology rules in the FE — exactly the anti-pattern frontend-architecture.md § App Boundary forbids ("do not duplicate backend validation or authorization rules as a source of truth"), and it would drift from `assertCompatible` the moment either side changes.
+
+**B (candidates endpoint) — read-side projection of the SAME compatibility predicate, not a parallel impl.** Add `getCandidateProcessors(sourceConnectionId)` to `IFulfillmentRoutingService` returning **`{ processorKind, processorConnectionId }[]`** (IDs + enum only — **no `connectionName`/`label`**, see review note), exposed via `GET /routing-rules/candidates`. **Extract the per-kind capability/topology predicate currently inlined in `assertCompatible`** into a shared helper that *both* `assertCompatible` (write-path validation) and `getCandidateProcessors` (read-path offer-set) call — so the dropdown can never offer something the PUT then 400s on, nor hide something it would accept. Compatibility stays authoritative in core (the service already injects `IIntegrationsService`). **Enumerate candidates from capability *metadata* (`supportedCapabilities`), not by instantiating every adapter** — avoid N adapter resolutions just to list. The FE renders each candidate's connection via `ConnectionEntityLabel` (name-first, cached `useConnectionsQuery`) and maps `processorKind → label` client-side (i18n-able, FE presentation) — so core takes **no** dependency on `Connection.name`.
+
+**Capability-driven degradation (no explicit suppression).** Divert options are *uniformly* "a connection that declares the capability this kind requires" — `ol_managed_carrier` → InPost connections declaring `ShippingProviderManager`; `source_brokered` → the Allegro connection *iff* it declares `ShippingProviderManager` (it won't until #833). So **#836 special-cases nothing**: Allegro Delivery appears automatically when #833 lands, with zero #836 change. Gate on capability (which the registry models), not consumer-liveness (which it doesn't).
+
+**FE — "default vs divert" semantics:**
+- "**Default**" = **rule absence** (the schema *forces* this: `processor_connection_id` is NOT NULL, so a "default/PS" row can't be stored; `resolve()` returns `source:'default'` only as a computed fallback). The panel **fabricates** a "PrestaShop (default)" row per live method for *display*; on save only **diverted** methods go into the replace-all `items[]`. Switching a method back to default = drop it from `items[]` (the replace-all delete removes the row). Never persist an explicit `omp_fulfilled` row in v1 — doing so would re-pin to the partner and erase the `source:'default'` signal #837 may branch on.
+- **Lead with processor *kind*; auto-resolve the connection.** Primary control is the kind (`PrestaShop (default)` / `InPost` / `Allegro Delivery`). The processor **connection** auto-selects when the candidates list has exactly one (`omp_fulfilled`→partner, `source_brokered`→self, `ol_managed_carrier`→the lone InPost conn); a connection picker appears only when >1 candidate exists. This is honest to today's single-partner topology *and* future-proofs multi-OMP with no code change.
+- Files: `api/mappings.{types,api,query-keys}.ts` (`RoutingRule`, `RoutingRuleInput`, `CandidateProcessor` types + `getRoutingRules`/`replaceRoutingRules`/`getRoutingCandidates` + `routingRules(connId)` keys); `hooks/use-routing-rules.ts` (`useRoutingRulesQuery` / `useRoutingCandidatesQuery` / `useReplaceRoutingRules`); `components/routing-rules-panel.tsx` (+ `.test.tsx`) — **kebab-case filename** (named export `RoutingRulesPanel`; neighbouring `MappingPanel.tsx` is pre-rule legacy).
+
+**Placement — 4th tab, placed FIRST, labelled "Fulfillment", on `connection-mappings-page.tsx`.** Routing is the *parent* decision (who fulfils?) so it leads, before Carriers (which-PS-carrier, only for the PS-fulfilled subset). Tab order: **Fulfillment → Carriers → Statuses → Payments**. Reusing the page inherits source↔partner resolution, capability gating, the desktop-only-edit banner, breadcrumb + tab a11y. Gate the tab on `connection.supportedCapabilities.includes('OrderSource')`, NOT `platformType === 'allegro'` (literal platformType dispatch banned outside `plugins/<platformType>/`). *(The page's "Allegro → PrestaShop mappings" title should eventually generalize to "connection fulfillment configuration" — a relabel, deferred, NOT #836.)*
+
+**Carrier-tab false-warn — fix in #836 (routing-scoped coverage).** Once a method is diverted, `deriveCarrierFallbackBanner` would wrongly count it as an "unmapped" PS carrier. The "needs a PS carrier" set is **defined by routing** — only methods resolving to `omp_fulfilled` need a PS carrier. Make the banner routing-aware: subtract diverted methods from `unmappedCount` (the page already loads per-connection data; add the routing-rules query). Leaving a known-false "sync will fail" warning behind the very feature that breaks it violates the trustworthy-diagnostics principle. *(Hoisting carrier-coverage to a backend derivation — the banner already duplicates the #516 chain client-side — is the longer-term direction, deferred.)*
+
+## 4. Steps
+
+| # | File | Acceptance |
+|---|---|---|
+| 1 | `libs/core/src/mappings/.../fulfillment-routing.service.interface.ts` + `.service.ts` (+ spec) — **extract `assertCompatible`'s per-kind predicate into a shared helper**, then add `getCandidateProcessors` using it (enumerate from capability **metadata**, no adapter instantiation) | Candidates + `replaceRules` validation share ONE predicate (no drift); returns **`{processorKind, processorConnectionId}[]`**; unit test asserts a candidate is never rejected by `replaceRules` and vice-versa. File headers. |
+| 2 | `apps/api/src/mappings/http/dto/routing-rule-input.dto.ts`, `upsert-routing-rules.dto.ts`, `routing-rule-response.dto.ts`, `candidate-processor-response.dto.ts` (`{processorKind, processorConnectionId}` only) | class-validator on `processorKind` (∈ `FulfillmentProcessorKindValues`), `sourceDeliveryMethodId`, `processorConnectionId`; `fromDomain` mapper; file headers |
+| 3 | `apps/api/src/mappings/http/fulfillment-routing.controller.ts` (+ spec) | GET/PUT/candidates under `connections/:connectionId/routing-rules` (`:connectionId` = **source** connection), `@Roles('admin')`; **full** exception map (Incompatible/Duplicate/ConnectionDisabled → 400, ConnectionNotFound → 404) |
+| 4 | `apps/api/src/mappings/mappings.module.ts` (or wherever `MappingsController` is registered) | controller registered; boots |
+| 5 | `apps/web/src/features/mappings/api/*` | routing + candidate types + api fns + query keys |
+| 6 | `apps/web/src/features/mappings/hooks/use-routing-rules.ts` | query + candidates + mutation hooks; invalidate on success |
+| 7 | `apps/web/src/features/mappings/components/routing-rules-panel.tsx` (+ `.test.tsx`) — **kebab-case** | **default-vs-divert**: all live methods listed, defaulting to "PrestaShop (default)"; **lead with kind**, connection auto-selects on singleton candidate, picker only when >1; only diverted rows submitted to the replace-all PUT; all 4 states; mobile/tablet |
+| 8 | `apps/web/src/pages/connections/connection-mappings-page.tsx` | **"Fulfillment" tab added FIRST** (order: Fulfillment → Carriers → Statuses → Payments); gated by `supportedCapabilities.includes('OrderSource')` (not platformType) |
+| 9 | `apps/api/test/integration/.../routing-rules.int-spec.ts` | GET/PUT round-trip + 400-on-incompatible vertical slice (mirrors #832 `fulfillment-routing.int-spec.ts`) |
+| 10 | `apps/web/src/pages/connections/connection-mappings-page.tsx` (`deriveCarrierFallbackBanner`) | **routing-aware carrier-coverage**: subtract diverted methods from `unmappedCount` so the Carrier banner doesn't false-warn for methods routed away from PS. **Compute the banner only after BOTH carrier-mappings and routing-rules queries have loaded** (no false-warn flicker before routing rules resolve). Component test covers the diverted-method exclusion. |
+
+## 5. Validate
+
+- **Architecture:** API delegates to the core service via token; no business logic in the controller; FE uses `useApiClient` + feature hooks; no boundary violations. The (B) core addition keeps compatibility authoritative in core.
+- **Naming:** `*.controller.ts` / `*-response.dto.ts` / `use-*.ts` / `*.types.ts` per standards.
+- **Testing:** controller spec (happy + 400 mapping), service spec for `getCandidateProcessors`, FE component test (happy/loading/error/empty + incompatible filtered out).
+- **Security:** `@Roles('admin')` + `@UseGuards` inherited; input validated via DTO; no secrets.
+- **Migration:** none (table exists from #832).
+- **Sequencing:** ship independently against `IFulfillmentRoutingService` (grill-me decision (a)); do **not** couple the #836 merge to #835. The config is inert until a consumer wires `resolve()`, but the UI degrades honestly (capability-derived options) so it never offers a meaningless action.
+- **Predicate consistency:** candidates and `replaceRules` validation must call the **same** extracted predicate (step 1) — the safety property that makes capability-degradation correct.
+- **Parallel-safety vs #835:** FE files are `apps/web/src/features/mappings/**` + the page (disjoint from #835's `libs/core/src/{shipping}` + `inpost`). The one shared backend file is `fulfillment-routing.service.ts` (additive `getCandidateProcessors` + predicate extraction) — coordinate the touch with the in-flight #835.
+
+## 6. Risks / open questions
+
+- **Declared-but-not-consumed window** — if #833 ships the Allegro Delivery adapter (declares `ShippingProviderManager`) before #837 wires its `resolve()` dispatch, the `source_brokered` divert appears but is inert. Accepted: same contract-as-seam decoupling as the overall sequencing; gate on capability, not consumer-liveness. Closed by the consumer issue.
+- **#835 overlap** — `fulfillment-routing.service.ts` (additive method + predicate extraction). Low risk; coordinate.
+- **Page-title generalization** (deferred) — "Allegro → PrestaShop mappings" → "connection fulfillment configuration" once non-PS processors are first-class. Relabel, not restructure; not #836.
+- **Backend carrier-coverage derivation** (deferred) — `deriveCarrierFallbackBanner` duplicates the #516 chain client-side; long-term it should be a backend coverage read. #836's routing-aware subtraction (step 10) is a step toward it, not away.
+
+> **Review applied (tech-review, 2026-05-25):** option B locked (A duplicates backend rules — FE anti-pattern); full exception mapping (`ConnectionNotFound`→404 / `ConnectionDisabled`→400); kebab-case component filename; capability-based gating; int-spec (step 9); candidates returns `connectionName`/`label`; file headers.
+
+> **Tech-review #2 applied (2026-05-25, post-grill):** candidates contract trimmed to `{processorKind, processorConnectionId}` — dropped `connectionName`/`label` (FE resolves names via `ConnectionEntityLabel`, maps kind→label client-side; core takes no `Connection.name` dep); `getCandidateProcessors` enumerates from capability **metadata** (no adapter instantiation); carrier banner computed only after both queries load (no false-warn flicker); "Fulfillment"-first default-tab change is intentional.
+
+> **Grill-me applied (2026-05-25):** ship independently against the contract (a); "default = rule-absence" (schema-forced, preserves `source:'default'`); lead-with-kind + singleton auto-select for the processor connection; explicit `omp_fulfilled` rules deferred to multi-OMP; `getCandidateProcessors` = read-side projection of the **shared** `assertCompatible` predicate (step 1); pure capability-degradation (no suppression — Allegro Delivery lights up via #833); 4th tab "Fulfillment" placed **first**; Carrier-banner made routing-aware (step 10). Full design tree resolved — ready to implement.

--- a/libs/core/src/mappings/application/interfaces/fulfillment-routing.service.interface.ts
+++ b/libs/core/src/mappings/application/interfaces/fulfillment-routing.service.interface.ts
@@ -11,6 +11,7 @@
 
 import type { FulfillmentRoutingRule } from '../../domain/entities/fulfillment-routing-rule.entity';
 import type {
+  CandidateProcessor,
   FulfillmentRoutingQuery,
   FulfillmentRoutingResolution,
   FulfillmentRoutingRuleInput,
@@ -19,6 +20,15 @@ import type {
 export interface IFulfillmentRoutingService {
   /** All routing rules scoped to a source connection. */
   getRules(sourceConnectionId: string): Promise<FulfillmentRoutingRule[]>;
+
+  /**
+   * The processors a source connection's delivery methods may be routed to,
+   * for the routing-config UI (#836). Enumerates active connections and keeps
+   * those compatible per the same predicate `replaceRules` validates against,
+   * so the UI never offers an option the write path would reject. Metadata-only
+   * (no adapter instantiation).
+   */
+  getCandidateProcessors(sourceConnectionId: string): Promise<CandidateProcessor[]>;
 
   /**
    * Replace all routing rules for a source connection. Each rule's processor

--- a/libs/core/src/mappings/application/services/fulfillment-routing.service.spec.ts
+++ b/libs/core/src/mappings/application/services/fulfillment-routing.service.spec.ts
@@ -9,6 +9,7 @@
 
 import type { AdapterMetadata, IIntegrationsService } from '@openlinker/core/integrations';
 import type { Connection, ConnectionPort } from '@openlinker/core/identifier-mapping';
+import { ConnectionNotFoundException } from '@openlinker/core/identifier-mapping';
 import { FulfillmentRoutingService } from './fulfillment-routing.service';
 import type { FulfillmentRoutingRepositoryPort } from '../../domain/ports/fulfillment-routing-repository.port';
 import { FulfillmentRoutingRule } from '../../domain/entities/fulfillment-routing-rule.entity';
@@ -275,12 +276,20 @@ describe('FulfillmentRoutingService', () => {
   });
 
   describe('getRules', () => {
-    it('should delegate to the repository', async () => {
+    it('should delegate to the repository when the connection exists', async () => {
       const rules = [makeRule()];
+      connectionPort.get.mockResolvedValue({ id: SOURCE } as Connection);
       repository.findBySourceConnectionId.mockResolvedValue(rules);
 
       await expect(service.getRules(SOURCE)).resolves.toBe(rules);
       expect(repository.findBySourceConnectionId).toHaveBeenCalledWith(SOURCE);
+    });
+
+    it('should reject and not query rules when the connection does not exist', async () => {
+      connectionPort.get.mockRejectedValue(new ConnectionNotFoundException(SOURCE));
+
+      await expect(service.getRules(SOURCE)).rejects.toBeInstanceOf(ConnectionNotFoundException);
+      expect(repository.findBySourceConnectionId).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/core/src/mappings/application/services/fulfillment-routing.service.spec.ts
+++ b/libs/core/src/mappings/application/services/fulfillment-routing.service.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AdapterMetadata, IIntegrationsService } from '@openlinker/core/integrations';
-import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { Connection, ConnectionPort } from '@openlinker/core/identifier-mapping';
 import { FulfillmentRoutingService } from './fulfillment-routing.service';
 import type { FulfillmentRoutingRepositoryPort } from '../../domain/ports/fulfillment-routing-repository.port';
 import { FulfillmentRoutingRule } from '../../domain/entities/fulfillment-routing-rule.entity';
@@ -38,6 +38,7 @@ function makeRule(overrides: Partial<FulfillmentRoutingRule> = {}): FulfillmentR
 describe('FulfillmentRoutingService', () => {
   let repository: jest.Mocked<FulfillmentRoutingRepositoryPort>;
   let integrations: jest.Mocked<IIntegrationsService>;
+  let connectionPort: jest.Mocked<ConnectionPort>;
   let service: FulfillmentRoutingService;
 
   /** Stub `getAdapter` to return a connection declaring the given capabilities. */
@@ -46,6 +47,23 @@ describe('FulfillmentRoutingService', () => {
       connection: { id: connectionId } as Connection,
       metadata: { supportedCapabilities: capabilities } as AdapterMetadata,
     });
+  }
+
+  /** Stub `getAdapter` to return per-connection capabilities (for candidate enumeration). */
+  function declareCapabilitiesByConnection(capsByConnection: Record<string, string[]>): void {
+    integrations.getAdapter.mockImplementation((connectionId: string) =>
+      Promise.resolve({
+        connection: { id: connectionId } as Connection,
+        metadata: {
+          supportedCapabilities: capsByConnection[connectionId] ?? [],
+        } as AdapterMetadata,
+      }),
+    );
+  }
+
+  /** Build a minimal active-connection list for `connectionPort.list`. */
+  function activeConnections(...ids: string[]): Connection[] {
+    return ids.map((id) => ({ id }) as Connection);
   }
 
   beforeEach(() => {
@@ -60,7 +78,14 @@ describe('FulfillmentRoutingService', () => {
       resolveAdapterMetadata: jest.fn(),
       listCapabilityAdapters: jest.fn(),
     };
-    service = new FulfillmentRoutingService(repository, integrations);
+    connectionPort = {
+      get: jest.fn(),
+      list: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      disable: jest.fn(),
+    };
+    service = new FulfillmentRoutingService(repository, integrations, connectionPort);
   });
 
   describe('resolve', () => {
@@ -256,6 +281,111 @@ describe('FulfillmentRoutingService', () => {
 
       await expect(service.getRules(SOURCE)).resolves.toBe(rules);
       expect(repository.findBySourceConnectionId).toHaveBeenCalledWith(SOURCE);
+    });
+  });
+
+  describe('getCandidateProcessors', () => {
+    it('offers each connection only under the kinds its capabilities + topology allow', async () => {
+      declareCapabilitiesByConnection({
+        [SOURCE]: ['OrderSource'],
+        [PS]: ['OrderProcessorManager'],
+        [INPOST]: ['ShippingProviderManager'],
+      });
+      connectionPort.list.mockResolvedValue(activeConnections(SOURCE, PS, INPOST));
+
+      const candidates = await service.getCandidateProcessors(SOURCE);
+
+      expect(candidates).toEqual(
+        expect.arrayContaining([
+          { processorKind: 'omp_fulfilled', processorConnectionId: PS },
+          { processorKind: 'ol_managed_carrier', processorConnectionId: INPOST },
+        ]),
+      );
+      // SOURCE declares only OrderSource → no source_brokered (needs SPM), not an OMP/carrier.
+      expect(candidates).not.toContainEqual({
+        processorKind: 'source_brokered',
+        processorConnectionId: SOURCE,
+      });
+      // A distinct carrier connection is never an OMP candidate.
+      expect(candidates).not.toContainEqual({
+        processorKind: 'omp_fulfilled',
+        processorConnectionId: INPOST,
+      });
+      expect(connectionPort.list).toHaveBeenCalledWith({ status: 'active' });
+    });
+
+    it('offers source_brokered for the source connection when it declares ShippingProviderManager', async () => {
+      declareCapabilitiesByConnection({ [SOURCE]: ['OrderSource', 'ShippingProviderManager'] });
+      connectionPort.list.mockResolvedValue(activeConnections(SOURCE));
+
+      const candidates = await service.getCandidateProcessors(SOURCE);
+
+      expect(candidates).toContainEqual({
+        processorKind: 'source_brokered',
+        processorConnectionId: SOURCE,
+      });
+      // Topology: an OL-managed carrier must be distinct from the source.
+      expect(candidates).not.toContainEqual({
+        processorKind: 'ol_managed_carrier',
+        processorConnectionId: SOURCE,
+      });
+    });
+
+    it('never offers a candidate that replaceRules would reject (shared-predicate consistency)', async () => {
+      declareCapabilitiesByConnection({
+        [SOURCE]: ['OrderSource', 'ShippingProviderManager'],
+        [PS]: ['OrderProcessorManager'],
+        [INPOST]: ['ShippingProviderManager'],
+      });
+      connectionPort.list.mockResolvedValue(activeConnections(SOURCE, PS, INPOST));
+      repository.replaceForConnection.mockResolvedValue([]);
+
+      const candidates = await service.getCandidateProcessors(SOURCE);
+      expect(candidates.length).toBeGreaterThan(0);
+
+      for (const candidate of candidates) {
+        await expect(
+          service.replaceRules(SOURCE, [
+            {
+              sourceDeliveryMethodId: `m-${candidate.processorKind}-${candidate.processorConnectionId}`,
+              processorKind: candidate.processorKind,
+              processorConnectionId: candidate.processorConnectionId,
+            },
+          ]),
+        ).resolves.toBeDefined();
+      }
+    });
+
+    it('propagates when the source connection cannot be resolved', async () => {
+      integrations.getAdapter.mockRejectedValue(new Error('connection not found'));
+
+      await expect(service.getCandidateProcessors(SOURCE)).rejects.toThrow('connection not found');
+      expect(connectionPort.list).not.toHaveBeenCalled();
+    });
+
+    it('skips an active connection whose adapter metadata cannot be resolved', async () => {
+      const BROKEN = 'conn-broken';
+      // SOURCE + PS resolve normally; BROKEN (stale adapterKey, plugin removed)
+      // rejects during enumeration. It must be skipped, not fail the whole list.
+      integrations.getAdapter.mockImplementation((connectionId: string) => {
+        if (connectionId === BROKEN) {
+          return Promise.reject(new Error('adapter not registered'));
+        }
+        const caps: Record<string, string[]> = {
+          [SOURCE]: ['OrderSource'],
+          [PS]: ['OrderProcessorManager'],
+        };
+        return Promise.resolve({
+          connection: { id: connectionId } as Connection,
+          metadata: { supportedCapabilities: caps[connectionId] ?? [] } as AdapterMetadata,
+        });
+      });
+      connectionPort.list.mockResolvedValue(activeConnections(SOURCE, PS, BROKEN));
+
+      const candidates = await service.getCandidateProcessors(SOURCE);
+
+      expect(candidates).toContainEqual({ processorKind: 'omp_fulfilled', processorConnectionId: PS });
+      expect(candidates.some((c) => c.processorConnectionId === BROKEN)).toBe(false);
     });
   });
 });

--- a/libs/core/src/mappings/application/services/fulfillment-routing.service.ts
+++ b/libs/core/src/mappings/application/services/fulfillment-routing.service.ts
@@ -67,6 +67,12 @@ export class FulfillmentRoutingService implements IFulfillmentRoutingService {
   ) {}
 
   async getRules(sourceConnectionId: string): Promise<FulfillmentRoutingRule[]> {
+    // Validate existence (throws ConnectionNotFoundException → 404 on unknown),
+    // but NOT active status — an operator can still read the routing config of a
+    // disabled connection. Uniform "unknown connection → 404" with
+    // getCandidateProcessors / replaceRules, which additionally require active
+    // (they resolve adapter metadata via getAdapter).
+    await this.connectionPort.get(sourceConnectionId);
     return this.repository.findBySourceConnectionId(sourceConnectionId);
   }
 
@@ -80,28 +86,40 @@ export class FulfillmentRoutingService implements IFulfillmentRoutingService {
     // connection whose adapter wouldn't construct (e.g. missing credentials).
     const connections = await this.connectionPort.list({ status: 'active' });
 
+    // Resolve each connection's adapter metadata concurrently (the lookups are
+    // independent). A connection whose metadata can't be resolved (e.g. its
+    // plugin was removed, leaving a stale adapterKey) is simply not an offerable
+    // processor — drop it rather than blanking the whole candidate list.
+    const resolved = await Promise.all(
+      connections.map(async (connection) => {
+        try {
+          const { metadata } = await this.integrations.getAdapter(connection.id);
+          return { connectionId: connection.id, capabilities: metadata.supportedCapabilities };
+        } catch (error) {
+          this.logger.debug(
+            `Skipping connection ${connection.id} in candidate enumeration: ` +
+              `adapter metadata unresolved (${(error as Error).message})`,
+          );
+          return null;
+        }
+      }),
+    );
+
+    // Promise.all preserves input order, so candidate order follows the
+    // connection list deterministically.
     const candidates: CandidateProcessor[] = [];
-    for (const connection of connections) {
-      // A connection whose adapter metadata can't be resolved (e.g. its plugin
-      // was removed, leaving a stale adapterKey) is simply not an offerable
-      // processor — skip it rather than blanking the whole candidate list.
-      let capabilities: readonly string[];
-      try {
-        const { metadata } = await this.integrations.getAdapter(connection.id);
-        capabilities = metadata.supportedCapabilities;
-      } catch (error) {
-        this.logger.debug(
-          `Skipping connection ${connection.id} in candidate enumeration: ` +
-            `adapter metadata unresolved (${(error as Error).message})`,
-        );
-        continue;
-      }
+    for (const entry of resolved) {
+      if (!entry) continue;
       for (const processorKind of FulfillmentProcessorKindValues) {
         if (
-          this.evaluateCompatibility(processorKind, sourceConnectionId, connection.id, capabilities)
-            .compatible
+          this.evaluateCompatibility(
+            processorKind,
+            sourceConnectionId,
+            entry.connectionId,
+            entry.capabilities,
+          ).compatible
         ) {
-          candidates.push({ processorKind, processorConnectionId: connection.id });
+          candidates.push({ processorKind, processorConnectionId: entry.connectionId });
         }
       }
     }

--- a/libs/core/src/mappings/application/services/fulfillment-routing.service.ts
+++ b/libs/core/src/mappings/application/services/fulfillment-routing.service.ts
@@ -16,17 +16,22 @@
  */
 
 import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
 import {
   type CoreCapability,
   IIntegrationsService,
   INTEGRATIONS_SERVICE_TOKEN,
 } from '@openlinker/core/integrations';
+import { CONNECTION_PORT_TOKEN, type ConnectionPort } from '@openlinker/core/identifier-mapping';
 import type { IFulfillmentRoutingService } from '../interfaces/fulfillment-routing.service.interface';
 import { FULFILLMENT_ROUTING_REPOSITORY_TOKEN } from '../../mappings.tokens';
 import { FulfillmentRoutingRepositoryPort } from '../../domain/ports/fulfillment-routing-repository.port';
 import type { FulfillmentRoutingRule } from '../../domain/entities/fulfillment-routing-rule.entity';
 import {
+  type CandidateProcessor,
   FULFILLMENT_PROCESSOR_KIND,
+  FulfillmentProcessorKindValues,
+  type FulfillmentProcessorKind,
   type FulfillmentRoutingQuery,
   type FulfillmentRoutingResolution,
   type FulfillmentRoutingRuleInput,
@@ -50,15 +55,57 @@ const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
 
 @Injectable()
 export class FulfillmentRoutingService implements IFulfillmentRoutingService {
+  private readonly logger = new Logger(FulfillmentRoutingService.name);
+
   constructor(
     @Inject(FULFILLMENT_ROUTING_REPOSITORY_TOKEN)
     private readonly repository: FulfillmentRoutingRepositoryPort,
     @Inject(INTEGRATIONS_SERVICE_TOKEN)
     private readonly integrations: IIntegrationsService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connectionPort: ConnectionPort,
   ) {}
 
   async getRules(sourceConnectionId: string): Promise<FulfillmentRoutingRule[]> {
     return this.repository.findBySourceConnectionId(sourceConnectionId);
+  }
+
+  async getCandidateProcessors(sourceConnectionId: string): Promise<CandidateProcessor[]> {
+    // Validates the source exists + is active (throws ConnectionNotFound /
+    // ConnectionDisabled, mapped to 404/400 at the HTTP boundary).
+    await this.integrations.getAdapter(sourceConnectionId);
+
+    // Metadata-only enumeration: `getAdapter` is a metadata-only lookup (no
+    // adapter instance is constructed), so listing candidates can't fail on a
+    // connection whose adapter wouldn't construct (e.g. missing credentials).
+    const connections = await this.connectionPort.list({ status: 'active' });
+
+    const candidates: CandidateProcessor[] = [];
+    for (const connection of connections) {
+      // A connection whose adapter metadata can't be resolved (e.g. its plugin
+      // was removed, leaving a stale adapterKey) is simply not an offerable
+      // processor — skip it rather than blanking the whole candidate list.
+      let capabilities: readonly string[];
+      try {
+        const { metadata } = await this.integrations.getAdapter(connection.id);
+        capabilities = metadata.supportedCapabilities;
+      } catch (error) {
+        this.logger.debug(
+          `Skipping connection ${connection.id} in candidate enumeration: ` +
+            `adapter metadata unresolved (${(error as Error).message})`,
+        );
+        continue;
+      }
+      for (const processorKind of FulfillmentProcessorKindValues) {
+        if (
+          this.evaluateCompatibility(processorKind, sourceConnectionId, connection.id, capabilities)
+            .compatible
+        ) {
+          candidates.push({ processorKind, processorConnectionId: connection.id });
+        }
+      }
+    }
+    return candidates;
   }
 
   async replaceRules(
@@ -103,10 +150,11 @@ export class FulfillmentRoutingService implements IFulfillmentRoutingService {
   }
 
   /**
-   * Capability + topology compatibility for a single rule. `getAdapter`
-   * resolves the connection's adapter metadata and throws
+   * Capability + topology compatibility for a single rule (write path).
+   * Resolves the processor connection's adapter metadata (`getAdapter` throws
    * `ConnectionNotFoundException` / `ConnectionDisabledException` for an
-   * invalid processor connection — those propagate unchanged.
+   * invalid processor connection — those propagate unchanged) and delegates
+   * the decision to the shared `evaluateCompatibility` predicate.
    */
   private async assertCompatible(
     sourceConnectionId: string,
@@ -114,62 +162,77 @@ export class FulfillmentRoutingService implements IFulfillmentRoutingService {
   ): Promise<void> {
     const { processorKind, processorConnectionId } = item;
     const { metadata } = await this.integrations.getAdapter(processorConnectionId);
-    const capabilities = metadata.supportedCapabilities;
+    const { compatible, reason } = this.evaluateCompatibility(
+      processorKind,
+      sourceConnectionId,
+      processorConnectionId,
+      metadata.supportedCapabilities,
+    );
+    if (!compatible) {
+      throw new IncompatibleProcessorException(processorConnectionId, processorKind, reason);
+    }
+  }
 
+  /**
+   * Pure per-kind capability + topology predicate — the **single source of
+   * truth** shared by `assertCompatible` (write-path validation) and
+   * `getCandidateProcessors` (read-path offer-set). Keeping both paths on one
+   * predicate guarantees the routing-config UI never offers a processor that
+   * `replaceRules` would reject, nor hides one it would accept (#836).
+   */
+  private evaluateCompatibility(
+    processorKind: FulfillmentProcessorKind,
+    sourceConnectionId: string,
+    processorConnectionId: string,
+    capabilities: readonly string[],
+  ): { compatible: boolean; reason: string } {
     switch (processorKind) {
       case FULFILLMENT_PROCESSOR_KIND.OmpFulfilled:
-        if (!capabilities.includes(ORDER_PROCESSOR_MANAGER_CAPABILITY)) {
-          throw new IncompatibleProcessorException(
-            processorConnectionId,
-            processorKind,
-            `does not declare the ${ORDER_PROCESSOR_MANAGER_CAPABILITY} capability`,
-          );
-        }
-        return;
+        return capabilities.includes(ORDER_PROCESSOR_MANAGER_CAPABILITY)
+          ? { compatible: true, reason: '' }
+          : {
+              compatible: false,
+              reason: `does not declare the ${ORDER_PROCESSOR_MANAGER_CAPABILITY} capability`,
+            };
 
       case FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier:
         if (!capabilities.includes(SHIPPING_PROVIDER_MANAGER_CAPABILITY)) {
-          throw new IncompatibleProcessorException(
-            processorConnectionId,
-            processorKind,
-            `does not declare the ${SHIPPING_PROVIDER_MANAGER_CAPABILITY} capability`,
-          );
+          return {
+            compatible: false,
+            reason: `does not declare the ${SHIPPING_PROVIDER_MANAGER_CAPABILITY} capability`,
+          };
         }
         if (processorConnectionId === sourceConnectionId) {
-          throw new IncompatibleProcessorException(
-            processorConnectionId,
-            processorKind,
-            'an OL-managed carrier must be a connection distinct from the order source',
-          );
+          return {
+            compatible: false,
+            reason: 'an OL-managed carrier must be a connection distinct from the order source',
+          };
         }
-        return;
+        return { compatible: true, reason: '' };
 
       case FULFILLMENT_PROCESSOR_KIND.SourceBrokered:
         if (!capabilities.includes(SHIPPING_PROVIDER_MANAGER_CAPABILITY)) {
-          throw new IncompatibleProcessorException(
-            processorConnectionId,
-            processorKind,
-            `does not declare the ${SHIPPING_PROVIDER_MANAGER_CAPABILITY} capability`,
-          );
+          return {
+            compatible: false,
+            reason: `does not declare the ${SHIPPING_PROVIDER_MANAGER_CAPABILITY} capability`,
+          };
         }
         if (processorConnectionId !== sourceConnectionId) {
-          throw new IncompatibleProcessorException(
-            processorConnectionId,
-            processorKind,
-            'a source-brokered processor must be the order source connection itself',
-          );
+          return {
+            compatible: false,
+            reason: 'a source-brokered processor must be the order source connection itself',
+          };
         }
-        return;
+        return { compatible: true, reason: '' };
 
       default: {
         // Exhaustiveness guard: a new FulfillmentProcessorKind added without a
         // matching compatibility rule must fail loud, never pass unvalidated.
         const exhaustive: never = processorKind;
-        throw new IncompatibleProcessorException(
-          processorConnectionId,
-          String(exhaustive),
-          'unknown processor kind has no compatibility rule',
-        );
+        return {
+          compatible: false,
+          reason: `unknown processor kind '${String(exhaustive)}' has no compatibility rule`,
+        };
       }
     }
   }

--- a/libs/core/src/mappings/domain/types/fulfillment-routing.types.ts
+++ b/libs/core/src/mappings/domain/types/fulfillment-routing.types.ts
@@ -100,3 +100,19 @@ export interface FulfillmentRoutingResolution {
   processorConnectionId: string | null;
   source: FulfillmentRoutingSource;
 }
+
+/**
+ * A processor option the operator may route a source delivery method to,
+ * for the routing-config UI (#836). Read-side projection of the SAME
+ * compatibility predicate `replaceRules` validates against — so any returned
+ * candidate is guaranteed to pass `replaceRules`, and any rejected one is
+ * never offered.
+ *
+ * IDs + kind only by design: the FE resolves the connection's display name
+ * (`ConnectionEntityLabel`, name-first) and maps `processorKind → label`
+ * client-side, so core takes no dependency on connection naming or i18n.
+ */
+export interface CandidateProcessor {
+  processorKind: FulfillmentProcessorKind;
+  processorConnectionId: string;
+}

--- a/libs/core/src/mappings/index.ts
+++ b/libs/core/src/mappings/index.ts
@@ -38,4 +38,5 @@ export type {
   FulfillmentRoutingRuleInput,
   FulfillmentRoutingQuery,
   FulfillmentRoutingResolution,
+  CandidateProcessor,
 } from './domain/types/fulfillment-routing.types';

--- a/libs/core/src/mappings/mappings.module.ts
+++ b/libs/core/src/mappings/mappings.module.ts
@@ -13,6 +13,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { IntegrationsModule } from '@openlinker/core/integrations';
+import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { StatusMappingOrmEntity } from './infrastructure/persistence/entities/status-mapping.orm-entity';
 import { CarrierMappingOrmEntity } from './infrastructure/persistence/entities/carrier-mapping.orm-entity';
 import { PaymentMappingOrmEntity } from './infrastructure/persistence/entities/payment-mapping.orm-entity';
@@ -45,6 +46,10 @@ import {
       FulfillmentRoutingRuleOrmEntity,
     ]),
     IntegrationsModule,
+    // Provides CONNECTION_PORT_TOKEN — FulfillmentRoutingService enumerates
+    // active connections for getCandidateProcessors (#836). IntegrationsModule
+    // imports IdentifierMappingModule but does not re-export the token.
+    IdentifierMappingModule,
   ],
   providers: [
     StatusMappingRepository,

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -96,7 +96,12 @@ describe('ShipmentDispatchService', () => {
       findByProviderShipmentId: jest.fn(),
       update: jest.fn(),
     };
-    routing = { getRules: jest.fn(), replaceRules: jest.fn(), resolve: jest.fn() };
+    routing = {
+      getRules: jest.fn(),
+      getCandidateProcessors: jest.fn(),
+      replaceRules: jest.fn(),
+      resolve: jest.fn(),
+    };
     adapter = {
       generateLabel: jest.fn(),
       getTracking: jest.fn(),


### PR DESCRIPTION
## What & why

Exposes the #832 fulfillment-routing model to operators via a connection-scoped HTTP API and a **Fulfillment** tab in the connection mappings cockpit. Until now the routing model was inert configuration with no operator surface; #835 (#843) wired a consumer (`ShipmentDispatchService.resolve()`), so this config is now live end-to-end.

Routing is **default vs divert**: a source delivery method stays with the default order-management platform (rule *absence*) unless an operator diverts it to a capability-compatible processor. Only diverted methods are persisted (replace-all PUT).

## Backend

- **`IFulfillmentRoutingService.getCandidateProcessors(sourceConnectionId)`** — enumerates active connections and returns the processor kinds each is capability-compatible with for the source. Read-candidates and write-validation now share **one** `evaluateCompatibility` predicate, so the dropdown can never offer a combination the PUT would reject (nor hide one it would accept). Enumeration is fault-tolerant: a connection whose adapter metadata can't resolve (stale `adapterKey`, removed plugin) is skipped, not fatal.
- **`FulfillmentRoutingController`** (`@Roles('admin')`) at `/connections/:connectionId/routing-rules`: `GET` (rules), `GET /candidates`, `PUT` (replace-all). Domain exceptions mapped at the boundary — incompatible / duplicate / disabled → **400**, unknown connection → **404**.
- Request/response DTOs; the candidates contract is IDs + kind only (FE resolves the connection name via `ConnectionEntityLabel`).
- Wire `IdentifierMappingModule` into core `MappingsModule` so `CONNECTION_PORT_TOKEN` resolves (it is not re-exported by `IntegrationsModule`).

## Frontend

- **`RoutingRulesPanel`** — per-method default-vs-divert editor mirroring `MappingPanel` (vanilla CSS / existing OKLCH tokens, **no new styles**). The divert dropdown is filtered to the candidates endpoint; `omp_fulfilled` is the default (never an explicit divert option in v1); `ConnectionEntityLabel` renders diverted targets; orphaned/saved-but-unavailable selections stay visible so a replace-all save never silently drops them.
- Capability-gated **Fulfillment** tab (`OrderSource`), shown first when present — gated on the capability, not a `platformType` literal, so any future `OrderSource` adapter inherits it.
- Carrier-fallback banner is now **routing-aware**: methods diverted to a non-OMP processor are excluded from the unmapped count.

## Tests

- Service spec — candidates, shared-predicate symmetry, fault-tolerant skip.
- Controller spec — delegation + full exception → HTTP mapping.
- `RoutingRulesPanel` component test — loading / error / empty / default / divert+save / compatibility filter / pre-populate.
- HTTP vertical-slice int-spec (`routing-rules.int-spec.ts`) — PUT→GET round-trip, candidates, 400/404, admin guard.

## Quality gate

`pnpm type-check`, `pnpm lint` (+ `check:invariants`: no token drift, cross-context imports conform), unit tests (core / api / web), and routing integration specs (HTTP + service) all green.

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)