### PR TITLE
refactor(integrations): drop redundant `/validate` endpoint to close last host→plugin OAuth coupling (#864)

### DIFF
--- a/apps/api/src/integrations/application/interfaces/oauth-connection.service.interface.ts
+++ b/apps/api/src/integrations/application/interfaces/oauth-connection.service.interface.ts
@@ -52,12 +52,6 @@ export interface IOAuthConnectionService {
   completeAuthorization(code: string, stateData: OAuthStateData): Promise<Connection>;
 
   /**
-   * Validate that a connection's configuration is correct. Currently retained
-   * verbatim with platform-aware checks pending the #587 cleanup (grill Q4).
-   */
-  validateConnection(connectionId: string): Promise<{ valid: boolean; errors: string[] }>;
-
-  /**
    * Persist a short-lived completed marker after a successful callback. Enables
    * idempotent replay of the callback within the TTL window.
    */

--- a/apps/api/src/integrations/application/services/oauth-connection.service.ts
+++ b/apps/api/src/integrations/application/services/oauth-connection.service.ts
@@ -22,7 +22,6 @@ import {
   BadRequestException,
   InternalServerErrorException,
   Inject,
-  NotFoundException,
 } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
 import { randomUUID, randomBytes } from 'crypto';
@@ -40,12 +39,6 @@ import type {
   OAuthCredentialBlob,
   OAuthAccountIdentity,
 } from '@openlinker/core/integrations';
-// `validateConnection` retains platform-aware config checks pending the #587
-// cleanup (grill Q4); it is the one Allegro-coupled method in this otherwise
-// neutral service. Tracked for relocation behind the plugin's config-shape
-// validator.
-import type { AllegroConnectionConfig } from '@openlinker/integrations-allegro';
-import { AllegroEnvironmentValues } from '@openlinker/integrations-allegro';
 import { ConnectionService } from './connection.service';
 import type { IOAuthConnectionService } from '../interfaces/oauth-connection.service.interface';
 import type {
@@ -188,68 +181,6 @@ export class OAuthConnectionService implements IOAuthConnectionService {
       );
     }
     return this.createConnection(credentialBlob, identity, stateData);
-  }
-
-  async validateConnection(connectionId: string): Promise<{ valid: boolean; errors: string[] }> {
-    const errors: string[] = [];
-
-    try {
-      const connection = await this.connectionService.get(connectionId);
-
-      if (connection.platformType !== 'allegro') {
-        errors.push(
-          `Connection is not an Allegro connection (platformType: ${connection.platformType})`
-        );
-        return { valid: false, errors };
-      }
-
-      if (!connection.config) {
-        errors.push('Connection is missing config');
-        return { valid: false, errors };
-      }
-
-      const config = connection.config as unknown as AllegroConnectionConfig;
-
-      if (!config.environment) {
-        errors.push('Config is missing environment');
-      } else if (!AllegroEnvironmentValues.includes(config.environment)) {
-        errors.push(
-          `Invalid environment: ${config.environment}. Must be one of: ${AllegroEnvironmentValues.join(', ')}`
-        );
-      }
-
-      if (config.apiBaseUrl) {
-        try {
-          new URL(config.apiBaseUrl);
-        } catch {
-          errors.push(`Invalid apiBaseUrl format: ${config.apiBaseUrl}`);
-        }
-      }
-
-      if (!connection.credentialsRef) {
-        errors.push('Connection is missing credentialsRef');
-      }
-
-      const valid = errors.length === 0;
-      if (valid) {
-        this.logger.debug(`Connection ${connectionId} validation passed`);
-      } else {
-        this.logger.warn(`Connection ${connectionId} validation failed: ${errors.join(', ')}`);
-      }
-      return { valid, errors };
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        this.logger.warn(`Connection not found for validation: ${connectionId}`);
-        errors.push(`Connection not found: ${connectionId}`);
-        return { valid: false, errors };
-      }
-      this.logger.error(
-        `Error validating connection ${connectionId}: ${(error as Error).message}`,
-        error
-      );
-      errors.push(`Failed to validate connection: ${(error as Error).message}`);
-      return { valid: false, errors };
-    }
   }
 
   async markStateCompleted(

--- a/apps/api/src/integrations/http/allegro.controller.spec.ts
+++ b/apps/api/src/integrations/http/allegro.controller.spec.ts
@@ -2,7 +2,7 @@
  * Allegro Controller Unit Tests
  *
  * Unit tests for AllegroController, verifying HTTP endpoint handling,
- * OAuth flow, connection validation, cursor queries, and command queries.
+ * OAuth flow, cursor queries, and command queries.
  *
  * @module apps/api/src/integrations/http
  */
@@ -53,7 +53,6 @@ describe('AllegroController', () => {
       generateAuthorizationUrl: jest.fn(),
       validateState: jest.fn(),
       completeAuthorization: jest.fn(),
-      validateConnection: jest.fn(),
       markStateCompleted: jest.fn(),
       checkCompletedState: jest.fn(),
     } as unknown as jest.Mocked<IOAuthConnectionService>;
@@ -301,39 +300,6 @@ describe('AllegroController', () => {
       oauthService.completeAuthorization.mockRejectedValue(new Error('Token exchange failed'));
 
       await expect(controller.callback(query)).rejects.toThrow('Token exchange failed');
-    });
-  });
-
-  describe('validate', () => {
-    it('should validate connection successfully', async () => {
-      const connectionId = 'connection-123';
-      const validationResult = {
-        valid: true,
-        errors: [],
-      };
-
-      oauthService.validateConnection.mockResolvedValue(validationResult);
-
-      const result = await controller.validate(connectionId);
-
-      expect(result).toEqual(validationResult);
-      expect(oauthService.validateConnection).toHaveBeenCalledWith(connectionId);
-    });
-
-    it('should return validation errors when connection is invalid', async () => {
-      const connectionId = 'connection-123';
-      const validationResult = {
-        valid: false,
-        errors: ['Config is missing environment', 'Connection is missing credentialsRef'],
-      };
-
-      oauthService.validateConnection.mockResolvedValue(validationResult);
-
-      const result = await controller.validate(connectionId);
-
-      expect(result).toEqual(validationResult);
-      expect(result.valid).toBe(false);
-      expect(result.errors.length).toBeGreaterThan(0);
     });
   });
 

--- a/apps/api/src/integrations/http/allegro.controller.ts
+++ b/apps/api/src/integrations/http/allegro.controller.ts
@@ -2,8 +2,7 @@
  * Allegro Integration Controller
  *
  * HTTP REST API endpoints for Allegro integration operations. Handles OAuth
- * flow (connect, callback), connection validation, and Allegro-specific
- * connection management.
+ * flow (connect, callback) and Allegro-specific connection management.
  *
  * @module apps/api/src/integrations/http
  */
@@ -221,41 +220,6 @@ export class AllegroController {
       this.logger.error(`OAuth callback error: ${(error as Error).message}`, error);
       throw error;
     }
-  }
-
-  @ApiBearerAuth()
-  @Get('connections/:id/validate')
-  @ApiOperation({ summary: 'Validate Allegro connection configuration' })
-  @ApiParam({
-    name: 'id',
-    description: 'Connection ID (UUID)',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Connection validation result',
-    schema: {
-      type: 'object',
-      properties: {
-        valid: {
-          type: 'boolean',
-          example: true,
-        },
-        errors: {
-          type: 'array',
-          items: { type: 'string' },
-          example: [],
-        },
-      },
-    },
-  })
-  @ApiResponse({ status: 404, description: 'Connection not found' })
-  async validate(@Param('id') connectionId: string): Promise<{
-    valid: boolean;
-    errors: string[];
-  }> {
-    this.logger.log(`Validating Allegro connection: ${connectionId}`);
-    return this.oauthService.validateConnection(connectionId);
   }
 
   @ApiBearerAuth()

--- a/docs/architecture/adrs/013-neutral-oauth-completion-port.md
+++ b/docs/architecture/adrs/013-neutral-oauth-completion-port.md
@@ -38,3 +38,7 @@ Introduce a neutral **`OAuthCompletionPort`** in CORE with three methods — `bu
 - Related issues: #859, #546 (modularity epic), #820 (same-account guard), #819 (re-auth in place)
 - Related ADRs: [ADR-003](./003-plugin-sdk-trust-model.md), [ADR-008](./008-auth-failure-classifier-connection-reauth.md)
 - Primary doc section: [docs/architecture-overview.md](../../architecture-overview.md) § Plugin Manager / Integrations
+
+## Updates
+
+- **2026-05-28 (#864):** the deferred Allegro-coupling in `OAuthConnectionService.validateConnection` (first Cons line above) was resolved by dropping the redundant `GET /integrations/allegro/connections/:id/validate` endpoint and its backing service method. The host now value-imports zero plugin packages. The decision recorded in this ADR is unchanged; this is a pointer to the trade-off's closure.

--- a/docs/plans/implementation-plan-864-validate-connection-allegro-cleanup.md
+++ b/docs/plans/implementation-plan-864-validate-connection-allegro-cleanup.md
@@ -1,0 +1,52 @@
+# Implementation Plan — #864 Close the last host→plugin OAuth coupling
+
+**Issue:** #864 · **Follow-up to:** #859 / ADR-013 · **Layer:** Interface (host) — subtractive
+**Branch:** `864-validate-connection-allegro-cleanup` · **ADR:** not required (subtractive cleanup; closes a known trade-off recorded in ADR-013)
+
+> Closes the one residual Allegro coupling in `apps/api`'s neutral OAuth surface, explicitly tracked in ADR-013 §Cons. After this PR, `OAuthConnectionService` value-imports zero plugin packages — the modularity epic (#546) is complete for the OAuth slice.
+
+## 1. Goal & non-goals
+
+**Goal:** drop `OAuthConnectionService.validateConnection` and the `GET /integrations/allegro/connections/:id/validate` endpoint that backs it. The endpoint is redundant with already-shipped capabilities:
+
+- **Shape validation** (#586/#587): `ConnectionConfigShapeValidatorPort` runs on create *and* update via `ConnectionService.validateConfigShape`, throwing `InvalidConnectionConfigException` → 400 with a flat error list. Allegro's `AllegroConnectionConfigShapeValidatorAdapter` covers the env-value, base-URL, and shape checks the host method duplicates today.
+- **Live-credential validation** (#583): `ConnectionTesterPort` (host-dispatched via `ConnectionService.testConnection` → `POST /connections/:id/test`) covers "are these credentials live?".
+
+**Non-goals:** any other change. No new types, no FE work, no behaviour change to anything else.
+
+## 2. Research findings (drives the Option-2 call)
+
+- **No FE consumer.** `grep -rnE "integrations/allegro/connections.*validate|validateConnection" apps/web/src` → 0 hits.
+- **No int-spec consumer.** The OAuth int-spec I shipped under #859 covers connect/callback only.
+- **Only callers of `validateConnection`** are: the `AllegroController.validate` handler, the interface declaration, and 2 cases in the controller spec.
+- **Only host-side importers of `AllegroConnectionConfig` + `AllegroEnvironmentValues`** are in `oauth-connection.service.ts:47-48,211,215,217` (the validateConnection method body). Nothing else in `apps/{api,worker}` imports these symbols.
+- **Existing shape coverage:** `libs/integrations/allegro/src/application/dto/allegro-connection-config.dto.ts` declares `environment` with the `AllegroEnvironmentValues` constraint, `apiBaseUrl`, and the rest — class-validator runs on every `ConnectionService.create` / `update` and produces a flat `{path, message}[]` for any shape failure, mapped to a 400 with `BadRequestException({message, errors})`.
+
+**Conclusion:** `validateConnection`'s checks are 100% covered by the plugin validator on every write; the post-write read-style validator is dead surface, only ever called by a route the FE doesn't use.
+
+## 3. Decision: drop, don't relocate
+
+Picked **Option 2** from the issue body. Option 1 (delegate `validateConnection` to the plugin validator and re-flatten errors into the `{valid, errors[]}` string-array shape) would have preserved the surface — but the surface has no consumer. Dropping is strictly cleaner: less code, fewer tests, fewer endpoints, no new error-flattening adapter on the host. If a future operator workflow needs a read-style validity probe, it's a small additive change to either resurface it (delegating to the plugin validator) or expose `POST /connections/:id/test`.
+
+## 4. Step-by-step
+
+| # | File | Change |
+|---|---|---|
+| 1 | `apps/api/src/integrations/application/services/oauth-connection.service.ts` | Remove the `validateConnection` method (lines ~193-253). Drop the now-unused imports: `NotFoundException` from `@nestjs/common`, `AllegroConnectionConfig` + `AllegroEnvironmentValues` from `@openlinker/integrations-allegro`. Remove the deferred-coupling comment block immediately above the imports. |
+| 2 | `apps/api/src/integrations/application/interfaces/oauth-connection.service.interface.ts` | Remove the `validateConnection` method signature + its JSDoc block from `IOAuthConnectionService`. |
+| 3 | `apps/api/src/integrations/http/allegro.controller.ts` | Remove the `@Get('connections/:id/validate')` handler (`validate` method) and its Swagger decorators (`@ApiOperation`, `@ApiParam`, `@ApiResponse`s, `@ApiBearerAuth`). |
+| 4 | `apps/api/src/integrations/http/allegro.controller.spec.ts` | Remove the `validate: jest.fn()` from the mock, the `describe('validate', …)` block + its 2 `it()` cases. |
+| 5 | `docs/architecture/adrs/013-neutral-oauth-completion-port.md` | **No edit** — ADRs are append-only per the README practice. The PR description references this PR/#864 as the resolution of the recorded trade-off; the git log + issue cross-link is the audit trail. |
+
+## 5. Validation
+
+- **Architecture**: strictly subtractive. The neutral `OAuthConnectionService` now value-imports zero plugin packages — `@openlinker/integrations-allegro` is no longer in its dependency graph. The cross-context import guard (`scripts/check-cross-context-imports.mjs`) keeps its allow-list intact; we just stop tripping a previously-tolerated host→plugin coupling.
+- **Naming/structure**: no new files. No naming concerns.
+- **Test coverage**: the existing service unit spec never covered `validateConnection` (it was the deferred Allegro-coupled method in #859); no test removal needed there. The controller spec loses two tests with the route; the remaining 17 tests cover connect / callback / cursors / commands.
+- **Behaviour**: `GET /integrations/allegro/connections/:id/validate` returns **404** after this PR. The FE doesn't call it; no operator workflow documented as dependent. Note in the PR body.
+- **Security**: no impact. The endpoint was admin-bearer-gated (existing); removal reduces attack surface marginally.
+- **Quality gate**: `pnpm lint && pnpm type-check && pnpm test` — must pass with zero errors. `pnpm test:integration` (apps/api) — must remain green; expect the same pre-existing flakes (apps/web full-suite parallelism, PS-harness cold-cache) and **no** new failures.
+
+## 6. Risk
+
+Single soft-breaking behaviour change: the `/validate` endpoint disappears. Mitigation: documented in the PR body; FE confirmed not to consume it. If a future caller surfaces, resurfacing the endpoint by delegating to the plugin validator is a small additive change against the unchanged `ConnectionConfigShapeValidatorRegistryService` seam.


### PR DESCRIPTION
## What & why

Closes the one residual Allegro coupling in `apps/api`'s neutral OAuth surface — the deferred trade-off explicitly recorded in [ADR-013](./docs/architecture/adrs/013-neutral-oauth-completion-port.md) §Cons after #859 shipped. **The host `OAuthConnectionService` now value-imports zero plugin packages** — the modularity epic (#546) is complete for the OAuth slice.

Removes `GET /integrations/allegro/connections/:id/validate` and its backing `OAuthConnectionService.validateConnection` method. Both were redundant with already-shipped capabilities:

- **Shape validation** (#586/#587): `ConnectionConfigShapeValidatorPort` runs on every connection create/update via `ConnectionService.validateConfigShape`, throwing `InvalidConnectionConfigException` → 400 with a flat error list. Allegro's `AllegroConnectionConfigShapeValidatorAdapter` covers the same `environment` / `apiBaseUrl` / shape checks the host method duplicated.
- **Live-credential validation** (#583): `ConnectionTesterPort` (host-dispatched via `ConnectionService.testConnection` → `POST /connections/:id/test`) covers "are these credentials live?".

## Why drop, not relocate

The issue body and ADR-013 phrasing both said "relocate" — but the research justified the simpler Option-2:

- **Zero FE consumers** — `grep -rnE "integrations/allegro/connections.*validate|validateConnection" apps/web/src` returns 0 hits.
- **Zero int-spec consumers** — the OAuth int-spec from #859 covers connect/callback only.
- **Full redundancy** — every check `validateConnection` ran (`AllegroEnvironmentValues.includes(...)`, `new URL(config.apiBaseUrl)`, "config missing"/"credentialsRef missing") is enforced *at write time* by #587 with strictly richer error messages. The read-style probe added nothing the platform validator wasn't already enforcing.

Relocation would have meant: build a new endpoint that re-resolves the per-adapter `ConnectionConfigShapeValidatorPort`, catch `InvalidConnectionConfigException`, flatten `errors[]` into `string[]`. **All work, zero callers.** Dropping is strictly cleaner.

## What changed (5 files, surgical)

| File | Δ | What |
|---|---|---|
| `apps/api/src/integrations/application/services/oauth-connection.service.ts` | −69 | Remove `validateConnection` method + 3 now-unused imports (`NotFoundException`, `AllegroConnectionConfig`, `AllegroEnvironmentValues`) + the deferred-coupling comment block. |
| `apps/api/src/integrations/application/interfaces/oauth-connection.service.interface.ts` | −6 | Drop the `validateConnection` signature + JSDoc from `IOAuthConnectionService`. |
| `apps/api/src/integrations/http/allegro.controller.ts` | −38 | Remove the `@Get('connections/:id/validate')` handler + its 7 Swagger decorators. Refresh the file header. |
| `apps/api/src/integrations/http/allegro.controller.spec.ts` | −36 | Drop the `validateConnection: jest.fn()` mock + the `describe('validate', …)` block (2 cases). Refresh the file header. |
| `docs/architecture/adrs/013-neutral-oauth-completion-port.md` | +4 | Non-decision-changing `## Updates` footer pointing to this PR — per the README's append-only convention, interpreted pragmatically (the recorded *decision* is unchanged; the footer just makes the trade-off's closure discoverable). |

## Behaviour change

⚠️ Soft-breaking — `GET /integrations/allegro/connections/:id/validate` now returns **404**.

- **FE**: confirmed non-dependent (grep returns 0 hits).
- **External consumers**: none documented. The endpoint was admin-bearer-gated and rolled out via #859 a few days ago; no integration tooling is known to consume it.
- **Resurfacing path** (if a future caller appears): delegate to the unchanged `ConnectionConfigShapeValidatorRegistryService.get(adapterKey).validate(config)` and flatten the plugin's `InvalidConnectionConfigException.errors[]` into the `{ valid, errors[] }` wire shape. Small additive change against the already-shipped seam.

## Tests

- **apps/api**: 429 → 427 (exactly the 2 removed `describe('validate', …)` cases — no incidental loss).
- **libs/core / libs/integrations / apps/web**: unchanged.
- **Int-spec**: the OAuth int-spec from #859 (`apps/api/test/integration/oauth-connection.int-spec.ts`) doesn't touch `/validate` — unaffected. No int-spec changes needed.
- **No 404-assertion test added**: would be testing NestJS's not-registered-route behavior, not OL behavior. Deliberate omission.

## Quality gate

| Gate | Result |
|---|---|
| `pnpm lint` + all invariants (cross-context imports, service interfaces, plugin-author-guide line-range guard, ADR README index, design tokens, migration timestamps) | ✅ 0 errors |
| `pnpm type-check` | ✅ 11 packages clean |
| `pnpm test` (full unit suite) | ✅ pre-commit hook passed first-try (no apps/web parallelism flake this time). apps/api 427/427, libs/core 905/905, apps/web 1222/1222 confirmed in isolation. |

## Related

- Issue: #864
- Predecessor: #865 (the #859 OAuth-port relocation that introduced ADR-013 and recorded the trade-off this PR resolves)
- Precedents: #586/#587 (config shape validator), #583 (connection tester), #859 (neutral OAuth port + ADR-013)

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)
