### PR TITLE
feat(shipping,api): paczkomat pickup-point cache + read-through lookup API (#766)

### DIFF
--- a/apps/api/src/shipping/http/dto/list-pickup-points-query.dto.ts
+++ b/apps/api/src/shipping/http/dto/list-pickup-points-query.dto.ts
@@ -1,0 +1,45 @@
+/**
+ * List Pickup-Points Query DTO
+ *
+ * Query parameters for GET /pickup-points. `connectionId` selects which
+ * shipping-provider connection to search (its credentials hit the provider's
+ * points API); the rest narrow the provider-side search. Maps 1:1 to the
+ * core `FindPickupPointsQuery`.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsOptional, IsString, IsUUID, Max, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListPickupPointsQueryDto {
+  @ApiProperty({ description: 'Shipping-provider connection id (UUID) to search' })
+  @IsUUID()
+  connectionId!: string;
+
+  @ApiPropertyOptional({ description: 'Free-text search (provider-defined)' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  searchText?: string;
+
+  @ApiPropertyOptional({ description: 'City filter' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  city?: string;
+
+  @ApiPropertyOptional({ description: 'Postal code filter' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  postalCode?: string;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100, description: 'Max results' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/apps/api/src/shipping/http/dto/pickup-point-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/pickup-point-response.dto.ts
@@ -1,0 +1,62 @@
+/**
+ * Pickup-Point Response DTO
+ *
+ * HTTP projection of the `PickupPoint` domain value (#766). Exposes the full
+ * provider-side metadata the picker (#769) renders: address, availability
+ * status, geo, and the structured 7-day opening-hours grid.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  PickupPointStatusValues,
+  type PickupPoint,
+  type PickupPointAddress,
+  type PickupPointOpeningHours,
+  type PickupPointStatus,
+} from '@openlinker/core/shipping';
+
+class PickupPointAddressDto implements PickupPointAddress {
+  @ApiProperty() line1!: string;
+  @ApiPropertyOptional() line2?: string;
+  @ApiProperty() city!: string;
+  @ApiProperty() postalCode!: string;
+  @ApiProperty() country!: string;
+}
+
+export class PickupPointResponseDto {
+  @ApiProperty({ description: 'Provider-issued pickup-point id (e.g. POZ08A)' })
+  providerId!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ type: PickupPointAddressDto })
+  address!: PickupPointAddressDto;
+
+  @ApiProperty({ enum: PickupPointStatusValues, description: 'Availability status' })
+  status!: PickupPointStatus;
+
+  @ApiPropertyOptional({ description: 'Latitude (WGS84)' })
+  lat?: number;
+
+  @ApiPropertyOptional({ description: 'Longitude (WGS84)' })
+  lon?: number;
+
+  @ApiPropertyOptional({
+    description: 'Structured 7-day opening-hours grid in the provider-local timezone',
+  })
+  openingHours?: PickupPointOpeningHours;
+
+  static fromDomain(point: PickupPoint): PickupPointResponseDto {
+    const dto = new PickupPointResponseDto();
+    dto.providerId = point.providerId;
+    dto.name = point.name;
+    dto.address = { ...point.address };
+    dto.status = point.status;
+    dto.lat = point.lat;
+    dto.lon = point.lon;
+    dto.openingHours = point.openingHours;
+    return dto;
+  }
+}

--- a/apps/api/src/shipping/http/pickup-point.controller.spec.ts
+++ b/apps/api/src/shipping/http/pickup-point.controller.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Pickup-Point Controller unit tests (#766).
+ *
+ * Mocks IPickupPointLookupService. Covers DTO mapping on search, the
+ * unsupported-capability → 422 and provider-error → 502 mappings, and the
+ * cached-read hit/miss (404) paths.
+ */
+import {
+  BadGatewayException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import {
+  PickupPointFinderNotSupportedException,
+  type IPickupPointLookupService,
+  type PickupPoint,
+} from '@openlinker/core/shipping';
+import { CapabilityNotEnabledException } from '@openlinker/core/integrations';
+import { PickupPointController } from './pickup-point.controller';
+import { ListPickupPointsQueryDto } from './dto/list-pickup-points-query.dto';
+
+const point: PickupPoint = {
+  providerId: 'POZ08A',
+  name: 'Paczkomat POZ08A',
+  address: { line1: 'Krakowska 12', city: 'Poznań', postalCode: '60-001', country: 'PL' },
+  status: 'active',
+};
+
+function makeQuery(overrides: Partial<ListPickupPointsQueryDto> = {}): ListPickupPointsQueryDto {
+  return Object.assign(new ListPickupPointsQueryDto(), {
+    connectionId: '33333333-3333-4333-8333-333333333333',
+    limit: 20,
+    ...overrides,
+  });
+}
+
+describe('PickupPointController', () => {
+  let lookup: jest.Mocked<IPickupPointLookupService>;
+  let controller: PickupPointController;
+
+  beforeEach(() => {
+    lookup = { search: jest.fn(), getCachedPoint: jest.fn() };
+    controller = new PickupPointController(lookup);
+  });
+
+  describe('search', () => {
+    it('should map provider results to DTOs and forward the query', async () => {
+      lookup.search.mockResolvedValue([point]);
+
+      const result = await controller.search(makeQuery({ city: 'Poznań', searchText: 'rynek' }));
+
+      expect(result).toHaveLength(1);
+      expect(result[0].providerId).toBe('POZ08A');
+      expect(result[0].status).toBe('active');
+      expect(lookup.search).toHaveBeenCalledWith('33333333-3333-4333-8333-333333333333', {
+        searchText: 'rynek',
+        city: 'Poznań',
+        postalCode: undefined,
+        limit: 20,
+      });
+    });
+
+    it('should map an unsupported finder sub-capability to 422', async () => {
+      lookup.search.mockRejectedValue(new PickupPointFinderNotSupportedException('conn-1'));
+
+      await expect(controller.search(makeQuery())).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should map a connection-capability error (disabled/unsupported) to 422', async () => {
+      lookup.search.mockRejectedValue(
+        new CapabilityNotEnabledException('conn-1', 'inpost.shipx.v1', 'ShippingProviderManager'),
+      );
+
+      await expect(controller.search(makeQuery())).rejects.toBeInstanceOf(
+        UnprocessableEntityException,
+      );
+    });
+
+    it('should map a provider/transport error to 502', async () => {
+      lookup.search.mockRejectedValue(new Error('ShipX 500'));
+
+      await expect(controller.search(makeQuery())).rejects.toBeInstanceOf(BadGatewayException);
+    });
+  });
+
+  describe('getCached', () => {
+    it('should return the cached point as a DTO on hit', async () => {
+      lookup.getCachedPoint.mockResolvedValue(point);
+
+      const result = await controller.getCached('POZ08A');
+
+      expect(result.providerId).toBe('POZ08A');
+      expect(lookup.getCachedPoint).toHaveBeenCalledWith('POZ08A');
+    });
+
+    it('should return 404 on cache miss', async () => {
+      lookup.getCachedPoint.mockResolvedValue(null);
+
+      await expect(controller.getCached('NOPE')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/shipping/http/pickup-point.controller.ts
+++ b/apps/api/src/shipping/http/pickup-point.controller.ts
@@ -1,0 +1,105 @@
+/**
+ * Pickup-Point Controller
+ *
+ * HTTP endpoints for the manual paczkomat picker (#766/#769): a live
+ * provider-backed search (results write-through cached by id) and a fast by-id
+ * cached read. Goes through `IPickupPointLookupService` — never the cache port
+ * directly (repository/cache ports are banned cross-context in apps/**).
+ * Admin + JWT.
+ *
+ * @module apps/api/src/shipping/http
+ */
+import {
+  BadGatewayException,
+  Controller,
+  Get,
+  Inject,
+  NotFoundException,
+  Param,
+  Query,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  type FindPickupPointsQuery,
+  type IPickupPointLookupService,
+  PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
+  PickupPointFinderNotSupportedException,
+} from '@openlinker/core/shipping';
+import {
+  CapabilityNotEnabledException,
+  CapabilityNotSupportedException,
+} from '@openlinker/core/integrations';
+import { Logger } from '@openlinker/shared/logging';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { ListPickupPointsQueryDto } from './dto/list-pickup-points-query.dto';
+import { PickupPointResponseDto } from './dto/pickup-point-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('pickup-points')
+@Controller('pickup-points')
+export class PickupPointController {
+  private readonly logger = new Logger(PickupPointController.name);
+
+  constructor(
+    @Inject(PICKUP_POINT_LOOKUP_SERVICE_TOKEN)
+    private readonly lookup: IPickupPointLookupService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: "Search a connection's pickup points (live; results cached by id)" })
+  @ApiResponse({ status: 200, type: [PickupPointResponseDto] })
+  @ApiResponse({ status: 422, description: 'Connection has no pickup-point network' })
+  @ApiResponse({ status: 502, description: 'Shipping provider rejected the points lookup' })
+  async search(@Query() query: ListPickupPointsQueryDto): Promise<PickupPointResponseDto[]> {
+    const find: FindPickupPointsQuery = {
+      searchText: query.searchText,
+      city: query.city,
+      postalCode: query.postalCode,
+      limit: query.limit,
+    };
+    try {
+      const points = await this.lookup.search(query.connectionId, find);
+      return points.map((point) => PickupPointResponseDto.fromDomain(point));
+    } catch (error) {
+      throw this.toHttpException(error);
+    }
+  }
+
+  // Connection-agnostic: paczkomat ids are a single national namespace, so the
+  // cache key needs no connectionId. A miss returns 404 — there is no live
+  // by-id fall-through (the finder is search-only); re-search to re-warm.
+  @Get(':providerId')
+  @ApiOperation({ summary: 'Get a cached pickup point by provider id' })
+  @ApiResponse({ status: 200, type: PickupPointResponseDto })
+  @ApiResponse({ status: 404, description: 'Point not in cache' })
+  async getCached(@Param('providerId') providerId: string): Promise<PickupPointResponseDto> {
+    const point = await this.lookup.getCachedPoint(providerId);
+    if (!point) {
+      throw new NotFoundException(`Pickup point not cached: ${providerId}`);
+    }
+    return PickupPointResponseDto.fromDomain(point);
+  }
+
+  /**
+   * Map lookup errors to HTTP. "This connection can't service a pickup-point
+   * lookup" — the finder sub-capability is absent, or the capability is
+   * unsupported by the adapter / disabled on the connection — is a well-formed
+   * request against an incapable connection → 422 (OL never reached a
+   * provider). Anything else is an upstream provider/transport failure → 502,
+   * so the picker never falls through to a bare 500.
+   */
+  private toHttpException(error: unknown): Error {
+    if (
+      error instanceof PickupPointFinderNotSupportedException ||
+      error instanceof CapabilityNotSupportedException ||
+      error instanceof CapabilityNotEnabledException
+    ) {
+      return new UnprocessableEntityException(error.message);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    this.logger.warn(`Pickup-point search failed: ${message}`);
+    return new BadGatewayException(message);
+  }
+}

--- a/apps/api/src/shipping/shipping.module.ts
+++ b/apps/api/src/shipping/shipping.module.ts
@@ -6,7 +6,9 @@
  * `ShipmentRepositoryPort` + dispatch seam from #763/#835), plus `OrdersModule`
  * for `ORDER_RECORD_SERVICE_TOKEN` — the controller resolves each shipment's
  * `orderId → Order.customerId` for the customer column (#770). Registers the
- * shipment controller. Mirrors `MappingsApiModule`.
+ * shipment controller plus the pickup-point controller (#766) — the latter
+ * resolves `PICKUP_POINT_LOOKUP_SERVICE_TOKEN` from the core `ShippingModule`.
+ * Mirrors `MappingsApiModule`.
  *
  * @module apps/api/src/shipping
  */
@@ -15,9 +17,10 @@ import { ShippingModule } from '@openlinker/core/shipping';
 import { OrdersModule } from '@openlinker/core/orders';
 
 import { ShipmentController } from './http/shipment.controller';
+import { PickupPointController } from './http/pickup-point.controller';
 
 @Module({
   imports: [ShippingModule, OrdersModule],
-  controllers: [ShipmentController],
+  controllers: [ShipmentController, PickupPointController],
 })
 export class ShippingApiModule {}

--- a/apps/api/test/integration/pickup-point-cache.int-spec.ts
+++ b/apps/api/test/integration/pickup-point-cache.int-spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Pickup-Point Cache Integration Test (#766)
+ *
+ * Proves the Redis-backed `PickupPointCachePort` wiring end-to-end against a
+ * real Redis (Testcontainers): the @Global `CacheModule` resolves
+ * `CACHE_PORT_TOKEN` into `RedisPickupPointCacheAdapter`, and a full
+ * `PickupPoint` — nested address, structured opening-hours grid,
+ * `temporarily-unavailable` status — round-trips through JSON serialization
+ * intact. Key construction / TTL value are unit-covered (adapter spec); this
+ * covers the seam those miss: DI resolution + real-Redis serialization fidelity.
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  PICKUP_POINT_CACHE_TOKEN,
+  type PickupPoint,
+  type PickupPointCachePort,
+} from '@openlinker/core/shipping';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+
+const point: PickupPoint = {
+  providerId: 'POZ08A',
+  name: 'Paczkomat POZ08A',
+  address: {
+    line1: 'ul. Krakowska 12',
+    line2: 'obok sklepu',
+    city: 'Poznań',
+    postalCode: '60-001',
+    country: 'PL',
+  },
+  status: 'temporarily-unavailable',
+  lat: 52.4064,
+  lon: 16.9252,
+  openingHours: {
+    mo: { intervals: [{ open: '08:00', close: '20:00' }] },
+    tu: { intervals: [{ open: '08:00', close: '20:00' }] },
+    we: { intervals: [{ open: '08:00', close: '20:00' }] },
+    th: { intervals: [{ open: '08:00', close: '20:00' }] },
+    fr: { intervals: [{ open: '08:00', close: '20:00' }] },
+    sa: { intervals: [{ open: '10:00', close: '14:00' }] },
+    su: { intervals: null },
+  },
+};
+
+describe('Pickup-Point Cache Integration', () => {
+  let harness: IntegrationTestHarness;
+  let cache: PickupPointCachePort;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    cache = harness.getApp().get<PickupPointCachePort>(PICKUP_POINT_CACHE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('should round-trip a full pickup point through real Redis', async () => {
+    await cache.put(point);
+
+    const result = await cache.get('POZ08A');
+
+    expect(result).toEqual(point);
+  });
+
+  it('should return null for an uncached provider id', async () => {
+    await expect(cache.get('DOES-NOT-EXIST')).resolves.toBeNull();
+  });
+});

--- a/docs/plans/implementation-plan-766-paczkomat-cache.md
+++ b/docs/plans/implementation-plan-766-paczkomat-cache.md
@@ -1,0 +1,169 @@
+# Implementation Plan — #766 Paczkomat caching service (Redis 24h TTL)
+
+**Issue:** #766 · **Design parent:** #727 (`docs/specs/product-spec-727-inpost-integration.md` SC-2)
+**Layer:** CORE (shipping infrastructure + application) + Interface (API)
+**Branch:** `766-paczkomat-cache`
+
+---
+
+## 1. Understand the task
+
+Provide a fast, persistent paczkomat (pickup-point) lookup path so the manual
+picker UI (#769) can search/render lockers without hammering ShipX on every
+keystroke, and so a chosen point can be re-read in <10 ms when generating a
+label.
+
+### What already shipped (the foundation, #727.1 / #727.2 — verified on `main`)
+
+- **`PickupPointCachePort`** (`domain/ports/pickup-point-cache.port.ts`) —
+  deliberately **narrow**: `get(providerId): Promise<PickupPoint | null>` (does
+  **not** refetch) and `put(point): Promise<void>` (TTL impl-handled). No
+  `connectionId` in the key (paczkomat ids are a single national namespace —
+  `providerId` is "globally unique per provider"), no query method, no
+  `delete`/`refresh` ("explicit invalidation isn't a v1 use case; SC-2 is
+  TTL-driven"). Token `PICKUP_POINT_CACHE_TOKEN` already exists.
+- **`PickupPoint` / `PickupPointStatus`** (`domain/types/pickup-point.types.ts`)
+  — `status: 'active' | 'temporarily-unavailable'`, structured address +
+  opening hours. `FindPickupPointsQuery` co-located.
+- **`PickupPointFinder`** sub-capability (`findPickupPoints(query) → PickupPoint[]`)
+  + `isPickupPointFinder` guard. **Implemented by the InPost adapter** over ShipX
+  `/v1/points` (and `FakeInpostShippingAdapter` with `seedPickupPoints`). It is
+  **search-only — there is no get-by-id** finder call.
+- **`CachePort`** (`@openlinker/shared/cache`) — `get<T>(key)`, `set<T>(key,val,ttlSec)`,
+  `delete(key)`; Redis adapter + in-memory fake (`@openlinker/shared/cache/testing`).
+  Token `CACHE_PORT_TOKEN`. This is the Redis seam #766 sits on.
+- **`ShipmentDispatchService`** shows the per-connection adapter-resolution
+  pattern to mirror: `integrations.getCapabilityAdapter<ShippingProviderManagerPort>(connId, 'ShippingProviderManager')`.
+- `ShippingModule` already imports `IntegrationsModule` and carries a comment
+  reserving the `PICKUP_POINT_CACHE_TOKEN` binding **for this issue**.
+
+### Non-goals (explicit)
+
+- Full snapshot of all ~15k PL paczkomats (issue: v2 if perf demands).
+- Geo-radius / map search (issue: v2).
+- Cache invalidation on ShipX update (issue: v2).
+- **Per-search-query result caching** — the shipped port caches **by id only**;
+  caching whole query→list results would mean widening the #727.1 contract,
+  which its author explicitly argued against. Deferred (see §5 deviations).
+- **Background refresh of "most-frequently-queried" points** — deferred to a
+  follow-up (see §5). The shipped port has no `refresh`, the finder is
+  search-only (so "refresh point X" is impossible by id), and "most-queried"
+  needs new frequency state. Weak fit against the as-shipped design.
+
+---
+
+## 2. Design (recommended scope — "Option B")
+
+Two collaborators, layered cleanly:
+
+1. **`RedisPickupPointCacheAdapter implements PickupPointCachePort`**
+   (infrastructure) — the literal port impl, backed by the shared `CachePort`.
+   - `get(providerId)` → `cache.get<PickupPoint>(keyFor(providerId))`
+   - `put(point)` → `cache.set(keyFor(point.providerId), point, TTL_SECONDS)`
+   - Key: `paczkomat:point:{providerId}`. TTL: `PICKUP_POINT_CACHE_TTL_SECONDS`
+     = 86_400 (24 h), env-overridable (`OL_PACZKOMAT_CACHE_TTL_SEC`, clamped).
+   - The full `PickupPoint` (incl. `status`) round-trips through JSON, so
+     `temporarily-unavailable` propagation is automatic (no field dropping).
+
+2. **`PickupPointLookupService implements IPickupPointLookupService`**
+   (application) — the read-through orchestration the picker consumes.
+   - `search(connectionId, query) → PickupPoint[]`: resolve the connection's
+     `ShippingProviderManagerPort` via `IIntegrationsService`, narrow with
+     `isPickupPointFinder` (throw `PickupPointFinderNotSupportedException` if
+     absent), call `findPickupPoints(query)`, **write each result through to the
+     cache** (`put`), return the live list. Cache write-through failures are
+     swallowed (warn-log) — they must never fail a live search.
+   - `getCachedPoint(providerId) → PickupPoint | null`: thin pass-through to the
+     cache for the fast by-id re-read (label generation / picker confirmation).
+
+   This is the documented reading of the issue's "cache miss falls through to
+   ShipX, then writes to cache": **search is always live (fresh list); each
+   point is cached by id** for fast subsequent reads. There is no by-id live
+   fall-through because the finder exposes no by-id call.
+
+3. **`PickupPointController`** (API, `@Controller('pickup-points')`, `@Roles('admin')`)
+   - `GET /pickup-points?connectionId=&searchText=&city=&postalCode=&limit=` →
+     `lookup.search(...)` → `PickupPointResponseDto[]`.
+   - `GET /pickup-points/:providerId?connectionId=` → `lookup.getCachedPoint(...)`
+     (404 when not cached). (`connectionId` accepted for symmetry/forward-compat
+     though the cache key is connection-agnostic.)
+   - Maps `PickupPointFinderNotSupportedException` → 422, integration/transport
+     errors → 502 (mirrors `ShipmentController.toHttpException`).
+
+### Data flow
+
+```
+FE picker (#769)
+  │  GET /pickup-points?connectionId=…&searchText=…
+  ▼
+PickupPointController → IPickupPointLookupService.search()
+  │  resolve ShippingProviderManagerPort by connectionId (IntegrationsService)
+  │  isPickupPointFinder guard
+  ▼
+InpostShippingAdapter.findPickupPoints(query)  ── ShipX GET /v1/points
+  │  write-through each point → PickupPointCachePort.put()
+  ▼                                   │
+return PickupPoint[]                  ▼
+                          RedisPickupPointCacheAdapter → CachePort.set(key, point, 86400)
+
+later: GET /pickup-points/:id → lookup.getCachedPoint → CachePort.get  (<10ms)
+```
+
+---
+
+## 3. Step-by-step
+
+| # | File | Change | Acceptance |
+|---|------|--------|-----------|
+| 1 | `libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-cache.adapter.ts` | `RedisPickupPointCacheAdapter implements PickupPointCachePort`; inject `CACHE_PORT_TOKEN`; key + TTL constant | get→cache.get; put→cache.set with 86400s; key `paczkomat:point:{id}` |
+| 2 | `libs/core/src/shipping/application/interfaces/pickup-point-lookup.service.interface.ts` | `IPickupPointLookupService` (`search`, `getCachedPoint`) | interface-only file |
+| 3 | `libs/core/src/shipping/application/services/pickup-point-lookup.service.ts` | `PickupPointLookupService` (resolve adapter, guard, search, write-through, cached read) | write-through failure swallowed; unsupported→exception |
+| 4 | `libs/core/src/shipping/domain/exceptions/pickup-point-finder-not-supported.exception.ts` | domain exception | carries connectionId |
+| 5 | `libs/core/src/shipping/shipping.tokens.ts` | add `PICKUP_POINT_LOOKUP_SERVICE_TOKEN` | Symbol only |
+| 6 | `libs/core/src/shipping/shipping.module.ts` | import `CacheModule`; bind `PICKUP_POINT_CACHE_TOKEN`→adapter, `PICKUP_POINT_LOOKUP_SERVICE_TOKEN`→service; export both | boots; comment updated |
+| 7 | `libs/core/src/shipping/index.ts` | export `IPickupPointLookupService` type (+ token via `export *`) + the new exception | barrel compiles |
+| 8 | `apps/api/src/shipping/http/dto/list-pickup-points-query.dto.ts` | query DTO (class-validator) | `connectionId` required; rest optional |
+| 9 | `apps/api/src/shipping/http/dto/pickup-point-response.dto.ts` | response DTO + `fromDomain` | Swagger-annotated |
+| 10 | `apps/api/src/shipping/http/pickup-point.controller.ts` | `PickupPointController` | search + cached-read endpoints; exception mapping |
+| 11 | `apps/api/src/shipping/shipping.module.ts` | register `PickupPointController` | controller resolves lookup via token |
+| 12 | Specs: `redis-pickup-point-cache.adapter.spec.ts`, `pickup-point-lookup.service.spec.ts`, `pickup-point.controller.spec.ts` | unit | hit / miss / TTL value / write-through / unsupported / search→DTO |
+| 13 | `apps/api/test/integration/pickup-point-cache.int-spec.ts` | integration (Testcontainers Redis) | round-trip + TTL expiry against real Redis |
+
+---
+
+## 4. Testing strategy
+
+- **Cache adapter** (unit): in-memory `CachePort` fake — assert key + that `set`
+  is called with `ttlSec=86400`; get-hit returns the point; get-miss → null;
+  `temporarily-unavailable` status survives round-trip.
+- **Lookup service** (unit): mock `CachePort` + `IIntegrationsService`; use
+  `FakeInpostShippingAdapter.seedPickupPoints`. Cover: search returns live list
+  and write-through `put`s each; adapter without finder → exception; cache `put`
+  throwing does not fail search.
+- **Controller** (unit): mock `IPickupPointLookupService`; search maps to DTOs;
+  unsupported→422; cached-miss→404.
+- **Integration** (`*.int-spec.ts`, Testcontainers Redis): real round-trip +
+  short-TTL expiry (set ttl=1s via env, assert expiry) to prove "TTL respected"
+  AC against real Redis, not a fake.
+
+---
+
+## 5. Validation / deviations from the literal issue
+
+- **Architecture:** domain port untouched; impl is infra (depends on shared
+  `CachePort`, not Redis directly); orchestration is an application service
+  depending only on ports + `I*Service`; controller injects via Symbol token
+  (never the repo/cache port directly across `apps/**`). ✔ cross-context rules.
+- **No migration** (Redis only). **No new core→integration value imports**
+  (adapter resolved at runtime via `IntegrationsService`).
+- **Deviation 1 — query-result caching dropped:** the shipped port is by-id
+  only; we cache each point by id, not whole query results. Honors #727.1's
+  explicit "bulk/query semantics aren't a domain concern" decision rather than
+  widening the contract. Search stays live (acceptable: lists must be fresh).
+- **Deviation 2 — background refresh deferred:** carved to a follow-up issue
+  (commented on #766). Rationale: no `refresh` on the port (by design), finder
+  is search-only, "most-queried" needs new frequency state — genuine v2 polish,
+  and TTL-driven freshness is the shipped design intent.
+
+These two deviations are the reason this needs a ⏸️ scope confirmation before
+implementing.

--- a/libs/core/src/shipping/application/interfaces/pickup-point-lookup.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/pickup-point-lookup.service.interface.ts
@@ -1,0 +1,27 @@
+/**
+ * Pickup-Point Lookup Service Interface
+ *
+ * Read-through orchestration over `PickupPointCachePort` + a connection's
+ * `PickupPointFinder` capability (#766). `search` runs a live provider lookup
+ * (lists must be fresh) and write-throughs each result to the cache;
+ * `getCachedPoint` is the fast by-id read used to re-render a previously chosen
+ * locker. Consumed by the manual paczkomat picker (#769).
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+import type { FindPickupPointsQuery, PickupPoint } from '../../domain/types/pickup-point.types';
+
+export interface IPickupPointLookupService {
+  /**
+   * Live provider search; write-throughs each returned point to the cache.
+   * Throws `PickupPointFinderNotSupportedException` when the connection's
+   * adapter has no pickup-point network (e.g. a courier-only carrier).
+   */
+  search(connectionId: string, query: FindPickupPointsQuery): Promise<PickupPoint[]>;
+
+  /**
+   * Fast by-id read from cache. `null` on miss — there is no live by-id
+   * fall-through because the finder capability is search-only.
+   */
+  getCachedPoint(providerId: string): Promise<PickupPoint | null>;
+}

--- a/libs/core/src/shipping/application/services/pickup-point-lookup.service.spec.ts
+++ b/libs/core/src/shipping/application/services/pickup-point-lookup.service.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Pickup-Point Lookup Service unit tests (#766).
+ *
+ * Mocks IIntegrationsService (→ a finder-capable / courier-only adapter stub)
+ * and PickupPointCachePort. Covers: live search + per-point write-through, the
+ * unsupported-capability branch, and cache-write-through resilience.
+ */
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import { PickupPointLookupService } from './pickup-point-lookup.service';
+import type { PickupPointCachePort } from '../../domain/ports/pickup-point-cache.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import type { PickupPointFinder } from '../../domain/ports/capabilities/pickup-point-finder.capability';
+import type { PickupPoint } from '../../domain/types/pickup-point.types';
+import { PickupPointFinderNotSupportedException } from '../../domain/exceptions/pickup-point-finder-not-supported.exception';
+
+const CONN = 'conn-inpost';
+
+function makePoint(overrides: Partial<PickupPoint> = {}): PickupPoint {
+  return {
+    providerId: 'POZ08A',
+    name: 'Paczkomat POZ08A',
+    address: { line1: 'Krakowska 12', city: 'Poznań', postalCode: '60-001', country: 'PL' },
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function finderAdapter(points: PickupPoint[]): ShippingProviderManagerPort & PickupPointFinder {
+  return {
+    generateLabel: jest.fn(),
+    getTracking: jest.fn(),
+    getSupportedMethods: jest.fn().mockReturnValue(['paczkomat']),
+    findPickupPoints: jest.fn().mockResolvedValue(points),
+  } as unknown as ShippingProviderManagerPort & PickupPointFinder;
+}
+
+function courierOnlyAdapter(): ShippingProviderManagerPort {
+  return {
+    generateLabel: jest.fn(),
+    getTracking: jest.fn(),
+    getSupportedMethods: jest.fn().mockReturnValue(['kurier']),
+  } as unknown as ShippingProviderManagerPort;
+}
+
+describe('PickupPointLookupService', () => {
+  let cache: jest.Mocked<PickupPointCachePort>;
+  let getCapabilityAdapter: jest.Mock;
+  let service: PickupPointLookupService;
+
+  beforeEach(() => {
+    cache = { get: jest.fn(), put: jest.fn().mockResolvedValue(undefined) };
+    getCapabilityAdapter = jest.fn();
+    const integrations = { getCapabilityAdapter } as unknown as IIntegrationsService;
+    service = new PickupPointLookupService(integrations, cache);
+  });
+
+  describe('search', () => {
+    it('should return the live provider results when the adapter is a pickup-point finder', async () => {
+      const points = [makePoint(), makePoint({ providerId: 'WAW01A' })];
+      getCapabilityAdapter.mockResolvedValue(finderAdapter(points));
+
+      const result = await service.search(CONN, { city: 'Poznań' });
+
+      expect(result).toEqual(points);
+      expect(getCapabilityAdapter).toHaveBeenCalledWith(CONN, 'ShippingProviderManager');
+    });
+
+    it('should write each returned point through to the cache', async () => {
+      const points = [makePoint(), makePoint({ providerId: 'WAW01A' })];
+      getCapabilityAdapter.mockResolvedValue(finderAdapter(points));
+
+      await service.search(CONN, {});
+
+      expect(cache.put).toHaveBeenCalledTimes(2);
+      expect(cache.put).toHaveBeenCalledWith(points[0]);
+      expect(cache.put).toHaveBeenCalledWith(points[1]);
+    });
+
+    it('should throw PickupPointFinderNotSupportedException when the adapter has no finder', async () => {
+      getCapabilityAdapter.mockResolvedValue(courierOnlyAdapter());
+
+      await expect(service.search(CONN, {})).rejects.toBeInstanceOf(
+        PickupPointFinderNotSupportedException,
+      );
+      expect(cache.put).not.toHaveBeenCalled();
+    });
+
+    it('should still return live results when a cache write-through fails', async () => {
+      const points = [makePoint()];
+      getCapabilityAdapter.mockResolvedValue(finderAdapter(points));
+      cache.put.mockRejectedValueOnce(new Error('redis down'));
+
+      await expect(service.search(CONN, {})).resolves.toEqual(points);
+    });
+  });
+
+  describe('getCachedPoint', () => {
+    it('should return the cached point on hit', async () => {
+      const point = makePoint();
+      cache.get.mockResolvedValue(point);
+
+      await expect(service.getCachedPoint('POZ08A')).resolves.toEqual(point);
+      expect(cache.get).toHaveBeenCalledWith('POZ08A');
+    });
+
+    it('should return null on miss', async () => {
+      cache.get.mockResolvedValue(null);
+      await expect(service.getCachedPoint('NOPE')).resolves.toBeNull();
+    });
+  });
+});

--- a/libs/core/src/shipping/application/services/pickup-point-lookup.service.ts
+++ b/libs/core/src/shipping/application/services/pickup-point-lookup.service.ts
@@ -1,0 +1,73 @@
+/**
+ * Pickup-Point Lookup Service
+ *
+ * Read-through orchestration the manual paczkomat picker (#769) consumes:
+ * resolves the connection's `ShippingProviderManagerPort`, narrows to the
+ * `PickupPointFinder` sub-capability, runs a live provider search, and
+ * write-throughs each returned point to `PickupPointCachePort` so a later
+ * by-id read is a sub-10ms cache hit. Search stays live because lists must be
+ * fresh; only individual points are cached (the #727.1 port is by-id only).
+ *
+ * Cache write-through failures are swallowed (warn-logged) — a degraded cache
+ * must never fail a live search.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IPickupPointLookupService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+
+import type { IPickupPointLookupService } from '../interfaces/pickup-point-lookup.service.interface';
+import { PickupPointCachePort } from '../../domain/ports/pickup-point-cache.port';
+import type { ShippingProviderManagerPort } from '../../domain/ports/shipping-provider-manager.port';
+import { isPickupPointFinder } from '../../domain/ports/capabilities/pickup-point-finder.capability';
+import type { FindPickupPointsQuery, PickupPoint } from '../../domain/types/pickup-point.types';
+import { PickupPointFinderNotSupportedException } from '../../domain/exceptions/pickup-point-finder-not-supported.exception';
+import { PICKUP_POINT_CACHE_TOKEN } from '../../shipping.tokens';
+
+/** Capability the connection must declare to host a pickup-point network. */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+@Injectable()
+export class PickupPointLookupService implements IPickupPointLookupService {
+  private readonly logger = new Logger(PickupPointLookupService.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+    @Inject(PICKUP_POINT_CACHE_TOKEN)
+    private readonly cache: PickupPointCachePort,
+  ) {}
+
+  async search(connectionId: string, query: FindPickupPointsQuery): Promise<PickupPoint[]> {
+    const adapter = await this.integrations.getCapabilityAdapter<ShippingProviderManagerPort>(
+      connectionId,
+      SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+    );
+    if (!isPickupPointFinder(adapter)) {
+      throw new PickupPointFinderNotSupportedException(connectionId);
+    }
+
+    const points = await adapter.findPickupPoints(query);
+    await this.warmCache(points);
+    return points;
+  }
+
+  getCachedPoint(providerId: string): Promise<PickupPoint | null> {
+    return this.cache.get(providerId);
+  }
+
+  private async warmCache(points: readonly PickupPoint[]): Promise<void> {
+    await Promise.all(
+      points.map(async (point) => {
+        try {
+          await this.cache.put(point);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.warn(`Failed to cache pickup point ${point.providerId}: ${message}`);
+        }
+      }),
+    );
+  }
+}

--- a/libs/core/src/shipping/domain/exceptions/pickup-point-finder-not-supported.exception.ts
+++ b/libs/core/src/shipping/domain/exceptions/pickup-point-finder-not-supported.exception.ts
@@ -1,0 +1,17 @@
+/**
+ * Pickup-Point Finder Not Supported Exception
+ *
+ * Thrown by `PickupPointLookupService` when the resolved connection's
+ * `ShippingProviderManagerPort` does not implement the `PickupPointFinder`
+ * sub-capability (e.g. a courier-only carrier with no locker network). Mapped
+ * to HTTP 422 at the controller boundary.
+ *
+ * @module libs/core/src/shipping/domain/exceptions
+ */
+export class PickupPointFinderNotSupportedException extends Error {
+  constructor(connectionId: string) {
+    super(`Connection does not support pickup-point lookup: ${connectionId}`);
+    this.name = 'PickupPointFinderNotSupportedException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -91,6 +91,7 @@ export { ShipmentNotFoundException } from './domain/exceptions/shipment-not-foun
 export { UndispatchableResolutionException } from './domain/exceptions/undispatchable-resolution.exception';
 export { ShipmentNotCancellableException } from './domain/exceptions/shipment-not-cancellable.exception';
 export { ShipmentCancellationNotSupportedException } from './domain/exceptions/shipment-cancellation-not-supported.exception';
+export { PickupPointFinderNotSupportedException } from './domain/exceptions/pickup-point-finder-not-supported.exception';
 
 // Application — dispatch seam (#835). Interface + types only; the service
 // class is injected via SHIPMENT_DISPATCH_SERVICE_TOKEN (exported above via
@@ -105,3 +106,7 @@ export type {
 // injected via SHIPMENT_QUERY_SERVICE_TOKEN / SHIPMENT_CANCELLATION_SERVICE_TOKEN.
 export type { IShipmentQueryService } from './application/interfaces/shipment-query.service.interface';
 export type { IShipmentCancellationService } from './application/interfaces/shipment-cancellation.service.interface';
+
+// Application — pickup-point lookup seam (#766). Interface only; the service is
+// injected via PICKUP_POINT_LOOKUP_SERVICE_TOKEN.
+export type { IPickupPointLookupService } from './application/interfaces/pickup-point-lookup.service.interface';

--- a/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-cache.adapter.spec.ts
+++ b/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-cache.adapter.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Redis Pickup-Point Cache Adapter unit tests (#766).
+ *
+ * The adapter's only logic is key construction + the fixed TTL + delegation to
+ * the shared CachePort, so this mocks CachePort and asserts exactly that.
+ * Real-Redis serialization fidelity is covered by the integration spec.
+ */
+import type { CachePort } from '@openlinker/shared/cache';
+import {
+  PICKUP_POINT_CACHE_TTL_SECONDS,
+  RedisPickupPointCacheAdapter,
+} from './redis-pickup-point-cache.adapter';
+import type { PickupPoint } from '../../domain/types/pickup-point.types';
+
+const point: PickupPoint = {
+  providerId: 'POZ08A',
+  name: 'Paczkomat POZ08A',
+  address: { line1: 'Krakowska 12', city: 'Poznań', postalCode: '60-001', country: 'PL' },
+  status: 'temporarily-unavailable',
+};
+
+describe('RedisPickupPointCacheAdapter', () => {
+  let cache: jest.Mocked<CachePort>;
+  let adapter: RedisPickupPointCacheAdapter;
+
+  beforeEach(() => {
+    cache = {
+      get: jest.fn(),
+      set: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn(),
+    };
+    adapter = new RedisPickupPointCacheAdapter(cache);
+  });
+
+  describe('get', () => {
+    it('should read by the namespaced provider-id key', async () => {
+      cache.get.mockResolvedValue(point);
+
+      const result = await adapter.get('POZ08A');
+
+      expect(result).toEqual(point);
+      expect(cache.get).toHaveBeenCalledWith('paczkomat:point:POZ08A');
+    });
+
+    it('should return null on cache miss', async () => {
+      cache.get.mockResolvedValue(null);
+      await expect(adapter.get('NOPE')).resolves.toBeNull();
+    });
+  });
+
+  describe('put', () => {
+    it('should write the point under its provider-id key with a 24h TTL', async () => {
+      await adapter.put(point);
+
+      expect(cache.set).toHaveBeenCalledWith(
+        'paczkomat:point:POZ08A',
+        point,
+        PICKUP_POINT_CACHE_TTL_SECONDS,
+      );
+      expect(PICKUP_POINT_CACHE_TTL_SECONDS).toBe(86_400);
+    });
+  });
+});

--- a/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-cache.adapter.ts
+++ b/libs/core/src/shipping/infrastructure/adapters/redis-pickup-point-cache.adapter.ts
@@ -1,0 +1,52 @@
+/**
+ * Redis Pickup-Point Cache Adapter
+ *
+ * Redis-backed implementation of `PickupPointCachePort` (#766). Stores each
+ * paczkomat-style pickup point keyed by its globally-unique provider id with a
+ * 24h TTL, on top of the shared `CachePort` (values JSON-serialized at that
+ * boundary). The full `PickupPoint` round-trips — including
+ * `status: 'temporarily-unavailable'` and the structured opening-hours grid —
+ * so staleness/availability surfaces in the picker (#769) with no extra work.
+ *
+ * By design this is a pure cache: `get` never refetches (read-through
+ * orchestration lives in `PickupPointLookupService`), and there is no
+ * invalidation/refresh method — freshness is TTL-driven per #727.1.
+ *
+ * @module libs/core/src/shipping/infrastructure/adapters
+ * @see {@link PickupPointCachePort} for the port contract
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { CACHE_PORT_TOKEN, type CachePort } from '@openlinker/shared/cache';
+
+import type { PickupPointCachePort } from '../../domain/ports/pickup-point-cache.port';
+import type { PickupPoint } from '../../domain/types/pickup-point.types';
+
+/**
+ * 24h, per #766 SC-2. Fixed (not env-tunable) — the acceptance criterion pins
+ * the cache lifetime at 24h; widen to a config knob only if a real operability
+ * need surfaces.
+ */
+export const PICKUP_POINT_CACHE_TTL_SECONDS = 86_400;
+
+/** Connection-agnostic: paczkomat ids are a single national namespace. */
+const KEY_PREFIX = 'paczkomat:point:';
+
+@Injectable()
+export class RedisPickupPointCacheAdapter implements PickupPointCachePort {
+  constructor(
+    @Inject(CACHE_PORT_TOKEN)
+    private readonly cache: CachePort,
+  ) {}
+
+  get(providerId: string): Promise<PickupPoint | null> {
+    return this.cache.get<PickupPoint>(keyFor(providerId));
+  }
+
+  async put(point: PickupPoint): Promise<void> {
+    await this.cache.set(keyFor(point.providerId), point, PICKUP_POINT_CACHE_TTL_SECONDS);
+  }
+}
+
+function keyFor(providerId: string): string {
+  return `${KEY_PREFIX}${providerId}`;
+}

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -12,8 +12,11 @@
  * to the module preserves the hexagonal boundary documented in
  * engineering-standards §"ORM ↔ Domain Mapping".
  *
- * No binding for `PICKUP_POINT_CACHE_TOKEN` here — the Redis-backed
- * adapter implementation is provided by #766 (paczkomat caching service).
+ * Paczkomat caching (#766): binds `PICKUP_POINT_CACHE_TOKEN` to the
+ * Redis-backed `RedisPickupPointCacheAdapter` and `PICKUP_POINT_LOOKUP_SERVICE_TOKEN`
+ * to the read-through `PickupPointLookupService`. `CACHE_PORT_TOKEN` is provided
+ * by the host-global `CacheModule` (`@openlinker/shared/cache`), so it is not
+ * imported here.
  *
  * @module libs/core/src/shipping
  */
@@ -24,10 +27,14 @@ import { MappingsModule } from '@openlinker/core/mappings';
 
 import { ShipmentOrmEntity } from './infrastructure/persistence/entities/shipment.orm-entity';
 import { ShipmentRepository } from './infrastructure/persistence/repositories/shipment.repository';
+import { RedisPickupPointCacheAdapter } from './infrastructure/adapters/redis-pickup-point-cache.adapter';
 import { ShipmentDispatchService } from './application/services/shipment-dispatch.service';
 import { ShipmentQueryService } from './application/services/shipment-query.service';
 import { ShipmentCancellationService } from './application/services/shipment-cancellation.service';
+import { PickupPointLookupService } from './application/services/pickup-point-lookup.service';
 import {
+  PICKUP_POINT_CACHE_TOKEN,
+  PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
   SHIPMENT_CANCELLATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_SERVICE_TOKEN,
   SHIPMENT_QUERY_SERVICE_TOKEN,
@@ -65,12 +72,24 @@ import {
       provide: SHIPMENT_CANCELLATION_SERVICE_TOKEN,
       useExisting: ShipmentCancellationService,
     },
+    RedisPickupPointCacheAdapter,
+    {
+      provide: PICKUP_POINT_CACHE_TOKEN,
+      useExisting: RedisPickupPointCacheAdapter,
+    },
+    PickupPointLookupService,
+    {
+      provide: PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
+      useExisting: PickupPointLookupService,
+    },
   ],
   exports: [
     SHIPMENT_REPOSITORY_TOKEN,
     SHIPMENT_DISPATCH_SERVICE_TOKEN,
     SHIPMENT_QUERY_SERVICE_TOKEN,
     SHIPMENT_CANCELLATION_SERVICE_TOKEN,
+    PICKUP_POINT_CACHE_TOKEN,
+    PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
   ],
 })
 export class ShippingModule {}

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -15,3 +15,4 @@ export const PICKUP_POINT_CACHE_TOKEN = Symbol('PickupPointCachePort');
 export const SHIPMENT_DISPATCH_SERVICE_TOKEN = Symbol('IShipmentDispatchService');
 export const SHIPMENT_QUERY_SERVICE_TOKEN = Symbol('IShipmentQueryService');
 export const SHIPMENT_CANCELLATION_SERVICE_TOKEN = Symbol('IShipmentCancellationService');
+export const PICKUP_POINT_LOOKUP_SERVICE_TOKEN = Symbol('IPickupPointLookupService');


### PR DESCRIPTION
## What & why

Fast, persistent paczkomat lookup for the manual picker (#769), built on the deliberately-narrow `PickupPointCachePort` + `PickupPointFinder` foundation shipped in #727.1 / #727.2.

**Core (`libs/core/src/shipping`)**
- **`RedisPickupPointCacheAdapter`** implements `PickupPointCachePort` over the shared `CachePort` (`@openlinker/shared/cache`), keyed by globally-unique provider id with a fixed **24h TTL**. The full `PickupPoint` round-trips — incl. `temporarily-unavailable` status + the structured opening-hours grid.
- **`PickupPointLookupService`** (`IPickupPointLookupService`) — read-through orchestration: resolves the connection's `ShippingProviderManagerPort` via `IIntegrationsService`, narrows to the `PickupPointFinder` sub-capability, runs a **live** ShipX search, **write-throughs** each result to the cache by id, returns the list. `getCachedPoint` is the fast by-id re-read. Cache write-through failures are swallowed (warn-logged) so a degraded cache never fails a live search.
- `PickupPointFinderNotSupportedException`; `PICKUP_POINT_LOOKUP_SERVICE_TOKEN` + module bindings (incl. the previously-reserved `PICKUP_POINT_CACHE_TOKEN`) + barrel exports.

**API (`apps/api` shipping)**
- **`PickupPointController`** — `GET /pickup-points` (live search; results cached by id) and `GET /pickup-points/:providerId` (cached read; 404 on miss). Admin + JWT. Connection-capability failures (finder absent / capability unsupported / disabled) → **422**; provider/transport failures → **502**.

## Scope (Option B) & decisions
Honors the by-id-only `#727.1` port rather than re-opening its contract:
- **Query-result caching** and **background refresh of most-queried points** are **deferred to #849** — both re-open the shipped contract or need new state (the finder is search-only; the port has no `refresh` by design). Genuine v2.
- `connectionId` is dropped from the cached-read endpoint (the cache key is connection-agnostic — paczkomat ids are one national namespace).
- **No migration** (Redis only).

## How to test
```bash
pnpm type-check && pnpm lint && pnpm test
pnpm --filter @openlinker/api test:integration -- pickup-point-cache   # real Redis (Docker)
```
All green locally: type-check (11 pkgs), lint (cross-context conforms), unit (`libs/core` + `apps/api`, incl. adapter / lookup-service / controller specs), and the real-Redis round-trip int-spec (proves the `@Global CacheModule` → adapter DI wiring + nested-`PickupPoint` JSON fidelity).

## Review
Cleared a `/tech-review` pass — applied the two actionable suggestions (capability-failure → 422 mapping; cache adapter placed in the documented `infrastructure/adapters/`). The reviewer-endorsed gap (no HTTP-level int-spec for the search path — heavy fixture cost for a unit-covered path) is intentionally left.

## Related
- Closes #766
- Follow-up: #849 (cache v2 — background refresh + query-result caching)
- Unblocks #769 (manual paczkomat picker). Design parent: #727 (SC-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)