### PR TITLE
feat(prestashop): implement OrderFulfillmentUpdater (capability B) (#858)

### DIFF
--- a/apps/api/test/integration/helpers/prestashop-fixture.helper.ts
+++ b/apps/api/test/integration/helpers/prestashop-fixture.helper.ts
@@ -52,6 +52,7 @@ const WS_RESOURCES = [
   'carts',
   'orders',
   'order_carriers',
+  'order_histories', // #858: OrderFulfillmentUpdater POSTs order_histories to advance state
   'order_states',
   'customers',
   'addresses',

--- a/apps/api/test/integration/prestashop/prestashop-order-fulfillment-update.int-spec.ts
+++ b/apps/api/test/integration/prestashop/prestashop-order-fulfillment-update.int-spec.ts
@@ -1,0 +1,335 @@
+/**
+ * PrestaShop Order Fulfillment Update Int-Spec (#858 — capability B)
+ *
+ * Verifies `PrestashopOrderProcessorManagerAdapter.updateFulfillment` against a
+ * real PrestaShop Testcontainer: the state transition must go through the
+ * PS-intended `POST /order_histories` primitive (so `current_state` advances)
+ * and tracking must land on the `order_carriers` association.
+ *
+ * Module-free by design (`installOlModule: false`): `updateFulfillment` does
+ * not touch the OL Dynamic carrier sidecar, so this spec avoids the CI-flaky
+ * module-install path (#716) and runs on CI like `prestashop-harness-smoke`.
+ * An order is still needed to transition; it is created module-free via the
+ * `OrderIngestionService` ingest path with a `defaultCarrierId` on the PS
+ * connection (carrier-resolution chain step 2 — no sidecar write), mirroring
+ * S-2 of `allegro-prestashop-carrier-mapping.int-spec.ts`.
+ *
+ * Asserts: a new `order_histories` row at the shipped state id, `current_state`
+ * advanced to 4, `order_carriers.tracking_number` set, and idempotency (a
+ * second call adds no further history row and leaves tracking unchanged).
+ *
+ * NOT asserted — accepted gap (#858 Q6): actual buyer-email *delivery*. That's
+ * PrestaShop's own contract behind `sendmail=1` (which OL's unit spec proves we
+ * request); verifying delivery needs an SMTP catcher, disproportionate here.
+ * The `current_state` advance below is also the design's proof that a WS
+ * `order_histories` POST actually transitions state on PS 9.0.2 — and that the
+ * `sendmail=1` flag does NOT 500 the POST when the container has no SMTP
+ * transport (PS attempts the mail, fails silently, and the state still lands).
+ *
+ * @module apps/api/test/integration/prestashop
+ */
+import { randomUUID } from 'crypto';
+import {
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  IIdentifierMappingService,
+} from '@openlinker/core/identifier-mapping';
+import { INTEGRATIONS_SERVICE_TOKEN, IIntegrationsService } from '@openlinker/core/integrations';
+import {
+  ORDER_INGESTION_SERVICE_TOKEN,
+  IOrderIngestionService,
+  OrderProcessorManagerPort,
+  isOrderFulfillmentUpdater,
+} from '@openlinker/core/orders';
+import { ProductOrmEntity, ProductVariantOrmEntity } from '@openlinker/core/products/orm-entities';
+import { getTestHarness, IntegrationTestHarness } from '../setup';
+import {
+  PrestashopTestContainer,
+  startPrestashopContainer,
+} from '../helpers/prestashop-container.helper';
+import {
+  DefaultPrestashopCarriers,
+  getDefaultPsCarriers,
+  seedPrestashopProductForOrders,
+} from '../helpers/prestashop-fixture.helper';
+import {
+  AllegroTestSourceStub,
+  installAllegroTestSourceStub,
+} from '../helpers/allegro-test-source-stub.helper';
+import {
+  createTestAllegroSourceConnection,
+  createTestPrestashopDestinationConnection,
+} from '../helpers/test-connection.helper';
+import { createIncomingOrderForCarrierMapping } from '../fixtures/incoming-order.fixtures';
+
+const SHIPPED_STATE_ID = 4;
+const TRACKING_NUMBER = 'TRACK-INT-858';
+
+interface PsOrderRow {
+  id: string | number;
+  current_state: string | number;
+}
+interface PsOrderHistoryRow {
+  id: string | number;
+  id_order: string | number;
+  id_order_state: string | number;
+}
+interface PsOrderCarrierRow {
+  id: string | number;
+  id_order: string | number;
+  tracking_number?: string;
+}
+
+function basicAuthHeader(apiKey: string): string {
+  return `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}`;
+}
+
+/** GET a single PS resource and unwrap its singular envelope. */
+async function fetchPsOrder(ps: PrestashopTestContainer, idOrder: number): Promise<PsOrderRow> {
+  const response = await fetch(`${ps.baseUrl}/api/orders/${idOrder}?output_format=JSON`, {
+    headers: { Authorization: basicAuthHeader(ps.webserviceApiKey) },
+  });
+  if (!response.ok) {
+    throw new Error(`PS WS GET /api/orders/${idOrder} failed: ${response.status}`);
+  }
+  const json = (await response.json()) as { order?: PsOrderRow };
+  if (!json.order) {
+    throw new Error(`PS WS GET /api/orders/${idOrder} returned no 'order' envelope`);
+  }
+  return json.order;
+}
+
+/** GET a list resource filtered by `id_order`, normalised to an array. */
+async function fetchPsListByOrder<T>(
+  ps: PrestashopTestContainer,
+  resource: 'order_histories' | 'order_carriers',
+  idOrder: number
+): Promise<T[]> {
+  const url =
+    `${ps.baseUrl}/api/${resource}?output_format=JSON&display=full&filter[id_order]=${idOrder}`;
+  const response = await fetch(url, {
+    headers: { Authorization: basicAuthHeader(ps.webserviceApiKey) },
+  });
+  if (!response.ok) {
+    throw new Error(`PS WS GET /api/${resource} (id_order=${idOrder}) failed: ${response.status}`);
+  }
+  const json = (await response.json()) as Record<string, unknown>;
+  const data = json[resource];
+  if (Array.isArray(data)) return data as T[];
+  return data ? [data as T] : [];
+}
+
+/** Walk identifier_mappings to get the PS-side numeric order id from the OL id. */
+async function resolveDestinationOrderId(
+  harness: IntegrationTestHarness,
+  internalOrderId: string,
+  destinationConnectionId: string
+): Promise<number> {
+  const identifierMapping = harness
+    .getApp()
+    .get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);
+  const externals = await identifierMapping.getExternalIds('Order', internalOrderId);
+  const match = externals.find((m) => m.connectionId === destinationConnectionId);
+  if (!match) {
+    throw new Error(
+      `No PS-side mapping for OL order ${internalOrderId} on ${destinationConnectionId}: ${JSON.stringify(externals)}`
+    );
+  }
+  const parsed = Number(match.externalId);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`PS-side order id not a positive integer: '${match.externalId}'`);
+  }
+  return parsed;
+}
+
+/**
+ * Seed one orderable PS product + the OL Product/ProductVariant rows + the two
+ * identifier_mappings (source Offer mapping + destination Product mapping) the
+ * ingest path needs. Mirrors `seedScenario` in the carrier-mapping spec.
+ */
+async function seedOrderableProduct(opts: {
+  harness: IntegrationTestHarness;
+  psMysqlAddress: Parameters<typeof seedPrestashopProductForOrders>[0];
+  externalOfferId: string;
+  psReference: string;
+  psName: string;
+  allegroConnectionId: string;
+  prestashopConnectionId: string;
+}): Promise<void> {
+  const psProduct = await seedPrestashopProductForOrders(opts.psMysqlAddress, {
+    reference: opts.psReference,
+    name: opts.psName,
+  });
+
+  const dataSource = opts.harness.getDataSource();
+  const identifierMapping = opts.harness
+    .getApp()
+    .get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);
+
+  const internalProductId = await identifierMapping.getOrCreateInternalId(
+    'Product',
+    String(psProduct.idProduct),
+    opts.prestashopConnectionId
+  );
+  const internalVariantId = `ol_variant_${randomUUID().replace(/-/g, '')}`;
+
+  await identifierMapping.createMapping(
+    'Offer',
+    opts.externalOfferId,
+    opts.allegroConnectionId,
+    internalVariantId
+  );
+
+  const productRepo = dataSource.getRepository(ProductOrmEntity);
+  await productRepo.save(
+    productRepo.create({
+      id: internalProductId,
+      name: opts.psName,
+      sku: opts.psReference,
+      price: 100.0,
+      currency: 'PLN',
+    })
+  );
+  const variantRepo = dataSource.getRepository(ProductVariantOrmEntity);
+  await variantRepo.save(
+    variantRepo.create({
+      id: internalVariantId,
+      productId: internalProductId,
+      sku: opts.psReference,
+    })
+  );
+}
+
+describe('PrestaShop order fulfillment update (#858)', () => {
+  let harness: IntegrationTestHarness;
+  let ps: PrestashopTestContainer;
+  let stub: AllegroTestSourceStub;
+  let allegroConnectionId: string;
+  let prestashopConnectionId: string;
+  let defaultCarriers: DefaultPrestashopCarriers;
+  let psOrderId: number;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    // Module-free: updateFulfillment never touches the OL sidecar, so we skip
+    // the CI-flaky module install. The OL Dynamic carrier stub row is still
+    // seeded by applyPrestashopFixture, so discoverDynamicCarrierId() passes.
+    ps = await startPrestashopContainer({ installOlModule: false });
+    defaultCarriers = await getDefaultPsCarriers(ps.mysqlAddress);
+
+    stub = installAllegroTestSourceStub(harness);
+    const allegro = await createTestAllegroSourceConnection(harness.getDataSource(), {
+      adapterKey: stub.adapterKey,
+      platformType: stub.platformType,
+    });
+    allegroConnectionId = allegro.id;
+
+    const prestashop = await createTestPrestashopDestinationConnection(harness.getDataSource(), {
+      baseUrl: ps.baseUrl,
+      webserviceApiKey: ps.webserviceApiKey,
+      // defaultCarrierId → carrier-resolution chain step 2, no OL sidecar write.
+      defaultCarrierId: defaultCarriers.myCheapCarrier.idCarrier,
+    });
+    prestashopConnectionId = prestashop.id;
+
+    await seedOrderableProduct({
+      harness,
+      psMysqlAddress: ps.mysqlAddress,
+      externalOfferId: 'ALG-OFFER-858',
+      psReference: 'SEEDED-SKU-858',
+      psName: 'Fulfillment-update product',
+      allegroConnectionId,
+      prestashopConnectionId,
+    });
+
+    // Create the order to transition (module-free ingest path).
+    stub.setNextIncomingOrder(
+      createIncomingOrderForCarrierMapping({
+        externalOrderId: 'ALG-858',
+        methodId: 'paczkomat-858',
+        externalOfferId: 'ALG-OFFER-858',
+        sku: 'SEEDED-SKU-858',
+      })
+    );
+    const ingestion = harness.getApp().get<IOrderIngestionService>(ORDER_INGESTION_SERVICE_TOKEN);
+    const results = await ingestion.syncOrderFromSource(allegroConnectionId, 'ALG-858');
+    if (results[0]?.status !== 'success') {
+      throw new Error(
+        `Order seed failed: ${results[0] ? results[0].error.message : 'no result'}`
+      );
+    }
+    psOrderId = await resolveDestinationOrderId(
+      harness,
+      results[0].orderRef.orderId,
+      prestashopConnectionId
+    );
+  }, 15 * 60_000);
+
+  afterAll(async () => {
+    if (ps) {
+      await ps.cleanup();
+    }
+  });
+
+  it('should transition state via order_histories + write tracking, idempotently', async () => {
+    const integrations = harness
+      .getApp()
+      .get<IIntegrationsService>(INTEGRATIONS_SERVICE_TOKEN);
+    const adapter = await integrations.getCapabilityAdapter<OrderProcessorManagerPort>(
+      prestashopConnectionId,
+      'OrderProcessorManager'
+    );
+    if (!isOrderFulfillmentUpdater(adapter)) {
+      throw new Error('PrestaShop adapter does not implement OrderFulfillmentUpdater');
+    }
+
+    // Sanity: the seeded order is not already shipped.
+    const before = await fetchPsOrder(ps, psOrderId);
+    expect(Number(before.current_state)).not.toBe(SHIPPED_STATE_ID);
+
+    // First update — transition + tracking.
+    await adapter.updateFulfillment({
+      externalOrderId: String(psOrderId),
+      status: 'shipped',
+      trackingNumber: TRACKING_NUMBER,
+    });
+
+    const after = await fetchPsOrder(ps, psOrderId);
+    expect(Number(after.current_state)).toBe(SHIPPED_STATE_ID);
+
+    const historiesAfterFirst = await fetchPsListByOrder<PsOrderHistoryRow>(
+      ps,
+      'order_histories',
+      psOrderId
+    );
+    const shippedHistories = historiesAfterFirst.filter(
+      (h) => Number(h.id_order_state) === SHIPPED_STATE_ID
+    );
+    expect(shippedHistories.length).toBe(1); // proves the transition went via order_histories
+
+    const carriers = await fetchPsListByOrder<PsOrderCarrierRow>(ps, 'order_carriers', psOrderId);
+    expect(carriers.length).toBeGreaterThan(0);
+    expect(carriers[0].tracking_number).toBe(TRACKING_NUMBER);
+
+    // Second update — idempotent: no new shipped history row, tracking unchanged.
+    await adapter.updateFulfillment({
+      externalOrderId: String(psOrderId),
+      status: 'shipped',
+      trackingNumber: TRACKING_NUMBER,
+    });
+
+    const historiesAfterSecond = await fetchPsListByOrder<PsOrderHistoryRow>(
+      ps,
+      'order_histories',
+      psOrderId
+    );
+    expect(
+      historiesAfterSecond.filter((h) => Number(h.id_order_state) === SHIPPED_STATE_ID).length
+    ).toBe(1);
+    const carriersAfter = await fetchPsListByOrder<PsOrderCarrierRow>(
+      ps,
+      'order_carriers',
+      psOrderId
+    );
+    expect(carriersAfter[0].tracking_number).toBe(TRACKING_NUMBER);
+  });
+});

--- a/docs/plans/implementation-plan-prestashop-order-fulfillment-updater.md
+++ b/docs/plans/implementation-plan-prestashop-order-fulfillment-updater.md
@@ -1,0 +1,132 @@
+# Implementation Plan — #858 PrestaShop `OrderFulfillmentUpdater` (capability B)
+
+**Issue:** [#858](https://github.com/openlinker-project/openlinker/issues/858) (follow-up of #837 / E3 of #732)
+**Branch:** `858-prestashop-order-fulfillment-updater`
+**Layer:** Integration (PrestaShop adapter) + a one-method mapper-interface widening. **No CORE change, no migration, no manifest change.**
+
+> #837 shipped the `OrderFulfillmentUpdater` port + the `ShipmentDispatchNotificationService` orchestration. The destination half degrades to `destinations[].status='unsupported'` because no adapter implements B. This issue implements it for PrestaShop — once it lands the orchestration drives it automatically (the guard `isOrderFulfillmentUpdater` starts returning true).
+
+---
+
+## 1. Goal & scope
+
+Implement `updateFulfillment({ externalOrderId, status, trackingNumber? })` on `PrestashopOrderProcessorManagerAdapter` (declare `implements OrderProcessorManagerPort, DestinationOptionsReader, OrderFulfillmentUpdater`).
+
+**In scope:** the adapter method (tracking write + state transition + the buyer "shipped" email via `sendmail=1` + idempotency), a typed `sendEmail` write-option on the WS client, exposing a compile-time-exhaustive status→PS-state-id mapping on the mapper interface, the PS test WS-key grant for `order_histories`/`order_carriers`, a unit spec (request-shape + ordering matrix), and a module-free PS-Testcontainer int-spec (real state + tracking).
+
+> **Design settled via a full `/grill-me` + repeated `/tech-review`.** See §6 Decision log (Q1–Q6). Two follow-ups filed: **#861** (durable per-destination notify-state / idempotency source-of-truth) and **#862** (operator-configurable OL→PS order-state mapping).
+
+**Out of scope / deferred:**
+- Branch-3 (Allegro Delivery) backfilled-tracking → OMP propagation — **#838** (reuses this same method).
+- Asserting actual email **delivery** — PS's own contract behind `sendmail`; needs an SMTP catcher (disproportionate). OL's contribution (sending `sendmail=1`) is unit-covered; the container asserts `order_histories` row + `current_state` advance + tracking. Documented accepted gap (Q6). **Re-open trigger:** if field reports show shipped emails not firing, add a MailHog assertion then.
+- Durable notify-state / retry-to-convergence (**#861**) and configurable OL→PS state mapping (**#862**) — own slices.
+- Any change to `createOrder` semantics, the orchestration, or the capability port.
+
+---
+
+## 2. Research findings (verified against the branch)
+
+- **Adapter:** `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts` — `class PrestashopOrderProcessorManagerAdapter implements OrderProcessorManagerPort, DestinationOptionsReader`. Constructor injects `IPrestashopWebserviceClient httpClient`, `IdentifierMappingPort`, `IPrestashopOrderMapper orderMapper`, `Connection`, provisioners, `IPrestashopOpenLinkerModuleClient`, optional `IMappingConfigService`.
+- **WS client** (`IPrestashopWebserviceClient`): `getResource(resource, id)`, `listResources(resource, filters?, limit?, offset?)`, `createResource(resource, data)` → POST `/api/{resource}`, `updateResource(resource, id, data)` → PUT `/api/{resource}/{id}` (**full-replace** — must send the whole resource body incl. `id`). `listResources` supports `{ custom: { <field>: <value> } }` → `filter[field]=[value]`.
+- **`order_histories` is the PS-intended state-transition primitive.** No existing code touches it. `createResource('order_histories', { id_order, id_order_state })` is a POST that creates an `OrderHistory` row → PS changes the order's `current_state` and fires the state-machine side-effects (buyer email, stock, invoice). This is **the** reason #858 forbids the `orders` full-replace.
+- **`order_carriers`** holds `tracking_number` (`PrestashopOrderCarrier` in `prestashop.mapper.interface.ts:112` — `{ id, id_order, id_carrier, tracking_number?, … }`). The WS-client spec already exercises `updateResource('order_carriers', id, {...})`.
+- **Status mapping:** `prestashop-order.mapper.ts:418` `private mapOrderStatusToPrestashop(status): number` (`shipped → 4`, `delivered → 5`, …), used by `mapOrderCreate`. It is **private** — needs exposing on `IPrestashopOrderMapper` to reuse from the adapter (single-source the mapping).
+- **Capability B** is exported from `@openlinker/core/orders`: `OrderFulfillmentUpdater` + `isOrderFulfillmentUpdater`; `updateFulfillment(input: { externalOrderId: string; status: OrderStatus; trackingNumber?: string }): Promise<void>`.
+- **PS-Testcontainer harness:** `apps/api/test/integration/helpers/prestashop-container.helper.ts` → `startPrestashopContainer({ installOlModule? })` returns `{ baseUrl, webserviceApiKey, olDynamicCarrierId, plnCurrencyId, mysqlAddress, cleanup }`. The **OL-module install** is the CI-flaky path (#716) — this feature does NOT need it, so the spec runs with `installOlModule: false`.
+- Existing PS-container specs: `orders/allegro-prestashop-carrier-mapping.int-spec.ts` (full ingest→order create), `orders/prestashop-harness-smoke.int-spec.ts`, `prestashop/prestashop-webhook-provisioning.int-spec.ts`.
+
+---
+
+## 3. Design
+
+### 3.1 Mapper — single-sourced + compile-time-exhaustive (Q5)
+Expose `mapStatusToPrestashopStateId(status: OrderStatus): number` on `IPrestashopOrderMapper`; make the impl public and **switch on the typed `OrderStatus`** (drop `.toLowerCase()`) with a `never` exhaustiveness guard in `default` that throws. Adding an `OrderStatus` member without mapping it becomes a **compile error**, not a silent default-to-`pending` (which on the projection path, with `sendmail`, would mis-transition + mis-email). `mapOrderCreate` reuses the same method. The state-ids assume a **default PS install** (`shipped→4`, …) — this is the **fallback tier** of the operator-configurable resolution chain tracked in **#862**. The exhaustive-throw is behaviour-preserving: a grep confirms the only callers are `mapOrderCreate` + `updateFulfillment`, both passing a typed `OrderStatus`, so `default` was already unreachable.
+
+### 3.2 WS-client `sendEmail` write-option (Q3 — option A′)
+Add a typed `PrestashopWriteOptions { sendEmail?: boolean }` to `createResource`/`updateResource` on `IPrestashopWebserviceClient`; the client maps `sendEmail:true` → append `?sendmail=1` to the write URL. PS-WS-protocol knowledge (the wire param) stays **in the PS-WS client**; the adapter expresses **intent** (`{ sendEmail: true }`). Opt-in per call — never a client default, so non-order writes never email. (Rejected: raw `{ query }` bag — leaks wire detail to the adapter + untyped junk-drawer on a shared client.)
+
+### 3.3 `updateFulfillment` (adapter) — idempotent projector (Q1/Q2/Q4)
+```
+updateFulfillment({ externalOrderId, status, trackingNumber? }):
+  order = getResource('orders', externalOrderId)            // throws if gone
+  targetStateId = mapper.mapStatusToPrestashopStateId(status)
+
+  // B. Tracking FIRST (when supplied) — so the state-email renders the link,
+  //    and a failure here aborts before the irreversible email.
+  if trackingNumber: writeTracking(externalOrderId, trackingNumber)
+
+  // A. State transition LAST — the single irreversible side-effect.
+  if Number(order.current_state) !== targetStateId:
+    createResource('order_histories',
+                   { id_order: externalOrderId, id_order_state: targetStateId },
+                   { sendEmail: true })                      // → ?sendmail=1 (buyer email)
+  // else already in target → skip (idempotent; no duplicate "shipped" email)
+  // any WS failure → throw PrestashopApiException (no compensation)
+
+writeTracking(externalOrderId, trackingNumber):
+  rows = listResources('order_carriers', { custom: { id_order: externalOrderId } })
+  if rows empty: warn + skip (do NOT fabricate a PS-managed row)
+  row = max-by(id)(rows)                                     // PS "current" carrier = highest id
+  if row.tracking_number === trackingNumber: return          // idempotent no-op
+  updateResource('order_carriers', row.id, { ...row, tracking_number: trackingNumber })  // full-replace
+```
+
+### 3.4 Contract — the load-bearing semantics (Q1/Q4)
+- **Idempotent desired-state projector, NOT a state machine.** Projects the supplied status; does not enforce PS lifecycle ordering — monotonicity/legality is the domain's concern (**#861/#827**). The `current_state === target → skip` guard's real job is **duplicate-email prevention** (PS doesn't dedupe `order_histories`).
+- **Irreversible side-effect last.** The buyer email (the one un-recallable effect) fires only after tracking is confirmed (tracking-first). Any failure before it leaves a clean, retriable state — no tracking-less email ever sent.
+- **Non-atomic + forward-recoverable.** Two non-transactional WS writes; on partial failure we **throw** (→ per-destination `'failed'` in the orchestration) and do **not** compensate. Convergence (re-drive until reflected) is the notify-state layer's job (**#861**), not this adapter's.
+- **No identifier-mapping call** — `externalOrderId` is the PS order id, resolved upstream by the orchestration.
+
+### 3.5 WS-key requirement (finding)
+`updateFulfillment` writes `order_histories` + `order_carriers`. The connection's WS key **must grant those resources** or PS returns `401 Invalid API key for <resource>`. Add both to the PS **test WS-key fixture** (`applyPrestashopFixture`) and **document the operator requirement** (a PS connection's WS key needs `order_histories`/`order_carriers` CRUD).
+
+### 3.6 Files
+```
+libs/integrations/prestashop/src/infrastructure/
+  http/prestashop-webservice.client.interface.ts   (+ PrestashopWriteOptions; createResource/updateResource opts)
+  http/prestashop-webservice.client.ts             (+ sendEmail → ?sendmail=1; reuse singularizeResource)
+  mappers/prestashop.mapper.interface.ts           (+ mapStatusToPrestashopStateId on IPrestashopOrderMapper)
+  mappers/prestashop-order.mapper.ts               (public + exhaustive switch)
+  adapters/prestashop-order-processor-manager.adapter.ts        (+ implements OrderFulfillmentUpdater; updateFulfillment + writeTracking)
+  adapters/__tests__/...adapter.spec.ts            (updateFulfillment matrix incl. sendEmail + ordering + max-id + warn-skip)
+apps/api/test/integration/
+  helpers/prestashop-fixture.helper.ts             (WS-key grant: order_histories + order_carriers)
+  prestashop/prestashop-order-fulfillment-update.int-spec.ts    (PS container, installOlModule:false)
+```
+**Migration: none.**
+
+---
+
+## 4. Step-by-step
+
+1. **WS client (Q3/A′)** — `PrestashopWriteOptions { sendEmail? }` on the interface + impl; map → `?sendmail=1`. *AC:* WS-client unit asserts **both** `sendEmail:true` → URL contains `?sendmail=1` **and** `sendEmail` absent → no `sendmail` param (catches an always-append regression); existing PS write specs green.
+2. **Mapper (Q5)** — expose `mapStatusToPrestashopStateId` on the interface; public + exhaustive `never`-guarded switch; `mapOrderCreate` reuses it. *AC:* type-check; mapper/adapter specs green.
+3. **Adapter (Q1/Q2/Q4)** — `implements … OrderFulfillmentUpdater`; `updateFulfillment` (tracking-first, `sendEmail:true`, throw/no-compensate) + `writeTracking` (max-id, warn-skip, no fabricate). *AC:* `isOrderFulfillmentUpdater(adapter) === true`.
+4. **Unit spec (Q6)** — sendmail option requested; **call ordering** (tracking before `order_histories`); skip-when-in-state; max-id row; warn-skip when no row; tracking-unchanged skip; state-only when no tracking; WS-error wrap.
+5. **WS-key fixture grant** — add `order_histories` + `order_carriers` to the PS WS-key fixture (fixes the 401).
+6. **Integration spec (Q6)** — PS container (`installOlModule:false`); create the order via the ingest path with a `defaultCarrierId` (no OL module — relies on `applyPrestashopFixture` always seeding the OL Dynamic carrier **stub** row so `discoverDynamicCarrierId()`, always called in `createOrder`, passes); call `updateFulfillment`; assert `current_state===4` + a new `order_histories` row + `order_carriers` tracking; re-invoke → idempotency. Header documents the email-delivery gap.
+7. **Quality gate** — `pnpm lint && type-check && test`; `pnpm test:integration` (new spec + full suite — #833 lesson); `migration:show` (none).
+
+> **Gating AC (the load-bearing proof):** #858 is *not done* until the container probe is green on `current_state===4` + the new `order_histories` row. That green run is simultaneously the design's proof that WS `order_histories` advances state on PS 9.0.2. If it comes back negative after the WS-key grant, **stop and escalate** per §5 (module-side endpoint) — never the `orders` full-replace.
+
+---
+
+## 5. Validation
+- **Architecture:** Integration-only; reuses the existing port/guard; status mapping single-sourced in the mapper; the WS-client widening keeps PS-WS-protocol knowledge in the PS-WS client (no order-domain leak). Domain/core untouched.
+- **Confidence boundary (Q6):** unit proves OL-owned logic (sendmail requested, ordering, wire-map); container proves PS-behavior OL depends on (state advances via `order_histories`, tracking lands, idempotency); email **delivery** is PS's contract behind `sendmail` — documented accepted gap (SMTP catcher disproportionate).
+- **`POST order_histories` probe (resolved approach):** the container spec is the proof PS 9.0.2 advances `current_state` from a WS `order_histories` POST. If it does **not**, escalate (module-side endpoint) — **never** the forbidden `orders` full-replace.
+- **Security:** no secrets; WS auth via the connection's stored credentials. `sendmail` is opt-in per call (no accidental emails on other writes).
+
+---
+
+## 6. Decision log (full `/grill-me` + `/tech-review`)
+| # | Decision | Why |
+|---|---|---|
+| Q1 | Idempotent **projector**, non-monotonic; **tracking-first** (irreversible email last) | adapter projects desired state; lifecycle/legality is the domain's (#861/#827); the skip-if-in-state guard = duplicate-email prevention |
+| Q2 | `order_carriers`: **max-id** row (PS "current" carrier), **warn-skip don't fabricate** | `rows[0]` trusts unspecified WS order; fabricating a PS-managed row violates the projector principle |
+| Q3 | **A′** — typed `{ sendEmail }` write-option; client maps → `?sendmail=1` | PS-WS-protocol (wire param) belongs in the PS-WS client; adapter expresses intent; avoids untyped query junk-drawer |
+| Q4 | **Non-atomic, throw, no compensation**, irreversible-last; convergence = re-drive (#861) | correctness = convergence over idempotent re-drives, not per-call atomicity; rollback adds failure modes without buying correctness |
+| Q5 | Mapper is the home; **compile-time-exhaustive** switch; accept+document default-install ids | single-source the table; extending `OrderStatus` must be a compile error, not a silent mis-transition; configurable mapping is #862 |
+| Q6 | Unit = param+ordering+wire-map; container = state+tracking+idempotency; **email delivery = documented gap** | test what OL owns at the cheapest layer; PS's own side-effect (behind a flag we set) isn't worth an SMTP-catcher harness |
+
+**Follow-ups filed:** **#861** (durable per-destination notify-state / idempotency source-of-truth — the per-target retry model #837 deferred), **#862** (operator-configurable OL→PS order-state resolution chain — the override tier in front of this default mapper).

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.adapter.spec.ts
@@ -1605,4 +1605,199 @@ describe('PrestashopOrderProcessorManagerAdapter', () => {
       });
     });
   });
+
+  describe('updateFulfillment (#858)', () => {
+    const PS_ORDER_ID = '5001';
+    const SHIPPED_STATE_ID = 4;
+
+    beforeEach(() => {
+      mockOrderMapper.mapStatusToPrestashopStateId = jest.fn().mockReturnValue(SHIPPED_STATE_ID);
+    });
+
+    it('should transition state via POST order_histories with sendmail when not in the target state', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '2', id_carrier: 7 });
+
+      await adapter.updateFulfillment({ externalOrderId: PS_ORDER_ID, status: 'shipped' });
+
+      expect(mockOrderMapper.mapStatusToPrestashopStateId).toHaveBeenCalledWith('shipped');
+      // sendmail=1 (the buyer "shipped" email) is requested via the typed option.
+      expect(mockHttpClient.createResource).toHaveBeenCalledWith(
+        'order_histories',
+        { id_order: PS_ORDER_ID, id_order_state: SHIPPED_STATE_ID },
+        { sendEmail: true }
+      );
+    });
+
+    it('should skip the order_histories POST when already in the target state (idempotent)', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '4', id_carrier: 7 });
+
+      await adapter.updateFulfillment({ externalOrderId: PS_ORDER_ID, status: 'shipped' });
+
+      // No order_histories POST at all (covers both the 3-arg and a future 2-arg shape).
+      expect(mockHttpClient.createResource).not.toHaveBeenCalledWith(
+        'order_histories',
+        expect.anything()
+      );
+      expect(mockHttpClient.createResource).not.toHaveBeenCalledWith(
+        'order_histories',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('should write tracking BEFORE transitioning state (irreversible email last)', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '2', id_carrier: 7 });
+      mockHttpClient.listResources = jest
+        .fn()
+        .mockImplementation((resource: string) =>
+          resource === 'order_carriers'
+            ? Promise.resolve([
+                { id: '900', id_order: PS_ORDER_ID, id_carrier: 7, tracking_number: '' },
+              ])
+            : Promise.resolve([])
+        );
+
+      await adapter.updateFulfillment({
+        externalOrderId: PS_ORDER_ID,
+        status: 'shipped',
+        trackingNumber: 'TRACK-9',
+      });
+
+      // Tracking (updateResource on order_carriers) must precede the
+      // order_histories POST, so the shipped email renders the tracking link.
+      const trackingOrder = mockHttpClient.updateResource.mock.invocationCallOrder[0];
+      const historyOrder = mockHttpClient.createResource.mock.invocationCallOrder[0];
+      expect(trackingOrder).toBeLessThan(historyOrder);
+    });
+
+    it('should write tracking by full-replacing the existing order_carriers row', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '4', id_carrier: 7 });
+      const carrierRow = {
+        id: '900',
+        id_order: PS_ORDER_ID,
+        id_carrier: 7,
+        weight: '1.2',
+        tracking_number: '',
+      };
+      mockHttpClient.listResources = jest
+        .fn()
+        .mockImplementation((resource: string) =>
+          resource === 'order_carriers' ? Promise.resolve([carrierRow]) : Promise.resolve([])
+        );
+
+      await adapter.updateFulfillment({
+        externalOrderId: PS_ORDER_ID,
+        status: 'shipped',
+        trackingNumber: 'TRACK-9',
+      });
+
+      expect(mockHttpClient.updateResource).toHaveBeenCalledWith('order_carriers', '900', {
+        ...carrierRow,
+        tracking_number: 'TRACK-9',
+      });
+    });
+
+    it('should write tracking to the max-id order_carriers row when several exist (re-ship)', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '4', id_carrier: 7 });
+      mockHttpClient.listResources = jest
+        .fn()
+        .mockImplementation((resource: string) =>
+          resource === 'order_carriers'
+            ? Promise.resolve([
+                { id: '900', id_order: PS_ORDER_ID, id_carrier: 7, tracking_number: '' },
+                { id: '905', id_order: PS_ORDER_ID, id_carrier: 9, tracking_number: '' },
+              ])
+            : Promise.resolve([])
+        );
+
+      await adapter.updateFulfillment({
+        externalOrderId: PS_ORDER_ID,
+        status: 'shipped',
+        trackingNumber: 'TRACK-9',
+      });
+
+      // The current carrier is the highest id (905), not rows[0] (900).
+      expect(mockHttpClient.updateResource).toHaveBeenCalledWith(
+        'order_carriers',
+        '905',
+        expect.objectContaining({ tracking_number: 'TRACK-9' })
+      );
+    });
+
+    it('should warn and skip (not fabricate) when no order_carriers row exists', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '4', id_carrier: 7 });
+      mockHttpClient.listResources = jest.fn().mockResolvedValue([]);
+
+      await adapter.updateFulfillment({
+        externalOrderId: PS_ORDER_ID,
+        status: 'shipped',
+        trackingNumber: 'TRACK-9',
+      });
+
+      // No fabrication: neither a PUT nor a POST to order_carriers.
+      expect(mockHttpClient.updateResource).not.toHaveBeenCalled();
+      expect(mockHttpClient.createResource).not.toHaveBeenCalledWith(
+        'order_carriers',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('should skip the tracking write when the value is unchanged (idempotent)', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '4', id_carrier: 7 });
+      mockHttpClient.listResources = jest
+        .fn()
+        .mockImplementation((resource: string) =>
+          resource === 'order_carriers'
+            ? Promise.resolve([
+                { id: '900', id_order: PS_ORDER_ID, id_carrier: 7, tracking_number: 'TRACK-9' },
+              ])
+            : Promise.resolve([])
+        );
+
+      await adapter.updateFulfillment({
+        externalOrderId: PS_ORDER_ID,
+        status: 'shipped',
+        trackingNumber: 'TRACK-9',
+      });
+
+      expect(mockHttpClient.updateResource).not.toHaveBeenCalled();
+    });
+
+    it('should not touch order_carriers when no trackingNumber is supplied', async () => {
+      mockHttpClient.getResource = jest
+        .fn()
+        .mockResolvedValue({ id: PS_ORDER_ID, current_state: '2', id_carrier: 7 });
+
+      await adapter.updateFulfillment({ externalOrderId: PS_ORDER_ID, status: 'shipped' });
+
+      expect(mockHttpClient.listResources).not.toHaveBeenCalledWith(
+        'order_carriers',
+        expect.anything()
+      );
+      expect(mockHttpClient.updateResource).not.toHaveBeenCalled();
+    });
+
+    it('should wrap a WebService failure in PrestashopApiException', async () => {
+      mockHttpClient.getResource = jest.fn().mockRejectedValue(new Error('WS 500'));
+
+      await expect(
+        adapter.updateFulfillment({ externalOrderId: PS_ORDER_ID, status: 'shipped' })
+      ).rejects.toBeInstanceOf(PrestashopApiException);
+    });
+  });
 });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -14,7 +14,12 @@
  * @implements {OrderProcessorManagerPort}
  */
 import type { OrderProcessorManagerPort, OrderCreate, OrderRef } from '@openlinker/core/orders';
-import type { DestinationOptionsReader, MappingOption } from '@openlinker/core/orders';
+import type {
+  DestinationOptionsReader,
+  OrderFulfillmentUpdater,
+  OrderStatus,
+  MappingOption,
+} from '@openlinker/core/orders';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { MappingAlreadyExistsError, DuplicateIdentifierMappingError, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IMappingConfigService } from '@openlinker/core/mappings';
@@ -23,6 +28,7 @@ import type { IPrestashopOpenLinkerModuleClient } from '../http/prestashop-openl
 import type {
   IPrestashopOrderMapper,
   PrestashopOrder,
+  PrestashopOrderCarrier,
 } from '../mappers/prestashop.mapper.interface';
 import type {
   PrestashopCarrier,
@@ -60,7 +66,7 @@ interface PrestashopCarrierRow {
  * Handles order creation in PrestaShop via WebService API.
  */
 export class PrestashopOrderProcessorManagerAdapter
-  implements OrderProcessorManagerPort, DestinationOptionsReader
+  implements OrderProcessorManagerPort, DestinationOptionsReader, OrderFulfillmentUpdater
 {
   private readonly logger = new Logger(PrestashopOrderProcessorManagerAdapter.name);
 
@@ -571,6 +577,129 @@ export class PrestashopOrderProcessorManagerAdapter
         undefined
       );
     }
+  }
+
+  /**
+   * Update an already-created PrestaShop order's status + tracking (#858,
+   * capability `OrderFulfillmentUpdater`). Drives the destination half of the
+   * #837 mark-sent orchestration; `externalOrderId` is the PS order id,
+   * resolved upstream from the order's `syncStatus`.
+   *
+   * **Idempotent desired-state projector, not a state machine.** It projects the
+   * supplied status onto the order; it does NOT enforce PS lifecycle ordering —
+   * monotonicity/legality is the domain's concern (see #861/#827). Safe to
+   * re-apply: the state transition is skipped when already in the target state,
+   * and the tracking write is skipped when unchanged.
+   *
+   * **Ordering — tracking first, state last.** The single irreversible
+   * side-effect is the buyer email, fired by `POST /order_histories` +
+   * `sendmail=1` (the PS-intended primitive; never a `current_state`
+   * full-replace, which skips side-effects). Tracking is written on the
+   * `order_carriers` association *before* the transition so the "shipped" email
+   * renders the tracking link, and so any failure before the email leaves a
+   * clean, forward-recoverable state (no tracking-less email ever sent).
+   *
+   * **Non-atomic + forward-recoverable.** The two WS writes aren't transactional
+   * (PS has no cross-request transaction). On partial failure we throw (surfaces
+   * as a per-destination failure in the orchestration) and do NOT compensate —
+   * the partial state is benign and converges on idempotent re-invocation. The
+   * convergence guarantee (re-drive until reflected) belongs to the notify-state
+   * layer (#861), not this adapter.
+   */
+  async updateFulfillment(input: {
+    externalOrderId: string;
+    status: OrderStatus;
+    trackingNumber?: string;
+  }): Promise<void> {
+    const { externalOrderId, status, trackingNumber } = input;
+    try {
+      const order = await this.httpClient.getResource<PrestashopOrder>('orders', externalOrderId);
+      const targetStateId = this.orderMapper.mapStatusToPrestashopStateId(status);
+
+      // B. Tracking FIRST (when supplied) — so the state-email below renders the
+      //    tracking link, and a failure here aborts before the irreversible email.
+      if (trackingNumber) {
+        await this.writeTracking(externalOrderId, trackingNumber);
+      }
+
+      // A. State transition LAST — the single irreversible side-effect.
+      //    `sendmail: true` → `?sendmail=1` fires PS's order-state customer email.
+      //    Skipped when already in the target state → idempotent (no duplicate
+      //    "shipped" email on re-notify).
+      if (Number(order.current_state) !== targetStateId) {
+        await this.httpClient.createResource(
+          'order_histories',
+          { id_order: externalOrderId, id_order_state: targetStateId },
+          { sendEmail: true }
+        );
+        this.logger.log(
+          `PrestaShop order ${externalOrderId} → state ${targetStateId} (status='${status}') ` +
+            `via order_histories+sendmail (connection: ${this.connection.id})`
+        );
+      } else {
+        this.logger.debug(
+          `PrestaShop order ${externalOrderId} already in state ${targetStateId} — ` +
+            `skipping order_histories (connection: ${this.connection.id})`
+        );
+      }
+    } catch (error) {
+      if (
+        error instanceof PrestashopResourceNotFoundException ||
+        error instanceof PrestashopApiException
+      ) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to update PrestaShop order ${externalOrderId} fulfillment: ${message}`,
+        error
+      );
+      throw new PrestashopApiException(
+        `Failed to update PrestaShop order ${externalOrderId} fulfillment: ${message}`,
+        undefined,
+        undefined,
+        this.connection.id
+      );
+    }
+  }
+
+  /**
+   * Set `tracking_number` on the order's **current** `order_carriers` row — the
+   * highest `id_order_carrier` (PrestaShop's notion of the active carrier;
+   * re-ships append new rows, `Order::getIdOrderCarrier` reads `DESC`). The WS
+   * PUT is full-replace, so we read-then-write the whole row. Idempotent: skips
+   * when the value is already set.
+   *
+   * If no `order_carriers` row exists (anomalous — PS auto-creates one for any
+   * carried order), we warn and skip rather than fabricate a PS-managed row;
+   * the state transition still applies and the anomaly surfaces in logs.
+   */
+  private async writeTracking(externalOrderId: string, trackingNumber: string): Promise<void> {
+    const rows = await this.httpClient.listResources<PrestashopOrderCarrier>('order_carriers', {
+      custom: { id_order: externalOrderId },
+    });
+    if (rows.length === 0) {
+      this.logger.warn(
+        `PrestaShop order ${externalOrderId} has no order_carriers row — cannot attach ` +
+          `tracking '${trackingNumber}' (connection: ${this.connection.id})`
+      );
+      return;
+    }
+    // PS's "current" carrier is the highest id_order_carrier; WS list ordering is
+    // unspecified, so pick max-id explicitly rather than trusting rows[0].
+    const row = rows.reduce((latest, r) => (Number(r.id) > Number(latest.id) ? r : latest));
+
+    if (String(row.tracking_number ?? '') === trackingNumber) {
+      this.logger.debug(
+        `PrestaShop order ${externalOrderId} tracking already '${trackingNumber}' — ` +
+          `skipping order_carriers write (connection: ${this.connection.id})`
+      );
+      return;
+    }
+    await this.httpClient.updateResource('order_carriers', row.id, {
+      ...row,
+      tracking_number: trackingNumber,
+    });
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-webservice.client.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/__tests__/prestashop-webservice.client.spec.ts
@@ -466,6 +466,46 @@ describe('PrestashopWebserviceClient', () => {
     });
   });
 
+  describe('write options — sendmail (#858)', () => {
+    const mockOk = (): void => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify({ prestashop: { order_history: { id: '77' } } })),
+      });
+    };
+    const lastUrl = (): string =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument -- test mock: dynamic spy
+      String((global.fetch as jest.Mock).mock.calls[0][0]);
+
+    it('should append ?sendmail=1 (and singularize order_histories) when sendEmail is true', async () => {
+      mockOk();
+
+      await client.createResource(
+        'order_histories',
+        { id_order: '999', id_order_state: 4 },
+        { sendEmail: true }
+      );
+
+      expect(lastUrl()).toBe('https://shop.example.com/api/order_histories?sendmail=1');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment -- test mock: dynamic spy
+      const init = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+      expect(init.method).toBe('POST');
+      // Irregular plural: order_histories → <order_history> envelope.
+      expect(init.body as string).toContain('<order_history>');
+    });
+
+    it('should NOT append sendmail when the option is absent (no always-append regression)', async () => {
+      mockOk();
+
+      await client.createResource('order_histories', { id_order: '999', id_order_state: 4 });
+
+      expect(lastUrl()).toBe('https://shop.example.com/api/order_histories');
+      expect(lastUrl()).not.toContain('sendmail');
+    });
+  });
+
   describe('retry logic', () => {
     it('should retry on server errors (5xx)', async () => {
       const mockResponse = {

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.interface.ts
@@ -30,6 +30,19 @@ export interface PrestashopQueryFilters {
  *
  * HTTP client for PrestaShop WebService API operations.
  */
+/**
+ * Optional control flags for a PrestaShop WebService write (POST/PUT).
+ *
+ * `sendEmail` maps to the `?sendmail=1` *query* param PrestaShop reads to fire
+ * the order-state customer email on an `order_histories` write (#858). It is a
+ * PS-WS-protocol concern, so the client owns the wire mapping; callers express
+ * intent (`{ sendEmail: true }`). Opt-in per call — never a client default —
+ * so non-order writes (carts, customers, …) never email.
+ */
+export interface PrestashopWriteOptions {
+  sendEmail?: boolean;
+}
+
 export interface IPrestashopWebserviceClient {
   /**
    * Get a single resource by ID
@@ -70,7 +83,11 @@ export interface IPrestashopWebserviceClient {
    * @throws PrestashopAuthenticationException if authentication fails
    * @throws PrestashopApiException for other API errors
    */
-  createResource<T = unknown>(resource: string, data: Record<string, unknown>): Promise<T>;
+  createResource<T = unknown>(
+    resource: string,
+    data: Record<string, unknown>,
+    options?: PrestashopWriteOptions,
+  ): Promise<T>;
 
   /**
    * Update an existing resource (PUT).
@@ -93,6 +110,7 @@ export interface IPrestashopWebserviceClient {
     resource: string,
     id: string | number,
     data: Record<string, unknown>,
+    options?: PrestashopWriteOptions,
   ): Promise<T>;
 }
 

--- a/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
+++ b/libs/integrations/prestashop/src/infrastructure/http/prestashop-webservice.client.ts
@@ -11,6 +11,7 @@
 import type {
   IPrestashopWebserviceClient,
   PrestashopQueryFilters,
+  PrestashopWriteOptions,
 } from './prestashop-webservice.client.interface';
 import type {
   PrestashopConnectionConfig,
@@ -25,6 +26,22 @@ import { PrestashopQueryBuilder } from './prestashop-query.builder';
 import { PrestashopResponseParser } from './prestashop-response.parser';
 import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import { XMLBuilder } from 'fast-xml-parser';
+
+/**
+ * Resources whose PrestaShop singular element name is not the plural minus a
+ * trailing 's' (the naive `slice(0,-1)`). The WS XML envelope and the response
+ * key both use the singular, so these must be mapped explicitly — e.g.
+ * `order_histories → order_history`, not `order_historie`.
+ */
+const IRREGULAR_RESOURCE_SINGULARS: Readonly<Record<string, string>> = {
+  addresses: 'address',
+  order_histories: 'order_history',
+};
+
+/** PrestaShop singular element name for a WS resource (handles irregular plurals). */
+function singularizeResource(resource: string): string {
+  return IRREGULAR_RESOURCE_SINGULARS[resource] ?? resource.slice(0, -1);
+}
 
 /**
  * Retry configuration
@@ -179,16 +196,21 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
     return this.normalizeCollection<T>(parsed, resource);
   }
 
-  async createResource<T = unknown>(resource: string, data: Record<string, unknown>): Promise<T> {
-    return this.writeResource<T>(resource, undefined, data);
+  async createResource<T = unknown>(
+    resource: string,
+    data: Record<string, unknown>,
+    options?: PrestashopWriteOptions
+  ): Promise<T> {
+    return this.writeResource<T>(resource, undefined, data, options);
   }
 
   async updateResource<T = unknown>(
     resource: string,
     id: string | number,
-    data: Record<string, unknown>
+    data: Record<string, unknown>,
+    options?: PrestashopWriteOptions
   ): Promise<T> {
-    return this.writeResource<T>(resource, id, data);
+    return this.writeResource<T>(resource, id, data, options);
   }
 
   /**
@@ -203,10 +225,16 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
   private async writeResource<T = unknown>(
     resource: string,
     id: string | number | undefined,
-    data: Record<string, unknown>
+    data: Record<string, unknown>,
+    options?: PrestashopWriteOptions
   ): Promise<T> {
     const path = PrestashopQueryBuilder.buildResourcePath(resource, id);
-    const url = `${this.baseUrl}${path}`;
+    const requestUrl = `${this.baseUrl}${path}`;
+    // `sendmail=1` is a PrestaShop WS *query* flag (not a body field) that
+    // fires the order-state customer email on an `order_histories` write (#858).
+    const url = options?.sendEmail
+      ? `${requestUrl}${requestUrl.includes('?') ? '&' : '?'}sendmail=1`
+      : requestUrl;
 
     const isUpdate = id !== undefined;
     this.logger.debug(
@@ -217,12 +245,8 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
     const responseFormat: 'auto' | 'json' | 'xml' = configResponseFormat ?? 'auto';
 
     // Wrap data in PrestaShop format: { prestashop: { customer: { ... } } }
-    // Handle special cases for resource singularization
-    // 'addresses' → 'address' (not 'addresse')
-    let resourceKey = resource.slice(0, -1); // e.g., 'customer' from 'customers'
-    if (resource === 'addresses') {
-      resourceKey = 'address'; // Special case: addresses → address
-    }
+    // Singular element name (handles irregular plurals like addresses/order_histories).
+    const resourceKey = singularizeResource(resource);
     const wrappedData = {
       prestashop: {
         [resourceKey]: data,
@@ -255,9 +279,8 @@ export class PrestashopWebserviceClient implements IPrestashopWebserviceClient {
     // Note: Some resources have irregular singular forms (e.g., 'addresses' → 'address', not 'addresse')
     const parsedObj = parsed as Record<string, unknown>;
 
-    // Handle special cases for resource singularization
-    // 'addresses' → 'address' (not 'addresse')
-    const singularResourceKey = resource === 'addresses' ? 'address' : resourceKey;
+    // `resourceKey` is already the irregular-aware singular (see singularizeResource).
+    const singularResourceKey = resourceKey;
 
     // Try with prestashop wrapper first
     if (parsedObj.prestashop && typeof parsedObj.prestashop === 'object') {

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -14,7 +14,7 @@ import type {
   PrestashopOrderRow,
 } from './prestashop.mapper.interface';
 import type { Order, OrderItem, OrderTotals } from '@openlinker/core/orders';
-import type { OrderCreate } from '@openlinker/core/orders';
+import type { OrderCreate, OrderStatus } from '@openlinker/core/orders';
 import { PrestashopProvisioningException } from '@openlinker/integrations-prestashop';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -172,7 +172,7 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
     // Map order status to PrestaShop status ID
     // PrestaShop uses numeric status IDs. For MVP, we'll use common defaults:
     // 1 = pending, 2 = payment accepted, 3 = preparation in progress, etc.
-    const statusId = this.mapOrderStatusToPrestashop(orderCreate.status);
+    const statusId = this.mapStatusToPrestashopStateId(orderCreate.status);
 
     // Map order rows (line items)
     const orderRows = orderCreate.items.map((item, index) => {
@@ -409,15 +409,21 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
   }
 
   /**
-   * Map OpenLinker order status to PrestaShop status ID
+   * Map OpenLinker `OrderStatus` to a PrestaShop order-state id.
    *
-   * PrestaShop uses numeric status IDs. This maps common OpenLinker statuses
-   * to PrestaShop defaults. In production, status IDs should be configurable
-   * or fetched from PrestaShop.
+   * **Assumes a default PrestaShop install** (state ids 1/2/4/5/6/7). Merchants
+   * who customize the order-state catalogue (rename/reorder/add states) would
+   * need a per-connection override — the resolution-chain follow-up tracked in
+   * #862. This is the fallback tier of that chain.
+   *
+   * The switch is **compile-time exhaustive over `OrderStatus`**: adding a new
+   * status to the union without mapping it here is a type error (the `never`
+   * guard), not a silent default-to-pending — which on the `updateFulfillment`
+   * projection path (with `sendmail`) would otherwise mis-transition + mis-email.
    */
-  private mapOrderStatusToPrestashop(status: string): number {
-    // Common PrestaShop order status IDs (default installation)
-    switch (status.toLowerCase()) {
+  mapStatusToPrestashopStateId(status: OrderStatus): number {
+    // Default-install PrestaShop order-state ids.
+    switch (status) {
       case 'pending':
         return 1; // Awaiting check payment
       case 'processing':
@@ -430,8 +436,12 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
         return 6; // Canceled
       case 'refunded':
         return 7; // Refunded
-      default:
-        return 1; // Default to pending
+      default: {
+        const _exhaustive: never = status;
+        throw new Error(
+          `Unmapped OrderStatus → PrestaShop state id: ${String(_exhaustive)} (update the mapper / #862)`
+        );
+      }
     }
   }
 

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop.mapper.interface.ts
@@ -9,7 +9,7 @@
  */
 import type { Product, ProductVariant } from '@openlinker/core/products';
 import type { Inventory } from '@openlinker/core/inventory';
-import type { Order, OrderCreate } from '@openlinker/core/orders';
+import type { Order, OrderCreate, OrderStatus } from '@openlinker/core/orders';
 
 /**
  * PrestaShop product data (from API response)
@@ -229,4 +229,12 @@ export interface IPrestashopOrderMapper {
      */
     externalCarrierId?: number
   ): Record<string, unknown>;
+
+  /**
+   * Map an OpenLinker `OrderStatus` to its PrestaShop order-state id
+   * (e.g. `'shipped' → 4`). Single source of truth for the status→state-id
+   * table, reused by `mapOrderCreate` and by the order-fulfillment update
+   * (#858 capability B).
+   */
+  mapStatusToPrestashopStateId(status: OrderStatus): number;
 }


### PR DESCRIPTION
## What & why

Implements `updateFulfillment` on `PrestashopOrderProcessorManagerAdapter` (`implements … OrderFulfillmentUpdater`) so the **#837** mark-sent orchestration's destination half works for PrestaShop. The guard `isOrderFulfillmentUpdater` now returns true, so `ShipmentDispatchNotificationService` drives it automatically — `destinations[].status` flips `unsupported → ok/failed` with no orchestration change.

Design settled via a full `/grill-me` + repeated `/tech-review` (decision log in `docs/plans/implementation-plan-prestashop-order-fulfillment-updater.md` §6).

## Key decisions

- **Idempotent desired-state projector, not a state machine.** It projects the supplied status; lifecycle/legality stays in the domain. The `current_state`-skip guard's real job is **duplicate-email prevention** (PS doesn't dedupe `order_histories`).
- **State transition via `POST /order_histories` + `sendmail=1`** — the PS-intended primitive that fires the buyer "shipped" email and side-effects. **Never** the `orders` full-replace (which skips them). Tracking on the `order_carriers` association.
- **Tracking-first ordering** — the one irreversible side-effect (the email) is sequenced **last**, so any failure before it leaves a clean, retriable state and never sends a tracking-less email.
- **`order_carriers`:** write the **max-id** (current) row; **warn-and-skip, don't fabricate** when absent (projector principle).
- **Non-atomic + forward-recoverable:** throw on partial failure, no compensation; convergence is the notify-state layer's job (**#861**).

## Mechanics

- **WS client:** typed `{ sendEmail }` write-option mapped to `?sendmail=1` (PS-WS-protocol stays in the client; the adapter expresses intent). Also teaches the client the `order_histories → order_history` irregular plural.
- **Mapper:** `mapStatusToPrestashopStateId` exposed on `IPrestashopOrderMapper`, made **compile-time-exhaustive** over `OrderStatus` (extending the union is now a compile error, not a silent default-to-pending). Assumes default PS state ids — the fallback tier of the configurable resolution chain in **#862**.
- **PS test WS-key fixture:** grant `order_histories` (alongside existing `order_carriers`) — also a **real operator requirement**: a PrestaShop connection's WS key must grant these resources or `updateFulfillment` 401s.

## Tests / verification

- **Unit:** sendmail option requested, **tracking-before-state ordering** (`invocationCallOrder`), max-id row, warn-skip, idempotency (skip-when-in-state / tracking-unchanged), error-wrap; plus WS-client `sendmail` cases (present → `?sendmail=1`, absent → none).
- **Integration (module-free PS-Testcontainer, `installOlModule:false`):** proves `current_state` advances via the WS `order_histories` POST on **real PS 9.0.2** + tracking lands on `order_carriers` + idempotency. This was the load-bearing uncertainty — **resolved positive**, so no module-side endpoint needed. Email *delivery* is a documented accepted gap (no SMTP in the container; the `sendmail=1`-without-SMTP path is validated not to 500).
- **Gate:** type-check ✅ · lint ✅ (0 errors, invariants) · full unit suite ✅ · full integration suite ran with this spec passing (the lone suite failure, `auth-refresh`, was an environmental Docker-harness-boot flake — confirmed green in isolation after pruning stopped containers; unrelated to this PrestaShop-only change). No migration, no manifest change.

## Follow-ups
- **#861** — durable per-destination notify-state / idempotency source-of-truth (the per-target retry model #837 deferred).
- **#862** — operator-configurable OL→PS order-state resolution chain (override tier in front of this default mapper).

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)