### PR TITLE
feat(shipping,api): shipment read + command HTTP API (#846)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -20,7 +20,6 @@ import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { CustomersModule } from '@openlinker/core/customers';
 import { ContentModule } from '@openlinker/core/content';
 import { AiModule as CoreAiModule } from '@openlinker/core/ai';
-import { ShippingModule } from '@openlinker/core/shipping';
 import { AuthModule } from './auth/auth.module';
 import { IntegrationsModule } from './integrations/integrations.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
@@ -34,6 +33,7 @@ import { CursorsModule } from './cursors/cursors.module';
 import { MappingsApiModule } from './mappings/mappings.module';
 import { AiApiModule } from './ai/ai.module';
 import { ContentApiModule } from './content/content.module';
+import { ShippingApiModule } from './shipping/shipping.module';
 
 @Module({
   imports: [
@@ -63,7 +63,7 @@ import { ContentApiModule } from './content/content.module';
     CoreAiModule, // Editable prompt-template storage + render service (#341)
     AiApiModule, // REST surface for prompt templates (#341)
     ContentApiModule, // REST surface for product content editor + AI suggest (#339 + #342)
-    ShippingModule, // Shipment aggregate + ShipmentRepositoryPort binding (#763)
+    ShippingApiModule, // Shipment read + command HTTP API (#846); imports core ShippingModule (#763/#835)
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/shipping/http/dto/dispatch-result-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/dispatch-result-response.dto.ts
@@ -1,0 +1,30 @@
+/**
+ * Dispatch Result Response DTO
+ *
+ * Response for POST /shipments/generate-label. Mirrors the core
+ * `ShipmentDispatchResult` discriminated union: `dispatched` carries the
+ * created/in-flight shipment; `omp_fulfilled` carries none (the OMP ships
+ * externally — no OL label).
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { ShipmentDispatchResult } from '@openlinker/core/shipping';
+import { ShipmentResponseDto } from './shipment-response.dto';
+
+export class DispatchResultResponseDto {
+  @ApiProperty({ enum: ['dispatched', 'omp_fulfilled'] })
+  kind!: 'dispatched' | 'omp_fulfilled';
+
+  @ApiPropertyOptional({ type: ShipmentResponseDto, description: 'Present only when kind=dispatched' })
+  shipment?: ShipmentResponseDto;
+
+  static fromResult(result: ShipmentDispatchResult): DispatchResultResponseDto {
+    const dto = new DispatchResultResponseDto();
+    dto.kind = result.kind;
+    if (result.kind === 'dispatched') {
+      dto.shipment = ShipmentResponseDto.fromDomain(result.shipment);
+    }
+    return dto;
+  }
+}

--- a/apps/api/src/shipping/http/dto/generate-label.dto.ts
+++ b/apps/api/src/shipping/http/dto/generate-label.dto.ts
@@ -1,0 +1,159 @@
+/**
+ * Generate Label DTO
+ *
+ * Request body for POST /shipments/generate-label. A 1:1 reshape of the core
+ * `ShipmentDispatchInput` (#835) — routing keys (`sourceConnectionId`,
+ * `sourceDeliveryMethodId`) plus the caller-supplied label payload
+ * (`shippingMethod`, `paczkomatId?`, `recipient`, `parcel`). The dispatch seam
+ * fills `shipmentId` (after creating the row) and `connectionId` (from the
+ * resolved processor) itself, so they're absent here.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { Type } from 'class-transformer';
+import {
+  IsEmail,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ShippingMethodValues, type ShippingMethod } from '@openlinker/core/shipping';
+
+class ShipmentAddressDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  street!: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  buildingNumber!: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  city!: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  postCode!: string;
+
+  @ApiProperty({ description: 'ISO 3166-1 alpha-2 (e.g. PL)' })
+  @IsString()
+  @IsNotEmpty()
+  countryCode!: string;
+}
+
+class ShipmentRecipientDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @ApiProperty()
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  phone!: string;
+
+  @ApiPropertyOptional({ type: ShipmentAddressDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShipmentAddressDto)
+  address?: ShipmentAddressDto;
+}
+
+class ShipmentDimensionsDto {
+  @ApiProperty({ description: 'Millimetres' })
+  @IsInt()
+  @Min(1)
+  length!: number;
+
+  @ApiProperty({ description: 'Millimetres' })
+  @IsInt()
+  @Min(1)
+  width!: number;
+
+  @ApiProperty({ description: 'Millimetres' })
+  @IsInt()
+  @Min(1)
+  height!: number;
+}
+
+class ShipmentParcelDto {
+  @ApiPropertyOptional({ description: 'Carrier size code for locker shipments' })
+  @IsOptional()
+  @IsString()
+  template?: string;
+
+  @ApiPropertyOptional({ type: ShipmentDimensionsDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShipmentDimensionsDto)
+  dimensions?: ShipmentDimensionsDto;
+
+  @ApiPropertyOptional({ description: 'Weight in grams (courier shipments)' })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  weightGrams?: number;
+}
+
+export class GenerateLabelDto {
+  @ApiProperty({ description: 'Order-source connection id (the routing rule scope)' })
+  @IsUUID()
+  sourceConnectionId!: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Source-side delivery method id; null resolves to the omp_fulfilled default',
+  })
+  @IsOptional()
+  @IsString()
+  sourceDeliveryMethodId?: string | null;
+
+  @ApiProperty({ description: 'Internal order id (ol_order_*)' })
+  @IsString()
+  @IsNotEmpty()
+  orderId!: string;
+
+  @ApiProperty({ enum: ShippingMethodValues })
+  @IsEnum(ShippingMethodValues)
+  shippingMethod!: ShippingMethod;
+
+  @ApiPropertyOptional({ description: 'Required when shippingMethod === paczkomat' })
+  @IsOptional()
+  @IsString()
+  paczkomatId?: string;
+
+  @ApiProperty({ type: ShipmentRecipientDto })
+  @ValidateNested()
+  @Type(() => ShipmentRecipientDto)
+  recipient!: ShipmentRecipientDto;
+
+  @ApiProperty({ type: ShipmentParcelDto })
+  @ValidateNested()
+  @Type(() => ShipmentParcelDto)
+  parcel!: ShipmentParcelDto;
+}

--- a/apps/api/src/shipping/http/dto/list-shipments-query.dto.ts
+++ b/apps/api/src/shipping/http/dto/list-shipments-query.dto.ts
@@ -1,0 +1,79 @@
+/**
+ * List Shipments Query DTO
+ *
+ * Query parameters for GET /shipments. All fields optional.
+ *
+ * NOTE on coercion: query params arrive as strings. `hasTracking` uses an
+ * explicit `@Transform` ('true'/'false' → boolean) — NOT `@Type(() => Boolean)`,
+ * which would coerce `"false"` to `true`. Date bounds validate the raw ISO
+ * string via `@IsDateString` and are converted to `Date` in the controller —
+ * NOT `@Type(() => Date)`, which would hand `@IsDateString` a `Date` object.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsDateString, IsEnum, IsInt, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ShipmentStatusValues,
+  ShippingMethodValues,
+  type ShipmentStatus,
+  type ShippingMethod,
+} from '@openlinker/core/shipping';
+
+export class ListShipmentsQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by internal order id (ol_order_*)' })
+  @IsOptional()
+  @IsString()
+  orderId?: string;
+
+  @ApiPropertyOptional({ enum: ShipmentStatusValues, description: 'Filter by shipment status' })
+  @IsOptional()
+  @IsEnum(ShipmentStatusValues)
+  status?: ShipmentStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by shipping-provider connection id (UUID)' })
+  @IsOptional()
+  @IsUUID()
+  connectionId?: string;
+
+  @ApiPropertyOptional({ enum: ShippingMethodValues, description: 'Filter by shipping method' })
+  @IsOptional()
+  @IsEnum(ShippingMethodValues)
+  shippingMethod?: ShippingMethod;
+
+  @ApiPropertyOptional({
+    description: 'true → only shipments with a tracking number; false → only those without',
+  })
+  @IsOptional()
+  @Transform(({ value }): unknown =>
+    value === 'true' ? true : value === 'false' ? false : value,
+  )
+  @IsBoolean()
+  hasTracking?: boolean;
+
+  @ApiPropertyOptional({ description: 'Inclusive lower bound on createdAt (ISO-8601)' })
+  @IsOptional()
+  @IsDateString()
+  createdFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Inclusive upper bound on createdAt (ISO-8601)' })
+  @IsOptional()
+  @IsDateString()
+  createdTo?: string;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Page size' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/apps/api/src/shipping/http/dto/paginated-shipments-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/paginated-shipments-response.dto.ts
@@ -1,0 +1,24 @@
+/**
+ * Paginated Shipments Response DTO
+ *
+ * Response envelope for GET /shipments. Mirrors `PaginatedSyncJobsResponseDto`
+ * (items + total + limit + offset).
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { ShipmentResponseDto } from './shipment-response.dto';
+
+export class PaginatedShipmentsResponseDto {
+  @ApiProperty({ type: [ShipmentResponseDto] })
+  items!: ShipmentResponseDto[];
+
+  @ApiProperty({ description: 'Total number of shipments matching the filters' })
+  total!: number;
+
+  @ApiProperty({ description: 'Page size used for this response' })
+  limit!: number;
+
+  @ApiProperty({ description: 'Offset used for this response' })
+  offset!: number;
+}

--- a/apps/api/src/shipping/http/dto/shipment-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/shipment-response.dto.ts
@@ -1,0 +1,84 @@
+/**
+ * Shipment Response DTO
+ *
+ * HTTP projection of the `Shipment` domain entity for the `/shipments` read +
+ * command API (#846). Exposes only shipment fields — no secrets/credentials;
+ * `connectionId` is a UUID reference, not a credential. Timestamps are
+ * serialized as ISO-8601 strings.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { ShipmentStatusValues, ShippingMethodValues , ShipmentStatus, ShippingMethod } from '@openlinker/core/shipping';
+import type { Shipment } from '@openlinker/core/shipping';
+
+export class ShipmentResponseDto {
+  @ApiProperty({ description: 'Internal shipment id (ol_shipment_*)' })
+  id!: string;
+
+  @ApiProperty({ description: 'Internal order id (ol_order_*)' })
+  orderId!: string;
+
+  @ApiProperty({ description: 'Shipping-provider connection id (UUID)' })
+  connectionId!: string;
+
+  @ApiProperty({ enum: ShippingMethodValues })
+  shippingMethod!: ShippingMethod;
+
+  @ApiProperty({ enum: ShipmentStatusValues })
+  status!: ShipmentStatus;
+
+  @ApiProperty({ nullable: true, description: 'Provider-issued shipment id' })
+  providerShipmentId!: string | null;
+
+  @ApiProperty({ nullable: true, description: 'Paczkomat / pickup-point id' })
+  paczkomatId!: string | null;
+
+  @ApiProperty({ nullable: true })
+  trackingNumber!: string | null;
+
+  @ApiProperty({ nullable: true, description: 'Opaque adapter reference to the label PDF' })
+  labelPdfRef!: string | null;
+
+  @ApiProperty({ nullable: true, type: String, format: 'date-time' })
+  dispatchedAt!: string | null;
+
+  @ApiProperty({ nullable: true, type: String, format: 'date-time' })
+  deliveredAt!: string | null;
+
+  @ApiProperty({ nullable: true, type: String, format: 'date-time' })
+  cancelledAt!: string | null;
+
+  @ApiProperty({ nullable: true, type: String, format: 'date-time' })
+  failedAt!: string | null;
+
+  @ApiProperty({ nullable: true, description: 'Last provider/dispatch failure message' })
+  errorMessage!: string | null;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  createdAt!: string;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  updatedAt!: string;
+
+  static fromDomain(shipment: Shipment): ShipmentResponseDto {
+    const dto = new ShipmentResponseDto();
+    dto.id = shipment.id;
+    dto.orderId = shipment.orderId;
+    dto.connectionId = shipment.connectionId;
+    dto.shippingMethod = shipment.shippingMethod;
+    dto.status = shipment.status;
+    dto.providerShipmentId = shipment.providerShipmentId;
+    dto.paczkomatId = shipment.paczkomatId;
+    dto.trackingNumber = shipment.trackingNumber;
+    dto.labelPdfRef = shipment.labelPdfRef;
+    dto.dispatchedAt = shipment.dispatchedAt?.toISOString() ?? null;
+    dto.deliveredAt = shipment.deliveredAt?.toISOString() ?? null;
+    dto.cancelledAt = shipment.cancelledAt?.toISOString() ?? null;
+    dto.failedAt = shipment.failedAt?.toISOString() ?? null;
+    dto.errorMessage = shipment.errorMessage;
+    dto.createdAt = shipment.createdAt.toISOString();
+    dto.updatedAt = shipment.updatedAt.toISOString();
+    return dto;
+  }
+}

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Shipment Controller unit tests (#846).
+ *
+ * Mocks the three `I*Service` seams and asserts: list filter/pagination
+ * mapping (incl. date coercion + hasTracking), active/by-id 404s, generate-label
+ * delegation + both result kinds, cancel delegation, and the domain→HTTP
+ * exception mapping.
+ */
+
+import {
+  BadGatewayException,
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import {
+  type IShipmentCancellationService,
+  type IShipmentDispatchService,
+  type IShipmentQueryService,
+  Shipment,
+  ShipmentCancellationNotSupportedException,
+  ShipmentNotCancellableException,
+  ShipmentNotFoundException,
+  UndispatchableResolutionException,
+} from '@openlinker/core/shipping';
+
+import { ShipmentController } from './shipment.controller';
+import type { GenerateLabelDto } from './dto/generate-label.dto';
+import type { ListShipmentsQueryDto } from './dto/list-shipments-query.dto';
+
+function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? 'b3f1c2d4-0000-4000-8000-000000000001',
+    overrides.shippingMethod ?? 'paczkomat',
+    overrides.status ?? 'generated',
+    overrides.providerShipmentId ?? 'shipx-1',
+    overrides.paczkomatId ?? 'POZ08A',
+    overrides.trackingNumber ?? '6800000001',
+    overrides.labelPdfRef ?? 'shipx:label:1',
+    null,
+    null,
+    null,
+    null,
+    null,
+    new Date('2026-05-20T10:00:00.000Z'),
+    new Date('2026-05-20T10:00:00.000Z'),
+  );
+}
+
+function makeGenerateLabelDto(overrides: Partial<GenerateLabelDto> = {}): GenerateLabelDto {
+  return {
+    sourceConnectionId: 'a1b2c3d4-0000-4000-8000-000000000002',
+    orderId: 'ol_order_1',
+    shippingMethod: 'kurier',
+    recipient: { email: 'buyer@example.com', phone: '+48500600700' },
+    parcel: { template: 'medium' },
+    ...overrides,
+  } as GenerateLabelDto;
+}
+
+describe('ShipmentController', () => {
+  let query: jest.Mocked<IShipmentQueryService>;
+  let dispatch: jest.Mocked<IShipmentDispatchService>;
+  let cancellation: jest.Mocked<IShipmentCancellationService>;
+  let controller: ShipmentController;
+
+  beforeEach(() => {
+    query = {
+      list: jest.fn(),
+      getById: jest.fn(),
+      getActiveByOrderId: jest.fn(),
+    };
+    dispatch = { dispatch: jest.fn() };
+    cancellation = { cancel: jest.fn() };
+    controller = new ShipmentController(query, dispatch, cancellation);
+  });
+
+  describe('list', () => {
+    it('should map filters (with date coercion + hasTracking) and echo pagination', async () => {
+      query.list.mockResolvedValue({ items: [makeShipment()], total: 1 });
+      const dto: ListShipmentsQueryDto = {
+        status: 'generated',
+        hasTracking: false,
+        createdFrom: '2026-05-01T00:00:00.000Z',
+        createdTo: '2026-05-31T23:59:59.000Z',
+        limit: 10,
+        offset: 20,
+      };
+
+      const result = await controller.list(dto);
+
+      expect(query.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'generated',
+          hasTracking: false,
+          createdFrom: new Date('2026-05-01T00:00:00.000Z'),
+          createdTo: new Date('2026-05-31T23:59:59.000Z'),
+        }),
+        { limit: 10, offset: 20 },
+      );
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(10);
+      expect(result.offset).toBe(20);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].id).toBe('ol_shipment_1');
+    });
+
+    it('should default limit/offset and leave undefined date bounds undefined', async () => {
+      query.list.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.list({});
+
+      expect(query.list).toHaveBeenCalledWith(
+        expect.objectContaining({ createdFrom: undefined, createdTo: undefined }),
+        { limit: 20, offset: 0 },
+      );
+    });
+  });
+
+  describe('getActive', () => {
+    it('should throw BadRequest when orderId is missing', async () => {
+      await expect(controller.getActive(undefined)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('should throw NotFound when no active shipment exists', async () => {
+      query.getActiveByOrderId.mockResolvedValue(null);
+      await expect(controller.getActive('ol_order_1')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should return the active shipment', async () => {
+      query.getActiveByOrderId.mockResolvedValue(makeShipment());
+      const result = await controller.getActive('ol_order_1');
+      expect(result.id).toBe('ol_shipment_1');
+    });
+  });
+
+  describe('getById', () => {
+    it('should throw NotFound when absent', async () => {
+      query.getById.mockResolvedValue(null);
+      await expect(controller.getById('missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should return the shipment DTO', async () => {
+      query.getById.mockResolvedValue(makeShipment());
+      const result = await controller.getById('ol_shipment_1');
+      expect(result.trackingNumber).toBe('6800000001');
+    });
+  });
+
+  describe('generateLabel', () => {
+    it('should build the dispatch input (null source method) and return the dispatched result', async () => {
+      const shipment = makeShipment();
+      dispatch.dispatch.mockResolvedValue({ kind: 'dispatched', shipment });
+
+      const result = await controller.generateLabel(makeGenerateLabelDto());
+
+      expect(dispatch.dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceDeliveryMethodId: null, orderId: 'ol_order_1' }),
+      );
+      expect(result.kind).toBe('dispatched');
+      expect(result.shipment?.id).toBe('ol_shipment_1');
+    });
+
+    it('should return omp_fulfilled with no shipment', async () => {
+      dispatch.dispatch.mockResolvedValue({ kind: 'omp_fulfilled' });
+      const result = await controller.generateLabel(makeGenerateLabelDto());
+      expect(result.kind).toBe('omp_fulfilled');
+      expect(result.shipment).toBeUndefined();
+    });
+
+    it('should map UndispatchableResolutionException to 422', async () => {
+      dispatch.dispatch.mockRejectedValue(new UndispatchableResolutionException('no connection'));
+      await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should map a provider failure to 502', async () => {
+      dispatch.dispatch.mockRejectedValue(new Error('paczkomat unavailable'));
+      await expect(controller.generateLabel(makeGenerateLabelDto())).rejects.toBeInstanceOf(
+        BadGatewayException,
+      );
+    });
+  });
+
+  describe('cancel', () => {
+    it('should return the cancelled shipment', async () => {
+      cancellation.cancel.mockResolvedValue(makeShipment({ status: 'cancelled' }));
+      const result = await controller.cancel('ol_shipment_1');
+      expect(result.status).toBe('cancelled');
+    });
+
+    it('should map ShipmentNotFoundException to 404', async () => {
+      cancellation.cancel.mockRejectedValue(new ShipmentNotFoundException('missing'));
+      await expect(controller.cancel('missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('should map ShipmentNotCancellableException to 409', async () => {
+      cancellation.cancel.mockRejectedValue(
+        new ShipmentNotCancellableException('ol_shipment_1', 'status is dispatched'),
+      );
+      await expect(controller.cancel('ol_shipment_1')).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('should map ShipmentCancellationNotSupportedException to 422', async () => {
+      cancellation.cancel.mockRejectedValue(
+        new ShipmentCancellationNotSupportedException('ol_shipment_1', 'conn-x'),
+      );
+      await expect(controller.cancel('ol_shipment_1')).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+  });
+});

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -1,0 +1,187 @@
+/**
+ * Shipment Controller
+ *
+ * HTTP REST endpoints for shipments (#846): a filtered/paginated list, single
+ * + active-by-order reads, and the two commands — generate-label (delegates to
+ * the #835 dispatch seam) and cancel. Reads/commands go through `I*Service`
+ * seams (never `ShipmentRepositoryPort` — banned cross-context in apps/**).
+ * Domain exceptions are mapped to HTTP at this boundary. Admin + JWT.
+ *
+ * @module apps/api/src/shipping/http
+ */
+
+import {
+  BadGatewayException,
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  type IShipmentCancellationService,
+  type IShipmentDispatchService,
+  type IShipmentQueryService,
+  type ShipmentDispatchInput,
+  type ShipmentFilters,
+  SHIPMENT_CANCELLATION_SERVICE_TOKEN,
+  SHIPMENT_DISPATCH_SERVICE_TOKEN,
+  SHIPMENT_QUERY_SERVICE_TOKEN,
+  ShipmentCancellationNotSupportedException,
+  ShipmentNotCancellableException,
+  ShipmentNotFoundException,
+  UndispatchableResolutionException,
+} from '@openlinker/core/shipping';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { DispatchResultResponseDto } from './dto/dispatch-result-response.dto';
+import { GenerateLabelDto } from './dto/generate-label.dto';
+import { ListShipmentsQueryDto } from './dto/list-shipments-query.dto';
+import { PaginatedShipmentsResponseDto } from './dto/paginated-shipments-response.dto';
+import { ShipmentResponseDto } from './dto/shipment-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('shipments')
+@Controller('shipments')
+export class ShipmentController {
+  constructor(
+    @Inject(SHIPMENT_QUERY_SERVICE_TOKEN)
+    private readonly query: IShipmentQueryService,
+    @Inject(SHIPMENT_DISPATCH_SERVICE_TOKEN)
+    private readonly dispatch: IShipmentDispatchService,
+    @Inject(SHIPMENT_CANCELLATION_SERVICE_TOKEN)
+    private readonly cancellation: IShipmentCancellationService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List shipments across orders and connections' })
+  @ApiResponse({ status: 200, type: PaginatedShipmentsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async list(@Query() query: ListShipmentsQueryDto): Promise<PaginatedShipmentsResponseDto> {
+    const limit = query.limit ?? 20;
+    const offset = query.offset ?? 0;
+    const filters: ShipmentFilters = {
+      orderId: query.orderId,
+      status: query.status,
+      connectionId: query.connectionId,
+      shippingMethod: query.shippingMethod,
+      hasTracking: query.hasTracking,
+      createdFrom: query.createdFrom ? new Date(query.createdFrom) : undefined,
+      createdTo: query.createdTo ? new Date(query.createdTo) : undefined,
+    };
+
+    const page = await this.query.list(filters, { limit, offset });
+    return {
+      items: page.items.map((shipment) => ShipmentResponseDto.fromDomain(shipment)),
+      total: page.total,
+      limit,
+      offset,
+    };
+  }
+
+  // Declared BEFORE `:id` — Express matches in order, so `:id` would otherwise
+  // capture the literal segment `active`.
+  @Get('active')
+  @ApiOperation({ summary: "Get an order's current active (non-terminal) shipment" })
+  @ApiQuery({ name: 'orderId', type: String, required: true })
+  @ApiResponse({ status: 200, type: ShipmentResponseDto })
+  @ApiResponse({ status: 404, description: 'No active shipment for the order' })
+  async getActive(@Query('orderId') orderId?: string): Promise<ShipmentResponseDto> {
+    if (!orderId) {
+      throw new BadRequestException('orderId query parameter is required');
+    }
+    const shipment = await this.query.getActiveByOrderId(orderId);
+    if (!shipment) {
+      throw new NotFoundException(`No active shipment for order: ${orderId}`);
+    }
+    return ShipmentResponseDto.fromDomain(shipment);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a shipment by id' })
+  @ApiResponse({ status: 200, type: ShipmentResponseDto })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  async getById(@Param('id') id: string): Promise<ShipmentResponseDto> {
+    const shipment = await this.query.getById(id);
+    if (!shipment) {
+      throw new NotFoundException(`Shipment not found: ${id}`);
+    }
+    return ShipmentResponseDto.fromDomain(shipment);
+  }
+
+  @Post('generate-label')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Generate a shipping label for an order via the resolved fulfillment processor',
+  })
+  @ApiResponse({ status: 200, type: DispatchResultResponseDto })
+  @ApiResponse({ status: 422, description: 'Routing resolution cannot be dispatched' })
+  @ApiResponse({ status: 502, description: 'Shipping provider rejected label generation' })
+  async generateLabel(@Body() dto: GenerateLabelDto): Promise<DispatchResultResponseDto> {
+    const input: ShipmentDispatchInput = {
+      sourceConnectionId: dto.sourceConnectionId,
+      sourceDeliveryMethodId: dto.sourceDeliveryMethodId ?? null,
+      orderId: dto.orderId,
+      shippingMethod: dto.shippingMethod,
+      paczkomatId: dto.paczkomatId,
+      recipient: dto.recipient,
+      parcel: dto.parcel,
+    };
+    try {
+      const result = await this.dispatch.dispatch(input);
+      return DispatchResultResponseDto.fromResult(result);
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+  }
+
+  @Post(':id/cancel')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Cancel a not-yet-dispatched shipment' })
+  @ApiResponse({ status: 200, type: ShipmentResponseDto })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  @ApiResponse({ status: 409, description: 'Shipment is past the cancellable window' })
+  @ApiResponse({ status: 422, description: 'Provider does not support cancellation' })
+  async cancel(@Param('id') id: string): Promise<ShipmentResponseDto> {
+    try {
+      const shipment = await this.cancellation.cancel(id);
+      return ShipmentResponseDto.fromDomain(shipment);
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+  }
+
+  /**
+   * Map shipment domain exceptions to HTTP. A `generateLabel` provider
+   * rejection (rethrown by the dispatch seam after persisting `failed`) is an
+   * upstream failure → 502, so ordinary command errors never fall through to a
+   * bare 500.
+   */
+  private toHttpException(error: unknown): Error {
+    if (error instanceof ShipmentNotFoundException) {
+      return new NotFoundException(error.message);
+    }
+    if (error instanceof ShipmentNotCancellableException) {
+      return new ConflictException(error.message);
+    }
+    if (
+      error instanceof ShipmentCancellationNotSupportedException ||
+      error instanceof UndispatchableResolutionException
+    ) {
+      return new UnprocessableEntityException(error.message);
+    }
+    if (error instanceof Error) {
+      return new BadGatewayException(error.message);
+    }
+    return new BadGatewayException(String(error));
+  }
+}

--- a/apps/api/src/shipping/shipping.module.ts
+++ b/apps/api/src/shipping/shipping.module.ts
@@ -1,0 +1,20 @@
+/**
+ * Shipping API Module
+ *
+ * Wires the shipment HTTP layer (#846). Imports the core `ShippingModule` for
+ * the query / dispatch / cancellation service bindings (and the underlying
+ * `ShipmentRepositoryPort` + dispatch seam from #763/#835) and registers the
+ * shipment controller. Mirrors `MappingsApiModule`.
+ *
+ * @module apps/api/src/shipping
+ */
+import { Module } from '@nestjs/common';
+import { ShippingModule } from '@openlinker/core/shipping';
+
+import { ShipmentController } from './http/shipment.controller';
+
+@Module({
+  imports: [ShippingModule],
+  controllers: [ShipmentController],
+})
+export class ShippingApiModule {}

--- a/apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts
+++ b/apps/api/test/integration/helpers/inpost-test-shipping-stub.helper.ts
@@ -26,6 +26,7 @@ import {
 import type {
   GenerateLabelCommand,
   GenerateLabelResult,
+  ShipmentCanceller,
   ShippingMethod,
   ShippingProviderManagerPort,
   TrackingSnapshot,
@@ -45,7 +46,10 @@ export function installInpostTestShippingStub(harness: IntegrationTestHarness): 
     .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
 
   let counter = 0;
-  const shippingStub: ShippingProviderManagerPort = {
+  // Implements ShipmentCanceller too (#846): the cancel command resolves this
+  // adapter and narrows via `isShipmentCanceller`. #835's dispatch spec ignores
+  // the extra method, so adding it is backward-compatible.
+  const shippingStub: ShippingProviderManagerPort & ShipmentCanceller = {
     getSupportedMethods(): readonly ShippingMethod[] {
       return ['paczkomat', 'kurier'];
     },
@@ -59,6 +63,9 @@ export function installInpostTestShippingStub(harness: IntegrationTestHarness): 
     },
     getTracking(_input: { providerShipmentId: string }): Promise<TrackingSnapshot> {
       return Promise.resolve({ status: 'generated', providerStatus: 'generated' });
+    },
+    cancelShipment(_input: { providerShipmentId: string }): Promise<void> {
+      return Promise.resolve();
     },
   };
 

--- a/apps/api/test/integration/shipments-read.int-spec.ts
+++ b/apps/api/test/integration/shipments-read.int-spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Shipments Read + Command API Integration Test (#846)
+ *
+ * Exercises the `/shipments` HTTP surface end-to-end against real Postgres +
+ * Nest wiring. Shipments are seeded through the generate-label endpoint (the
+ * #835 dispatch seam routed to the in-memory stub adapter) rather than the
+ * repository, mirroring `shipment-dispatch.int-spec.ts` and keeping the test
+ * off `ShipmentRepositoryPort` (banned cross-context).
+ *
+ * Covers: list shape + filters (status / connectionId / hasTracking — the
+ * boolean-coercion regression) + pagination; by-id + active reads + 404s;
+ * generate-label dispatched + omp_fulfilled; cancel happy path + idempotency.
+ * The not-cancellable-state / cancellation-not-supported branches are covered
+ * by the cancellation-service unit spec.
+ *
+ * @module apps/api/test/integration
+ */
+import request from 'supertest';
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+import { createTestConnection } from './helpers/test-connection.helper';
+import {
+  INPOST_TEST_ADAPTER_KEY,
+  installInpostTestShippingStub,
+} from './helpers/inpost-test-shipping-stub.helper';
+
+const RECIPIENT = {
+  email: 'buyer@example.com',
+  phone: '+48500600700',
+  address: {
+    street: 'Krakowska',
+    buildingNumber: '12',
+    city: 'Poznań',
+    postCode: '60-001',
+    countryCode: 'PL',
+  },
+};
+const PARCEL = { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1200 };
+const METHOD = 'allegro-courier';
+
+describe('Shipments Read + Command API Integration', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    installInpostTestShippingStub(harness);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const routingService = (): IFulfillmentRoutingService =>
+    harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+
+  async function seedRoute(): Promise<{ sourceId: string; carrierId: string }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    const carrier = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: INPOST_TEST_ADAPTER_KEY,
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    await routingService().replaceRules(source.id, [
+      {
+        sourceDeliveryMethodId: METHOD,
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: carrier.id,
+      },
+    ]);
+    return { sourceId: source.id, carrierId: carrier.id };
+  }
+
+  // Returns the supertest `Test` (not awaited) so callers can chain `.expect`.
+  function generateLabel(
+    http: ReturnType<typeof request>,
+    token: string,
+    sourceId: string,
+    orderId: string,
+    deliveryMethodId: string = METHOD,
+  ): request.Test {
+    return http
+      .post('/shipments/generate-label')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        sourceConnectionId: sourceId,
+        sourceDeliveryMethodId: deliveryMethodId,
+        orderId,
+        shippingMethod: 'kurier',
+        recipient: RECIPIENT,
+        parcel: PARCEL,
+      });
+  }
+
+  describe('POST /shipments/generate-label', () => {
+    it('should dispatch a label-generating order to a persisted generated shipment', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+      const { sourceId, carrierId } = await seedRoute();
+
+      const res = await generateLabel(http, token, sourceId, 'ol_order_gl_1').expect(200);
+
+      expect(res.body.kind).toBe('dispatched');
+      expect(res.body.shipment).toMatchObject({
+        orderId: 'ol_order_gl_1',
+        connectionId: carrierId,
+        status: 'generated',
+      });
+      expect(res.body.shipment.providerShipmentId).toMatch(/^stub-/);
+      expect(res.body.shipment.trackingNumber).toBeNull();
+    });
+
+    it('should return omp_fulfilled with no shipment for an unmapped method', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+      const { sourceId } = await seedRoute();
+
+      const res = await generateLabel(http, token, sourceId, 'ol_order_omp', 'unmapped').expect(200);
+
+      expect(res.body).toEqual({ kind: 'omp_fulfilled' });
+    });
+
+    it('should reject an invalid body with 400', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+
+      await http
+        .post('/shipments/generate-label')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ sourceConnectionId: 'not-a-uuid', orderId: '', shippingMethod: 'pigeon' })
+        .expect(400);
+    });
+  });
+
+  describe('GET /shipments', () => {
+    it('should return an empty page when no shipments exist', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+
+      const res = await http.get('/shipments').set('Authorization', `Bearer ${token}`).expect(200);
+
+      expect(res.body).toMatchObject({ items: [], total: 0, limit: 20, offset: 0 });
+    });
+
+    it('should list seeded shipments and filter by status / connectionId', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+      const { sourceId, carrierId } = await seedRoute();
+      await generateLabel(http, token, sourceId, 'ol_order_list_1').expect(200);
+
+      const all = await http.get('/shipments').set('Authorization', `Bearer ${token}`).expect(200);
+      expect(all.body.total).toBe(1);
+      expect(all.body.items[0].orderId).toBe('ol_order_list_1');
+
+      const byStatus = await http
+        .get('/shipments?status=generated')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(byStatus.body.total).toBe(1);
+
+      const byConn = await http
+        .get(`/shipments?connectionId=${carrierId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(byConn.body.total).toBe(1);
+
+      const otherConn = await http
+        .get('/shipments?connectionId=00000000-0000-4000-8000-000000000000')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(otherConn.body.total).toBe(0);
+    });
+
+    it('should honour hasTracking coercion — false includes the stub shipment, true excludes it', async () => {
+      // The stub returns trackingNumber: null, so the seeded shipment has no
+      // tracking. This is the regression guard for the @Transform fix: a naive
+      // @Type(() => Boolean) would coerce "false" → true and break this.
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+      const { sourceId } = await seedRoute();
+      await generateLabel(http, token, sourceId, 'ol_order_tracking').expect(200);
+
+      const withoutTracking = await http
+        .get('/shipments?hasTracking=false')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(withoutTracking.body.total).toBe(1);
+
+      const withTracking = await http
+        .get('/shipments?hasTracking=true')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(withTracking.body.total).toBe(0);
+    });
+
+    it('should paginate', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+      const { sourceId } = await seedRoute();
+      await generateLabel(http, token, sourceId, 'ol_order_p1').expect(200);
+      await generateLabel(http, token, sourceId, 'ol_order_p2').expect(200);
+
+      const page = await http
+        .get('/shipments?limit=1&offset=0')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(page.body.total).toBe(2);
+      expect(page.body.items).toHaveLength(1);
+      expect(page.body.limit).toBe(1);
+    });
+  });
+
+  describe('GET /shipments/:id and /active', () => {
+    it('should read a shipment by id and by active-order, and 404 when absent', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+      const { sourceId } = await seedRoute();
+      const created = await generateLabel(http, token, sourceId, 'ol_order_read').expect(200);
+      const id = created.body.shipment.id as string;
+
+      const byId = await http
+        .get(`/shipments/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(byId.body.id).toBe(id);
+
+      const active = await http
+        .get('/shipments/active?orderId=ol_order_read')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(active.body.id).toBe(id);
+
+      await http
+        .get('/shipments/ol_shipment_missing')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+      await http
+        .get('/shipments/active?orderId=ol_order_none')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+  });
+
+  describe('POST /shipments/:id/cancel', () => {
+    it('should cancel a generated shipment and become idempotent', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+      const { sourceId } = await seedRoute();
+      const created = await generateLabel(http, token, sourceId, 'ol_order_cancel').expect(200);
+      const id = created.body.shipment.id as string;
+
+      const cancelled = await http
+        .post(`/shipments/${id}/cancel`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(cancelled.body.status).toBe('cancelled');
+      expect(cancelled.body.cancelledAt).not.toBeNull();
+
+      // Now terminal: no active shipment for the order.
+      await http
+        .get('/shipments/active?orderId=ol_order_cancel')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+
+      // Idempotent re-cancel.
+      const again = await http
+        .post(`/shipments/${id}/cancel`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(again.body.status).toBe('cancelled');
+    });
+
+    it('should 404 when cancelling a missing shipment', async () => {
+      const http = harness.getHttp();
+      const token = await loginAsAdmin(http, harness.getDataSource());
+
+      await http
+        .post('/shipments/ol_shipment_missing/cancel')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+  });
+});

--- a/docs/plans/implementation-plan-846-shipment-read-command-api.md
+++ b/docs/plans/implementation-plan-846-shipment-read-command-api.md
@@ -1,0 +1,178 @@
+# Implementation Plan: Shipment read + command HTTP API (#846)
+
+**Date**: 2026-05-26
+**Status**: Ready for implementation
+**Estimated Effort**: M (3–7 days) — core query + cancellation services, repo `findMany`, API module + controller + DTOs, unit + integration tests. No migration.
+**Branch**: `846-shipment-read-command-api`
+
+---
+
+## 0. Premise reconciliation (read first)
+
+Verified against the fresh `main` (`8827216`, after #843/#844 merged):
+
+- ✅ **Dispatch engine exists** — `ShipmentDispatchService` (#835/PR #843) already does routing-resolution → `generateLabel` → persist → idempotency → failure-handling, with `IShipmentDispatchService` + `SHIPMENT_DISPATCH_SERVICE_TOKEN` exported from `@openlinker/core/shipping`. It is **unwired** (no trigger calls it; its docs name the trigger as #769/#771 — i.e. an HTTP endpoint that does not exist).
+- ❌ **No HTTP surface** — `apps/api/src/shipping` does not exist; no shipment controller anywhere.
+- ❌ **No list query** — `ShipmentRepositoryPort` has `findById` / `findByOrderId` / `findActiveByOrderId` / `findByProviderShipmentId` / `create` / `update`, but **no** filtered+paginated list.
+- ❌ **No cancel orchestration** — `ShipmentCanceller` sub-capability + `isShipmentCanceller` guard exist on the port, but nothing calls `cancelShipment`.
+
+So #846 = (a) the read surface (`GET /shipments` + by-id) over a new repo `findMany`, behind a query service; (b) the command surface that **wires the existing dispatch seam** (`POST /shipments/generate-label`) and adds the **cancel orchestration** absorbed from #845 (`POST /shipments/:id/cancel`). #845's engine is superseded by #835 — only its cancel residual lands here.
+
+---
+
+## 1. Goal & layer
+
+**Goal**: Expose shipment reads + commands over HTTP so the FE shipment surfaces (#769 order panel, #770 `/shipments`, #839 Allegro Delivery) can list/inspect shipments and trigger label generation / cancellation.
+
+**Layers touched**:
+- **CORE** (`libs/core/src/shipping`): repo `findMany`, query service, cancellation service, one domain exception, two tokens, barrel + module wiring.
+- **INTERFACE** (`apps/api/src/shipping`): API module, controller, DTOs.
+
+**Explicit non-goals**:
+- Re-building the dispatch engine (done — #835).
+- Status read-back / propagation to Allegro/PS (#768 webhook, #772 polling, #838 Allegro poll).
+- Order→recipient/parcel assembly (operator input / #767 paczkomat-from-PS-module / PII sourcing — the caller supplies the label payload, per #835's Design A).
+- FE pages/components (#769/#770/#839).
+- Bulk actions, CSV export, analytics (v2 per #727 A5).
+- A migration (none — `findMany` and cancel use existing columns/indexes).
+
+---
+
+## 2. Architecture compliance (the load-bearing constraint)
+
+`scripts/check-cross-context-imports.mjs` (under `pnpm lint`) **forbids** importing `*RepositoryPort` from `@openlinker/core/<ctx>` in `apps/**` unless allow-listed. The sync read controller's `SyncJobRepositoryPort` import is an allow-listed *legacy* coupling ("rewire via ISyncJobsService"). A **new** controller importing `ShipmentRepositoryPort` would fail the gate.
+
+**⇒ The controller injects `I*Service` interfaces only** (allowed cross-context surface): `IShipmentQueryService`, `IShipmentDispatchService`, `IShipmentCancellationService`, their Symbol tokens, the `Shipment` entity, `as const` status/method values, type aliases (`ShipmentFilters`, `ShipmentDispatchInput`, …) and exceptions. No repo-port import in `apps/api`. The repo `findMany` stays intra-context behind the query service.
+
+This also satisfies engineering-standards §"Services must always implement an interface".
+
+---
+
+## 3. Data flow
+
+```
+GET /shipments?status&connectionId&method&hasTracking&orderId&createdFrom&createdTo&limit&offset
+  ShipmentController.list(query)
+   → IShipmentQueryService.list(filters, pagination)
+     → ShipmentRepositoryPort.findMany(filters, pagination)  [findAndCount, createdAt DESC]
+   → PaginatedShipmentsResponseDto { items, total, limit, offset }
+
+GET /shipments/:id
+  → IShipmentQueryService.getById(id) → 404 ShipmentNotFound if null → ShipmentResponseDto
+
+POST /shipments/generate-label  (body ≅ ShipmentDispatchInput)
+  → IShipmentDispatchService.dispatch(input)           [existing #835 seam]
+   → { kind:'dispatched', shipment } | { kind:'omp_fulfilled' }
+   → DispatchResultResponseDto  (generateLabel failure → domain error → mapped HTTP)
+
+POST /shipments/:id/cancel
+  → IShipmentCancellationService.cancel(id)
+   → repo.findById → guard state → integrations.getCapabilityAdapter('ShippingProviderManager')
+     → isShipmentCanceller? → adapter.cancelShipment({ providerShipmentId }) (when present)
+   → repo.update(id, { status:'cancelled', cancelledAt }) → ShipmentResponseDto
+```
+
+---
+
+## 4. Step-by-step (each tied to a path + acceptance)
+
+### CORE
+
+1. **`libs/core/src/shipping/domain/types/shipment-query.types.ts`** (new)
+   - `ShipmentFilters` = `{ orderId?, status?: ShipmentStatus, connectionId?, shippingMethod?: ShippingMethod, hasTracking?: boolean, createdFrom?: Date, createdTo?: Date }`.
+   - `ShipmentPagination` = `{ limit: number; offset: number }`.
+   - `PaginatedShipments` = `{ items: readonly Shipment[]; total: number }`.
+   - *AC*: types-only file, header comment; mirrors sync's `SyncJobFilters`/`PaginatedSyncJobs`.
+
+2. **`libs/core/src/shipping/domain/ports/shipment-repository.port.ts`** (edit)
+   - Add `findMany(filters: ShipmentFilters, pagination: ShipmentPagination): Promise<PaginatedShipments>`.
+   - *AC*: doc comment; no other methods touched.
+
+3. **`libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts`** (edit)
+   - Implement `findMany` via `repository.findAndCount({ where, order:{ createdAt:'DESC' }, skip:offset, take:limit })`. Build `where` dynamically: equality for `orderId`/`status`/`connectionId`/`shippingMethod`; `hasTracking===true → Not(IsNull())`, `===false → IsNull()`; date range → `Between` / `MoreThanOrEqual` / `LessThanOrEqual` on `createdAt`. Map rows via existing `toDomain`. Add `findActiveByOrderId` is already present — reused by the query service (step 4).
+   - *AC*: all filters combine (AND); returns `{ items, total }`; covered by integration test.
+   - *Index note (deferred, per review)*: `createdAt` ordering + range filter has no supporting index (existing indexes cover `orderId`/`connectionId`/`status`). Acceptable at MVP shipment volume — a deliberate deferral, not an oversight.
+
+4. **`libs/core/src/shipping/application/interfaces/shipment-query.service.interface.ts`** (new)
+   - `IShipmentQueryService` { `list(filters, pagination): Promise<PaginatedShipments>`; `getById(id: string): Promise<Shipment | null>`; `getActiveByOrderId(orderId: string): Promise<Shipment | null>` }.
+   - `getActiveByOrderId` added per review — serves #769's order panel from the domain's own "active" definition (`TerminalShipmentStatusValues` via `findActiveByOrderId`) instead of making the FE re-derive terminal-state logic.
+
+5. **`libs/core/src/shipping/application/services/shipment-query.service.ts`** (new)
+   - `ShipmentQueryService implements IShipmentQueryService`, `@Inject(SHIPMENT_REPOSITORY_TOKEN)`. Thin delegation to `findMany` / `findById` / `findActiveByOrderId`.
+   - *AC*: implements interface; no business logic beyond pass-through; unit-tested.
+   - *Header note (per review)*: the file header must state this service exists to keep the controller off `ShipmentRepositoryPort` (the `*RepositoryPort` cross-context import is banned in `apps/**` — see §2), so a future reader doesn't "simplify" it by injecting the repo into the controller and reintroducing the violation.
+
+6. **`libs/core/src/shipping/domain/exceptions/shipment-not-cancellable.exception.ts`** + **`.../shipment-cancellation-not-supported.exception.ts`** (new — split per review)
+   - `ShipmentNotCancellableException(shipmentId, reason)` — wrong **state** (terminal / already `dispatched` / `in-transit`). → 409.
+   - `ShipmentCancellationNotSupportedException(shipmentId, connectionId)` — the resolved provider adapter does **not** implement `ShipmentCanceller`. → 422. Split so #769 can distinguish "can't cancel anymore" from "this carrier doesn't support cancel" (review SUGGESTION). Both extend `Error` (pattern of `ShipmentNotFoundException`).
+
+7. **`libs/core/src/shipping/application/interfaces/shipment-cancellation.service.interface.ts`** (new)
+   - `IShipmentCancellationService` { `cancel(shipmentId: string): Promise<Shipment>` }.
+
+8. **`libs/core/src/shipping/application/services/shipment-cancellation.service.ts`** (new)
+   - Injects `SHIPMENT_REPOSITORY_TOKEN` + `INTEGRATIONS_SERVICE_TOKEN`.
+   - `cancel(id)`: `findById` → `ShipmentNotFoundException` if null; if status already `cancelled` → return as-is (idempotent); if terminal (`delivered`/`failed`) or already `dispatched`/`in-transit` → `ShipmentNotCancellableException`; resolve adapter via `getCapabilityAdapter<ShippingProviderManagerPort>(connectionId,'ShippingProviderManager')`; `isShipmentCanceller(adapter)` false → `ShipmentCancellationNotSupportedException`; when `providerShipmentId` present, `adapter.cancelShipment({ providerShipmentId })`; `repo.update(id, { status:'cancelled', cancelledAt: new Date() })`.
+   - Cancellable states: `draft`, `generated` (pre-dispatch only — matches `ShipmentCanceller` contract). `log.warn` on adapter error then rethrow.
+   - *AC*: all branches unit-tested.
+
+9. **`libs/core/src/shipping/shipping.tokens.ts`** (edit)
+   - Add `SHIPMENT_QUERY_SERVICE_TOKEN = Symbol('IShipmentQueryService')`, `SHIPMENT_CANCELLATION_SERVICE_TOKEN = Symbol('IShipmentCancellationService')`.
+
+10. **`libs/core/src/shipping/shipping.module.ts`** (edit)
+    - Provide `ShipmentQueryService` + `ShipmentCancellationService`; bind both tokens (`useExisting`); add to `exports`. (`IntegrationsModule` already imported for the dispatch seam — covers the cancellation service's `INTEGRATIONS_SERVICE_TOKEN`.)
+
+11. **`libs/core/src/shipping/index.ts`** (edit)
+    - Export type `IShipmentQueryService`, `IShipmentCancellationService`; types `ShipmentFilters`, `ShipmentPagination`, `PaginatedShipments`; `ShipmentNotCancellableException` + `ShipmentCancellationNotSupportedException` (values). Tokens auto-exported via `export * from './shipping.tokens'`.
+
+12. **Unit specs** — `shipment-query.service.spec.ts`, `shipment-cancellation.service.spec.ts` (mock ports per standards).
+
+### INTERFACE (`apps/api/src/shipping`)
+
+13. **`http/dto/list-shipments-query.dto.ts`** — `status?` (`@IsEnum(ShipmentStatusValues)`), `connectionId?` (`@IsUUID`), `shippingMethod?` (`@IsEnum(ShippingMethodValues)`), `orderId?` (`@IsString`), `limit=20` (`@Type(()=>Number) @IsInt @Min(1) @Max(100)`), `offset=0` (`@Type(()=>Number) @IsInt @Min(0)`). Enum/uuid/int fields mirror `list-sync-jobs-query.dto.ts`.
+    - **Query-param coercion (per review — the sync DTO has no bool/date params, so its idiom does NOT transfer):**
+      - `hasTracking?`: `@IsOptional() @Transform(({ value }) => value === 'true' ? true : value === 'false' ? false : value) @IsBoolean()`. **Not** `@Type(() => Boolean)` — `Boolean("false") === true`.
+      - `createdFrom?` / `createdTo?`: `@IsOptional() @IsDateString()` — validate the **raw ISO string**; the controller/service converts to `Date` for the repo `Between`/`MoreThanOrEqual`/`LessThanOrEqual`. **Not** `@Type(() => Date)` + `@IsISO8601()` (the transform hands `@IsISO8601` a `Date`, which fails).
+
+14. **`http/dto/shipment-response.dto.ts`** — flat projection of `Shipment` + `static fromDomain(s: Shipment)`. Swagger-annotated.
+
+15. **`http/dto/paginated-shipments-response.dto.ts`** — `{ items: ShipmentResponseDto[]; total; limit; offset }` (mirror sync).
+
+16. **`http/dto/generate-label.dto.ts`** — request body ≅ `ShipmentDispatchInput`: `sourceConnectionId` (`@IsUUID`), `sourceDeliveryMethodId: string | null` (`@IsString @IsOptional`/nullable), `orderId` (`@IsString`), `shippingMethod` (`@IsEnum(ShippingMethodValues)`), `paczkomatId?`, nested `recipient` (`@ValidateNested @Type` → `RecipientDto` with nested `AddressDto`), nested `parcel` (`@ValidateNested @Type` → `ParcelDto` with nested `DimensionsDto`). Maps 1:1 to `ShipmentDispatchInput`.
+
+17. **`http/dto/dispatch-result-response.dto.ts`** — `{ kind: 'dispatched' | 'omp_fulfilled'; shipment?: ShipmentResponseDto }`.
+
+18. **`http/shipment.controller.ts`** — `@ApiTags('shipments') @ApiBearerAuth() @Roles('admin') @Controller('shipments')`:
+    - `@Get()` `list(@Query() q)` → convert `createdFrom`/`createdTo` strings → `Date`, build `ShipmentFilters` → `IShipmentQueryService.list` → paginated DTO.
+    - `@Get('active')` `getActive(@Query('orderId') orderId)` → `IShipmentQueryService.getActiveByOrderId` → `ShipmentResponseDto` or 404. **Declare BEFORE `@Get(':id')`** — Express matches in order, so `:id` would otherwise capture `active`.
+    - `@Get(':id')` → `getById` → `NotFoundException` if null → `ShipmentResponseDto`.
+    - `@Post('generate-label')` `@HttpCode(200)` → build `ShipmentDispatchInput` from DTO → `IShipmentDispatchService.dispatch` → `DispatchResultResponseDto`.
+    - `@Post(':id/cancel')` `@HttpCode(200)` → `IShipmentCancellationService.cancel` → `ShipmentResponseDto`.
+    - Private `toHttpException(e)`: `ShipmentNotFoundException`→404, `ShipmentNotCancellableException`→409, `ShipmentCancellationNotSupportedException`→422, `UndispatchableResolutionException`→422, other (generateLabel provider failure)→`BadGatewayException` (502) preserving message. Mirrors `fulfillment-routing.controller.ts`.
+    - **Generate-label serialization (per review — documented v1 decision):** this endpoint is the first *live* caller of `ShipmentDispatchService`, whose idempotency (`findActiveByOrderId → create`) is explicitly **non-atomic** (the schema allows N shipments/order; no DB guard). v1 accepts the best-effort guard (a duplicate rapid submit is caught by `findActiveByOrderId` in the overwhelming-majority single-operator case) + the FE disabling the button while in-flight (#769). A hard guard (idempotency key / partial unique index on active-per-order) is a deliberate follow-up, **recorded in the PR body** so the trade-off is explicit. No silent inheritance of the seam's precondition.
+
+19. **`apps/api/src/shipping/shipping.module.ts`** (`ShippingApiModule`, new) — `imports:[CoreShippingModule]`, `controllers:[ShipmentController]`.
+
+20. **`apps/api/src/app.module.ts`** (edit) — register `ShippingApiModule` in `imports`. Per review, route the core `ShippingModule` in *through* `ShippingApiModule` only and **drop the now-redundant direct `ShippingModule` import** — but first grep `apps/api` for other direct injectors of `SHIPMENT_*_TOKEN` outside the new controller; if any exist, keep the direct import too. (Tokens stay in the graph either way since `ShippingApiModule` imports core `ShippingModule`.)
+
+21. **`http/shipment.controller.spec.ts`** — unit: list mapping + pagination echo; getById 404; generate-label delegation + both result kinds; cancel delegation; `toHttpException` mapping per exception.
+
+22. **`apps/api/test/integration/shipments-read.int-spec.ts`** — mirror `sync-jobs-read.int-spec.ts`: seed shipments (repo/ORM), assert list shape + each filter (incl. `hasTracking=false` proving the coercion fix) + pagination no-overlap + by-id + 404 + active-by-order; cancel happy path + non-cancellable-state + cancellation-not-supported; generate-label happy path + omp_fulfilled — reuse `helpers/inpost-test-shipping-stub.helper.ts` + a `replaceRules` routing rule, as `shipment-dispatch.int-spec.ts` does. (`'shipments'` already in `setup.ts` `tablesToTruncate`.)
+    - **Stub verification (per review):** confirm `inpost-test-shipping-stub.helper.ts` actually implements `ShipmentCanceller` (`cancelShipment`). #835 only needed `generateLabel`/`getTracking`/`getSupportedMethods`, so it may not. If absent, **extending the stub to implement `cancelShipment` is an in-scope step of #846** (needed for the cancel happy-path test); a second no-`ShipmentCanceller` stub (or a flag) backs the `ShipmentCancellationNotSupportedException` case.
+
+---
+
+## 5. Validation
+
+- **Architecture**: controller depends only on `I*Service` + tokens + entity + type aliases + exceptions → passes `check-cross-context-imports`. Repo port stays intra-context. Domain entity stays anemic (ADR-011) — cancellation logic in the application service, not on `Shipment`. New tokens follow #595 (`<NAME>_TOKEN = Symbol('Interface')` in `shipping.tokens.ts`, auto-exported by the sub-barrel). Types in `*.types.ts`. Services implement interfaces in separate files.
+- **Security**: all endpoints behind app-global `JwtAuthGuard` + `@Roles('admin')`; DTO validation at the boundary (`class-validator`, nested validation on recipient/parcel); response DTOs project only shipment fields — no secrets/credentials. `connectionId` is a UUID reference, not a credential.
+- **Testing**: unit ≥ standards (services + controller); integration covers read/filter/pagination/by-id/404 + cancel + generate-label. `pnpm lint && pnpm type-check && pnpm test` green; integration via `pnpm test:integration`.
+- **Migration**: none — `pnpm --filter @openlinker/api migration:show` must show nothing pending.
+
+## 6. Risks / open questions
+
+- **R1 — `@Roles('admin')`**: chosen to match the just-merged `fulfillment-routing.controller`. If shipments should be operator-visible under a non-admin role, adjust the decorator. *(Default: admin.)*
+- **R2 — generate-label DTO weight**: the body mirrors `ShipmentDispatchInput` (recipient + parcel), which is heavy but is exactly what #835's seam consumes and what #769 will build. Keeping it a 1:1 reshape minimises drift (same rationale as #835's `ShipmentDispatchInput`).
+- **R3 — generateLabel failure HTTP code**: mapping the rethrown provider error to `502 Bad Gateway` (upstream failure) vs `400`. Default 502 with the domain message; revisit if a validation-class error needs 400.
+- **R4 — cancel of a `draft` with no `providerShipmentId`**: no provider call needed — just flip to `cancelled`. Handled (adapter call gated on `providerShipmentId` presence).
+- **R5 — generate-label double-submit (review IMPORTANT)**: the HTTP endpoint is the first live caller of the non-atomic dispatch seam; concurrent submits can double-create shipments → duplicate labels/cost. **v1 decision**: accept the best-effort `findActiveByOrderId` guard + FE in-flight button-disable (#769); a hard guard (idempotency key / partial unique index on active-per-order) is a tracked follow-up. Recorded in the PR body.
+- **R6 — query-param coercion (review IMPORTANT)**: `hasTracking`/`createdFrom`/`createdTo` use `@Transform`/`@IsDateString` (not `@Type(()=>Boolean|Date)`); the `hasTracking=false` integration assertion guards the regression.

--- a/libs/core/src/shipping/application/interfaces/shipment-cancellation.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/shipment-cancellation.service.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * Shipment Cancellation Service Interface
+ *
+ * Command seam for voiding a not-yet-dispatched shipment (#846, absorbing the
+ * cancel residual from #845). Resolves the shipment's shipping-provider
+ * adapter, narrows the `ShipmentCanceller` sub-capability, voids the provider
+ * shipment, and advances the `Shipment` to `cancelled`.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+
+import type { Shipment } from '../../domain/entities/shipment.entity';
+
+export interface IShipmentCancellationService {
+  /**
+   * Cancel a `draft`/`generated` shipment. Idempotent for an already-cancelled
+   * row (returned unchanged). Throws `ShipmentNotFoundException` when absent,
+   * `ShipmentNotCancellableException` when past the cancellable window, and
+   * `ShipmentCancellationNotSupportedException` when the provider adapter lacks
+   * `ShipmentCanceller`.
+   */
+  cancel(shipmentId: string): Promise<Shipment>;
+}

--- a/libs/core/src/shipping/application/interfaces/shipment-query.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/shipment-query.service.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Shipment Query Service Interface
+ *
+ * Read seam for the shipment HTTP API (#846). Exists so the API controller
+ * depends on an `I*Service` rather than `ShipmentRepositoryPort` directly —
+ * the `*RepositoryPort` cross-context import is banned in `apps/**`
+ * (`scripts/check-cross-context-imports.mjs`). Keeps shipment persistence
+ * intra-context; the controller sees only this interface.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import type {
+  PaginatedShipments,
+  ShipmentFilters,
+  ShipmentPagination,
+} from '../../domain/types/shipment-query.types';
+
+export interface IShipmentQueryService {
+  /** Filtered, paginated list across all orders/connections (most-recent first). */
+  list(filters: ShipmentFilters, pagination: ShipmentPagination): Promise<PaginatedShipments>;
+
+  /** Single shipment by internal id, or null when absent. */
+  getById(id: string): Promise<Shipment | null>;
+
+  /**
+   * Most-recent non-terminal shipment for an order, or null. Serves the
+   * order-detail "Shipment" panel from the domain's own "active" definition
+   * (`TerminalShipmentStatusValues`) so the FE doesn't re-derive it.
+   */
+  getActiveByOrderId(orderId: string): Promise<Shipment | null>;
+}

--- a/libs/core/src/shipping/application/services/shipment-cancellation.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-cancellation.service.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Shipment Cancellation Service unit tests (#846).
+ *
+ * Mocks `ShipmentRepositoryPort` + `IIntegrationsService` (→ a fake
+ * `ShippingProviderManager` adapter that may or may not implement
+ * `ShipmentCanceller`). Covers: generated→cancelled happy path, draft with no
+ * provider shipment (no provider call), idempotent re-cancel, not-found,
+ * non-cancellable state, provider-lacks-canceller, and provider error rethrow.
+ */
+
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+
+import { ShipmentCancellationService } from './shipment-cancellation.service';
+import { Shipment } from '../../domain/entities/shipment.entity';
+import { ShipmentCancellationNotSupportedException } from '../../domain/exceptions/shipment-cancellation-not-supported.exception';
+import { ShipmentNotCancellableException } from '../../domain/exceptions/shipment-not-cancellable.exception';
+import { ShipmentNotFoundException } from '../../domain/exceptions/shipment-not-found.exception';
+import type { ShipmentCanceller } from '../../domain/ports/capabilities/shipment-canceller.capability';
+import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import type { ShipmentStatus } from '../../domain/types/shipment-status.types';
+
+const CONNECTION = 'conn-inpost';
+
+function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? CONNECTION,
+    overrides.shippingMethod ?? 'paczkomat',
+    overrides.status ?? 'generated',
+    // Honour an explicit `null` (the draft-with-no-provider case) — `??` would
+    // wrongly fall through to the default.
+    overrides.providerShipmentId !== undefined ? overrides.providerShipmentId : 'shipx-1',
+    overrides.paczkomatId ?? 'POZ08A',
+    overrides.trackingNumber ?? null,
+    overrides.labelPdfRef ?? 'shipx:label:1',
+    null,
+    null,
+    overrides.cancelledAt ?? null,
+    null,
+    null,
+    new Date(),
+    new Date(),
+  );
+}
+
+describe('ShipmentCancellationService', () => {
+  let repository: jest.Mocked<ShipmentRepositoryPort>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let cancellerAdapter: jest.Mocked<ShippingProviderManagerPort & ShipmentCanceller>;
+  let service: ShipmentCancellationService;
+
+  beforeEach(() => {
+    repository = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findByProviderShipmentId: jest.fn(),
+      update: jest.fn(),
+    };
+    cancellerAdapter = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: jest.fn(),
+      cancelShipment: jest.fn().mockResolvedValue(undefined),
+    };
+    integrations = {
+      getAdapter: jest.fn(),
+      getCapabilityAdapter: jest.fn().mockResolvedValue(cancellerAdapter),
+      resolveAdapterMetadata: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+    };
+    service = new ShipmentCancellationService(repository, integrations);
+  });
+
+  it('should void the provider shipment and persist cancelled for a generated shipment', async () => {
+    const shipment = makeShipment({ status: 'generated', providerShipmentId: 'shipx-1' });
+    repository.findById.mockResolvedValue(shipment);
+    const cancelled = makeShipment({ status: 'cancelled', cancelledAt: new Date() });
+    repository.update.mockResolvedValue(cancelled);
+
+    const result = await service.cancel('ol_shipment_1');
+
+    expect(integrations.getCapabilityAdapter).toHaveBeenCalledWith(
+      CONNECTION,
+      'ShippingProviderManager',
+    );
+    expect(cancellerAdapter.cancelShipment).toHaveBeenCalledWith({ providerShipmentId: 'shipx-1' });
+    expect(repository.update).toHaveBeenCalledWith(
+      'ol_shipment_1',
+      expect.objectContaining({ status: 'cancelled', cancelledAt: expect.any(Date) }),
+    );
+    expect(result).toBe(cancelled);
+  });
+
+  it('should skip the provider call for a draft with no provider shipment', async () => {
+    repository.findById.mockResolvedValue(
+      makeShipment({ status: 'draft', providerShipmentId: null }),
+    );
+    repository.update.mockResolvedValue(makeShipment({ status: 'cancelled' }));
+
+    await service.cancel('ol_shipment_1');
+
+    expect(cancellerAdapter.cancelShipment).not.toHaveBeenCalled();
+    expect(repository.update).toHaveBeenCalledWith(
+      'ol_shipment_1',
+      expect.objectContaining({ status: 'cancelled' }),
+    );
+  });
+
+  it('should return the shipment unchanged when already cancelled (idempotent)', async () => {
+    const cancelled = makeShipment({ status: 'cancelled' });
+    repository.findById.mockResolvedValue(cancelled);
+
+    const result = await service.cancel('ol_shipment_1');
+
+    expect(result).toBe(cancelled);
+    expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw ShipmentNotFoundException when the shipment does not exist', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    await expect(service.cancel('missing')).rejects.toBeInstanceOf(ShipmentNotFoundException);
+  });
+
+  it.each<ShipmentStatus>(['dispatched', 'in-transit', 'delivered', 'failed'])(
+    'should throw ShipmentNotCancellableException when status is %s',
+    async (status) => {
+      repository.findById.mockResolvedValue(makeShipment({ status }));
+
+      await expect(service.cancel('ol_shipment_1')).rejects.toBeInstanceOf(
+        ShipmentNotCancellableException,
+      );
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+      expect(repository.update).not.toHaveBeenCalled();
+    },
+  );
+
+  it('should throw ShipmentCancellationNotSupportedException when the adapter lacks ShipmentCanceller', async () => {
+    repository.findById.mockResolvedValue(makeShipment({ status: 'generated' }));
+    const nonCanceller: ShippingProviderManagerPort = {
+      generateLabel: jest.fn(),
+      getTracking: jest.fn(),
+      getSupportedMethods: jest.fn(),
+    };
+    integrations.getCapabilityAdapter.mockResolvedValue(nonCanceller);
+
+    await expect(service.cancel('ol_shipment_1')).rejects.toBeInstanceOf(
+      ShipmentCancellationNotSupportedException,
+    );
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+
+  it('should rethrow when the provider cancelShipment rejects', async () => {
+    repository.findById.mockResolvedValue(makeShipment({ status: 'generated' }));
+    const boom = new Error('provider cancel rejected');
+    cancellerAdapter.cancelShipment.mockRejectedValue(boom);
+
+    await expect(service.cancel('ol_shipment_1')).rejects.toBe(boom);
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});

--- a/libs/core/src/shipping/application/services/shipment-cancellation.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-cancellation.service.ts
@@ -1,0 +1,101 @@
+/**
+ * Shipment Cancellation Service
+ *
+ * Voids a not-yet-dispatched shipment (#846, absorbing the cancel residual
+ * from #845). Resolves the shipment's shipping-provider adapter via the
+ * integrations registry, narrows the `ShipmentCanceller` sub-capability, calls
+ * `cancelShipment` on the provider (when a provider shipment exists), and
+ * advances the `Shipment` to `cancelled`.
+ *
+ * Cancellable window: `draft` / `generated` only — once `dispatched` the
+ * carrier has the parcel and provider-side cancel is no longer a clean void
+ * (matches the `ShipmentCanceller` contract). Terminal states are rejected.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IShipmentCancellationService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+
+import type { IShipmentCancellationService } from '../interfaces/shipment-cancellation.service.interface';
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import { ShipmentCancellationNotSupportedException } from '../../domain/exceptions/shipment-cancellation-not-supported.exception';
+import { ShipmentNotCancellableException } from '../../domain/exceptions/shipment-not-cancellable.exception';
+import { ShipmentNotFoundException } from '../../domain/exceptions/shipment-not-found.exception';
+import { isShipmentCanceller } from '../../domain/ports/capabilities/shipment-canceller.capability';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import { SHIPMENT_STATUS, type ShipmentStatus } from '../../domain/types/shipment-status.types';
+import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+/** Capability the shipment's connection must declare to resolve a provider adapter. */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+/** Statuses from which a shipment can still be voided (pre-dispatch). */
+const CANCELLABLE_STATUSES: readonly ShipmentStatus[] = [
+  SHIPMENT_STATUS.Draft,
+  SHIPMENT_STATUS.Generated,
+];
+
+@Injectable()
+export class ShipmentCancellationService implements IShipmentCancellationService {
+  private readonly logger = new Logger(ShipmentCancellationService.name);
+
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+  ) {}
+
+  async cancel(shipmentId: string): Promise<Shipment> {
+    const shipment = await this.shipments.findById(shipmentId);
+    if (!shipment) {
+      throw new ShipmentNotFoundException(shipmentId);
+    }
+
+    // Idempotent: re-cancelling an already-cancelled shipment is a no-op.
+    if (shipment.status === SHIPMENT_STATUS.Cancelled) {
+      return shipment;
+    }
+
+    if (!CANCELLABLE_STATUSES.includes(shipment.status)) {
+      throw new ShipmentNotCancellableException(
+        shipmentId,
+        `status is '${shipment.status}' (only ${CANCELLABLE_STATUSES.join(' / ')} can be cancelled)`,
+      );
+    }
+
+    const adapter = await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
+      shipment.connectionId,
+      SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+    );
+    if (!isShipmentCanceller(adapter)) {
+      throw new ShipmentCancellationNotSupportedException(shipmentId, shipment.connectionId);
+    }
+
+    // A `draft` may have no provider shipment yet (label never generated) — only
+    // void provider-side when there's something to void.
+    if (shipment.providerShipmentId) {
+      try {
+        await adapter.cancelShipment({ providerShipmentId: shipment.providerShipmentId });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `cancelShipment failed for shipment ${shipmentId} (provider ${shipment.providerShipmentId}): ${message}`,
+        );
+        // Intentionally leave the row untouched (still `generated`) — a failed
+        // void should stay cancellable/retryable, NOT flip to a terminal state.
+        // (Contrast the dispatch seam, which persists `failed` on label-gen error.)
+        throw error;
+      }
+    }
+
+    return this.shipments.update(shipmentId, {
+      status: SHIPMENT_STATUS.Cancelled,
+      cancelledAt: new Date(),
+    });
+  }
+}

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -90,6 +90,7 @@ describe('ShipmentDispatchService', () => {
   beforeEach(() => {
     repository = {
       create: jest.fn(),
+      findMany: jest.fn(),
       findById: jest.fn(),
       findByOrderId: jest.fn(),
       findActiveByOrderId: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-query.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-query.service.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Shipment Query Service unit tests (#846).
+ *
+ * Mocks `ShipmentRepositoryPort` and asserts the read seam delegates list /
+ * by-id / active-by-order straight through. The service is intentionally a
+ * pass-through (it exists to keep the controller off the repo port), so the
+ * tests pin that contract rather than business logic.
+ */
+
+import { ShipmentQueryService } from './shipment-query.service';
+import { Shipment } from '../../domain/entities/shipment.entity';
+import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type {
+  PaginatedShipments,
+  ShipmentFilters,
+  ShipmentPagination,
+} from '../../domain/types/shipment-query.types';
+
+function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? 'conn-inpost',
+    overrides.shippingMethod ?? 'paczkomat',
+    overrides.status ?? 'generated',
+    overrides.providerShipmentId ?? 'shipx-1',
+    overrides.paczkomatId ?? 'POZ08A',
+    overrides.trackingNumber ?? '6800000001',
+    overrides.labelPdfRef ?? 'shipx:label:1',
+    null,
+    null,
+    null,
+    null,
+    null,
+    new Date(),
+    new Date(),
+  );
+}
+
+describe('ShipmentQueryService', () => {
+  let repository: jest.Mocked<ShipmentRepositoryPort>;
+  let service: ShipmentQueryService;
+
+  beforeEach(() => {
+    repository = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findByProviderShipmentId: jest.fn(),
+      update: jest.fn(),
+    };
+    service = new ShipmentQueryService(repository);
+  });
+
+  describe('list', () => {
+    it('should delegate filters + pagination to the repository and return the page', async () => {
+      const filters: ShipmentFilters = { status: 'generated', hasTracking: true };
+      const pagination: ShipmentPagination = { limit: 20, offset: 0 };
+      const page: PaginatedShipments = { items: [makeShipment()], total: 1 };
+      repository.findMany.mockResolvedValue(page);
+
+      const result = await service.list(filters, pagination);
+
+      expect(repository.findMany).toHaveBeenCalledWith(filters, pagination);
+      expect(result).toBe(page);
+    });
+  });
+
+  describe('getById', () => {
+    it('should return the shipment when found', async () => {
+      const shipment = makeShipment();
+      repository.findById.mockResolvedValue(shipment);
+
+      await expect(service.getById('ol_shipment_1')).resolves.toBe(shipment);
+      expect(repository.findById).toHaveBeenCalledWith('ol_shipment_1');
+    });
+
+    it('should return null when not found', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(service.getById('missing')).resolves.toBeNull();
+    });
+  });
+
+  describe('getActiveByOrderId', () => {
+    it('should delegate to the repository active-by-order lookup', async () => {
+      const shipment = makeShipment();
+      repository.findActiveByOrderId.mockResolvedValue(shipment);
+
+      await expect(service.getActiveByOrderId('ol_order_1')).resolves.toBe(shipment);
+      expect(repository.findActiveByOrderId).toHaveBeenCalledWith('ol_order_1');
+    });
+  });
+});

--- a/libs/core/src/shipping/application/services/shipment-query.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-query.service.ts
@@ -1,0 +1,47 @@
+/**
+ * Shipment Query Service
+ *
+ * Read seam for the shipment HTTP API (#846). Thin delegation to
+ * `ShipmentRepositoryPort` (list / by-id / active-by-order).
+ *
+ * NOTE: this service exists deliberately to keep the API controller off
+ * `ShipmentRepositoryPort` — the `*RepositoryPort` cross-context import is
+ * banned in `apps/**` (`scripts/check-cross-context-imports.mjs`). Do NOT
+ * "simplify" by injecting the repository into the controller directly; that
+ * reintroduces the boundary violation. The indirection is the point.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IShipmentQueryService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+
+import type { IShipmentQueryService } from '../interfaces/shipment-query.service.interface';
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import type {
+  PaginatedShipments,
+  ShipmentFilters,
+  ShipmentPagination,
+} from '../../domain/types/shipment-query.types';
+import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+@Injectable()
+export class ShipmentQueryService implements IShipmentQueryService {
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+  ) {}
+
+  async list(filters: ShipmentFilters, pagination: ShipmentPagination): Promise<PaginatedShipments> {
+    return this.shipments.findMany(filters, pagination);
+  }
+
+  async getById(id: string): Promise<Shipment | null> {
+    return this.shipments.findById(id);
+  }
+
+  async getActiveByOrderId(orderId: string): Promise<Shipment | null> {
+    return this.shipments.findActiveByOrderId(orderId);
+  }
+}

--- a/libs/core/src/shipping/domain/exceptions/shipment-cancellation-not-supported.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/shipment-cancellation-not-supported.exception.ts
@@ -1,0 +1,24 @@
+/**
+ * Shipment Cancellation Not Supported Exception
+ *
+ * Thrown by `ShipmentCancellationService` when the resolved shipping-provider
+ * adapter for the shipment's connection does not implement the
+ * `ShipmentCanceller` sub-capability — i.e. the carrier integration cannot
+ * void a shipment. Distinct from `ShipmentNotCancellableException` (wrong
+ * lifecycle state) so the API surface can return 422 (capability gap) rather
+ * than 409 (state conflict).
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+export class ShipmentCancellationNotSupportedException extends Error {
+  constructor(
+    public readonly shipmentId: string,
+    public readonly connectionId: string,
+  ) {
+    super(
+      `Shipment ${shipmentId} cannot be cancelled: connection ${connectionId} does not support shipment cancellation`,
+    );
+    this.name = 'ShipmentCancellationNotSupportedException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/domain/exceptions/shipment-not-cancellable.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/shipment-not-cancellable.exception.ts
@@ -1,0 +1,23 @@
+/**
+ * Shipment Not Cancellable Exception
+ *
+ * Thrown by `ShipmentCancellationService` when a shipment is in a state that
+ * can no longer be cancelled — it has already dispatched / is in transit, or
+ * has reached a terminal state (`delivered` / `failed`). Distinct from
+ * `ShipmentCancellationNotSupportedException` (which is about the provider
+ * adapter lacking the `ShipmentCanceller` capability) so callers can render a
+ * "can't cancel anymore" message separately from "this carrier doesn't support
+ * cancel". Maps to HTTP 409 at the API boundary.
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+export class ShipmentNotCancellableException extends Error {
+  constructor(
+    public readonly shipmentId: string,
+    public readonly reason: string,
+  ) {
+    super(`Shipment ${shipmentId} cannot be cancelled: ${reason}`);
+    this.name = 'ShipmentNotCancellableException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/domain/ports/shipment-repository.port.ts
+++ b/libs/core/src/shipping/domain/ports/shipment-repository.port.ts
@@ -16,6 +16,11 @@
 
 import type { Shipment } from '../entities/shipment.entity';
 import type {
+  PaginatedShipments,
+  ShipmentFilters,
+  ShipmentPagination,
+} from '../types/shipment-query.types';
+import type {
   CreateShipmentInput,
   UpdateShipmentInput,
 } from '../types/shipment.types';
@@ -28,6 +33,13 @@ export interface ShipmentRepositoryPort {
    * initialised to `null`.
    */
   create(input: CreateShipmentInput): Promise<Shipment>;
+
+  /**
+   * Filtered, paginated list across all orders/connections, ordered by
+   * `createdAt DESC`. Filters combine with AND; `total` is the unpaginated
+   * match count. Backs the `/shipments` read API (#846).
+   */
+  findMany(filters: ShipmentFilters, pagination: ShipmentPagination): Promise<PaginatedShipments>;
 
   findById(id: string): Promise<Shipment | null>;
 

--- a/libs/core/src/shipping/domain/types/shipment-query.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-query.types.ts
@@ -1,0 +1,41 @@
+/**
+ * Shipment Query Types
+ *
+ * Filter + pagination + paginated-result contracts for the shipment read
+ * surface (#846). Consumed by `ShipmentRepositoryPort.findMany` (domain) and
+ * the `IShipmentQueryService` read seam (application). Mirrors the sync
+ * context's `SyncJobFilters` / `SyncJobPagination` / `PaginatedSyncJobs`
+ * shape so the `/shipments` read API matches the `/sync/jobs` precedent.
+ *
+ * @module libs/core/src/shipping/domain/types
+ */
+
+import type { Shipment } from '../entities/shipment.entity';
+import type { ShipmentStatus } from './shipment-status.types';
+import type { ShippingMethod } from './shipping-method.types';
+
+export interface ShipmentFilters {
+  /** Internal order id (`ol_order_*`). */
+  orderId?: string;
+  status?: ShipmentStatus;
+  /** Shipping-provider connection id (UUID). */
+  connectionId?: string;
+  shippingMethod?: ShippingMethod;
+  /** `true` → only shipments with a tracking number; `false` → only those without. */
+  hasTracking?: boolean;
+  /** Inclusive lower bound on `createdAt`. */
+  createdFrom?: Date;
+  /** Inclusive upper bound on `createdAt`. */
+  createdTo?: Date;
+}
+
+export interface ShipmentPagination {
+  limit: number;
+  offset: number;
+}
+
+export interface PaginatedShipments {
+  items: readonly Shipment[];
+  /** Total rows matching the filters, ignoring pagination. */
+  total: number;
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -65,6 +65,12 @@ export type {
   UpdateShipmentInput,
 } from './domain/types/shipment.types';
 
+export type {
+  ShipmentFilters,
+  ShipmentPagination,
+  PaginatedShipments,
+} from './domain/types/shipment-query.types';
+
 // Domain entity
 export { Shipment } from './domain/entities/shipment.entity';
 
@@ -83,6 +89,8 @@ export { isPickupPointFinder } from './domain/ports/capabilities/pickup-point-fi
 // Domain exceptions
 export { ShipmentNotFoundException } from './domain/exceptions/shipment-not-found.exception';
 export { UndispatchableResolutionException } from './domain/exceptions/undispatchable-resolution.exception';
+export { ShipmentNotCancellableException } from './domain/exceptions/shipment-not-cancellable.exception';
+export { ShipmentCancellationNotSupportedException } from './domain/exceptions/shipment-cancellation-not-supported.exception';
 
 // Application — dispatch seam (#835). Interface + types only; the service
 // class is injected via SHIPMENT_DISPATCH_SERVICE_TOKEN (exported above via
@@ -92,3 +100,8 @@ export type {
   ShipmentDispatchInput,
   ShipmentDispatchResult,
 } from './application/types/shipment-dispatch.types';
+
+// Application — read + cancel seams (#846). Interfaces only; services are
+// injected via SHIPMENT_QUERY_SERVICE_TOKEN / SHIPMENT_CANCELLATION_SERVICE_TOKEN.
+export type { IShipmentQueryService } from './application/interfaces/shipment-query.service.interface';
+export type { IShipmentCancellationService } from './application/interfaces/shipment-cancellation.service.interface';

--- a/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
@@ -14,7 +14,16 @@
  */
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Not, Repository } from 'typeorm';
+import {
+  Between,
+  type FindOptionsWhere,
+  In,
+  IsNull,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  Not,
+  Repository,
+} from 'typeorm';
 
 import { formatInternalId } from '@openlinker/core/identifier-mapping';
 
@@ -22,6 +31,11 @@ import { Shipment } from '../../../domain/entities/shipment.entity';
 import { ShipmentNotFoundException } from '../../../domain/exceptions/shipment-not-found.exception';
 import type { ShipmentRepositoryPort } from '../../../domain/ports/shipment-repository.port';
 import { TerminalShipmentStatusValues } from '../../../domain/types/shipment-status.types';
+import type {
+  PaginatedShipments,
+  ShipmentFilters,
+  ShipmentPagination,
+} from '../../../domain/types/shipment-query.types';
 import type {
   CreateShipmentInput,
   UpdateShipmentInput,
@@ -39,6 +53,20 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
     const entity = this.buildOrmEntity(input);
     const saved = await this.repository.save(entity);
     return this.toDomain(saved);
+  }
+
+  async findMany(
+    filters: ShipmentFilters,
+    pagination: ShipmentPagination,
+  ): Promise<PaginatedShipments> {
+    const where = this.buildWhere(filters);
+    const [entities, total] = await this.repository.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip: pagination.offset,
+      take: pagination.limit,
+    });
+    return { items: entities.map((entity) => this.toDomain(entity)), total };
   }
 
   async findById(id: string): Promise<Shipment | null> {
@@ -101,6 +129,26 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
     entity.failedAt = null;
     entity.errorMessage = null;
     return entity;
+  }
+
+  private buildWhere(filters: ShipmentFilters): FindOptionsWhere<ShipmentOrmEntity> {
+    const where: FindOptionsWhere<ShipmentOrmEntity> = {};
+    if (filters.orderId !== undefined) where.orderId = filters.orderId;
+    if (filters.status !== undefined) where.status = filters.status;
+    if (filters.connectionId !== undefined) where.connectionId = filters.connectionId;
+    if (filters.shippingMethod !== undefined) where.shippingMethod = filters.shippingMethod;
+    if (filters.hasTracking !== undefined) {
+      where.trackingNumber = filters.hasTracking ? Not(IsNull()) : IsNull();
+    }
+    const { createdFrom, createdTo } = filters;
+    if (createdFrom !== undefined && createdTo !== undefined) {
+      where.createdAt = Between(createdFrom, createdTo);
+    } else if (createdFrom !== undefined) {
+      where.createdAt = MoreThanOrEqual(createdFrom);
+    } else if (createdTo !== undefined) {
+      where.createdAt = LessThanOrEqual(createdTo);
+    }
+    return where;
   }
 
   private buildUpdatePayload(patch: UpdateShipmentInput): Partial<ShipmentOrmEntity> {

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -25,7 +25,14 @@ import { MappingsModule } from '@openlinker/core/mappings';
 import { ShipmentOrmEntity } from './infrastructure/persistence/entities/shipment.orm-entity';
 import { ShipmentRepository } from './infrastructure/persistence/repositories/shipment.repository';
 import { ShipmentDispatchService } from './application/services/shipment-dispatch.service';
-import { SHIPMENT_DISPATCH_SERVICE_TOKEN, SHIPMENT_REPOSITORY_TOKEN } from './shipping.tokens';
+import { ShipmentQueryService } from './application/services/shipment-query.service';
+import { ShipmentCancellationService } from './application/services/shipment-cancellation.service';
+import {
+  SHIPMENT_CANCELLATION_SERVICE_TOKEN,
+  SHIPMENT_DISPATCH_SERVICE_TOKEN,
+  SHIPMENT_QUERY_SERVICE_TOKEN,
+  SHIPMENT_REPOSITORY_TOKEN,
+} from './shipping.tokens';
 
 @Module({
   imports: [
@@ -48,7 +55,22 @@ import { SHIPMENT_DISPATCH_SERVICE_TOKEN, SHIPMENT_REPOSITORY_TOKEN } from './sh
       provide: SHIPMENT_DISPATCH_SERVICE_TOKEN,
       useExisting: ShipmentDispatchService,
     },
+    ShipmentQueryService,
+    {
+      provide: SHIPMENT_QUERY_SERVICE_TOKEN,
+      useExisting: ShipmentQueryService,
+    },
+    ShipmentCancellationService,
+    {
+      provide: SHIPMENT_CANCELLATION_SERVICE_TOKEN,
+      useExisting: ShipmentCancellationService,
+    },
   ],
-  exports: [SHIPMENT_REPOSITORY_TOKEN, SHIPMENT_DISPATCH_SERVICE_TOKEN],
+  exports: [
+    SHIPMENT_REPOSITORY_TOKEN,
+    SHIPMENT_DISPATCH_SERVICE_TOKEN,
+    SHIPMENT_QUERY_SERVICE_TOKEN,
+    SHIPMENT_CANCELLATION_SERVICE_TOKEN,
+  ],
 })
 export class ShippingModule {}

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -13,3 +13,5 @@
 export const SHIPMENT_REPOSITORY_TOKEN = Symbol('ShipmentRepositoryPort');
 export const PICKUP_POINT_CACHE_TOKEN = Symbol('PickupPointCachePort');
 export const SHIPMENT_DISPATCH_SERVICE_TOKEN = Symbol('IShipmentDispatchService');
+export const SHIPMENT_QUERY_SERVICE_TOKEN = Symbol('IShipmentQueryService');
+export const SHIPMENT_CANCELLATION_SERVICE_TOKEN = Symbol('IShipmentCancellationService');


### PR DESCRIPTION
## What & why

Adds the shipment HTTP surface around the existing dispatch seam (`ShipmentDispatchService`, shipped in #835). This is the **middle layer** that no prior issue owned: the read API + command endpoints the FE shipment surfaces (#769 / #770 / #839) depend on.

**Core (`libs/core/src/shipping`)**
- `ShipmentRepositoryPort.findMany(filters, pagination)` + impl — filters: `status` / `connectionId` / `shippingMethod` / `orderId` / `hasTracking` / `createdFrom`–`createdTo`; offset pagination; `createdAt DESC`.
- `ShipmentQueryService` (`IShipmentQueryService`) — read seam (`list` / `getById` / `getActiveByOrderId`).
- `ShipmentCancellationService` (`IShipmentCancellationService`) — the cancel residual absorbed from #845 (whose engine #835 superseded): resolve adapter → narrow `ShipmentCanceller` → void → `cancelled`.
- Two domain exceptions (`ShipmentNotCancellableException` → 409, `ShipmentCancellationNotSupportedException` → 422), two Symbol-token bindings.

**API (`apps/api/src/shipping`)**
- `ShipmentController` @ `/shipments`: `GET /` (filters + pagination), `GET /active?orderId=`, `GET /:id`, `POST /generate-label` (delegates to the dispatch seam), `POST /:id/cancel`. DTOs + domain→HTTP mapping. Wired via `ShippingApiModule`.

## Key design decisions
- **Reads go through `I*Service` seams, never `ShipmentRepositoryPort`** — a new cross-context repo-port import in `apps/**` is banned by `check-cross-context-imports` (the sync controller's is allow-listed legacy). The thin `ShipmentQueryService` exists for this reason; its header says so.
- **Query-param coercion**: `hasTracking` uses `@Transform` (`'true'`/`'false'` → boolean, not `@Type(() => Boolean)` which coerces `"false"` → `true`); date bounds use `@IsDateString` on the raw string, converted to `Date` in the controller.
- **generate-label serialization (v1 limitation)**: this is the first *live* caller of the dispatch seam, whose idempotency (`findActiveByOrderId → create`) is explicitly **non-atomic** (schema allows N shipments/order, no DB guard). v1 relies on the best-effort guard + FE in-flight button-disable (#769); a hard guard (idempotency key / partial-unique index) is a tracked follow-up.
- A UUID-valid-but-nonexistent `sourceConnectionId` resolves to no rule → `{ kind: 'omp_fulfilled' }` (no error), inherited from the #832 `resolve()` contract — #769 should handle `omp_fulfilled` explicitly.
- **No migration** (uses existing `shipments` columns/indexes).

## How to test
```bash
pnpm type-check && pnpm lint && pnpm test
pnpm test:integration shipments-read   # 10 cases incl. the hasTracking=false coercion guard + cancel flow
```
All green locally: 878 core + 426 api unit; `shipments-read` 10 + `shipment-dispatch` 3 integration. Cross-context invariant check conforms.

## Related
- Closes #846
- Builds on #835 (`ShipmentDispatchService`) / #832 (routing model). Supersedes the engine half of #845 (commented there; left open for maintainer close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)