### PR TITLE
feat(shipping,orders): order-side dispatch-notify capabilities + orchestration (#837)

### DIFF
--- a/apps/api/test/integration/helpers/dispatch-notify-test-stubs.helper.ts
+++ b/apps/api/test/integration/helpers/dispatch-notify-test-stubs.helper.ts
@@ -1,0 +1,196 @@
+/**
+ * Dispatch-Notify Test Stubs Helper (#837)
+ *
+ * Registers three synthetic adapters with the running Nest app's
+ * `AdapterRegistryService` + `AdapterFactoryResolverService` — the same public
+ * plugin seam real integrations use (#570 / #574):
+ *   - a **source** adapter: `OrderSourcePort` + `OrderDispatchNotifier` (A)
+ *   - a **destination** adapter: `OrderProcessorManagerPort` +
+ *     `OrderFulfillmentUpdater` (B)
+ *   - a **carrier** adapter: `ShippingProviderManagerPort` whose `generateLabel`
+ *     returns a synchronous tracking number (the branch-2 / InPost shape), so a
+ *     shipment seeded through the real #835 dispatch seam carries a waybill.
+ *
+ * The dispatch-notify seam (#837) resolves the source via
+ * `getCapabilityAdapter('OrderSource')` + `isOrderDispatchNotifier`, and each
+ * destination via `getCapabilityAdapter('OrderProcessorManager')` +
+ * `isOrderFulfillmentUpdater`. The real Allegro / PrestaShop adapters would hit
+ * their APIs over HTTP, so the int-spec routes to these in-memory stubs while
+ * still exercising the full resolution chain (`OrderRecord` + identifier
+ * mapping + connection → adapter) against real Postgres. The source + dest
+ * stubs record their calls for assertions.
+ *
+ * Lifetime: suite-scoped (`AdapterRegistryService.register` throws on a second
+ * call for the same adapterKey). Call once in `beforeAll`; clear the `calls`
+ * arrays per-test in `beforeEach` (`resetTestHarness` only clears the DB).
+ *
+ * @module apps/api/test/integration/helpers
+ */
+import {
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterFactoryResolverService,
+  AdapterRegistryPort,
+} from '@openlinker/core/integrations';
+import type {
+  DispatchCarrierHint,
+  OrderDispatchNotifier,
+  OrderFeedInput,
+  OrderFeedOutput,
+  OrderFulfillmentUpdater,
+  OrderProcessorManagerPort,
+  OrderSourcePort,
+  OrderStatus,
+} from '@openlinker/core/orders';
+import type {
+  GenerateLabelResult,
+  ShippingMethod,
+  ShippingProviderManagerPort,
+  TrackingSnapshot,
+} from '@openlinker/core/shipping';
+import type { IntegrationTestHarness } from '../setup';
+
+export const DISPATCH_SOURCE_ADAPTER_KEY = 'allegro.dispatchnotify.test.v1';
+export const DISPATCH_SOURCE_PLATFORM_TYPE = 'allegro';
+export const DISPATCH_DEST_ADAPTER_KEY = 'prestashop.fulfillmentupdate.test.v1';
+export const DISPATCH_DEST_PLATFORM_TYPE = 'prestashop';
+export const DISPATCH_CARRIER_ADAPTER_KEY = 'inpost.dispatchnotify.test.v1';
+export const DISPATCH_CARRIER_PLATFORM_TYPE = 'inpost';
+/** Synchronous tracking number the carrier stub stamps onto generated shipments. */
+export const DISPATCH_CARRIER_TRACKING_NUMBER = 'TRACK-XYZ-1';
+
+export interface SourceNotifyCall {
+  externalOrderId: string;
+  trackingNumber?: string;
+  carrier?: DispatchCarrierHint;
+}
+
+export interface DestFulfillmentCall {
+  externalOrderId: string;
+  status: OrderStatus;
+  trackingNumber?: string;
+}
+
+export interface DispatchNotifyTestStubs {
+  readonly source: {
+    readonly adapterKey: string;
+    readonly platformType: string;
+    readonly calls: SourceNotifyCall[];
+  };
+  readonly dest: {
+    readonly adapterKey: string;
+    readonly platformType: string;
+    readonly calls: DestFulfillmentCall[];
+  };
+  readonly carrier: {
+    readonly adapterKey: string;
+    readonly platformType: string;
+    readonly trackingNumber: string;
+  };
+}
+
+export function installDispatchNotifyTestStubs(
+  harness: IntegrationTestHarness,
+): DispatchNotifyTestStubs {
+  const adapterRegistry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+  const factoryResolver = harness
+    .getApp()
+    .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
+
+  const sourceCalls: SourceNotifyCall[] = [];
+  const destCalls: DestFulfillmentCall[] = [];
+
+  const sourceStub: OrderSourcePort & OrderDispatchNotifier = {
+    listOrderFeed(_input: OrderFeedInput): Promise<OrderFeedOutput> {
+      return Promise.resolve({ items: [], nextCursor: null });
+    },
+    getOrder(): Promise<never> {
+      return Promise.reject(new Error('dispatch-notify stub: getOrder is not exercised'));
+    },
+    notifyDispatched(input): Promise<void> {
+      sourceCalls.push({ ...input });
+      return Promise.resolve();
+    },
+  };
+
+  const destStub: OrderProcessorManagerPort & OrderFulfillmentUpdater = {
+    createOrder(): Promise<never> {
+      return Promise.reject(new Error('dispatch-notify stub: createOrder is not exercised'));
+    },
+    updateFulfillment(input): Promise<void> {
+      destCalls.push({ ...input });
+      return Promise.resolve();
+    },
+  };
+
+  let carrierCounter = 0;
+  const carrierStub: ShippingProviderManagerPort = {
+    getSupportedMethods(): readonly ShippingMethod[] {
+      return ['paczkomat', 'kurier'];
+    },
+    generateLabel(): Promise<GenerateLabelResult> {
+      carrierCounter += 1;
+      return Promise.resolve({
+        providerShipmentId: `stub-${carrierCounter}`,
+        trackingNumber: DISPATCH_CARRIER_TRACKING_NUMBER,
+        labelPdfRef: `stub:label:${carrierCounter}`,
+      });
+    },
+    getTracking(): Promise<TrackingSnapshot> {
+      return Promise.resolve({ status: 'generated', providerStatus: 'generated' });
+    },
+  };
+
+  adapterRegistry.register({
+    adapterKey: DISPATCH_SOURCE_ADAPTER_KEY,
+    platformType: DISPATCH_SOURCE_PLATFORM_TYPE,
+    supportedCapabilities: ['OrderSource'],
+    displayName: 'Allegro dispatch-notify (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+  adapterRegistry.register({
+    adapterKey: DISPATCH_DEST_ADAPTER_KEY,
+    platformType: DISPATCH_DEST_PLATFORM_TYPE,
+    supportedCapabilities: ['OrderProcessorManager'],
+    displayName: 'PrestaShop fulfillment-update (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+  adapterRegistry.register({
+    adapterKey: DISPATCH_CARRIER_ADAPTER_KEY,
+    platformType: DISPATCH_CARRIER_PLATFORM_TYPE,
+    supportedCapabilities: ['ShippingProviderManager'],
+    displayName: 'InPost dispatch-notify carrier (integration-test stub)',
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+
+  factoryResolver.registerFactory(DISPATCH_SOURCE_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(sourceStub as unknown as T),
+  });
+  factoryResolver.registerFactory(DISPATCH_DEST_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(destStub as unknown as T),
+  });
+  factoryResolver.registerFactory(DISPATCH_CARRIER_ADAPTER_KEY, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(carrierStub as unknown as T),
+  });
+
+  return {
+    source: {
+      adapterKey: DISPATCH_SOURCE_ADAPTER_KEY,
+      platformType: DISPATCH_SOURCE_PLATFORM_TYPE,
+      calls: sourceCalls,
+    },
+    dest: {
+      adapterKey: DISPATCH_DEST_ADAPTER_KEY,
+      platformType: DISPATCH_DEST_PLATFORM_TYPE,
+      calls: destCalls,
+    },
+    carrier: {
+      adapterKey: DISPATCH_CARRIER_ADAPTER_KEY,
+      platformType: DISPATCH_CARRIER_PLATFORM_TYPE,
+      trackingNumber: DISPATCH_CARRIER_TRACKING_NUMBER,
+    },
+  };
+}

--- a/apps/api/test/integration/shipment-dispatch-notification.int-spec.ts
+++ b/apps/api/test/integration/shipment-dispatch-notification.int-spec.ts
@@ -1,0 +1,245 @@
+/**
+ * Shipment Dispatch Notification Integration Test (#837)
+ *
+ * Exercises the "mark sent on source + OMP" orchestration end-to-end against
+ * real Postgres. `ShipmentDispatchNotificationService.notifyDispatched`:
+ *   - resolves the order's source + destination(s) from its `OrderRecord`,
+ *   - resolves the source external id from the identifier-mapping table,
+ *   - resolves the carrier hint from the shipment's processor connection,
+ *   - drives `OrderDispatchNotifier` on the source (A) and
+ *     `OrderFulfillmentUpdater` on each destination (B), then
+ *   - transitions the `Shipment` to `dispatched`.
+ *
+ * The shipment is seeded through the real #835 dispatch seam (routed to an
+ * in-memory carrier stub that returns a synchronous tracking number), never
+ * the repository — mirroring `shipments-read.int-spec.ts` and keeping the test
+ * off the cross-context-banned `ShipmentRepositoryPort`. The source + dest
+ * capability adapters are likewise in-memory stubs, so the full resolution
+ * chain is real while the marketplace HTTP calls are not. This verifies the
+ * orchestration wiring, NOT the PrestaShop write (capability B's PrestaShop
+ * implementation is a focused follow-up; until it lands the destination half
+ * degrades to `unsupported`).
+ *
+ * Covers: happy path (A + B invoked with resolved external ids + carrier hint →
+ * `dispatched`); status-gate at-most-once (a second notify after `dispatched`
+ * is skipped and re-invokes neither A nor B).
+ *
+ * @module apps/api/test/integration
+ */
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import {
+  CORE_ENTITY_TYPE,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  IIdentifierMappingService,
+} from '@openlinker/core/identifier-mapping';
+import {
+  IShipmentDispatchNotificationService,
+  IShipmentDispatchService,
+  IShipmentQueryService,
+  SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
+  SHIPMENT_DISPATCH_SERVICE_TOKEN,
+  SHIPMENT_QUERY_SERVICE_TOKEN,
+} from '@openlinker/core/shipping';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import {
+  DISPATCH_CARRIER_ADAPTER_KEY,
+  DISPATCH_CARRIER_TRACKING_NUMBER,
+  DISPATCH_DEST_ADAPTER_KEY,
+  DISPATCH_SOURCE_ADAPTER_KEY,
+  DispatchNotifyTestStubs,
+  installDispatchNotifyTestStubs,
+} from './helpers/dispatch-notify-test-stubs.helper';
+import { createTestOrderRecord } from './fixtures/order.fixtures';
+
+const SOURCE_EXTERNAL_ID = 'allegro-checkout-AAA';
+const DEST_EXTERNAL_ID = 'ps-order-77';
+const SOURCE_DELIVERY_METHOD_ID = 'allegro-courier';
+const RECIPIENT = {
+  email: 'buyer@example.com',
+  phone: '+48500600700',
+  address: {
+    street: 'Krakowska',
+    buildingNumber: '12',
+    city: 'Poznań',
+    postCode: '60-001',
+    countryCode: 'PL',
+  },
+};
+const PARCEL = { dimensions: { length: 200, width: 150, height: 100 }, weightGrams: 1200 };
+
+describe('Shipment Dispatch Notification Integration', () => {
+  let harness: IntegrationTestHarness;
+  let stubs: DispatchNotifyTestStubs;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    stubs = installDispatchNotifyTestStubs(harness);
+  });
+
+  beforeEach(() => {
+    // Stubs are suite-scoped; the recorded calls must be cleared per-test
+    // (resetTestHarness only truncates the database).
+    stubs.source.calls.length = 0;
+    stubs.dest.calls.length = 0;
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const notificationService = (): IShipmentDispatchNotificationService =>
+    harness
+      .getApp()
+      .get<IShipmentDispatchNotificationService>(SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN);
+  const dispatchService = (): IShipmentDispatchService =>
+    harness.getApp().get<IShipmentDispatchService>(SHIPMENT_DISPATCH_SERVICE_TOKEN);
+  const queryService = (): IShipmentQueryService =>
+    harness.getApp().get<IShipmentQueryService>(SHIPMENT_QUERY_SERVICE_TOKEN);
+  const routingService = (): IFulfillmentRoutingService =>
+    harness.getApp().get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+  const identifierMapping = (): IIdentifierMappingService =>
+    harness.getApp().get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);
+
+  /**
+   * Seed the full resolution graph for one dispatched shipment:
+   * source + dest + carrier connections, an `ol_managed_carrier` routing rule,
+   * the Order→source identifier mapping, an OrderRecord (source + a synced
+   * destination), and a `generated` shipment (with tracking) produced by the
+   * real dispatch seam. Returns the shipment id + destination connection id.
+   */
+  async function seedDispatchableShipment(orderId: string): Promise<{
+    shipmentId: string;
+    destId: string;
+  }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: DISPATCH_SOURCE_ADAPTER_KEY,
+      enabledCapabilities: ['OrderSource'],
+    });
+    const dest = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      name: 'PrestaShop destination',
+      adapterKey: DISPATCH_DEST_ADAPTER_KEY,
+      enabledCapabilities: ['OrderProcessorManager'],
+    });
+    const carrier = await createTestConnection(dataSource, {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: DISPATCH_CARRIER_ADAPTER_KEY,
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+
+    await routingService().replaceRules(source.id, [
+      {
+        sourceDeliveryMethodId: SOURCE_DELIVERY_METHOD_ID,
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: carrier.id,
+      },
+    ]);
+
+    await identifierMapping().createMapping(
+      CORE_ENTITY_TYPE.Order,
+      SOURCE_EXTERNAL_ID,
+      source.id,
+      orderId,
+    );
+
+    await createTestOrderRecord(dataSource, {
+      internalOrderId: orderId,
+      sourceConnectionId: source.id,
+      syncStatus: [
+        {
+          destinationConnectionId: dest.id,
+          status: 'synced',
+          externalOrderId: DEST_EXTERNAL_ID,
+        },
+      ],
+    });
+
+    const dispatched = await dispatchService().dispatch({
+      sourceConnectionId: source.id,
+      sourceDeliveryMethodId: SOURCE_DELIVERY_METHOD_ID,
+      orderId,
+      shippingMethod: 'kurier',
+      recipient: RECIPIENT,
+      parcel: PARCEL,
+    });
+    if (dispatched.kind !== 'dispatched') {
+      throw new Error(`expected a dispatched shipment, got ${dispatched.kind}`);
+    }
+
+    return { shipmentId: dispatched.shipment.id, destId: dest.id };
+  }
+
+  it('should notify source + destination with resolved ids and transition the shipment to dispatched', async () => {
+    const { shipmentId, destId } = await seedDispatchableShipment('ol_order_notify_1');
+
+    const result = await notificationService().notifyDispatched({ shipmentId });
+
+    expect(result).toEqual({
+      shipmentId,
+      outcome: 'notified',
+      source: 'ok',
+      destinations: [{ connectionId: destId, status: 'ok' }],
+    });
+
+    // A — source mark-sent received the resolved external id, the synchronous
+    // tracking number, and the carrier hint resolved from the shipment's
+    // (InPost) processor connection.
+    expect(stubs.source.calls).toEqual([
+      {
+        externalOrderId: SOURCE_EXTERNAL_ID,
+        trackingNumber: DISPATCH_CARRIER_TRACKING_NUMBER,
+        carrier: { platformType: 'inpost' },
+      },
+    ]);
+
+    // B — destination fulfillment-update received the dest external id resolved
+    // from OrderRecord.syncStatus, OL status 'shipped', and the tracking number.
+    expect(stubs.dest.calls).toEqual([
+      {
+        externalOrderId: DEST_EXTERNAL_ID,
+        status: 'shipped',
+        trackingNumber: DISPATCH_CARRIER_TRACKING_NUMBER,
+      },
+    ]);
+
+    // Transition is persisted (re-read from Postgres through the read seam).
+    const persisted = await queryService().getById(shipmentId);
+    expect(persisted?.status).toBe('dispatched');
+    expect(persisted?.dispatchedAt).not.toBeNull();
+  });
+
+  it('should skip a second notify after dispatch and re-invoke neither source nor destination', async () => {
+    const { shipmentId } = await seedDispatchableShipment('ol_order_notify_2');
+
+    const first = await notificationService().notifyDispatched({ shipmentId });
+    expect(first.outcome).toBe('notified');
+    expect(stubs.source.calls).toHaveLength(1);
+    expect(stubs.dest.calls).toHaveLength(1);
+
+    const second = await notificationService().notifyDispatched({ shipmentId });
+
+    // Status-gate: the persisted `dispatched` transition makes the second call a
+    // no-op — the at-most-once guarantee for the source waybill-attach.
+    expect(second).toEqual({
+      shipmentId,
+      outcome: 'skipped-not-generated',
+      source: 'absent',
+      destinations: [],
+    });
+    expect(stubs.source.calls).toHaveLength(1);
+    expect(stubs.dest.calls).toHaveLength(1);
+  });
+});

--- a/docs/plans/implementation-plan-allegro-order-side-dispatch.md
+++ b/docs/plans/implementation-plan-allegro-order-side-dispatch.md
@@ -1,0 +1,178 @@
+# Implementation Plan — #837 Allegro order-side dispatch (mark-sent + waybill + tracking propagation)
+
+**Issue:** [#837](https://github.com/openlinker-project/openlinker/issues/837) (E3 of #732)
+**Spec:** `docs/specs/product-spec-732-allegro-delivery-shipment.md` (§3.7 → A8, "dispatch decomposed" step 5, §5 US-5 / AC-5)
+**Branch:** `837-allegro-order-side-dispatch`
+**Layer:** CORE (two capability ports + orchestration) + Integration (allegro source-notify, prestashop dest-update)
+**Effort:** L (two greenfield capabilities + adapter impls + orchestration)
+
+> Design settled via `/grill-me` + repeated deep `/tech-review`. **Designed capability-first** — PrestaShop/Allegro/InPost are *implementations*, not design drivers. See §6 Decision log.
+
+---
+
+## 1. Goal & scope
+
+Implement the spec's **step 5** ("mark order sent on source + OMP") as **two generic, reusable capability ports** plus a branch-agnostic core orchestration service:
+
+- **(A) Order-source dispatch-notify** — the order *source* (marketplace) is told an order's items shipped → it marks the order sent (+ attaches a waybill when one is supplied). Allegro implements it (`PUT …/fulfillment {status:SENT}` + `POST …/shipments`).
+- **(B) Destination order-fulfillment update** — the OMP *processor* receives a post-create status + tracking update. PrestaShop implements it.
+- **Orchestration** — `ShipmentDispatchNotificationService` (shipping ctx): given a dispatched `Shipment`, resolve the order's source + destination connection(s) from its `OrderRecord`, and drive A + B.
+
+**Per-branch behaviour (spec "dispatch decomposed"):**
+- **Branch 2 (InPost / #727):** OL pushes shipped+tracking to Allegro (full A: SENT + waybill from the InPost shipment's synchronous `Shipment.trackingNumber`) **and** the OMP (B).
+- **Branch 3 (Allegro Delivery / #833):** Allegro already brokered the shipment → A = `SENT` only (no waybill); B updates the OMP. (No dependency on #838's async waybill.)
+
+**In scope:** capabilities A + B (ports + `is*` guards), Allegro impl of A, the orchestration service (drives both A and B; the destination half degrades to `unsupported` until a B adapter exists), the `Shipment → dispatched` transition, unit + integration tests.
+
+**Out of scope / deferred:**
+- **PrestaShop impl of capability B** (`OrderFulfillmentUpdater`) → **focused follow-up issue.** Rationale (settled via deep `/tech-review`, §6 Q7): the *architecture* is the capability port + orchestration (identical whether the PS adapter lands now or next), and OL's established idiom is **port-then-per-adapter-impl** (#763 port→#812 InPost impl; #832 model→#835 dispatch). The PS write is the one genuinely-uncertain piece — it must use PS's intended primitives (`POST /order_histories` for the state transition so the buyer "shipped" side-effects fire + the `order_carriers` association for tracking, **never** the `orders` full-replace) and needs a PrestaShop-Testcontainer verification that is disproportionate to bundle into this PR. The orchestration already degrades gracefully (`destinations[].status = 'unsupported'`), so #837 is not half-built without it.
+- The **trigger model** (manual / auto-on-paid / auto-on-shipped, #727 SC-1) — the service ships **trigger-agnostic & unwired**, exactly as #835 shipped `dispatch()` without a live caller; the call-site is #769/#771.
+- **B auto-retry** on failure → best-effort in v1 (see §3.4); a per-target notify-state model is the follow-up.
+- **Branch-3 (Allegro Delivery) tracking → OMP** — at #837-notify time the Allegro-Delivery waybill is null (issued async), so B propagates `'shipped'` to the OMP **without** tracking; pushing the **backfilled** tracking to the OMP is **#838's** job (it reuses capability B once it polls the carrier waybill). For branch-3 the buyer already sees tracking on Allegro (it brokered the shipment), so OMP-side tracking is secondary. Explicit designed boundary, not a hole.
+- **Dynamic `GET /order/carriers`** resolution + persisting carrier on the `Shipment` → not needed in v1 (no migration).
+- Dispatch manifest (#831), shipment-status poll (#838).
+
+---
+
+## 2. Research findings (capability-first; verified)
+
+- **Capability homes (sub-capability pattern, ADR-002).** `OrderSourcePort` (read-only) and `OrderProcessorManagerPort` (only `createOrder`) each get a co-located sub-capability under `orders/domain/ports/capabilities/` + an `is*` guard — same shape as `ShipmentCanceller`/`SourceOptionsReader`/`OfferCreator`. **Sub-capabilities are NOT in `manifest.supportedCapabilities`** → no manifest/routing-int-spec ripple (contrast #833).
+- **`OrderRecord` is the resolution backbone.** `IOrderRecordService.getOrderRecord(internalOrderId)` → `sourceConnectionId` + `syncStatus[]` (each: `destinationConnectionId` + `externalOrderId`). So the orchestration resolves the **dest** external id directly from `syncStatus`, and the **source** external id via `IdentifierMappingPort.getExternalIds(Order, internalOrderId)` filtered to `sourceConnectionId`.
+- **No new status-mapping surface.** `OrderStatusValues` already has `'shipped'`/`'delivered'`; the PS mapper already has `mapOrderStatusToPrestashop(status)` (`prestashop-order.mapper.ts:418`). Capability B carries OL `OrderStatus 'shipped'`; the dest reuses that mapping + adds a tracking write. `StatusMapping` (source-status→dest-state at create) is untouched.
+- **Allegro order-side shapes (verified against developer.allegro.pl):** `PUT /order/checkout-forms/{id}/fulfillment` → `{ "status": "SENT" }` (+ optional `checkoutForm.revision` query, 409 on stale); `POST /order/checkout-forms/{id}/shipments` → `{ carrierId, waybill, carrierName?, lineItems? }` where `carrierId` is from the fixed `GET /order/carriers` vocab and `carrierName` is required only for `carrierId='OTHER'`.
+- **Module graph verified acyclic:** `OrdersModule` does NOT import `ShippingModule`; `ORDER_RECORD_SERVICE_TOKEN` is exported from `OrdersModule`. So `shipping → orders` (and `shipping → identifier-mapping`) are clean new edges.
+- **`IAllegroHttpClient`** has `put`/`post` returning `{ data, status, headers }`. The Allegro order-source adapter is read-only today and does **not** inject identifier-mapping — and won't need to (capabilities take `externalOrderId`, orchestration-resolved).
+
+---
+
+## 3. Design
+
+### 3.1 Capability A — `OrderDispatchNotifier` (orders ctx)
+`libs/core/src/orders/domain/ports/capabilities/order-dispatch-notifier.capability.ts` (+ `isOrderDispatchNotifier` guard):
+```ts
+interface OrderDispatchNotifier {
+  /** Tell the order source an order's items have been dispatched: mark it sent,
+   *  and attach the waybill when `trackingNumber` is supplied (absent ⇒ the
+   *  source already holds it, e.g. source-brokered branch 3). */
+  notifyDispatched(input: {
+    externalOrderId: string;                 // resolved by the orchestration
+    trackingNumber?: string;
+    carrier?: DispatchCarrierHint;           // neutral; adapter maps to its own carrier vocab
+  }): Promise<void>;
+}
+```
+`DispatchCarrierHint = { platformType: string }` (orders types). Allegro impl: `PUT …/fulfillment {status:'SENT'}` always; `POST …/shipments` iff `trackingNumber` present, resolving `carrierId` from a **static** `platformType → Allegro carrierId` map (`inpost→INPOST`, …) with `OTHER` + humanized `carrierName` fallback.
+
+### 3.2 Capability B — `OrderFulfillmentUpdater` (orders ctx)
+`libs/core/src/orders/domain/ports/capabilities/order-fulfillment-updater.capability.ts` (+ `isOrderFulfillmentUpdater` guard):
+```ts
+interface OrderFulfillmentUpdater {
+  /** Update an already-created destination order's status + tracking. */
+  updateFulfillment(input: {
+    externalOrderId: string;                 // resolved by the orchestration (from OrderRecord.syncStatus)
+    status: OrderStatus;                     // v1: 'shipped'
+    trackingNumber?: string;
+  }): Promise<void>;
+}
+```
+PS impl reuses `mapOrderStatusToPrestashop(status)` + writes tracking (PS order update; exact WS shape an impl detail).
+
+### 3.3 Orchestration — `ShipmentDispatchNotificationService` (shipping ctx)
+`libs/core/src/shipping/application/services/` (+ `application/interfaces/…service.interface.ts`). Deps (all via ports/tokens): `SHIPMENT_REPOSITORY_TOKEN`, `INTEGRATIONS_SERVICE_TOKEN`, `ORDER_RECORD_SERVICE_TOKEN`, `IDENTIFIER_MAPPING_*`.
+```
+notifyDispatched({ shipmentId }):
+  shipment = shipments.findById(shipmentId)
+  if shipment.status !== 'generated': return { skipped: 'not-generated' }   // status-gate ⇒ A at-most-once
+  record  = orderRecord.getOrderRecord(shipment.orderId)
+  carrier = { platformType: integrations.getAdapter(shipment.connectionId).metadata.platformType }
+  // A — source notify (primary)
+  aOutcome = 'absent'
+  if record.sourceConnectionId:
+    sourceExtId = getExternalIds(Order, shipment.orderId).find(connectionId===sourceConnectionId)
+    if sourceExtId:
+      src = getCapabilityAdapter<OrderSourcePort>(sourceConnectionId, 'OrderSource')
+      if isOrderDispatchNotifier(src):
+        try { src.notifyDispatched({ externalOrderId: sourceExtId, trackingNumber: shipment.trackingNumber ?? undefined, carrier }); aOutcome='ok' }
+        catch { aOutcome='failed'; log }
+  // B — dest update(s), best-effort, per-destination (allSettled)
+  for syncStatus entry with externalOrderId:
+    dest = getCapabilityAdapter<OrderProcessorManagerPort>(entry.destinationConnectionId, 'OrderProcessorManager')
+    if isOrderFulfillmentUpdater(dest):
+      try { dest.updateFulfillment({ externalOrderId: entry.externalOrderId, status:'shipped', trackingNumber: shipment.trackingNumber ?? undefined }) } catch { log }
+  // transition
+  if aOutcome === 'ok' OR aOutcome === 'absent':
+    shipments.update(shipmentId, { status:'dispatched', dispatchedAt: now })
+  return per-target outcomes
+```
+
+### 3.4 Idempotency / partial-failure (the load-bearing semantics)
+- **Status-gate** (`notify only if 'generated'`) makes A's `POST …/shipments` run **at most once** — the dup-safety guard (the `POST /shipments` dedup is `needs-sandbox-probe`).
+- **`dispatched` set on A-success OR A-absent** (no source / no capability) — so a non-marketplace-sourced shipment still advances; **A-failure leaves `generated`** (→ retriable: next notify retries A *and* B, B being idempotent).
+- **B is best-effort** (logged, **not** auto-retried in v1): once A succeeds we set `dispatched`, gating re-notify — so a B failure after A-success is *not* retried. Accepted v1 cut (B = OMP-internal, idempotent, surfaced in logs); a per-target notify-state (à la `OrderRecord.syncStatus`) is the follow-up.
+- **Per-call defensiveness:** Allegro "already SENT"/409-stale-`revision` treated as success.
+- **Concurrency caveat:** the gate is not atomic — the live call-site (#769/#771) must serialise per order (same caveat `ShipmentDispatchService` documents).
+- **Branch-3 tracking timing:** B runs with whatever `Shipment.trackingNumber` exists at notify time. Branch-2 (InPost) has it synchronously; branch-3 (Allegro Delivery) has `null` then → B pushes status only, and #838 propagates the backfilled tracking to the OMP later via the same capability B (see §1 deferred). #837 does not re-run B.
+
+### 3.5 Files
+```
+libs/core/src/orders/                                          [NEW capabilities + barrel]
+  domain/ports/capabilities/order-dispatch-notifier.capability.ts      (+ guard)
+  domain/ports/capabilities/order-fulfillment-updater.capability.ts    (+ guard)
+  domain/ports/capabilities/__tests__/*.spec.ts                        (guard specs)
+  domain/types/dispatch-carrier-hint.types.ts                          (DispatchCarrierHint)
+  index.ts                                                             (export new interfaces + guards + type)
+
+libs/core/src/shipping/                                        [NEW service + wiring]
+  application/interfaces/shipment-dispatch-notification.service.interface.ts
+  application/services/shipment-dispatch-notification.service.ts (+ .spec.ts)
+  application/types/shipment-dispatch-notification.types.ts            (result type)
+  shipping.tokens.ts                                                   (+ SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN)
+  shipping.module.ts                                                   (+ OrdersModule, IdentifierMappingModule; provide service+token)
+
+libs/integrations/allegro/src/                                 [impl A]
+  infrastructure/adapters/allegro-order-source.adapter.ts              (implements OrderDispatchNotifier)
+  domain/types/allegro-order-fulfillment.types.ts                     (SENT const + carrier map, sandbox-flagged)
+  domain/exceptions/allegro-order-dispatch-rejected.exception.ts
+  __tests__/…spec.ts
+
+libs/integrations/prestashop/src/                              [impl B — DEFERRED to follow-up]
+  (prestashop-order-processor-manager.adapter.ts implements OrderFulfillmentUpdater
+   via POST /order_histories + order_carriers; PS-Testcontainer-verified there)
+
+apps/api/test/integration/                                     [int-spec]
+  helpers/dispatch-notify-test-stubs.helper.ts                        (source+dest+carrier stubs)
+  shipment-dispatch-notification.int-spec.ts                          (orchestration only)
+```
+**Migration: none.**
+
+---
+
+## 4. Step-by-step
+
+1. **Capability ports + guards + carrier-hint type** (orders) — `OrderDispatchNotifier`, `OrderFulfillmentUpdater`, `is*` guards, `DispatchCarrierHint`; export via `@openlinker/core/orders` barrel; guard specs. *AC:* guards narrow correctly; barrel exports.
+2. **Orchestration service** (shipping) — `ShipmentDispatchNotificationService` per §3.3/§3.4 + interface + token + result type; `shipping.module.ts` imports `OrdersModule` + `IdentifierMappingModule`, provides service+token. *AC:* unit spec covers A-ok→dispatched, A-absent→dispatched, A-fail→generated, B per-dest allSettled, B-fail logged-not-fatal, status-gate skip-if-not-generated; implements an `I*Service` (satisfies #852 invariant).
+3. **Allegro impl of A** — `AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptionsReader, OrderDispatchNotifier`; `notifyDispatched` (PUT fulfillment SENT + conditional POST shipments + static carrier map + 409/already-sent handling); fulfillment/carrier types + exception; sandbox-flag enum/shapes/carrierId vocab. *AC:* adapter spec (SENT-only, SENT+waybill, carrier map, OTHER fallback, 409→success). **No manifest change.**
+4. **PrestaShop impl of B** — **DEFERRED to a focused follow-up** (§1, §6 Q7). The PS `updateFulfillment` must transition state via `POST /order_histories` (so the buyer "shipped" side-effects fire) and write tracking on the **`order_carriers`** association (not via the `orders` full-replace), verified with a PS-Testcontainer int-spec there. The orchestration degrades to `destinations[].status = 'unsupported'` until it lands, so #837 ships complete without it. **No manifest change.**
+5. **Integration coverage** — orchestration int-spec (`shipment-dispatch-notification.int-spec.ts`) mirroring `shipments-read.int-spec.ts`: seeds a `generated` shipment (with tracking) through the **real #835 dispatch seam** routed to an in-memory carrier stub, plus **stub** source (`OrderDispatchNotifier`) + dest (`OrderFulfillmentUpdater`) adapters → asserts A+B invoked with the resolved external ids + carrier hint, and `Shipment → dispatched` (read back via `IShipmentQueryService`, off the cross-context-banned `ShipmentRepositoryPort`). Also asserts the status-gate at-most-once on a second notify. Verifies the *orchestration*, not the (deferred) PS write. *AC:* green on the standard harness + full int-suite stays green (#833 lesson).
+6. **Quality gate** — `pnpm lint && pnpm type-check && pnpm test`; **`pnpm test:integration`** (full — manifest unaffected, but routing/orders int-specs must stay green per the #833 lesson); `migration:show` (expect none pending).
+
+---
+
+## 5. Validation
+- **Architecture:** capability-first (ports neutral; no PS/Allegro leakage in core); sub-capability + `is*` guard (ADR-002); cross-context edges `shipping → orders` / `shipping → identifier-mapping` verified acyclic + contract-compliant (`I*Service`/capability-port/token imports only); domain stays framework-free.
+- **No manifest/`supportedCapabilities` change** → no routing-int-spec ripple (the #833 lesson); but still run the full int-suite.
+- **Naming:** `*.capability.ts` + `is*`, `*.service.ts`/`*.service.interface.ts` (#852-compliant), `*.types.ts`, `*.exception.ts`.
+- **Security:** no secrets; vault-resolved OAuth reused; external-id resolution via identifier-mapping.
+- **Sandbox caveats (flagged, localized):** Allegro fulfillment `SENT` spelling, `POST …/shipments` body + `carrierId` vocab + `carrierName`-for-OTHER, the `revision`/409 optimistic-lock, `POST /shipments` dedup — each a single named constant / localized branch.
+- **Documented v1 cuts:** B best-effort (no auto-retry); `dispatched` on A-success-or-absent; trigger deferred; carrier static-map (no `GET /order/carriers`); no migration.
+
+## 6. Decision log (`/grill-me` + `/tech-review`)
+| # | Decision | Why |
+|---|---|---|
+| Q1 | Branch-3 = Allegro-already-knows (SENT + dest-update, no waybill); branch-2 = full waybill-attach; waybill from `Shipment.trackingNumber` | spec "dispatch decomposed" step 5 + verified Allegro order API; dissolves the #838 async-waybill chicken-and-egg |
+| Q2 | Full **A + B**, capability-first | issue AC bundles both; both are generic reusable capabilities |
+| Q3 | A `OrderDispatchNotifier` + B `OrderFulfillmentUpdater` as sub-capabilities; both take **`externalOrderId`** (orchestration-resolves) | sub-cap pattern; `createOrder`'s internal-id convention doesn't transfer (operate on *already-mapped* orders); avoids redundant re-resolution (B) + injecting id-mapping into the source adapter (A) |
+| Q4 | Reuse OL `OrderStatus 'shipped'` (PS mapper already maps it) | zero new status-mapping surface; keeps #827's three axes honest |
+| Q5 | Neutral carrier hint = processor **`platformType`**; Allegro adapter static-maps → recognized `carrierId`, `OTHER`+humanized fallback | a-vs-b is an adapter-internal detail behind the neutral port; `displayName` is operator-arbitrary (rejected); no `GET /order/carriers`, no migration |
+| Q6 | `ShipmentDispatchNotificationService` in **shipping** (verified acyclic); `dispatched` on A-success-or-absent; status-gate (A dup-safety) + `allSettled` per-dest B (best-effort); trigger deferred | shipment-driven + owns the `Shipment` update; partial-failure semantics made explicit; mirrors #835 unwired precedent |
+| Q7 | **Defer the PrestaShop impl of capability B to a follow-up**; #837 ships the ports + orchestration + Allegro impl of A | The architecture is the port + orchestration (identical whether the PS adapter lands now or next); OL's idiom is port-then-per-adapter-impl (#763→#812, #832→#835); the PS write is the one uncertain piece (must use `POST /order_histories` + `order_carriers`, never the `orders` full-replace) and needs a PS-Testcontainer verification disproportionate to bundle here; orchestration degrades to `unsupported`, so #837 is not half-built |

--- a/libs/core/src/orders/domain/ports/capabilities/__tests__/dispatch-notify-capabilities.spec.ts
+++ b/libs/core/src/orders/domain/ports/capabilities/__tests__/dispatch-notify-capabilities.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Dispatch-notify capability guards — unit tests (#837)
+ *
+ * @module libs/core/src/orders/domain/ports/capabilities/__tests__
+ */
+import type { OrderProcessorManagerPort } from '../../order-processor-manager.port';
+import type { OrderSourcePort } from '../../order-source.port';
+import {
+  type OrderDispatchNotifier,
+  isOrderDispatchNotifier,
+} from '../order-dispatch-notifier.capability';
+import {
+  type OrderFulfillmentUpdater,
+  isOrderFulfillmentUpdater,
+} from '../order-fulfillment-updater.capability';
+
+describe('isOrderDispatchNotifier', () => {
+  const base: OrderSourcePort = { listOrderFeed: jest.fn(), getOrder: jest.fn() };
+
+  it('returns true when the adapter implements notifyDispatched', () => {
+    const withCap: OrderSourcePort & OrderDispatchNotifier = { ...base, notifyDispatched: jest.fn() };
+    expect(isOrderDispatchNotifier(withCap)).toBe(true);
+  });
+
+  it('returns false when the adapter does not implement notifyDispatched', () => {
+    expect(isOrderDispatchNotifier(base)).toBe(false);
+  });
+});
+
+describe('isOrderFulfillmentUpdater', () => {
+  const base: OrderProcessorManagerPort = { createOrder: jest.fn() };
+
+  it('returns true when the adapter implements updateFulfillment', () => {
+    const withCap: OrderProcessorManagerPort & OrderFulfillmentUpdater = {
+      ...base,
+      updateFulfillment: jest.fn(),
+    };
+    expect(isOrderFulfillmentUpdater(withCap)).toBe(true);
+  });
+
+  it('returns false when the adapter does not implement updateFulfillment', () => {
+    expect(isOrderFulfillmentUpdater(base)).toBe(false);
+  });
+});

--- a/libs/core/src/orders/domain/ports/capabilities/order-dispatch-notifier.capability.ts
+++ b/libs/core/src/orders/domain/ports/capabilities/order-dispatch-notifier.capability.ts
@@ -1,0 +1,54 @@
+/**
+ * Order Dispatch Notifier Capability
+ *
+ * Optional sub-capability of `OrderSourcePort` (#837) — order *sources* that can
+ * be told an order's items have been dispatched declare `implements
+ * OrderDispatchNotifier`. The source marks the order sent (so the buyer sees
+ * tracking) and, when a waybill is supplied, attaches it.
+ *
+ * This is the generic "step 5 — mark sent on the source" capability from the
+ * #732 spec. It is **not** Allegro-specific: any marketplace source that
+ * supports a mark-shipped + push-tracking write implements it. Allegro maps it
+ * to `PUT /order/checkout-forms/{id}/fulfillment {status:SENT}` plus, when a
+ * waybill is present, `POST /order/checkout-forms/{id}/shipments`.
+ *
+ * Call sites resolve the source adapter via
+ * `getCapabilityAdapter<OrderSourcePort>(sourceConnectionId, 'OrderSource')`
+ * then narrow with `isOrderDispatchNotifier` before invoking, degrading
+ * gracefully (skip) when the source doesn't implement it.
+ *
+ * Forward-compat: v1 carries no status argument — the sole intent is
+ * "dispatched / sent". A future "notify delivered to the source" would add a
+ * typed status field here rather than a new method.
+ *
+ * @module libs/core/src/orders/domain/ports/capabilities
+ * @see {@link OrderSourcePort} for the base port
+ */
+import type { DispatchCarrierHint } from '../../types/dispatch-carrier-hint.types';
+import type { OrderSourcePort } from '../order-source.port';
+
+export interface OrderDispatchNotifier {
+  /**
+   * Notify the order source that the order's items have been dispatched.
+   *
+   * - Always marks the order "sent" on the source.
+   * - `trackingNumber` present ⇒ also attach the waybill (the source-brokered
+   *   branch omits it — the source already holds the waybill it issued).
+   * - `carrier` hints which carrier produced the waybill; the adapter maps it
+   *   to its own carrier vocabulary.
+   *
+   * `externalOrderId` is resolved upstream by the orchestration (the source's
+   * external order id), so the adapter performs no identifier mapping.
+   */
+  notifyDispatched(input: {
+    externalOrderId: string;
+    trackingNumber?: string;
+    carrier?: DispatchCarrierHint;
+  }): Promise<void>;
+}
+
+export function isOrderDispatchNotifier(
+  adapter: OrderSourcePort,
+): adapter is OrderSourcePort & OrderDispatchNotifier {
+  return typeof (adapter as Partial<OrderDispatchNotifier>).notifyDispatched === 'function';
+}

--- a/libs/core/src/orders/domain/ports/capabilities/order-fulfillment-updater.capability.ts
+++ b/libs/core/src/orders/domain/ports/capabilities/order-fulfillment-updater.capability.ts
@@ -1,0 +1,49 @@
+/**
+ * Order Fulfillment Updater Capability
+ *
+ * Optional sub-capability of `OrderProcessorManagerPort` (#837) — order
+ * *destinations* (OMPs) that can update an already-created order's status +
+ * tracking declare `implements OrderFulfillmentUpdater`. Complements
+ * `createOrder` (the only base-port method), which mirrors the order at ingest;
+ * this pushes a post-create fulfillment update (e.g. "shipped" + tracking).
+ *
+ * Generic by design — any OMP that supports a status/tracking write implements
+ * it; PrestaShop maps the neutral `OrderStatus` to its native order state and
+ * writes the tracking number.
+ *
+ * Axis note (#827): a *shipment* event (`Shipment.status='dispatched'`) drives
+ * this *order-status* update (`'shipped'`). That is a legitimate cross-axis
+ * trigger — do NOT conflate this with the shipment-status axis or a future
+ * operator-workflow-status axis; they stay separate.
+ *
+ * Call sites resolve the destination adapter via
+ * `getCapabilityAdapter<OrderProcessorManagerPort>(destConnectionId,
+ * 'OrderProcessorManager')` then narrow with `isOrderFulfillmentUpdater`,
+ * degrading gracefully (skip) when a destination doesn't implement it.
+ *
+ * @module libs/core/src/orders/domain/ports/capabilities
+ * @see {@link OrderProcessorManagerPort} for the base port
+ */
+import type { OrderStatus } from '../../types/order.types';
+import type { OrderProcessorManagerPort } from '../order-processor-manager.port';
+
+export interface OrderFulfillmentUpdater {
+  /**
+   * Update an already-created destination order's status + tracking.
+   *
+   * `externalOrderId` is resolved upstream by the orchestration (from the
+   * order's `syncStatus` for this destination). v1 carries `status: 'shipped'`;
+   * the adapter maps the neutral `OrderStatus` to its native order state.
+   */
+  updateFulfillment(input: {
+    externalOrderId: string;
+    status: OrderStatus;
+    trackingNumber?: string;
+  }): Promise<void>;
+}
+
+export function isOrderFulfillmentUpdater(
+  adapter: OrderProcessorManagerPort,
+): adapter is OrderProcessorManagerPort & OrderFulfillmentUpdater {
+  return typeof (adapter as Partial<OrderFulfillmentUpdater>).updateFulfillment === 'function';
+}

--- a/libs/core/src/orders/domain/types/dispatch-carrier-hint.types.ts
+++ b/libs/core/src/orders/domain/types/dispatch-carrier-hint.types.ts
@@ -1,0 +1,25 @@
+/**
+ * Dispatch Carrier Hint
+ *
+ * Neutral carrier reference passed to `OrderDispatchNotifier.notifyDispatched`
+ * when attaching a waybill to the order source. The orchestration sources it
+ * from the shipping processor connection's `platformType` (a stable carrier
+ * identity for an own-contract single-carrier integration, e.g. `'inpost'`);
+ * the source adapter maps it to its own carrier vocabulary (#837 Q5).
+ *
+ * Kept platform-agnostic by design — the core never knows a given marketplace's
+ * carrier id set; that mapping lives behind the source adapter.
+ *
+ * @module libs/core/src/orders/domain/types
+ */
+export interface DispatchCarrierHint {
+  /**
+   * The shipping processor connection's `platformType` (e.g. `'inpost'`).
+   *
+   * NOTE: `platformType` ≈ carrier holds for own-contract single-carrier
+   * integrations (today's only waybill-attaching branch). A future multi-carrier
+   * broker integration would need a richer carrier identity sourced from the
+   * shipping adapter — extend this type then, not the call sites.
+   */
+  platformType: string;
+}

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -18,6 +18,13 @@ export type { DestinationOptionsReader } from './domain/ports/capabilities/desti
 export { isDestinationOptionsReader } from './domain/ports/capabilities/destination-options-reader.capability';
 export type { SourceOptionsReader } from './domain/ports/capabilities/source-options-reader.capability';
 export { isSourceOptionsReader } from './domain/ports/capabilities/source-options-reader.capability';
+// Dispatch-notify sub-capabilities (#837): mark-sent on the source + post-create
+// fulfillment update on the destination.
+export type { OrderDispatchNotifier } from './domain/ports/capabilities/order-dispatch-notifier.capability';
+export { isOrderDispatchNotifier } from './domain/ports/capabilities/order-dispatch-notifier.capability';
+export type { OrderFulfillmentUpdater } from './domain/ports/capabilities/order-fulfillment-updater.capability';
+export { isOrderFulfillmentUpdater } from './domain/ports/capabilities/order-fulfillment-updater.capability';
+export type { DispatchCarrierHint } from './domain/types/dispatch-carrier-hint.types';
 export type { MappingOption, MappingOptionKind } from './domain/types/mapping-option.types';
 export { MappingOptionKindValues } from './domain/types/mapping-option.types';
 

--- a/libs/core/src/shipping/application/interfaces/shipment-dispatch-notification.service.interface.ts
+++ b/libs/core/src/shipping/application/interfaces/shipment-dispatch-notification.service.interface.ts
@@ -1,0 +1,22 @@
+/**
+ * Shipment Dispatch Notification Service Interface
+ *
+ * Contract for the branch-agnostic "mark sent" orchestration (#837, spec
+ * step 5): given a dispatched `Shipment`, notify the order source (mark sent +
+ * attach waybill via `OrderDispatchNotifier`) and update the destination
+ * OMP(s) (status + tracking via `OrderFulfillmentUpdater`). Trigger-agnostic:
+ * the live caller (manual / auto-on-shipped) is #769/#771, mirroring how
+ * `IShipmentDispatchService` shipped without a trigger in #835.
+ *
+ * @module libs/core/src/shipping/application/interfaces
+ */
+import type {
+  ShipmentDispatchNotificationInput,
+  ShipmentDispatchNotificationResult,
+} from '../types/shipment-dispatch-notification.types';
+
+export interface IShipmentDispatchNotificationService {
+  notifyDispatched(
+    input: ShipmentDispatchNotificationInput,
+  ): Promise<ShipmentDispatchNotificationResult>;
+}

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -110,14 +110,14 @@ describe('ShipmentDispatchNotificationService', () => {
     );
   });
 
-  it('returns shipment-not-found when the shipment does not exist', async () => {
+  it('should return shipment-not-found when the shipment does not exist', async () => {
     shipments.findById.mockResolvedValue(null);
     const result = await service.notifyDispatched({ shipmentId: 'missing' });
     expect(result.outcome).toBe('shipment-not-found');
     expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
   });
 
-  it('skips (status-gate) when the shipment is not generated', async () => {
+  it('should skip (status-gate) when the shipment is not generated', async () => {
     shipments.findById.mockResolvedValue(makeShipment({ status: 'dispatched' }));
     const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
     expect(result.outcome).toBe('skipped-not-generated');
@@ -125,7 +125,7 @@ describe('ShipmentDispatchNotificationService', () => {
     expect(shipments.update).not.toHaveBeenCalled();
   });
 
-  it('notifies source + destination and advances to dispatched on success', async () => {
+  it('should notify source + destination and advance to dispatched on success', async () => {
     shipments.findById.mockResolvedValue(makeShipment());
     const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
 
@@ -146,7 +146,7 @@ describe('ShipmentDispatchNotificationService', () => {
     expect(result).toMatchObject({ outcome: 'notified', source: 'ok', destinations: [{ connectionId: PS, status: 'ok' }] });
   });
 
-  it('does NOT advance to dispatched when the source notify fails (retriable)', async () => {
+  it('should not advance to dispatched when the source notify fails (retriable)', async () => {
     shipments.findById.mockResolvedValue(makeShipment());
     sourceNotify.mockRejectedValue(new Error('Allegro 422'));
 
@@ -157,7 +157,7 @@ describe('ShipmentDispatchNotificationService', () => {
     expect(destUpdate).toHaveBeenCalled(); // B still attempted
   });
 
-  it('advances to dispatched when there is no source-notify capability (absent)', async () => {
+  it('should advance to dispatched when there is no source-notify capability (absent)', async () => {
     shipments.findById.mockResolvedValue(makeShipment());
     (integrations.getCapabilityAdapter as jest.Mock).mockImplementation((_c: string, cap: string) =>
       Promise.resolve(
@@ -173,7 +173,7 @@ describe('ShipmentDispatchNotificationService', () => {
     expect(shipments.update).toHaveBeenCalledWith('ol_shipment_1', expect.objectContaining({ status: 'dispatched' }));
   });
 
-  it('marks an unsupported destination without failing, and still dispatches', async () => {
+  it('should mark an unsupported destination without failing and still dispatch', async () => {
     shipments.findById.mockResolvedValue(makeShipment());
     (integrations.getCapabilityAdapter as jest.Mock).mockImplementation((_c: string, cap: string) =>
       Promise.resolve(
@@ -189,7 +189,7 @@ describe('ShipmentDispatchNotificationService', () => {
     expect(shipments.update).toHaveBeenCalledWith('ol_shipment_1', expect.objectContaining({ status: 'dispatched' }));
   });
 
-  it('treats a destination failure as best-effort (logged, not fatal) and still dispatches', async () => {
+  it('should treat a destination failure as best-effort and still dispatch', async () => {
     shipments.findById.mockResolvedValue(makeShipment());
     destUpdate.mockRejectedValue(new Error('PS 500'));
 
@@ -197,6 +197,38 @@ describe('ShipmentDispatchNotificationService', () => {
 
     expect(result.source).toBe('ok');
     expect(result.destinations).toEqual([{ connectionId: PS, status: 'failed' }]);
+    expect(shipments.update).toHaveBeenCalledWith('ol_shipment_1', expect.objectContaining({ status: 'dispatched' }));
+  });
+
+  it('should isolate per-destination outcomes when one of several destinations fails', async () => {
+    const PS2 = 'conn-ps-2';
+    shipments.findById.mockResolvedValue(makeShipment());
+    orderRecords.getOrderRecord.mockResolvedValue(
+      makeRecord({
+        syncStatus: [
+          { destinationConnectionId: PS, status: 'synced', externalOrderId: 'ps-100' },
+          { destinationConnectionId: PS2, status: 'synced', externalOrderId: 'ps-200' },
+        ],
+      }),
+    );
+    // First destination succeeds, second rejects — the rejection must not
+    // suppress the first's `ok` (Promise.all over per-item try/catch).
+    const destUpdate2 = jest.fn().mockRejectedValue(new Error('PS2 500'));
+    (integrations.getCapabilityAdapter as jest.Mock).mockImplementation((connId: string, cap: string) =>
+      Promise.resolve(
+        cap === 'OrderSource'
+          ? { listOrderFeed: jest.fn(), getOrder: jest.fn(), notifyDispatched: sourceNotify }
+          : { createOrder: jest.fn(), updateFulfillment: connId === PS2 ? destUpdate2 : destUpdate },
+      ),
+    );
+
+    const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
+
+    expect(result.destinations).toEqual([
+      { connectionId: PS, status: 'ok' },
+      { connectionId: PS2, status: 'failed' },
+    ]);
+    // Source succeeded → still advances despite the partial destination failure.
     expect(shipments.update).toHaveBeenCalledWith('ol_shipment_1', expect.objectContaining({ status: 'dispatched' }));
   });
 });

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * ShipmentDispatchNotificationService — unit tests (#837)
+ *
+ * @module libs/core/src/shipping/application/services
+ */
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
+import type { IOrderRecordService, OrderRecord } from '@openlinker/core/orders';
+
+import { Shipment } from '../../domain/entities/shipment.entity';
+import type { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import { ShipmentDispatchNotificationService } from './shipment-dispatch-notification.service';
+
+const SOURCE = 'conn-allegro';
+const INPOST = 'conn-inpost';
+const PS = 'conn-ps';
+
+function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
+  return new Shipment(
+    overrides.id ?? 'ol_shipment_1',
+    overrides.orderId ?? 'ol_order_1',
+    overrides.connectionId ?? INPOST,
+    overrides.shippingMethod ?? 'paczkomat',
+    overrides.status ?? 'generated',
+    overrides.providerShipmentId ?? 'prov-1',
+    overrides.paczkomatId ?? 'POZ08A',
+    overrides.trackingNumber ?? '6800000001',
+    overrides.labelPdfRef ?? 'shipx:label:1',
+    overrides.dispatchedAt ?? null,
+    overrides.deliveredAt ?? null,
+    overrides.cancelledAt ?? null,
+    overrides.failedAt ?? null,
+    overrides.errorMessage ?? null,
+    overrides.createdAt ?? new Date('2026-05-27T10:00:00.000Z'),
+    overrides.updatedAt ?? new Date('2026-05-27T10:00:00.000Z'),
+    overrides.sourceDeliveryMethodId ?? 'allegro-method',
+  );
+}
+
+function makeRecord(partial: Partial<OrderRecord> = {}): OrderRecord {
+  // The service only reads `sourceConnectionId` + `syncStatus`; return a thin
+  // shape rather than the full positional entity.
+  return {
+    sourceConnectionId: SOURCE,
+    syncStatus: [{ destinationConnectionId: PS, status: 'synced', externalOrderId: 'ps-100' }],
+    ...partial,
+  } as OrderRecord;
+}
+
+describe('ShipmentDispatchNotificationService', () => {
+  let shipments: jest.Mocked<ShipmentRepositoryPort>;
+  let integrations: jest.Mocked<IIntegrationsService>;
+  let orderRecords: jest.Mocked<IOrderRecordService>;
+  let identifierMapping: jest.Mocked<IIdentifierMappingService>;
+  let service: ShipmentDispatchNotificationService;
+
+  let sourceNotify: jest.Mock;
+  let destUpdate: jest.Mock;
+
+  beforeEach(() => {
+    shipments = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findById: jest.fn(),
+      findByOrderId: jest.fn(),
+      findActiveByOrderId: jest.fn(),
+      findByProviderShipmentId: jest.fn(),
+      update: jest.fn(),
+    };
+    orderRecords = {
+      persistOrder: jest.fn(),
+      updateSyncStatus: jest.fn(),
+      persistIncomingSnapshot: jest.fn(),
+      getOrderRecord: jest.fn().mockResolvedValue(makeRecord()),
+    };
+    identifierMapping = {
+      getInternalId: jest.fn(),
+      getExternalIds: jest
+        .fn()
+        .mockResolvedValue([{ externalId: 'allegro-cf-1', platformType: 'allegro', connectionId: SOURCE, entityType: 'Order' }]),
+      getOrCreateInternalId: jest.fn(),
+      createMapping: jest.fn(),
+      batchGetOrCreateInternalIds: jest.fn(),
+    } as unknown as jest.Mocked<IIdentifierMappingService>;
+
+    sourceNotify = jest.fn().mockResolvedValue(undefined);
+    destUpdate = jest.fn().mockResolvedValue(undefined);
+
+    integrations = {
+      getAdapter: jest.fn().mockResolvedValue({ connection: {}, metadata: { platformType: 'inpost' } }),
+      getCapabilityAdapter: jest.fn(),
+      listCapabilityAdapters: jest.fn(),
+      resolveAdapterMetadata: jest.fn(),
+    } as unknown as jest.Mocked<IIntegrationsService>;
+
+    // Default: source implements OrderDispatchNotifier; dest implements OrderFulfillmentUpdater.
+    (integrations.getCapabilityAdapter as jest.Mock).mockImplementation((_connId: string, cap: string) =>
+      Promise.resolve(
+        cap === 'OrderSource'
+          ? { listOrderFeed: jest.fn(), getOrder: jest.fn(), notifyDispatched: sourceNotify }
+          : { createOrder: jest.fn(), updateFulfillment: destUpdate },
+      ),
+    );
+
+    service = new ShipmentDispatchNotificationService(
+      shipments,
+      integrations,
+      orderRecords,
+      identifierMapping,
+    );
+  });
+
+  it('returns shipment-not-found when the shipment does not exist', async () => {
+    shipments.findById.mockResolvedValue(null);
+    const result = await service.notifyDispatched({ shipmentId: 'missing' });
+    expect(result.outcome).toBe('shipment-not-found');
+    expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+  });
+
+  it('skips (status-gate) when the shipment is not generated', async () => {
+    shipments.findById.mockResolvedValue(makeShipment({ status: 'dispatched' }));
+    const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
+    expect(result.outcome).toBe('skipped-not-generated');
+    expect(sourceNotify).not.toHaveBeenCalled();
+    expect(shipments.update).not.toHaveBeenCalled();
+  });
+
+  it('notifies source + destination and advances to dispatched on success', async () => {
+    shipments.findById.mockResolvedValue(makeShipment());
+    const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
+
+    expect(sourceNotify).toHaveBeenCalledWith({
+      externalOrderId: 'allegro-cf-1',
+      trackingNumber: '6800000001',
+      carrier: { platformType: 'inpost' },
+    });
+    expect(destUpdate).toHaveBeenCalledWith({
+      externalOrderId: 'ps-100',
+      status: 'shipped',
+      trackingNumber: '6800000001',
+    });
+    expect(shipments.update).toHaveBeenCalledWith(
+      'ol_shipment_1',
+      expect.objectContaining({ status: 'dispatched', dispatchedAt: expect.any(Date) }),
+    );
+    expect(result).toMatchObject({ outcome: 'notified', source: 'ok', destinations: [{ connectionId: PS, status: 'ok' }] });
+  });
+
+  it('does NOT advance to dispatched when the source notify fails (retriable)', async () => {
+    shipments.findById.mockResolvedValue(makeShipment());
+    sourceNotify.mockRejectedValue(new Error('Allegro 422'));
+
+    const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
+
+    expect(result.source).toBe('failed');
+    expect(shipments.update).not.toHaveBeenCalled(); // stays generated → retriable
+    expect(destUpdate).toHaveBeenCalled(); // B still attempted
+  });
+
+  it('advances to dispatched when there is no source-notify capability (absent)', async () => {
+    shipments.findById.mockResolvedValue(makeShipment());
+    (integrations.getCapabilityAdapter as jest.Mock).mockImplementation((_c: string, cap: string) =>
+      Promise.resolve(
+        cap === 'OrderSource'
+          ? { listOrderFeed: jest.fn(), getOrder: jest.fn() } // no notifyDispatched
+          : { createOrder: jest.fn(), updateFulfillment: destUpdate },
+      ),
+    );
+
+    const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
+
+    expect(result.source).toBe('absent');
+    expect(shipments.update).toHaveBeenCalledWith('ol_shipment_1', expect.objectContaining({ status: 'dispatched' }));
+  });
+
+  it('marks an unsupported destination without failing, and still dispatches', async () => {
+    shipments.findById.mockResolvedValue(makeShipment());
+    (integrations.getCapabilityAdapter as jest.Mock).mockImplementation((_c: string, cap: string) =>
+      Promise.resolve(
+        cap === 'OrderSource'
+          ? { listOrderFeed: jest.fn(), getOrder: jest.fn(), notifyDispatched: sourceNotify }
+          : { createOrder: jest.fn() }, // no updateFulfillment
+      ),
+    );
+
+    const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
+
+    expect(result.destinations).toEqual([{ connectionId: PS, status: 'unsupported' }]);
+    expect(shipments.update).toHaveBeenCalledWith('ol_shipment_1', expect.objectContaining({ status: 'dispatched' }));
+  });
+
+  it('treats a destination failure as best-effort (logged, not fatal) and still dispatches', async () => {
+    shipments.findById.mockResolvedValue(makeShipment());
+    destUpdate.mockRejectedValue(new Error('PS 500'));
+
+    const result = await service.notifyDispatched({ shipmentId: 'ol_shipment_1' });
+
+    expect(result.source).toBe('ok');
+    expect(result.destinations).toEqual([{ connectionId: PS, status: 'failed' }]);
+    expect(shipments.update).toHaveBeenCalledWith('ol_shipment_1', expect.objectContaining({ status: 'dispatched' }));
+  });
+});

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.ts
@@ -120,7 +120,13 @@ export class ShipmentDispatchNotificationService
     try {
       const { metadata } = await this.integrations.getAdapter(connectionId);
       return { platformType: metadata.platformType };
-    } catch {
+    } catch (error) {
+      // Degraded but non-fatal: with no hint, a source adapter attaching a
+      // waybill falls back to its catch-all carrier (Allegro → OTHER + a generic
+      // name). Log so that silent downgrade is traceable rather than invisible.
+      this.logger.debug(
+        `Carrier-hint resolution failed for connection ${connectionId}; a waybill (if any) will use the source adapter's catch-all carrier: ${this.message(error)}`,
+      );
       return undefined;
     }
   }
@@ -178,12 +184,15 @@ export class ShipmentDispatchNotificationService
     shipment: Shipment,
     record: OrderRecord | null,
   ): Promise<DestinationOutcome[]> {
-    const synced = (record?.syncStatus ?? []).filter(
+    // Gate on external-id presence, NOT on sync status: if a destination carries
+    // an externalOrderId the order exists there, so a shipped+tracking update is
+    // valid even if that destination's last sync attempt failed.
+    const withExternalId = (record?.syncStatus ?? []).filter(
       (s): s is typeof s & { externalOrderId: string } => Boolean(s.externalOrderId),
     );
 
     return Promise.all(
-      synced.map(async (entry): Promise<DestinationOutcome> => {
+      withExternalId.map(async (entry): Promise<DestinationOutcome> => {
         try {
           const adapter = await this.integrations.getCapabilityAdapter<OrderProcessorManagerPort>(
             entry.destinationConnectionId,

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.ts
@@ -1,0 +1,214 @@
+/**
+ * Shipment Dispatch Notification Service
+ *
+ * The branch-agnostic "mark sent on source + OMP" orchestration (#837, spec
+ * step 5). Given a dispatched `Shipment`, it resolves the order's source and
+ * destination connection(s) from its `OrderRecord` and drives two generic
+ * capabilities: `OrderDispatchNotifier` on the source (mark sent + attach the
+ * waybill when one exists) and `OrderFulfillmentUpdater` on each destination
+ * (status + tracking). The branch is irrelevant by construction — an InPost
+ * (own-contract) shipment carries a synchronous `trackingNumber` so the source
+ * gets a waybill; an Allegro-Delivery (source-brokered) shipment has none yet,
+ * so the source is merely marked sent (it already holds the waybill it issued).
+ *
+ * Idempotency / partial-failure (see implementation-plan §3.4):
+ * - **Status-gate**: only notifies a `generated` shipment, so the source
+ *   waybill-attach (`POST …/shipments`, dedup `needs-sandbox-probe`) runs at
+ *   most once per shipment.
+ * - **`dispatched` set on A-success OR A-absent** (no source / no capability),
+ *   so a non-marketplace-sourced shipment still advances; an A-failure leaves
+ *   `generated` (retriable).
+ * - **B is best-effort** (per-destination, isolated, logged) — once A succeeds
+ *   the status-gate blocks re-notify, so a B failure is not auto-retried in v1
+ *   (a per-target notify-state model is the follow-up; branch-3 late tracking
+ *   propagation is #838's).
+ * - The gate is not atomic — the live call-site (#769/#771) must serialise per
+ *   order (same caveat as `ShipmentDispatchService`).
+ *
+ * Unwired in #837 (no trigger), exactly as #835 shipped `dispatch()`.
+ *
+ * @module libs/core/src/shipping/application/services
+ * @implements {IShipmentDispatchNotificationService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+} from '@openlinker/core/integrations';
+import {
+  CORE_ENTITY_TYPE,
+  IIdentifierMappingService,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+} from '@openlinker/core/identifier-mapping';
+import {
+  type DispatchCarrierHint,
+  type IOrderRecordService,
+  type OrderProcessorManagerPort,
+  type OrderRecord,
+  type OrderSourcePort,
+  isOrderDispatchNotifier,
+  isOrderFulfillmentUpdater,
+  ORDER_RECORD_SERVICE_TOKEN,
+} from '@openlinker/core/orders';
+
+import type { IShipmentDispatchNotificationService } from '../interfaces/shipment-dispatch-notification.service.interface';
+import type {
+  ShipmentDispatchNotificationInput,
+  ShipmentDispatchNotificationResult,
+} from '../types/shipment-dispatch-notification.types';
+import type { Shipment } from '../../domain/entities/shipment.entity';
+import { ShipmentRepositoryPort } from '../../domain/ports/shipment-repository.port';
+import { SHIPMENT_STATUS } from '../../domain/types/shipment-status.types';
+import { SHIPMENT_REPOSITORY_TOKEN } from '../../shipping.tokens';
+
+const ORDER_SOURCE_CAPABILITY = 'OrderSource';
+const ORDER_PROCESSOR_MANAGER_CAPABILITY = 'OrderProcessorManager';
+
+type SourceOutcome = 'ok' | 'failed' | 'absent';
+type DestinationOutcome = { connectionId: string; status: 'ok' | 'failed' | 'unsupported' };
+
+@Injectable()
+export class ShipmentDispatchNotificationService
+  implements IShipmentDispatchNotificationService
+{
+  private readonly logger = new Logger(ShipmentDispatchNotificationService.name);
+
+  constructor(
+    @Inject(SHIPMENT_REPOSITORY_TOKEN)
+    private readonly shipments: ShipmentRepositoryPort,
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecords: IOrderRecordService,
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IIdentifierMappingService,
+  ) {}
+
+  async notifyDispatched(
+    input: ShipmentDispatchNotificationInput,
+  ): Promise<ShipmentDispatchNotificationResult> {
+    const shipment = await this.shipments.findById(input.shipmentId);
+    if (!shipment) {
+      return { shipmentId: input.shipmentId, outcome: 'shipment-not-found', source: 'absent', destinations: [] };
+    }
+    // Status-gate: at-most-once notify (and at-most-once source waybill-attach).
+    if (shipment.status !== SHIPMENT_STATUS.Generated) {
+      return { shipmentId: shipment.id, outcome: 'skipped-not-generated', source: 'absent', destinations: [] };
+    }
+
+    const record = await this.orderRecords.getOrderRecord(shipment.orderId);
+    const carrier = await this.resolveCarrierHint(shipment.connectionId);
+
+    const source = await this.notifySource(shipment, record, carrier);
+    const destinations = await this.updateDestinations(shipment, record);
+
+    // Advance to dispatched when the source was notified or there was nothing to
+    // notify (no marketplace source). An A-failure leaves `generated` → retriable.
+    if (source === 'ok' || source === 'absent') {
+      await this.shipments.update(shipment.id, {
+        status: SHIPMENT_STATUS.Dispatched,
+        dispatchedAt: new Date(),
+      });
+    }
+
+    return { shipmentId: shipment.id, outcome: 'notified', source, destinations };
+  }
+
+  /** Carrier hint = the shipping processor connection's platformType (#837 Q5). */
+  private async resolveCarrierHint(connectionId: string): Promise<DispatchCarrierHint | undefined> {
+    try {
+      const { metadata } = await this.integrations.getAdapter(connectionId);
+      return { platformType: metadata.platformType };
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** A — mark sent on the order source (+ attach waybill when present). */
+  private async notifySource(
+    shipment: Shipment,
+    record: OrderRecord | null,
+    carrier: DispatchCarrierHint | undefined,
+  ): Promise<SourceOutcome> {
+    if (!record?.sourceConnectionId) {
+      return 'absent';
+    }
+    const externalIds = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.Order,
+      shipment.orderId,
+    );
+    const sourceExternalId = externalIds.find(
+      (e) => e.connectionId === record.sourceConnectionId,
+    )?.externalId;
+    if (!sourceExternalId) {
+      return 'absent';
+    }
+
+    let adapter: OrderSourcePort;
+    try {
+      adapter = await this.integrations.getCapabilityAdapter<OrderSourcePort>(
+        record.sourceConnectionId,
+        ORDER_SOURCE_CAPABILITY,
+      );
+    } catch {
+      return 'absent';
+    }
+    if (!isOrderDispatchNotifier(adapter)) {
+      return 'absent';
+    }
+
+    try {
+      await adapter.notifyDispatched({
+        externalOrderId: sourceExternalId,
+        trackingNumber: shipment.trackingNumber ?? undefined,
+        carrier,
+      });
+      return 'ok';
+    } catch (error) {
+      this.logger.warn(
+        `Source dispatch-notify failed for shipment ${shipment.id} (order ${shipment.orderId}): ${this.message(error)}`,
+      );
+      return 'failed';
+    }
+  }
+
+  /** B — push status + tracking to each synced destination OMP (best-effort). */
+  private async updateDestinations(
+    shipment: Shipment,
+    record: OrderRecord | null,
+  ): Promise<DestinationOutcome[]> {
+    const synced = (record?.syncStatus ?? []).filter(
+      (s): s is typeof s & { externalOrderId: string } => Boolean(s.externalOrderId),
+    );
+
+    return Promise.all(
+      synced.map(async (entry): Promise<DestinationOutcome> => {
+        try {
+          const adapter = await this.integrations.getCapabilityAdapter<OrderProcessorManagerPort>(
+            entry.destinationConnectionId,
+            ORDER_PROCESSOR_MANAGER_CAPABILITY,
+          );
+          if (!isOrderFulfillmentUpdater(adapter)) {
+            return { connectionId: entry.destinationConnectionId, status: 'unsupported' };
+          }
+          await adapter.updateFulfillment({
+            externalOrderId: entry.externalOrderId,
+            status: 'shipped',
+            trackingNumber: shipment.trackingNumber ?? undefined,
+          });
+          return { connectionId: entry.destinationConnectionId, status: 'ok' };
+        } catch (error) {
+          this.logger.warn(
+            `Destination fulfillment-update failed for shipment ${shipment.id} dest ${entry.destinationConnectionId}: ${this.message(error)}`,
+          );
+          return { connectionId: entry.destinationConnectionId, status: 'failed' };
+        }
+      }),
+    );
+  }
+
+  private message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/libs/core/src/shipping/application/types/shipment-dispatch-notification.types.ts
+++ b/libs/core/src/shipping/application/types/shipment-dispatch-notification.types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shipment Dispatch Notification Types
+ *
+ * Input/result contract for `IShipmentDispatchNotificationService.notifyDispatched`
+ * (#837, spec step 5). Inline unions (not `as const`) — this is an internal
+ * service result, not a wire/DB type, mirroring `ShipmentDispatchResult`.
+ *
+ * @module libs/core/src/shipping/application/types
+ */
+
+export interface ShipmentDispatchNotificationInput {
+  /** Internal Shipment id (`ol_shipment_*`) that has reached `generated`. */
+  shipmentId: string;
+}
+
+/**
+ * Per-target outcome. `source` is the order-source notify (A); `destinations`
+ * are the per-OMP fulfillment updates (B, best-effort). `outcome` is the
+ * top-level disposition.
+ */
+export interface ShipmentDispatchNotificationResult {
+  shipmentId: string;
+  /**
+   * - `notified` — the shipment was `generated` and the notify ran.
+   * - `skipped-not-generated` — the status-gate skipped it (already dispatched/terminal).
+   * - `shipment-not-found` — no shipment for the id.
+   */
+  outcome: 'notified' | 'skipped-not-generated' | 'shipment-not-found';
+  /** Source mark-sent: `absent` = no source / source doesn't implement the capability. */
+  source: 'ok' | 'failed' | 'absent';
+  destinations: ReadonlyArray<{
+    connectionId: string;
+    status: 'ok' | 'failed' | 'unsupported';
+  }>;
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -110,3 +110,11 @@ export type { IShipmentCancellationService } from './application/interfaces/ship
 // Application — pickup-point lookup seam (#766). Interface only; the service is
 // injected via PICKUP_POINT_LOOKUP_SERVICE_TOKEN.
 export type { IPickupPointLookupService } from './application/interfaces/pickup-point-lookup.service.interface';
+
+// Application — dispatch-notify seam (#837). Interface + result types only; the
+// service is injected via SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN.
+export type { IShipmentDispatchNotificationService } from './application/interfaces/shipment-dispatch-notification.service.interface';
+export type {
+  ShipmentDispatchNotificationInput,
+  ShipmentDispatchNotificationResult,
+} from './application/types/shipment-dispatch-notification.types';

--- a/libs/core/src/shipping/shipping.module.ts
+++ b/libs/core/src/shipping/shipping.module.ts
@@ -24,6 +24,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { MappingsModule } from '@openlinker/core/mappings';
+import { OrdersModule } from '@openlinker/core/orders';
+import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 
 import { ShipmentOrmEntity } from './infrastructure/persistence/entities/shipment.orm-entity';
 import { ShipmentRepository } from './infrastructure/persistence/repositories/shipment.repository';
@@ -32,10 +34,12 @@ import { ShipmentDispatchService } from './application/services/shipment-dispatc
 import { ShipmentQueryService } from './application/services/shipment-query.service';
 import { ShipmentCancellationService } from './application/services/shipment-cancellation.service';
 import { PickupPointLookupService } from './application/services/pickup-point-lookup.service';
+import { ShipmentDispatchNotificationService } from './application/services/shipment-dispatch-notification.service';
 import {
   PICKUP_POINT_CACHE_TOKEN,
   PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
   SHIPMENT_CANCELLATION_SERVICE_TOKEN,
+  SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
   SHIPMENT_DISPATCH_SERVICE_TOKEN,
   SHIPMENT_QUERY_SERVICE_TOKEN,
   SHIPMENT_REPOSITORY_TOKEN,
@@ -50,6 +54,11 @@ import {
     // imports ShippingModule except the host app graph.
     IntegrationsModule,
     MappingsModule,
+    // #837 mark-sent orchestration: resolve the order's source + destination
+    // capabilities (OrdersModule) and the source's external order id
+    // (IdentifierMappingModule). Acyclic — OrdersModule does not import ShippingModule.
+    OrdersModule,
+    IdentifierMappingModule,
   ],
   providers: [
     ShipmentRepository,
@@ -82,6 +91,11 @@ import {
       provide: PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
       useExisting: PickupPointLookupService,
     },
+    ShipmentDispatchNotificationService,
+    {
+      provide: SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
+      useExisting: ShipmentDispatchNotificationService,
+    },
   ],
   exports: [
     SHIPMENT_REPOSITORY_TOKEN,
@@ -90,6 +104,7 @@ import {
     SHIPMENT_CANCELLATION_SERVICE_TOKEN,
     PICKUP_POINT_CACHE_TOKEN,
     PICKUP_POINT_LOOKUP_SERVICE_TOKEN,
+    SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN,
   ],
 })
 export class ShippingModule {}

--- a/libs/core/src/shipping/shipping.tokens.ts
+++ b/libs/core/src/shipping/shipping.tokens.ts
@@ -16,3 +16,6 @@ export const SHIPMENT_DISPATCH_SERVICE_TOKEN = Symbol('IShipmentDispatchService'
 export const SHIPMENT_QUERY_SERVICE_TOKEN = Symbol('IShipmentQueryService');
 export const SHIPMENT_CANCELLATION_SERVICE_TOKEN = Symbol('IShipmentCancellationService');
 export const PICKUP_POINT_LOOKUP_SERVICE_TOKEN = Symbol('IPickupPointLookupService');
+export const SHIPMENT_DISPATCH_NOTIFICATION_SERVICE_TOKEN = Symbol(
+  'IShipmentDispatchNotificationService',
+);

--- a/libs/integrations/allegro/src/domain/exceptions/allegro-order-dispatch-rejected.exception.ts
+++ b/libs/integrations/allegro/src/domain/exceptions/allegro-order-dispatch-rejected.exception.ts
@@ -1,0 +1,18 @@
+/**
+ * Allegro Order Dispatch Rejected Exception
+ *
+ * Thrown when the Allegro order-side dispatch (mark-sent via
+ * `PUT …/fulfillment`, or waybill-attach via `POST …/shipments`) is rejected.
+ * Carries a readable reason derived from the Allegro error response.
+ *
+ * @module libs/integrations/allegro/src/domain/exceptions
+ */
+export class AllegroOrderDispatchRejectedException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AllegroOrderDispatchRejectedException';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AllegroOrderDispatchRejectedException);
+    }
+  }
+}

--- a/libs/integrations/allegro/src/domain/types/allegro-order-fulfillment.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-order-fulfillment.types.ts
@@ -1,0 +1,41 @@
+/**
+ * Allegro Order-Side Fulfillment Wire Types (#837)
+ *
+ * Shapes for marking an Allegro order sent + attaching a waybill, via
+ * `PUT /order/checkout-forms/{id}/fulfillment` and
+ * `POST /order/checkout-forms/{id}/shipments`. Verified against the Allegro
+ * orders tutorial; the enum spelling, carrier vocabulary, and `OTHER` rules are
+ * doc-derived — each isolated to a named constant so a sandbox correction is a
+ * one-line edit (`needs-sandbox-probe`, #837).
+ *
+ * @module libs/integrations/allegro/src/domain/types
+ */
+
+/** Fulfillment status set on mark-sent. `needs-sandbox-probe`: enum spelling. */
+export const ALLEGRO_FULFILLMENT_STATUS_SENT = 'SENT';
+
+export interface AllegroSetFulfillmentRequest {
+  status: string;
+}
+
+export interface AllegroAttachShipmentRequest {
+  carrierId: string;
+  waybill: string;
+  /** Required by Allegro only when `carrierId === 'OTHER'`. */
+  carrierName?: string;
+}
+
+/** Allegro's catch-all carrier id (from the fixed `GET /order/carriers` vocab). */
+export const ALLEGRO_OTHER_CARRIER_ID = 'OTHER';
+
+/**
+ * Static map: OL shipping-processor `platformType` → Allegro `carrierId`.
+ * Anything not listed falls back to `OTHER` + a `carrierName`. The carrier ids
+ * are doc-derived from `GET /order/carriers` (`needs-sandbox-probe`); a dynamic
+ * carriers lookup is a later refinement (#837 Q5).
+ */
+export const ALLEGRO_CARRIER_BY_PLATFORM_TYPE: Readonly<Record<string, string>> = {
+  inpost: 'INPOST',
+  dpd: 'DPD',
+  dhl: 'DHL',
+};

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -15,6 +15,8 @@ import type {
   AllegroCheckoutForm,
   AllegroOrderEventsResponse,
 } from '../../../domain/types/allegro-api.types';
+import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
+import { AllegroOrderDispatchRejectedException } from '../../../domain/exceptions/allegro-order-dispatch-rejected.exception';
 
 describe('AllegroOrderSourceAdapter', () => {
   let adapter: AllegroOrderSourceAdapter;
@@ -45,6 +47,67 @@ describe('AllegroOrderSourceAdapter', () => {
     );
 
     adapter = new AllegroOrderSourceAdapter(connectionId, httpClient, connection);
+  });
+
+  describe('notifyDispatched (#837)', () => {
+    it('marks the order sent only (no waybill) for the source-brokered branch', async () => {
+      await adapter.notifyDispatched({ externalOrderId: 'cf-1' });
+      expect(httpClient.put).toHaveBeenCalledWith('/order/checkout-forms/cf-1/fulfillment', {
+        status: 'SENT',
+      });
+      expect(httpClient.post).not.toHaveBeenCalled();
+    });
+
+    it('marks sent and attaches the waybill with a mapped carrierId for an own-contract shipment', async () => {
+      await adapter.notifyDispatched({
+        externalOrderId: 'cf-1',
+        trackingNumber: '680',
+        carrier: { platformType: 'inpost' },
+      });
+      expect(httpClient.put).toHaveBeenCalledWith('/order/checkout-forms/cf-1/fulfillment', {
+        status: 'SENT',
+      });
+      expect(httpClient.post).toHaveBeenCalledWith('/order/checkout-forms/cf-1/shipments', {
+        carrierId: 'INPOST',
+        waybill: '680',
+      });
+    });
+
+    it('falls back to OTHER + carrierName for an unmapped carrier', async () => {
+      await adapter.notifyDispatched({
+        externalOrderId: 'cf-1',
+        trackingNumber: '680',
+        carrier: { platformType: 'wackycarrier' },
+      });
+      expect(httpClient.post).toHaveBeenCalledWith('/order/checkout-forms/cf-1/shipments', {
+        carrierId: 'OTHER',
+        waybill: '680',
+        carrierName: 'wackycarrier',
+      });
+    });
+
+    it('treats a 409 on fulfillment as already-sent (success) and still attaches the waybill', async () => {
+      httpClient.put.mockRejectedValueOnce(new AllegroApiException('conflict', 409));
+      await expect(
+        adapter.notifyDispatched({
+          externalOrderId: 'cf-1',
+          trackingNumber: '680',
+          carrier: { platformType: 'inpost' },
+        }),
+      ).resolves.toBeUndefined();
+      expect(httpClient.post).toHaveBeenCalled();
+    });
+
+    it('wraps a waybill-attach failure into AllegroOrderDispatchRejectedException', async () => {
+      httpClient.post.mockRejectedValueOnce(new AllegroApiException('bad carrier', 400));
+      await expect(
+        adapter.notifyDispatched({
+          externalOrderId: 'cf-1',
+          trackingNumber: '680',
+          carrier: { platformType: 'inpost' },
+        }),
+      ).rejects.toBeInstanceOf(AllegroOrderDispatchRejectedException);
+    });
   });
 
   describe('listOrderFeed', () => {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -50,7 +50,7 @@ describe('AllegroOrderSourceAdapter', () => {
   });
 
   describe('notifyDispatched (#837)', () => {
-    it('marks the order sent only (no waybill) for the source-brokered branch', async () => {
+    it('should mark the order sent only (no waybill) for the source-brokered branch', async () => {
       await adapter.notifyDispatched({ externalOrderId: 'cf-1' });
       expect(httpClient.put).toHaveBeenCalledWith('/order/checkout-forms/cf-1/fulfillment', {
         status: 'SENT',
@@ -58,7 +58,7 @@ describe('AllegroOrderSourceAdapter', () => {
       expect(httpClient.post).not.toHaveBeenCalled();
     });
 
-    it('marks sent and attaches the waybill with a mapped carrierId for an own-contract shipment', async () => {
+    it('should mark sent and attach the waybill with a mapped carrierId for an own-contract shipment', async () => {
       await adapter.notifyDispatched({
         externalOrderId: 'cf-1',
         trackingNumber: '680',
@@ -73,7 +73,7 @@ describe('AllegroOrderSourceAdapter', () => {
       });
     });
 
-    it('falls back to OTHER + carrierName for an unmapped carrier', async () => {
+    it('should fall back to OTHER + carrierName for an unmapped carrier', async () => {
       await adapter.notifyDispatched({
         externalOrderId: 'cf-1',
         trackingNumber: '680',
@@ -86,7 +86,7 @@ describe('AllegroOrderSourceAdapter', () => {
       });
     });
 
-    it('treats a 409 on fulfillment as already-sent (success) and still attaches the waybill', async () => {
+    it('should treat a 409 on fulfillment as already-sent (success) and still attach the waybill', async () => {
       httpClient.put.mockRejectedValueOnce(new AllegroApiException('conflict', 409));
       await expect(
         adapter.notifyDispatched({
@@ -98,7 +98,7 @@ describe('AllegroOrderSourceAdapter', () => {
       expect(httpClient.post).toHaveBeenCalled();
     });
 
-    it('wraps a waybill-attach failure into AllegroOrderDispatchRejectedException', async () => {
+    it('should wrap a waybill-attach failure into AllegroOrderDispatchRejectedException', async () => {
       httpClient.post.mockRejectedValueOnce(new AllegroApiException('bad carrier', 400));
       await expect(
         adapter.notifyDispatched({

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -10,7 +10,13 @@
  * @implements {OrderSourcePort}
  */
 
-import type { OrderSourcePort, SourceOptionsReader, MappingOption } from '@openlinker/core/orders';
+import type {
+  OrderSourcePort,
+  SourceOptionsReader,
+  OrderDispatchNotifier,
+  DispatchCarrierHint,
+  MappingOption,
+} from '@openlinker/core/orders';
 import type {
   OrderFeedInput,
   OrderFeedOutput,
@@ -32,6 +38,13 @@ import type {
 } from '../../domain/types/allegro-api.types';
 import { ALLEGRO_ORDER_STATUS_OPTIONS } from '../../domain/types/allegro-order-status.types';
 import { ALLEGRO_PAYMENT_TYPE_OPTIONS } from '../../domain/types/allegro-payment-type.types';
+import {
+  ALLEGRO_CARRIER_BY_PLATFORM_TYPE,
+  ALLEGRO_FULFILLMENT_STATUS_SENT,
+  ALLEGRO_OTHER_CARRIER_ID,
+} from '../../domain/types/allegro-order-fulfillment.types';
+import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
+import { AllegroOrderDispatchRejectedException } from '../../domain/exceptions/allegro-order-dispatch-rejected.exception';
 
 type OrderFeedItem = OrderFeedOutput['items'][number];
 
@@ -45,7 +58,9 @@ type OrderFeedItem = OrderFeedOutput['items'][number];
  * `OrderIngestionService` against the `IncomingOrder` payload, so the adapter
  * does not need the identifier-mapping port itself.
  */
-export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptionsReader {
+export class AllegroOrderSourceAdapter
+  implements OrderSourcePort, SourceOptionsReader, OrderDispatchNotifier
+{
   private readonly logger = new Logger(AllegroOrderSourceAdapter.name);
 
   constructor(
@@ -54,6 +69,72 @@ export class AllegroOrderSourceAdapter implements OrderSourcePort, SourceOptions
     _connection: Connection
   ) {
     void _connection;
+  }
+
+  /**
+   * Order-side dispatch (#837): mark the Allegro order sent, and attach the
+   * waybill when one is supplied (own-contract branch). For the source-brokered
+   * branch (Allegro Delivery) no `trackingNumber` is passed — Allegro already
+   * holds the waybill it issued — so only the fulfillment status is set.
+   */
+  async notifyDispatched(input: {
+    externalOrderId: string;
+    trackingNumber?: string;
+    carrier?: DispatchCarrierHint;
+  }): Promise<void> {
+    // 1. Mark sent. Treat a 409 (stale optimistic-lock revision / already-sent)
+    //    as success for idempotency. `needs-sandbox-probe`: exact 409 semantics.
+    try {
+      await this.httpClient.put(
+        `/order/checkout-forms/${input.externalOrderId}/fulfillment`,
+        { status: ALLEGRO_FULFILLMENT_STATUS_SENT },
+      );
+    } catch (error) {
+      if (this.isAlreadySentOrStale(error)) {
+        this.logger.debug(
+          `Allegro order ${input.externalOrderId} fulfillment already sent / stale revision — treating as success (connection: ${this.connectionId})`,
+        );
+      } else {
+        throw this.toRejected(error, `mark Allegro order ${input.externalOrderId} sent`);
+      }
+    }
+
+    // 2. Attach the waybill when present (own-contract branch).
+    if (input.trackingNumber) {
+      const { carrierId, carrierName } = this.resolveCarrier(input.carrier);
+      try {
+        await this.httpClient.post(
+          `/order/checkout-forms/${input.externalOrderId}/shipments`,
+          { carrierId, waybill: input.trackingNumber, ...(carrierName ? { carrierName } : {}) },
+        );
+      } catch (error) {
+        throw this.toRejected(error, `attach waybill to Allegro order ${input.externalOrderId}`);
+      }
+    }
+  }
+
+  /** Map the neutral carrier hint → Allegro's fixed carrier vocab (OTHER+name fallback). */
+  private resolveCarrier(carrier?: DispatchCarrierHint): { carrierId: string; carrierName?: string } {
+    const platformType = carrier?.platformType;
+    const known = platformType ? ALLEGRO_CARRIER_BY_PLATFORM_TYPE[platformType] : undefined;
+    if (known) {
+      return { carrierId: known };
+    }
+    return { carrierId: ALLEGRO_OTHER_CARRIER_ID, carrierName: platformType ?? 'Carrier' };
+  }
+
+  private isAlreadySentOrStale(error: unknown): boolean {
+    return (
+      error instanceof AllegroApiException &&
+      (error.statusCode === 409 || /already/i.test(error.message))
+    );
+  }
+
+  private toRejected(error: unknown, context: string): Error {
+    if (error instanceof AllegroApiException) {
+      return new AllegroOrderDispatchRejectedException(`Failed to ${context}: ${error.message}`);
+    }
+    return error instanceof Error ? error : new Error(String(error));
   }
 
   /**


### PR DESCRIPTION
## What & why

Implements the spec's **step 5** ("mark order sent on source + OMP", #732 E3) as **two generic capability ports** plus a **branch-agnostic orchestration service** — designed capability-first (Allegro/PrestaShop/InPost are *implementations*, not design drivers).

### Capabilities (orders ctx, sub-capability + `is*`-guard pattern, ADR-002)
- **`OrderDispatchNotifier`** (sub-capability of `OrderSourcePort`) — tell the order *source* an order shipped: mark sent, and attach a waybill when one is supplied. **Implemented by Allegro**: `PUT /order/checkout-forms/{id}/fulfillment {status:SENT}` always; conditional `POST /order/checkout-forms/{id}/shipments` with a static `platformType → carrierId` map (`inpost→INPOST`, …) and an `OTHER` + humanized-`carrierName` fallback. Already-sent / `409`-stale-revision are treated as success.
- **`OrderFulfillmentUpdater`** (sub-capability of `OrderProcessorManagerPort`) — push post-create status + tracking to a destination OMP. **Port + orchestration wiring only in this PR** (see deferral below).

### Orchestration (`ShipmentDispatchNotificationService`, shipping ctx)
Given a `generated` `Shipment`: resolves the order's source + destination(s) from its `OrderRecord`, the source external id from the identifier-mapping table, and the carrier hint from the shipment's processor connection; drives **A** (source mark-sent, primary) + **B** (per-destination fulfillment-update, best-effort `allSettled`); then transitions the `Shipment` to `dispatched`.

- **Status-gate** → at-most-once notify (the source waybill-attach runs once).
- `dispatched` set on **A-success-or-absent** (A-failure leaves `generated` → retriable).
- **Trigger-agnostic & unwired**, mirroring how #835 shipped `dispatch()` without a live caller (the call-site is #769/#771).

Sub-capabilities are **not** in `manifest.supportedCapabilities`, so there is **no routing/manifest ripple**. **No migration.**

## Deferred (deliberate — see plan §6 Q7)
The **PrestaShop impl of capability B** is a focused follow-up. The architecture is the port + orchestration (identical whether the PS adapter lands now or next), and OL's idiom is port-then-per-adapter-impl (#763→#812, #832→#835). The PS write is the one genuinely-uncertain piece — it must use `POST /order_histories` (so the buyer "shipped" side-effects fire) + the `order_carriers` association for tracking, **never** the `orders` full-replace — and needs a PrestaShop-Testcontainer verification disproportionate to bundle here. The orchestration degrades to `destinations[].status='unsupported'` until it lands, so this PR is complete, not half-built.

## Tests
- Capability-guard unit specs; orchestration unit spec (full partial-failure matrix); Allegro adapter spec (SENT-only, SENT+waybill, carrier map, `OTHER` fallback, 409→success).
- **Orchestration int-spec** — seeds a `generated` shipment (with tracking) through the **real #835 dispatch seam** (in-memory carrier stub) plus stub source/dest capability adapters; asserts A+B invoked with the resolved external ids + carrier hint, the `dispatched` transition (read back via `IShipmentQueryService`, off the cross-context-banned `ShipmentRepositoryPort`), and the status-gate at-most-once.

## Quality gate
`pnpm lint` (0 errors) · `pnpm type-check` · `pnpm test` (all unit suites) · **full** `pnpm test:integration` (39/39 suites, 222 passed, zero ripple to routing/orders specs) · `migration:show` (none pending). Cross-context + service-interface invariants pass.

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)