### PR TITLE
feat(orders): interface + token DI for resolver; add service-interface lint invariant (#712)

### DIFF
--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -404,6 +404,13 @@ export class ProductSyncService {
 }
 ```
 
+**Two clarifications (#712):**
+
+1. **Implementing a capability `*Port` satisfies the rule.** A service that adapts a domain port — e.g. `RedisSyncLockService implements SyncLockPort`, `SyncJobQueueService implements SyncJobQueuePort` — already codes against an interface and is injected via a Symbol token. It does **not** also need a redundant parallel `I{Name}Service`; the port *is* its contract.
+2. **The interface file may live in `application/interfaces/` or be colocated in `application/services/`.** Both conventions are in use across contexts; either location is accepted (the file just has to exist for the service it backs).
+
+**Enforcement.** `scripts/check-service-interfaces.mjs` (run from `pnpm lint` via `pnpm check:invariants`) asserts that every `libs/core/src/**/application/services/*.service.ts` declares an `implements` clause referencing either an `I*Service` with a sibling `*.service.interface.ts` (in either location above) or a `*Port`. It fails the build with a `file` + reason on any regression.
+
 ### Type Definitions in Separate Files
 
 **All types must be defined in separate files** (`*.types.ts`). Types should not be defined inline in service, entity, or other implementation files.

--- a/docs/plans/implementation-plan-service-interface-coverage.md
+++ b/docs/plans/implementation-plan-service-interface-coverage.md
@@ -1,0 +1,94 @@
+# Implementation Plan — Service-interface coverage to 100% + lint enforcement (#712)
+
+> Status: DRAFT (awaiting scope sign-off). Branch: `712-service-interface-coverage`.
+
+## 1. Understand the task
+
+**Goal.** Close the gap on the documented mandatory rule — *"Services must always implement an interface"* (`docs/engineering-standards.md § Service Interface Implementation`, echoed in `.claude/rules/backend.md`) — for every application service in `libs/core`, and add a lint invariant so it can never regress.
+
+**Layer.** Backend / DX (no new runtime feature; tech-debt + tooling). Touches CORE application layer wiring + a repo-level invariant script.
+
+**Explicit non-goals.**
+- No behavior change to any service. Pure structural + DI-wiring change.
+- Not relocating the 24 interface files that live in `application/interfaces/` vs the 22 in `application/services/` — both conventions stay valid (standardizing on one location is a separate refactor, out of scope).
+- No full static enforcement of *token-binding* across all 50 services (criterion 3 of the issue) — see "Deferred" below. We fix the one unbound service and enforce the *interface* invariant.
+- Out of scope: services outside `libs/core` (apps, integrations) — the issue scopes this to `libs/core/src/**/application/services/*.service.ts`.
+
+## 2. Research — current state (audited 2026-05-26 against `origin/main` @ a6256ff)
+
+The issue's premise ("~34 interface files for ~38 services, 89%") is **stale** — coverage has improved through intervening merges. Current reality:
+
+- **50** application services under `libs/core/src/**/application/services/*.service.ts`.
+- **46** `*.service.interface.ts` files (24 in `application/interfaces/`, 22 colocated in `application/services/`).
+- **46/50** services declare an `implements I…Service` (or a `*Port`) clause.
+
+**Exactly 4 services lack a same-named `I*Service` interface file:**
+
+| Service | Implements today | Bound in module | Verdict |
+|---|---|---|---|
+| `IntegrationsContentPublisher` (content) | `ContentPublisherPort` | `useExisting` under port token | **Compliant in spirit** — port-adapter |
+| `RedisSyncLockService` (sync) | `SyncLockPort` | `useExisting` under port token | **Compliant in spirit** — port-adapter |
+| `SyncJobQueueService` (sync) | `SyncJobQueuePort` | `useExisting` under port token | **Compliant in spirit** — port-adapter |
+| `OrderItemRefResolverService` (orders) | **nothing** | bare provider (concrete-class inject) | **TRUE GAP** |
+
+So 3 of the 4 already satisfy the rule's *intent*: they implement a capability **Port** (an interface) and are injected via a Symbol token. Forcing a redundant parallel `I{Name}Service` onto a port-adapter would make the class implement two overlapping interfaces — architecturally worse, not better.
+
+The genuinely non-compliant service is **`OrderItemRefResolverService`**:
+- No interface file, no `implements` clause.
+- Injected as a **concrete class** into `order-ingestion.service.ts` (constructor L66, used L212) — violating "code against interfaces, inject via token."
+- Sole consumer: `order-ingestion.service.ts`. Registered as a bare provider in `orders.module.ts` (L49).
+- Public surface: `tryResolve(connectionId, productRef): Promise<ItemResolutionResult>` and `resolve(connectionId, productRef): Promise<ResolvedOrderItemProduct>` (types re-exported from `./order-item-ref-resolver.types`).
+
+**#665 (OfferLinkingService drift, referenced by #712) is already resolved** — `offer-linking.service.ts` has its interface in `listings/application/interfaces/` and declares `implements`. No action needed.
+
+**Invariant-script wiring.** `pnpm lint` → `pnpm -r lint && pnpm check:invariants`; `check:invariants` chains plain Node ESM `scripts/check-*.mjs`. New check slots into that chain.
+
+## 3. Design
+
+**Decision (recommended — "Option B / intent-honoring"):** treat *implementing a capability `*Port`* as satisfying the service-interface rule for port-adapters, and fix only the one true gap. Then enforce the rule with a lint invariant whose acceptance condition matches the architecture.
+
+### 3a. Fix `OrderItemRefResolverService` (orders context)
+- New interface `IOrderItemRefResolverService` in `orders/application/interfaces/order-item-ref-resolver.service.interface.ts` (matches the orders-context convention — `order-record`, `order-sync`, etc. all live in `application/interfaces/`). Re-uses the existing `ItemResolutionResult` / `ResolvedOrderItemProduct` types.
+- `OrderItemRefResolverService implements IOrderItemRefResolverService`.
+- New token `ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN = Symbol('IOrderItemRefResolverService')` in `orders/orders.tokens.ts`.
+- `orders.module.ts`: keep concrete provider, add `{ provide: ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN, useExisting: OrderItemRefResolverService }` (mirrors the other order services).
+- `order-ingestion.service.ts`: inject `@Inject(ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN) private readonly orderItemRefResolver: IOrderItemRefResolverService` instead of the concrete class.
+- Token reaches consumers via the orders barrel (`export * from './orders.tokens'` already in place).
+
+### 3b. Lint invariant `scripts/check-service-interfaces.mjs`
+For every `libs/core/src/**/application/services/*.service.ts` (excluding `*.spec.ts`, `*.service.interface.ts`):
+- It MUST declare an `implements <X>` clause where `<X>` is **either**
+  - an `I*Service` interface that has a sibling `*.service.interface.ts` file in the same context (in `application/interfaces/` **or** `application/services/`), **or**
+  - a `*Port` capability port.
+- Fails with a `file:line` + the rule that fired (style consistent with `check-cross-context-imports.mjs`).
+- Wired into the `check:invariants` chain in root `package.json`.
+
+### 3c. Docs
+`docs/engineering-standards.md § Service Interface Implementation`:
+- Reference `scripts/check-service-interfaces.mjs` as the enforcement.
+- Clarify (a) implementing a capability **Port** satisfies the rule for port-adapters, and (b) interface files may live in `application/interfaces/` or colocated in `application/services/`.
+
+## 4. Step-by-step
+
+| # | File | Change | Acceptance |
+|---|---|---|---|
+| 1 | `orders/application/interfaces/order-item-ref-resolver.service.interface.ts` | New `IOrderItemRefResolverService` (2 methods, JSDoc header) | type-check passes; methods match impl |
+| 2 | `orders/application/services/order-item-ref-resolver.service.ts` | `implements IOrderItemRefResolverService` + import | declares implements |
+| 3 | `orders/orders.tokens.ts` | Add `ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN` | Symbol-only export |
+| 4 | `orders/orders.module.ts` | Add `useExisting` token binding | DI resolves; worker+api boot |
+| 5 | `orders/application/services/order-ingestion.service.ts` | Inject via token + interface type | no concrete-class injection |
+| 6 | `scripts/check-service-interfaces.mjs` | New invariant script | fails on a planted violation, passes clean |
+| 7 | root `package.json` | Add script to `check:invariants` chain | `pnpm lint` runs it |
+| 8 | `docs/engineering-standards.md` | Reference script + clarify Port/location nuance | doc matches reality |
+| 9 | `order-item-ref-resolver.service.spec.ts` (if present) / `order-ingestion` spec | Update DI provider wiring to token | `pnpm test` green |
+
+## 5. Validate (quality gate)
+- `pnpm lint` (incl. the new invariant) — zero errors.
+- `pnpm type-check` — zero errors.
+- `pnpm test` — all unit tests pass; update any spec that constructs `OrderIngestionService`/resolver via concrete class to use the token.
+- Sanity: the new invariant flags a deliberately-broken service, then passes on the clean tree.
+- No ORM/schema change → no migration.
+
+## Deferred (explicitly out of scope, note in PR)
+- Static enforcement of token-binding for *all* services (issue criterion 3) — requires parsing module provider graphs; only `OrderItemRefResolverService` was unbound and is fixed here.
+- Standardizing interface-file location to a single directory across all contexts.

--- a/libs/core/src/orders/application/interfaces/order-item-ref-resolver.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-item-ref-resolver.service.interface.ts
@@ -1,0 +1,36 @@
+/**
+ * Order Item Ref Resolver Service Interface
+ *
+ * Defines the contract for resolving external-only IncomingOrder item references
+ * (offer / product / variant / sku) to internal OpenLinker product and variant IDs.
+ *
+ * @module libs/core/src/orders/application/interfaces
+ */
+import type { IncomingOrderItemRef } from '../../domain/types/incoming-order.types';
+import type {
+  ItemResolutionResult,
+  ResolvedOrderItemProduct,
+} from '../services/order-item-ref-resolver.types';
+
+export interface IOrderItemRefResolverService {
+  /**
+   * Resolve an item reference, swallowing missing-mapping failures.
+   *
+   * Returns `{ resolved: true, ... }` on success, or `{ resolved: false, ... }`
+   * when the underlying mapping is missing. Non-mapping errors propagate.
+   */
+  tryResolve(
+    connectionId: string,
+    productRef: IncomingOrderItemRef
+  ): Promise<ItemResolutionResult>;
+
+  /**
+   * Resolve an item reference to internal product/variant IDs.
+   *
+   * @throws MissingOrderItemMappingError when no mapping exists for the reference.
+   */
+  resolve(
+    connectionId: string,
+    productRef: IncomingOrderItemRef
+  ): Promise<ResolvedOrderItemProduct>;
+}

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -21,7 +21,7 @@ import type {
 } from '@openlinker/core/customers';
 import type { IOrderSyncService } from '../../interfaces/order-sync.service.interface';
 import type { IOrderRecordService } from '../../interfaces/order-record.service.interface';
-import type { OrderItemRefResolverService } from '../order-item-ref-resolver.service';
+import type { IOrderItemRefResolverService } from '../../interfaces/order-item-ref-resolver.service.interface';
 import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
 
 describe('OrderIngestionService', () => {
@@ -37,7 +37,7 @@ describe('OrderIngestionService', () => {
   let orderSyncService: jest.Mocked<IOrderSyncService>;
   let orderRecordService: jest.Mocked<IOrderRecordService>;
   let orderSource: jest.Mocked<OrderSourcePort>;
-  let orderItemRefResolver: jest.Mocked<OrderItemRefResolverService>;
+  let orderItemRefResolver: jest.Mocked<IOrderItemRefResolverService>;
   let customerIdentityResolver: jest.Mocked<ICustomerIdentityResolverService>;
   let customerProjectionUpdater: jest.Mocked<IOrderCustomerProjectionUpdaterService>;
 
@@ -84,7 +84,7 @@ describe('OrderIngestionService', () => {
     orderItemRefResolver = {
       resolve: jest.fn(),
       tryResolve: jest.fn(),
-    } as unknown as jest.Mocked<OrderItemRefResolverService>;
+    } as unknown as jest.Mocked<IOrderItemRefResolverService>;
 
     orderSyncService = {
       syncOrder: jest.fn(),

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -37,12 +37,16 @@ import type {
   OrderIngestionOptions,
   OrderIngestionResult,
 } from '../interfaces/order-ingestion.service.interface';
-import { ORDER_SYNC_SERVICE_TOKEN, ORDER_RECORD_SERVICE_TOKEN } from '../../orders.tokens';
+import {
+  ORDER_SYNC_SERVICE_TOKEN,
+  ORDER_RECORD_SERVICE_TOKEN,
+  ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN,
+} from '../../orders.tokens';
 import { IOrderRecordService } from '../interfaces/order-record.service.interface';
+import { IOrderItemRefResolverService } from '../interfaces/order-item-ref-resolver.service.interface';
 import type { IncomingOrder } from '../../domain/types/incoming-order.types';
 import type { Order } from '../../domain/types/order.types';
 import { Logger } from '@openlinker/shared/logging';
-import { OrderItemRefResolverService } from './order-item-ref-resolver.service';
 import { MissingOrderItemMappingError } from '../../domain/exceptions/missing-order-item-mapping.error';
 
 @Injectable()
@@ -63,7 +67,8 @@ export class OrderIngestionService implements IOrderIngestionService {
     private readonly lock: SyncLockPort,
     @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
     private readonly identifierMapping: IIdentifierMappingService,
-    private readonly orderItemRefResolver: OrderItemRefResolverService,
+    @Inject(ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN)
+    private readonly orderItemRefResolver: IOrderItemRefResolverService,
     @Inject(ORDER_SYNC_SERVICE_TOKEN)
     private readonly orderSyncService: IOrderSyncService,
     @Inject(CUSTOMER_IDENTITY_RESOLVER_SERVICE_TOKEN)

--- a/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
+++ b/libs/core/src/orders/application/services/order-item-ref-resolver.service.ts
@@ -11,6 +11,7 @@ import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTIT
 import { IProductsService, PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
 import type { IncomingOrderItemRef } from '../../domain/types/incoming-order.types';
 import { MissingOrderItemMappingError } from '../../domain/exceptions/missing-order-item-mapping.error';
+import type { IOrderItemRefResolverService } from '../interfaces/order-item-ref-resolver.service.interface';
 import type {
   ItemResolutionResult,
   ResolvedOrderItemProduct,
@@ -19,7 +20,7 @@ import type {
 export type { ItemResolutionResult, ResolvedOrderItemProduct };
 
 @Injectable()
-export class OrderItemRefResolverService {
+export class OrderItemRefResolverService implements IOrderItemRefResolverService {
   constructor(
     @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
     private readonly identifierMapping: IIdentifierMappingService,

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -21,6 +21,7 @@ import {
   ORDER_RECORD_REPOSITORY_TOKEN,
   ORDER_RECORD_SERVICE_TOKEN,
   ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
+  ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN,
 } from './orders.tokens';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
@@ -70,6 +71,10 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     {
       provide: ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
       useExisting: OrderDestinationRetryService,
+    },
+    {
+      provide: ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN,
+      useExisting: OrderItemRefResolverService,
     },
   ],
   exports: [

--- a/libs/core/src/orders/orders.tokens.ts
+++ b/libs/core/src/orders/orders.tokens.ts
@@ -14,6 +14,7 @@ export const ORDER_INGESTION_SERVICE_TOKEN = Symbol('IOrderIngestionService');
 export const ORDER_RECORD_REPOSITORY_TOKEN = Symbol('OrderRecordRepositoryPort');
 export const ORDER_RECORD_SERVICE_TOKEN = Symbol('IOrderRecordService');
 export const ORDER_DESTINATION_RETRY_SERVICE_TOKEN = Symbol('IOrderDestinationRetryService');
+export const ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN = Symbol('IOrderItemRefResolverService');
 
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:integration": "pnpm --filter @openlinker/api test:integration",
     "test:php": "cd apps/prestashop-module/openlinker && composer install --no-interaction --quiet && vendor/bin/phpunit",
     "lint": "pnpm -r lint && pnpm check:invariants",
-    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-libs-build-scripts.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs && node scripts/check-cross-context-imports.mjs",
+    "check:invariants": "bash scripts/check-fixture-purity.sh && node scripts/check-render-template-fixture-drift.mjs && node scripts/check-migration-timestamps.mjs --self-check && node scripts/check-migration-timestamps.mjs && node scripts/check-design-tokens.mjs && node scripts/check-create-adapter.mjs && node scripts/check-libs-build-scripts.mjs && node scripts/check-plugin-guide-quotes.mjs && node scripts/check-repo-urls.mjs && node scripts/check-cross-context-imports.mjs && node scripts/check-service-interfaces.mjs --self-check && node scripts/check-service-interfaces.mjs",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
     "create-adapter": "node scripts/create-adapter.mjs",

--- a/scripts/check-service-interfaces.mjs
+++ b/scripts/check-service-interfaces.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * check-service-interfaces.mjs
+ *
+ * Lint-time invariant for the service-interface rule documented at
+ * docs/engineering-standards.md § Service Interface Implementation
+ * ("Services must always implement an interface") and .claude/rules/backend.md.
+ *
+ * Rule. Every application service —
+ *   `libs/core/src/<ctx>/application/services/*.service.ts`
+ *   (excluding `*.spec.ts` and `*.service.interface.ts`)
+ * — MUST declare an `implements <X>` heritage clause where `<X>` is either:
+ *
+ *   (a) an `I*Service` interface that has a sibling `*.service.interface.ts`
+ *       file in the same context — colocated in `application/services/` OR in
+ *       `application/interfaces/` (both conventions are in use), OR
+ *   (b) a capability `*Port` interface (a service that adapts a domain port —
+ *       e.g. RedisSyncLockService implements SyncLockPort — already satisfies
+ *       the "code against an interface" intent; forcing a redundant parallel
+ *       I*Service onto a port-adapter would be worse, not better).
+ *       `*RepositoryPort` does NOT count — repository ports are an intra-context
+ *       persistence concern, not the service's outward contract.
+ *
+ * A service that implements nothing, or whose declared `I*Service` has no
+ * sibling interface file, fails the build with a file + reason.
+ *
+ * The service class in a file is identified by its filename-derived name
+ * (`foo-bar.service.ts` → `FooBar` or `FooBarService`) so a helper class
+ * declared earlier in the file doesn't get checked in its place.
+ *
+ * Run with `--self-check` to exercise the classifier against synthetic inputs
+ * (no filesystem) — mirrors `check-migration-timestamps.mjs --self-check`.
+ *
+ * Scope. `libs/core/src/<ctx>/application/services/` only — matching the
+ * scope #712 defines. Services in apps/integrations are out of scope here.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, relative, dirname, basename, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(__dirname, '..');
+const SERVICES_GLOB_ROOT = join(repoRoot, 'libs', 'core', 'src');
+const SERVICES_PATH_SEGMENT = `application${sep}services${sep}`;
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.git', '.turbo']);
+
+const I_SERVICE_RE = /^I[A-Z][A-Za-z0-9]*Service$/;
+const PORT_RE = /^[A-Z][A-Za-z0-9]*Port$/;
+const REPOSITORY_PORT_RE = /RepositoryPort$/;
+
+const DOCS_REF = 'docs/engineering-standards.md#service-interface-implementation';
+
+/** Recursively collect files under `dir`. */
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      files.push(...(await walk(join(dir, entry.name))));
+    } else if (entry.isFile()) {
+      files.push(join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+/** Is this an in-scope application service file? Path-separator agnostic. */
+function isServiceFile(repoRel) {
+  return (
+    repoRel.includes(SERVICES_PATH_SEGMENT) &&
+    repoRel.endsWith('.service.ts') &&
+    !repoRel.endsWith('.spec.ts') &&
+    !repoRel.endsWith('.service.interface.ts')
+  );
+}
+
+/** `order-item-ref-resolver` → `OrderItemRefResolver`. */
+function toPascalCase(kebab) {
+  return kebab
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+/**
+ * All exported classes with their heritage clause (text between the class name
+ * and the opening `{`). Returns `[{ className, heritage }]`.
+ */
+function parseClasses(content) {
+  const re = /export\s+(?:default\s+)?(?:abstract\s+)?class\s+(\w+)([^{]*)\{/gs;
+  const classes = [];
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    classes.push({ className: m[1], heritage: m[2] });
+  }
+  return classes;
+}
+
+/**
+ * Pick the service class for a file by its filename-derived name. A
+ * `foo-bar.service.ts` file's class is `FooBar` or `FooBarService`; if neither
+ * is present, fall back to the first exported class.
+ */
+function pickServiceClass(classes, fileBase) {
+  const pascal = toPascalCase(fileBase);
+  const candidates = new Set([pascal, `${pascal}Service`]);
+  return classes.find((c) => candidates.has(c.className)) ?? classes[0] ?? null;
+}
+
+/** Parse the comma-separated identifiers after `implements` (generics stripped). */
+function parseImplements(heritage) {
+  const m = heritage.match(/\bimplements\b([\s\S]+)$/);
+  if (!m) return [];
+  return m[1]
+    .split(',')
+    .map((s) => s.replace(/<[\s\S]*$/, '').trim()) // drop generic args
+    .filter(Boolean);
+}
+
+/**
+ * Pure classifier — no filesystem. Given the file content, its base name (no
+ * `.service.ts`), and whether a sibling interface file exists, decide whether
+ * the service satisfies the rule. Returns `{ ok, reason }`.
+ */
+function evaluateService({ content, fileBase, siblingExists }) {
+  const picked = pickServiceClass(parseClasses(content), fileBase);
+  if (!picked) {
+    return { ok: false, reason: 'no exported class found' };
+  }
+
+  const implemented = parseImplements(picked.heritage);
+  if (implemented.length === 0) {
+    const suggested = `I${picked.className}${picked.className.endsWith('Service') ? '' : 'Service'}`;
+    return {
+      ok: false,
+      reason: `class ${picked.className} implements no interface — add an ${suggested} interface (sibling *.service.interface.ts) or implement a capability *Port`,
+    };
+  }
+
+  const serviceIfaces = implemented.filter((n) => I_SERVICE_RE.test(n));
+  if (serviceIfaces.length > 0) {
+    if (!siblingExists) {
+      return {
+        ok: false,
+        reason: `declares 'implements ${serviceIfaces.join(', ')}' but no sibling *.service.interface.ts exists (looked in ./ and ../interfaces/)`,
+      };
+    }
+    return { ok: true };
+  }
+
+  const ports = implemented.filter((n) => PORT_RE.test(n) && !REPOSITORY_PORT_RE.test(n));
+  if (ports.length > 0) return { ok: true };
+
+  return {
+    ok: false,
+    reason: `class ${picked.className} implements [${implemented.join(', ')}] — none is an I*Service (with sibling file) or a non-repository *Port`,
+  };
+}
+
+/** Does a sibling interface file exist for this service (either convention)? */
+function siblingInterfaceExists(absFile) {
+  const dir = dirname(absFile);
+  const base = basename(absFile, '.service.ts');
+  const colocated = join(dir, `${base}.service.interface.ts`);
+  const interfacesDir = join(dirname(dir), 'interfaces', `${base}.service.interface.ts`);
+  return existsSync(colocated) || existsSync(interfacesDir);
+}
+
+async function main() {
+  const files = (await walk(SERVICES_GLOB_ROOT)).filter((f) =>
+    isServiceFile(relative(repoRoot, f))
+  );
+
+  const violations = [];
+  let checked = 0;
+
+  for (const file of files) {
+    const repoRel = relative(repoRoot, file);
+    const content = await readFile(file, 'utf8');
+    const result = evaluateService({
+      content,
+      fileBase: basename(file, '.service.ts'),
+      siblingExists: siblingInterfaceExists(file),
+    });
+    checked += 1;
+    if (!result.ok) violations.push({ file: repoRel, reason: result.reason });
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `✓ check-service-interfaces: ${checked} core application service(s) checked. All implement an interface.`
+    );
+    process.exit(0);
+  }
+
+  console.error(`✗ check-service-interfaces: ${violations.length} violation(s).\n`);
+  for (const v of violations) {
+    console.error(`  ${v.file}`);
+    console.error(`    rule: ${v.reason}`);
+    console.error(`    docs: ${DOCS_REF}`);
+    console.error('');
+  }
+  process.exit(1);
+}
+
+/**
+ * Self-test the pure classifier against synthetic inputs. Runs in-process —
+ * no filesystem, no real services — so it stays green regardless of the tree.
+ */
+function selfCheck() {
+  const svc = (impl) =>
+    `import { Injectable } from '@nestjs/common';\n@Injectable()\nexport class FooBarService${impl} {\n  doThing(): void {}\n}\n`;
+
+  const cases = [
+    {
+      name: 'implements nothing → fail',
+      input: { content: svc(''), fileBase: 'foo-bar', siblingExists: false },
+      ok: false,
+    },
+    {
+      name: 'I*Service + sibling present → pass',
+      input: {
+        content: svc(' implements IFooBarService'),
+        fileBase: 'foo-bar',
+        siblingExists: true,
+      },
+      ok: true,
+    },
+    {
+      name: 'I*Service + no sibling → fail',
+      input: {
+        content: svc(' implements IFooBarService'),
+        fileBase: 'foo-bar',
+        siblingExists: false,
+      },
+      ok: false,
+    },
+    {
+      name: 'capability *Port → pass',
+      input: {
+        content: svc(' implements SyncLockPort'),
+        fileBase: 'foo-bar',
+        siblingExists: false,
+      },
+      ok: true,
+    },
+    {
+      name: 'only *RepositoryPort → fail',
+      input: {
+        content: svc(' implements FooRepositoryPort'),
+        fileBase: 'foo-bar',
+        siblingExists: false,
+      },
+      ok: false,
+    },
+    {
+      name: 'only lifecycle iface → fail',
+      input: {
+        content: svc(' implements OnModuleInit'),
+        fileBase: 'foo-bar',
+        siblingExists: false,
+      },
+      ok: false,
+    },
+    {
+      name: 'helper class first, service class matches filename → pass',
+      input: {
+        content: `class FooBarHelper {}\n@Injectable()\nexport class FooBarService implements IFooBarService {\n  doThing(): void {}\n}\n`,
+        fileBase: 'foo-bar',
+        siblingExists: true,
+      },
+      ok: true,
+    },
+    {
+      name: 'class without Service suffix matching filename (port-adapter) → pass',
+      input: {
+        content: `@Injectable()\nexport class IntegrationsContentPublisher implements ContentPublisherPort {}\n`,
+        fileBase: 'integrations-content-publisher',
+        siblingExists: false,
+      },
+      ok: true,
+    },
+  ];
+
+  const failures = [];
+  for (const c of cases) {
+    const got = evaluateService(c.input).ok;
+    if (got !== c.ok) failures.push(`  ✗ ${c.name}: expected ok=${c.ok}, got ok=${got}`);
+  }
+
+  if (failures.length === 0) {
+    console.log(
+      `✓ check-service-interfaces --self-check: ${cases.length} classifier case(s) passed.`
+    );
+    process.exit(0);
+  }
+
+  console.error('✗ check-service-interfaces --self-check failed:\n');
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+const run = process.argv.includes('--self-check') ? selfCheck : main;
+Promise.resolve(run()).catch((err) => {
+  console.error('check-service-interfaces: fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What & why

Closes #712.

`docs/engineering-standards.md` states "Services must always implement an interface", but enforcement was advisory. This closes the gap in `libs/core` and adds a lint invariant so it can't regress.

**The gap was smaller than #712 assumed** (it predated several merges). Audited state: 46/50 core application services already had interfaces; 3 of the remaining 4 already implement a capability `*Port` and are token-bound. The **one genuinely non-compliant service was `OrderItemRefResolverService`** — no interface, and injected into `OrderIngestionService` as a concrete class.

## Changes

- **`IOrderItemRefResolverService`** added (`orders/application/interfaces/`); the service now implements it and is injected via a new `ORDER_ITEM_REF_RESOLVER_SERVICE_TOKEN` (bound `useExisting` in `OrdersModule`, mirroring the sibling order services). `OrderIngestionService` switches from concrete-class injection to `@Inject(token)` + interface type.
- **`scripts/check-service-interfaces.mjs`** — new invariant wired into `pnpm check:invariants` (→ `pnpm lint`). Every `libs/core/**/application/services/*.service.ts` must declare `implements` referencing either an `I*Service` with a sibling `*.service.interface.ts` (in `./` or `../interfaces/`) **or** a non-repository `*Port`. Ships a `--self-check` mode (8 classifier cases) run ahead of the real pass, mirroring `check-migration-timestamps.mjs --self-check`.
- **`engineering-standards.md`** documents the two clarifications: capability-`Port` implementation satisfies the rule for port-adapters, and interface files may live in `application/interfaces/` or be colocated in `application/services/`.

## Scope decision (please confirm on merge)

Implements the **intent-honoring** reading of #712: a capability `*Port` counts as the service's interface for port-adapters (`RedisSyncLockService`, `SyncJobQueueService`, `IntegrationsContentPublisher`), rather than forcing redundant parallel `I*Service` interfaces onto them.

**Deferred:** full static enforcement of interface-typed token binding across *all* services (issue criterion 3) — only `OrderItemRefResolverService` was unbound and is fixed here; a module-graph-parsing lint is a separate effort.

## How tested

- `pnpm lint` (incl. new invariant + `--self-check`), `pnpm type-check`, `pnpm test` — all green (libs/core 878, apps/api 428, apps/worker 141, all packages).
- New invariant verified to catch all failure modes (implements-nothing, `I*Service` with no sibling file, repository-port-only, helper-class-first) and pass clean on all 50 services.
- Worker integration suite booted `AppModule` successfully (`allegro-masked-email-identity`, `marketplace-offers-sync`), confirming the DI rewiring resolves. Note: 7 worker int-specs fail to **compile** due to pre-existing bit-rot (e.g. `markSucceeded` called with 1 arg vs the 2-arg `(id, outcome)` signature) — unrelated to this change and exactly the gap #786 tracks.

## Migration

None — no ORM/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)