### PR TITLE
fix(prestashop): paginate via limit=offset,count, not a bogus offset param (#851)

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-query.builder.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-query.builder.spec.ts
@@ -90,7 +90,7 @@ describe('PrestashopQueryBuilder', () => {
   });
 
   describe('buildQueryWithPagination', () => {
-    it('should include limit parameter', () => {
+    it('should emit count-only limit when no offset is given', () => {
       const query = PrestashopQueryBuilder.buildQueryWithPagination(
         'products',
         undefined,
@@ -98,9 +98,26 @@ describe('PrestashopQueryBuilder', () => {
         50
       );
       expect(query).toContain('limit=50');
+      // PrestaShop has no standalone `offset` parameter — it must never appear.
+      expect(query).not.toContain('offset=');
     });
 
-    it('should include offset parameter', () => {
+    it('should emit `limit=offset,count` when paginating with an offset (#851)', () => {
+      // PrestaShop pagination syntax is `limit=[offset,]count` (offset 0-indexed),
+      // NOT a separate `offset=` param. limit=200, offset=200 → page 2 of 200.
+      const query = PrestashopQueryBuilder.buildQueryWithPagination(
+        'products',
+        undefined,
+        undefined,
+        200,
+        200
+      );
+      expect(query).toContain('limit=200,200');
+      expect(query).not.toContain('offset=');
+      expect(query).not.toContain('limit=200&'); // not the bare count form
+    });
+
+    it('should drop a bare offset that has no count (cannot be expressed in PrestaShop)', () => {
       const query = PrestashopQueryBuilder.buildQueryWithPagination(
         'products',
         undefined,
@@ -108,10 +125,11 @@ describe('PrestashopQueryBuilder', () => {
         undefined,
         100
       );
-      expect(query).toContain('offset=100');
+      expect(query).not.toContain('offset=');
+      expect(query).not.toContain('limit=');
     });
 
-    it('should combine filters and pagination', () => {
+    it('should combine filters and offset pagination', () => {
       const filters = {
         status: 'pending',
       };
@@ -123,8 +141,9 @@ describe('PrestashopQueryBuilder', () => {
         50
       );
       expect(query).toContain('filter[current_state]=[pending]');
-      expect(query).toContain('limit=25');
-      expect(query).toContain('offset=50');
+      // offset=50, count=25 → `limit=50,25`.
+      expect(query).toContain('limit=50,25');
+      expect(query).not.toContain('offset=');
     });
   });
 

--- a/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-webservice.client.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-webservice.client.spec.ts
@@ -247,8 +247,10 @@ describe('PrestashopWebserviceClient', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
       const url = fetchCall[0] as string;
 
-      expect(url).toContain('limit=50');
-      expect(url).toContain('offset=100');
+      // PrestaShop paging syntax is `limit=[offset,]count` — offset=100, count=50.
+      // A standalone `offset=` param is silently ignored by PrestaShop (#851).
+      expect(url).toContain('limit=100,50');
+      expect(url).not.toContain('offset=');
     });
 
     it('should use default page size when limit not provided', async () => {
@@ -271,6 +273,76 @@ describe('PrestashopWebserviceClient', () => {
       const url = fetchCall[0] as string;
 
       expect(url).toContain('limit=100'); // Default page size
+    });
+
+    it('should walk every page when paginated by offset and terminate (#851 regression)', async () => {
+      // Emulate PrestaShop's real `limit=[offset,]count` semantics: a comma value
+      // means [offset, count]; a bare value means count from offset 0. Crucially,
+      // there is NO `offset=` parameter — under the pre-fix builder the URL carried
+      // `limit=2&offset=2`, this fake would parse `limit=2` (offset 0) and return the
+      // same first page forever, so the walk below would never see a short page and
+      // would spin to its guard, collecting only the first page's IDs.
+      const catalog = ['101', '102', '103', '104', '105'];
+      const pageSize = 2;
+
+      (global.fetch as jest.Mock).mockImplementation((url: string) => {
+        const query = url.split('?')[1] ?? '';
+        const limitParam =
+          query
+            .split('&')
+            .find((p) => p.startsWith('limit='))
+            ?.slice('limit='.length) ?? '';
+        let offset = 0;
+        let count = catalog.length;
+        if (limitParam.includes(',')) {
+          const [rawOffset, rawCount] = limitParam.split(',');
+          offset = Number(rawOffset);
+          count = Number(rawCount);
+        } else if (limitParam.length > 0) {
+          count = Number(limitParam);
+        }
+        const slice = catalog.slice(offset, offset + count);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                prestashop: { products: { product: slice.map((id) => ({ id })) } },
+              })
+            ),
+        });
+      });
+
+      // Mirror MasterProductSyncAllHandler.collectExternalIds with a generous guard.
+      const MAX_PAGES = 50;
+      const collected: string[] = [];
+      let offset = 0;
+      let pages = 0;
+      for (let page = 0; page < MAX_PAGES; page++) {
+        pages++;
+        const batch = await client.listResources<{ id: string }>(
+          'products',
+          { display: '[id]' },
+          pageSize,
+          offset
+        );
+        if (batch.length === 0) break;
+        collected.push(...batch.map((r) => String(r.id)));
+        if (batch.length < pageSize) break;
+        offset += batch.length;
+      }
+
+      // Terminated naturally on the short final page (3 = 2 + 2 + 1), not on the guard.
+      expect(pages).toBe(3);
+      expect(collected).toEqual(catalog);
+
+      // Page 2 must request the offset slice via the comma form, never `offset=`.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- test mock: narrowing dynamic spy / fixture / response shape
+      const secondUrl = (global.fetch as jest.Mock).mock.calls[1][0] as string;
+      expect(secondUrl).toContain('limit=2,2');
+      expect(secondUrl).not.toContain('offset=');
     });
 
     it('should normalize collection response to array', async () => {

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-query.builder.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-query.builder.ts
@@ -155,13 +155,17 @@ export class PrestashopQueryBuilder {
     const baseQuery = this.buildQuery(resource, filters, config);
     const params: string[] = [baseQuery];
 
-    // Pagination
+    // Pagination. PrestaShop's WebService has no standalone `offset` parameter:
+    // paging is expressed entirely through `limit` using the `[offset,]count`
+    // comma syntax (offset 0-indexed). e.g. `limit=200,200` = 200 rows starting
+    // at element 201. A bare `offset=N` is silently ignored by PrestaShop, which
+    // made every page return the same first `count` rows (issue #851). The comma
+    // form requires a count, so an offset with no limit cannot be expressed and
+    // is dropped — the only offset>0 caller (listExternalIds) always passes limit.
     if (limit !== undefined && limit > 0) {
-      params.push(`limit=${limit}`);
-    }
-
-    if (offset !== undefined && offset > 0) {
-      params.push(`offset=${offset}`);
+      params.push(
+        offset !== undefined && offset > 0 ? `limit=${offset},${limit}` : `limit=${limit}`
+      );
     }
 
     return params.join('&');


### PR DESCRIPTION
Closes #851

## Problem

Triggering a PrestaShop product sync ("Trigger sync…" → `master.product.syncAll`) spun in a long loop re-fetching the same products until it hit the handler's `MAX_PAGES=1000` guard — the reporter's *"infinite loop … ended on MAX_PAGE const."*

## Root cause

`PrestashopQueryBuilder.buildQueryWithPagination` emitted a standalone `offset=N` query parameter. **The PrestaShop WebService API has no such parameter** — paging is expressed entirely through `limit` using the `[offset,]count` comma syntax (offset is 0-indexed; e.g. `limit=200,200` returns 200 rows starting at element 201).

Verified against the official docs:
- *devdocs — Additional list parameters*: `limit` → `[offset,]limit`, example `/api/states/?limit=9,5` = "the first 5 states starting from the 10th element."
- *devdocs — Cheat sheet*: `limit Starting index, Number` → "Limit the result to 'Number' from the 'Index'."

PrestaShop silently ignored `offset=` and returned the **same first `count` rows for every page**. The only `offset>0` caller is `ProductMasterPort.listExternalIds` (catalog discovery). Because every page came back full, the handler's loop never saw the short/empty page that terminates it, and ran to its guard. The defensive `Set`-dedup then collapsed it to the first page's IDs — which also means **any catalog larger than one page silently synced only its first page** (a latent data-completeness bug hiding under the visible loop).

## Fix

Emit `limit=${offset},${limit}` when `offset > 0`, else `limit=${limit}`. The comma form requires a count, so a bare offset cannot be expressed and is dropped (the sole `offset>0` caller always passes `limit`). Every other `listResources` caller passes offset 0/undefined and is byte-for-byte unchanged — blast radius is one method.

| Loop page | Handler args | Emitted query | Result |
|---|---|---|---|
| 0 | `{limit:200, offset:0}` | `limit=200` | first 200 |
| 1 | `{limit:200, offset:200}` | `limit=200,200` | 200 from element 201 ✅ |
| 2 | `{limit:200, offset:400}` | `limit=400,200` | 200 from element 401 ✅ |

## Tests

- Corrected the two specs that asserted the unsupported separate-param shape (`prestashop-query.builder.spec.ts`, `prestashop-webservice.client.spec.ts`).
- Added query-builder cases: `limit=200,200` for offset paging, count-only when no offset, and a dropped bare offset.
- Added a **webservice-client regression** that emulates PrestaShop's real `limit=[offset,]count` parsing and walks pages exactly as the discovery handler does — it terminates on the short final page and unions all IDs. **Under the old builder this walk would never terminate naturally** (it would spin to its guard, collecting only page one).

## Verification

- `pnpm lint` ✓ · `pnpm type-check` ✓
- `@openlinker/integrations-prestashop` 275 ✓ · worker `master-product-sync-all` 7 ✓
- `apps/web` passes in isolation (156 files / 1222 tests); it flakes only under full-suite parallelism (unrelated to this backend-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)