### PR TITLE
feat(allegro,api): validate same-seller identity on in-place Allegro re-auth (#820)

### DIFF
--- a/apps/api/src/integrations/application/services/allegro-oauth.service.spec.ts
+++ b/apps/api/src/integrations/application/services/allegro-oauth.service.spec.ts
@@ -13,6 +13,7 @@ import { AllegroOAuthService } from './allegro-oauth.service';
 import { ConnectionService } from './connection.service';
 import type { ICredentialsService } from '@openlinker/core/integrations';
 import { CREDENTIALS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import { AllegroAccountReader } from '@openlinker/integrations-allegro';
 
 describe('AllegroOAuthService', () => {
   let service: AllegroOAuthService;
@@ -25,6 +26,7 @@ describe('AllegroOAuthService', () => {
   let connectionService: jest.Mocked<
     Pick<ConnectionService, 'get' | 'create' | 'update' | 'updateCredentials'>
   >;
+  let accountReader: { fetchSellerIdentity: jest.Mock };
 
   beforeEach(async () => {
     redisClient = {
@@ -46,12 +48,17 @@ describe('AllegroOAuthService', () => {
       Pick<ConnectionService, 'get' | 'create' | 'update' | 'updateCredentials'>
     >;
 
+    accountReader = {
+      fetchSellerIdentity: jest.fn().mockResolvedValue({ sellerId: 'seller-1', login: 'my_shop' }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AllegroOAuthService,
         { provide: ConnectionService, useValue: connectionService },
         { provide: 'REDIS_CLIENT', useValue: redisClient },
         { provide: CREDENTIALS_SERVICE_TOKEN, useValue: credentials },
+        { provide: AllegroAccountReader, useValue: accountReader },
       ],
     }).compile();
 
@@ -274,7 +281,15 @@ describe('AllegroOAuthService', () => {
         'conn-existing',
         expect.objectContaining({ accessToken: 'fresh-tok', refreshToken: 'fresh-rt' })
       );
-      expect(connectionService.update).toHaveBeenCalledWith('conn-existing', { status: 'active' });
+      // Backfill path: the legacy mock connection carries no stored sellerId,
+      // so re-auth adopts the freshly-verified seller into the config (#820).
+      expect(connectionService.update).toHaveBeenCalledWith(
+        'conn-existing',
+        expect.objectContaining({
+          status: 'active',
+          config: expect.objectContaining({ sellerId: 'seller-1' }),
+        })
+      );
       expect(connectionService.create).not.toHaveBeenCalled();
       expect(credentials.create).not.toHaveBeenCalled();
       expect(result).toEqual(expect.objectContaining({ id: 'conn-existing', status: 'active' }));
@@ -303,6 +318,103 @@ describe('AllegroOAuthService', () => {
 
       expect(connectionService.updateCredentials).not.toHaveBeenCalled();
       expect(connectionService.update).not.toHaveBeenCalled();
+    });
+
+    it('persists the seller id on the connection config when creating a new connection (#820)', async () => {
+      credentials.create.mockResolvedValue(undefined as never);
+      connectionService.create.mockResolvedValue({ id: 'conn-1', name: 'Test' } as never);
+
+      await service.storeCredentialsAndCreateConnection(
+        { access_token: 'tok', token_type: 'bearer' },
+        { clientId: 'cid', clientSecret: 'csec', redirectUri: 'https://example.com/cb', environment: 'sandbox' }
+      );
+
+      expect(accountReader.fetchSellerIdentity).toHaveBeenCalledWith(expect.any(String), 'tok');
+      expect(connectionService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ config: expect.objectContaining({ sellerId: 'seller-1' }) })
+      );
+    });
+
+    it('re-authenticates in place when the new token authorizes the same seller (#820)', async () => {
+      connectionService.get.mockResolvedValue({
+        id: 'conn-existing',
+        name: 'My Allegro',
+        platformType: 'allegro',
+        status: 'needs_reauth',
+        config: { environment: 'sandbox', sellerId: 'seller-1' },
+      } as never);
+      connectionService.updateCredentials.mockResolvedValue(undefined as never);
+      connectionService.update.mockResolvedValue({
+        id: 'conn-existing',
+        name: 'My Allegro',
+        status: 'active',
+      } as never);
+      accountReader.fetchSellerIdentity.mockResolvedValue({ sellerId: 'seller-1', login: 'my_shop' });
+
+      await service.storeCredentialsAndCreateConnection(
+        { access_token: 'fresh-tok', token_type: 'bearer' },
+        {
+          clientId: 'cid',
+          clientSecret: 'csec',
+          redirectUri: 'https://example.com/cb',
+          environment: 'sandbox',
+          connectionId: 'conn-existing',
+        }
+      );
+
+      expect(connectionService.updateCredentials).toHaveBeenCalled();
+      expect(connectionService.update).toHaveBeenCalledWith(
+        'conn-existing',
+        expect.objectContaining({
+          status: 'active',
+          config: expect.objectContaining({ sellerId: 'seller-1' }),
+        })
+      );
+    });
+
+    it('rejects re-auth when the new token authorizes a different seller, without rotating credentials (#820)', async () => {
+      connectionService.get.mockResolvedValue({
+        id: 'conn-existing',
+        name: 'My Allegro',
+        platformType: 'allegro',
+        status: 'needs_reauth',
+        config: { environment: 'sandbox', sellerId: 'seller-1' },
+      } as never);
+      accountReader.fetchSellerIdentity.mockResolvedValue({
+        sellerId: 'seller-2',
+        login: 'other_shop',
+      });
+
+      await expect(
+        service.storeCredentialsAndCreateConnection(
+          { access_token: 'fresh-tok', token_type: 'bearer' },
+          {
+            clientId: 'cid',
+            clientSecret: 'csec',
+            redirectUri: 'https://example.com/cb',
+            environment: 'sandbox',
+            connectionId: 'conn-existing',
+          }
+        )
+      ).rejects.toThrow(BadRequestException);
+
+      // Mismatch is rejected BEFORE any credential rotation or status flip.
+      expect(connectionService.updateCredentials).not.toHaveBeenCalled();
+      expect(connectionService.update).not.toHaveBeenCalled();
+    });
+
+    it('aborts OAuth completion when the seller-identity read fails (#820)', async () => {
+      accountReader.fetchSellerIdentity.mockRejectedValue(new Error('me failed'));
+
+      await expect(
+        service.storeCredentialsAndCreateConnection(
+          { access_token: 'tok', token_type: 'bearer' },
+          { clientId: 'cid', clientSecret: 'csec', redirectUri: 'https://example.com/cb', environment: 'sandbox' }
+        )
+      ).rejects.toThrow(InternalServerErrorException);
+
+      expect(credentials.create).not.toHaveBeenCalled();
+      expect(connectionService.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/integrations/application/services/allegro-oauth.service.ts
+++ b/apps/api/src/integrations/application/services/allegro-oauth.service.ts
@@ -18,8 +18,8 @@ import {
 import { Logger } from '@openlinker/shared/logging';
 import { randomUUID, randomBytes } from 'crypto';
 import { RedisClientType } from 'redis';
-import type { AllegroConnectionConfig } from '@openlinker/integrations-allegro';
-import { AllegroEnvironmentValues } from '@openlinker/integrations-allegro';
+import type { AllegroConnectionConfig, AllegroAccountIdentity } from '@openlinker/integrations-allegro';
+import { AllegroEnvironmentValues, AllegroAccountReader } from '@openlinker/integrations-allegro';
 import { ConnectionService } from './connection.service';
 import type { Connection, ConnectionConfig } from '@openlinker/core/identifier-mapping';
 import {
@@ -47,7 +47,8 @@ export class AllegroOAuthService implements IAllegroOAuthService {
     @Inject('REDIS_CLIENT')
     private readonly redisClient: RedisClientType,
     @Inject(CREDENTIALS_SERVICE_TOKEN)
-    private readonly credentials: ICredentialsService
+    private readonly credentials: ICredentialsService,
+    private readonly accountReader: AllegroAccountReader
   ) {}
 
   /**
@@ -305,12 +306,23 @@ export class AllegroOAuthService implements IAllegroOAuthService {
     tokenResponse: AllegroOAuthTokenResponse,
     stateData: OAuthStateData
   ): Promise<Connection> {
+    // Capture the seller identity for the freshly-issued token up front, so
+    // both the create and re-auth paths share one verified anchor. A failure
+    // is fatal (see resolveSellerIdentity) — a connection is never
+    // seller-anchored to an unverified account.
+    const identity = await this.resolveSellerIdentity(tokenResponse, stateData.environment);
+
     // Re-authentication path (#819): when state carries an existing
     // connectionId, rotate that connection's credentials in place and clear
     // its needs_reauth flag instead of minting a new connection — re-using the
     // connection preserves all connection-scoped identifier mappings.
     if (stateData.connectionId) {
-      return this.reauthenticateExistingConnection(tokenResponse, stateData, stateData.connectionId);
+      return this.reauthenticateExistingConnection(
+        tokenResponse,
+        stateData,
+        stateData.connectionId,
+        identity
+      );
     }
 
     this.logger.log(
@@ -355,6 +367,7 @@ export class AllegroOAuthService implements IAllegroOAuthService {
     // Prepare connection config
     const config: AllegroConnectionConfig = {
       environment: stateData.environment as 'sandbox' | 'production',
+      sellerId: identity.sellerId,
       ...(stateData.masterCatalogConnectionId
         ? { masterCatalogConnectionId: stateData.masterCatalogConnectionId }
         : {}),
@@ -390,26 +403,38 @@ export class AllegroOAuthService implements IAllegroOAuthService {
   private async reauthenticateExistingConnection(
     tokenResponse: AllegroOAuthTokenResponse,
     stateData: OAuthStateData,
-    connectionId: string
+    connectionId: string,
+    identity: AllegroAccountIdentity
   ): Promise<Connection> {
     this.logger.log(`Re-authenticating existing Allegro connection in place: ${connectionId}`);
 
-    // Resolve + guard: must be an existing Allegro connection.
-    //
-    // ASSUMPTION (#819 / ADR-008): the operator re-authenticates the SAME
-    // Allegro seller account. We validate platformType but NOT that the new
-    // token authorizes the same seller — OpenLinker doesn't yet persist the
-    // Allegro account id on the connection. Re-authing with a different
-    // developer app / seller would silently rebind this connection while
-    // retaining mappings keyed to the previous seller's external-id space.
-    // It's admin-gated and the operator supplies their own credentials, so
-    // it's a foot-gun, not a security hole. Validating seller identity here
-    // is a tracked follow-up.
     const existing = await this.connectionService.get(connectionId);
     if (existing.platformType !== 'allegro') {
       throw new BadRequestException(
         `Connection ${connectionId} is not an Allegro connection (platformType: ${existing.platformType})`
       );
+    }
+
+    // Same-seller guard (#820): the in-place re-auth preserves the connection
+    // id and every connection-scoped identifier mapping, so the new token MUST
+    // authorize the same Allegro seller. Reject BEFORE rotating credentials
+    // when the stored seller differs. A connection created before #820 has no
+    // stored sellerId — nothing to compare against — so it's backfilled below
+    // rather than rejected.
+    const storedSellerId = (existing.config as { sellerId?: string } | undefined)?.sellerId;
+    if (storedSellerId && storedSellerId !== identity.sellerId) {
+      this.logger.warn(
+        `Allegro re-auth seller mismatch on connection ${connectionId} (name: ${existing.name}): ` +
+          `stored=${storedSellerId}, incoming=${identity.sellerId} (login: ${identity.login})`
+      );
+      throw new BadRequestException({
+        message:
+          `This authorization is for a different Allegro seller (login '${identity.login}', ` +
+          `id ${identity.sellerId}) than connection "${existing.name}" is bound to ` +
+          `(seller id ${storedSellerId}). Re-authenticate with the original seller account, ` +
+          `or create a new connection.`,
+        code: 'ALLEGRO_SELLER_MISMATCH',
+      });
     }
 
     // Same credential blob shape the create path persists, with the rotated token.
@@ -428,8 +453,23 @@ export class AllegroOAuthService implements IAllegroOAuthService {
       credentials as unknown as Record<string, unknown>
     );
 
-    // Clear the re-auth flag — return the connection to active service.
-    const connection = await this.connectionService.update(connectionId, { status: 'active' });
+    // Clear the re-auth flag and persist (or backfill) the verified seller id.
+    // The shape-validator re-runs on the merged config (non-whitelisting, so
+    // adjacent fields pass through).
+    const mergedConfig = {
+      ...((existing.config as Record<string, unknown> | undefined) ?? {}),
+      sellerId: identity.sellerId,
+    };
+    const connection = await this.connectionService.update(connectionId, {
+      status: 'active',
+      config: mergedConfig as ConnectionConfig,
+    });
+
+    if (!storedSellerId) {
+      this.logger.log(
+        `Backfilled Allegro sellerId=${identity.sellerId} on connection ${connectionId} during re-auth`
+      );
+    }
 
     this.logger.log(
       `Connection re-authenticated successfully: ${connection.id} (name: ${connection.name}, status: ${connection.status})`
@@ -554,6 +594,31 @@ export class AllegroOAuthService implements IAllegroOAuthService {
       // Self-heal: drop the poisoned marker so a subsequent write can succeed cleanly.
       await this.redisClient.del(key);
       return null;
+    }
+  }
+
+  /**
+   * Resolve the Allegro seller identity for a freshly-issued token via the
+   * plugin's account reader (#820). A failure is fatal to OAuth completion —
+   * a connection must never be seller-anchored to an unverified account — so
+   * it surfaces as 500; the callback state stays uncompleted, so the operator
+   * can retry. (Mirrors how `exchangeCodeForToken` wraps its own fetch.)
+   */
+  private async resolveSellerIdentity(
+    tokenResponse: AllegroOAuthTokenResponse,
+    environment: string
+  ): Promise<AllegroAccountIdentity> {
+    try {
+      return await this.accountReader.fetchSellerIdentity(
+        this.getApiBaseUrl(environment),
+        tokenResponse.access_token
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to verify Allegro seller identity: ${(error as Error).message}`,
+        error instanceof Error ? error.stack : undefined
+      );
+      throw new InternalServerErrorException('Failed to verify Allegro seller identity');
     }
   }
 

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -18,6 +18,7 @@ import {
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
 import { SyncModule } from '@openlinker/core/sync';
 import { RedisConfigModule } from '@openlinker/shared/redis';
+import { AllegroAccountReader } from '@openlinker/integrations-allegro';
 import { apiPlugins } from '../plugins';
 import { ConnectionController } from './http/connection.controller';
 import { AdapterController } from './http/adapter.controller';
@@ -37,6 +38,7 @@ import { ALLEGRO_OAUTH_SERVICE_TOKEN } from './application/interfaces/allegro-oa
   controllers: [ConnectionController, AdapterController, AllegroController],
   providers: [
     ConnectionService,
+    AllegroAccountReader, // #820 — injected into AllegroOAuthService for the seller-identity check
     AllegroOAuthService,
     { provide: ALLEGRO_OAUTH_SERVICE_TOKEN, useExisting: AllegroOAuthService },
   ],

--- a/docs/plans/implementation-plan-820-allegro-same-seller-reauth.md
+++ b/docs/plans/implementation-plan-820-allegro-same-seller-reauth.md
@@ -1,0 +1,65 @@
+# Implementation Plan — #820 Validate same-seller identity on Allegro re-auth
+
+**Issue:** #820 · **Builds on:** #819 / [ADR-008](../architecture/adrs/008-auth-failure-classifier-connection-reauth.md) · **Spawned:** #859 (relocate the whole Allegro OAuth surface into the plugin)
+**Layer:** Integration (Allegro plugin — the `/me` seam) + Interface/Application (apps/api OAuth orchestration)
+**Branch:** `820-allegro-same-seller-reauth`
+
+> Design settled via `/grill-me` (Q1–Q5). The decisions and their rationale are inline below.
+
+## 1. Problem
+
+`AllegroOAuthService.reauthenticateExistingConnection` (#819 in-place re-auth) rotates a flagged connection's OAuth credentials while **preserving the connection id** (and all connection-scoped identifier mappings). It validates only `platformType === 'allegro'` — **not** that the new token authorizes the **same Allegro seller**. Re-authing with a different seller silently rebinds the connection while keeping mappings keyed to the old seller's external-id space → wrong-but-quiet lookups (404s). Admin-gated + operator creds → **foot-gun, not a security hole**, but it inverts the mapping-preservation benefit. Add a guard.
+
+**Non-goals:** a confirm/override UX (hard reject — Q2); seller validation for non-Allegro platforms; relocating the rest of the Allegro OAuth surface (tracked as **#859**); any change to the #819 trigger or the token-refresh path (refresh reuses the same refresh-token → same seller → can't rebind, so no check there).
+
+## 2. Research findings (verified)
+
+- **Seller-id source — `GET /me` → `id` (string)**, with `Accept: application/vnd.allegro.public.v1+json`; `/me` also returns `login`. Verified against developer.allegro.pl ([account docs](https://developer.allegro.pl/tutorials/jak-zarzadzac-kontem-danymi-uzytkownika-ZM9YAKgPgi2), [GET /me news](https://developer.allegro.pl/news/get-me-dodalismy-informacje-o-super-sprzedawcy-nn9Y12wyesl)). No code reads it today (the connection-tester calls `/me` but ignores the body).
+- **OAuth service** (`apps/api/.../allegro-oauth.service.ts`): `storeCredentialsAndCreateConnection(tokenResponse, stateData)` branches to `reauthenticateExistingConnection` when `stateData.connectionId` is set, else creates. It owns Allegro host knowledge locally (`getApiBaseUrl`, token URL, `fetchWithTimeout`) — the wart #859 will fix.
+- **Persistence:** `Connection.config` is jsonb; the Allegro shape (`AllegroConnectionConfig`) is validated by `AllegroConnectionConfigDto` via `AllegroConnectionConfigShapeValidatorAdapter`, which runs `validate(..., { whitelist: false, forbidNonWhitelisted: false })` — **unknown fields pass**. So `ConnectionService.update({ config })` re-validating the merged blob is safe on live data → **no migration**; `sellerId` rides the jsonb.
+
+## 3. Design (decisions locked)
+
+**Plugin owns the `/me` contract; host orchestrates the check.** (Q4: architecture-correct seam, not inlined in the host wart.)
+
+1. **Plugin package** — `AllegroAccountReader.fetchSellerIdentity(baseUrl, accessToken): Promise<AllegroAccountIdentity>` (`{ sellerId, login }`). Owns `GET {baseUrl}/me` (Accept header, Bearer, `AbortController` timeout) + parses `AllegroMeResponse { id, login }`; throws on non-200 or missing `id`. `@Injectable()`, exported from the package barrel.
+2. **Host OAuth service** injects `AllegroAccountReader`. In `storeCredentialsAndCreateConnection`, after token-exchange, fetch the identity **once before branching** (Q1: a `/me` failure hard-fails the callback uniformly — recoverable, since the state isn't marked completed):
+   - **Create path:** include `sellerId` in the `config` passed to `connectionService.create` (every new connection is seller-anchored from birth).
+   - **Re-auth path:** pass the identity into `reauthenticateExistingConnection`.
+3. **`reauthenticateExistingConnection`** (check **before** any credential rotation):
+   - `stored = (existing.config as AllegroConnectionConfig).sellerId`
+   - **mismatch** (`stored && stored !== fresh.sellerId`) → `BadRequestException({ message, code: 'ALLEGRO_SELLER_MISMATCH' })` (Q2). Message built from the connection's own `name` + the **incoming** `login` (in hand from `/me`) + both ids (Q3: persist `sellerId` only; derive the message, don't cache the mutable `login`). `warn`-log `{ connectionId, connectionName, storedSellerId, incomingSellerId, incomingLogin }` (Q5). No rotation.
+   - **match or legacy-null** → rotate credentials (existing), then `update(connectionId, { status: 'active', config: { ...existing.config, sellerId: fresh.sellerId } })` (backfills legacy connections; idempotent on match). `info`-log the backfill when `stored` was null.
+
+### Data flow
+```
+callback → exchangeCodeForToken → tokenResponse
+        │  AllegroAccountReader.fetchSellerIdentity(getApiBaseUrl(env), access_token) → { sellerId, login }
+        ▼
+  storeCredentialsAndCreateConnection
+    ├── create:  connectionService.create({ config: { …, sellerId } })
+    └── re-auth: reauthenticateExistingConnection(…, identity)
+            stored vs fresh.sellerId →
+              mismatch → BadRequest ALLEGRO_SELLER_MISMATCH (no rotation, warn-log)
+              match/null → updateCredentials + update({ status:'active', config:{…,sellerId} })
+```
+
+## 4. Step-by-step
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `libs/integrations/allegro/src/domain/types/allegro-config.types.ts` | `AllegroConnectionConfig` += `sellerId?: string` |
+| 2 | `libs/integrations/allegro/src/domain/types/allegro-account.types.ts` (NEW) | `AllegroMeResponse { id: string; login: string }`, `AllegroAccountIdentity { sellerId: string; login: string }` |
+| 3 | `libs/integrations/allegro/src/infrastructure/http/allegro-account-reader.ts` (NEW) | `@Injectable() AllegroAccountReader.fetchSellerIdentity(baseUrl, accessToken)` — raw `GET /me`, Accept header, timeout, parse `{id,login}`→`{sellerId,login}`, throw on non-200/missing id |
+| 4 | allegro package barrel (`index.ts`) | export `AllegroAccountReader` + the account types |
+| 5 | `libs/integrations/allegro/src/application/dto/allegro-connection-config.dto.ts` | `+ @IsOptional() @IsString() @IsNotEmpty() sellerId?: string` |
+| 6 | `apps/api/src/integrations/application/services/allegro-oauth.service.ts` | inject `AllegroAccountReader`; fetch identity before branching; create-path config gains `sellerId`; `reauthenticateExistingConnection(+identity)` = match-check (reject + code + log) + backfill; replace the stale ASSUMPTION comment |
+| 7 | apps/api integrations module | register `AllegroAccountReader` provider so it injects into the OAuth service |
+| 8 | `allegro-account-reader.spec.ts` (NEW, package) | mock `global.fetch`: success → `{sellerId,login}`; non-200 → throws; missing `id` → throws |
+| 9 | `allegro-oauth.service.spec.ts` (apps/api) | provide a mock `AllegroAccountReader`; cover create-persists-sellerId, re-auth match, **re-auth mismatch (rejects, no rotation)**, legacy-null backfill, reader-failure aborts |
+
+## 5. Validation
+
+- **Architecture:** the new Allegro `/me` knowledge lands in the plugin (per #859's direction); host stays orchestration-only for the new bit. No core change, no migration (jsonb config; validator is non-whitelisting). Seller id/login are public — safe to store(`id`)/log.
+- **Testing:** unit-only. The reader's HTTP is unit-tested in the package (mock `fetch`); the OAuth-service logic is unit-tested against a mocked reader (no `global.fetch` stubbing in apps/api). No int-spec — the Allegro OAuth callback has no existing integration harness and the logic is fully unit-coverable.
+- **Quality gate:** `pnpm lint && pnpm type-check && pnpm test`.

--- a/libs/integrations/allegro/src/application/dto/allegro-connection-config.dto.ts
+++ b/libs/integrations/allegro/src/application/dto/allegro-connection-config.dto.ts
@@ -150,4 +150,12 @@ export class AllegroConnectionConfigDto {
   @ValidateNested()
   @Type(() => AllegroSellerDefaultsDto)
   sellerDefaults?: AllegroSellerDefaultsDto;
+
+  // Allegro seller/account id captured at OAuth completion (#820). The
+  // same-seller re-auth guard compares against it. Optional so pre-#820
+  // connections validate cleanly; backfilled on next re-auth.
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  sellerId?: string;
 }

--- a/libs/integrations/allegro/src/domain/types/allegro-account.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-account.types.ts
@@ -1,0 +1,25 @@
+/**
+ * Allegro Account Types
+ *
+ * Shapes for the authenticated-account read (`GET /me`). Used by
+ * `AllegroAccountReader` to capture the seller identity at OAuth completion so
+ * an in-place re-auth (#819) can verify it still authorizes the same seller
+ * (#820). `AllegroMeResponse` types only the fields we consume; `/me` returns
+ * more (email, company, features, …).
+ *
+ * This file contains types only (per engineering standards).
+ *
+ * @module libs/integrations/allegro/src/domain/types
+ */
+
+/** Subset of Allegro `GET /me` we read. `id` is the stable account id. */
+export interface AllegroMeResponse {
+  id: string;
+  login: string;
+}
+
+/** Neutral seller identity captured from `/me`. `sellerId` is the match key. */
+export interface AllegroAccountIdentity {
+  sellerId: string;
+  login: string;
+}

--- a/libs/integrations/allegro/src/domain/types/allegro-config.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-config.types.ts
@@ -56,6 +56,15 @@ export interface AllegroConnectionConfig {
    * creation fails fast with `SELLER_DEFAULTS_NOT_CONFIGURED` if missing.
    */
   sellerDefaults?: AllegroSellerDefaultsConfig;
+
+  /**
+   * Allegro seller/account id (`GET /me` → `id`) captured at OAuth completion.
+   * The stable anchor an in-place re-auth (#819) checks against to verify the
+   * new token authorizes the same seller (#820). Optional at the type level so
+   * connections created before #820 parse cleanly — they backfill on next
+   * re-auth.
+   */
+  sellerId?: string;
 }
 
 

--- a/libs/integrations/allegro/src/index.ts
+++ b/libs/integrations/allegro/src/index.ts
@@ -26,6 +26,7 @@ export {
 // Types
 export { AllegroConnectionConfig, AllegroEnvironment, AllegroEnvironmentValues } from './domain/types/allegro-config.types';
 export { AllegroCredentials } from './domain/types/allegro-credentials.types';
+export type { AllegroMeResponse, AllegroAccountIdentity } from './domain/types/allegro-account.types';
 export {
   PolishVoivodeshipValues,
   type PolishVoivodeship,
@@ -63,6 +64,9 @@ export { AllegroQuantityCommandRepositoryPort, AllegroQuantityCommandFilters } f
 
 // Tokens
 export { ALLEGRO_QUANTITY_COMMAND_REPOSITORY_TOKEN } from './allegro.tokens';
+
+// Account reader (#820 — seller-identity read for same-seller re-auth guard)
+export { AllegroAccountReader } from './infrastructure/http/allegro-account-reader';
 
 // Token Refresh
 export { AllegroTokenRefreshService } from './infrastructure/token-refresh/allegro-token-refresh.service';

--- a/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-account-reader.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/__tests__/allegro-account-reader.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * AllegroAccountReader unit tests (#820).
+ *
+ * Mocks global fetch to cover the `/me` happy path and the two failure modes
+ * the OAuth flow treats as fatal (non-200, missing account id).
+ */
+import { AllegroAccountReader } from '../allegro-account-reader';
+import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
+import { AllegroAuthenticationException } from '../../../domain/exceptions/allegro-authentication.exception';
+import { AllegroNetworkException } from '../../../domain/exceptions/allegro-network.exception';
+
+const BASE_URL = 'https://allegro.pl.allegrosandbox.pl';
+const TOKEN = 'access-tok';
+
+describe('AllegroAccountReader', () => {
+  let reader: AllegroAccountReader;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    reader = new AllegroAccountReader();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  function mockFetch(impl: () => Partial<Response>): jest.Mock {
+    const fn = jest.fn().mockResolvedValue(impl());
+    global.fetch = fn as unknown as typeof fetch;
+    return fn;
+  }
+
+  it('should return the seller identity from a 200 /me response', async () => {
+    const fetchMock = mockFetch(() => ({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: '12345678', login: 'my_shop' }),
+    }));
+
+    const identity = await reader.fetchSellerIdentity(BASE_URL, TOKEN);
+
+    expect(identity).toEqual({ sellerId: '12345678', login: 'my_shop' });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${BASE_URL}/me`);
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+    expect((init.headers as Record<string, string>).Accept).toBe(
+      'application/vnd.allegro.public.v1+json'
+    );
+  });
+
+  it('should fall back to the id for login when login is absent', async () => {
+    mockFetch(() => ({ ok: true, status: 200, json: () => Promise.resolve({ id: '999' }) }));
+
+    await expect(reader.fetchSellerIdentity(BASE_URL, TOKEN)).resolves.toEqual({
+      sellerId: '999',
+      login: '999',
+    });
+  });
+
+  it('should throw AllegroAuthenticationException on a 401', async () => {
+    mockFetch(() => ({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: () => Promise.resolve('{"error":"invalid_token"}'),
+    }));
+
+    await expect(reader.fetchSellerIdentity(BASE_URL, TOKEN)).rejects.toBeInstanceOf(
+      AllegroAuthenticationException
+    );
+  });
+
+  it('should throw AllegroApiException on a non-401 error response', async () => {
+    mockFetch(() => ({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: () => Promise.resolve('upstream boom'),
+    }));
+
+    await expect(reader.fetchSellerIdentity(BASE_URL, TOKEN)).rejects.toBeInstanceOf(
+      AllegroApiException
+    );
+  });
+
+  it('should throw AllegroApiException when the body carries no account id', async () => {
+    mockFetch(() => ({ ok: true, status: 200, json: () => Promise.resolve({ login: 'x' }) }));
+
+    await expect(reader.fetchSellerIdentity(BASE_URL, TOKEN)).rejects.toBeInstanceOf(
+      AllegroApiException
+    );
+  });
+
+  it('should throw AllegroNetworkException when the request fails at the network level', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new TypeError('fetch failed')) as unknown as typeof fetch;
+
+    await expect(reader.fetchSellerIdentity(BASE_URL, TOKEN)).rejects.toBeInstanceOf(
+      AllegroNetworkException
+    );
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/http/allegro-account-reader.ts
+++ b/libs/integrations/allegro/src/infrastructure/http/allegro-account-reader.ts
@@ -1,0 +1,86 @@
+/**
+ * Allegro Account Reader
+ *
+ * Reads the authenticated seller identity from Allegro `GET /me` for a raw
+ * access token (used at OAuth completion, before a connection — and therefore
+ * the per-connection `AllegroHttpClient` — exists). Owns the `/me` request
+ * contract (path, `Accept` version header) and response parsing, keeping that
+ * Allegro-API knowledge in the plugin package rather than the host (#820;
+ * the broader OAuth-surface relocation is tracked in #859).
+ *
+ * @module libs/integrations/allegro/src/infrastructure/http
+ * @see {@link AllegroMeResponse} for the consumed response shape
+ */
+import { Injectable } from '@nestjs/common';
+
+import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
+import { AllegroAuthenticationException } from '../../domain/exceptions/allegro-authentication.exception';
+import { AllegroNetworkException } from '../../domain/exceptions/allegro-network.exception';
+import type {
+  AllegroAccountIdentity,
+  AllegroMeResponse,
+} from '../../domain/types/allegro-account.types';
+
+const ME_REQUEST_TIMEOUT_MS = 10_000;
+/** Allegro requires this versioned media type on every REST call. */
+const ALLEGRO_ACCEPT_HEADER = 'application/vnd.allegro.public.v1+json';
+
+@Injectable()
+export class AllegroAccountReader {
+  /**
+   * Fetch the seller identity authorized by `accessToken`. `baseUrl` is the
+   * environment's Allegro API host (the host resolves it). Throws on a non-200
+   * response or a body without a usable account `id` — callers treat a failure
+   * as fatal to OAuth completion so a connection is never seller-anchored to an
+   * unverified account.
+   */
+  async fetchSellerIdentity(baseUrl: string, accessToken: string): Promise<AllegroAccountIdentity> {
+    const meUrl = new URL('/me', baseUrl).toString();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ME_REQUEST_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetch(meUrl, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: ALLEGRO_ACCEPT_HEADER,
+        },
+        signal: controller.signal,
+      });
+    } catch (error) {
+      // DNS / TLS / connection-refused / abort-on-timeout — transient, retryable.
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AllegroNetworkException(`Allegro GET /me request failed: ${message}`, meUrl, {
+        cause: error,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      const responseBody = await response.text().catch(() => undefined);
+      const message = `Allegro GET /me failed: ${response.status} ${response.statusText}`;
+      if (response.status === 401) {
+        throw new AllegroAuthenticationException(message, response.status, meUrl);
+      }
+      throw new AllegroApiException(message, response.status, responseBody, meUrl);
+    }
+
+    const body = (await response.json()) as Partial<AllegroMeResponse> | null;
+    if (!body || typeof body.id !== 'string' || body.id.length === 0) {
+      throw new AllegroApiException(
+        'Allegro GET /me returned no account id',
+        response.status,
+        undefined,
+        meUrl,
+      );
+    }
+
+    return {
+      sellerId: body.id,
+      login: typeof body.login === 'string' && body.login.length > 0 ? body.login : body.id,
+    };
+  }
+}


### PR DESCRIPTION
## What & why

The #819 in-place re-auth preserves a flagged Allegro connection's id (and every connection-scoped identifier mapping) while rotating OAuth credentials — but it only validated `platformType`. Re-authenticating with a **different Allegro seller** silently rebound the connection, leaving mappings keyed to the old seller's external-id space (quiet 404s on later syncs). It's admin-gated + operator-supplied creds, so a foot-gun, not a hole — this adds the guard.

## Approach

**Plugin (`libs/integrations/allegro`)** — owns the new Allegro-API knowledge:
- **`AllegroAccountReader.fetchSellerIdentity(baseUrl, accessToken)`** — owns the `GET /me` contract (path, `Accept: application/vnd.allegro.public.v1+json`, parsing) → `{ sellerId, login }`. Maps `401 → AllegroAuthenticationException`, other non-2xx / missing-id → `AllegroApiException`, network/abort → `AllegroNetworkException`.
- `AllegroConnectionConfig` + `AllegroConnectionConfigDto` gain optional `sellerId` — rides the existing jsonb config (**no migration**; the shape validator is non-whitelisting, so re-validating the merged config on backfill is safe on live data).

**Host (`apps/api`)** — orchestrates the check:
- `AllegroOAuthService` injects the reader and resolves the seller identity **once before branching**. A `/me` failure aborts completion as 500 — the callback state isn't marked completed, so the operator can retry.
- **Create path** persists `sellerId`. **Re-auth path** rejects with `BadRequestException({ code: 'ALLEGRO_SELLER_MISMATCH' })` **before** rotating credentials when the stored seller differs (message names the connection, the incoming login, and both ids), and **backfills** the verified seller for pre-#820 connections. Mismatch → `warn` log, backfill → `info` log.

The `sellerId` is the stable match key; `login` is read live from `/me` for the message (not cached — it's a mutable label).

## Decisions
- **`/me` knowledge lands in the plugin**, not the host — the architecture-correct seam. Relocating the *rest* of the Allegro OAuth surface (token exchange, env→host) behind a neutral OAuth-completion port is tracked as **#859**.
- Mismatch → **hard reject** (no confirm-flow); legacy connections → **silent backfill**. (Settled via `/grill-me`.)
- **No migration, no core change.**

## How to test
```bash
pnpm type-check && pnpm lint && pnpm test
pnpm --filter @openlinker/api test:integration -- app-boot   # DI wiring (Docker)
```
All green: type-check (11 pkgs), lint (cross-context conforms), unit — `AllegroAccountReader` 6 cases (200 / login-fallback / 401 / non-401 / missing-id / network) + `AllegroOAuthService` 5 new/updated (create-persists / re-auth match / mismatch-rejects-without-rotation / legacy backfill / reader-failure aborts); app-boot int-spec confirms the new provider resolves.

## Related
- Closes #820
- Builds on #819 / [ADR-008](../blob/main/docs/architecture/adrs/008-auth-failure-classifier-connection-reauth.md)
- Follow-up: #859 (relocate the Allegro OAuth surface into the plugin behind a neutral port)

🤖 Generated with [Claude Code](https://claude.com/claude-code)