### PR TITLE
docs(seo): link openlinker.io site + deep-link section pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](https://github.com/openlinker-project/openlinker/issues/670)
 
+**[openlinker.io](https://openlinker.io)** · [Architecture](https://openlinker.io/en/architecture) · [Integrations](https://openlinker.io/en/integrations) · [vs BaseLinker](https://openlinker.io/en/vs/baselinker)
+
 **Sync orders, inventory, and listings between your shop and the marketplaces you sell on. Self-hosted, open-source, pluggable.**
 
 If you sell on your own shop *and* on marketplaces like Allegro, you've already lived the pain: orders coming in from multiple places, inventory drifting between channels, manually rewriting product descriptions for every listing, customer data scattered across systems. The usual answers are SaaS channel managers (you pay forever and your data lives on their servers) or custom scripts (fragile and yours to maintain alone). OpenLinker is the third option: a self-hosted, open-source orchestration platform that does the same job, on your servers, with your data, with code you can read and extend.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,23 @@
+# OpenLinker
+
+> Open-source, self-hosted, API-first e-commerce orchestration platform. Sync orders, inventory, and listings between your shop (PrestaShop, …) and the marketplaces you sell on (Allegro, …). Built on Hexagonal Architecture (ports and adapters) in a pnpm monorepo — platforms plug in as packages that implement typed capability ports, so adding a platform is a plugin, not a fork.
+
+The canonical, always-current version of this file is served by the project site at https://openlinker.io/llms.txt. This copy lives in the source repository so AI crawlers reading the code also find the site.
+
+## Site
+
+- [openlinker.io](https://openlinker.io): Project homepage
+- [Architecture](https://openlinker.io/en/architecture): Bounded contexts, capability ports, and data flow
+- [Integrations](https://openlinker.io/en/integrations): Supported and planned platform integrations
+- [vs BaseLinker](https://openlinker.io/en/vs/baselinker): How OpenLinker compares to BaseLinker
+- [llms.txt](https://openlinker.io/llms.txt): Canonical site-hosted version of this file
+
+## Repository documentation
+
+- [Architecture Overview](https://github.com/openlinker-project/openlinker/blob/main/docs/architecture-overview.md): Bounded contexts, capability ports, and data flow
+- [Engineering Standards](https://github.com/openlinker-project/openlinker/blob/main/docs/engineering-standards.md): Naming, file layout, and the repository-port pattern
+- [Plugin Author Guide](https://github.com/openlinker-project/openlinker/blob/main/docs/plugin-author-guide.md): Adding a new integration as a plugin
+- [Getting Started](https://github.com/openlinker-project/openlinker/blob/main/docs/getting-started.md): From a clean machine to a working PrestaShop + Allegro setup
+- [Testing Guide](https://github.com/openlinker-project/openlinker/blob/main/docs/testing-guide.md): Unit and Testcontainers-based integration tests
+- [Public API Contract](https://github.com/openlinker-project/openlinker/blob/main/PUBLIC_API.md): What's stable for plugin authors and downstream consumers
+- [README](https://github.com/openlinker-project/openlinker/blob/main/README.md): Overview, capabilities, integrations, and quickstart

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/openlinker-project/openlinker.git"
   },
-  "homepage": "https://github.com/openlinker-project/openlinker#readme",
+  "homepage": "https://openlinker.io",
   "bugs": {
     "url": "https://github.com/openlinker-project/openlinker/issues"
   },


### PR DESCRIPTION
## Summary
- Surfaces the project site (openlinker.io) from the repo and deep-links its canonical section pages, so readers and crawlers land on the exact reference rather than just the homepage.
- Points `package.json` `homepage` at the marketing site — a clean machine-readable pointer that surfaces in any registry/npm view.
- Adds a root `llms.txt` mirroring the site's `/llms.txt` plus the key repo docs, so AI crawlers reading the repo discover the site.

## Changes
- `README.md` — adds a site nav line directly under the badge block: `openlinker.io · Architecture · Integrations · vs BaseLinker`, deep-linking `/en/architecture`, `/en/integrations`, `/en/vs/baselinker`.
- `package.json` — `homepage` changed from the GitHub `#readme` anchor → `https://openlinker.io`.
- `llms.txt` (new, repo root) — llmstxt.org format: H1 + summary, a **Site** section (incl. the canonical `/llms.txt`) and a **Repository documentation** section pointing at `architecture-overview.md`, `engineering-standards.md`, `plugin-author-guide.md`, `getting-started.md`, `testing-guide.md`, `PUBLIC_API.md`, and the README.

## Test plan
- [x] Lint passes (`pnpm lint`) — ran via the pre-commit hook (full lint + `check:invariants`, incl. the repo-URL drift guard; no forbidden slugs introduced).
- [x] Type check passes (`pnpm type-check`) — no TS touched; covered by the pre-commit gate.
- [x] Unit tests pass (`pnpm test`) — ran green via the pre-commit hook.
- [x] All five linked URLs verified live (HTTP 200, on-topic): `openlinker.io`, `/en/architecture`, `/en/integrations`, `/en/vs/baselinker`, `/llms.txt`.
- [x] Prettier clean on `README.md` / `package.json` (`llms.txt` is `.txt`, outside the repo Prettier glob — intentional).

## Tech review
✅ APPROVED — docs/SEO-only, 3 files, no code/ports/migration/tests touched. No BLOCKING or IMPORTANT issues; no open SUGGESTIONs. Domain links all resolve, `homepage` is valid JSON, every doc referenced by `llms.txt` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)